### PR TITLE
test(napi/parser): add raw_transfer_back conformance suite

### DIFF
--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -72,6 +72,7 @@
     "build-browser-bundle": "node scripts/build-browser-bundle.js",
     "test": "pnpm run test-node run",
     "test-node": "vitest --dir ./test",
+    "test-raw-back": "vitest run --dir ./test raw-transfer-back",
     "test-browser": "vitest -c vitest.config.browser.ts",
     "bench": "vitest bench --run ./bench.bench.js"
   },

--- a/napi/parser/test/raw-transfer-back-api.ts
+++ b/napi/parser/test/raw-transfer-back-api.ts
@@ -1,0 +1,44 @@
+// Interface seam between the raw transfer back conformance suite and the implementation.
+//
+// This is the ONLY file the suite needs to touch when the implementation lands:
+// * `RAW_TRANSFER_BACK_SUPPORTED` gates the whole suite (skipped while `false`).
+// * `roundtrip()` performs: encode ESTree program into the arena buffer on the JS side
+//   (`src-js/raw-transfer/serialize.js`), then call the native round-trip binding, which
+//   placement-constructs the `Allocator` in the buffer, forms `&Program`, parses `sourceText`
+//   independently, and returns the comparison results.
+//
+// Wiring TODO (PR 2 of raw_transfer_back, see `tasks/ast_tools/src/generators/raw_transfer_back.rs` plan):
+// 1. Import `encodeRawBack` from `../src-js/raw-transfer/serialize.js`.
+// 2. Import `rawTransferBackRoundtrip` binding from `../src-js/bindings.js`.
+// 3. Set `RAW_TRANSFER_BACK_SUPPORTED = true` (or feature-detect the binding).
+
+import type { Program } from "./parser.ts";
+
+export const RAW_TRANSFER_BACK_SUPPORTED = false;
+
+export interface RoundtripOptions {
+  filename: string;
+  // `null` = encode without source text: spans pass through unconverted and comments are
+  // unavailable, so codegen comparison must run with comments disabled on both sides.
+  sourceText: string | null;
+  astType: "js" | "ts";
+  preserveParens: boolean;
+}
+
+export interface RoundtripResult {
+  // `ContentEq` between round-tripped and directly-parsed `Program` (spans excluded).
+  contentEq: boolean;
+  // Codegen output of the round-tripped `Program`.
+  printed: string;
+  // Codegen output of the directly-parsed `Program`.
+  expected: string;
+}
+
+// oxlint-disable-next-line no-unused-vars
+export function roundtrip(program: Program, options: RoundtripOptions): RoundtripResult {
+  throw new Error(
+    "raw_transfer_back is not implemented yet. " +
+      "Wire this function to `encodeRawBack` + the `rawTransferBackRoundtrip` binding, " +
+      "and set `RAW_TRANSFER_BACK_SUPPORTED = true`.",
+  );
+}

--- a/napi/parser/test/raw-transfer-back-common.ts
+++ b/napi/parser/test/raw-transfer-back-common.ts
@@ -1,0 +1,41 @@
+// Constants used in both main thread and worker in raw transfer back tests.
+//
+// The raw transfer back conformance suite mirrors the raw transfer suite (`parse-raw.test.ts`):
+// same fixture sets, same worker architecture, same known-failures filtering mechanism.
+//
+// Difference in oracle: instead of comparing deserialized output against Acorn / TS-ESLint JSON,
+// each case round-trips `ESTree -> encode -> arena -> &Program` and asserts, on the Rust side:
+// 1. `ContentEq` between the round-tripped `Program` and a direct parse of the same source
+//    (spans excluded by design - `Span` is `#[content_eq(skip)]`).
+// 2. Byte-equal codegen output from both programs.
+
+import { join as pathJoin } from "node:path";
+
+export const TEST_TYPE_TEST262 = 0;
+export const TEST_TYPE_JSX = 1;
+export const TEST_TYPE_TS = 2;
+export const TEST_TYPE_FIXTURE = 3;
+export const TEST_TYPE_INLINE_FIXTURE = 4;
+
+export const TEST_TYPE_MAIN_MASK = 7;
+// Encode without providing source text (spans pass through raw, comments unavailable).
+// Codegen comparison runs with comments disabled on both sides.
+export const TEST_TYPE_NO_SOURCE = 8;
+// Parse and encode with `preserveParens: true` (default in this suite is `false`).
+export const TEST_TYPE_PRESERVE_PARENS = 16;
+// Re-run on main thread with Vitest's `expect` for a pretty diff.
+export const TEST_TYPE_PRETTY = 32;
+
+// Path to known-failures snapshot for this suite.
+// Same line grammar as `tasks/coverage` snapshots: `Mismatch: <path>` lines, parsed by
+// `getTestFailurePaths()` in `raw-transfer-back.test.ts`.
+// Regenerate with: `UPDATE_RAW_TRANSFER_BACK_SNAPSHOT=true pnpm vitest run --dir ./test raw-transfer-back`
+export const FAILS_SNAPSHOT_PATH = pathJoin(
+  import.meta.dirname,
+  "snapshots/raw-transfer-back.snap",
+);
+
+// Prefixes used in the snapshot's `Mismatch:` lines, one per fixture set.
+export const TEST262_MISMATCH_PREFIX = "test262";
+export const JSX_MISMATCH_PREFIX = "acorn-jsx";
+export const TS_MISMATCH_PREFIX = "typescript";

--- a/napi/parser/test/raw-transfer-back-worker.ts
+++ b/napi/parser/test/raw-transfer-back-worker.ts
@@ -1,0 +1,210 @@
+// Worker for raw transfer back conformance tests.
+//
+// Mirror of `parse-raw-worker.ts`, with the round-trip oracle instead of JSON comparison:
+// parse via raw transfer -> ESTree program -> encode back into arena -> native side asserts
+// `ContentEq` + codegen equality against an independent direct parse of the same source.
+
+import { readFile } from "node:fs/promises";
+import { basename, join as pathJoin } from "node:path";
+
+import { parseSync } from "./parser.ts";
+import {
+  ACORN_TEST262_DIR_PATH,
+  JSX_DIR_PATH,
+  ROOT_DIR_PATH,
+  TEST262_DIR_PATH,
+  TS_DIR_PATH,
+} from "./parse-raw-common.ts";
+import {
+  TEST_TYPE_FIXTURE,
+  TEST_TYPE_INLINE_FIXTURE,
+  TEST_TYPE_JSX,
+  TEST_TYPE_MAIN_MASK,
+  TEST_TYPE_NO_SOURCE,
+  TEST_TYPE_PRESERVE_PARENS,
+  TEST_TYPE_TEST262,
+  TEST_TYPE_TS,
+} from "./raw-transfer-back-common.ts";
+import { roundtrip } from "./raw-transfer-back-api.ts";
+import { makeUnitsFromTest } from "./typescript-make-units-from-test.ts";
+
+import type { ParserOptions, Program } from "./parser.ts";
+
+type TestCaseProps = string | { filename: string; sourceText: string };
+
+// Run test case and return whether it passes.
+// This is the entry point when run as a worker.
+export default async function (data: { type: number; props: TestCaseProps }): Promise<boolean> {
+  try {
+    await runCase(data, simpleExpect);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Run test case with specified `expect` implementation.
+// If test fails, will throw an error.
+// Can be called from main thread.
+export async function runCase(
+  { type, props }: { type: number; props: TestCaseProps },
+  expect: ExpectFunction,
+): Promise<void> {
+  const noSource = (type & TEST_TYPE_NO_SOURCE) !== 0,
+    preserveParens = (type & TEST_TYPE_PRESERVE_PARENS) !== 0;
+  type &= TEST_TYPE_MAIN_MASK;
+
+  switch (type) {
+    case TEST_TYPE_TEST262:
+      await runTest262Case(props as string, noSource, preserveParens, expect);
+      break;
+    case TEST_TYPE_JSX:
+      await runJsxCase(props as string, noSource, preserveParens, expect);
+      break;
+    case TEST_TYPE_TS:
+      await runTsCase(props as string, noSource, preserveParens, expect);
+      break;
+    case TEST_TYPE_FIXTURE: {
+      const path = props as string;
+      const sourceText = await readFile(pathJoin(ROOT_DIR_PATH, path), "utf8");
+      roundtripCheck(basename(path), sourceText, null, noSource, preserveParens, expect);
+      break;
+    }
+    case TEST_TYPE_INLINE_FIXTURE: {
+      const { filename, sourceText } = props as { filename: string; sourceText: string };
+      roundtripCheck(filename, sourceText, null, noSource, preserveParens, expect);
+      break;
+    }
+    default:
+      throw new Error("Unexpected test type");
+  }
+}
+
+// Run Test262 test case
+async function runTest262Case(
+  path: string,
+  noSource: boolean,
+  preserveParens: boolean,
+  expect: ExpectFunction,
+): Promise<void> {
+  const filename = basename(path);
+  const [sourceText, acornJson] = await Promise.all([
+    readFile(pathJoin(TEST262_DIR_PATH, path), "utf8"),
+    readFile(pathJoin(ACORN_TEST262_DIR_PATH, `${path}on`), "utf8"),
+  ]);
+  const sourceType = getSourceTypeFromJSON(acornJson);
+  roundtripCheck(filename, sourceText, { sourceType }, noSource, preserveParens, expect);
+}
+
+// Run JSX test case
+async function runJsxCase(
+  filename: string,
+  noSource: boolean,
+  preserveParens: boolean,
+  expect: ExpectFunction,
+): Promise<void> {
+  const sourcePath = pathJoin(JSX_DIR_PATH, filename),
+    jsonPath = sourcePath.slice(0, -1) + "on"; // `.jsx` -> `.json`
+  const [sourceText, acornJson] = await Promise.all([
+    readFile(sourcePath, "utf8"),
+    readFile(jsonPath, "utf8"),
+  ]);
+  const sourceType = getSourceTypeFromJSON(acornJson);
+  roundtripCheck(filename, sourceText, { sourceType }, noSource, preserveParens, expect);
+}
+
+// Run TypeScript test case.
+// Same sub-case extraction as `parse-raw-worker.ts`. The TS-ESLint expected JSON is not needed;
+// the oracle is the round trip itself.
+async function runTsCase(
+  path: string,
+  noSource: boolean,
+  preserveParens: boolean,
+  expect: ExpectFunction,
+): Promise<void> {
+  const tsPath = path.slice(0, -3); // Trim off `.md`
+  let sourceText = await readFile(pathJoin(TS_DIR_PATH, tsPath), "utf8");
+
+  // Trim off UTF-8 BOM
+  if (sourceText.charCodeAt(0) === 0xfeff) sourceText = sourceText.slice(1);
+
+  const { tests } = makeUnitsFromTest(tsPath, sourceText);
+
+  for (const { name: filename, content: code, sourceType } of tests) {
+    const options: ParserOptions = {
+      sourceType: sourceType.module ? "module" : "unambiguous",
+      astType: "ts",
+    };
+    roundtripCheck(filename, code, options, noSource, preserveParens, expect);
+  }
+}
+
+// Parse source via raw transfer, encode the ESTree program back into the arena,
+// and assert codegen equality + `ContentEq` against an independent direct parse.
+function roundtripCheck(
+  filename: string,
+  sourceText: string,
+  options: ParserOptions | null,
+  noSource: boolean,
+  preserveParens: boolean,
+  expect: ExpectFunction,
+): void {
+  const parseOptions: ParserOptions = {
+    ...options,
+    preserveParens,
+    experimentalRawTransfer: true,
+  };
+  const { program, errors } = parseSync(filename, sourceText, parseOptions);
+
+  // Our parser is not recoverable. Skip fixtures which fail to parse (fatal error
+  // produces an empty program) - there is nothing meaningful to round-trip.
+  if (errors.length > 0 && isEmptyProgram(program)) return;
+
+  const astType = options?.astType === "ts" || /\.[mc]?tsx?$/.test(filename) ? "ts" : "js";
+  const result = roundtrip(program, {
+    filename,
+    sourceText: noSource ? null : sourceText,
+    astType,
+    preserveParens,
+  });
+
+  // Codegen comparison first: on failure, the printed diff is the readable artifact.
+  expect(result.printed).toEqual(result.expected);
+  expect(result.contentEq).toBe(true);
+}
+
+function isEmptyProgram(program: Program): boolean {
+  return program.start === 0 && program.end === 0 && program.body.length === 0;
+}
+
+// Acorn JSON files always end with:
+// ```
+//   "sourceType": "script",
+//   "hashbang": null,
+//   "start": 0,
+//   "end": <some integer>,
+// }
+// ```
+// For speed, extract `sourceType` with a slice, rather than parsing the JSON.
+function getSourceTypeFromJSON(json: string): "script" | "module" {
+  const index = json.lastIndexOf('"sourceType": "');
+  return json.slice(index + 15, index + 21) as "script" | "module";
+}
+
+// Type for expect function
+interface ExpectFunction {
+  (value: any): {
+    toEqual: (expected: any) => void;
+    toBe: (expected: any) => void;
+  };
+}
+
+// Very simple `expect` implementation.
+// Only supports `expect(x).toEqual(y)` and `expect(x).toBe(y)`, and both use only a simple `===` comparison.
+// Therefore, only works for primitive values e.g. strings and booleans.
+const simpleExpect: ExpectFunction = (value: any) => {
+  const toBe = (expected: any): void => {
+    if (value !== expected) throw new Error("Mismatch");
+  };
+  return { toEqual: toBe, toBe };
+};

--- a/napi/parser/test/raw-transfer-back.test.ts
+++ b/napi/parser/test/raw-transfer-back.test.ts
@@ -1,0 +1,326 @@
+// Conformance suite for raw transfer back (ESTree -> arena).
+//
+// Mirror of `parse-raw.test.ts` (the raw transfer suite): same fixture sets, same worker
+// architecture, same known-failures filtering. The oracle differs: each case round-trips
+// `parse -> ESTree -> encode -> &Program` and asserts `ContentEq` + codegen equality against
+// an independent direct parse (see `raw-transfer-back-worker.ts`).
+//
+// While `RAW_TRANSFER_BACK_SUPPORTED` is `false` in `raw-transfer-back-api.ts`, the whole
+// suite is skipped. Set env var `RUN_RAW_TRANSFER_BACK_TESTS=true` to force-run it.
+//
+// Known failures are tracked in `snapshots/raw-transfer-back.snap` (same `Mismatch:` line
+// grammar as `tasks/coverage` snapshots). Regenerate after implementation progress with:
+// `UPDATE_RAW_TRANSFER_BACK_SNAPSHOT=true pnpm vitest run --dir ./test raw-transfer-back`
+
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join as pathJoin } from "node:path";
+import Tinypool from "tinypool";
+import { describe, expect, it } from "vitest";
+
+import {
+  ACORN_TEST262_DIR_PATH,
+  JSX_DIR_PATH,
+  ROOT_DIR_PATH,
+  TARGET_DIR_PATH,
+  TS_ESTREE_DIR_PATH,
+} from "./parse-raw-common.ts";
+import {
+  FAILS_SNAPSHOT_PATH,
+  JSX_MISMATCH_PREFIX,
+  TEST262_MISMATCH_PREFIX,
+  TEST_TYPE_FIXTURE,
+  TEST_TYPE_INLINE_FIXTURE,
+  TEST_TYPE_JSX,
+  TEST_TYPE_NO_SOURCE,
+  TEST_TYPE_PRESERVE_PARENS,
+  TEST_TYPE_PRETTY,
+  TEST_TYPE_TEST262,
+  TEST_TYPE_TS,
+  TS_MISMATCH_PREFIX,
+} from "./raw-transfer-back-common.ts";
+import { RAW_TRANSFER_BACK_SUPPORTED } from "./raw-transfer-back-api.ts";
+
+// Define `describe` and `it` variants which run/skip tests based on environment variables
+const { env } = process;
+const isEnabled = (envValue: string | undefined) => envValue === "true" || envValue === "1";
+
+const isUpdateMode = isEnabled(env.UPDATE_RAW_TRANSFER_BACK_SNAPSHOT);
+const isSuiteEnabled =
+  RAW_TRANSFER_BACK_SUPPORTED || isEnabled(env.RUN_RAW_TRANSFER_BACK_TESTS) || isUpdateMode;
+
+const noop = Object.assign(() => {}, { concurrent() {}, each: () => () => {} });
+const [describeBack, itBack] = isSuiteEnabled ? [describe, it] : [noop as any, noop as any];
+
+// Vitest errors on a file which registers no tests. While the suite is pending
+// implementation, register a single visible skipped test.
+if (!isSuiteEnabled) {
+  it.skip("raw_transfer_back conformance (pending implementation — see raw-transfer-back-api.ts)", () => {});
+}
+
+// Extra dimensions (heavy: full fixture sets re-run), opt-in via env vars,
+// same pattern as `RUN_RAW_RANGE_TESTS` in the raw transfer suite.
+const [describeNoSource] =
+  isSuiteEnabled && isEnabled(env.RUN_RAW_TRANSFER_BACK_NO_SOURCE_TESTS)
+    ? [describe]
+    : [noop as any];
+const [describePreserveParens] =
+  isSuiteEnabled && isEnabled(env.RUN_RAW_TRANSFER_BACK_PRESERVE_PARENS_TESTS)
+    ? [describe]
+    : [noop as any];
+
+// Worker pool for running test cases.
+// Vitest provides parallelism across test files, but not across cases within a single test file.
+// So we run each case in a worker to achieve parallelism.
+const pool = new Tinypool({
+  filename: new URL("./raw-transfer-back-worker.ts", import.meta.url).href,
+});
+
+type RunCase = (typeof import("./raw-transfer-back-worker.ts"))["runCase"];
+type TestCaseData = Parameters<RunCase>[0];
+
+let runCase: RunCase;
+
+// Run test case in a worker
+async function runCaseInWorker(type: TestCaseData["type"], props: TestCaseData["props"]) {
+  const success = await pool.run({ type, props });
+
+  // If test failed in worker, run it again in main thread with Vitest's `expect`,
+  // to get a nice diff and stack trace
+  if (!success) {
+    if (!runCase) ({ runCase } = await import("./raw-transfer-back-worker.ts"));
+
+    type |= TEST_TYPE_PRETTY;
+    await runCase({ type, props }, expect);
+    throw new Error("Failed on worker but unexpectedly passed on main thread");
+  }
+}
+
+// Download fixtures (same set as raw transfer suite; cached in `target`, shared with benchmarks).
+const benchFixtureUrls = [
+  // TypeScript syntax (2.81MB)
+  "https://cdn.jsdelivr.net/gh/microsoft/TypeScript@v5.3.3/src/compiler/checker.ts",
+  // Real world app tsx (415KB) — excalidraw App.tsx (master @ f6d85bc8)
+  "https://cdn.jsdelivr.net/gh/excalidraw/excalidraw@f6d85bc80fe328e8f472636eb0d541f7bb891aa0/packages/excalidraw/components/App.tsx",
+  // Real world content-heavy app jsx (3K)
+  "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx",
+  // Heavy with classes (554K)
+  "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs",
+  // ES5 (3.9M)
+  "https://cdn.jsdelivr.net/npm/antd@4.16.1/dist/antd.js",
+];
+
+let benchFixturePaths: string[] = [];
+if (isSuiteEnabled) {
+  await mkdir(TARGET_DIR_PATH, { recursive: true });
+  benchFixturePaths = await Promise.all(
+    benchFixtureUrls.map(async (url) => {
+      const filename = url.split("/").at(-1),
+        path = pathJoin(TARGET_DIR_PATH, filename);
+      try {
+        await stat(path);
+      } catch {
+        const res = await fetch(url);
+        const sourceText = await res.text();
+        await writeFile(path, sourceText);
+      }
+      return path.slice(ROOT_DIR_PATH.length + 1);
+    }),
+  );
+}
+
+// Enumerate fixtures.
+//
+// Same fixture sets as the raw transfer suite. Unlike that suite, the ESTree-shape fail lists
+// (`estree_*.snap`) are NOT applied - a shape mismatch vs Acorn does not prevent a round trip.
+// Only this suite's own known-failures list filters cases (and the worker skips sources which
+// fail to parse, since our parser is not recoverable).
+let test262FixturePaths: string[] = [];
+let jsxFixturePaths: string[] = [];
+let tsFixturePaths: string[] = [];
+
+if (isSuiteEnabled) {
+  const failPaths = isUpdateMode ? new Set<string>() : await getTestFailurePaths();
+
+  for (let path of await readdir(ACORN_TEST262_DIR_PATH, { recursive: true })) {
+    if (!path.endsWith(".json")) continue;
+    path = path.slice(0, -2); // `.json` -> `.js`
+    if (!failPaths.has(`${TEST262_MISMATCH_PREFIX}/${path}`)) test262FixturePaths.push(path);
+  }
+
+  jsxFixturePaths = (await readdir(JSX_DIR_PATH, { recursive: true })).filter(
+    (path) => path.endsWith(".jsx") && !failPaths.has(`${JSX_MISMATCH_PREFIX}/${path}`),
+  );
+
+  tsFixturePaths = (await readdir(TS_ESTREE_DIR_PATH, { recursive: true })).filter(
+    (path) => path.endsWith(".md") && !failPaths.has(`${TS_MISMATCH_PREFIX}/${path}`),
+  );
+}
+
+describeBack.concurrent("test262", () => {
+  // oxlint-disable-next-line jest/expect-expect
+  itBack.each(test262FixturePaths)("%s", (path: string) =>
+    runCaseInWorker(TEST_TYPE_TEST262, path),
+  );
+});
+
+describeBack.concurrent("JSX", () => {
+  // oxlint-disable-next-line jest/expect-expect
+  itBack.each(jsxFixturePaths)("%s", (filename: string) =>
+    runCaseInWorker(TEST_TYPE_JSX, filename),
+  );
+});
+
+describeBack.concurrent("TypeScript", () => {
+  // oxlint-disable-next-line jest/expect-expect
+  itBack.each(tsFixturePaths)("%s", (path: string) => runCaseInWorker(TEST_TYPE_TS, path));
+});
+
+describeNoSource.concurrent("no-source test262", () => {
+  // oxlint-disable-next-line jest/expect-expect
+  itBack.each(test262FixturePaths)("%s", (path: string) =>
+    runCaseInWorker(TEST_TYPE_TEST262 | TEST_TYPE_NO_SOURCE, path),
+  );
+});
+
+describePreserveParens.concurrent("preserveParens test262", () => {
+  // oxlint-disable-next-line jest/expect-expect
+  itBack.each(test262FixturePaths)("%s", (path: string) =>
+    runCaseInWorker(TEST_TYPE_TEST262 | TEST_TYPE_PRESERVE_PARENS, path),
+  );
+});
+
+// Edge cases not covered by Test262. Superset of the raw transfer suite's list -
+// these exercise exactly the hard paths of the encoder (lone surrogates, lossy replacement
+// characters, hashbangs, import phases). All option variants run (the set is small).
+const edgeCases = [
+  // ECMA stage 3
+  'import defer * as ns from "x";',
+  'import source src from "x";',
+  'import.defer("x");',
+  'import.source("x");',
+  // `StringLiteral`s containing lone surrogates and/or lossy replacement characters
+  ';"\\uD800\\uDBFF";',
+  ';"�\\u{FFFD}";',
+  ';"�\\u{FFFD}\\uD800\\uDBFF�\\u{FFFD}";',
+  // `TemplateLiteral`s containing lone surrogates and/or lossy replacement characters
+  "`\\uD800\\uDBFF${x}\\uD800\\uDBFF`;",
+  "`�\\u{FFFD}${x}�\\u{FFFD}`;",
+  "`�\\u{FFFD}\\uD800${x}\\uDBFF�\\u{FFFD}`;",
+  // Hashbangs
+  "#!/usr/bin/env node\nlet x;",
+  "#!/usr/bin/env node\nlet x;\n// foo",
+  // Directives vs body split
+  '"use strict";\n"not a directive after this";\nlet x = "use strict";',
+  // Parenthesized expressions
+  "let x = (1 + 2);",
+  // Numeric edge cases (f64 round-trip, radix raws, infinity)
+  "x = [0, -0, 1e400, 0x1F, 0o17, 0b11, 1_000_000, .5, 5., NaN];",
+  // BigInt
+  "x = [0n, 123n, 0xFFn, 0o77n, 0b11n];",
+  // RegExp
+  "x = /ab+c/gu; y = /[\\u{1F600}]/v;",
+  // Assignment targets (ESTree patterns re-interpreted by position)
+  "[a, [b], ...c] = arr; ({ d, e: { f }, ...g } = obj);",
+  "[a = 1, { b } = {}] = arr;",
+  "for ([x, ...y] of z) {} for ({ p: q } in r) {}",
+  // Holes in array literals and patterns
+  "x = [, , 1, , ]; [, a, , ...b] = y;",
+];
+
+describeBack.concurrent("edge cases", () => {
+  describeBack.each(edgeCases)("%s", (sourceText: string) => {
+    for (const [label, extraType] of [
+      ["", 0],
+      ["no-source", TEST_TYPE_NO_SOURCE],
+      ["preserveParens", TEST_TYPE_PRESERVE_PARENS],
+    ] as const) {
+      // oxlint-disable-next-line jest/expect-expect
+      itBack(`JS ${label}`, () =>
+        runCaseInWorker(TEST_TYPE_INLINE_FIXTURE | extraType, {
+          filename: "dummy.js",
+          sourceText,
+        }),
+      );
+      // oxlint-disable-next-line jest/expect-expect
+      itBack(`TS ${label}`, () =>
+        runCaseInWorker(TEST_TYPE_INLINE_FIXTURE | extraType, {
+          filename: "dummy.ts",
+          sourceText,
+        }),
+      );
+    }
+  });
+});
+
+// Large real-world files, all option variants.
+describeBack.concurrent("fixtures", () => {
+  // oxlint-disable-next-line jest/expect-expect
+  itBack.each(benchFixturePaths)("%s", (path: string) => runCaseInWorker(TEST_TYPE_FIXTURE, path));
+  // oxlint-disable-next-line jest/expect-expect
+  itBack.each(benchFixturePaths)("%s no-source", (path: string) =>
+    runCaseInWorker(TEST_TYPE_FIXTURE | TEST_TYPE_NO_SOURCE, path),
+  );
+  // oxlint-disable-next-line jest/expect-expect
+  itBack.each(benchFixturePaths)("%s preserveParens", (path: string) =>
+    runCaseInWorker(TEST_TYPE_FIXTURE | TEST_TYPE_PRESERVE_PARENS, path),
+  );
+});
+
+// Get `Set` of known-failing test paths (prefixed, e.g. `test262/<path>`) from snapshot file
+async function getTestFailurePaths(): Promise<Set<string>> {
+  const mismatchPrefix = "Mismatch: ",
+    mismatchPrefixLen = mismatchPrefix.length;
+
+  let snapshot: string;
+  try {
+    snapshot = await readFile(FAILS_SNAPSHOT_PATH, "utf8");
+  } catch {
+    return new Set();
+  }
+  return new Set(
+    snapshot
+      .split("\n")
+      .filter((line) => line.startsWith(mismatchPrefix))
+      .map((line) => line.slice(mismatchPrefixLen)),
+  );
+}
+
+// Snapshot update mode: run every fixture in every suite, collect failures,
+// and rewrite `snapshots/raw-transfer-back.snap` (`tasks/coverage` snapshot style:
+// `Passed: n/m` header per suite + sorted `Mismatch:` lines).
+if (isUpdateMode) {
+  describe("update snapshot", () => {
+    it("regenerates raw-transfer-back.snap", { timeout: 60 * 60 * 1000 }, async () => {
+      const suites: [string, number, string[]][] = [
+        [TEST262_MISMATCH_PREFIX, TEST_TYPE_TEST262, test262FixturePaths],
+        [JSX_MISMATCH_PREFIX, TEST_TYPE_JSX, jsxFixturePaths],
+        [TS_MISMATCH_PREFIX, TEST_TYPE_TS, tsFixturePaths],
+      ];
+
+      let out =
+        "raw_transfer_back conformance\n" +
+        "Round trip: parse -> ESTree -> encode -> arena -> ContentEq + codegen equality.\n" +
+        "Regenerate: UPDATE_RAW_TRANSFER_BACK_SNAPSHOT=true pnpm vitest run --dir ./test raw-transfer-back\n";
+
+      for (const [prefix, type, paths] of suites) {
+        const failures: string[] = [];
+        const results: Promise<void>[] = [];
+        for (const path of paths) {
+          results.push(
+            pool.run({ type, props: path }).then((success: boolean) => {
+              if (!success) failures.push(`${prefix}/${path}`);
+            }),
+          );
+        }
+        await Promise.all(results);
+        failures.sort();
+
+        out += `\n${prefix} Summary:\nPassed: ${paths.length - failures.length}/${paths.length}\n`;
+        for (const failure of failures) out += `Mismatch: ${failure}\n`;
+      }
+
+      await writeFile(FAILS_SNAPSHOT_PATH, out);
+      expect(true).toBe(true);
+    });
+  });
+}

--- a/napi/parser/test/snapshots/raw-transfer-back.snap
+++ b/napi/parser/test/snapshots/raw-transfer-back.snap
@@ -1,0 +1,15 @@
+raw_transfer_back conformance
+Round trip: parse -> ESTree -> encode -> arena -> ContentEq + codegen equality.
+Regenerate: UPDATE_RAW_TRANSFER_BACK_SNAPSHOT=true pnpm vitest run --dir ./test raw-transfer-back
+
+Suite is pending implementation (`RAW_TRANSFER_BACK_SUPPORTED = false` in
+test/raw-transfer-back-api.ts). No results recorded yet.
+
+test262 Summary:
+Passed: 0/0
+
+acorn-jsx Summary:
+Passed: 0/0
+
+typescript Summary:
+Passed: 0/0


### PR DESCRIPTION
## Summary

Establishes the conformance suite for `raw_transfer_back` — the reverse of raw transfer: a JS-side serializer writes an ESTree AST back into the arena buffer as real oxc struct layouts, and Rust consumes it as `&Program` with zero decode work. The suite lands ahead of the implementation so it can be built test-first against a fixed oracle.

Mirrors `parse-raw.test.ts` piece for piece:

- Same fixture sets: estree-conformance test262 (~30k cases), acorn-jsx, TypeScript `.md` sub-cases, inline edge cases, and the five downloaded bench files — 58,691 tests enumerated.
- Same Tinypool worker-per-case architecture with fail-on-worker → pretty re-run on main thread.
- Same known-failures mechanism: `test/snapshots/raw-transfer-back.snap` uses the `Mismatch:` line grammar from `tasks/coverage` snapshots, regenerated with `UPDATE_RAW_TRANSFER_BACK_SNAPSHOT=true`. This is the bring-up ratchet.

Where it deliberately differs:

- The oracle is the round trip itself: parse → ESTree → encode → `&Program`, asserting `ContentEq` (spans excluded by design) plus codegen byte-equality against an independent direct parse — not comparison against Acorn/TS-ESLint JSON. The `estree_*.snap` fail lists are therefore not applied; shape mismatches vs Acorn don't prevent a round trip.
- The edge-case list adds back-direction hazards: directive/body splitting, f64 + radix numerics, BigInt, RegExp, assignment-target re-interpretation by position, and array holes.
- Extra dimensions (`no-source`, `preserveParens`) are env-gated like `RUN_RAW_RANGE_TESTS`.

`raw-transfer-back-api.ts` is the single wiring seam: while `RAW_TRANSFER_BACK_SUPPORTED` is `false` the suite registers one visible skipped test and stays green with no native-build dependency at collection time. Force-running with `RUN_RAW_TRANSFER_BACK_TESTS=true` drives every case through the full chain to the seam's not-implemented error, which validates the plumbing end to end.

Draft until the encoder lands and the seam is wired.

🤖 Assembled with [Claude Code](https://claude.com/claude-code)