### PR TITLE
perf(formatter): stage IR element buffers on the heap instead of the arena

### DIFF
--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -47,7 +47,7 @@ pub mod buffer {
 
 pub use oxc_formatter_core::{
     Argument, Arguments, Buffer, BufferExtensions, Format, FormatElement, FormatOptions,
-    FormatState, Formatted, Formatter, GroupId, MemoizeFormat, Memoized, SourceText,
+    FormatState, Formatted, Formatter, GroupId, HeapVecBuffer, MemoizeFormat, Memoized, SourceText,
     UniqueGroupIdBuilder, VecBuffer,
 };
 
@@ -74,11 +74,15 @@ pub fn format<'ast>(
     let capacity = (context.source_text().len() * 2) / 5;
 
     let mut state = FormatState::new(context, allocator);
-    let mut buffer = VecBuffer::with_capacity(capacity, &mut state);
+    // Stage the document on the heap; the arena gets one exactly-sized copy at the end.
+    // Staging in the arena would strand the pre-allocation (files dominated by interned
+    // content barely touch the root buffer) plus every grown-out-of allocation.
+    let mut buffer = HeapVecBuffer::with_capacity(capacity, &mut state);
 
     buffer.write_fmt(arguments);
 
-    let elements = buffer.into_vec();
+    let elements = buffer.take_into_arena_vec();
+    drop(buffer);
     let mut context = state.into_context();
 
     let tailwind_classes = context.take_tailwind_classes();

--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -7,8 +7,8 @@ use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{
-        Comments, FormatElement, JoinBuilderJsExt as _, JsFormatContext, JsFormatter,
-        JsFormatterExt as _, SourceText, VecBuffer,
+        Comments, FormatElement, HeapVecBuffer, JoinBuilderJsExt as _, JsFormatContext,
+        JsFormatter, JsFormatterExt as _, SourceText,
         buffer::RemoveSoftLinesBuffer,
         format_element,
         prelude::{
@@ -737,14 +737,14 @@ fn write_grouped_arguments<'a>(
 
     // First write the most expanded variant because it needs `arguments`.
     let most_expanded = {
-        let mut buffer = VecBuffer::new(f.state_mut());
+        let mut buffer = HeapVecBuffer::new(f.state_mut());
         buffer.write_element(FormatElement::Tag(Tag::StartEntry));
 
         format_all_elements_broken_out(node, elements.iter().cloned(), true, &mut buffer);
 
         buffer.write_element(FormatElement::Tag(Tag::EndEntry));
 
-        buffer.into_vec().into_arena_slice()
+        buffer.take_into_arena_slice()
     };
 
     // Now reformat the first or last argument if they happen to be a function or arrow function expression.
@@ -825,7 +825,7 @@ fn write_grouped_arguments<'a>(
 
     // Write the second variant that forces the group of the first/last argument to expand.
     let middle_variant = {
-        let mut buffer = VecBuffer::new(f.state_mut());
+        let mut buffer = HeapVecBuffer::new(f.state_mut());
 
         buffer.write_element(FormatElement::Tag(Tag::StartEntry));
 
@@ -863,7 +863,7 @@ fn write_grouped_arguments<'a>(
 
         buffer.write_element(FormatElement::Tag(Tag::EndEntry));
 
-        buffer.into_vec().into_arena_slice()
+        buffer.take_into_arena_slice()
     };
 
     // If the grouped content breaks, then we can skip the most_flat variant,
@@ -874,7 +874,7 @@ fn write_grouped_arguments<'a>(
     } else {
         // Write the most flat variant with the first or last argument grouped.
         let most_flat = {
-            let mut buffer = VecBuffer::new(f.state_mut());
+            let mut buffer = HeapVecBuffer::new(f.state_mut());
             buffer.write_element(FormatElement::Tag(Tag::StartEntry));
 
             write!(
@@ -898,7 +898,7 @@ fn write_grouped_arguments<'a>(
 
             buffer.write_element(FormatElement::Tag(Tag::EndEntry));
 
-            buffer.into_vec().into_arena_slice()
+            buffer.take_into_arena_slice()
         };
 
         ArenaVec::from_array_in([most_flat, middle_variant, most_expanded], f)

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -4,7 +4,7 @@ use oxc_span::GetSpan;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{
-        Buffer, BufferExtensions, Format, JsFormatter, VecBuffer,
+        Buffer, BufferExtensions, Format, HeapVecBuffer, JsFormatter,
         prelude::{FormatElements, format_once, line_suffix_boundary, *},
         trivia::FormatTrailingComments,
     },
@@ -836,9 +836,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AssignmentLike<'a, '_> {
             // which is computed only when we format it
             // 3. we compute the layout
             // 4. we write the left node inside the main buffer based on the layout
-            let mut buffer = VecBuffer::new(f.state_mut());
+            let mut buffer = HeapVecBuffer::new(f.state_mut());
             let is_left_short = self.write_left(&mut Formatter::new(&mut buffer));
-            let formatted_left = buffer.into_vec();
+            let formatted_left = buffer.take_heap_vec();
+            drop(buffer);
             let left_may_break = formatted_left.may_directly_break();
 
             let left = format_once(|f| f.write_elements(formatted_left));

--- a/crates/oxc_formatter_core/src/buffer.rs
+++ b/crates/oxc_formatter_core/src/buffer.rs
@@ -7,7 +7,7 @@ use std::{
 
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::{Allocator, ArenaVec, TakeIn};
+use oxc_allocator::{Allocator, ArenaVec};
 
 use crate::{
     Argument, Arguments, Format, FormatElement, FormatState,
@@ -45,10 +45,11 @@ pub trait Buffer<'ast, C> {
     /// Replaces the elements starting at `start` with `replacement`.
     ///
     /// Used by streaming IR transforms (currently `SortImportsTransform`) to splice a reordered
-    /// chunk back into the buffer. Only `VecBuffer` supports this; the wrapper buffers
-    /// (`PreambleBuffer`, `Inspect`, `RemoveSoftLinesBuffer`) are only ever active inside
-    /// inner-expression contexts, never on the call stack while a streaming chunk is being
-    /// flushed, so they implement this as `unreachable!()`.
+    /// chunk back into the buffer. Only the vector-backed buffers (`VecBuffer`,
+    /// `HeapVecBuffer`) support this; the wrapper buffers (`PreambleBuffer`, `Inspect`,
+    /// `RemoveSoftLinesBuffer`) are only ever active inside inner-expression contexts,
+    /// never on the call stack while a streaming chunk is being flushed, so they implement
+    /// this as `unreachable!()`.
     fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]);
 }
 
@@ -110,11 +111,6 @@ impl<'buf, 'ast, C> VecBuffer<'buf, 'ast, C> {
     pub fn into_vec(self) -> ArenaVec<'ast, FormatElement<'ast>> {
         self.elements
     }
-
-    /// Takes the elements without consuming self
-    pub fn take_vec(&mut self) -> ArenaVec<'ast, FormatElement<'ast>> {
-        self.elements.take_in(self.state)
-    }
 }
 
 impl<'ast, C> Deref for VecBuffer<'_, 'ast, C> {
@@ -132,6 +128,103 @@ impl<C> DerefMut for VecBuffer<'_, '_, C> {
 }
 
 impl<'ast, C> Buffer<'ast, C> for VecBuffer<'_, 'ast, C> {
+    fn write_element(&mut self, element: FormatElement<'ast>) {
+        self.elements.push(element);
+    }
+
+    fn elements(&self) -> &[FormatElement<'ast>] {
+        self
+    }
+
+    fn state(&self) -> &FormatState<'ast, C> {
+        self.state
+    }
+
+    fn state_mut(&mut self) -> &mut FormatState<'ast, C> {
+        self.state
+    }
+
+    fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]) {
+        self.elements.splice(start.., replacement.iter().cloned());
+    }
+}
+
+/// Heap-backed [`Buffer`], the staging twin of [`VecBuffer`].
+///
+/// Use it to build an element sequence whose final length isn't known up front
+/// (interned content, best-fitting variants, a whole document), then move the result
+/// into the arena exactly-sized via [`HeapVecBuffer::take_into_arena_vec`] /
+/// [`HeapVecBuffer::take_into_arena_slice`].
+///
+/// Growing a vector directly in the arena strands every grown-out-of allocation for the
+/// rest of the format run (the arena is a bump allocator and never reclaims; growth can
+/// reuse the allocation only when nothing else was bumped in between, which practically
+/// never holds while formatting). Heap growth is reclaimed by the system allocator, and
+/// the arena receives only the final, exactly-sized copy.
+///
+/// The backing vector is borrowed from the [`FormatState`] scratch pool and returned on
+/// drop, so nested/repeated staging allocates nothing in the steady state.
+pub struct HeapVecBuffer<'buf, 'ast, C> {
+    state: &'buf mut FormatState<'ast, C>,
+    elements: Vec<FormatElement<'ast>>,
+}
+
+impl<'buf, 'ast, C> HeapVecBuffer<'buf, 'ast, C> {
+    pub fn new(state: &'buf mut FormatState<'ast, C>) -> Self {
+        let elements = state.take_scratch_buffer();
+        Self { state, elements }
+    }
+
+    /// Creates a buffer whose backing vector holds at least `capacity` elements.
+    pub fn with_capacity(capacity: usize, state: &'buf mut FormatState<'ast, C>) -> Self {
+        let mut elements = state.take_scratch_buffer();
+        elements.reserve(capacity);
+        Self { state, elements }
+    }
+
+    /// Removes the last element written to this buffer, if any.
+    pub fn pop(&mut self) -> Option<FormatElement<'ast>> {
+        self.elements.pop()
+    }
+
+    /// Moves the buffered elements into an exactly-sized arena vector, leaving the buffer empty.
+    pub fn take_into_arena_vec(&mut self) -> ArenaVec<'ast, FormatElement<'ast>> {
+        let allocator = self.state.allocator();
+        ArenaVec::from_iter_in(self.elements.drain(..), &allocator)
+    }
+
+    /// Moves the buffered elements into an exactly-sized arena slice, leaving the buffer empty.
+    pub fn take_into_arena_slice(&mut self) -> &'ast [FormatElement<'ast>] {
+        self.take_into_arena_vec().into_arena_slice()
+    }
+
+    /// Takes the buffered elements as a heap vector, leaving the buffer empty.
+    ///
+    /// For replay flows that later move the elements into another buffer
+    /// (e.g. via [`BufferExtensions::write_elements`]), where nothing should
+    /// land in the arena at all. The taken vector's capacity is lost to the
+    /// scratch pool; prefer the `take_into_arena_*` methods when the content's
+    /// final home is the arena.
+    pub fn take_heap_vec(&mut self) -> Vec<FormatElement<'ast>> {
+        std::mem::take(&mut self.elements)
+    }
+}
+
+impl<C> Drop for HeapVecBuffer<'_, '_, C> {
+    fn drop(&mut self) {
+        self.state.return_scratch_buffer(std::mem::take(&mut self.elements));
+    }
+}
+
+impl<'ast, C> Deref for HeapVecBuffer<'_, 'ast, C> {
+    type Target = [FormatElement<'ast>];
+
+    fn deref(&self) -> &Self::Target {
+        &self.elements
+    }
+}
+
+impl<'ast, C> Buffer<'ast, C> for HeapVecBuffer<'_, 'ast, C> {
     fn write_element(&mut self, element: FormatElement<'ast>) {
         self.elements.push(element);
     }

--- a/crates/oxc_formatter_core/src/builders.rs
+++ b/crates/oxc_formatter_core/src/builders.rs
@@ -9,7 +9,7 @@ use oxc_allocator::ArenaVec;
 
 use crate::{
     Argument, Arguments, Buffer, Format, FormatContext, FormatElement, FormatOptions, Formatter,
-    GroupId, VecBuffer,
+    GroupId, HeapVecBuffer,
     format::write,
     format_element::{
         self, LineMode, PrintMode, TextWidth,
@@ -883,7 +883,9 @@ impl<'fmt, 'ast, C> BestFitting<'fmt, 'ast, C> {
 
 impl<'ast, C> Format<'ast, C> for BestFitting<'_, 'ast, C> {
     fn fmt(&self, f: &mut Formatter<'_, 'ast, C>) {
-        let mut buffer = VecBuffer::new(f.state_mut());
+        // Stage each variant on the heap so only the exactly-sized variant slices
+        // land in the arena (see `HeapVecBuffer`).
+        let mut buffer = HeapVecBuffer::new(f.state_mut());
         let variants = self.variants.items();
 
         let mut formatted_variants = Vec::with_capacity(variants.len());
@@ -893,8 +895,9 @@ impl<'ast, C> Format<'ast, C> for BestFitting<'_, 'ast, C> {
             buffer.write_fmt(Arguments::from(variant));
             buffer.write_element(FormatElement::Tag(EndEntry));
 
-            formatted_variants.push(buffer.take_vec().into_arena_slice());
+            formatted_variants.push(buffer.take_into_arena_slice());
         }
+        drop(buffer);
 
         let formatted_variants = ArenaVec::from_iter_in(formatted_variants, f);
 

--- a/crates/oxc_formatter_core/src/formatter.rs
+++ b/crates/oxc_formatter_core/src/formatter.rs
@@ -5,7 +5,8 @@ use std::borrow::Cow;
 use oxc_allocator::{Allocator, ArenaVec, GetAllocator};
 
 use crate::{
-    Argument, Arguments, Buffer, FormatContext, FormatElement, FormatState, VecBuffer,
+    Argument, Arguments, Buffer, FormatContext, FormatElement, FormatState,
+    buffer::HeapVecBuffer,
     builders::{FillBuilder, JoinBuilder},
     format::{Format, write},
     format_element::Interned,
@@ -60,12 +61,19 @@ impl<'buf, 'ast, C> Formatter<'buf, 'ast, C> {
     }
 
     /// Formats `content` into an interned element without writing it to the formatter's buffer.
+    ///
+    /// The content is staged in a [`HeapVecBuffer`] and lands in the arena exactly-sized,
+    /// so the arena only ever holds the final interned slice, not the staging growth.
     pub fn intern(&mut self, content: &dyn Format<'ast, C>) -> Option<FormatElement<'ast>> {
-        let mut buffer = VecBuffer::new(self.state_mut());
+        let mut buffer = HeapVecBuffer::new(self.state_mut());
         write(&mut buffer, Arguments::new(&[Argument::new(&content)]));
-        let elements = buffer.into_vec();
 
-        self.intern_vec(elements)
+        match buffer.len() {
+            0 => None,
+            // Doesn't get cheaper than calling clone, use the element directly
+            1 => buffer.pop(),
+            _ => Some(FormatElement::Interned(Interned::new(buffer.take_into_arena_vec()))),
+        }
     }
 
     #[expect(clippy::unused_self)] // Keep `self` the same as the original source

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -39,8 +39,8 @@ pub mod test_support;
 
 pub use arguments::{Argument, Arguments};
 pub use buffer::{
-    Buffer, BufferExtensions, Inspect, PreambleBuffer, Recorded, Recording, RemoveSoftLinesBuffer,
-    VecBuffer,
+    Buffer, BufferExtensions, HeapVecBuffer, Inspect, PreambleBuffer, Recorded, Recording,
+    RemoveSoftLinesBuffer, VecBuffer,
 };
 pub use diagnostics::{ActualStart, FormatError, InvalidDocumentError, PrintError};
 pub use embedded::{

--- a/crates/oxc_formatter_core/src/state.rs
+++ b/crates/oxc_formatter_core/src/state.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Allocator, GetAllocator};
 use rustc_hash::FxHashMap;
 
-use crate::{GroupId, UniqueGroupIdBuilder, format_element::Interned};
+use crate::{FormatElement, GroupId, UniqueGroupIdBuilder, format_element::Interned};
 
 /// This structure stores the state that is relevant for the formatting of the whole document.
 ///
@@ -15,6 +15,15 @@ pub struct FormatState<'ast, C> {
     // For the document IR printing process
     /// The interned elements that have been printed to this point
     printed_interned_elements: FxHashMap<Interned<'ast>, usize>,
+    /// Reusable heap staging buffers for [`crate::HeapVecBuffer`], LIFO.
+    ///
+    /// Element sequences of unknown length (interned content, best-fitting variants) are
+    /// staged on the heap and copied into the arena exactly-sized once complete. Staging
+    /// directly in the arena would leave every grown-out-of allocation behind for the rest
+    /// of the format run — the arena is a bump allocator and never reclaims. The pool holds
+    /// one buffer per nesting level, each retaining its high-water capacity, so staging
+    /// costs no allocation at all in the steady state.
+    scratch_buffers: Vec<Vec<FormatElement<'ast>>>,
 }
 
 impl<C: std::fmt::Debug> std::fmt::Debug for FormatState<'_, C> {
@@ -31,6 +40,25 @@ impl<'ast, C> FormatState<'ast, C> {
             allocator,
             group_id_builder: UniqueGroupIdBuilder::default(),
             printed_interned_elements: FxHashMap::default(),
+            scratch_buffers: Vec::new(),
+        }
+    }
+
+    /// Takes a heap staging buffer from the pool (empty, capacity retained), or creates one.
+    ///
+    /// Used by [`crate::HeapVecBuffer`]; see [`FormatState::scratch_buffers`] for why staging
+    /// happens on the heap. Return it with [`FormatState::return_scratch_buffer`] once done.
+    pub(crate) fn take_scratch_buffer(&mut self) -> Vec<FormatElement<'ast>> {
+        self.scratch_buffers.pop().unwrap_or_default()
+    }
+
+    /// Returns a staging buffer to the pool so its capacity is reused.
+    pub(crate) fn return_scratch_buffer(&mut self, mut buffer: Vec<FormatElement<'ast>>) {
+        // A capacity-less buffer has nothing worth pooling
+        // (e.g. the leftover of `HeapVecBuffer::take_heap_vec`).
+        if buffer.capacity() > 0 {
+            buffer.clear();
+            self.scratch_buffers.push(buffer);
         }
     }
 

--- a/crates/oxc_formatter_json/src/format.rs
+++ b/crates/oxc_formatter_json/src/format.rs
@@ -2,7 +2,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::Expression;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter_core::{
-    Buffer, Document, Format, FormatContext, FormatState, Formatted, VecBuffer,
+    Buffer, Document, Format, FormatContext, FormatState, Formatted, HeapVecBuffer,
     builders::{hard_line_break, text},
     write,
 };
@@ -35,14 +35,16 @@ pub fn format<'a>(
         parsed.source_offset,
     );
     let mut state = FormatState::new(context, allocator);
-    // TODO: Use `with_capacity` for perf, like `oxc_formatter` does
-    let mut buffer = VecBuffer::new(&mut state);
+    // Stage the document on the heap; the arena gets one exactly-sized copy at the end
+    // (see `HeapVecBuffer`).
+    let mut buffer = HeapVecBuffer::new(&mut state);
 
     // BOM detection runs on the original `source_text`; `wrapped_source` may prepend `(`.
     let has_bom = source_text.starts_with(ZWNBSP);
     write!(&mut buffer, FormatJsonRoot { expression: parsed.expression, has_bom });
 
-    let elements = buffer.into_vec();
+    let elements = buffer.take_into_arena_vec();
+    drop(buffer);
     let context = state.into_context();
 
     if let Some(err) = context.take_error() {


### PR DESCRIPTION
The allocation-tracking snapshots show the formatter's arena reaching **525 MB for antd.js** (6.7 MB source) — ~18× the parser's arena for the same file, while the live document is only ~61 MB. The arena is a bump allocator: any vector that grows inside it strands every grown-out-of allocation for the rest of the format run, and in-place growth almost never applies because other allocations (AstNode wrappers, nested buffers) land in between.

Per-phase measurement of `Allocator::used_bytes()` attributed the garbage to:

- **`intern()` staging (~270 MB on antd.js)**: every interned island was built in an arena `VecBuffer` growing from capacity 0. The default call-arguments path interns each call's argument list, and a UMD bundle is one giant nested call expression, so nearly the whole document flows through interns (the root slice ends up with 294 elements; 67k interned islands hold the rest).
- **Root buffer pre-allocation (~64 MB on antd.js)**: `format()` reserves 0.4×source-length elements in the arena up front, which is dead weight whenever content ends up in interned islands instead.
- (~71 MB of transient `AstNode` wrappers — not addressed here, needs a design change.)

## Change

New `HeapVecBuffer` in `oxc_formatter_core`: a heap-backed staging twin of `VecBuffer`, drawing its backing vector from a LIFO scratch pool on `FormatState` (one buffer per nesting level, capacity retained across uses, so staging allocates nothing in the steady state). Sequences whose length isn't known up front are built on the heap — where growth reallocations are actually freed — and the arena receives one exactly-sized copy of the final content.

Converted call sites:

- `Formatter::intern`
- `BestFitting` variant construction
- the three grouped-argument variant builders in `arguments.rs`
- the assignment-like left-hand-side staging (replayed into the parent buffer via `take_heap_vec`; nothing lands in the arena at all)
- both document roots: JS `format()` and JSON `format()` (resolves the `TODO` there about pre-sizing)

`VecBuffer::take_vec` lost its last caller and is removed.

## Results

Arena bytes after parse + IR build (`Allocator::used_bytes()`), tracked benchmark files:

| file | before | after | |
|---|---|---|---|
| antd.js | 363.2 MB | 180.3 MB | −50% |
| checker.ts | 104.0 MB | 77.3 MB | −26% |
| App.tsx | 21.7 MB | 14.6 MB | −33% |
| pdf.mjs | 35.0 MB | 28.7 MB | −18% |
| kitchen-sink.tsx | 45.4 MB | 38.8 MB | −15% |
| binder.ts | 6.5 MB | 4.8 MB | −26% |

Output is byte-identical on all of the files above, fixture/unit suites for `oxc_formatter` and `oxc_formatter_json` pass, and hyperfine shows parity to 1.03× faster (antd.js 146.8 → 142.9 ms mean); the heap-side churn stays flat thanks to the scratch pool.

The `tasks/track_memory_allocations` snapshots are not regenerated here — their byte lines are Linux-CI reference values, so they need the CI job's diff.

---

Investigated and implemented with Claude Code; reviewed and driven by me.