### PR TITLE
ci(benchmark): add CodSpeed memory measurement for pipeline benchmarks

### DIFF
--- a/.github/scripts/generate-benchmark-matrix.js
+++ b/.github/scripts/generate-benchmark-matrix.js
@@ -68,6 +68,20 @@ function getFeatureForComponent(component) {
   return "compiler";
 }
 
+/**
+ * Build matrix entries for components.
+ * `pipeline` additionally runs the memory instrument in the same job.
+ * @param {string[]} components - Component names
+ * @returns {Array<{component: string, feature: string, mode: string}>} Matrix entries
+ */
+function buildMatrixEntries(components) {
+  return components.map((component) => ({
+    component,
+    feature: getFeatureForComponent(component),
+    mode: component === "pipeline" ? "simulation,memory" : "simulation",
+  }));
+}
+
 /** @type {Map<string, string[]>} Cache of cargo tree results keyed by feature */
 const depsCache = new Map();
 
@@ -126,26 +140,20 @@ function isComponentAffected(component, changedFiles) {
 
 /**
  * Determine which components are affected by changes
- * @returns {Promise<Array<{component: string, feature: string}>>} Array of affected component objects
+ * @returns {Promise<Array<{component: string, feature: string, mode: string}>>} Matrix entries for affected components
  */
 async function determineAffectedComponents() {
   const changedFiles = await getChangedFiles();
 
   // Manual trigger - run all benchmarks
   if (changedFiles === null) {
-    return ALL_COMPONENTS.map((component) => ({
-      component,
-      feature: getFeatureForComponent(component),
-    }));
+    return buildMatrixEntries(ALL_COMPONENTS);
   }
 
   // Check for global changes
   if (checkGlobalChanges(changedFiles)) {
     console.error("Global changes detected - will run all benchmarks");
-    return ALL_COMPONENTS.map((component) => ({
-      component,
-      feature: getFeatureForComponent(component),
-    }));
+    return buildMatrixEntries(ALL_COMPONENTS);
   }
 
   // Check benchmark and common task files - affects all components
@@ -155,10 +163,7 @@ async function determineAffectedComponents() {
     )
   ) {
     console.error("Benchmark/common task files changed - will run all benchmarks");
-    return ALL_COMPONENTS.map((component) => ({
-      component,
-      feature: getFeatureForComponent(component),
-    }));
+    return buildMatrixEntries(ALL_COMPONENTS);
   }
 
   // If no crate files changed, no benchmarks need to run
@@ -173,22 +178,17 @@ async function determineAffectedComponents() {
   for (const component of ALL_COMPONENTS) {
     console.error(`\nChecking component: ${component}`);
     if (isComponentAffected(component, changedFiles)) {
-      affectedComponents.push({
-        component,
-        feature: getFeatureForComponent(component),
-      });
+      affectedComponents.push(component);
     }
   }
 
   if (affectedComponents.length === 0) {
     console.error("\nNo components were affected by the changes");
   } else {
-    console.error(
-      `\nAffected components: ${affectedComponents.map((obj) => obj.component).join(", ")}`,
-    );
+    console.error(`\nAffected components: ${affectedComponents.join(", ")}`);
   }
 
-  return affectedComponents;
+  return buildMatrixEntries(affectedComponents);
 }
 
 /**
@@ -216,10 +216,7 @@ async function main() {
   } catch (error) {
     console.error("Error generating benchmark matrix:", error);
     // On error, run all benchmarks as a fallback
-    const fallbackMatrix = ALL_COMPONENTS.map((component) => ({
-      component,
-      feature: getFeatureForComponent(component),
-    }));
+    const fallbackMatrix = buildMatrixEntries(ALL_COMPONENTS);
     console.log(JSON.stringify(fallbackMatrix));
     process.exit(0);
   }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -73,6 +73,8 @@ jobs:
           save-cache: ${{ github.ref_name == 'main' }}
           tools: cargo-codspeed
 
+      # Memory mode reuses these binaries: cargo-codspeed maps both simulation and
+      # memory modes to the same `analysis` build (`--cfg codspeed`) and directory.
       - name: Build benchmark
         env:
           RUSTFLAGS: "-C debuginfo=1 -C strip=none -g --cfg codspeed"
@@ -93,5 +95,5 @@ jobs:
         uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
         timeout-minutes: 30
         with:
-          mode: simulation
+          mode: ${{ matrix.mode }}
           run: cargo codspeed run ${{ matrix.component }}


### PR DESCRIPTION
Adds CodSpeed's [Memory Instrument](https://codspeed.io/docs/instruments/memory) for the `pipeline` benchmarks: peak memory, total allocated bytes, allocation count, and a memory timeline per benchmark case, tracked with baseline comparison on PRs alongside the existing CPU simulation runs.

## Changes

- `generate-benchmark-matrix.js`: entry construction is factored into a `buildMatrixEntries()` helper used by all five construction sites. All entries now carry an explicit `mode`: `simulation` for every component, `simulation,memory` for `pipeline` — so the pipeline job runs both instruments and inherits the existing changed-file affection logic.
- `benchmark.yml`: the action's `mode:` input comes from the matrix. Job names and count are unchanged.

No build-step changes needed: `cargo-codspeed` maps memory mode to the same `analysis` build the workflow already stages (`MeasurementMode::Memory` → `BuildMode::Analysis`), and the pinned action v4.18.5 supports memory mode (added in v4.17.0) including comma-separated multi-mode runs.

Notes:

- The first memory numbers on this PR will have no baseline; comparisons start after the post-merge main run.
- Memory metrics reflect the bench crate's deliberate `NeverGrowInPlaceAllocator` worst-case realloc behavior — consistent run-to-run, which is what matters for regression tracking.

AI Disclosure: This was generated with Claude Code, Fable 5. It has been tested and reviewed by me for correctness.