### PR TITLE
perf(lsp): deduplicate concurrent identical diagnostic runs

### DIFF
--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -234,7 +234,7 @@ impl Tool for ServerFormatter {
                 .ok_or_else(|| "In-memory formatting requires content".to_string())?;
 
             let Some(result) =
-                self.format_in_memory(document.uri, source_text, &document.language_id)
+                self.format_in_memory(&document.uri, source_text, &document.language_id)
             else {
                 return Ok(vec![]); // currently not supported
             };

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -647,7 +647,7 @@ impl Tool for ServerLinter {
     /// Lint a file with the current linter
     /// - If the file is not lintable or ignored, an empty vector is returned
     fn run_diagnostic(&self, document: &TextDocument) -> DiagnosticResult {
-        Ok(vec![(document.uri.clone(), self.run_file(document.uri, document.text.as_deref())?)])
+        Ok(vec![(document.uri.clone(), self.run_file(&document.uri, document.text.as_deref())?)])
     }
 
     /// Lint a file with the current linter

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -670,6 +670,14 @@ impl Tool for ServerLinter {
         self.run_diagnostic(document)
     }
 
+    fn should_lint_on_change(&self) -> bool {
+        self.run == Run::OnType
+    }
+
+    fn should_lint_on_save(&self) -> bool {
+        self.run == Run::OnSave
+    }
+
     fn remove_uri_cache(&self, uri: &Uri) {
         self.code_actions.pin().remove(uri);
     }

--- a/apps/oxlint/src/lsp/tester.rs
+++ b/apps/oxlint/src/lsp/tester.rs
@@ -226,7 +226,7 @@ impl Tester<'_> {
             let range = Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX));
             let reports = FileResult {
                 diagnostic: linter.run_diagnostic(&TextDocument::new(
-                    &uri,
+                    uri.clone(),
                     oxc_language_server::LanguageId::default(),
                     None,
                 )),

--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -9,13 +9,15 @@ use tower_lsp_server::{
     jsonrpc::{Error, ErrorCode, Result},
     ls_types::{
         CodeActionParams, CodeActionResponse, ConfigurationItem, Diagnostic,
-        DidChangeConfigurationParams, DidChangeTextDocumentParams, DidChangeWatchedFilesParams,
-        DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-        DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
-        DocumentDiagnosticReportKind, DocumentDiagnosticReportResult, DocumentFormattingParams,
-        ExecuteCommandParams, FullDocumentDiagnosticReport, InitializeParams, InitializeResult,
-        InitializedParams, MessageType, RelatedFullDocumentDiagnosticReport, ServerInfo,
+        DiagnosticServerCancellationData, DidChangeConfigurationParams,
+        DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidChangeWorkspaceFoldersParams,
+        DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
+        DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportKind,
+        DocumentDiagnosticReportResult, DocumentFormattingParams, ExecuteCommandParams,
+        FullDocumentDiagnosticReport, InitializeParams, InitializeResult, InitializedParams,
+        MessageType, RelatedFullDocumentDiagnosticReport, ServerInfo,
         TextDocumentContentChangeEvent, TextEdit, Uri, WorkspaceEdit,
+        error_codes::SERVER_CANCELLED,
     },
 };
 use tracing::{debug, error, info, warn};
@@ -583,6 +585,7 @@ impl LanguageServer for Backend {
             let Some(worker) = self.worker_manager.get_worker_for_uri(&uri).await else {
                 return;
             };
+            let document_version = self.file_system.get_version(&uri);
             let document = self.file_system.get_document(uri);
             let document_uri = document.uri.clone();
             let handle = tokio::runtime::Handle::current();
@@ -594,6 +597,14 @@ impl LanguageServer for Backend {
             // unwrap because we want to panic if the task panics,
             // because it should not happen and we want to know about it.
             .unwrap();
+
+            if document_version != self.file_system.get_version(&document_uri) {
+                debug!(
+                    "document version changed while diagnostics were running, skipping diagnostics for {}",
+                    document_uri.as_str()
+                );
+                return;
+            }
 
             match diagnostics {
                 Err(err) => {
@@ -875,6 +886,7 @@ impl LanguageServer for Backend {
                 RelatedFullDocumentDiagnosticReport::default(),
             )));
         };
+        let document_version = self.file_system.get_version(&uri);
         let document = self.file_system.get_document(uri.clone());
 
         let handle = tokio::runtime::Handle::current();
@@ -886,6 +898,20 @@ impl LanguageServer for Backend {
         // unwrap because we want to panic if the task panics,
         // because it should not happen and we want to know about it.
         .unwrap();
+
+        if self.file_system.get_version(&uri) != document_version {
+            return Err(Error {
+                code: ErrorCode::ServerError(SERVER_CANCELLED),
+                message: Cow::Borrowed("document version changed while diagnostics were running"),
+                data: Some(
+                    // We expect that the client already requested a new diagnostics request, so we do not need to retrigger it.
+                    serde_json::to_value(DiagnosticServerCancellationData {
+                        retrigger_request: false,
+                    })
+                    .unwrap(),
+                ),
+            });
+        }
 
         let diagnostics = match diagnostics {
             Err(err) => {

--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -585,18 +585,17 @@ impl LanguageServer for Backend {
             let Some(worker) = self.worker_manager.get_worker_for_uri(&uri).await else {
                 return;
             };
+            // Gate before entering the deduplicated path so the shared future always runs the
+            // full lint. On save this collapses with the plugin's Fix-All pull (same version).
+            if !worker.should_lint_on_save().await {
+                return;
+            }
             let document_version = self.file_system.get_version(&uri);
             let document = self.file_system.get_document(uri);
             let document_uri = document.uri.clone();
-            let handle = tokio::runtime::Handle::current();
-            // use `spawn_blocking` because this is a very CPU intensive task and we do not want to block the async runtime.
-            let diagnostics = tokio::task::spawn_blocking(move || {
-                handle.block_on(async move { worker.run_diagnostic_on_save(&document).await })
-            })
-            .await
-            // unwrap because we want to panic if the task panics,
-            // because it should not happen and we want to know about it.
-            .unwrap();
+            let diagnostics = worker
+                .run_diagnostic_deduped(&document, document_version.unwrap_or_default())
+                .await;
 
             if document_version != self.file_system.get_version(&document_uri) {
                 debug!(
@@ -649,16 +648,13 @@ impl LanguageServer for Backend {
         let document = self.file_system.get_document(uri);
 
         if self.capabilities.get().is_some_and(|cap| cap.diagnostic_mode == DiagnosticMode::Push) {
+            // Gate before the deduplicated path so the shared future always runs the full lint.
+            if !worker.should_lint_on_change().await {
+                return;
+            }
             let document_uri = document.uri.clone();
-            let handle = tokio::runtime::Handle::current();
-            // use `spawn_blocking` because this is a very CPU intensive task and we do not want to block the async runtime.
-            let diagnostics = tokio::task::spawn_blocking(move || {
-                handle.block_on(async move { worker.run_diagnostic_on_change(&document).await })
-            })
-            .await
-            // unwrap because we want to panic if the task panics,
-            // because it should not happen and we want to know about it.
-            .unwrap();
+            let diagnostics =
+                worker.run_diagnostic_deduped(&document, params.text_document.version).await;
 
             match diagnostics {
                 Err(err) => {
@@ -719,18 +715,13 @@ impl LanguageServer for Backend {
                 return;
             };
 
+            let document_version = self.file_system.get_version(&uri);
             let document = self.file_system.get_document(uri);
 
             let document_uri = document.uri.clone();
-            let handle = tokio::runtime::Handle::current();
-            // use `spawn_blocking` because this is a very CPU intensive task and we do not want to block the async runtime.
-            let diagnostics = tokio::task::spawn_blocking(move || {
-                handle.block_on(async move { worker.run_diagnostic(&document).await })
-            })
-            .await
-            // unwrap because we want to panic if the task panics,
-            // because it should not happen and we want to know about it.
-            .unwrap();
+            let diagnostics = worker
+                .run_diagnostic_deduped(&document, document_version.unwrap_or_default())
+                .await;
 
             match diagnostics {
                 Err(err) => {
@@ -889,15 +880,8 @@ impl LanguageServer for Backend {
         let document_version = self.file_system.get_version(&uri);
         let document = self.file_system.get_document(uri.clone());
 
-        let handle = tokio::runtime::Handle::current();
-        // use `spawn_blocking` because this is a very CPU intensive task and we do not want to block the async runtime.
-        let diagnostics = tokio::task::spawn_blocking(move || {
-            handle.block_on(async move { worker.run_diagnostic(&document).await })
-        })
-        .await
-        // unwrap because we want to panic if the task panics,
-        // because it should not happen and we want to know about it.
-        .unwrap();
+        let diagnostics =
+            worker.run_diagnostic_deduped(&document, document_version.unwrap_or_default()).await;
 
         if self.file_system.get_version(&uri) != document_version {
             return Err(Error {

--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -25,7 +25,6 @@ use crate::{
     capabilities::{Capabilities, DiagnosticMode, server_capabilities},
     file_system::LSPFileSystem,
     options::WorkspaceOption,
-    worker::WorkspaceWorker,
     worker_manager::WorkerManager,
 };
 
@@ -74,7 +73,7 @@ pub struct Backend {
 impl LanguageServer for Backend {
     /// Initialize the language server with the given parameters.
     /// This method sets up workspace workers, capabilities, and starts the
-    /// [WorkspaceWorker]s if the client sent the configuration with initialization options.
+    /// [crate::worker::WorkspaceWorker]s if the client sent the configuration with initialization options.
     ///
     /// See: <https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize>
     #[expect(deprecated)] // `params.root_uri` is deprecated, we are only falling back to it if no workspace folder is provided
@@ -184,9 +183,9 @@ impl LanguageServer for Backend {
     }
 
     /// It registers dynamic capabilities like file watchers and formatting if the client supports it.
-    /// It also starts the [WorkspaceWorker]s if they did not start during initialization.
+    /// It also starts the [crate::worker::WorkspaceWorker]s if they did not start during initialization.
     /// If the client supports `workspace/configuration` request, it will request the configuration for each workspace folder
-    /// and start the [WorkspaceWorker]s with the received configuration.
+    /// and start the [crate::worker::WorkspaceWorker]s with the received configuration.
     ///
     /// See: <https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialized>
     async fn initialized(&self, _params: InitializedParams) {
@@ -236,7 +235,7 @@ impl LanguageServer for Backend {
                     let Some(worker) = self.worker_manager.get_worker_for_uri(uri).await else {
                         continue;
                     };
-                    let document = self.file_system.get_document(uri);
+                    let document = self.file_system.get_document(uri.clone());
                     let diagnostics = worker.run_diagnostic(&document).await;
                     match diagnostics {
                         Err(err) => {
@@ -315,7 +314,7 @@ impl LanguageServer for Backend {
         Ok(())
     }
 
-    /// This method updates the configuration of each [WorkspaceWorker] and restarts them if necessary.
+    /// This method updates the configuration of each [crate::worker::WorkspaceWorker] and restarts them if necessary.
     /// It also manages dynamic registrations for file watchers and formatting based on the new configuration.
     /// It will remove/add dynamic registrations if the client supports it.
     /// As an example, if a workspace changes the configuration file path, the file watcher will be updated.
@@ -359,7 +358,7 @@ impl LanguageServer for Backend {
         {
             let configs = self
                 .request_workspace_configuration(
-                    workers.iter().map(WorkspaceWorker::get_root_uri).collect(),
+                    workers.iter().map(|worker| worker.get_root_uri()).collect(),
                 )
                 .await;
 
@@ -495,8 +494,8 @@ impl LanguageServer for Backend {
         }
     }
 
-    /// The server will start new [WorkspaceWorker]s for added workspace folders
-    /// and stop and remove [WorkspaceWorker]s for removed workspace folders including:
+    /// The server will start new [crate::worker::WorkspaceWorker]s for added workspace folders
+    /// and stop and remove [crate::worker::WorkspaceWorker]s for removed workspace folders including:
     /// - clearing diagnostics
     /// - unregistering file watchers
     ///
@@ -584,10 +583,21 @@ impl LanguageServer for Backend {
             let Some(worker) = self.worker_manager.get_worker_for_uri(&uri).await else {
                 return;
             };
-            let document = self.file_system.get_document(&uri);
-            match worker.run_diagnostic_on_save(&document).await {
+            let document = self.file_system.get_document(uri);
+            let document_uri = document.uri.clone();
+            let handle = tokio::runtime::Handle::current();
+            // use `spawn_blocking` because this is a very CPU intensive task and we do not want to block the async runtime.
+            let diagnostics = tokio::task::spawn_blocking(move || {
+                handle.block_on(async move { worker.run_diagnostic_on_save(&document).await })
+            })
+            .await
+            // unwrap because we want to panic if the task panics,
+            // because it should not happen and we want to know about it.
+            .unwrap();
+
+            match diagnostics {
                 Err(err) => {
-                    error!("running diagnostics for {} failed: {err}", uri.as_str());
+                    error!("running diagnostics for {} failed: {err}", document_uri.as_str());
                     if self.capabilities.get().is_some_and(|cap| cap.show_message) {
                         self.client.show_message(MessageType::ERROR, err).await;
                     }
@@ -615,9 +625,6 @@ impl LanguageServer for Backend {
         {
             self.file_system.set(uri.clone(), content);
         }
-
-        let document = self.file_system.get_document(&uri);
-
         let Some(worker) = self.worker_manager.get_worker_for_uri(&uri).await else {
             return;
         };
@@ -628,10 +635,23 @@ impl LanguageServer for Backend {
         // Sadly, some editors/extensions have bugs, so we need to make sure the cache is cleared on change.
         worker.remove_uri_cache(&uri).await;
 
+        let document = self.file_system.get_document(uri);
+
         if self.capabilities.get().is_some_and(|cap| cap.diagnostic_mode == DiagnosticMode::Push) {
-            match worker.run_diagnostic_on_change(&document).await {
+            let document_uri = document.uri.clone();
+            let handle = tokio::runtime::Handle::current();
+            // use `spawn_blocking` because this is a very CPU intensive task and we do not want to block the async runtime.
+            let diagnostics = tokio::task::spawn_blocking(move || {
+                handle.block_on(async move { worker.run_diagnostic_on_change(&document).await })
+            })
+            .await
+            // unwrap because we want to panic if the task panics,
+            // because it should not happen and we want to know about it.
+            .unwrap();
+
+            match diagnostics {
                 Err(err) => {
-                    error!("running diagnostics for {} failed: {err}", uri.as_str());
+                    error!("running diagnostics for {} failed: {err}", document_uri.as_str());
                     if self.capabilities.get().is_some_and(|cap| cap.show_message) {
                         self.client.show_message(MessageType::ERROR, err).await;
                     }
@@ -639,7 +659,7 @@ impl LanguageServer for Backend {
                 Ok(diagnostics) => {
                     if !diagnostics.is_empty() {
                         let version_map = ConcurrentHashMap::default();
-                        version_map.pin().insert(uri.clone(), params.text_document.version);
+                        version_map.pin().insert(document_uri, params.text_document.version);
                         self.publish_all_diagnostics(diagnostics, version_map).await;
                     }
                 }
@@ -651,7 +671,7 @@ impl LanguageServer for Backend {
     /// It will lint the file and send diagnostics, if necessary.
     ///
     /// In single file mode (no workspace was configured during initialize), a new
-    /// [WorkspaceWorker] is created dynamically using the file's parent directory as
+    /// [crate::worker::WorkspaceWorker] is created dynamically using the file's parent directory as
     /// the workspace root if no existing worker covers the URI.
     ///
     /// See: <https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didOpen>
@@ -687,11 +707,22 @@ impl LanguageServer for Backend {
                 return;
             };
 
-            let document = self.file_system.get_document(&uri);
+            let document = self.file_system.get_document(uri);
 
-            match worker.run_diagnostic(&document).await {
+            let document_uri = document.uri.clone();
+            let handle = tokio::runtime::Handle::current();
+            // use `spawn_blocking` because this is a very CPU intensive task and we do not want to block the async runtime.
+            let diagnostics = tokio::task::spawn_blocking(move || {
+                handle.block_on(async move { worker.run_diagnostic(&document).await })
+            })
+            .await
+            // unwrap because we want to panic if the task panics,
+            // because it should not happen and we want to know about it.
+            .unwrap();
+
+            match diagnostics {
                 Err(err) => {
-                    error!("running diagnostics for {} failed: {err}", uri.as_str());
+                    error!("running diagnostics for {} failed: {err}", document_uri.as_str());
                     if self.capabilities.get().is_some_and(|cap| cap.show_message) {
                         self.client.show_message(MessageType::ERROR, err).await;
                     }
@@ -699,7 +730,7 @@ impl LanguageServer for Backend {
                 Ok(diagnostics) => {
                     if !diagnostics.is_empty() {
                         let version_map = ConcurrentHashMap::default();
-                        version_map.pin().insert(uri, params.text_document.version);
+                        version_map.pin().insert(document_uri, params.text_document.version);
                         self.publish_all_diagnostics(diagnostics, version_map).await;
                     }
                 }
@@ -837,15 +868,23 @@ impl LanguageServer for Backend {
         &self,
         params: DocumentDiagnosticParams,
     ) -> Result<DocumentDiagnosticReportResult> {
-        let uri = &params.text_document.uri;
-        let Some(worker) = self.worker_manager.get_worker_for_uri(uri).await else {
+        let uri = params.text_document.uri;
+        let Some(worker) = self.worker_manager.get_worker_for_uri(&uri).await else {
             return Ok(DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(
                 RelatedFullDocumentDiagnosticReport::default(),
             )));
         };
+        let document = self.file_system.get_document(uri.clone());
 
-        let document = self.file_system.get_document(uri);
-        let diagnostics = worker.run_diagnostic(&document).await;
+        let handle = tokio::runtime::Handle::current();
+        // use `spawn_blocking` because this is a very CPU intensive task and we do not want to block the async runtime.
+        let diagnostics = tokio::task::spawn_blocking(move || {
+            handle.block_on(async move { worker.run_diagnostic(&document).await })
+        })
+        .await
+        // unwrap because we want to panic if the task panics,
+        // because it should not happen and we want to know about it.
+        .unwrap();
 
         let diagnostics = match diagnostics {
             Err(err) => {
@@ -861,12 +900,12 @@ impl LanguageServer for Backend {
 
         let uri_diagnostics = diagnostics
             .iter()
-            .filter(|(diag_uri, _)| diag_uri == uri)
+            .filter(|(diag_uri, _)| *diag_uri == uri)
             .flat_map(|(_, diags)| diags.clone())
             .collect::<Vec<_>>();
 
         let related_diagnostics =
-            diagnostics.into_iter().filter(|(diag_uri, _)| diag_uri != uri).collect::<Vec<_>>();
+            diagnostics.into_iter().filter(|(diag_uri, _)| *diag_uri != uri).collect::<Vec<_>>();
 
         Ok(DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(
             RelatedFullDocumentDiagnosticReport {
@@ -902,8 +941,8 @@ impl LanguageServer for Backend {
     ///
     /// See: <https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting>
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
-        let uri = &params.text_document.uri;
-        let Some(worker) = self.worker_manager.get_worker_for_uri(uri).await else {
+        let uri = params.text_document.uri;
+        let Some(worker) = self.worker_manager.get_worker_for_uri(&uri).await else {
             return Ok(None);
         };
 
@@ -924,7 +963,7 @@ impl LanguageServer for Backend {
 
 impl Backend {
     /// Create a new Backend with the given client.
-    /// The Backend will manage multiple [WorkspaceWorker]s and their configurations.
+    /// The Backend will manage multiple [crate::worker::WorkspaceWorker]s and their configurations.
     /// It also holds the capabilities of the language server and an in-memory file system.
     /// The client is used to communicate with the LSP client.
     pub fn new(client: Client, server_info: ServerInfo, worker_manager: WorkerManager) -> Self {

--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -623,7 +623,7 @@ impl LanguageServer for Backend {
             .next()
             .map(|c: TextDocumentContentChangeEvent| c.text)
         {
-            self.file_system.set(uri.clone(), content);
+            self.file_system.set_with_version(uri.clone(), params.text_document.version, content);
         }
         let Some(worker) = self.worker_manager.get_worker_for_uri(&uri).await else {
             return;
@@ -699,6 +699,7 @@ impl LanguageServer for Backend {
         self.file_system.set_with_language(
             uri.clone(),
             LanguageId::new(params.text_document.language_id),
+            params.text_document.version,
             content,
         );
 

--- a/crates/oxc_language_server/src/file_system.rs
+++ b/crates/oxc_language_server/src/file_system.rs
@@ -11,7 +11,14 @@ use crate::{ConcurrentHashMap, LanguageId, TextDocument};
 
 #[derive(Debug, Default)]
 pub struct LSPFileSystem {
-    files: ConcurrentHashMap<Uri, (LanguageId, Arc<str>)>,
+    files: ConcurrentHashMap<Uri, OpenDocument>,
+}
+
+#[derive(Debug)]
+struct OpenDocument {
+    language_id: LanguageId,
+    version: i32,
+    text: Arc<str>,
 }
 
 /// Represents a resolved file path that can be used for file system operations.
@@ -80,24 +87,45 @@ impl LSPFileSystem {
     }
 
     pub fn set(&self, uri: Uri, content: String) {
-        let language_id = self.get_language_id(&uri).unwrap_or_default();
-        self.files.pin().insert(uri, (language_id, Arc::from(content)));
+        let version = self.get_version(&uri).unwrap_or_default();
+        self.set_with_version(uri, version, content);
     }
 
-    pub fn set_with_language(&self, uri: Uri, language_id: LanguageId, content: String) {
-        self.files.pin().insert(uri, (language_id, Arc::from(content)));
+    pub fn set_with_version(&self, uri: Uri, version: i32, content: String) {
+        let language_id = self.get_language_id(&uri).unwrap_or_default();
+        self.set_with_language(uri, language_id, version, content);
+    }
+
+    pub fn set_with_language(
+        &self,
+        uri: Uri,
+        language_id: LanguageId,
+        version: i32,
+        content: String,
+    ) {
+        self.files
+            .pin()
+            .insert(uri, OpenDocument { language_id, version, text: Arc::from(content) });
     }
 
     pub fn get_language_id(&self, uri: &Uri) -> Option<LanguageId> {
-        self.files.pin().get(uri).map(|(lang, _)| lang.clone())
+        self.files.pin().get(uri).map(|doc| doc.language_id.clone())
+    }
+
+    pub fn get_version(&self, uri: &Uri) -> Option<i32> {
+        self.files.pin().get(uri).map(|doc| doc.version)
     }
 
     pub fn get_document(&self, uri: Uri) -> TextDocument {
         let binding = self.files.pin();
-        let Some((language_id, content)) = binding.get(&uri) else {
+        let Some(doc) = binding.get(&uri) else {
             return TextDocument { uri, language_id: LanguageId::default(), text: None };
         };
-        TextDocument { uri, language_id: language_id.clone(), text: Some(Arc::clone(content)) }
+        TextDocument {
+            uri,
+            language_id: doc.language_id.clone(),
+            text: Some(Arc::clone(&doc.text)),
+        }
     }
 
     pub fn remove(&self, uri: &Uri) {

--- a/crates/oxc_language_server/src/file_system.rs
+++ b/crates/oxc_language_server/src/file_system.rs
@@ -92,15 +92,12 @@ impl LSPFileSystem {
         self.files.pin().get(uri).map(|(lang, _)| lang.clone())
     }
 
-    pub fn get_document<'a>(&self, uri: &'a Uri) -> TextDocument<'a> {
-        self.files.pin().get(uri).map_or_else(
-            || TextDocument { uri, language_id: LanguageId::default(), text: None },
-            |(language_id, content)| TextDocument {
-                uri,
-                language_id: language_id.clone(),
-                text: Some(Arc::clone(content)),
-            },
-        )
+    pub fn get_document(&self, uri: Uri) -> TextDocument {
+        let binding = self.files.pin();
+        let Some((language_id, content)) = binding.get(&uri) else {
+            return TextDocument { uri, language_id: LanguageId::default(), text: None };
+        };
+        TextDocument { uri, language_id: language_id.clone(), text: Some(Arc::clone(content)) }
     }
 
     pub fn remove(&self, uri: &Uri) {

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -26,7 +26,7 @@ pub use crate::worker_manager::WorkerManager;
 
 pub type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TextDocument {
     pub uri: Uri,
     pub language_id: LanguageId,

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -27,14 +27,14 @@ pub use crate::worker_manager::WorkerManager;
 pub type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
 
 #[derive(Debug)]
-pub struct TextDocument<'a> {
-    pub uri: &'a Uri,
+pub struct TextDocument {
+    pub uri: Uri,
     pub language_id: LanguageId,
     pub text: Option<Arc<str>>,
 }
 
-impl<'a> TextDocument<'a> {
-    pub fn new(uri: &'a Uri, language_id: LanguageId, text: Option<Arc<str>>) -> Self {
+impl TextDocument {
+    pub fn new(uri: Uri, language_id: LanguageId, text: Option<Arc<str>>) -> Self {
         Self { uri, language_id, text }
     }
 }

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -2235,8 +2235,8 @@ mod test_suite {
         use crate::tests::{FakeToolDelays, create_dynamic_workspace_manager};
 
         use super::*;
+
         #[tokio::test]
-        #[ignore = "This needs to be fixed"]
         async fn test_request_locks() {
             let delay = 100;
             let mut server = TestServer::new_initialized(

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -20,21 +20,31 @@ use crate::{
 pub struct FakeToolBuilder {
     diagnostic_mode: DiagnosticMode,
     cache_uris: Option<Arc<Mutex<Vec<Uri>>>>,
+    delays: FakeToolDelays,
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct FakeToolDelays {
+    run_diagnostic: u64,
 }
 
 impl FakeToolBuilder {
     pub fn new(diagnostic_mode: DiagnosticMode) -> Self {
-        Self { diagnostic_mode, cache_uris: None }
+        Self { diagnostic_mode, cache_uris: None, delays: FakeToolDelays::default() }
     }
 
     pub fn with_cache_tracking(self, cache_uris: Arc<Mutex<Vec<Uri>>>) -> Self {
         Self { cache_uris: Some(cache_uris), ..self }
     }
+
+    pub fn with_delays(self, delays: FakeToolDelays) -> Self {
+        Self { delays, ..self }
+    }
 }
 
 impl ToolBuilder for FakeToolBuilder {
     fn build_boxed(&self, _root_uri: &Uri, _options: serde_json::Value) -> Box<dyn Tool> {
-        Box::new(FakeTool { cache_uris: self.cache_uris.clone() })
+        Box::new(FakeTool { cache_uris: self.cache_uris.clone(), delays: self.delays })
     }
 
     fn server_capabilities(
@@ -56,6 +66,7 @@ impl ToolBuilder for FakeToolBuilder {
 
 pub struct FakeTool {
     cache_uris: Option<Arc<Mutex<Vec<Uri>>>>,
+    delays: FakeToolDelays,
 }
 
 pub const FAKE_COMMAND: &str = "fake.command";
@@ -155,6 +166,9 @@ impl Tool for FakeTool {
     }
 
     fn run_diagnostic(&self, document: &TextDocument) -> DiagnosticResult {
+        if self.delays.run_diagnostic > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(self.delays.run_diagnostic));
+        }
         if let Some(cache_uris) = &self.cache_uris {
             cache_uris.lock().unwrap().push(document.uri.clone());
         }
@@ -2212,6 +2226,71 @@ mod test_suite {
             server.send_ack(&Id::Number(0)).await;
 
             server.shutdown(2).await;
+        }
+    }
+
+    mod request_locks {
+        use std::time::Instant;
+
+        use crate::tests::{FakeToolDelays, create_dynamic_workspace_manager};
+
+        use super::*;
+        #[tokio::test]
+        #[ignore = "This needs to be fixed"]
+        async fn test_request_locks() {
+            let delay = 100;
+            let mut server = TestServer::new_initialized(
+                |client| {
+                    Backend::new(
+                        client,
+                        server_info(),
+                        create_dynamic_workspace_manager(
+                            FakeToolBuilder::new(DiagnosticMode::Pull)
+                                .with_delays(FakeToolDelays { run_diagnostic: delay }),
+                        ),
+                    )
+                },
+                initialize_request(InitializeRequestOptions::default()),
+            )
+            .await;
+
+            let file = format!("{WORKSPACE}/diagnostics.config");
+            server.send_request(did_open(&file, "content")).await;
+
+            let now = Instant::now();
+
+            // Send multiple diagnostic requests
+            for i in 0..5 {
+                server.send_request(diagnostic(1 + i, &file)).await;
+            }
+            server.send_request(code_action(6, &file)).await;
+
+            let mut diagnostic_responses = 0;
+            loop {
+                let response = server.recv_response().await;
+                if response.id() == &Id::Number(6) {
+                    break;
+                }
+                diagnostic_responses += 1;
+            }
+
+            let elapsed = now.elapsed().as_millis();
+
+            while diagnostic_responses < 5 {
+                let response = server.recv_response().await;
+                assert_ne!(response.id(), &Id::Number(6));
+                diagnostic_responses += 1;
+            }
+
+            server.shutdown(7).await;
+
+            // The diagnostic request should not block the code action request,
+            // so the total elapsed time should be less than delay * number of diagnostic requests.
+            assert!(
+                elapsed < u128::from(delay * 5),
+                "Diagnostic requests are blocking the code action request, elapsed time: {elapsed}ms, expected under {}ms",
+                delay * 5
+            );
         }
     }
 }

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -2292,5 +2292,47 @@ mod test_suite {
                 delay * 5
             );
         }
+
+        #[tokio::test]
+        async fn test_diagnostic_returns_server_cancelled_when_document_version_changes() {
+            let delay = 100;
+            let mut server = TestServer::new_initialized(
+                |client| {
+                    Backend::new(
+                        client,
+                        server_info(),
+                        create_dynamic_workspace_manager(
+                            FakeToolBuilder::new(DiagnosticMode::Pull)
+                                .with_delays(FakeToolDelays { run_diagnostic: delay }),
+                        ),
+                    )
+                },
+                initialize_request(InitializeRequestOptions {
+                    pull_mode: true,
+                    ..Default::default()
+                }),
+            )
+            .await;
+
+            let file = format!("{WORKSPACE}/diagnostics.config");
+            server.send_request(did_open(&file, "old content")).await;
+
+            server.send_request(diagnostic(3, &file)).await;
+            server.send_request(did_change(&file, "new content")).await;
+
+            let diagnostic_response = server.recv_response().await;
+            assert_eq!(diagnostic_response.id(), &Id::Number(3));
+            let error = diagnostic_response.error().unwrap();
+            assert_eq!(
+                error.code,
+                ErrorCode::ServerError(tower_lsp_server::ls_types::error_codes::SERVER_CANCELLED)
+            );
+            assert_eq!(
+                error.data.as_ref().unwrap()["retriggerRequest"],
+                serde_json::Value::Bool(false)
+            );
+
+            server.shutdown(4).await;
+        }
     }
 }

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -138,6 +138,22 @@ pub trait Tool: Send + Sync {
         Ok(Vec::new())
     }
 
+    /// Whether this tool should compute diagnostics in response to a document change (`onType`).
+    ///
+    /// This mirrors the gating inside [`Tool::run_diagnostic_on_change`], but is exposed
+    /// separately so callers can decide *whether* to lint before entering the deduplicated
+    /// diagnostic path (which always runs the full [`Tool::run_diagnostic`]).
+    fn should_lint_on_change(&self) -> bool {
+        true
+    }
+
+    /// Whether this tool should compute diagnostics in response to a document save (`onSave`).
+    ///
+    /// See [`Tool::should_lint_on_change`] for why this is separate from the gated run method.
+    fn should_lint_on_save(&self) -> bool {
+        true
+    }
+
     /// Remove internal cache for the given URI, if any.
     fn remove_uri_cache(&self, _uri: &Uri) {
         // Default implementation does nothing.

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -1,5 +1,12 @@
-use std::{path::Path, sync::Arc};
+use std::{
+    path::Path,
+    sync::{
+        Arc, Mutex as StdMutex,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
+use futures::future::{BoxFuture, FutureExt, Shared};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde_json::json;
 use tokio::sync::{Mutex, RwLock};
@@ -21,6 +28,45 @@ use crate::{
     tool::{DiagnosticResult, Tool, ToolBuilder},
 };
 
+/// Result of a diagnostic run, shareable between concurrent callers.
+///
+/// Must stay [`Clone`] so it can be the output of a [`Shared`] future.
+type DiagnosticRunResult = Result<Vec<(Uri, Vec<Diagnostic>)>, String>;
+
+/// A diagnostic computation that is currently running for a specific document version.
+///
+/// Concurrent requests for the same `(uri, version)` clone and await the same [`Shared`]
+/// future instead of spawning a second identical lint run. This collapses the two lints
+/// that otherwise happen on a single save (the server's own on-save lint and the plugin's
+/// Fix-All warm-up pull) into exactly one.
+struct InFlightDiagnostic {
+    /// Unique per run. Removal is keyed on this rather than on `version` so a finishing run
+    /// never deletes a newer entry that happens to reuse the same document version.
+    id: u64,
+    version: i32,
+    future: Shared<BoxFuture<'static, DiagnosticRunResult>>,
+}
+
+/// Removes the in-flight entry created by a run when that run completes, is cancelled, or
+/// panics. Held only by the run that inserted the entry (joiners rely on it); removal is a
+/// no-op unless the entry still carries the same `id`.
+struct InFlightGuard {
+    worker: Arc<WorkspaceWorker>,
+    uri: Uri,
+    id: u64,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        // Ignore a poisoned lock: the critical sections never panic, and `Drop` must not.
+        if let Ok(mut inflight) = self.worker.inflight_diagnostics.lock()
+            && inflight.get(&self.uri).is_some_and(|entry| entry.id == self.id)
+        {
+            inflight.remove(&self.uri);
+        }
+    }
+}
+
 /// A worker that manages the individual tool for a specific workspace
 /// and returns back the results of the running tool.
 ///
@@ -38,6 +84,12 @@ pub struct WorkspaceWorker {
     diagnostic_mode: DiagnosticMode,
     // Keep track of published diagnostics to clear them on shutdown (only in push mode)
     published_diagnostics: Mutex<FxHashSet<Uri>>,
+    // Diagnostic runs currently in flight, keyed by URI, used to deduplicate concurrent
+    // identical requests. See [`InFlightDiagnostic`]. A synchronous mutex so [`InFlightGuard`]
+    // can clean up from `Drop`; critical sections are short and never `.await`.
+    inflight_diagnostics: StdMutex<FxHashMap<Uri, InFlightDiagnostic>>,
+    // Monotonic id source for [`InFlightDiagnostic::id`].
+    next_run_id: AtomicU64,
 }
 
 impl WorkspaceWorker {
@@ -56,6 +108,8 @@ impl WorkspaceWorker {
             options: Mutex::new(None),
             diagnostic_mode,
             published_diagnostics: Mutex::new(FxHashSet::default()),
+            inflight_diagnostics: StdMutex::new(FxHashMap::default()),
+            next_run_id: AtomicU64::new(0),
         }
     }
 
@@ -181,6 +235,80 @@ impl WorkspaceWorker {
             tool.run_diagnostic_on_save(document)
         })
         .await
+    }
+
+    /// Whether the tool should compute diagnostics on document change (`onType`).
+    pub async fn should_lint_on_change(&self) -> bool {
+        self.tool.read().await.as_ref().is_some_and(|tool| tool.should_lint_on_change())
+    }
+
+    /// Whether the tool should compute diagnostics on document save (`onSave`).
+    pub async fn should_lint_on_save(&self) -> bool {
+        self.tool.read().await.as_ref().is_some_and(|tool| tool.should_lint_on_save())
+    }
+
+    /// Run diagnostics for `document`, deduplicating concurrent identical requests.
+    ///
+    /// If another run for the same `(uri, version)` is already in flight, this joins it and
+    /// returns its result instead of starting a second lint. The CPU-intensive work is offloaded
+    /// to a blocking thread inside the shared future, so callers await it directly (no outer
+    /// `spawn_blocking` needed).
+    ///
+    /// The canonical computation is always the full [`Self::run_diagnostic`]; the `onType`/`onSave`
+    /// gating is decided by the caller via [`Self::should_lint_on_change`]/[`Self::should_lint_on_save`]
+    /// *before* calling this, so the shared future is never poisoned with a gated-empty result.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when the underlying tool's diagnostic run fails; the message is propagated
+    /// from the tool.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal `spawn_blocking` task panics. The diagnostic run is not expected to
+    /// panic, so this surfaces the bug instead of hiding it.
+    pub async fn run_diagnostic_deduped(
+        self: &Arc<Self>,
+        document: &TextDocument,
+        version: i32,
+    ) -> Result<Vec<(Uri, Vec<Diagnostic>)>, String> {
+        let uri = document.uri.clone();
+
+        // `_guard` is `Some` only for the run that creates the entry; its `Drop` removes that
+        // entry on completion, cancellation, or panic. Joiners get `None` and rely on the creator.
+        let (shared, _guard) = {
+            let mut inflight = self.inflight_diagnostics.lock().unwrap();
+            match inflight.get(&uri) {
+                // A run for the exact same content version is already in flight: join it.
+                Some(entry) if entry.version == version => (entry.future.clone(), None),
+                // No run, or an older version is running (superseded by this newer request).
+                // Phase 1 does not cancel the older run; it is left to finish and its result
+                // is discarded by the caller's version check. Phase 2 adds cancellation.
+                _ => {
+                    let id = self.next_run_id.fetch_add(1, Ordering::Relaxed);
+                    let worker = Arc::clone(self);
+                    let document = document.clone();
+                    let future = async move {
+                        let handle = tokio::runtime::Handle::current();
+                        tokio::task::spawn_blocking(move || {
+                            handle.block_on(async move { worker.run_diagnostic(&document).await })
+                        })
+                        .await
+                        .unwrap()
+                    }
+                    .boxed()
+                    .shared();
+                    inflight.insert(
+                        uri.clone(),
+                        InFlightDiagnostic { id, version, future: future.clone() },
+                    );
+                    let guard = InFlightGuard { worker: Arc::clone(self), uri, id };
+                    (future, Some(guard))
+                }
+            }
+        };
+
+        shared.await
     }
 
     /// Format a file with the current formatter

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -102,7 +102,7 @@ impl WorkspaceWorker {
     /// Common aggregator for tool-provided diagnostics.
     async fn collect_diagnostics_with<F>(
         &self,
-        document: &TextDocument<'_>,
+        document: &TextDocument,
         run: F,
     ) -> Result<Vec<(Uri, Vec<Diagnostic>)>, String>
     where
@@ -149,7 +149,7 @@ impl WorkspaceWorker {
     /// When calling `Tool::run_diagnostic` results into an error.
     pub async fn run_diagnostic(
         &self,
-        document: &TextDocument<'_>,
+        document: &TextDocument,
     ) -> Result<Vec<(Uri, Vec<Diagnostic>)>, String> {
         self.collect_diagnostics_with(document, |tool, document| tool.run_diagnostic(document))
             .await
@@ -161,7 +161,7 @@ impl WorkspaceWorker {
     /// When calling `Tool::run_diagnostic_on_change` results into an error.
     pub async fn run_diagnostic_on_change(
         &self,
-        document: &TextDocument<'_>,
+        document: &TextDocument,
     ) -> Result<Vec<(Uri, Vec<Diagnostic>)>, String> {
         self.collect_diagnostics_with(document, |tool, document| {
             tool.run_diagnostic_on_change(document)
@@ -175,7 +175,7 @@ impl WorkspaceWorker {
     /// When calling `Tool::run_diagnostic_on_save` results into an error.
     pub async fn run_diagnostic_on_save(
         &self,
-        document: &TextDocument<'_>,
+        document: &TextDocument,
     ) -> Result<Vec<(Uri, Vec<Diagnostic>)>, String> {
         self.collect_diagnostics_with(document, |tool, document| {
             tool.run_diagnostic_on_save(document)
@@ -190,7 +190,7 @@ impl WorkspaceWorker {
     ///
     /// # Errors
     /// When calling `Tool::run_format` results into an error.
-    pub async fn format_file(&self, document: &TextDocument<'_>) -> Result<Vec<TextEdit>, String> {
+    pub async fn format_file(&self, document: &TextDocument) -> Result<Vec<TextEdit>, String> {
         let tool_guard = self.tool.read().await;
         let Some(tool) = tool_guard.as_ref() else {
             return Ok(Vec::new());
@@ -348,7 +348,7 @@ impl WorkspaceWorker {
             };
 
             for uri in file_system.keys() {
-                let document = file_system.get_document(&uri);
+                let document = file_system.get_document(uri);
                 let Ok(mut reports) = tool.run_diagnostic(&document) else {
                     // If diagnostics could not be run, skip this URI, but continue with others
                     // TODO: Should we aggregate errors instead? One by one, or all together?
@@ -735,7 +735,7 @@ mod tests {
         worker.start_worker(serde_json::Value::Null).await;
 
         let diagnostics_no_content = worker
-            .run_diagnostic(&TextDocument::new(&uri, LanguageId::default(), None))
+            .run_diagnostic(&TextDocument::new(uri.clone(), LanguageId::default(), None))
             .await
             .unwrap();
 
@@ -749,7 +749,7 @@ mod tests {
 
         let diagnostics_with_content = worker
             .run_diagnostic(&TextDocument::new(
-                &uri,
+                uri.clone(),
                 LanguageId::default(),
                 Some(Arc::from("helloworld")),
             ))
@@ -766,7 +766,7 @@ mod tests {
 
         let no_diagnostics = worker
             .run_diagnostic(&TextDocument::new(
-                &Uri::from_str("file:///root/unknown.file").unwrap(),
+                Uri::from_str("file:///root/unknown.file").unwrap(),
                 LanguageId::default(),
                 None,
             ))
@@ -777,7 +777,7 @@ mod tests {
 
         let error = worker
             .run_diagnostic(&TextDocument::new(
-                &Uri::from_str("file:///root/error.config").unwrap(),
+                Uri::from_str("file:///root/error.config").unwrap(),
                 LanguageId::default(),
                 None,
             ))
@@ -799,7 +799,7 @@ mod tests {
         worker.start_worker(serde_json::Value::Null).await;
 
         let diagnostics_no_content = worker
-            .run_diagnostic_on_change(&TextDocument::new(&uri, LanguageId::default(), None))
+            .run_diagnostic_on_change(&TextDocument::new(uri.clone(), LanguageId::default(), None))
             .await
             .unwrap();
 
@@ -813,7 +813,7 @@ mod tests {
 
         let diagnostics_with_content = worker
             .run_diagnostic_on_change(&TextDocument::new(
-                &uri,
+                uri.clone(),
                 LanguageId::default(),
                 Some(Arc::from("helloworld")),
             ))
@@ -830,7 +830,7 @@ mod tests {
 
         let no_diagnostics = worker
             .run_diagnostic_on_change(&TextDocument::new(
-                &Uri::from_str("file:///root/unknown.file").unwrap(),
+                Uri::from_str("file:///root/unknown.file").unwrap(),
                 LanguageId::default(),
                 None,
             ))
@@ -841,7 +841,7 @@ mod tests {
 
         let error = worker
             .run_diagnostic_on_change(&TextDocument::new(
-                &Uri::from_str("file:///root/error.config").unwrap(),
+                Uri::from_str("file:///root/error.config").unwrap(),
                 LanguageId::default(),
                 None,
             ))
@@ -862,7 +862,7 @@ mod tests {
         worker.start_worker(serde_json::Value::Null).await;
 
         let diagnostics_no_content = worker
-            .run_diagnostic_on_save(&TextDocument::new(&uri, LanguageId::default(), None))
+            .run_diagnostic_on_save(&TextDocument::new(uri.clone(), LanguageId::default(), None))
             .await
             .unwrap();
 
@@ -876,7 +876,7 @@ mod tests {
 
         let diagnostics_with_content = worker
             .run_diagnostic_on_save(&TextDocument::new(
-                &uri,
+                uri.clone(),
                 LanguageId::default(),
                 Some(Arc::from("helloworld")),
             ))
@@ -893,7 +893,7 @@ mod tests {
 
         let no_diagnostics = worker
             .run_diagnostic_on_save(&TextDocument::new(
-                &Uri::from_str("file:///root/unknown.file").unwrap(),
+                Uri::from_str("file:///root/unknown.file").unwrap(),
                 LanguageId::default(),
                 None,
             ))
@@ -904,7 +904,7 @@ mod tests {
 
         let error = worker
             .run_diagnostic_on_save(&TextDocument::new(
-                &Uri::from_str("file:///root/error.config").unwrap(),
+                Uri::from_str("file:///root/error.config").unwrap(),
                 LanguageId::default(),
                 None,
             ))

--- a/crates/oxc_language_server/src/worker_manager.rs
+++ b/crates/oxc_language_server/src/worker_manager.rs
@@ -16,32 +16,6 @@ use crate::{
     worker::WorkspaceWorker,
 };
 
-enum WorkerGuardInner<'a> {
-    Vec(RwLockReadGuard<'a, Vec<WorkspaceWorker>>),
-    Single(&'a WorkspaceWorker),
-}
-
-/// A RAII guard that holds a shared read lock over the workers list and exposes
-/// a reference to a single [`WorkspaceWorker`] inside it.
-///
-/// Obtained from [`WorkerManager::get_worker_for_uri`].
-/// The read lock is held for as long as this guard is alive.
-pub struct WorkerGuard<'a> {
-    guard: WorkerGuardInner<'a>,
-    index: usize,
-}
-
-impl std::ops::Deref for WorkerGuard<'_> {
-    type Target = WorkspaceWorker;
-
-    fn deref(&self) -> &Self::Target {
-        match &self.guard {
-            WorkerGuardInner::Vec(vec_guard) => &vec_guard[self.index],
-            WorkerGuardInner::Single(single_guard) => single_guard,
-        }
-    }
-}
-
 /// The mode that the [`WorkerManager`] is operating in, which determines how it manages workers and delegates the task to the tool.
 pub enum ManagerMode {
     // the manager works in 2 modes, when no workspaces are configured, it creates workers dynamically for file URIs.
@@ -53,7 +27,7 @@ pub enum ManagerMode {
     // The manager will create workers dynamically for file URIs. It also supports workspaces configured by the client, but does not require them.
     // This is useful for tasks on URIs that are outside of any configured workspace.
     // At first it is `None` until the diagnostic mode is known, then it is set to a worker with the root URI `file:///` and the same diagnostic mode as the other workers.
-    DynamicWithWorkspaces(Box<OnceCell<WorkspaceWorker>>),
+    DynamicWithWorkspaces(Box<OnceCell<Arc<WorkspaceWorker>>>),
 }
 
 /// Manages the lifecycle of [`WorkspaceWorker`]s for the language server.
@@ -68,10 +42,10 @@ pub enum ManagerMode {
 /// - Dynamically creating / tearing down workers in single-file mode.
 /// - Handling workspace-folder additions and removals atomically.
 ///
-/// **Workers are never cloned** – they are expensive and each root URI must
-/// have at most one live worker at any point in time.
+/// Workers are stored behind [`Arc`] so request handlers can move a cheap handle
+/// into background tasks while each root URI still has at most one live worker.
 pub struct WorkerManager {
-    workers: RwLock<Vec<WorkspaceWorker>>,
+    workers: RwLock<Vec<Arc<WorkspaceWorker>>>,
     mode: ManagerMode,
     tool_builder: Arc<dyn ToolBuilder>,
 }
@@ -104,7 +78,7 @@ impl WorkerManager {
         workers: Vec<WorkspaceWorker>,
         diagnostic_mode: DiagnosticMode,
     ) {
-        *self.workers.write().await = workers;
+        *self.workers.write().await = workers.into_iter().map(Arc::new).collect();
 
         // for dynamic workspaces we need to start them manually
         if let ManagerMode::DynamicWithWorkspaces(cell) = &self.mode {
@@ -113,11 +87,11 @@ impl WorkerManager {
                 "dynamic worker should not be set when starting the manager"
             );
 
-            let worker = WorkspaceWorker::new(
+            let worker = Arc::new(WorkspaceWorker::new(
                 "file:///".parse().unwrap(),
                 Arc::clone(&self.tool_builder),
                 diagnostic_mode,
-            );
+            ));
             worker.start_worker(serde_json::Value::Null).await;
 
             let _ = cell.set(worker);
@@ -155,14 +129,14 @@ impl WorkerManager {
 
     /// Acquire a shared read lock over the worker list.
     /// Does not include the dynamic worker in `DynamicWithWorkspaces` mode, which must be accessed by `read_dynamic_worker`.
-    pub async fn read_workspace_workers(&self) -> RwLockReadGuard<'_, Vec<WorkspaceWorker>> {
+    pub async fn read_workspace_workers(&self) -> RwLockReadGuard<'_, Vec<Arc<WorkspaceWorker>>> {
         self.workers.read().await
     }
 
     /// Return the dynamic worker from `DynamicWithWorkspaces` mode, if enabled.
-    pub fn read_dynamic_worker(&self) -> Option<&WorkspaceWorker> {
+    pub fn read_dynamic_worker(&self) -> Option<Arc<WorkspaceWorker>> {
         if let ManagerMode::DynamicWithWorkspaces(worker) = &self.mode {
-            return worker.get();
+            return worker.get().map(Arc::clone);
         }
         None
     }
@@ -188,7 +162,7 @@ impl WorkerManager {
 
     /// Append new workers to the list (used after `didChangeWorkspaceFolders`).
     pub async fn add_workers(&self, workers: Vec<WorkspaceWorker>) {
-        self.workers.write().await.extend(workers);
+        self.workers.write().await.extend(workers.into_iter().map(Arc::new));
     }
 
     /// Build a new [`WorkspaceWorker`] for the given root URI without starting
@@ -205,7 +179,7 @@ impl WorkerManager {
     /// For non-`file://` URIs the first worker (index `0`) is returned when
     /// the list is non-empty, mirroring the behaviour of rust-analyzer and
     /// typescript-language-server.
-    fn find_worker_index_for_uri(workers: &[WorkspaceWorker], uri: &Uri) -> Option<usize> {
+    fn find_worker_index_for_uri(workers: &[Arc<WorkspaceWorker>], uri: &Uri) -> Option<usize> {
         if uri.scheme().as_str() != "file" {
             return if workers.is_empty() { None } else { Some(0) };
         }
@@ -232,9 +206,9 @@ impl WorkerManager {
     // SAFETY: call this method only when you are sure, that we are not in `DynamicWithWorkspaces` mode,
     // or else it will return [`None`] for URIs that are outside of any workspace.
     fn find_worker_for_uri<'a>(
-        workers: &'a [WorkspaceWorker],
+        workers: &'a [Arc<WorkspaceWorker>],
         uri: &Uri,
-    ) -> Option<&'a WorkspaceWorker> {
+    ) -> Option<&'a Arc<WorkspaceWorker>> {
         let index = Self::find_worker_index_for_uri(workers, uri)?;
         Some(&workers[index])
     }
@@ -247,11 +221,11 @@ impl WorkerManager {
     /// For non-`file://` URIs the first worker in the list is returned,
     /// mirroring the behaviour of rust-analyzer and
     /// typescript-language-server.
-    pub async fn get_worker_for_uri(&self, uri: &Uri) -> Option<WorkerGuard<'_>> {
+    pub async fn get_worker_for_uri(&self, uri: &Uri) -> Option<Arc<WorkspaceWorker>> {
         {
             let guard = self.workers.read().await;
             if let Some(index) = Self::find_worker_index_for_uri(&guard, uri) {
-                return Some(WorkerGuard { guard: WorkerGuardInner::Vec(guard), index });
+                return Some(Arc::clone(&guard[index]));
             }
         }
 
@@ -264,7 +238,7 @@ impl WorkerManager {
                 return None;
             };
             // In DynamicWithWorkspaces mode, if no worker matches the URI, fallback to the dynamic worker.
-            return Some(WorkerGuard { guard: WorkerGuardInner::Single(worker), index: 0 });
+            return Some(Arc::clone(worker));
         }
 
         None
@@ -315,8 +289,8 @@ impl WorkerManager {
         &self,
         added: &[WorkspaceFolder],
         removed: &[WorkspaceFolder],
-    ) -> Vec<WorkspaceWorker> {
-        let mut workers_to_shutdown: Vec<WorkspaceWorker> = vec![];
+    ) -> Vec<Arc<WorkspaceWorker>> {
+        let mut workers_to_shutdown: Vec<Arc<WorkspaceWorker>> = vec![];
         let mut workers = self.workers.write().await;
 
         // Transition out of single-file mode when real workspace folders arrive.
@@ -390,9 +364,9 @@ impl WorkerManager {
             if self.is_single_file_mode() && Self::find_worker_for_uri(&workers, uri).is_none() {
                 #[expect(clippy::missing_panics_doc)]
                 // We wrapped the worker in `Some` to avoid moving it before acquiring the lock, so it should always be `Some` here.
-                workers.push(worker.take().expect(
+                workers.push(Arc::new(worker.take().expect(
                     "freshly created worker should be available when storing it in the list",
-                ));
+                )));
             }
         }
 


### PR DESCRIPTION
🚧 **Draft — stacked on #23768 and #23797 (@Sysix). Please don't merge until those land.**

The first 4 commits are @Sysix's (included so the branch builds; GitHub shows them under his name). Only the last commit is mine. Once the stack lands I'll rebase onto `main` so this is a single commit, and un-draft.

## Idea
After #23768 diagnostics run off-thread, so requests can overlap. From what I can see, a single save then triggers two full type-aware lints for the same `(uri, version)` — the server's on-save lint and the editor's Fix-All pull — which run at the same time and compete for CPU. In my testing on a large monorepo (IntelliJ, type-aware on), collapsing them into one run took roughly 25% off the Fix-All time on a big file.

## What it does
A small per-worker registry of in-flight runs, keyed by URI. Requests for the same `(uri, version)` await one shared future instead of starting a second identical lint. Each run has a unique id and an RAII guard removes its entry on completion, cancellation, or panic (keyed by id, so a finishing run never deletes a newer entry that reused the same version). The `onType`/`onSave` gating moves to `Tool` predicates checked before this path, so the shared future always runs the full `run_diagnostic`. Passes `cargo fmt` and `clippy` (pedantic). A follow-up could add cancelling the older run when a newer version arrives.

IDE-side counterpart: oxc-project/oxc-intellij-plugin#542. Refs oxc-project/oxc-intellij-plugin#366.

Builds directly on your work, @Sysix — if you'd rather fold it into your stack yourself, that's completely fine by me.
