### PR TITLE
fix(linter/eslint/no-throw-literal): handle assigned errors

### DIFF
--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -575,12 +575,38 @@ fn could_be_error_impl(
             let decl = ctx.nodes().get_node(ctx.scoping().symbol_declaration(symbol_id));
             match decl.kind() {
                 AstKind::VariableDeclarator(decl) => {
-                    if let Some(init) = &decl.init {
-                        could_be_error_impl(ctx, init, visited)
-                    } else {
-                        // TODO: warn about throwing undefined
-                        false
+                    if decl
+                        .init
+                        .as_ref()
+                        .is_some_and(|init| could_be_error_impl(ctx, init, visited))
+                    {
+                        return true;
                     }
+
+                    ctx.scoping().get_resolved_references(symbol_id).any(|reference| {
+                        if !reference.is_write() {
+                            return false;
+                        }
+
+                        let reference_node = ctx.nodes().get_node(reference.node_id());
+                        if reference_node.span().end > ident.span.start {
+                            return false;
+                        }
+
+                        let AstKind::AssignmentExpression(assignment) =
+                            ctx.nodes().parent_kind(reference.node_id())
+                        else {
+                            return false;
+                        };
+
+                        assignment.operator == AssignmentOperator::Assign
+                            && matches!(
+                                &assignment.left,
+                                AssignmentTarget::AssignmentTargetIdentifier(target)
+                                    if target.span == reference_node.span()
+                            )
+                            && could_be_error_impl(ctx, &assignment.right, visited)
+                    })
                 }
                 AstKind::Function(_)
                 | AstKind::Class(_)

--- a/crates/oxc_linter/src/rules/eslint/no_throw_literal.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_throw_literal.rs
@@ -139,6 +139,7 @@ fn test() {
         "throw obj?.foo() satisfies Direction",
         // local reference resolution
         "const err = new Error(); throw err;",
+        "let err: Error | null = null; err = new Error('My error'); throw err;",
         "function main(x) { throw x; }", // cannot determine type of x
         "function main(x: any) { throw x; }",
         "function main(x: TypeError) { throw x; }",
@@ -169,6 +170,7 @@ fn test() {
         "throw 'error' satisfies Error",
         // local reference resolution
         "let foo = 'foo'; throw foo;",
+        "let err: Error | null = null; throw err; err = new Error('My error');",
         "let foo = 'foo' as unknown as Error; throw foo;",
         "function foo() {}; throw foo;",
         "const foo = () => {}; throw foo;",

--- a/crates/oxc_linter/src/snapshots/eslint_no_throw_literal.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_throw_literal.snap
@@ -157,6 +157,13 @@ source: crates/oxc_linter/src/tester.rs
   help: Throwing literals or non-Error objects is not recommended. Use an Error object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
+   ╭─[no_throw_literal.tsx:1:37]
+ 1 │ let err: Error | null = null; throw err; err = new Error('My error');
+   ·                                     ───
+   ╰────
+  help: Throwing literals or non-Error objects is not recommended. Use an Error object instead.
+
+  ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:44]
  1 │ let foo = 'foo' as unknown as Error; throw foo;
    ·                                            ───


### PR DESCRIPTION
The Oxlint implementation of `no-throw-literal` detects a lint violation when a thrown variable was initialized with a non-error value and assigned an Error before being thrown. This is because `could_be_error` only inspected initialization and not later assignment. The fix adds additional checks for direct = writes to that symbol occurring before the throw.

```ts
let err: Error | null = null;
err = new Error('My error');
throw err; // this gets flagged as not an Error
```

## Playground examples

- [eslint](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tdGhyb3ctbGl0ZXJhbDogXCJlcnJvclwiKi9cbmxldCBlcnI6IEVycm9yIHwgbnVsbCA9IG51bGw7XG5lcnIgPSBuZXcgRXJyb3IoJ015IGVycm9yJyk7XG50aHJvdyBlcnI7Iiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319LCJwYXJzZXIiOiJAdHlwZXNjcmlwdC1lc2xpbnQvcGFyc2VyIn19fQ==)
- [oxlint](https://playground.oxc.rs/?lintRules=eslint%2Fno-throw-literal&options=%7B%22run%22%3A%7B%22lint%22%3Atrue%2C%22formatter%22%3Afalse%2C%22transform%22%3Afalse%2C%22isolatedDeclarations%22%3Afalse%2C%22whitespace%22%3Afalse%2C%22mangle%22%3Afalse%2C%22compress%22%3Afalse%2C%22scope%22%3Atrue%2C%22symbol%22%3Atrue%2C%22cfg%22%3Afalse%7D%2C%22parser%22%3A%7B%22extension%22%3A%22tsx%22%2C%22allowReturnOutsideFunction%22%3Atrue%2C%22preserveParens%22%3Atrue%2C%22allowV8Intrinsics%22%3Atrue%2C%22semanticErrors%22%3Atrue%7D%2C%22linter%22%3A%7B%7D%2C%22formatter%22%3A%7B%22useTabs%22%3Afalse%2C%22tabWidth%22%3A2%2C%22endOfLine%22%3A%22lf%22%2C%22printWidth%22%3A80%2C%22singleQuote%22%3Afalse%2C%22jsxSingleQuote%22%3Afalse%2C%22quoteProps%22%3A%22as-needed%22%2C%22trailingComma%22%3A%22all%22%2C%22semi%22%3Atrue%2C%22arrowParens%22%3A%22always%22%2C%22bracketSpacing%22%3Atrue%2C%22bracketSameLine%22%3Afalse%2C%22objectWrap%22%3A%22preserve%22%2C%22singleAttributePerLine%22%3Afalse%7D%2C%22transformer%22%3A%7B%22target%22%3A%22es2015%22%2C%22useDefineForClassFields%22%3Atrue%2C%22experimentalDecorators%22%3Atrue%2C%22emitDecoratorMetadata%22%3Atrue%2C%22optimizeEnums%22%3Atrue%2C%22optimizeConstEnums%22%3Atrue%7D%2C%22isolatedDeclarations%22%3A%7B%22stripInternal%22%3Afalse%7D%2C%22codegen%22%3A%7B%22normal%22%3Atrue%2C%22jsdoc%22%3Atrue%2C%22annotation%22%3Atrue%2C%22legal%22%3Atrue%7D%2C%22compress%22%3A%7B%7D%2C%22mangle%22%3A%7B%22topLevel%22%3Atrue%2C%22keepNames%22%3Afalse%7D%2C%22controlFlow%22%3A%7B%22verbose%22%3Afalse%7D%2C%22inject%22%3A%7B%22inject%22%3A%7B%7D%7D%2C%22define%22%3A%7B%22define%22%3A%7B%7D%7D%7D&code=let+err%3A+Error+%7C+null+%3D+null%3B%0Aerr+%3D+new+Error%28%27My+error%27%29%3B%0Athrow+err%3B)