### PR TITLE
perf(semantic, allocator): branchless `clone_in` for semantic IDs

### DIFF
--- a/crates/oxc_allocator/src/bitset.rs
+++ b/crates/oxc_allocator/src/bitset.rs
@@ -6,7 +6,7 @@ use std::{
     slice,
 };
 
-use crate::{Allocator, Box, CloneIn};
+use crate::{Allocator, Box, CloneIn, CloneInSemanticIds};
 
 const USIZE_BITS: usize = usize::BITS as usize;
 
@@ -177,7 +177,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BitSet<'_> {
 
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> BitSet<'new_alloc> {
         let slice = self.entries.as_ref();

--- a/crates/oxc_allocator/src/clone_in.rs
+++ b/crates/oxc_allocator/src/clone_in.rs
@@ -8,20 +8,36 @@ use std::{
 
 use crate::{Allocator, Box, HashMap, Vec};
 
+/// Option to pass to [`CloneIn::clone_in_impl`] to determine how to clone semantic IDs.
+///
+/// * [`CloneInSemanticIds::With`] to clone by copying current value.
+/// * [`CloneInSemanticIds::Without`] to clone by substituting a dummy value -
+///   `NonMaxU32(0)` for a plain ID, `None` for an optional ID.
+///
+/// This is designed so that cloning semantic IDs is branchless and cheap.
+/// See `SemanticId` trait in `oxc_syntax` crate.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum CloneInSemanticIds {
+    With = 0,
+    Without = u32::MAX,
+}
+
 /// A trait to explicitly clone an object into an arena allocator.
 ///
 /// As a convention `Cloned` associated type should always be the same as `Self`,
 /// It'd only differ in the lifetime, Here's an example:
 ///
 /// ```
-/// # use oxc_allocator::{Allocator, CloneIn, Vec};
+/// # use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds, Vec};
 /// # struct Struct<'a> {a: Vec<'a, u8>, b: u8}
 ///
 /// impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Struct<'old_alloc> {
 ///     type Cloned = Struct<'new_alloc>;
+///
 ///     fn clone_in_impl(
 ///         &self,
-///         with_semantic_ids: bool,
+///         with_semantic_ids: CloneInSemanticIds,
 ///         allocator: &'new_alloc Allocator,
 ///     ) -> Self::Cloned {
 ///         Struct {
@@ -32,9 +48,8 @@ use crate::{Allocator, Box, HashMap, Vec};
 /// }
 /// ```
 ///
-/// Implementations of this trait on non-allocated items usually short-circuit to `Clone::clone`;
+/// Implementations of this trait on non-allocated items usually delegate to `Clone::clone`.
 /// However, it **isn't** guaranteed.
-///
 pub trait CloneIn<'new_alloc>: Sized {
     /// The type of the cloned object.
     ///
@@ -47,7 +62,7 @@ pub trait CloneIn<'new_alloc>: Sized {
     #[expect(clippy::inline_always)]
     #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        self.clone_in_impl(false, allocator)
+        self.clone_in_impl(CloneInSemanticIds::Without, allocator)
     }
 
     /// Almost identical as `clone_in`, but for some special type, it will also clone the semantic ids.
@@ -56,25 +71,28 @@ pub trait CloneIn<'new_alloc>: Sized {
     #[expect(clippy::inline_always)]
     #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        self.clone_in_impl(true, allocator)
+        self.clone_in_impl(CloneInSemanticIds::With, allocator)
     }
 
     /// Clone `self` into `allocator`, threading whether semantic ids should be preserved as a
-    /// runtime `with_semantic_ids` flag rather than as two separate methods. This is the method
-    /// that implementors provide; `clone_in` and `clone_in_with_semantic_ids` are thin wrappers
-    /// around it.
+    /// runtime `with_semantic_ids` flag rather than as two separate methods.
     ///
-    /// It exists so the `CloneIn` derive can emit a *single* recursive traversal that serves both
-    /// `clone_in` (`with_semantic_ids == false`) and `clone_in_with_semantic_ids`
-    /// (`with_semantic_ids == true`), instead of monomorphizing two near-identical traversals over
-    /// the whole AST. Id fields recurse when `with_semantic_ids` is `true` and reset to their
-    /// default when it is `false`.
+    /// This is the method that implementors provide.
+    /// `clone_in` and `clone_in_with_semantic_ids` are thin wrappers around it.
     ///
-    /// Prefer calling `clone_in` or `clone_in_with_semantic_ids` at call sites — they name the
-    /// intent and delegate here.
+    /// It exists so the `CloneIn` derive can emit a *single* recursive traversal that serves both:
+    /// * `clone_in`: `with_semantic_ids == CloneInSemanticIds::Without`
+    /// * `clone_in_with_semantic_ids`: `with_semantic_ids == CloneInSemanticIds::With`
+    ///
+    /// This is instead of monomorphizing two near-identical traversals over the whole AST.
+    /// ID fields copy existing values when `with_semantic_ids == CloneInSemanticIds::With`,
+    /// and reset to their default when `CloneInSemanticIds::Without`.
+    ///
+    /// Prefer calling `clone_in` or `clone_in_with_semantic_ids` at call sites —
+    /// they name the intent and delegate here.
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned;
 }
@@ -86,7 +104,11 @@ where
     type Cloned = Option<C>;
 
     #[inline]
-    fn clone_in_impl(&self, with_semantic_ids: bool, allocator: &'alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: CloneInSemanticIds,
+        allocator: &'alloc Allocator,
+    ) -> Self::Cloned {
         self.as_ref().map(|it| it.clone_in_impl(with_semantic_ids, allocator))
     }
 }
@@ -100,7 +122,7 @@ where
     #[inline]
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Box::new_in(self.as_ref().clone_in_impl(with_semantic_ids, allocator), &allocator)
@@ -115,7 +137,7 @@ where
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         let slice = self.as_ref();
@@ -165,7 +187,7 @@ where
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         // The implementation below is equivalent to:
@@ -206,7 +228,7 @@ where
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         // Keys in original hash map are guaranteed to be unique.
@@ -227,21 +249,19 @@ where
     }
 }
 
-impl<'alloc, T: Copy + Default> CloneIn<'alloc> for Cell<T> {
-    type Cloned = Cell<T>;
+impl<'alloc, T, C> CloneIn<'alloc> for Cell<T>
+where
+    T: Copy + CloneIn<'alloc, Cloned = C>,
+{
+    type Cloned = Cell<C>;
 
-    // `#[inline(never)]` so the `with_semantic_ids` branch below is *not* inlined at every id-field
-    // clone site. Consumers that only clone *without* semantic ids (e.g. the napi transform/parse
-    // bindings, via `oxc_transformer`) would otherwise carry the dead preserve branch at every site
-    // — ~16 KiB on the transform binary. Outlining it to one function per `Cell<T>` keeps those
-    // binaries at their pre-`clone_in_impl` size, while consumers that clone *with* ids (rolldown,
-    // oxlint's react compiler) are unaffected — their win comes from the shared traversal, not this leaf.
-    #[inline(never)]
-    fn clone_in_impl(&self, with_semantic_ids: bool, _: &'alloc Allocator) -> Self::Cloned {
-        // `Cell` in the AST only ever holds semantic ids (`Cell<NodeId>`, `Cell<Option<ScopeId>>`,
-        // etc.). Preserve them when cloning *with* semantic ids, otherwise reset to the default
-        // (`NodeId::DUMMY`, `None`, ...) so ids aren't carried into a fresh clone.
-        if with_semantic_ids { Cell::new(self.get()) } else { Cell::new(T::default()) }
+    #[inline]
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: CloneInSemanticIds,
+        allocator: &'alloc Allocator,
+    ) -> Self::Cloned {
+        Cell::new(self.get().clone_in_impl(with_semantic_ids, allocator))
     }
 }
 
@@ -250,7 +270,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for &str {
 
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         allocator.alloc_str(self)
@@ -263,7 +283,7 @@ macro_rules! impl_clone_in {
             impl<'alloc> CloneIn<'alloc> for $t {
                 type Cloned = Self;
                 #[inline(always)]
-                fn clone_in_impl(&self, _with_semantic_ids: bool, _: &'alloc Allocator) -> Self {
+                fn clone_in_impl(&self, _with_semantic_ids: CloneInSemanticIds, _: &'alloc Allocator) -> Self {
                     *self
                 }
             }

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -75,7 +75,7 @@ pub use allocator::Allocator;
 #[cfg(feature = "bitset")]
 pub use bitset::BitSet;
 pub use boxed::{Box, Box as ArenaBox};
-pub use clone_in::CloneIn;
+pub use clone_in::{CloneIn, CloneInSemanticIds};
 pub use convert::{FromIn, IntoIn};
 pub use hash_map::{HashMap, HashMap as ArenaHashMap};
 pub use hash_set::{HashSet, HashSet as ArenaHashSet};

--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -1,6 +1,6 @@
 use bitflags::bitflags;
 
-use oxc_allocator::{Allocator, CloneIn};
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_span::{ContentEq, Span};
@@ -126,7 +126,11 @@ impl ContentEq for CommentNewlines {
 impl<'alloc> CloneIn<'alloc> for CommentNewlines {
     type Cloned = Self;
 
-    fn clone_in_impl(&self, _with_semantic_ids: bool, _: &'alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: CloneInSemanticIds,
+        _: &'alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -5,7 +5,7 @@ use std::{
     fmt::{self, Display},
 };
 
-use oxc_allocator::{Allocator, CloneIn, Dummy};
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds, Dummy};
 use oxc_data_structures::inline_string::InlineString;
 use oxc_span::ContentEq;
 
@@ -172,7 +172,11 @@ impl ContentEq for RegExpFlags {
 impl<'alloc> CloneIn<'alloc> for RegExpFlags {
     type Cloned = Self;
 
-    fn clone_in_impl(&self, _with_semantic_ids: bool, _: &'alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: CloneInSemanticIds,
+        _: &'alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -5,7 +5,7 @@
 
 use std::cell::Cell;
 
-use oxc_allocator::{Allocator, CloneIn};
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds};
 
 use crate::ast::comment::*;
 use crate::ast::js::*;
@@ -18,7 +18,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Program<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Program {
@@ -30,7 +30,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for Program<'_> {
             hashbang: CloneIn::clone_in_impl(&self.hashbang, with_semantic_ids, allocator),
             directives: CloneIn::clone_in_impl(&self.directives, with_semantic_ids, allocator),
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -40,7 +43,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Expression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -213,7 +216,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for IdentifierName<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         IdentifierName {
@@ -229,14 +232,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for IdentifierReference<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         IdentifierReference {
             node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
             span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
             name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
-            reference_id: CloneIn::clone_in_impl(&self.reference_id, with_semantic_ids, allocator),
+            reference_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.reference_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -246,14 +252,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingIdentifier<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         BindingIdentifier {
             node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
             span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
             name: CloneIn::clone_in_impl(&self.name, with_semantic_ids, allocator),
-            symbol_id: CloneIn::clone_in_impl(&self.symbol_id, with_semantic_ids, allocator),
+            symbol_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.symbol_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -263,7 +272,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for LabelIdentifier<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         LabelIdentifier {
@@ -279,7 +288,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ThisExpression {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ThisExpression {
@@ -294,7 +303,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ArrayExpression {
@@ -310,7 +319,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayExpressionElement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -377,7 +386,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Elision {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Elision {
@@ -392,7 +401,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ObjectExpression {
@@ -408,7 +417,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectPropertyKind<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -431,7 +440,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectProperty<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ObjectProperty {
@@ -452,7 +461,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PropertyKey<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -524,7 +533,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PropertyKind {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -536,7 +545,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TemplateLiteral<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TemplateLiteral {
@@ -553,7 +562,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TaggedTemplateExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TaggedTemplateExpression {
@@ -575,7 +584,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TemplateElement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TemplateElement {
@@ -597,7 +606,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TemplateElementValue<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TemplateElementValue {
@@ -612,7 +621,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for MemberExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -634,7 +643,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ComputedMemberExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ComputedMemberExpression {
@@ -652,7 +661,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for StaticMemberExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         StaticMemberExpression {
@@ -670,7 +679,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PrivateFieldExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         PrivateFieldExpression {
@@ -688,7 +697,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CallExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         CallExpression {
@@ -712,7 +721,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for NewExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         NewExpression {
@@ -735,7 +744,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportMeta {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ImportMeta {
@@ -750,7 +759,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for NewTarget {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         NewTarget {
@@ -765,7 +774,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for SpreadElement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         SpreadElement {
@@ -781,7 +790,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Argument<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -845,7 +854,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for UpdateExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         UpdateExpression {
@@ -863,7 +872,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for UnaryExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         UnaryExpression {
@@ -880,7 +889,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BinaryExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         BinaryExpression {
@@ -898,7 +907,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PrivateInExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         PrivateInExpression {
@@ -915,7 +924,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for LogicalExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         LogicalExpression {
@@ -933,7 +942,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ConditionalExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ConditionalExpression {
@@ -951,7 +960,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         AssignmentExpression {
@@ -969,7 +978,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTarget<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -1001,7 +1010,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for SimpleAssignmentTarget<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -1038,7 +1047,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPattern<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -1057,7 +1066,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayAssignmentTarget<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ArrayAssignmentTarget {
@@ -1074,7 +1083,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectAssignmentTarget<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ObjectAssignmentTarget {
@@ -1091,7 +1100,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetRest<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         AssignmentTargetRest {
@@ -1107,7 +1116,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetMaybeDefault<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -1139,7 +1148,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetWithDefault<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         AssignmentTargetWithDefault {
@@ -1156,7 +1165,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetProperty<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -1181,7 +1190,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPropertyIdentifier<'_> 
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         AssignmentTargetPropertyIdentifier {
@@ -1198,7 +1207,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentTargetPropertyProperty<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         AssignmentTargetPropertyProperty {
@@ -1216,7 +1225,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for SequenceExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         SequenceExpression {
@@ -1232,7 +1241,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Super {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Super {
@@ -1247,7 +1256,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AwaitExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         AwaitExpression {
@@ -1263,7 +1272,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ChainExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ChainExpression {
@@ -1279,7 +1288,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ChainElement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -1307,7 +1316,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ParenthesizedExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ParenthesizedExpression {
@@ -1323,7 +1332,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Statement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -1421,7 +1430,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Directive<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Directive {
@@ -1438,7 +1447,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Hashbang<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Hashbang {
@@ -1454,14 +1463,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for BlockStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         BlockStatement {
             node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
             span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -1471,7 +1483,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Declaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -1515,7 +1527,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         VariableDeclaration {
@@ -1534,7 +1546,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclarationKind {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -1546,7 +1558,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclarator<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         VariableDeclarator {
@@ -1570,7 +1582,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for EmptyStatement {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         EmptyStatement {
@@ -1585,7 +1597,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExpressionStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ExpressionStatement {
@@ -1601,7 +1613,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for IfStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         IfStatement {
@@ -1619,7 +1631,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for DoWhileStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         DoWhileStatement {
@@ -1636,7 +1648,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for WhileStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         WhileStatement {
@@ -1653,7 +1665,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ForStatement {
@@ -1663,7 +1675,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForStatement<'_> {
             test: CloneIn::clone_in_impl(&self.test, with_semantic_ids, allocator),
             update: CloneIn::clone_in_impl(&self.update, with_semantic_ids, allocator),
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -1673,7 +1688,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForStatementInit<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -1737,7 +1752,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForInStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ForInStatement {
@@ -1746,7 +1761,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForInStatement<'_> {
             left: CloneIn::clone_in_impl(&self.left, with_semantic_ids, allocator),
             right: CloneIn::clone_in_impl(&self.right, with_semantic_ids, allocator),
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -1756,7 +1774,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForStatementLeft<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -1786,7 +1804,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForOfStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ForOfStatement {
@@ -1796,7 +1814,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for ForOfStatement<'_> {
             left: CloneIn::clone_in_impl(&self.left, with_semantic_ids, allocator),
             right: CloneIn::clone_in_impl(&self.right, with_semantic_ids, allocator),
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -1806,7 +1827,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ContinueStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ContinueStatement {
@@ -1822,7 +1843,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BreakStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         BreakStatement {
@@ -1838,7 +1859,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ReturnStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ReturnStatement {
@@ -1854,7 +1875,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for WithStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         WithStatement {
@@ -1862,7 +1883,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for WithStatement<'_> {
             span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
             object: CloneIn::clone_in_impl(&self.object, with_semantic_ids, allocator),
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -1872,7 +1896,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for SwitchStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         SwitchStatement {
@@ -1880,7 +1904,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for SwitchStatement<'_> {
             span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
             discriminant: CloneIn::clone_in_impl(&self.discriminant, with_semantic_ids, allocator),
             cases: CloneIn::clone_in_impl(&self.cases, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -1890,7 +1917,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for SwitchCase<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         SwitchCase {
@@ -1907,7 +1934,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for LabeledStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         LabeledStatement {
@@ -1924,7 +1951,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ThrowStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ThrowStatement {
@@ -1940,7 +1967,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TryStatement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TryStatement {
@@ -1958,7 +1985,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CatchClause<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         CatchClause {
@@ -1966,7 +1993,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for CatchClause<'_> {
             span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
             param: CloneIn::clone_in_impl(&self.param, with_semantic_ids, allocator),
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -1976,7 +2006,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CatchParameter<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         CatchParameter {
@@ -1997,7 +2027,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for DebuggerStatement {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         DebuggerStatement {
@@ -2012,7 +2042,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingPattern<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -2041,7 +2071,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentPattern<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         AssignmentPattern {
@@ -2058,7 +2088,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectPattern<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ObjectPattern {
@@ -2075,7 +2105,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingProperty<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         BindingProperty {
@@ -2094,7 +2124,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayPattern<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ArrayPattern {
@@ -2111,7 +2141,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BindingRestElement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         BindingRestElement {
@@ -2127,7 +2157,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Function<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Function {
@@ -2147,7 +2177,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for Function<'_> {
             params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
             return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
             pure: CloneIn::clone_in_impl(&self.pure, with_semantic_ids, allocator),
             pife: CloneIn::clone_in_impl(&self.pife, with_semantic_ids, allocator),
         }
@@ -2160,7 +2193,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FunctionType {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -2172,7 +2205,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameters<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         FormalParameters {
@@ -2190,7 +2223,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameter<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         FormalParameter {
@@ -2222,7 +2255,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameterKind {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -2234,7 +2267,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameterRest<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         FormalParameterRest {
@@ -2256,7 +2289,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for FunctionBody<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         FunctionBody {
@@ -2273,7 +2306,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrowFunctionExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ArrowFunctionExpression {
@@ -2289,7 +2322,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrowFunctionExpression<'_> {
             params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
             return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
             pure: CloneIn::clone_in_impl(&self.pure, with_semantic_ids, allocator),
             pife: CloneIn::clone_in_impl(&self.pife, with_semantic_ids, allocator),
         }
@@ -2301,7 +2337,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for YieldExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         YieldExpression {
@@ -2318,7 +2354,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Class<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Class {
@@ -2342,7 +2378,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for Class<'_> {
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
             r#abstract: CloneIn::clone_in_impl(&self.r#abstract, with_semantic_ids, allocator),
             declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -2353,7 +2392,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ClassType {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -2365,7 +2404,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ClassBody<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ClassBody {
@@ -2381,7 +2420,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ClassElement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -2415,7 +2454,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinition<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         MethodDefinition {
@@ -2445,7 +2484,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinitionType {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -2457,7 +2496,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PropertyDefinition<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         PropertyDefinition {
@@ -2494,7 +2533,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PropertyDefinitionType {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -2507,7 +2546,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinitionKind {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -2519,7 +2558,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for PrivateIdentifier<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         PrivateIdentifier {
@@ -2535,14 +2574,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for StaticBlock<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         StaticBlock {
             node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
             span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -2552,7 +2594,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ModuleDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -2588,7 +2630,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AccessorPropertyType {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -2600,7 +2642,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AccessorProperty<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         AccessorProperty {
@@ -2633,7 +2675,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ImportExpression {
@@ -2651,7 +2693,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ImportDeclaration {
@@ -2672,7 +2714,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportPhase {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -2684,7 +2726,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportDeclarationSpecifier<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -2710,7 +2752,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportSpecifier<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ImportSpecifier {
@@ -2728,7 +2770,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportDefaultSpecifier<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ImportDefaultSpecifier {
@@ -2744,7 +2786,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportNamespaceSpecifier<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ImportNamespaceSpecifier {
@@ -2760,7 +2802,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for WithClause<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         WithClause {
@@ -2778,7 +2820,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for WithClauseKeyword {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -2790,7 +2832,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportAttribute<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ImportAttribute {
@@ -2807,7 +2849,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportAttributeKey<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -2830,7 +2872,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportNamedDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ExportNamedDeclaration {
@@ -2850,7 +2892,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ExportDefaultDeclaration {
@@ -2866,7 +2908,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportAllDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ExportAllDeclaration {
@@ -2885,7 +2927,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportSpecifier<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ExportSpecifier {
@@ -2903,7 +2945,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclarationKind<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -2975,7 +3017,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ModuleExportName<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -3001,7 +3043,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for V8IntrinsicExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         V8IntrinsicExpression {
@@ -3018,7 +3060,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BooleanLiteral {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         BooleanLiteral {
@@ -3034,7 +3076,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for NullLiteral {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         NullLiteral {
@@ -3049,7 +3091,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for NumericLiteral<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         NumericLiteral {
@@ -3067,7 +3109,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for StringLiteral<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         StringLiteral {
@@ -3089,7 +3131,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BigIntLiteral<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         BigIntLiteral {
@@ -3107,7 +3149,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for RegExpLiteral<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         RegExpLiteral {
@@ -3124,7 +3166,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for RegExp<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         RegExp {
@@ -3139,7 +3181,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for RegExpPattern<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         RegExpPattern {
@@ -3154,7 +3196,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXElement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXElement {
@@ -3180,7 +3222,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXOpeningElement {
@@ -3202,7 +3244,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXClosingElement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXClosingElement {
@@ -3218,7 +3260,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXFragment<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXFragment {
@@ -3244,7 +3286,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningFragment {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXOpeningFragment {
@@ -3259,7 +3301,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXClosingFragment {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXClosingFragment {
@@ -3274,7 +3316,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXElementName<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -3308,7 +3350,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXNamespacedName<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXNamespacedName {
@@ -3325,7 +3367,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXMemberExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXMemberExpression {
@@ -3342,7 +3384,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXMemberExpressionObject<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -3364,7 +3406,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXExpressionContainer<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXExpressionContainer {
@@ -3380,7 +3422,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -3446,7 +3488,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXEmptyExpression {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXEmptyExpression {
@@ -3461,7 +3503,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeItem<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -3484,7 +3526,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXAttribute<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXAttribute {
@@ -3501,7 +3543,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadAttribute<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXSpreadAttribute {
@@ -3517,7 +3559,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeName<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -3540,7 +3582,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeValue<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -3569,7 +3611,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXIdentifier<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXIdentifier {
@@ -3585,7 +3627,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXChild<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -3615,7 +3657,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadChild<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXSpreadChild {
@@ -3631,7 +3673,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXText<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSXText {
@@ -3648,7 +3690,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSThisParameter<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSThisParameter {
@@ -3669,7 +3711,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSEnumDeclaration {
@@ -3688,14 +3730,17 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumBody<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSEnumBody {
             node_id: CloneIn::clone_in_impl(&self.node_id, with_semantic_ids, allocator),
             span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
             members: CloneIn::clone_in_impl(&self.members, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -3705,7 +3750,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumMember<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSEnumMember {
@@ -3722,7 +3767,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSEnumMemberName<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -3751,7 +3796,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAnnotation<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSTypeAnnotation {
@@ -3771,7 +3816,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSLiteralType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSLiteralType {
@@ -3787,7 +3832,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSLiteral<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -3818,7 +3863,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -3948,7 +3993,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConditionalType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSConditionalType {
@@ -3958,7 +4003,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConditionalType<'_> {
             extends_type: CloneIn::clone_in_impl(&self.extends_type, with_semantic_ids, allocator),
             true_type: CloneIn::clone_in_impl(&self.true_type, with_semantic_ids, allocator),
             false_type: CloneIn::clone_in_impl(&self.false_type, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -3968,7 +4016,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSUnionType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSUnionType {
@@ -3984,7 +4032,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIntersectionType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSIntersectionType {
@@ -4000,7 +4048,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSParenthesizedType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSParenthesizedType {
@@ -4020,7 +4068,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeOperator<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSTypeOperator {
@@ -4042,7 +4090,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeOperatorOperator {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -4054,7 +4102,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSArrayType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSArrayType {
@@ -4070,7 +4118,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIndexedAccessType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSIndexedAccessType {
@@ -4087,7 +4135,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTupleType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSTupleType {
@@ -4107,7 +4155,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNamedTupleMember<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSNamedTupleMember {
@@ -4125,7 +4173,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSOptionalType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSOptionalType {
@@ -4145,7 +4193,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSRestType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSRestType {
@@ -4165,7 +4213,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTupleElement<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -4227,7 +4275,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSAnyKeyword {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSAnyKeyword {
@@ -4242,7 +4290,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSStringKeyword {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSStringKeyword {
@@ -4257,7 +4305,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSBooleanKeyword {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSBooleanKeyword {
@@ -4272,7 +4320,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNumberKeyword {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSNumberKeyword {
@@ -4287,7 +4335,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNeverKeyword {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSNeverKeyword {
@@ -4302,7 +4350,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIntrinsicKeyword {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSIntrinsicKeyword {
@@ -4317,7 +4365,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSUnknownKeyword {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSUnknownKeyword {
@@ -4332,7 +4380,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNullKeyword {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSNullKeyword {
@@ -4347,7 +4395,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSUndefinedKeyword {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSUndefinedKeyword {
@@ -4362,7 +4410,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSVoidKeyword {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSVoidKeyword {
@@ -4377,7 +4425,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSSymbolKeyword {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSSymbolKeyword {
@@ -4392,7 +4440,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSThisType {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSThisType {
@@ -4407,7 +4455,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSObjectKeyword {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSObjectKeyword {
@@ -4422,7 +4470,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSBigIntKeyword {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSBigIntKeyword {
@@ -4437,7 +4485,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeReference<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSTypeReference {
@@ -4458,7 +4506,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeName<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -4480,7 +4528,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSQualifiedName<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSQualifiedName {
@@ -4497,7 +4545,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameterInstantiation<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSTypeParameterInstantiation {
@@ -4513,7 +4561,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameter<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSTypeParameter {
@@ -4534,7 +4582,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeParameterDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSTypeParameterDeclaration {
@@ -4550,7 +4598,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAliasDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSTypeAliasDeclaration {
@@ -4568,7 +4616,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAliasDeclaration<'_> {
                 allocator,
             ),
             declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -4579,7 +4630,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSAccessibility {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -4591,7 +4642,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSClassImplements<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSClassImplements {
@@ -4612,7 +4663,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSInterfaceDeclaration {
@@ -4627,7 +4678,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceDeclaration<'_> {
             extends: CloneIn::clone_in_impl(&self.extends, with_semantic_ids, allocator),
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
             declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -4637,7 +4691,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceBody<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSInterfaceBody {
@@ -4653,7 +4707,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSPropertySignature<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSPropertySignature {
@@ -4677,7 +4731,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSSignature<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -4713,7 +4767,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIndexSignature<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSIndexSignature {
@@ -4736,7 +4790,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSCallSignatureDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSCallSignatureDeclaration {
@@ -4750,7 +4804,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSCallSignatureDeclaration<'_> {
             this_param: CloneIn::clone_in_impl(&self.this_param, with_semantic_ids, allocator),
             params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
             return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -4761,7 +4818,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMethodSignatureKind {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -4773,7 +4830,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMethodSignature<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSMethodSignature {
@@ -4791,7 +4848,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMethodSignature<'_> {
             this_param: CloneIn::clone_in_impl(&self.this_param, with_semantic_ids, allocator),
             params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
             return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -4801,7 +4861,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConstructSignatureDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSConstructSignatureDeclaration {
@@ -4814,7 +4874,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConstructSignatureDeclaration<'_> {
             ),
             params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
             return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -4824,7 +4887,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSIndexSignatureName<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSIndexSignatureName {
@@ -4845,7 +4908,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceHeritage<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSInterfaceHeritage {
@@ -4866,7 +4929,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypePredicate<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSTypePredicate {
@@ -4892,7 +4955,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypePredicateName<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -4913,7 +4976,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSModuleDeclaration {
@@ -4923,7 +4986,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclaration<'_> {
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
             kind: CloneIn::clone_in_impl(&self.kind, with_semantic_ids, allocator),
             declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -4934,7 +5000,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclarationKind {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -4946,7 +5012,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclarationName<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -4967,7 +5033,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclarationBody<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -4986,7 +5052,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSGlobalDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSGlobalDeclaration {
@@ -4995,7 +5061,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSGlobalDeclaration<'_> {
             global_span: CloneIn::clone_in_impl(&self.global_span, with_semantic_ids, allocator),
             body: CloneIn::clone_in_impl(&self.body, with_semantic_ids, allocator),
             declare: CloneIn::clone_in_impl(&self.declare, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -5005,7 +5074,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleBlock<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSModuleBlock {
@@ -5022,7 +5091,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeLiteral<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSTypeLiteral {
@@ -5038,7 +5107,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInferType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSInferType {
@@ -5058,7 +5127,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeQuery<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSTypeQuery {
@@ -5079,7 +5148,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeQueryExprName<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -5104,7 +5173,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSImportType {
@@ -5127,7 +5196,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportTypeQualifier<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -5148,7 +5217,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportTypeQualifiedName<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSImportTypeQualifiedName {
@@ -5165,7 +5234,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSFunctionType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSFunctionType {
@@ -5179,7 +5248,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSFunctionType<'_> {
             this_param: CloneIn::clone_in_impl(&self.this_param, with_semantic_ids, allocator),
             params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
             return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -5189,7 +5261,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConstructorType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSConstructorType {
@@ -5203,7 +5275,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSConstructorType<'_> {
             ),
             params: CloneIn::clone_in_impl(&self.params, with_semantic_ids, allocator),
             return_type: CloneIn::clone_in_impl(&self.return_type, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -5213,7 +5288,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMappedType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSMappedType {
@@ -5229,7 +5304,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMappedType<'_> {
             ),
             optional: CloneIn::clone_in_impl(&self.optional, with_semantic_ids, allocator),
             readonly: CloneIn::clone_in_impl(&self.readonly, with_semantic_ids, allocator),
-            scope_id: CloneIn::clone_in_impl(&self.scope_id, with_semantic_ids, allocator),
+            scope_id: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(
+                &self.scope_id,
+                with_semantic_ids,
+            ),
         }
     }
 }
@@ -5240,7 +5318,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMappedTypeModifierOperator {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -5252,7 +5330,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTemplateLiteralType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSTemplateLiteralType {
@@ -5269,7 +5347,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSAsExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSAsExpression {
@@ -5290,7 +5368,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSSatisfiesExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSSatisfiesExpression {
@@ -5311,7 +5389,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAssertion<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSTypeAssertion {
@@ -5332,7 +5410,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportEqualsDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSImportEqualsDeclaration {
@@ -5354,7 +5432,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleReference<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -5378,7 +5456,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSExternalModuleReference<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSExternalModuleReference {
@@ -5394,7 +5472,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNonNullExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSNonNullExpression {
@@ -5410,7 +5488,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Decorator<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Decorator {
@@ -5426,7 +5504,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSExportAssignment<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSExportAssignment {
@@ -5442,7 +5520,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSNamespaceExportDeclaration<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSNamespaceExportDeclaration {
@@ -5458,7 +5536,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInstantiationExpression<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         TSInstantiationExpression {
@@ -5480,7 +5558,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportOrExportKind {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -5492,7 +5570,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSDocNullableType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSDocNullableType {
@@ -5513,7 +5591,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSDocNonNullableType<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSDocNonNullableType {
@@ -5534,7 +5612,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSDocUnknownType {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         JSDocUnknownType {
@@ -5550,7 +5628,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CommentKind {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -5563,7 +5641,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CommentPosition {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -5576,7 +5654,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CommentContent {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -5588,7 +5666,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Comment {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Comment {

--- a/crates/oxc_regular_expression/src/ast_impl/allocator.rs
+++ b/crates/oxc_regular_expression/src/ast_impl/allocator.rs
@@ -1,11 +1,15 @@
-use oxc_allocator::{Allocator, CloneIn};
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds};
 
 use crate::ast::Modifier;
 
 impl<'alloc> CloneIn<'alloc> for Modifier {
     type Cloned = Self;
 
-    fn clone_in_impl(&self, _with_semantic_ids: bool, _: &'alloc Allocator) -> Self::Cloned {
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: CloneInSemanticIds,
+        _: &'alloc Allocator,
+    ) -> Self::Cloned {
         *self
     }
 }

--- a/crates/oxc_regular_expression/src/generated/derive_clone_in.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_clone_in.rs
@@ -5,7 +5,7 @@
 
 use std::cell::Cell;
 
-use oxc_allocator::{Allocator, CloneIn};
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds};
 
 use crate::ast::*;
 
@@ -14,7 +14,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Pattern<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Pattern {
@@ -29,7 +29,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Disjunction<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Disjunction {
@@ -44,7 +44,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Alternative<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Alternative {
@@ -59,7 +59,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Term<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -108,7 +108,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BoundaryAssertion {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         BoundaryAssertion {
@@ -124,7 +124,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BoundaryAssertionKind {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -136,7 +136,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for LookAroundAssertion<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         LookAroundAssertion {
@@ -153,7 +153,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for LookAroundAssertionKind {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -165,7 +165,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Quantifier<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Quantifier {
@@ -183,7 +183,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Character {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Character {
@@ -200,7 +200,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterKind {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -212,7 +212,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassEscape {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         CharacterClassEscape {
@@ -228,7 +228,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassEscapeKind {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -240,7 +240,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for UnicodePropertyEscape<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         UnicodePropertyEscape {
@@ -258,7 +258,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Dot {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Dot { span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator) }
@@ -270,7 +270,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClass<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         CharacterClass {
@@ -289,7 +289,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassContentsKind {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -301,7 +301,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassContents<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         match self {
@@ -334,7 +334,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassRange {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         CharacterClassRange {
@@ -350,7 +350,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ClassStringDisjunction<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ClassStringDisjunction {
@@ -366,7 +366,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for ClassString<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         ClassString {
@@ -382,7 +382,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CapturingGroup<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         CapturingGroup {
@@ -398,7 +398,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for IgnoreGroup<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         IgnoreGroup {
@@ -414,7 +414,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Modifiers {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Modifiers {
@@ -430,7 +430,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for IndexedReference {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         IndexedReference {
@@ -445,7 +445,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for NamedReference<'_> {
 
     fn clone_in_impl(
         &self,
-        with_semantic_ids: bool,
+        with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         NamedReference {

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -3,7 +3,7 @@ use std::{collections::hash_map::Entry, fmt, mem};
 use rustc_hash::{FxHashMap, FxHashSet};
 use self_cell::self_cell;
 
-use oxc_allocator::{Allocator, ArenaVec, BitSet, CloneIn};
+use oxc_allocator::{Allocator, ArenaVec, BitSet, CloneIn, CloneInSemanticIds};
 use oxc_index::IndexVec;
 use oxc_span::Span;
 use oxc_str::{ArenaIdentHashMap, Ident};
@@ -31,11 +31,15 @@ impl CloneIn<'_> for Redeclaration {
     type Cloned = Self;
 
     #[inline]
-    fn clone_in_impl(&self, with_semantic_ids: bool, _allocator: &Allocator) -> Self::Cloned {
-        if with_semantic_ids {
-            self.clone()
-        } else {
-            Self { span: self.span, declaration: NodeId::DUMMY, flags: self.flags }
+    fn clone_in_impl(
+        &self,
+        with_semantic_ids: CloneInSemanticIds,
+        allocator: &Allocator,
+    ) -> Self::Cloned {
+        Self {
+            span: self.span,
+            declaration: self.declaration.clone_in_impl(with_semantic_ids, allocator),
+            flags: self.flags,
         }
     }
 }

--- a/crates/oxc_span/src/source_type.rs
+++ b/crates/oxc_span/src/source_type.rs
@@ -7,7 +7,7 @@ use std::{
     str::FromStr,
 };
 
-use oxc_allocator::{Allocator, CloneIn, Dummy};
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds, Dummy};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 
@@ -103,7 +103,7 @@ impl<'a> CloneIn<'a> for SourceType {
     type Cloned = Self;
 
     #[inline]
-    fn clone_in_impl(&self, _with_semantic_ids: bool, _: &'a Allocator) -> Self {
+    fn clone_in_impl(&self, _with_semantic_ids: CloneInSemanticIds, _: &'a Allocator) -> Self {
         *self
     }
 }

--- a/crates/oxc_span/src/span.rs
+++ b/crates/oxc_span/src/span.rs
@@ -8,7 +8,7 @@ use miette::{LabeledSpan, SourceOffset, SourceSpan};
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer as SerdeSerializer, ser::SerializeMap};
 
-use oxc_allocator::{Allocator, CloneIn, Dummy};
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds, Dummy};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 
@@ -635,7 +635,7 @@ impl<'a> CloneIn<'a> for Span {
     type Cloned = Self;
 
     #[inline]
-    fn clone_in_impl(&self, _with_semantic_ids: bool, _: &'a Allocator) -> Self {
+    fn clone_in_impl(&self, _with_semantic_ids: CloneInSemanticIds, _: &'a Allocator) -> Self {
         *self
     }
 }

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -11,8 +11,8 @@ use std::{
 };
 
 use oxc_allocator::{
-    Allocator, ArenaStringBuilder, CloneIn, Dummy, FromIn, GetAllocator, IdentBuildHasher,
-    ident_hash,
+    Allocator, ArenaStringBuilder, CloneIn, CloneInSemanticIds, Dummy, FromIn, GetAllocator,
+    IdentBuildHasher, ident_hash,
 };
 #[cfg(feature = "serialize")]
 use oxc_estree::{ESTree, JsonSafeString, Serializer as ESTreeSerializer};
@@ -454,7 +454,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Ident<'_> {
     #[inline]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         let s = allocator.alloc_str(self.as_str());

--- a/crates/oxc_str/src/str.rs
+++ b/crates/oxc_str/src/str.rs
@@ -4,7 +4,9 @@ use std::{
     ops::Deref,
 };
 
-use oxc_allocator::{Allocator, ArenaStringBuilder, CloneIn, Dummy, FromIn, GetAllocator};
+use oxc_allocator::{
+    Allocator, ArenaStringBuilder, CloneIn, CloneInSemanticIds, Dummy, FromIn, GetAllocator,
+};
 #[cfg(feature = "serialize")]
 use oxc_estree::{ESTree, Serializer as ESTreeSerializer};
 #[cfg(feature = "serialize")]
@@ -119,7 +121,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Str<'_> {
     #[inline]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         Str::from_in(self.as_str(), allocator)

--- a/crates/oxc_syntax/src/generated/derive_clone_in.rs
+++ b/crates/oxc_syntax/src/generated/derive_clone_in.rs
@@ -5,7 +5,7 @@
 
 use std::cell::Cell;
 
-use oxc_allocator::{Allocator, CloneIn};
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds};
 
 use crate::number::*;
 use crate::operator::*;
@@ -16,7 +16,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for NumberBase {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -29,7 +29,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BigintBase {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -42,7 +42,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for AssignmentOperator {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -55,7 +55,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for BinaryOperator {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -68,7 +68,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for LogicalOperator {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -81,7 +81,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for UnaryOperator {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self
@@ -94,7 +94,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for UpdateOperator {
     #[inline(always)]
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         allocator: &'new_alloc Allocator,
     ) -> Self::Cloned {
         *self

--- a/crates/oxc_syntax/src/lib.rs
+++ b/crates/oxc_syntax/src/lib.rs
@@ -17,6 +17,7 @@ pub mod operator;
 pub mod precedence;
 pub mod reference;
 pub mod scope;
+pub mod semantic_id;
 #[cfg(feature = "serialize")]
 mod serialize;
 pub mod symbol;

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -2,13 +2,16 @@
 
 use bitflags::bitflags;
 
-use oxc_allocator::{Allocator, CloneIn, Dummy};
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds, Dummy};
 use oxc_ast_macros::ast;
 use oxc_index::define_nonmax_u32_index_type;
+
+use crate::semantic_id::SemanticId;
 
 define_nonmax_u32_index_type! {
     /// AST Node ID
     #[ast]
+    #[clone_in(semantic_id)]
     #[content_eq(skip)]
     #[estree(skip)]
     pub struct NodeId;
@@ -41,17 +44,14 @@ impl<'a> Dummy<'a> for NodeId {
 impl<'alloc> CloneIn<'alloc> for NodeId {
     type Cloned = Self;
 
-    #[inline]
-    fn clone_in_impl(&self, with_semantic_ids: bool, _: &'alloc Allocator) -> Self {
-        if with_semantic_ids {
-            *self
-        } else {
-            // `with_semantic_ids == false` should never reach this, because `CloneIn` skips
-            // `node_id` field, filling it with its default instead.
-            unreachable!();
-        }
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this method only delegates
+    fn clone_in_impl(&self, with_semantic_ids: CloneInSemanticIds, _: &'alloc Allocator) -> Self {
+        self.clone_id(with_semantic_ids)
     }
 }
+
+impl SemanticId for NodeId {}
 
 bitflags! {
     /// Contains additional information about an AST node.

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -3,15 +3,16 @@ use oxc_index::define_nonmax_u32_index_type;
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 
-use oxc_allocator::{Allocator, CloneIn};
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds};
 
-use crate::{node::NodeId, scope::ScopeId, symbol::SymbolId};
+use crate::{node::NodeId, scope::ScopeId, semantic_id::SemanticId, symbol::SymbolId};
 
 use oxc_ast_macros::ast;
 
 define_nonmax_u32_index_type! {
     #[ast]
     #[builder(default)]
+    #[clone_in(semantic_id)]
     #[content_eq(skip)]
     #[estree(skip)]
     pub struct ReferenceId;
@@ -21,17 +22,13 @@ impl<'alloc> CloneIn<'alloc> for ReferenceId {
     type Cloned = Self;
 
     #[expect(clippy::inline_always)]
-    #[inline(always)]
-    fn clone_in_impl(&self, with_semantic_ids: bool, _: &'alloc Allocator) -> Self {
-        if with_semantic_ids {
-            *self
-        } else {
-            // `with_semantic_ids == false` should never reach this, because `CloneIn` skips
-            // `reference_id` field, filling it with its default instead.
-            unreachable!();
-        }
+    #[inline(always)] // Because this method only delegates
+    fn clone_in_impl(&self, with_semantic_ids: CloneInSemanticIds, _: &'alloc Allocator) -> Self {
+        self.clone_id(with_semantic_ids)
     }
 }
+
+impl SemanticId for ReferenceId {}
 
 bitflags! {
     /// Describes how a symbol is being referenced in the AST.
@@ -226,7 +223,7 @@ impl<'alloc> CloneIn<'alloc> for ReferenceFlags {
 
     fn clone_in_impl(
         &self,
-        _with_semantic_ids: bool,
+        _with_semantic_ids: CloneInSemanticIds,
         _: &'alloc oxc_allocator::Allocator,
     ) -> Self::Cloned {
         *self

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -1,12 +1,15 @@
 use bitflags::bitflags;
-use oxc_allocator::{Allocator, CloneIn};
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds};
 use oxc_index::define_nonmax_u32_index_type;
 
 use oxc_ast_macros::ast;
 
+use crate::semantic_id::SemanticId;
+
 define_nonmax_u32_index_type! {
     #[ast]
     #[builder(default)]
+    #[clone_in(semantic_id)]
     #[content_eq(skip)]
     #[estree(skip)]
     pub struct ScopeId;
@@ -16,17 +19,13 @@ impl<'alloc> CloneIn<'alloc> for ScopeId {
     type Cloned = Self;
 
     #[expect(clippy::inline_always)]
-    #[inline(always)]
-    fn clone_in_impl(&self, with_semantic_ids: bool, _: &'alloc Allocator) -> Self {
-        if with_semantic_ids {
-            *self
-        } else {
-            // `with_semantic_ids == false` should never reach this, because `CloneIn` skips
-            // `scope_id` field, filling it with its default instead.
-            unreachable!();
-        }
+    #[inline(always)] // Because this method only delegates
+    fn clone_in_impl(&self, with_semantic_ids: CloneInSemanticIds, _: &'alloc Allocator) -> Self {
+        self.clone_id(with_semantic_ids)
     }
 }
+
+impl SemanticId for ScopeId {}
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/oxc_syntax/src/semantic_id.rs
+++ b/crates/oxc_syntax/src/semantic_id.rs
@@ -1,0 +1,173 @@
+//! [`SemanticId`] trait for branchless cloning of semantic ID types.
+
+use std::cell::Cell;
+
+use nonmax::NonMaxU32;
+use oxc_allocator::CloneInSemanticIds;
+use oxc_index::Idx;
+
+// The branchless bit-tricks in [`SemanticId`]'s methods rely on the exact discriminant values of
+// [`CloneInSemanticIds`]. This crate is separate from the one that defines [`CloneInSemanticIds`],
+// so assert the discriminants here rather than relying on them by proximity.
+const _: () = {
+    assert!(CloneInSemanticIds::With as u32 == 0);
+    assert!(CloneInSemanticIds::Without as u32 == u32::MAX);
+};
+
+/// A semantic ID type - a [`NonMaxU32`]-backed index (`NodeId`, `ScopeId`, `SymbolId`, `ReferenceId`),
+/// created by [`define_nonmax_u32_index_type!`].
+///
+/// Provides methods to clone a semantic ID, keeping it when cloning with semantic IDs
+/// and resetting it when cloning without - branchless in both cases:
+///
+/// * [`clone_id`] - `CloneIn::clone_in_impl` for ID types delegates to it.
+/// * [`clone_cell_option_id`] - the `CloneIn` derive calls it to clone `Cell<Option<Id>>` fields
+///   (`ScopeId`, `SymbolId`, `ReferenceId`).
+///
+/// The [`Idx`] bound provides [`index`] and [`from_usize`], the two operations these methods need.
+///
+/// [`define_nonmax_u32_index_type!`]: oxc_index::define_nonmax_u32_index_type
+/// [`clone_id`]: SemanticId::clone_id
+/// [`clone_cell_option_id`]: SemanticId::clone_cell_option_id
+/// [`index`]: Idx::index
+/// [`from_usize`]: Idx::from_usize
+pub trait SemanticId: Idx {
+    /// Clone a semantic ID.
+    ///
+    /// Behavior depends on value of `with_semantic_ids`:
+    ///
+    /// * [`CloneInSemanticIds::With`]: Copy the current value.
+    /// * [`CloneInSemanticIds::Without`]: Reset to the dummy ID `Id(0)`.
+    ///
+    /// Branchless - a single OR instruction.
+    ///
+    /// # How this works
+    ///
+    /// `index & mask`, where `mask` is all-ones for [`With`] (discriminant `0`)
+    /// and all-zeros for [`Without`] (discriminant `u32::MAX`), then rebuilt.
+    /// `from_usize`'s bounds check is elided: `index & mask <= index <= MAX`.
+    ///
+    /// <https://godbolt.org/z/1KWdc5hnb>
+    ///
+    /// [`With`]: CloneInSemanticIds::With
+    /// [`Without`]: CloneInSemanticIds::Without
+    #[must_use]
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this method is only a single instruction
+    fn clone_id(&self, with_semantic_ids: CloneInSemanticIds) -> Self {
+        let mask = !(with_semantic_ids as u32);
+        // `index()` of a `NonMaxU32`-backed type always fits in `u32`, so `as u32` can't truncate
+        #[expect(clippy::cast_possible_truncation)]
+        let index = self.index() as u32;
+        let masked = index & mask;
+        Self::from_usize(masked as usize)
+    }
+
+    /// Clone a `Cell<Option<Id>>` semantic ID field.
+    ///
+    /// Behavior depends on value of `with_semantic_ids`:
+    ///
+    /// * [`CloneInSemanticIds::With`]: Copy the current value.
+    /// * [`CloneInSemanticIds::Without`]: Reset to `None`.
+    ///
+    /// Branchless - a load plus an AND-NOT operation
+    /// (a single `bic` instruction on aarch64, `not` + `and` on x86_64).
+    ///
+    /// <https://godbolt.org/z/1KWdc5hnb>
+    ///
+    /// # How this works
+    ///
+    /// The in-memory representation of `Option<Id>` (equivalently `Option<NonMaxU32>`) is:
+    ///
+    /// * `None` = `0` (niche optimization - `NonMaxU32` wraps a `NonZeroU32` whose niche is 0).
+    /// * `Some(v)` = `!v` (`NonMaxU32` stores its value bitwise-inverted, and is never 0).
+    ///
+    /// On that representation, "keep, or replace with `None`" is `bits & mask`,
+    /// where `mask` is all-ones for [`With`] and all-zeros for [`Without`].
+    ///
+    /// The code below computes exactly that, but via safe APIs.
+    /// `bits` rebuilds the stored form as a plain logical value (`!id.index()` for `Some`, `0` for `None`),
+    /// and `NonMaxU32::new(!x)` inverts the encoding (`new` returns `None` exactly when `x == 0`).
+    /// Correctness is plain logic and doesn't depend on the representation - only the codegen does.
+    /// The compiler folds it all to the same instructions as an unsafe `transmute`-based version.
+    ///
+    /// [`With`]: CloneInSemanticIds::With
+    /// [`Without`]: CloneInSemanticIds::Without
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this method is only a few instructions
+    fn clone_cell_option_id(
+        cell: &Cell<Option<Self>>,
+        with_semantic_ids: CloneInSemanticIds,
+    ) -> Cell<Option<Self>> {
+        let mask = !(with_semantic_ids as u32);
+        // `index()` of a `NonMaxU32`-backed type always fits in `u32`, so `as u32` can't truncate
+        #[expect(clippy::cast_possible_truncation)]
+        let bits = match cell.get() {
+            Some(id) => !(id.index() as u32),
+            None => 0,
+        };
+        let masked = bits & mask;
+        let raw = NonMaxU32::new(!masked);
+        Cell::new(raw.map(|raw| Self::from_usize(raw.get() as usize)))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::cell::Cell;
+
+    use oxc_allocator::CloneInSemanticIds;
+
+    use crate::node::NodeId;
+
+    use super::SemanticId;
+
+    // `NonMaxU32` cannot represent `u32::MAX`, so `u32::MAX - 1` is the largest ID we can test
+    const INPUTS: [u32; 11] = [
+        0,
+        1,
+        2,
+        42,
+        1000,
+        u32::MAX / 2 - 1,
+        u32::MAX / 2,
+        u32::MAX / 2 + 1,
+        u32::MAX - 1000,
+        u32::MAX - 2,
+        u32::MAX - 1,
+    ];
+
+    #[test]
+    fn clone_id() {
+        for n in INPUTS {
+            let id = NodeId::from_usize(n as usize);
+            // `With` copies the current value
+            assert_eq!(id.clone_id(CloneInSemanticIds::With), id);
+            // `Without` resets to the dummy ID `NodeId(0)`
+            assert_eq!(id.clone_id(CloneInSemanticIds::Without), NodeId::from_usize(0));
+        }
+    }
+
+    #[test]
+    fn clone_cell_option_id() {
+        // `None` is returned unchanged by both variants
+        let cell = Cell::new(None);
+        assert_eq!(NodeId::clone_cell_option_id(&cell, CloneInSemanticIds::With).get(), None);
+        assert_eq!(NodeId::clone_cell_option_id(&cell, CloneInSemanticIds::Without).get(), None);
+
+        for n in INPUTS {
+            let id = NodeId::from_usize(n as usize);
+            let cell = Cell::new(Some(id));
+            // `With` copies the current value
+            assert_eq!(
+                NodeId::clone_cell_option_id(&cell, CloneInSemanticIds::With).get(),
+                Some(id)
+            );
+            // `Without` resets to `None`
+            assert_eq!(
+                NodeId::clone_cell_option_id(&cell, CloneInSemanticIds::Without).get(),
+                None
+            );
+        }
+    }
+}

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -1,14 +1,17 @@
 use bitflags::bitflags;
-use oxc_allocator::{Allocator, CloneIn};
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds};
 use oxc_index::define_nonmax_u32_index_type;
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 
 use oxc_ast_macros::ast;
 
+use crate::semantic_id::SemanticId;
+
 define_nonmax_u32_index_type! {
     #[ast]
     #[builder(default)]
+    #[clone_in(semantic_id)]
     #[content_eq(skip)]
     #[estree(skip)]
     pub struct SymbolId;
@@ -18,17 +21,13 @@ impl<'alloc> CloneIn<'alloc> for SymbolId {
     type Cloned = Self;
 
     #[expect(clippy::inline_always)]
-    #[inline(always)]
-    fn clone_in_impl(&self, with_semantic_ids: bool, _: &'alloc Allocator) -> Self {
-        if with_semantic_ids {
-            *self
-        } else {
-            // `with_semantic_ids == false` should never reach this, because `CloneIn` skips
-            // `symbol_id` field, filling it with its default instead.
-            unreachable!();
-        }
+    #[inline(always)] // Because this method only delegates
+    fn clone_in_impl(&self, with_semantic_ids: CloneInSemanticIds, _: &'alloc Allocator) -> Self {
+        self.clone_id(with_semantic_ids)
     }
 }
+
+impl SemanticId for SymbolId {}
 
 define_nonmax_u32_index_type! {
     pub struct RedeclarationId;

--- a/tasks/ast_tools/src/derives/clone_in.rs
+++ b/tasks/ast_tools/src/derives/clone_in.rs
@@ -38,19 +38,23 @@ impl Derive for DeriveCloneIn {
         &[("clone_in", attr_positions!(StructMaybeDerived | EnumMaybeDerived | StructField))]
     }
 
-    /// Parse `#[clone_in(default)]` on struct, enum, or struct field.
+    /// Parse `#[clone_in(default)]` on struct, enum, or struct field,
+    /// or `#[clone_in(semantic_id)]` on struct.
     fn parse_attr(&self, _attr_name: &str, location: AttrLocation, part: AttrPart) -> Result<()> {
         // No need to check attr name is `clone_in`, because that's the only attribute this derive handles.
-        if !matches!(part, AttrPart::Tag("default")) {
-            return Err(());
-        }
-
-        match location {
-            AttrLocation::Struct(struct_def) => struct_def.clone_in.is_default = true,
-            AttrLocation::Enum(enum_def) => enum_def.clone_in.is_default = true,
-            AttrLocation::StructField(struct_def, field_index) => {
-                struct_def.fields[field_index].clone_in.is_default = true;
-            }
+        match part {
+            AttrPart::Tag("default") => match location {
+                AttrLocation::Struct(struct_def) => struct_def.clone_in.is_default = true,
+                AttrLocation::Enum(enum_def) => enum_def.clone_in.is_default = true,
+                AttrLocation::StructField(struct_def, field_index) => {
+                    struct_def.fields[field_index].clone_in.is_default = true;
+                }
+                _ => return Err(()),
+            },
+            AttrPart::Tag("semantic_id") => match location {
+                AttrLocation::Struct(struct_def) => struct_def.clone_in.is_semantic_id = true,
+                _ => return Err(()),
+            },
             _ => return Err(()),
         }
 
@@ -65,7 +69,7 @@ impl Derive for DeriveCloneIn {
             use std::cell::Cell;
 
             ///@@line_break
-            use oxc_allocator::{Allocator, CloneIn};
+            use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds};
         }
     }
 
@@ -88,10 +92,19 @@ fn derive_struct(struct_def: &StructDef, schema: &Schema) -> TokenStream {
         let fields = struct_def.fields.iter().map(|field| {
             let field_ident = field.ident();
             if struct_field_is_default(field, schema) {
-                // Fields (or fields whose type is) marked `#[clone_in(default)]` always reset to
-                // their default. Semantic id `Cell`s are *not* marked — they thread the
-                // `with_semantic_ids` flag through their `CloneIn` impl instead (see `oxc_allocator`).
+                // Fields (or fields whose type is) marked `#[clone_in(default)]` always reset to their default
                 quote!( #field_ident: Default::default() )
+            } else if struct_field_is_semantic_id_cell_option(field, schema) {
+                // `Cell<Option<Id>>` semantic ID fields (`scope_id`, `symbol_id`, `reference_id`)
+                // clone via `SemanticId::clone_cell_option_id`, which keeps the ID or resets it to `None`,
+                // depending on `with_semantic_ids`.
+                //
+                // The generic `Option<T>` / `Cell<T>` `CloneIn` impls can't produce that reset -
+                // `Option<T>`'s impl maps over `Some`, which would reset `Some(id)` to `Some(dummy)`, not `None`.
+                //
+                // `SemanticId` lives in `oxc_syntax`, so it's named by its full path here rather than
+                // imported in the prelude (which is shared with crates that don't depend on `oxc_syntax`).
+                quote!( #field_ident: oxc_syntax::semantic_id::SemanticId::clone_cell_option_id(&self.#field_ident, with_semantic_ids) )
             } else {
                 quote!( #field_ident: CloneIn::clone_in_impl(&self.#field_ident, with_semantic_ids, allocator) )
             }
@@ -118,6 +131,17 @@ fn struct_field_is_default(field: &FieldDef, schema: &Schema) -> bool {
             _ => false,
         }
     }
+}
+
+/// Get if a struct field is a `Cell<Option<Id>>`, where `Id` is a semantic ID type
+/// (marked `#[clone_in(semantic_id)]`).
+///
+/// Such fields are cloned with `SemanticId::clone_cell_option_id`.
+fn struct_field_is_semantic_id_cell_option(field: &FieldDef, schema: &Schema) -> bool {
+    let TypeDef::Cell(cell_def) = field.type_def(schema) else { return false };
+    let TypeDef::Option(option_def) = cell_def.inner_type(schema) else { return false };
+    let TypeDef::Struct(struct_def) = option_def.inner_type(schema) else { return false };
+    struct_def.clone_in.is_semantic_id
 }
 
 fn derive_enum(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
@@ -209,7 +233,7 @@ fn generate_impl(
             #inline
             fn clone_in_impl(
                 &self,
-                #flag_param: bool,
+                #flag_param: CloneInSemanticIds,
                 allocator: &'new_alloc Allocator,
             ) -> Self::Cloned {
                 #clone_in_impl_body

--- a/tasks/ast_tools/src/schema/extensions/clone_in.rs
+++ b/tasks/ast_tools/src/schema/extensions/clone_in.rs
@@ -3,6 +3,9 @@
 pub struct CloneInType {
     /// `true` if should be replaced with default value when cloning
     pub is_default: bool,
+    /// `true` if type is a semantic ID (`NodeId`, `ScopeId`, `SymbolId`, `ReferenceId`).
+    /// Fields of these types are cloned using `SemanticId` trait.
+    pub is_semantic_id: bool,
 }
 
 /// Details for `CloneIn` derive on a struct field.


### PR DESCRIPTION
Follow-on after #24422.

Make cloning semantic IDs (`NodeId`, `ScopeId` etc) use branchless arithmetic.

* Cloning `NodeId` now just uses a single OR operation to take into account whether to preserve the existing ID (`clone_in_with_semantic_ids`) or substitute a dummy ID (`clone_in`).
* Cloning `Cell<Option<ScopeId>>` is 2 instructions (NOT + AND) on x86_64, or just 1 on aarch64 (NOT-AND).

https://godbolt.org/z/1KWdc5hnb

The mechanism is a type `CloneInSemanticIds` which is used as `with_semantic_ids` instead of a `bool`:

```rs
#[repr(u32)]
pub enum CloneInSemanticIds {
    With = 0,
    Without = u32::MAX,
}
```

This is 4 bytes, rather than `bool`'s 1 byte, but that makes no difference - either way it takes 1 register to pass between functions. The choice of discriminants is what enables the cheap arithmetic.

This is even smaller in terms of binary size than the previous solution of marking `Cell::clone_in_impl` as `#[inline(never)]` (OR instruction is smaller than function call), and it's more performant as it loses the function call overhead. It also keeps `Cell`'s blanket implementation of `CloneIn` generalized.

Between #24422 and this PR, merging `CloneIn` with/without semantic IDs into a single path has gained us a large binary size reduction, and lost us nothing - or may even have gained us a marginal perf improvement.

No visible change on our benchmarks, as we don't use `CloneIn` much, but it may well be a measurable improvement for Rolldown, which clones whole ASTs.