### PR TITLE
fix(codegen): preserve normal comments before operands

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -22,12 +22,12 @@ pub enum CommentKind {
     MultiLineBlock = 2,
 }
 
-/// Information about a comment's position relative to a token.
+/// Information about a comment's position relative to its syntactic target.
 #[ast]
 #[generate_derive(CloneIn, ContentEq)]
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub enum CommentPosition {
-    /// Comments prior to a token until another token or trailing comment.
+    /// Comments attached to the start of the following token.
     ///
     /// e.g.
     ///
@@ -43,6 +43,10 @@ pub enum CommentPosition {
     /// Comments tailing a token until a newline.
     /// e.g. `token /* trailing */ // trailing`
     Trailing = 1,
+
+    /// Leading comments attached to a token that starts a statement.
+    /// Distinguishes statement trivia when transforms move its expression elsewhere.
+    StatementLeading = 2,
 }
 
 /// Annotation comment that has special meaning.
@@ -151,7 +155,7 @@ pub struct Comment {
     #[estree(rename = "type")]
     pub kind: CommentKind,
 
-    /// Leading or trailing comment
+    /// Attachment position.
     #[estree(skip)]
     pub position: CommentPosition,
 
@@ -211,13 +215,26 @@ impl Comment {
     /// Returns `true` if this comment is before a token.
     #[inline]
     pub fn is_leading(self) -> bool {
-        self.position == CommentPosition::Leading
+        matches!(self.position, CommentPosition::Leading | CommentPosition::StatementLeading)
     }
 
     /// Returns `true` if this comment is after a token.
     #[inline]
     pub fn is_trailing(self) -> bool {
         self.position == CommentPosition::Trailing
+    }
+
+    /// Returns `true` if this comment leads a statement.
+    #[inline]
+    pub fn is_statement_leading(self) -> bool {
+        self.position == CommentPosition::StatementLeading
+    }
+
+    /// Marks this leading comment as leading a statement.
+    #[inline]
+    pub fn set_statement_leading(&mut self) {
+        debug_assert!(self.is_leading());
+        self.position = CommentPosition::StatementLeading;
     }
 
     /// Is comment without a special meaning.

--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -231,11 +231,9 @@ impl<'a> BinaryExpressionVisitor<'a> {
         p.print_soft_space();
         let right = self.e.right();
         if let Binaryish::Logical(e) = self.e {
-            // Annotation-gated (see the helper's doc): statements get merged
-            // into logical RHS positions on mutated ASTs. Pass the unstripped
-            // right — `Binaryish::right()` removes the paren layers the helper
-            // needs to probe.
-            p.print_annotation_comments_before_expression(&e.right);
+            // Pass the unstripped right: `Binaryish::right()` removes the paren layers
+            // that the comment printer needs to probe.
+            p.print_operand_comments_before_expression(&e.right);
         }
         if !cjs_module_lexer::try_print_equality_string(p, self.operator, right) {
             right.gen_expr(p, self.right_precedence, self.ctx);

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -24,9 +24,9 @@ fn is_pife_function(expression: &Expression<'_>) -> bool {
 }
 
 fn should_print_operand_comment_group(comments: &[Comment]) -> bool {
-    !comments.iter().any(|comment| comment.is_legal())
-        && (comments.iter().any(|comment| comment.is_annotation())
-            || comments.iter().all(|comment| !comment.is_statement_leading()))
+    comments.iter().any(|comment| comment.is_annotation())
+        || (!comments.iter().any(|comment| comment.is_legal())
+            && comments.iter().all(|comment| !comment.is_statement_leading()))
 }
 
 /// Which annotation kind an emission site expects to recover from

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::hash_map::Entry};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -21,6 +21,12 @@ fn is_pife_function(expression: &Expression<'_>) -> bool {
         Expression::FunctionExpression(function) => function.pife,
         _ => false,
     }
+}
+
+fn should_print_operand_comment_group(comments: &[Comment]) -> bool {
+    !comments.iter().any(|comment| comment.is_legal())
+        && (comments.iter().any(|comment| comment.is_annotation())
+            || comments.iter().all(|comment| !comment.is_statement_leading()))
 }
 
 /// Which annotation kind an emission site expects to recover from
@@ -182,11 +188,16 @@ impl Codegen<'_> {
     pub(crate) fn print_leading_comments_anchored_to_self(&mut self, start: u32) {
         if let Some(comments) = self.get_comments(start) {
             self.print_comments(&comments);
-            if self.last_byte() == Some(b'\n') {
-                self.print_indent();
-            } else {
-                self.consume_pending_indent_space();
-            }
+            self.glue_after_comment_group();
+        }
+    }
+
+    /// Glue the next token to a just-printed comment group.
+    fn glue_after_comment_group(&mut self) {
+        if self.last_byte() == Some(b'\n') {
+            self.print_indent();
+        } else {
+            self.consume_pending_indent_space();
         }
     }
 
@@ -196,46 +207,48 @@ impl Codegen<'_> {
     /// comment at the `(`, `a || (/* c */ x)` at `x` — an operand printer only
     /// sees one node, so the walk happens here for every emission site.
     pub(crate) fn print_leading_comments_before_expression(&mut self, expression: &Expression<'_>) {
-        if self.comments.is_empty() || is_pife_function(expression) {
-            return;
-        }
-        self.print_leading_comments_anchored_to_self(expression.span().start);
-        if let Expression::ParenthesizedExpression(paren) = expression {
-            self.print_leading_comments_before_expression(&paren.expression);
-        }
+        self.print_groups_before_expression(expression, false);
     }
 
-    /// Print an expression's comment group only when it contains an annotation
-    /// comment, probing parenthesized layers like
-    /// [`Self::print_leading_comments_before_expression`].
+    /// Print expression trivia before an operand, excluding statement trivia.
     ///
-    /// This is the variant for emission sites that mutating consumers move
-    /// statements into (the minifier merges `if(a)x;if(b)x;` into
-    /// `if(a||(b,..))x`; rolldown finalizes moved nodes with their original
-    /// spans). Comments are anchored by source position, so a dissolved
-    /// statement's leading normal-comment group can coincide with the moved
-    /// operand's span start — printing it there misplaces statement-level
-    /// trivia inside an expression and is not idempotent
-    /// (`test_normal_comment_before_logical_rhs_not_printed` documents the
-    /// falsifier). Annotations are the one comment kind with expression-level
-    /// meaning, so they still pass through.
-    pub(crate) fn print_annotation_comments_before_expression(
+    /// Transforms can move a statement's expression here without changing its span.
+    /// Annotations still print; legal comments remain for orphan handling.
+    pub(crate) fn print_operand_comments_before_expression(&mut self, expression: &Expression<'_>) {
+        self.print_groups_before_expression(expression, true);
+    }
+
+    fn print_groups_before_expression(
         &mut self,
         expression: &Expression<'_>,
+        filter_statement_comments: bool,
     ) {
-        if self.comments.is_empty() || is_pife_function(expression) {
+        if self.comments.is_empty() {
             return;
         }
-        let start = expression.span().start;
-        if self
-            .comments
-            .get(&start)
-            .is_some_and(|comments| comments.iter().any(|comment| comment.is_annotation()))
-        {
-            self.print_leading_comments_anchored_to_self(start);
+
+        let mut expression = expression;
+        let mut printed = false;
+        loop {
+            // A PIFE function prints its leading comments inside its own `(` wrap.
+            if is_pife_function(expression) {
+                break;
+            }
+
+            if let Entry::Occupied(entry) = self.comments.entry(expression.span().start)
+                && (!filter_statement_comments || should_print_operand_comment_group(entry.get()))
+            {
+                let comments = entry.remove();
+                self.print_comments(&comments);
+                printed = true;
+            }
+
+            let Expression::ParenthesizedExpression(paren) = expression else { break };
+            expression = &paren.expression;
         }
-        if let Expression::ParenthesizedExpression(paren) = expression {
-            self.print_annotation_comments_before_expression(&paren.expression);
+
+        if printed {
+            self.glue_after_comment_group();
         }
     }
 
@@ -327,12 +340,15 @@ impl Codegen<'_> {
         };
 
         if first.preceded_by_newline() {
+            // A leading line break supersedes glue left by a previous group.
+            self.clear_pending_indent_space();
             // Skip printing newline if this comment is already on a newline.
             if let Some(b) = self.last_byte() {
                 match b {
                     b'\n' => self.print_indent(),
                     b'\t' => { /* noop */ }
                     _ => {
+                        self.code.trim_trailing_ascii_whitespace();
                         self.print_hard_newline();
                         self.print_indent();
                     }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2000,14 +2000,13 @@ impl GenExpr for ConditionalExpression<'_> {
             p.print_soft_space();
             p.print_ascii_byte(b'?');
             p.print_soft_space();
-            // Annotation-gated (see the helper's doc): `if/else` bodies get
-            // merged into consequents on mutated ASTs.
-            p.print_annotation_comments_before_expression(&self.consequent);
+            // `if/else` bodies can get merged into consequents on mutated ASTs.
+            p.print_operand_comments_before_expression(&self.consequent);
             self.consequent.print_expr(p, Precedence::Yield, Context::empty());
             p.print_soft_space();
             p.print_colon();
             p.print_soft_space();
-            p.print_leading_comments_before_expression(&self.alternate);
+            p.print_operand_comments_before_expression(&self.alternate);
             self.alternate.print_expr(p, Precedence::Yield, ctx & Context::FORBID_IN);
         });
     }

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -54,7 +54,7 @@ fn test_comments_before_expression_operands() {
     );
     test(
         "condition ?\n  /* v8 ignore next */ uncovered() :\n  coveredAlternate();",
-        "condition ? \n/* v8 ignore next */ uncovered() : coveredAlternate();\n",
+        "condition ?\n/* v8 ignore next */ uncovered() : coveredAlternate();\n",
     );
     test(
         "const value = { aFunction: /* istanbul ignore next */ () => {} };",
@@ -146,16 +146,37 @@ fn test_minify_comment_glue_idempotency() {
     );
 }
 
-// Normal-comment groups must NOT be printed before a logical RHS: the minifier
-// merges statements into logical right-hand sides (`if(a)x;if(b)x;` ->
-// `if(a||(b,..))x`), which can anchor a removed statement's banner comments at
-// the RHS span start; printing them mid-expression breaks minify idempotency
-// (minifier_test262 `language/asi/S7.9_A5.8_T1.js`). Only annotation-bearing
-// groups (coverage directives etc.) are printed.
+// Normal comments from a pristine parse are expression trivia, so logical RHS
+// and conditional-consequent printers preserve them. Statement trivia is
+// covered separately by the minifier's dissolved-statement tests.
 #[test]
-fn test_normal_comment_before_logical_rhs_not_printed() {
-    test("const value = a ?? /* plain comment */ [];", "const value = a ?? [];\n");
-    test("const value = a || //\n////////\n(b, c);", "const value = a || (b, c);\n");
+fn test_normal_comment_before_operand_positions() {
+    for (source, expected) in [
+        (
+            "const value = a ?? /* plain comment */ [];",
+            "const value = a ?? /* plain comment */ [];\n",
+        ),
+        (
+            "const value = a ? /* plain comment */ b : c;",
+            "const value = a ? /* plain comment */ b : c;\n",
+        ),
+        (
+            "const value = a ? b : /* plain comment */ c;",
+            "const value = a ? b : /* plain comment */ c;\n",
+        ),
+        // The first line comment is trailing; the own-line banner leads the operand.
+        ("const value = a || //\n////////\n(b, c);", "const value = a ||\n////////\n(b, c);\n"),
+    ] {
+        test(source, expected);
+        test_idempotency(source);
+    }
+
+    test_idempotency(
+        "const value = a ? // operator comment\n// operand comment\n/*#__PURE__*/ (() => b)() : c;",
+    );
+
+    // Legal comments defer to statement-boundary orphan handling.
+    test("const value = a ?? /*! legal */ [];", "const value = a ?? [];\n/*! legal */\n");
 }
 
 #[test]

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -175,6 +175,15 @@ fn test_normal_comment_before_operand_positions() {
         "const value = a ? // operator comment\n// operand comment\n/*#__PURE__*/ (() => b)() : c;",
     );
 
+    // Operand groups print all-or-nothing. If an annotation shares an anchor
+    // with a legal comment, deferring the group would strand the annotation
+    // because orphan handling extracts only the legal comment.
+    test(
+        "const value = a ?? /*! legal */ /* istanbul ignore next */ f();",
+        "const value = a ?? /*! legal */ /* istanbul ignore next */ f();\n",
+    );
+    test_idempotency("const value = a ?? /*! legal */ /* istanbul ignore next */ f();");
+
     // Legal comments defer to statement-boundary orphan handling.
     test("const value = a ?? /*! legal */ [];", "const value = a ?? [];\n/*! legal */\n");
 }

--- a/crates/oxc_codegen/tests/integration/snapshots/coverage.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/coverage.snap
@@ -106,7 +106,7 @@ catch(e) {
 ----------
 try {
 	something();
-} 
+}
 /* istanbul ignore next */
 catch (e) {}
 

--- a/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
@@ -189,7 +189,9 @@ isFunction(options)
 : options
                 
 ----------
-isFunction(options) ? /*#__PURE__*/ (() => extend({ name: options.name }, extraOptions, { setup: options }))() : options;
+isFunction(options) ?
+// by Rollup, so we have to wrap it in a pure-annotated IIFE.
+/*#__PURE__*/ (() => extend({ name: options.name }, extraOptions, { setup: options }))() : options;
 
 ########## 10
 isFunction(options) ? /*#__PURE__*/ (() => extend({ name: options.name }, extraOptions, { setup: options }))() : options;

--- a/crates/oxc_minifier/tests/peephole/dissolved_statement_comments.rs
+++ b/crates/oxc_minifier/tests/peephole/dissolved_statement_comments.rs
@@ -1,0 +1,48 @@
+//! Statement-leading comments whose statement dissolves into an expression
+//! operand must not print in that operand. The parser marks their origin and
+//! codegen's operand printers keep them out without minifier cooperation.
+
+use crate::test;
+
+/// test262 `language/asi/S7.9_A5.8_T1.js`: the banner leads the second
+/// assignment statement, which fuses into the merged `if` test.
+#[test]
+fn drops_banner_of_fused_statement() {
+    test(
+        "var z = 0, x = 0, y = 0;
+z = x + ++y;
+if (z !== 2 && x !== 0) throw new Test262Error('');
+// banner
+z = x + ++y;
+if (z !== 3 && x !== 0) throw new Test262Error('');",
+        "var z = 0, x = 0, y = 0;
+if (z = x + ++y, z !== 2 && x !== 0 || (z = x + ++y, z !== 3 && x !== 0)) throw new Test262Error('');",
+    );
+}
+
+/// webpack `CssParser.js`: a JSDoc cast leads the `if` body, which becomes
+/// the `&&` right-hand side.
+#[test]
+fn drops_jsdoc_of_if_body_converted_to_logical() {
+    test(
+        "if (module.exportType === 'style')
+	/** @type {BuildMeta} */
+	(module.buildMeta).needIdInConcatenation = true;",
+        "module.exportType === 'style' && (module.buildMeta.needIdInConcatenation = !0);",
+    );
+}
+
+#[test]
+fn drops_comments_of_if_else_converted_to_conditional() {
+    test(
+        "if (a) /* yes */ b();
+else /* no */ c();",
+        "a ? b() : c();",
+    );
+}
+
+/// Annotations retain expression-level meaning when their statement dissolves.
+#[test]
+fn keeps_annotation_of_dissolved_statement() {
+    test("if (a) /* istanbul ignore next */ b();", "a && /* istanbul ignore next */ b();");
+}

--- a/crates/oxc_minifier/tests/peephole/mod.rs
+++ b/crates/oxc_minifier/tests/peephole/mod.rs
@@ -1,6 +1,7 @@
 mod collapse_variable_declarations;
 mod convert_to_dotted_properties;
 mod dead_code_elimination;
+mod dissolved_statement_comments;
 mod esbuild;
 mod fold_constants;
 mod inline;

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -132,6 +132,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         stmt_ctx: StatementContext,
     ) -> Statement<'a> {
+        self.lexer.trivia_builder.mark_statement_leading_comments(self.cur_token().start());
         let has_no_side_effects_comment =
             self.lexer.trivia_builder.previous_token_has_no_side_effects_comment();
         let pure_comment_index = self.lexer.trivia_builder.previous_token_has_pure_comment();

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -57,6 +57,16 @@ impl<'a> TriviaBuilder<'a> {
         self.has_no_side_effects_comment
     }
 
+    /// Mark the leading comments attached to `statement_start` as statement trivia.
+    pub fn mark_statement_leading_comments(&mut self, statement_start: u32) {
+        for comment in self.comments.iter_mut().rev() {
+            if comment.attached_to != statement_start || !comment.is_leading() {
+                break;
+            }
+            comment.set_statement_leading();
+        }
+    }
+
     pub fn mark_pure_comment_not_applied(&mut self, index: usize) {
         if let Some(comment) = self.comments.get_mut(index) {
             debug_assert!(comment.is_pure());
@@ -430,7 +440,7 @@ mod test {
             Comment {
                 span: Span::new(9, 24),
                 kind: CommentKind::SingleLineBlock,
-                position: CommentPosition::Leading,
+                position: CommentPosition::StatementLeading,
                 attached_to: 70,
                 newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
                 content: CommentContent::None,
@@ -438,7 +448,7 @@ mod test {
             Comment {
                 span: Span::new(33, 45),
                 kind: CommentKind::Line,
-                position: CommentPosition::Leading,
+                position: CommentPosition::StatementLeading,
                 attached_to: 70,
                 newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
                 content: CommentContent::None,
@@ -446,7 +456,7 @@ mod test {
             Comment {
                 span: Span::new(54, 69),
                 kind: CommentKind::SingleLineBlock,
-                position: CommentPosition::Leading,
+                position: CommentPosition::StatementLeading,
                 attached_to: 70,
                 newlines: CommentNewlines::Leading,
                 content: CommentContent::None,
@@ -494,7 +504,7 @@ token /* Trailing 1 */
             Comment {
                 span: Span::new(20, 35),
                 kind: CommentKind::SingleLineBlock,
-                position: CommentPosition::Leading,
+                position: CommentPosition::StatementLeading,
                 attached_to: 36,
                 newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
                 content: CommentContent::None,
@@ -509,6 +519,18 @@ token /* Trailing 1 */
             },
         ];
         assert_eq!(comments, expected);
+    }
+
+    #[test]
+    fn statement_leading_is_distinct_from_expression_leading() {
+        let source_text = "/* statement */ foo(); const x = /* expression */ bar();";
+        let comments = get_comments(source_text);
+
+        assert_eq!(comments.len(), 2);
+        assert!(comments[0].is_statement_leading());
+        assert!(comments[0].is_leading());
+        assert_eq!(comments[1].position, CommentPosition::Leading);
+        assert!(!comments[1].is_statement_leading());
     }
 
     #[test]
@@ -527,7 +549,7 @@ token /* Trailing 1 */
             Comment {
                 span: Span::new(1, 13),
                 kind: CommentKind::MultiLineBlock,
-                position: CommentPosition::Leading,
+                position: CommentPosition::StatementLeading,
                 attached_to: 28,
                 newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
                 content: CommentContent::None,
@@ -535,7 +557,7 @@ token /* Trailing 1 */
             Comment {
                 span: Span::new(14, 26),
                 kind: CommentKind::MultiLineBlock,
-                position: CommentPosition::Leading,
+                position: CommentPosition::StatementLeading,
                 attached_to: 28,
                 newlines: CommentNewlines::Leading | CommentNewlines::Trailing,
                 content: CommentContent::None,
@@ -554,7 +576,7 @@ function bar() {}";
         let function_start = u32::try_from(source_text.find("function").unwrap()).unwrap();
 
         assert_eq!(comments.len(), 1);
-        assert_eq!(comments[0].position, CommentPosition::Leading);
+        assert_eq!(comments[0].position, CommentPosition::StatementLeading);
         assert_eq!(comments[0].attached_to, function_start);
         assert!(comments[0].is_legal());
         assert!(comments[0].followed_by_newline());
@@ -567,7 +589,7 @@ function bar() {}";
         let function_start = u32::try_from(source_text.find("function").unwrap()).unwrap();
 
         assert_eq!(comments.len(), 1);
-        assert_eq!(comments[0].position, CommentPosition::Leading);
+        assert_eq!(comments[0].position, CommentPosition::StatementLeading);
         assert_eq!(comments[0].attached_to, function_start);
         assert!(comments[0].is_legal());
         assert!(comments[0].followed_by_newline());
@@ -586,7 +608,7 @@ function bar() {}";
         let bar_start = u32::try_from(source_text.rfind("function").unwrap()).unwrap();
 
         assert_eq!(comments.len(), 1);
-        assert_eq!(comments[0].position, CommentPosition::Leading);
+        assert_eq!(comments[0].position, CommentPosition::StatementLeading);
         assert_eq!(comments[0].attached_to, bar_start);
         assert!(comments[0].is_no_side_effects());
     }
@@ -598,7 +620,7 @@ function bar() {}";
         let function_start = u32::try_from(source_text.find("function").unwrap()).unwrap();
 
         assert_eq!(comments.len(), 1);
-        assert_eq!(comments[0].position, CommentPosition::Leading);
+        assert_eq!(comments[0].position, CommentPosition::StatementLeading);
         assert_eq!(comments[0].attached_to, function_start);
         assert!(comments[0].is_no_side_effects());
         assert!(comments[0].followed_by_newline());
@@ -611,7 +633,7 @@ function bar() {}";
         let new_start = u32::try_from(source_text.find("new").unwrap()).unwrap();
 
         assert_eq!(comments.len(), 1);
-        assert_eq!(comments[0].position, CommentPosition::Leading);
+        assert_eq!(comments[0].position, CommentPosition::StatementLeading);
         assert_eq!(comments[0].attached_to, new_start);
         assert!(comments[0].is_pure());
     }


### PR DESCRIPTION
#24510 made logical and conditional operand printers accept only annotation-bearing comment groups. That prevents a statement banner from moving into an expression when a transform dissolves the statement but reuses its expression with the original span. The same filter also drops ordinary comments that genuinely lead operands in an unmodified parse.

`attached_to` alone cannot distinguish these cases. It only records the source start used for lookup: both a comment leading an expression and one leading a statement can point at the same start. Once a transform erases the statement boundary while retaining the expression span, codegen cannot recover the comment's original owner from the transformed AST.

The parser still has that ownership information, so this change records it before transforms run. Comments attached at statement boundaries become `StatementLeading`; other before-token comments remain `Leading`. `StatementLeading` is origin metadata, not a separate printing style. Operand printers can preserve ordinary `Leading` expression trivia while rejecting `StatementLeading` trivia. Annotations still print because they retain expression-level meaning, while legal comments remain available to orphan handling.

## Example

Input:

```js
const value = a ?? /* plain comment */ [];
```

Before:

```js
const value = a ?? [];
```

After:

```js
const value = a ?? /* plain comment */ [];
```

Tests cover normal comments on logical right-hand sides and both conditional branches, comment-group idempotency, legal-comment orphaning, parser attachment boundaries including arrow lookahead, and minifier transforms that dissolve statement bodies into operands.

Verified with all codegen comment integration tests, the dissolved-statement minifier tests, and codegen Clippy. `just ready` completed formatting and the full workspace check; its all-features test stopped only on the environment-sensitive stacktrace snapshot's Node version (`v25.8.1` locally versus `v26.5.0` recorded) after 133 codegen integration tests passed.

Follow-up: #24578 adds the trailing-comment attachment boundary as the second PR in this stack.

This PR was assisted by OpenAI Codex.
