### PR TITLE
feat(estree): expose source text to serializers

### DIFF
--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -47,7 +47,8 @@ impl Program<'_> {
     /// Serialize AST to ESTree JSON.
     pub fn to_estree_json(&self, include_ts_fields: bool, ranges: bool) -> String {
         let capacity = self.source_text.len() * JSON_CAPACITY_RATIO_COMPACT;
-        let mut serializer = CompactSerializer::with_capacity(capacity, include_ts_fields, ranges);
+        let mut serializer = CompactSerializer::with_capacity(capacity, include_ts_fields, ranges)
+            .with_source_text(self.source_text);
         self.serialize(&mut serializer);
         serializer.into_string()
     }
@@ -55,7 +56,8 @@ impl Program<'_> {
     /// Serialize AST to pretty-printed ESTree JSON.
     pub fn to_pretty_estree_json(&self, include_ts_fields: bool, ranges: bool) -> String {
         let capacity = self.source_text.len() * JSON_CAPACITY_RATIO_PRETTY;
-        let mut serializer = PrettySerializer::with_capacity(capacity, include_ts_fields, ranges);
+        let mut serializer = PrettySerializer::with_capacity(capacity, include_ts_fields, ranges)
+            .with_source_text(self.source_text);
         self.serialize(&mut serializer);
         serializer.into_string()
     }
@@ -63,7 +65,8 @@ impl Program<'_> {
     /// Serialize AST to ESTree JSON, with list of fixes.
     pub fn to_estree_json_with_fixes(&self, include_ts_fields: bool, ranges: bool) -> String {
         let capacity = self.source_text.len() * JSON_CAPACITY_RATIO_COMPACT;
-        let serializer = CompactFixesSerializer::with_capacity(capacity, include_ts_fields, ranges);
+        let serializer = CompactFixesSerializer::with_capacity(capacity, include_ts_fields, ranges)
+            .with_source_text(self.source_text);
         serializer.serialize_with_fixes(self)
     }
 
@@ -74,7 +77,8 @@ impl Program<'_> {
         ranges: bool,
     ) -> String {
         let capacity = self.source_text.len() * JSON_CAPACITY_RATIO_PRETTY;
-        let serializer = PrettyFixesSerializer::with_capacity(capacity, include_ts_fields, ranges);
+        let serializer = PrettyFixesSerializer::with_capacity(capacity, include_ts_fields, ranges)
+            .with_source_text(self.source_text);
         serializer.serialize_with_fixes(self)
     }
 }

--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -39,8 +39,11 @@ pub trait Serializer {
     /// Type of `Formatter` this serializer uses.
     type Formatter: Formatter;
 
+    /// Borrowed handle to source text associated with this serializer.
+    type SourceText: AsRef<str> + Copy;
+
     /// Type of struct serializer this serializer uses.
-    type StructSerializer: StructSerializer;
+    type StructSerializer: StructSerializer<SourceText = Self::SourceText>;
     /// Type of sequence serializer this serializer uses.
     type SequenceSerializer: SequenceSerializer;
 
@@ -49,6 +52,9 @@ pub trait Serializer {
 
     /// Get whether output should contain `range` fields.
     fn ranges(&self) -> bool;
+
+    /// Get the source text associated with this serialization, if provided.
+    fn source_text(&self) -> Option<Self::SourceText>;
 
     /// Serialize struct.
     fn serialize_struct(self) -> Self::StructSerializer;
@@ -71,27 +77,28 @@ pub trait Serializer {
 }
 
 /// ESTree serializer which produces compact JSON.
-pub type CompactSerializer = ESTreeSerializer<ConfigNoFixes, CompactFormatter>;
+pub type CompactSerializer = ESTreeSerializer<'static, ConfigNoFixes, CompactFormatter>;
 
 /// ESTree serializer which produces pretty JSON.
-pub type PrettySerializer = ESTreeSerializer<ConfigNoFixes, PrettyFormatter>;
+pub type PrettySerializer = ESTreeSerializer<'static, ConfigNoFixes, PrettyFormatter>;
 
 /// ESTree serializer which produces compact JSON.
-pub type CompactFixesSerializer = ESTreeSerializer<ConfigFixes, CompactFormatter>;
+pub type CompactFixesSerializer = ESTreeSerializer<'static, ConfigFixes, CompactFormatter>;
 
 /// ESTree serializer which produces pretty JSON.
-pub type PrettyFixesSerializer = ESTreeSerializer<ConfigFixes, PrettyFormatter>;
+pub type PrettyFixesSerializer = ESTreeSerializer<'static, ConfigFixes, PrettyFormatter>;
 
 /// ESTree serializer.
-pub struct ESTreeSerializer<C: Config, F: Formatter> {
+pub struct ESTreeSerializer<'a, C: Config, F: Formatter> {
     buffer: CodeBuffer,
     formatter: F,
     trace_path: NonEmptyStack<TracePathPart>,
     fixes_buffer: CodeBuffer,
     config: C,
+    source_text: Option<&'a str>,
 }
 
-impl<C: Config, F: Formatter> ESTreeSerializer<C, F> {
+impl<C: Config, F: Formatter> ESTreeSerializer<'static, C, F> {
     /// Create new [`ESTreeSerializer`].
     pub fn new(include_ts_fields: bool, ranges: bool) -> Self {
         Self {
@@ -100,6 +107,7 @@ impl<C: Config, F: Formatter> ESTreeSerializer<C, F> {
             trace_path: NonEmptyStack::new(TracePathPart::Index(0)),
             fixes_buffer: CodeBuffer::new(),
             config: C::new(include_ts_fields, ranges),
+            source_text: None,
         }
     }
 
@@ -111,6 +119,21 @@ impl<C: Config, F: Formatter> ESTreeSerializer<C, F> {
             trace_path: NonEmptyStack::new(TracePathPart::Index(0)),
             fixes_buffer: CodeBuffer::new(),
             config: C::new(include_ts_fields, ranges),
+            source_text: None,
+        }
+    }
+}
+
+impl<C: Config, F: Formatter> ESTreeSerializer<'_, C, F> {
+    /// Associate source text with this serializer.
+    pub fn with_source_text(self, source_text: &'_ str) -> ESTreeSerializer<'_, C, F> {
+        ESTreeSerializer {
+            buffer: self.buffer,
+            formatter: self.formatter,
+            trace_path: self.trace_path,
+            fixes_buffer: self.fixes_buffer,
+            config: self.config,
+            source_text: Some(source_text),
         }
     }
 
@@ -157,17 +180,18 @@ impl<C: Config, F: Formatter> ESTreeSerializer<C, F> {
     }
 }
 
-impl<C: Config, F: Formatter> Default for ESTreeSerializer<C, F> {
+impl<C: Config, F: Formatter> Default for ESTreeSerializer<'static, C, F> {
     #[inline(always)]
     fn default() -> Self {
         Self::new(true, false)
     }
 }
 
-impl<'s, C: Config, F: Formatter> Serializer for &'s mut ESTreeSerializer<C, F> {
+impl<'s, 'a, C: Config, F: Formatter> Serializer for &'s mut ESTreeSerializer<'a, C, F> {
     type Formatter = F;
-    type StructSerializer = ESTreeStructSerializer<'s, C, F>;
-    type SequenceSerializer = ESTreeSequenceSerializer<'s, C, F>;
+    type SourceText = &'a str;
+    type StructSerializer = ESTreeStructSerializer<'s, 'a, C, F>;
+    type SequenceSerializer = ESTreeSequenceSerializer<'s, 'a, C, F>;
 
     /// Get whether output should contain TS fields.
     #[inline(always)]
@@ -181,15 +205,21 @@ impl<'s, C: Config, F: Formatter> Serializer for &'s mut ESTreeSerializer<C, F> 
         self.config.ranges()
     }
 
+    /// Get the source text associated with this serialization, if provided.
+    #[inline(always)]
+    fn source_text(&self) -> Option<Self::SourceText> {
+        self.source_text
+    }
+
     /// Serialize struct.
     #[inline(always)]
-    fn serialize_struct(self) -> ESTreeStructSerializer<'s, C, F> {
+    fn serialize_struct(self) -> ESTreeStructSerializer<'s, 'a, C, F> {
         ESTreeStructSerializer::new(self)
     }
 
     /// Serialize sequence.
     #[inline(always)]
-    fn serialize_sequence(self) -> ESTreeSequenceSerializer<'s, C, F> {
+    fn serialize_sequence(self) -> ESTreeSequenceSerializer<'s, 'a, C, F> {
         ESTreeSequenceSerializer::new(self)
     }
 
@@ -249,4 +279,26 @@ pub enum TracePathPart {
 
 impl TracePathPart {
     pub const DUMMY: Self = TracePathPart::Index(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct SourceText;
+
+    impl ESTree for SourceText {
+        fn serialize<S: Serializer>(&self, serializer: S) {
+            let source_text = serializer.source_text().unwrap();
+            JsonSafeString(source_text.as_ref()).serialize(serializer);
+        }
+    }
+
+    #[test]
+    fn serializer_provides_source_text() {
+        let mut serializer =
+            CompactSerializer::new(false, false).with_source_text("let answer = 42;");
+        SourceText.serialize(&mut serializer);
+        assert_eq!(serializer.into_string(), r#""let answer = 42;""#);
+    }
 }

--- a/crates/oxc_estree/src/serialize/sequences.rs
+++ b/crates/oxc_estree/src/serialize/sequences.rs
@@ -12,16 +12,16 @@ pub trait SequenceSerializer {
 /// Serializer for sequences.
 ///
 /// This is returned by `ESTreeSerializer::serialize_sequence`.
-pub struct ESTreeSequenceSerializer<'s, C: Config, F: Formatter> {
+pub struct ESTreeSequenceSerializer<'s, 'a, C: Config, F: Formatter> {
     /// Serializer
-    serializer: &'s mut ESTreeSerializer<C, F>,
+    serializer: &'s mut ESTreeSerializer<'a, C, F>,
     /// Length of sequence
     len: usize,
 }
 
-impl<'s, C: Config, F: Formatter> ESTreeSequenceSerializer<'s, C, F> {
+impl<'s, 'a, C: Config, F: Formatter> ESTreeSequenceSerializer<'s, 'a, C, F> {
     /// Create new [`ESTreeSequenceSerializer`].
-    pub(super) fn new(mut serializer: &'s mut ESTreeSerializer<C, F>) -> Self {
+    pub(super) fn new(mut serializer: &'s mut ESTreeSerializer<'a, C, F>) -> Self {
         // Push item to `trace_path`. It will be replaced with a `TracePathPart::Index`
         // when serializing each item in the sequence, and popped off again in `end` method.
         if serializer.config.fixes() {
@@ -34,7 +34,7 @@ impl<'s, C: Config, F: Formatter> ESTreeSequenceSerializer<'s, C, F> {
     }
 }
 
-impl<C: Config, F: Formatter> SequenceSerializer for ESTreeSequenceSerializer<'_, C, F> {
+impl<C: Config, F: Formatter> SequenceSerializer for ESTreeSequenceSerializer<'_, '_, C, F> {
     /// Serialize sequence entry.
     fn serialize_element<T: ESTree + ?Sized>(&mut self, value: &T) {
         // Update last item in trace path to current sequence index

--- a/crates/oxc_estree/src/serialize/structs.rs
+++ b/crates/oxc_estree/src/serialize/structs.rs
@@ -9,6 +9,7 @@ use super::{
 pub trait StructSerializer {
     type Config: Config;
     type Formatter: Formatter;
+    type SourceText: AsRef<str> + Copy;
 
     /// Serialize struct field.
     ///
@@ -51,22 +52,25 @@ pub trait StructSerializer {
 
     /// Get whether output should contain `range` fields.
     fn ranges(&self) -> bool;
+
+    /// Get the source text associated with this serialization, if provided.
+    fn source_text(&self) -> Option<Self::SourceText>;
 }
 
 /// Serializer for structs.
 ///
 /// This is returned by `ESTreeSerializer::serialize_struct`.
-pub struct ESTreeStructSerializer<'s, C: Config, F: Formatter> {
+pub struct ESTreeStructSerializer<'s, 'a, C: Config, F: Formatter> {
     /// Serializer
-    serializer: &'s mut ESTreeSerializer<C, F>,
+    serializer: &'s mut ESTreeSerializer<'a, C, F>,
     /// State of struct.
     /// Starts as `StructState::Empty`, transitions to `StructState::HasFields` on first field.
     state: StructState,
 }
 
-impl<'s, C: Config, F: Formatter> ESTreeStructSerializer<'s, C, F> {
+impl<'s, 'a, C: Config, F: Formatter> ESTreeStructSerializer<'s, 'a, C, F> {
     /// Create new [`ESTreeStructSerializer`].
-    pub(super) fn new(mut serializer: &'s mut ESTreeSerializer<C, F>) -> Self {
+    pub(super) fn new(mut serializer: &'s mut ESTreeSerializer<'a, C, F>) -> Self {
         // Push item to `trace_path`. It will be replaced with a `TracePathPart::Key`
         // when serializing each field in the struct, and popped off again in `end` method.
         if serializer.config.fixes() {
@@ -79,9 +83,10 @@ impl<'s, C: Config, F: Formatter> ESTreeStructSerializer<'s, C, F> {
     }
 }
 
-impl<C: Config, F: Formatter> StructSerializer for ESTreeStructSerializer<'_, C, F> {
+impl<'a, C: Config, F: Formatter> StructSerializer for ESTreeStructSerializer<'_, 'a, C, F> {
     type Config = C;
     type Formatter = F;
+    type SourceText = &'a str;
 
     /// Serialize struct field.
     ///
@@ -181,6 +186,12 @@ impl<C: Config, F: Formatter> StructSerializer for ESTreeStructSerializer<'_, C,
     fn ranges(&self) -> bool {
         self.serializer.ranges()
     }
+
+    /// Get the source text associated with this serialization, if provided.
+    #[inline(always)]
+    fn source_text(&self) -> Option<Self::SourceText> {
+        self.serializer.source_text()
+    }
 }
 
 /// State of [`StructSerializer`].
@@ -229,15 +240,16 @@ pub struct FlatStructSerializer<'p, P: StructSerializer>(pub &'p mut P);
 
 impl<'p, P: StructSerializer> Serializer for FlatStructSerializer<'p, P> {
     type Formatter = P::Formatter;
+    type SourceText = P::SourceText;
     type StructSerializer = Self;
-    type SequenceSerializer = ESTreeSequenceSerializer<'p, P::Config, P::Formatter>;
+    type SequenceSerializer = ESTreeSequenceSerializer<'p, 'static, P::Config, P::Formatter>;
 
     /// Serialize struct.
     fn serialize_struct(self) -> Self {
         self
     }
 
-    fn serialize_sequence(self) -> ESTreeSequenceSerializer<'p, P::Config, P::Formatter> {
+    fn serialize_sequence(self) -> ESTreeSequenceSerializer<'p, 'static, P::Config, P::Formatter> {
         const {
             panic!("Cannot flatten a sequence into a struct");
         }
@@ -261,6 +273,12 @@ impl<'p, P: StructSerializer> Serializer for FlatStructSerializer<'p, P> {
         self.0.ranges()
     }
 
+    /// Get the source text associated with this serialization, if provided.
+    #[inline(always)]
+    fn source_text(&self) -> Option<Self::SourceText> {
+        self.0.source_text()
+    }
+
     fn buffer_mut(&mut self) -> &mut CodeBuffer {
         const {
             panic!("Cannot flatten anything but a struct into another struct");
@@ -277,6 +295,7 @@ impl<'p, P: StructSerializer> Serializer for FlatStructSerializer<'p, P> {
 impl<P: StructSerializer> StructSerializer for FlatStructSerializer<'_, P> {
     type Config = P::Config;
     type Formatter = P::Formatter;
+    type SourceText = P::SourceText;
 
     /// Serialize struct field.
     ///
@@ -340,6 +359,12 @@ impl<P: StructSerializer> StructSerializer for FlatStructSerializer<'_, P> {
     #[inline(always)]
     fn ranges(&self) -> bool {
         self.0.ranges()
+    }
+
+    /// Get the source text associated with this serialization, if provided.
+    #[inline(always)]
+    fn source_text(&self) -> Option<Self::SourceText> {
+        self.0.source_text()
     }
 }
 

--- a/crates/oxc_estree_tokens/src/json/mod.rs
+++ b/crates/oxc_estree_tokens/src/json/mod.rs
@@ -59,10 +59,10 @@ impl ESTreeConfig for TokenSerializerConfig {
 }
 
 /// Serializer for tokens to compact JSON.
-type CompactTokenSerializer = ESTreeSerializer<TokenSerializerConfig, CompactFormatter>;
+type CompactTokenSerializer = ESTreeSerializer<'static, TokenSerializerConfig, CompactFormatter>;
 
 /// Serializer for tokens to pretty-printed JSON.
-type PrettyTokenSerializer = ESTreeSerializer<TokenSerializerConfig, PrettyFormatter>;
+type PrettyTokenSerializer = ESTreeSerializer<'static, TokenSerializerConfig, PrettyFormatter>;
 
 /// Serialize tokens to JSON.
 ///


### PR DESCRIPTION
This is deliberately an `Option<&str>` as we may be serializing standalone/manually constructed nodes.