### PR TITLE
feat(parser): improve diagnostics for unparenthesized LHS on exponential expr

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -1188,10 +1188,21 @@ pub fn mixed_coalesce(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn unexpected_exponential(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Unexpected exponentiation expression")
-        .with_help(format!("Wrap {x0} expression in parentheses to enforce operator precedence"))
-        .with_label(span1)
+pub fn unary_exponentiation_left_operand(operator: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!(
+        "A unary expression with the '{operator}' operator cannot be used as the left operand of an exponentiation expression"
+    ))
+    .with_help("Wrap the unary expression in parentheses to make the precedence explicit")
+    .with_label(span)
+}
+
+#[cold]
+pub fn type_assertion_exponentiation_left_operand(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(
+        "A type assertion cannot be used as the left operand of an exponentiation expression",
+    )
+    .with_help("Wrap the type assertion in parentheses to make the precedence explicit")
+    .with_label(span)
 }
 
 #[cold]

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1408,15 +1408,25 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             } else if kind.is_binary_operator() {
                 let span = self.end_span(lhs_span);
                 let op = map_binary_operator(kind);
-                if op == BinaryOperator::Exponential
-                    && !lhs_parenthesized
-                    && let Some(key) = match lhs {
-                        Expression::AwaitExpression(_) => Some("await"),
-                        Expression::UnaryExpression(_) => Some("unary"),
+                if op == BinaryOperator::Exponential && !lhs_parenthesized {
+                    let diagnostic = match &lhs {
+                        Expression::AwaitExpression(_) => Some(
+                            diagnostics::unary_exponentiation_left_operand("await", lhs.span()),
+                        ),
+                        Expression::UnaryExpression(unary) => {
+                            Some(diagnostics::unary_exponentiation_left_operand(
+                                unary.operator.as_str(),
+                                lhs.span(),
+                            ))
+                        }
+                        Expression::TSTypeAssertion(_) => Some(
+                            diagnostics::type_assertion_exponentiation_left_operand(lhs.span()),
+                        ),
                         _ => None,
+                    };
+                    if let Some(diagnostic) = diagnostic {
+                        self.error(diagnostic);
                     }
-                {
-                    self.error(diagnostics::unexpected_exponential(key, lhs.span()));
                 }
                 Expression::new_binary_expression(span, lhs, op, rhs, self)
             } else {

--- a/tasks/coverage/misc/fail/exponentiation-left-operands.ts
+++ b/tasks/coverage/misc/fail/exponentiation-left-operands.ts
@@ -1,0 +1,3 @@
+-value ** 2;
+await value ** 2;
+<number>value ** 2;

--- a/tasks/coverage/misc/pass/parenthesized-exponentiation-left-operands.ts
+++ b/tasks/coverage/misc/pass/parenthesized-exponentiation-left-operands.ts
@@ -1,0 +1,2 @@
+(-value) ** 2;
+(<number>value) ** 2;

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 71/71 (100.00%)
-Positive Passed: 71/71 (100.00%)
+AST Parsed     : 72/72 (100.00%)
+Positive Passed: 72/72 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 71/71 (100.00%)
-Positive Passed: 71/71 (100.00%)
+AST Parsed     : 72/72 (100.00%)
+Positive Passed: 72/72 (100.00%)

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -4817,26 +4817,26 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·                        ╰── yield expression not allowed in formal parameter
    ╰────
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[babel/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/10/input.js:1:1]
  1 │ -5 ** 6;
    · ──
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[babel/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/11/input.js:1:1]
  1 │ -(5) ** 6;
    · ────
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[babel/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/12/input.js:1:2]
  1 │ (-5 ** 6);
    ·  ──
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
   × Unexpected token
    ╭─[babel/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/13/input.js:1:4]
@@ -4850,40 +4850,40 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·    ──
    ╰────
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[babel/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/15/input.js:1:1]
  1 │ -(5) ** 6;
    · ────
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[babel/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/16/input.js:1:2]
  1 │ (-5 ** 6);
    ·  ──
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'await' operator cannot be used as the left operand of an exponentiation expression
    ╭─[babel/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/await-before-exponential/input.js:1:13]
  1 │ async () => await 5 ** 6;
    ·             ───────
    ╰────
-  help: Wrap await expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'await' operator cannot be used as the left operand of an exponentiation expression
    ╭─[babel/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/await-unary-before-exponential/input.js:1:13]
  1 │ async () => await -5 ** 6;
    ·             ────────
    ╰────
-  help: Wrap await expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[babel/packages/babel-parser/test/fixtures/es2016/exponentiation-operator/nested-unary-before-exponential/input.js:1:2]
  1 │ (-+5 ** 6);
    ·  ───
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
   × Illegal 'use strict' directive in function with non-simple parameter list
    ╭─[babel/packages/babel-parser/test/fixtures/es2016/simple-parameter-list/array-pattern/input.js:2:3]
@@ -13786,19 +13786,19 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·        ────
    ╰────
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'await' operator cannot be used as the left operand of an exponentiation expression
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/exponentiation/await-non-null-before-exponential/input.ts:1:14]
  1 │ async (a) => await a! ** 6;
    ·              ────────
    ╰────
-  help: Wrap await expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/exponentiation/unary-non-null-before-exponential/input.ts:1:8]
  1 │ (a) => +a! ** 6;
    ·        ───
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
   × Unexpected token
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/export/declare-invalid/input.ts:1:16]

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
-AST Parsed     : 71/71 (100.00%)
-Positive Passed: 71/71 (100.00%)
-Negative Passed: 152/152 (100.00%)
+AST Parsed     : 72/72 (100.00%)
+Positive Passed: 72/72 (100.00%)
+Negative Passed: 153/153 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -116,6 +116,31 @@ Negative Passed: 152/152 (100.00%)
    ·                         ─────
    ╰────
   help: for octal literals use the '0o' prefix instead
+
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
+   ╭─[misc/fail/exponentiation-left-operands.ts:1:1]
+ 1 │ -value ** 2;
+   · ──────
+ 2 │ await value ** 2;
+   ╰────
+  help: Wrap the unary expression in parentheses to make the precedence explicit
+
+  × A unary expression with the 'await' operator cannot be used as the left operand of an exponentiation expression
+   ╭─[misc/fail/exponentiation-left-operands.ts:2:1]
+ 1 │ -value ** 2;
+ 2 │ await value ** 2;
+   · ───────────
+ 3 │ <number>value ** 2;
+   ╰────
+  help: Wrap the unary expression in parentheses to make the precedence explicit
+
+  × A type assertion cannot be used as the left operand of an exponentiation expression
+   ╭─[misc/fail/exponentiation-left-operands.ts:3:1]
+ 2 │ await value ** 2;
+ 3 │ <number>value ** 2;
+   · ─────────────
+   ╰────
+  help: Wrap the type assertion in parentheses to make the precedence explicit
 
   × TS(2309): An export assignment cannot be used in a module with other exported elements
    ╭─[misc/fail/export-equal-with-normal-export.ts:4:1]

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -17835,61 +17835,61 @@ Negative Passed: 4651/4651 (100.00%)
  25 │ 
     ╰────
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '~' operator cannot be used as the left operand of an exponentiation expression
     ╭─[test262/test/language/expressions/exponentiation/exp-operator-syntax-error-bitnot-unary-expression-base.js:26:1]
  25 │ $DONOTEVALUATE();
  26 │ ~3 ** 2;
     · ──
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'delete' operator cannot be used as the left operand of an exponentiation expression
     ╭─[test262/test/language/expressions/exponentiation/exp-operator-syntax-error-delete-unary-expression-base.js:26:1]
  25 │ $DONOTEVALUATE();
  26 │ delete o.p ** 2;
     · ──────────
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[test262/test/language/expressions/exponentiation/exp-operator-syntax-error-logical-not-unary-expression-base.js:26:1]
  25 │ $DONOTEVALUATE();
  26 │ !1 ** 2;
     · ──
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[test262/test/language/expressions/exponentiation/exp-operator-syntax-error-negate-unary-expression-base.js:26:1]
  25 │ $DONOTEVALUATE();
  26 │ -3 ** 2;
     · ──
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
     ╭─[test262/test/language/expressions/exponentiation/exp-operator-syntax-error-plus-unary-expression-base.js:26:1]
  25 │ $DONOTEVALUATE();
  26 │ +1 ** 2;
     · ──
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[test262/test/language/expressions/exponentiation/exp-operator-syntax-error-typeof-unary-expression-base.js:26:1]
  25 │ $DONOTEVALUATE();
  26 │ typeof 1 ** 2;
     · ────────
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'void' operator cannot be used as the left operand of an exponentiation expression
     ╭─[test262/test/language/expressions/exponentiation/exp-operator-syntax-error-void-unary-expression-base.js:26:1]
  25 │ $DONOTEVALUATE();
  26 │ void 1 ** 2;
     · ──────
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
   × Illegal 'use strict' directive in function with non-simple parameter list
      ╭─[test262/test/language/expressions/function/array-destructuring-param-strict-body.js:132:3]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -20364,1520 +20364,1564 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  8 │     }
    ╰────
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:7:8]
  6 │ // TempateHead & TemplateTail are empty
  7 │ `${1 + typeof t1 ** t2 ** t1}`;
    ·        ─────────
  8 │ `${-t1 ** t2 - t1}`;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:8:4]
  7 │ `${1 + typeof t1 ** t2 ** t1}`;
  8 │ `${-t1 ** t2 - t1}`;
    ·    ───
  9 │ `${-++t1 ** t2 - t1}`;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:9:4]
   8 │ `${-t1 ** t2 - t1}`;
   9 │ `${-++t1 ** t2 - t1}`;
     ·    ─────
  10 │ `${-t1++ ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:10:4]
   9 │ `${-++t1 ** t2 - t1}`;
  10 │ `${-t1++ ** t2 - t1}`;
     ·    ─────
  11 │ `${!t1 ** t2 ** --t1 }`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:11:4]
  10 │ `${-t1++ ** t2 - t1}`;
  11 │ `${!t1 ** t2 ** --t1 }`;
     ·    ───
  12 │ `${typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:12:4]
  11 │ `${!t1 ** t2 ** --t1 }`;
  12 │ `${typeof t1 ** t2 ** t1}`;
     ·    ─────────
  13 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:14:4]
  13 │ 
  14 │ `${-t1 ** t2 - t1}${-t1 ** t2 - t1}`;
     ·    ───
  15 │ `${-++t1 ** t2 - t1}${-++t1 ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:14:21]
  13 │ 
  14 │ `${-t1 ** t2 - t1}${-t1 ** t2 - t1}`;
     ·                     ───
  15 │ `${-++t1 ** t2 - t1}${-++t1 ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:15:4]
  14 │ `${-t1 ** t2 - t1}${-t1 ** t2 - t1}`;
  15 │ `${-++t1 ** t2 - t1}${-++t1 ** t2 - t1}`;
     ·    ─────
  16 │ `${-t1++ ** t2 - t1}${-t1++ ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:15:23]
  14 │ `${-t1 ** t2 - t1}${-t1 ** t2 - t1}`;
  15 │ `${-++t1 ** t2 - t1}${-++t1 ** t2 - t1}`;
     ·                       ─────
  16 │ `${-t1++ ** t2 - t1}${-t1++ ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:16:4]
  15 │ `${-++t1 ** t2 - t1}${-++t1 ** t2 - t1}`;
  16 │ `${-t1++ ** t2 - t1}${-t1++ ** t2 - t1}`;
     ·    ─────
  17 │ `${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 }`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:16:23]
  15 │ `${-++t1 ** t2 - t1}${-++t1 ** t2 - t1}`;
  16 │ `${-t1++ ** t2 - t1}${-t1++ ** t2 - t1}`;
     ·                       ─────
  17 │ `${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 }`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:17:4]
  16 │ `${-t1++ ** t2 - t1}${-t1++ ** t2 - t1}`;
  17 │ `${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 }`;
     ·    ───
  18 │ `${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:17:25]
  16 │ `${-t1++ ** t2 - t1}${-t1++ ** t2 - t1}`;
  17 │ `${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 }`;
     ·                         ───
  18 │ `${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:18:4]
  17 │ `${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 }`;
  18 │ `${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1}`;
     ·    ─────────
  19 │ `${1 + typeof t1 ** t2 ** t1}${1 + typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:18:28]
  17 │ `${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 }`;
  18 │ `${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1}`;
     ·                            ─────────
  19 │ `${1 + typeof t1 ** t2 ** t1}${1 + typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:19:8]
  18 │ `${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1}`;
  19 │ `${1 + typeof t1 ** t2 ** t1}${1 + typeof t1 ** t2 ** t1}`;
     ·        ─────────
  20 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:19:36]
  18 │ `${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1}`;
  19 │ `${1 + typeof t1 ** t2 ** t1}${1 + typeof t1 ** t2 ** t1}`;
     ·                                    ─────────
  20 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:21:4]
  20 │ 
  21 │ `${-t1 ** t2 - t1} hello world ${-t1 ** t2 - t1}`;
     ·    ───
  22 │ `${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:21:34]
  20 │ 
  21 │ `${-t1 ** t2 - t1} hello world ${-t1 ** t2 - t1}`;
     ·                                  ───
  22 │ `${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:22:4]
  21 │ `${-t1 ** t2 - t1} hello world ${-t1 ** t2 - t1}`;
  22 │ `${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1}`;
     ·    ─────
  23 │ `${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:22:36]
  21 │ `${-t1 ** t2 - t1} hello world ${-t1 ** t2 - t1}`;
  22 │ `${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1}`;
     ·                                    ─────
  23 │ `${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:23:4]
  22 │ `${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1}`;
  23 │ `${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1}`;
     ·    ─────
  24 │ `${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 }`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:23:36]
  22 │ `${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1}`;
  23 │ `${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1}`;
     ·                                    ─────
  24 │ `${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 }`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:24:4]
  23 │ `${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1}`;
  24 │ `${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 }`;
     ·    ───
  25 │ `${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:24:38]
  23 │ `${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1}`;
  24 │ `${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 }`;
     ·                                      ───
  25 │ `${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:25:4]
  24 │ `${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 }`;
  25 │ `${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1}`;
     ·    ─────────
  26 │ `${1 + typeof t1 ** t2 ** t1} hello world ${1 + typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:25:41]
  24 │ `${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 }`;
  25 │ `${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1}`;
     ·                                         ─────────
  26 │ `${1 + typeof t1 ** t2 ** t1} hello world ${1 + typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:26:8]
  25 │ `${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1}`;
  26 │ `${1 + typeof t1 ** t2 ** t1} hello world ${1 + typeof t1 ** t2 ** t1}`;
     ·        ─────────
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError1.ts:26:49]
  25 │ `${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1}`;
  26 │ `${1 + typeof t1 ** t2 ** t1} hello world ${1 + typeof t1 ** t2 ** t1}`;
     ·                                                 ─────────
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:7:10]
  6 │ // With templateHead
  7 │ `hello ${-t1 ** t2 - t1}`;
    ·          ───
  8 │ `hello ${-++t1 ** t2 - t1}`;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:8:10]
  7 │ `hello ${-t1 ** t2 - t1}`;
  8 │ `hello ${-++t1 ** t2 - t1}`;
    ·          ─────
  9 │ `hello ${-t1++ ** t2 - t1}`;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:9:10]
   8 │ `hello ${-++t1 ** t2 - t1}`;
   9 │ `hello ${-t1++ ** t2 - t1}`;
     ·          ─────
  10 │ `hello ${!t1 ** t2 ** --t1 }`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:10:10]
   9 │ `hello ${-t1++ ** t2 - t1}`;
  10 │ `hello ${!t1 ** t2 ** --t1 }`;
     ·          ───
  11 │ `hello ${typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:11:10]
  10 │ `hello ${!t1 ** t2 ** --t1 }`;
  11 │ `hello ${typeof t1 ** t2 ** t1}`;
     ·          ─────────
  12 │ `hello ${1 + typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:12:14]
  11 │ `hello ${typeof t1 ** t2 ** t1}`;
  12 │ `hello ${1 + typeof t1 ** t2 ** t1}`;
     ·              ─────────
  13 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:14:10]
  13 │ 
  14 │ `hello ${-t1 ** t2 - t1}${-t1 ** t2 - t1}`;
     ·          ───
  15 │ `hello ${-++t1 ** t2 - t1}${-++t1 ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:14:27]
  13 │ 
  14 │ `hello ${-t1 ** t2 - t1}${-t1 ** t2 - t1}`;
     ·                           ───
  15 │ `hello ${-++t1 ** t2 - t1}${-++t1 ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:15:10]
  14 │ `hello ${-t1 ** t2 - t1}${-t1 ** t2 - t1}`;
  15 │ `hello ${-++t1 ** t2 - t1}${-++t1 ** t2 - t1}`;
     ·          ─────
  16 │ `hello ${-t1++ ** t2 - t1}${-t1++ ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:15:29]
  14 │ `hello ${-t1 ** t2 - t1}${-t1 ** t2 - t1}`;
  15 │ `hello ${-++t1 ** t2 - t1}${-++t1 ** t2 - t1}`;
     ·                             ─────
  16 │ `hello ${-t1++ ** t2 - t1}${-t1++ ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:16:10]
  15 │ `hello ${-++t1 ** t2 - t1}${-++t1 ** t2 - t1}`;
  16 │ `hello ${-t1++ ** t2 - t1}${-t1++ ** t2 - t1}`;
     ·          ─────
  17 │ `hello ${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 }`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:16:29]
  15 │ `hello ${-++t1 ** t2 - t1}${-++t1 ** t2 - t1}`;
  16 │ `hello ${-t1++ ** t2 - t1}${-t1++ ** t2 - t1}`;
     ·                             ─────
  17 │ `hello ${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 }`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:17:10]
  16 │ `hello ${-t1++ ** t2 - t1}${-t1++ ** t2 - t1}`;
  17 │ `hello ${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 }`;
     ·          ───
  18 │ `hello ${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:17:31]
  16 │ `hello ${-t1++ ** t2 - t1}${-t1++ ** t2 - t1}`;
  17 │ `hello ${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 }`;
     ·                               ───
  18 │ `hello ${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:18:10]
  17 │ `hello ${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 }`;
  18 │ `hello ${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1}`;
     ·          ─────────
  19 │ `hello ${1 + typeof t1 ** t2 ** t1}${1 + typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:18:34]
  17 │ `hello ${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 }`;
  18 │ `hello ${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1}`;
     ·                                  ─────────
  19 │ `hello ${1 + typeof t1 ** t2 ** t1}${1 + typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:19:14]
  18 │ `hello ${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1}`;
  19 │ `hello ${1 + typeof t1 ** t2 ** t1}${1 + typeof t1 ** t2 ** t1}`;
     ·              ─────────
  20 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:19:42]
  18 │ `hello ${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1}`;
  19 │ `hello ${1 + typeof t1 ** t2 ** t1}${1 + typeof t1 ** t2 ** t1}`;
     ·                                          ─────────
  20 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:21:10]
  20 │ 
  21 │ `hello ${-t1 ** t2 - t1} hello world ${-t1 ** t2 - t1}`;
     ·          ───
  22 │ `hello ${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:21:40]
  20 │ 
  21 │ `hello ${-t1 ** t2 - t1} hello world ${-t1 ** t2 - t1}`;
     ·                                        ───
  22 │ `hello ${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:22:10]
  21 │ `hello ${-t1 ** t2 - t1} hello world ${-t1 ** t2 - t1}`;
  22 │ `hello ${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1}`;
     ·          ─────
  23 │ `hello ${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:22:42]
  21 │ `hello ${-t1 ** t2 - t1} hello world ${-t1 ** t2 - t1}`;
  22 │ `hello ${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1}`;
     ·                                          ─────
  23 │ `hello ${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:23:10]
  22 │ `hello ${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1}`;
  23 │ `hello ${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1}`;
     ·          ─────
  24 │ `hello ${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 }`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:23:42]
  22 │ `hello ${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1}`;
  23 │ `hello ${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1}`;
     ·                                          ─────
  24 │ `hello ${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 }`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:24:10]
  23 │ `hello ${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1}`;
  24 │ `hello ${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 }`;
     ·          ───
  25 │ `hello ${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:24:44]
  23 │ `hello ${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1}`;
  24 │ `hello ${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 }`;
     ·                                            ───
  25 │ `hello ${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:25:10]
  24 │ `hello ${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 }`;
  25 │ `hello ${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1}`;
     ·          ─────────
  26 │ `hello ${1 + typeof t1 ** t2 ** t1} hello world ${1 + typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:25:47]
  24 │ `hello ${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 }`;
  25 │ `hello ${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1}`;
     ·                                               ─────────
  26 │ `hello ${1 + typeof t1 ** t2 ** t1} hello world ${1 + typeof t1 ** t2 ** t1}`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:26:14]
  25 │ `hello ${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1}`;
  26 │ `hello ${1 + typeof t1 ** t2 ** t1} hello world ${1 + typeof t1 ** t2 ** t1}`;
     ·              ─────────
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError2.ts:26:55]
  25 │ `hello ${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1}`;
  26 │ `hello ${1 + typeof t1 ** t2 ** t1} hello world ${1 + typeof t1 ** t2 ** t1}`;
     ·                                                       ─────────
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:7:4]
  6 │ // With TemplateTail
  7 │ `${-t1 ** t2 - t1} world`;
    ·    ───
  8 │ `${-++t1 ** t2 - t1} world`;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:8:4]
  7 │ `${-t1 ** t2 - t1} world`;
  8 │ `${-++t1 ** t2 - t1} world`;
    ·    ─────
  9 │ `${-t1++ ** t2 - t1} world`;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:9:4]
   8 │ `${-++t1 ** t2 - t1} world`;
   9 │ `${-t1++ ** t2 - t1} world`;
     ·    ─────
  10 │ `${!t1 ** t2 ** --t1 } world`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:10:4]
   9 │ `${-t1++ ** t2 - t1} world`;
  10 │ `${!t1 ** t2 ** --t1 } world`;
     ·    ───
  11 │ `${typeof t1 ** t2 ** t1} world`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:11:4]
  10 │ `${!t1 ** t2 ** --t1 } world`;
  11 │ `${typeof t1 ** t2 ** t1} world`;
     ·    ─────────
  12 │ `${1 + typeof t1 ** t2 ** t1} world`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:12:8]
  11 │ `${typeof t1 ** t2 ** t1} world`;
  12 │ `${1 + typeof t1 ** t2 ** t1} world`;
     ·        ─────────
  13 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:14:4]
  13 │ 
  14 │ `${-t1 ** t2 - t1}${-t1 ** t2 - t1} world`;
     ·    ───
  15 │ `${-++t1 ** t2 - t1}${-++t1 ** t2 - t1} world`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:14:21]
  13 │ 
  14 │ `${-t1 ** t2 - t1}${-t1 ** t2 - t1} world`;
     ·                     ───
  15 │ `${-++t1 ** t2 - t1}${-++t1 ** t2 - t1} world`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:15:4]
  14 │ `${-t1 ** t2 - t1}${-t1 ** t2 - t1} world`;
  15 │ `${-++t1 ** t2 - t1}${-++t1 ** t2 - t1} world`;
     ·    ─────
  16 │ `${-t1++ ** t2 - t1}${-t1++ ** t2 - t1} world`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:15:23]
  14 │ `${-t1 ** t2 - t1}${-t1 ** t2 - t1} world`;
  15 │ `${-++t1 ** t2 - t1}${-++t1 ** t2 - t1} world`;
     ·                       ─────
  16 │ `${-t1++ ** t2 - t1}${-t1++ ** t2 - t1} world`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:16:4]
  15 │ `${-++t1 ** t2 - t1}${-++t1 ** t2 - t1} world`;
  16 │ `${-t1++ ** t2 - t1}${-t1++ ** t2 - t1} world`;
     ·    ─────
  17 │ `${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 } world`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:16:23]
  15 │ `${-++t1 ** t2 - t1}${-++t1 ** t2 - t1} world`;
  16 │ `${-t1++ ** t2 - t1}${-t1++ ** t2 - t1} world`;
     ·                       ─────
  17 │ `${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 } world`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:17:4]
  16 │ `${-t1++ ** t2 - t1}${-t1++ ** t2 - t1} world`;
  17 │ `${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 } world`;
     ·    ───
  18 │ `${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1} world`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:17:25]
  16 │ `${-t1++ ** t2 - t1}${-t1++ ** t2 - t1} world`;
  17 │ `${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 } world`;
     ·                         ───
  18 │ `${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1} world`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:18:4]
  17 │ `${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 } world`;
  18 │ `${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1} world`;
     ·    ─────────
  19 │ `${1 + typeof t1 ** t2 ** t1}${1 + typeof t1 ** t2 ** t1} world`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:18:28]
  17 │ `${!t1 ** t2 ** --t1 }${!t1 ** t2 ** --t1 } world`;
  18 │ `${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1} world`;
     ·                            ─────────
  19 │ `${1 + typeof t1 ** t2 ** t1}${1 + typeof t1 ** t2 ** t1} world`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:19:8]
  18 │ `${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1} world`;
  19 │ `${1 + typeof t1 ** t2 ** t1}${1 + typeof t1 ** t2 ** t1} world`;
     ·        ─────────
  20 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:19:36]
  18 │ `${typeof t1 ** t2 ** t1}${typeof t1 ** t2 ** t1} world`;
  19 │ `${1 + typeof t1 ** t2 ** t1}${1 + typeof t1 ** t2 ** t1} world`;
     ·                                    ─────────
  20 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:21:4]
  20 │ 
  21 │ `${-t1 ** t2 - t1} hello world ${-t1 ** t2 - t1} !!`;
     ·    ───
  22 │ `${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1} !!`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:21:34]
  20 │ 
  21 │ `${-t1 ** t2 - t1} hello world ${-t1 ** t2 - t1} !!`;
     ·                                  ───
  22 │ `${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1} !!`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:22:4]
  21 │ `${-t1 ** t2 - t1} hello world ${-t1 ** t2 - t1} !!`;
  22 │ `${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1} !!`;
     ·    ─────
  23 │ `${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1} !!`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:22:36]
  21 │ `${-t1 ** t2 - t1} hello world ${-t1 ** t2 - t1} !!`;
  22 │ `${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1} !!`;
     ·                                    ─────
  23 │ `${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1} !!`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:23:4]
  22 │ `${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1} !!`;
  23 │ `${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1} !!`;
     ·    ─────
  24 │ `${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 } !!`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:23:36]
  22 │ `${-++t1 ** t2 - t1} hello world ${-++t1 ** t2 - t1} !!`;
  23 │ `${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1} !!`;
     ·                                    ─────
  24 │ `${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 } !!`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:24:4]
  23 │ `${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1} !!`;
  24 │ `${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 } !!`;
     ·    ───
  25 │ `${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1} !!`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:24:38]
  23 │ `${-t1++ ** t2 - t1} hello world ${-t1++ ** t2 - t1} !!`;
  24 │ `${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 } !!`;
     ·                                      ───
  25 │ `${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1} !!`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:25:4]
  24 │ `${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 } !!`;
  25 │ `${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1} !!`;
     ·    ─────────
  26 │ `${1 + typeof t1 ** t2 ** t1} hello world ${1 + typeof t1 ** t2 ** t1} !!`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:25:41]
  24 │ `${!t1 ** t2 ** --t1 } hello world ${!t1 ** t2 ** --t1 } !!`;
  25 │ `${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1} !!`;
     ·                                         ─────────
  26 │ `${1 + typeof t1 ** t2 ** t1} hello world ${1 + typeof t1 ** t2 ** t1} !!`;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:26:8]
  25 │ `${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1} !!`;
  26 │ `${1 + typeof t1 ** t2 ** t1} hello world ${1 + typeof t1 ** t2 ** t1} !!`;
     ·        ─────────
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorInTemplateStringWithSyntaxError3.ts:26:49]
  25 │ `${typeof t1 ** t2 ** t1} hello world ${typeof t1 ** t2 ** t1} !!`;
  26 │ `${1 + typeof t1 ** t2 ** t1} hello world ${1 + typeof t1 ** t2 ** t1} !!`;
     ·                                                 ─────────
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:2:1]
  1 │ // Error: early syntax error using ES7 SimpleUnaryExpression on left-hand side without ()
  2 │ -1 ** 2;
    · ──
  3 │ +1 ** 2
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:3:1]
  2 │ -1 ** 2;
  3 │ +1 ** 2
    · ──
  4 │ 1 ** -2 ** 3;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:4:6]
  3 │ +1 ** 2
  4 │ 1 ** -2 ** 3;
    ·      ──
  5 │ 1 ** -2 ** -3;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:5:6]
  4 │ 1 ** -2 ** 3;
  5 │ 1 ** -2 ** -3;
    ·      ──
  6 │ -1 ** -2 ** -3;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:6:7]
  5 │ 1 ** -2 ** -3;
  6 │ -1 ** -2 ** -3;
    ·       ──
  7 │ -(1 ** 2) ** 3;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:6:1]
  5 │ 1 ** -2 ** -3;
  6 │ -1 ** -2 ** -3;
    · ──
  7 │ -(1 ** 2) ** 3;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:7:1]
  6 │ -1 ** -2 ** -3;
  7 │ -(1 ** 2) ** 3;
    · ─────────
  8 │ 
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:11:1]
  10 │ 
  11 │ -++temp ** 3;
     · ───────
  12 │ +--temp ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:12:1]
  11 │ -++temp ** 3;
  12 │ +--temp ** 3;
     · ───────
  13 │ -temp++ ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:13:1]
  12 │ +--temp ** 3;
  13 │ -temp++ ** 3;
     · ───────
  14 │ +temp-- ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:14:1]
  13 │ -temp++ ** 3;
  14 │ +temp-- ** 3;
     · ───────
  15 │ 1 ** -++temp ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:15:6]
  14 │ +temp-- ** 3;
  15 │ 1 ** -++temp ** 3;
     ·      ───────
  16 │ 1 ** +--temp ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:16:6]
  15 │ 1 ** -++temp ** 3;
  16 │ 1 ** +--temp ** 3;
     ·      ───────
  17 │ 1 ** -temp++ ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:17:6]
  16 │ 1 ** +--temp ** 3;
  17 │ 1 ** -temp++ ** 3;
     ·      ───────
  18 │ 1 ** +temp-- ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:18:6]
  17 │ 1 ** -temp++ ** 3;
  18 │ 1 ** +temp-- ** 3;
     ·      ───────
  19 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:20:1]
  19 │ 
  20 │ -3 ** temp++;
     · ──
  21 │ -3 ** temp--;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:21:1]
  20 │ -3 ** temp++;
  21 │ -3 ** temp--;
     · ──
  22 │ -3 ** ++temp;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:22:1]
  21 │ -3 ** temp--;
  22 │ -3 ** ++temp;
     · ──
  23 │ -3 ** --temp;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:23:1]
  22 │ -3 ** ++temp;
  23 │ -3 ** --temp;
     · ──
  24 │ +3 ** temp++;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:24:1]
  23 │ -3 ** --temp;
  24 │ +3 ** temp++;
     · ──
  25 │ +3 ** temp--;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:25:1]
  24 │ +3 ** temp++;
  25 │ +3 ** temp--;
     · ──
  26 │ +3 ** ++temp;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:26:1]
  25 │ +3 ** temp--;
  26 │ +3 ** ++temp;
     · ──
  27 │ +3 ** --temp;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:27:1]
  26 │ +3 ** ++temp;
  27 │ +3 ** --temp;
     · ──
  28 │ -3 ** temp++ ** 2;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:28:1]
  27 │ +3 ** --temp;
  28 │ -3 ** temp++ ** 2;
     · ──
  29 │ -3 ** temp-- ** 2;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:29:1]
  28 │ -3 ** temp++ ** 2;
  29 │ -3 ** temp-- ** 2;
     · ──
  30 │ -3 ** ++temp ** 2;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:30:1]
  29 │ -3 ** temp-- ** 2;
  30 │ -3 ** ++temp ** 2;
     · ──
  31 │ -3 ** --temp ** 2;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '-' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:31:1]
  30 │ -3 ** ++temp ** 2;
  31 │ -3 ** --temp ** 2;
     · ──
  32 │ +3 ** temp++ ** 2;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:32:1]
  31 │ -3 ** --temp ** 2;
  32 │ +3 ** temp++ ** 2;
     · ──
  33 │ +3 ** temp-- ** 2;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:33:1]
  32 │ +3 ** temp++ ** 2;
  33 │ +3 ** temp-- ** 2;
     · ──
  34 │ +3 ** ++temp ** 2;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:34:1]
  33 │ +3 ** temp-- ** 2;
  34 │ +3 ** ++temp ** 2;
     · ──
  35 │ +3 ** --temp ** 2;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '+' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError1.ts:35:1]
  34 │ +3 ** ++temp ** 2;
  35 │ +3 ** --temp ** 2;
     · ──
  36 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'delete' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:4:1]
  3 │ 
  4 │ delete --temp ** 3;
    · ─────────────
  5 │ delete ++temp ** 3;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'delete' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:5:1]
  4 │ delete --temp ** 3;
  5 │ delete ++temp ** 3;
    · ─────────────
  6 │ delete temp-- ** 3;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'delete' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:6:1]
  5 │ delete ++temp ** 3;
  6 │ delete temp-- ** 3;
    · ─────────────
  7 │ delete temp++ ** 3;
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'delete' operator cannot be used as the left operand of an exponentiation expression
    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:7:1]
  6 │ delete temp-- ** 3;
  7 │ delete temp++ ** 3;
    · ─────────────
  8 │ 
    ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'delete' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:10:6]
   9 │ 
  10 │ 1 ** delete --temp ** 3;
     ·      ─────────────
  11 │ 1 ** delete ++temp ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'delete' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:11:6]
  10 │ 1 ** delete --temp ** 3;
  11 │ 1 ** delete ++temp ** 3;
     ·      ─────────────
  12 │ 1 ** delete temp-- ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'delete' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:12:6]
  11 │ 1 ** delete ++temp ** 3;
  12 │ 1 ** delete temp-- ** 3;
     ·      ─────────────
  13 │ 1 ** delete temp++ ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'delete' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:13:6]
  12 │ 1 ** delete temp-- ** 3;
  13 │ 1 ** delete temp++ ** 3;
     ·      ─────────────
  14 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:15:1]
  14 │ 
  15 │ typeof --temp ** 3;
     · ─────────────
  16 │ typeof temp-- ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:16:1]
  15 │ typeof --temp ** 3;
  16 │ typeof temp-- ** 3;
     · ─────────────
  17 │ typeof 3 ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:17:1]
  16 │ typeof temp-- ** 3;
  17 │ typeof 3 ** 4;
     · ────────
  18 │ typeof temp++ ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:18:1]
  17 │ typeof 3 ** 4;
  18 │ typeof temp++ ** 4;
     · ─────────────
  19 │ typeof temp-- ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:19:1]
  18 │ typeof temp++ ** 4;
  19 │ typeof temp-- ** 4;
     · ─────────────
  20 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:21:6]
  20 │ 
  21 │ 1 ** typeof --temp ** 3;
     ·      ─────────────
  22 │ 1 ** typeof temp-- ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:22:6]
  21 │ 1 ** typeof --temp ** 3;
  22 │ 1 ** typeof temp-- ** 3;
     ·      ─────────────
  23 │ 1 ** typeof 3 ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:23:6]
  22 │ 1 ** typeof temp-- ** 3;
  23 │ 1 ** typeof 3 ** 4;
     ·      ────────
  24 │ 1 ** typeof temp++ ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:24:6]
  23 │ 1 ** typeof 3 ** 4;
  24 │ 1 ** typeof temp++ ** 4;
     ·      ─────────────
  25 │ 1 ** typeof temp-- ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'typeof' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:25:6]
  24 │ 1 ** typeof temp++ ** 4;
  25 │ 1 ** typeof temp-- ** 4;
     ·      ─────────────
  26 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'void' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:27:1]
  26 │ 
  27 │ void --temp ** 3;
     · ───────────
  28 │ void temp-- ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'void' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:28:1]
  27 │ void --temp ** 3;
  28 │ void temp-- ** 3;
     · ───────────
  29 │ void 3 ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'void' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:29:1]
  28 │ void temp-- ** 3;
  29 │ void 3 ** 4;
     · ──────
  30 │ void temp++ ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'void' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:30:1]
  29 │ void 3 ** 4;
  30 │ void temp++ ** 4;
     · ───────────
  31 │ void temp-- ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'void' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:31:1]
  30 │ void temp++ ** 4;
  31 │ void temp-- ** 4;
     · ───────────
  32 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'void' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:33:6]
  32 │ 
  33 │ 1 ** void --temp ** 3;
     ·      ───────────
  34 │ 1 ** void temp-- ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'void' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:34:6]
  33 │ 1 ** void --temp ** 3;
  34 │ 1 ** void temp-- ** 3;
     ·      ───────────
  35 │ 1 ** void 3 ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'void' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:35:6]
  34 │ 1 ** void temp-- ** 3;
  35 │ 1 ** void 3 ** 4;
     ·      ──────
  36 │ 1 ** void temp++ ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'void' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:36:6]
  35 │ 1 ** void 3 ** 4;
  36 │ 1 ** void temp++ ** 4;
     ·      ───────────
  37 │ 1 ** void temp-- ** 4 ;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the 'void' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:37:6]
  36 │ 1 ** void temp++ ** 4;
  37 │ 1 ** void temp-- ** 4 ;
     ·      ───────────
  38 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '~' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:39:1]
  38 │ 
  39 │ ~ --temp ** 3;
     · ────────
  40 │ ~temp-- ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '~' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:40:1]
  39 │ ~ --temp ** 3;
  40 │ ~temp-- ** 3;
     · ───────
  41 │ ~3 ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '~' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:41:1]
  40 │ ~temp-- ** 3;
  41 │ ~3 ** 4;
     · ──
  42 │ ~temp++ ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '~' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:42:1]
  41 │ ~3 ** 4;
  42 │ ~temp++ ** 4;
     · ───────
  43 │ ~temp-- ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '~' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:43:1]
  42 │ ~temp++ ** 4;
  43 │ ~temp-- ** 4;
     · ───────
  44 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '~' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:45:6]
  44 │ 
  45 │ 1 ** ~ --temp ** 3;
     ·      ────────
  46 │ 1 ** ~temp-- ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '~' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:46:6]
  45 │ 1 ** ~ --temp ** 3;
  46 │ 1 ** ~temp-- ** 3;
     ·      ───────
  47 │ 1 ** ~3 ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '~' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:47:6]
  46 │ 1 ** ~temp-- ** 3;
  47 │ 1 ** ~3 ** 4;
     ·      ──
  48 │ 1 ** ~temp++ ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '~' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:48:6]
  47 │ 1 ** ~3 ** 4;
  48 │ 1 ** ~temp++ ** 4;
     ·      ───────
  49 │ 1 ** ~temp-- ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '~' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:49:6]
  48 │ 1 ** ~temp++ ** 4;
  49 │ 1 ** ~temp-- ** 4;
     ·      ───────
  50 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:51:1]
  50 │ 
  51 │ ! --temp ** 3;
     · ────────
  52 │ !temp-- ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:52:1]
  51 │ ! --temp ** 3;
  52 │ !temp-- ** 3;
     · ───────
  53 │ !3 ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:53:1]
  52 │ !temp-- ** 3;
  53 │ !3 ** 4;
     · ──
  54 │ !temp++ ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:54:1]
  53 │ !3 ** 4;
  54 │ !temp++ ** 4;
     · ───────
  55 │ !temp-- ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:55:1]
  54 │ !temp++ ** 4;
  55 │ !temp-- ** 4;
     · ───────
  56 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:57:6]
  56 │ 
  57 │ 1 ** ! --temp ** 3;
     ·      ────────
  58 │ 1 ** !temp-- ** 3;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:58:6]
  57 │ 1 ** ! --temp ** 3;
  58 │ 1 ** !temp-- ** 3;
     ·      ───────
  59 │ 1 ** !3 ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:59:6]
  58 │ 1 ** !temp-- ** 3;
  59 │ 1 ** !3 ** 4;
     ·      ──
  60 │ 1 ** !temp++ ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:60:6]
  59 │ 1 ** !3 ** 4;
  60 │ 1 ** !temp++ ** 4;
     ·      ───────
  61 │ 1 ** !temp-- ** 4;
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
 
-  × Unexpected exponentiation expression
+  × A unary expression with the '!' operator cannot be used as the left operand of an exponentiation expression
     ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:61:6]
  60 │ 1 ** !temp++ ** 4;
  61 │ 1 ** !temp-- ** 4;
     ·      ───────
  62 │ 
     ╰────
-  help: Wrap unary expression in parentheses to enforce operator precedence
+  help: Wrap the unary expression in parentheses to make the precedence explicit
+
+  × A type assertion cannot be used as the left operand of an exponentiation expression
+    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:63:1]
+ 62 │ 
+ 63 │ <number>temp ** 3;
+    · ────────────
+ 64 │ <number>++temp ** 3;
+    ╰────
+  help: Wrap the type assertion in parentheses to make the precedence explicit
+
+  × A type assertion cannot be used as the left operand of an exponentiation expression
+    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:64:1]
+ 63 │ <number>temp ** 3;
+ 64 │ <number>++temp ** 3;
+    · ──────────────
+ 65 │ <number>--temp ** 3;
+    ╰────
+  help: Wrap the type assertion in parentheses to make the precedence explicit
+
+  × A type assertion cannot be used as the left operand of an exponentiation expression
+    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:65:1]
+ 64 │ <number>++temp ** 3;
+ 65 │ <number>--temp ** 3;
+    · ──────────────
+ 66 │ <number>temp++ ** 3;
+    ╰────
+  help: Wrap the type assertion in parentheses to make the precedence explicit
+
+  × A type assertion cannot be used as the left operand of an exponentiation expression
+    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:66:1]
+ 65 │ <number>--temp ** 3;
+ 66 │ <number>temp++ ** 3;
+    · ──────────────
+ 67 │ <number>temp-- ** 3;
+    ╰────
+  help: Wrap the type assertion in parentheses to make the precedence explicit
+
+  × A type assertion cannot be used as the left operand of an exponentiation expression
+    ╭─[typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts:67:1]
+ 66 │ <number>temp++ ** 3;
+ 67 │ <number>temp-- ** 3;
+    · ──────────────
+    ╰────
+  help: Wrap the type assertion in parentheses to make the precedence explicit
 
   × A rest parameter or binding pattern may not have a trailing comma.
    ╭─[typescript/tests/cases/conformance/es7/trailingCommasInBindingPatterns.ts:1:12]

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 71/71 (100.00%)
-Positive Passed: 66/71 (92.96%)
+AST Parsed     : 72/72 (100.00%)
+Positive Passed: 67/72 (93.06%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 71/71 (100.00%)
-Positive Passed: 71/71 (100.00%)
+AST Parsed     : 72/72 (100.00%)
+Positive Passed: 72/72 (100.00%)


### PR DESCRIPTION
## Summary

- Report operator-specific diagnostics when unary and `await` expressions are used as exponentiation left operands.
- Reject unparenthesized TypeScript type assertions in the same position while preserving explicitly parenthesized forms.
- Add regression fixtures and update the affected conformance snapshots.
