### PR TITLE
chore(semantic): remove stale hash set TODO

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -167,8 +167,6 @@ pub fn check_identifier(name: &str, span: Span, ctx: &SemanticBuilder<'_>) {
                 ctx.error(diagnostics::class_static_block_await(span));
             }
         }
-        // TODO: Revisit this match arm when we add `Ident` and pre-hash the identifier names and see if a HashSet
-        // becomes better for performance again.
         "implements" | "interface" | "let" | "package" | "private" | "protected" | "public"
         | "static" | "yield" => {
             if !ctx.strict_mode() || ctx.in_ambient_context() {


### PR DESCRIPTION
## Summary

- remove the stale TODO about revisiting strict-mode identifier matching
- retain the existing direct match for the ten reserved identifier names

## Rationale

The prerequisites mentioned by the TODO have landed: identifier names now use `Ident` and carry precomputed hashes. I compared the current match with an `IdentHashSet` implementation that accepts `Ident` directly.

On ARM64, the match compiles to a string-length decision tree with inline byte/word comparisons. The hash-set version uses the precomputed hash and hashbrown's SwissTable probe, but also adds `LazyLock` access, a larger stack frame (368 bytes versus 272 bytes), and substantially more register saves in `check_identifier`.

### Benchmark methodology

To avoid sequential-baseline and thermal-order artifacts, I built and preserved separate optimized binaries for the match and hash-set implementations, restored the worktree to the match, and ran alternating ABBA comparisons. Each run used 100 samples, a 5-second warmup, 15-20 seconds of measurement, and a 1% Criterion noise threshold.

The benchmark inputs are especially favorable to the hash set: they contained 39 to 25,013 checked identifiers and effectively 100% of the lookups missed the reserved-name set.

Results:

- `RadixUIAdoptionSection.jsx` (39 identifiers): hash set 2.08% slower in the forward comparison; match 1.82% faster in the reverse comparison.
- `kitchen-sink.tsx` (25,013 identifiers): hash set 0.81% faster forward and 0.39% faster in the reverse comparison; both were within the 1% noise threshold.
- `binder.ts` (5,861 identifiers): hash set 0.88% slower forward; match 0.33% faster in reverse, but the reverse confidence interval crossed zero.

The original 2% regression therefore reproduces when benchmark order is reversed. The hash set can show a sub-1% gain on the largest miss-heavy input, but it does not establish a general end-to-end improvement and adds a reproducible small-input regression plus more initialization and generated-code complexity. The direct match remains preferable, and the TODO no longer has a useful follow-up action.

