### PR TITLE
fix(parser): release native parse result eagerly

### DIFF
--- a/napi/parser/src-js/wrap.js
+++ b/napi/parser/src-js/wrap.js
@@ -1,20 +1,21 @@
 export function wrap(result) {
-  let program, module, comments, errors;
+  // Move native-owned fields into JavaScript values immediately. Retaining the NAPI class in
+  // these getter closures delays its finalizer, which can keep one large serialized AST alive
+  // for every discarded parse result until Node eventually drains the native finalizer queue.
+  const { program: programJson, module, comments, errors } = result;
+  let program;
   return {
     get program() {
-      if (!program) program = jsonParseAst(result.program);
+      if (!program) program = jsonParseAst(programJson);
       return program;
     },
     get module() {
-      if (!module) module = result.module;
       return module;
     },
     get comments() {
-      if (!comments) comments = result.comments;
       return comments;
     },
     get errors() {
-      if (!errors) errors = result.errors;
       return errors;
     },
   };

--- a/napi/parser/test/wrap.test.js
+++ b/napi/parser/test/wrap.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { wrap } from "../src-js/wrap.js";
+
+describe("wrap", () => {
+  it("releases every native-owned field eagerly", () => {
+    const accessed = [];
+    const nativeResult = {
+      get program() {
+        accessed.push("program");
+        return '{"node":{"type":"Program","body":[]},"fixes":[]}';
+      },
+      get module() {
+        accessed.push("module");
+        return { hasModuleSyntax: false };
+      },
+      get comments() {
+        accessed.push("comments");
+        return [];
+      },
+      get errors() {
+        accessed.push("errors");
+        return [];
+      },
+    };
+
+    const result = wrap(nativeResult);
+
+    expect(accessed).toEqual(["program", "module", "comments", "errors"]);
+    expect(result.errors).toEqual([]);
+    expect(result.program).toEqual({ type: "Program", body: [] });
+    expect(accessed).toEqual(["program", "module", "comments", "errors"]);
+  });
+});


### PR DESCRIPTION
## Summary

- move all native-owned `ParseResult` fields into JavaScript values as soon as the wrapper is created
- avoid retaining the NAPI class in lazy getter closures
- add regression coverage that verifies all native getters are consumed eagerly and only once

## Root cause

`wrap()` previously captured the native `ParseResult` object in four JavaScript getter closures. When callers only inspected `errors` or discarded the wrapper, the serialized AST remained owned by the NAPI class until Node drained its native finalizer queue. Repeated parses therefore accumulated large native strings even after forced JavaScript GC.

The wrapper now transfers the serialized program, module record, comments, and errors to ordinary JavaScript values immediately. Program JSON parsing remains lazy, but the native result can be finalized as soon as `wrap()` returns.

In a local release build using the package's `allocator` feature, 1,200 parses that only inspect `errors` previously grew RSS from 51 MB to peaks above 480 MB. With this change, RSS stabilized at 66-67 MB.

## Validation

- `pnpm --dir napi/parser run build`
- `pnpm --dir napi/parser test` (114 tests passed)
- targeted `oxfmt` and `oxlint` checks passed
- `just ready` completed formatting and full workspace `cargo check`; the full test stage stopped on an unrelated Node-version snapshot (`v26.5.0` expected vs local `v24.14.0`)

Fixes #24472.

Implemented and validated with OpenAI Codex assistance. I reviewed the resulting code and test behavior.
