### PR TITLE
feat(minifier): Move sequences in assignment out of target position

### DIFF
--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -715,6 +715,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
                 Expression::AssignmentExpression(e) => {
                     Self::minimize_normal_assignment_to_combined_logical_assignment(e, ctx);
                     Self::minimize_normal_assignment_to_combined_assignment(e, ctx);
+                    Self::fold_sequence_expression(expr, ctx);
                     Self::minimize_assignment_to_update_expression(expr, ctx);
                     Self::remove_unused_assignment_expr(expr, ctx);
                 }

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1835,6 +1835,7 @@ impl<'a> PeepholeOptimizations {
     /// - `-(a, b)` -> `a, -b`
     /// - `await (a, b)` -> `a, await b`
     /// - `yield (a, b)` -> `a, yield b`
+    /// - `x = (a, b)` -> `a, x = b`
     pub fn fold_sequence_expression(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let argument = match expr {
             Expression::BinaryExpression(binary_expr) => &mut binary_expr.left,
@@ -1848,6 +1849,15 @@ impl<'a> PeepholeOptimizations {
             Expression::YieldExpression(yield_expr) => {
                 let Some(maybe_sequence_expression) = &mut yield_expr.argument else { return };
                 maybe_sequence_expression
+            }
+            Expression::AssignmentExpression(assign_expr)
+                if assign_expr.operator.is_assign()
+                    && matches!(
+                        assign_expr.left,
+                        AssignmentTarget::AssignmentTargetIdentifier(_)
+                    ) =>
+            {
+                &mut assign_expr.right
             }
             _ => {
                 return;

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -411,7 +411,7 @@ fn js_parser_test() {
     test("a = !!(!b && !c)", "a = !b && !c;");
     test("a = !!(!b || !c)", "a = !b || !c;");
     test("a = !!(!b ?? !c)", "a = !b;");
-    test("a = !!(b, c)", "a = (b, !!c);");
+    test("a = !!(b, c)", "b, a = !!c;");
     test("a = Boolean(b); var Boolean", "a = Boolean(b);var Boolean;");
     test("a = Boolean()", "a = !1;");
     test("a = Boolean(b)", "a = !!b;");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -543,7 +543,7 @@ fn test_unary_ops_string_compare() {
 #[test]
 fn test_fold_logical_op() {
     fold("x = true && x", "x = x");
-    fold("x = [foo()] && x", "x = (foo(),x)");
+    fold("x = [foo()] && x", "(foo(),x = x)");
 
     fold("x = false && x", "x = !1");
     fold("x = true || x", "x = !0");
@@ -571,7 +571,7 @@ fn test_fold_logical_op() {
     fold("x = foo() || true && bar()", "x = foo() || bar()");
     fold("x = foo() || false && bar()", "x = foo() || !1");
     fold("x = foo() && false && bar()", "x = foo() && !1");
-    fold("x = foo() && false || bar()", "x = (foo(), bar())");
+    fold("x = foo() && false || bar()", "(foo(), x = bar())");
     fold("x = foo() || false || bar()", "x = foo() || bar()");
     fold("x = foo() && true && bar()", "x = foo() && bar()");
     fold("x = foo() || true || bar()", "x = foo() || !0");
@@ -616,7 +616,7 @@ fn test_fold_logical_op() {
 fn test_fold_logical_op2() {
     fold("x = function(){} && x", "x=x");
     fold("x = true && function(){}", "x=function(){}");
-    fold("x = [(function(){alert(x)})()] && x", "x=((function(){alert(x)})(),x)");
+    fold("x = [(function(){alert(x)})()] && x", "((function(){alert(x)})(),x=x)");
 }
 
 // `cjs-module-lexer` scans `module.exports = { ... }` syntactically. esbuild
@@ -703,8 +703,8 @@ fn test_fold_opt_chain() {
     fold("x = null?.[foo]", "x = void 0");
     fold("x = undefined?.()", "x = void 0");
     fold("x = null?.()", "x = void 0");
-    fold("x = (foo(), null)?.y", "x = (foo(), void 0)");
-    fold("x = (foo(), null)?.()", "x = (foo(), void 0)");
+    fold("x = (foo(), null)?.y", "(foo(), x = void 0)");
+    fold("x = (foo(), null)?.()", "(foo(), x = void 0)");
 
     // Nested: nullish base short-circuits the entire chain even when the
     // optional is not on the outermost element.
@@ -712,7 +712,7 @@ fn test_fold_opt_chain() {
     fold("x = ((null))?.foo", "x = void 0");
     fold("x = null?.foo()", "x = void 0");
     fold("x = null?.foo.bar.baz()", "x = void 0");
-    fold("x = (foo(), null)?.bar.baz", "x = (foo(), void 0)");
+    fold("x = (foo(), null)?.bar.baz", "(foo(), x = void 0)");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/minimize_conditional_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_conditional_expression.rs
@@ -73,10 +73,10 @@ fn minimize_conditional_exprs() {
         "var a; v = a == null ? void 0 : a.b.c[d](e)",
         "chrome79",
     );
-    test("v = cmp !== 0 ? cmp : (bar, cmp);", "v = (cmp === 0 && bar, cmp);");
-    test("v = cmp === 0 ? cmp : (bar, cmp);", "v = (cmp === 0 || bar, cmp);");
-    test("v = cmp !== 0 ? (bar, cmp) : cmp;", "v = (cmp === 0 || bar, cmp);");
-    test("v = cmp === 0 ? (bar, cmp) : cmp;", "v = (cmp === 0 && bar, cmp);");
+    test("v = cmp !== 0 ? cmp : (bar, cmp);", "cmp === 0 && bar, v = cmp;");
+    test("v = cmp === 0 ? cmp : (bar, cmp);", "cmp === 0 || bar, v = cmp;");
+    test("v = cmp !== 0 ? (bar, cmp) : cmp;", "cmp === 0 || bar, v = cmp;");
+    test("v = cmp === 0 ? (bar, cmp) : cmp;", "cmp === 0 && bar, v = cmp;");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
@@ -273,7 +273,7 @@ fn remove_empty_function() {
     test_options("var foo = () => {}; foo(...a, b)", "[...a], b", &options);
     test_options("var foo = () => {}; foo(...a, ...b)", "[...a], [...b]", &options);
     test_options("var foo = () => {}; x = foo()", "x = void 0", &options);
-    test_options("var foo = () => {}; x = foo(a(), b())", "x = (a(), b(), void 0)", &options);
+    test_options("var foo = () => {}; x = foo(a(), b())", "a(), b(), x = void 0", &options);
     test_options("var foo = function () {}; foo()", "", &options);
 
     test_same_options("function foo({}) {} foo()", &options);

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -1024,7 +1024,7 @@ fn test_flatten_array_spread_elements() {
 }
 
 #[test]
-fn fold_sequence_expression() {
+fn test_fold_sequence_expression() {
     test("(a(), b) + c", "a(), b + c");
     test("(a(), b, c) + d", "a(), b, c + d");
 
@@ -1046,4 +1046,13 @@ fn fold_sequence_expression() {
         "async function a() { await (c(1), d(2), 3) }",
         "async function a() { c(1), d(2), await 3 }",
     );
+
+    test("a = (x, z)", "x, a = z");
+    test_same("a += (x, z)");
+    test_same("a -= (x, z)");
+    test_same("this.#test = (x, z)");
+    test_same("a.b = (x, z)");
+    test_same("a ||= (x, z)");
+    test_same("a ??= (x, z)");
+    test_same("a &&= (x, z)");
 }

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -19,7 +19,7 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 2.14 MB    | 711.03 kB  | 724.14 kB  | 160.38 kB  | 181.07 kB  |          2 | victory.js 
 
-3.20 MB    | 1.00 MB    | 1.01 MB    | 322.59 kB  | 331.56 kB  |          2 | echarts.js 
+3.20 MB    | 1.00 MB    | 1.01 MB    | 322.58 kB  | 331.56 kB  |          2 | echarts.js 
 
 6.69 MB    | 2.13 MB    | 2.31 MB    | 455.50 kB  | 488.28 kB  |          5 | antd.js    
 


### PR DESCRIPTION
Move sequence expressions inside of assignment expression when operator is `=` and pattern is an identifier