### PR TITLE
fix(codegen): preserve trailing statement comments

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -40,7 +40,7 @@ pub enum CommentPosition {
     #[default]
     Leading = 0,
 
-    /// Comments tailing a token until a newline.
+    /// Comments attached to the end of the preceding token on the same line.
     /// e.g. `token /* trailing */ // trailing`
     Trailing = 1,
 
@@ -144,10 +144,15 @@ pub struct Comment {
     /// The span of the comment text, with leading and trailing delimiters.
     pub span: Span,
 
-    /// Start of token this leading comment is attached to.
+    /// Source boundary this comment is attached to.
+    ///
+    /// Leading comments use the start of the following token:
     /// `/* Leading */ token`
     ///                ^ This start
-    /// NOTE: Trailing comment attachment is not computed yet.
+    ///
+    /// Trailing comments use the end of the preceding token:
+    /// `token /* Trailing */`
+    ///       ^ This end
     #[estree(skip)]
     pub attached_to: u32,
 

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -87,29 +87,51 @@ impl Codegen<'_> {
                 continue;
             }
             let mut add = false;
-            if comment.is_leading() {
-                if comment.is_legal() && self.options.print_legal_comment() {
-                    add = true;
-                }
-                if comment.is_jsdoc() && self.options.print_jsdoc_comment() {
-                    add = true;
-                }
-                if comment.is_annotation() && self.options.print_annotation_comment() {
-                    add = true;
-                }
-                if comment.is_normal() && self.options.print_normal_comment() {
-                    add = true;
-                }
+            if comment.is_legal() && self.options.print_legal_comment() {
+                add = true;
+            }
+            if comment.is_jsdoc() && self.options.print_jsdoc_comment() {
+                add = true;
+            }
+            if comment.is_annotation() && self.options.print_annotation_comment() {
+                add = true;
+            }
+            if comment.is_normal() && self.options.print_normal_comment() {
+                add = true;
             }
             if add {
-                if comment.is_legal()
-                    && let Err(idx) = self.legal_comment_keys.binary_search(&comment.attached_to)
-                {
-                    self.legal_comment_keys.insert(idx, comment.attached_to);
+                if comment.is_leading() {
+                    if comment.is_legal()
+                        && let Err(idx) =
+                            self.legal_comment_keys.binary_search(&comment.attached_to)
+                    {
+                        self.legal_comment_keys.insert(idx, comment.attached_to);
+                    }
+                    self.comments.entry(comment.attached_to).or_default().push(*comment);
+                } else if comment.is_trailing() {
+                    self.trailing_comments.entry(comment.attached_to).or_default().push(*comment);
                 }
-                self.comments.entry(comment.attached_to).or_default().push(*comment);
             }
         }
+    }
+
+    #[inline]
+    pub(crate) fn has_trailing_comments(&self) -> bool {
+        !self.trailing_comments.is_empty()
+    }
+
+    #[cold]
+    pub(crate) fn print_trailing_comments(&mut self, end: u32) {
+        let Some(comments) = self.trailing_comments.remove(&end) else { return };
+
+        // Statement printers normally leave a newline behind, while minified
+        // expression statements defer their semicolon. Restore the token end
+        // before placing the same-line group after it.
+        self.print_semicolon_if_needed();
+        self.code.trim_trailing_ascii_whitespace_and_newlines();
+        self.clear_pending_indent_space();
+        self.print_soft_space();
+        self.print_comments(&comments);
     }
 
     pub(crate) fn has_comment(&self, start: u32) -> bool {

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -99,6 +99,9 @@ impl Gen for Directive<'_> {
         quote.print(p);
         p.print_ascii_byte(b';');
         p.print_soft_newline();
+        if p.has_trailing_comments() {
+            p.print_trailing_comments(self.span.end);
+        }
     }
 }
 
@@ -196,6 +199,9 @@ impl Gen for Statement<'_> {
                 decl.print(p, ctx);
                 p.print_semicolon_after_statement();
             }
+        }
+        if p.has_trailing_comments() {
+            p.print_trailing_comments(self.span().end);
         }
     }
 }

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -129,6 +129,9 @@ pub struct Codegen<'a> {
     // Builders
     comments: CommentsMap,
 
+    /// Trailing comments keyed by the end of the preceding token.
+    trailing_comments: CommentsMap,
+
     /// Pure / no-side-effects annotation comments keyed by `attached_to`,
     /// so the emission site can recover verbatim source text instead of a
     /// canonicalised literal (rolldown#9408). The emission site falls back
@@ -195,6 +198,7 @@ impl<'a> Codegen<'a> {
             indent: 0,
             quote: Quote::Double,
             comments: CommentsMap::default(),
+            trailing_comments: CommentsMap::default(),
             annotation_comments: FxHashMap::default(),
             legal_comment_keys: Vec::new(),
             #[cfg(feature = "sourcemap")]

--- a/crates/oxc_codegen/src/options.rs
+++ b/crates/oxc_codegen/src/options.rs
@@ -17,7 +17,7 @@ pub struct CodegenOptions {
 
     /// Print comments?
     ///
-    /// At present, only some leading comments are preserved.
+    /// Leading comments and trailing comments attached to emitted statements are preserved.
     ///
     /// Default is [CommentOptions::default].
     pub comments: CommentOptions,
@@ -98,8 +98,6 @@ impl CodegenOptions {
 /// Comment Options
 pub struct CommentOptions {
     /// Print normal comments that do not have special meanings.
-    ///
-    /// At present only statement level comments are printed.
     ///
     /// Default is `true`.
     pub normal: bool,

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -225,6 +225,40 @@ fn test_comment_at_top_of_file() {
 }
 
 #[test]
+fn test_trailing_comments_after_node_boundaries() {
+    for (source, expected) in [
+        ("foo; // statement\nbar;", "foo; // statement\nbar;\n"),
+        ("if (foo) {} // statement\nbar;", "if (foo) {} // statement\nbar;\n"),
+        (
+            "function f() {\n foo; /* one */ /* two */\n bar;\n}",
+            "function f() {\n\tfoo; /* one */ /* two */\n\tbar;\n}\n",
+        ),
+    ] {
+        test(source, expected);
+        test_idempotency(source);
+    }
+}
+
+#[test]
+fn test_trailing_comments_outside_statement_boundaries_are_not_printed() {
+    test("const value = foo /* after identifier */\n + bar;", "const value = foo + bar;\n");
+    test("const value = foo() /* after call */\n .bar;", "const value = foo().bar;\n");
+    test("const f = (value /* after parameter */\n) => value;", "const f = (value) => value;\n");
+    test("try {} catch (error) // after paren\n{}", "try {} catch (error) {}\n");
+    test("const xs = [a, // after comma\nb];", "const xs = [a, b];\n");
+    test("const value = a + // after operator\nb;", "const value = a + b;\n");
+}
+
+#[test]
+fn test_trailing_comments_minify_idempotency() {
+    use oxc_codegen::CodegenOptions;
+
+    let options = CodegenOptions { minify: true, ..CodegenOptions::default() };
+    crate::tester::test_options("foo; // trailing\nbar;", "foo;// trailing\nbar;", options.clone());
+    test_idempotency_options("foo; // trailing\nbar;", &options);
+}
+
+#[test]
 fn unit() {
     test_same("<div>{/* Hello */}</div>;\n");
     // A comment-only JSX expression container must not leak a leading space onto

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -904,7 +904,7 @@ fn html_comments() {
     );
     test_unambiguous(
         "const test = 'a'; <!-- comment\nconsole.log('test');\n",
-        "const test = \"a\";\nconsole.log(\"test\");\n",
+        "const test = \"a\"; <!-- comment\nconsole.log(\"test\");\n",
     );
     test_unambiguous("const x = 1;\n--> comment\n", "const x = 1;\n--> comment\n");
     test_unambiguous(
@@ -914,12 +914,12 @@ fn html_comments() {
     // `<!--` comments out rest of line - everything after is a comment
     test_unambiguous(
         "const test = 'a'; <!-- Test --> console.log('not executed'); //\n",
-        "const test = \"a\";\n",
+        "const test = \"a\"; <!-- Test --> console.log('not executed'); //\n",
     );
     // Injection: `<!--` comments out rest of line, but code on NEXT line executes
     test_unambiguous(
         "const test = 'a'; <!--\nconsole.log('injection');\n",
-        "const test = \"a\";\nconsole.log(\"injection\");\n",
+        "const test = \"a\"; <!--\nconsole.log(\"injection\");\n",
     );
     // `-->` at start of line is also a comment
     test_unambiguous(

--- a/crates/oxc_codegen/tests/integration/snapshots/ts.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/ts.snap
@@ -310,8 +310,8 @@ import defaultExport, { export1 } from 'module-name';
 import defaultExport, * as name from 'module-name';
 import 'module-name';
 import {} from "mod";
-export let name1, name2;
-export const name3 = 1, name4 = 2;
+export let name1, name2; // also var
+export const name3 = 1, name4 = 2; // also var, let
 export function functionName() {/* … */}
 export class ClassName {}
 export function* generatorFunctionName() {/* … */}

--- a/crates/oxc_data_structures/src/code_buffer.rs
+++ b/crates/oxc_data_structures/src/code_buffer.rs
@@ -684,6 +684,14 @@ impl CodeBuffer {
         }
     }
 
+    /// Remove trailing spaces, tabs, and line breaks from the buffer.
+    #[inline]
+    pub fn trim_trailing_ascii_whitespace_and_newlines(&mut self) {
+        while self.buf.last().is_some_and(u8::is_ascii_whitespace) {
+            self.buf.pop();
+        }
+    }
+
     /// Get contents of buffer as a byte slice.
     ///
     /// # Example
@@ -796,6 +804,14 @@ mod test {
 
         let source = code.into_string();
         assert_eq!(source, s);
+    }
+
+    #[test]
+    fn trim_trailing_ascii_whitespace_and_newlines() {
+        let mut code = CodeBuffer::default();
+        code.print_str("foo \t\r\n\t");
+        code.trim_trailing_ascii_whitespace_and_newlines();
+        assert_eq!(code.as_str(), "foo");
     }
 
     #[test]

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -29,6 +29,9 @@ pub struct TriviaBuilder<'a> {
     /// Previous token kind, used to indicates comments are trailing from what kind
     previous_kind: Kind,
 
+    /// End of the previous token, used as the attachment boundary for trailing comments.
+    previous_token_end: u32,
+
     /// Index of the pure comment in `comments` vec, or `None` if no pure comment for the current token.
     pub(super) pure_comment: Option<usize>,
 
@@ -44,6 +47,7 @@ impl<'a> TriviaBuilder<'a> {
             saw_newline: true,
             saw_newline_for_comment: true,
             previous_kind: Kind::Undetermined,
+            previous_token_end: 0,
             pure_comment: None,
             has_no_side_effects_comment: false,
         }
@@ -113,10 +117,17 @@ impl<'a> TriviaBuilder<'a> {
         // The last unprocessed comment is on a newline.
         let len = self.comments.len();
         if self.processed < len {
-            let comment = &mut self.comments[len - 1];
-            comment.set_followed_by_newline(true);
-            if !self.saw_newline && !Self::should_stay_leading(comment) {
-                self.processed = self.comments.len();
+            let becomes_trailing = {
+                let comment = &mut self.comments[len - 1];
+                comment.set_followed_by_newline(true);
+                !self.saw_newline && !Self::should_stay_leading(comment)
+            };
+            if becomes_trailing {
+                self.attach_pending_comments(
+                    CommentPosition::Trailing,
+                    self.previous_token_end,
+                    len,
+                );
             }
         }
         self.saw_newline = true;
@@ -125,7 +136,6 @@ impl<'a> TriviaBuilder<'a> {
 
     #[inline]
     pub fn handle_token(&mut self, token: Token) {
-        self.previous_kind = token.kind();
         self.saw_newline = false;
         self.saw_newline_for_comment = false;
         // Cold path: any unprocessed comments since the last token become leading comments
@@ -133,14 +143,16 @@ impl<'a> TriviaBuilder<'a> {
         // `processed == comments.len()`, so this branch is skipped.
         let len = self.comments.len();
         if self.processed < len {
-            self.attach_pending_leading_comments(token.start(), len);
+            self.attach_pending_comments(CommentPosition::Leading, token.start(), len);
         }
+        self.previous_kind = token.kind();
+        self.previous_token_end = token.end();
     }
 
     #[cold]
-    fn attach_pending_leading_comments(&mut self, attached_to: u32, len: usize) {
-        for comment in &mut self.comments[self.processed..] {
-            comment.position = CommentPosition::Leading;
+    fn attach_pending_comments(&mut self, position: CommentPosition, attached_to: u32, len: usize) {
+        for comment in &mut self.comments[self.processed..len] {
+            comment.position = position;
             comment.attached_to = attached_to;
         }
         self.processed = len;
@@ -225,25 +237,32 @@ impl<'a> TriviaBuilder<'a> {
         // Use `saw_newline_for_comment` which tracks newlines since the last comment or token,
         // not just since the last token.
         comment.set_preceded_by_newline(self.saw_newline_for_comment);
-        if comment.is_line() {
+        let becomes_trailing = if comment.is_line() {
             // A line comment is always followed by a newline. This is never set in `handle_newline`.
             comment.set_followed_by_newline(true);
-            if self.should_be_treated_as_trailing_comment() && !Self::should_stay_leading(&comment)
-            {
-                self.processed = self.comments.len() + 1; // +1 to include this comment.
-            }
+            let becomes_trailing = self.should_be_treated_as_trailing_comment()
+                && !Self::should_stay_leading(&comment);
             self.saw_newline = true;
             self.saw_newline_for_comment = true;
+            becomes_trailing
         } else {
             // Block comments don't end with a newline, so reset saw_newline_for_comment.
             // If there's a newline after the block comment, `handle_newline` will set it back to true.
             self.saw_newline_for_comment = false;
-        }
+            false
+        };
 
         // Set annotation flags here (not in `parse_annotation`) so the index is correct
         // even when the dedup check above skips a duplicate from parser lookahead/rewind.
         self.set_annotation_flags(&comment, self.comments.len());
         self.comments.push(comment);
+        if becomes_trailing {
+            self.attach_pending_comments(
+                CommentPosition::Trailing,
+                self.previous_token_end,
+                self.comments.len(),
+            );
+        }
     }
 
     /// Parse Notation
@@ -465,7 +484,7 @@ mod test {
                 span: Span::new(76, 92),
                 kind: CommentKind::SingleLineBlock,
                 position: CommentPosition::Trailing,
-                attached_to: 0,
+                attached_to: 75,
                 newlines: CommentNewlines::None,
                 content: CommentContent::None,
             },
@@ -473,7 +492,7 @@ mod test {
                 span: Span::new(93, 106),
                 kind: CommentKind::Line,
                 position: CommentPosition::Trailing,
-                attached_to: 0,
+                attached_to: 75,
                 newlines: CommentNewlines::Trailing,
                 content: CommentContent::None,
             },
@@ -513,12 +532,36 @@ token /* Trailing 1 */
                 span: Span::new(42, 58),
                 kind: CommentKind::SingleLineBlock,
                 position: CommentPosition::Trailing,
-                attached_to: 0,
+                attached_to: 41,
                 newlines: CommentNewlines::Trailing,
                 content: CommentContent::None,
             },
         ];
         assert_eq!(comments, expected);
+    }
+
+    #[test]
+    fn trailing_comment_groups_attach_to_previous_token_end() {
+        for (source_text, count) in [
+            ("foo /* block 1 */ /* block 2 */ // line\nbar;", 3),
+            ("foo /* block 1 */ /* block 2 */\nbar;", 2),
+        ] {
+            let comments = get_comments(source_text);
+            assert_eq!(comments.len(), count);
+            assert!(comments.iter().all(|comment| comment.is_trailing()));
+            assert!(comments.iter().all(|comment| comment.attached_to == 3));
+        }
+    }
+
+    #[test]
+    fn trailing_comment_attachment_survives_arrow_lookahead() {
+        let source_text = "const f = (value /* trailing */\n) => value;";
+        let comments = get_comments(source_text);
+        let value_end = u32::try_from(source_text.find("value ").unwrap() + "value".len()).unwrap();
+
+        assert_eq!(comments.len(), 1);
+        assert!(comments[0].is_trailing());
+        assert_eq!(comments[0].attached_to, value_end);
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #24567; review that lower PR first.

Trailing comments currently have no source boundary that codegen can use for lookup. Comments after emitted statements are therefore dropped even though the statement end is a safe place to restore them.

This follow-up attaches each complete trailing group to the previous token end, then consumes groups whose anchor matches an emitted directive or statement end. The attachment survives parser lookahead, and an empty-map guard keeps programs without trailing comments off the per-statement lookup path.

The consumer is intentionally limited to statement boundaries. Comments after identifiers, calls, parameters, operators, and punctuation remain unprinted until those nodes have placement rules of their own; retaining the metadata without guessing a placement avoids moving comments to the wrong construct.

## Example

Input:

```js
foo; // trailing
bar;
```

Before:

```js
foo;
bar;
```

After:

```js
foo; // trailing
bar;
```

Tests cover mixed block/line trailing groups, directives and statements, minified-output idempotency, intentionally unconsumed node boundaries, HTML comments, TypeScript snapshots, parser lookahead, and the buffer trimming helper.

Verified with the codegen comment, HTML-comment, and TypeScript integration tests; the data-structures unit test; parser and AST tests; and Clippy for both touched crates.

This PR was assisted by OpenAI Codex.
