### PR TITLE
fix(linter/jsx-a11y/autocomplete-valid): allow personal name tokens

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
@@ -78,6 +78,7 @@ declare_oxc_lint!(
 );
 
 static VALID_AUTOCOMPLETE_VALUES: phf::Set<&'static str> = phf::phf_set![
+    "additional-name",
     "address-level1",
     "address-level2",
     "address-level3",
@@ -103,10 +104,15 @@ static VALID_AUTOCOMPLETE_VALUES: phf::Set<&'static str> = phf::phf_set![
     "country-name",
     "current-password",
     "email",
+    "family-name",
+    "given-name",
+    "honorific-prefix",
+    "honorific-suffix",
     "impp",
     "language",
     "name",
     "new-password",
+    "nickname",
     "off",
     "on",
     "one-time-code",
@@ -202,6 +208,8 @@ fn test() {
 
     let pass = vec![
         ("<input type='text' />;", None, None),
+        ("<input type='text' autocomplete='family-name' />;", None, None),
+        ("<input type='text' autocomplete='given-name' />;", None, None),
         ("<input type='text' autocomplete='name' />;", None, None),
         // ("<input type='text' autocomplete='' />;", None, None),
         ("<input type='text' autocomplete='off' />;", None, None),


### PR DESCRIPTION
## Summary

`jsx-a11y/autocomplete-valid` reports `given-name` and `family-name` as invalid even though both are valid HTML autocomplete tokens. The hardcoded list also omits four other personal-name tokens.

This adds all six missing tokens:

- `additional-name`
- `family-name`
- `given-name`
- `honorific-prefix`
- `honorific-suffix`
- `nickname`

Regression tests cover the reported `given-name` and `family-name` false positives.

## Reference

- https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-field

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p oxc_linter --lib autocomplete_valid`
- `cargo test -p oxc_linter --lib`
- `git diff --check`

## AI disclosure

I used Codex to help investigate and prepare this change. I reviewed the code and ran the validation commands above.
