### PR TITLE
perf(formatter): accumulate JSX child-list builders on the heap

### DIFF
--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -47,8 +47,8 @@ pub mod buffer {
 
 pub use oxc_formatter_core::{
     Argument, Arguments, Buffer, BufferExtensions, Format, FormatElement, FormatOptions,
-    FormatState, Formatted, Formatter, GroupId, HeapVecBuffer, MemoizeFormat, Memoized, SourceText,
-    UniqueGroupIdBuilder, VecBuffer,
+    FormatState, Formatted, Formatter, GroupId, HeapVecBuffer, MemoizeFormat, Memoized,
+    ScratchBuffer, SourceText, UniqueGroupIdBuilder, VecBuffer,
 };
 
 pub use self::builders::JoinBuilderJsExt;

--- a/crates/oxc_formatter/src/print/jsx/child_list.rs
+++ b/crates/oxc_formatter/src/print/jsx/child_list.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, ArenaVec, TakeIn};
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -6,7 +6,7 @@ use crate::{
     ast_nodes::AstNode,
     format_args,
     formatter::{
-        Comments, FormatElement, VecBuffer,
+        Buffer, Comments, FormatElement, FormatState, JsFormatContext, ScratchBuffer,
         prelude::{tag::GroupMode, *},
     },
     utils::{
@@ -19,6 +19,41 @@ use crate::{
     write,
 };
 use std::cell::RefCell;
+
+/// Heap accumulator [`Buffer`] for the child-list builders.
+///
+/// The builders accumulate elements across separate `write()` calls while other content is formatted in between,
+/// so their buffers can't stage in the arena (every growth would strand the old allocation, see `HeapVecBuffer`)
+/// nor share the format run's scratch vector (the flat and multiline builders write alternately, breaking its LIFO discipline).
+///
+/// Instead each builder checks its own [`ScratchBuffer`] out of the thread-local cache and writes through this adapter;
+/// the arena receives one exactly-sized copy when the finished result is interned ([`Formatter::intern_elements`]).
+struct ChildListBuffer<'buf, 'a> {
+    state: &'buf mut FormatState<'a, JsFormatContext<'a>>,
+    elements: &'buf mut Vec<FormatElement<'a>>,
+}
+
+impl<'a> Buffer<'a, JsFormatContext<'a>> for ChildListBuffer<'_, 'a> {
+    fn write_element(&mut self, element: FormatElement<'a>) {
+        self.elements.push(element);
+    }
+
+    fn elements(&self) -> &[FormatElement<'a>] {
+        self.elements
+    }
+
+    fn state(&self) -> &FormatState<'a, JsFormatContext<'a>> {
+        self.state
+    }
+
+    fn state_mut(&mut self) -> &mut FormatState<'a, JsFormatContext<'a>> {
+        self.state
+    }
+
+    fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'a>]) {
+        self.elements.splice(start.., replacement.iter().cloned());
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct FormatJsxChildList {
@@ -47,8 +82,8 @@ impl FormatJsxChildList {
         };
 
         let mut force_multiline = layout.is_multiline();
-        let mut flat = FlatBuilder::new(force_multiline, f.allocator());
-        let mut multiline = MultilineBuilder::new(multiline_layout, f.allocator());
+        let mut flat = FlatBuilder::new(force_multiline);
+        let mut multiline = MultilineBuilder::new(multiline_layout);
 
         let mut children = jsx_split_children(children, f.context().comments());
 
@@ -553,12 +588,12 @@ enum MultilineLayout {
 #[derive(Debug)]
 struct MultilineBuilder<'a> {
     layout: MultilineLayout,
-    result: ArenaVec<'a, FormatElement<'a>>,
+    result: ScratchBuffer<'a>,
 }
 
 impl<'a> MultilineBuilder<'a> {
-    fn new(layout: MultilineLayout, allocator: &'a Allocator) -> Self {
-        Self { layout, result: ArenaVec::new_in(&allocator) }
+    fn new(layout: MultilineLayout) -> Self {
+        Self { layout, result: ScratchBuffer::checkout() }
     }
 
     /// Formats an element that does not require a separator
@@ -596,29 +631,24 @@ impl<'a> MultilineBuilder<'a> {
         separator: Option<&dyn Format<'a, JsFormatContext<'a>>>,
         f: &mut JsFormatter<'_, 'a>,
     ) {
-        let elements = std::mem::replace(&mut self.result, ArenaVec::new_in(f));
+        let mut buffer = ChildListBuffer { state: f.state_mut(), elements: &mut self.result };
+        match self.layout {
+            MultilineLayout::Fill => {
+                // Make sure that the separator and content only ever write a single element
+                buffer.write_element(FormatElement::Tag(Tag::StartEntry));
+                write!(buffer, [content]);
+                buffer.write_element(FormatElement::Tag(Tag::EndEntry));
 
-        self.result = {
-            let mut buffer = VecBuffer::new_with_vec(f.state_mut(), elements);
-            match self.layout {
-                MultilineLayout::Fill => {
-                    // Make sure that the separator and content only ever write a single element
+                if let Some(separator) = separator {
                     buffer.write_element(FormatElement::Tag(Tag::StartEntry));
-                    write!(buffer, [content]);
+                    write!(buffer, [separator]);
                     buffer.write_element(FormatElement::Tag(Tag::EndEntry));
-
-                    if let Some(separator) = separator {
-                        buffer.write_element(FormatElement::Tag(Tag::StartEntry));
-                        write!(buffer, [separator]);
-                        buffer.write_element(FormatElement::Tag(Tag::EndEntry));
-                    }
-                }
-                MultilineLayout::NoFill => {
-                    write!(buffer, [content, separator]);
                 }
             }
-            buffer.into_vec()
-        };
+            MultilineLayout::NoFill => {
+                write!(buffer, [content, separator]);
+            }
+        }
     }
 
     /// Writes a separator into the last entry if it is an entry.
@@ -643,13 +673,13 @@ impl<'a> MultilineBuilder<'a> {
 #[derive(Debug)]
 pub struct FormatMultilineChildren<'a> {
     layout: MultilineLayout,
-    elements: RefCell<ArenaVec<'a, FormatElement<'a>>>,
+    elements: RefCell<ScratchBuffer<'a>>,
 }
 
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatMultilineChildren<'a> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let format_inner = format_with(|f| {
-            if let Some(elements) = f.intern_vec(self.elements.borrow_mut().take_in(f)) {
+            if let Some(elements) = f.intern_elements(&mut self.elements.borrow_mut()) {
                 match self.layout {
                     MultilineLayout::Fill => f.write_elements([
                         FormatElement::Tag(Tag::StartFill),
@@ -695,13 +725,13 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatMultilineChildren<'a> {
 
 #[derive(Debug)]
 struct FlatBuilder<'a> {
-    result: ArenaVec<'a, FormatElement<'a>>,
+    result: ScratchBuffer<'a>,
     disabled: bool,
 }
 
 impl<'a> FlatBuilder<'a> {
-    fn new(disabled: bool, allocator: &'a Allocator) -> Self {
-        Self { result: ArenaVec::new_in(&allocator), disabled }
+    fn new(disabled: bool) -> Self {
+        Self { result: ScratchBuffer::checkout(), disabled }
     }
 
     fn write(
@@ -713,20 +743,14 @@ impl<'a> FlatBuilder<'a> {
             return;
         }
 
-        let result = std::mem::replace(&mut self.result, ArenaVec::new_in(f));
-
-        self.result = {
-            let elements = result;
-            let mut buffer = VecBuffer::new_with_vec(f.state_mut(), elements);
-
-            write!(buffer, [content]);
-
-            buffer.into_vec()
-        }
+        let mut buffer = ChildListBuffer { state: f.state_mut(), elements: &mut self.result };
+        write!(buffer, [content]);
     }
 
     fn disable(&mut self) {
         self.disabled = true;
+        // Abandoned content; clear so the scratch returns to the cache empty.
+        self.result.clear();
     }
 
     fn finish(self) -> FormatFlatChildren<'a> {
@@ -741,12 +765,12 @@ impl<'a> FlatBuilder<'a> {
 
 #[derive(Debug)]
 pub struct FormatFlatChildren<'a> {
-    elements: RefCell<ArenaVec<'a, FormatElement<'a>>>,
+    elements: RefCell<ScratchBuffer<'a>>,
 }
 
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatFlatChildren<'a> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        if let Some(elements) = f.intern_vec(self.elements.borrow_mut().take_in(f)) {
+        if let Some(elements) = f.intern_elements(&mut self.elements.borrow_mut()) {
             f.write_element(elements);
         }
     }

--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -35,6 +35,8 @@ Pick by what you're building:
   - it moves into the `Document` for free, and heap-staging it costs an extra copy for no benefit
 - Unknown-length staging that ends interned/sliced: `HeapVecBuffer`
   - a watermarked view over a shared, thread-cached scratch vector; the arena receives one exactly-sized copy (see its rustdoc for the full rationale)
+- Accumulating across interleaved `write()` calls (multiple builders open at once): check a `ScratchBuffer` out per builder behind a private `Buffer` adapter, finish via `Formatter::intern_elements`
+  - the shared scratch's LIFO rule rules out `HeapVecBuffer` there (see `ChildListBuffer` in `oxc_formatter`)
 - Known-length sequences: build exact-sized directly (e.g. `ArenaVec::from_iter_in`)
 
 `Formatter::intern` and `BestFitting` already stage on the heap; consumer crates get this for free.

--- a/crates/oxc_formatter_core/src/buffer.rs
+++ b/crates/oxc_formatter_core/src/buffer.rs
@@ -91,13 +91,7 @@ pub struct VecBuffer<'buf, 'ast, C> {
 
 impl<'buf, 'ast, C> VecBuffer<'buf, 'ast, C> {
     pub fn new(state: &'buf mut FormatState<'ast, C>) -> Self {
-        Self::new_with_vec(state, ArenaVec::new_in(state))
-    }
-
-    pub fn new_with_vec(
-        state: &'buf mut FormatState<'ast, C>,
-        elements: ArenaVec<'ast, FormatElement<'ast>>,
-    ) -> Self {
+        let elements = ArenaVec::new_in(state);
         Self { state, elements }
     }
 
@@ -196,16 +190,7 @@ impl<'buf, 'ast, C> HeapVecBuffer<'buf, 'ast, C> {
         let allocator = self.state.allocator();
         let watermark = self.watermark;
         let scratch = self.state.scratch_mut();
-        let tail = &scratch[watermark..];
-        let len = tail.len();
-        let mut vec = ArenaVec::with_capacity_in(len, &allocator);
-        // SAFETY: `vec` has capacity for `len` elements, and the heap and arena buffers cannot overlap.
-        // `FormatElement` is not `Drop` (`ArenaVec` const-asserts `!needs_drop` on construction),
-        // so the bitwise move duplicates no owning state and the `truncate()` below merely forgets the moved-out elements.
-        unsafe {
-            std::ptr::copy_nonoverlapping(tail.as_ptr(), vec.as_mut_ptr(), len);
-            vec.set_len(len);
-        }
+        let vec = move_elements_into_arena(allocator, &scratch[watermark..]);
         scratch.truncate(watermark);
         vec
     }
@@ -222,6 +207,27 @@ impl<C> Drop for HeapVecBuffer<'_, '_, C> {
         let watermark = self.watermark;
         self.state.scratch_mut().truncate(watermark);
     }
+}
+
+/// Bitwise-moves `elements` into an exactly-sized arena vector.
+///
+/// The caller must treat the source elements as moved-out and forget them
+/// (truncate the vector, or let it drop, `FormatElement` has no drop glue).
+pub(crate) fn move_elements_into_arena<'ast>(
+    allocator: &'ast Allocator,
+    elements: &[FormatElement<'ast>],
+) -> ArenaVec<'ast, FormatElement<'ast>> {
+    let len = elements.len();
+    let mut vec = ArenaVec::with_capacity_in(len, &allocator);
+    // SAFETY: `vec` has capacity for `len` elements,
+    // and the source (heap) and destination (arena) buffers cannot overlap.
+    // `FormatElement` is not `Drop` (`ArenaVec` const-asserts `!needs_drop` on construction),
+    // so the bitwise move duplicates no owning state and the caller forgetting the source elements merely drops the stale copies.
+    unsafe {
+        std::ptr::copy_nonoverlapping(elements.as_ptr(), vec.as_mut_ptr(), len);
+        vec.set_len(len);
+    }
+    vec
 }
 
 impl<'ast, C> Deref for HeapVecBuffer<'_, 'ast, C> {

--- a/crates/oxc_formatter_core/src/formatter.rs
+++ b/crates/oxc_formatter_core/src/formatter.rs
@@ -2,11 +2,11 @@
 
 use std::borrow::Cow;
 
-use oxc_allocator::{Allocator, ArenaVec, GetAllocator};
+use oxc_allocator::{Allocator, GetAllocator};
 
 use crate::{
     Argument, Arguments, Buffer, FormatContext, FormatElement, FormatState,
-    buffer::HeapVecBuffer,
+    buffer::{HeapVecBuffer, move_elements_into_arena},
     builders::{FillBuilder, JoinBuilder},
     format::{Format, write},
     format_element::Interned,
@@ -67,8 +67,8 @@ impl<'buf, 'ast, C> Formatter<'buf, 'ast, C> {
         let mut buffer = HeapVecBuffer::new(self.state_mut());
         write(&mut buffer, Arguments::new(&[Argument::new(&content)]));
 
-        // Intentionally not delegated to `intern_vec`:
-        // dispatching on the heap buffer lets the 0/1-element cases return without ever allocating an `ArenaVec`.
+        // Dispatching on the heap buffer lets the 0/1-element cases return
+        // without ever allocating an `ArenaVec`.
         match buffer.len() {
             0 => None,
             // Doesn't get cheaper than calling clone, use the element directly
@@ -77,16 +77,22 @@ impl<'buf, 'ast, C> Formatter<'buf, 'ast, C> {
         }
     }
 
-    #[expect(clippy::unused_self)] // Keep `self` the same as the original source
-    pub fn intern_vec(
+    /// Interns a pre-built element sequence (e.g. a builder's heap accumulator),
+    /// moving it into the arena exactly-sized. The source is cleared,
+    /// retaining its capacity for the caller (a [`crate::ScratchBuffer`] returns it to the cache).
+    pub fn intern_elements(
         &self,
-        mut elements: ArenaVec<'ast, FormatElement<'ast>>,
+        elements: &mut Vec<FormatElement<'ast>>,
     ) -> Option<FormatElement<'ast>> {
         match elements.len() {
             0 => None,
             // Doesn't get cheaper than calling clone, use the element directly
             1 => elements.pop(),
-            _ => Some(FormatElement::Interned(Interned::new(elements))),
+            _ => {
+                let vec = move_elements_into_arena(self.allocator(), elements);
+                elements.clear();
+                Some(FormatElement::Interned(Interned::new(vec)))
+            }
         }
     }
 

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -67,7 +67,7 @@ pub use options::{
 pub use printer::{PrintResult, PrintWidth, Printed, Printer, PrinterOptions};
 pub(crate) use simple_context::SimpleFormatContext;
 pub use source_text::SourceText;
-pub use state::FormatState;
+pub use state::{FormatState, ScratchBuffer};
 pub use text_range::TextRange;
 pub use traits::{FormatContext, FormatOptions};
 

--- a/crates/oxc_formatter_core/src/state.rs
+++ b/crates/oxc_formatter_core/src/state.rs
@@ -13,16 +13,20 @@ thread_local! {
         const { RefCell::new(Vec::new()) };
 }
 
-/// The heap staging vector backing [`crate::HeapVecBuffer`] (see there for why staging is heap-backed).
-/// One vector per format run, shared by all nesting levels like a stack via watermarks:
-/// each buffer records the length at creation, pushes its elements, and drains its own tail on completion.
-/// Sound because IR staging is strictly LIFO (an inner buffer always completes before its enclosing one resumes).
+/// A heap staging vector checked out of the thread-local `SCRATCH_CACHE` on creation and returned on drop (panics included),
+/// so its high-water capacity is reused across checkouts.
 ///
-/// Checked out of [`SCRATCH_CACHE`] on creation and returned on drop (panics included).
+/// Two users:
+/// - [`FormatState`] holds one per format run, shared by all [`crate::HeapVecBuffer`]s like a stack via watermarks:
+///   each buffer records the length at creation, pushes its elements, and drains its own tail on completion.
+///   Sound because IR staging is strictly LIFO (an inner buffer always completes before its enclosing one resumes)
+/// - Accumulators that outlive a single staging scope (interleaved builders, see `ChildListBuffer` in `oxc_formatter`) check out their own.
+///   The cache itself is an unordered pool with no LIFO requirement
+#[derive(Debug)]
 pub struct ScratchBuffer<'ast>(Vec<FormatElement<'ast>>);
 
 impl<'ast> ScratchBuffer<'ast> {
-    fn checkout() -> Self {
+    pub fn checkout() -> Self {
         let vec = SCRATCH_CACHE.with_borrow_mut(Vec::pop).unwrap_or_default();
         // SAFETY: cached vectors are always empty (checkin clears them);
         // an empty vector holds no values, so re-branding its element lifetime is sound.
@@ -32,15 +36,28 @@ impl<'ast> ScratchBuffer<'ast> {
     }
 }
 
+impl<'ast> std::ops::Deref for ScratchBuffer<'ast> {
+    type Target = Vec<FormatElement<'ast>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ScratchBuffer<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl Drop for ScratchBuffer<'_> {
     fn drop(&mut self) {
-        // Every `HeapVecBuffer` drains its own tail on completion;
-        // a leftover means a buffer leaked elements past its watermark.
-        // Checked here because every format run: root, fragment, or embedded — ends by dropping its `FormatState`.
+        // Every user drains the vector on completion (`HeapVecBuffer`s their own tail,
+        // accumulators via `Formatter::intern_elements`); a leftover means elements leaked.
         // (Skipped mid-unwind: buffers up the stack haven't truncated their tails yet.)
         debug_assert!(
             self.0.is_empty() || std::thread::panicking(),
-            "scratch buffer not fully drained at the end of the format run"
+            "scratch buffer returned to the cache before being fully drained"
         );
         let mut vec = mem::take(&mut self.0);
         // A buffer that never grew has nothing worth caching

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -17,19 +17,19 @@ App.tsx:
   sys alloc bytes: 985182 # 985.18 kB
   sys peak growth: 443550 # 443.55 kB
   arena allocs: 211998
-  arena reallocs: 1679
-  arena size: 22302080 # 22.30 MB
+  arena reallocs: 1645
+  arena size: 22023480 # 22.02 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
   sys allocs: 54
-  sys reallocs: 26
+  sys reallocs: 28
   sys deallocs: 53
-  sys alloc bytes: 10116 # 10.12 kB
-  sys peak growth: 2856 # 2.86 kB
+  sys alloc bytes: 17796 # 17.80 kB
+  sys peak growth: 10536 # 10.54 kB
   arena allocs: 1155
-  arena reallocs: 69
-  arena size: 169128 # 169.13 kB
+  arena reallocs: 0
+  arena size: 155608 # 155.61 kB
 
 pdf.mjs:
   file size: 567296 # 567.30 kB
@@ -72,6 +72,6 @@ kitchen-sink.tsx:
   sys alloc bytes: 3180244 # 3.18 MB
   sys peak growth: 1499988 # 1.50 MB
   arena allocs: 567769
-  arena reallocs: 5992
-  arena size: 48529696 # 48.53 MB
+  arena reallocs: 5195
+  arena size: 48002616 # 48.00 MB
 


### PR DESCRIPTION
The JSX child-list builders (`MultilineBuilder` / `FlatBuilder` in `child_list.rs`) were the last IR staging path still growing vectors in the arena.

They accumulate elements across the whole child-list loop while arbitrary child content is
formatted in between, so every growth stranded its old allocation (the same pattern #24582 removed from `intern` / `BestFitting` / grouped arguments).

They can't use `HeapVecBuffer`: the flat and multiline builders write *alternately* for each child, which would interleave their segments in the shared scratch vector and break its LIFO watermark discipline. The thread-local cache behind it has no such requirement though.

So each builder now checks out its own `ScratchBuffer` and writes into it through a small private `Buffer` adapter (`ChildListBuffer`); the finished result reaches the arena as one exactly-sized copy via the new `Formatter::intern_elements`, which clears the source so its capacity returns to the cache on drop.

Now arena reallocs for `RadixUIAdoptionSection.jsx` is 0.
