### PR TITLE
refactor(linter): simplify prefer-class-fields constructor lookup

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_class_fields.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_class_fields.rs
@@ -95,17 +95,17 @@ impl Rule for PreferClassFields {
         };
 
         // Find constructor
-        let constructor = class.body.body.iter().find(|element| {
-            matches!(
-                element,
-                ClassElement::MethodDefinition(method)
-                    if method.kind == MethodDefinitionKind::Constructor
-                        && !method.r#static
-                        && !method.computed
-            )
-        });
-
-        let Some(ClassElement::MethodDefinition(constructor)) = constructor else {
+        let Some(constructor) = class.body.body.iter().find_map(|element| {
+            if let ClassElement::MethodDefinition(method) = element
+                && method.kind == MethodDefinitionKind::Constructor
+                && !method.r#static
+                && !method.computed
+            {
+                Some(method)
+            } else {
+                None
+            }
+        }) else {
             return;
         };
 


### PR DESCRIPTION
## Summary

- return the matching constructor directly from `find_map`
- remove the duplicated `MethodDefinition` pattern match
