### PR TITLE
refactor(linter): use ancestor kinds for constructor check

### DIFF
--- a/crates/oxc_linter/src/rules/react/state_in_constructor.rs
+++ b/crates/oxc_linter/src/rules/react/state_in_constructor.rs
@@ -145,12 +145,13 @@ fn has_parent_es6_component<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bo
 
 /// Checks if a node is inside a constructor method.
 pub fn is_in_constructor(ctx: &LintContext, node_id: NodeId) -> bool {
-    for ancestor_id in ctx.nodes().ancestor_ids(node_id) {
-        if let AstKind::MethodDefinition(method) = ctx.nodes().kind(ancestor_id) {
-            return method.kind.is_constructor();
-        }
-    }
-    false
+    ctx.nodes()
+        .ancestor_kinds(node_id)
+        .find_map(|kind| match kind {
+            AstKind::MethodDefinition(method) => Some(method),
+            _ => None,
+        })
+        .is_some_and(|method| method.kind.is_constructor())
 }
 
 #[test]
@@ -295,6 +296,20 @@ fn test() {
             "
                     function Foo () {
                       return <div>Foo</div>
+                    }
+                  ",
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            "
+                    class Foo extends React.Component {
+                      constructor(props) {
+                        class Bar {
+                          method() {
+                            this.state = { bar: 0 }
+                          }
+                        }
+                      }
                     }
                   ",
             Some(serde_json::json!(["never"])),


### PR DESCRIPTION
## Summary

- replace manual ancestor ID traversal with `ancestor_kinds`
- stop at the nearest method definition to preserve the original early-return behavior
- add a regression test for a nested non-constructor method inside a constructor

## Testing

- `cargo test -p oxc_linter state_in_constructor`

## AI usage

This change and PR description were prepared with OpenAI Codex assistance. The contributor remains responsible for reviewing, testing, and understanding the submitted change.