### PR TITLE
refactor(parser): move abstract constructor check to the parser

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -61,6 +61,16 @@ pub fn unexpected_token(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Unexpected token").with_label(span)
 }
 
+/// 'abstract' modifier can only appear on a class, method, or property declaration. (1242)
+#[cold]
+pub fn illegal_abstract_modifier(span: Span) -> OxcDiagnostic {
+    ts_error(
+        "1242",
+        "'abstract' modifier can only appear on a class, method, or property declaration.",
+    )
+    .with_label(span)
+}
+
 #[cold]
 pub fn private_identifier_in_property_name(name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("Private identifier '#{name}' is not allowed in property names"))

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -810,6 +810,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 if method.value.generator {
                     self.error(diagnostics::constructor_generator(span));
                 }
+                if method.r#type.is_abstract() {
+                    self.error(diagnostics::illegal_abstract_modifier(span));
+                }
             }
         }
 

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -219,10 +219,6 @@ pub fn check_method_definition<'a>(method: &MethodDefinition<'a>, ctx: &Semantic
     let is_abstract = method.r#type.is_abstract();
 
     if is_abstract {
-        // constructors cannot be abstract, no matter what
-        if method.kind.is_constructor() {
-            ctx.error(diagnostics::illegal_abstract_modifier(method.key.span()));
-        }
         // abstract cannot be used with private identifiers
         if method.key.is_private_identifier() {
             ctx.error(diagnostics::abstract_cannot_be_used_with_private_identifier(

--- a/crates/oxc_semantic/src/diagnostics.rs
+++ b/crates/oxc_semantic/src/diagnostics.rs
@@ -367,16 +367,6 @@ pub fn function_implementation_missing(span: Span) -> OxcDiagnostic {
     .with_label(span)
 }
 
-/// 'abstract' modifier can only appear on a class, method, or property declaration. (1242)
-#[cold]
-pub fn illegal_abstract_modifier(span: Span) -> OxcDiagnostic {
-    ts_error(
-        "1242",
-        "'abstract' modifier can only appear on a class, method, or property declaration.",
-    )
-    .with_label(span)
-}
-
 /// 'abstract' modifier cannot be used with a private identifier. (18019)
 #[cold]
 pub fn abstract_cannot_be_used_with_private_identifier(span: Span) -> OxcDiagnostic {

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -14575,19 +14575,19 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  9 │ }
    ╰────
 
-  × TS(1183): An implementation cannot be declared in ambient contexts.
-   ╭─[typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts:2:28]
- 1 │ declare abstract class A {
- 2 │     abstract constructor() {}
-   ·                            ▲
- 3 │ }
-   ╰────
-
   × TS(1242): 'abstract' modifier can only appear on a class, method, or property declaration.
    ╭─[typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts:2:14]
  1 │ declare abstract class A {
  2 │     abstract constructor() {}
    ·              ───────────
+ 3 │ }
+   ╰────
+
+  × TS(1183): An implementation cannot be declared in ambient contexts.
+   ╭─[typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractDeclarations.d.ts:2:28]
+ 1 │ declare abstract class A {
+ 2 │     abstract constructor() {}
+   ·                            ▲
  3 │ }
    ╰────
 


### PR DESCRIPTION
## Summary
- report TS1242 for abstract constructors in the parser
- remove the equivalent semantic diagnostic
- update TypeScript parser coverage snapshots

## Why?

This check needs to be moved to the parser, as the data is not retained after we change the Constructor ast type.