### PR TITLE
refactor(parser): move abstract private check to the parser

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -793,6 +793,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn check_method_definition(&mut self, method: &MethodDefinition<'a>) {
+        if method.r#type.is_abstract() && method.key.is_private_identifier() {
+            self.error(diagnostics::abstract_with_private_identifier(method.key.span()));
+        }
+
         if !method.computed
             && let Some((name, span)) = method.key.prop_name()
         {

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -218,15 +218,6 @@ pub fn check_class<'a>(class: &Class<'a>, ctx: &SemanticBuilder<'a>) {
 pub fn check_method_definition<'a>(method: &MethodDefinition<'a>, ctx: &SemanticBuilder<'a>) {
     let is_abstract = method.r#type.is_abstract();
 
-    if is_abstract {
-        // abstract cannot be used with private identifiers
-        if method.key.is_private_identifier() {
-            ctx.error(diagnostics::abstract_cannot_be_used_with_private_identifier(
-                method.key.span(),
-            ));
-        }
-    }
-
     let is_empty_body = method.value.r#type == FunctionType::TSEmptyBodyFunctionExpression;
     // Illegal to have `constructor(public foo);`
     if method.kind.is_constructor() && is_empty_body {

--- a/crates/oxc_semantic/src/diagnostics.rs
+++ b/crates/oxc_semantic/src/diagnostics.rs
@@ -367,13 +367,6 @@ pub fn function_implementation_missing(span: Span) -> OxcDiagnostic {
     .with_label(span)
 }
 
-/// 'abstract' modifier cannot be used with a private identifier. (18019)
-#[cold]
-pub fn abstract_cannot_be_used_with_private_identifier(span: Span) -> OxcDiagnostic {
-    ts_error("18019", "'abstract' modifier cannot be used with a private identifier.")
-        .with_label(span)
-}
-
 /// A parameter property is only allowed in a constructor implementation.ts(2369)
 #[cold]
 pub fn parameter_property_only_in_constructor_impl(span: Span) -> OxcDiagnostic {


### PR DESCRIPTION
## Summary
- report TS18019 for abstract private methods during parsing
- reuse the parser diagnostic already used for abstract private properties
- remove the equivalent semantic check and diagnostic

Stacked on #24595.
