### PR TITLE
feat(str): export `Str` as `ArenaStr`

### DIFF
--- a/crates/oxc_str/src/lib.rs
+++ b/crates/oxc_str/src/lib.rs
@@ -8,7 +8,7 @@ mod str;
 
 pub use compact_str::{CompactStr, MAX_INLINE_LEN};
 pub use ident::{ArenaIdentHashMap, Ident, IdentHashMap, IdentHashSet};
-pub use str::Str;
+pub use str::{Str, Str as ArenaStr};
 
 #[doc(hidden)]
 pub mod __internal {


### PR DESCRIPTION
Companion to #23746. Re-export `Str` under `ArenaStr` alias, following convention of `ArenaVec`, `ArenaBox` etc.

Within Oxc we can continue to use `Str` as it's unambiguous - we only have one arena string type. But it'd be helpful for Oxc's consumers. e.g. Rolldown has a lot of repetition of `oxc::ast::ast::Str` which could be shortened to `ArenaStr`, without causing ambiguity with other string types.