### PR TITLE
fix(oxfmt): keep tailwind classes glued to template expr with `preserveWhitespace`

### DIFF
--- a/apps/oxfmt/test/api/sort_tailwindcss.test.ts
+++ b/apps/oxfmt/test/api/sort_tailwindcss.test.ts
@@ -493,6 +493,25 @@ const A = (
     expect(result.errors).toStrictEqual([]);
   });
 
+  // Regression test for https://github.com/oxc-project/oxc/issues/24464
+  it("should not split a class glued to an expression when preserveWhitespace is true", async () => {
+    let input = "const A = <div className={`text-white flex bg-${color}`}>Hello</div>;";
+    let result = await format("test.tsx", input, { sortTailwindcss: { preserveWhitespace: true } });
+
+    // `bg-` touches ${color} and must stay glued to it; other classes are still sorted
+    expect(result.code).toContain("`flex text-white bg-${color}`");
+    expect(result.errors).toStrictEqual([]);
+
+    input =
+      "const A = <div className={`mb-4 flex items-center rounded-full bg-${color}/10`}>Hello</div>;";
+    result = await format("test.tsx", input, { sortTailwindcss: { preserveWhitespace: true } });
+
+    // `bg-` and the `/10` modifier must stay glued to ${color}
+    expect(result.code).toContain("bg-${color}/10`");
+    expect(result.code).not.toContain("bg- ");
+    expect(result.errors).toStrictEqual([]);
+  });
+
   it("should collapse newlines to single space when preserveWhitespace is false (default)", async () => {
     const input = `<div className={\`flex
 items-center

--- a/crates/oxc_formatter/src/utils/tailwindcss.rs
+++ b/crates/oxc_formatter/src/utils/tailwindcss.rs
@@ -326,20 +326,12 @@ pub fn write_tailwind_template_element<'a>(
 ) {
     let content = f.source_text().text_for(element);
 
-    if ctx.preserve_whitespace {
-        let index = f.context_mut().add_tailwind_class(content.to_string());
-        f.write_element(FormatElement::TailwindClass(index));
-        return;
-    }
-
     // Get quasi position from context (set when the quasi was written in template.rs)
     let is_first = ctx.is_first_quasi;
     let is_last = ctx.is_last_quasi;
 
-    // Check if binary expression context requires preserving boundary whitespace
-    let collapse = can_collapse_whitespace_template(element, is_first, is_last, f);
-
-    // Split into prefix/sortable/suffix
+    // Split into prefix/sortable/suffix.
+    // Classes glued to an adjacent `${...}` expression must stay in place even when preserving whitespace;
     let (prefix, sortable, suffix) = split_template_content(content, is_first, is_last);
 
     // Write prefix (unsorted class touching previous expression)
@@ -348,14 +340,18 @@ pub fn write_tailwind_template_element<'a>(
     }
 
     // Write sortable content
-    let trimmed = sortable.trim();
-
-    if trimmed.is_empty() {
+    if ctx.preserve_whitespace {
+        // Whitespace (including whitespace-only content) round-trips through the sorter unchanged
+        let index = f.context_mut().add_tailwind_class(sortable.to_string());
+        f.write_element(FormatElement::TailwindClass(index));
+    } else if sortable.trim().is_empty() {
         // Whitespace-only → normalize to single space
         if !sortable.is_empty() {
             write!(f, text(" "));
         }
     } else {
+        // Check if binary expression context requires preserving boundary whitespace
+        let collapse = can_collapse_whitespace_template(element, is_first, is_last, f);
         let has_leading_ws = sortable.starts_with(|c: char| c.is_ascii_whitespace());
         let has_trailing_ws = sortable.ends_with(|c: char| c.is_ascii_whitespace());
 
@@ -365,7 +361,7 @@ pub fn write_tailwind_template_element<'a>(
             write!(f, text(" "));
         }
 
-        let index = f.context_mut().add_tailwind_class(trimmed.to_string());
+        let index = f.context_mut().add_tailwind_class(sortable.trim().to_string());
         f.write_element(FormatElement::TailwindClass(index));
 
         // Trailing space: required if not at end of template, or if binary context requires it


### PR DESCRIPTION
Fixes #24464

When `preserveWhitespace` was enabled, the ignore process was being skipped.