### PR TITLE
fix(linter/eslint/prefer-destructuring): handle typed declarations

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1268,7 +1268,7 @@ export interface DummyRuleMap {
   "prefer-destructuring"?:
     | RuleNoConfig
     | [AllowWarnDeny, PreferDestructuringOption]
-    | [AllowWarnDeny, PreferDestructuringOption, PreferDestructuringRenamedPropertiesConfig];
+    | [AllowWarnDeny, PreferDestructuringOption, PreferDestructuringEnforcementConfig];
   "prefer-exponentiation-operator"?: RuleNoConfig;
   "prefer-named-capture-group"?: RuleNoConfig;
   "prefer-numeric-literals"?: RuleNoConfig;
@@ -4148,7 +4148,8 @@ export interface PreferDestructuringAssignmentConfig {
   AssignmentExpression?: PreferDestructuringTargetOption;
   VariableDeclarator?: PreferDestructuringTargetOption;
 }
-export interface PreferDestructuringRenamedPropertiesConfig {
+export interface PreferDestructuringEnforcementConfig {
+  enforceForDeclarationWithTypeAnnotation?: boolean;
   enforceForRenamedProperties?: boolean;
 }
 export interface PreferPromiseRejectErrors {

--- a/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
@@ -116,16 +116,14 @@ impl PreferDestructuringOption {
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-struct PreferDestructuringRenamedPropertiesConfig {
+struct PreferDestructuringEnforcementConfig {
     enforce_for_renamed_properties: bool,
+    enforce_for_declaration_with_type_annotation: bool,
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
 #[serde(default)]
-struct PreferDestructuringConfig(
-    PreferDestructuringOption,
-    PreferDestructuringRenamedPropertiesConfig,
-);
+struct PreferDestructuringConfig(PreferDestructuringOption, PreferDestructuringEnforcementConfig);
 
 impl PreferDestructuringConfig {
     fn into_rule(self) -> PreferDestructuring {
@@ -135,6 +133,9 @@ impl PreferDestructuringConfig {
             variable_declarator,
             assignment_expression,
             enforce_for_renamed_properties: self.1.enforce_for_renamed_properties,
+            enforce_for_declaration_with_type_annotation: self
+                .1
+                .enforce_for_declaration_with_type_annotation,
         }
     }
 }
@@ -150,6 +151,8 @@ pub struct PreferDestructuring {
     assignment_expression: PreferDestructuringTargetConfig,
     /// Determines whether the object destructuring rule applies to renamed variables.
     enforce_for_renamed_properties: bool,
+    /// Determines whether the rule applies to variable declarations with type annotations.
+    enforce_for_declaration_with_type_annotation: bool,
 }
 
 declare_oxc_lint!(
@@ -245,6 +248,11 @@ impl Rule for PreferDestructuring {
                 }
             }
             AstKind::VariableDeclarator(declarator) => {
+                let has_type_annotation = declarator.type_annotation.is_some();
+                if has_type_annotation && !self.enforce_for_declaration_with_type_annotation {
+                    return;
+                }
+
                 // Skip `using` and `await using` declarations - destructuring doesn't apply to them
                 if matches!(
                     declarator.kind,
@@ -272,53 +280,56 @@ impl Rule for PreferDestructuring {
                                 if self.variable_declarator.array {
                                     ctx.diagnostic(prefer_array_destructuring(init.span()));
                                 }
-                            } else {
-                                if self.enforce_for_renamed_properties
-                                    && self.variable_declarator.object
-                                {
-                                    ctx.diagnostic(prefer_object_destructuring(right.span()));
-                                }
+                            } else if self.variable_declarator.object {
                                 if let Expression::StringLiteral(string_literal) =
                                     &comp_expr.expression
-                                    && self.variable_declarator.object
                                     && name.is_some_and(|v| v == string_literal.value)
                                 {
-                                    ctx.diagnostic_with_fix(
-                                        prefer_object_destructuring(init.span()),
-                                        |fixer| {
-                                            generate_fix(
-                                                &fixer,
-                                                string_literal.span.shrink(1),
-                                                get_object_span_without_redundant_parentheses(
-                                                    &comp_expr.object,
-                                                ),
-                                                declarator.span(),
-                                            )
-                                        },
-                                    );
+                                    if has_type_annotation {
+                                        ctx.diagnostic(prefer_object_destructuring(init.span()));
+                                    } else {
+                                        ctx.diagnostic_with_fix(
+                                            prefer_object_destructuring(init.span()),
+                                            |fixer| {
+                                                generate_fix(
+                                                    &fixer,
+                                                    string_literal.span.shrink(1),
+                                                    get_object_span_without_redundant_parentheses(
+                                                        &comp_expr.object,
+                                                    ),
+                                                    declarator.span(),
+                                                )
+                                            },
+                                        );
+                                    }
+                                } else if self.enforce_for_renamed_properties {
+                                    ctx.diagnostic(prefer_object_destructuring(right.span()));
                                 }
                             }
                         }
                         MemberExpression::StaticMemberExpression(static_expr)
                             if self.variable_declarator.object =>
                         {
-                            if self.enforce_for_renamed_properties {
-                                ctx.diagnostic(prefer_object_destructuring(right.span()));
-                            }
                             if name.is_some_and(|name| name == static_expr.property.name.as_str()) {
-                                ctx.diagnostic_with_fix(
-                                    prefer_object_destructuring(init.span()),
-                                    |fixer| {
-                                        generate_fix(
-                                            &fixer,
-                                            static_expr.property.span,
-                                            get_object_span_without_redundant_parentheses(
-                                                &static_expr.object,
-                                            ),
-                                            declarator.span(),
-                                        )
-                                    },
-                                );
+                                if has_type_annotation {
+                                    ctx.diagnostic(prefer_object_destructuring(init.span()));
+                                } else {
+                                    ctx.diagnostic_with_fix(
+                                        prefer_object_destructuring(init.span()),
+                                        |fixer| {
+                                            generate_fix(
+                                                &fixer,
+                                                static_expr.property.span,
+                                                get_object_span_without_redundant_parentheses(
+                                                    &static_expr.object,
+                                                ),
+                                                declarator.span(),
+                                            )
+                                        },
+                                    );
+                                }
+                            } else if self.enforce_for_renamed_properties {
+                                ctx.diagnostic(prefer_object_destructuring(right.span()));
                             }
                         }
                         _ => {}
@@ -382,6 +393,26 @@ fn test() {
     let pass = vec![
         ("var [foo] = array;", None),
         ("var { foo } = object;", None),
+        ("const foo: string = object.foo;", None),
+        ("const foo: string = object['foo'];", None),
+        ("const foo: string = array[0];", None),
+        (
+            "const object = { foo: 'value' as const }; const foo: string = object.foo;",
+            Some(serde_json::json!([
+                {
+                    "VariableDeclarator": { "array": false, "object": true },
+                    "AssignmentExpression": { "array": false, "object": false }
+                },
+                {
+                    "enforceForDeclarationWithTypeAnnotation": false,
+                    "enforceForRenamedProperties": false
+                }
+            ])),
+        ),
+        (
+            "const foo: string = object.foo;",
+            Some(serde_json::json!([{ "object": true }, { "enforceForRenamedProperties": true }])),
+        ),
         (
             "a = b.c",
             Some(
@@ -584,6 +615,44 @@ fn test() {
         ("var foo = array[0];", None),
         ("foo = array[0];", None),
         ("var foo = object.foo;", None),
+        (
+            "var foo: string = object.foo;",
+            Some(
+                serde_json::json!([{ "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }]),
+            ),
+        ),
+        (
+            "var foo: string = object['foo'];",
+            Some(
+                serde_json::json!([{ "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }]),
+            ),
+        ),
+        (
+            "var foo: string = array[0];",
+            Some(
+                serde_json::json!([{ "array": true }, { "enforceForDeclarationWithTypeAnnotation": true }]),
+            ),
+        ),
+        (
+            "var foo: string = object.foo;",
+            Some(serde_json::json!([
+                { "object": true },
+                {
+                    "enforceForDeclarationWithTypeAnnotation": true,
+                    "enforceForRenamedProperties": true
+                }
+            ])),
+        ),
+        (
+            "var foo: string = object['foo'];",
+            Some(serde_json::json!([
+                { "object": true },
+                {
+                    "enforceForDeclarationWithTypeAnnotation": true,
+                    "enforceForRenamedProperties": true
+                }
+            ])),
+        ),
         ("var foo = (a, b).foo;", None),
         ("var length = (() => {}).length;", None),
         ("var foo = (a = b).foo;", None),
@@ -739,6 +808,20 @@ fn test() {
         ),
         ("var foo = object.foo, /* comment */ a;", "var {foo} = object, /* comment */ a;", None),
         ("var foo = object['foo'];", "var {foo} = object;", None),
+        (
+            "var foo: string = object.foo;",
+            "var foo: string = object.foo;",
+            Some(
+                serde_json::json!([{ "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }]),
+            ),
+        ),
+        (
+            "var foo: string = object['foo'];",
+            "var foo: string = object['foo'];",
+            Some(
+                serde_json::json!([{ "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }]),
+            ),
+        ),
         ("foo = object.foo;", "foo = object.foo;", None),
         ("foo = object['foo'];", "foo = object['foo'];", None),
     ];

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_destructuring.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_destructuring.snap
@@ -24,6 +24,41 @@ source: crates/oxc_linter/src/tester.rs
   help: Use object destructuring rather than direct member access.
 
   ⚠ eslint(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:1:19]
+ 1 │ var foo: string = object.foo;
+   ·                   ──────────
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ eslint(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:1:19]
+ 1 │ var foo: string = object['foo'];
+   ·                   ─────────────
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ eslint(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:1:19]
+ 1 │ var foo: string = array[0];
+   ·                   ────────
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ eslint(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:1:19]
+ 1 │ var foo: string = object.foo;
+   ·                   ──────────
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ eslint(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:1:19]
+ 1 │ var foo: string = object['foo'];
+   ·                   ─────────────
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ eslint(prefer-destructuring): Use Object destructuring.
    ╭─[prefer_destructuring.tsx:1:11]
  1 │ var foo = (a, b).foo;
    ·           ──────────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -5987,7 +5987,7 @@
                   "$ref": "#/definitions/PreferDestructuringOption"
                 },
                 {
-                  "$ref": "#/definitions/PreferDestructuringRenamedPropertiesConfig"
+                  "$ref": "#/definitions/PreferDestructuringEnforcementConfig"
                 }
               ],
               "maxItems": 3,
@@ -17016,11 +17016,25 @@
           "$ref": "#/definitions/PreferDestructuringOption"
         },
         {
-          "$ref": "#/definitions/PreferDestructuringRenamedPropertiesConfig"
+          "$ref": "#/definitions/PreferDestructuringEnforcementConfig"
         }
       ],
       "maxItems": 2,
       "minItems": 2
+    },
+    "PreferDestructuringEnforcementConfig": {
+      "type": "object",
+      "properties": {
+        "enforceForDeclarationWithTypeAnnotation": {
+          "default": false,
+          "type": "boolean"
+        },
+        "enforceForRenamedProperties": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
     },
     "PreferDestructuringOption": {
       "anyOf": [
@@ -17031,16 +17045,6 @@
           "$ref": "#/definitions/PreferDestructuringAssignmentConfig"
         }
       ]
-    },
-    "PreferDestructuringRenamedPropertiesConfig": {
-      "type": "object",
-      "properties": {
-        "enforceForRenamedProperties": {
-          "default": false,
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
     },
     "PreferDestructuringTargetOption": {
       "type": "object",


### PR DESCRIPTION
## Summary

- skip prefer-destructuring diagnostics for variable declarations with type annotations by default
- add enforceForDeclarationWithTypeAnnotation for typescript-eslint compatibility
- report without an autofix when annotated declarations are explicitly enforced, preserving the declared type
- cover object, computed-property, array, renamed-property, and reporter configuration cases

This matches the current `@typescript-eslint/prefer-`destructuring behavior.

Fixes #24615.
