### PR TITLE
feat(parser)!: decode JSX entities during parsing

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2677,10 +2677,16 @@ impl Gen for JSXAttributeValue<'_> {
             Self::Fragment(fragment) => fragment.print(p, ctx),
             Self::Element(el) => el.print(p, ctx),
             Self::StringLiteral(lit) => {
-                let quote = if lit.value.contains('"') { b'\'' } else { b'"' };
-                p.print_ascii_byte(quote);
-                p.print_str(&lit.value);
-                p.print_ascii_byte(quote);
+                if let Some(raw) = &lit.raw
+                    && lit.value != raw.as_str()[1..raw.len() - 1]
+                {
+                    p.print_str(raw.as_str());
+                } else {
+                    let quote = if lit.value.contains('"') { b'\'' } else { b'"' };
+                    p.print_ascii_byte(quote);
+                    p.print_str(&lit.value);
+                    p.print_ascii_byte(quote);
+                }
             }
             Self::ExpressionContainer(expr_container) => expr_container.print(p, ctx),
         }
@@ -2768,7 +2774,7 @@ impl Gen for JSXClosingFragment {
 impl Gen for JSXText<'_> {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping(self.span);
-        p.print_str(self.value.as_str());
+        p.print_str(self.raw.as_ref().unwrap_or(&self.value).as_str());
     }
 }
 

--- a/crates/oxc_formatter/src/print/jsx/child_list.rs
+++ b/crates/oxc_formatter/src/print/jsx/child_list.rs
@@ -12,7 +12,7 @@ use crate::{
     utils::{
         jsx::{
             JsxChild, JsxChildrenIterator, JsxRawSpace, JsxSpace, is_meaningful_jsx_text,
-            is_whitespace_jsx_expression, jsx_split_children,
+            is_whitespace_jsx_expression, jsx_split_children, jsx_text_source,
         },
         suppressed::FormatSuppressedNode,
     },
@@ -386,8 +386,8 @@ impl FormatJsxChildList {
                     }
                 }
                 JSXChild::Text(text) => {
-                    meta.meaningful_text =
-                        meta.meaningful_text || is_meaningful_jsx_text(&text.value);
+                    meta.meaningful_text = meta.meaningful_text
+                        || is_meaningful_jsx_text(jsx_text_source(text).as_str());
                 }
                 JSXChild::Spread(_) => {}
             }

--- a/crates/oxc_formatter/src/print/jsx/element.rs
+++ b/crates/oxc_formatter/src/print/jsx/element.rs
@@ -9,7 +9,7 @@ use crate::{
     parentheses::NeedsParentheses,
     print::jsx::{FormatChildrenResult, FormatOpeningElement},
     utils::{
-        jsx::{WrapState, is_meaningful_jsx_text},
+        jsx::{WrapState, is_meaningful_jsx_text, jsx_text_source},
         suppressed::FormatSuppressedNode,
     },
     write,
@@ -329,7 +329,7 @@ impl<'a, 'b> AnyJsxTagWithChildren<'a, 'b> {
 
                 match child.as_ast_nodes() {
                     AstNodes::JSXText(text) => {
-                        if is_meaningful_jsx_text(&text.value) {
+                        if is_meaningful_jsx_text(jsx_text_source(text.as_ref()).as_str()) {
                             ElementLayout::Default
                         } else {
                             ElementLayout::NoChildren

--- a/crates/oxc_formatter/src/print/jsx/mod.rs
+++ b/crates/oxc_formatter/src/print/jsx/mod.rs
@@ -404,6 +404,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXSpreadChild<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXText<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        write!(f, text(self.value().as_str()));
+        write!(f, text(crate::utils::jsx::jsx_text_source(self.as_ref()).as_str()));
     }
 }

--- a/crates/oxc_formatter/src/print/jsx/opening_element.rs
+++ b/crates/oxc_formatter/src/print/jsx/opening_element.rs
@@ -63,7 +63,7 @@ fn is_multiline_string_literal_attribute(attribute: &JSXAttributeItem<'_>) -> bo
     let JSXAttributeItem::Attribute(attr) = attribute else {
         return false;
     };
-    attr.value.as_ref().is_some_and(|value| matches!(value, JSXAttributeValue::StringLiteral(string) if string.value.contains('\n')))
+    attr.value.as_ref().is_some_and(|value| matches!(value, JSXAttributeValue::StringLiteral(string) if string.raw.as_ref().unwrap_or(&string.value).contains('\n')))
 }
 
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatOpeningElement<'a, '_> {
@@ -158,7 +158,8 @@ pub enum OpeningElementLayout {
 
 /// Returns `true` if this is an attribute with a string literal initializer that does not contain any new line characters.
 fn is_single_line_string_literal_attribute(attribute: &JSXAttributeItem) -> bool {
-    as_string_literal_attribute_value(attribute).is_some_and(|string| !string.value.contains('\n'))
+    as_string_literal_attribute_value(attribute)
+        .is_some_and(|string| !string.raw.as_ref().unwrap_or(&string.value).contains('\n'))
 }
 
 /// Returns `Some` if the initializer value of this attribute is a string literal.

--- a/crates/oxc_formatter/src/utils/jsx.rs
+++ b/crates/oxc_formatter/src/utils/jsx.rs
@@ -41,6 +41,12 @@ pub fn is_meaningful_jsx_text(text: &str) -> bool {
     !has_newline
 }
 
+/// Get the source representation of JSX text, falling back to its semantic value for synthetic
+/// nodes.
+pub fn jsx_text_source<'a>(text: &JSXText<'a>) -> Str<'a> {
+    text.raw.unwrap_or(text.value)
+}
+
 /// Indicates that an element should always be wrapped in parentheses, should be wrapped
 /// only when it's line broken, or should not be wrapped at all.
 #[derive(Copy, Clone, Debug)]
@@ -274,8 +280,8 @@ pub fn jsx_split_children<'a, 'b>(
                 // Split the text into words
                 // Keep track if there's any leading/trailing empty line, new line or whitespace
 
-                let text_value = &text.value;
-                let mut chunks = JsxSplitChunksIterator::new(text_value).peekable();
+                let text_value = jsx_text_source(text);
+                let mut chunks = JsxSplitChunksIterator::new(text_value.as_str()).peekable();
 
                 // Text starting with a whitespace
                 if let Some(JsxTextChunk::Whitespace(_whitespace)) = chunks.peek() {

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -10,7 +10,7 @@ use oxc_ast::{
     AstKind,
     ast::{
         Expression, JSXAttributeItem, JSXAttributeValue, JSXChild, JSXElementName, JSXExpression,
-        JSXExpressionContainer,
+        JSXExpressionContainer, JSXText, StringLiteral,
     },
 };
 use oxc_codegen::CodegenOptions;
@@ -382,7 +382,7 @@ impl JsxCurlyBracePresence {
                     self.check_expression_container(ctx, container, node, false);
                 }
                 JSXChild::Text(text) => {
-                    let text_value = text.value.as_str();
+                    let text_value = jsx_text_source(text);
                     if self.children.is_always()
                         && !contains_only_html_entities(text_value)
                         && !is_whitespace(text_value)
@@ -425,7 +425,7 @@ impl JsxCurlyBracePresence {
                     report_missing_curly_for_string_attribute_value(
                         ctx,
                         string.span,
-                        string.value.as_str(),
+                        jsx_attribute_string_source(string),
                     );
                 }
             }
@@ -506,6 +506,15 @@ impl JsxCurlyBracePresence {
             _ => {}
         }
     }
+}
+
+fn jsx_text_source<'a>(text: &JSXText<'a>) -> &'a str {
+    text.raw.as_ref().unwrap().as_str()
+}
+
+fn jsx_attribute_string_source<'a>(string: &StringLiteral<'a>) -> &'a str {
+    let raw = string.raw.as_ref().unwrap();
+    &raw.as_str()[1..raw.len() - 1]
 }
 
 fn is_allowed_string_like_in_container<'a>(

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -61,7 +61,8 @@ impl Rule for JsxNoCommentTextnodes {
             return;
         };
 
-        if has_comment_pattern(&jsx_text.value) {
+        let text = jsx_text.raw.as_ref().unwrap();
+        if has_comment_pattern(text) {
             ctx.diagnostic(jsx_no_comment_textnodes_diagnostic(jsx_text.span));
         }
     }

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -4,6 +4,7 @@ use oxc_allocator::{Allocator, ArenaBox, ArenaVec, Dummy, GetAllocator};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 use oxc_str::Str;
+use oxc_syntax::xml_entities::decode_entities;
 
 use crate::{ParserConfig as Config, ParserImpl, diagnostics, lexer::Kind};
 
@@ -458,7 +459,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_jsx_attribute_value(&mut self) -> JSXAttributeValue<'a> {
         match self.cur_kind() {
             Kind::Str => {
-                let str_lit = self.parse_literal_string();
+                let mut str_lit = self.parse_literal_string();
+                str_lit.value = decode_entities(str_lit.value, self.allocator());
                 JSXAttributeValue::StringLiteral(self.alloc(str_lit))
             }
             Kind::LCurly => {
@@ -505,7 +507,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_jsx_text(&mut self) -> ArenaBox<'a, JSXText<'a>> {
         let span = self.cur_token().span();
         let raw = Str::from(self.cur_src());
-        let value = Str::from(self.cur_string());
+        let value = decode_entities(Str::from(self.cur_string()), self.allocator());
         self.bump_any();
         JSXText::boxed(span, value, Some(raw), self)
     }

--- a/crates/oxc_syntax/src/xml_entities.rs
+++ b/crates/oxc_syntax/src/xml_entities.rs
@@ -1,8 +1,8 @@
 //! XML Entities
 
-use phf::{Map, phf_map};
-
 use oxc_allocator::{Allocator, ArenaStringBuilder};
+use oxc_str::Str;
+use phf::{Map, phf_map};
 
 /// XML Entities
 ///
@@ -264,91 +264,139 @@ pub const XML_ENTITIES: Map<&'static str, char> = phf_map! {
     "diams" => '\u{2666}',
 };
 
-/// Replace entities like `&nbsp;`, `&#123;`, and `&#xDEADBEEF;` with the characters they
-/// encode.
+/// Decode XML/HTML character references in `text`.
 ///
-/// If either the text contains an entity to decode or `acc` is already initialized, the decoded
-/// string is appended to `acc`. Otherwise, `acc` remains `None`, allowing callers to reuse the
-/// original string without copying.
-///
-/// See <https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references>.
-/// Adapted from TypeScript's JSX transformer:
-/// <https://github.com/microsoft/TypeScript/blob/514f7e639a2a8466c075c766ee9857a30ed4e196/src/compiler/transformers/jsx.ts#L617-L635>.
-pub fn decode_entities<'a>(
-    s: &str,
-    acc: &mut Option<ArenaStringBuilder<'a>>,
-    text_len: usize,
-    allocator: &'a Allocator,
-) {
-    let mut chars = s.char_indices();
-    let mut prev = 0;
-    while let Some((i, c)) = chars.next() {
-        if c == '&' {
-            let mut start = i;
-            let mut end = None;
-            for (j, c) in chars.by_ref() {
-                if c == ';' {
-                    end.replace(j);
-                    break;
-                } else if c == '&' {
-                    start = j;
-                }
-            }
-            if let Some(end) = end {
-                let buffer = acc.get_or_insert_with(|| {
-                    ArenaStringBuilder::with_capacity_in(text_len, allocator)
-                });
+/// Returns `text` without allocating if it contains no valid character references.
+pub fn decode_entities<'a>(text: Str<'a>, allocator: &'a Allocator) -> Str<'a> {
+    let mut output = None;
+    decode_entities_impl(text.as_str(), |chunk| {
+        let output = output
+            .get_or_insert_with(|| ArenaStringBuilder::with_capacity_in(text.len(), allocator));
+        chunk.push_to(output);
+    });
+    output.map_or(text, Str::from)
+}
 
-                buffer.push_str(&s[prev..start]);
-                prev = end + 1;
-                let word = &s[start + 1..end];
-                if let Some(decimal) = word.strip_prefix('#') {
-                    if let Some(hex) = decimal.strip_prefix('x') {
-                        if let Some(c) = u32::from_str_radix(hex, 16).ok().and_then(char::from_u32)
-                        {
-                            // `&#x0123;`
-                            buffer.push(c);
-                            continue;
-                        }
-                    } else if let Some(c) = decimal.parse::<u32>().ok().and_then(char::from_u32) {
-                        // `&#0123;`
-                        buffer.push(c);
-                        continue;
-                    }
-                } else if let Some(c) = XML_ENTITIES.get(word) {
-                    // e.g. `&quote;`, `&amp;`
-                    buffer.push(*c);
-                    continue;
-                }
-                // Fallback
-                buffer.push('&');
-                buffer.push_str(word);
-                buffer.push(';');
-            } else {
-                // Reached end of text without finding a `;` after the `&`.
-                // No point searching for a further `&`, so exit the loop.
-                break;
-            }
+/// Append `text`, with XML/HTML character references decoded, to `output`.
+pub fn decode_entities_into(text: &str, output: &mut ArenaStringBuilder<'_>) {
+    if !decode_entities_impl(text, |chunk| chunk.push_to(output)) {
+        output.push_str(text);
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DecodedChunk<'a> {
+    Str(&'a str),
+    Char(char),
+}
+
+impl DecodedChunk<'_> {
+    fn push_to(self, output: &mut ArenaStringBuilder<'_>) {
+        match self {
+            Self::Str(s) => output.push_str(s),
+            Self::Char(c) => output.push(c),
         }
     }
+}
 
-    if let Some(buffer) = acc.as_mut() {
-        buffer.push_str(&s[prev..]);
+/// Call `emit` for each chunk of decoded text.
+///
+/// Returns `true` if at least one character reference was decoded. If it returns `false`, `emit`
+/// was not called.
+fn decode_entities_impl<'a>(s: &'a str, mut emit: impl FnMut(DecodedChunk<'a>)) -> bool {
+    let mut chars = s.char_indices();
+    let mut prev = 0;
+    let mut decoded = false;
+
+    while let Some((i, c)) = chars.next() {
+        if c != '&' {
+            continue;
+        }
+
+        let mut start = i;
+        let mut end = None;
+        for (j, c) in chars.by_ref() {
+            if c == ';' {
+                end = Some(j);
+                break;
+            }
+            if c == '&' {
+                start = j;
+            }
+        }
+
+        let Some(end) = end else {
+            break;
+        };
+        let word = &s[start + 1..end];
+        let entity = if let Some(decimal) = word.strip_prefix('#') {
+            if let Some(hex) = decimal.strip_prefix('x') {
+                u32::from_str_radix(hex, 16).ok().and_then(char::from_u32)
+            } else {
+                decimal.parse::<u32>().ok().and_then(char::from_u32)
+            }
+        } else {
+            XML_ENTITIES.get(word).copied()
+        };
+
+        let Some(entity) = entity else {
+            continue;
+        };
+
+        emit(DecodedChunk::Str(&s[prev..start]));
+        emit(DecodedChunk::Char(entity));
+        prev = end + 1;
+        decoded = true;
     }
+
+    if decoded {
+        emit(DecodedChunk::Str(&s[prev..]));
+    }
+    decoded
 }
 
 #[cfg(test)]
 mod tests {
-    use oxc_allocator::Allocator;
+    use oxc_allocator::{Allocator, ArenaStringBuilder};
+    use oxc_str::Str;
 
-    use super::decode_entities;
+    use super::{decode_entities, decode_entities_into};
+
+    fn decode(input: &str) -> String {
+        let allocator = Allocator::default();
+        decode_entities(Str::from(input), &allocator).to_string()
+    }
 
     #[test]
-    fn entity_after_stray_amp() {
+    fn decodes_named_and_numeric_entities() {
+        assert_eq!(decode("&amp;&gt;&quot;"), "&>\"");
+        assert_eq!(decode("&#38;&#62;&#34;"), "&>\"");
+        assert_eq!(decode("&#x26;&#x3e;&#x22;"), "&>\"");
+        assert_eq!(decode("&#x1f600;"), "😀");
+    }
+
+    #[test]
+    fn preserves_invalid_entities() {
+        for input in ["&unknown;", "&amp", "&#x110000;", "&#xD800;", "&#wat;"] {
+            let allocator = Allocator::default();
+            let decoded = decode_entities(Str::from(input), &allocator);
+            assert_eq!(decoded, input);
+            assert_eq!(decoded.as_ptr(), input.as_ptr());
+        }
+    }
+
+    #[test]
+    fn decodes_entity_after_stray_ampersand() {
+        assert_eq!(decode("& &amp;"), "& &");
+        assert_eq!(decode("&unknown; &amp;"), "&unknown; &");
+        assert_eq!(decode("&&amp;"), "&&");
+    }
+
+    #[test]
+    fn appends_decoded_entities() {
         let allocator = Allocator::default();
-        let input = "& &amp;";
-        let mut acc = None;
-        decode_entities(input, &mut acc, input.len(), &allocator);
-        assert_eq!(acc.as_ref().unwrap().as_str(), "& &");
+        let mut output = ArenaStringBuilder::from_str_in("prefix ", &allocator);
+        decode_entities_into("&amp; suffix", &mut output);
+        assert_eq!(output, "prefix & suffix");
     }
 }

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -102,7 +102,7 @@ use oxc_syntax::{
     line_terminator::is_line_terminator,
     reference::ReferenceFlags,
     symbol::SymbolFlags,
-    xml_entities::decode_entities,
+    xml_entities::decode_entities_into,
 };
 use oxc_traverse::{BoundIdentifier, Traverse};
 
@@ -914,17 +914,7 @@ impl<'a> JsxImpl<'a> {
     ) -> Expression<'a> {
         match value {
             Some(JSXAttributeValue::StringLiteral(s)) => {
-                let mut decoded = None;
-                decode_entities(s.value.as_str(), &mut decoded, s.value.len(), ctx.allocator());
-                let jsx_text = if let Some(decoded) = decoded {
-                    // Text contains HTML entities which were decoded.
-                    // `decoded` contains the decoded string as an `ArenaString`. Convert it to `Str`.
-                    Str::from(decoded)
-                } else {
-                    // No HTML entities needed to be decoded. Use the original `Str` without copying.
-                    s.value
-                };
-                Expression::new_string_literal(s.span, jsx_text, None, ctx)
+                Expression::new_string_literal(s.span, s.value, None, ctx)
             }
             Some(JSXAttributeValue::Element(e)) => self.transform_jsx_element(e, ctx),
             Some(JSXAttributeValue::Fragment(e)) => {
@@ -1009,8 +999,14 @@ impl<'a> JsxImpl<'a> {
     }
 
     fn transform_jsx_text(text: &JSXText<'a>, ctx: &TraverseCtx<'a>) -> Option<Expression<'a>> {
-        Self::fixup_whitespace_and_decode_entities(text.value, ctx)
-            .map(|value| Expression::new_string_literal(text.span, value, None, ctx))
+        let value = match text.raw {
+            Some(raw) if raw.chars().any(is_line_terminator) => {
+                Self::fixup_whitespace(raw, true, ctx)
+            }
+            Some(_) => Some(text.value),
+            None => Self::fixup_whitespace(text.value, false, ctx),
+        };
+        value.map(|value| Expression::new_string_literal(text.span, value, None, ctx))
     }
 
     /// JSX trims whitespace at the end and beginning of lines, except that the
@@ -1028,31 +1024,32 @@ impl<'a> JsxImpl<'a> {
     /// - Remove empty lines and join the rest with " ".
     ///
     /// <https://github.com/microsoft/TypeScript/blob/f0374ce2a9c465e27a15b7fa4a347e2bd9079450/src/compiler/transformers/jsx.ts#L557-L608>
-    fn fixup_whitespace_and_decode_entities(
+    fn fixup_whitespace(
         text: Str<'a>,
+        should_decode_entities: bool,
         ctx: &TraverseCtx<'a>,
     ) -> Option<Str<'a>> {
-        // Avoid copying strings in the common case where there's only 1 line of text,
-        // and it contains no HTML entities that need decoding.
+        // Avoid copying strings in the common case where there's only 1 line of text and no
+        // character references need decoding.
         //
         // Where we do have to decode HTML entities, or concatenate multiple lines, assemble the
-        // concatenated text directly in arena, in an `ArenaString` (the accumulator `acc`),
-        // to avoid allocations. Initialize that `ArenaString` with capacity equal to length of
-        // the original text. This may be a bit more capacity than is required, once whitespace
-        // is removed, but it's highly unlikely to be insufficient capacity, so the `ArenaString`
-        // shouldn't need to reallocate while it's being constructed.
+        // concatenated text directly in an arena string builder (the accumulator `acc`) to avoid
+        // intermediate allocations. Initialize it with capacity equal to the original text length.
+        // This may be a bit more capacity than required once whitespace is removed, but it is
+        // unlikely to be insufficient, so the builder should not need to reallocate.
         //
         // When first line containing some text is found:
-        // * If it contains HTML entities, decode them and write decoded text to accumulator `acc`.
+        // * If entity decoding is enabled and it contains an ampersand, write decoded text to
+        //   accumulator `acc`.
         // * Otherwise, store trimmed text in `only_line` as a `Str<'a>`.
         //
         // When another line containing some text is found:
         // * If accumulator isn't already initialized, initialize it, starting with `only_line`.
         // * Push a space to the accumulator.
-        // * Decode current line into the accumulator.
+        // * Append current line to the accumulator, decoding it when requested.
         //
         // At the end:
-        // * If accumulator is initialized, convert the `ArenaString` to a `Str` and return it.
+        // * If accumulator is initialized, convert the arena string builder to a `Str` and return it.
         // * If `only_line` contains a string, that means only 1 line contained text, and that line
         //   didn't contain any HTML entities which needed decoding.
         //   So we can just return the `Str` that's in `only_line` (without any copying).
@@ -1069,6 +1066,7 @@ impl<'a> JsxImpl<'a> {
                         &mut acc,
                         &mut only_line,
                         text.len(),
+                        should_decode_entities,
                         ctx,
                     );
                 }
@@ -1087,6 +1085,7 @@ impl<'a> JsxImpl<'a> {
                 &mut acc,
                 &mut only_line,
                 text.len(),
+                should_decode_entities,
                 ctx,
             );
         }
@@ -1099,6 +1098,7 @@ impl<'a> JsxImpl<'a> {
         acc: &mut Option<ArenaStringBuilder<'a>>,
         only_line: &mut Option<Str<'a>>,
         text_len: usize,
+        should_decode_entities: bool,
         ctx: &TraverseCtx<'a>,
     ) {
         if let Some(buffer) = acc.as_mut() {
@@ -1114,8 +1114,16 @@ impl<'a> JsxImpl<'a> {
             *acc = Some(buffer);
         }
 
-        // Decode any HTML entities in this line
-        decode_entities(trimmed_line.as_str(), acc, text_len, ctx.allocator());
+        if should_decode_entities {
+            if acc.is_none() && trimmed_line.contains('&') {
+                *acc = Some(ArenaStringBuilder::with_capacity_in(text_len, ctx.allocator()));
+            }
+            if let Some(buffer) = acc.as_mut() {
+                decode_entities_into(trimmed_line.as_str(), buffer);
+            }
+        } else if let Some(buffer) = acc.as_mut() {
+            buffer.push_str(trimmed_line.as_str());
+        }
 
         if acc.is_none() {
             // This is the first line containing text, and there are no HTML entities in this line.

--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -2,12 +2,4 @@ commit: e8fd1202
 
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)
-Positive Passed: 35/39 (89.74%)
-Mismatch: tasks/coverage/estree-conformance/tests/acorn-jsx/pass/010.jsx
-
-Mismatch: tasks/coverage/estree-conformance/tests/acorn-jsx/pass/013.jsx
-
-Mismatch: tasks/coverage/estree-conformance/tests/acorn-jsx/pass/020.jsx
-
-Mismatch: tasks/coverage/estree-conformance/tests/acorn-jsx/pass/046.jsx
-
+Positive Passed: 39/39 (100.00%)

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 637d5746
 
 estree_typescript Summary:
 AST Parsed     : 9719/9719 (100.00%)
-Positive Passed: 9701/9719 (99.81%)
+Positive Passed: 9704/9719 (99.85%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleDetectionIsolatedModulesCjsFileScope.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleNodeImportRequireEmit.ts
@@ -22,12 +22,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewr
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferComments.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferDeclaration.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitNesting.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsCjsFromJs.ts
 


### PR DESCRIPTION
## Summary

- decode named, decimal, and hexadecimal JSX character references while building parser AST values
- preserve source-exact `raw` text for codegen, formatting, lint fixes, and multiline JSX whitespace handling
- avoid decoding again in the JSX transformer while retaining support for synthetic AST nodes
- bring Acorn JSX ESTree conformance to 39/39 and remove three TypeScript ESTree mismatches

Follow-up to #24617.

Closes #9667.
