### PR TITLE
feat(track-memory-allocations): track heap deallocs, alloc bytes, and peak growth

### DIFF
--- a/crates/oxc_allocator/src/arena/create.rs
+++ b/crates/oxc_allocator/src/arena/create.rs
@@ -409,13 +409,16 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         debug_assert!(size >= requested_layout.size());
         debug_assert!(size > 0);
 
+        // Mark the upcoming allocation as a chunk operation, so the allocation-tracking
+        // task can exclude it from its heap metrics. Must be set immediately before the
+        // `alloc` call, with no allocations in between.
+        #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
+        crate::tracking::start_chunk_operation();
+
         // Allocate memory for the chunk.
         // SAFETY: `layout` has non-zero size.
         let start_ptr = unsafe { alloc::alloc(layout) };
         let start_ptr = NonNull::new(start_ptr)?;
-
-        #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
-        crate::tracking::record_chunk_allocation();
 
         // The `ChunkFooter` is at the end of the chunk.
         // SAFETY: We allocated `new_size_without_footer + CHUNK_FOOTER_SIZE` bytes, starting at `start_ptr`,

--- a/crates/oxc_allocator/src/arena/drop.rs
+++ b/crates/oxc_allocator/src/arena/drop.rs
@@ -149,6 +149,12 @@ unsafe fn dealloc_chunk(footer_ptr: NonNull<ChunkFooter>) {
         }
     }
 
+    // Mark the upcoming deallocation as a chunk operation, so the allocation-tracking
+    // task can exclude it from its heap metrics. Must be set immediately before the
+    // `dealloc` call, with no allocations in between.
+    #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
+    crate::tracking::start_chunk_operation();
+
     // SAFETY: Each `ChunkFooter`'s `backing_alloc_ptr` and `layout` describe its backing allocation.
     // `is_fixed_size` is `false`, so backing allocation was made via global allocator.
     unsafe { alloc::dealloc(backing_alloc_ptr, layout) };

--- a/crates/oxc_allocator/src/tracking.rs
+++ b/crates/oxc_allocator/src/tracking.rs
@@ -11,23 +11,30 @@
 
 use std::{
     cell::Cell,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use crate::{Allocator, arena::Arena};
 
-/// Number of chunks all [`Arena`]s have requested from the system allocator, in total.
+/// Whether the next call to the system allocator is an [`Arena`] chunk being allocated
+/// or deallocated.
 ///
-/// This is a global counter, not a per-arena one, because short-lived arenas
-/// (e.g. the arena backing `oxc_semantic`'s `Scoping`) are often created and dropped inside
-/// the operation being measured, so their counters cannot be read after the operation completes.
-static NUM_CHUNK_ALLOC: AtomicUsize = AtomicUsize::new(0);
+/// Chunk operations are marked so that `tasks/track_memory_allocations`'s global allocator
+/// wrapper can exclude them from its heap metrics: chunk sizes are quantized and
+/// platform-dependent (whether an arena needs one more chunk depends on byte totals, which
+/// vary across architectures with type layout — see #22621), so counting them would make
+/// the snapshots platform-dependent.
+///
+/// This is a marker, not a counter: [`start_chunk_operation`] is called immediately before
+/// the chunk's `alloc`/`dealloc` call, and the global allocator wrapper consumes the marker
+/// while that call is on the stack. There are no allocations in between, but another
+/// *thread* allocating at that exact moment could steal the marker; the tracking task's
+/// measured workload is single-threaded, so this cannot happen in practice.
+static CHUNK_OPERATION_PENDING: AtomicBool = AtomicBool::new(false);
 
-/// Record that a chunk was allocated from the system allocator.
-pub fn record_chunk_allocation() {
-    // Counter maxes out at `usize::MAX`, but if there's that many allocations,
-    // the exact number is not important
-    NUM_CHUNK_ALLOC.update(Ordering::Relaxed, Ordering::Relaxed, |count| count.saturating_add(1));
+/// Mark that the next system allocator call is an [`Arena`] chunk operation.
+pub fn start_chunk_operation() {
+    CHUNK_OPERATION_PENDING.store(true, Ordering::Relaxed);
 }
 
 /// Counters of allocations and reallocations made in an [`Allocator`].
@@ -91,9 +98,12 @@ impl Allocator {
         self.arena().get_allocation_stats()
     }
 
-    /// Get number of chunks all [`Arena`]s have requested from the system allocator, in total.
+    /// Consume the pending chunk-operation marker (see [`CHUNK_OPERATION_PENDING`]).
+    ///
+    /// Returns `true` if the system allocator call currently on the stack is an [`Arena`]
+    /// chunk being allocated or deallocated.
     #[doc(hidden)]
-    pub fn global_chunk_allocation_count() -> usize {
-        NUM_CHUNK_ALLOC.load(Ordering::Relaxed)
+    pub fn take_pending_chunk_operation() -> bool {
+        CHUNK_OPERATION_PENDING.swap(false, Ordering::Relaxed)
     }
 }

--- a/tasks/track_memory_allocations/README.md
+++ b/tasks/track_memory_allocations/README.md
@@ -4,6 +4,19 @@ This task keeps track of the number of system allocations as well as arena alloc
 
 Update the snapshots with `cargo allocs`.
 
+## Metrics
+
+Recorded per file and per stage (parser, semantic, transformer, minifier, formatter):
+
+- `file size` - size of the source text
+- `sys allocs` / `sys reallocs` / `sys deallocs` - system allocator activity during the stage
+- `sys alloc bytes` - total bytes requested from the system allocator during the stage (allocation sizes plus reallocation growth)
+- `sys peak growth` - high-water mark of live heap memory during the stage, relative to the live bytes when the stage started; captures transient heap the stage needs even when it frees it again before finishing
+- `arena allocs` / `arena reallocs` - arena allocator activity during the stage
+- `arena size` - bytes used in the arena at the end of the stage (cumulative: the arena is not reset between stages, so this includes the AST built by the parser)
+
+Arena chunk allocations and deallocations are excluded from all `sys` metrics: chunk sizes are quantized and platform-dependent (whether an arena needs one more chunk depends on byte totals that vary across architectures), and for long-lived arenas chunk growth reflects the arena's history rather than the stage's own behavior. Arenas mark their chunk operations for the tracking allocator to skip.
+
 ## Cross-platform reproducibility
 
-Allocation counts are identical on all platforms: the task pins mimalloc as the global allocator and excludes arena chunk allocations from the system allocation counts. `arena size` is not exactly reproducible: type layout differs slightly across architectures (e.g. hashbrown's table control groups are 16 bytes on x86_64 vs 8 bytes on aarch64), which shifts arena byte totals by up to ~128 bytes per file. So that a snapshot generated on any platform passes CI on the others, the snapshots are YAML: `cargo allocs` parses the committed snapshot and keeps its `arena size` value when the measured one is within `APPROX_BYTES_TOLERANCE` (1024 bytes) of it; only differences beyond the tolerance rewrite the value.
+Allocation counts are identical on all platforms: the task pins mimalloc as the global allocator and excludes arena chunk allocations from the system allocation counts. `arena size` is not exactly reproducible: type layout differs slightly across architectures (e.g. hashbrown's table control groups are 16 bytes on x86_64 vs 8 bytes on aarch64), which shifts arena byte totals by up to ~128 bytes per file. So that a snapshot generated on any platform passes CI on the others, the snapshots are YAML: `cargo allocs` parses the committed snapshot and keeps a byte metric's committed value when the measured one is within that metric's tolerance (`arena size`: 1024 bytes; `sys alloc bytes` and `sys peak growth`: 1%, minimum 4 kB); only differences beyond the tolerance rewrite the value.

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -2,6 +2,9 @@ checker.ts:
   file size: 2922154 # 2.92 MB
   sys allocs: 11013
   sys reallocs: 492
+  sys deallocs: 11012
+  sys alloc bytes: 5918285 # 5.92 MB
+  sys peak growth: 2990058 # 2.99 MB
   arena allocs: 1081815
   arena reallocs: 118690
   arena size: 138513064 # 138.51 MB
@@ -10,6 +13,9 @@ App.tsx:
   file size: 415342 # 415.34 kB
   sys allocs: 2532
   sys reallocs: 80
+  sys deallocs: 2531
+  sys alloc bytes: 985182 # 985.18 kB
+  sys peak growth: 443550 # 443.55 kB
   arena allocs: 212668
   arena reallocs: 25343
   arena size: 29608600 # 29.61 MB
@@ -18,6 +24,9 @@ RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
   sys allocs: 54
   sys reallocs: 26
+  sys deallocs: 53
+  sys alloc bytes: 10116 # 10.12 kB
+  sys peak growth: 2856 # 2.86 kB
   arena allocs: 1155
   arena reallocs: 157
   arena size: 210048 # 210.05 kB
@@ -26,6 +35,9 @@ pdf.mjs:
   file size: 567296 # 567.30 kB
   sys allocs: 4019
   sys reallocs: 172
+  sys deallocs: 4018
+  sys alloc bytes: 2050032 # 2.05 MB
+  sys peak growth: 1164624 # 1.16 MB
   arena allocs: 437639
   arena reallocs: 43489
   arena size: 44872224 # 44.87 MB
@@ -34,6 +46,9 @@ antd.js:
   file size: 6686316 # 6.69 MB
   sys allocs: 34121
   sys reallocs: 3994
+  sys deallocs: 34120
+  sys alloc bytes: 20850396 # 20.85 MB
+  sys peak growth: 13841112 # 13.84 MB
   arena allocs: 2586207
   arena reallocs: 302459
   arena size: 525725120 # 525.73 MB
@@ -42,6 +57,9 @@ binder.ts:
   file size: 193077 # 193.08 kB
   sys allocs: 457
   sys reallocs: 35
+  sys deallocs: 456
+  sys alloc bytes: 291781 # 291.78 kB
+  sys peak growth: 195661 # 195.66 kB
   arena allocs: 64083
   arena reallocs: 6932
   arena size: 8574752 # 8.57 MB
@@ -50,6 +68,9 @@ kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
   sys allocs: 9565
   sys reallocs: 2815
+  sys deallocs: 9564
+  sys alloc bytes: 3180244 # 3.18 MB
+  sys peak growth: 1499988 # 1.50 MB
   arena allocs: 569903
   arena reallocs: 60147
   arena size: 57887072 # 57.89 MB

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -2,6 +2,9 @@ checker.ts:
   file size: 2922154 # 2.92 MB
   sys allocs: 155
   sys reallocs: 5
+  sys deallocs: 155
+  sys alloc bytes: 15028748 # 15.03 MB
+  sys peak growth: 10203896 # 10.20 MB
   arena allocs: 152755
   arena reallocs: 28253
   arena size: 19046536 # 19.05 MB
@@ -10,6 +13,9 @@ App.tsx:
   file size: 415342 # 415.34 kB
   sys allocs: 63
   sys reallocs: 8
+  sys deallocs: 63
+  sys alloc bytes: 2136669 # 2.14 MB
+  sys peak growth: 1620605 # 1.62 MB
   arena allocs: 17028
   arena reallocs: 2702
   arena size: 2915504 # 2.92 MB
@@ -18,6 +24,9 @@ RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
   sys allocs: 21
   sys reallocs: 0
+  sys deallocs: 21
+  sys alloc bytes: 17368 # 17.37 kB
+  sys peak growth: 11628 # 11.63 kB
   arena allocs: 32
   arena reallocs: 6
   arena size: 35760 # 35.76 kB
@@ -26,6 +35,9 @@ pdf.mjs:
   file size: 567296 # 567.30 kB
   sys allocs: 2469
   sys reallocs: 205
+  sys deallocs: 2469
+  sys alloc bytes: 5348727 # 5.35 MB
+  sys peak growth: 3707391 # 3.71 MB
   arena allocs: 47467
   arena reallocs: 7742
   arena size: 6356528 # 6.36 MB
@@ -34,6 +46,9 @@ antd.js:
   file size: 6686316 # 6.69 MB
   sys allocs: 1044
   sys reallocs: 56
+  sys deallocs: 1044
+  sys alloc bytes: 29987563 # 29.99 MB
+  sys peak growth: 19934725 # 19.93 MB
   arena allocs: 372552
   arena reallocs: 76745
   arena size: 49031840 # 49.03 MB
@@ -42,6 +57,9 @@ binder.ts:
   file size: 193077 # 193.08 kB
   sys allocs: 33
   sys reallocs: 1
+  sys deallocs: 33
+  sys alloc bytes: 963614 # 963.61 kB
+  sys peak growth: 658042 # 658.04 kB
   arena allocs: 7076
   arena reallocs: 824
   arena size: 1157952 # 1.16 MB
@@ -50,6 +68,9 @@ kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
   sys allocs: 2309
   sys reallocs: 175
+  sys deallocs: 2309
+  sys alloc bytes: 5353468 # 5.35 MB
+  sys peak growth: 3738631 # 3.74 MB
   arena allocs: 88097
   arena reallocs: 15654
   arena size: 10190368 # 10.19 MB

--- a/tasks/track_memory_allocations/allocs_parser.yaml
+++ b/tasks/track_memory_allocations/allocs_parser.yaml
@@ -2,6 +2,9 @@ checker.ts:
   file size: 2922154 # 2.92 MB
   sys allocs: 1818
   sys reallocs: 10
+  sys deallocs: 1818
+  sys alloc bytes: 67847 # 67.85 kB
+  sys peak growth: 2432 # 2.43 kB
   arena allocs: 264366
   arena reallocs: 22860
   arena size: 12985152 # 12.99 MB
@@ -10,6 +13,9 @@ App.tsx:
   file size: 415342 # 415.34 kB
   sys allocs: 360
   sys reallocs: 13
+  sys deallocs: 360
+  sys alloc bytes: 50315 # 50.31 kB
+  sys peak growth: 26404 # 26.40 kB
   arena allocs: 44464
   arena reallocs: 3537
   arena size: 2244408 # 2.24 MB
@@ -18,6 +24,9 @@ RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
   sys allocs: 1
   sys reallocs: 0
+  sys deallocs: 1
+  sys alloc bytes: 108 # 108 B
+  sys peak growth: 108 # 108 B
   arena allocs: 367
   arena reallocs: 66
   arena size: 21200 # 21.20 kB
@@ -26,6 +35,9 @@ pdf.mjs:
   file size: 567296 # 567.30 kB
   sys allocs: 337
   sys reallocs: 67
+  sys deallocs: 337
+  sys alloc bytes: 34110 # 34.11 kB
+  sys peak growth: 12140 # 12.14 kB
   arena allocs: 90583
   arena reallocs: 8153
   arena size: 4559872 # 4.56 MB
@@ -34,6 +46,9 @@ antd.js:
   file size: 6686316 # 6.69 MB
   sys allocs: 3661
   sys reallocs: 221
+  sys deallocs: 3661
+  sys alloc bytes: 232077 # 232.08 kB
+  sys peak growth: 48264 # 48.26 kB
   arena allocs: 528577
   arena reallocs: 55355
   arena size: 29421920 # 29.42 MB
@@ -42,6 +57,9 @@ binder.ts:
   file size: 193077 # 193.08 kB
   sys allocs: 85
   sys reallocs: 0
+  sys deallocs: 85
+  sys alloc bytes: 3016 # 3.02 kB
+  sys peak growth: 251 # 251 B
   arena allocs: 16620
   arena reallocs: 1476
   arena size: 917416 # 917.42 kB
@@ -50,6 +68,9 @@ kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
   sys allocs: 2051
   sys reallocs: 160
+  sys deallocs: 2051
+  sys alloc bytes: 117964 # 117.96 kB
+  sys peak growth: 14644 # 14.64 kB
   arena allocs: 138059
   arena reallocs: 11905
   arena size: 6495776 # 6.50 MB

--- a/tasks/track_memory_allocations/allocs_semantic.yaml
+++ b/tasks/track_memory_allocations/allocs_semantic.yaml
@@ -2,6 +2,9 @@ checker.ts:
   file size: 2922154 # 2.92 MB
   sys allocs: 46
   sys reallocs: 0
+  sys deallocs: 46
+  sys alloc bytes: 3866958 # 3.87 MB
+  sys peak growth: 3858362 # 3.86 MB
   arena allocs: 0
   arena reallocs: 0
   arena size: 12985152 # 12.99 MB
@@ -10,6 +13,9 @@ App.tsx:
   file size: 415342 # 415.34 kB
   sys allocs: 7
   sys reallocs: 0
+  sys deallocs: 7
+  sys alloc bytes: 360848 # 360.85 kB
+  sys peak growth: 360848 # 360.85 kB
   arena allocs: 0
   arena reallocs: 0
   arena size: 2244408 # 2.24 MB
@@ -18,6 +24,9 @@ RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
   sys allocs: 7
   sys reallocs: 0
+  sys deallocs: 7
+  sys alloc bytes: 2748 # 2.75 kB
+  sys peak growth: 2748 # 2.75 kB
   arena allocs: 0
   arena reallocs: 0
   arena size: 21200 # 21.20 kB
@@ -26,6 +35,9 @@ pdf.mjs:
   file size: 567296 # 567.30 kB
   sys allocs: 12
   sys reallocs: 0
+  sys deallocs: 12
+  sys alloc bytes: 833710 # 833.71 kB
+  sys peak growth: 832762 # 832.76 kB
   arena allocs: 0
   arena reallocs: 0
   arena size: 4559872 # 4.56 MB
@@ -34,6 +46,9 @@ antd.js:
   file size: 6686316 # 6.69 MB
   sys allocs: 24
   sys reallocs: 0
+  sys deallocs: 24
+  sys alloc bytes: 5512934 # 5.51 MB
+  sys peak growth: 5441278 # 5.44 MB
   arena allocs: 0
   arena reallocs: 0
   arena size: 29421920 # 29.42 MB
@@ -42,6 +57,9 @@ binder.ts:
   file size: 193077 # 193.08 kB
   sys allocs: 14
   sys reallocs: 0
+  sys deallocs: 14
+  sys alloc bytes: 247026 # 247.03 kB
+  sys peak growth: 246886 # 246.89 kB
   arena allocs: 0
   arena reallocs: 0
   arena size: 917416 # 917.42 kB
@@ -50,6 +68,9 @@ kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
   sys allocs: 33
   sys reallocs: 0
+  sys deallocs: 33
+  sys alloc bytes: 1103942 # 1.10 MB
+  sys peak growth: 1101954 # 1.10 MB
   arena allocs: 0
   arena reallocs: 0
   arena size: 6495776 # 6.50 MB

--- a/tasks/track_memory_allocations/allocs_transformer.yaml
+++ b/tasks/track_memory_allocations/allocs_transformer.yaml
@@ -2,6 +2,9 @@ checker.ts:
   file size: 2922154 # 2.92 MB
   sys allocs: 18
   sys reallocs: 0
+  sys deallocs: 44
+  sys alloc bytes: 2351 # 2.35 kB
+  sys peak growth: 2243 # 2.24 kB
   arena allocs: 1959
   arena reallocs: 5
   arena size: 13073848 # 13.07 MB
@@ -10,6 +13,9 @@ App.tsx:
   file size: 415342 # 415.34 kB
   sys allocs: 23
   sys reallocs: 2
+  sys deallocs: 28
+  sys alloc bytes: 2796 # 2.80 kB
+  sys peak growth: 2584 # 2.58 kB
   arena allocs: 618
   arena reallocs: 17
   arena size: 2277696 # 2.28 MB
@@ -18,6 +24,9 @@ RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
   sys allocs: 19
   sys reallocs: 2
+  sys deallocs: 24
+  sys alloc bytes: 2208 # 2.21 kB
+  sys peak growth: 2144 # 2.14 kB
   arena allocs: 258
   arena reallocs: 13
   arena size: 34616 # 34.62 kB
@@ -26,6 +35,9 @@ pdf.mjs:
   file size: 567296 # 567.30 kB
   sys allocs: 13
   sys reallocs: 0
+  sys deallocs: 18
+  sys alloc bytes: 1610 # 1.61 kB
+  sys peak growth: 1610 # 1.61 kB
   arena allocs: 2
   arena reallocs: 0
   arena size: 4559896 # 4.56 MB
@@ -34,6 +46,9 @@ antd.js:
   file size: 6686316 # 6.69 MB
   sys allocs: 13
   sys reallocs: 0
+  sys deallocs: 19
+  sys alloc bytes: 1611 # 1.61 kB
+  sys peak growth: 1611 # 1.61 kB
   arena allocs: 2
   arena reallocs: 0
   arena size: 29421944 # 29.42 MB
@@ -42,6 +57,9 @@ binder.ts:
   file size: 193077 # 193.08 kB
   sys allocs: 15
   sys reallocs: 0
+  sys deallocs: 25
+  sys alloc bytes: 1625 # 1.62 kB
+  sys peak growth: 1625 # 1.62 kB
   arena allocs: 154
   arena reallocs: 0
   arena size: 924256 # 924.26 kB
@@ -50,6 +68,9 @@ kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
   sys allocs: 182
   sys reallocs: 3
+  sys deallocs: 196
+  sys alloc bytes: 16794 # 16.79 kB
+  sys peak growth: 3218 # 3.22 kB
   arena allocs: 6132
   arena reallocs: 280
   arena size: 6829872 # 6.83 MB

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -43,6 +43,24 @@ impl AtomicCounter {
         self.0.update(SeqCst, SeqCst, |count| count.saturating_add(1));
     }
 
+    /// Add `n` to the counter, returning the new value.
+    fn add(&self, n: usize) -> usize {
+        self.0.update(SeqCst, SeqCst, |count| count.saturating_add(n)).saturating_add(n)
+    }
+
+    fn sub(&self, n: usize) {
+        self.0.update(SeqCst, SeqCst, |count| count.saturating_sub(n));
+    }
+
+    /// Raise the counter to `value` if it is currently lower.
+    fn update_max(&self, value: usize) {
+        self.0.update(SeqCst, SeqCst, |count| count.max(value));
+    }
+
+    fn set(&self, value: usize) {
+        self.0.store(value, SeqCst);
+    }
+
     fn reset(&self) {
         self.0.store(0, SeqCst);
     }
@@ -50,58 +68,138 @@ impl AtomicCounter {
 
 /// Live counters for the system (heap) allocator, updated by [`TrackedAllocator`].
 ///
-/// To track a new heap metric: add an [`AtomicCounter`] here, update it in the
-/// [`GlobalAlloc`] impl, read it out in [`HeapTracker::read`], and reset it in
-/// [`HeapTracker::reset`].
+/// To track a new heap metric: add an [`AtomicCounter`] here, update it in the `record_*`
+/// methods called from the [`GlobalAlloc`] impl, then read it out in [`HeapTracker::read`]
+/// (for counters diffed per stage) or directly off the field (for gauges read in
+/// [`record_stats_in`]).
 struct HeapTracker {
     /// Number of system allocations
     allocs: AtomicCounter,
     /// Number of system reallocations
     reallocs: AtomicCounter,
+    /// Number of system deallocations
+    deallocs: AtomicCounter,
+    /// Total bytes requested from the system allocator: allocation sizes, plus growth
+    /// from reallocations. A monotonic counter.
+    alloc_bytes: AtomicCounter,
+    /// Bytes currently allocated from the system allocator. A live gauge, never reset.
+    live_size: AtomicCounter,
+    /// High-water mark of [`live_size`](Self::live_size) since the last
+    /// [`reset_peak`](Self::reset_peak).
+    peak_size: AtomicCounter,
 }
 
-static HEAP: HeapTracker =
-    HeapTracker { allocs: AtomicCounter::new(), reallocs: AtomicCounter::new() };
+static HEAP: HeapTracker = HeapTracker {
+    allocs: AtomicCounter::new(),
+    reallocs: AtomicCounter::new(),
+    deallocs: AtomicCounter::new(),
+    alloc_bytes: AtomicCounter::new(),
+    live_size: AtomicCounter::new(),
+    peak_size: AtomicCounter::new(),
+};
 
 impl HeapTracker {
+    fn record_alloc(&self, size: usize) {
+        self.allocs.increment();
+        self.grow(size);
+    }
+
+    fn record_dealloc(&self, size: usize) {
+        self.deallocs.increment();
+        self.live_size.sub(size);
+    }
+
+    fn record_realloc(&self, old_size: usize, new_size: usize) {
+        self.reallocs.increment();
+        if new_size >= old_size {
+            self.grow(new_size - old_size);
+        } else {
+            self.live_size.sub(old_size - new_size);
+        }
+    }
+
+    /// Record `delta` new bytes obtained from the system allocator.
+    fn grow(&self, delta: usize) {
+        self.alloc_bytes.add(delta);
+        let live_size = self.live_size.add(delta);
+        self.peak_size.update_max(live_size);
+    }
+
     fn read(&self) -> HeapCounters {
-        HeapCounters { allocs: self.allocs.get(), reallocs: self.reallocs.get() }
+        HeapCounters {
+            allocs: self.allocs.get(),
+            reallocs: self.reallocs.get(),
+            deallocs: self.deallocs.get(),
+            alloc_bytes: self.alloc_bytes.get(),
+        }
+    }
+
+    /// Start a new peak measurement window: the high-water mark restarts from the
+    /// current live size.
+    fn reset_peak(&self) {
+        self.peak_size.set(self.live_size.get());
     }
 
     fn reset(&self) {
         self.allocs.reset();
         self.reallocs.reset();
+        self.deallocs.reset();
+        self.alloc_bytes.reset();
+        // `live_size` and `peak_size` are gauges of real live memory, not counters;
+        // they are never reset to zero.
     }
+}
+
+/// Whether the system allocator call currently on the stack is an arena chunk operation.
+///
+/// Chunk operations are excluded from all heap metrics: whether an arena needs one more
+/// chunk — and how big it is — depends on byte totals that vary across platforms with
+/// target type layout (e.g. hashbrown tables are wider on x86_64 than aarch64; see
+/// #22621), and for long-lived arenas chunk growth reflects the arena's history rather
+/// than the measured operation's own behavior. Arenas mark their chunk operations
+/// immediately before calling the system allocator (see `oxc_allocator::tracking`), and
+/// this consumes the marker.
+fn is_chunk_operation() -> bool {
+    #[cfg(not(feature = "is_all_features"))]
+    return Allocator::take_pending_chunk_operation();
+    #[cfg(feature = "is_all_features")]
+    false
 }
 
 // SAFETY: Methods simply delegate to `MiMalloc` allocator to ensure that the allocator
 // is the same across different platforms for the purposes of tracking allocations.
+//
+// Note: `is_chunk_operation` must be consumed unconditionally (even when the allocation
+// fails), so it comes first in the `&&` chains below.
 #[expect(clippy::undocumented_unsafe_blocks)]
 unsafe impl GlobalAlloc for TrackedAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let ret = unsafe { MiMalloc.alloc(layout) };
-        if !ret.is_null() {
-            HEAP.allocs.increment();
+        if !is_chunk_operation() && !ret.is_null() {
+            HEAP.record_alloc(layout.size());
         }
         ret
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         unsafe { MiMalloc.dealloc(ptr, layout) };
+        if !is_chunk_operation() {
+            HEAP.record_dealloc(layout.size());
+        }
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         let ret = unsafe { MiMalloc.alloc_zeroed(layout) };
-        if !ret.is_null() {
-            HEAP.allocs.increment();
+        if !is_chunk_operation() && !ret.is_null() {
+            HEAP.record_alloc(layout.size());
         }
         ret
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         let ret = unsafe { MiMalloc.realloc(ptr, layout, new_size) };
-        if !ret.is_null() {
-            HEAP.reallocs.increment();
+        if !is_chunk_operation() && !ret.is_null() {
+            HEAP.record_realloc(layout.size(), new_size);
         }
         ret
     }
@@ -117,6 +215,14 @@ struct StageStats {
     /// The arena is not reset between stages, so this includes content from earlier stages
     /// (e.g. the AST the parser built).
     arena_used_bytes: usize,
+    /// Peak growth of live heap memory during the measured operation: the high-water mark
+    /// of bytes allocated from the system allocator, minus the live bytes when the
+    /// operation started. Captures transient heap the operation needs even when it frees
+    /// it again before finishing. Arena chunk memory is excluded (see
+    /// [`is_chunk_operation`]): chunk sizes are quantized and platform-dependent, and for
+    /// long-lived arenas they reflect the arena's growth history rather than the measured
+    /// operation's own heap use.
+    sys_peak_growth_bytes: usize,
 }
 
 impl StageStats {
@@ -128,12 +234,23 @@ impl StageStats {
     fn metrics(&self, file_size: usize) -> Vec<Metric> {
         let Counters { heap, arena } = &self.counters;
         vec![
-            Metric::exact_bytes("file size", file_size),
+            Metric::bytes("file size", file_size, 0),
             Metric::count("sys allocs", heap.allocs),
             Metric::count("sys reallocs", heap.reallocs),
+            Metric::count("sys deallocs", heap.deallocs),
+            Metric::bytes(
+                "sys alloc bytes",
+                heap.alloc_bytes,
+                relative_tolerance(heap.alloc_bytes),
+            ),
+            Metric::bytes(
+                "sys peak growth",
+                self.sys_peak_growth_bytes,
+                relative_tolerance(self.sys_peak_growth_bytes),
+            ),
             Metric::count("arena allocs", arena.allocs),
             Metric::count("arena reallocs", arena.reallocs),
-            Metric::approx_bytes("arena size", self.arena_used_bytes),
+            Metric::bytes("arena size", self.arena_used_bytes, ARENA_SIZE_TOLERANCE),
         ]
     }
 }
@@ -147,22 +264,25 @@ struct Counters {
 }
 
 /// Counters of the system (heap) allocator.
+///
+/// Arena chunk operations are excluded from all of these — [`TrackedAllocator`] skips
+/// system allocator calls marked as chunk operations (see [`is_chunk_operation`]).
 #[derive(Debug)]
 struct HeapCounters {
-    /// Number of allocations, excluding arena chunk allocations
+    /// Number of allocations
     allocs: usize,
     /// Number of reallocations
     reallocs: usize,
+    /// Number of deallocations
+    deallocs: usize,
+    /// Total bytes requested from the system allocator: allocation sizes, plus growth
+    /// from reallocations
+    alloc_bytes: usize,
 }
 
 /// Counters of an arena [`Allocator`].
 #[derive(Debug)]
 struct ArenaCounters {
-    /// Number of chunks arenas have requested from the system allocator.
-    /// Tracked separately so chunk allocations can be excluded from heap `allocs`
-    /// (see [`Counters::diff_since`]). Not printed in snapshots because the count is
-    /// platform-dependent.
-    chunk_allocs: usize,
     /// Number of allocations
     allocs: usize,
     /// Number of reallocations
@@ -311,37 +431,28 @@ impl Counters {
     fn record(allocator: &Allocator) -> Self {
         let heap = HEAP.read();
         #[cfg(not(feature = "is_all_features"))]
-        let ((allocs, reallocs), chunk_allocs) =
-            (allocator.get_allocation_stats(), Allocator::global_chunk_allocation_count());
+        let (allocs, reallocs) = allocator.get_allocation_stats();
         #[cfg(feature = "is_all_features")]
-        let ((allocs, reallocs), chunk_allocs) = ((0, 0), 0);
+        let (allocs, reallocs) = (0, 0);
 
-        Self { heap, arena: ArenaCounters { chunk_allocs, allocs, reallocs } }
+        Self { heap, arena: ArenaCounters { allocs, reallocs } }
     }
 
     /// Counters accumulated since `prev` was recorded. This is useful for measuring
     /// allocations made during a specific operation without needing to reset the counters.
+    ///
+    /// Arena chunk operations need no correction here: they are already excluded at the
+    /// source by [`TrackedAllocator`] (see [`is_chunk_operation`]). All remaining counters
+    /// grow on element counts, which are identical on all platforms.
     fn diff_since(&self, prev: &Self) -> Self {
-        // Arena chunk allocations go through the system allocator, so they are included in heap
-        // `allocs`. Exclude them. Whether an arena needs one more chunk depends on the total number
-        // of bytes allocated in the arena, and that byte total varies across platforms with target
-        // type layout and alignment (e.g. hashbrown tables are wider on x86_64 than aarch64).
-        // Counting chunk requests therefore made snapshots platform-dependent whenever an arena's
-        // content size sat close to a chunk boundary on one platform (see #22621 for a previous
-        // instance). All other allocation classes grow on element counts, which are identical on
-        // all platforms.
-        let chunk_allocs = self.arena.chunk_allocs.saturating_sub(prev.arena.chunk_allocs);
         Self {
             heap: HeapCounters {
-                allocs: self
-                    .heap
-                    .allocs
-                    .saturating_sub(prev.heap.allocs)
-                    .saturating_sub(chunk_allocs),
+                allocs: self.heap.allocs.saturating_sub(prev.heap.allocs),
                 reallocs: self.heap.reallocs.saturating_sub(prev.heap.reallocs),
+                deallocs: self.heap.deallocs.saturating_sub(prev.heap.deallocs),
+                alloc_bytes: self.heap.alloc_bytes.saturating_sub(prev.heap.alloc_bytes),
             },
             arena: ArenaCounters {
-                chunk_allocs,
                 allocs: self.arena.allocs.saturating_sub(prev.arena.allocs),
                 reallocs: self.arena.reallocs.saturating_sub(prev.arena.reallocs),
             },
@@ -355,25 +466,36 @@ where
     F: FnOnce() -> R,
 {
     let before = Counters::record(allocator);
+    let live_before = HEAP.live_size.get();
+    HEAP.reset_peak();
     let result = f();
     let counters = Counters::record(allocator).diff_since(&before);
-    let stats = StageStats { counters, arena_used_bytes: allocator.used_bytes() };
+    let stats = StageStats {
+        counters,
+        arena_used_bytes: allocator.used_bytes(),
+        sys_peak_growth_bytes: HEAP.peak_size.get().saturating_sub(live_before),
+    };
 
     (result, stats)
 }
 
-/// Tolerance in bytes when comparing a measured [`MetricKind::ApproxBytes`] metric against
-/// the value already in the committed snapshot.
+/// Tolerance in bytes when comparing a measured `arena size` against the value already
+/// in the committed snapshot.
 ///
-/// Byte totals are not exactly reproducible across architectures: some type layouts depend
-/// on the target (e.g. hashbrown's table control groups are 16 bytes on x86_64 but 8 bytes
-/// on aarch64), so each live `HashMap` shifts byte totals by a few bytes per platform.
-/// The observed drift between x86_64 and aarch64 is at most 128 bytes per file. Keeping the
-/// committed value when the difference is within this tolerance makes snapshots generated
-/// on one platform pass the `git diff` check on the others.
-/// Real regressions (e.g. growing an AST node type) change byte totals by orders of
-/// magnitude more than this; changes below the tolerance are treated as noise.
-const APPROX_BYTES_TOLERANCE: usize = 1024;
+/// The observed cross-architecture drift of arena content is at most 128 bytes per file
+/// (see [`MetricKind::Bytes`] for why byte totals drift at all); 1024 gives an 8x
+/// margin while still catching any real change (e.g. growing an AST node type changes
+/// arena sizes by orders of magnitude more).
+const ARENA_SIZE_TOLERANCE: usize = 1024;
+
+/// Tolerance for byte metrics whose cross-architecture drift scales with the amount of
+/// work a stage does — every heap hashbrown table allocated during the stage (and every
+/// one live at the peak) contributes a few bytes of drift (see
+/// [`MetricKind::Bytes`]) — so a flat tolerance can't fit both small and large
+/// values: 1%, with a floor for small values.
+fn relative_tolerance(value: usize) -> usize {
+    (value / 100).max(4096)
+}
 
 /// One row of a snapshot: a labelled value plus how it should be snapshotted and rendered.
 struct Metric {
@@ -386,16 +508,24 @@ struct Metric {
 
 /// How a metric's value behaves across platforms, which decides how it is snapshotted
 /// and rendered.
+#[derive(Clone, Copy)]
 enum MetricKind {
     /// A count, identical on every platform. Snapshotted exactly.
     Count,
-    /// A byte total, identical on every platform. Snapshotted exactly and rendered with
-    /// a human-readable size comment.
-    ExactBytes,
-    /// A byte total that varies slightly across architectures. Keeps the committed value
-    /// when within [`APPROX_BYTES_TOLERANCE`] of it, and is rendered with a human-readable
-    /// size comment.
-    ApproxBytes,
+    /// A byte total, rendered with a human-readable size comment.
+    ///
+    /// Byte totals can vary slightly across architectures: some type layouts depend on
+    /// the target (e.g. hashbrown's table control groups are 16 bytes on x86_64 but
+    /// 8 bytes on aarch64), so each live `HashMap` shifts byte totals by a few bytes per
+    /// platform. Keeping the committed value when the measured one is within `tolerance`
+    /// of it makes snapshots generated on one platform pass the `git diff` check on the
+    /// others; real regressions are far larger and rewrite the value.
+    Bytes {
+        /// Maximum difference from the committed value that is treated as cross-platform
+        /// noise rather than a real change. `0` for byte totals that are identical on
+        /// every platform.
+        tolerance: usize,
+    },
 }
 
 impl Metric {
@@ -403,31 +533,22 @@ impl Metric {
         Self { label, value, kind: MetricKind::Count }
     }
 
-    fn exact_bytes(label: &'static str, value: usize) -> Self {
-        Self { label, value, kind: MetricKind::ExactBytes }
-    }
-
-    fn approx_bytes(label: &'static str, value: usize) -> Self {
-        Self { label, value, kind: MetricKind::ApproxBytes }
+    fn bytes(label: &'static str, value: usize, tolerance: usize) -> Self {
+        Self { label, value, kind: MetricKind::Bytes { tolerance } }
     }
 
     /// The value to record in the snapshot, given the committed value (if any).
     ///
-    /// [`MetricKind::ApproxBytes`] metrics keep the committed value when the measured one
-    /// is within [`APPROX_BYTES_TOLERANCE`] of it; all other kinds record the measured
-    /// value exactly.
+    /// [`MetricKind::Bytes`] metrics keep the committed value when the measured one is
+    /// within their tolerance of it; everything else records the measured value exactly.
     fn snapshot_value(&self, committed: Option<i64>) -> usize {
-        if !matches!(self.kind, MetricKind::ApproxBytes) {
+        let MetricKind::Bytes { tolerance } = self.kind else {
             return self.value;
-        }
+        };
         let Some(committed) = committed.and_then(|value| usize::try_from(value).ok()) else {
             return self.value;
         };
-        if self.value.abs_diff(committed) <= APPROX_BYTES_TOLERANCE {
-            committed
-        } else {
-            self.value
-        }
+        if self.value.abs_diff(committed) <= tolerance { committed } else { self.value }
     }
 }
 
@@ -469,7 +590,7 @@ fn render_file_stats(
         let value = metric.snapshot_value(committed);
         match metric.kind {
             MetricKind::Count => writeln!(out, "  {}: {value}", metric.label),
-            MetricKind::ExactBytes | MetricKind::ApproxBytes => {
+            MetricKind::Bytes { .. } => {
                 writeln!(out, "  {}: {value} # {}", metric.label, format_size(value, DECIMAL))
             }
         }


### PR DESCRIPTION
Adds three heap-side metrics to the allocation snapshots, using the metric machinery from #24587:

- `sys deallocs` (exact count) — system deallocations per stage; read against `sys allocs` it shows whether a stage churns or retains heap.
- `sys alloc bytes` — cumulative bytes requested from the system allocator per stage (allocation sizes plus reallocation growth).
- `sys peak growth` — high-water mark of live heap during a stage relative to the live bytes at stage start, via live-bytes accounting in the `GlobalAlloc` wrapper. Captures transient heap a stage needs even when it frees it before finishing.

Arena chunk operations are excluded from all `sys` metrics at the source: `oxc_allocator` marks each chunk allocation/deallocation immediately before calling the system allocator (task-only `track_allocations` feature, compiled out everywhere else), and the task's tracking allocator consumes the marker and skips the call. This replaces the previous global chunk counter + per-stage subtraction: a subtraction can correct counts but not a high-water mark, and chunk sizes are quantized and platform-dependent (whether an arena needs one more chunk depends on byte totals that vary across architectures with type layout — the #22621 mechanism). The first CI run demonstrated this concretely: kitchen-sink's minifier peak differed deterministically by 720 kB between aarch64 and x86_64 because the mangler's temporary arena crossed a chunk-growth boundary only on x86_64; and antd's formatter "peak" was 762 MB of main-arena chunk-doubling history rather than formatter behavior (now 13.8 MB of actual heap use).

Cross-platform tolerances: the cumulative byte metrics still drift with the number of heap hashbrown tables allocated (their control-group width is architecture-dependent), so they use a relative tolerance (1%, 4 kB floor) via the committed-value comparison from #24565; `arena size` keeps its tight 1024-byte tolerance.

Sample values for checker.ts (2.9 MB source): parser needs only 2.4 kB of transient heap (fully arena-based), semantic peaks at 3.9 MB, the minifier is the pipeline's largest heap consumer at 10.2 MB, and the formatter requests 5.9 MB total while peaking at 3 MB (heavy alloc/free churn).

🤖 Implemented with [Claude Code](https://claude.com/claude-code).