### PR TITLE
refactor(all): pass `[v]` for single-value `ArenaVec` builder args

### DIFF
--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, ArenaVec};
+use oxc_allocator::Allocator;
 use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_codegen::{Codegen, CodegenOptions, IndentChar};
 use oxc_span::SPAN;
@@ -860,8 +860,7 @@ fn template_literal_escape_when_building_ast() {
         cooked: Some(Str::from_str_in(cooked, &ast)),
     };
     let element = TemplateElement::new_escape_raw(SPAN, value, true, &ast);
-    let quasis = ArenaVec::from_value_in(element, &ast);
-    let template_literal = TemplateLiteral::new(SPAN, quasis, [], &ast);
+    let template_literal = TemplateLiteral::new(SPAN, [element], [], &ast);
 
     let expr = Expression::new_template_literal(
         SPAN,
@@ -870,16 +869,7 @@ fn template_literal_escape_when_building_ast() {
         &ast,
     );
     let stmt = Statement::new_expression_statement(SPAN, expr, &ast);
-    let program = Program::new(
-        SPAN,
-        oxc_span::SourceType::mjs(),
-        "",
-        [],
-        None,
-        [],
-        ArenaVec::from_value_in(stmt, &ast),
-        &ast,
-    );
+    let program = Program::new(SPAN, oxc_span::SourceType::mjs(), "", [], None, [], [stmt], &ast);
 
     let result = Codegen::new().build(&program).code;
     // The raw value should have been escaped by template_element with escape_raw: true

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -697,7 +697,6 @@ impl<'a> IsolatedDeclarations<'a> {
     ) -> ArenaBox<'a, FormalParameters<'a>> {
         let parameter =
             FormalParameter::new(SPAN, [], kind, NONE, NONE, false, None, false, false, self);
-        let items = ArenaVec::from_value_in(parameter, self);
-        FormalParameters::boxed(SPAN, FormalParameterKind::Signature, items, NONE, self)
+        FormalParameters::boxed(SPAN, FormalParameterKind::Signature, [parameter], NONE, self)
     }
 }

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -106,15 +106,13 @@ impl<'a> IsolatedDeclarations<'a> {
                 self.error(default_export_inferred(expr.span()));
             }
 
-            let declarations = ArenaVec::from_value_in(
-                VariableDeclarator::new(SPAN, kind, id, type_annotation, None, false, self),
-                self,
-            );
+            let declaration =
+                VariableDeclarator::new(SPAN, kind, id, type_annotation, None, false, self);
 
             let variable_statement = Statement::new_variable_declaration(
                 decl_span,
                 kind,
-                declarations,
+                [declaration],
                 self.is_declare(),
                 self,
             );

--- a/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaVec, TakeIn};
+use oxc_allocator::TakeIn;
 use oxc_ast::ast::*;
 
 use oxc_semantic::ScopeFlags;
@@ -134,7 +134,7 @@ impl<'a> PeepholeOptimizations {
             let scope_id = ctx.create_child_scope_of_current(ScopeFlags::empty());
             let new_consequent = Statement::new_block_statement_with_scope_id(
                 if_stmt.consequent.span(),
-                ArenaVec::from_value_in(if_stmt.consequent.take_in(ctx), ctx),
+                [if_stmt.consequent.take_in(ctx)],
                 scope_id,
                 ctx,
             );

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -551,8 +551,7 @@ impl<'a> PeepholeOptimizations {
                     prev_var_decl.declarations.push(decl);
                     continue;
                 }
-                let decls = ArenaVec::from_value_in(decl, ctx);
-                let new_decl = VariableDeclaration::boxed(span, kind, decls, declare, ctx);
+                let new_decl = VariableDeclaration::boxed(span, kind, [decl], declare, ctx);
                 result.push(Statement::VariableDeclaration(new_decl));
             }
         }

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -725,7 +725,7 @@ impl<'a> PeepholeOptimizations {
             let mut expr = match arg {
                 Argument::SpreadElement(e) => Expression::new_array_expression(
                     e.span,
-                    ArenaVec::from_value_in(ArrayExpressionElement::SpreadElement(e), ctx),
+                    [ArrayExpressionElement::SpreadElement(e)],
                     ctx,
                 ),
                 match_expression!(Argument) => arg.into_expression(),

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -972,14 +972,11 @@ impl<'a> PeepholeOptimizations {
         if let Some(r_id_pat) = r_id_pat {
             let base_arr = Expression::new_array_expression(
                 SPAN,
-                ArenaVec::from_value_in(
-                    ArrayExpressionElement::new_spread_element(
-                        SPAN,
-                        Expression::Identifier(arguments_id.take_in_box(ctx)),
-                        ctx,
-                    ),
+                [ArrayExpressionElement::new_spread_element(
+                    SPAN,
+                    Expression::Identifier(arguments_id.take_in_box(ctx)),
                     ctx,
-                ),
+                )],
                 ctx,
             );
             // wrap with `.slice(offset)`
@@ -996,10 +993,7 @@ impl<'a> PeepholeOptimizations {
                     SPAN,
                     callee,
                     NONE,
-                    ArenaVec::from_value_in(
-                        Argument::new_numeric_literal(SPAN, offset, None, NumberBase::Decimal, ctx),
-                        ctx,
-                    ),
+                    [Argument::new_numeric_literal(SPAN, offset, None, NumberBase::Decimal, ctx)],
                     false,
                     ctx,
                 )
@@ -1262,11 +1256,11 @@ impl<'a> PeepholeOptimizations {
                     }
                     // `new Array(literal)` -> `[literal]`
                     else if arg.is_literal() || matches!(arg, Expression::ArrayExpression(_)) {
-                        let elements = ArenaVec::from_value_in(
-                            ArrayExpressionElement::from(arg.take_in(ctx)),
+                        let new_value = Expression::new_array_expression(
+                            *span,
+                            [ArrayExpressionElement::from(arg.take_in(ctx))],
                             ctx,
                         );
-                        let new_value = Expression::new_array_expression(*span, elements, ctx);
                         ctx.replace_expression(expr, new_value);
                     }
                     // `new Array(x)` -> `Array(x)`
@@ -1776,15 +1770,12 @@ impl<'a> PeepholeOptimizations {
                 ctx,
             ),
             NONE,
-            ArenaVec::from_value_in(
-                Argument::new_string_literal(
-                    expr.span(),
-                    Str::from_str_in(delimiter, ctx),
-                    None,
-                    ctx,
-                ),
+            [Argument::new_string_literal(
+                expr.span(),
+                Str::from_str_in(delimiter, ctx),
+                None,
                 ctx,
-            ),
+            )],
             false,
             true,
             ctx,

--- a/crates/oxc_minifier/tests/ecmascript/to_number.rs
+++ b/crates/oxc_minifier/tests/ecmascript/to_number.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, ArenaVec};
+use oxc_allocator::Allocator;
 use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_ecmascript::{ToNumber, WithoutGlobalReferenceInformation};
 use oxc_span::SPAN;
@@ -20,19 +20,16 @@ fn test() {
     let empty_object = Expression::new_object_expression(SPAN, [], ast);
     let object_with_to_string = Expression::new_object_expression(
         SPAN,
-        ArenaVec::from_value_in(
-            ObjectPropertyKind::new_object_property(
-                SPAN,
-                PropertyKind::Init,
-                PropertyKey::new_static_identifier(SPAN, "toString", ast),
-                Expression::new_string_literal(SPAN, "foo", None, ast),
-                false,
-                false,
-                false,
-                ast,
-            ),
+        [ObjectPropertyKind::new_object_property(
+            SPAN,
+            PropertyKind::Init,
+            PropertyKey::new_static_identifier(SPAN, "toString", ast),
+            Expression::new_string_literal(SPAN, "foo", None, ast),
+            false,
+            false,
+            false,
             ast,
-        ),
+        )],
         ast,
     );
     let empty_object_number = empty_object.to_number(&WithoutGlobalReferenceInformation {});
@@ -47,10 +44,8 @@ fn test() {
     // Test arrays with boolean elements - should convert to NaN
     let false_literal = ArrayExpressionElement::new_boolean_literal(SPAN, false, ast);
     let true_literal = ArrayExpressionElement::new_boolean_literal(SPAN, true, ast);
-    let array_with_false =
-        Expression::new_array_expression(SPAN, ArenaVec::from_value_in(false_literal, ast), ast);
-    let array_with_true =
-        Expression::new_array_expression(SPAN, ArenaVec::from_value_in(true_literal, ast), ast);
+    let array_with_false = Expression::new_array_expression(SPAN, [false_literal], ast);
+    let array_with_true = Expression::new_array_expression(SPAN, [true_literal], ast);
     let array_with_false_number = array_with_false.to_number(&WithoutGlobalReferenceInformation {});
     let array_with_true_number = array_with_true.to_number(&WithoutGlobalReferenceInformation {});
 

--- a/crates/oxc_minifier/tests/ecmascript/to_string.rs
+++ b/crates/oxc_minifier/tests/ecmascript/to_string.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, ArenaVec};
+use oxc_allocator::Allocator;
 use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_ecmascript::{ToJsString, WithoutGlobalReferenceInformation};
 use oxc_span::SPAN;
@@ -20,19 +20,16 @@ fn test() {
     let empty_object = Expression::new_object_expression(SPAN, [], ast);
     let object_with_to_string = Expression::new_object_expression(
         SPAN,
-        ArenaVec::from_value_in(
-            ObjectPropertyKind::new_object_property(
-                SPAN,
-                PropertyKind::Init,
-                PropertyKey::new_static_identifier(SPAN, "toString", ast),
-                Expression::new_string_literal(SPAN, "foo", None, ast),
-                false,
-                false,
-                false,
-                ast,
-            ),
+        [ObjectPropertyKind::new_object_property(
+            SPAN,
+            PropertyKind::Init,
+            PropertyKey::new_static_identifier(SPAN, "toString", ast),
+            Expression::new_string_literal(SPAN, "foo", None, ast),
+            false,
+            false,
+            false,
             ast,
-        ),
+        )],
         ast,
     );
     let empty_object_string = empty_object.to_js_string(&WithoutGlobalReferenceInformation {});

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaBox, ArenaVec};
+use oxc_allocator::ArenaBox;
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::FileExtension;
 use oxc_syntax::precedence::Precedence;
@@ -237,7 +237,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let params = FormalParameters::boxed(
             ident.span,
             FormalParameterKind::ArrowFormalParameters,
-            ArenaVec::from_value_in(formal_parameter, self),
+            [formal_parameter],
             NONE,
             self,
         );
@@ -321,7 +321,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             });
             let span = self.end_span(span);
             let expr_stmt = Statement::new_expression_statement(span, expr, self);
-            FunctionBody::boxed(span, [], ArenaVec::from_value_in(expr_stmt, self), self)
+            FunctionBody::boxed(span, [], [expr_stmt], self)
         } else {
             self.parse_function_body()
         };

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1233,14 +1233,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self,
         );
 
-        let outer_properties =
-            ArenaVec::from_value_in(ObjectPropertyKind::ObjectProperty(with_property), self);
+        let outer_property = ObjectPropertyKind::ObjectProperty(with_property);
 
         // Allow optional trailing comma: `{ with: { type: "json" }, }`
         let _ = self.eat(Kind::Comma);
 
         self.expect(Kind::RCurly);
-        ObjectExpression::boxed(self.end_span(span), outer_properties, self)
+        ObjectExpression::boxed(self.end_span(span), [outer_property], self)
     }
 
     /// Parse TypeScript import type attributes object: `{ type: "json" }`

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -2226,7 +2226,7 @@ fn ox_build_gated_const_decl<'a>(
     Statement::VariableDeclaration(VariableDeclaration::boxed(
         SPAN,
         VariableDeclarationKind::Const,
-        ArenaVec::from_value_in(declarator, ast),
+        [declarator],
         false,
         ast,
     ))
@@ -2770,15 +2770,12 @@ fn ox_add_imports_to_program<'a>(
                 SPAN,
                 Expression::new_identifier(SPAN, "require", ast),
                 None::<ArenaBox<TSTypeParameterInstantiation>>,
-                ArenaVec::from_value_in(
-                    Argument::from(Expression::new_string_literal(
-                        SPAN,
-                        ox_atom(ast, module_name),
-                        None,
-                        ast,
-                    )),
+                [Argument::from(Expression::new_string_literal(
+                    SPAN,
+                    ox_atom(ast, module_name),
+                    None,
                     ast,
-                ),
+                ))],
                 false,
                 ast,
             );
@@ -2794,7 +2791,7 @@ fn ox_add_imports_to_program<'a>(
             let decl = VariableDeclaration::boxed(
                 SPAN,
                 VariableDeclarationKind::Const,
-                ArenaVec::from_value_in(declarator, ast),
+                [declarator],
                 false,
                 ast,
             );

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -121,10 +121,7 @@ pub fn codegen_function<'a>(
             SPAN,
             oxc_ast::ast::Expression::new_identifier(SPAN, memo_cache_name, ast),
             None::<oxc_allocator::Box<oxc_ast::ast::TSTypeParameterInstantiation>>,
-            oxc_allocator::ArenaVec::from_value_in(
-                oxc_ast::ast::Argument::from(ox_number(ast, cache_count as f64)),
-                ast,
-            ),
+            [oxc_ast::ast::Argument::from(ox_number(ast, cache_count as f64))],
             false,
             ast,
         );
@@ -145,7 +142,7 @@ pub fn codegen_function<'a>(
             oxc_ast::ast::Statement::VariableDeclaration(oxc_ast::ast::VariableDeclaration::boxed(
                 SPAN,
                 oxc_ast::ast::VariableDeclarationKind::Const,
-                oxc_allocator::ArenaVec::from_value_in(declarator, ast),
+                [declarator],
                 false,
                 ast,
             ));
@@ -412,15 +409,12 @@ fn ox_symbol_for<'a>(ast: &oxc_ast::builder::AstBuilder<'a>, name: &str) -> oxc:
         SPAN,
         callee,
         None::<oxc_allocator::Box<oxc::TSTypeParameterInstantiation>>,
-        oxc_allocator::ArenaVec::from_value_in(
-            oxc::Argument::from(oxc_ast::ast::Expression::new_string_literal(
-                SPAN,
-                ox_str(ast, name),
-                None,
-                ast,
-            )),
+        [oxc::Argument::from(oxc_ast::ast::Expression::new_string_literal(
+            SPAN,
+            ox_str(ast, name),
+            None,
             ast,
-        ),
+        ))],
         false,
         ast,
     )
@@ -742,7 +736,7 @@ fn ox_codegen_reactive_scope<'a>(
                 oxc_ast::ast::VariableDeclaration::boxed(
                     SPAN,
                     oxc::VariableDeclarationKind::Let,
-                    oxc_allocator::ArenaVec::from_value_in(declarator, &cx.ast),
+                    [declarator],
                     false,
                     &cx.ast,
                 ),
@@ -859,11 +853,7 @@ fn ox_codegen_reactive_scope<'a>(
             Some(oxc_ast::ast::Expression::new_identifier(SPAN, ox_str(&cx.ast, name), &cx.ast)),
             &cx.ast,
         );
-        let consequent = oxc_ast::ast::Statement::new_block_statement(
-            SPAN,
-            oxc_allocator::ArenaVec::from_value_in(return_stmt, &cx.ast),
-            &cx.ast,
-        );
+        let consequent = oxc_ast::ast::Statement::new_block_statement(SPAN, [return_stmt], &cx.ast);
         statements
             .push(oxc_ast::ast::Statement::new_if_statement(SPAN, test, consequent, None, &cx.ast));
     }
@@ -1098,13 +1088,8 @@ fn ox_codegen_for_in<'a>(
         false,
         &cx.ast,
     );
-    let decl = oxc_ast::ast::VariableDeclaration::boxed(
-        SPAN,
-        var_decl_kind,
-        oxc_allocator::ArenaVec::from_value_in(declarator, &cx.ast),
-        false,
-        &cx.ast,
-    );
+    let decl =
+        oxc_ast::ast::VariableDeclaration::boxed(SPAN, var_decl_kind, [declarator], false, &cx.ast);
     let left = oxc::ForStatementLeft::VariableDeclaration(decl);
     Ok(Some(oxc_ast::ast::Statement::new_for_in_statement(SPAN, left, right, body, &cx.ast)))
 }
@@ -1155,13 +1140,8 @@ fn ox_codegen_for_of<'a>(
         false,
         &cx.ast,
     );
-    let decl = oxc_ast::ast::VariableDeclaration::boxed(
-        SPAN,
-        var_decl_kind,
-        oxc_allocator::ArenaVec::from_value_in(declarator, &cx.ast),
-        false,
-        &cx.ast,
-    );
+    let decl =
+        oxc_ast::ast::VariableDeclaration::boxed(SPAN, var_decl_kind, [declarator], false, &cx.ast);
     let left = oxc::ForStatementLeft::VariableDeclaration(decl);
     Ok(Some(oxc_ast::ast::Statement::new_for_of_statement(SPAN, false, left, right, body, &cx.ast)))
 }
@@ -1517,7 +1497,7 @@ fn ox_make_var_decl<'a>(
     oxc::Statement::VariableDeclaration(oxc_ast::ast::VariableDeclaration::boxed(
         SPAN,
         kind,
-        oxc_allocator::ArenaVec::from_value_in(declarator, &cx.ast),
+        [declarator],
         false,
         &cx.ast,
     ))
@@ -2561,11 +2541,9 @@ fn ox_codegen_function_expression<'a>(
             };
             match single_return_arg {
                 Some(arg) => {
-                    let stmts = oxc_allocator::ArenaVec::from_value_in(
-                        oxc_ast::ast::Statement::new_expression_statement(SPAN, arg, &cx.ast),
-                        &cx.ast,
-                    );
-                    let body = oxc_ast::ast::FunctionBody::boxed(SPAN, [], stmts, &cx.ast);
+                    let stmt =
+                        oxc_ast::ast::Statement::new_expression_statement(SPAN, arg, &cx.ast);
+                    let body = oxc_ast::ast::FunctionBody::boxed(SPAN, [], [stmt], &cx.ast);
                     ox_build_arrow(cx, fn_result.params, body, fn_result.is_async, true)
                 }
                 None => {
@@ -2614,11 +2592,13 @@ fn ox_codegen_function_expression<'a>(
             false,
             &cx.ast,
         );
-        let props = oxc_allocator::ArenaVec::from_value_in(
-            oxc::ObjectPropertyKind::ObjectProperty(oxc_allocator::ArenaBox::new_in(prop, &cx.ast)),
+        let object = oxc_ast::ast::Expression::new_object_expression(
+            SPAN,
+            [oxc::ObjectPropertyKind::ObjectProperty(oxc_allocator::ArenaBox::new_in(
+                prop, &cx.ast,
+            ))],
             &cx.ast,
         );
-        let object = oxc_ast::ast::Expression::new_object_expression(SPAN, props, &cx.ast);
         let member = oxc_ast::ast::MemberExpression::new_computed_member_expression(
             SPAN,
             object,
@@ -3087,10 +3067,7 @@ fn ox_dispatcher_guard_stmt<'a>(
         SPAN,
         oxc_ast::ast::Expression::new_identifier(SPAN, guard_name, ast),
         None::<oxc_allocator::Box<oxc::TSTypeParameterInstantiation>>,
-        oxc_allocator::ArenaVec::from_value_in(
-            oxc_ast::ast::Argument::from(ox_number(ast, kind as u8 as f64)),
-            ast,
-        ),
+        [oxc_ast::ast::Argument::from(ox_number(ast, kind as u8 as f64))],
         false,
         ast,
     );
@@ -3114,10 +3091,7 @@ fn ox_create_hook_guard<'a>(
     let try_block = oxc_ast::ast::BlockStatement::new(SPAN, try_stmts, ast);
     let finalizer = oxc_ast::ast::BlockStatement::new(
         SPAN,
-        oxc_allocator::ArenaVec::from_value_in(
-            ox_dispatcher_guard_stmt(ast, guard_name, after),
-            ast,
-        ),
+        [ox_dispatcher_guard_stmt(ast, guard_name, after)],
         ast,
     );
     oxc_ast::ast::Statement::new_try_statement(
@@ -3166,12 +3140,7 @@ fn ox_create_call_expression<'a>(
         GuardKind::AllowHook,
         GuardKind::DisallowHook,
     );
-    let body = oxc_ast::ast::FunctionBody::boxed(
-        SPAN,
-        [],
-        oxc_allocator::ArenaVec::from_value_in(guarded, ast),
-        ast,
-    );
+    let body = oxc_ast::ast::FunctionBody::boxed(SPAN, [], [guarded], ast);
     let params = oxc_ast::ast::FormalParameters::boxed(
         SPAN,
         oxc_ast::ast::FormalParameterKind::FormalParameter,

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -984,9 +984,8 @@ impl<'a> ArrowFunctionConverter<'a> {
             NONE,
             ctx,
         );
-        let statements =
-            ArenaVec::from_value_in(Statement::new_expression_statement(SPAN, init, ctx), ctx);
-        let body = FunctionBody::new(SPAN, [], statements, ctx);
+        let statement = Statement::new_expression_statement(SPAN, init, ctx);
+        let body = FunctionBody::new(SPAN, [], [statement], ctx);
         let init = Expression::new_arrow_function_expression_with_scope_id_and_pure_and_pife(
             SPAN, true, false, NONE, params, NONE, body, scope_id, false, false, ctx,
         );

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -185,7 +185,7 @@ impl<'a> ModuleImportsStore<'a> {
 
         let args = {
             let arg = Argument::new_string_literal(SPAN, source, None, ctx);
-            ArenaVec::from_value_in(arg, ctx)
+            [arg]
         };
         let Some(Import::Default(local)) = names.into_iter().next() else { unreachable!() };
         let id = local.create_binding_pattern(ctx);
@@ -193,7 +193,7 @@ impl<'a> ModuleImportsStore<'a> {
         let decl = {
             let init = Expression::new_call_expression(SPAN, callee, NONE, args, false, ctx);
             let decl = VariableDeclarator::new(SPAN, var_kind, id, NONE, Some(init), false, ctx);
-            ArenaVec::from_value_in(decl, ctx)
+            [decl]
         };
         Statement::new_variable_declaration(SPAN, var_kind, decl, false, ctx)
     }

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -530,7 +530,7 @@ impl<'a> LegacyDecorator<'a> {
             let params = FormalParameters::boxed(
                 SPAN,
                 FormalParameterKind::FormalParameter,
-                ArenaVec::from_value_in(param, ctx),
+                [param],
                 NONE,
                 ctx,
             );
@@ -949,7 +949,7 @@ impl<'a> LegacyDecorator<'a> {
                         ),
                         ctx,
                     );
-                    let body = ArenaVec::from_value_in(class_alias_with_this_assignment, ctx);
+                    let body = [class_alias_with_this_assignment];
                     let scope_id = ctx.create_child_scope_of_current(ScopeFlags::ClassStaticBlock);
                     let element =
                         ClassElement::new_static_block_with_scope_id(SPAN, body, scope_id, ctx);
@@ -1025,7 +1025,7 @@ impl<'a> LegacyDecorator<'a> {
         let var_declaration = Declaration::new_variable_declaration(
             span,
             VariableDeclarationKind::Let,
-            ArenaVec::from_value_in(declarator, ctx),
+            [declarator],
             false,
             ctx,
         );
@@ -1461,8 +1461,7 @@ impl<'a> LegacyDecorator<'a> {
         let kind = ImportOrExportKind::Value;
         let local = ModuleExportName::IdentifierReference(class_binding.create_read_reference(ctx));
         let exported = ModuleExportName::new_identifier_name(SPAN, class_binding.name, ctx);
-        let specifiers =
-            ArenaVec::from_value_in(ExportSpecifier::new(SPAN, local, exported, kind, ctx), ctx);
+        let specifiers = [ExportSpecifier::new(SPAN, local, exported, kind, ctx)];
         let export_class_reference = ModuleDeclaration::new_export_named_declaration(
             SPAN, None, specifiers, None, kind, NONE, ctx,
         );

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -298,8 +298,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         // Modify the wrapper function
         func.r#async = false;
         func.generator = false;
-        func.body =
-            Some(FunctionBody::boxed(SPAN, [], ArenaVec::from_value_in(statement, ctx), ctx));
+        func.body = Some(FunctionBody::boxed(SPAN, [], [statement], ctx));
         func.scope_id.set(Some(wrapper_scope_id));
         sync_function_symbol_flags(func, ctx);
     }

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -89,7 +89,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
         if !allow_multiple_statements {
             new_stmt = Statement::new_block_statement_with_scope_id(
                 SPAN,
-                ArenaVec::from_value_in(new_stmt, ctx),
+                [new_stmt],
                 parent_scope_id,
                 ctx,
             );
@@ -124,13 +124,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                 // for await (let i of test)
                 let mut declarator = variable.declarations.pop().unwrap();
                 declarator.init = Some(step_value);
-                Statement::new_variable_declaration(
-                    SPAN,
-                    declarator.kind,
-                    ArenaVec::from_value_in(declarator, ctx),
-                    false,
-                    ctx,
-                )
+                Statement::new_variable_declaration(SPAN, declarator.kind, [declarator], false, ctx)
             }
             left @ match_assignment_target!(ForStatementLeft) => {
                 // for await (i of test), for await ({ i } of test)
@@ -232,54 +226,45 @@ impl<'a> AsyncGeneratorFunctions<'a> {
         items.push(Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ArenaVec::from_value_in(
-                VariableDeclarator::new(
-                    SPAN,
-                    VariableDeclarationKind::Var,
-                    iterator_abrupt_completion.create_binding_pattern(ctx),
-                    NONE,
-                    Some(Expression::new_boolean_literal(SPAN, false, ctx)),
-                    false,
-                    ctx,
-                ),
+            [VariableDeclarator::new(
+                SPAN,
+                VariableDeclarationKind::Var,
+                iterator_abrupt_completion.create_binding_pattern(ctx),
+                NONE,
+                Some(Expression::new_boolean_literal(SPAN, false, ctx)),
+                false,
                 ctx,
-            ),
+            )],
             false,
             ctx,
         ));
         items.push(Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ArenaVec::from_value_in(
-                VariableDeclarator::new(
-                    SPAN,
-                    VariableDeclarationKind::Var,
-                    iterator_had_error_key.create_binding_pattern(ctx),
-                    NONE,
-                    Some(Expression::new_boolean_literal(SPAN, false, ctx)),
-                    false,
-                    ctx,
-                ),
+            [VariableDeclarator::new(
+                SPAN,
+                VariableDeclarationKind::Var,
+                iterator_had_error_key.create_binding_pattern(ctx),
+                NONE,
+                Some(Expression::new_boolean_literal(SPAN, false, ctx)),
+                false,
                 ctx,
-            ),
+            )],
             false,
             ctx,
         ));
         items.push(Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ArenaVec::from_value_in(
-                VariableDeclarator::new(
-                    SPAN,
-                    VariableDeclarationKind::Var,
-                    iterator_error_key.create_binding_pattern(ctx),
-                    NONE,
-                    None,
-                    false,
-                    ctx,
-                ),
+            [VariableDeclarator::new(
+                SPAN,
+                VariableDeclarationKind::Var,
+                iterator_error_key.create_binding_pattern(ctx),
+                NONE,
+                None,
+                false,
                 ctx,
-            ),
+            )],
             false,
             ctx,
         ));
@@ -390,12 +375,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                 ctx,
             );
 
-            BlockStatement::new_with_scope_id(
-                SPAN,
-                ArenaVec::from_value_in(for_statement, ctx),
-                block_scope_id,
-                ctx,
-            )
+            BlockStatement::new_with_scope_id(SPAN, [for_statement], block_scope_id, ctx)
         };
 
         let catch_clause = {
@@ -479,31 +459,28 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                         ),
                         Statement::new_block_statement_with_scope_id(
                             SPAN,
-                            ArenaVec::from_value_in(
-                                Statement::new_expression_statement(
+                            [Statement::new_expression_statement(
+                                SPAN,
+                                Expression::new_await_expression(
                                     SPAN,
-                                    Expression::new_await_expression(
+                                    Expression::new_call_expression(
                                         SPAN,
-                                        Expression::new_call_expression(
+                                        Expression::new_static_member_expression(
                                             SPAN,
-                                            Expression::new_static_member_expression(
-                                                SPAN,
-                                                iterator_key.create_read_expression(ctx),
-                                                IdentifierName::new(SPAN, "return", ctx),
-                                                false,
-                                                ctx,
-                                            ),
-                                            NONE,
-                                            [],
+                                            iterator_key.create_read_expression(ctx),
+                                            IdentifierName::new(SPAN, "return", ctx),
                                             false,
                                             ctx,
                                         ),
+                                        NONE,
+                                        [],
+                                        false,
                                         ctx,
                                     ),
                                     ctx,
                                 ),
                                 ctx,
-                            ),
+                            )],
                             if_block_scope_id,
                             ctx,
                         ),
@@ -513,7 +490,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                 };
                 let block = BlockStatement::new_with_scope_id(
                     SPAN,
-                    ArenaVec::from_value_in(if_statement, ctx),
+                    [if_statement],
                     try_block_scope_id,
                     ctx,
                 );
@@ -528,14 +505,11 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                             iterator_had_error_key.create_read_expression(ctx),
                             Statement::new_block_statement_with_scope_id(
                                 SPAN,
-                                ArenaVec::from_value_in(
-                                    Statement::new_throw_statement(
-                                        SPAN,
-                                        iterator_error_key.create_read_expression(ctx),
-                                        ctx,
-                                    ),
+                                [Statement::new_throw_statement(
+                                    SPAN,
+                                    iterator_error_key.create_read_expression(ctx),
                                     ctx,
-                                ),
+                                )],
                                 if_block_scope_id,
                                 ctx,
                             ),
@@ -543,22 +517,13 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                             ctx,
                         )
                     };
-                    BlockStatement::new_with_scope_id(
-                        SPAN,
-                        ArenaVec::from_value_in(if_statement, ctx),
-                        finally_scope_id,
-                        ctx,
-                    )
+                    BlockStatement::new_with_scope_id(SPAN, [if_statement], finally_scope_id, ctx)
                 };
                 Statement::new_try_statement(SPAN, block, NONE, Some(finally), ctx)
             };
 
-            let block_statement = BlockStatement::new_with_scope_id(
-                SPAN,
-                ArenaVec::from_value_in(try_statement, ctx),
-                finally_scope_id,
-                ctx,
-            );
+            let block_statement =
+                BlockStatement::new_with_scope_id(SPAN, [try_statement], finally_scope_id, ctx);
             Some(block_statement)
         };
 

--- a/crates/oxc_transformer/src/es2020/export_namespace_from.rs
+++ b/crates/oxc_transformer/src/es2020/export_namespace_from.rs
@@ -98,7 +98,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExportNamespaceFrom {
                     let export_named_decl = ExportNamedDeclaration::boxed(
                         span,
                         None,
-                        ArenaVec::from_value_in(export_specifier, ctx),
+                        [export_specifier],
                         None,
                         export_kind,
                         NONE,

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -28,7 +28,7 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-nullish-coalescing-operator>
 //! * Nullish coalescing TC39 proposal: <https://github.com/tc39-transfer/proposal-nullish-coalescing>
 
-use oxc_allocator::{ArenaBox, ArenaVec, ReplaceWith};
+use oxc_allocator::{ArenaBox, ReplaceWith};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::{ScopeFlags, SymbolFlags};
 use oxc_span::SPAN;
@@ -150,17 +150,14 @@ impl<'a> NullishCoalescingOperator {
             let params = FormalParameters::new(
                 SPAN,
                 FormalParameterKind::ArrowFormalParameters,
-                ArenaVec::from_value_in(param, ctx),
+                [param],
                 NONE,
                 ctx,
             );
             let body = FunctionBody::new(
                 SPAN,
                 [],
-                ArenaVec::from_value_in(
-                    Statement::new_expression_statement(SPAN, new_expr, ctx),
-                    ctx,
-                ),
+                [Statement::new_expression_statement(SPAN, new_expr, ctx)],
                 ctx,
             );
             let arrow_function =

--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -399,12 +399,11 @@ impl<'a> OptionalChaining<'a> {
         };
 
         // `expr.bind(context)`
-        let arguments = ArenaVec::from_value_in(context, ctx);
         let property = IdentifierName::new(SPAN, "bind", ctx);
         let callee =
             MemberExpression::new_static_member_expression(SPAN, expr, property, false, ctx);
         let callee = Expression::from(callee);
-        Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx)
+        Expression::new_call_expression(SPAN, callee, NONE, [context], false, ctx)
     }
 
     /// Recursively transform chain expression elements

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -345,18 +345,15 @@ impl<'a> ClassProperties<'a> {
         let super_func_decl = Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ArenaVec::from_value_in(
-                VariableDeclarator::new(
-                    SPAN,
-                    VariableDeclarationKind::Var,
-                    super_binding.create_binding_pattern(ctx),
-                    NONE,
-                    Some(super_func),
-                    false,
-                    ctx,
-                ),
+            [VariableDeclarator::new(
+                SPAN,
+                VariableDeclarationKind::Var,
+                super_binding.create_binding_pattern(ctx),
+                NONE,
+                Some(super_func),
+                false,
                 ctx,
-            ),
+            )],
             false,
             ctx,
         );
@@ -605,7 +602,7 @@ impl<'a> ConstructorParamsSuperReplacer<'a, '_> {
                     ctx,
                 ),
                 NONE,
-                ArenaVec::from_value_in(Argument::from(super_call), ctx),
+                [Argument::from(super_call)],
                 false,
                 ctx,
             )

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -1946,15 +1946,8 @@ impl<'a> ClassProperties<'a> {
             prop_binding.create_read_expression(ctx)
         };
         let callee = create_member_callee(callee, static_ident!("has"), span, ctx);
-        let argument = self.create_check_in_rhs(right, ctx);
-        Expression::new_call_expression(
-            span,
-            callee,
-            NONE,
-            ArenaVec::from_value_in(Argument::from(argument), ctx),
-            false,
-            ctx,
-        )
+        let argument = Argument::from(self.create_check_in_rhs(right, ctx));
+        Expression::new_call_expression(span, callee, NONE, [argument], false, ctx)
     }
 
     /// Duplicate object to be used in get/set pair.

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -219,8 +219,7 @@ impl<'a> ClassProperties<'a> {
             false,
             ctx,
         );
-        let obj =
-            Expression::new_object_expression(SPAN, ArenaVec::from_value_in(property, ctx), ctx);
+        let obj = Expression::new_object_expression(SPAN, [property], ctx);
 
         // Insert after class
         let class_details = self.current_class();

--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -3,7 +3,6 @@
 
 use std::path::Path;
 
-use oxc_allocator::ArenaVec;
 use oxc_ast::{ast::*, builder::AstBuilder, builder::NONE};
 use oxc_span::SPAN;
 use oxc_traverse::BoundIdentifier;
@@ -26,13 +25,7 @@ pub(super) fn create_variable_declaration<'a>(
         false,
         ctx,
     );
-    Statement::new_variable_declaration(
-        SPAN,
-        kind,
-        ArenaVec::from_value_in(declarator, ctx),
-        false,
-        ctx,
-    )
+    Statement::new_variable_declaration(SPAN, kind, [declarator], false, ctx)
 }
 
 /// Convert an iterator of `Expression`s into an iterator of `Statement::ExpressionStatement`s.

--- a/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
@@ -105,18 +105,15 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
         let using_stmt = Statement::new_variable_declaration(
             SPAN,
             variable_decl_kind,
-            ArenaVec::from_value_in(
-                VariableDeclarator::new(
-                    SPAN,
-                    variable_decl_kind,
-                    binding_pattern,
-                    NONE,
-                    Some(temp_id.create_read_expression(ctx)),
-                    false,
-                    ctx,
-                ),
+            [VariableDeclarator::new(
+                SPAN,
+                variable_decl_kind,
+                binding_pattern,
+                NONE,
+                Some(temp_id.create_read_expression(ctx)),
+                false,
                 ctx,
-            ),
+            )],
             false,
             ctx,
         );
@@ -433,18 +430,15 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                             inner_block.push(Statement::new_variable_declaration(
                                 span,
                                 VariableDeclarationKind::Var,
-                                ArenaVec::from_value_in(
-                                    VariableDeclarator::new(
-                                        span,
-                                        VariableDeclarationKind::Var,
-                                        var_id.create_spanned_binding_pattern(span, ctx),
-                                        NONE,
-                                        Some(expr),
-                                        false,
-                                        ctx,
-                                    ),
+                                [VariableDeclarator::new(
+                                    span,
+                                    VariableDeclarationKind::Var,
+                                    var_id.create_spanned_binding_pattern(span, ctx),
+                                    NONE,
+                                    Some(expr),
+                                    false,
                                     ctx,
-                                ),
+                                )],
                                 false,
                                 ctx,
                             ));
@@ -452,18 +446,15 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                             program_body.push(Statement::new_export_named_declaration(
                                 SPAN,
                                 None,
-                                ArenaVec::from_value_in(
-                                    ExportSpecifier::new(
-                                        SPAN,
-                                        ModuleExportName::IdentifierReference(
-                                            var_id.create_read_reference(ctx),
-                                        ),
-                                        ModuleExportName::new_identifier_name(SPAN, "default", ctx),
-                                        ImportOrExportKind::Value,
-                                        ctx,
+                                [ExportSpecifier::new(
+                                    SPAN,
+                                    ModuleExportName::IdentifierReference(
+                                        var_id.create_read_reference(ctx),
                                     ),
+                                    ModuleExportName::new_identifier_name(SPAN, "default", ctx),
+                                    ImportOrExportKind::Value,
                                     ctx,
-                                ),
+                                )],
                                 None,
                                 ImportOrExportKind::Value,
                                 NONE,
@@ -735,7 +726,7 @@ impl<'a> ExplicitResourceManagement<'a> {
                                 ctx,
                             ),
                             NONE,
-                            ArenaVec::from_value_in(Argument::from(old_init), ctx),
+                            [Argument::from(old_init)],
                             false,
                             ctx,
                         ));
@@ -759,25 +750,22 @@ impl<'a> ExplicitResourceManagement<'a> {
                         Statement::new_variable_declaration(
                             SPAN,
                             VariableDeclarationKind::Var,
-                            ArenaVec::from_value_in(
-                                VariableDeclarator::new(
+                            [VariableDeclarator::new(
+                                SPAN,
+                                VariableDeclarationKind::Var,
+                                using_ctx.create_binding_pattern(ctx),
+                                NONE,
+                                Some(Expression::new_call_expression(
                                     SPAN,
-                                    VariableDeclarationKind::Var,
-                                    using_ctx.create_binding_pattern(ctx),
+                                    callee,
                                     NONE,
-                                    Some(Expression::new_call_expression(
-                                        SPAN,
-                                        callee,
-                                        NONE,
-                                        [],
-                                        false,
-                                        ctx,
-                                    )),
+                                    [],
                                     false,
                                     ctx,
-                                ),
+                                )),
+                                false,
                                 ctx,
-                            ),
+                            )],
                             false,
                             ctx,
                         ),
@@ -880,7 +868,7 @@ impl<'a> ExplicitResourceManagement<'a> {
                             ctx,
                         ),
                         NONE,
-                        ArenaVec::from_value_in(Argument::from(old_init), ctx),
+                        [Argument::from(old_init)],
                         false,
                         ctx,
                     ));
@@ -897,18 +885,15 @@ impl<'a> ExplicitResourceManagement<'a> {
         let helper = Declaration::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ArenaVec::from_value_in(
-                VariableDeclarator::new(
-                    SPAN,
-                    VariableDeclarationKind::Var,
-                    using_ctx.create_binding_pattern(ctx),
-                    NONE,
-                    Some(Expression::new_call_expression(SPAN, callee, NONE, [], false, ctx)),
-                    false,
-                    ctx,
-                ),
+            [VariableDeclarator::new(
+                SPAN,
+                VariableDeclarationKind::Var,
+                using_ctx.create_binding_pattern(ctx),
+                NONE,
+                Some(Expression::new_call_expression(SPAN, callee, NONE, [], false, ctx)),
+                false,
                 ctx,
-            ),
+            )],
             false,
             ctx,
         );
@@ -976,12 +961,7 @@ impl<'a> ExplicitResourceManagement<'a> {
         CatchClause::boxed_with_scope_id(
             SPAN,
             Some(catch_parameter),
-            BlockStatement::new_with_scope_id(
-                SPAN,
-                ArenaVec::from_value_in(stmt, ctx),
-                block_scope_id,
-                ctx,
-            ),
+            BlockStatement::new_with_scope_id(SPAN, [stmt], block_scope_id, ctx),
             catch_scope_id,
             ctx,
         )
@@ -1017,7 +997,7 @@ impl<'a> ExplicitResourceManagement<'a> {
 
         BlockStatement::boxed_with_scope_id(
             SPAN,
-            ArenaVec::from_value_in(Statement::new_expression_statement(SPAN, stmt, ctx), ctx),
+            [Statement::new_expression_statement(SPAN, stmt, ctx)],
             finally_scope_id,
             ctx,
         )
@@ -1036,18 +1016,15 @@ impl<'a> ExplicitResourceManagement<'a> {
         Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ArenaVec::from_value_in(
-                VariableDeclarator::new(
-                    SPAN,
-                    VariableDeclarationKind::Var,
-                    binding.create_spanned_binding_pattern(original_span, ctx),
-                    NONE,
-                    Some(class_expr),
-                    false,
-                    ctx,
-                ),
+            [VariableDeclarator::new(
+                SPAN,
+                VariableDeclarationKind::Var,
+                binding.create_spanned_binding_pattern(original_span, ctx),
+                NONE,
+                Some(class_expr),
+                false,
                 ctx,
-            ),
+            )],
             false,
             ctx,
         )

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -571,7 +571,7 @@ impl<'a> JsxImpl<'a> {
             let stmt = Statement::new_variable_declaration(
                 SPAN,
                 VariableDeclarationKind::Var,
-                ArenaVec::from_value_in(declarator, ctx),
+                [declarator],
                 false,
                 ctx,
             );

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -181,7 +181,7 @@ impl<'a> JsxSource<'a> {
         let var_decl = Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ArenaVec::from_value_in(decl, ctx),
+            [decl],
             false,
             ctx,
         );

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -660,14 +660,11 @@ impl<'a> ReactRefresh<'a> {
             let function_body = FunctionBody::new(
                 SPAN,
                 [],
-                ArenaVec::from_value_in(
-                    Statement::new_return_statement(
-                        SPAN,
-                        Some(Expression::new_array_expression(SPAN, custom_hooks_in_scope, ctx)),
-                        ctx,
-                    ),
+                [Statement::new_return_statement(
+                    SPAN,
+                    Some(Expression::new_array_expression(SPAN, custom_hooks_in_scope, ctx)),
                     ctx,
-                ),
+                )],
                 ctx,
             );
             let scope_id = ctx.create_child_scope_of_current(ScopeFlags::Function);

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -459,7 +459,7 @@ impl<'a> StyledComponents<'a> {
             );
             self.add_properties(&mut properties, ctx);
             let object = ObjectExpression::boxed(SPAN, properties, ctx);
-            let arguments = ArenaVec::from_value_in(Argument::ObjectExpression(object), ctx);
+            let arguments = [Argument::ObjectExpression(object)];
             expr.replace_with(|object| {
                 let property = IdentifierName::new(SPAN, "withConfig", ctx);
                 let callee =
@@ -1160,18 +1160,15 @@ mod tests {
 
         let mut lit = TemplateLiteral::new(
             SPAN,
-            ArenaVec::from_value_in(
-                TemplateElement::new(
-                    SPAN,
-                    TemplateElementValue {
-                        raw: Str::from_str_in(input, &ast),
-                        cooked: Some(Str::from_str_in(input, &ast)),
-                    },
-                    true,
-                    &ast,
-                ),
+            [TemplateElement::new(
+                SPAN,
+                TemplateElementValue {
+                    raw: Str::from_str_in(input, &ast),
+                    cooked: Some(Str::from_str_in(input, &ast)),
+                },
+                true,
                 &ast,
-            ),
+            )],
             [],
             &ast,
         );

--- a/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
+++ b/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
@@ -242,7 +242,7 @@ impl<'a> TaggedTemplateTransform {
         let stmt = Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ArenaVec::from_value_in(variable, ctx),
+            [variable],
             false,
             ctx,
         );

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -591,12 +591,7 @@ impl<'a> TypeScriptAnnotations<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         let scope_id = ctx.insert_scope_below_statement(&stmt, ScopeFlags::empty());
-        Statement::new_block_statement_with_scope_id(
-            span,
-            ArenaVec::from_value_in(stmt, ctx),
-            scope_id,
-            ctx,
-        )
+        Statement::new_block_statement_with_scope_id(span, [stmt], scope_id, ctx)
     }
 
     fn replace_for_statement_body_with_empty_block_if_ts(

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -187,12 +187,11 @@ impl<'a> TypeScriptEnum {
         let id = param_binding.create_binding_pattern(ctx);
 
         // ((Foo) => {
-        let params = FormalParameter::new(SPAN, [], id, NONE, NONE, false, None, false, false, ctx);
-        let params = ArenaVec::from_value_in(params, ctx);
+        let param = FormalParameter::new(SPAN, [], id, NONE, NONE, false, None, false, false, ctx);
         let params = FormalParameters::boxed(
             SPAN,
             FormalParameterKind::ArrowFormalParameters,
-            params,
+            [param],
             NONE,
             ctx,
         );
@@ -240,7 +239,7 @@ impl<'a> TypeScriptEnum {
         let arguments = if (is_export || is_not_top_scope) && !is_already_declared {
             // }({});
             let object_arg = Argument::new_object_expression(SPAN, [], ctx);
-            ArenaVec::from_value_in(object_arg, ctx)
+            [object_arg]
         } else {
             // }(Foo || {});
             let op = LogicalOperator::Or;
@@ -252,7 +251,7 @@ impl<'a> TypeScriptEnum {
             );
             let right = Expression::new_object_expression(SPAN, [], ctx);
             let argument = Argument::new_logical_expression(span, left, op, right, ctx);
-            ArenaVec::from_value_in(argument, ctx)
+            [argument]
         };
 
         let call_expression = Expression::new_call_expression_with_pure(
@@ -305,7 +304,7 @@ impl<'a> TypeScriptEnum {
                 false,
                 ctx,
             );
-            ArenaVec::from_value_in(decl, ctx)
+            [decl]
         };
         let variable_declaration =
             Declaration::new_variable_declaration(span, kind, decls, false, ctx);

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
+use oxc_allocator::{ArenaBox, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::{Reference, SymbolFlags};
 use oxc_span::SPAN;
@@ -170,19 +170,16 @@ impl<'a> TypeScriptModule {
                     str_lit.lone_surrogates,
                     ctx,
                 );
-                let arguments = ArenaVec::from_value_in(Argument::StringLiteral(str_lit), ctx);
+                let argument = Argument::StringLiteral(str_lit);
                 (
                     VariableDeclarationKind::Const,
-                    Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx),
+                    Expression::new_call_expression(SPAN, callee, NONE, [argument], false, ctx),
                 )
             }
         };
-        let decls = ArenaVec::from_value_in(
-            VariableDeclarator::new(SPAN, kind, binding, NONE, Some(init), false, ctx),
-            ctx,
-        );
+        let decl = VariableDeclarator::new(SPAN, kind, binding, NONE, Some(init), false, ctx);
 
-        Some(Declaration::new_variable_declaration(SPAN, kind, decls, false, ctx))
+        Some(Declaration::new_variable_declaration(SPAN, kind, [decl], false, ctx))
     }
 
     #[expect(clippy::self_only_used_in_recursion)]

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -326,12 +326,11 @@ impl<'a> TypeScriptNamespace {
         ctx: &TraverseCtx<'a>,
     ) -> Declaration<'a> {
         let kind = VariableDeclarationKind::Let;
-        let declarations = {
+        let decl = {
             let pattern = binding.create_spanned_binding_pattern(binding_span, ctx);
-            let decl = VariableDeclarator::new(span, kind, pattern, NONE, None, false, ctx);
-            ArenaVec::from_value_in(decl, ctx)
+            VariableDeclarator::new(span, kind, pattern, NONE, None, false, ctx)
         };
-        Declaration::new_variable_declaration(span, kind, declarations, false, ctx)
+        Declaration::new_variable_declaration(span, kind, [decl], false, ctx)
     }
 
     // `namespace Foo { }` -> `let Foo; (function (_Foo) { })(Foo || (Foo = {}));`
@@ -349,9 +348,8 @@ impl<'a> TypeScriptNamespace {
         let callee = {
             let params = {
                 let pattern = param_binding.create_binding_pattern(ctx);
-                let items =
-                    ArenaVec::from_value_in(FormalParameter::new_plain(SPAN, pattern, ctx), ctx);
-                FormalParameters::new(SPAN, FormalParameterKind::FormalParameter, items, NONE, ctx)
+                let item = FormalParameter::new_plain(SPAN, pattern, ctx);
+                FormalParameters::new(SPAN, FormalParameterKind::FormalParameter, [item], NONE, ctx)
             };
             let function_expr =
                 Expression::FunctionExpression(Function::boxed_plain_with_scope_id(
@@ -373,7 +371,7 @@ impl<'a> TypeScriptNamespace {
         // (function (_N) { var M; (function (_M) { var x; })(M || (M = _N.M || (_N.M = {})));})(N || (N = {}));
         //                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^^^^^^^
         //                                                   Nested namespace arguments         Normal namespace arguments
-        let arguments = {
+        let argument = {
             // M
             let logical_left = binding.create_read_expression(ctx);
 
@@ -427,17 +425,16 @@ impl<'a> TypeScriptNamespace {
                 logical_right = Expression::new_parenthesized_expression(SPAN, logical_right, ctx);
             }
 
-            let expr = Expression::new_logical_expression(
+            Argument::new_logical_expression(
                 SPAN,
                 logical_left,
                 LogicalOperator::Or,
                 logical_right,
                 ctx,
-            );
-            ArenaVec::from_value_in(Argument::from(expr), ctx)
+            )
         };
 
-        let expr = Expression::new_call_expression(span, callee, NONE, arguments, false, ctx);
+        let expr = Expression::new_call_expression(span, callee, NONE, [argument], false, ctx);
         Statement::new_expression_statement(span, expr, ctx)
     }
 

--- a/crates/oxc_transformer/src/utils/ast_builder.rs
+++ b/crates/oxc_transformer/src/utils/ast_builder.rs
@@ -28,8 +28,8 @@ pub fn create_bind_call<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let callee = create_member_callee(callee, static_ident!("bind"), span, ctx);
-    let arguments = ArenaVec::from_value_in(Argument::from(this), ctx);
-    Expression::new_call_expression(span, callee, NONE, arguments, false, ctx)
+    let this = Argument::from(this);
+    Expression::new_call_expression(span, callee, NONE, [this], false, ctx)
 }
 
 /// `object` -> `object.call(...arguments)`.
@@ -40,8 +40,8 @@ pub fn create_call_call<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let callee = create_member_callee(callee, static_ident!("call"), span, ctx);
-    let arguments = ArenaVec::from_value_in(Argument::from(this), ctx);
-    Expression::new_call_expression(span, callee, NONE, arguments, false, ctx)
+    let this = Argument::from(this);
+    Expression::new_call_expression(span, callee, NONE, [this], false, ctx)
 }
 
 /// Wrap an `Expression` in an arrow function IIFE (immediately invoked function expression)
@@ -148,10 +148,7 @@ pub fn create_super_call<'a>(
         SPAN,
         Expression::new_super(SPAN, ctx),
         NONE,
-        ArenaVec::from_value_in(
-            Argument::new_spread_element(SPAN, args_binding.create_read_expression(ctx), ctx),
-            ctx,
-        ),
+        [Argument::new_spread_element(SPAN, args_binding.create_read_expression(ctx), ctx)],
         false,
         ctx,
     )

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -521,9 +521,9 @@ impl<'a> ModuleRunnerTransform<'a> {
         } else {
             let callee =
                 Expression::new_identifier(SPAN, static_ident!("__vite_ssr_exportAll__"), ctx);
-            let arguments = ArenaVec::from_value_in(Argument::from(ident), ctx);
+            let ident = Argument::from(ident);
             // `export * from 'vue'` -> `__vite_ssr_exportAll__(__vite_ssr_import_0__);`
-            let call = Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx);
+            let call = Expression::new_call_expression(SPAN, callee, NONE, [ident], false, ctx);
             let export = Statement::new_expression_statement(span, call, ctx);
             // names from `export *` cannot be known, so add it right after the import.
             hoist_imports.extend([import, export]);
@@ -711,7 +711,7 @@ impl<'a> ModuleRunnerTransform<'a> {
             false,
             ctx,
         );
-        Argument::new_object_expression(SPAN, ArenaVec::from_value_in(imported_names, ctx), ctx)
+        Argument::new_object_expression(SPAN, [imported_names], ctx)
     }
 
     // `const __vite_ssr_import_0__ = await __vite_ssr_import__('vue', { importedNames: ['foo'] });`
@@ -731,13 +731,8 @@ impl<'a> ModuleRunnerTransform<'a> {
 
         let kind = VariableDeclarationKind::Const;
         let declarator = VariableDeclarator::new(SPAN, kind, pattern, NONE, Some(init), false, ctx);
-        let declaration = Declaration::new_variable_declaration(
-            span,
-            kind,
-            ArenaVec::from_value_in(declarator, ctx),
-            false,
-            ctx,
-        );
+        let declaration =
+            Declaration::new_variable_declaration(span, kind, [declarator], false, ctx);
         Statement::from(declaration)
     }
 
@@ -779,7 +774,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         let kind = FormalParameterKind::FormalParameter;
         let params = FormalParameters::new(SPAN, kind, [], NONE, ctx);
         let statement = Statement::new_return_statement(SPAN, Some(expr), ctx);
-        let body = FunctionBody::new(SPAN, [], ArenaVec::from_value_in(statement, ctx), ctx);
+        let body = FunctionBody::new(SPAN, [], [statement], ctx);
         let r#type = FunctionType::FunctionExpression;
         let scope_id = ctx.create_child_scope(ctx.scoping().root_scope_id(), ScopeFlags::Function);
         Expression::new_function_expression_with_scope_id_and_pure_and_pife(
@@ -865,13 +860,8 @@ impl<'a> ModuleRunnerTransform<'a> {
         let kind = VariableDeclarationKind::Const;
         let declarator =
             VariableDeclarator::new(SPAN, kind, pattern, NONE, Some(right), false, ctx);
-        let declaration = Declaration::new_variable_declaration(
-            span,
-            kind,
-            ArenaVec::from_value_in(declarator, ctx),
-            false,
-            ctx,
-        );
+        let declaration =
+            Declaration::new_variable_declaration(span, kind, [declarator], false, ctx);
         Statement::from(declaration)
     }
 }


### PR DESCRIPTION
Pure refactor. Just shorten code.

#24621 made AST builder methods take arrays as params.

Replace `ArenaVec::from_value_in(v, alloc)` with `[v]` where the `ArenaVec` is passed to an AST builder method.

```rs
let block = Statement::new_block_statement(
    SPAN,
    ArenaVec::from_value_in(return_stmt, ctx),
    ctx,
);
```

\->

```rs
let block = Statement::new_block_statement(SPAN, [return_stmt], ctx);
```

