### PR TITLE
refactor(ast_visit, isolated_declarations, minifier, transformer): pass array literals for `from_array_in` builder args

### DIFF
--- a/crates/oxc_ast_visit/src/utf8_to_utf16/mod.rs
+++ b/crates/oxc_ast_visit/src/utf8_to_utf16/mod.rs
@@ -138,7 +138,7 @@ impl Utf8ToUtf16 {
 
 #[cfg(test)]
 mod test {
-    use oxc_allocator::{Allocator, ArenaVec};
+    use oxc_allocator::Allocator;
     use oxc_ast::{ast::*, builder::AstBuilder};
     use oxc_span::{GetSpan, SourceType, Span};
 
@@ -153,20 +153,17 @@ mod test {
             Span::new(0, 15),
             SourceType::default(),
             ";'🤨' // 🤨",
-            ArenaVec::from_value_in(Comment::new(8, 15, CommentKind::Line), &ast),
+            [Comment::new(8, 15, CommentKind::Line)],
             None,
             [],
-            ArenaVec::from_array_in(
-                [
-                    Statement::new_empty_statement(Span::new(0, 1), &ast),
-                    Statement::new_expression_statement(
-                        Span::new(1, 7),
-                        Expression::new_string_literal(Span::new(1, 7), "🤨", None, &ast),
-                        &ast,
-                    ),
-                ],
-                &ast,
-            ),
+            [
+                Statement::new_empty_statement(Span::new(0, 1), &ast),
+                Statement::new_expression_statement(
+                    Span::new(1, 7),
+                    Expression::new_string_literal(Span::new(1, 7), "🤨", None, &ast),
+                    &ast,
+                ),
+            ],
             &ast,
         );
 

--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -96,10 +96,7 @@ impl<'a> IsolatedDeclarations<'a> {
                                 SPAN,
                                 TSType::new_ts_union_type(
                                     SPAN,
-                                    ArenaVec::from_array_in(
-                                        [ts_type, TSType::new_ts_undefined_keyword(SPAN, self)],
-                                        self,
-                                    ),
+                                    [ts_type, TSType::new_ts_undefined_keyword(SPAN, self)],
                                     self,
                                 ),
                                 self,

--- a/crates/oxc_isolated_declarations/src/return_type.rs
+++ b/crates/oxc_isolated_declarations/src/return_type.rs
@@ -1,6 +1,6 @@
 use std::cell::Cell;
 
-use oxc_allocator::{Allocator, ArenaVec, CloneIn, GetAllocator};
+use oxc_allocator::{Allocator, CloneIn, GetAllocator};
 use oxc_ast::ast::{
     ArrowFunctionExpression, BindingIdentifier, Expression, Function, FunctionBody,
     ReturnStatement, TSType, TSTypeAliasDeclaration, TSTypeName, TSTypeQueryExprName,
@@ -112,10 +112,7 @@ impl<'a> FunctionReturnType<'a> {
                 expr_type = TSType::new_ts_parenthesized_type(SPAN, expr_type, transformer);
             }
 
-            let types = ArenaVec::from_array_in(
-                [expr_type, TSType::new_ts_undefined_keyword(SPAN, transformer)],
-                transformer,
-            );
+            let types = [expr_type, TSType::new_ts_undefined_keyword(SPAN, transformer)];
             expr_type = TSType::new_ts_union_type(SPAN, types, transformer);
         }
         Some(expr_type)

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -94,7 +94,7 @@ impl<'a> PeepholeOptimizations {
                 let new_expr = if base_has_side_effects {
                     Expression::new_sequence_expression(
                         span,
-                        ArenaVec::from_array_in([base, Expression::new_void_0(span, ctx)], ctx),
+                        [base, Expression::new_void_0(span, ctx)],
                         ctx,
                     )
                 } else {
@@ -146,19 +146,16 @@ impl<'a> PeepholeOptimizations {
                 if should_keep_indirect_access {
                     return Some(Expression::new_sequence_expression(
                         logical_expr.span,
-                        ArenaVec::from_array_in(
-                            [
-                                Expression::new_numeric_literal(
-                                    logical_expr.left.span(),
-                                    0.0,
-                                    None,
-                                    NumberBase::Decimal,
-                                    ctx,
-                                ),
-                                logical_expr.right.take_in(ctx),
-                            ],
-                            ctx,
-                        ),
+                        [
+                            Expression::new_numeric_literal(
+                                logical_expr.left.span(),
+                                0.0,
+                                None,
+                                NumberBase::Decimal,
+                                ctx,
+                            ),
+                            logical_expr.right.take_in(ctx),
+                        ],
                         ctx,
                     ));
                 }
@@ -171,8 +168,8 @@ impl<'a> PeepholeOptimizations {
             // or: false_with_sideeffects && foo() => false_with_sideeffects, foo()
             let left = logical_expr.left.take_in(ctx);
             let right = logical_expr.right.take_in(ctx);
-            let vec = ArenaVec::from_array_in([left, right], ctx);
-            let sequence_expr = Expression::new_sequence_expression(logical_expr.span, vec, ctx);
+            let sequence_expr =
+                Expression::new_sequence_expression(logical_expr.span, [left, right], ctx);
             return Some(sequence_expr);
         } else if let Expression::LogicalExpression(left_child) = &mut logical_expr.left
             && left_child.operator == logical_expr.operator
@@ -215,10 +212,8 @@ impl<'a> PeepholeOptimizations {
             ValueType::Null | ValueType::Undefined => {
                 Some(if left.may_have_side_effects(ctx) {
                     // e.g. `(a(), null) ?? 1` => `(a(), null, 1)`
-                    let expressions = ArenaVec::from_array_in(
-                        [logical_expr.left.take_in(ctx), logical_expr.right.take_in(ctx)],
-                        ctx,
-                    );
+                    let expressions =
+                        [logical_expr.left.take_in(ctx), logical_expr.right.take_in(ctx)];
                     Expression::new_sequence_expression(logical_expr.span, expressions, ctx)
                 } else {
                     let should_keep_indirect_access =
@@ -227,19 +222,16 @@ impl<'a> PeepholeOptimizations {
                     if should_keep_indirect_access {
                         return Some(Expression::new_sequence_expression(
                             logical_expr.span,
-                            ArenaVec::from_array_in(
-                                [
-                                    Expression::new_numeric_literal(
-                                        logical_expr.left.span(),
-                                        0.0,
-                                        None,
-                                        NumberBase::Decimal,
-                                        ctx,
-                                    ),
-                                    logical_expr.right.take_in(ctx),
-                                ],
-                                ctx,
-                            ),
+                            [
+                                Expression::new_numeric_literal(
+                                    logical_expr.left.span(),
+                                    0.0,
+                                    None,
+                                    NumberBase::Decimal,
+                                    ctx,
+                                ),
+                                logical_expr.right.take_in(ctx),
+                            ],
                             ctx,
                         ));
                     }
@@ -258,19 +250,16 @@ impl<'a> PeepholeOptimizations {
                 if should_keep_indirect_access {
                     return Some(Expression::new_sequence_expression(
                         logical_expr.span,
-                        ArenaVec::from_array_in(
-                            [
-                                Expression::new_numeric_literal(
-                                    logical_expr.right.span(),
-                                    0.0,
-                                    None,
-                                    NumberBase::Decimal,
-                                    ctx,
-                                ),
-                                logical_expr.left.take_in(ctx),
-                            ],
-                            ctx,
-                        ),
+                        [
+                            Expression::new_numeric_literal(
+                                logical_expr.right.span(),
+                                0.0,
+                                None,
+                                NumberBase::Decimal,
+                                ctx,
+                            ),
+                            logical_expr.left.take_in(ctx),
+                        ],
                         ctx,
                     ));
                 }

--- a/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
@@ -157,19 +157,16 @@ impl<'a> PeepholeOptimizations {
         {
             return Some(Expression::new_sequence_expression(
                 expr.span,
-                ArenaVec::from_array_in(
-                    [
-                        Self::join_with_left_associative_op(
-                            expr.test.span(),
-                            LogicalOperator::Or,
-                            expr.test.take_in(ctx),
-                            alternate.expressions[0].take_in(ctx),
-                            ctx,
-                        ),
-                        expr.consequent.take_in(ctx),
-                    ],
-                    ctx,
-                ),
+                [
+                    Self::join_with_left_associative_op(
+                        expr.test.span(),
+                        LogicalOperator::Or,
+                        expr.test.take_in(ctx),
+                        alternate.expressions[0].take_in(ctx),
+                        ctx,
+                    ),
+                    expr.consequent.take_in(ctx),
+                ],
                 ctx,
             ));
         }
@@ -181,19 +178,16 @@ impl<'a> PeepholeOptimizations {
         {
             return Some(Expression::new_sequence_expression(
                 expr.span,
-                ArenaVec::from_array_in(
-                    [
-                        Self::join_with_left_associative_op(
-                            expr.test.span(),
-                            LogicalOperator::And,
-                            expr.test.take_in(ctx),
-                            consequent.expressions[0].take_in(ctx),
-                            ctx,
-                        ),
-                        expr.alternate.take_in(ctx),
-                    ],
-                    ctx,
-                ),
+                [
+                    Self::join_with_left_associative_op(
+                        expr.test.span(),
+                        LogicalOperator::And,
+                        expr.test.take_in(ctx),
+                        consequent.expressions[0].take_in(ctx),
+                        ctx,
+                    ),
+                    expr.alternate.take_in(ctx),
+                ],
                 ctx,
             ));
         }
@@ -570,10 +564,7 @@ impl<'a> PeepholeOptimizations {
             }
 
             // "a ? b : b" => "a, b"
-            let expressions = ArenaVec::from_array_in(
-                [expr.test.take_in(ctx), expr.consequent.take_in(ctx)],
-                ctx,
-            );
+            let expressions = [expr.test.take_in(ctx), expr.consequent.take_in(ctx)];
             return Some(Expression::new_sequence_expression(expr.span, expressions, ctx));
         }
 

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -339,7 +339,8 @@ impl<'a> PeepholeOptimizations {
         let Some(v) = e.test.evaluate_value_to_boolean(ctx) else { return };
         let new_expr = if e.test.may_have_side_effects(ctx) {
             // "(a, true) ? b : c" => "a, b"
-            let exprs = ArenaVec::from_array_in(
+            Expression::new_sequence_expression(
+                e.span,
                 [
                     {
                         let mut test = e.test.take_in(ctx);
@@ -349,8 +350,7 @@ impl<'a> PeepholeOptimizations {
                     if v { e.consequent.take_in(ctx) } else { e.alternate.take_in(ctx) },
                 ],
                 ctx,
-            );
-            Expression::new_sequence_expression(e.span, exprs, ctx)
+            )
         } else {
             let result_expr = if v { e.consequent.take_in(ctx) } else { e.alternate.take_in(ctx) };
             let should_keep_as_sequence_expr = Self::should_keep_indirect_access(&result_expr, ctx);
@@ -358,19 +358,16 @@ impl<'a> PeepholeOptimizations {
             if should_keep_as_sequence_expr {
                 Expression::new_sequence_expression(
                     e.span,
-                    ArenaVec::from_array_in(
-                        [
-                            Expression::new_numeric_literal(
-                                e.span,
-                                0.0,
-                                None,
-                                NumberBase::Decimal,
-                                ctx,
-                            ),
-                            result_expr,
-                        ],
-                        ctx,
-                    ),
+                    [
+                        Expression::new_numeric_literal(
+                            e.span,
+                            0.0,
+                            None,
+                            NumberBase::Decimal,
+                            ctx,
+                        ),
+                        result_expr,
+                    ],
                     ctx,
                 )
             } else {
@@ -592,10 +589,7 @@ impl<'a> PeepholeOptimizations {
     ) -> Expression<'a> {
         Expression::new_sequence_expression(
             span,
-            ArenaVec::from_array_in(
-                [Expression::new_numeric_literal(span, 0.0, None, NumberBase::Decimal, ctx), expr],
-                ctx,
-            ),
+            [Expression::new_numeric_literal(span, 0.0, None, NumberBase::Decimal, ctx), expr],
             ctx,
         )
     }

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -594,10 +594,7 @@ impl<'a> PeepholeOptimizations {
                     (false, false) => {
                         let new_expr = Expression::new_sequence_expression(
                             binary_expr.span,
-                            ArenaVec::from_array_in(
-                                [binary_expr.left.take_in(ctx), binary_expr.right.take_in(ctx)],
-                                ctx,
-                            ),
+                            [binary_expr.left.take_in(ctx), binary_expr.right.take_in(ctx)],
                             ctx,
                         );
                         ctx.replace_expression(e, new_expr);

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1577,13 +1577,10 @@ impl<'a> PeepholeOptimizations {
 
         let new_callee = Expression::new_sequence_expression(
             span,
-            ArenaVec::from_array_in(
-                [
-                    Expression::new_numeric_literal(span, 0.0, None, NumberBase::Decimal, ctx),
-                    arg_expr.take_in(ctx),
-                ],
-                ctx,
-            ),
+            [
+                Expression::new_numeric_literal(span, 0.0, None, NumberBase::Decimal, ctx),
+                arg_expr.take_in(ctx),
+            ],
             ctx,
         );
         ctx.replace_expression(&mut expr.callee, new_callee);

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -1366,8 +1366,7 @@ impl<'a> ConstructorBodyThisAfterSuperInserter<'a, '_> {
         let assignment = self.create_assignment_to_this_temp_var();
         let span = expr.span();
         expr.replace_with(|expr| {
-            let exprs = ArenaVec::from_array_in([expr, assignment], self.ctx);
-            Expression::new_sequence_expression(span, exprs, self.ctx)
+            Expression::new_sequence_expression(span, [expr, assignment], self.ctx)
         });
     }
 

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -592,8 +592,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
                 generator_function_id,
                 ctx,
             );
-            let statements = ArenaVec::from_array_in([statement, caller_function], ctx);
-            let body = FunctionBody::boxed(SPAN, [], statements, ctx);
+            let body = FunctionBody::boxed(SPAN, [], [statement, caller_function], ctx);
             let params = Self::create_empty_params(ctx);
             let wrapper_function = Self::create_function(
                 FunctionType::FunctionExpression,

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -281,29 +281,26 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                 Some(ForStatementInit::new_variable_declaration(
                     SPAN,
                     VariableDeclarationKind::Var,
-                    ArenaVec::from_array_in(
-                        [
-                            VariableDeclarator::new(
-                                SPAN,
-                                VariableDeclarationKind::Var,
-                                iterator_key.create_binding_pattern(ctx),
-                                NONE,
-                                Some(iterator),
-                                false,
-                                ctx,
-                            ),
-                            VariableDeclarator::new(
-                                SPAN,
-                                VariableDeclarationKind::Var,
-                                step_key.create_binding_pattern(ctx),
-                                NONE,
-                                None,
-                                false,
-                                ctx,
-                            ),
-                        ],
-                        ctx,
-                    ),
+                    [
+                        VariableDeclarator::new(
+                            SPAN,
+                            VariableDeclarationKind::Var,
+                            iterator_key.create_binding_pattern(ctx),
+                            NONE,
+                            Some(iterator),
+                            false,
+                            ctx,
+                        ),
+                        VariableDeclarator::new(
+                            SPAN,
+                            VariableDeclarationKind::Var,
+                            step_key.create_binding_pattern(ctx),
+                            NONE,
+                            None,
+                            false,
+                            ctx,
+                        ),
+                    ],
                     false,
                     ctx,
                 )),
@@ -392,33 +389,30 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                 {
                     BlockStatement::new_with_scope_id(
                         SPAN,
-                        ArenaVec::from_array_in(
-                            [
-                                Statement::new_expression_statement(
+                        [
+                            Statement::new_expression_statement(
+                                SPAN,
+                                Expression::new_assignment_expression(
                                     SPAN,
-                                    Expression::new_assignment_expression(
-                                        SPAN,
-                                        AssignmentOperator::Assign,
-                                        iterator_had_error_key.create_write_target(ctx),
-                                        Expression::new_boolean_literal(SPAN, true, ctx),
-                                        ctx,
-                                    ),
+                                    AssignmentOperator::Assign,
+                                    iterator_had_error_key.create_write_target(ctx),
+                                    Expression::new_boolean_literal(SPAN, true, ctx),
                                     ctx,
                                 ),
-                                Statement::new_expression_statement(
+                                ctx,
+                            ),
+                            Statement::new_expression_statement(
+                                SPAN,
+                                Expression::new_assignment_expression(
                                     SPAN,
-                                    Expression::new_assignment_expression(
-                                        SPAN,
-                                        AssignmentOperator::Assign,
-                                        iterator_error_key.create_write_target(ctx),
-                                        err_ident.create_read_expression(ctx),
-                                        ctx,
-                                    ),
+                                    AssignmentOperator::Assign,
+                                    iterator_error_key.create_write_target(ctx),
+                                    err_ident.create_read_expression(ctx),
                                     ctx,
                                 ),
-                            ],
-                            ctx,
-                        ),
+                                ctx,
+                            ),
+                        ],
                         block_scope_id,
                         ctx,
                     )

--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -49,7 +49,7 @@
 
 use std::mem;
 
-use oxc_allocator::{ArenaVec, CloneIn, GetAllocator, ReplaceWith, TakeIn};
+use oxc_allocator::{CloneIn, GetAllocator, ReplaceWith, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::{GetSpan, SPAN, Span};
 use oxc_traverse::{Ancestor, BoundIdentifier, MaybeBoundIdentifier, Traverse};
@@ -551,8 +551,7 @@ impl<'a> OptionalChaining<'a> {
                 // `eval?.()` is an indirect eval call transformed to `(0,eval)()`
                 let zero = Expression::new_number_0(ctx);
                 expr.replace_with(|original_callee| {
-                    let expressions = ArenaVec::from_array_in([zero, original_callee], ctx);
-                    Expression::new_sequence_expression(SPAN, expressions, ctx)
+                    Expression::new_sequence_expression(SPAN, [zero, original_callee], ctx)
                 });
             }
 

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -1049,11 +1049,8 @@ impl<'a> ClassProperties<'a> {
                     // Source = `++object.#prop` (prefix `++`)
 
                     // `(_object$prop = _assertClassBrand(Class, object, _prop)._, ++_object$prop)`
-                    let mut value = Expression::new_sequence_expression(
-                        SPAN,
-                        ArenaVec::from_array_in([assignment, update_expr], ctx),
-                        ctx,
-                    );
+                    let mut value =
+                        Expression::new_sequence_expression(SPAN, [assignment, update_expr], ctx);
 
                     // If no shortcut, wrap in `_assertClassBrand(Class, object, <value>)`
                     if let Some(class_ident) = class_ident {
@@ -1080,10 +1077,7 @@ impl<'a> ClassProperties<'a> {
                     // `(_object$prop = _assertClassBrand(Class, object, _prop)._, _object$prop2 = _object$prop++, _object$prop)`
                     let mut value = Expression::new_sequence_expression(
                         SPAN,
-                        ArenaVec::from_array_in(
-                            [assignment, assignment2, temp_binding.create_read_expression(ctx)],
-                            ctx,
-                        ),
+                        [assignment, assignment2, temp_binding.create_read_expression(ctx)],
                         ctx,
                     );
 
@@ -1107,10 +1101,7 @@ impl<'a> ClassProperties<'a> {
                     // is consumed (i.e. not in an `ExpressionStatement`)
                     Expression::new_sequence_expression(
                         span,
-                        ArenaVec::from_array_in(
-                            [assignment3, temp_binding2.create_read_expression(ctx)],
-                            ctx,
-                        ),
+                        [assignment3, temp_binding2.create_read_expression(ctx)],
                         ctx,
                     )
                 }
@@ -1154,11 +1145,8 @@ impl<'a> ClassProperties<'a> {
                 if prefix {
                     // Source = `++object.#prop` (prefix `++`)
                     // `(_object$prop = _classPrivateFieldGet(_prop, object), ++_object$prop)`
-                    let value = Expression::new_sequence_expression(
-                        SPAN,
-                        ArenaVec::from_array_in([assignment, update_expr], ctx),
-                        ctx,
-                    );
+                    let value =
+                        Expression::new_sequence_expression(SPAN, [assignment, update_expr], ctx);
                     // `_classPrivateFieldSet(_prop, object, <value>)`
                     self.create_private_setter(
                         &private_name,
@@ -1179,10 +1167,7 @@ impl<'a> ClassProperties<'a> {
                     // `(_object$prop = _classPrivateFieldGet(_prop, object), _object$prop2 = _object$prop++, _object$prop)`
                     let value = Expression::new_sequence_expression(
                         SPAN,
-                        ArenaVec::from_array_in(
-                            [assignment, assignment2, temp_binding.create_read_expression(ctx)],
-                            ctx,
-                        ),
+                        [assignment, assignment2, temp_binding.create_read_expression(ctx)],
                         ctx,
                     );
 
@@ -1201,10 +1186,7 @@ impl<'a> ClassProperties<'a> {
                     // is consumed (i.e. not in an `ExpressionStatement`)
                     Expression::new_sequence_expression(
                         span,
-                        ArenaVec::from_array_in(
-                            [set_call, temp_binding2.create_read_expression(ctx)],
-                            ctx,
-                        ),
+                        [set_call, temp_binding2.create_read_expression(ctx)],
                         ctx,
                     )
                 }
@@ -2062,10 +2044,7 @@ impl<'a> ClassProperties<'a> {
     ) -> Expression<'a> {
         let arguments = Expression::new_array_expression(
             SPAN,
-            ArenaVec::from_array_in(
-                [ArrayExpressionElement::from(prop_ident), ArrayExpressionElement::from(object)],
-                ctx,
-            ),
+            [ArrayExpressionElement::from(prop_ident), ArrayExpressionElement::from(object)],
             ctx,
         );
         let arguments = ArenaVec::from_array_in(
@@ -2290,8 +2269,7 @@ impl<'a> ClassProperties<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let error = self.create_throw_error(Helper::WriteOnlyError, private_name, ctx);
-        let expressions = ArenaVec::from_array_in([object, error], ctx);
-        Expression::new_sequence_expression(span, expressions, ctx)
+        Expression::new_sequence_expression(span, [object, error], ctx)
     }
 
     /// _checkInRHS(object)

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -369,31 +369,28 @@ impl<'a> ClassProperties<'a> {
         // `{writable: true, value: <value>}`
         let prop_def = Expression::new_object_expression(
             SPAN,
-            ArenaVec::from_array_in(
-                [
-                    ObjectPropertyKind::new_object_property(
-                        SPAN,
-                        PropertyKind::Init,
-                        PropertyKey::new_static_identifier(SPAN, "writable", ctx),
-                        Expression::new_boolean_literal(SPAN, true, ctx),
-                        false,
-                        false,
-                        false,
-                        ctx,
-                    ),
-                    ObjectPropertyKind::new_object_property(
-                        SPAN,
-                        PropertyKind::Init,
-                        PropertyKey::new_static_identifier(SPAN, "value", ctx),
-                        value,
-                        false,
-                        false,
-                        false,
-                        ctx,
-                    ),
-                ],
-                ctx,
-            ),
+            [
+                ObjectPropertyKind::new_object_property(
+                    SPAN,
+                    PropertyKind::Init,
+                    PropertyKey::new_static_identifier(SPAN, "writable", ctx),
+                    Expression::new_boolean_literal(SPAN, true, ctx),
+                    false,
+                    false,
+                    false,
+                    ctx,
+                ),
+                ObjectPropertyKind::new_object_property(
+                    SPAN,
+                    PropertyKind::Init,
+                    PropertyKey::new_static_identifier(SPAN, "value", ctx),
+                    value,
+                    false,
+                    false,
+                    false,
+                    ctx,
+                ),
+            ],
             ctx,
         );
 

--- a/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
@@ -522,11 +522,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
         if prefix {
             // Source = `++super$prop` (prefix `++`)
             // `(_super$prop = _superPropGet(_Class, prop, _Class), ++_super$prop)`
-            let value = Expression::new_sequence_expression(
-                SPAN,
-                ArenaVec::from_array_in([assignment, update_expr], ctx),
-                ctx,
-            );
+            let value = Expression::new_sequence_expression(SPAN, [assignment, update_expr], ctx);
             // `_superPropSet(_Class, prop, value, _Class, 1)`
             self.create_super_prop_set(span, property1, value, ctx)
         } else {
@@ -538,10 +534,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
             // `(_super$prop = _superPropGet(_Class, prop, _Class), _super$prop2 = _super$prop++, _super$prop)`
             let value = Expression::new_sequence_expression(
                 SPAN,
-                ArenaVec::from_array_in(
-                    [assignment, assignment2, temp_binding.create_read_expression(ctx)],
-                    ctx,
-                ),
+                [assignment, assignment2, temp_binding.create_read_expression(ctx)],
                 ctx,
             );
 
@@ -550,7 +543,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
             // `(_superPropSet(_Class, prop, value, _Class, 1), _super$prop2)`
             Expression::new_sequence_expression(
                 span,
-                ArenaVec::from_array_in([set_call, temp_binding2.create_read_expression(ctx)], ctx),
+                [set_call, temp_binding2.create_read_expression(ctx)],
                 ctx,
             )
         }

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -33,7 +33,6 @@
 //!
 //! * Babel plugin implementation: <https://github.com/babel/babel/blob/v7.26.2/packages/babel-plugin-transform-react-jsx-source/src/index.ts>
 
-use oxc_allocator::ArenaVec;
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_data_structures::rope::{Rope, get_line_column};
 use oxc_span::SPAN;
@@ -171,8 +170,7 @@ impl<'a> JsxSource<'a> {
             )
         };
 
-        let properties = ArenaVec::from_array_in([filename, line_number, column_number], ctx);
-        Expression::new_object_expression(SPAN, properties, ctx)
+        Expression::new_object_expression(SPAN, [filename, line_number, column_number], ctx)
     }
 
     pub fn get_filename_var_statement(&self, ctx: &TraverseCtx<'a>) -> Option<Statement<'a>> {

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -189,13 +189,10 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
             ));
 
             let callee = self.refresh_reg.to_expression(ctx);
-            let arguments = ArenaVec::from_array_in(
-                [
-                    Argument::from(binding.create_read_expression(ctx)),
-                    Argument::new_string_literal(SPAN, *persistent_id, None, ctx),
-                ],
-                ctx,
-            );
+            let arguments = [
+                Argument::from(binding.create_read_expression(ctx)),
+                Argument::new_string_literal(SPAN, *persistent_id, None, ctx),
+            ];
             Statement::new_expression_statement(
                 SPAN,
                 Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx),

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -44,7 +44,7 @@
 //! TODO(improve-on-babel): When flags is empty, we could output `RegExp("(?<=x)")` instead of `RegExp("(?<=x)", "")`.
 //! (actually these would be improvements on ESBuild, not Babel)
 
-use oxc_allocator::{ArenaVec, GetAllocator};
+use oxc_allocator::GetAllocator;
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_regular_expression::{
     RegexUnsupportedPatterns, has_unsupported_regular_expression_pattern,
@@ -165,18 +165,15 @@ impl<'a> RegExp {
             ctx.create_ident_expr(SPAN, regexp, symbol_id, ReferenceFlags::read())
         };
 
-        let arguments = ArenaVec::from_array_in(
-            [
-                Argument::new_string_literal(SPAN, pattern_text, None, ctx),
-                Argument::new_string_literal(
-                    SPAN,
-                    Str::from_str_in(flags.to_inline_string().as_str(), ctx),
-                    None,
-                    ctx,
-                ),
-            ],
-            ctx,
-        );
+        let arguments = [
+            Argument::new_string_literal(SPAN, pattern_text, None, ctx),
+            Argument::new_string_literal(
+                SPAN,
+                Str::from_str_in(flags.to_inline_string().as_str(), ctx),
+                None,
+                ctx,
+            ),
+        ];
 
         *expr = Expression::new_new_expression(regexp.span, callee, NONE, arguments, ctx);
     }

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -232,8 +232,7 @@ impl<'a> ModuleRunnerTransform<'a> {
                 // <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#method_binding>
                 let zero =
                     Expression::new_numeric_literal(SPAN, 0f64, None, NumberBase::Decimal, ctx);
-                let expressions = ArenaVec::from_array_in([zero, expr], ctx);
-                Expression::new_sequence_expression(ident.span, expressions, ctx)
+                Expression::new_sequence_expression(ident.span, [zero, expr], ctx)
             } else {
                 expr
             }
@@ -806,14 +805,11 @@ impl<'a> ModuleRunnerTransform<'a> {
         let getter = Self::create_function_with_return_statement(expr, ctx);
         let object = Expression::new_object_expression(
             SPAN,
-            ArenaVec::from_array_in(
-                [
-                    Self::create_object_property("enumerable", None, ctx),
-                    Self::create_object_property("configurable", None, ctx),
-                    Self::create_object_property("get", Some(getter), ctx),
-                ],
-                ctx,
-            ),
+            [
+                Self::create_object_property("enumerable", None, ctx),
+                Self::create_object_property("configurable", None, ctx),
+                Self::create_object_property("get", Some(getter), ctx),
+            ],
             ctx,
         );
 


### PR DESCRIPTION
Pure refactor. Just shorten code.

#24621 made AST builder methods take arrays as params.

Replace `ArenaVec::from_array_in(...)` arguments written inline at AST builder method call sites with the array literals.

```rs
let block = Statement::new_block_statement(SPAN, ArenaVec::from_array_in([x, y], ctx), ctx);
```

\->

```rs
let block = Statement::new_block_statement(SPAN, [x, y], ctx);
```