### PR TITLE
test(minifier): simplify `ArenaVec` builder args to array

### DIFF
--- a/crates/oxc_minifier/tests/ecmascript/array_join.rs
+++ b/crates/oxc_minifier/tests/ecmascript/array_join.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, ArenaBox, ArenaVec, CloneIn};
+use oxc_allocator::{Allocator, ArenaBox, CloneIn};
 use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_ecmascript::{ArrayJoin, WithoutGlobalReferenceInformation};
 use oxc_span::SPAN;
@@ -9,26 +9,30 @@ fn test() {
     let ast = AstBuilder::new(&allocator);
     let ast = &ast;
 
-    let mut elements = ArenaVec::new_in(ast);
-    elements.push(ArrayExpressionElement::new_elision(SPAN, ast));
-    elements.push(ArrayExpressionElement::new_null_literal(SPAN, ast));
-    elements.push(ArrayExpressionElement::new_numeric_literal(
+    let array = ArrayExpression::new(
         SPAN,
-        42f64,
-        None,
-        NumberBase::Decimal,
+        [
+            ArrayExpressionElement::new_elision(SPAN, ast),
+            ArrayExpressionElement::new_null_literal(SPAN, ast),
+            ArrayExpressionElement::new_numeric_literal(
+                SPAN,
+                42f64,
+                None,
+                NumberBase::Decimal,
+                ast,
+            ),
+            ArrayExpressionElement::new_string_literal(SPAN, "foo", None, ast),
+            ArrayExpressionElement::new_boolean_literal(SPAN, true, ast),
+            ArrayExpressionElement::new_big_int_literal(
+                SPAN,
+                "42",
+                Some(Str::from("42n")),
+                BigintBase::Decimal,
+                ast,
+            ),
+        ],
         ast,
-    ));
-    elements.push(ArrayExpressionElement::new_string_literal(SPAN, "foo", None, ast));
-    elements.push(ArrayExpressionElement::new_boolean_literal(SPAN, true, ast));
-    elements.push(ArrayExpressionElement::new_big_int_literal(
-        SPAN,
-        "42",
-        Some(Str::from("42n")),
-        BigintBase::Decimal,
-        ast,
-    ));
-    let array = ArrayExpression::new(SPAN, elements, ast);
+    );
     let mut array2 = array.clone_in(&allocator);
     array2.elements.push(ArrayExpressionElement::ArrayExpression(ArenaBox::new_in(array, ast)));
     array2.elements.push(ArrayExpressionElement::new_object_expression(SPAN, [], ast));


### PR DESCRIPTION
Pure refactor. Just shorten code.

Replace pattern of creating a `Vec` and pushing to it repeatedly with just passing an array to the AST builder method.

This is shorter and more performant - though perf doesn't matter, because it's just in a test.