### PR TITLE
refactor(parser): shorten code constructing `ObjectPropertyKind`

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1222,7 +1222,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         };
 
         // Create the outer `with: { ... }` property
-        let with_property = ObjectProperty::boxed(
+        let with_property = ObjectPropertyKind::new_object_property(
             self.end_span(with_key_span),
             PropertyKind::Init,
             PropertyKey::StaticIdentifier(with_key),
@@ -1233,13 +1233,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self,
         );
 
-        let outer_property = ObjectPropertyKind::ObjectProperty(with_property);
-
         // Allow optional trailing comma: `{ with: { type: "json" }, }`
         let _ = self.eat(Kind::Comma);
 
         self.expect(Kind::RCurly);
-        ObjectExpression::boxed(self.end_span(span), [outer_property], self)
+        ObjectExpression::boxed(self.end_span(span), [with_property], self)
     }
 
     /// Parse TypeScript import type attributes object: `{ type: "json" }`


### PR DESCRIPTION
Pure refactor. Shorten code by using an AST builder method that creates the desired type directly, 