### PR TITLE
fix(allocator): `Vec::from_array_in` do not allocate zero-length array

### DIFF
--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -204,6 +204,10 @@ impl<'alloc, T> Vec<'alloc, T> {
     ) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
+        if N == 0 {
+            return Vec::new_in(allocator);
+        }
+
         let allocator = allocator.allocator();
         let boxed = Box::new_in(array, &allocator);
         let ptr = Box::into_non_null(boxed).as_ptr().cast::<T>();


### PR DESCRIPTION
`Vec::from_array_in` doesn't need to allocate when the array passed to it is zero-length.

This wasn't unsound as `Allocator` accepts zero-sized allocations, but it was pointless. Allocating a zero-sized type still aligns the bump cursor to the type's alignment, which is an allocation of sorts - it's not zero-cost.

Just delegate to `Vec::new_in` instead.