### PR TITLE
feat(linter/node): implement no-top-level-await rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1234,6 +1234,7 @@ export interface DummyRuleMap {
   "node/no-path-concat"?: RuleNoConfig;
   "node/no-process-env"?: RuleNoConfig | [AllowWarnDeny, NoProcessEnvConfig];
   "node/no-sync"?: RuleNoConfig | [AllowWarnDeny, NoSyncConfig];
+  "node/no-top-level-await"?: RuleNoConfig | [AllowWarnDeny, NoTopLevelAwaitConfig];
   "object-shorthand"?:
     RuleNoConfig | [AllowWarnDeny, ShorthandType] | [AllowWarnDeny, ShorthandType, ObjectShorthandOptions];
   "operator-assignment"?: RuleNoConfig | [AllowWarnDeny, AlwaysNever];
@@ -4045,6 +4046,14 @@ export interface NoSyncConfig {
    * Function names to ignore.
    */
   ignores?: string[];
+}
+export interface NoTopLevelAwaitConfig {
+  /**
+   * If `true`, top-level `await` is allowed in files that start with a
+   * hashbang (`#!`), which marks them as executable scripts rather than
+   * importable modules.
+   */
+  ignoreBin?: boolean;
 }
 export interface ObjectShorthandOptions {
   avoidExplicitReturnArrows?: boolean;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5085,11 +5085,8 @@ impl RuleRunner for crate::rules::node::no_sync::NoSync {
 }
 
 impl RuleRunner for crate::rules::node::no_top_level_await::NoTopLevelAwait {
-    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
-        AstType::AwaitExpression,
-        AstType::ForOfStatement,
-        AstType::VariableDeclaration,
-    ]));
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Program]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5084,6 +5084,15 @@ impl RuleRunner for crate::rules::node::no_sync::NoSync {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::node::no_top_level_await::NoTopLevelAwait {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AwaitExpression,
+        AstType::ForOfStatement,
+        AstType::VariableDeclaration,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner
     for crate::rules::vue::component_definition_name_casing::ComponentDefinitionNameCasing
 {

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5085,8 +5085,11 @@ impl RuleRunner for crate::rules::node::no_sync::NoSync {
 }
 
 impl RuleRunner for crate::rules::node::no_top_level_await::NoTopLevelAwait {
-    const NODE_TYPES: Option<&AstTypesBitset> =
-        Some(&AstTypesBitset::from_types(&[AstType::Program]));
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AwaitExpression,
+        AstType::ForOfStatement,
+        AstType::VariableDeclaration,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -376,6 +376,7 @@ pub use crate::rules::node::no_new_require::NoNewRequire as NodeNoNewRequire;
 pub use crate::rules::node::no_path_concat::NoPathConcat as NodeNoPathConcat;
 pub use crate::rules::node::no_process_env::NoProcessEnv as NodeNoProcessEnv;
 pub use crate::rules::node::no_sync::NoSync as NodeNoSync;
+pub use crate::rules::node::no_top_level_await::NoTopLevelAwait as NodeNoTopLevelAwait;
 pub use crate::rules::oxc::approx_constant::ApproxConstant as OxcApproxConstant;
 pub use crate::rules::oxc::bad_array_method_on_arguments::BadArrayMethodOnArguments as OxcBadArrayMethodOnArguments;
 pub use crate::rules::oxc::bad_bitwise_operator::BadBitwiseOperator as OxcBadBitwiseOperator;
@@ -1668,6 +1669,7 @@ pub enum RuleEnum {
     NodeNoPathConcat(NodeNoPathConcat),
     NodeNoProcessEnv(NodeNoProcessEnv),
     NodeNoSync(NodeNoSync),
+    NodeNoTopLevelAwait(NodeNoTopLevelAwait),
     VueComponentDefinitionNameCasing(VueComponentDefinitionNameCasing),
     VueDefineEmitsDeclaration(VueDefineEmitsDeclaration),
     VueDefinePropsDeclaration(VueDefinePropsDeclaration),
@@ -2614,7 +2616,8 @@ const NODE_NO_NEW_REQUIRE_ID: usize = NODE_NO_MIXED_REQUIRES_ID + 1usize;
 const NODE_NO_PATH_CONCAT_ID: usize = NODE_NO_NEW_REQUIRE_ID + 1usize;
 const NODE_NO_PROCESS_ENV_ID: usize = NODE_NO_PATH_CONCAT_ID + 1usize;
 const NODE_NO_SYNC_ID: usize = NODE_NO_PROCESS_ENV_ID + 1usize;
-const VUE_COMPONENT_DEFINITION_NAME_CASING_ID: usize = NODE_NO_SYNC_ID + 1usize;
+const NODE_NO_TOP_LEVEL_AWAIT_ID: usize = NODE_NO_SYNC_ID + 1usize;
+const VUE_COMPONENT_DEFINITION_NAME_CASING_ID: usize = NODE_NO_TOP_LEVEL_AWAIT_ID + 1usize;
 const VUE_DEFINE_EMITS_DECLARATION_ID: usize = VUE_COMPONENT_DEFINITION_NAME_CASING_ID + 1usize;
 const VUE_DEFINE_PROPS_DECLARATION_ID: usize = VUE_DEFINE_EMITS_DECLARATION_ID + 1usize;
 const VUE_DEFINE_PROPS_DESTRUCTURING_ID: usize = VUE_DEFINE_PROPS_DECLARATION_ID + 1usize;
@@ -3593,6 +3596,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(_) => NODE_NO_PATH_CONCAT_ID,
             Self::NodeNoProcessEnv(_) => NODE_NO_PROCESS_ENV_ID,
             Self::NodeNoSync(_) => NODE_NO_SYNC_ID,
+            Self::NodeNoTopLevelAwait(_) => NODE_NO_TOP_LEVEL_AWAIT_ID,
             Self::VueComponentDefinitionNameCasing(_) => VUE_COMPONENT_DEFINITION_NAME_CASING_ID,
             Self::VueDefineEmitsDeclaration(_) => VUE_DEFINE_EMITS_DECLARATION_ID,
             Self::VueDefinePropsDeclaration(_) => VUE_DEFINE_PROPS_DECLARATION_ID,
@@ -4554,6 +4558,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::NAME,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::NAME,
             Self::NodeNoSync(_) => NodeNoSync::NAME,
+            Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::NAME,
             Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::NAME,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::NAME,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::NAME,
@@ -5571,6 +5576,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::CATEGORY,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::CATEGORY,
             Self::NodeNoSync(_) => NodeNoSync::CATEGORY,
+            Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::CATEGORY,
             Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::CATEGORY,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::CATEGORY,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::CATEGORY,
@@ -6535,6 +6541,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::FIX,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::FIX,
             Self::NodeNoSync(_) => NodeNoSync::FIX,
+            Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::FIX,
             Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::FIX,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::FIX,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::FIX,
@@ -7749,6 +7756,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::documentation(),
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::documentation(),
             Self::NodeNoSync(_) => NodeNoSync::documentation(),
+            Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::documentation(),
             Self::VueComponentDefinitionNameCasing(_) => {
                 VueComponentDefinitionNameCasing::documentation()
             }
@@ -10110,6 +10118,8 @@ impl RuleEnum {
             Self::NodeNoSync(_) => {
                 NodeNoSync::config_schema(generator).or_else(|| NodeNoSync::schema(generator))
             }
+            Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::config_schema(generator)
+                .or_else(|| NodeNoTopLevelAwait::schema(generator)),
             Self::VueComponentDefinitionNameCasing(_) => {
                 VueComponentDefinitionNameCasing::config_schema(generator)
                     .or_else(|| VueComponentDefinitionNameCasing::schema(generator))
@@ -11047,6 +11057,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(_) => "node",
             Self::NodeNoProcessEnv(_) => "node",
             Self::NodeNoSync(_) => "node",
+            Self::NodeNoTopLevelAwait(_) => "node",
             Self::VueComponentDefinitionNameCasing(_) => "vue",
             Self::VueDefineEmitsDeclaration(_) => "vue",
             Self::VueDefinePropsDeclaration(_) => "vue",
@@ -13669,6 +13680,9 @@ impl RuleEnum {
                 Ok(Self::NodeNoProcessEnv(NodeNoProcessEnv::from_configuration(value)?))
             }
             Self::NodeNoSync(_) => Ok(Self::NodeNoSync(NodeNoSync::from_configuration(value)?)),
+            Self::NodeNoTopLevelAwait(_) => {
+                Ok(Self::NodeNoTopLevelAwait(NodeNoTopLevelAwait::from_configuration(value)?))
+            }
             Self::VueComponentDefinitionNameCasing(_) => {
                 Ok(Self::VueComponentDefinitionNameCasing(
                     VueComponentDefinitionNameCasing::from_configuration(value)?,
@@ -14620,6 +14634,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(rule) => rule.to_configuration(),
             Self::NodeNoProcessEnv(rule) => rule.to_configuration(),
             Self::NodeNoSync(rule) => rule.to_configuration(),
+            Self::NodeNoTopLevelAwait(rule) => rule.to_configuration(),
             Self::VueComponentDefinitionNameCasing(rule) => rule.to_configuration(),
             Self::VueDefineEmitsDeclaration(rule) => rule.to_configuration(),
             Self::VueDefinePropsDeclaration(rule) => rule.to_configuration(),
@@ -15468,6 +15483,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(rule) => rule.run(node, ctx),
             Self::NodeNoProcessEnv(rule) => rule.run(node, ctx),
             Self::NodeNoSync(rule) => rule.run(node, ctx),
+            Self::NodeNoTopLevelAwait(rule) => rule.run(node, ctx),
             Self::VueComponentDefinitionNameCasing(rule) => rule.run(node, ctx),
             Self::VueDefineEmitsDeclaration(rule) => rule.run(node, ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.run(node, ctx),
@@ -16328,6 +16344,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(rule) => rule.run_once(ctx),
             Self::NodeNoProcessEnv(rule) => rule.run_once(ctx),
             Self::NodeNoSync(rule) => rule.run_once(ctx),
+            Self::NodeNoTopLevelAwait(rule) => rule.run_once(ctx),
             Self::VueComponentDefinitionNameCasing(rule) => rule.run_once(ctx),
             Self::VueDefineEmitsDeclaration(rule) => rule.run_once(ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.run_once(ctx),
@@ -17301,6 +17318,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeNoProcessEnv(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeNoSync(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::NodeNoTopLevelAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueComponentDefinitionNameCasing(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueDefineEmitsDeclaration(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18166,6 +18184,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(rule) => rule.should_run(ctx),
             Self::NodeNoProcessEnv(rule) => rule.should_run(ctx),
             Self::NodeNoSync(rule) => rule.should_run(ctx),
+            Self::NodeNoTopLevelAwait(rule) => rule.should_run(ctx),
             Self::VueComponentDefinitionNameCasing(rule) => rule.should_run(ctx),
             Self::VueDefineEmitsDeclaration(rule) => rule.should_run(ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.should_run(ctx),
@@ -19375,6 +19394,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::IS_TSGOLINT_RULE,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::IS_TSGOLINT_RULE,
             Self::NodeNoSync(_) => NodeNoSync::IS_TSGOLINT_RULE,
+            Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::IS_TSGOLINT_RULE,
             Self::VueComponentDefinitionNameCasing(_) => {
                 VueComponentDefinitionNameCasing::IS_TSGOLINT_RULE
             }
@@ -20410,6 +20430,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::VERSION,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::VERSION,
             Self::NodeNoSync(_) => NodeNoSync::VERSION,
+            Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::VERSION,
             Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::VERSION,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::VERSION,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::VERSION,
@@ -21466,6 +21487,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::HAS_CONFIG,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::HAS_CONFIG,
             Self::NodeNoSync(_) => NodeNoSync::HAS_CONFIG,
+            Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::HAS_CONFIG,
             Self::VueComponentDefinitionNameCasing(_) => {
                 VueComponentDefinitionNameCasing::HAS_CONFIG
             }
@@ -22435,6 +22457,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::INFO,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::INFO,
             Self::NodeNoSync(_) => NodeNoSync::INFO,
+            Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::INFO,
             Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::INFO,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::INFO,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::INFO,
@@ -23291,6 +23314,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(rule) => rule.types_info(),
             Self::NodeNoProcessEnv(rule) => rule.types_info(),
             Self::NodeNoSync(rule) => rule.types_info(),
+            Self::NodeNoTopLevelAwait(rule) => rule.types_info(),
             Self::VueComponentDefinitionNameCasing(rule) => rule.types_info(),
             Self::VueDefineEmitsDeclaration(rule) => rule.types_info(),
             Self::VueDefinePropsDeclaration(rule) => rule.types_info(),
@@ -24138,6 +24162,7 @@ impl RuleEnum {
             Self::NodeNoPathConcat(rule) => rule.run_info(),
             Self::NodeNoProcessEnv(rule) => rule.run_info(),
             Self::NodeNoSync(rule) => rule.run_info(),
+            Self::NodeNoTopLevelAwait(rule) => rule.run_info(),
             Self::VueComponentDefinitionNameCasing(rule) => rule.run_info(),
             Self::VueDefineEmitsDeclaration(rule) => rule.run_info(),
             Self::VueDefinePropsDeclaration(rule) => rule.run_info(),
@@ -25117,6 +25142,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::NodeNoPathConcat(NodeNoPathConcat::default()),
         RuleEnum::NodeNoProcessEnv(NodeNoProcessEnv::default()),
         RuleEnum::NodeNoSync(NodeNoSync::default()),
+        RuleEnum::NodeNoTopLevelAwait(NodeNoTopLevelAwait::default()),
         RuleEnum::VueComponentDefinitionNameCasing(VueComponentDefinitionNameCasing::default()),
         RuleEnum::VueDefineEmitsDeclaration(VueDefineEmitsDeclaration::default()),
         RuleEnum::VueDefinePropsDeclaration(VueDefinePropsDeclaration::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -853,6 +853,7 @@ pub(crate) mod node {
     pub mod no_path_concat;
     pub mod no_process_env;
     pub mod no_sync;
+    pub mod no_top_level_await;
 }
 
 /// <https://github.com/vuejs/eslint-plugin-vue>

--- a/crates/oxc_linter/src/rules/node/no_top_level_await.rs
+++ b/crates/oxc_linter/src/rules/node/no_top_level_await.rs
@@ -1,0 +1,153 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn no_top_level_await_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Top-level `await` is forbidden in published modules.")
+        .with_help("Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct NoTopLevelAwaitConfig {
+    /// If `true`, top-level `await` is allowed in files that start with a
+    /// hashbang (`#!`), which marks them as executable scripts rather than
+    /// importable modules.
+    ignore_bin: bool,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct NoTopLevelAwait(Box<NoTopLevelAwaitConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows the use of top-level `await`, including `for await...of` loops
+    /// and `await using` declarations that are not nested inside a function.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Node.js v20.19 introduced `require(esm)`, but ES modules with top-level
+    /// `await` cannot be loaded with `require(esm)`. Avoiding top-level `await`
+    /// keeps a published module loadable from both CommonJS `require()` and ESM
+    /// `import`.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const foo = await import('foo');
+    ///
+    /// for await (const e of asyncIterate()) {
+    ///     // ...
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// async function fn() {
+    ///     const foo = await import('foo');
+    /// }
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// #### ignoreBin
+    ///
+    /// `{ type: boolean, default: false }`
+    ///
+    /// When set to `true`, top-level `await` is allowed in files that begin with
+    /// a hashbang (`#!`), since those are executable scripts rather than
+    /// importable modules.
+    ///
+    /// Example of **correct** code for this rule with `{ "ignoreBin": true }`:
+    /// ```js
+    /// #!/usr/bin/env node
+    /// const foo = await import('foo');
+    /// ```
+    NoTopLevelAwait,
+    node,
+    restriction,
+    config = NoTopLevelAwaitConfig,
+    version = "next",
+    short_description = "Disallow top-level `await` in published modules.",
+);
+
+impl Rule for NoTopLevelAwait {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let span = match node.kind() {
+            AstKind::AwaitExpression(await_expr) => await_expr.span,
+            AstKind::ForOfStatement(for_of) if for_of.r#await => for_of.span,
+            AstKind::VariableDeclaration(decl) if decl.kind.is_await() => decl.span,
+            _ => return,
+        };
+
+        // Only report when not nested inside a function (i.e. top-level).
+        if ctx
+            .nodes()
+            .ancestor_kinds(node.id())
+            .any(|kind| matches!(kind, AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)))
+        {
+            return;
+        }
+
+        // `ignoreBin`: skip executable scripts that start with a hashbang.
+        if self.0.ignore_bin && ctx.source_text().starts_with("#!") {
+            return;
+        }
+
+        ctx.diagnostic(no_top_level_await_diagnostic(span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("import * as foo from 'foo'", None),
+        ("for (const e of iterate()) { /* ... */ }", None),
+        ("async function fn () { const foo = await import('foo') }", None),
+        ("async function fn () { for await (const e of asyncIterate()) { /* ... */ } }", None),
+        ("const fn = async () => await import('foo')", None),
+        ("const fn = async () => { for await (const e of asyncIterate()) { /* ... */ } }", None),
+        ("async function f() { await using foo = x }", None),
+        (
+            "#!/usr/bin/env node\nconst foo = await import('foo')",
+            Some(serde_json::json!([{ "ignoreBin": true }])),
+        ),
+        (
+            "#!/usr/bin/env node\nfor await (const e of asyncIterate()) { /* ... */ }",
+            Some(serde_json::json!([{ "ignoreBin": true }])),
+        ),
+    ];
+
+    let fail = vec![
+        ("const foo = await import('foo')", None),
+        ("for await (const e of asyncIterate()) { /* ... */ }", None),
+        ("await using foo = x", None),
+        // `ignoreBin` without a hashbang still reports.
+        ("const foo = await import('foo')", Some(serde_json::json!([{ "ignoreBin": true }]))),
+        // A hashbang without `ignoreBin` still reports.
+        ("#!/usr/bin/env node\nconst foo = await import('foo')", None),
+    ];
+
+    // Top-level `await` is only valid in ES modules, so parse the fixtures as modules.
+    Tester::new(NoTopLevelAwait::NAME, NoTopLevelAwait::PLUGIN, pass, fail)
+        .change_rule_path_extension("mts")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/node/no_top_level_await.rs
+++ b/crates/oxc_linter/src/rules/node/no_top_level_await.rs
@@ -27,7 +27,7 @@ struct NoTopLevelAwaitConfig {
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
-pub struct NoTopLevelAwait(Box<NoTopLevelAwaitConfig>);
+pub struct NoTopLevelAwait(NoTopLevelAwaitConfig);
 
 declare_oxc_lint!(
     /// ### What it does

--- a/crates/oxc_linter/src/rules/node/no_top_level_await.rs
+++ b/crates/oxc_linter/src/rules/node/no_top_level_await.rs
@@ -1,13 +1,6 @@
-use oxc_ast::{
-    AstKind,
-    ast::{
-        ArrowFunctionExpression, AwaitExpression, ForOfStatement, Function, VariableDeclaration,
-    },
-};
-use oxc_ast_visit::{Visit, walk};
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::ScopeFlags;
 use oxc_span::Span;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -80,60 +73,29 @@ impl Rule for NoTopLevelAwait {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::Program(program) = node.kind() else {
-            return;
+        let span = match node.kind() {
+            AstKind::AwaitExpression(await_expr) => await_expr.span,
+            AstKind::ForOfStatement(for_of) if for_of.r#await => for_of.span,
+            AstKind::VariableDeclaration(decl) if decl.kind.is_await() => decl.span,
+            _ => return,
         };
+
+        // Only report when not nested inside a function (i.e. top-level).
+        if ctx
+            .nodes()
+            .ancestor_kinds(node.id())
+            .any(|kind| matches!(kind, AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)))
+        {
+            return;
+        }
 
         // `ignoreBin`: skip executable scripts that start with a hashbang.
         if self.0.ignore_bin && ctx.source_text().starts_with("#!") {
             return;
         }
 
-        // Top-level `await` can only appear outside of any function, so walk just
-        // the top-level code and stop descending at every function boundary. This
-        // keeps the rule off the per-node dispatch path for the ubiquitous
-        // `VariableDeclaration` and `ForOfStatement` nodes (most of which live
-        // inside functions); we visit only the small slice of code that can
-        // actually hold a top-level `await`.
-        let mut visitor = TopLevelAwaitVisitor { spans: vec![] };
-        visitor.visit_program(program);
-
-        for span in visitor.spans {
-            ctx.diagnostic(no_top_level_await_diagnostic(span));
-        }
+        ctx.diagnostic(no_top_level_await_diagnostic(span));
     }
-}
-
-/// Collects the spans of top-level `await` expressions, `for await...of` loops,
-/// and `await using` declarations. Recursion stops at function boundaries, so
-/// everything it visits is guaranteed to be top-level.
-struct TopLevelAwaitVisitor {
-    spans: Vec<Span>,
-}
-
-impl<'a> Visit<'a> for TopLevelAwaitVisitor {
-    fn visit_await_expression(&mut self, expr: &AwaitExpression<'a>) {
-        self.spans.push(expr.span);
-        walk::walk_await_expression(self, expr);
-    }
-
-    fn visit_for_of_statement(&mut self, stmt: &ForOfStatement<'a>) {
-        if stmt.r#await {
-            self.spans.push(stmt.span);
-        }
-        walk::walk_for_of_statement(self, stmt);
-    }
-
-    fn visit_variable_declaration(&mut self, decl: &VariableDeclaration<'a>) {
-        if decl.kind.is_await() {
-            self.spans.push(decl.span);
-        }
-        walk::walk_variable_declaration(self, decl);
-    }
-
-    // Do not descend into functions — their contents are not top-level.
-    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
-    fn visit_arrow_function_expression(&mut self, _func: &ArrowFunctionExpression<'a>) {}
 }
 
 #[test]
@@ -181,9 +143,6 @@ fn test() {
         ("if (cond) { await import('foo') }", None),
         ("for (const e of iterate()) { await handle(e) }", None),
         ("{ await using foo = x }", None),
-        // `await` reached through export declarations is still top-level.
-        ("export const foo = await import('foo')", None),
-        ("export default await import('foo')", None),
         // `ignoreBin` without a hashbang still reports.
         ("const foo = await import('foo')", Some(serde_json::json!([{ "ignoreBin": true }]))),
         // A hashbang without `ignoreBin` still reports.

--- a/crates/oxc_linter/src/rules/node/no_top_level_await.rs
+++ b/crates/oxc_linter/src/rules/node/no_top_level_await.rs
@@ -66,22 +66,6 @@ declare_oxc_lint!(
     ///     const foo = await import('foo');
     /// }
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// #### ignoreBin
-    ///
-    /// `{ type: boolean, default: false }`
-    ///
-    /// When set to `true`, top-level `await` is allowed in files that begin with
-    /// a hashbang (`#!`), since those are executable scripts rather than
-    /// importable modules.
-    ///
-    /// Example of **correct** code for this rule with `{ "ignoreBin": true }`:
-    /// ```js
-    /// #!/usr/bin/env node
-    /// const foo = await import('foo');
-    /// ```
     NoTopLevelAwait,
     node,
     restriction,

--- a/crates/oxc_linter/src/rules/node/no_top_level_await.rs
+++ b/crates/oxc_linter/src/rules/node/no_top_level_await.rs
@@ -1,6 +1,13 @@
-use oxc_ast::AstKind;
+use oxc_ast::{
+    AstKind,
+    ast::{
+        ArrowFunctionExpression, AwaitExpression, ForOfStatement, Function, VariableDeclaration,
+    },
+};
+use oxc_ast_visit::{Visit, walk};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
+use oxc_semantic::ScopeFlags;
 use oxc_span::Span;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -89,29 +96,60 @@ impl Rule for NoTopLevelAwait {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let span = match node.kind() {
-            AstKind::AwaitExpression(await_expr) => await_expr.span,
-            AstKind::ForOfStatement(for_of) if for_of.r#await => for_of.span,
-            AstKind::VariableDeclaration(decl) if decl.kind.is_await() => decl.span,
-            _ => return,
-        };
-
-        // Only report when not nested inside a function (i.e. top-level).
-        if ctx
-            .nodes()
-            .ancestor_kinds(node.id())
-            .any(|kind| matches!(kind, AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)))
-        {
+        let AstKind::Program(program) = node.kind() else {
             return;
-        }
+        };
 
         // `ignoreBin`: skip executable scripts that start with a hashbang.
         if self.0.ignore_bin && ctx.source_text().starts_with("#!") {
             return;
         }
 
-        ctx.diagnostic(no_top_level_await_diagnostic(span));
+        // Top-level `await` can only appear outside of any function, so walk just
+        // the top-level code and stop descending at every function boundary. This
+        // keeps the rule off the per-node dispatch path for the ubiquitous
+        // `VariableDeclaration` and `ForOfStatement` nodes (most of which live
+        // inside functions); we visit only the small slice of code that can
+        // actually hold a top-level `await`.
+        let mut visitor = TopLevelAwaitVisitor { spans: vec![] };
+        visitor.visit_program(program);
+
+        for span in visitor.spans {
+            ctx.diagnostic(no_top_level_await_diagnostic(span));
+        }
     }
+}
+
+/// Collects the spans of top-level `await` expressions, `for await...of` loops,
+/// and `await using` declarations. Recursion stops at function boundaries, so
+/// everything it visits is guaranteed to be top-level.
+struct TopLevelAwaitVisitor {
+    spans: Vec<Span>,
+}
+
+impl<'a> Visit<'a> for TopLevelAwaitVisitor {
+    fn visit_await_expression(&mut self, expr: &AwaitExpression<'a>) {
+        self.spans.push(expr.span);
+        walk::walk_await_expression(self, expr);
+    }
+
+    fn visit_for_of_statement(&mut self, stmt: &ForOfStatement<'a>) {
+        if stmt.r#await {
+            self.spans.push(stmt.span);
+        }
+        walk::walk_for_of_statement(self, stmt);
+    }
+
+    fn visit_variable_declaration(&mut self, decl: &VariableDeclaration<'a>) {
+        if decl.kind.is_await() {
+            self.spans.push(decl.span);
+        }
+        walk::walk_variable_declaration(self, decl);
+    }
+
+    // Do not descend into functions — their contents are not top-level.
+    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
+    fn visit_arrow_function_expression(&mut self, _func: &ArrowFunctionExpression<'a>) {}
 }
 
 #[test]
@@ -159,6 +197,9 @@ fn test() {
         ("if (cond) { await import('foo') }", None),
         ("for (const e of iterate()) { await handle(e) }", None),
         ("{ await using foo = x }", None),
+        // `await` reached through export declarations is still top-level.
+        ("export const foo = await import('foo')", None),
+        ("export default await import('foo')", None),
         // `ignoreBin` without a hashbang still reports.
         ("const foo = await import('foo')", Some(serde_json::json!([{ "ignoreBin": true }]))),
         // A hashbang without `ignoreBin` still reports.

--- a/crates/oxc_linter/src/rules/node/no_top_level_await.rs
+++ b/crates/oxc_linter/src/rules/node/no_top_level_await.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
     ///
     /// Node.js v20.19 introduced `require(esm)`, but ES modules with top-level
     /// `await` cannot be loaded with `require(esm)`. Avoiding top-level `await`
-    /// keeps a published module loadable from both CommonJS `require()` and ESM
+    /// keeps a module loadable from both CommonJS `require()` and ESM
     /// `import`.
     ///
     /// ### Examples
@@ -64,7 +64,7 @@ declare_oxc_lint!(
     restriction,
     config = NoTopLevelAwaitConfig,
     version = "next",
-    short_description = "Disallow top-level `await` in published modules.",
+    short_description = "Disallow top-level `await` in modules.",
 );
 
 impl Rule for NoTopLevelAwait {

--- a/crates/oxc_linter/src/rules/node/no_top_level_await.rs
+++ b/crates/oxc_linter/src/rules/node/no_top_level_await.rs
@@ -121,11 +121,19 @@ fn test() {
     let pass = vec![
         ("import * as foo from 'foo'", None),
         ("for (const e of iterate()) { /* ... */ }", None),
+        // Plain `using` (without `await`) is not top-level `await`.
+        ("using foo = x", None),
+        // `await` nested inside any function form is allowed.
         ("async function fn () { const foo = await import('foo') }", None),
         ("async function fn () { for await (const e of asyncIterate()) { /* ... */ } }", None),
         ("const fn = async () => await import('foo')", None),
         ("const fn = async () => { for await (const e of asyncIterate()) { /* ... */ } }", None),
         ("async function f() { await using foo = x }", None),
+        ("class A { async foo () { const bar = await import('bar') } }", None),
+        ("const o = { async foo () { const bar = await import('bar') } }", None),
+        // A top-level `await` inside a nested function is allowed even when the
+        // outer function is not async.
+        ("function outer () { return async function () { await import('foo') } }", None),
         (
             "#!/usr/bin/env node\nconst foo = await import('foo')",
             Some(serde_json::json!([{ "ignoreBin": true }])),
@@ -134,12 +142,23 @@ fn test() {
             "#!/usr/bin/env node\nfor await (const e of asyncIterate()) { /* ... */ }",
             Some(serde_json::json!([{ "ignoreBin": true }])),
         ),
+        (
+            "#!/usr/bin/env node\nawait using foo = x",
+            Some(serde_json::json!([{ "ignoreBin": true }])),
+        ),
     ];
 
     let fail = vec![
         ("const foo = await import('foo')", None),
+        // A bare top-level `await` expression statement (not inside a declaration).
+        ("await import('foo')", None),
         ("for await (const e of asyncIterate()) { /* ... */ }", None),
         ("await using foo = x", None),
+        // `await` nested in non-function statements (block, `if`, loop) is still top-level.
+        ("{ await import('foo') }", None),
+        ("if (cond) { await import('foo') }", None),
+        ("for (const e of iterate()) { await handle(e) }", None),
+        ("{ await using foo = x }", None),
         // `ignoreBin` without a hashbang still reports.
         ("const foo = await import('foo')", Some(serde_json::json!([{ "ignoreBin": true }]))),
         // A hashbang without `ignoreBin` still reports.

--- a/crates/oxc_linter/src/snapshots/node_no_top_level_await.snap
+++ b/crates/oxc_linter/src/snapshots/node_no_top_level_await.snap
@@ -59,6 +59,20 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
 
   ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+   ╭─[no_top_level_await.mts:1:20]
+ 1 │ export const foo = await import('foo')
+   ·                    ───────────────────
+   ╰────
+  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+
+  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+   ╭─[no_top_level_await.mts:1:16]
+ 1 │ export default await import('foo')
+   ·                ───────────────────
+   ╰────
+  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+
+  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
    ╭─[no_top_level_await.mts:1:13]
  1 │ const foo = await import('foo')
    ·             ───────────────────

--- a/crates/oxc_linter/src/snapshots/node_no_top_level_await.snap
+++ b/crates/oxc_linter/src/snapshots/node_no_top_level_await.snap
@@ -11,6 +11,13 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
    ╭─[no_top_level_await.mts:1:1]
+ 1 │ await import('foo')
+   · ───────────────────
+   ╰────
+  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+
+  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+   ╭─[no_top_level_await.mts:1:1]
  1 │ for await (const e of asyncIterate()) { /* ... */ }
    · ───────────────────────────────────────────────────
    ╰────
@@ -20,6 +27,34 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_top_level_await.mts:1:1]
  1 │ await using foo = x
    · ───────────────────
+   ╰────
+  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+
+  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+   ╭─[no_top_level_await.mts:1:3]
+ 1 │ { await import('foo') }
+   ·   ───────────────────
+   ╰────
+  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+
+  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+   ╭─[no_top_level_await.mts:1:13]
+ 1 │ if (cond) { await import('foo') }
+   ·             ───────────────────
+   ╰────
+  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+
+  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+   ╭─[no_top_level_await.mts:1:30]
+ 1 │ for (const e of iterate()) { await handle(e) }
+   ·                              ───────────────
+   ╰────
+  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+
+  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+   ╭─[no_top_level_await.mts:1:3]
+ 1 │ { await using foo = x }
+   ·   ───────────────────
    ╰────
   help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
 

--- a/crates/oxc_linter/src/snapshots/node_no_top_level_await.snap
+++ b/crates/oxc_linter/src/snapshots/node_no_top_level_await.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+   ╭─[no_top_level_await.mts:1:13]
+ 1 │ const foo = await import('foo')
+   ·             ───────────────────
+   ╰────
+  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+
+  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+   ╭─[no_top_level_await.mts:1:1]
+ 1 │ for await (const e of asyncIterate()) { /* ... */ }
+   · ───────────────────────────────────────────────────
+   ╰────
+  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+
+  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+   ╭─[no_top_level_await.mts:1:1]
+ 1 │ await using foo = x
+   · ───────────────────
+   ╰────
+  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+
+  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+   ╭─[no_top_level_await.mts:1:13]
+ 1 │ const foo = await import('foo')
+   ·             ───────────────────
+   ╰────
+  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+
+  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+   ╭─[no_top_level_await.mts:2:13]
+ 1 │ #!/usr/bin/env node
+ 2 │ const foo = await import('foo')
+   ·             ───────────────────
+   ╰────
+  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.

--- a/crates/oxc_linter/src/snapshots/node_no_top_level_await.snap
+++ b/crates/oxc_linter/src/snapshots/node_no_top_level_await.snap
@@ -59,20 +59,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
 
   ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
-   ╭─[no_top_level_await.mts:1:20]
- 1 │ export const foo = await import('foo')
-   ·                    ───────────────────
-   ╰────
-  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
-
-  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
-   ╭─[no_top_level_await.mts:1:16]
- 1 │ export default await import('foo')
-   ·                ───────────────────
-   ╰────
-  help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
-
-  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
    ╭─[no_top_level_await.mts:1:13]
  1 │ const foo = await import('foo')
    ·             ───────────────────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -5726,6 +5726,26 @@
             }
           ]
         },
+        "node/no-top-level-await": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/NoTopLevelAwaitConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "object-shorthand": {
           "anyOf": [
             {
@@ -15349,6 +15369,18 @@
           },
           "uniqueItems": true,
           "markdownDescription": "An array of variable names that are allowed to alias `this`."
+        }
+      },
+      "additionalProperties": false
+    },
+    "NoTopLevelAwaitConfig": {
+      "type": "object",
+      "properties": {
+        "ignoreBin": {
+          "description": "If `true`, top-level `await` is allowed in files that start with a\nhashbang (`#!`), which marks them as executable scripts rather than\nimportable modules.",
+          "default": false,
+          "type": "boolean",
+          "markdownDescription": "If `true`, top-level `await` is allowed in files that start with a\nhashbang (`#!`), which marks them as executable scripts rather than\nimportable modules."
         }
       },
       "additionalProperties": false

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -362,6 +362,7 @@ node/no-new-require                                        |   1421
 node/no-path-concat                                        |  21217
 node/no-process-env                                        |  94090
 node/no-sync                                               |  62606
+node/no-top-level-await                                    |  32314
 oxc/approx-constant                                        |  14295
 oxc/bad-array-method-on-arguments                          |  94090
 oxc/bad-bitwise-operator                                   |  33609


### PR DESCRIPTION
This implements [`no-top-level-await`](https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-top-level-await.md) from the Node ESLint plugin (#493).

AI Disclosure: Generated with Claude Code. Reviewed and tested by me.

I have an alternative implementation using a Program visitor but it made no difference performance-wise on vscode or in benchmarking outside extreme cases, so I don't think it's really worth the trouble vs the simpler implementation here. It's still in the commit history if that implementation is preferred.

There is one notable difference between this and the original implementation, which is that the `convertPath` option is not implemented, and the checking of `package.json`/`.npmignore` is not implemented (it was used for checking if the given module was actually exposed in the library) as there's no way to check against those in oxlint. There's an argument to be made that this makes the rule not worth implementing, and I'm open to that argument if we'd prefer to mark this rule as unsupported instead.

All tests were ported from the original rule (excluding those reliant on the mentioned config options/checks that were skipped). I've also had Claude add a few additional test cases (see commit 40418f7e635e6ba6d98ff80b17f8e895428ad8f3) on top to cover behavior that wasn't tested previously. I have confirmed that all of these tests are identical to the behavior of the upstream rule, but I can remove them if we don't want to have any divergence from the upstream test suite.