### PR TITLE
docs(linter): Mark `n/no-unpublished-bin` and `vue/prefer-v-model` as unsupported.

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -57,6 +57,9 @@
     "import/order": "Not implementing this in Oxlint as its behavior is covered very well by [Oxfmt's import sorting](https://oxc.rs/docs/guide/usage/formatter/sorting.html).",
     "unicorn/template-indent": "Stylistic rule.",
     "unicorn/no-non-function-verb-prefix": "Requires type information. Not currently possible to implement in oxlint.",
+    "unicorn/prefer-json-parse-buffer": "Deprecated.",
+    "unicorn/prevent-abbreviations": "Deprecated.",
+    "unicorn/better-regex": "Deprecated.",
 
     "jsdoc/type-formatting": "Experimental rule in the original plugin, may reconsider once stable.",
     "jsdoc/convert-to-jsdoc-comments": "Experimental rule in the original plugin, may reconsider once stable.",

--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -359,6 +359,7 @@
     "vue/prefer-separate-static-class": "Not currently possible, as it requires Vue template parsing.",
     "vue/prefer-template": "Not currently possible, as it requires Vue template parsing.",
     "vue/prefer-true-attribute-shorthand": "Not currently possible, as it requires Vue template parsing.",
+    "vue/prefer-v-model": "Not currently possible, as it requires Vue template parsing.",
     "vue/quote-props": "Stylistic rule.",
     "vue/require-component-is": "Not currently possible, as it requires Vue template parsing.",
     "vue/require-explicit-emits": "Not currently possible, as it requires Vue template parsing.",

--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -53,6 +53,7 @@
     "n/prefer-global/timers": "No need to implement, the same policy can be enforced with generic restriction rules such as `no-restricted-imports` and `no-restricted-globals`.",
     "n/prefer-global/url": "No need to implement, the same policy can be enforced with generic restriction rules such as `no-restricted-imports` and `no-restricted-globals`.",
     "n/prefer-global/url-search-params": "No need to implement, the same policy can be enforced with generic restriction rules such as `no-restricted-imports` and `no-restricted-globals`.",
+    "n/no-unpublished-bin": "No support for this rule in Oxlint, as it requires knowledge of the package.json file and its `bin` field.",
     "import/order": "Not implementing this in Oxlint as its behavior is covered very well by [Oxfmt's import sorting](https://oxc.rs/docs/guide/usage/formatter/sorting.html).",
     "unicorn/template-indent": "Stylistic rule.",
     "unicorn/no-non-function-verb-prefix": "Requires type information. Not currently possible to implement in oxlint.",


### PR DESCRIPTION
We can't parse package.json as part of a rule, and it's not relevant on npm >=10 anyway.

https://github.com/eslint-community/eslint-plugin-n/blob/HEAD/docs/rules/no-unpublished-bin.md

Also mark `vue/prefer-v-model` as unsupported because it requires Vue template parsing.