### PR TITLE
refactor(minifier): model symbol effects explicitly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,7 +2262,6 @@ dependencies = [
 name = "oxc_minifier"
 version = "0.140.0"
 dependencies = [
- "bitflags",
  "cow-utils",
  "insta",
  "itoa",

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -35,8 +35,6 @@ oxc_span = { workspace = true }
 oxc_str = { workspace = true }
 oxc_syntax = { workspace = true }
 oxc_traverse = { workspace = true }
-
-bitflags = { workspace = true }
 cow-utils = { workspace = true }
 itoa = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/oxc_minifier/src/peephole/minimize_logical_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_logical_expression.rs
@@ -4,7 +4,7 @@ use oxc_compat::ESFeature;
 use oxc_semantic::ReferenceFlags;
 use oxc_span::{ContentEq, GetSpan, SPAN};
 
-use crate::{TraverseCtx, symbol_facts::SymbolFact};
+use crate::{TraverseCtx, symbol_facts::MemberWriteEffect};
 
 use super::PeepholeOptimizations;
 
@@ -315,7 +315,7 @@ impl<'a> PeepholeOptimizations {
         if let Expression::Identifier(ident) = object.get_inner_expression()
             && let Some(symbol_id) = ctx.scoping().get_reference(ident.reference_id()).symbol_id()
         {
-            ctx.state.symbol_facts.insert(symbol_id, SymbolFact::MEMBER_WRITE_HAZARD);
+            ctx.state.symbol_facts.record(symbol_id, MemberWriteEffect::Hazard);
         }
     }
 }

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -11,7 +11,7 @@ use oxc_syntax::scope::ScopeFlags;
 use super::PeepholeOptimizations;
 use crate::{
     ReusableTraverseCtx, Traverse, TraverseCtx, minifier_traverse::traverse_mut_with_ctx,
-    symbol_facts::SymbolFact, symbol_liveness,
+    symbol_facts::MemberWriteEffect, symbol_liveness,
 };
 
 #[derive(Default)]
@@ -599,26 +599,26 @@ impl<'a> Normalize {
     /// `MinifierState::symbol_facts`. `object` is the member expression's object;
     /// walking it to the base identifier determines the chain depth.
     ///
-    /// Sets `MEMBER_WRITE_HAZARD` iff the op reads the property
+    /// Records a member-write hazard iff the op reads the property
     /// (`is_read_modify`), the write is chained (`a.b.c = 1` — dropping the
     /// intermediate `a.b = {}` would throw), or the key may be `"__proto__"` or a
     /// non-literal computed value (`key_is_unsafe` — the write may install
     /// setters).
     ///
-    /// Additionally sets `PROTO_WRITTEN` for the same unsafe keys — a purely
-    /// syntactic fact; the sole-reference exemption is applied at the consumer
-    /// (`is_member_assign_to_unused_binding`), where the reference count is
-    /// current rather than frozen at seed time.
+    /// Unsafe keys record the stronger `MayMutatePrototype` state — a purely
+    /// syntactic effect. The sole-reference exemption is applied at the
+    /// consumer (`is_member_assign_to_unused_binding`), where the reference
+    /// count is current rather than frozen at seed time.
     fn record_member_write_hazard(
         object: &Expression<'a>,
         key_is_unsafe: bool,
         is_read_modify: bool,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        // In DCE mode only `PROTO_WRITTEN` has a live consumer (the opt-in
-        // drop); `MEMBER_WRITE_HAZARD`'s default-path reader is full-minify
-        // only. Skip hazard-only work (safe-key read-modify ops, chained
-        // writes, chained deletes) before walking the chain.
+        // In DCE mode only possible prototype mutation has a live consumer
+        // (the opt-in drop); the default hazard reader is full-minify only.
+        // Skip hazard-only work (safe-key read-modify ops, chained writes,
+        // chained deletes) before walking the chain.
         if ctx.state.dce && !key_is_unsafe {
             return;
         }
@@ -644,11 +644,12 @@ impl<'a> Normalize {
         let Some(symbol_id) = ctx.scoping().get_reference(base.reference_id()).symbol_id() else {
             return;
         };
-        let mut facts = SymbolFact::MEMBER_WRITE_HAZARD;
-        if key_is_unsafe {
-            facts |= SymbolFact::PROTO_WRITTEN;
-        }
-        ctx.state.symbol_facts.insert(symbol_id, facts);
+        let effect = if key_is_unsafe {
+            MemberWriteEffect::MayMutatePrototype
+        } else {
+            MemberWriteEffect::Hazard
+        };
+        ctx.state.symbol_facts.record(symbol_id, effect);
     }
 
     fn remove_unused_use_strict_directive(body: &mut FunctionBody<'a>, ctx: &TraverseCtx<'a>) {

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -2,13 +2,10 @@ use crate::generated::ancestor::Ancestor;
 use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::ast::*;
 use oxc_ast_visit::VisitJs;
-use oxc_ecmascript::{
-    constant_evaluation::{ConstantEvaluation, ConstantValue},
-    side_effects::MayHaveSideEffects,
-};
+use oxc_ecmascript::{constant_evaluation::ConstantEvaluation, side_effects::MayHaveSideEffects};
 use oxc_span::GetSpan;
 
-use crate::{TraverseCtx, keep_var::KeepVar};
+use crate::{TraverseCtx, keep_var::KeepVar, state::FunctionSummary};
 
 use super::PeepholeOptimizations;
 
@@ -498,13 +495,18 @@ impl<'a> PeepholeOptimizations {
         let Some(symbol_id) = id.and_then(|id| id.symbol_id.get()) else { return };
         let binding_scope_id = ctx.scoping().symbol_scope_id(symbol_id);
         let binding_scope_flags = ctx.scoping().scope_flags(binding_scope_id);
-        // These bindings can be replaced without producing a resolved write
-        // reference: redeclarations are span-only in semantic, direct eval can
-        // assign through the scope chain, and Script globals alias properties
-        // of the global object. A different function may therefore win at
-        // runtime even when this declaration is pure.
-        if !ctx.scoping().symbol_redeclarations(symbol_id).is_empty()
-            || binding_scope_flags.contains_direct_eval()
+        // Redeclarations are span-only in semantic and create no references,
+        // so the read-only-reference check below cannot see them. A different
+        // declaration of the same symbol may be impure and win at runtime.
+        if !ctx.scoping().symbol_redeclarations(symbol_id).is_empty() {
+            ctx.state.pure_functions.remove(&symbol_id);
+            return;
+        }
+        // Direct eval and Script global properties can replace the binding
+        // without producing a resolved write reference. Discard any summary
+        // from an earlier pass; removing the last eval may make the binding
+        // safe later, while Script roots are rejected again on every pass.
+        if binding_scope_flags.contains_direct_eval()
             || (ctx.source_type().is_script() && binding_scope_id == ctx.scoping().root_scope_id())
         {
             ctx.state.pure_functions.remove(&symbol_id);
@@ -513,7 +515,11 @@ impl<'a> PeepholeOptimizations {
         if ctx.scoping().get_resolved_references(symbol_id).all(|r| r.flags().is_read_only()) {
             ctx.state.pure_functions.insert(
                 symbol_id,
-                if body.is_empty() { Some(ConstantValue::Undefined) } else { None },
+                if body.is_empty() {
+                    FunctionSummary::SideEffectFreeReturnsUndefined
+                } else {
+                    FunctionSummary::SideEffectFree
+                },
             );
         }
     }
@@ -523,10 +529,11 @@ impl<'a> PeepholeOptimizations {
         if let Expression::Identifier(ident) = &e.callee {
             let reference_id = ident.reference_id();
             if let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id()
-                && matches!(
-                    ctx.state.pure_functions.get(&symbol_id),
-                    Some(Some(ConstantValue::Undefined))
-                )
+                && ctx
+                    .state
+                    .pure_functions
+                    .get(&symbol_id)
+                    .is_some_and(|summary| summary.returns_undefined())
             {
                 let mut exprs = Self::fold_arguments_into_needed_expressions(&mut e.arguments, ctx);
                 if exprs.is_empty() {

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -1,8 +1,7 @@
 use std::iter;
 
 use crate::{
-    CompressOptionsUnused, TraverseCtx, generated::ancestor::Ancestor, symbol_facts::SymbolFact,
-    symbol_value::FreshValueKind,
+    CompressOptionsUnused, TraverseCtx, generated::ancestor::Ancestor, symbol_value::FreshValueKind,
 };
 use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::ast::*;
@@ -664,7 +663,10 @@ impl<'a> PeepholeOptimizations {
                     && let Some(symbol_id) =
                         ctx.scoping().get_reference(id.reference_id()).symbol_id()
                 {
-                    ctx.state.pure_functions.contains_key(&symbol_id)
+                    ctx.state
+                        .pure_functions
+                        .get(&symbol_id)
+                        .is_some_and(|summary| summary.is_side_effect_free())
                 } else {
                     false
                 })
@@ -798,7 +800,7 @@ impl<'a> PeepholeOptimizations {
     ///   `=` write to a safe single-level member of a provably-unused fresh
     ///   local is unobservable (terser parity) — unless the symbol carries a
     ///   member-write hazard (compound/update/chained ops, potential
-    ///   `__proto__` setters) — the `MEMBER_WRITE_HAZARD` fact in
+    ///   `__proto__` setters) — the persistent member-write effect in
     ///   `MinifierState::symbol_facts`. See `docs/ASSUMPTIONS.md`.
     fn remove_unused_member_assignment(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         if Self::is_script_root_scope(ctx) {
@@ -850,7 +852,7 @@ impl<'a> PeepholeOptimizations {
         }
         // Program-wide, execution-order-independent hazards: another member op
         // on this symbol reads the property or may install setters.
-        if ctx.state.symbol_facts.has(symbol_id, SymbolFact::MEMBER_WRITE_HAZARD) {
+        if ctx.state.symbol_facts.effect(symbol_id).is_hazardous() {
             return false;
         }
         if !assign_expr.right.may_have_side_effects(ctx) {
@@ -971,13 +973,13 @@ impl<'a> PeepholeOptimizations {
     /// 4. No `__proto__` write may have installed a setter that another
     ///    reference could trigger
     fn is_member_assign_to_unused_binding(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
-        // A potential `__proto__` write anywhere in the program (`PROTO_WRITTEN`
-        // is seeded by `Normalize`, so traversal order doesn't matter) may have
-        // installed a setter that a sibling property write triggers. Bail while
+        // A potential `__proto__` write anywhere in the program is recorded by
+        // Normalize, so traversal order does not matter. It may have installed
+        // a setter that a sibling property write triggers. Bail while
         // any OTHER reference exists; when the candidate is the symbol's only
         // remaining reference, it either is the proto write itself or the proto
         // write is already gone, so no setter can ever fire.
-        if ctx.state.symbol_facts.has(symbol_id, SymbolFact::PROTO_WRITTEN)
+        if ctx.state.symbol_facts.effect(symbol_id).may_mutate_prototype()
             && ctx.scoping().get_resolved_reference_ids(symbol_id).len() > 1
         {
             return false;

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -1,4 +1,3 @@
-use oxc_ecmascript::constant_evaluation::ConstantValue;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::{Allocator, BitSet};
@@ -12,6 +11,28 @@ use crate::{
     CompressOptions, symbol_facts::PersistentSymbolFacts, symbol_liveness::SymbolLiveness,
     symbol_value::SymbolValues,
 };
+
+/// What the minifier has proved about calls to a locally declared function.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum FunctionSummary {
+    /// No reusable call-site proof is available.
+    #[default]
+    Unknown,
+    /// Calling the function has no side effects, but its result is unknown.
+    SideEffectFree,
+    /// Calling the function has no side effects and returns `undefined`.
+    SideEffectFreeReturnsUndefined,
+}
+
+impl FunctionSummary {
+    pub fn is_side_effect_free(self) -> bool {
+        matches!(self, Self::SideEffectFree | Self::SideEffectFreeReturnsUndefined)
+    }
+
+    pub fn returns_undefined(self) -> bool {
+        self == Self::SideEffectFreeReturnsUndefined
+    }
+}
 
 /// Dirty data accumulated by the `replace_*` / `drop_*` helper calls between
 /// two consumption points. Live from `MinifierState::new` so the pre-loop
@@ -70,18 +91,15 @@ pub struct MinifierState<'a> {
     /// out. See the `if ctx.state.dce` branch in `peephole/mod.rs`.
     pub dce: bool,
 
-    /// The return value of function declarations that are pure
-    pub pure_functions: FxHashMap<SymbolId, Option<ConstantValue<'a>>>,
+    /// Reusable call-site proofs for locally declared functions.
+    pub pure_functions: FxHashMap<SymbolId, FunctionSummary>,
 
     pub symbol_values: SymbolValues<'a>,
 
     /// Private member usage for classes
     pub class_symbols_stack: ClassSymbolsStack<'a>,
 
-    /// Program-wide, monotone per-symbol facts. See
-    /// [`SymbolFact`](crate::symbol_facts::SymbolFact) for each bit and its
-    /// consumer, and [`PersistentSymbolFacts`] for the lifecycle contract
-    /// every fact obeys.
+    /// Program-wide, monotone member-write effects.
     pub symbol_facts: PersistentSymbolFacts,
 
     /// One frame per enclosing function body (program root at the bottom).
@@ -147,11 +165,11 @@ impl<'a> MinifierState<'a> {
     /// Whether `Normalize`'s member-write scan should seed `symbol_facts`,
     /// i.e. whether any consumer is live in this configuration. In full
     /// minify the default-mode write-only property drop reads
-    /// `MEMBER_WRITE_HAZARD` and the shared drop predicate reads
-    /// `PROTO_WRITTEN`. In DCE mode the default path is disabled and only the
-    /// `property_write_side_effects: false` opt-in drop runs (reading
-    /// `PROTO_WRITTEN`), so with the knob left on nothing reads the facts and
-    /// seeding is skipped.
+    /// hazardous-member state and the shared drop predicate reads possible
+    /// prototype mutation. In DCE mode the default path is disabled and only
+    /// the `property_write_side_effects: false` opt-in drop reads the prototype
+    /// state, so with the knob left on nothing reads the effects and seeding is
+    /// skipped.
     pub fn seeds_symbol_facts(&self) -> bool {
         !self.dce || !self.options.treeshake.property_write_side_effects
     }

--- a/crates/oxc_minifier/src/symbol_facts.rs
+++ b/crates/oxc_minifier/src/symbol_facts.rs
@@ -1,79 +1,62 @@
-use bitflags::bitflags;
 use rustc_hash::FxHashMap;
 
 use oxc_syntax::symbol::SymbolId;
 
-bitflags! {
-    /// A set of monotone facts held about a single symbol. See
-    /// [`PersistentSymbolFacts`] for the lifecycle every bit must obey. Do not
-    /// add a bit without a consumer.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-    pub struct SymbolFact: u8 {
-        /// The symbol has a hazardous member-write operation anywhere in the
-        /// program: compound / logical-assignment / update / chained-delete ops,
-        /// which READ the property before writing (so a sibling plain write's
-        /// value is observable); bases of chained member writes (`a` in
-        /// `a.b.c = 1`, whose intermediate object must not be dropped); and
-        /// writes through `__proto__` or non-literal computed keys, which may
-        /// install setters. The DEFAULT-mode drop of write-only property
-        /// assignments (`remove_unused_member_assignment`) must skip such symbols.
-        const MEMBER_WRITE_HAZARD = 1 << 0;
+/// The strongest program-wide effect recorded for member writes to a symbol.
+///
+/// Effects form a monotone order. A possible prototype mutation is also an
+/// ordinary write hazard, so recording it must preserve both consumers.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MemberWriteEffect {
+    #[default]
+    None,
+    /// A compound, logical, update, chained, or otherwise hazardous member
+    /// operation can observe a sibling property write.
+    Hazard,
+    /// A `__proto__` or unsafe computed-key write may install a setter that
+    /// makes a later property write observable.
+    ///
+    /// Normalize seeds this completely: fixed-point transforms cannot create
+    /// a proto-write key that was not already covered. Key folding starts from
+    /// a conservatively unsafe key, while forming a compound assignment changes
+    /// only the operator, not the key.
+    MayMutatePrototype,
+}
 
-        /// The symbol has a potential `__proto__` write anywhere in the program:
-        /// an explicit `.__proto__` static-key write, or a computed-key write
-        /// whose key is unsafe per `member_key_is_safe` (not provably a string
-        /// other than `"__proto__"`). Either can install a setter that makes a
-        /// later property write on the symbol side-effectful. This deliberately
-        /// reuses the hazard scan's key class: literal `o[null]`/`o[true]` keys
-        /// can never coerce to `"__proto__"`, but distinguishing them would only
-        /// drop more in shapes that don't occur in real code, at the cost of a
-        /// second key classifier.
-        ///
-        /// A purely syntactic fact: consumed by the shared drop predicate
-        /// (`is_member_assign_to_unused_binding`, guarding both the default and
-        /// opt-in write-only property drops), which pairs it with a query-time
-        /// reference count to exempt a sole-reference proto write.
-        ///
-        /// Seeded entirely by `Normalize`; the fixed-point loop cannot create a
-        /// proto write Normalize did not see. A computed non-literal key is seeded
-        /// before any folding, so a key later folded to the literal `"__proto__"`
-        /// was already covered, and forming a compound assignment only changes the
-        /// operator, never the key.
-        const PROTO_WRITTEN = 1 << 1;
+impl MemberWriteEffect {
+    pub fn is_hazardous(self) -> bool {
+        self >= Self::Hazard
+    }
+
+    pub fn may_mutate_prototype(self) -> bool {
+        self >= Self::MayMutatePrototype
     }
 }
 
-/// Program-wide, monotone facts about symbols, keyed by `SymbolId`.
+/// Program-wide, monotone member-write effects keyed by `SymbolId`.
 ///
-/// Lifecycle contract (also the fit criterion for any future [`SymbolFact`] bit):
-/// - seeded by `Normalize` before the fixed-point loop, so membership is
-///   execution-order independent (a per-pass set populated during the same
-///   traversal that drops writes would be traversal-order dependent);
-/// - extended mid-loop only where a pass CREATES a new fact instance (e.g.
-///   forming a new compound assignment in `mark_assignment_target_as_read`);
-/// - monotone: bits are only ever set, never cleared —
-///   `PeepholeOptimizations::enter_program` deliberately leaves it alone;
-/// - staleness is sound: a SET bit whose hazard has since been optimized away
-///   only FORGOES an optimization, never enables a wrong one. A fact belongs
-///   here only if that holds for it. (The reverse direction — a MISSING bit —
-///   is unsound to act on, which is exactly why seeding must complete before
-///   the loop and why creation sites must insert eagerly; monotonicity does
-///   not cover it.)
+/// Lifecycle contract:
+/// - seeded by Normalize before the fixed-point loop, so membership is
+///   execution-order independent;
+/// - extended mid-loop only where a pass creates a stronger effect;
+/// - never downgraded or cleared between peephole passes;
+/// - stale stronger effects only forgo an optimization, but a missing effect is
+///   unsound. Seeding must therefore complete before the loop, and creation
+///   sites must record stronger effects eagerly.
 #[derive(Debug, Default)]
 pub struct PersistentSymbolFacts {
-    facts: FxHashMap<SymbolId, SymbolFact>,
+    effects: FxHashMap<SymbolId, MemberWriteEffect>,
 }
 
 impl PersistentSymbolFacts {
-    /// Record `fact` for `symbol_id`, unioned with any facts already held.
     #[inline]
-    pub fn insert(&mut self, symbol_id: SymbolId, fact: SymbolFact) {
-        self.facts.entry(symbol_id).or_default().insert(fact);
+    pub fn record(&mut self, symbol_id: SymbolId, effect: MemberWriteEffect) {
+        let current = self.effects.entry(symbol_id).or_default();
+        *current = (*current).max(effect);
     }
 
-    /// Whether `symbol_id` carries `fact`.
     #[inline]
-    pub fn has(&self, symbol_id: SymbolId, fact: SymbolFact) -> bool {
-        self.facts.get(&symbol_id).is_some_and(|f| f.contains(fact))
+    pub fn effect(&self, symbol_id: SymbolId) -> MemberWriteEffect {
+        self.effects.get(&symbol_id).copied().unwrap_or_default()
     }
 }

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -901,7 +901,7 @@ fn test_property_write_side_effects() {
         &options,
     );
     // Literal non-string keys can't coerce to `"__proto__"` but are kept
-    // conservatively — see `SymbolFact::PROTO_WRITTEN` docs.
+    // conservatively — see `MemberWriteEffect::MayMutatePrototype`.
     test_options(
         "const a = {}; a[null] = 1; a.a = 1;",
         "const a = {}; a[null] = 1, a.a = 1;",
@@ -921,9 +921,10 @@ fn test_property_write_side_effects() {
 
     // `__proto__` assignment inside a hoisted function — traversal reaches the
     // function body only AFTER `obj.a = 1`, so the old per-pass tracking never saw
-    // it in time and wrongly dropped `obj.a = 1`. `PROTO_WRITTEN` is seeded by
-    // `Normalize` before the fixed-point loop, so it is caught regardless of
-    // order. `f` has an observable side effect (`g()`), so it is not tree-shaken:
+    // it in time and wrongly dropped `obj.a = 1`. `MayMutatePrototype` is
+    // recorded by `Normalize` before the fixed-point loop, so it is caught
+    // regardless of order. `f` has an observable side effect (`g()`), so it is
+    // not tree-shaken:
     // the setter really is installed when `f()` runs, and the sibling `obj.a = 1`
     // that would trigger it must survive.
     test_options(


### PR DESCRIPTION
Pure-call summaries and member-write hazards encoded semantic states through nested `Option` values and independent bitflags. Reviewers had to reconstruct which combinations were valid and which implications producers must maintain.

This introduces `FunctionSummary` for reusable call proofs and an ordered `MemberWriteEffect` for `None < Hazard < MayMutatePrototype`. Prototype mutation is therefore hazardous by construction, the removed bitflag dependency is no longer needed, and producers and consumers share named contracts. Behavior is unchanged relative to #24636.

The PR tip passed the full `oxc_minifier` suite independently. The completed stack also passed clippy with warnings denied, formatting, minsize and allocation regeneration, and `just ready`.

## Stack

1. #24636 — function-summary correctness
2. **#24637 — explicit symbol effect types**
3. #24638 — grouped reference counts
4. #24639 — merged persistent metadata
5. #24640 — SymbolState facade

Implemented with AI assistance (OpenAI Codex). The contributor remains responsible for reviewing, understanding, and submitting the changes under the repository AI usage policy.