### PR TITLE
refactor(minifier): group symbol reference counts

### DIFF
--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -235,7 +235,7 @@ impl<'a> PeepholeOptimizations {
             return;
         };
         // Skip if there are write references.
-        if symbol_value.write_references_count > 0 {
+        if symbol_value.references.has_writes() {
             return;
         }
         let Some(cv) = &symbol_value.initialized_constant else { return };
@@ -244,7 +244,7 @@ impl<'a> PeepholeOptimizations {
         if symbol_value.implicit_undefined {
             return;
         }
-        if symbol_value.read_references_count == 1
+        if symbol_value.references.has_single_read()
             || match cv {
                 ConstantValue::Number(n) => n.fract() == 0.0 && *n >= -99.0 && *n <= 999.0,
                 ConstantValue::BigInt(_) => false,

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1461,8 +1461,8 @@ impl<'a> PeepholeOptimizations {
             // consult the shared metadata explicitly for consistency with the
             // other count-based consumers.
             if ctx.state.symbol_is_implicitly_observable(prev_decl_id.symbol_id())
-                || symbol_value.read_references_count > 1
-                || symbol_value.write_references_count > 0
+                || symbol_value.references.has_multiple_reads()
+                || symbol_value.references.has_writes()
             {
                 return true;
             }

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -187,8 +187,8 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    /// Check if a symbol is mutated, using the O(1) cached `write_references_count`
-    /// from `SymbolValue` when available, falling back to the O(num_refs) scan in
+    /// Check if a symbol is mutated, using the O(1) cached reference counts from
+    /// `SymbolValue` when available, falling back to the O(num_refs) scan in
     /// `Scoping::symbol_is_mutated` for symbols without cached values.
     ///
     /// Only variable declarators have cached values (populated during
@@ -196,7 +196,7 @@ impl<'a> PeepholeOptimizations {
     /// and other binding kinds still take the fallback path.
     fn is_symbol_mutated(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
         if let Some(sv) = ctx.state.symbol_values.get_symbol_value(symbol_id) {
-            sv.write_references_count > 0
+            sv.references.has_writes()
         } else {
             ctx.scoping().symbol_is_mutated(symbol_id)
         }

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -782,7 +782,7 @@ impl<'a> PeepholeOptimizations {
         let Some(symbol_value) = ctx.state.symbol_values.get_symbol_value(symbol_id) else {
             return false;
         };
-        if symbol_value.read_references_count > 0 {
+        if symbol_value.references.has_reads() {
             return false;
         }
         let new_expr = assign_expr.right.take_in(ctx);
@@ -996,8 +996,7 @@ impl<'a> PeepholeOptimizations {
             return false;
         }
         // Check: all references are member write targets (O(1) via pre-computed count).
-        sv.write_references_count == 0
-            && sv.read_references_count == sv.member_write_target_read_count
+        sv.references.has_only_member_write_target_reads()
     }
 
     fn remove_unused_class_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {

--- a/crates/oxc_minifier/src/symbol_value.rs
+++ b/crates/oxc_minifier/src/symbol_value.rs
@@ -1,6 +1,6 @@
 use oxc_ecmascript::constant_evaluation::ConstantValue;
 use oxc_index::IndexVec;
-use oxc_syntax::symbol::SymbolId;
+use oxc_syntax::{reference::ReferenceFlags, symbol::SymbolId};
 
 /// The kind of fresh value a binding was initialized with, or `None` when the
 /// value may alias another binding (or is untracked).
@@ -27,6 +27,59 @@ pub enum FreshValueKind {
     Array,
 }
 
+/// Cached counts for the resolved references to a symbol.
+///
+/// Keep queries here so consumers do not have to coordinate related counters
+/// or repeat the invariant that member-write target reads are a subset of all
+/// reads.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ReferenceCounts {
+    reads: u32,
+    writes: u32,
+    member_write_target_reads: u32,
+}
+
+impl ReferenceCounts {
+    #[inline]
+    pub fn record(&mut self, flags: ReferenceFlags) {
+        debug_assert!(!flags.is_member_write_target() || flags.is_read());
+        if flags.is_read() {
+            self.reads += 1;
+        }
+        if flags.is_write() {
+            self.writes += 1;
+        }
+        if flags.is_member_write_target() {
+            self.member_write_target_reads += 1;
+        }
+    }
+
+    #[inline]
+    pub fn has_reads(self) -> bool {
+        self.reads > 0
+    }
+
+    #[inline]
+    pub fn has_writes(self) -> bool {
+        self.writes > 0
+    }
+
+    #[inline]
+    pub fn has_single_read(self) -> bool {
+        self.reads == 1
+    }
+
+    #[inline]
+    pub fn has_multiple_reads(self) -> bool {
+        self.reads > 1
+    }
+
+    #[inline]
+    pub fn has_only_member_write_target_reads(self) -> bool {
+        self.writes == 0 && self.reads == self.member_write_target_reads
+    }
+}
+
 #[derive(Debug)]
 pub struct SymbolValue<'a> {
     /// Initialized constant value evaluated from expressions.
@@ -42,13 +95,7 @@ pub struct SymbolValue<'a> {
     /// resolve the value through `initialized_constant`.
     pub implicit_undefined: bool,
 
-    pub read_references_count: u32,
-    pub write_references_count: u32,
-
-    /// Number of read references that are member write targets (e.g. `a` in `a.foo = 1`).
-    /// These reads exist only to access the object for a property write, not to use the value.
-    /// Always <= `read_references_count`.
-    pub member_write_target_read_count: u32,
+    pub references: ReferenceCounts,
 
     /// The kind of fresh value the symbol holds (cannot alias another binding),
     /// or `FreshValueKind::None` when the value may alias. Set for function/class

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -18,7 +18,7 @@ use crate::{
     generated::ancestor::Ancestor,
     options::CompressOptions,
     state::MinifierState,
-    symbol_value::{FreshValueKind, SymbolValue},
+    symbol_value::{FreshValueKind, ReferenceCounts, SymbolValue},
 };
 
 use oxc_ast_visit::Visit;
@@ -180,7 +180,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
             .get_reference(reference_id)
             .symbol_id()
             .and_then(|symbol_id| self.state.symbol_values.get_symbol_value(symbol_id))
-            .filter(|sv| sv.write_references_count == 0)
+            .filter(|sv| !sv.references.has_writes())
             .and_then(|sv| sv.initialized_constant.as_ref())
     }
 
@@ -290,19 +290,9 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         falsy_init: bool,
         init_absent: bool,
     ) {
-        let mut read_references_count = 0;
-        let mut write_references_count = 0;
-        let mut member_write_target_read_count = 0;
-        for r in self.scoping().get_resolved_references(symbol_id) {
-            if r.is_read() {
-                read_references_count += 1;
-            }
-            if r.is_write() {
-                write_references_count += 1;
-            }
-            if r.flags().is_member_write_target() {
-                member_write_target_read_count += 1;
-            }
+        let mut references = ReferenceCounts::default();
+        for reference in self.scoping().get_resolved_references(symbol_id) {
+            references.record(reference.flags());
         }
 
         let scope_id = self.scoping().symbol_scope_id(symbol_id);
@@ -320,7 +310,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         // doesn't prove write-once).
         let boolean_falsy = falsy_init
             && value_withheld
-            && write_references_count == 0
+            && !references.has_writes()
             && !scope_flags.contains(ScopeFlags::DirectEval)
             && !(self.source_type().is_script() && scope_id == self.scoping().root_scope_id());
 
@@ -332,9 +322,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         let symbol_value = SymbolValue {
             initialized_constant,
             implicit_undefined,
-            read_references_count,
-            write_references_count,
-            member_write_target_read_count,
+            references,
             kind,
             boolean_falsy,
         };

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1327,7 +1327,7 @@ fn test_inline_values_in_template_literal() {
 // write-ref hangs around in `Scoping` (#22736).
 //
 // Test options keep unused declarations (`CompressOptionsUnused::Keep`), so
-// `let x` survives — but with `write_references_count == 0` the inline pass
+// `let x` survives — but with no cached write references the inline pass
 // replaces `return x` with the constant value. Without the drop walk, the
 // dropped subtree's stale write-ref leaves the count at 1 and inline is
 // blocked.

--- a/crates/oxc_minifier/tests/peephole/inline.rs
+++ b/crates/oxc_minifier/tests/peephole/inline.rs
@@ -59,7 +59,7 @@ fn readonly_var_reassigned() {
 fn readonly_var_reassigned_cross_function_read() {
     // The read crosses a function boundary (the gap this path targets), but
     // `foo` is also reassigned. The predicate's read-loop ignores writes, so it
-    // relies on the downstream `write_references_count` guard in
+    // relies on the downstream cached write-reference guard in
     // `inline_identifier_reference` to block inlining — substituting `1` would be
     // wrong once `foo = 2` runs before `f()` is called.
     test_smallest(


### PR DESCRIPTION
`SymbolValue` exposed three related counters directly, so every consumer had to coordinate read, write, and member-write-target invariants itself.

This groups them in `ReferenceCounts` and exposes factual queries such as `has_single_read` and `has_only_member_write_target_reads`. The existing 48-byte `SymbolValue` layout is preserved, and the refactor does not change minified output.

The PR tip passed the full `oxc_minifier` suite independently. The completed stack also passed clippy with warnings denied, formatting, minsize and allocation regeneration, and `just ready`.

## Stack

1. #24636 — function-summary correctness
2. #24637 — explicit symbol effect types
3. **#24638 — grouped reference counts**
4. #24639 — merged persistent metadata
5. #24640 — SymbolState facade

Implemented with AI assistance (OpenAI Codex). The contributor remains responsible for reviewing, understanding, and submitting the changes under the repository AI usage policy.