### PR TITLE
refactor(minifier): group symbol state

### DIFF
--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -53,6 +53,7 @@ mod peephole;
 mod state;
 mod symbol_liveness;
 mod symbol_metadata;
+mod symbol_state;
 mod symbol_value;
 mod traverse_context;
 

--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -231,7 +231,7 @@ impl<'a> PeepholeOptimizations {
         let Expression::Identifier(ident) = expr else { return };
         let reference_id = ident.reference_id();
         let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id() else { return };
-        let Some(symbol_value) = ctx.state.symbol_values.get_symbol_value(symbol_id) else {
+        let Some(symbol_value) = ctx.state.symbols.value(symbol_id) else {
             return;
         };
         // Skip if there are write references.

--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -117,11 +117,7 @@ impl<'a> PeepholeOptimizations {
                 let reference_id = ident.reference_id();
                 let span = ident.span;
                 if let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id()
-                    && ctx
-                        .state
-                        .symbol_values
-                        .get_symbol_value(symbol_id)
-                        .is_some_and(|sv| sv.boolean_falsy)
+                    && ctx.state.symbols.value(symbol_id).is_some_and(|sv| sv.boolean_falsy)
                 {
                     let new_expr = Expression::new_boolean_literal(span, false, ctx);
                     ctx.replace_expression(expr, new_expr);

--- a/crates/oxc_minifier/src/peephole/minimize_logical_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_logical_expression.rs
@@ -315,7 +315,7 @@ impl<'a> PeepholeOptimizations {
         if let Expression::Identifier(ident) = object.get_inner_expression()
             && let Some(symbol_id) = ctx.scoping().get_reference(ident.reference_id()).symbol_id()
         {
-            ctx.state.record_member_write_effect(symbol_id, MemberWriteEffect::Hazard);
+            ctx.state.symbols.record_member_write_effect(symbol_id, MemberWriteEffect::Hazard);
         }
     }
 }

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1450,9 +1450,7 @@ impl<'a> PeepholeOptimizations {
             if ctx.is_expression_whose_name_needs_to_be_kept(prev_decl_init) {
                 return true;
             }
-            let Some(symbol_value) =
-                ctx.state.symbol_values.get_symbol_value(prev_decl_id.symbol_id())
-            else {
+            let Some(symbol_value) = ctx.state.symbols.value(prev_decl_id.symbol_id()) else {
                 return true;
             };
             // Implicitly observable bindings remain live independently of
@@ -1460,7 +1458,7 @@ impl<'a> PeepholeOptimizations {
             // An `export { foo }` specifier also contributes a reference, but
             // consult the shared metadata explicitly for consistency with the
             // other count-based consumers.
-            if ctx.state.symbol_is_implicitly_observable(prev_decl_id.symbol_id())
+            if ctx.state.symbols.is_implicitly_observable(prev_decl_id.symbol_id())
                 || symbol_value.references.has_multiple_reads()
                 || symbol_value.references.has_writes()
             {

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -195,7 +195,7 @@ impl<'a> PeepholeOptimizations {
     /// `exit_variable_declarator` → `init_symbol_value`); function declarations
     /// and other binding kinds still take the fallback path.
     fn is_symbol_mutated(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
-        if let Some(sv) = ctx.state.symbol_values.get_symbol_value(symbol_id) {
+        if let Some(sv) = ctx.state.symbols.value(symbol_id) {
             sv.references.has_writes()
         } else {
             ctx.scoping().symbol_is_mutated(symbol_id)
@@ -466,7 +466,7 @@ impl<'a> PeepholeOptimizations {
 
 impl<'a> Traverse<'a> for PeepholeOptimizations {
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
-        ctx.state.symbol_values.reset();
+        ctx.state.symbols.reset_values();
         // Any module loader (`import`, `export * from`, `export … from`) can, on a
         // cycle, evaluate a foreign module that observes a not-yet-assigned binding
         // our exports close over. So the program root starts its prelude "unsafe"
@@ -495,8 +495,8 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     }
 
     fn exit_program(&mut self, _program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
-        // Only check class_symbols_stack in full optimization mode (not DCE mode)
-        debug_assert!(ctx.state.dce || ctx.state.class_symbols_stack.is_exhausted());
+        // Private member usage is collected only in full optimization mode.
+        debug_assert!(ctx.state.dce || ctx.state.private_member_usage.is_at_root());
     }
 
     fn exit_statements(
@@ -865,7 +865,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         if ctx.state.dce {
             return;
         }
-        ctx.state.class_symbols_stack.push_class_scope();
+        ctx.state.private_member_usage.enter_class();
     }
 
     fn exit_class_body(&mut self, body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -874,7 +874,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         }
         Self::remove_dead_code_exit_class_body(body, ctx);
         Self::remove_unused_private_members(body, ctx);
-        ctx.state.class_symbols_stack.pop_class_scope(Self::get_declared_private_symbols(body));
+        ctx.state.private_member_usage.exit_class(Self::declared_private_member_names(body));
     }
 
     fn exit_catch_clause(&mut self, catch: &mut CatchClause<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -892,7 +892,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         if ctx.state.dce {
             return;
         }
-        ctx.state.class_symbols_stack.push_private_member_to_current_class(node.field.name.into());
+        ctx.state.private_member_usage.record_use(node.field.name.into());
     }
 
     fn exit_private_in_expression(
@@ -903,7 +903,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         if ctx.state.dce {
             return;
         }
-        ctx.state.class_symbols_stack.push_private_member_to_current_class(node.left.name.into());
+        ctx.state.private_member_usage.record_use(node.left.name.into());
     }
 }
 

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -649,7 +649,7 @@ impl<'a> Normalize {
         } else {
             MemberWriteEffect::Hazard
         };
-        ctx.state.record_member_write_effect(symbol_id, effect);
+        ctx.state.symbols.record_member_write_effect(symbol_id, effect);
     }
 
     fn remove_unused_use_strict_directive(body: &mut FunctionBody<'a>, ctx: &TraverseCtx<'a>) {

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -499,7 +499,7 @@ impl<'a> PeepholeOptimizations {
         // so the read-only-reference check below cannot see them. A different
         // declaration of the same symbol may be impure and win at runtime.
         if !ctx.scoping().symbol_redeclarations(symbol_id).is_empty() {
-            ctx.state.clear_function_summary(symbol_id);
+            ctx.state.symbols.clear_function_summary(symbol_id);
             return;
         }
         // Direct eval and Script global properties can replace the binding
@@ -509,11 +509,11 @@ impl<'a> PeepholeOptimizations {
         if binding_scope_flags.contains_direct_eval()
             || (ctx.source_type().is_script() && binding_scope_id == ctx.scoping().root_scope_id())
         {
-            ctx.state.clear_function_summary(symbol_id);
+            ctx.state.symbols.clear_function_summary(symbol_id);
             return;
         }
         if ctx.scoping().get_resolved_references(symbol_id).all(|r| r.flags().is_read_only()) {
-            ctx.state.set_function_summary(
+            ctx.state.symbols.set_function_summary(
                 symbol_id,
                 if body.is_empty() {
                     FunctionSummary::SideEffectFreeReturnsUndefined
@@ -529,7 +529,7 @@ impl<'a> PeepholeOptimizations {
         if let Expression::Identifier(ident) = &e.callee {
             let reference_id = ident.reference_id();
             if let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id()
-                && ctx.state.function_summary(symbol_id).returns_undefined()
+                && ctx.state.symbols.function_summary(symbol_id).returns_undefined()
             {
                 let mut exprs = Self::fold_arguments_into_needed_expressions(&mut e.arguments, ctx);
                 if exprs.is_empty() {

--- a/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
@@ -13,18 +13,19 @@ impl<'a> PeepholeOptimizations {
 
     /// Count-based unusedness for declaration removal and IIFE folding. The
     /// assignment, member-write, and single-use-substitution consumers instead
-    /// pair `symbol_is_implicitly_observable` with their own count thresholds,
+    /// pair `is_implicitly_observable` with their own count thresholds,
     /// because some runtime semantics can observe a binding independently of
     /// resolved references.
     pub(super) fn symbol_is_unused_by_count(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
-        !ctx.state.symbol_is_implicitly_observable(symbol_id)
+        !ctx.state.symbols.is_implicitly_observable(symbol_id)
             && ctx.scoping().symbol_is_unused(symbol_id)
     }
 
     /// Function declarations additionally consume graph deadness, allowing
     /// self- and mutually-recursive cycles to be removed.
     fn function_has_no_live_references(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
-        Self::symbol_is_unused_by_count(symbol_id, ctx) || ctx.state.function_is_dead(symbol_id)
+        Self::symbol_is_unused_by_count(symbol_id, ctx)
+            || ctx.state.symbols.function_is_dead(symbol_id)
     }
 
     /// Return `true` when an exact function-valued initializer contains every
@@ -52,7 +53,7 @@ impl<'a> PeepholeOptimizations {
         };
 
         // Covers exports, Script-root bindings, Annex B aliases, and `using`.
-        if ctx.state.symbol_is_implicitly_observable(symbol_id) {
+        if ctx.state.symbols.is_implicitly_observable(symbol_id) {
             return false;
         }
 

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -663,7 +663,7 @@ impl<'a> PeepholeOptimizations {
                     && let Some(symbol_id) =
                         ctx.scoping().get_reference(id.reference_id()).symbol_id()
                 {
-                    ctx.state.function_summary(symbol_id).is_side_effect_free()
+                    ctx.state.symbols.function_summary(symbol_id).is_side_effect_free()
                 } else {
                     false
                 })
@@ -773,10 +773,10 @@ impl<'a> PeepholeOptimizations {
         }
         // Cannot remove writes to implicitly observable bindings, for example
         // `export let foo; foo = 1;`.
-        if ctx.state.symbol_is_implicitly_observable(symbol_id) {
+        if ctx.state.symbols.is_implicitly_observable(symbol_id) {
             return false;
         }
-        let Some(symbol_value) = ctx.state.symbol_values.get_symbol_value(symbol_id) else {
+        let Some(symbol_value) = ctx.state.symbols.value(symbol_id) else {
             return false;
         };
         if symbol_value.references.has_reads() {
@@ -839,17 +839,13 @@ impl<'a> PeepholeOptimizations {
         // function/class/array throws a strict-mode `TypeError` or has an
         // observable value-domain effect (see `member_write_key_denied`), so the
         // write is not dead even though the binding is otherwise unused.
-        let kind = ctx
-            .state
-            .symbol_values
-            .get_symbol_value(symbol_id)
-            .map_or(FreshValueKind::None, |sv| sv.kind);
+        let kind = ctx.state.symbols.value(symbol_id).map_or(FreshValueKind::None, |sv| sv.kind);
         if Self::member_write_key_denied(&assign_expr.left, kind) {
             return false;
         }
         // Program-wide, execution-order-independent hazards: another member op
         // on this symbol reads the property or may install setters.
-        if ctx.state.member_write_effect(symbol_id).is_hazardous() {
+        if ctx.state.symbols.member_write_effect(symbol_id).is_hazardous() {
             return false;
         }
         if !assign_expr.right.may_have_side_effects(ctx) {
@@ -976,17 +972,17 @@ impl<'a> PeepholeOptimizations {
         // any OTHER reference exists; when the candidate is the symbol's only
         // remaining reference, it either is the proto write itself or the proto
         // write is already gone, so no setter can ever fire.
-        if ctx.state.member_write_effect(symbol_id).may_mutate_prototype()
+        if ctx.state.symbols.member_write_effect(symbol_id).may_mutate_prototype()
             && ctx.scoping().get_resolved_reference_ids(symbol_id).len() > 1
         {
             return false;
         }
 
         // Check: symbol creates a fresh value and is not implicitly observable.
-        if ctx.state.symbol_is_implicitly_observable(symbol_id) {
+        if ctx.state.symbols.is_implicitly_observable(symbol_id) {
             return false;
         }
-        let Some(sv) = ctx.state.symbol_values.get_symbol_value(symbol_id) else {
+        let Some(sv) = ctx.state.symbols.value(symbol_id) else {
             return false;
         };
         if sv.kind == FreshValueKind::None {

--- a/crates/oxc_minifier/src/peephole/remove_unused_private_members.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_private_members.rs
@@ -22,8 +22,7 @@ impl<'a> PeepholeOptimizations {
                         return true;
                     };
                     let name: Str = private_id.name.into();
-                    if ctx.state.class_symbols_stack.is_private_member_used_in_current_class(&name)
-                    {
+                    if ctx.state.private_member_usage.is_used(&name) {
                         return true;
                     }
                     prop.value.as_ref().is_some_and(|value| value.may_have_side_effects(ctx))
@@ -33,15 +32,14 @@ impl<'a> PeepholeOptimizations {
                         return true;
                     };
                     let name: Str = private_id.name.into();
-                    ctx.state.class_symbols_stack.is_private_member_used_in_current_class(&name)
+                    ctx.state.private_member_usage.is_used(&name)
                 }
                 ClassElement::AccessorProperty(accessor) => {
                     let PropertyKey::PrivateIdentifier(private_id) = &accessor.key else {
                         return true;
                     };
                     let name: Str = private_id.name.into();
-                    if ctx.state.class_symbols_stack.is_private_member_used_in_current_class(&name)
-                    {
+                    if ctx.state.private_member_usage.is_used(&name) {
                         return true;
                     }
                     accessor.value.as_ref().is_some_and(|value| value.may_have_side_effects(ctx))
@@ -64,7 +62,7 @@ impl<'a> PeepholeOptimizations {
         });
     }
 
-    pub fn get_declared_private_symbols(body: &ClassBody<'a>) -> impl Iterator<Item = Str<'a>> {
+    pub fn declared_private_member_names(body: &ClassBody<'a>) -> impl Iterator<Item = Str<'a>> {
         body.body.iter().filter_map(|element| match element {
             ClassElement::PropertyDefinition(prop) => {
                 let PropertyKey::PrivateIdentifier(private_id) = &prop.key else {

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -1,18 +1,13 @@
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 
 use oxc_allocator::{Allocator, BitSet};
 use oxc_data_structures::stack::NonEmptyStack;
 use oxc_semantic::Scoping;
 use oxc_span::SourceType;
 use oxc_str::Str;
-use oxc_syntax::{scope::ScopeId, symbol::SymbolId};
+use oxc_syntax::scope::ScopeId;
 
-use crate::{
-    CompressOptions,
-    symbol_liveness::SymbolLiveness,
-    symbol_metadata::{FunctionSummary, MemberWriteEffect, PersistentSymbolMetadata},
-    symbol_value::SymbolValues,
-};
+use crate::{CompressOptions, symbol_state::SymbolState};
 
 /// Dirty data accumulated by the `replace_*` / `drop_*` helper calls between
 /// two consumption points. Live from `MinifierState::new` so the pre-loop
@@ -71,13 +66,14 @@ pub struct MinifierState<'a> {
     /// out. See the `if ctx.state.dce` branch in `peephole/mod.rs`.
     pub dce: bool,
 
-    /// Sparse metadata that remains valid across peephole iterations.
-    persistent_symbols: FxHashMap<SymbolId, PersistentSymbolMetadata>,
+    /// Dense per-pass values, sparse persistent metadata, and optional
+    /// reachability data indexed by semantic symbols.
+    pub(crate) symbols: SymbolState<'a>,
 
-    pub symbol_values: SymbolValues<'a>,
-
-    /// Private member usage for classes
-    pub class_symbols_stack: ClassSymbolsStack<'a>,
+    /// Private-name usage scoped by nested classes. This tracks `#name`
+    /// strings, not semantic `SymbolId`s, so it deliberately stays outside
+    /// `SymbolState`.
+    pub private_member_usage: PrivateMemberUsageStack<'a>,
 
     /// One frame per enclosing function body (program root at the bottom).
     /// `(body_scope, body_unsafe)`. While `body_unsafe` is false, the next
@@ -101,13 +97,6 @@ pub struct MinifierState<'a> {
     /// refresh.
     pub(crate) dirty: PassDirty<'a>,
 
-    /// Implicitly observable bindings plus the optional recursive-function
-    /// graph. Present for modules or when unused removal is enabled; a `using`
-    /// declaration can also create it lazily. Stable metadata is seeded from
-    /// scoping and Normalize; post-flush analysis derives reachability from the
-    /// current semantic reference lists.
-    pub(crate) symbol_liveness: Option<SymbolLiveness<'a>>,
-
     /// Scratch buffer reused by `try_fold_concat` to build template literal
     /// quasis without allocating a fresh `String` per call.
     pub concat_scratch: String,
@@ -121,19 +110,16 @@ impl<'a> MinifierState<'a> {
         scoping: &Scoping,
         allocator: &'a Allocator,
     ) -> Self {
-        let symbol_liveness =
-            SymbolLiveness::new_if_enabled(source_type, &options, scoping, allocator);
+        let symbols = SymbolState::new(source_type, &options, scoping, allocator);
         Self {
             source_type,
             options,
             dce,
-            persistent_symbols: FxHashMap::default(),
-            symbol_values: SymbolValues::new(scoping.symbols_len()),
-            class_symbols_stack: ClassSymbolsStack::new(),
+            symbols,
+            private_member_usage: PrivateMemberUsageStack::new(),
             body_unsafe_stack: NonEmptyStack::new((scoping.root_scope_id(), false)),
             mutated: false,
             dirty: PassDirty::new(scoping.references_len(), allocator),
-            symbol_liveness,
             concat_scratch: String::new(),
         }
     }
@@ -150,53 +136,6 @@ impl<'a> MinifierState<'a> {
         !self.dce || !self.options.treeshake.property_write_side_effects
     }
 
-    pub(crate) fn set_function_summary(&mut self, symbol_id: SymbolId, summary: FunctionSummary) {
-        self.persistent_symbols.entry(symbol_id).or_default().set_function_summary(summary);
-    }
-
-    pub(crate) fn clear_function_summary(&mut self, symbol_id: SymbolId) {
-        if let Some(metadata) = self.persistent_symbols.get_mut(&symbol_id) {
-            // Clear in place: removing this shared entry would also erase its
-            // monotone member-write effect.
-            metadata.set_function_summary(FunctionSummary::Unknown);
-        }
-    }
-
-    pub(crate) fn function_summary(&self, symbol_id: SymbolId) -> FunctionSummary {
-        self.persistent_symbols
-            .get(&symbol_id)
-            .map_or(FunctionSummary::Unknown, PersistentSymbolMetadata::function_summary)
-    }
-
-    pub(crate) fn record_member_write_effect(
-        &mut self,
-        symbol_id: SymbolId,
-        effect: MemberWriteEffect,
-    ) {
-        self.persistent_symbols.entry(symbol_id).or_default().record_member_write_effect(effect);
-    }
-
-    pub(crate) fn member_write_effect(&self, symbol_id: SymbolId) -> MemberWriteEffect {
-        self.persistent_symbols
-            .get(&symbol_id)
-            .map_or(MemberWriteEffect::None, PersistentSymbolMetadata::member_write_effect)
-    }
-
-    /// Whether runtime semantics have an implicit observation channel that
-    /// remains even if every resolved reference disappears from the current
-    /// AST.
-    pub(crate) fn symbol_is_implicitly_observable(&self, symbol_id: SymbolId) -> bool {
-        self.symbol_liveness
-            .as_ref()
-            .is_some_and(|liveness| liveness.is_implicitly_observable(symbol_id))
-    }
-
-    /// Whether post-flush graph analysis proved a function declaration
-    /// unreachable from executing code.
-    pub(crate) fn function_is_dead(&self, symbol_id: SymbolId) -> bool {
-        self.symbol_liveness.as_ref().is_some_and(|liveness| liveness.function_is_dead(symbol_id))
-    }
-
     /// Returns whether the AST was mutated since the last call, and resets.
     /// Read and reset are one operation so the signal cannot be cleared
     /// anywhere except at its single consumption point.
@@ -210,43 +149,39 @@ impl<'a> MinifierState<'a> {
     }
 }
 
-/// Stack to track class symbol information
-pub struct ClassSymbolsStack<'a> {
+/// Private member names used in each currently enclosing class.
+pub struct PrivateMemberUsageStack<'a> {
     stack: NonEmptyStack<FxHashSet<Str<'a>>>,
 }
 
-impl<'a> ClassSymbolsStack<'a> {
+impl<'a> PrivateMemberUsageStack<'a> {
     pub fn new() -> Self {
         Self { stack: NonEmptyStack::new(FxHashSet::default()) }
     }
 
-    /// Check if the stack is exhausted
-    pub fn is_exhausted(&self) -> bool {
+    /// Whether all class scopes have been exited.
+    pub fn is_at_root(&self) -> bool {
         self.stack.is_exhausted()
     }
 
-    /// Enter a new class scope
-    pub fn push_class_scope(&mut self) {
+    pub fn enter_class(&mut self) {
         self.stack.push(FxHashSet::default());
     }
 
-    /// Exit the current class scope
-    pub fn pop_class_scope(&mut self, declared_private_symbols: impl Iterator<Item = Str<'a>>) {
-        let mut used_private_symbols = self.stack.pop();
-        declared_private_symbols.for_each(|name| {
-            used_private_symbols.remove(&name);
+    /// Exit a class and propagate uses of names declared by an outer class.
+    pub fn exit_class(&mut self, declared_private_members: impl Iterator<Item = Str<'a>>) {
+        let mut used_private_members = self.stack.pop();
+        declared_private_members.for_each(|name| {
+            used_private_members.remove(&name);
         });
-        // if the symbol was not declared in this class, that is declared in the class outside the current class
-        self.stack.last_mut().extend(used_private_symbols);
+        self.stack.last_mut().extend(used_private_members);
     }
 
-    /// Add a private member to the current class scope
-    pub fn push_private_member_to_current_class(&mut self, name: Str<'a>) {
+    pub fn record_use(&mut self, name: Str<'a>) {
         self.stack.last_mut().insert(name);
     }
 
-    /// Check if a private member is used in the current class scope
-    pub fn is_private_member_used_in_current_class(&self, name: &Str<'a>) -> bool {
+    pub fn is_used(&self, name: &Str<'a>) -> bool {
         self.stack.last().contains(name)
     }
 }

--- a/crates/oxc_minifier/src/symbol_liveness/mod.rs
+++ b/crates/oxc_minifier/src/symbol_liveness/mod.rs
@@ -464,7 +464,7 @@ pub fn register_function(function: &Function<'_>, ctx: &mut TraverseCtx<'_>) {
     }
     let allocator = ctx.allocator();
     let TraverseCtx { state, scoping, .. } = ctx;
-    if let Some(liveness) = &mut state.symbol_liveness {
+    if let Some(liveness) = state.symbols.liveness_mut() {
         liveness.register_function(function, state.source_type, scoping.scoping(), allocator);
     }
 }
@@ -484,15 +484,15 @@ pub fn register_using_declaration(
     let allocator = ctx.allocator();
     let TraverseCtx { state, scoping, .. } = ctx;
     let liveness = state
-        .symbol_liveness
-        .get_or_insert_with(|| SymbolLiveness::new(source_type, scoping.scoping(), allocator));
+        .symbols
+        .ensure_liveness(|| SymbolLiveness::new(source_type, scoping.scoping(), allocator));
     liveness.mark_bound_names(declaration);
 }
 
 /// Normalize hook: record runtime bindings exposed by a named export.
 pub fn register_named_export(declaration: &ExportNamedDeclaration<'_>, ctx: &mut TraverseCtx<'_>) {
     let TraverseCtx { state, scoping, .. } = ctx;
-    let Some(liveness) = &mut state.symbol_liveness else { return };
+    let Some(liveness) = state.symbols.liveness_mut() else { return };
 
     if !declaration.export_kind.is_type()
         && let Some(inner) = &declaration.declaration
@@ -537,7 +537,7 @@ pub fn register_default_export(
         _ => None,
     };
     if let Some(symbol_id) = symbol_id
-        && let Some(liveness) = &mut ctx.state.symbol_liveness
+        && let Some(liveness) = ctx.state.symbols.liveness_mut()
     {
         liveness.mark_implicitly_observable(symbol_id);
     }
@@ -555,7 +555,7 @@ pub fn register_default_export(
 /// cannot resurrect a published dead function, so additions alone need no
 /// recompute. Scope-only rewrites preserve the nearest function owner.
 pub fn dead_references_affect_analysis(ctx: &TraverseCtx<'_>) -> bool {
-    let Some(liveness) = &ctx.state.symbol_liveness else { return false };
+    let Some(liveness) = ctx.state.symbols.liveness() else { return false };
     let Some(graph) = &liveness.recursive_functions else { return false };
     // The analysis is disabled while the root scope contains direct eval, so
     // removed references cannot affect it. The flag may be stale if this pass
@@ -581,8 +581,7 @@ pub fn analyze<'a>(program: &Program<'a>, ctx: &mut TraverseCtx<'a>, recompute: 
     let _ = program;
 
     #[cfg(debug_assertions)]
-    if let Some(dead) = ctx.state.symbol_liveness.as_ref().and_then(SymbolLiveness::dead_functions)
-    {
+    if let Some(dead) = ctx.state.symbols.liveness().and_then(SymbolLiveness::dead_functions) {
         debug_assert_dead_function_declarations_removed(program, ctx.scoping(), dead);
     }
 
@@ -591,7 +590,7 @@ pub fn analyze<'a>(program: &Program<'a>, ctx: &mut TraverseCtx<'a>, recompute: 
     }
 
     let TraverseCtx { state, scoping, .. } = ctx;
-    state.symbol_liveness.as_mut().is_some_and(|liveness| liveness.analyze(scoping.scoping()))
+    state.symbols.liveness_mut().is_some_and(|liveness| liveness.analyze(scoping.scoping()))
 }
 
 /// Debug contract for previously published graph deadness: it is consumed only

--- a/crates/oxc_minifier/src/symbol_state.rs
+++ b/crates/oxc_minifier/src/symbol_state.rs
@@ -1,0 +1,127 @@
+//! Minifier-owned symbol data, grouped by storage lifetime and density.
+
+use rustc_hash::FxHashMap;
+
+use oxc_allocator::Allocator;
+use oxc_index::IndexVec;
+use oxc_semantic::Scoping;
+use oxc_span::SourceType;
+use oxc_syntax::symbol::SymbolId;
+
+use crate::{
+    CompressOptions,
+    symbol_liveness::SymbolLiveness,
+    symbol_metadata::{FunctionSummary, MemberWriteEffect, PersistentSymbolMetadata},
+    symbol_value::SymbolValue,
+};
+
+/// Symbol-indexed data owned by the minifier.
+///
+/// The fields stay separate because they have different storage and reset
+/// contracts:
+/// - `values` is dense scratch rebuilt for each peephole pass;
+/// - `persistent` is sparse metadata retained across passes;
+/// - `liveness` is stable observability metadata plus optional graph results.
+pub struct SymbolState<'a> {
+    /// Per-pass scratch indexed directly by dense semantic symbol IDs.
+    ///
+    /// Sized once from `Scoping::symbols_len()`; no minifier pass mints new
+    /// symbols, so indexed writes intentionally panic if that contract changes.
+    values: IndexVec<SymbolId, Option<SymbolValue<'a>>>,
+    persistent: FxHashMap<SymbolId, PersistentSymbolMetadata>,
+    liveness: Option<SymbolLiveness<'a>>,
+}
+
+impl<'a> SymbolState<'a> {
+    pub fn new(
+        source_type: SourceType,
+        options: &CompressOptions,
+        scoping: &Scoping,
+        allocator: &'a Allocator,
+    ) -> Self {
+        let mut values = IndexVec::with_capacity(scoping.symbols_len());
+        values.resize_with(scoping.symbols_len(), || None);
+        Self {
+            values,
+            persistent: FxHashMap::default(),
+            liveness: SymbolLiveness::new_if_enabled(source_type, options, scoping, allocator),
+        }
+    }
+
+    /// Clear values without releasing the buffer so the next pass stays on
+    /// the indexed-write fast path.
+    pub fn reset_values(&mut self) {
+        for value in &mut self.values {
+            *value = None;
+        }
+    }
+
+    #[inline]
+    pub fn init_value(&mut self, symbol_id: SymbolId, value: SymbolValue<'a>) {
+        self.values[symbol_id] = Some(value);
+    }
+
+    #[inline]
+    pub fn value(&self, symbol_id: SymbolId) -> Option<&SymbolValue<'a>> {
+        self.values.get(symbol_id)?.as_ref()
+    }
+
+    pub fn set_function_summary(&mut self, symbol_id: SymbolId, summary: FunctionSummary) {
+        self.persistent.entry(symbol_id).or_default().set_function_summary(summary);
+    }
+
+    pub fn clear_function_summary(&mut self, symbol_id: SymbolId) {
+        if let Some(metadata) = self.persistent.get_mut(&symbol_id) {
+            // Clear in place: removing this shared entry would also erase its
+            // monotone member-write effect.
+            metadata.set_function_summary(FunctionSummary::Unknown);
+        }
+    }
+
+    pub fn function_summary(&self, symbol_id: SymbolId) -> FunctionSummary {
+        self.persistent
+            .get(&symbol_id)
+            .map_or(FunctionSummary::Unknown, PersistentSymbolMetadata::function_summary)
+    }
+
+    pub fn record_member_write_effect(&mut self, symbol_id: SymbolId, effect: MemberWriteEffect) {
+        self.persistent.entry(symbol_id).or_default().record_member_write_effect(effect);
+    }
+
+    pub fn member_write_effect(&self, symbol_id: SymbolId) -> MemberWriteEffect {
+        self.persistent
+            .get(&symbol_id)
+            .map_or(MemberWriteEffect::None, PersistentSymbolMetadata::member_write_effect)
+    }
+
+    /// Whether runtime semantics have an implicit observation channel that
+    /// remains even if every resolved reference disappears from the current
+    /// AST. Returns `false` when liveness state is absent; optimization
+    /// consumers may interpret that result only in configurations where
+    /// absence is safe.
+    pub fn is_implicitly_observable(&self, symbol_id: SymbolId) -> bool {
+        self.liveness.as_ref().is_some_and(|liveness| liveness.is_implicitly_observable(symbol_id))
+    }
+
+    /// Whether post-flush graph analysis proved a function declaration
+    /// unreachable from executing code. Returns `false` when liveness state is
+    /// absent because deadness was not proved.
+    pub fn function_is_dead(&self, symbol_id: SymbolId) -> bool {
+        self.liveness.as_ref().is_some_and(|liveness| liveness.function_is_dead(symbol_id))
+    }
+
+    pub fn liveness(&self) -> Option<&SymbolLiveness<'a>> {
+        self.liveness.as_ref()
+    }
+
+    pub fn liveness_mut(&mut self) -> Option<&mut SymbolLiveness<'a>> {
+        self.liveness.as_mut()
+    }
+
+    pub fn ensure_liveness(
+        &mut self,
+        create: impl FnOnce() -> SymbolLiveness<'a>,
+    ) -> &mut SymbolLiveness<'a> {
+        self.liveness.get_or_insert_with(create)
+    }
+}

--- a/crates/oxc_minifier/src/symbol_value.rs
+++ b/crates/oxc_minifier/src/symbol_value.rs
@@ -1,6 +1,5 @@
 use oxc_ecmascript::constant_evaluation::ConstantValue;
-use oxc_index::IndexVec;
-use oxc_syntax::{reference::ReferenceFlags, symbol::SymbolId};
+use oxc_syntax::reference::ReferenceFlags;
 
 /// The kind of fresh value a binding was initialized with, or `None` when the
 /// value may alias another binding (or is untracked).
@@ -111,43 +110,4 @@ pub struct SymbolValue<'a> {
     /// indistinguishable inside `if (x)` / `x ? …` / `!x`, so such reads fold to
     /// `false` there. See `minimize_expression_in_boolean_context` / #14001.
     pub boolean_falsy: bool,
-}
-
-/// Per-symbol scratch store indexed by `SymbolId`.
-///
-/// Symbol IDs are dense `u32`s, so an indexed `IndexVec` lookup beats a
-/// `FxHashMap` (hash + probe) on every hot path in the peephole pass.
-///
-/// Sized once from `Scoping::symbols_len()`; no minifier pass mints new
-/// symbols, so `init_value` panics on out-of-range — that's the signal to
-/// add a grow path.
-#[derive(Debug)]
-pub struct SymbolValues<'a> {
-    values: IndexVec<SymbolId, Option<SymbolValue<'a>>>,
-}
-
-impl<'a> SymbolValues<'a> {
-    pub(crate) fn new(len: usize) -> Self {
-        let mut values = IndexVec::with_capacity(len);
-        values.resize_with(len, || None);
-        Self { values }
-    }
-
-    /// Reset slots to `None` without releasing the buffer, so the next peephole
-    /// iteration's `init_value` stays on the indexed-write fast path.
-    pub fn reset(&mut self) {
-        for slot in &mut self.values {
-            *slot = None;
-        }
-    }
-
-    #[inline]
-    pub fn init_value(&mut self, symbol_id: SymbolId, symbol_value: SymbolValue<'a>) {
-        self.values[symbol_id] = Some(symbol_value);
-    }
-
-    #[inline]
-    pub fn get_symbol_value(&self, symbol_id: SymbolId) -> Option<&SymbolValue<'a>> {
-        self.values.get(symbol_id)?.as_ref()
-    }
 }

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -179,7 +179,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         self.scoping()
             .get_reference(reference_id)
             .symbol_id()
-            .and_then(|symbol_id| self.state.symbol_values.get_symbol_value(symbol_id))
+            .and_then(|symbol_id| self.state.symbols.value(symbol_id))
             .filter(|sv| !sv.references.has_writes())
             .and_then(|sv| sv.initialized_constant.as_ref())
     }
@@ -326,7 +326,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
             kind,
             boolean_falsy,
         };
-        self.state.symbol_values.init_value(symbol_id, symbol_value);
+        self.state.symbols.init_value(symbol_id, symbol_value);
     }
 
     /// If two expressions are equal.


### PR DESCRIPTION
`MinifierState` separately exposed dense per-pass values, sparse persistent metadata, and optional reachability state even though all three are indexed by semantic symbols. Its private-member stack also used symbol terminology despite storing names rather than `SymbolId`s.

This introduces a `SymbolState` facade that documents the three storage lifecycles and forwards their operations while leaving the reachability algorithm in its dedicated module. The class-local tracker is renamed around private-member usage so it cannot be confused with semantic symbol state.

The PR tip passed the full `oxc_minifier` suite independently. The completed stack also passed clippy with warnings denied, formatting, minsize and allocation regeneration, and `just ready`.

## Stack

1. #24636 — function-summary correctness
2. #24637 — explicit symbol effect types
3. #24638 — grouped reference counts
4. #24639 — merged persistent metadata
5. **#24640 — SymbolState facade**

Implemented with AI assistance (OpenAI Codex). The contributor remains responsible for reviewing, understanding, and submitting the changes under the repository AI usage policy.