### PR TITLE
refactor(react_compiler): use BitSet and IndexVec instead of hash containers

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
@@ -13,13 +13,14 @@
 //! 1. Forward data-flow: identify all macro tags (including property loads like `fbt.param`)
 //! 2. Reverse data-flow: merge arguments of macro invocations into the same scope
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::visitors;
 use crate::react_compiler_hir::{
     HirFunction, IdentifierId, InstructionValue, JsxTag, PrimitiveValue, PropertyLiteral, ScopeId,
 };
+use crate::react_compiler_utils::BitSet;
 
 /// Whether a macro requires its arguments to be transitively inlined (e.g., fbt)
 /// or just avoids having the top-level values be converted to variables (e.g., fbt.param).
@@ -34,7 +35,27 @@ enum InlineLevel {
 struct MacroDefinition {
     level: InlineLevel,
     /// Maps property names to their own MacroDefinition. `"*"` is a wildcard.
-    properties: Option<FxHashMap<String, MacroDefinition>>,
+    properties: Option<MacroKinds>,
+}
+
+/// Name -> definition map for macro tags, keyed like a map (last insert wins, no
+/// duplicate keys) but backed by a linear-scan `Vec`: the built-in FBT tags, their
+/// nested property tables, and any user-configured custom macros only ever amount to a
+/// handful of entries, so this avoids the hashing and monomorphization of a `HashMap`.
+#[derive(Debug, Clone)]
+struct MacroKinds(Vec<(String, MacroDefinition)>);
+
+impl MacroKinds {
+    fn get(&self, name: &str) -> Option<&MacroDefinition> {
+        self.0.iter().find(|(key, _)| key == name).map(|(_, def)| def)
+    }
+
+    fn insert(&mut self, name: String, def: MacroDefinition) {
+        match self.0.iter_mut().find(|(key, _)| *key == name) {
+            Some((_, existing)) => *existing = def,
+            None => self.0.push((name, def)),
+        }
+    }
 }
 
 fn shallow_macro() -> MacroDefinition {
@@ -46,49 +67,46 @@ fn transitive_macro() -> MacroDefinition {
 }
 
 fn fbt_macro() -> MacroDefinition {
-    let mut props = FxHashMap::default();
-    props.insert("*".to_string(), shallow_macro());
     // fbt.enum gets FBT_MACRO (recursive/transitive)
-    // We'll fill this in after construction since it's self-referential.
-    // Instead, we use a special marker and handle it in property lookup.
-    let mut fbt = MacroDefinition { level: InlineLevel::Transitive, properties: Some(props) };
-    // Add "enum" as a recursive reference (same as FBT_MACRO)
     // Since we can't do self-referential structs, we clone the structure.
+    // enum's enum is also recursive, but in practice the depth is bounded.
     let enum_macro = MacroDefinition {
         level: InlineLevel::Transitive,
-        properties: Some({
-            let mut p = FxHashMap::default();
-            p.insert("*".to_string(), shallow_macro());
-            // enum's enum is also recursive, but in practice the depth is bounded
-            p.insert("enum".to_string(), transitive_macro());
-            p
-        }),
+        properties: Some(MacroKinds(vec![
+            ("*".to_string(), shallow_macro()),
+            ("enum".to_string(), transitive_macro()),
+        ])),
     };
-    fbt.properties.as_mut().unwrap().insert("enum".to_string(), enum_macro);
-    fbt
+    MacroDefinition {
+        level: InlineLevel::Transitive,
+        properties: Some(MacroKinds(vec![
+            ("*".to_string(), shallow_macro()),
+            ("enum".to_string(), enum_macro),
+        ])),
+    }
 }
 
 /// Built-in FBT tags and their macro definitions.
-fn fbt_tags() -> FxHashMap<String, MacroDefinition> {
-    let mut tags = FxHashMap::default();
-    tags.insert("fbt".to_string(), fbt_macro());
-    tags.insert("fbt:param".to_string(), shallow_macro());
-    tags.insert("fbt:enum".to_string(), fbt_macro());
-    tags.insert("fbt:plural".to_string(), shallow_macro());
-    tags.insert("fbs".to_string(), fbt_macro());
-    tags.insert("fbs:param".to_string(), shallow_macro());
-    tags.insert("fbs:enum".to_string(), fbt_macro());
-    tags.insert("fbs:plural".to_string(), shallow_macro());
-    tags
+fn fbt_tags() -> MacroKinds {
+    MacroKinds(vec![
+        ("fbt".to_string(), fbt_macro()),
+        ("fbt:param".to_string(), shallow_macro()),
+        ("fbt:enum".to_string(), fbt_macro()),
+        ("fbt:plural".to_string(), shallow_macro()),
+        ("fbs".to_string(), fbt_macro()),
+        ("fbs:param".to_string(), shallow_macro()),
+        ("fbs:enum".to_string(), fbt_macro()),
+        ("fbs:plural".to_string(), shallow_macro()),
+    ])
 }
 
 /// Main entry point. Returns the set of identifier IDs that are fbt/macro operands.
 pub fn memoize_fbt_and_macro_operands_in_same_scope(
     func: &HirFunction,
     env: &mut Environment,
-) -> FxHashSet<IdentifierId> {
+) -> BitSet<IdentifierId> {
     // Phase 1: Build macro kinds map from built-in FBT tags + custom macros
-    let mut macro_kinds: FxHashMap<String, MacroDefinition> = fbt_tags();
+    let mut macro_kinds: MacroKinds = fbt_tags();
     if let Some(ref custom_macros) = env.config.custom_macros {
         for name in custom_macros {
             macro_kinds.insert(name.clone(), transitive_macro());
@@ -107,7 +125,7 @@ pub fn memoize_fbt_and_macro_operands_in_same_scope(
 /// things like `fbt.foo.bar(...)`.
 fn populate_macro_tags(
     func: &HirFunction,
-    macro_kinds: &FxHashMap<String, MacroDefinition>,
+    macro_kinds: &MacroKinds,
 ) -> FxHashMap<IdentifierId, MacroDefinition> {
     let mut macro_tags: FxHashMap<IdentifierId, MacroDefinition> = FxHashMap::default();
 
@@ -162,9 +180,9 @@ fn merge_macro_arguments(
     func: &HirFunction,
     env: &mut Environment,
     macro_tags: &mut FxHashMap<IdentifierId, MacroDefinition>,
-    macro_kinds: &FxHashMap<String, MacroDefinition>,
-) -> FxHashSet<IdentifierId> {
-    let mut macro_values: FxHashSet<IdentifierId> = macro_tags.keys().copied().collect();
+    macro_kinds: &MacroKinds,
+) -> BitSet<IdentifierId> {
+    let mut macro_values: BitSet<IdentifierId> = macro_tags.keys().copied().collect();
 
     // Iterate blocks in reverse order
     let block_ids: Vec<_> = func.body.blocks.keys().copied().collect();
@@ -335,7 +353,7 @@ fn visit_operands(
     lvalue_id: IdentifierId,
     value: &InstructionValue,
     env: &mut Environment,
-    macro_values: &mut FxHashSet<IdentifierId>,
+    macro_values: &mut BitSet<IdentifierId>,
     macro_tags: &mut FxHashMap<IdentifierId, MacroDefinition>,
 ) {
     macro_values.insert(lvalue_id);

--- a/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
@@ -15,9 +15,9 @@
 //!
 //! Ported from TypeScript `src/HIR/MergeOverlappingReactiveScopesHIR.ts`.
 
-use rustc_hash::FxHashMap;
-use rustc_hash::FxHashSet;
 use std::cmp;
+
+use oxc_index::IndexVec;
 
 use crate::react_compiler_hir::Instruction;
 use crate::react_compiler_hir::MutableRangeId;
@@ -27,29 +27,23 @@ use crate::react_compiler_hir::visitors::{each_instruction_lvalue_ids, each_term
 use crate::react_compiler_hir::{
     EvaluationOrder, HirFunction, IdentifierId, InstructionValue, ScopeId, Type,
 };
-use crate::react_compiler_utils::DisjointSet;
+use crate::react_compiler_utils::{BitSet, DisjointSet};
 
 // =============================================================================
 // ScopeInfo
 // =============================================================================
 
-struct ScopeStartEntry {
-    id: EvaluationOrder,
-    scopes: Vec<ScopeId>,
-}
-
-struct ScopeEndEntry {
+/// A set of scopes that all start (or all end) at the same evaluation order.
+struct ScopeEntry {
     id: EvaluationOrder,
     scopes: Vec<ScopeId>,
 }
 
 struct ScopeInfo {
     /// Sorted descending by id (so we can pop from the end for smallest)
-    scope_starts: Vec<ScopeStartEntry>,
+    scope_starts: Vec<ScopeEntry>,
     /// Sorted descending by id (so we can pop from the end for smallest)
-    scope_ends: Vec<ScopeEndEntry>,
-    /// Maps IdentifierId -> ScopeId for all places that have a scope
-    place_scopes: FxHashMap<IdentifierId, ScopeId>,
+    scope_ends: Vec<ScopeEntry>,
 }
 
 // =============================================================================
@@ -93,21 +87,25 @@ fn is_mutable(env: &Environment, id: EvaluationOrder, identifier_id: IdentifierI
 // collectScopeInfo
 // =============================================================================
 
-fn collect_scope_info(func: &HirFunction, env: &Environment) -> ScopeInfo {
-    let mut scope_starts_map: FxHashMap<EvaluationOrder, Vec<ScopeId>> = FxHashMap::default();
-    let mut scope_ends_map: FxHashMap<EvaluationOrder, Vec<ScopeId>> = FxHashMap::default();
-    let mut place_scopes: FxHashMap<IdentifierId, ScopeId> = FxHashMap::default();
+fn collect_scope_info(
+    func: &HirFunction,
+    env: &Environment,
+) -> (ScopeInfo, IndexVec<IdentifierId, Option<ScopeId>>) {
+    let mut scope_start_pairs: Vec<(EvaluationOrder, ScopeId)> = Vec::new();
+    let mut scope_end_pairs: Vec<(EvaluationOrder, ScopeId)> = Vec::new();
+    let mut place_scopes: IndexVec<IdentifierId, Option<ScopeId>> =
+        IndexVec::from_vec(vec![None; env.identifiers.len()]);
 
     let mut collect_place_scope = |identifier_id: IdentifierId, env: &Environment| {
         let scope_id = match env.identifiers[identifier_id].scope {
             Some(s) => s,
             None => return,
         };
-        place_scopes.insert(identifier_id, scope_id);
+        place_scopes[identifier_id] = Some(scope_id);
         let range = &env.scopes[scope_id].range;
         if range.start != range.end {
-            scope_starts_map.entry(range.start).or_default().push(scope_id);
-            scope_ends_map.entry(range.end).or_default().push(scope_id);
+            scope_start_pairs.push((range.start, scope_id));
+            scope_end_pairs.push((range.end, scope_id));
         }
     };
 
@@ -135,31 +133,32 @@ fn collect_scope_info(func: &HirFunction, env: &Environment) -> ScopeInfo {
         }
     }
 
-    // Deduplicate scope IDs in each entry, preserving insertion order.
-    // The TS uses Set<ReactiveScope> which preserves insertion order and deduplicates.
-    // We must NOT sort by ScopeId here — the insertion order determines which scope
-    // becomes the root in the disjoint set union.
-    fn dedup_preserve_order(scopes: &mut Vec<ScopeId>) {
-        let mut seen = FxHashSet::default();
-        scopes.retain(|s| seen.insert(*s));
-    }
-    for scopes in scope_starts_map.values_mut() {
-        dedup_preserve_order(scopes);
-    }
-    for scopes in scope_ends_map.values_mut() {
-        dedup_preserve_order(scopes);
+    // Group pairs into per-evaluation-order entries, sorted descending by id (for
+    // pop-from-end), deduplicating scope IDs within each entry while preserving
+    // insertion order. The TS uses Set<ReactiveScope> which preserves insertion order
+    // and deduplicates. We must NOT sort scopes by ScopeId here — the insertion order
+    // determines which scope becomes the root in the disjoint set union, so the sort
+    // by id must be stable.
+    fn group_pairs(mut pairs: Vec<(EvaluationOrder, ScopeId)>) -> Vec<ScopeEntry> {
+        pairs.sort_by_key(|(id, _)| cmp::Reverse(*id));
+        let mut entries: Vec<ScopeEntry> = Vec::new();
+        for (id, scope) in pairs {
+            match entries.last_mut() {
+                Some(entry) if entry.id == id => {
+                    if !entry.scopes.contains(&scope) {
+                        entry.scopes.push(scope);
+                    }
+                }
+                _ => entries.push(ScopeEntry { id, scopes: vec![scope] }),
+            }
+        }
+        entries
     }
 
-    // Convert to sorted vecs (descending by id for pop-from-end)
-    let mut scope_starts: Vec<ScopeStartEntry> =
-        scope_starts_map.into_iter().map(|(id, scopes)| ScopeStartEntry { id, scopes }).collect();
-    scope_starts.sort_unstable_by_key(|a| std::cmp::Reverse(a.id));
+    let scope_starts = group_pairs(scope_start_pairs);
+    let scope_ends = group_pairs(scope_end_pairs);
 
-    let mut scope_ends: Vec<ScopeEndEntry> =
-        scope_ends_map.into_iter().map(|(id, scopes)| ScopeEndEntry { id, scopes }).collect();
-    scope_ends.sort_unstable_by_key(|a| std::cmp::Reverse(a.id));
-
-    ScopeInfo { scope_starts, scope_ends, place_scopes }
+    (ScopeInfo { scope_starts, scope_ends }, place_scopes)
 }
 
 // =============================================================================
@@ -303,11 +302,9 @@ fn get_overlapping_reactive_scopes(
 ///
 /// Corresponds to TS `mergeOverlappingReactiveScopesHIR(fn: HIRFunction): void`.
 pub fn merge_overlapping_reactive_scopes_hir(func: &mut HirFunction, env: &mut Environment) {
-    // Collect scope info
-    let scope_info = collect_scope_info(func, env);
-
-    // Save place_scopes before moving scope_info
-    let place_scopes = scope_info.place_scopes.clone();
+    // Collect scope info. `place_scopes` is kept aside; `get_overlapping_reactive_scopes`
+    // consumes the rest of `ScopeInfo`.
+    let (scope_info, place_scopes) = collect_scope_info(func, env);
 
     // Find overlapping scopes
     let mut joined_scopes = get_overlapping_reactive_scopes(func, env, scope_info);
@@ -326,11 +323,11 @@ pub fn merge_overlapping_reactive_scopes_hir(func: &mut HirFunction, env: &mut E
     // When scope.range is updated, ALL identifiers referencing that range object
     // automatically see the new values. We use MutableRangeId to identify which
     // identifiers share the same logical range as a root scope.
-    let mut original_root_range_ids: FxHashMap<ScopeId, MutableRangeId> = FxHashMap::default();
+    let mut seen_roots = BitSet::<ScopeId>::new();
+    let mut original_root_range_ids: Vec<(ScopeId, MutableRangeId)> = Vec::new();
     for (_, root_id) in &scope_groups {
-        if !original_root_range_ids.contains_key(root_id) {
-            let range_id = env.scopes[*root_id].range.id;
-            original_root_range_ids.insert(*root_id, range_id);
+        if seen_roots.insert(*root_id) {
+            original_root_range_ids.push((*root_id, env.scopes[*root_id].range.id));
         }
     }
 
@@ -362,10 +359,11 @@ pub fn merge_overlapping_reactive_scopes_hir(func: &mut HirFunction, env: &mut E
     // Note: we intentionally do NOT update mutable_range for repointed identifiers,
     // matching TS behavior where identifier.mutableRange still references the old scope's
     // range object after scope repointing.
-    for (identifier_id, original_scope) in &place_scopes {
+    for (identifier_id, original_scope) in place_scopes.iter_enumerated() {
+        let Some(original_scope) = original_scope else { continue };
         let next_scope = joined_scopes.find(*original_scope);
         if next_scope != *original_scope {
-            env.identifiers[*identifier_id].scope = Some(next_scope);
+            env.identifiers[identifier_id].scope = Some(next_scope);
         }
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
@@ -13,8 +13,6 @@
 
 use std::mem::replace;
 
-use rustc_hash::FxHashSet;
-
 use oxc_str::Ident;
 
 use crate::react_compiler_hir::environment::Environment;
@@ -22,6 +20,7 @@ use crate::react_compiler_hir::{
     FunctionId, HirFunction, IdentifierId, InstructionValue, NonLocalBinding,
 };
 use crate::react_compiler_ssa::enter_ssa::placeholder_function;
+use crate::react_compiler_utils::BitSet;
 
 /// Outline anonymous function expressions that have no captured context variables.
 ///
@@ -29,7 +28,7 @@ use crate::react_compiler_ssa::enter_ssa::placeholder_function;
 pub fn outline_functions<'a>(
     func: &mut HirFunction<'a>,
     env: &mut Environment<'a>,
-    fbt_operands: &FxHashSet<IdentifierId>,
+    fbt_operands: &BitSet<IdentifierId>,
 ) {
     // Collect per-instruction actions to maintain depth-first name allocation order.
     // Each entry: (instr index, function_id to recurse into, should_outline)
@@ -57,7 +56,7 @@ pub fn outline_functions<'a>(
                     // 3. Not an fbt operand
                     if inner_func.context.is_empty()
                         && inner_func.id.is_none()
-                        && !fbt_operands.contains(&lvalue_id)
+                        && !fbt_operands.contains(lvalue_id)
                     {
                         actions.push(Action::RecurseAndOutline {
                             instr_idx: instr_id.index(),

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -47,6 +47,7 @@ use crate::react_compiler_hir::reactive::ReactiveStatement;
 use crate::react_compiler_hir::reactive::ReactiveTerminal;
 use crate::react_compiler_hir::reactive::ReactiveTerminalTargetKind;
 use crate::react_compiler_hir::reactive::ReactiveValue;
+use crate::react_compiler_utils::BitSet;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
 
@@ -76,7 +77,7 @@ pub fn codegen_function<'a>(
     func: &ReactiveFunction<'a>,
     env: &mut Environment<'a>,
     unique_identifiers: IdentHashSet<'a>,
-    fbt_operands: FxHashSet<IdentifierId>,
+    fbt_operands: BitSet<IdentifierId>,
 ) -> Result<crate::react_compiler::entrypoint::compile_result::CodegenFunction<'a>, OxcDiagnostic> {
     use crate::react_compiler::entrypoint::compile_result::CodegenFunction as OxcCodegenFunction;
     use oxc_span::SPAN;
@@ -185,7 +186,7 @@ pub fn codegen_function<'a>(
 fn ox_codegen_outlined<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
     env: &mut Environment<'a>,
-    fbt_operands: FxHashSet<IdentifierId>,
+    fbt_operands: BitSet<IdentifierId>,
 ) -> Result<
     Vec<crate::react_compiler::entrypoint::compile_result::OutlinedFunction<'a>>,
     OxcDiagnostic,
@@ -267,7 +268,7 @@ struct OxcContext<'a, 'env> {
     object_methods: FxHashMap<IdentifierId, (InstructionValue<'a>, Option<Span>)>,
     unique_identifiers: IdentHashSet<'a>,
     #[allow(dead_code)]
-    fbt_operands: FxHashSet<IdentifierId>,
+    fbt_operands: BitSet<IdentifierId>,
     synthesized_names: IdentHashMap<'a, Ident<'a>>,
 }
 
@@ -276,7 +277,7 @@ impl<'a, 'env> OxcContext<'a, 'env> {
         ast: oxc_ast::builder::AstBuilder<'a>,
         env: &'env mut Environment<'a>,
         unique_identifiers: IdentHashSet<'a>,
-        fbt_operands: FxHashSet<IdentifierId>,
+        fbt_operands: BitSet<IdentifierId>,
     ) -> Self {
         OxcContext {
             ast,
@@ -2825,7 +2826,7 @@ fn ox_codegen_jsx_attribute<'a>(
                 oxc_ast::ast::JSXAttributeName::new_identifier(SPAN, ox_str(&cx.ast, name), &cx.ast)
             };
 
-            let is_fbt_operand = cx.fbt_operands.contains(&place.identifier);
+            let is_fbt_operand = cx.fbt_operands.contains(place.identifier);
             let inner_value = ox_codegen_place_to_expression(cx, place)?;
             let attr_value = match inner_value {
                 oxc::Expression::StringLiteral(ref s)

--- a/crates/oxc_react_compiler/src/react_compiler_utils/bit_set.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_utils/bit_set.rs
@@ -1,0 +1,149 @@
+//! Bit set keyed by a typed index.
+//!
+//! [`BitSet<I>`] is a replacement for `FxHashSet<I>` where `I` is a dense [`oxc_index`]
+//! index type (e.g. the HIR IDs defined with `define_nonmax_u32_index_type!`).
+//!
+//! Prefer it over a hash set when the key space is a dense, bounded universe of IDs
+//! (per-function or per-program index spaces):
+//!
+//! - Membership is a single shift + mask — no hashing.
+//! - Memory is 1 bit per possible ID, so even a mostly-empty set over a universe of
+//!   thousands of IDs costs a few hundred bytes.
+//! - All methods forward to a shared non-generic implementation, so each additional
+//!   `I` costs almost no binary size, unlike hash sets which monomorphize several KiB
+//!   of probe/grow machinery per element type.
+//! - Iteration yields IDs in ascending index order, which is deterministic across runs.
+//!
+//! Stick with a hash set when the key space is unbounded or extremely sparse relative
+//! to its maximum index (e.g. string keys, or IDs sampled from a huge universe).
+//!
+//! The API is intentionally limited to what current callers need (`insert` / `contains`
+//! / `iter`); grow it as the `FxHashSet` -> `BitSet` migration reaches more passes.
+
+use std::{fmt, marker::PhantomData};
+
+use oxc_index::Idx;
+
+const BITS: usize = usize::BITS as usize;
+
+/// Non-generic implementation backing [`BitSet`].
+///
+/// All real code lives here so that `BitSet<I>` instantiations share it.
+#[derive(Clone, Default)]
+struct RawBitSet {
+    words: Vec<usize>,
+}
+
+impl RawBitSet {
+    fn insert(&mut self, index: usize) -> bool {
+        let word_index = index / BITS;
+        if word_index >= self.words.len() {
+            self.words.resize(word_index + 1, 0);
+        }
+        let bit = 1 << (index % BITS);
+        let word = &mut self.words[word_index];
+        let is_new = *word & bit == 0;
+        *word |= bit;
+        is_new
+    }
+
+    fn contains(&self, index: usize) -> bool {
+        match self.words.get(index / BITS) {
+            Some(word) => word & (1 << (index % BITS)) != 0,
+            None => false,
+        }
+    }
+
+    fn iter(&self) -> RawIter<'_> {
+        RawIter {
+            words: &self.words,
+            word_index: 0,
+            current: self.words.first().copied().unwrap_or(0),
+        }
+    }
+}
+
+/// Iterator over set bit indices, ascending.
+struct RawIter<'a> {
+    words: &'a [usize],
+    word_index: usize,
+    current: usize,
+}
+
+impl Iterator for RawIter<'_> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<usize> {
+        while self.current == 0 {
+            self.word_index += 1;
+            self.current = *self.words.get(self.word_index)?;
+        }
+        let bit = self.current.trailing_zeros() as usize;
+        // Clear the lowest set bit.
+        self.current &= self.current - 1;
+        Some(self.word_index * BITS + bit)
+    }
+}
+
+/// A set of typed indices backed by a bit vector. See the [module docs](self) for
+/// when to prefer this over `FxHashSet<I>`.
+#[derive(Clone)]
+pub struct BitSet<I: Idx> {
+    raw: RawBitSet,
+    marker: PhantomData<I>,
+}
+
+impl<I: Idx> BitSet<I> {
+    /// Create an empty set.
+    #[inline]
+    pub fn new() -> Self {
+        Self { raw: RawBitSet::default(), marker: PhantomData }
+    }
+
+    /// Add `id` to the set. Returns `true` if it was not already present.
+    #[inline]
+    pub fn insert(&mut self, id: I) -> bool {
+        self.raw.insert(id.index())
+    }
+
+    /// Returns `true` if `id` is in the set.
+    #[inline]
+    pub fn contains(&self, id: I) -> bool {
+        self.raw.contains(id.index())
+    }
+
+    /// Iterate over the IDs in the set in ascending index order.
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = I> + '_ {
+        self.raw.iter().map(I::from_usize)
+    }
+}
+
+impl<I: Idx> Default for BitSet<I> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<I: Idx> Extend<I> for BitSet<I> {
+    fn extend<T: IntoIterator<Item = I>>(&mut self, iter: T) {
+        for id in iter {
+            self.insert(id);
+        }
+    }
+}
+
+impl<I: Idx> FromIterator<I> for BitSet<I> {
+    fn from_iter<T: IntoIterator<Item = I>>(iter: T) -> Self {
+        let mut set = Self::new();
+        set.extend(iter);
+        set
+    }
+}
+
+impl<I: Idx> fmt::Debug for BitSet<I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}

--- a/crates/oxc_react_compiler/src/react_compiler_utils/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_utils/mod.rs
@@ -1,8 +1,10 @@
 use indexmap::{IndexMap, IndexSet};
 use rustc_hash::FxBuildHasher;
 
+pub mod bit_set;
 pub mod disjoint_set;
 
+pub use bit_set::BitSet;
 pub use disjoint_set::DisjointSet;
 
 /// `IndexMap` keyed with the fast `FxHasher` (rustc-hash) instead of the default SipHash.


### PR DESCRIPTION
## What

`FxHashMap`/`FxHashSet` monomorphize several KiB of probe/grow/rehash machinery per key/value type. `oxc_react_compiler` is the single largest owner of hash-container instantiations in the oxlint binary, and many of its maps/sets are keyed by dense per-function HIR indices (`IdentifierId`, `ScopeId`, `BlockId`, ...) where a hash table is the wrong data structure.

This adds a `BitSet<I: Idx>` in `react_compiler_utils` (next to `DisjointSet`) and migrates two passes as a first step:

- **`BitSet<I>`** — all real code lives in a non-generic backing type, so every typed-index instantiation shares one implementation instead of emitting its own probe/grow copy. 1 bit per possible ID, deterministic ascending iteration. API is deliberately limited to what current callers need (`insert`/`contains`/`iter`); it can grow as more passes migrate.
- **`memoize_fbt_and_macro_operands_in_same_scope`** — fbt-operand set → `BitSet<IdentifierId>`; the small built-in macro tables → linear-scan `Vec<(String, _)>`.
- **`merge_overlapping_reactive_scopes_hir`** — `place_scopes` → `IndexVec<IdentifierId, Option<ScopeId>>`; scope-start/end maps → sorted pair vectors that preserve the original insertion-order semantics (which decide disjoint-set union roots).

Snapshot output is byte-identical.

## Why

Binary size. Measured on oxlint (arm64 fat-LTO release, cargo-bloat with v0 mangling): container machinery is ~4.7% of `.text` as directly-attributable symbols (a lower bound — LTO inlines the hot paths into callers), and `oxc_react_compiler` owns the largest share. These two passes are a scoped proof-of-approach; the bulk of the win lands as the remaining ID-keyed containers migrate, since an instantiation's machinery only disappears once its last user is converted.

## Follow-ups

- Migrate the rest of `oxc_react_compiler`'s ID-keyed sets (→ `BitSet`) and dense maps (→ `IndexVec`), per-file snapshot-gated; the fixpoint passes (e.g. `infer_mutation_aliasing_effects`) last, as they need set-union operations on `BitSet`.
- Benchmark the full migration (react_compiler bench, interleaved A/B) as its gate — these swaps remove hashing and don't add allocations, but the wholesale change should be measured.

---
AI usage disclosure: prepared with Claude Code and reviewed before submission.
