### PR TITLE
fix(linter): emit valid disable comments in JSX

### DIFF
--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -8,10 +8,11 @@ use std::{
 };
 
 use oxc_allocator::{Allocator, ArenaBox};
+use oxc_ast::AstKind;
 use oxc_diagnostics::{OxcDiagnostic, Severity};
 use oxc_parser::Token;
 use oxc_semantic::Semantic;
-use oxc_span::{SourceType, Span};
+use oxc_span::{GetSpan, SourceType, Span};
 
 use crate::{
     AllowWarnDeny, FrameworkFlags,
@@ -316,7 +317,16 @@ impl<'a> ContextHost<'a> {
     pub(crate) fn push_diagnostic(&self, mut diagnostic: Message) {
         if self.with_ignore_fixes {
             let source_text = self.semantic().source_text();
-            diagnostic.add_ignore_fix(self.current_sub_host().source_text_offset, source_text);
+            let jsx_child_offset = self
+                .source_type()
+                .is_jsx()
+                .then(|| self.jsx_child_offset(diagnostic.span))
+                .flatten();
+            diagnostic.add_ignore_fix(
+                self.current_sub_host().source_text_offset,
+                source_text,
+                jsx_child_offset,
+            );
         }
         if self.current_sub_host().source_text_offset != 0 {
             diagnostic.move_offset(self.current_sub_host().source_text_offset);
@@ -324,12 +334,89 @@ impl<'a> ContextHost<'a> {
         self.diagnostics.borrow_mut().push(diagnostic);
     }
 
+    fn jsx_child_offset(&self, diagnostic_span: Span) -> Option<u32> {
+        let nodes = self.semantic().nodes();
+        let source_text = self.semantic().source_text().as_bytes();
+        let (node_id, node) = nodes
+            .iter_enumerated()
+            .filter(|(_, node)| node.kind().span().contains_inclusive(diagnostic_span))
+            .min_by_key(|(_, node)| {
+                let span = node.kind().span();
+                span.end - span.start
+            })?;
+
+        let mut child_offset = None;
+        let mut in_attribute = false;
+        for kind in std::iter::once(node.kind()).chain(nodes.ancestor_kinds(node_id)) {
+            match kind {
+                // A same-line attribute diagnostic still needs a JSX comment before its child
+                // element. Discard the expression-container anchor and keep walking to it.
+                AstKind::JSXAttribute(_) | AstKind::JSXSpreadAttribute(_) => {
+                    child_offset = None;
+                    in_attribute = true;
+                }
+                AstKind::JSXText(text) => {
+                    child_offset.get_or_insert(text.span.start);
+                }
+                AstKind::JSXSpreadChild(spread) => {
+                    child_offset = Some(spread.span.start);
+                }
+                AstKind::JSXExpressionContainer(container) => {
+                    let container_start = container.span.start as usize;
+                    let diagnostic_start = diagnostic_span.start as usize;
+                    if source_text
+                        .get(container_start..diagnostic_start)
+                        .is_some_and(|prefix| prefix.contains(&b'\n') || prefix.contains(&b'\r'))
+                    {
+                        // Later lines inside `{...}` are JavaScript and need a normal comment.
+                        return None;
+                    }
+                    // Anchor before the expression container, not a JSX element nested inside
+                    // its JavaScript expression.
+                    child_offset = Some(container.span.start);
+                }
+                AstKind::JSXClosingElement(closing) => {
+                    child_offset.get_or_insert(closing.span.start);
+                }
+                AstKind::JSXElement(element) => {
+                    if in_attribute {
+                        let element_start = element.span.start as usize;
+                        let diagnostic_start = diagnostic_span.start as usize;
+                        if source_text.get(element_start..diagnostic_start).is_some_and(|prefix| {
+                            prefix.contains(&b'\n') || prefix.contains(&b'\r')
+                        }) {
+                            return None;
+                        }
+                        in_attribute = false;
+                    }
+                    if child_offset.is_some() {
+                        return child_offset;
+                    }
+                    child_offset = Some(element.span.start);
+                }
+                AstKind::JSXFragment(fragment) => {
+                    if child_offset.is_some() {
+                        return child_offset;
+                    }
+                    child_offset = Some(fragment.span.start);
+                }
+                _ => {}
+            }
+        }
+
+        None
+    }
+
     // Append a list of diagnostics. Only used in report_unused_directives.
     fn append_diagnostics(&self, mut diagnostics: Vec<Message>) {
         if self.with_ignore_fixes {
             let source_text = self.semantic().source_text();
             for diagnostic in &mut diagnostics {
-                diagnostic.add_ignore_fix(self.current_sub_host().source_text_offset, source_text);
+                diagnostic.add_ignore_fix(
+                    self.current_sub_host().source_text_offset,
+                    source_text,
+                    None,
+                );
             }
         }
         if self.current_sub_host().source_text_offset != 0 {
@@ -552,5 +639,143 @@ impl<'a> ContextHost<'a> {
 impl<'a> From<ContextHost<'a>> for Vec<Message> {
     fn from(ctx_host: ContextHost<'a>) -> Self {
         ctx_host.diagnostics.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_semantic::SemanticBuilder;
+
+    use super::*;
+
+    fn byte_offset(source: &str, needle: &str) -> u32 {
+        u32::try_from(source.find(needle).unwrap()).unwrap()
+    }
+
+    fn with_tsx_host(source: &str, f: impl FnOnce(&ContextHost<'_>)) {
+        let allocator = Allocator::default();
+        let parser_ret = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        assert!(parser_ret.diagnostics.is_empty());
+        let program = allocator.alloc(parser_ret.program);
+        let semantic = SemanticBuilder::new_linter().build(program).semantic;
+        let host = ContextHost::new(
+            "test.tsx",
+            vec![ContextSubHost::new(
+                semantic,
+                Arc::new(ModuleRecord::default()),
+                0,
+                ContextSubHostOptions::default(),
+            )],
+            &allocator,
+            LintOptions { with_ignore_fixes: true, ..LintOptions::default() },
+            Arc::default(),
+        );
+        f(&host);
+    }
+
+    #[test]
+    fn jsx_child_offset_finds_same_line_nested_element() {
+        let source = "const node = <div><button onClick={submit} role=\"button\" /></div>;";
+        let start = byte_offset(source, "<button");
+        let end = byte_offset(source, "/></div>") + 2;
+
+        with_tsx_host(source, |host| {
+            assert_eq!(host.jsx_child_offset(Span::new(start, end)), Some(start));
+        });
+    }
+
+    #[test]
+    fn jsx_child_offset_distinguishes_children_from_attributes() {
+        let child_source = "const node = <div>{foo}</div>;";
+        let child_error = byte_offset(child_source, "foo");
+        let child_offset = byte_offset(child_source, "{foo}");
+        with_tsx_host(child_source, |host| {
+            assert_eq!(host.jsx_child_offset(Span::sized(child_error, 3)), Some(child_offset));
+        });
+
+        let attribute_source = "const node = <div value={foo} />;";
+        let attribute_error = byte_offset(attribute_source, "foo");
+        with_tsx_host(attribute_source, |host| {
+            assert_eq!(host.jsx_child_offset(Span::sized(attribute_error, 3)), None);
+        });
+
+        let nested_attribute_source = "const node = <Parent>\n  <Child value={foo} />\n</Parent>;";
+        let nested_attribute_error = byte_offset(nested_attribute_source, "foo");
+        let nested_child_offset = byte_offset(nested_attribute_source, "<Child");
+        with_tsx_host(nested_attribute_source, |host| {
+            assert_eq!(
+                host.jsx_child_offset(Span::sized(nested_attribute_error, 3)),
+                Some(nested_child_offset)
+            );
+        });
+
+        let multiline_expression_source = "const node = <div>{foo &&\n  bar}</div>;";
+        let multiline_expression_error = byte_offset(multiline_expression_source, "bar");
+        with_tsx_host(multiline_expression_source, |host| {
+            assert_eq!(host.jsx_child_offset(Span::sized(multiline_expression_error, 3)), None);
+        });
+
+        let multiline_attribute_source =
+            "const node = <Parent>\n  <Child\n    value={foo}\n  />\n</Parent>;";
+        let multiline_attribute_error = byte_offset(multiline_attribute_source, "foo");
+        with_tsx_host(multiline_attribute_source, |host| {
+            assert_eq!(host.jsx_child_offset(Span::sized(multiline_attribute_error, 3)), None);
+        });
+
+        let spread_attribute_source =
+            "const node = <Parent>\n  <Child\n    {...props}\n  />\n</Parent>;";
+        let spread_attribute_error = byte_offset(spread_attribute_source, "props");
+        with_tsx_host(spread_attribute_source, |host| {
+            assert_eq!(host.jsx_child_offset(Span::sized(spread_attribute_error, 5)), None);
+        });
+    }
+
+    #[test]
+    fn jsx_child_offset_handles_closing_tags_and_spread_children() {
+        let closing_source = "const node = <div>\n</div>;";
+        let closing_offset = byte_offset(closing_source, "</div>");
+        with_tsx_host(closing_source, |host| {
+            assert_eq!(host.jsx_child_offset(Span::sized(closing_offset, 6)), Some(closing_offset));
+        });
+
+        let spread_source = "const node = <div>\n  {...foo}\n</div>;";
+        let spread_error = byte_offset(spread_source, "foo");
+        let spread_offset = byte_offset(spread_source, "{...foo}");
+        with_tsx_host(spread_source, |host| {
+            assert_eq!(host.jsx_child_offset(Span::sized(spread_error, 3)), Some(spread_offset));
+        });
+    }
+
+    #[test]
+    fn push_diagnostic_adds_valid_jsx_ignore_fix() {
+        let source = "const node = (\n  <>\n    <p>Another child</p>\n    <div\n      onClick={() => history.redirect('/')}\n      role=\"link\"\n    />\n  </>\n);";
+        let element_start = byte_offset(source, "<div");
+        let element_end = byte_offset(source, "/>\n  </>") + 2;
+        let line_start = byte_offset(source, "    <div");
+
+        with_tsx_host(source, |host| {
+            host.push_diagnostic(Message::new(
+                OxcDiagnostic::warn("interactive element must be focusable")
+                    .with_error_code("jsx-a11y", "interactive-supports-focus")
+                    .with_label(Span::new(element_start, element_end)),
+                PossibleFixes::None,
+            ));
+
+            let diagnostics = host.take_diagnostics();
+            let PossibleFixes::Multiple(fixes) = &diagnostics[0].fixes else {
+                panic!("expected line and section ignore fixes");
+            };
+            assert_eq!(fixes.len(), 2);
+            assert_eq!(
+                fixes[0].content,
+                "    {/* oxlint-disable-next-line jsx-a11y/interactive-supports-focus */}\n"
+            );
+            assert_eq!(fixes[0].span, Span::empty(line_start));
+            assert_eq!(fixes[0].kind, FixKind::IgnoreFix);
+        });
     }
 }

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -18,7 +18,7 @@ use crate::{
     AllowWarnDeny, FrameworkFlags,
     config::{LintConfig, LintPlugins, OxlintEnv, OxlintGlobals, OxlintSettings},
     disable_directives::{DisableDirectives, DisableDirectivesBuilder, RuleCommentType},
-    fixer::{Fix, FixKind, Message, PossibleFixes},
+    fixer::{Fix, FixKind, IgnoreFixContext, Message, PossibleFixes},
     frameworks::FrameworkOptions,
     module_record::ModuleRecord,
     options::LintOptions,
@@ -47,6 +47,8 @@ pub struct ContextSubHost<'a> {
     pub(super) parser_tokens: ArenaBox<'a, [Token]>,
     /// The source text offset of the sub host
     pub(super) source_text_offset: u32,
+    /// Whether eslint-style disable directives are respected.
+    respect_eslint_disable_directives: bool,
 }
 
 impl<'a> ContextSubHost<'a> {
@@ -80,6 +82,7 @@ impl<'a> ContextSubHost<'a> {
             disable_directives,
             framework_options: options.framework_options,
             parser_tokens: options.parser_tokens,
+            respect_eslint_disable_directives: options.respect_eslint_disable_directives,
         }
     }
 
@@ -103,6 +106,10 @@ impl<'a> ContextSubHost<'a> {
     /// Shared reference to the [`FrameworkOptions`]
     pub fn framework_options(&self) -> FrameworkOptions {
         self.framework_options
+    }
+
+    fn respect_eslint_disable_directives(&self) -> bool {
+        self.respect_eslint_disable_directives
     }
 }
 
@@ -317,15 +324,16 @@ impl<'a> ContextHost<'a> {
     pub(crate) fn push_diagnostic(&self, mut diagnostic: Message) {
         if self.with_ignore_fixes {
             let source_text = self.semantic().source_text();
-            let jsx_child_offset = self
-                .source_type()
-                .is_jsx()
-                .then(|| self.jsx_child_offset(diagnostic.span))
-                .flatten();
+            let context = if self.source_type().is_jsx() {
+                self.jsx_ignore_fix_context(diagnostic.span)
+            } else {
+                IgnoreFixContext::JavaScript
+            };
             diagnostic.add_ignore_fix(
                 self.current_sub_host().source_text_offset,
                 source_text,
-                jsx_child_offset,
+                context,
+                self.current_sub_host().respect_eslint_disable_directives(),
             );
         }
         if self.current_sub_host().source_text_offset != 0 {
@@ -334,26 +342,35 @@ impl<'a> ContextHost<'a> {
         self.diagnostics.borrow_mut().push(diagnostic);
     }
 
-    fn jsx_child_offset(&self, diagnostic_span: Span) -> Option<u32> {
+    fn jsx_ignore_fix_context(&self, diagnostic_span: Span) -> IgnoreFixContext {
         let nodes = self.semantic().nodes();
         let source_text = self.semantic().source_text().as_bytes();
-        let (node_id, node) = nodes
+        let Some((node_id, node)) = nodes
             .iter_enumerated()
             .filter(|(_, node)| node.kind().span().contains_inclusive(diagnostic_span))
             .min_by_key(|(_, node)| {
                 let span = node.kind().span();
                 span.end - span.start
-            })?;
+            })
+        else {
+            return IgnoreFixContext::JavaScript;
+        };
 
         let mut child_offset = None;
         let mut in_attribute = false;
+        let mut expression_offset = None;
         for kind in std::iter::once(node.kind()).chain(nodes.ancestor_kinds(node_id)) {
             match kind {
                 // A same-line attribute diagnostic still needs a JSX comment before its child
                 // element. Discard the expression-container anchor and keep walking to it.
-                AstKind::JSXAttribute(_) | AstKind::JSXSpreadAttribute(_) => {
+                AstKind::JSXAttribute(_) => {
                     child_offset = None;
                     in_attribute = true;
+                }
+                AstKind::JSXSpreadAttribute(spread) => {
+                    child_offset = None;
+                    in_attribute = true;
+                    expression_offset = Some(spread.argument.span().start);
                 }
                 AstKind::JSXText(text) => {
                     child_offset.get_or_insert(text.span.start);
@@ -369,8 +386,9 @@ impl<'a> ContextHost<'a> {
                         .is_some_and(|prefix| prefix.contains(&b'\n') || prefix.contains(&b'\r'))
                     {
                         // Later lines inside `{...}` are JavaScript and need a normal comment.
-                        return None;
+                        return IgnoreFixContext::JavaScript;
                     }
+                    expression_offset = Some(container.span.start + 1);
                     // Anchor before the expression container, not a JSX element nested inside
                     // its JavaScript expression.
                     child_offset = Some(container.span.start);
@@ -385,18 +403,22 @@ impl<'a> ContextHost<'a> {
                         if source_text.get(element_start..diagnostic_start).is_some_and(|prefix| {
                             prefix.contains(&b'\n') || prefix.contains(&b'\r')
                         }) {
-                            return None;
+                            return expression_offset.map_or(
+                                IgnoreFixContext::Unavailable,
+                                IgnoreFixContext::JsxExpression,
+                            );
                         }
                         in_attribute = false;
+                        expression_offset = None;
                     }
-                    if child_offset.is_some() {
-                        return child_offset;
+                    if let Some(child_offset) = child_offset {
+                        return IgnoreFixContext::JsxChild(child_offset);
                     }
                     child_offset = Some(element.span.start);
                 }
                 AstKind::JSXFragment(fragment) => {
-                    if child_offset.is_some() {
-                        return child_offset;
+                    if let Some(child_offset) = child_offset {
+                        return IgnoreFixContext::JsxChild(child_offset);
                     }
                     child_offset = Some(fragment.span.start);
                 }
@@ -404,7 +426,7 @@ impl<'a> ContextHost<'a> {
             }
         }
 
-        None
+        IgnoreFixContext::JavaScript
     }
 
     // Append a list of diagnostics. Only used in report_unused_directives.
@@ -415,7 +437,8 @@ impl<'a> ContextHost<'a> {
                 diagnostic.add_ignore_fix(
                     self.current_sub_host().source_text_offset,
                     source_text,
-                    None,
+                    IgnoreFixContext::JavaScript,
+                    self.current_sub_host().respect_eslint_disable_directives(),
                 );
             }
         }
@@ -684,7 +707,10 @@ mod tests {
         let end = byte_offset(source, "/></div>") + 2;
 
         with_tsx_host(source, |host| {
-            assert_eq!(host.jsx_child_offset(Span::new(start, end)), Some(start));
+            assert_eq!(
+                host.jsx_ignore_fix_context(Span::new(start, end)),
+                IgnoreFixContext::JsxChild(start)
+            );
         });
     }
 
@@ -694,13 +720,19 @@ mod tests {
         let child_error = byte_offset(child_source, "foo");
         let child_offset = byte_offset(child_source, "{foo}");
         with_tsx_host(child_source, |host| {
-            assert_eq!(host.jsx_child_offset(Span::sized(child_error, 3)), Some(child_offset));
+            assert_eq!(
+                host.jsx_ignore_fix_context(Span::sized(child_error, 3)),
+                IgnoreFixContext::JsxChild(child_offset)
+            );
         });
 
         let attribute_source = "const node = <div value={foo} />;";
         let attribute_error = byte_offset(attribute_source, "foo");
         with_tsx_host(attribute_source, |host| {
-            assert_eq!(host.jsx_child_offset(Span::sized(attribute_error, 3)), None);
+            assert_eq!(
+                host.jsx_ignore_fix_context(Span::sized(attribute_error, 3)),
+                IgnoreFixContext::JavaScript
+            );
         });
 
         let nested_attribute_source = "const node = <Parent>\n  <Child value={foo} />\n</Parent>;";
@@ -708,29 +740,48 @@ mod tests {
         let nested_child_offset = byte_offset(nested_attribute_source, "<Child");
         with_tsx_host(nested_attribute_source, |host| {
             assert_eq!(
-                host.jsx_child_offset(Span::sized(nested_attribute_error, 3)),
-                Some(nested_child_offset)
+                host.jsx_ignore_fix_context(Span::sized(nested_attribute_error, 3)),
+                IgnoreFixContext::JsxChild(nested_child_offset)
             );
         });
 
         let multiline_expression_source = "const node = <div>{foo &&\n  bar}</div>;";
         let multiline_expression_error = byte_offset(multiline_expression_source, "bar");
         with_tsx_host(multiline_expression_source, |host| {
-            assert_eq!(host.jsx_child_offset(Span::sized(multiline_expression_error, 3)), None);
+            assert_eq!(
+                host.jsx_ignore_fix_context(Span::sized(multiline_expression_error, 3)),
+                IgnoreFixContext::JavaScript
+            );
         });
 
         let multiline_attribute_source =
             "const node = <Parent>\n  <Child\n    value={foo}\n  />\n</Parent>;";
         let multiline_attribute_error = byte_offset(multiline_attribute_source, "foo");
         with_tsx_host(multiline_attribute_source, |host| {
-            assert_eq!(host.jsx_child_offset(Span::sized(multiline_attribute_error, 3)), None);
+            assert_eq!(
+                host.jsx_ignore_fix_context(Span::sized(multiline_attribute_error, 3)),
+                IgnoreFixContext::JsxExpression(multiline_attribute_error)
+            );
         });
 
         let spread_attribute_source =
             "const node = <Parent>\n  <Child\n    {...props}\n  />\n</Parent>;";
         let spread_attribute_error = byte_offset(spread_attribute_source, "props");
         with_tsx_host(spread_attribute_source, |host| {
-            assert_eq!(host.jsx_child_offset(Span::sized(spread_attribute_error, 5)), None);
+            assert_eq!(
+                host.jsx_ignore_fix_context(Span::sized(spread_attribute_error, 5)),
+                IgnoreFixContext::JsxExpression(spread_attribute_error)
+            );
+        });
+
+        let string_attribute_source =
+            "const node = <Parent>\n  <Child\n    value=\"foo\"\n  />\n</Parent>;";
+        let string_attribute_error = byte_offset(string_attribute_source, "foo");
+        with_tsx_host(string_attribute_source, |host| {
+            assert_eq!(
+                host.jsx_ignore_fix_context(Span::sized(string_attribute_error, 3)),
+                IgnoreFixContext::Unavailable
+            );
         });
     }
 
@@ -739,14 +790,20 @@ mod tests {
         let closing_source = "const node = <div>\n</div>;";
         let closing_offset = byte_offset(closing_source, "</div>");
         with_tsx_host(closing_source, |host| {
-            assert_eq!(host.jsx_child_offset(Span::sized(closing_offset, 6)), Some(closing_offset));
+            assert_eq!(
+                host.jsx_ignore_fix_context(Span::sized(closing_offset, 6)),
+                IgnoreFixContext::JsxChild(closing_offset)
+            );
         });
 
         let spread_source = "const node = <div>\n  {...foo}\n</div>;";
         let spread_error = byte_offset(spread_source, "foo");
         let spread_offset = byte_offset(spread_source, "{...foo}");
         with_tsx_host(spread_source, |host| {
-            assert_eq!(host.jsx_child_offset(Span::sized(spread_error, 3)), Some(spread_offset));
+            assert_eq!(
+                host.jsx_ignore_fix_context(Span::sized(spread_error, 3)),
+                IgnoreFixContext::JsxChild(spread_offset)
+            );
         });
     }
 
@@ -776,6 +833,41 @@ mod tests {
             );
             assert_eq!(fixes[0].span, Span::empty(line_start));
             assert_eq!(fixes[0].kind, FixKind::IgnoreFix);
+        });
+    }
+
+    #[test]
+    fn push_diagnostic_adds_effective_multiline_jsx_attribute_ignore_fix() {
+        let source = "const node = (\n  <div\n    value={foo}\n  />\n);";
+        let error_start = byte_offset(source, "foo");
+
+        with_tsx_host(source, |host| {
+            host.push_diagnostic(Message::new(
+                OxcDiagnostic::warn("undefined variable")
+                    .with_error_code("eslint", "no-undef")
+                    .with_label(Span::sized(error_start, 3)),
+                PossibleFixes::None,
+            ));
+
+            let diagnostics = host.take_diagnostics();
+            let PossibleFixes::Multiple(fixes) = &diagnostics[0].fixes else {
+                panic!("expected line and section ignore fixes");
+            };
+            assert_eq!(fixes.len(), 2);
+            assert_eq!(fixes[0].content, "\n      // oxlint-disable-next-line no-undef\n      ");
+            assert_eq!(fixes[0].span, Span::empty(error_start));
+
+            let mut fixed = source.to_string();
+            fixed.insert_str(fixes[0].span.start as usize, &fixes[0].content);
+
+            let allocator = Allocator::default();
+            let parser_ret = Parser::new(&allocator, &fixed, SourceType::tsx()).parse();
+            assert!(parser_ret.diagnostics.is_empty());
+            let program = allocator.alloc(parser_ret.program);
+            let semantic = SemanticBuilder::new_linter().build(program).semantic;
+            let directives = DisableDirectivesBuilder::new().build(&fixed, semantic.comments());
+            let shifted_error_start = error_start + u32::try_from(fixes[0].content.len()).unwrap();
+            assert!(directives.contains("no-undef", Span::sized(shifted_error_start, 3)));
         });
     }
 }

--- a/crates/oxc_linter/src/fixer/disable_fix.rs
+++ b/crates/oxc_linter/src/fixer/disable_fix.rs
@@ -10,12 +10,21 @@ enum DisableDirective {
     Section,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IgnoreFixContext {
+    JavaScript,
+    JsxChild(u32),
+    JsxExpression(u32),
+    Unavailable,
+}
+
 impl Message {
     pub(crate) fn add_ignore_fix(
         &mut self,
         section_offset: u32,
         section_source_text: &str,
-        jsx_child_offset: Option<u32>,
+        context: IgnoreFixContext,
+        respect_eslint_disable_directives: bool,
     ) {
         // If the error is exactly at the section offset and has 0 span length, it means that the file is the problem
         // and attaching a ignore comment would not ignore the error.
@@ -26,16 +35,24 @@ impl Message {
 
         let Some(rule_name) = oxc_code_short_canonical_name(&self.error.code) else { return };
 
-        self.fixes.extend_fix(vec![
-            disable_for_this_line_with_jsx_child(
+        let mut fixes = Vec::with_capacity(2);
+        if context != IgnoreFixContext::Unavailable {
+            fixes.push(disable_for_this_line_with_context(
                 &rule_name,
                 self.span.start,
                 section_offset,
                 section_source_text,
-                jsx_child_offset,
-            ),
-            disable_for_this_section(&rule_name, section_offset, section_source_text),
-        ]);
+                context,
+                respect_eslint_disable_directives,
+            ));
+        }
+        fixes.push(disable_for_this_section_with_respect(
+            &rule_name,
+            section_offset,
+            section_source_text,
+            respect_eslint_disable_directives,
+        ));
+        self.fixes.extend_fix(fixes);
     }
 }
 
@@ -46,15 +63,17 @@ fn disable_for_this_line(
     section_offset: u32,
     section_source_text: &str,
 ) -> Fix {
-    disable_for_this_line_with_jsx_child(
+    disable_for_this_line_with_context(
         rule_name,
         error_offset,
         section_offset,
         section_source_text,
-        None,
+        IgnoreFixContext::JavaScript,
+        true,
     )
 }
 
+#[cfg(test)]
 fn disable_for_this_line_with_jsx_child(
     rule_name: &str,
     error_offset: u32,
@@ -62,10 +81,45 @@ fn disable_for_this_line_with_jsx_child(
     section_source_text: &str,
     jsx_child_offset: Option<u32>,
 ) -> Fix {
+    disable_for_this_line_with_context(
+        rule_name,
+        error_offset,
+        section_offset,
+        section_source_text,
+        jsx_child_offset.map_or(IgnoreFixContext::JavaScript, IgnoreFixContext::JsxChild),
+        true,
+    )
+}
+
+fn disable_for_this_line_with_context(
+    rule_name: &str,
+    error_offset: u32,
+    section_offset: u32,
+    section_source_text: &str,
+    context: IgnoreFixContext,
+    respect_eslint_disable_directives: bool,
+) -> Fix {
     let bytes = section_source_text.as_bytes();
     let message = format!("Disable {rule_name} for this line");
 
-    if let Some(jsx_child_offset) = jsx_child_offset {
+    if let IgnoreFixContext::JsxExpression(insert_offset) = context {
+        let line_start = line_start_offset(insert_offset, bytes) as usize;
+        let indentation_len = bytes[line_start..insert_offset as usize]
+            .iter()
+            .take_while(|byte| matches!(byte, b' ' | b'\t'))
+            .count();
+        let indentation = String::from_utf8_lossy(&bytes[line_start..line_start + indentation_len]);
+        return Fix {
+            message: Some(Cow::Owned(message)),
+            content: Cow::Owned(format!(
+                "\n{indentation}  // oxlint-disable-next-line {rule_name}\n{indentation}  "
+            )),
+            span: Span::empty(insert_offset),
+            kind: FixKind::IgnoreFix,
+        };
+    }
+
+    if let IgnoreFixContext::JsxChild(jsx_child_offset) = context {
         let child_line_start = line_start_offset(jsx_child_offset, bytes);
         let error_line_start = line_start_offset(error_offset, bytes);
         let target_offset =
@@ -86,9 +140,11 @@ fn disable_for_this_line_with_jsx_child(
             whitespace_range.iter().take_while(|c| matches!(c, b' ' | b'\t')).count();
         let whitespace = String::from_utf8_lossy(&whitespace_range[..whitespace_len]);
 
-        if let Some(existing_comment_end) =
-            get_existing_jsx_disable_comment_end(target_offset, bytes)
-        {
+        if let Some(existing_comment_end) = get_existing_jsx_disable_comment_end(
+            target_offset,
+            bytes,
+            respect_eslint_disable_directives,
+        ) {
             return Fix {
                 message: Some(Cow::Owned(message)),
                 content: Cow::Owned(format!(" {rule_name}")),
@@ -108,7 +164,9 @@ fn disable_for_this_line_with_jsx_child(
     }
 
     // Reuse an inline disable-line comment on the same line when present.
-    if let Some(existing_comment_end) = get_inline_disable_line_comment_end(error_offset, bytes) {
+    if let Some(existing_comment_end) =
+        get_inline_disable_line_comment_end(error_offset, bytes, respect_eslint_disable_directives)
+    {
         return Fix {
             message: Some(Cow::Owned(message)),
             content: Cow::Owned(format!(" {rule_name}")),
@@ -130,9 +188,12 @@ fn disable_for_this_line_with_jsx_child(
         get_section_insert_position(section_offset, line_break_offset, bytes);
 
     // Reuse an existing disable-next-line comment when present by appending the rule.
-    if let Some(existing_comment_end) =
-        get_existing_disable_comment_end(insert_offset, DisableDirective::NextLine, bytes)
-    {
+    if let Some(existing_comment_end) = get_existing_disable_comment_end(
+        insert_offset,
+        DisableDirective::NextLine,
+        bytes,
+        respect_eslint_disable_directives,
+    ) {
         return Fix {
             message: Some(Cow::Owned(message)),
             content: Cow::Owned(format!(" {rule_name}")),
@@ -176,7 +237,11 @@ fn line_start_offset(offset: u32, bytes: &[u8]) -> u32 {
 }
 
 #[expect(clippy::cast_possible_truncation)]
-fn get_existing_jsx_disable_comment_end(target_offset: u32, bytes: &[u8]) -> Option<u32> {
+fn get_existing_jsx_disable_comment_end(
+    target_offset: u32,
+    bytes: &[u8],
+    respect_eslint_disable_directives: bool,
+) -> Option<u32> {
     let target_offset = target_offset as usize;
     let prefix = bytes.get(..target_offset)?;
     let comment_start = prefix.windows(3).rposition(|window| window == b"{/*")?;
@@ -216,11 +281,16 @@ fn get_existing_jsx_disable_comment_end(target_offset: u32, bytes: &[u8]) -> Opt
         index += 1;
     }
 
-    let directive = b"oxlint-disable-next-line";
-    if !content[index..].starts_with(directive) {
+    let directive_len = if content[index..].starts_with(b"oxlint-disable-next-line") {
+        b"oxlint-disable-next-line".len()
+    } else if respect_eslint_disable_directives
+        && content[index..].starts_with(b"eslint-disable-next-line")
+    {
+        b"eslint-disable-next-line".len()
+    } else {
         return None;
-    }
-    index += directive.len();
+    };
+    index += directive_len;
 
     if index < content.len() && !content[index].is_ascii_whitespace() {
         return None;
@@ -234,10 +304,20 @@ fn get_existing_jsx_disable_comment_end(target_offset: u32, bytes: &[u8]) -> Opt
     Some((content_start + merge_end) as u32)
 }
 
+#[cfg(test)]
 fn disable_for_this_section(
     rule_name: &str,
     section_offset: u32,
     section_source_text: &str,
+) -> Fix {
+    disable_for_this_section_with_respect(rule_name, section_offset, section_source_text, true)
+}
+
+fn disable_for_this_section_with_respect(
+    rule_name: &str,
+    section_offset: u32,
+    section_source_text: &str,
+    respect_eslint_disable_directives: bool,
 ) -> Fix {
     let bytes = section_source_text.as_bytes();
     let message = format!("Disable {rule_name} for this whole file");
@@ -245,9 +325,12 @@ fn disable_for_this_section(
     let (content_prefix, insert_offset) = get_section_insert_position(section_offset, 0, bytes);
 
     // Reuse an existing section disable comment when present by appending the rule.
-    if let Some(existing_comment_end) =
-        get_existing_disable_comment_end(insert_offset, DisableDirective::Section, bytes)
-    {
+    if let Some(existing_comment_end) = get_existing_disable_comment_end(
+        insert_offset,
+        DisableDirective::Section,
+        bytes,
+        respect_eslint_disable_directives,
+    ) {
         return Fix {
             message: Some(Cow::Owned(message)),
             content: Cow::Owned(format!(" {rule_name}")),
@@ -315,7 +398,11 @@ fn get_section_insert_position(
 }
 
 #[expect(clippy::cast_possible_truncation)]
-fn get_inline_disable_line_comment_end(error_offset: u32, bytes: &[u8]) -> Option<u32> {
+fn get_inline_disable_line_comment_end(
+    error_offset: u32,
+    bytes: &[u8],
+    respect_eslint_disable_directives: bool,
+) -> Option<u32> {
     let error_offset = error_offset as usize;
     if error_offset > bytes.len() {
         return None;
@@ -329,14 +416,20 @@ fn get_inline_disable_line_comment_end(error_offset: u32, bytes: &[u8]) -> Optio
     let comment_start = bytes[error_offset..line_end].windows(2).position(|w| w == b"//")?;
     let comment_offset = error_offset + comment_start;
 
-    get_disable_comment_end_at_comment_start(comment_offset, DisableDirective::Line, bytes)
-        .map(|offset| offset as u32)
+    get_disable_comment_end_at_comment_start(
+        comment_offset,
+        DisableDirective::Line,
+        bytes,
+        respect_eslint_disable_directives,
+    )
+    .map(|offset| offset as u32)
 }
 
 fn get_disable_comment_end_at_line_start(
     line_start: usize,
     directive: DisableDirective,
     bytes: &[u8],
+    respect_eslint_disable_directives: bool,
 ) -> Option<usize> {
     if line_start > bytes.len() {
         return None;
@@ -346,7 +439,12 @@ fn get_disable_comment_end_at_line_start(
         return None;
     }
 
-    get_disable_comment_end_at_comment_start(line_start, directive, bytes)
+    get_disable_comment_end_at_comment_start(
+        line_start,
+        directive,
+        bytes,
+        respect_eslint_disable_directives,
+    )
 }
 
 #[expect(clippy::cast_possible_truncation)]
@@ -354,6 +452,7 @@ fn get_existing_disable_comment_end(
     insert_offset: u32,
     directive: DisableDirective,
     bytes: &[u8],
+    respect_eslint_disable_directives: bool,
 ) -> Option<u32> {
     let insert_offset = insert_offset as usize;
 
@@ -362,7 +461,12 @@ fn get_existing_disable_comment_end(
     }
 
     // First check the insertion line itself (e.g. section offsets that already point at a comment).
-    if let Some(line_end) = get_disable_comment_end_at_line_start(insert_offset, directive, bytes) {
+    if let Some(line_end) = get_disable_comment_end_at_line_start(
+        insert_offset,
+        directive,
+        bytes,
+        respect_eslint_disable_directives,
+    ) {
         return Some(line_end as u32);
     }
 
@@ -390,14 +494,20 @@ fn get_existing_disable_comment_end(
         line_start -= 1;
     }
 
-    get_disable_comment_end_at_line_start(line_start, directive, bytes)
-        .map(|line_end| line_end as u32)
+    get_disable_comment_end_at_line_start(
+        line_start,
+        directive,
+        bytes,
+        respect_eslint_disable_directives,
+    )
+    .map(|line_end| line_end as u32)
 }
 
 fn get_disable_comment_end_at_comment_start(
     comment_start: usize,
     directive: DisableDirective,
     bytes: &[u8],
+    respect_eslint_disable_directives: bool,
 ) -> Option<usize> {
     if comment_start > bytes.len() {
         return None;
@@ -429,7 +539,9 @@ fn get_disable_comment_end_at_comment_start(
         DisableDirective::NextLine => {
             if line[idx..].starts_with(b"oxlint-disable-next-line") {
                 Some(b"oxlint-disable-next-line".len())
-            } else if line[idx..].starts_with(b"eslint-disable-next-line") {
+            } else if respect_eslint_disable_directives
+                && line[idx..].starts_with(b"eslint-disable-next-line")
+            {
                 Some(b"eslint-disable-next-line".len())
             } else {
                 None
@@ -438,7 +550,9 @@ fn get_disable_comment_end_at_comment_start(
         DisableDirective::Line => {
             if line[idx..].starts_with(b"oxlint-disable-line") {
                 Some(b"oxlint-disable-line".len())
-            } else if line[idx..].starts_with(b"eslint-disable-line") {
+            } else if respect_eslint_disable_directives
+                && line[idx..].starts_with(b"eslint-disable-line")
+            {
                 Some(b"eslint-disable-line".len())
             } else {
                 None
@@ -447,7 +561,9 @@ fn get_disable_comment_end_at_comment_start(
         DisableDirective::Section => {
             if line[idx..].starts_with(b"oxlint-disable") {
                 Some(b"oxlint-disable".len())
-            } else if line[idx..].starts_with(b"eslint-disable") {
+            } else if respect_eslint_disable_directives
+                && line[idx..].starts_with(b"eslint-disable")
+            {
                 Some(b"eslint-disable".len())
             } else {
                 None
@@ -1016,16 +1132,21 @@ mod tests {
     }
 
     #[test]
-    fn disable_for_this_line_keeps_js_comment_for_jsx_attribute() {
+    fn disable_for_this_line_uses_js_comment_inside_multiline_jsx_attribute_expression() {
         let source = "const node = (\n  <div\n    value={foo}\n  />\n);";
         let error_offset = source.find("foo").unwrap() as u32;
-        let line_start = source.find("    value").unwrap() as u32;
 
-        let fix =
-            super::disable_for_this_line_with_jsx_child("no-undef", error_offset, 0, source, None);
+        let fix = super::disable_for_this_line_with_context(
+            "no-undef",
+            error_offset,
+            0,
+            source,
+            super::IgnoreFixContext::JsxExpression(error_offset),
+            true,
+        );
 
-        assert_eq!(fix.content, "    // oxlint-disable-next-line no-undef\n");
-        assert_eq!(fix.span, Span::empty(line_start));
+        assert_eq!(fix.content, "\n      // oxlint-disable-next-line no-undef\n      ");
+        assert_eq!(fix.span, Span::empty(error_offset));
     }
 
     #[test]
@@ -1046,6 +1167,49 @@ mod tests {
 
         assert_eq!(fix.content, " jsx-a11y/control-has-associated-label");
         assert_eq!(fix.span, Span::empty(insert_offset as u32));
+    }
+
+    #[test]
+    fn disable_for_this_line_merges_respected_eslint_jsx_comment() {
+        let existing = "{/* eslint-disable-next-line no-alert */}";
+        let source = format!("const node = <div>\n  {existing}\n  <button />\n</div>;");
+        let child_offset = source.find("<button").unwrap() as u32;
+        let insert_offset = source.find(existing).unwrap() + existing.find(" */}").unwrap();
+
+        let fix = super::disable_for_this_line_with_context(
+            "jsx-a11y/control-has-associated-label",
+            child_offset,
+            0,
+            &source,
+            super::IgnoreFixContext::JsxChild(child_offset),
+            true,
+        );
+
+        assert_eq!(fix.content, " jsx-a11y/control-has-associated-label");
+        assert_eq!(fix.span, Span::empty(insert_offset as u32));
+    }
+
+    #[test]
+    fn disable_for_this_line_does_not_merge_ignored_eslint_jsx_comment() {
+        let existing = "{/* eslint-disable-next-line no-alert */}";
+        let source = format!("const node = <div>\n  {existing}\n  <button />\n</div>;");
+        let child_offset = source.find("<button").unwrap() as u32;
+        let line_start = source.find("  <button").unwrap() as u32;
+
+        let fix = super::disable_for_this_line_with_context(
+            "jsx-a11y/control-has-associated-label",
+            child_offset,
+            0,
+            &source,
+            super::IgnoreFixContext::JsxChild(child_offset),
+            false,
+        );
+
+        assert_eq!(
+            fix.content,
+            "  {/* oxlint-disable-next-line jsx-a11y/control-has-associated-label */}\n"
+        );
+        assert_eq!(fix.span, Span::empty(line_start));
     }
 
     #[test]

--- a/crates/oxc_linter/src/fixer/disable_fix.rs
+++ b/crates/oxc_linter/src/fixer/disable_fix.rs
@@ -11,7 +11,12 @@ enum DisableDirective {
 }
 
 impl Message {
-    pub(crate) fn add_ignore_fix(&mut self, section_offset: u32, section_source_text: &str) {
+    pub(crate) fn add_ignore_fix(
+        &mut self,
+        section_offset: u32,
+        section_source_text: &str,
+        jsx_child_offset: Option<u32>,
+    ) {
         // If the error is exactly at the section offset and has 0 span length, it means that the file is the problem
         // and attaching a ignore comment would not ignore the error.
         // This is because the ignore comment would need to be placed before the error offset, which is not possible.
@@ -22,20 +27,85 @@ impl Message {
         let Some(rule_name) = oxc_code_short_canonical_name(&self.error.code) else { return };
 
         self.fixes.extend_fix(vec![
-            disable_for_this_line(&rule_name, self.span.start, section_offset, section_source_text),
+            disable_for_this_line_with_jsx_child(
+                &rule_name,
+                self.span.start,
+                section_offset,
+                section_source_text,
+                jsx_child_offset,
+            ),
             disable_for_this_section(&rule_name, section_offset, section_source_text),
         ]);
     }
 }
 
+#[cfg(test)]
 fn disable_for_this_line(
     rule_name: &str,
     error_offset: u32,
     section_offset: u32,
     section_source_text: &str,
 ) -> Fix {
+    disable_for_this_line_with_jsx_child(
+        rule_name,
+        error_offset,
+        section_offset,
+        section_source_text,
+        None,
+    )
+}
+
+fn disable_for_this_line_with_jsx_child(
+    rule_name: &str,
+    error_offset: u32,
+    section_offset: u32,
+    section_source_text: &str,
+    jsx_child_offset: Option<u32>,
+) -> Fix {
     let bytes = section_source_text.as_bytes();
     let message = format!("Disable {rule_name} for this line");
+
+    if let Some(jsx_child_offset) = jsx_child_offset {
+        let child_line_start = line_start_offset(jsx_child_offset, bytes);
+        let error_line_start = line_start_offset(error_offset, bytes);
+        let target_offset =
+            if child_line_start == error_line_start { jsx_child_offset } else { error_offset };
+        let target_line_start = line_start_offset(target_offset, bytes);
+        let line_prefix = &bytes[target_line_start as usize..target_offset as usize];
+
+        let (content_prefix, insert_offset, trailing_indent) =
+            if line_prefix.iter().all(|byte| matches!(byte, b' ' | b'\t')) {
+                let (content_prefix, insert_offset) =
+                    get_section_insert_position(section_offset, target_line_start, bytes);
+                (content_prefix, insert_offset, String::new())
+            } else {
+                ("", target_offset, " ".repeat((target_offset - target_line_start) as usize))
+            };
+        let whitespace_range = &bytes[insert_offset as usize..target_offset as usize];
+        let whitespace_len =
+            whitespace_range.iter().take_while(|c| matches!(c, b' ' | b'\t')).count();
+        let whitespace = String::from_utf8_lossy(&whitespace_range[..whitespace_len]);
+
+        if let Some(existing_comment_end) =
+            get_existing_jsx_disable_comment_end(target_offset, bytes)
+        {
+            return Fix {
+                message: Some(Cow::Owned(message)),
+                content: Cow::Owned(format!(" {rule_name}")),
+                span: Span::empty(existing_comment_end),
+                kind: FixKind::IgnoreFix,
+            };
+        }
+
+        return Fix {
+            message: Some(Cow::Owned(message)),
+            content: Cow::Owned(format!(
+                "{content_prefix}{whitespace}{{/* oxlint-disable-next-line {rule_name} */}}\n{trailing_indent}"
+            )),
+            span: Span::empty(insert_offset),
+            kind: FixKind::IgnoreFix,
+        };
+    }
 
     // Reuse an inline disable-line comment on the same line when present.
     if let Some(existing_comment_end) = get_inline_disable_line_comment_end(error_offset, bytes) {
@@ -92,6 +162,76 @@ fn disable_for_this_line(
         span: Span::empty(insert_offset),
         kind: FixKind::IgnoreFix,
     }
+}
+
+fn line_start_offset(offset: u32, bytes: &[u8]) -> u32 {
+    let mut line_start = offset;
+    for byte in bytes[..offset as usize].iter().rev() {
+        if *byte == b'\n' || *byte == b'\r' {
+            break;
+        }
+        line_start -= 1;
+    }
+    line_start
+}
+
+#[expect(clippy::cast_possible_truncation)]
+fn get_existing_jsx_disable_comment_end(target_offset: u32, bytes: &[u8]) -> Option<u32> {
+    let target_offset = target_offset as usize;
+    let prefix = bytes.get(..target_offset)?;
+    let comment_start = prefix.windows(3).rposition(|window| window == b"{/*")?;
+    let content_start = comment_start + 3;
+    let close_start = content_start
+        + bytes
+            .get(content_start..target_offset)?
+            .windows(3)
+            .position(|window| window == b"*/}")?;
+
+    let between_comment_and_target = bytes.get(close_start + 3..target_offset)?;
+    if !between_comment_and_target.iter().all(u8::is_ascii_whitespace) {
+        return None;
+    }
+    let mut line_break_count = 0;
+    let mut index = 0;
+    while index < between_comment_and_target.len() {
+        match between_comment_and_target[index] {
+            b'\r' => {
+                line_break_count += 1;
+                if between_comment_and_target.get(index + 1) == Some(&b'\n') {
+                    index += 1;
+                }
+            }
+            b'\n' => line_break_count += 1,
+            _ => {}
+        }
+        index += 1;
+    }
+    if line_break_count != 1 {
+        return None;
+    }
+
+    let content = bytes.get(content_start..close_start)?;
+    let mut index = 0;
+    while index < content.len() && content[index].is_ascii_whitespace() {
+        index += 1;
+    }
+
+    let directive = b"oxlint-disable-next-line";
+    if !content[index..].starts_with(directive) {
+        return None;
+    }
+    index += directive.len();
+
+    if index < content.len() && !content[index].is_ascii_whitespace() {
+        return None;
+    }
+
+    let content_end =
+        content.iter().rposition(|byte| !byte.is_ascii_whitespace()).map_or(index, |last| last + 1);
+    let merge_end = find_description_start_offset(&content[index..content_end])
+        .map_or(content_end, |offset| index + offset);
+
+    Some((content_start + merge_end) as u32)
 }
 
 fn disable_for_this_section(
@@ -814,6 +954,98 @@ mod tests {
         let fix = super::disable_for_this_line("no-console", error_offset, 0, source);
 
         assert_eq!(fix.content, "// oxlint-disable-next-line no-console\n");
+    }
+
+    #[test]
+    fn disable_for_this_line_uses_jsx_comment_before_multiline_child() {
+        let source = "const node = (\n  <div>\n    <p>\n      \"\n    </p>\n  </div>\n);";
+        let error_offset = source.find('"').unwrap() as u32;
+        let child_offset = source.find("<p>").unwrap() as u32;
+        let line_start = source.find("      \"").unwrap() as u32;
+
+        let fix = super::disable_for_this_line_with_jsx_child(
+            "react/no-unescaped-entities",
+            error_offset,
+            0,
+            source,
+            Some(child_offset),
+        );
+
+        assert_eq!(
+            fix.content,
+            "      {/* oxlint-disable-next-line react/no-unescaped-entities */}\n"
+        );
+        assert_eq!(fix.span, Span::empty(line_start));
+    }
+
+    #[test]
+    fn disable_for_this_line_uses_jsx_comment_before_same_line_child() {
+        let source = "return (\n  <div><button onClick={submit} /></div>\n);";
+        let child_offset = source.find("<button").unwrap() as u32;
+        let error_offset = source.find("submit").unwrap() as u32;
+
+        let fix = super::disable_for_this_line_with_jsx_child(
+            "react/jsx-no-bind",
+            error_offset,
+            0,
+            source,
+            Some(child_offset),
+        );
+
+        assert_eq!(fix.content, "{/* oxlint-disable-next-line react/jsx-no-bind */}\n       ");
+        assert_eq!(fix.span, Span::empty(child_offset));
+    }
+
+    #[test]
+    fn disable_for_this_line_uses_jsx_comment_for_direct_expression_child() {
+        let source = "const node = <div>\n  {foo}\n</div>;";
+        let child_offset = source.find("{foo}").unwrap() as u32;
+        let error_offset = source.find("foo").unwrap() as u32;
+        let line_start = source.find("  {foo}").unwrap() as u32;
+
+        let fix = super::disable_for_this_line_with_jsx_child(
+            "no-undef",
+            error_offset,
+            0,
+            source,
+            Some(child_offset),
+        );
+
+        assert_eq!(fix.content, "  {/* oxlint-disable-next-line no-undef */}\n");
+        assert_eq!(fix.span, Span::empty(line_start));
+    }
+
+    #[test]
+    fn disable_for_this_line_keeps_js_comment_for_jsx_attribute() {
+        let source = "const node = (\n  <div\n    value={foo}\n  />\n);";
+        let error_offset = source.find("foo").unwrap() as u32;
+        let line_start = source.find("    value").unwrap() as u32;
+
+        let fix =
+            super::disable_for_this_line_with_jsx_child("no-undef", error_offset, 0, source, None);
+
+        assert_eq!(fix.content, "    // oxlint-disable-next-line no-undef\n");
+        assert_eq!(fix.span, Span::empty(line_start));
+    }
+
+    #[test]
+    fn disable_for_this_line_merges_existing_jsx_comment() {
+        let existing = "{/* oxlint-disable-next-line no-alert */}";
+        let source = format!("const node = <div>\n  {existing}\n  <button />\n</div>;");
+        let child_offset = source.find("<button").unwrap() as u32;
+        let error_offset = child_offset;
+        let insert_offset = source.find(existing).unwrap() + existing.find(" */}").unwrap();
+
+        let fix = super::disable_for_this_line_with_jsx_child(
+            "jsx-a11y/control-has-associated-label",
+            error_offset,
+            0,
+            &source,
+            Some(child_offset),
+        );
+
+        assert_eq!(fix.content, " jsx-a11y/control-has-associated-label");
+        assert_eq!(fix.span, Span::empty(insert_offset as u32));
     }
 
     #[test]

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -8,6 +8,7 @@ use crate::LintContext;
 
 mod disable_fix;
 mod fix;
+pub use disable_fix::IgnoreFixContext;
 pub use fix::{CompositeFix, Fix, FixKind, MergeFixesError, PossibleFixes, RuleFix};
 
 pub fn oxc_code_short_canonical_name(code: &OxcCode) -> Option<String> {

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -495,7 +495,7 @@ impl TsGoLintState {
                                 );
 
                                 if self.with_ignore_fixes {
-                                    message.add_ignore_fix(0, &source_text_owned);
+                                    message.add_ignore_fix(0, &source_text_owned, None);
                                 }
 
                                 message.error.severity = if severity == AllowWarnDeny::Deny {

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -20,7 +20,7 @@ use super::{AllowWarnDeny, ConfigStore, DisableDirectives, ResolvedLinterState, 
 
 use crate::{
     CompositeFix, FixKind, Fixer, Message, PossibleFixes, RuleTimingRecord, RuleTimingSource,
-    RuleTimingStore, WEBSITE_BASE_RULES_URL, suppression::DiffManager,
+    RuleTimingStore, WEBSITE_BASE_RULES_URL, fixer::IgnoreFixContext, suppression::DiffManager,
 };
 
 /// State required to initialize the `tsgolint` linter.
@@ -495,7 +495,16 @@ impl TsGoLintState {
                                 );
 
                                 if self.with_ignore_fixes {
-                                    message.add_ignore_fix(0, &source_text_owned, None);
+                                    message.add_ignore_fix(
+                                        0,
+                                        &source_text_owned,
+                                        IgnoreFixContext::JavaScript,
+                                        resolved_config
+                                            .config
+                                            .options
+                                            .respect_eslint_disable_directives
+                                            .unwrap_or(true),
+                                    );
                                 }
 
                                 message.error.severity = if severity == AllowWarnDeny::Deny {


### PR DESCRIPTION
## Summary

- classify ignore-fix diagnostics as JavaScript, JSX children, or JSX attribute expressions only when ignore fixes are requested
- emit brace-escaped directives before JSX children and valid JavaScript directives inside multiline attribute expressions
- merge adjacent JSX directives for oxlint and for respected ESLint comments, while keeping ignored ESLint directives separate
- omit the unsafe line action when a multiline quoted JSX attribute has no valid line-comment insertion point

Fixes #24570

## Architecture

This replaces the original LSP-specific implementation with a focused port on top of the ignore-fix architecture introduced by #24951 and #24958, following the maintainer feedback on this PR.

## Checks

- cargo fmt --all -- --check
- cargo test -p oxc_linter --lib: 1227 passed, 1 ignored
- cargo clippy -p oxc_linter --all-targets --all-features -- -D warnings
- focused regression verifies that the multiline JSX attribute edit both parses and suppresses the target rule
- cargo test -p oxlint --lib lsp:: --no-default-features with the three environment-dependent TSGoLint cases skipped: 71 passed
- cargo lintgen
- git diff --check

The workspace-wide just ready command reached cargo check but the local machine does not have cmake, which libmimalloc-sys2 requires. The focused linter and LSP checks above are green; CI will run the full workspace in its provisioned environment.

## AI disclosure

OpenAI Codex assisted with implementation and testing. I reviewed the resulting code, regression coverage, and final diff.