### PR TITLE
fix(config): reject malformed glob patterns

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -725,7 +725,7 @@ fn render_config_builder_error(
 mod test {
     use std::fs;
 
-    use crate::{DEFAULT_OXLINTRC_NAME, tester::Tester};
+    use crate::{DEFAULT_OXLINTRC_NAME, cli::CliRunResult, tester::Tester};
     use oxc_linter::rules::RULES;
 
     // lints the full directory of fixtures,
@@ -1242,6 +1242,36 @@ mod test {
         tester.test_and_snapshot(&["-c", ".oxlintrc.json", "test.js"]);
         tester.test_and_snapshot(&["-c", ".oxlintrc.json", "test.ts"]);
         tester.test_and_snapshot(&["-c", ".oxlintrc.json", "other.jsx"]);
+    }
+
+    #[test]
+    fn test_rejects_malformed_override_globs() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::create_dir(temp_dir.path().join("src")).unwrap();
+        fs::write(temp_dir.path().join("src/app.js"), "debugger;").unwrap();
+
+        for (pattern, reason) in [
+            ("src/**/*.{js,ts", "unclosed brace expansion"),
+            ("src/[abpp.js", "unclosed character class"),
+        ] {
+            let config = serde_json::json!({
+                "rules": { "no-debugger": "error" },
+                "overrides": [{
+                    "files": [pattern],
+                    "rules": { "no-debugger": "off" }
+                }]
+            });
+            fs::write(temp_dir.path().join(".oxlintrc.json"), serde_json::to_vec(&config).unwrap())
+                .unwrap();
+
+            let (output, result) = Tester::new()
+                .with_cwd(temp_dir.path().to_path_buf())
+                .test_output(&["-c", ".oxlintrc.json", "src/app.js"]);
+
+            assert!(matches!(result, CliRunResult::InvalidOptionConfig));
+            assert!(output.contains(pattern), "{output}");
+            assert!(output.contains(reason), "{output}");
+        }
     }
 
     #[test]

--- a/crates/oxc_config/src/glob_set.rs
+++ b/crates/oxc_config/src/glob_set.rs
@@ -1,5 +1,5 @@
 use schemars::JsonSchema;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 
 /// A set of glob patterns.
 /// Patterns are matched against paths relative to the configuration file's directory.
@@ -8,7 +8,75 @@ pub struct GlobSet(Vec<String>);
 
 impl<'de> Deserialize<'de> for GlobSet {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Self::new(Vec::<String>::deserialize(deserializer)?))
+        let patterns = Vec::<String>::deserialize(deserializer)?;
+        for pattern in &patterns {
+            validate_glob(pattern).map_err(|reason| {
+                de::Error::custom(format_args!("invalid glob `{pattern}`: {reason}"))
+            })?;
+        }
+        Ok(Self::new(patterns))
+    }
+}
+
+fn validate_glob(pattern: &str) -> Result<(), &'static str> {
+    let mut brace_depth = 0_u8;
+    let mut in_class = false;
+    let mut class_has_item = false;
+    let mut class_at_start = false;
+    let mut escaped = false;
+
+    for byte in pattern.bytes() {
+        if escaped {
+            escaped = false;
+            if in_class {
+                class_has_item = true;
+                class_at_start = false;
+            }
+            continue;
+        }
+
+        if byte == b'\\' {
+            escaped = true;
+            continue;
+        }
+
+        if in_class {
+            if matches!(byte, b'!' | b'^') && class_at_start {
+                class_at_start = false;
+            } else if byte == b']' && class_has_item {
+                in_class = false;
+            } else {
+                class_has_item = true;
+                class_at_start = false;
+            }
+            continue;
+        }
+
+        match byte {
+            b'[' => {
+                in_class = true;
+                class_has_item = false;
+                class_at_start = true;
+            }
+            b'{' => {
+                brace_depth = brace_depth
+                    .checked_add(1)
+                    .filter(|depth| *depth <= 10)
+                    .ok_or("brace expansion nesting exceeds 10 levels")?;
+            }
+            b'}' if brace_depth > 0 => brace_depth -= 1,
+            _ => {}
+        }
+    }
+
+    if escaped {
+        Err("trailing escape")
+    } else if in_class {
+        Err("unclosed character class")
+    } else if brace_depth > 0 {
+        Err("unclosed brace expansion")
+    } else {
+        Ok(())
     }
 }
 
@@ -95,5 +163,23 @@ mod test {
         let glob_set: GlobSet = from_value(json!(["../foo.js"])).unwrap();
         assert!(glob_set.is_match("../foo.js"));
         assert!(!glob_set.is_match("foo.js"));
+    }
+
+    #[test]
+    fn rejects_malformed_globs() {
+        for (pattern, reason) in [
+            ("src/**/*.{js,ts", "unclosed brace expansion"),
+            ("src/[abpp.js", "unclosed character class"),
+            ("src/file.js\\", "trailing escape"),
+        ] {
+            let error = from_value::<GlobSet>(json!([pattern])).unwrap_err().to_string();
+            assert!(error.contains(pattern), "{error}");
+            assert!(error.contains(reason), "{error}");
+        }
+    }
+
+    #[test]
+    fn accepts_escaped_glob_metacharacters() {
+        from_value::<GlobSet>(json!([r"src/\{app\}.js", r"src/\[app\].js"])).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- validate glob syntax when deserializing `GlobSet` instead of silently accepting malformed patterns
- report the offending pattern and a focused reason for unclosed braces/classes or trailing escapes
- preserve escaped glob metacharacters and the documented 10-level brace nesting limit
- add config-unit and end-to-end oxlint CLI regression coverage

Fixes #24612

## Testing

- `cargo test -p oxc_config glob_set` (3 passed)
- `cargo test -p oxlint --lib test_rejects_malformed_override_globs --no-default-features` (1 passed, 390 filtered)
- `cargo fmt --all -- --check`
- `git diff --check`

The oxlint test build reports the existing unrelated unused `ConfigStoreBuilder` warning.

## AI disclosure

This contribution was prepared with assistance from OpenAI Codex. I reviewed the validation logic against `fast-glob` 1.0.1 documented syntax and implementation limits, reproduced the malformed-pattern behavior, and ran the focused tests listed above.