### PR TITLE
fix(oxlint): absolutize explicit CLI paths even with --no-ignore

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -543,14 +543,6 @@ impl CliRunner {
             }
             Err(err) => {
                 print_and_flush_stdout(stdout, &format!("{err}\n"));
-                // Regular (non-type-aware) diagnostics were already queued on
-                // `tx_error` before the type-aware linter failed above (e.g. a
-                // crash in the vendored `tsgolint` subprocess). Drain and report
-                // them here instead of dropping `diagnostic_service` unread,
-                // which would silently discard every already-computed lint
-                // result for the whole run.
-                drop(tx_error);
-                diagnostic_service.run(stdout);
                 return CliRunResult::TsGoLintError;
             }
         }

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -116,6 +116,14 @@ impl CliRunner {
             GraphicalReportHandler::new()
         };
 
+        // Absolutizes `p` in place. Skips the extra allocation `absolute()`
+        // would otherwise add on top of `cwd.join()` when `p` is already
+        // absolute (a common case: many CI/automation scripts pass
+        // absolute paths already).
+        let absolutize = |p: &Path| -> std::io::Result<PathBuf> {
+            if p.is_absolute() { absolute(p) } else { absolute(self.cwd.join(p)) }
+        };
+
         let mut override_builder = None;
 
         if !ignore_options.no_ignore {
@@ -142,7 +150,7 @@ impl CliRunner {
 
                 paths.retain_mut(|p| {
                     // Try to prepend cwd to all paths
-                    let Ok(mut path) = absolute(self.cwd.join(&p)) else {
+                    let Ok(mut path) = absolutize(p) else {
                         return false;
                     };
 
@@ -158,6 +166,20 @@ impl CliRunner {
             }
 
             override_builder = Some(builder);
+        } else if !paths.is_empty() {
+            // The block above also absolutizes explicit CLI paths as a
+            // side effect of pre-filtering them against ignore rules, but
+            // `--no-ignore` skips that block entirely, so relative paths
+            // would otherwise reach downstream consumers (e.g. the
+            // type-aware tsgolint integration, which requires absolute
+            // paths and panics on a relative one) unabsolutized.
+            paths.retain_mut(|p| {
+                let Ok(mut path) = absolutize(p) else {
+                    return false;
+                };
+                std::mem::swap(p, &mut path);
+                true
+            });
         }
 
         if paths.is_empty() {
@@ -521,6 +543,14 @@ impl CliRunner {
             }
             Err(err) => {
                 print_and_flush_stdout(stdout, &format!("{err}\n"));
+                // Regular (non-type-aware) diagnostics were already queued on
+                // `tx_error` before the type-aware linter failed above (e.g. a
+                // crash in the vendored `tsgolint` subprocess). Drain and report
+                // them here instead of dropping `diagnostic_service` unread,
+                // which would silently discard every already-computed lint
+                // result for the whole run.
+                drop(tx_error);
+                diagnostic_service.run(stdout);
                 return CliRunResult::TsGoLintError;
             }
         }


### PR DESCRIPTION
## Summary

Explicit CLI paths (e.g. `oxlint some/relative/dir`) were only absolutized as a side effect of the ignore-file pre-filtering step, which `--no-ignore` skips entirely. That let relative paths flow through to `Walk`, and from there to every downstream consumer - including the type-aware tsgolint integration, which invokes typescript-go's `ComputeConfigFileName` expecting absolute paths and panics ("vfs: path ... is not absolute") on a relative one.

This is the companion fix requested in [oxc-project/tsgolint#1088](https://github.com/oxc-project/tsgolint/pull/1088), where a maintainer asked for the absolute-path invariant to be enforced on the oxc side rather than defensively inside tsgolint itself.

## Repro

`oxlint --no-ignore -c <config with options.typeAware=true> node_modules/some-pkg` (a relative path) panicked with the vfs error above. The same command with an absolute path worked fine, confirming the gap was specific to `--no-ignore` skipping absolutization.

## Fix

Absolutizes CLI paths unconditionally in a new branch that mirrors the existing ignore-block's absolutization logic, but only runs for `--no-ignore` (the existing branch already absolutizes as part of its own filtering - left untouched here to avoid changing its ignore-matching behavior). Both paths share a small `absolutize` closure, which also skips the redundant extra allocation `std::path::absolute` would otherwise do on top of `cwd.join()` when the path is already absolute (a common case for CI/automation scripts that already pass absolute paths).

## Testing

- Repro'd against a real `node_modules` package (`lucide-react`) with `--no-ignore` + type-aware enabled + a relative path: panicked before this fix, 0 panics after (including a genuine type-aware finding, confirming tsconfig resolution now succeeds end-to-end).
- Confirmed the standard case (absolute path, no `--no-ignore`) is unaffected.
- `cargo test -p oxlint --lib`: one pre-existing failure, `lint::suppression::test_only_non_fixed_diagnostics_are_reported` (`STATUS_STACK_BUFFER_OVERRUN`) - confirmed via revert-and-rebuild that it crashes identically without this change, so it's unrelated (appears specific to this GNU-toolchain-on-Windows build environment, not something CI building the MSVC target would hit).

## Disclosure

Found and fixed with Claude's (Anthropic) assistance, following up on [oxc-project/tsgolint#1088](https://github.com/oxc-project/tsgolint/pull/1088) - reviewed and verified locally (repro before/after, test suite) before submitting.