### PR TITLE
fix(minifier): don't treat a conditionally-assigned var as write-once

### DIFF
--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -22,10 +22,19 @@ impl<'a> PeepholeOptimizations {
         // `init_value`, which turns it into the `boolean_falsy` fact (see
         // `SymbolValue::boolean_falsy`).
         let falsy_init = init_constant.as_ref().is_some_and(Self::is_falsy_constant);
+        let declaration_in_body_statement_list =
+            !decl.kind.is_var() || Self::is_declaration_in_body_statement_list(ctx);
         let value = if Self::is_for_statement_init(ctx) {
             // for-statement initializers have their value set by the for statement itself.
             None
-        } else if decl.kind.is_var() && !Self::is_hoisted_var_inlineable(decl, symbol_id, ctx) {
+        } else if decl.kind.is_var()
+            && !Self::is_hoisted_var_inlineable(
+                decl,
+                symbol_id,
+                declaration_in_body_statement_list,
+                ctx,
+            )
+        {
             // `var` is hoisted: reads before the initializer line see `undefined`.
             // Skip unless the safety predicate proves no such read exists.
             None
@@ -33,7 +42,13 @@ impl<'a> PeepholeOptimizations {
             // No initializer hoists to `undefined`; otherwise reuse the constant.
             decl.init.as_ref().map_or(Some(ConstantValue::Undefined), |_| init_constant)
         };
-        let kind = decl.init.as_ref().map_or(FreshValueKind::None, Self::fresh_value_kind);
+        // A conditional `var` may still hold its previous value or hoisted
+        // `undefined`, so its initializer alone cannot prove the binding fresh.
+        let kind = if declaration_in_body_statement_list {
+            decl.init.as_ref().map_or(FreshValueKind::None, Self::fresh_value_kind)
+        } else {
+            FreshValueKind::None
+        };
         ctx.init_value(symbol_id, value, kind, falsy_init, decl.init.is_none());
     }
 
@@ -49,10 +64,28 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
+    /// Whether a declaration is a direct item in the current body rather than
+    /// nested in another statement position. Other positions are rejected
+    /// conservatively: in particular, brace-less conditional bodies carry no
+    /// scope that could reveal that the initializer is optional (#24531).
+    fn is_declaration_in_body_statement_list(ctx: &TraverseCtx<'a>) -> bool {
+        for ancestor in ctx.ancestors() {
+            match ancestor {
+                Ancestor::VariableDeclarationDeclarations(_)
+                | Ancestor::ExportNamedDeclarationDeclaration(_) => {}
+                Ancestor::ProgramBody(_) | Ancestor::FunctionBodyStatements(_) => return true,
+                _ => return false,
+            }
+        }
+        false
+    }
+
     /// Predicate for inlining a hoisted `var x = <literal>;`. True when no read
     /// can observe `x` as its hoisted `undefined`:
     /// - the declarator sits at the current body's top scope and that body is
     ///   still in its declarative prelude;
+    /// - the declaration is a direct body statement-list item rather than a
+    ///   conditional, loop, or other nested statement position;
     /// - it has an initializer (uninitialized `var foo;` would inline to
     ///   `undefined`, which churns existing tests for marginal benefit);
     /// - script-mode top-level vars are excluded (they alias the global object);
@@ -75,9 +108,13 @@ impl<'a> PeepholeOptimizations {
     fn is_hoisted_var_inlineable(
         decl: &VariableDeclarator<'a>,
         symbol_id: SymbolId,
+        declaration_in_body_statement_list: bool,
         ctx: &TraverseCtx<'a>,
     ) -> bool {
-        if decl.init.is_none() || Self::is_script_root_scope(ctx) {
+        if decl.init.is_none()
+            || !declaration_in_body_statement_list
+            || Self::is_script_root_scope(ctx)
+        {
             return false;
         }
         // `body_unsafe` is set by a preceding non-declarative statement, and the

--- a/crates/oxc_minifier/tests/peephole/inline.rs
+++ b/crates/oxc_minifier/tests/peephole/inline.rs
@@ -4,6 +4,91 @@ use crate::{
     CompressOptions, test_options, test_options_source_type, test_same_options, test_smallest,
 };
 
+// https://github.com/oxc-project/oxc/issues/24531
+// A `var` assigned only inside a conditional holds its hoisted `undefined`
+// on the untaken path; single-statement block flattening produces a
+// brace-less `if (c) var x = v;` whose declarator has no block scope, so
+// the value must not be treated as write-once.
+#[test]
+fn conditional_var_declarator_not_inlined() {
+    let options = CompressOptions::smallest();
+    test_options(
+        "function t() { if (window.x) { var callback = true } return () => callback ? 'ng' : 'ok'; } NOOP(t());",
+        "function t() { if (window.x) var callback = !0; return () => callback ? 'ng' : 'ok'; } NOOP(t());",
+        &options,
+    );
+    // The already-flattened form.
+    test_options(
+        "function t() { if (window.x) var callback = true; return () => callback ? 'ng' : 'ok'; } NOOP(t());",
+        "function t() { if (window.x) var callback = !0; return () => callback ? 'ng' : 'ok'; } NOOP(t());",
+        &options,
+    );
+}
+
+#[test]
+fn conditional_var_alternate_after_declarative_consequent_not_inlined() {
+    // The alternate is still conditional when the consequent is itself
+    // declarative and therefore has not ended the body's prelude.
+    test_smallest(
+        "function t(c) { if (c) var a = 1; else var flag = true; return () => flag ? 'ng' : 'ok'; } NOOP(t());",
+        "function t(c) { if (c) var a = 1; else var flag = !0; return () => flag ? 'ng' : 'ok'; } NOOP(t());",
+    );
+}
+
+#[test]
+fn conditional_var_is_not_assumed_fresh() {
+    // The untaken path leaves `x` undefined, so dropping the member write would
+    // remove a TypeError.
+    test_smallest(
+        "export function f(a) { if (a) var x = {}; x.p = 1; }",
+        "export function f(a) { if (a) var x = {}; x.p = 1; }",
+    );
+}
+
+#[test]
+fn single_conditional_falsy_var_still_folds_in_boolean_context() {
+    // Both possible values (`undefined` and `false`) are falsy, so the special
+    // boolean-context fact remains valid for a symbol with one declaration.
+    test_smallest(
+        "export function f(a) { if (a) var x = false; return x ? 'bad' : 'ok'; }",
+        "export function f(a) { if (a) var x = !1; return 'ok'; }",
+    );
+}
+
+#[test]
+fn conditional_labeled_var_declarator_not_inlined() {
+    // A label introduces no scope, so the ancestry check must reject this
+    // conditional body explicitly.
+    test_smallest(
+        "function t(c) { if (c) L: var flag = true; return () => flag ? 'ng' : 'ok'; } NOOP(t());",
+        "function t(c) { if (c) L: var flag = !0; return () => flag ? 'ng' : 'ok'; } NOOP(t());",
+    );
+}
+
+#[test]
+fn unconditional_var_declarator_positions_still_inline() {
+    let options = CompressOptions::smallest();
+    // Unconditional declarators at the body top keep inlining.
+    test_options(
+        "function t() { var flag = false; return () => flag ? 'a' : 'b'; } NOOP(t());",
+        "function t() { return () => 'b'; } NOOP(t());",
+        &options,
+    );
+    // Direct declarations terminate at the module's ProgramBody ancestor.
+    test_options(
+        "var flag = true; export function f() { return flag ? 'a' : 'b'; }",
+        "export function f() { return 'a'; }",
+        &options,
+    );
+    // Export declarations add one transparent ancestry wrapper before the
+    // module's ProgramBody ancestor.
+    test_options(
+        "export var flag = true; export function f() { return flag ? 'a' : 'b'; }",
+        "export var flag = !0; export function f() { return 'a'; }",
+        &options,
+    );
+}
+
 // https://github.com/oxc-project/oxc/issues/13051
 #[test]
 fn readonly_var() {


### PR DESCRIPTION
A `var` initializer nested under a conditional does not dominate later reads: when the branch is not taken, the binding still has its hoisted `undefined` value. After single-statement block flattening, the declarator can become a brace-less `if` body with function scope, so the previous scope-based check incorrectly treated the initializer as unconditional and inlined it.

This PR requires a hoisted initializer to be a direct item in a function or program statement list before caching its constant or fresh-value fact. Conditional, loop, labeled, and other nested statement positions are rejected conservatively. This can retain safe freshness-based folds, but the minsize corpus is byte-identical.

For a binding with exactly one runtime value declaration, a lone conditional falsy initializer remains foldable in boolean context because both possible values—the initializer and hoisted `undefined`—are falsy.

## Example

```js
function test() {
  if (window.doesntExist) var callback = true;
  return () => console.log(callback ? "ng" : "ok");
}
```

The previous output replaced the callback body with `console.log("ng")`. This PR keeps the conditional read. It also prevents a conditional fresh initializer from hiding a required `TypeError` on a later member write.

## Stack boundary

This lower PR does not cover bindings with multiple runtime value declarations. At this commit alone, source-ordered value facts for those bindings remain unsound; the required next stack entry, #24658, closes that gap. The two PRs should be reviewed and merged back-to-back.

The full `oxc_minifier` suite passes with 616 tests and 42 ignored; clippy, formatting, runtime and repeat-compression repros pass, and regenerated minsize and allocation snapshots are byte-identical.

Fixes #24531.

## Stack

1. **#24650 — conditional `var` initializer facts**
2. #24658 — redeclared binding facts

Implemented with AI assistance (Claude Code and OpenAI Codex). The contributor remains responsible for reviewing, understanding, and submitting the changes under the repository AI usage policy.