### PR TITLE
refactor(minifier): make pass changes transactional

### DIFF
--- a/crates/oxc_minifier/src/compression_pass.rs
+++ b/crates/oxc_minifier/src/compression_pass.rs
@@ -16,7 +16,16 @@ use oxc_ast::ast::*;
 use oxc_semantic::Scoping;
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
-use crate::{TraverseCtx, symbol_liveness, traverse_context::as_direct_eval_call};
+use crate::{
+    ReusableTraverseCtx, TraverseCtx, minifier_traverse::traverse_mut_with_ctx,
+    peephole::PeepholeOptimizations, symbol_liveness, traverse_context::as_direct_eval_call,
+};
+
+/// The fixed-point decision produced by one completed peephole pass.
+#[must_use]
+pub struct PassOutcome {
+    pub(crate) needs_another_pass: bool,
+}
 
 /// Refresh `ScopeFlags::DirectEval` from live direct-eval call sites.
 ///
@@ -194,7 +203,7 @@ fn debug_assert_no_stale_direct_eval(program: &Program<'_>, scoping: &Scoping) {
 /// resolved references from scoping, refresh direct-eval flags if an
 /// `eval(...)` call was dropped, and re-initialize the accumulator.
 ///
-/// [`end_pass`] calls this after Normalize (so the fixed-point loop starts
+/// Pass completion calls this after Normalize (so the fixed-point loop starts
 /// against already-pruned scoping and Normalize's drops cost no extra
 /// peephole pass) and after every peephole pass — quiet ones included, where
 /// every step below is a cheap no-op.
@@ -248,17 +257,56 @@ fn flush_pass_changes(program: &Program<'_>, ctx: &mut TraverseCtx<'_>) -> bool 
     liveness_inputs_changed
 }
 
-/// Complete a compression pass by flushing accumulated changes into scoping,
-/// then deriving function reachability from those settled semantic references.
-/// Keeping the pair together makes the ordering structural. Returns whether
-/// newly dead functions demand another pass.
-pub fn end_pass<'a>(
+/// Complete semantic bookkeeping by flushing accumulated changes into
+/// scoping, then deriving function reachability from those settled references.
+/// Keeping the pair together makes the ordering structural.
+fn finish_pass<'a>(
     program: &Program<'a>,
     ctx: &mut TraverseCtx<'a>,
     force_liveness_analysis: bool,
 ) -> bool {
     let liveness_inputs_changed = flush_pass_changes(program, ctx);
     symbol_liveness::analyze(program, ctx, force_liveness_analysis || liveness_inputs_changed)
+}
+
+/// Finish Normalize's semantic journal before the unconditional first
+/// peephole pass. Normalize's shape changes do not drive fixed-point
+/// convergence, so consume the revisit request and ignore newly dead functions:
+/// pass one runs regardless and consumes both forms of progress.
+pub fn finish_normalize_pass<'a>(program: &Program<'a>, ctx: &mut TraverseCtx<'a>) {
+    let _ = ctx.state.take_revisit_requested();
+    finish_pass(program, ctx, /* force_liveness_analysis */ true);
+    debug_assert_pass_changes_clean(ctx);
+}
+
+/// Run and finish one ordinary peephole pass as a single transaction.
+///
+/// The returned outcome combines AST/fact progress with newly published dead
+/// functions. A revisit request alone does not force liveness recomputation;
+/// reference removal and dropped direct eval continue to gate that analysis.
+pub fn run_peephole_pass<'a>(
+    program: &mut Program<'a>,
+    ctx: &mut ReusableTraverseCtx<'a>,
+) -> PassOutcome {
+    debug_assert_pass_changes_clean(ctx.get_mut());
+    ctx.state_mut().symbols.reset_values();
+    traverse_mut_with_ctx(&mut PeepholeOptimizations, program, ctx);
+
+    let ctx = ctx.get_mut();
+    let revisit_requested = ctx.state.take_revisit_requested();
+    let newly_dead = finish_pass(program, ctx, /* force_liveness_analysis */ false);
+    debug_assert!(
+        !newly_dead || revisit_requested,
+        "ordinary liveness progress must follow a recorded pass change"
+    );
+    debug_assert_pass_changes_clean(ctx);
+
+    PassOutcome { needs_another_pass: revisit_requested || newly_dead }
+}
+
+#[inline]
+fn debug_assert_pass_changes_clean(ctx: &TraverseCtx<'_>) {
+    debug_assert!(ctx.state.pass_changes_are_clean());
 }
 
 /// Walks the live program to find scopes containing direct `eval(...)` calls.

--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -4,7 +4,7 @@ use oxc_semantic::{Scoping, SemanticBuilder};
 
 use crate::{
     CompressOptions, ReusableTraverseCtx, compression_pass,
-    peephole::{Normalize, NormalizeOptions, PeepholeOptimizations},
+    peephole::{Normalize, NormalizeOptions},
     state::MinifierState,
 };
 
@@ -122,26 +122,10 @@ impl<'a> Compressor<'a> {
         // analysis makes source-level dead cycles (`function f() { f() }`)
         // visible to pass 1. Ignore the result because pass 1 runs
         // unconditionally and consumes any newly dead functions.
-        compression_pass::end_pass(program, ctx.get_mut(), /* force_liveness_analysis */ true);
-        // Start the loop from a clean signal: Normalize's drops are flushed
-        // above, so a Normalize-only mutation must not force a pointless
-        // extra iteration.
-        ctx.state_mut().take_mutated();
+        compression_pass::finish_normalize_pass(program, ctx.get_mut());
         loop {
-            PeepholeOptimizations.run_once(program, ctx);
-            let mutated = ctx.state_mut().take_mutated();
-            // Flush every pass. Reachability is recomputed only when a removed
-            // reference belonged to a graph candidate or direct eval was
-            // dropped; only those changes can invalidate the previous verdict.
-            let found_new_dead_functions = compression_pass::end_pass(
-                program,
-                ctx.get_mut(),
-                /* force_liveness_analysis */ false,
-            );
-            // Liveness requests another pass only for a newly dead function
-            // (bounded by the candidate set); ordinary AST mutation also keeps
-            // the fixed-point loop running. The iteration cap backstops churn.
-            if !mutated && !found_new_dead_functions {
+            let outcome = compression_pass::run_peephole_pass(program, ctx);
+            if !outcome.needs_another_pass {
                 break;
             }
             if let Some(max) = max_iterations {

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -22,19 +22,15 @@ use oxc_syntax::{scope::ScopeId, symbol::SymbolId};
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 
-use crate::{ReusableTraverseCtx, Traverse, TraverseCtx, minifier_traverse::traverse_mut_with_ctx};
+use crate::{Traverse, TraverseCtx};
 
 pub use self::normalize::{Normalize, NormalizeOptions};
 
-/// Stateless peephole optimizer. The `dce` flag, the `mutated` signal, and
-/// the per-pass `PassChanges` accumulator all live on `MinifierState`.
+/// Stateless peephole optimizer. Configuration and the per-pass
+/// `PassChanges` accumulator live on `MinifierState`.
 pub struct PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
-    pub fn run_once(&mut self, program: &mut Program<'a>, ctx: &mut ReusableTraverseCtx<'a>) {
-        traverse_mut_with_ctx(self, program, ctx);
-    }
-
     pub fn commutative_pair<'x, A, F, G, RetF: 'x, RetG: 'x>(
         pair: (&'x A, &'x A),
         check_a: F,
@@ -209,13 +205,12 @@ impl<'a> PeepholeOptimizations {
 
 impl<'a> Traverse<'a> for PeepholeOptimizations {
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
-        ctx.state.symbols.reset_values();
         // Any module loader (`import`, `export * from`, `export … from`) can, on a
         // cycle, evaluate a foreign module that observes a not-yet-assigned binding
         // our exports close over. So the program root starts its prelude "unsafe"
         // when the body has any loader — bailing every program-scope var inline.
-        // Loaders are hoisted, so scan the whole body (an import may follow a
-        // leading var); the result never changes across passes.
+        // Loaders are hoisted, so scan the whole current body each pass (an
+        // import may follow a leading var, or an earlier pass may remove one).
         let module_has_loaders = program
             .body
             .iter()
@@ -225,7 +220,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         // than reallocating (matching the `reset`/`clear` above).
         *ctx.state.body_unsafe_stack.last_mut() =
             (ctx.scoping().root_scope_id(), module_has_loaders);
-        // `PassChanges` is managed by the end-of-pass sequence, not reset per
+        // `PassChanges` is managed by pass completion, not reset per
         // traversal.
     }
 

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -341,7 +341,7 @@ impl<'a> Normalize {
             return;
         }
         // `replace_expression` walks the dropped ident into `PassChanges`, so
-        // its resolved reference is pruned by the pre-loop `end_pass` flush,
+        // its resolved reference is pruned by `finish_normalize_pass`,
         // before pass 1 — otherwise the symbol would look referenced forever.
         let new_arg =
             Expression::new_numeric_literal(ident.span, 0.0, None, NumberBase::Decimal, ctx);

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -9,12 +9,17 @@ use oxc_syntax::scope::ScopeId;
 
 use crate::{CompressOptions, symbol_state::SymbolState};
 
-/// Changes accumulated by the `replace_*` / `drop_*` helper calls between two
-/// consumption points. Live from `MinifierState::new` so the pre-loop
-/// `Normalize` pass records drops through the same typed helpers as the
-/// peephole loop; consumed and reset or resized by [`crate::compression_pass`]
-/// after Normalize and after every peephole pass.
+/// Changes accumulated between two pass-completion boundaries. Live from
+/// `MinifierState::new` so the pre-loop `Normalize` pass records drops through
+/// the same typed helpers as the peephole loop; consumed and reset or resized
+/// by [`crate::compression_pass`] after Normalize and every peephole pass.
 pub struct PassChanges<'a> {
+    /// Whether the completed pass changed facts or AST shape in a way that
+    /// requires another peephole traversal. This signal does not itself force
+    /// liveness analysis; removed candidate references and dropped direct eval
+    /// calls continue to gate that work independently.
+    revisit_requested: bool,
+
     /// `ReferenceId`s whose AST node has been removed and not re-installed
     /// in any later mutation this pass.
     ///
@@ -42,6 +47,7 @@ pub struct PassChanges<'a> {
 impl<'a> PassChanges<'a> {
     pub fn new(references_len: usize, allocator: &'a Allocator) -> Self {
         Self {
+            revisit_requested: false,
             removed_references: BitSet::new_in(references_len, allocator),
             direct_eval_dropped: false,
         }
@@ -90,14 +96,8 @@ pub struct MinifierState<'a> {
     /// `init_symbol_value`.
     pub body_unsafe_stack: NonEmptyStack<(ScopeId, bool)>,
 
-    /// Set when a typed helper mutates the AST. Private by design: the only
-    /// writers are the helpers on `MinifierTraverseCtx`; the only reader is
-    /// the fixed-point loop driver via `take_mutated()`.
-    mutated: bool,
-
-    /// Per-pass change accumulator populated by `replace_*` / `drop_*` helpers
-    /// as subtrees are removed. Consumed by `compression_pass` after Normalize
-    /// and every peephole pass to drive the incremental scoping refresh.
+    /// Per-pass change accumulator populated by typed mutation helpers and
+    /// consumed by `compression_pass` after Normalize and every peephole pass.
     pub(crate) pass_changes: PassChanges<'a>,
 
     /// Scratch buffer reused by `try_fold_concat` to build template literal
@@ -121,7 +121,6 @@ impl<'a> MinifierState<'a> {
             symbols,
             private_member_usage: PrivateMemberUsageStack::new(),
             body_unsafe_stack: NonEmptyStack::new((scoping.root_scope_id(), false)),
-            mutated: false,
             pass_changes: PassChanges::new(scoping.references_len(), allocator),
             concat_scratch: String::new(),
         }
@@ -139,16 +138,33 @@ impl<'a> MinifierState<'a> {
         !self.dce || !self.options.treeshake.property_write_side_effects
     }
 
-    /// Returns whether the AST was mutated since the last call, and resets.
-    /// Read and reset are one operation so the signal cannot be cleared
-    /// anywhere except at its single consumption point.
-    pub(crate) fn take_mutated(&mut self) -> bool {
-        std::mem::take(&mut self.mutated)
+    /// Request another peephole traversal after the current pass completes.
+    ///
+    /// This is deliberately separate from [`Self::record_ast_change`] for
+    /// future fact-only callers such as #24060. Such a caller may enable more
+    /// transforms without changing the AST, resolved references, or direct-eval
+    /// scope flags.
+    pub(crate) fn request_revisit(&mut self) {
+        self.pass_changes.revisit_requested = true;
     }
 
-    /// Record that a typed helper mutated the AST.
-    pub(crate) fn record_mutation(&mut self) {
-        self.mutated = true;
+    /// Record an AST change and schedule the traversal needed to consume it.
+    /// Typed mutation helpers use this as their AST-change entry point.
+    pub(crate) fn record_ast_change(&mut self) {
+        self.request_revisit();
+    }
+
+    /// Return whether the completed pass requested another traversal, then
+    /// reset the signal for the next pass.
+    pub(crate) fn take_revisit_requested(&mut self) -> bool {
+        std::mem::take(&mut self.pass_changes.revisit_requested)
+    }
+
+    /// Whether every per-pass change has been consumed.
+    pub(crate) fn pass_changes_are_clean(&self) -> bool {
+        !self.pass_changes.revisit_requested
+            && self.pass_changes.removed_references.is_empty()
+            && !self.pass_changes.direct_eval_dropped
     }
 }
 

--- a/crates/oxc_minifier/src/symbol_liveness/mod.rs
+++ b/crates/oxc_minifier/src/symbol_liveness/mod.rs
@@ -574,7 +574,7 @@ pub fn dead_references_affect_analysis(ctx: &TraverseCtx<'_>) -> bool {
 
 /// Assert that the completed pass removed every previously published dead
 /// declaration, then optionally analyze settled semantic references and
-/// publish newly dead functions. Called only by the end-of-pass sequence after
+/// publish newly dead functions. Called only by pass completion after
 /// scoping has been flushed.
 pub fn analyze<'a>(program: &Program<'a>, ctx: &mut TraverseCtx<'a>, recompute: bool) -> bool {
     #[cfg(not(debug_assertions))]

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -399,13 +399,13 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     /// Replace an expression slot. Marks the pass as having mutated the AST.
     ///
     /// Prefer this over a direct `*slot = new; ctx.notice_change();` pair —
-    /// the mutation flag is private to `MinifierState`, so the typed helpers
-    /// are the only way to record the mutation (compiler-enforced).
+    /// the typed helper keeps dropped-subtree bookkeeping, the slot update,
+    /// and the pass revisit request together.
     #[inline]
     pub fn replace_expression(&mut self, slot: &mut Expression<'a>, new: Expression<'a>) {
         self.dropped_subtree_collector().visit_expression(slot);
         *slot = new;
-        self.state.record_mutation();
+        self.state.record_ast_change();
     }
 
     /// Replace a statement slot. Marks the pass as having mutated the AST.
@@ -413,7 +413,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     pub fn replace_statement(&mut self, slot: &mut Statement<'a>, new: Statement<'a>) {
         self.dropped_subtree_collector().visit_statement(slot);
         *slot = new;
-        self.state.record_mutation();
+        self.state.record_ast_change();
     }
 
     /// Replace an assignment-target-property slot. Marks the pass as having mutated the AST.
@@ -425,7 +425,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     ) {
         self.dropped_subtree_collector().visit_assignment_target_property(slot);
         *slot = new;
-        self.state.record_mutation();
+        self.state.record_ast_change();
     }
 
     /// Replace a property-key slot. Marks the pass as having mutated the AST.
@@ -433,7 +433,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     pub fn replace_property_key(&mut self, slot: &mut PropertyKey<'a>, new: PropertyKey<'a>) {
         self.dropped_subtree_collector().visit_property_key(slot);
         *slot = new;
-        self.state.record_mutation();
+        self.state.record_ast_change();
     }
 
     /// Replace a `for-in` / `for-of` statement's `left` slot. Same contract
@@ -446,7 +446,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     ) {
         self.dropped_subtree_collector().visit_for_statement_left(slot);
         *slot = new;
-        self.state.record_mutation();
+        self.state.record_ast_change();
     }
 
     /// Mark the pass as having mutated the AST in place (operand swap, in-place
@@ -455,7 +455,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     /// replacement.
     #[inline]
     pub fn notice_change(&mut self) {
-        self.state.record_mutation();
+        self.state.record_ast_change();
     }
 
     /// Mark an expression subtree as about to be dropped (popped from a collection,
@@ -468,7 +468,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     #[inline]
     pub fn drop_expression(&mut self, expr: &Expression<'a>) {
         self.dropped_subtree_collector().visit_expression(expr);
-        self.state.record_mutation();
+        self.state.record_ast_change();
     }
 
     /// Mark a statement subtree as about to be dropped. Same contract as
@@ -476,7 +476,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     #[inline]
     pub fn drop_statement(&mut self, stmt: &Statement<'a>) {
         self.dropped_subtree_collector().visit_statement(stmt);
-        self.state.record_mutation();
+        self.state.record_ast_change();
     }
 
     /// Mark a class element subtree as about to be dropped. Same contract as
@@ -484,7 +484,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     #[inline]
     pub fn drop_class_element(&mut self, element: &ClassElement<'a>) {
         self.dropped_subtree_collector().visit_class_element(element);
-        self.state.record_mutation();
+        self.state.record_ast_change();
     }
 
     /// Mark a variable declarator as about to be dropped. Walks the whole
@@ -495,7 +495,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     #[inline]
     pub fn drop_variable_declarator(&mut self, decl: &VariableDeclarator<'a>) {
         self.dropped_subtree_collector().visit_variable_declarator(decl);
-        self.state.record_mutation();
+        self.state.record_ast_change();
     }
 
     /// Mark a switch case subtree as about to be dropped. Walks the entire case —
@@ -505,6 +505,6 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     #[inline]
     pub fn drop_switch_case(&mut self, switch_case: &SwitchCase<'a>) {
         self.dropped_subtree_collector().visit_switch_case(switch_case);
-        self.state.record_mutation();
+        self.state.record_ast_change();
     }
 }

--- a/crates/oxc_minifier/tests/mod.rs
+++ b/crates/oxc_minifier/tests/mod.rs
@@ -8,6 +8,7 @@ use oxc_allocator::Allocator;
 use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_compat::EngineTargets;
 use oxc_parser::{ParseOptions, Parser};
+use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 
 pub(crate) use oxc_minifier::{
@@ -52,14 +53,47 @@ pub(crate) fn test_options(source_text: &str, expected: &str, options: &Compress
     test_options_source_type(source_text, expected, SourceType::mjs(), options);
 }
 
-/// Assert one capped compression run without the usual idempotency check.
-/// A deliberately low `max_iterations` may conservatively retain code that a
-/// second independent run can remove.
+/// Assert output and iteration count, including the usual idempotency check.
 #[track_caller]
-pub(crate) fn test_options_once(source_text: &str, expected: &str, options: &CompressOptions) {
-    let actual = run(source_text, SourceType::mjs(), Some(options.clone()));
+pub(crate) fn test_options_with_iterations(
+    source_text: &str,
+    expected: &str,
+    expected_iterations: u8,
+    options: &CompressOptions,
+) {
+    let (first, iterations) =
+        run_with_iterations(source_text, SourceType::mjs(), Some(options.clone()));
+    let expected = run(expected, SourceType::mjs(), None);
+    assert_eq!(first, expected, "\nfor source\n{source_text}\nexpect\n{expected}\ngot\n{first}");
+    assert_eq!(
+        iterations, expected_iterations,
+        "\niteration count for source\n{source_text}\nexpect\n{expected_iterations}\ngot\n{iterations}"
+    );
+
+    let second = run(&first, SourceType::mjs(), Some(options.clone()));
+    assert_eq!(
+        first, second,
+        "\nidempotency for source\n{source_text}\ngot\n{first}\nthen\n{second}"
+    );
+}
+
+/// Assert one capped compression run and its iteration count without an
+/// idempotency check. A deliberately low cap can conservatively retain code.
+#[track_caller]
+pub(crate) fn test_options_once_with_iterations(
+    source_text: &str,
+    expected: &str,
+    expected_iterations: u8,
+    options: &CompressOptions,
+) {
+    let (actual, iterations) =
+        run_with_iterations(source_text, SourceType::mjs(), Some(options.clone()));
     let expected = run(expected, SourceType::mjs(), None);
     assert_eq!(actual, expected, "\nfor source\n{source_text}\nexpect\n{expected}\ngot\n{actual}");
+    assert_eq!(
+        iterations, expected_iterations,
+        "\niteration count for source\n{source_text}\nexpect\n{expected_iterations}\ngot\n{iterations}"
+    );
 }
 
 #[track_caller]
@@ -107,6 +141,15 @@ pub(crate) fn test_same_options_source_type(
 
 #[track_caller]
 fn run(source_text: &str, source_type: SourceType, options: Option<CompressOptions>) -> String {
+    run_with_iterations(source_text, source_type, options).0
+}
+
+#[track_caller]
+fn run_with_iterations(
+    source_text: &str,
+    source_type: SourceType,
+    options: Option<CompressOptions>,
+) -> (String, u8) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type)
         .with_options(ParseOptions { allow_return_outside_function: true, ..Default::default() })
@@ -114,11 +157,13 @@ fn run(source_text: &str, source_type: SourceType, options: Option<CompressOptio
     assert!(!ret.panicked, "{source_text}");
     assert!(ret.diagnostics.is_empty(), "{source_text}");
     let mut program = ret.program;
-    if let Some(options) = options {
-        Compressor::new(&allocator).build(&mut program, options);
-    }
-    Codegen::new()
+    let iterations = options.map_or(0, |options| {
+        let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+        Compressor::new(&allocator).build_with_scoping(&mut program, scoping, options)
+    });
+    let code = Codegen::new()
         .with_options(CodegenOptions { single_quote: true, ..Default::default() })
         .build(&program)
-        .code
+        .code;
+    (code, iterations)
 }

--- a/crates/oxc_minifier/tests/peephole/compression_pass.rs
+++ b/crates/oxc_minifier/tests/peephole/compression_pass.rs
@@ -1,0 +1,26 @@
+use crate::{CompressOptions, test_options, test_options_with_iterations};
+
+#[test]
+fn iteration_counts() {
+    let options = CompressOptions::smallest();
+    test_options_with_iterations("foo();", "foo();", 0, &options);
+    test_options_with_iterations("let x = 1;", "", 1, &options);
+
+    let options = CompressOptions { drop_debugger: true, ..CompressOptions::smallest() };
+    test_options_with_iterations("debugger", "", 0, &options);
+}
+
+#[test]
+fn normalize_flushes_before_initial_liveness() {
+    let options = CompressOptions { drop_console: true, ..CompressOptions::smallest() };
+    test_options("console.log(eval('x')); function f() { f() }", "", &options);
+
+    let options = CompressOptions::smallest();
+    test_options("function f() { f() } void f;", "", &options);
+}
+
+#[test]
+fn dropped_direct_eval_converges_after_liveness_refresh() {
+    let options = CompressOptions::smallest();
+    test_options_with_iterations("if (false) eval('x'); function f() { f() }", "", 2, &options);
+}

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -9,14 +9,22 @@ use oxc_span::SourceType;
 
 #[track_caller]
 fn run(source_text: &str, source_type: SourceType, options: Option<CompressOptions>) -> String {
+    run_with_iterations(source_text, source_type, options).0
+}
+
+#[track_caller]
+fn run_with_iterations(
+    source_text: &str,
+    source_type: SourceType,
+    options: Option<CompressOptions>,
+) -> (String, u8) {
     let allocator = Allocator::default();
     let mut ret = Parser::new(&allocator, source_text, source_type).parse();
     assert!(ret.diagnostics.is_empty(), "Parser errors: {:?}", ret.diagnostics);
     let program = &mut ret.program;
-    if let Some(options) = options {
-        Compressor::new(&allocator).dead_code_elimination(program, options);
-    }
-    Codegen::new().build(program).code
+    let iterations = options
+        .map_or(0, |options| Compressor::new(&allocator).dead_code_elimination(program, options));
+    (Codegen::new().build(program).code, iterations)
 }
 
 #[track_caller]
@@ -30,6 +38,24 @@ fn test(source_text: &str, expected: &str) {
         expected,
         SourceType::default(),
         CompressOptions::dce(),
+    );
+}
+
+#[track_caller]
+fn test_with_iterations(source_text: &str, expected: &str, expected_iterations: u8) {
+    let t = "('production' == 'production')";
+    let f = "('production' == 'development')";
+    let source_text = source_text.cow_replace("true", t);
+    let source_text = source_text.cow_replace("false", f);
+    let iterations = test_with_options_source_type(
+        &source_text,
+        expected,
+        SourceType::default(),
+        CompressOptions::dce(),
+    );
+    assert_eq!(
+        iterations, expected_iterations,
+        "\niteration count for source\n{source_text}\nexpect\n{expected_iterations}\ngot\n{iterations}"
     );
 }
 
@@ -59,8 +85,8 @@ fn test_with_options_source_type(
     expected: &str,
     source_type: SourceType,
     options: CompressOptions,
-) {
-    let result = run(source_text, source_type, Some(options.clone()));
+) -> u8 {
+    let (result, iterations) = run_with_iterations(source_text, source_type, Some(options.clone()));
     let expected = run(expected, source_type, None);
     assert_eq!(result, expected, "\nfor source\n{source_text}\nexpect\n{expected}\ngot\n{result}");
 
@@ -70,6 +96,7 @@ fn test_with_options_source_type(
         result, second,
         "\nidempotency for source\n{source_text}\ngot\n{result}\nthen\n{second}"
     );
+    iterations
 }
 
 #[test]
@@ -417,6 +444,11 @@ console.log([
 ])
         ",
     );
+}
+
+#[test]
+fn dropped_direct_eval_converges_after_liveness_refresh() {
+    test_with_iterations("if (false) eval('x'); function f() { f() }", "", 2);
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/mod.rs
+++ b/crates/oxc_minifier/tests/peephole/mod.rs
@@ -1,4 +1,5 @@
 mod collapse_variable_declarations;
+mod compression_pass;
 mod convert_to_dotted_properties;
 mod dead_code_elimination;
 mod esbuild;

--- a/crates/oxc_minifier/tests/peephole/normalize.rs
+++ b/crates/oxc_minifier/tests/peephole/normalize.rs
@@ -36,8 +36,8 @@ fn test_void_ident() {
 
 // Leak regression: Normalize runs before the peephole fixed-point loop, but
 // `PassChanges` is live from `MinifierState::new`, so Normalize's typed-helper
-// drops are recorded like any pass's and consumed by the pre-loop `end_pass`
-// flush. A leaked read makes `x` look referenced, blocking
+// drops are recorded like any pass's and consumed by
+// `finish_normalize_pass`. A leaked read makes `x` look referenced, blocking
 // unused-declaration removal.
 #[test]
 fn test_void_ident_does_not_leak_reference() {

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -1,9 +1,9 @@
 use oxc_span::SourceType;
 
 use crate::{
-    CompressOptions, CompressOptionsUnused, TreeShakeOptions, test_options, test_options_once,
-    test_options_source_type, test_same_options, test_same_options_source_type, test_same_smallest,
-    test_smallest,
+    CompressOptions, CompressOptionsUnused, TreeShakeOptions, test_options,
+    test_options_once_with_iterations, test_options_source_type, test_options_with_iterations,
+    test_same_options, test_same_options_source_type, test_same_smallest, test_smallest,
 };
 
 // Leak regression: dropping an unused declarator must walk the whole
@@ -653,13 +653,14 @@ fn recursive_function_with_var_redeclaration() {
 
 #[test]
 fn recursive_function_var_redeclaration_converges_on_count_pass() {
-    test_smallest("function f() { f() } var f;", "");
+    let options = CompressOptions::smallest();
+    test_options_with_iterations("function f() { f() } var f;", "", 2, &options);
 
     // The first pass removes the function using published graph deadness.
     // Its body reference is pruned only at the following flush, so a capped
     // run conservatively retains the sibling `var` declaration.
     let options = CompressOptions { max_iterations: Some(0), ..CompressOptions::smallest() };
-    test_options_once("function f() { f() } var f;", "var f;", &options);
+    test_options_once_with_iterations("function f() { f() } var f;", "var f;", 0, &options);
 }
 
 // ---- Export observability ----


### PR DESCRIPTION
Pass progress and semantic cleanup were consumed separately, allowing the fixed-point driver to observe a partially completed pass. The reset and convergence contract was therefore spread across multiple call sites.

Treat one peephole pass as a transaction: traversal, reference pruning, direct-eval refresh, and reachability analysis complete before returning one convergence result. Normalize uses the same completion boundary but discards its revisit result because the first peephole pass is unconditional. The revisit signal remains private and can only be consumed through its take-and-reset API.

No measurable performance change is expected. Output is byte-identical to the base with identical iteration counts; CodSpeed CI is the performance evidence.

## Stack

1. #24651 — pass finalization
2. **#24652 — pass transaction**
3. #24653 — compression configuration

Verified with the full `oxc_minifier` test suite, including full-compression and DCE iteration assertions, clippy with warnings denied, formatting, minsize and allocation regeneration, and differential corpora; snapshots are unchanged.

Implemented with AI assistance (OpenAI Codex). The contributor remains responsible for reviewing, understanding, and submitting the changes under the repository AI usage policy.