### PR TITLE
refactor(minifier): group compression configuration

### DIFF
--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -5,7 +5,7 @@ use oxc_semantic::{Scoping, SemanticBuilder};
 use crate::{
     CompressOptions, ReusableTraverseCtx, compression_pass,
     peephole::{Normalize, NormalizeOptions},
-    state::MinifierState,
+    state::{CompressionMode, MinifierState},
 };
 
 pub struct Compressor<'a> {
@@ -17,9 +17,8 @@ impl<'a> Compressor<'a> {
         Self { allocator }
     }
 
-    /// Full minify: removes dead code and shrinks the output (`dce = false`).
-    /// For tree-shaking only, see [`Self::dead_code_elimination`] and the
-    /// `MinifierState::dce` docs.
+    /// Full minify: removes dead code and applies size-reducing transforms.
+    /// For tree-shaking only, see [`Self::dead_code_elimination`].
     pub fn build(self, program: &mut Program<'a>, options: CompressOptions) {
         let scoping = SemanticBuilder::new().build(program).semantic.into_scoping();
         self.build_with_scoping(program, scoping, options);
@@ -52,7 +51,7 @@ impl<'a> Compressor<'a> {
         let state = MinifierState::new(
             program.source_type,
             options,
-            /* dce */ false,
+            CompressionMode::Full,
             &scoping,
             self.allocator,
         );
@@ -66,9 +65,8 @@ impl<'a> Compressor<'a> {
         Self::run_in_loop(max_iterations, program, &mut ctx)
     }
 
-    /// Tree-shaking only: removes dead and unused code, but does not shrink the
-    /// output like [`Self::build`] (`dce = true`). Rolldown runs this on its
-    /// own. See the `MinifierState::dce` docs.
+    /// Tree-shaking only: removes dead and unused code, but does not otherwise
+    /// shrink the output like [`Self::build`]. Rolldown runs this on its own.
     pub fn dead_code_elimination(self, program: &mut Program<'a>, options: CompressOptions) -> u8 {
         let scoping = SemanticBuilder::new().build(program).semantic.into_scoping();
         self.dead_code_elimination_with_scoping(program, scoping, options)
@@ -90,7 +88,7 @@ impl<'a> Compressor<'a> {
         let state = MinifierState::new(
             program.source_type,
             options,
-            /* dce */ true,
+            CompressionMode::TreeShakeOnly,
             &scoping,
             self.allocator,
         );

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -67,6 +67,8 @@ use oxc_str::CompactStr;
 use oxc_syntax::class::ClassId;
 use rustc_hash::FxHashMap;
 
+use crate::state::CompressionMode;
+
 pub use oxc_mangler::{MangleOptions, MangleOptionsKeepNames};
 
 pub(crate) use crate::generated::traverse::Traverse;
@@ -108,16 +110,16 @@ impl<'a> Minifier {
     }
 
     pub fn minify(self, allocator: &'a Allocator, program: &mut Program<'a>) -> MinifierReturn {
-        self.build(false, allocator, program)
+        self.build(CompressionMode::Full, allocator, program)
     }
 
     pub fn dce(self, allocator: &'a Allocator, program: &mut Program<'a>) -> MinifierReturn {
-        self.build(true, allocator, program)
+        self.build(CompressionMode::TreeShakeOnly, allocator, program)
     }
 
     fn build(
         self,
-        dce: bool,
+        mode: CompressionMode,
         allocator: &'a Allocator,
         program: &mut Program<'a>,
     ) -> MinifierReturn {
@@ -129,7 +131,7 @@ impl<'a> Minifier {
                 let stats = semantic.stats();
                 let scoping = semantic.into_scoping();
                 let compressor = Compressor::new(allocator);
-                let iterations = if dce {
+                let iterations = if matches!(mode, CompressionMode::TreeShakeOnly) {
                     let options = CompressOptions {
                         target: options.target,
                         treeshake: options.treeshake,

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -234,7 +234,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
 
     fn exit_program(&mut self, _program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         // Private member usage is collected only in full optimization mode.
-        debug_assert!(ctx.state.dce || ctx.state.private_member_usage.is_at_root());
+        debug_assert!(ctx.is_tree_shake_only() || ctx.state.private_member_usage.is_at_root());
     }
 
     fn exit_statements(
@@ -250,7 +250,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     }
 
     fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             match stmt {
                 Statement::BlockStatement(_) => Self::try_optimize_block(stmt, ctx),
                 Statement::IfStatement(_) => Self::try_fold_if(stmt, ctx),
@@ -319,7 +319,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     }
 
     fn exit_for_statement(&mut self, stmt: &mut ForStatement<'a>, ctx: &mut TraverseCtx<'a>) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         Self::substitute_for_statement(stmt, ctx);
@@ -327,7 +327,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     }
 
     fn exit_return_statement(&mut self, stmt: &mut ReturnStatement<'a>, ctx: &mut TraverseCtx<'a>) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         Self::substitute_return_statement(stmt, ctx);
@@ -338,7 +338,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         decl: &mut VariableDeclaration<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         Self::substitute_variable_declaration(decl, ctx);
@@ -366,9 +366,8 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         // folds stay on because the removal passes don't evaluate compound
         // conditions themselves: `if ('production' === 'production')` must fold
         // to `true` before the dead branch can be dropped. Passes that only
-        // shrink code (`substitute_*`, `minimize_*`) are left out. See the `dce`
-        // docs in `state.rs`.
-        if ctx.state.dce {
+        // shrink code (`substitute_*`, `minimize_*`) are left out.
+        if ctx.is_tree_shake_only() {
             match expr {
                 Expression::TemplateLiteral(t) => {
                     Self::inline_template_literal(t, ctx);
@@ -493,7 +492,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     }
 
     fn exit_unary_expression(&mut self, expr: &mut UnaryExpression<'a>, ctx: &mut TraverseCtx<'a>) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         if expr.operator.is_not() {
@@ -502,7 +501,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     }
 
     fn exit_call_expression(&mut self, e: &mut CallExpression<'a>, ctx: &mut TraverseCtx<'a>) {
-        if !ctx.state.dce {
+        if !ctx.is_tree_shake_only() {
             Self::substitute_call_expression(e, ctx);
             Self::remove_empty_spread_arguments(&mut e.arguments);
         }
@@ -512,7 +511,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     }
 
     fn exit_new_expression(&mut self, e: &mut NewExpression<'a>, ctx: &mut TraverseCtx<'a>) {
-        if !ctx.state.dce {
+        if !ctx.is_tree_shake_only() {
             Self::substitute_new_expression(e, ctx);
             Self::remove_empty_spread_arguments(&mut e.arguments);
         }
@@ -520,7 +519,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     }
 
     fn exit_object_property(&mut self, prop: &mut ObjectProperty<'a>, ctx: &mut TraverseCtx<'a>) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         Self::substitute_object_property(prop, ctx);
@@ -531,7 +530,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         node: &mut AssignmentTargetProperty<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         Self::substitute_assignment_target_property(node, ctx);
@@ -542,14 +541,14 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         prop: &mut AssignmentTargetPropertyProperty<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         Self::substitute_assignment_target_property_property(prop, ctx);
     }
 
     fn exit_binding_property(&mut self, prop: &mut BindingProperty<'a>, ctx: &mut TraverseCtx<'a>) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         Self::substitute_binding_property(prop, ctx);
@@ -560,7 +559,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         prop: &mut MethodDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         Self::substitute_method_definition(prop, ctx);
@@ -571,7 +570,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         prop: &mut PropertyDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         Self::substitute_property_definition(prop, ctx);
@@ -582,7 +581,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         prop: &mut AccessorProperty<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         Self::substitute_accessor_property(prop, ctx);
@@ -593,21 +592,21 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         expr: &mut MemberExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         Self::convert_to_dotted_properties(expr, ctx);
     }
 
     fn enter_class_body(&mut self, _body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         ctx.state.private_member_usage.enter_class();
     }
 
     fn exit_class_body(&mut self, body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         Self::remove_dead_code_exit_class_body(body, ctx);
@@ -616,7 +615,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     }
 
     fn exit_catch_clause(&mut self, catch: &mut CatchClause<'a>, ctx: &mut TraverseCtx<'a>) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         Self::substitute_catch_clause(catch, ctx);
@@ -627,7 +626,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         node: &mut PrivateFieldExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         ctx.state.private_member_usage.record_use(node.field.name.into());
@@ -638,7 +637,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         node: &mut PrivateInExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return;
         }
         ctx.state.private_member_usage.record_use(node.left.name.into());

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -99,7 +99,7 @@ impl<'a> Traverse<'a> for Normalize {
         // every console call (statement position included) to `void 0`.
         stmts.retain(|stmt| match stmt {
             Statement::EmptyStatement(_) => false,
-            Statement::DebuggerStatement(_) if ctx.state.options.drop_debugger => false,
+            Statement::DebuggerStatement(_) if ctx.options().drop_debugger => false,
             _ => true,
         });
     }
@@ -130,7 +130,7 @@ impl<'a> Traverse<'a> for Normalize {
         // Handled outside the match below so the replacement can go through
         // `ctx.replace_expression`, which walks the dropped call (its
         // argument subtrees may contain resolved references) into `PassChanges`.
-        if ctx.state.options.drop_console
+        if ctx.options().drop_console
             && let Expression::CallExpression(call_expr) = &*expr
             && Self::is_console_call_expression(call_expr)
         {
@@ -167,7 +167,7 @@ impl<'a> Traverse<'a> for Normalize {
         node: &mut AssignmentTarget<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if !ctx.state.should_track_member_write_effects() {
+        if !ctx.should_track_member_write_effects() {
             return;
         }
         let Some(target) = node.as_simple_assignment_target() else { return };
@@ -182,7 +182,7 @@ impl<'a> Traverse<'a> for Normalize {
 
     /// `o.x++` / `--o.x` read the property before writing.
     fn exit_update_expression(&mut self, e: &mut UpdateExpression<'a>, ctx: &mut TraverseCtx<'a>) {
-        if !ctx.state.should_track_member_write_effects() {
+        if !ctx.should_track_member_write_effects() {
             return;
         }
         Self::record_simple_target_member_write_hazard(
@@ -196,7 +196,7 @@ impl<'a> Traverse<'a> for Normalize {
     /// single-level delete is harmless — but a CHAINED delete (`delete a.b.c`)
     /// reads the intermediate object `a.b`, hazarding the base `a`.
     fn exit_unary_expression(&mut self, e: &mut UnaryExpression<'a>, ctx: &mut TraverseCtx<'a>) {
-        if !ctx.state.should_track_member_write_effects() {
+        if !ctx.should_track_member_write_effects() {
             return;
         }
         if e.operator.is_delete()
@@ -615,11 +615,12 @@ impl<'a> Normalize {
         is_read_modify: bool,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        // In DCE mode only possible prototype mutation has a live consumer
-        // (the opt-in drop); the default hazard reader is full-minify only.
+        // In tree-shake-only mode only possible prototype mutation has a live
+        // consumer (the opt-in drop); the default hazard reader is full-minify
+        // only.
         // Skip hazard-only work (safe-key read-modify ops, chained writes,
         // chained deletes) before walking the chain.
-        if ctx.state.dce && !key_is_unsafe {
+        if ctx.is_tree_shake_only() && !key_is_unsafe {
             return;
         }
         let mut depth = 1u32;

--- a/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
@@ -6,7 +6,7 @@ use oxc_syntax::symbol::SymbolId;
 
 impl<'a> PeepholeOptimizations {
     pub(super) fn can_remove_unused_declarators(ctx: &TraverseCtx<'a>) -> bool {
-        ctx.state.options.unused != CompressOptionsUnused::Keep
+        ctx.options().unused != CompressOptionsUnused::Keep
             && !Self::is_script_root_scope(ctx)
             && !ctx.scoping().root_scope_flags().contains_direct_eval()
     }
@@ -159,7 +159,7 @@ impl<'a> PeepholeOptimizations {
 
     pub fn remove_unused_function_declaration(stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         let Statement::FunctionDeclaration(f) = stmt else { return };
-        if ctx.state.options.unused == CompressOptionsUnused::Keep {
+        if ctx.options().unused == CompressOptionsUnused::Keep {
             return;
         }
         let Some(id) = &f.id else { return };
@@ -176,7 +176,7 @@ impl<'a> PeepholeOptimizations {
 
     pub fn remove_unused_class_declaration(stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         let Statement::ClassDeclaration(c) = stmt else { return };
-        if ctx.state.options.unused == CompressOptionsUnused::Keep {
+        if ctx.options().unused == CompressOptionsUnused::Keep {
             return;
         }
         let Some(id) = &c.id else { return };
@@ -230,7 +230,7 @@ impl<'a> PeepholeOptimizations {
     /// ```
     pub fn remove_unused_import_specifiers(stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         if ctx.options().treeshake.invalid_import_side_effects
-            || ctx.state.options.unused == CompressOptionsUnused::Keep
+            || ctx.options().unused == CompressOptionsUnused::Keep
         {
             return;
         }

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -688,8 +688,8 @@ impl<'a> PeepholeOptimizations {
         !Self::has_side_effects_or_preserved_iife(e, ctx)
     }
 
-    /// `Expression::may_have_side_effects`, except that in DCE-only mode an IIFE
-    /// call (`(function () {...})()` / `(() => {...})()`) is reported as
+    /// `Expression::may_have_side_effects`, except that in tree-shake-only mode
+    /// an IIFE call (`(function () {...})()` / `(() => {...})()`) is reported as
     /// effectful so its structure survives — matching Rollup / esbuild
     /// tree-shaking (see `preserve_iife_in_dce_mode`). Full minification still
     /// drops a pure-bodied IIFE, just as it inlines IIFE bodies. Every
@@ -699,9 +699,9 @@ impl<'a> PeepholeOptimizations {
         e: &Expression<'a>,
         ctx: &TraverseCtx<'a>,
     ) -> bool {
-        // Check the cheap DCE-preservation case first: in DCE-only mode an IIFE
-        // call is always kept, so its (potentially deep) body walk is skipped.
-        if ctx.state.dce
+        // Check the cheap preservation case first: in tree-shake-only mode an
+        // IIFE call is always kept, so its (potentially deep) body walk is skipped.
+        if ctx.is_tree_shake_only()
             && matches!(e, Expression::CallExpression(call) if call.callee.is_function())
         {
             return true;
@@ -742,7 +742,7 @@ impl<'a> PeepholeOptimizations {
     ) -> bool {
         let Expression::AssignmentExpression(assign_expr) = &*e else { return false };
         if matches!(
-            ctx.state.options.unused,
+            ctx.options().unused,
             CompressOptionsUnused::Keep | CompressOptionsUnused::KeepAssign
         ) {
             return false;
@@ -816,9 +816,9 @@ impl<'a> PeepholeOptimizations {
             return Self::is_member_assign_to_unused_binding(symbol_id, ctx);
         }
 
-        // Default path. Full-minify only: in DCE (tree-shaking) mode rolldown
-        // owns `property_write_side_effects` as its opt-in knob.
-        if ctx.state.dce {
+        // Default path. Full-minify only: in tree-shake-only mode rolldown owns
+        // `property_write_side_effects` as its opt-in knob.
+        if ctx.is_tree_shake_only() {
             return false;
         }
         if ctx.current_scope_flags().contains_direct_eval() {

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -2072,7 +2072,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     /// Take the IIFE body out for inlining and propagate `pure` onto a
-    /// call/new body. Bails in DCE-only mode — see the
+    /// call/new body. Bails in tree-shake-only mode — see the
     /// `preserve_iife_in_dce_mode` test.
     /// Returns `None` to signal the caller should leave the IIFE intact.
     fn try_take_iife_body(
@@ -2080,7 +2080,7 @@ impl<'a> PeepholeOptimizations {
         is_pure: bool,
         ctx: &TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
-        if ctx.state.dce {
+        if ctx.is_tree_shake_only() {
             return None;
         }
         let mut taken = body.take_in(ctx);

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -9,6 +9,25 @@ use oxc_syntax::scope::ScopeId;
 
 use crate::{CompressOptions, symbol_state::SymbolState};
 
+/// Compression pipeline selected for this run.
+#[derive(Clone, Copy)]
+pub enum CompressionMode {
+    /// Remove dead code and apply size-reducing transformations.
+    Full,
+    /// Remove dead and unused code without otherwise shrinking the output.
+    /// This still runs the constant folds needed to expose removable branches,
+    /// but skips transforms whose only purpose is smaller syntax. Rolldown uses
+    /// this pipeline for tree-shaking with or without output minification.
+    TreeShakeOnly,
+}
+
+/// Immutable configuration shared by all compression passes in one run.
+struct CompressionConfig {
+    source_type: SourceType,
+    options: CompressOptions,
+    mode: CompressionMode,
+}
+
 /// Changes accumulated between two pass-completion boundaries. Live from
 /// `MinifierState::new` so the pre-loop `Normalize` pass records drops through
 /// the same typed helpers as the peephole loop; consumed and reset or resized
@@ -55,26 +74,9 @@ impl<'a> PassChanges<'a> {
 }
 
 pub struct MinifierState<'a> {
-    pub source_type: SourceType,
-
-    pub options: CompressOptions,
-
-    /// Two modes: tree-shaking only (`true`), or full minify (`false`).
-    /// `Compressor::dead_code_elimination` uses `true`; `Compressor::build`
-    /// uses `false`.
-    ///
-    /// "DCE" here does not mean "removes dead code" (full minify does that
-    /// too). It means tree-shaking: remove code that nothing imports, without
-    /// making the rest smaller. Rolldown runs this on every tree-shaking build,
-    /// with or without `minify`, so users can see this output directly.
-    ///
-    /// In this mode `exit_*` only runs the passes that remove code, plus the
-    /// constant folds those removals need. For example, `fold_binary_expr`
-    /// folds `'production' === 'production'` to `true` so the dead `else`
-    /// branch can be dropped (this is how `define` values remove branches). The
-    /// passes that only shrink code (`substitute_*`, `minimize_*`) are left
-    /// out. See the `if ctx.state.dce` branch in `peephole/mod.rs`.
-    pub dce: bool,
+    /// Source semantics, compression options, and pipeline selection fixed for
+    /// the lifetime of this run.
+    config: CompressionConfig,
 
     /// Dense per-pass values, sparse persistent metadata, and optional
     /// reachability data indexed by semantic symbols.
@@ -106,18 +108,16 @@ pub struct MinifierState<'a> {
 }
 
 impl<'a> MinifierState<'a> {
-    pub fn new(
+    pub(crate) fn new(
         source_type: SourceType,
         options: CompressOptions,
-        dce: bool,
+        mode: CompressionMode,
         scoping: &Scoping,
         allocator: &'a Allocator,
     ) -> Self {
         let symbols = SymbolState::new(source_type, &options, scoping, allocator);
         Self {
-            source_type,
-            options,
-            dce,
+            config: CompressionConfig { source_type, options, mode },
             symbols,
             private_member_usage: PrivateMemberUsageStack::new(),
             body_unsafe_stack: NonEmptyStack::new((scoping.root_scope_id(), false)),
@@ -130,12 +130,24 @@ impl<'a> MinifierState<'a> {
     /// i.e. whether any consumer is live in this configuration. In full
     /// minify the default-mode write-only property drop reads
     /// hazardous-member state and the shared drop predicate reads possible
-    /// prototype mutation. In DCE mode the default path is disabled and only
-    /// the `property_write_side_effects: false` opt-in drop reads the prototype
-    /// state, so with the knob left on nothing reads the effects and seeding is
-    /// skipped.
-    pub fn should_track_member_write_effects(&self) -> bool {
-        !self.dce || !self.options.treeshake.property_write_side_effects
+    /// prototype mutation. In tree-shake-only mode the default path is disabled
+    /// and only the `property_write_side_effects: false` opt-in drop reads the
+    /// prototype state, so with the knob left on nothing reads the effects and
+    /// seeding is skipped.
+    pub(crate) fn should_track_member_write_effects(&self) -> bool {
+        !self.is_tree_shake_only() || !self.options().treeshake.property_write_side_effects
+    }
+
+    pub(crate) fn options(&self) -> &CompressOptions {
+        &self.config.options
+    }
+
+    pub(crate) fn source_type(&self) -> SourceType {
+        self.config.source_type
+    }
+
+    pub(crate) fn is_tree_shake_only(&self) -> bool {
+        matches!(self.config.mode, CompressionMode::TreeShakeOnly)
     }
 
     /// Request another peephole traversal after the current pass completes.

--- a/crates/oxc_minifier/src/symbol_liveness/mod.rs
+++ b/crates/oxc_minifier/src/symbol_liveness/mod.rs
@@ -459,13 +459,14 @@ pub fn register_function(function: &Function<'_>, ctx: &mut TraverseCtx<'_>) {
     if !function.is_declaration() {
         return;
     }
-    if ctx.state.options.unused == CompressOptionsUnused::Keep {
+    if ctx.options().unused == CompressOptionsUnused::Keep {
         return;
     }
+    let source_type = ctx.source_type();
     let allocator = ctx.allocator();
     let TraverseCtx { state, scoping, .. } = ctx;
     if let Some(liveness) = state.symbols.liveness_mut() {
-        liveness.register_function(function, state.source_type, scoping.scoping(), allocator);
+        liveness.register_function(function, source_type, scoping.scoping(), allocator);
     }
 }
 
@@ -480,7 +481,7 @@ pub fn register_using_declaration(
         return;
     }
 
-    let source_type = ctx.state.source_type;
+    let source_type = ctx.source_type();
     let allocator = ctx.allocator();
     let TraverseCtx { state, scoping, .. } = ctx;
     let liveness = state

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -82,11 +82,11 @@ impl<'a> GlobalContext<'a> for &mut TraverseCtx<'a, MinifierState<'a>> {
 
 impl<'a> MayHaveSideEffectsContext<'a> for TraverseCtx<'a, MinifierState<'a>> {
     fn annotations(&self) -> bool {
-        self.state.options.treeshake.annotations
+        self.options().treeshake.annotations
     }
 
     fn manual_pure_functions(&self, callee: &Expression) -> bool {
-        let pure_functions = &self.state.options.treeshake.manual_pure_functions;
+        let pure_functions = &self.options().treeshake.manual_pure_functions;
         if pure_functions.is_empty() {
             return false;
         }
@@ -94,15 +94,15 @@ impl<'a> MayHaveSideEffectsContext<'a> for TraverseCtx<'a, MinifierState<'a>> {
     }
 
     fn property_read_side_effects(&self) -> PropertyReadSideEffects {
-        self.state.options.treeshake.property_read_side_effects
+        self.options().treeshake.property_read_side_effects
     }
 
     fn property_write_side_effects(&self) -> bool {
-        self.state.options.treeshake.property_write_side_effects
+        self.options().treeshake.property_write_side_effects
     }
 
     fn unknown_global_side_effects(&self) -> bool {
-        self.state.options.treeshake.unknown_global_side_effects
+        self.options().treeshake.unknown_global_side_effects
     }
 }
 
@@ -154,7 +154,7 @@ impl<'a> ConstantEvaluationCtx<'a> for TraverseCtx<'a, MinifierState<'a>> {}
 
 impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     pub fn options(&self) -> &CompressOptions {
-        &self.state.options
+        self.state.options()
     }
 
     /// Check if the target engines supports a feature.
@@ -165,7 +165,18 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     }
 
     pub fn source_type(&self) -> SourceType {
-        self.state.source_type
+        self.state.source_type()
+    }
+
+    /// Whether this run removes dead code without applying size-only rewrites.
+    pub fn is_tree_shake_only(&self) -> bool {
+        self.state.is_tree_shake_only()
+    }
+
+    /// Whether `Normalize` should seed persistent member-write metadata for a
+    /// consumer enabled by this configuration.
+    pub fn should_track_member_write_effects(&self) -> bool {
+        self.state.should_track_member_write_effects()
     }
 
     pub fn is_global_reference(&self, ident: &IdentifierReference<'a>) -> bool {


### PR DESCRIPTION
Compression configuration was split across three `MinifierState` fields, while the `dce` boolean obscured that full compression also removes dead code. Consumers had to reconstruct the active mode and keep related inputs synchronized.

Group the run's immutable inputs in `CompressionConfig` and represent pipeline selection with named `CompressionMode` variants. Traversal code reads configuration through focused context accessors, while the public compressor and minifier APIs remain unchanged.

No measurable performance change is expected. Output is byte-identical to the base with identical iteration counts; CodSpeed CI is the performance evidence.

## Stack

1. #24651 — pass finalization
2. #24652 — pass transaction
3. **#24653 — compression configuration**

Verified with the full `oxc_minifier` test suite, clippy with warnings denied, formatting, minsize and allocation regeneration, and differential compress-only and full-minify corpora; snapshots are unchanged.

Implemented with AI assistance (OpenAI Codex). The contributor remains responsible for reviewing, understanding, and submitting the changes under the repository AI usage policy.