### PR TITLE
feat(linter/unicorn): implement `consistent-export-decorator-position` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -348,6 +348,7 @@ export type ReturnAwaitOption = "in-try-catch" | "always" | "error-handling-corr
 export type PathOption = "always" | "never";
 export type TypesOption = "always" | "never" | "prefer-import";
 export type BomOptionType = "always" | "never";
+export type ConsistentExportDecoratorPositionOption = "above" | "before" | "after";
 export type NonZero = "greater-than" | "not-equal";
 export type ExplicitTimerDelayMode = "always" | "never";
 export type ModuleStylesOverride =
@@ -1521,6 +1522,8 @@ export interface DummyRuleMap {
   "unicorn/consistent-date-clone"?: RuleNoConfig;
   "unicorn/consistent-empty-array-spread"?: RuleNoConfig;
   "unicorn/consistent-existence-index-check"?: RuleNoConfig;
+  "unicorn/consistent-export-decorator-position"?:
+    RuleNoConfig | [AllowWarnDeny, ConsistentExportDecoratorPositionOption];
   "unicorn/consistent-function-scoping"?: RuleNoConfig | [AllowWarnDeny, ConsistentFunctionScoping];
   "unicorn/consistent-template-literal-escape"?: RuleNoConfig;
   "unicorn/custom-error-definition"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3006,6 +3006,11 @@ impl RuleRunner
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::consistent_export_decorator_position::ConsistentExportDecoratorPosition {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[AstType::Class]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::consistent_function_scoping::ConsistentFunctionScoping {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -605,6 +605,7 @@ pub use crate::rules::unicorn::consistent_assert::ConsistentAssert as UnicornCon
 pub use crate::rules::unicorn::consistent_date_clone::ConsistentDateClone as UnicornConsistentDateClone;
 pub use crate::rules::unicorn::consistent_empty_array_spread::ConsistentEmptyArraySpread as UnicornConsistentEmptyArraySpread;
 pub use crate::rules::unicorn::consistent_existence_index_check::ConsistentExistenceIndexCheck as UnicornConsistentExistenceIndexCheck;
+pub use crate::rules::unicorn::consistent_export_decorator_position::ConsistentExportDecoratorPosition as UnicornConsistentExportDecoratorPosition;
 pub use crate::rules::unicorn::consistent_function_scoping::ConsistentFunctionScoping as UnicornConsistentFunctionScoping;
 pub use crate::rules::unicorn::consistent_template_literal_escape::ConsistentTemplateLiteralEscape as UnicornConsistentTemplateLiteralEscape;
 pub use crate::rules::unicorn::custom_error_definition::CustomErrorDefinition as UnicornCustomErrorDefinition;
@@ -1331,6 +1332,7 @@ pub enum RuleEnum {
     UnicornConsistentDateClone(UnicornConsistentDateClone),
     UnicornConsistentEmptyArraySpread(UnicornConsistentEmptyArraySpread),
     UnicornConsistentExistenceIndexCheck(UnicornConsistentExistenceIndexCheck),
+    UnicornConsistentExportDecoratorPosition(UnicornConsistentExportDecoratorPosition),
     UnicornConsistentFunctionScoping(UnicornConsistentFunctionScoping),
     UnicornConsistentTemplateLiteralEscape(UnicornConsistentTemplateLiteralEscape),
     UnicornCustomErrorDefinition(UnicornCustomErrorDefinition),
@@ -2238,8 +2240,10 @@ const UNICORN_CONSISTENT_DATE_CLONE_ID: usize = UNICORN_CONSISTENT_ASSERT_ID + 1
 const UNICORN_CONSISTENT_EMPTY_ARRAY_SPREAD_ID: usize = UNICORN_CONSISTENT_DATE_CLONE_ID + 1usize;
 const UNICORN_CONSISTENT_EXISTENCE_INDEX_CHECK_ID: usize =
     UNICORN_CONSISTENT_EMPTY_ARRAY_SPREAD_ID + 1usize;
-const UNICORN_CONSISTENT_FUNCTION_SCOPING_ID: usize =
+const UNICORN_CONSISTENT_EXPORT_DECORATOR_POSITION_ID: usize =
     UNICORN_CONSISTENT_EXISTENCE_INDEX_CHECK_ID + 1usize;
+const UNICORN_CONSISTENT_FUNCTION_SCOPING_ID: usize =
+    UNICORN_CONSISTENT_EXPORT_DECORATOR_POSITION_ID + 1usize;
 const UNICORN_CONSISTENT_TEMPLATE_LITERAL_ESCAPE_ID: usize =
     UNICORN_CONSISTENT_FUNCTION_SCOPING_ID + 1usize;
 const UNICORN_CUSTOM_ERROR_DEFINITION_ID: usize =
@@ -3222,6 +3226,9 @@ impl RuleEnum {
             Self::UnicornConsistentExistenceIndexCheck(_) => {
                 UNICORN_CONSISTENT_EXISTENCE_INDEX_CHECK_ID
             }
+            Self::UnicornConsistentExportDecoratorPosition(_) => {
+                UNICORN_CONSISTENT_EXPORT_DECORATOR_POSITION_ID
+            }
             Self::UnicornConsistentFunctionScoping(_) => UNICORN_CONSISTENT_FUNCTION_SCOPING_ID,
             Self::UnicornConsistentTemplateLiteralEscape(_) => {
                 UNICORN_CONSISTENT_TEMPLATE_LITERAL_ESCAPE_ID
@@ -4196,6 +4203,9 @@ impl RuleEnum {
             Self::UnicornConsistentEmptyArraySpread(_) => UnicornConsistentEmptyArraySpread::NAME,
             Self::UnicornConsistentExistenceIndexCheck(_) => {
                 UnicornConsistentExistenceIndexCheck::NAME
+            }
+            Self::UnicornConsistentExportDecoratorPosition(_) => {
+                UnicornConsistentExportDecoratorPosition::NAME
             }
             Self::UnicornConsistentFunctionScoping(_) => UnicornConsistentFunctionScoping::NAME,
             Self::UnicornConsistentTemplateLiteralEscape(_) => {
@@ -5189,6 +5199,9 @@ impl RuleEnum {
             }
             Self::UnicornConsistentExistenceIndexCheck(_) => {
                 UnicornConsistentExistenceIndexCheck::CATEGORY
+            }
+            Self::UnicornConsistentExportDecoratorPosition(_) => {
+                UnicornConsistentExportDecoratorPosition::CATEGORY
             }
             Self::UnicornConsistentFunctionScoping(_) => UnicornConsistentFunctionScoping::CATEGORY,
             Self::UnicornConsistentTemplateLiteralEscape(_) => {
@@ -6185,6 +6198,9 @@ impl RuleEnum {
             Self::UnicornConsistentEmptyArraySpread(_) => UnicornConsistentEmptyArraySpread::FIX,
             Self::UnicornConsistentExistenceIndexCheck(_) => {
                 UnicornConsistentExistenceIndexCheck::FIX
+            }
+            Self::UnicornConsistentExportDecoratorPosition(_) => {
+                UnicornConsistentExportDecoratorPosition::FIX
             }
             Self::UnicornConsistentFunctionScoping(_) => UnicornConsistentFunctionScoping::FIX,
             Self::UnicornConsistentTemplateLiteralEscape(_) => {
@@ -7273,6 +7289,9 @@ impl RuleEnum {
             }
             Self::UnicornConsistentExistenceIndexCheck(_) => {
                 UnicornConsistentExistenceIndexCheck::documentation()
+            }
+            Self::UnicornConsistentExportDecoratorPosition(_) => {
+                UnicornConsistentExportDecoratorPosition::documentation()
             }
             Self::UnicornConsistentFunctionScoping(_) => {
                 UnicornConsistentFunctionScoping::documentation()
@@ -9161,6 +9180,10 @@ impl RuleEnum {
                 UnicornConsistentExistenceIndexCheck::config_schema(generator)
                     .or_else(|| UnicornConsistentExistenceIndexCheck::schema(generator))
             }
+            Self::UnicornConsistentExportDecoratorPosition(_) => {
+                UnicornConsistentExportDecoratorPosition::config_schema(generator)
+                    .or_else(|| UnicornConsistentExportDecoratorPosition::schema(generator))
+            }
             Self::UnicornConsistentFunctionScoping(_) => {
                 UnicornConsistentFunctionScoping::config_schema(generator)
                     .or_else(|| UnicornConsistentFunctionScoping::schema(generator))
@@ -10752,6 +10775,7 @@ impl RuleEnum {
             Self::UnicornConsistentDateClone(_) => "unicorn",
             Self::UnicornConsistentEmptyArraySpread(_) => "unicorn",
             Self::UnicornConsistentExistenceIndexCheck(_) => "unicorn",
+            Self::UnicornConsistentExportDecoratorPosition(_) => "unicorn",
             Self::UnicornConsistentFunctionScoping(_) => "unicorn",
             Self::UnicornConsistentTemplateLiteralEscape(_) => "unicorn",
             Self::UnicornCustomErrorDefinition(_) => "unicorn",
@@ -12628,6 +12652,11 @@ impl RuleEnum {
                     UnicornConsistentExistenceIndexCheck::from_configuration(value)?,
                 ))
             }
+            Self::UnicornConsistentExportDecoratorPosition(_) => {
+                Ok(Self::UnicornConsistentExportDecoratorPosition(
+                    UnicornConsistentExportDecoratorPosition::from_configuration(value)?,
+                ))
+            }
             Self::UnicornConsistentFunctionScoping(_) => {
                 Ok(Self::UnicornConsistentFunctionScoping(
                     UnicornConsistentFunctionScoping::from_configuration(value)?,
@@ -14339,6 +14368,7 @@ impl RuleEnum {
             Self::UnicornConsistentDateClone(rule) => rule.to_configuration(),
             Self::UnicornConsistentEmptyArraySpread(rule) => rule.to_configuration(),
             Self::UnicornConsistentExistenceIndexCheck(rule) => rule.to_configuration(),
+            Self::UnicornConsistentExportDecoratorPosition(rule) => rule.to_configuration(),
             Self::UnicornConsistentFunctionScoping(rule) => rule.to_configuration(),
             Self::UnicornConsistentTemplateLiteralEscape(rule) => rule.to_configuration(),
             Self::UnicornCustomErrorDefinition(rule) => rule.to_configuration(),
@@ -15193,6 +15223,7 @@ impl RuleEnum {
             Self::UnicornConsistentDateClone(rule) => rule.run(node, ctx),
             Self::UnicornConsistentEmptyArraySpread(rule) => rule.run(node, ctx),
             Self::UnicornConsistentExistenceIndexCheck(rule) => rule.run(node, ctx),
+            Self::UnicornConsistentExportDecoratorPosition(rule) => rule.run(node, ctx),
             Self::UnicornConsistentFunctionScoping(rule) => rule.run(node, ctx),
             Self::UnicornConsistentTemplateLiteralEscape(rule) => rule.run(node, ctx),
             Self::UnicornCustomErrorDefinition(rule) => rule.run(node, ctx),
@@ -16057,6 +16088,7 @@ impl RuleEnum {
             Self::UnicornConsistentDateClone(rule) => rule.run_once(ctx),
             Self::UnicornConsistentEmptyArraySpread(rule) => rule.run_once(ctx),
             Self::UnicornConsistentExistenceIndexCheck(rule) => rule.run_once(ctx),
+            Self::UnicornConsistentExportDecoratorPosition(rule) => rule.run_once(ctx),
             Self::UnicornConsistentFunctionScoping(rule) => rule.run_once(ctx),
             Self::UnicornConsistentTemplateLiteralEscape(rule) => rule.run_once(ctx),
             Self::UnicornCustomErrorDefinition(rule) => rule.run_once(ctx),
@@ -16996,6 +17028,9 @@ impl RuleEnum {
             Self::UnicornConsistentExistenceIndexCheck(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
             }
+            Self::UnicornConsistentExportDecoratorPosition(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
             Self::UnicornConsistentFunctionScoping(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornConsistentTemplateLiteralEscape(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
@@ -17903,6 +17938,7 @@ impl RuleEnum {
             Self::UnicornConsistentDateClone(rule) => rule.should_run(ctx),
             Self::UnicornConsistentEmptyArraySpread(rule) => rule.should_run(ctx),
             Self::UnicornConsistentExistenceIndexCheck(rule) => rule.should_run(ctx),
+            Self::UnicornConsistentExportDecoratorPosition(rule) => rule.should_run(ctx),
             Self::UnicornConsistentFunctionScoping(rule) => rule.should_run(ctx),
             Self::UnicornConsistentTemplateLiteralEscape(rule) => rule.should_run(ctx),
             Self::UnicornCustomErrorDefinition(rule) => rule.should_run(ctx),
@@ -18947,6 +18983,9 @@ impl RuleEnum {
             }
             Self::UnicornConsistentExistenceIndexCheck(_) => {
                 UnicornConsistentExistenceIndexCheck::IS_TSGOLINT_RULE
+            }
+            Self::UnicornConsistentExportDecoratorPosition(_) => {
+                UnicornConsistentExportDecoratorPosition::IS_TSGOLINT_RULE
             }
             Self::UnicornConsistentFunctionScoping(_) => {
                 UnicornConsistentFunctionScoping::IS_TSGOLINT_RULE
@@ -20089,6 +20128,9 @@ impl RuleEnum {
             Self::UnicornConsistentExistenceIndexCheck(_) => {
                 UnicornConsistentExistenceIndexCheck::VERSION
             }
+            Self::UnicornConsistentExportDecoratorPosition(_) => {
+                UnicornConsistentExportDecoratorPosition::VERSION
+            }
             Self::UnicornConsistentFunctionScoping(_) => UnicornConsistentFunctionScoping::VERSION,
             Self::UnicornConsistentTemplateLiteralEscape(_) => {
                 UnicornConsistentTemplateLiteralEscape::VERSION
@@ -21131,6 +21173,9 @@ impl RuleEnum {
             Self::UnicornConsistentExistenceIndexCheck(_) => {
                 UnicornConsistentExistenceIndexCheck::HAS_CONFIG
             }
+            Self::UnicornConsistentExportDecoratorPosition(_) => {
+                UnicornConsistentExportDecoratorPosition::HAS_CONFIG
+            }
             Self::UnicornConsistentFunctionScoping(_) => {
                 UnicornConsistentFunctionScoping::HAS_CONFIG
             }
@@ -22150,6 +22195,9 @@ impl RuleEnum {
             Self::UnicornConsistentExistenceIndexCheck(_) => {
                 UnicornConsistentExistenceIndexCheck::INFO
             }
+            Self::UnicornConsistentExportDecoratorPosition(_) => {
+                UnicornConsistentExportDecoratorPosition::INFO
+            }
             Self::UnicornConsistentFunctionScoping(_) => UnicornConsistentFunctionScoping::INFO,
             Self::UnicornConsistentTemplateLiteralEscape(_) => {
                 UnicornConsistentTemplateLiteralEscape::INFO
@@ -23048,6 +23096,7 @@ impl RuleEnum {
             Self::UnicornConsistentDateClone(rule) => rule.types_info(),
             Self::UnicornConsistentEmptyArraySpread(rule) => rule.types_info(),
             Self::UnicornConsistentExistenceIndexCheck(rule) => rule.types_info(),
+            Self::UnicornConsistentExportDecoratorPosition(rule) => rule.types_info(),
             Self::UnicornConsistentFunctionScoping(rule) => rule.types_info(),
             Self::UnicornConsistentTemplateLiteralEscape(rule) => rule.types_info(),
             Self::UnicornCustomErrorDefinition(rule) => rule.types_info(),
@@ -23899,6 +23948,7 @@ impl RuleEnum {
             Self::UnicornConsistentDateClone(rule) => rule.run_info(),
             Self::UnicornConsistentEmptyArraySpread(rule) => rule.run_info(),
             Self::UnicornConsistentExistenceIndexCheck(rule) => rule.run_info(),
+            Self::UnicornConsistentExportDecoratorPosition(rule) => rule.run_info(),
             Self::UnicornConsistentFunctionScoping(rule) => rule.run_info(),
             Self::UnicornConsistentTemplateLiteralEscape(rule) => rule.run_info(),
             Self::UnicornCustomErrorDefinition(rule) => rule.run_info(),
@@ -24843,6 +24893,9 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornConsistentEmptyArraySpread(UnicornConsistentEmptyArraySpread::default()),
         RuleEnum::UnicornConsistentExistenceIndexCheck(
             UnicornConsistentExistenceIndexCheck::default(),
+        ),
+        RuleEnum::UnicornConsistentExportDecoratorPosition(
+            UnicornConsistentExportDecoratorPosition::default(),
         ),
         RuleEnum::UnicornConsistentFunctionScoping(UnicornConsistentFunctionScoping::default()),
         RuleEnum::UnicornConsistentTemplateLiteralEscape(

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -491,6 +491,7 @@ pub(crate) mod unicorn {
     pub mod consistent_date_clone;
     pub mod consistent_empty_array_spread;
     pub mod consistent_existence_index_check;
+    pub mod consistent_export_decorator_position;
     pub mod consistent_function_scoping;
     pub mod consistent_template_literal_escape;
     pub mod custom_error_definition;

--- a/crates/oxc_linter/src/rules/unicorn/consistent_export_decorator_position.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_export_decorator_position.rs
@@ -199,7 +199,7 @@ fn has_blank_line_between(left: Span, right: Span, ctx: &LintContext) -> bool {
 
     let between_span = Span::new(left.end, right.start);
 
-    ctx.source_range(between_span).contains("\n")
+    ctx.source_range(between_span).contains('\n')
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/unicorn/consistent_export_decorator_position.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_export_decorator_position.rs
@@ -1,0 +1,312 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn consistent_export_decorator_position_diagnostic(
+    span: Span,
+    expected_position: &str,
+    actual_position: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Expected export decorators to be positioned `{expected_position}`, but found `{actual_position}`"))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ConsistentExportDecoratorPositionOption {
+    #[default]
+    /// Require decorators on the line above the export.
+    Above,
+    /// Require decorators before export on the same line.
+    Before,
+    /// Require decorators after export or export default.
+    After,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct ConsistentExportDecoratorPosition(ConsistentExportDecoratorPositionOption);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces a consistent position for decorators applied to an exported class,
+    /// relative to the `export` (or `export default`) keyword.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Decorators on an exported class can be written on the line above the export,
+    /// directly before it, or directly after it. All three are valid syntax, but mixing
+    /// styles across a codebase makes decorated classes harder to scan. This rule picks
+    /// one consistent style and enforces it everywhere.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule with default `"above"` option:
+    /// ```js
+    /// export default @decorator class Foo {}
+    ///
+    /// @decorator export default class Foo {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with default `"above"` option:
+    /// ```js
+    /// @decorator
+    /// export default class Foo {}
+    ///
+    /// @foo
+    /// @bar(options)
+    /// export class Foo {}
+    /// ```
+    ///
+    /// Examples of **incorrect** code for this rule with `"before"` option:
+    /// ```js
+    /// @decorator
+    /// export default class Foo {}
+    ///
+    /// export default @decorator class Foo {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with `"before"` option:
+    /// ```js
+    /// @decorator export default class Foo {}
+    ///
+    /// @foo @bar(options) export default class Foo {}
+    /// ```
+    ///
+    /// Examples of **incorrect** code for this rule with `"after"` option:
+    /// ```js
+    /// @decorator
+    /// export default class Foo {}
+    ///
+    /// @decorator export default class Foo {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with `"after"` option:
+    /// ```js
+    /// export default @decorator class Foo {}
+    ///
+    /// export default @foo @bar(options) class Foo {}
+    /// ```
+    ConsistentExportDecoratorPosition,
+    unicorn,
+    style,
+    pending,
+    config = ConsistentExportDecoratorPositionOption,
+    version = "next",
+    short_description = "Enforce consistent decorator position on exported classes.",
+);
+
+impl Rule for ConsistentExportDecoratorPosition {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Class(class) = node.kind() else {
+            return;
+        };
+
+        if class.decorators.is_empty() {
+            return;
+        }
+
+        let parent_node = ctx.nodes().parent_node(class.node_id());
+
+        let (AstKind::ExportDeclaration(_) | AstKind::ExportDefaultDeclaration(_)) =
+            parent_node.kind()
+        else {
+            return;
+        };
+
+        let expected_position = match self.0 {
+            ConsistentExportDecoratorPositionOption::Above => DecoratorPosition::Above,
+            ConsistentExportDecoratorPositionOption::Before => DecoratorPosition::Before,
+            ConsistentExportDecoratorPositionOption::After => DecoratorPosition::After,
+        };
+
+        let mut found_positions: FxHashMap<&str, u32> = FxHashMap::default();
+
+        for decorator in &class.decorators {
+            let actual_position = get_decorator_position(decorator.span(), parent_node.span(), ctx);
+            *found_positions.entry(actual_position.as_str()).or_insert(0) += 1;
+        }
+
+        let actual_position = if found_positions.len() > 1 {
+            "mixed"
+        } else {
+            found_positions.keys().next().copied().unwrap_or("")
+        };
+
+        if actual_position != expected_position.as_str() {
+            ctx.diagnostic(consistent_export_decorator_position_diagnostic(
+                // Match upstream: always report on the first decorator, even though
+                // pointing at the actually offending decorator would arguably be more accurate.
+                class.decorators[0].span(),
+                expected_position.as_str(),
+                actual_position,
+            ));
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DecoratorPosition {
+    Above,
+    Before,
+    After,
+}
+
+impl DecoratorPosition {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Above => "above",
+            Self::Before => "before",
+            Self::After => "after",
+        }
+    }
+}
+
+fn get_decorator_position(
+    decorator_span: Span,
+    parent_span: Span,
+    ctx: &LintContext,
+) -> DecoratorPosition {
+    if decorator_span.start < parent_span.start {
+        if has_blank_line_between(decorator_span, parent_span, ctx) {
+            DecoratorPosition::Above
+        } else {
+            DecoratorPosition::Before
+        }
+    } else {
+        DecoratorPosition::After
+    }
+}
+
+fn has_blank_line_between(left: Span, right: Span, ctx: &LintContext) -> bool {
+    if left.end >= right.start {
+        return false;
+    }
+
+    let between_span = Span::new(left.end, right.start);
+
+    ctx.source_range(between_span).contains("\n")
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use serde_json::json;
+
+    let pass = vec![
+        ("@decorator\nexport default class Foo {}", None),
+        ("@decorator\nexport default class {}", None),
+        ("@foo\n@bar(options)\nexport default class Foo {}", None),
+        ("@decorator\nexport class Foo {}", None),
+        ("@foo\n@bar(options)\nexport class Foo {}", None),
+        (
+            r"@decorator(
+                foo
+            )
+            export class Foo {}",
+            None,
+        ),
+        ("@decorator export default class Foo {}", Some(json!(["before"]))),
+        ("@foo @bar(options) export default class Foo {}", Some(json!(["before"]))),
+        ("@decorator export class Foo {}", Some(json!(["before"]))),
+        (
+            r"@decorator(
+                foo
+            ) export class Foo {}",
+            Some(json!(["before"])),
+        ),
+        ("export default @decorator class Foo {}", Some(json!(["after"]))),
+        ("export default @foo @bar(options) class Foo {}", Some(json!(["after"]))),
+        ("export @decorator class Foo {}", Some(json!(["after"]))),
+        ("class Foo {}", None),
+        ("@decorator\nclass Foo {}", None),
+        ("export default class Foo {}", None),
+        ("export class Foo {}", None),
+        ("export default (@decorator class Foo {})", None),
+        ("export default class Foo { @decorator method() {} }", None),
+        ("export {Foo}", None),
+    ];
+
+    let fail = vec![
+        ("export default @decorator class Foo {}", None),
+        ("export default @decorator class {}", None),
+        ("@decorator export default class Foo {}", None),
+        ("export @decorator class Foo {}", None),
+        ("@decorator export class Foo {}", None),
+        ("export default\n@decorator\nclass Foo {}", None),
+        ("export\n@decorator\nclass Foo {}", None),
+        ("export default @foo @bar(options) class Foo {}", None),
+        ("@foo @bar(options) export default class Foo {}", None),
+        ("@foo\n@bar export class Foo {}", None),
+        // `@foo export @bar class Foo {}` is a parser-level syntax error in oxc (decorators
+        // may not appear both before and after `export`/`export default`; see
+        // `decorators_in_export_and_class` in crates/oxc_parser/src/js/module.rs). When the
+        // parser reports any diagnostic, oxc_linter's service layer skips semantic analysis
+        // and never runs lint rules for that file (crates/oxc_linter/src/service/runtime.rs),
+        // so this rule's diagnostic can never take priority over the parser error. Left
+        // commented out for reviewers to decide whether these cases should be removed.
+        // ("@foo export @bar class Foo {}", None),
+        // ("@foo export default @bar class Foo {}", None),
+        (
+            r"@decorator(
+                foo
+            ) export class Foo {}",
+            None,
+        ),
+        (
+            r"namespace N {
+                @decorator export class Foo {}
+            }",
+            None,
+        ),
+        ("@decorator\nexport default class Foo {}", Some(json!(["before"]))),
+        ("@foo\n@bar export class Foo {}", Some(json!(["before"]))),
+        // Same parser-level syntax error as above; see the comment above the `None`-config
+        // cases for details.
+        // ("@foo export @bar class Foo {}", Some(json!(["before"]))),
+        // ("@foo export default @bar class Foo {}", Some(json!(["before"]))),
+        ("export default @decorator class Foo {}", Some(json!(["before"]))),
+        ("@decorator\nexport class Foo {}", Some(json!(["before"]))),
+        ("export @decorator class Foo {}", Some(json!(["before"]))),
+        ("@decorator\nexport default class Foo {}", Some(json!(["after"]))),
+        ("@decorator export default class Foo {}", Some(json!(["after"]))),
+        ("@decorator\nexport class Foo {}", Some(json!(["after"]))),
+        ("@decorator export class Foo {}", Some(json!(["after"]))),
+        // Same parser-level syntax error as above; see the comment above the `None`-config
+        // cases for details.
+        // ("@foo export @bar class Foo {}", Some(json!(["after"]))),
+        // ("@foo export default @bar class Foo {}", Some(json!(["after"]))),
+        ("export default @decorator(/* comment */ value) class Foo {}", None),
+        ("export default /* comment */ @decorator class Foo {}", None),
+        ("@decorator /* comment */ export default class Foo {}", None),
+        ("@decorator\nexport default abstract class Foo {}", Some(json!(["after"]))),
+        (
+            r"export default @decorator class Foo {
+                method() {}
+            }",
+            None,
+        ),
+    ];
+
+    Tester::new(
+        ConsistentExportDecoratorPosition::NAME,
+        ConsistentExportDecoratorPosition::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_consistent_export_decorator_position.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_consistent_export_decorator_position.snap
@@ -1,0 +1,174 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `after`
+   ╭─[consistent_export_decorator_position.tsx:1:16]
+ 1 │ export default @decorator class Foo {}
+   ·                ──────────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `after`
+   ╭─[consistent_export_decorator_position.tsx:1:16]
+ 1 │ export default @decorator class {}
+   ·                ──────────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `before`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ @decorator export default class Foo {}
+   · ──────────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `after`
+   ╭─[consistent_export_decorator_position.tsx:1:8]
+ 1 │ export @decorator class Foo {}
+   ·        ──────────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `before`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ @decorator export class Foo {}
+   · ──────────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `after`
+   ╭─[consistent_export_decorator_position.tsx:2:1]
+ 1 │ export default
+ 2 │ @decorator
+   · ──────────
+ 3 │ class Foo {}
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `after`
+   ╭─[consistent_export_decorator_position.tsx:2:1]
+ 1 │ export
+ 2 │ @decorator
+   · ──────────
+ 3 │ class Foo {}
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `after`
+   ╭─[consistent_export_decorator_position.tsx:1:16]
+ 1 │ export default @foo @bar(options) class Foo {}
+   ·                ────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `before`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ @foo @bar(options) export default class Foo {}
+   · ────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `mixed`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ @foo
+   · ────
+ 2 │ @bar export class Foo {}
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `before`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ ╭─▶ @decorator(
+ 2 │ │                   foo
+ 3 │ ╰─▶             ) export class Foo {}
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `before`
+   ╭─[consistent_export_decorator_position.tsx:2:17]
+ 1 │ namespace N {
+ 2 │                 @decorator export class Foo {}
+   ·                 ──────────
+ 3 │             }
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `before`, but found `above`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ @decorator
+   · ──────────
+ 2 │ export default class Foo {}
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `before`, but found `mixed`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ @foo
+   · ────
+ 2 │ @bar export class Foo {}
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `before`, but found `after`
+   ╭─[consistent_export_decorator_position.tsx:1:16]
+ 1 │ export default @decorator class Foo {}
+   ·                ──────────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `before`, but found `above`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ @decorator
+   · ──────────
+ 2 │ export class Foo {}
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `before`, but found `after`
+   ╭─[consistent_export_decorator_position.tsx:1:8]
+ 1 │ export @decorator class Foo {}
+   ·        ──────────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `after`, but found `above`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ @decorator
+   · ──────────
+ 2 │ export default class Foo {}
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `after`, but found `before`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ @decorator export default class Foo {}
+   · ──────────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `after`, but found `above`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ @decorator
+   · ──────────
+ 2 │ export class Foo {}
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `after`, but found `before`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ @decorator export class Foo {}
+   · ──────────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `after`
+   ╭─[consistent_export_decorator_position.tsx:1:16]
+ 1 │ export default @decorator(/* comment */ value) class Foo {}
+   ·                ───────────────────────────────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `after`
+   ╭─[consistent_export_decorator_position.tsx:1:30]
+ 1 │ export default /* comment */ @decorator class Foo {}
+   ·                              ──────────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `before`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ @decorator /* comment */ export default class Foo {}
+   · ──────────
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `after`, but found `above`
+   ╭─[consistent_export_decorator_position.tsx:1:1]
+ 1 │ @decorator
+   · ──────────
+ 2 │ export default abstract class Foo {}
+   ╰────
+
+  ⚠ unicorn(consistent-export-decorator-position): Expected export decorators to be positioned `above`, but found `after`
+   ╭─[consistent_export_decorator_position.tsx:1:16]
+ 1 │ export default @decorator class Foo {
+   ·                ──────────
+ 2 │                 method() {}
+   ╰────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1555,6 +1555,34 @@
       },
       "additionalProperties": false
     },
+    "ConsistentExportDecoratorPositionOption": {
+      "oneOf": [
+        {
+          "description": "Require decorators on the line above the export.",
+          "type": "string",
+          "enum": [
+            "above"
+          ],
+          "markdownDescription": "Require decorators on the line above the export."
+        },
+        {
+          "description": "Require decorators before export on the same line.",
+          "type": "string",
+          "enum": [
+            "before"
+          ],
+          "markdownDescription": "Require decorators before export on the same line."
+        },
+        {
+          "description": "Require decorators after export or export default.",
+          "type": "string",
+          "enum": [
+            "after"
+          ],
+          "markdownDescription": "Require decorators after export or export default."
+        }
+      ]
+    },
     "ConsistentFunctionScoping": {
       "type": "object",
       "properties": {
@@ -8756,6 +8784,26 @@
         },
         "unicorn/consistent-existence-index-check": {
           "$ref": "#/definitions/RuleNoConfig"
+        },
+        "unicorn/consistent-export-decorator-position": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/ConsistentExportDecoratorPositionOption"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
         },
         "unicorn/consistent-function-scoping": {
           "anyOf": [

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -528,6 +528,7 @@ unicorn/consistent-assert                                  |    103
 unicorn/consistent-date-clone                              |   1421
 unicorn/consistent-empty-array-spread                      |   4722
 unicorn/consistent-existence-index-check                   |  20604
+unicorn/consistent-export-decorator-position               |    300
 unicorn/consistent-function-scoping                        |  16812
 unicorn/consistent-template-literal-escape                 |    613
 unicorn/custom-error-definition                            |    300


### PR DESCRIPTION
Implements `unicorn/consistent-export-decorator-position`, part of #684.

Autofix is not implemented in this PR (unlike upstream).

## Skipped test cases

Three pairs of upstream `invalid` cases are commented out in the test module instead of being ported,
because they are parser-level syntax errors in oxc and cannot reach this rule:

```js
@foo export @bar class Foo {}
@foo export default @bar class Foo {}
```

Decorators may not appear both before and after `export` / `export default` (see `decorators_in_export_and_class` in `crates/oxc_parser/src/js/module.rs`). 

Since the parser reports a diagnostic for these inputs, `oxc_linter`'s service layer skips semantic analysis and never runs lint rules on that file, so this rule's diagnostic could never fire for them anyway.

Left commented in place (with the reasoning inline) rather than deleted.

## Snapshot verification against upstream

The generated snapshot (`crates/oxc_linter/src/snapshots/unicorn_consistent_export_decorator_position.snap`) was compared case-by-case against upstream's [`consistent-export-decorator-position.js.md`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/test/snapshots/consistent-export-decorator-position.js.md).

All 25 ported `invalid` cases (i.e. excluding the 3 skipped pairs above) match upstream in both diagnostic message text and error location: the actual position is judged for the whole decorator group (uniform, or `"mixed"` if decorators disagree with each other), and the diagnostic is always reported on `decorators[0]`, matching upstream's `getProblem()` algorithm.
## AI usage disclosure

AI assistance (Claude) was used while implementing this rule and its tests.
All code was reviewed, tested, and understood before submission, per [Oxc's AI usage policy](../CONTRIBUTING.md#ai-usage-policy).

