### PR TITLE
perf(diagnostics): box OxcDiagnosticInner to reduce binary size by 4%

### DIFF
--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -241,9 +241,6 @@ impl ConfigLoadError {
 ///
 /// This groups together failures related to the root configuration file
 /// and to any nested configuration files discovered during loading.
-// `OxcDiagnostic` is intentionally inlined (~176 bytes) to keep its construction
-// allocation-free, so the variant size difference is a deliberate trade-off.
-#[expect(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum CliConfigLoadError {
     /// An error that occurred while loading or parsing the root configuration.

--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -173,7 +173,7 @@ impl<'a> IntoIterator for &'a Diagnostics {
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[must_use]
 pub struct OxcDiagnostic {
-    inner: OxcDiagnosticInner,
+    inner: Box<OxcDiagnosticInner>,
 }
 
 impl Deref for OxcDiagnostic {
@@ -274,31 +274,28 @@ impl Diagnostic for OxcDiagnostic {
 impl OxcDiagnostic {
     /// Create new an error-level [`OxcDiagnostic`].
     pub fn error<T: Into<Cow<'static, str>>>(message: T) -> Self {
-        Self {
-            inner: OxcDiagnosticInner {
-                message: message.into(),
-                labels: Labels::None,
-                note: None,
-                help: None,
-                severity: Severity::Error,
-                code: OxcCode::default(),
-                url: None,
-            },
-        }
+        Self::new(Severity::Error, message.into())
     }
 
     /// Create new a warning-level [`OxcDiagnostic`].
     pub fn warn<T: Into<Cow<'static, str>>>(message: T) -> Self {
+        Self::new(Severity::Warning, message.into())
+    }
+
+    // Outlined so the `Box` allocation + field initialization exists once in the binary
+    // instead of being inlined into every diagnostic construction site.
+    #[inline(never)]
+    fn new(severity: Severity, message: Cow<'static, str>) -> Self {
         Self {
-            inner: OxcDiagnosticInner {
-                message: message.into(),
+            inner: Box::new(OxcDiagnosticInner {
+                message,
                 labels: Labels::None,
                 help: None,
                 note: None,
-                severity: Severity::Warning,
+                severity,
                 code: OxcCode::default(),
                 url: None,
-            },
+            }),
         }
     }
 
@@ -462,6 +459,6 @@ impl OxcDiagnostic {
 
     /// Consumes the diagnostic and returns the inner owned data.
     pub fn inner_owned(self) -> OxcDiagnosticInner {
-        self.inner
+        *self.inner
     }
 }


### PR DESCRIPTION
`OxcDiagnostic` is an unboxed ~304-byte struct constructed at thousands of
callsites. Boxing its inner data behind an 8-byte handle shrinks the stripped
`oxlint` release binary by ~549 KiB (-4.0%): oxc_linter -307 KiB,
oxc_react_compiler -102 KiB, and others.

This reverses #22406, which unboxed the inner to save a heap allocation. That is
now safe: the parser no longer constructs diagnostics on its hot path (see the
previous commit). Also drops the now-obsolete `large_enum_variant` expectation
on `CliConfigLoadError`, whose `OxcDiagnostic` variant is now small.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>