### PR TITLE
fix(minifier): invalidate facts for redeclared bindings

### DIFF
--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -308,22 +308,41 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
 
         let scope_id = self.scoping().symbol_scope_id(symbol_id);
         let scope_flags = self.scoping().scope_flags(scope_id);
+        // Declaration traversal is source-ordered, but a nested function can
+        // consume the first declaration's facts before a later declaration of
+        // the same symbol is visited. Disable every declaration-derived fact
+        // from the outset instead of trying to repair an already-consumed value.
+        let has_multiple_value_declarations = self
+            .scoping()
+            .symbol_redeclarations(symbol_id)
+            .iter()
+            .filter(|declaration| declaration.flags.is_value())
+            .nth(1)
+            .is_some();
 
         // `constant` is the value-context value, `None` when withheld (e.g. a hoisted
         // `var` past a dirty prelude). Capture before it's moved just below.
         let value_withheld = constant.is_none();
         let initialized_constant =
-            if scope_flags.contains(ScopeFlags::DirectEval) { None } else { constant };
+            if has_multiple_value_declarations || scope_flags.contains(ScopeFlags::DirectEval) {
+                None
+            } else {
+                constant
+            };
 
         // `boolean_falsy` (see `SymbolValue::boolean_falsy`) gated to a sound subset:
-        // write-once, outside a direct-`eval` scope, and not a script's top-level
-        // global (another script could reassign it, so a 0 in-module write count
-        // doesn't prove write-once).
-        let boolean_falsy = falsy_init
-            && value_withheld
-            && !references.has_writes()
-            && !scope_flags.contains(ScopeFlags::DirectEval)
-            && !(self.source_type().is_script() && scope_id == self.scoping().root_scope_id());
+        // one value declaration, no resolved writes, outside a direct-`eval` scope,
+        // and not a script's top-level global (another script could reassign it, so
+        // a 0 in-module write count doesn't prove write-once).
+        let boolean_falsy = if has_multiple_value_declarations {
+            false
+        } else {
+            falsy_init
+                && value_withheld
+                && !references.has_writes()
+                && !scope_flags.contains(ScopeFlags::DirectEval)
+                && !(self.source_type().is_script() && scope_id == self.scoping().root_scope_id())
+        };
 
         // See `SymbolValue::implicit_undefined` — only meaningful when the
         // recorded constant is the hoist-produced `undefined` of `let x;`.
@@ -334,7 +353,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
             initialized_constant,
             implicit_undefined,
             references,
-            kind,
+            kind: if has_multiple_value_declarations { FreshValueKind::None } else { kind },
             boolean_falsy,
         };
         self.state.symbols.init_value(symbol_id, symbol_value);

--- a/crates/oxc_minifier/tests/peephole/inline.rs
+++ b/crates/oxc_minifier/tests/peephole/inline.rs
@@ -55,6 +55,75 @@ fn single_conditional_falsy_var_still_folds_in_boolean_context() {
     );
 }
 
+// https://github.com/oxc-project/oxc/issues/24603
+#[test]
+fn conditional_var_redeclarations_do_not_overwrite_reaching_values() {
+    test_smallest(
+        "export function f(a) { if (a) var x = true; else var x = false; return x ? 'ok' : 'fail'; }",
+        "export function f(a) { if (a) var x = !0; else var x = !1; return x ? 'ok' : 'fail'; }",
+    );
+    // The result must not depend on which branch traversal visits last.
+    test_smallest(
+        "export function f(a) { if (a) var x = false; else var x = true; return x ? 'ok' : 'fail'; }",
+        "export function f(a) { if (a) var x = !1; else var x = !0; return x ? 'ok' : 'fail'; }",
+    );
+}
+
+#[test]
+fn redeclared_falsy_var_is_not_assumed_falsy() {
+    // The dirty prelude withholds the first declaration's constant. A nested
+    // reader can consume its independently cached boolean-falsy fact before
+    // traversal reaches the later declaration.
+    test_smallest(
+        "export function outer() { sideEffect(); var x = false; function read() { return x ? 'T' : 'F'; } var x = true; return read(); }",
+        "export function outer() { sideEffect(); var x = !1; function read() { return x ? 'T' : 'F'; } var x = !0; return read(); }",
+    );
+    // A conditional `var` that redeclares a parameter may leave the argument
+    // value untouched, so the falsy initializer is not the only runtime value.
+    test_smallest(
+        "export function f(x, c) { if (c) var x = false; return x ? 'T' : 'F'; }",
+        "export function f(x, c) { if (c) var x = !1; return x ? 'T' : 'F'; }",
+    );
+}
+
+#[test]
+fn redeclared_var_facts_are_disabled_before_first_use() {
+    // A nested function is traversed before the later declaration. Semantic
+    // redeclaration metadata must suppress the first declaration's constant
+    // immediately; invalidating the slot on the second visit is too late.
+    test_smallest(
+        "export function outer() { var x = false; function read() { return x ? 'ok' : 'fail'; } var x = true; return read(); }",
+        "export function outer() { var x = !1; function read() { return x ? 'ok' : 'fail'; } var x = !0; return read(); }",
+    );
+}
+
+#[test]
+fn redeclared_var_fact_invalidation_is_conservative() {
+    // Both declarations execute in order, so folding to `2` would be sound.
+    // Keep the conservative output until the fact cache can model declaration
+    // positions without weakening the early-consumer protection above.
+    test_smallest(
+        "export function f() { var x = 1; var x = 2; return () => x; }",
+        "export function f() { var x = 1, x = 2; return () => x; }",
+    );
+}
+
+#[test]
+fn redeclared_vars_are_not_assumed_fresh() {
+    // The last declaration visited is fresh, but the other branch may alias an
+    // external object with an observable setter.
+    test_smallest(
+        "export function f(a, o) { if (a) var x = o; else var x = {}; x.p = 1; }",
+        "export function f(a, o) { if (a) var x = o; else var x = {}; x.p = 1; }",
+    );
+    // As with constants, a nested consumer may run after a later declaration
+    // even though traversal sees it while the first declaration's fact is set.
+    test_smallest(
+        "export function outer(o) { var x = {}; function write() { x.p = 1; } var x = o; write(); }",
+        "export function outer(o) { var x = {}; function write() { x.p = 1; } var x = o; write(); }",
+    );
+}
+
 #[test]
 fn conditional_labeled_var_declarator_not_inlined() {
     // A label introduces no scope, so the ancestry check must reject this


### PR DESCRIPTION
Multiple runtime declarations can share one semantic `SymbolId`, while source-order traversal stores each declaration's constant, boolean-falsy, and fresh-value facts in the same slot. A nested function can consume the first declaration's facts before traversal reaches a later declaration, so invalidating only on the later visit cannot repair an already-applied fold.

This PR checks semantic redeclaration metadata at the first producer. When a binding has multiple runtime value declarations, it withholds all declaration-derived value facts from every producer. Type-only merges remain eligible, and per-symbol reference counts are preserved.

## Example

```js
export function f(a) {
  if (a) var x = true;
  else var x = false;
  return x ? "ok" : "fail";
}
```

After this PR, minification preserves the branch-dependent test:

```js
export function f(a){if(a)var x=!0;else var x=!1;return x?`ok`:`fail`}
```

The rule is deliberately conservative. It also protects member writes when one declaration may alias an external object, but it gives up valid source-order folds such as `var x = 1; var x = 2; return () => x`. A regression test pins that behavior. Recovering same-value or otherwise benign redeclarations would require reaching-definition or dominance analysis rather than this source-ordered fact cache.

The check only covers declarations sharing one `SymbolId`. Sloppy Annex B block functions can update an existing `var` through a separate semantic symbol; current `main` and this stack still mishandle that pre-existing case, tracked in #24659.

Together with required lower PR #24650, this makes cached declaration facts conservative for conditional positions and same-symbol redeclarations.

The full `oxc_minifier` suite passes with 621 tests and 42 ignored; clippy, formatting, the #24603 runtime and repeat-compression repros pass, and regenerated minsize and allocation snapshots are byte-identical.

Fixes #24603.

## Stack

1. #24650 — conditional `var` initializer facts
2. **#24658 — redeclared binding facts**

Implemented with AI assistance (Claude Code and OpenAI Codex). The contributor remains responsible for reviewing, understanding, and submitting the changes under the repository AI usage policy.