### PR TITLE
refactor(react_compiler): derive Copy for leaf HIR types

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -163,7 +163,7 @@ pub enum ReactFunctionType {
     Other,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum ParamPattern {
     Place(Place),
     Spread(SpreadPattern),
@@ -466,7 +466,7 @@ pub enum GotoVariant {
     Try,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Case {
     pub test: Option<Place>,
     pub block: BlockId,
@@ -497,7 +497,7 @@ pub enum InstructionKind {
     Function,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct LValue {
     pub place: Place,
     pub kind: InstructionKind,
@@ -839,7 +839,7 @@ pub enum FunctionExpressionType {
     FunctionDeclaration,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct TemplateQuasi<'a> {
     pub raw: Str<'a>,
     pub cooked: Option<Str<'a>>,
@@ -852,13 +852,13 @@ pub struct ManualMemoDependency<'a> {
     pub span: Option<Span>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum ManualMemoDependencyRoot<'a> {
     NamedLocal { value: Place, constant: bool },
     Global { identifier_name: Ident<'a> },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DependencyPathEntry<'a> {
     pub property: PropertyLiteral<'a>,
     pub optional: bool,
@@ -869,7 +869,7 @@ pub struct DependencyPathEntry<'a> {
 // Place, Identifier, and related types
 // =============================================================================
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Place {
     pub identifier: IdentifierId,
     pub effect: Effect,
@@ -877,7 +877,7 @@ pub struct Place {
     pub span: Option<Span>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Identifier<'a> {
     pub id: IdentifierId,
     pub declaration_id: DeclarationId,
@@ -888,7 +888,7 @@ pub struct Identifier<'a> {
     pub span: Option<Span>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct MutableRange {
     /// Unique identity for this logical range. Cloning preserves the ID
     /// (same logical range); use `Environment::new_mutable_range()` to create
@@ -970,7 +970,7 @@ impl std::fmt::Display for Effect {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct SpreadPattern {
     pub place: Place,
 }
@@ -980,7 +980,7 @@ pub struct ArrayPattern {
     pub items: Vec<ArrayPatternElement>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum ArrayPatternElement {
     Place(Place),
     Spread(SpreadPattern),
@@ -992,20 +992,20 @@ pub struct ObjectPattern<'a> {
     pub properties: Vec<ObjectPropertyOrSpread<'a>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum ObjectPropertyOrSpread<'a> {
     Property(ObjectProperty<'a>),
     Spread(SpreadPattern),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ObjectProperty<'a> {
     pub key: ObjectPropertyKey<'a>,
     pub property_type: ObjectPropertyType,
     pub place: Place,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum ObjectPropertyKey<'a> {
     String { name: Ident<'a> },
     Identifier { name: Ident<'a> },
@@ -1048,36 +1048,36 @@ impl std::fmt::Display for PropertyLiteral<'_> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum PlaceOrSpread {
     Place(Place),
     Spread(SpreadPattern),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum ArrayElement {
     Place(Place),
     Spread(SpreadPattern),
     Hole,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct LoweredFunction {
     pub func: FunctionId,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct BuiltinTag<'a> {
     pub name: Ident<'a>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum JsxTag<'a> {
     Place(Place),
     Builtin(BuiltinTag<'a>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum JsxAttribute<'a> {
     SpreadAttribute { argument: Place },
     Attribute { name: Ident<'a>, place: Place },
@@ -1099,7 +1099,7 @@ pub enum BindingKind {
     Unknown,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum VariableBinding<'a> {
     Identifier { identifier: IdentifierId, binding_kind: BindingKind },
     Global { name: Ident<'a> },
@@ -1109,7 +1109,7 @@ pub enum VariableBinding<'a> {
     ModuleLocal { name: Ident<'a> },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum NonLocalBinding<'a> {
     ImportDefault { name: Ident<'a>, module: Str<'a> },
     ImportSpecifier { name: Ident<'a>, module: Str<'a>, imported: Ident<'a> },
@@ -1161,7 +1161,7 @@ pub enum Type<'a> {
     ObjectMethod,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum PropertyNameKind<'a> {
     Literal { value: PropertyLiteral<'a> },
     Computed,

--- a/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
@@ -28,7 +28,7 @@ pub type PlaceList = SmallVec<[Place; 4]>;
 /// Equivalent to TS `eachInstructionLValue`.
 pub fn each_instruction_lvalue(instr: &Instruction) -> PlaceList {
     let mut result = PlaceList::new();
-    result.push(instr.lvalue.clone());
+    result.push(instr.lvalue);
     result.extend(each_instruction_value_lvalue(&instr.value));
     result
 }
@@ -42,14 +42,14 @@ pub fn each_instruction_value_lvalue(value: &InstructionValue) -> PlaceList {
         | InstructionValue::StoreContext { lvalue, .. }
         | InstructionValue::DeclareLocal { lvalue, .. }
         | InstructionValue::StoreLocal { lvalue, .. } => {
-            result.push(lvalue.place.clone());
+            result.push(lvalue.place);
         }
         InstructionValue::Destructure { lvalue, .. } => {
             result.extend(each_pattern_operand(&lvalue.pattern));
         }
         InstructionValue::PostfixUpdate { lvalue, .. }
         | InstructionValue::PrefixUpdate { lvalue, .. } => {
-            result.push(lvalue.clone());
+            result.push(*lvalue);
         }
         // All other variants have no lvalues
         InstructionValue::LoadLocal { .. }
@@ -113,86 +113,86 @@ pub fn each_instruction_value_operand_with_functions(
     match value {
         InstructionValue::NewExpression { callee, args, .. }
         | InstructionValue::CallExpression { callee, args, .. } => {
-            result.push(callee.clone());
+            result.push(*callee);
             result.extend(each_call_argument(args));
         }
         InstructionValue::BinaryExpression { left, right, .. } => {
-            result.push(left.clone());
-            result.push(right.clone());
+            result.push(*left);
+            result.push(*right);
         }
         InstructionValue::MethodCall { receiver, property, args, .. } => {
-            result.push(receiver.clone());
-            result.push(property.clone());
+            result.push(*receiver);
+            result.push(*property);
             result.extend(each_call_argument(args));
         }
         InstructionValue::DeclareContext { .. } | InstructionValue::DeclareLocal { .. } => {
             // no operands
         }
         InstructionValue::LoadLocal { place, .. } | InstructionValue::LoadContext { place, .. } => {
-            result.push(place.clone());
+            result.push(*place);
         }
         InstructionValue::StoreLocal { value: val, .. } => {
-            result.push(val.clone());
+            result.push(*val);
         }
         InstructionValue::StoreContext { lvalue, value: val, .. } => {
-            result.push(lvalue.place.clone());
-            result.push(val.clone());
+            result.push(lvalue.place);
+            result.push(*val);
         }
         InstructionValue::StoreGlobal { value: val, .. } => {
-            result.push(val.clone());
+            result.push(*val);
         }
         InstructionValue::Destructure { value: val, .. } => {
-            result.push(val.clone());
+            result.push(*val);
         }
         InstructionValue::PropertyLoad { object, .. } => {
-            result.push(object.clone());
+            result.push(*object);
         }
         InstructionValue::PropertyDelete { object, .. } => {
-            result.push(object.clone());
+            result.push(*object);
         }
         InstructionValue::PropertyStore { object, value: val, .. } => {
-            result.push(object.clone());
-            result.push(val.clone());
+            result.push(*object);
+            result.push(*val);
         }
         InstructionValue::ComputedLoad { object, property, .. } => {
-            result.push(object.clone());
-            result.push(property.clone());
+            result.push(*object);
+            result.push(*property);
         }
         InstructionValue::ComputedDelete { object, property, .. } => {
-            result.push(object.clone());
-            result.push(property.clone());
+            result.push(*object);
+            result.push(*property);
         }
         InstructionValue::ComputedStore { object, property, value: val, .. } => {
-            result.push(object.clone());
-            result.push(property.clone());
-            result.push(val.clone());
+            result.push(*object);
+            result.push(*property);
+            result.push(*val);
         }
         InstructionValue::UnaryExpression { value: val, .. } => {
-            result.push(val.clone());
+            result.push(*val);
         }
         InstructionValue::JsxExpression { tag, props, children, .. } => {
             if let JsxTag::Place(place) = tag {
-                result.push(place.clone());
+                result.push(*place);
             }
             for attribute in props {
                 match attribute {
                     JsxAttribute::Attribute { place, .. } => {
-                        result.push(place.clone());
+                        result.push(*place);
                     }
                     JsxAttribute::SpreadAttribute { argument, .. } => {
-                        result.push(argument.clone());
+                        result.push(*argument);
                     }
                 }
             }
             if let Some(children) = children {
                 for child in children {
-                    result.push(child.clone());
+                    result.push(*child);
                 }
             }
         }
         InstructionValue::JsxFragment { children, .. } => {
             for child in children {
-                result.push(child.clone());
+                result.push(*child);
             }
         }
         InstructionValue::ObjectExpression { properties, .. } => {
@@ -200,12 +200,12 @@ pub fn each_instruction_value_operand_with_functions(
                 match property {
                     ObjectPropertyOrSpread::Property(prop) => {
                         if let ObjectPropertyKey::Computed { name } = &prop.key {
-                            result.push(name.clone());
+                            result.push(*name);
                         }
-                        result.push(prop.place.clone());
+                        result.push(prop.place);
                     }
                     ObjectPropertyOrSpread::Spread(spread) => {
-                        result.push(spread.place.clone());
+                        result.push(spread.place);
                     }
                 }
             }
@@ -214,10 +214,10 @@ pub fn each_instruction_value_operand_with_functions(
             for element in elements {
                 match element {
                     ArrayElement::Place(place) => {
-                        result.push(place.clone());
+                        result.push(*place);
                     }
                     ArrayElement::Spread(spread) => {
-                        result.push(spread.place.clone());
+                        result.push(spread.place);
                     }
                     ArrayElement::Hole => {}
                 }
@@ -227,51 +227,51 @@ pub fn each_instruction_value_operand_with_functions(
         | InstructionValue::FunctionExpression { lowered_func, .. } => {
             let func = &functions[lowered_func.func];
             for ctx_place in &func.context {
-                result.push(ctx_place.clone());
+                result.push(*ctx_place);
             }
         }
         InstructionValue::TaggedTemplateExpression { tag, subexprs, .. } => {
-            result.push(tag.clone());
+            result.push(*tag);
             for subexpr in subexprs {
-                result.push(subexpr.clone());
+                result.push(*subexpr);
             }
         }
         InstructionValue::TypeCastExpression { value: val, .. } => {
-            result.push(val.clone());
+            result.push(*val);
         }
         InstructionValue::TemplateLiteral { subexprs, .. } => {
             for subexpr in subexprs {
-                result.push(subexpr.clone());
+                result.push(*subexpr);
             }
         }
         InstructionValue::Await { value: val, .. } => {
-            result.push(val.clone());
+            result.push(*val);
         }
         InstructionValue::GetIterator { collection, .. } => {
-            result.push(collection.clone());
+            result.push(*collection);
         }
         InstructionValue::IteratorNext { iterator, collection, .. } => {
-            result.push(iterator.clone());
-            result.push(collection.clone());
+            result.push(*iterator);
+            result.push(*collection);
         }
         InstructionValue::NextPropertyOf { value: val, .. } => {
-            result.push(val.clone());
+            result.push(*val);
         }
         InstructionValue::PostfixUpdate { value: val, .. }
         | InstructionValue::PrefixUpdate { value: val, .. } => {
-            result.push(val.clone());
+            result.push(*val);
         }
         InstructionValue::StartMemoize { deps, .. } => {
             if let Some(deps) = deps {
                 for dep in deps {
                     if let ManualMemoDependencyRoot::NamedLocal { value, .. } = &dep.root {
-                        result.push(value.clone());
+                        result.push(*value);
                     }
                 }
             }
         }
         InstructionValue::FinishMemoize { decl, .. } => {
-            result.push(decl.clone());
+            result.push(*decl);
         }
         InstructionValue::Debugger { .. }
         | InstructionValue::RegExpLiteral { .. }
@@ -292,10 +292,10 @@ pub fn each_call_argument(args: &[PlaceOrSpread]) -> PlaceList {
     for arg in args {
         match arg {
             PlaceOrSpread::Place(place) => {
-                result.push(place.clone());
+                result.push(*place);
             }
             PlaceOrSpread::Spread(spread) => {
-                result.push(spread.place.clone());
+                result.push(spread.place);
             }
         }
     }
@@ -311,10 +311,10 @@ pub fn each_pattern_operand(pattern: &Pattern) -> PlaceList {
             for item in &arr.items {
                 match item {
                     ArrayPatternElement::Place(place) => {
-                        result.push(place.clone());
+                        result.push(*place);
                     }
                     ArrayPatternElement::Spread(spread) => {
-                        result.push(spread.place.clone());
+                        result.push(spread.place);
                     }
                     ArrayPatternElement::Hole => {}
                 }
@@ -324,10 +324,10 @@ pub fn each_pattern_operand(pattern: &Pattern) -> PlaceList {
             for property in &obj.properties {
                 match property {
                     ObjectPropertyOrSpread::Property(prop) => {
-                        result.push(prop.place.clone());
+                        result.push(prop.place);
                     }
                     ObjectPropertyOrSpread::Spread(spread) => {
-                        result.push(spread.place.clone());
+                        result.push(spread.place);
                     }
                 }
             }
@@ -430,25 +430,25 @@ pub fn each_terminal_operand(terminal: &Terminal) -> PlaceList {
     let mut result = PlaceList::new();
     match terminal {
         Terminal::If { test, .. } => {
-            result.push(test.clone());
+            result.push(*test);
         }
         Terminal::Branch { test, .. } => {
-            result.push(test.clone());
+            result.push(*test);
         }
         Terminal::Switch { test, cases, .. } => {
-            result.push(test.clone());
+            result.push(*test);
             for case in cases {
                 if let Some(test) = &case.test {
-                    result.push(test.clone());
+                    result.push(*test);
                 }
             }
         }
         Terminal::Return { value, .. } | Terminal::Throw { value, .. } => {
-            result.push(value.clone());
+            result.push(*value);
         }
         Terminal::Try { handler_binding, .. } => {
             if let Some(binding) = handler_binding {
-                result.push(binding.clone());
+                result.push(*binding);
             }
         }
         Terminal::MaybeThrow { .. }
@@ -485,12 +485,10 @@ pub fn map_pattern_operands(pattern: &mut Pattern, f: &mut impl FnMut(Place) -> 
                 .items
                 .iter()
                 .map(|item| match item {
-                    ArrayPatternElement::Place(place) => {
-                        ArrayPatternElement::Place(f(place.clone()))
-                    }
+                    ArrayPatternElement::Place(place) => ArrayPatternElement::Place(f(*place)),
                     ArrayPatternElement::Spread(spread) => {
-                        let mut spread = spread.clone();
-                        spread.place = f(spread.place.clone());
+                        let mut spread = *spread;
+                        spread.place = f(spread.place);
                         ArrayPatternElement::Spread(spread)
                     }
                     ArrayPatternElement::Hole => ArrayPatternElement::Hole,
@@ -501,10 +499,10 @@ pub fn map_pattern_operands(pattern: &mut Pattern, f: &mut impl FnMut(Place) -> 
             for property in obj.properties.iter_mut() {
                 match property {
                     ObjectPropertyOrSpread::Property(prop) => {
-                        prop.place = f(prop.place.clone());
+                        prop.place = f(prop.place);
                     }
                     ObjectPropertyOrSpread::Spread(spread) => {
-                        spread.place = f(spread.place.clone());
+                        spread.place = f(spread.place);
                     }
                 }
             }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_method_call_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_method_call_scopes.rs
@@ -87,8 +87,8 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
         if scope_id == root_id {
             return;
         }
-        let scope_range = env.scopes[scope_id].range.clone();
-        let root_range = env.scopes[root_id].range.clone();
+        let scope_range = env.scopes[scope_id].range;
+        let root_range = env.scopes[root_id].range;
 
         let entry =
             range_updates.entry(root_id).or_insert_with(|| (root_range.start, root_range.end));

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
@@ -107,8 +107,8 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
         if scope_id == root_id {
             return;
         }
-        let scope_range = env.scopes[scope_id].range.clone();
-        let root_range = env.scopes[root_id].range.clone();
+        let scope_range = env.scopes[scope_id].range;
+        let root_range = env.scopes[root_id].range;
 
         let entry =
             range_updates.entry(root_id).or_insert_with(|| (root_range.start, root_range.end));

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
@@ -98,8 +98,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
     // (same reference) automatically see scope range modifications. In Rust, we
     // simulate this by recording original ranges and only syncing identifiers
     // whose mutableRange matches the original.
-    let original_scope_ranges: Vec<MutableRange> =
-        env.scopes.iter().map(|s| s.range.clone()).collect();
+    let original_scope_ranges: Vec<MutableRange> = env.scopes.iter().map(|s| s.range).collect();
 
     let mut active_block_fallthrough_ranges: Vec<BlockFallthroughRange> = Vec::new();
     let mut active_scopes: FxHashSet<ScopeId> = FxHashSet::default();
@@ -242,7 +241,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
                 // or for ternary/logical/optional terminals.
                 let value_range = if let Some(node) = &node {
                     // Value -> value transition (ternary/logical/optional): reuse range
-                    node.value_range.clone()
+                    node.value_range
                 } else {
                     // Transition from block -> value block
                     let ft = fallthrough.expect("Expected a fallthrough for value block");

--- a/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
@@ -356,8 +356,7 @@ fn fix_scope_and_identifier_ranges(func: &HirFunction, env: &mut Environment) {
     // reference as scope.range see the update automatically. We simulate
     // this by only syncing identifiers whose mutableRange matches the
     // scope's pre-update range.
-    let original_scope_ranges: Vec<MutableRange> =
-        env.scopes.iter().map(|s| s.range.clone()).collect();
+    let original_scope_ranges: Vec<MutableRange> = env.scopes.iter().map(|s| s.range).collect();
 
     for (_block_id, block) in &func.body.blocks {
         match &block.terminal {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -967,7 +967,7 @@ fn find_hoisted_context_declarations(
     ) {
         let decl_id = env.identifiers[place.identifier].declaration_id;
         if hoisted.contains_key(&decl_id) && hoisted.get(&decl_id).unwrap().is_none() {
-            hoisted.insert(decl_id, Some(place.clone()));
+            hoisted.insert(decl_id, Some(*place));
         }
     }
 
@@ -1181,7 +1181,7 @@ fn infer_block(
         let block = &func.body.blocks[&block_id];
         match &block.terminal {
             Terminal::Try { handler, handler_binding: Some(binding), .. } => {
-                TerminalAction::Try { handler: *handler, binding: binding.clone() }
+                TerminalAction::Try { handler: *handler, binding: *binding }
             }
             Terminal::MaybeThrow { handler: Some(handler_id), .. } => {
                 TerminalAction::MaybeThrow { handler_id: *handler_id }
@@ -1210,8 +1210,8 @@ fn infer_block(
                             if kind == ValueKind::Mutable || kind == ValueKind::Context {
                                 terminal_effects.push(context.intern_effect(
                                     AliasingEffect::Alias {
-                                        from: instr.lvalue.clone(),
-                                        into: handler_param.clone(),
+                                        from: instr.lvalue,
+                                        into: handler_param,
                                     },
                                 ));
                             }
@@ -1235,7 +1235,7 @@ fn infer_block(
                     block_mut.terminal
                 {
                     *term_effects = Some(vec![context.intern_effect(AliasingEffect::Freeze {
-                        value: value.clone(),
+                        value: *value,
                         reason: ValueReason::JsxCaptured,
                     })]);
                 }
@@ -1298,7 +1298,7 @@ fn apply_signature(
                                     .map(|s| s.label(format!("{} cannot be modified", variable))),
                             );
                         effects.push(AliasingEffect::MutateFrozen {
-                            place: mutate_value.clone(),
+                            place: *mutate_value,
                             error: diagnostic,
                         });
                     }
@@ -1452,7 +1452,7 @@ fn apply_effect(
                     let first_reason = primary_reason(&from_value.reason);
                     effects.push(AliasingEffect::Create {
                         value: from_value.kind,
-                        into: into.clone(),
+                        into: *into,
                         reason: first_reason,
                     });
                 }
@@ -1460,13 +1460,13 @@ fn apply_effect(
                     let first_reason = primary_reason(&from_value.reason);
                     effects.push(AliasingEffect::Create {
                         value: from_value.kind,
-                        into: into.clone(),
+                        into: *into,
                         reason: first_reason,
                     });
                     apply_effect(
                         context,
                         state,
-                        AliasingEffect::ImmutableCapture { from: from.clone(), into: into.clone() },
+                        AliasingEffect::ImmutableCapture { from: *from, into: *into },
                         initialized,
                         effects,
                         env,
@@ -1557,7 +1557,7 @@ fn apply_effect(
                 apply_effect(
                     context,
                     state,
-                    AliasingEffect::Capture { from: capture.clone(), into: into.clone() },
+                    AliasingEffect::Capture { from: *capture, into: *into },
                     initialized,
                     effects,
                     env,
@@ -1595,7 +1595,7 @@ fn apply_effect(
                 apply_effect(
                     context,
                     state,
-                    AliasingEffect::ImmutableCapture { from: from.clone(), into: into.clone() },
+                    AliasingEffect::ImmutableCapture { from: *from, into: *into },
                     initialized,
                     effects,
                     env,
@@ -1610,7 +1610,7 @@ fn apply_effect(
                 apply_effect(
                     context,
                     state,
-                    AliasingEffect::MaybeAlias { from: from.clone(), into: into.clone() },
+                    AliasingEffect::MaybeAlias { from: *from, into: *into },
                     initialized,
                     effects,
                     env,
@@ -1629,7 +1629,7 @@ fn apply_effect(
                     apply_effect(
                         context,
                         state,
-                        AliasingEffect::ImmutableCapture { from: from.clone(), into: into.clone() },
+                        AliasingEffect::ImmutableCapture { from: *from, into: *into },
                         initialized,
                         effects,
                         env,
@@ -1706,7 +1706,7 @@ fn apply_effect(
                                     context,
                                     state,
                                     AliasingEffect::MutateTransitiveConditionally {
-                                        value: function.clone(),
+                                        value: *function,
                                     },
                                     initialized,
                                     effects,
@@ -1786,7 +1786,7 @@ fn apply_effect(
                     context,
                     state,
                     AliasingEffect::Create {
-                        into: into.clone(),
+                        into: *into,
                         value: ValueKind::Mutable,
                         reason: ValueReason::Other,
                     },
@@ -1806,9 +1806,7 @@ fn apply_effect(
                         apply_effect(
                             context,
                             state,
-                            AliasingEffect::MutateTransitiveConditionally {
-                                value: operand.clone(),
-                            },
+                            AliasingEffect::MutateTransitiveConditionally { value: *operand },
                             initialized,
                             effects,
                             env,
@@ -1825,7 +1823,7 @@ fn apply_effect(
                     apply_effect(
                         context,
                         state,
-                        AliasingEffect::MaybeAlias { from: operand.clone(), into: into.clone() },
+                        AliasingEffect::MaybeAlias { from: *operand, into: *into },
                         initialized,
                         effects,
                         env,
@@ -1845,7 +1843,7 @@ fn apply_effect(
                         apply_effect(
                             context,
                             state,
-                            AliasingEffect::Capture { from: operand.clone(), into: other.clone() },
+                            AliasingEffect::Capture { from: *operand, into: *other },
                             initialized,
                             effects,
                             env,
@@ -1919,7 +1917,7 @@ fn apply_effect(
                     apply_effect(
                         context,
                         state,
-                        AliasingEffect::MutateFrozen { place: value.clone(), error: diagnostic },
+                        AliasingEffect::MutateFrozen { place: *value, error: diagnostic },
                         initialized,
                         effects,
                         env,
@@ -1940,9 +1938,9 @@ fn apply_effect(
                         );
 
                     let error_kind = if abstract_value.kind == ValueKind::Frozen {
-                        AliasingEffect::MutateFrozen { place: value.clone(), error: diagnostic }
+                        AliasingEffect::MutateFrozen { place: *value, error: diagnostic }
                     } else {
-                        AliasingEffect::MutateGlobal { place: value.clone(), error: diagnostic }
+                        AliasingEffect::MutateGlobal { place: *value, error: diagnostic }
                     };
                     apply_effect(context, state, error_kind, initialized, effects, env)?;
                 }
@@ -1974,27 +1972,21 @@ fn compute_signature_for_instruction(
     match value {
         InstructionValue::ArrayExpression { elements, .. } => {
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Mutable,
                 reason: ValueReason::Other,
             });
             for element in elements {
                 match element {
                     ArrayElement::Place(p) => {
-                        effects.push(AliasingEffect::Capture {
-                            from: p.clone(),
-                            into: lvalue.clone(),
-                        });
+                        effects.push(AliasingEffect::Capture { from: *p, into: *lvalue });
                     }
                     ArrayElement::Spread(s) => {
                         let ty = &env.types[env.identifiers[s.place.identifier].type_];
                         if let Some(mutate_iter) = conditionally_mutate_iterator(&s.place, ty) {
                             effects.push(mutate_iter);
                         }
-                        effects.push(AliasingEffect::Capture {
-                            from: s.place.clone(),
-                            into: lvalue.clone(),
-                        });
+                        effects.push(AliasingEffect::Capture { from: s.place, into: *lvalue });
                     }
                     ArrayElement::Hole => {}
                 }
@@ -2002,46 +1994,38 @@ fn compute_signature_for_instruction(
         }
         InstructionValue::ObjectExpression { properties, .. } => {
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Mutable,
                 reason: ValueReason::Other,
             });
             for property in properties {
                 match property {
                     ObjectPropertyOrSpread::Property(p) => {
-                        effects.push(AliasingEffect::Capture {
-                            from: p.place.clone(),
-                            into: lvalue.clone(),
-                        });
+                        effects.push(AliasingEffect::Capture { from: p.place, into: *lvalue });
                     }
                     ObjectPropertyOrSpread::Spread(s) => {
-                        effects.push(AliasingEffect::Capture {
-                            from: s.place.clone(),
-                            into: lvalue.clone(),
-                        });
+                        effects.push(AliasingEffect::Capture { from: s.place, into: *lvalue });
                     }
                 }
             }
         }
         InstructionValue::Await { value: await_value, .. } => {
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Mutable,
                 reason: ValueReason::Other,
             });
-            effects
-                .push(AliasingEffect::MutateTransitiveConditionally { value: await_value.clone() });
-            effects
-                .push(AliasingEffect::Capture { from: await_value.clone(), into: lvalue.clone() });
+            effects.push(AliasingEffect::MutateTransitiveConditionally { value: *await_value });
+            effects.push(AliasingEffect::Capture { from: *await_value, into: *lvalue });
         }
         InstructionValue::NewExpression { callee, args, span } => {
             let sig = get_function_call_signature(env, callee.identifier).ok().flatten();
             effects.push(AliasingEffect::Apply {
-                receiver: callee.clone(),
-                function: callee.clone(),
+                receiver: *callee,
+                function: *callee,
                 mutates_function: false,
                 args: args.iter().map(place_or_spread_to_hole).collect(),
-                into: lvalue.clone(),
+                into: *lvalue,
                 signature: sig,
                 span: *span,
             });
@@ -2049,11 +2033,11 @@ fn compute_signature_for_instruction(
         InstructionValue::CallExpression { callee, args, span } => {
             let sig = get_function_call_signature(env, callee.identifier).ok().flatten();
             effects.push(AliasingEffect::Apply {
-                receiver: callee.clone(),
-                function: callee.clone(),
+                receiver: *callee,
+                function: *callee,
                 mutates_function: true,
                 args: args.iter().map(place_or_spread_to_hole).collect(),
-                into: lvalue.clone(),
+                into: *lvalue,
                 signature: sig,
                 span: *span,
             });
@@ -2061,11 +2045,11 @@ fn compute_signature_for_instruction(
         InstructionValue::MethodCall { receiver, property, args, span } => {
             let sig = get_function_call_signature(env, property.identifier).ok().flatten();
             effects.push(AliasingEffect::Apply {
-                receiver: receiver.clone(),
-                function: property.clone(),
+                receiver: *receiver,
+                function: *property,
                 mutates_function: false,
                 args: args.iter().map(place_or_spread_to_hole).collect(),
-                into: lvalue.clone(),
+                into: *lvalue,
                 signature: sig,
                 span: *span,
             });
@@ -2073,26 +2057,23 @@ fn compute_signature_for_instruction(
         InstructionValue::PropertyDelete { object, .. }
         | InstructionValue::ComputedDelete { object, .. } => {
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Primitive,
                 reason: ValueReason::Other,
             });
-            effects.push(AliasingEffect::Mutate { value: object.clone(), reason: None });
+            effects.push(AliasingEffect::Mutate { value: *object, reason: None });
         }
         InstructionValue::PropertyLoad { object, .. }
         | InstructionValue::ComputedLoad { object, .. } => {
             let ty = &env.types[env.identifiers[lvalue.identifier].type_];
             if is_primitive_type(ty) {
                 effects.push(AliasingEffect::Create {
-                    into: lvalue.clone(),
+                    into: *lvalue,
                     value: ValueKind::Primitive,
                     reason: ValueReason::Other,
                 });
             } else {
-                effects.push(AliasingEffect::CreateFrom {
-                    from: object.clone(),
-                    into: lvalue.clone(),
-                });
+                effects.push(AliasingEffect::CreateFrom { from: *object, into: *lvalue });
             }
         }
         InstructionValue::PropertyStore { object, property, value: store_value, .. } => {
@@ -2108,21 +2089,19 @@ fn compute_signature_for_instruction(
                     None
                 }
             };
-            effects.push(AliasingEffect::Mutate { value: object.clone(), reason: mutation_reason });
-            effects
-                .push(AliasingEffect::Capture { from: store_value.clone(), into: object.clone() });
+            effects.push(AliasingEffect::Mutate { value: *object, reason: mutation_reason });
+            effects.push(AliasingEffect::Capture { from: *store_value, into: *object });
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Primitive,
                 reason: ValueReason::Other,
             });
         }
         InstructionValue::ComputedStore { object, value: store_value, .. } => {
-            effects.push(AliasingEffect::Mutate { value: object.clone(), reason: None });
-            effects
-                .push(AliasingEffect::Capture { from: store_value.clone(), into: object.clone() });
+            effects.push(AliasingEffect::Mutate { value: *object, reason: None });
+            effects.push(AliasingEffect::Capture { from: *store_value, into: *object });
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Primitive,
                 reason: ValueReason::Other,
             });
@@ -2137,65 +2116,55 @@ fn compute_signature_for_instruction(
                 .cloned()
                 .collect();
             effects.push(AliasingEffect::CreateFunction {
-                into: lvalue.clone(),
+                into: *lvalue,
                 function_id: lowered_func.func,
                 captures,
             });
         }
         InstructionValue::GetIterator { collection, .. } => {
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Mutable,
                 reason: ValueReason::Other,
             });
             let ty = &env.types[env.identifiers[collection.identifier].type_];
             if is_builtin_collection_type(ty) {
-                effects.push(AliasingEffect::Capture {
-                    from: collection.clone(),
-                    into: lvalue.clone(),
-                });
+                effects.push(AliasingEffect::Capture { from: *collection, into: *lvalue });
             } else {
-                effects
-                    .push(AliasingEffect::Alias { from: collection.clone(), into: lvalue.clone() });
-                effects.push(AliasingEffect::MutateTransitiveConditionally {
-                    value: collection.clone(),
-                });
+                effects.push(AliasingEffect::Alias { from: *collection, into: *lvalue });
+                effects.push(AliasingEffect::MutateTransitiveConditionally { value: *collection });
             }
         }
         InstructionValue::IteratorNext { iterator, collection, .. } => {
-            effects.push(AliasingEffect::MutateConditionally { value: iterator.clone() });
-            effects.push(AliasingEffect::CreateFrom {
-                from: collection.clone(),
-                into: lvalue.clone(),
-            });
+            effects.push(AliasingEffect::MutateConditionally { value: *iterator });
+            effects.push(AliasingEffect::CreateFrom { from: *collection, into: *lvalue });
         }
         InstructionValue::NextPropertyOf { .. } => {
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Primitive,
                 reason: ValueReason::Other,
             });
         }
         InstructionValue::JsxExpression { tag, props, children, .. } => {
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Frozen,
                 reason: ValueReason::JsxCaptured,
             });
             for operand in visitors::each_instruction_value_operand(value, env) {
                 effects.push(AliasingEffect::Freeze {
-                    value: operand.clone(),
+                    value: operand,
                     reason: ValueReason::JsxCaptured,
                 });
-                effects
-                    .push(AliasingEffect::Capture { from: operand.clone(), into: lvalue.clone() });
+                effects.push(AliasingEffect::Capture { from: operand, into: *lvalue });
             }
             if let JsxTag::Place(tag_place) = tag {
-                effects.push(AliasingEffect::Render { place: tag_place.clone() });
+                effects.push(AliasingEffect::Render { place: *tag_place });
             }
             if let Some(ch) = children {
                 for child in ch {
-                    effects.push(AliasingEffect::Render { place: child.clone() });
+                    effects.push(AliasingEffect::Render { place: *child });
                 }
             }
             for prop in props {
@@ -2204,34 +2173,33 @@ fn compute_signature_for_instruction(
                     if let Type::Function { return_type, .. } = prop_ty
                         && (is_jsx_type(return_type) || is_phi_with_jsx(return_type))
                     {
-                        effects.push(AliasingEffect::Render { place: prop_place.clone() });
+                        effects.push(AliasingEffect::Render { place: *prop_place });
                     }
                 }
             }
         }
         InstructionValue::JsxFragment { .. } => {
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Frozen,
                 reason: ValueReason::JsxCaptured,
             });
             for operand in visitors::each_instruction_value_operand(value, env) {
                 effects.push(AliasingEffect::Freeze {
-                    value: operand.clone(),
+                    value: operand,
                     reason: ValueReason::JsxCaptured,
                 });
-                effects
-                    .push(AliasingEffect::Capture { from: operand.clone(), into: lvalue.clone() });
+                effects.push(AliasingEffect::Capture { from: operand, into: *lvalue });
             }
         }
         InstructionValue::DeclareLocal { lvalue: dl, .. } => {
             effects.push(AliasingEffect::Create {
-                into: dl.place.clone(),
+                into: dl.place,
                 value: ValueKind::Primitive,
                 reason: ValueReason::Other,
             });
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Primitive,
                 reason: ValueReason::Other,
             });
@@ -2243,14 +2211,14 @@ fn compute_signature_for_instruction(
                         let ty = &env.types[env.identifiers[place.identifier].type_];
                         if is_primitive_type(ty) {
                             effects.push(AliasingEffect::Create {
-                                into: place.clone(),
+                                into: *place,
                                 value: ValueKind::Primitive,
                                 reason: ValueReason::Other,
                             });
                         } else {
                             effects.push(AliasingEffect::CreateFrom {
-                                from: dest_value.clone(),
-                                into: place.clone(),
+                                from: *dest_value,
+                                into: *place,
                             });
                         }
                     }
@@ -2262,21 +2230,18 @@ fn compute_signature_for_instruction(
                             ValueKind::Mutable
                         };
                         effects.push(AliasingEffect::Create {
-                            into: place.clone(),
+                            into: *place,
                             reason: ValueReason::Other,
                             value: value_kind,
                         });
-                        effects.push(AliasingEffect::Capture {
-                            from: dest_value.clone(),
-                            into: place.clone(),
-                        });
+                        effects.push(AliasingEffect::Capture { from: *dest_value, into: *place });
                     }
                 }
             }
-            effects.push(AliasingEffect::Assign { from: dest_value.clone(), into: lvalue.clone() });
+            effects.push(AliasingEffect::Assign { from: *dest_value, into: *lvalue });
         }
         InstructionValue::LoadContext { place, .. } => {
-            effects.push(AliasingEffect::CreateFrom { from: place.clone(), into: lvalue.clone() });
+            effects.push(AliasingEffect::CreateFrom { from: *place, into: *lvalue });
         }
         InstructionValue::DeclareContext { lvalue: dcl, .. } => {
             let decl_id = env.identifiers[dcl.place.identifier].declaration_id;
@@ -2287,15 +2252,15 @@ fn compute_signature_for_instruction(
                 || kind == InstructionKind::HoistedLet
             {
                 effects.push(AliasingEffect::Create {
-                    into: dcl.place.clone(),
+                    into: dcl.place,
                     value: ValueKind::Mutable,
                     reason: ValueReason::Other,
                 });
             } else {
-                effects.push(AliasingEffect::Mutate { value: dcl.place.clone(), reason: None });
+                effects.push(AliasingEffect::Mutate { value: dcl.place, reason: None });
             }
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Primitive,
                 reason: ValueReason::Other,
             });
@@ -2305,34 +2270,33 @@ fn compute_signature_for_instruction(
             if scl.kind == InstructionKind::Reassign
                 || context.hoisted_context_declarations.contains_key(&decl_id)
             {
-                effects.push(AliasingEffect::Mutate { value: scl.place.clone(), reason: None });
+                effects.push(AliasingEffect::Mutate { value: scl.place, reason: None });
             } else {
                 effects.push(AliasingEffect::Create {
-                    into: scl.place.clone(),
+                    into: scl.place,
                     value: ValueKind::Mutable,
                     reason: ValueReason::Other,
                 });
             }
-            effects
-                .push(AliasingEffect::Capture { from: sc_value.clone(), into: scl.place.clone() });
-            effects.push(AliasingEffect::Assign { from: sc_value.clone(), into: lvalue.clone() });
+            effects.push(AliasingEffect::Capture { from: *sc_value, into: scl.place });
+            effects.push(AliasingEffect::Assign { from: *sc_value, into: *lvalue });
         }
         InstructionValue::LoadLocal { place, .. } => {
-            effects.push(AliasingEffect::Assign { from: place.clone(), into: lvalue.clone() });
+            effects.push(AliasingEffect::Assign { from: *place, into: *lvalue });
         }
         InstructionValue::StoreLocal { lvalue: sl, value: sl_value, .. } => {
-            effects.push(AliasingEffect::Assign { from: sl_value.clone(), into: sl.place.clone() });
-            effects.push(AliasingEffect::Assign { from: sl_value.clone(), into: lvalue.clone() });
+            effects.push(AliasingEffect::Assign { from: *sl_value, into: sl.place });
+            effects.push(AliasingEffect::Assign { from: *sl_value, into: *lvalue });
         }
         InstructionValue::PostfixUpdate { lvalue: pf_lvalue, .. }
         | InstructionValue::PrefixUpdate { lvalue: pf_lvalue, .. } => {
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Primitive,
                 reason: ValueReason::Other,
             });
             effects.push(AliasingEffect::Create {
-                into: pf_lvalue.clone(),
+                into: *pf_lvalue,
                 value: ValueKind::Primitive,
                 reason: ValueReason::Other,
             });
@@ -2348,16 +2312,15 @@ fn compute_signature_for_instruction(
                 .with_labels(
                     instr.span.map(|s| s.label(format!("{} cannot be reassigned", variable))),
                 );
-            effects
-                .push(AliasingEffect::MutateGlobal { place: sg_value.clone(), error: diagnostic });
-            effects.push(AliasingEffect::Assign { from: sg_value.clone(), into: lvalue.clone() });
+            effects.push(AliasingEffect::MutateGlobal { place: *sg_value, error: diagnostic });
+            effects.push(AliasingEffect::Assign { from: *sg_value, into: *lvalue });
         }
         InstructionValue::TypeCastExpression { value: tc_value, .. } => {
-            effects.push(AliasingEffect::Assign { from: tc_value.clone(), into: lvalue.clone() });
+            effects.push(AliasingEffect::Assign { from: *tc_value, into: *lvalue });
         }
         InstructionValue::LoadGlobal { .. } => {
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Global,
                 reason: ValueReason::Global,
             });
@@ -2366,13 +2329,13 @@ fn compute_signature_for_instruction(
             if env.config.enable_preserve_existing_memoization_guarantees {
                 for operand in visitors::each_instruction_value_operand(value, env) {
                     effects.push(AliasingEffect::Freeze {
-                        value: operand.clone(),
+                        value: operand,
                         reason: ValueReason::HookCaptured,
                     });
                 }
             }
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Primitive,
                 reason: ValueReason::Other,
             });
@@ -2388,7 +2351,7 @@ fn compute_signature_for_instruction(
         | InstructionValue::TemplateLiteral { .. }
         | InstructionValue::UnaryExpression { .. } => {
             effects.push(AliasingEffect::Create {
-                into: lvalue.clone(),
+                into: *lvalue,
                 value: ValueKind::Primitive,
                 reason: ValueReason::Other,
             });
@@ -2418,7 +2381,7 @@ fn compute_effects_for_legacy_signature(
     let mut effects: Vec<AliasingEffect> = Vec::new();
 
     effects.push(AliasingEffect::Create {
-        into: lvalue.clone(),
+        into: *lvalue,
         value: signature.return_value_kind,
         reason: return_value_reason,
     });
@@ -2435,7 +2398,7 @@ fn compute_effects_for_legacy_signature(
                 }
             ))
             .with_labels(span.copied().map(|s| s.label("Cannot call impure function")));
-        effects.push(AliasingEffect::Impure { place: receiver.clone(), error: diagnostic });
+        effects.push(AliasingEffect::Impure { place: *receiver, error: diagnostic });
     }
 
     // TODO: check signature.known_incompatible and throw (TS line 2351-2370)
@@ -2446,16 +2409,13 @@ fn compute_effects_for_legacy_signature(
     if signature.mutable_only_if_operands_are_mutable
         && are_arguments_immutable_and_non_mutating(state, args, env, function_values)
     {
-        effects.push(AliasingEffect::Alias { from: receiver.clone(), into: lvalue.clone() });
+        effects.push(AliasingEffect::Alias { from: *receiver, into: *lvalue });
         for arg in args {
             match arg {
                 PlaceOrSpreadOrHole::Hole => continue,
                 PlaceOrSpreadOrHole::Place(place)
                 | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
-                    effects.push(AliasingEffect::ImmutableCapture {
-                        from: place.clone(),
-                        into: lvalue.clone(),
-                    });
+                    effects.push(AliasingEffect::ImmutableCapture { from: *place, into: *lvalue });
                 }
             }
         }
@@ -2468,40 +2428,36 @@ fn compute_effects_for_legacy_signature(
     let mut visit = |place: &Place, effect: Effect, effects: &mut Vec<AliasingEffect>| match effect
     {
         Effect::Store => {
-            effects.push(AliasingEffect::Mutate { value: place.clone(), reason: None });
-            stores.push(place.clone());
+            effects.push(AliasingEffect::Mutate { value: *place, reason: None });
+            stores.push(*place);
         }
         Effect::Capture => {
-            captures.push(place.clone());
+            captures.push(*place);
         }
         Effect::ConditionallyMutate => {
-            effects.push(AliasingEffect::MutateTransitiveConditionally { value: place.clone() });
+            effects.push(AliasingEffect::MutateTransitiveConditionally { value: *place });
         }
         Effect::ConditionallyMutateIterator => {
             let ty = &env.types[env.identifiers[place.identifier].type_];
             if let Some(mutate_iter) = conditionally_mutate_iterator(place, ty) {
                 effects.push(mutate_iter);
             }
-            effects.push(AliasingEffect::Capture { from: place.clone(), into: lvalue.clone() });
+            effects.push(AliasingEffect::Capture { from: *place, into: *lvalue });
         }
         Effect::Freeze => {
-            effects
-                .push(AliasingEffect::Freeze { value: place.clone(), reason: return_value_reason });
+            effects.push(AliasingEffect::Freeze { value: *place, reason: return_value_reason });
         }
         Effect::Mutate => {
-            effects.push(AliasingEffect::MutateTransitive { value: place.clone() });
+            effects.push(AliasingEffect::MutateTransitive { value: *place });
         }
         Effect::Read => {
-            effects.push(AliasingEffect::ImmutableCapture {
-                from: place.clone(),
-                into: lvalue.clone(),
-            });
+            effects.push(AliasingEffect::ImmutableCapture { from: *place, into: *lvalue });
         }
         _ => {}
     };
 
     if signature.callee_effect != Effect::Capture {
-        effects.push(AliasingEffect::Alias { from: receiver.clone(), into: lvalue.clone() });
+        effects.push(AliasingEffect::Alias { from: *receiver, into: *lvalue });
     }
 
     visit(receiver, signature.callee_effect, &mut effects);
@@ -2528,15 +2484,12 @@ fn compute_effects_for_legacy_signature(
     if !captures.is_empty() {
         if stores.is_empty() {
             for capture in &captures {
-                effects.push(AliasingEffect::Alias { from: capture.clone(), into: lvalue.clone() });
+                effects.push(AliasingEffect::Alias { from: *capture, into: *lvalue });
             }
         } else {
             for capture in &captures {
                 for store in &stores {
-                    effects.push(AliasingEffect::Capture {
-                        from: capture.clone(),
-                        into: store.clone(),
-                    });
+                    effects.push(AliasingEffect::Capture { from: *capture, into: *store });
                 }
             }
         }
@@ -2663,8 +2616,8 @@ fn compute_effects_for_aliasing_signature_config(
 ) -> Result<Option<Vec<AliasingEffect>>, OxcDiagnostic> {
     // Build substitutions from config strings to places
     let mut substitutions: FxHashMap<String, Vec<Place>> = FxHashMap::default();
-    substitutions.insert(config.receiver.to_string(), vec![receiver.clone()]);
-    substitutions.insert(config.returns.to_string(), vec![lvalue.clone()]);
+    substitutions.insert(config.receiver.to_string(), vec![*receiver]);
+    substitutions.insert(config.returns.to_string(), vec![*lvalue]);
 
     let mut mutable_spreads: FxHashSet<IdentifierId> = FxHashSet::default();
 
@@ -2674,9 +2627,9 @@ fn compute_effects_for_aliasing_signature_config(
             PlaceOrSpreadOrHole::Place(place)
             | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
                 if i < config.params.len() && !matches!(arg, PlaceOrSpreadOrHole::Spread(_)) {
-                    substitutions.insert(config.params[i].to_string(), vec![place.clone()]);
+                    substitutions.insert(config.params[i].to_string(), vec![*place]);
                 } else if let Some(rest) = config.rest {
-                    substitutions.entry(rest.to_string()).or_default().push(place.clone());
+                    substitutions.entry(rest.to_string()).or_default().push(*place);
                 } else {
                     return Ok(None);
                 }
@@ -2695,17 +2648,15 @@ fn compute_effects_for_aliasing_signature_config(
     for operand in context {
         let ident = &env.identifiers[operand.identifier];
         if let Some(ref name) = ident.name {
-            substitutions.insert(format!("@{}", name.value()), vec![operand.clone()]);
+            substitutions.insert(format!("@{}", name.value()), vec![*operand]);
         }
     }
 
     // Create temporaries (cached by lvalue + temp_name to be stable across fixpoint iterations)
     for temp_name in config.temporaries {
         let cache_key = (lvalue.identifier, temp_name.to_string());
-        let temp_place = temp_cache
-            .entry(cache_key)
-            .or_insert_with(|| create_temp_place(env, receiver.span))
-            .clone();
+        let temp_place =
+            *temp_cache.entry(cache_key).or_insert_with(|| create_temp_place(env, receiver.span));
         substitutions.insert(temp_name.to_string(), vec![temp_place]);
     }
 
@@ -2739,8 +2690,7 @@ fn compute_effects_for_aliasing_signature_config(
                 let intos = substitutions.get(*into).cloned().unwrap_or_default();
                 for f in &froms {
                     for t in &intos {
-                        effects
-                            .push(AliasingEffect::CreateFrom { from: f.clone(), into: t.clone() });
+                        effects.push(AliasingEffect::CreateFrom { from: *f, into: *t });
                     }
                 }
             }
@@ -2749,7 +2699,7 @@ fn compute_effects_for_aliasing_signature_config(
                 let intos = substitutions.get(*into).cloned().unwrap_or_default();
                 for f in &froms {
                     for t in &intos {
-                        effects.push(AliasingEffect::Assign { from: f.clone(), into: t.clone() });
+                        effects.push(AliasingEffect::Assign { from: *f, into: *t });
                     }
                 }
             }
@@ -2758,7 +2708,7 @@ fn compute_effects_for_aliasing_signature_config(
                 let intos = substitutions.get(*into).cloned().unwrap_or_default();
                 for f in &froms {
                     for t in &intos {
-                        effects.push(AliasingEffect::Alias { from: f.clone(), into: t.clone() });
+                        effects.push(AliasingEffect::Alias { from: *f, into: *t });
                     }
                 }
             }
@@ -2767,7 +2717,7 @@ fn compute_effects_for_aliasing_signature_config(
                 let intos = substitutions.get(*into).cloned().unwrap_or_default();
                 for f in &froms {
                     for t in &intos {
-                        effects.push(AliasingEffect::Capture { from: f.clone(), into: t.clone() });
+                        effects.push(AliasingEffect::Capture { from: *f, into: *t });
                     }
                 }
             }
@@ -2776,10 +2726,7 @@ fn compute_effects_for_aliasing_signature_config(
                 let intos = substitutions.get(*into).cloned().unwrap_or_default();
                 for f in &froms {
                     for t in &intos {
-                        effects.push(AliasingEffect::ImmutableCapture {
-                            from: f.clone(),
-                            into: t.clone(),
-                        });
+                        effects.push(AliasingEffect::ImmutableCapture { from: *f, into: *t });
                     }
                 }
             }
@@ -2825,7 +2772,7 @@ fn compute_effects_for_aliasing_signature_config(
                                 if let Some(places) = substitutions.get(*name)
                                     && let Some(p) = places.first()
                                 {
-                                    apply_args.push(PlaceOrSpreadOrHole::Place(p.clone()));
+                                    apply_args.push(PlaceOrSpreadOrHole::Place(*p));
                                 }
                             }
                             ApplyArgConfig::Spread { place: name, .. } => {
@@ -2833,7 +2780,7 @@ fn compute_effects_for_aliasing_signature_config(
                                     && let Some(p) = places.first()
                                 {
                                     apply_args.push(PlaceOrSpreadOrHole::Spread(SpreadPattern {
-                                        place: p.clone(),
+                                        place: *p,
                                     }));
                                 }
                             }
@@ -2915,8 +2862,8 @@ fn compute_effects_for_aliasing_signature(
 
     let mut mutable_spreads: FxHashSet<IdentifierId> = FxHashSet::default();
     let mut substitutions: FxHashMap<IdentifierId, Vec<Place>> = FxHashMap::default();
-    substitutions.insert(signature.receiver, vec![receiver.clone()]);
-    substitutions.insert(signature.returns, vec![lvalue.clone()]);
+    substitutions.insert(signature.receiver, vec![*receiver]);
+    substitutions.insert(signature.returns, vec![*lvalue]);
 
     for (i, arg) in args.iter().enumerate() {
         match arg {
@@ -2925,9 +2872,9 @@ fn compute_effects_for_aliasing_signature(
             | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
                 let is_spread = matches!(arg, PlaceOrSpreadOrHole::Spread(_));
                 if !is_spread && i < signature.params.len() {
-                    substitutions.insert(signature.params[i], vec![place.clone()]);
+                    substitutions.insert(signature.params[i], vec![*place]);
                 } else if let Some(rest_id) = signature.rest {
-                    substitutions.entry(rest_id).or_default().push(place.clone());
+                    substitutions.entry(rest_id).or_default().push(*place);
                 } else {
                     return Ok(None);
                 }
@@ -2945,7 +2892,7 @@ fn compute_effects_for_aliasing_signature(
 
     // Add context variable substitutions (identity mapping)
     for operand in context {
-        substitutions.insert(operand.identifier, vec![operand.clone()]);
+        substitutions.insert(operand.identifier, vec![*operand]);
     }
 
     // Create temporaries
@@ -2970,25 +2917,22 @@ fn compute_effects_for_aliasing_signature(
                     for t in &to_places {
                         effects.push(match eff {
                             AliasingEffect::MaybeAlias { .. } => {
-                                AliasingEffect::MaybeAlias { from: f.clone(), into: t.clone() }
+                                AliasingEffect::MaybeAlias { from: *f, into: *t }
                             }
                             AliasingEffect::Assign { .. } => {
-                                AliasingEffect::Assign { from: f.clone(), into: t.clone() }
+                                AliasingEffect::Assign { from: *f, into: *t }
                             }
                             AliasingEffect::ImmutableCapture { .. } => {
-                                AliasingEffect::ImmutableCapture {
-                                    from: f.clone(),
-                                    into: t.clone(),
-                                }
+                                AliasingEffect::ImmutableCapture { from: *f, into: *t }
                             }
                             AliasingEffect::Alias { .. } => {
-                                AliasingEffect::Alias { from: f.clone(), into: t.clone() }
+                                AliasingEffect::Alias { from: *f, into: *t }
                             }
                             AliasingEffect::CreateFrom { .. } => {
-                                AliasingEffect::CreateFrom { from: f.clone(), into: t.clone() }
+                                AliasingEffect::CreateFrom { from: *f, into: *t }
                             }
                             AliasingEffect::Capture { .. } => {
-                                AliasingEffect::Capture { from: f.clone(), into: t.clone() }
+                                AliasingEffect::Capture { from: *f, into: *t }
                             }
                             _ => unreachable!(),
                         });
@@ -3085,7 +3029,7 @@ fn compute_effects_for_aliasing_signature(
                                 if let Some(places) = substitutions.get(&p.identifier)
                                     && let Some(place) = places.first()
                                 {
-                                    apply_args.push(PlaceOrSpreadOrHole::Place(place.clone()));
+                                    apply_args.push(PlaceOrSpreadOrHole::Place(*place));
                                 }
                             }
                             PlaceOrSpreadOrHole::Spread(sp) => {
@@ -3093,7 +3037,7 @@ fn compute_effects_for_aliasing_signature(
                                     && let Some(place) = places.first()
                                 {
                                     apply_args.push(PlaceOrSpreadOrHole::Spread(SpreadPattern {
-                                        place: place.clone(),
+                                        place: *place,
                                     }));
                                 }
                             }
@@ -3169,7 +3113,7 @@ fn get_write_error_reason(abstract_value: &AbstractValue) -> String {
 
 fn conditionally_mutate_iterator(place: &Place, ty: &Type) -> Option<AliasingEffect> {
     if !is_builtin_collection_type(ty) {
-        Some(AliasingEffect::MutateTransitiveConditionally { value: place.clone() })
+        Some(AliasingEffect::MutateTransitiveConditionally { value: *place })
     } else {
         None
     }
@@ -3238,8 +3182,8 @@ fn is_phi_with_jsx(ty: &Type) -> bool {
 
 fn place_or_spread_to_hole(pos: &PlaceOrSpread) -> PlaceOrSpreadOrHole {
     match pos {
-        PlaceOrSpread::Place(p) => PlaceOrSpreadOrHole::Place(p.clone()),
-        PlaceOrSpread::Spread(s) => PlaceOrSpreadOrHole::Spread(s.clone()),
+        PlaceOrSpread::Place(p) => PlaceOrSpreadOrHole::Place(*p),
+        PlaceOrSpread::Spread(s) => PlaceOrSpreadOrHole::Spread(*s),
     }
 }
 
@@ -3250,12 +3194,12 @@ fn build_apply_operands(
     function: &Place,
     args: &[PlaceOrSpreadOrHole],
 ) -> Vec<(Place, bool, bool)> {
-    let mut result = vec![(receiver.clone(), false, false), (function.clone(), true, false)];
+    let mut result = vec![(*receiver, false, false), (*function, true, false)];
     for arg in args {
         match arg {
             PlaceOrSpreadOrHole::Hole => continue,
-            PlaceOrSpreadOrHole::Place(p) => result.push((p.clone(), false, false)),
-            PlaceOrSpreadOrHole::Spread(s) => result.push((s.place.clone(), false, true)),
+            PlaceOrSpreadOrHole::Place(p) => result.push((*p, false, false)),
+            PlaceOrSpreadOrHole::Spread(s) => result.push((s.place, false, true)),
         }
     }
     result

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
@@ -492,8 +492,8 @@ pub fn infer_mutation_aliasing_ranges(
             for (&pred, operand) in &phi.operands {
                 if !seen_blocks.contains(&pred) {
                     pending_phis.entry(pred).or_default().push(PendingPhiOperand {
-                        from: operand.clone(),
-                        into: phi.place.clone(),
+                        from: *operand,
+                        into: phi.place,
                         index,
                     });
                     index += 1;
@@ -559,7 +559,7 @@ pub fn infer_mutation_aliasing_ranges(
                                 MutationKind::Definite
                             },
                             reason: None,
-                            place: value.clone(),
+                            place: *value,
                         });
                         index += 1;
                     }
@@ -570,7 +570,7 @@ pub fn infer_mutation_aliasing_ranges(
                             transitive: false,
                             kind: MutationKind::Definite,
                             reason: reason.clone(),
-                            place: value.clone(),
+                            place: *value,
                         });
                         index += 1;
                     }
@@ -581,7 +581,7 @@ pub fn infer_mutation_aliasing_ranges(
                             transitive: false,
                             kind: MutationKind::Conditional,
                             reason: None,
-                            place: value.clone(),
+                            place: *value,
                         });
                         index += 1;
                     }
@@ -601,7 +601,7 @@ pub fn infer_mutation_aliasing_ranges(
                         function_effects.push(effect.clone());
                     }
                     AliasingEffect::Render { place } => {
-                        renders.push(PendingRender { index, place: place.clone() });
+                        renders.push(PendingRender { index, place: *place });
                         index += 1;
                         function_effects.push(effect.clone());
                     }
@@ -985,7 +985,7 @@ pub fn infer_mutation_aliasing_ranges(
     };
 
     function_effects.push(AliasingEffect::Create {
-        into: func.returns.clone(),
+        into: func.returns,
         value: return_value_kind,
         reason: ValueReason::KnownReturnSignature,
     });
@@ -994,20 +994,20 @@ pub fn infer_mutation_aliasing_ranges(
     let mut tracked: Vec<Place> = Vec::new();
     for param in &func.params {
         let place = match param {
-            ParamPattern::Place(p) => p.clone(),
-            ParamPattern::Spread(s) => s.place.clone(),
+            ParamPattern::Place(p) => *p,
+            ParamPattern::Spread(s) => s.place,
         };
         tracked.push(place);
     }
     for ctx in &func.context {
-        tracked.push(ctx.clone());
+        tracked.push(*ctx);
     }
-    tracked.push(func.returns.clone());
+    tracked.push(func.returns);
 
     let returns_identifier_id = func.returns.identifier;
 
     for i in 0..tracked.len() {
-        let into = tracked[i].clone();
+        let into = tracked[i];
         let mutation_index = index;
         index += 1;
 
@@ -1037,11 +1037,9 @@ pub fn infer_mutation_aliasing_ranges(
 
             if from_node.last_mutated == mutation_index {
                 if into.identifier == returns_identifier_id {
-                    function_effects
-                        .push(AliasingEffect::Alias { from: from.clone(), into: into.clone() });
+                    function_effects.push(AliasingEffect::Alias { from: *from, into });
                 } else {
-                    function_effects
-                        .push(AliasingEffect::Capture { from: from.clone(), into: into.clone() });
+                    function_effects.push(AliasingEffect::Capture { from: *from, into });
                 }
             }
         }
@@ -1068,12 +1066,12 @@ fn collect_param_effects(
         match local.kind {
             MutationKind::Conditional => {
                 function_effects.push(AliasingEffect::MutateConditionally {
-                    value: Place { span: local.span, ..place.clone() },
+                    value: Place { span: local.span, ..*place },
                 });
             }
             MutationKind::Definite => {
                 function_effects.push(AliasingEffect::Mutate {
-                    value: Place { span: local.span, ..place.clone() },
+                    value: Place { span: local.span, ..*place },
                     reason: node.mutation_reason.clone(),
                 });
             }
@@ -1084,12 +1082,12 @@ fn collect_param_effects(
         match transitive.kind {
             MutationKind::Conditional => {
                 function_effects.push(AliasingEffect::MutateTransitiveConditionally {
-                    value: Place { span: transitive.span, ..place.clone() },
+                    value: Place { span: transitive.span, ..*place },
                 });
             }
             MutationKind::Definite => {
                 function_effects.push(AliasingEffect::MutateTransitive {
-                    value: Place { span: transitive.span, ..place.clone() },
+                    value: Place { span: transitive.span, ..*place },
                 });
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
@@ -50,14 +50,14 @@ pub fn infer_reactive_scope_variables(
     let mut scopes: FxHashMap<IdentifierId, ScopeState> = FxHashMap::default();
 
     scope_identifiers.for_each(|identifier_id, group_id| {
-        let ident_range = env.identifiers[identifier_id].mutable_range.clone();
+        let ident_range = env.identifiers[identifier_id].mutable_range;
         let ident_span = env.identifiers[identifier_id].span;
 
         let state = scopes.entry(group_id).or_insert_with(|| {
             let scope_id = env.next_scope_id();
             // Initialize scope range from the first member
             let scope = &mut env.scopes[scope_id];
-            scope.range = ident_range.clone();
+            scope.range = ident_range;
             ScopeState { scope_id, span: ident_span }
         });
 
@@ -89,12 +89,12 @@ pub fn infer_reactive_scope_variables(
 
     // Update each identifier's mutable_range to match its scope's range
     for (&_identifier_id, state) in &scopes {
-        let scope_range = env.scopes[state.scope_id].range.clone();
+        let scope_range = env.scopes[state.scope_id].range;
         // Find all identifiers with this scope and update their mutable_range
         // We iterate through all identifiers and check their scope
         for ident in &mut env.identifiers {
             if ident.scope == Some(state.scope_id) {
-                ident.mutable_range = scope_range.clone();
+                ident.mutable_range = scope_range;
             }
         }
     }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
@@ -319,10 +319,10 @@ fn expand_fbt_scope_range(env: &mut Environment, scope_id: ScopeId, operand_id: 
         return;
     }
     env.scopes[scope_id].range.start = new_start;
-    let new_range = env.scopes[scope_id].range.clone();
+    let new_range = env.scopes[scope_id].range;
     for ident in &mut env.identifiers {
         if ident.scope == Some(scope_id) && ident.mutable_range.id == old_range_id {
-            ident.mutable_range = new_range.clone();
+            ident.mutable_range = new_range;
         }
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -773,7 +773,7 @@ impl<'a> PropertyPathRegistry<'a> {
         let parent_has_optional = self.nodes[parent_idx].has_optional;
         let idx = self.nodes.len();
         let mut new_path = parent_full_path.path.clone();
-        new_path.push(entry.clone());
+        new_path.push(*entry);
         self.nodes.push(PropertyPathNode {
             properties: FxHashMap::default(),
             optional_properties: FxHashMap::default(),
@@ -843,7 +843,7 @@ fn reduce_maybe_optional_chains(nodes: &mut BTreeSet<usize>, registry: &mut Prop
                         span: entry.span,
                     }
                 } else {
-                    entry.clone()
+                    *entry
                 };
                 curr_node = registry.get_or_create_property_entry(curr_node, &next_entry);
             }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -85,14 +85,14 @@ fn lower_value_to_temporary<'a>(
     if let InstructionValue::LoadLocal { ref place, .. } = value {
         let ident = &builder.environment().identifiers[place.identifier];
         if ident.name.is_none() {
-            return Ok(place.clone());
+            return Ok(*place);
         }
     }
     let span = value.span().cloned();
     let place = build_temporary_place(builder, span);
     builder.push(Instruction {
         id: EvaluationOrder::UNSET,
-        lvalue: place.clone(),
+        lvalue: place,
         value,
         span,
         effects: None,
@@ -711,7 +711,7 @@ fn lower_inner<'a>(
         let param_span = param.span;
         let place = build_temporary_place(&mut builder, Some(param_span));
         promote_temporary(&mut builder, place.identifier);
-        hir_params.push(ParamPattern::Place(place.clone()));
+        hir_params.push(ParamPattern::Place(place));
         let value = if let Some(initializer) = &param.initializer {
             lower_default_to_temp(&mut builder, param_span, initializer, place)?
         } else {
@@ -733,7 +733,7 @@ fn lower_inner<'a>(
     if let Some(rest) = &params.rest {
         let rest_span = rest.span;
         let place = build_temporary_place(&mut builder, Some(rest_span));
-        hir_params.push(ParamPattern::Spread(SpreadPattern { place: place.clone() }));
+        hir_params.push(ParamPattern::Spread(SpreadPattern { place }));
         lower_binding_assignment(
             &mut builder,
             rest_span,
@@ -915,11 +915,7 @@ fn lower_member_expression_impl<'a>(
                 None => lower_expression_to_temporary(builder, &m.object)?,
             };
             let prop_literal = PropertyLiteral::String(m.property.name);
-            let value = InstructionValue::PropertyLoad {
-                object: object.clone(),
-                property: prop_literal,
-                span,
-            };
+            let value = InstructionValue::PropertyLoad { object, property: prop_literal, span };
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Literal(prop_literal),
@@ -935,11 +931,7 @@ fn lower_member_expression_impl<'a>(
             // A numeric computed index is treated as a PropertyLoad (matches TS).
             if let oxc::Expression::NumericLiteral(lit) = &m.expression {
                 let prop_literal = PropertyLiteral::Number(FloatValue::new(lit.value));
-                let value = InstructionValue::PropertyLoad {
-                    object: object.clone(),
-                    property: prop_literal,
-                    span,
-                };
+                let value = InstructionValue::PropertyLoad { object, property: prop_literal, span };
                 return Ok(LoweredMemberExpression {
                     object,
                     property: MemberProperty::Literal(prop_literal),
@@ -947,11 +939,7 @@ fn lower_member_expression_impl<'a>(
                 });
             }
             let property = lower_expression_to_temporary(builder, &m.expression)?;
-            let value = InstructionValue::ComputedLoad {
-                object: object.clone(),
-                property: property.clone(),
-                span,
-            };
+            let value = InstructionValue::ComputedLoad { object, property, span };
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Computed(property),
@@ -1093,11 +1081,7 @@ fn lower_member_expression_from_simple_target<'a>(
             let span = Some(m.span);
             let object = lower_expression_to_temporary(builder, &m.object)?;
             let prop_literal = PropertyLiteral::String(m.property.name);
-            let value = InstructionValue::PropertyLoad {
-                object: object.clone(),
-                property: prop_literal,
-                span,
-            };
+            let value = InstructionValue::PropertyLoad { object, property: prop_literal, span };
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Literal(prop_literal),
@@ -1109,11 +1093,7 @@ fn lower_member_expression_from_simple_target<'a>(
             let object = lower_expression_to_temporary(builder, &m.object)?;
             if let oxc::Expression::NumericLiteral(lit) = &m.expression {
                 let prop_literal = PropertyLiteral::Number(FloatValue::new(lit.value));
-                let value = InstructionValue::PropertyLoad {
-                    object: object.clone(),
-                    property: prop_literal,
-                    span,
-                };
+                let value = InstructionValue::PropertyLoad { object, property: prop_literal, span };
                 return Ok(LoweredMemberExpression {
                     object,
                     property: MemberProperty::Literal(prop_literal),
@@ -1121,11 +1101,7 @@ fn lower_member_expression_from_simple_target<'a>(
                 });
             }
             let property = lower_expression_to_temporary(builder, &m.expression)?;
-            let value = InstructionValue::ComputedLoad {
-                object: object.clone(),
-                property: property.clone(),
-                span,
-            };
+            let value = InstructionValue::ComputedLoad { object, property, span };
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Computed(property),
@@ -1360,7 +1336,7 @@ fn lower_binding_assignment<'a>(
                                 Some(IdentifierForAssignment::Global { .. }) => {
                                     let temp = build_temporary_place(builder, Some(id.span));
                                     promote_temporary(builder, temp.identifier);
-                                    items.push(ArrayPatternElement::Place(temp.clone()));
+                                    items.push(ArrayPatternElement::Place(temp));
                                     followups.push((temp, element.as_ref().unwrap()));
                                 }
                                 None => {
@@ -1370,14 +1346,14 @@ fn lower_binding_assignment<'a>(
                         } else {
                             let temp = build_temporary_place(builder, Some(id.span));
                             promote_temporary(builder, temp.identifier);
-                            items.push(ArrayPatternElement::Place(temp.clone()));
+                            items.push(ArrayPatternElement::Place(temp));
                             followups.push((temp, element.as_ref().unwrap()));
                         }
                     }
                     Some(other) => {
                         let temp = build_temporary_place(builder, Some(other.span()));
                         promote_temporary(builder, temp.identifier);
-                        items.push(ArrayPatternElement::Place(temp.clone()));
+                        items.push(ArrayPatternElement::Place(temp));
                         followups.push((temp, other));
                     }
                 }
@@ -1407,7 +1383,7 @@ fn lower_binding_assignment<'a>(
                                     let temp = build_temporary_place(builder, Some(rest.span));
                                     promote_temporary(builder, temp.identifier);
                                     items.push(ArrayPatternElement::Spread(SpreadPattern {
-                                        place: temp.clone(),
+                                        place: temp,
                                     }));
                                     followups.push((temp, &rest.argument));
                                 }
@@ -1416,18 +1392,14 @@ fn lower_binding_assignment<'a>(
                         } else {
                             let temp = build_temporary_place(builder, Some(rest.span));
                             promote_temporary(builder, temp.identifier);
-                            items.push(ArrayPatternElement::Spread(SpreadPattern {
-                                place: temp.clone(),
-                            }));
+                            items.push(ArrayPatternElement::Spread(SpreadPattern { place: temp }));
                             followups.push((temp, &rest.argument));
                         }
                     }
                     _ => {
                         let temp = build_temporary_place(builder, Some(rest.span));
                         promote_temporary(builder, temp.identifier);
-                        items.push(ArrayPatternElement::Spread(SpreadPattern {
-                            place: temp.clone(),
-                        }));
+                        items.push(ArrayPatternElement::Spread(SpreadPattern { place: temp }));
                         followups.push((temp, &rest.argument));
                     }
                 }
@@ -1512,7 +1484,7 @@ fn lower_binding_assignment<'a>(
                             properties.push(ObjectPropertyOrSpread::Property(ObjectProperty {
                                 key,
                                 property_type: ObjectPropertyType::Property,
-                                place: temp.clone(),
+                                place: temp,
                             }));
                             followups.push((temp, &prop.value));
                         }
@@ -1523,7 +1495,7 @@ fn lower_binding_assignment<'a>(
                         properties.push(ObjectPropertyOrSpread::Property(ObjectProperty {
                             key,
                             property_type: ObjectPropertyType::Property,
-                            place: temp.clone(),
+                            place: temp,
                         }));
                         followups.push((temp, other));
                     }
@@ -1563,7 +1535,7 @@ fn lower_binding_assignment<'a>(
                             let temp = build_temporary_place(builder, Some(rest.span));
                             promote_temporary(builder, temp.identifier);
                             properties.push(ObjectPropertyOrSpread::Spread(SpreadPattern {
-                                place: temp.clone(),
+                                place: temp,
                             }));
                             followups.push((temp, &rest.argument));
                         }
@@ -1641,13 +1613,13 @@ fn lower_default_to_temp<'a>(
     let continuation_block = builder.reserve(builder.current_block_kind());
     let continuation_id = continuation_block.id;
 
-    let temp_consequent = temp.clone();
+    let temp_consequent = temp;
     let consequent = builder.try_enter(BlockKind::Value, |builder, _| {
         let default_value = lower_reorderable_expression(builder, default)?;
         lower_value_to_temporary(
             builder,
             InstructionValue::StoreLocal {
-                lvalue: LValue { place: temp_consequent.clone(), kind: InstructionKind::Const },
+                lvalue: LValue { place: temp_consequent, kind: InstructionKind::Const },
                 value: default_value,
                 span: Some(pat_span),
             },
@@ -1660,14 +1632,14 @@ fn lower_default_to_temp<'a>(
         })
     });
 
-    let temp_alternate = temp.clone();
-    let value_alternate = value.clone();
+    let temp_alternate = temp;
+    let value_alternate = value;
     let alternate = builder.try_enter(BlockKind::Value, |builder, _| {
         lower_value_to_temporary(
             builder,
             InstructionValue::StoreLocal {
-                lvalue: LValue { place: temp_alternate.clone(), kind: InstructionKind::Const },
-                value: value_alternate.clone(),
+                lvalue: LValue { place: temp_alternate, kind: InstructionKind::Const },
+                value: value_alternate,
                 span: Some(pat_span),
             },
         )?;
@@ -1951,7 +1923,7 @@ fn lower_assignment_target<'a>(
                                 Some(IdentifierForAssignment::Global { .. }) => {
                                     let temp = build_temporary_place(builder, Some(id.span));
                                     promote_temporary(builder, temp.identifier);
-                                    items.push(ArrayPatternElement::Place(temp.clone()));
+                                    items.push(ArrayPatternElement::Place(temp));
                                     followups.push((
                                         temp,
                                         FollowupTarget::MaybeDefault(element.as_ref().unwrap()),
@@ -1964,7 +1936,7 @@ fn lower_assignment_target<'a>(
                         } else {
                             let temp = build_temporary_place(builder, Some(id.span));
                             promote_temporary(builder, temp.identifier);
-                            items.push(ArrayPatternElement::Place(temp.clone()));
+                            items.push(ArrayPatternElement::Place(temp));
                             followups.push((
                                 temp,
                                 FollowupTarget::MaybeDefault(element.as_ref().unwrap()),
@@ -1974,7 +1946,7 @@ fn lower_assignment_target<'a>(
                     Some(other) => {
                         let temp = build_temporary_place(builder, Some(other.span()));
                         promote_temporary(builder, temp.identifier);
-                        items.push(ArrayPatternElement::Place(temp.clone()));
+                        items.push(ArrayPatternElement::Place(temp));
                         followups.push((temp, FollowupTarget::MaybeDefault(other)));
                     }
                 }
@@ -2005,7 +1977,7 @@ fn lower_assignment_target<'a>(
                                     let temp = build_temporary_place(builder, Some(rest.span));
                                     promote_temporary(builder, temp.identifier);
                                     items.push(ArrayPatternElement::Spread(SpreadPattern {
-                                        place: temp.clone(),
+                                        place: temp,
                                     }));
                                     followups.push((temp, FollowupTarget::Target(&rest.target)));
                                 }
@@ -2014,18 +1986,14 @@ fn lower_assignment_target<'a>(
                         } else {
                             let temp = build_temporary_place(builder, Some(rest.span));
                             promote_temporary(builder, temp.identifier);
-                            items.push(ArrayPatternElement::Spread(SpreadPattern {
-                                place: temp.clone(),
-                            }));
+                            items.push(ArrayPatternElement::Spread(SpreadPattern { place: temp }));
                             followups.push((temp, FollowupTarget::Target(&rest.target)));
                         }
                     }
                     _ => {
                         let temp = build_temporary_place(builder, Some(rest.span));
                         promote_temporary(builder, temp.identifier);
-                        items.push(ArrayPatternElement::Spread(SpreadPattern {
-                            place: temp.clone(),
-                        }));
+                        items.push(ArrayPatternElement::Spread(SpreadPattern { place: temp }));
                         followups.push((temp, FollowupTarget::Target(&rest.target)));
                     }
                 }
@@ -2106,7 +2074,7 @@ fn lower_assignment_target<'a>(
                             properties.push(ObjectPropertyOrSpread::Property(ObjectProperty {
                                 key,
                                 property_type: ObjectPropertyType::Property,
-                                place: temp.clone(),
+                                place: temp,
                             }));
                             followups.push((
                                 temp,
@@ -2157,7 +2125,7 @@ fn lower_assignment_target<'a>(
                             properties.push(ObjectPropertyOrSpread::Property(ObjectProperty {
                                 key,
                                 property_type: ObjectPropertyType::Property,
-                                place: temp.clone(),
+                                place: temp,
                             }));
                             followups.push((temp, FollowupTarget::Identifier(id)));
                         }
@@ -2216,7 +2184,7 @@ fn lower_assignment_target<'a>(
                                         ObjectProperty {
                                             key,
                                             property_type: ObjectPropertyType::Property,
-                                            place: temp.clone(),
+                                            place: temp,
                                         },
                                     ));
                                     followups
@@ -2229,7 +2197,7 @@ fn lower_assignment_target<'a>(
                                 properties.push(ObjectPropertyOrSpread::Property(ObjectProperty {
                                     key,
                                     property_type: ObjectPropertyType::Property,
-                                    place: temp.clone(),
+                                    place: temp,
                                 }));
                                 followups.push((temp, FollowupTarget::MaybeDefault(other)));
                             }
@@ -2272,7 +2240,7 @@ fn lower_assignment_target<'a>(
                             let temp = build_temporary_place(builder, Some(rest.span));
                             promote_temporary(builder, temp.identifier);
                             properties.push(ObjectPropertyOrSpread::Spread(SpreadPattern {
-                                place: temp.clone(),
+                                place: temp,
                             }));
                             followups.push((temp, FollowupTarget::Target(&rest.target)));
                         }
@@ -2479,13 +2447,13 @@ fn lower_assignment_target_default<'a>(
     let continuation_block = builder.reserve(builder.current_block_kind());
     let continuation_id = continuation_block.id;
 
-    let temp_consequent = temp.clone();
+    let temp_consequent = temp;
     let consequent = builder.try_enter(BlockKind::Value, |builder, _| {
         let default_value = lower_reorderable_expression(builder, default)?;
         lower_value_to_temporary(
             builder,
             InstructionValue::StoreLocal {
-                lvalue: LValue { place: temp_consequent.clone(), kind: InstructionKind::Const },
+                lvalue: LValue { place: temp_consequent, kind: InstructionKind::Const },
                 value: default_value,
                 span: Some(span),
             },
@@ -2498,14 +2466,14 @@ fn lower_assignment_target_default<'a>(
         })
     });
 
-    let temp_alternate = temp.clone();
-    let value_alternate = value.clone();
+    let temp_alternate = temp;
+    let value_alternate = value;
     let alternate = builder.try_enter(BlockKind::Value, |builder, _| {
         lower_value_to_temporary(
             builder,
             InstructionValue::StoreLocal {
-                lvalue: LValue { place: temp_alternate.clone(), kind: InstructionKind::Const },
-                value: value_alternate.clone(),
+                lvalue: LValue { place: temp_alternate, kind: InstructionKind::Const },
+                value: value_alternate,
                 span: Some(span),
             },
         )?;
@@ -2678,7 +2646,7 @@ fn lower_optional_member_expression_impl<'a>(
             lower_value_to_temporary(
                 builder,
                 InstructionValue::StoreLocal {
-                    lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
+                    lvalue: LValue { kind: InstructionKind::Const, place },
                     value: temp,
                     span,
                 },
@@ -2716,7 +2684,7 @@ fn lower_optional_member_expression_impl<'a>(
                 object = Some(lower_expression_to_temporary(builder, other)?);
             }
         }
-        let test_place = object.as_ref().unwrap().clone();
+        let test_place = *object.as_ref().unwrap();
         Ok(Terminal::Branch {
             test: test_place,
             consequent: consequent.id,
@@ -2731,12 +2699,12 @@ fn lower_optional_member_expression_impl<'a>(
 
     // Block to evaluate if the receiver is non-null/undefined.
     builder.try_enter_reserved(consequent, |builder| {
-        let lowered = lower_member_expression_impl(builder, member, Some(obj.clone()))?;
+        let lowered = lower_member_expression_impl(builder, member, Some(obj))?;
         let temp = lower_value_to_temporary(builder, lowered.value)?;
         lower_value_to_temporary(
             builder,
             InstructionValue::StoreLocal {
-                lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
+                lvalue: LValue { kind: InstructionKind::Const, place },
                 value: temp,
                 span,
             },
@@ -2787,7 +2755,7 @@ fn lower_optional_call_expression_impl<'a>(
             lower_value_to_temporary(
                 builder,
                 InstructionValue::StoreLocal {
-                    lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
+                    lvalue: LValue { kind: InstructionKind::Const, place },
                     value: temp,
                     span,
                 },
@@ -2845,8 +2813,8 @@ fn lower_optional_call_expression_impl<'a>(
         }
 
         let test_place = match callee_info.as_ref().unwrap() {
-            CalleeInfo::CallExpression { callee } => callee.clone(),
-            CalleeInfo::MethodCall { property, .. } => property.clone(),
+            CalleeInfo::CallExpression { callee } => *callee,
+            CalleeInfo::MethodCall { property, .. } => *property,
         };
 
         Ok(Terminal::Branch {
@@ -2868,8 +2836,8 @@ fn lower_optional_call_expression_impl<'a>(
             CalleeInfo::CallExpression { callee } => {
                 builder.push(Instruction {
                     id: EvaluationOrder::UNSET,
-                    lvalue: temp.clone(),
-                    value: InstructionValue::CallExpression { callee: callee.clone(), args, span },
+                    lvalue: temp,
+                    value: InstructionValue::CallExpression { callee: *callee, args, span },
                     span,
                     effects: None,
                 });
@@ -2877,10 +2845,10 @@ fn lower_optional_call_expression_impl<'a>(
             CalleeInfo::MethodCall { receiver, property } => {
                 builder.push(Instruction {
                     id: EvaluationOrder::UNSET,
-                    lvalue: temp.clone(),
+                    lvalue: temp,
                     value: InstructionValue::MethodCall {
-                        receiver: receiver.clone(),
-                        property: property.clone(),
+                        receiver: *receiver,
+                        property: *property,
                         args,
                         span,
                     },
@@ -2893,7 +2861,7 @@ fn lower_optional_call_expression_impl<'a>(
         lower_value_to_temporary(
             builder,
             InstructionValue::StoreLocal {
-                lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
+                lvalue: LValue { kind: InstructionKind::Const, place },
                 value: temp,
                 span,
             },
@@ -2917,7 +2885,7 @@ fn lower_optional_call_expression_impl<'a>(
         continuation_block,
     );
 
-    Ok(InstructionValue::LoadLocal { place: place.clone(), span: place.span })
+    Ok(InstructionValue::LoadLocal { place, span: place.span })
 }
 
 // =============================================================================
@@ -3475,8 +3443,8 @@ fn lower_expression<'a>(
                 lower_value_to_temporary(
                     builder,
                     InstructionValue::StoreLocal {
-                        lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
-                        value: left_place.clone(),
+                        lvalue: LValue { kind: InstructionKind::Const, place },
+                        value: left_place,
                         span: left_place.span,
                     },
                 )?;
@@ -3494,7 +3462,7 @@ fn lower_expression<'a>(
                 lower_value_to_temporary(
                     builder,
                     InstructionValue::StoreLocal {
-                        lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
+                        lvalue: LValue { kind: InstructionKind::Const, place },
                         value: right,
                         span: right_span,
                     },
@@ -3523,7 +3491,7 @@ fn lower_expression<'a>(
             let left_value = lower_expression_to_temporary(builder, &logical.left)?;
             builder.push(Instruction {
                 id: EvaluationOrder::UNSET,
-                lvalue: left_place.clone(),
+                lvalue: left_place,
                 value: InstructionValue::LoadLocal { place: left_value, span },
                 effects: None,
                 span,
@@ -3541,7 +3509,7 @@ fn lower_expression<'a>(
                 continuation_block,
             );
 
-            Ok(InstructionValue::LoadLocal { place: place.clone(), span: place.span })
+            Ok(InstructionValue::LoadLocal { place, span: place.span })
         }
         oxc::Expression::StaticMemberExpression(_)
         | oxc::Expression::ComputedMemberExpression(_)
@@ -3577,7 +3545,7 @@ fn lower_expression<'a>(
                 lower_value_to_temporary(
                     builder,
                     InstructionValue::StoreLocal {
-                        lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
+                        lvalue: LValue { kind: InstructionKind::Const, place },
                         value: consequent,
                         span,
                     },
@@ -3597,7 +3565,7 @@ fn lower_expression<'a>(
                 lower_value_to_temporary(
                     builder,
                     InstructionValue::StoreLocal {
-                        lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
+                        lvalue: LValue { kind: InstructionKind::Const, place },
                         value: alternate,
                         span,
                     },
@@ -3634,7 +3602,7 @@ fn lower_expression<'a>(
                 continuation_block,
             );
 
-            Ok(InstructionValue::LoadLocal { place: place.clone(), span: place.span })
+            Ok(InstructionValue::LoadLocal { place, span: place.span })
         }
         oxc::Expression::SequenceExpression(seq) => {
             let span = Some(seq.span);
@@ -3661,7 +3629,7 @@ fn lower_expression<'a>(
                     lower_value_to_temporary(
                         builder,
                         InstructionValue::StoreLocal {
-                            lvalue: LValue { kind: InstructionKind::Const, place: place.clone() },
+                            lvalue: LValue { kind: InstructionKind::Const, place },
                             value: last,
                             span,
                         },
@@ -3857,7 +3825,7 @@ fn lower_expression<'a>(
                         builder,
                         InstructionValue::BinaryExpression {
                             operator: binary_op,
-                            left: prev_value.clone(),
+                            left: prev_value,
                             right: one,
                             span: member_span,
                         },
@@ -3889,10 +3857,7 @@ fn lower_expression<'a>(
 
                     // Return previous for postfix, newValuePlace for prefix
                     let result_place = if update.prefix { new_value_place } else { prev_value };
-                    Ok(InstructionValue::LoadLocal {
-                        place: result_place.clone(),
-                        span: result_place.span,
-                    })
+                    Ok(InstructionValue::LoadLocal { place: result_place, span: result_place.span })
                 }
                 oxc::SimpleAssignmentTarget::AssignmentTargetIdentifier(ident) => {
                     let symbol = builder.scope().resolve_reference(ident);
@@ -4147,28 +4112,22 @@ fn lower_assignment_expression<'a>(
                             let temp = lower_value_to_temporary(
                                 builder,
                                 InstructionValue::StoreContext {
-                                    lvalue: LValue {
-                                        kind: InstructionKind::Reassign,
-                                        place: place.clone(),
-                                    },
+                                    lvalue: LValue { kind: InstructionKind::Reassign, place },
                                     value: right,
                                     span: place.span,
                                 },
                             )?;
-                            Ok(InstructionValue::LoadLocal { place: temp.clone(), span: temp.span })
+                            Ok(InstructionValue::LoadLocal { place: temp, span: temp.span })
                         } else {
                             let temp = lower_value_to_temporary(
                                 builder,
                                 InstructionValue::StoreLocal {
-                                    lvalue: LValue {
-                                        kind: InstructionKind::Reassign,
-                                        place: place.clone(),
-                                    },
+                                    lvalue: LValue { kind: InstructionKind::Reassign, place },
                                     value: right,
                                     span: place.span,
                                 },
                             )?;
-                            Ok(InstructionValue::LoadLocal { place: temp.clone(), span: temp.span })
+                            Ok(InstructionValue::LoadLocal { place: temp, span: temp.span })
                         }
                     }
                     _ => {
@@ -4181,7 +4140,7 @@ fn lower_assignment_expression<'a>(
                                 span: Some(ident_span),
                             },
                         )?;
-                        Ok(InstructionValue::LoadLocal { place: temp.clone(), span: temp.span })
+                        Ok(InstructionValue::LoadLocal { place: temp, span: temp.span })
                     }
                 }
             }
@@ -4248,7 +4207,7 @@ fn lower_assignment_expression<'a>(
                     }
                     _ => unreachable!(),
                 };
-                Ok(InstructionValue::LoadLocal { place: temp.clone(), span: temp.span })
+                Ok(InstructionValue::LoadLocal { place: temp, span: temp.span })
             }
             _ => {
                 // Destructuring assignment
@@ -4258,13 +4217,11 @@ fn lower_assignment_expression<'a>(
                     assign.left.span(),
                     InstructionKind::Reassign,
                     &assign.left,
-                    right.clone(),
+                    right,
                     AssignmentStyle::Destructure,
                 )?;
                 match result {
-                    Some(place) => {
-                        Ok(InstructionValue::LoadLocal { place: place.clone(), span: place.span })
-                    }
+                    Some(place) => Ok(InstructionValue::LoadLocal { place, span: place.span }),
                     None => Ok(InstructionValue::LoadLocal { place: right, span }),
                 }
             }
@@ -4333,10 +4290,7 @@ fn lower_assignment_expression<'a>(
                             lower_value_to_temporary(
                                 builder,
                                 InstructionValue::StoreContext {
-                                    lvalue: LValue {
-                                        kind: InstructionKind::Reassign,
-                                        place: place.clone(),
-                                    },
+                                    lvalue: LValue { kind: InstructionKind::Reassign, place },
                                     value: binary_place,
                                     span,
                                 },
@@ -4346,10 +4300,7 @@ fn lower_assignment_expression<'a>(
                             lower_value_to_temporary(
                                 builder,
                                 InstructionValue::StoreLocal {
-                                    lvalue: LValue {
-                                        kind: InstructionKind::Reassign,
-                                        place: place.clone(),
-                                    },
+                                    lvalue: LValue { kind: InstructionKind::Reassign, place },
                                     value: binary_place,
                                     span,
                                 },
@@ -4363,7 +4314,7 @@ fn lower_assignment_expression<'a>(
                             builder,
                             InstructionValue::StoreGlobal { name, value: binary_place, span },
                         )?;
-                        Ok(InstructionValue::LoadLocal { place: temp.clone(), span: temp.span })
+                        Ok(InstructionValue::LoadLocal { place: temp, span: temp.span })
                     }
                 }
             }
@@ -5913,7 +5864,7 @@ fn lower_statement<'a>(
             )?;
 
             let assign_result =
-                lower_for_in_of_left(builder, &for_in.left, left_span, next_property.clone())?;
+                lower_for_in_of_left(builder, &for_in.left, left_span, next_property)?;
             // Use the assign result (StoreLocal temp) as the test, matching TS behavior
             let test_value = assign_result.unwrap_or(next_property);
             let test = lower_value_to_temporary(
@@ -5979,7 +5930,7 @@ fn lower_statement<'a>(
             // Init block: GetIterator, goto test
             let iterator = lower_value_to_temporary(
                 builder,
-                InstructionValue::GetIterator { collection: value.clone(), span: value.span },
+                InstructionValue::GetIterator { collection: value, span: value.span },
             )?;
             builder.terminate_with_continuation(
                 Terminal::Goto {
@@ -6003,7 +5954,7 @@ fn lower_statement<'a>(
             )?;
 
             let assign_result =
-                lower_for_in_of_left(builder, &for_of.left, left_span, advance_iterator.clone())?;
+                lower_for_in_of_left(builder, &for_of.left, left_span, advance_iterator)?;
             // Use the assign result (StoreLocal temp) as the test, matching TS behavior
             let test_value = assign_result.unwrap_or(advance_iterator);
             let test = lower_value_to_temporary(
@@ -6157,7 +6108,7 @@ fn lower_statement<'a>(
                     lower_value_to_temporary(
                         builder,
                         InstructionValue::DeclareLocal {
-                            lvalue: LValue { kind: InstructionKind::Catch, place: place.clone() },
+                            lvalue: LValue { kind: InstructionKind::Catch, place },
                             span: param_span,
                         },
                     )?;
@@ -6168,7 +6119,7 @@ fn lower_statement<'a>(
             };
 
             // Create the handler (catch) block
-            let handler_binding_for_block = handler_binding_info.clone();
+            let handler_binding_for_block = handler_binding_info;
             let handler_span = handler_clause.span;
             // Use the catch param's span for the assignment, matching TS: handlerBinding.path.node.span
             let handler_param_span = handler_clause.param.as_ref().map(|p| p.pattern.span());
@@ -6179,7 +6130,7 @@ fn lower_statement<'a>(
                         handler_param_span.unwrap_or(handler_span),
                         InstructionKind::Catch,
                         pattern,
-                        place.clone(),
+                        *place,
                         AssignmentStyle::Assignment,
                     )?;
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -280,21 +280,21 @@ fn evaluate_instruction<'a>(
             Some(Constant::Primitive { value: *value, span: *span })
         }
         InstructionValue::LoadGlobal { binding, span } => {
-            Some(Constant::LoadGlobal { binding: binding.clone(), span: *span })
+            Some(Constant::LoadGlobal { binding: *binding, span: *span })
         }
         InstructionValue::ComputedLoad { object, property, span } => {
             let prop_value = read(constants, property);
             if let Some(Constant::Primitive { value: ref prim, .. }) = prop_value {
                 match prim {
                     PrimitiveValue::String(s) if is_valid_identifier(s.as_str()) => {
-                        let object = object.clone();
+                        let object = *object;
                         let span = *span;
                         let new_property = PropertyLiteral::String(Ident::from(s.as_str()));
                         func.instructions[instr_id.index()].value =
                             InstructionValue::PropertyLoad { object, property: new_property, span };
                     }
                     PrimitiveValue::Number(n) => {
-                        let object = object.clone();
+                        let object = *object;
                         let span = *span;
                         let new_property = PropertyLiteral::Number(*n);
                         func.instructions[instr_id.index()].value =
@@ -313,8 +313,8 @@ fn evaluate_instruction<'a>(
             if let Some(Constant::Primitive { value: ref prim, .. }) = prop_value {
                 match prim {
                     PrimitiveValue::String(s) if is_valid_identifier(s.as_str()) => {
-                        let object = object.clone();
-                        let store_value = value.clone();
+                        let object = *object;
+                        let store_value = *value;
                         let span = *span;
                         let new_property = PropertyLiteral::String(Ident::from(s.as_str()));
                         func.instructions[instr_id.index()].value =
@@ -326,8 +326,8 @@ fn evaluate_instruction<'a>(
                             };
                     }
                     PrimitiveValue::Number(n) => {
-                        let object = object.clone();
-                        let store_value = value.clone();
+                        let object = *object;
+                        let store_value = *value;
                         let span = *span;
                         let new_property = PropertyLiteral::Number(*n);
                         func.instructions[instr_id.index()].value =

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
@@ -232,7 +232,7 @@ fn rewrite_instruction(
                         match prop {
                             ObjectPropertyOrSpread::Property(p) => {
                                 if is_id_or_name_used(state, &env.identifiers, p.place.identifier) {
-                                    next_properties.get_or_insert_with(Vec::new).push(prop.clone());
+                                    next_properties.get_or_insert_with(Vec::new).push(*prop);
                                 }
                             }
                             ObjectPropertyOrSpread::Spread(s) => {
@@ -257,7 +257,7 @@ fn rewrite_instruction(
             // This is a const/let declaration where the variable is accessed later,
             // but where the value is always overwritten before being read.
             // Rewrite to DeclareLocal so the initializer value can be DCE'd.
-            let new_lvalue = lvalue.clone();
+            let new_lvalue = *lvalue;
             let new_span = *span;
             instr.value = InstructionValue::DeclareLocal { lvalue: new_lvalue, span: new_span };
         }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
@@ -239,7 +239,7 @@ fn process_manual_memo_call<'a>(
         }
 
         let memo_decl: Place = if manual_memo.kind == ManualMemoKind::UseMemo {
-            func.instructions[instr_id.index()].lvalue.clone()
+            func.instructions[instr_id.index()].lvalue
         } else {
             Place {
                 identifier: fn_place.identifier,
@@ -329,7 +329,7 @@ fn collect_temporaries<'a>(
             let all_places: Option<Vec<Place>> = elements
                 .iter()
                 .map(|e| match e {
-                    ArrayElement::Place(p) => Some(p.clone()),
+                    ArrayElement::Place(p) => Some(*p),
                     _ => None,
                 })
                 .collect();
@@ -378,7 +378,7 @@ pub fn collect_maybe_memo_dependencies<'a>(
         }),
         InstructionValue::PropertyLoad { object, property, span, .. } => {
             maybe_deps.get(&object.identifier).map(|object_dep| ManualMemoDependency {
-                root: object_dep.root.clone(),
+                root: object_dep.root,
                 path: {
                     let mut path = object_dep.path.clone();
                     path.push(DependencyPathEntry { property: *property, optional, span: *span });
@@ -395,10 +395,7 @@ pub fn collect_maybe_memo_dependencies<'a>(
                 Some(IdentifierName::Named(_))
             ) {
                 Some(ManualMemoDependency {
-                    root: ManualMemoDependencyRoot::NamedLocal {
-                        value: place.clone(),
-                        constant: false,
-                    },
+                    root: ManualMemoDependencyRoot::NamedLocal { value: *place, constant: false },
                     path: vec![],
                     span: place.span,
                 })
@@ -437,7 +434,7 @@ fn get_manual_memoization_replacement<'a>(
 ) -> InstructionValue<'a> {
     if kind == ManualMemoKind::UseMemo {
         // Replace with Call fn() - invoke the memo function directly
-        InstructionValue::CallExpression { callee: fn_place.clone(), args: vec![], span }
+        InstructionValue::CallExpression { callee: *fn_place, args: vec![], span }
     } else {
         // Replace with LoadLocal fn - just reference the function
         InstructionValue::LoadLocal {
@@ -478,7 +475,7 @@ fn make_manual_memoization_markers<'a>(
         lvalue: create_temporary_place(env, fn_expr.span),
         value: InstructionValue::FinishMemoize {
             manual_memo_id,
-            decl: memo_decl.clone(),
+            decl: *memo_decl,
             pruned: false,
             span: fn_expr.span,
         },
@@ -507,7 +504,7 @@ fn extract_manual_memoization_args<'a>(
 
     // Get the first arg (fn)
     let fn_place = match args.first() {
-        Some(PlaceOrSpread::Place(p)) => p.clone(),
+        Some(PlaceOrSpread::Place(p)) => *p,
         _ => {
             let span = instr.value.span().cloned();
             env.record_diagnostic(

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
@@ -127,7 +127,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                     inlined_functions.insert(callee_id);
 
                     // Capture the lvalue from the call instruction
-                    let call_lvalue = func.instructions[instr_id.index()].lvalue.clone();
+                    let call_lvalue = func.instructions[instr_id.index()].lvalue;
                     let block_terminal_id = func.body.blocks[&block_id].terminal.evaluation_order();
                     let block_terminal_span = func.body.blocks[&block_id].terminal.span().cloned();
                     let block_kind = func.body.blocks[&block_id].kind;
@@ -189,9 +189,9 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                                 let load_instr = Instruction {
                                     id: EvaluationOrder::UNSET,
                                     span: *ret_span,
-                                    lvalue: call_lvalue.clone(),
+                                    lvalue: call_lvalue,
                                     value: InstructionValue::LoadLocal {
-                                        place: value.clone(),
+                                        place: *value,
                                         span: *ret_span,
                                     },
                                     effects: None,
@@ -215,7 +215,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                         }
                     } else {
                         // Multi-return path: uses LabelTerminal
-                        let result = call_lvalue.clone();
+                        let result = call_lvalue;
 
                         // Set block terminal to Label
                         func.body.blocks.get_mut(&block_id).unwrap().terminal = Terminal::Label {
@@ -341,8 +341,8 @@ fn rewrite_block<'a>(
             span: *ret_span,
             lvalue: store_lvalue,
             value: InstructionValue::StoreLocal {
-                lvalue: LValue { kind: InstructionKind::Reassign, place: return_value.clone() },
-                value: value.clone(),
+                lvalue: LValue { kind: InstructionKind::Reassign, place: *return_value },
+                value: *value,
                 span: *ret_span,
             },
             effects: None,
@@ -374,7 +374,7 @@ fn declare_temporary<'a>(
         span: GENERATED_SOURCE,
         lvalue: declare_lvalue,
         value: InstructionValue::DeclareLocal {
-            lvalue: LValue { place: result.clone(), kind: InstructionKind::Let },
+            lvalue: LValue { place: *result, kind: InstructionKind::Let },
             span: result.span,
         },
         effects: None,

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/merge_consecutive_blocks.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/merge_consecutive_blocks.rs
@@ -111,7 +111,7 @@ pub fn merge_consecutive_blocks(
                     "Found a block with a single predecessor but where a phi has multiple ({}) operands",
                     phi.operands.len()
                 );
-                let operand = phi.operands.values().next().unwrap().clone();
+                let operand = *phi.operands.values().next().unwrap();
                 (phi.place.identifier, operand)
             })
             .collect();
@@ -129,11 +129,8 @@ pub fn merge_consecutive_blocks(
             };
             let instr = Instruction {
                 id: eval_order,
-                lvalue: lvalue.clone(),
-                value: InstructionValue::LoadLocal {
-                    place: operand.clone(),
-                    span: GENERATED_SOURCE,
-                },
+                lvalue,
+                value: InstructionValue::LoadLocal { place: operand, span: GENERATED_SOURCE },
                 span: GENERATED_SOURCE,
                 effects: Some(vec![AliasingEffect::Alias { from: operand, into: lvalue }]),
             };
@@ -161,11 +158,7 @@ pub fn merge_consecutive_blocks(
                 .iter()
                 .filter_map(|(pred_id, operand)| {
                     let mapped = merged.get(*pred_id);
-                    if mapped != *pred_id {
-                        Some((*pred_id, mapped, operand.clone()))
-                    } else {
-                        None
-                    }
+                    if mapped != *pred_id { Some((*pred_id, mapped, *operand)) } else { None }
                 })
                 .collect();
             for (old_id, new_id, operand) in updates {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
@@ -76,7 +76,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                     inlined_state.insert(
                                         lvalue_id,
                                         InlinedStateReplacement::LoadLocal {
-                                            place: arg.clone(),
+                                            place: *arg,
                                             span: arg.span,
                                         },
                                     );
@@ -93,8 +93,8 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                 inlined_state.insert(
                                     lvalue_id,
                                     InlinedStateReplacement::CallExpression {
-                                        callee: initializer.clone(),
-                                        arg: arg.clone(),
+                                        callee: *initializer,
+                                        arg: *arg,
                                         span: call_span,
                                     },
                                 );
@@ -111,7 +111,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                     inlined_state.insert(
                                         lvalue_id,
                                         InlinedStateReplacement::LoadLocal {
-                                            place: arg.clone(),
+                                            place: *arg,
                                             span: arg.span,
                                         },
                                     );
@@ -187,8 +187,8 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                             let span = *span;
                             let kind = lvalue.kind;
                             let store = InstructionValue::StoreLocal {
-                                lvalue: LValue { place: first_place.clone(), kind },
-                                value: value.clone(),
+                                lvalue: LValue { place: *first_place, kind },
+                                value: *value,
                                 span,
                             };
                             instr.value = store;
@@ -205,8 +205,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                 && let PlaceOrSpread::Place(arg) = &args[0]
                             {
                                 let span = *span;
-                                instr.value =
-                                    InstructionValue::LoadLocal { place: arg.clone(), span };
+                                instr.value = InstructionValue::LoadLocal { place: *arg, span };
                             }
                         }
                         Some(
@@ -225,18 +224,15 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                             if let Some(replacement) = inlined_state.get(&lvalue_id) {
                                 instr.value = match replacement {
                                     InlinedStateReplacement::LoadLocal { place, span } => {
-                                        InstructionValue::LoadLocal {
-                                            place: place.clone(),
-                                            span: *span,
-                                        }
+                                        InstructionValue::LoadLocal { place: *place, span: *span }
                                     }
                                     InlinedStateReplacement::CallExpression {
                                         callee,
                                         arg,
                                         span,
                                     } => InstructionValue::CallExpression {
-                                        callee: callee.clone(),
-                                        args: vec![PlaceOrSpread::Place(arg.clone())],
+                                        callee: *callee,
+                                        args: vec![PlaceOrSpread::Place(*arg)],
                                         span: *span,
                                     },
                                 };

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
@@ -276,7 +276,7 @@ fn collect_props<'a>(
                         attributes.push(OutlinedJsxAttribute {
                             original_name: *name,
                             new_name,
-                            place: place.clone(),
+                            place: *place,
                         });
                     }
                 }
@@ -305,7 +305,7 @@ fn collect_props<'a>(
                     attributes.push(OutlinedJsxAttribute {
                         original_name: child_name,
                         new_name,
-                        place: child.clone(),
+                        place: *child,
                     });
                 }
             }
@@ -324,7 +324,7 @@ fn emit_outlined_jsx<'a>(
 ) -> Option<Vec<Instruction<'a>>> {
     let props: Vec<JsxAttribute> = outlined_props
         .iter()
-        .map(|p| JsxAttribute::Attribute { name: p.new_name, place: p.place.clone() })
+        .map(|p| JsxAttribute::Attribute { name: p.new_name, place: p.place })
         .collect();
 
     // Create LoadGlobal for the outlined component
@@ -339,7 +339,7 @@ fn emit_outlined_jsx<'a>(
 
     let load_jsx = Instruction {
         id: EvaluationOrder::UNSET,
-        lvalue: load_place.clone(),
+        lvalue: load_place,
         value: InstructionValue::LoadGlobal {
             binding: NonLocalBinding::ModuleLocal { name: outlined_tag },
             span: None,
@@ -353,7 +353,7 @@ fn emit_outlined_jsx<'a>(
     let last_instr = &func.instructions[last_info.instr_idx];
     let jsx_expr = Instruction {
         id: EvaluationOrder::UNSET,
-        lvalue: last_instr.lvalue.clone(),
+        lvalue: last_instr.lvalue,
         value: InstructionValue::JsxExpression {
             tag: JsxTag::Place(load_place),
             props,
@@ -411,7 +411,7 @@ fn emit_outlined_fn<'a>(
     }
 
     // Return terminal uses the last instruction's lvalue
-    let last_lvalue = instr_table.last().unwrap().lvalue.clone();
+    let last_lvalue = instr_table.last().unwrap().lvalue;
 
     // Create return place
     let returns_id = env.next_identifier_id();
@@ -510,7 +510,7 @@ fn emit_updated_jsx<'a>(
                     .expect("Expected a new property for identifier");
                 new_props.push(JsxAttribute::Attribute {
                     name: new_prop.original_name,
-                    place: new_prop.place.clone(),
+                    place: new_prop.place,
                 });
             }
 
@@ -518,13 +518,13 @@ fn emit_updated_jsx<'a>(
                 kids.iter()
                     .map(|child| {
                         if jsx_ids.contains(&child.identifier) {
-                            child.clone()
+                            *child
                         } else {
                             // TS: invariant(newChild !== undefined, ...)
                             let new_prop = old_to_new_props
                                 .get(&child.identifier)
                                 .expect("Expected a new prop for child identifier");
-                            new_prop.place.clone()
+                            new_prop.place
                         }
                     })
                     .collect()
@@ -532,9 +532,9 @@ fn emit_updated_jsx<'a>(
 
             new_instrs.push(Instruction {
                 id: instr.id,
-                lvalue: instr.lvalue.clone(),
+                lvalue: instr.lvalue,
                 value: InstructionValue::JsxExpression {
-                    tag: tag.clone(),
+                    tag: *tag,
                     props: new_props,
                     children: new_children,
                     span: *span,
@@ -590,7 +590,7 @@ fn emit_destructure_props<'a>(
         properties.push(ObjectPropertyOrSpread::Property(ObjectProperty {
             key: ObjectPropertyKey::String { name: prop.new_name },
             property_type: ObjectPropertyType::Property,
-            place: prop.place.clone(),
+            place: prop.place,
         }));
     }
 
@@ -606,7 +606,7 @@ fn emit_destructure_props<'a>(
                 pattern: Pattern::Object(ObjectPattern { properties }),
                 kind: InstructionKind::Let,
             },
-            value: props_obj.clone(),
+            value: *props_obj,
             span: None,
         },
         span: None,

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -316,7 +316,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 let instr = &self.hir.instructions[instr_id.index()];
                 block_value.push(ReactiveStatement::Instruction(ReactiveInstruction {
                     id: instr.id,
-                    lvalue: Some(instr.lvalue.clone()),
+                    lvalue: Some(instr.lvalue),
                     value: ReactiveValue::Instruction(instr.value.clone()),
                     span: instr.span,
                 }));
@@ -369,7 +369,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     block_value.push(ReactiveStatement::Terminal(Box::new(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::If {
-                                test: test.clone(),
+                                test: *test,
                                 consequent: consequent_block,
                                 alternate: alternate_block,
                                 id: *id,
@@ -413,10 +413,8 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                         let case_schedule_id = self.cx.schedule(case_block_id, "case")?;
                         schedule_ids.push(case_schedule_id);
 
-                        reactive_cases.push(ReactiveSwitchCase {
-                            test: case.test.clone(),
-                            block: Some(consequent),
-                        });
+                        reactive_cases
+                            .push(ReactiveSwitchCase { test: case.test, block: Some(consequent) });
                     }
                     reactive_cases.reverse();
 
@@ -424,7 +422,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     block_value.push(ReactiveStatement::Terminal(Box::new(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::Switch {
-                                test: test.clone(),
+                                test: *test,
                                 cases: reactive_cases,
                                 id: *id,
                             },
@@ -782,7 +780,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::Try {
                                 block: try_body,
-                                handler_binding: handler_binding.clone(),
+                                handler_binding: *handler_binding,
                                 handler: handler_body,
                                 id: *id,
                             },
@@ -845,7 +843,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 Terminal::Return { value, id, .. } => {
                     block_value.push(ReactiveStatement::Terminal(Box::new(
                         ReactiveTerminalStatement {
-                            terminal: ReactiveTerminal::Return { value: value.clone(), id: *id },
+                            terminal: ReactiveTerminal::Return { value: *value, id: *id },
                             label: None,
                         },
                     )));
@@ -854,7 +852,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 Terminal::Throw { value, id, .. } => {
                     block_value.push(ReactiveStatement::Terminal(Box::new(
                         ReactiveTerminalStatement {
-                            terminal: ReactiveTerminal::Throw { value: value.clone(), id: *id },
+                            terminal: ReactiveTerminal::Throw { value: *value, id: *id },
                             label: None,
                         },
                     )));
@@ -885,7 +883,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     block_value.push(ReactiveStatement::Terminal(Box::new(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::If {
-                                test: test.clone(),
+                                test: *test,
                                 consequent: consequent_block,
                                 alternate: Some(alternate_block),
                                 id: *id,
@@ -932,9 +930,9 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 if instructions.is_empty() {
                     Ok(ValueBlockResult {
                         block: block_id_val,
-                        place: test.clone(),
+                        place: *test,
                         value: ReactiveValue::Instruction(InstructionValue::LoadLocal {
-                            place: test.clone(),
+                            place: *test,
                             span: test.span,
                         }),
                         id: *term_id,
@@ -990,7 +988,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                         let instr = &self.hir.instructions[iid.index()];
                         ReactiveInstruction {
                             id: instr.id,
-                            lvalue: Some(instr.lvalue.clone()),
+                            lvalue: Some(instr.lvalue),
                             value: ReactiveValue::Instruction(instr.value.clone()),
                             span: instr.span,
                         }
@@ -1003,7 +1001,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 } else {
                     Ok(ValueBlockResult {
                         block: final_result.block,
-                        place: final_result.place.clone(),
+                        place: final_result.place,
                         value: ReactiveValue::SequenceExpression {
                             instructions: all_instrs,
                             id: final_result.id,
@@ -1062,7 +1060,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 let call = ReactiveValue::SequenceExpression {
                     instructions: vec![ReactiveInstruction {
                         id: test_result.test.id,
-                        lvalue: Some(test_result.test.place.clone()),
+                        lvalue: Some(test_result.test.place),
                         value: test_result.test.value,
                         span: test_result.branch_span,
                     }],
@@ -1086,7 +1084,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 let left = ReactiveValue::SequenceExpression {
                     instructions: vec![ReactiveInstruction {
                         id: test_result.test.id,
-                        lvalue: Some(test_result.test.place.clone()),
+                        lvalue: Some(test_result.test.place),
                         value: test_result.test.value,
                         span: *span,
                     }],
@@ -1148,7 +1146,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 let instr = &self.hir.instructions[iid.index()];
                 ReactiveInstruction {
                     id: instr.id,
-                    lvalue: Some(instr.lvalue.clone()),
+                    lvalue: Some(instr.lvalue),
                     value: ReactiveValue::Instruction(instr.value.clone()),
                     span: instr.span,
                 }
@@ -1163,19 +1161,16 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 if ident.name.is_none() {
                     (
                         ReactiveValue::Instruction(InstructionValue::LoadLocal {
-                            place: store_value.clone(),
+                            place: *store_value,
                             span: store_value.span,
                         }),
-                        lvalue.place.clone(),
+                        lvalue.place,
                     )
                 } else {
-                    (
-                        ReactiveValue::Instruction(last_instr.value.clone()),
-                        last_instr.lvalue.clone(),
-                    )
+                    (ReactiveValue::Instruction(last_instr.value.clone()), last_instr.lvalue)
                 }
             }
-            _ => (ReactiveValue::Instruction(last_instr.value.clone()), last_instr.lvalue.clone()),
+            _ => (ReactiveValue::Instruction(last_instr.value.clone()), last_instr.lvalue),
         };
         let id = last_instr.id;
 
@@ -1210,7 +1205,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 let instr = &self.hir.instructions[iid.index()];
                 ReactiveInstruction {
                     id: instr.id,
-                    lvalue: Some(instr.lvalue.clone()),
+                    lvalue: Some(instr.lvalue),
                     value: ReactiveValue::Instruction(instr.value.clone()),
                     span: instr.span,
                 }
@@ -1219,7 +1214,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
 
         ValueBlockResult {
             block: continuation.block,
-            place: continuation.place.clone(),
+            place: continuation.place,
             value: ReactiveValue::SequenceExpression {
                 instructions: reactive_instrs,
                 id: continuation.id,

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
@@ -147,7 +147,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                         span: None, // GeneratedSource — matches TS createTemporaryPlace
                     };
                     let original = place;
-                    renamed.push((original, temporary.clone()));
+                    renamed.push((original, temporary));
                     temporary
                 });
 

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
@@ -131,7 +131,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
 
             state.early_return_value = Some(early_return_value.clone());
 
-            let return_value = value.clone();
+            let return_value = *value;
 
             return Ok(Transformed::ReplaceMany(vec![
                 // StoreLocal: reassign the early return value

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
@@ -72,7 +72,7 @@ pub trait ReactiveFunctionVisitor<'a> {
                 // Build a temporary ReactiveInstruction for the visitor
                 let reactive_instr = ReactiveInstruction {
                     id: instr.id,
-                    lvalue: Some(instr.lvalue.clone()),
+                    lvalue: Some(instr.lvalue),
                     value: ReactiveValue::Instruction(instr.value.clone()),
                     span: instr.span,
                 };

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
@@ -165,7 +165,7 @@ impl SSABuilder {
                 span: old_place.span,
             };
             let state = self.states.get_mut(&block_id).unwrap();
-            state.incomplete_phis.push(IncompletePhi { old_place: old_place.clone(), new_place });
+            state.incomplete_phis.push(IncompletePhi { old_place: *old_place, new_place });
             state.defs.insert(old_place.identifier, new_id);
             return new_id;
         }
@@ -212,7 +212,7 @@ impl SSABuilder {
             );
         }
 
-        let phi = Phi { place: new_place.clone(), operands: pred_defs };
+        let phi = Phi { place: *new_place, operands: pred_defs };
 
         self.pending_phis.entry(block_id).or_default().push(phi);
     }

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -115,7 +115,7 @@ fn pre_resolve_globals_recursive<'a>(
             let instr = &inner.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::LoadGlobal { binding, span, .. } => {
-                    load_globals.push((instr_id, binding.clone(), *span));
+                    load_globals.push((instr_id, *binding, *span));
                 }
                 InstructionValue::FunctionExpression {
                     lowered_func: LoweredFunction { func: fid },
@@ -1369,7 +1369,7 @@ impl<'a> Unifier<'a> {
                 Some(Type::Property {
                     object_type: Box::new(object_type),
                     object_name: *object_name,
-                    property_name: property_name.clone(),
+                    property_name: *property_name,
                 })
             }
             Type::Function { shape_id, return_type, is_constructor } => {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
@@ -192,6 +192,6 @@ fn visit(
                 .with_labels(place.span.map(|s| s.label(format!("this is {}", prev_kind)))));
         }
     }
-    identifiers.insert(place.identifier, (place.clone(), kind));
+    identifiers.insert(place.identifier, (*place, kind));
     Ok(())
 }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -389,7 +389,7 @@ fn add_dependency<'a>(
             }
         }
         Temporary::Global { binding } => {
-            let inferred = InferredDependency::Global { binding: binding.clone() };
+            let inferred = InferredDependency::Global { binding: *binding };
             let key = dep_to_key(&inferred);
             if dep_keys.insert(key) {
                 dependencies.push(inferred);
@@ -500,7 +500,7 @@ fn collect_dependencies<'a>(
                             });
                         }
                         Temporary::Global { binding } => {
-                            deps.push(InferredDependency::Global { binding: binding.clone() });
+                            deps.push(InferredDependency::Global { binding: *binding });
                         }
                     }
                 }
@@ -522,10 +522,8 @@ fn collect_dependencies<'a>(
                         );
                     }
                     InferredDependency::Global { binding } => {
-                        temporaries.insert(
-                            phi.place.identifier,
-                            Temporary::Global { binding: binding.clone() },
-                        );
+                        temporaries
+                            .insert(phi.place.identifier, Temporary::Global { binding: *binding });
                     }
                 }
             } else {
@@ -543,7 +541,7 @@ fn collect_dependencies<'a>(
 
             match &instr.value {
                 InstructionValue::LoadGlobal { binding, .. } => {
-                    temporaries.insert(lvalue_id, Temporary::Global { binding: binding.clone() });
+                    temporaries.insert(lvalue_id, Temporary::Global { binding: *binding });
                 }
                 InstructionValue::LoadContext { place, .. }
                 | InstructionValue::LoadLocal { place, .. } => {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
@@ -312,7 +312,7 @@ pub fn validate_hooks_usage(
                     let object_kind = get_kind_for_place(value, &value_kinds, &env.identifiers);
                     // Process instr.lvalue and all pattern operands (matching TS eachInstructionLValue)
                     let pattern_places = each_pattern_operand(&lvalue.pattern);
-                    let all_lvalues = once(instr.lvalue.clone()).chain(pattern_places);
+                    let all_lvalues = once(instr.lvalue).chain(pattern_places);
                     for place in all_lvalues {
                         let is_hook_property =
                             ident_is_hook_name(place.identifier, &env.identifiers);

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_locals_not_reassigned_after_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_locals_not_reassigned_after_render.rs
@@ -122,7 +122,7 @@ fn get_context_reassignment(
                             if let Some(reassignment_place) =
                                 reassigning_functions.get(&context_place.identifier)
                             {
-                                reassignment = Some(reassignment_place.clone());
+                                reassignment = Some(*reassignment_place);
                                 break;
                             }
                         }
@@ -151,24 +151,22 @@ fn get_context_reassignment(
                         } else {
                             // Propagate reassignment info on the lvalue
                             reassigning_functions
-                                .insert(instr.lvalue.identifier, reassignment_place.clone());
+                                .insert(instr.lvalue.identifier, *reassignment_place);
                         }
                     }
                 }
 
                 InstructionValue::StoreLocal { lvalue, value, .. } => {
                     if let Some(reassignment_place) = reassigning_functions.get(&value.identifier) {
-                        let reassignment_place = reassignment_place.clone();
-                        reassigning_functions
-                            .insert(lvalue.place.identifier, reassignment_place.clone());
+                        let reassignment_place = *reassignment_place;
+                        reassigning_functions.insert(lvalue.place.identifier, reassignment_place);
                         reassigning_functions.insert(instr.lvalue.identifier, reassignment_place);
                     }
                 }
 
                 InstructionValue::LoadLocal { place, .. } => {
                     if let Some(reassignment_place) = reassigning_functions.get(&place.identifier) {
-                        reassigning_functions
-                            .insert(instr.lvalue.identifier, reassignment_place.clone());
+                        reassigning_functions.insert(instr.lvalue.identifier, *reassignment_place);
                     }
                 }
 
@@ -184,7 +182,7 @@ fn get_context_reassignment(
                     if is_function_expression
                         && context_variables.contains(&lvalue.place.identifier)
                     {
-                        return Some(lvalue.place.clone());
+                        return Some(lvalue.place);
                     }
 
                     // In the outer function, track context variables
@@ -194,9 +192,8 @@ fn get_context_reassignment(
 
                     // Propagate reassigning function info through StoreContext
                     if let Some(reassignment_place) = reassigning_functions.get(&value.identifier) {
-                        let reassignment_place = reassignment_place.clone();
-                        reassigning_functions
-                            .insert(lvalue.place.identifier, reassignment_place.clone());
+                        let reassignment_place = *reassignment_place;
+                        reassigning_functions.insert(lvalue.place.identifier, reassignment_place);
                         reassigning_functions.insert(instr.lvalue.identifier, reassignment_place);
                     }
                 }
@@ -208,21 +205,21 @@ fn get_context_reassignment(
                     let operands: PlaceList = match &instr.value {
                         InstructionValue::CallExpression { callee, .. } => {
                             if env.has_no_alias_signature(callee.identifier) {
-                                smallvec![callee.clone()]
+                                smallvec![*callee]
                             } else {
                                 each_instruction_value_operand(&instr.value, env)
                             }
                         }
                         InstructionValue::MethodCall { receiver, property, .. } => {
                             if env.has_no_alias_signature(property.identifier) {
-                                smallvec![receiver.clone(), property.clone()]
+                                smallvec![*receiver, *property]
                             } else {
                                 each_instruction_value_operand(&instr.value, env)
                             }
                         }
                         InstructionValue::TaggedTemplateExpression { tag, .. } => {
                             if env.has_no_alias_signature(tag.identifier) {
-                                smallvec![tag.clone()]
+                                smallvec![*tag]
                             } else {
                                 each_instruction_value_operand(&instr.value, env)
                             }
@@ -249,8 +246,7 @@ fn get_context_reassignment(
                                 // If the operand is not frozen but does reassign, then the
                                 // lvalues of the instruction could also be reassigning
                                 for lvalue_id in each_instruction_lvalue_ids(instr) {
-                                    reassigning_functions
-                                        .insert(lvalue_id, reassignment_place.clone());
+                                    reassigning_functions.insert(lvalue_id, reassignment_place);
                                 }
                             }
                         }
@@ -262,7 +258,7 @@ fn get_context_reassignment(
         // Check terminal operands for reassigning functions
         for operand in each_terminal_operand(&block.terminal) {
             if let Some(reassignment_place) = reassigning_functions.get(&operand.identifier) {
-                return Some(reassignment_place.clone());
+                return Some(*reassignment_place);
             }
         }
     }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
@@ -466,20 +466,12 @@ fn collect_temporaries_sidemap(
             let instr = &func.instructions[instr_id.index()];
             match &instr.value {
                 InstructionValue::LoadLocal { place, .. } => {
-                    let temp = env
-                        .temporaries
-                        .get(&place.identifier)
-                        .cloned()
-                        .unwrap_or_else(|| place.clone());
+                    let temp = env.temporaries.get(&place.identifier).cloned().unwrap_or(*place);
                     env.define(instr.lvalue.identifier, temp);
                 }
                 InstructionValue::StoreLocal { lvalue, value, .. } => {
-                    let temp = env
-                        .temporaries
-                        .get(&value.identifier)
-                        .cloned()
-                        .unwrap_or_else(|| value.clone());
-                    env.define(instr.lvalue.identifier, temp.clone());
+                    let temp = env.temporaries.get(&value.identifier).cloned().unwrap_or(*value);
+                    env.define(instr.lvalue.identifier, temp);
                     env.define(lvalue.place.identifier, temp);
                 }
                 InstructionValue::PropertyLoad { object, property, .. } => {
@@ -488,11 +480,7 @@ fn collect_temporaries_sidemap(
                     {
                         continue;
                     }
-                    let temp = env
-                        .temporaries
-                        .get(&object.identifier)
-                        .cloned()
-                        .unwrap_or_else(|| object.clone());
+                    let temp = env.temporaries.get(&object.identifier).cloned().unwrap_or(*object);
                     env.define(instr.lvalue.identifier, temp);
                 }
                 _ => {}

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
@@ -340,10 +340,7 @@ fn record_temporaries<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSt
         state.temporaries.insert(
             lvalue.identifier,
             ManualMemoDependency {
-                root: ManualMemoDependencyRoot::NamedLocal {
-                    value: lvalue.clone(),
-                    constant: false,
-                },
+                root: ManualMemoDependencyRoot::NamedLocal { value: *lvalue, constant: false },
                 path: Vec::new(),
                 span: lvalue.span,
             },
@@ -394,7 +391,7 @@ fn record_deps_in_value<'h>(value: &ReactiveValue<'h>, state: &mut VisitorState<
                                 lvalue.place.identifier,
                                 ManualMemoDependency {
                                     root: ManualMemoDependencyRoot::NamedLocal {
-                                        value: lvalue.place.clone(),
+                                        value: lvalue.place,
                                         constant: false,
                                     },
                                     path: Vec::new(),
@@ -414,7 +411,7 @@ fn record_deps_in_value<'h>(value: &ReactiveValue<'h>, state: &mut VisitorState<
                                     place.identifier,
                                     ManualMemoDependency {
                                         root: ManualMemoDependencyRoot::NamedLocal {
-                                            value: place.clone(),
+                                            value: *place,
                                             constant: false,
                                         },
                                         path: Vec::new(),
@@ -437,7 +434,7 @@ fn start_memoize_operands(deps: &Option<Vec<ManualMemoDependency>>) -> Vec<Place
     if let Some(deps) = deps {
         for dep in deps {
             if let ManualMemoDependencyRoot::NamedLocal { value, .. } = &dep.root {
-                result.push(value.clone());
+                result.push(*value);
             }
         }
     }
@@ -629,7 +626,7 @@ fn validate_inferred_dep<'h>(
     let normalized_dep = if let Some(temp) = temporaries.get(&dep_id) {
         let mut path = temp.path.clone();
         path.extend_from_slice(dep_path);
-        ManualMemoDependency { root: temp.root.clone(), path, span: temp.span }
+        ManualMemoDependency { root: temp.root, path, span: temp.span }
     } else {
         let ident = &env.identifiers[dep_id];
         // TS: Diagnostics.invariant(dep.identifier.name?.kind === 'named', ...)


### PR DESCRIPTION
The `react_compiler` HIR is an SSA/CFG IR, not an AST clone, so most of it cannot be `Copy` (the aggregate nodes hold `Vec`/`FxIndexMap`/`Box`). But a number of its **leaf** types have all-`Copy` fields and were needlessly deriving only `Clone`.

This derives `Copy` on the 23 leaf HIR types where it is free — `Place`, `Identifier`, `MutableRange`, `LValue`, the pattern/element enums (`ParamPattern`, `SpreadPattern`, `ArrayPatternElement`, `ArrayElement`, `PlaceOrSpread`, `ObjectPropertyOrSpread`, `ObjectProperty`, `ObjectPropertyKey`), the JSX leaves (`JsxTag`, `JsxAttribute`, `BuiltinTag`), `LoweredFunction`, `TemplateQuasi`, `PropertyNameKind`, and the binding/dep leaves (`VariableBinding`, `NonLocalBinding`, `ManualMemoDependencyRoot`, `DependencyPathEntry`) — and drops the now-redundant `.clone()` / lazy-eval calls that clippy flags as a result.

The aggregate nodes are deliberately untouched. This is a pure internal cleanup: the fixtures snapshot is byte-identical.

Net **-151 lines** across 31 files.