### PR TITLE
refactor(react_compiler): drop Rc<FunctionSignature> from AliasingEffect::Apply

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -1223,7 +1223,6 @@ pub struct ReactiveScopeEarlyReturn {
 // Aliasing effects (runtime types, from AliasingEffects.ts)
 // =============================================================================
 
-use crate::react_compiler_hir::object_shape::FunctionSignature;
 use crate::react_compiler_hir::type_config::ValueKind;
 use crate::react_compiler_hir::type_config::ValueReason;
 
@@ -1268,7 +1267,10 @@ pub enum AliasingEffect {
         mutates_function: bool,
         args: Vec<PlaceOrSpreadOrHole>,
         into: Place,
-        signature: Option<std::rc::Rc<FunctionSignature>>,
+        /// Callee function `TypeId`, used to resolve the `FunctionSignature` from the
+        /// environment on demand. Storing the id (rather than an `Rc<FunctionSignature>`)
+        /// keeps this `Copy`/non-`Drop`, so `AliasingEffect` can be arena-allocated.
+        signature: Option<TypeId>,
         span: Option<Span>,
     },
     /// Function expression creation with captures.

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -1671,7 +1671,7 @@ fn apply_effect(
             mutates_function,
             ref args,
             ref into,
-            ref signature,
+            signature,
             ref span,
         } => {
             // First, check if the callee is a locally-declared function expression
@@ -1721,7 +1721,15 @@ fn apply_effect(
                     }
                 }
             }
-            if let Some(sig) = signature {
+            // Resolve the callee's `FunctionSignature` from its stored `TypeId`,
+            // cloning into a local so it is detached from the `env` borrow (the effect
+            // computations below take `&mut env`). This mirrors the previous
+            // `Rc<FunctionSignature>` snapshot taken at construction time.
+            let sig_owned = signature.and_then(|type_id| {
+                let ty = &env.types[type_id];
+                env.get_function_signature(ty).ok().flatten().cloned()
+            });
+            if let Some(sig) = &sig_owned {
                 // Check known_incompatible (TS line 2351-2370)
                 if let Some(ref incompatible_msg) = sig.known_incompatible
                     && env.enable_validations()
@@ -2019,38 +2027,35 @@ fn compute_signature_for_instruction(
             effects.push(AliasingEffect::Capture { from: *await_value, into: *lvalue });
         }
         InstructionValue::NewExpression { callee, args, span } => {
-            let sig = get_function_call_signature(env, callee.identifier).ok().flatten();
             effects.push(AliasingEffect::Apply {
                 receiver: *callee,
                 function: *callee,
                 mutates_function: false,
                 args: args.iter().map(place_or_spread_to_hole).collect(),
                 into: *lvalue,
-                signature: sig,
+                signature: Some(env.identifiers[callee.identifier].type_),
                 span: *span,
             });
         }
         InstructionValue::CallExpression { callee, args, span } => {
-            let sig = get_function_call_signature(env, callee.identifier).ok().flatten();
             effects.push(AliasingEffect::Apply {
                 receiver: *callee,
                 function: *callee,
                 mutates_function: true,
                 args: args.iter().map(place_or_spread_to_hole).collect(),
                 into: *lvalue,
-                signature: sig,
+                signature: Some(env.identifiers[callee.identifier].type_),
                 span: *span,
             });
         }
         InstructionValue::MethodCall { receiver, property, args, span } => {
-            let sig = get_function_call_signature(env, property.identifier).ok().flatten();
             effects.push(AliasingEffect::Apply {
                 receiver: *receiver,
                 function: *property,
                 mutates_function: false,
                 args: args.iter().map(place_or_spread_to_hole).collect(),
                 into: *lvalue,
-                signature: sig,
+                signature: Some(env.identifiers[property.identifier].type_),
                 span: *span,
             });
         }
@@ -3049,7 +3054,7 @@ fn compute_effects_for_aliasing_signature(
                         mutates_function: *mf,
                         args: apply_args,
                         into: apply_into,
-                        signature: s.clone(),
+                        signature: *s,
                         span: span.copied(),
                     });
                 } else {
@@ -3123,14 +3128,6 @@ fn is_builtin_collection_type(ty: &Type) -> bool {
     matches!(ty, Type::Object { shape_id: Some(id) }
         if *id == BUILT_IN_ARRAY_ID || *id == BUILT_IN_SET_ID || *id == BUILT_IN_MAP_ID
     )
-}
-
-fn get_function_call_signature(
-    env: &Environment,
-    callee_id: IdentifierId,
-) -> Result<Option<Rc<FunctionSignature>>, OxcDiagnostic> {
-    let ty = &env.types[env.identifiers[callee_id].type_];
-    Ok(env.get_function_signature(ty)?.map(|s| Rc::new(s.clone())))
 }
 
 fn is_ref_or_ref_value_for_id(env: &Environment, id: IdentifierId) -> bool {


### PR DESCRIPTION
`AliasingEffect::Apply` held `Option<Rc<FunctionSignature>>`. Objects allocated into an oxc arena are never dropped, so a refcounted `Rc` — like any `Drop` type — blocks moving the HIR into an arena.

The `Rc` was never shared ownership for its own sake; it was a borrow-detachment device. The signature is a deterministic lookup (`env.get_function_signature(env.types[…])`), read exactly once in the same pass that builds it and ignored by every later pass. The `Rc` existed only to snapshot the registry signature into owned data so `apply_effect` could read its fields while calling `&mut env` effect computations.

Store the callee's `TypeId` instead and resolve the `FunctionSignature` on demand. `TypeId` is `Copy`/non-`Drop` and lifetime-free, so no lifetime is forced onto `AliasingEffect`/`Terminal`/`HIR`. The id is propagated unchanged through the place-substitution remap in `compute_effects_for_aliasing_signature`, preserving the exact signature identity (re-deriving from the *substituted* callee place would not). The read site clones the resolved signature into a local to reproduce the previous borrow detachment. The now-dead `get_function_call_signature` helper is removed.

Pure internal change: the fixtures snapshot is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>