### PR TITLE
refactor(react_compiler): intern AliasingEffect diagnostics behind a DiagnosticId

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+use std::cell::RefCell;
 use std::mem::take;
 
 use cow_utils::CowUtils;
@@ -38,6 +40,10 @@ pub enum OutputMode {
     Lint,
 }
 
+/// Dedup key for interned aliasing-effect diagnostics: `(place, message, help)`,
+/// matching the effect interning key granularity so identical errors collapse.
+type AliasingDiagnosticKey = (IdentifierId, Cow<'static, str>, Option<Cow<'static, str>>);
+
 pub struct Environment<'a> {
     // Arena allocator for the compilation unit. HIR strings (identifier names,
     // shape ids, property keys) live here so they can be borrowed from the
@@ -57,6 +63,14 @@ pub struct Environment<'a> {
 
     // Error accumulation
     pub errors: Diagnostics,
+
+    // Interned diagnostics for aliasing-effect errors (MutateFrozen/MutateGlobal/
+    // Impure). Those effects store a `DiagnosticId` into this table instead of an
+    // owned `OxcDiagnostic`, so `AliasingEffect` stays `Copy`/non-`Drop` and can be
+    // arena-allocated. Deduplicated on (place, message, help) to mirror the effect
+    // interning key. `RefCell` because some effect-building passes hold `&Environment`.
+    aliasing_diagnostics: RefCell<IndexVec<DiagnosticId, OxcDiagnostic>>,
+    aliasing_diagnostic_dedup: RefCell<FxHashMap<AliasingDiagnosticKey, DiagnosticId>>,
 
     // Set during lowering when the function uses syntax the compiler can't handle
     // yet (currently `using`/`await using`, whose disposal semantics aren't
@@ -180,6 +194,8 @@ impl<'a> Environment<'a> {
             scopes: IndexVec::new(),
             functions: IndexVec::new(),
             errors: Diagnostics::new(),
+            aliasing_diagnostics: RefCell::new(IndexVec::new()),
+            aliasing_diagnostic_dedup: RefCell::new(FxHashMap::default()),
             skip_compilation: false,
             fn_type: ReactFunctionType::Other,
             output_mode: OutputMode::Client,
@@ -290,6 +306,32 @@ impl<'a> Environment<'a> {
 
     pub fn record_diagnostic(&mut self, diagnostic: OxcDiagnostic) {
         self.errors.push(diagnostic);
+    }
+
+    /// Intern an aliasing-effect diagnostic into the environment-owned side table,
+    /// returning a `Copy` [`DiagnosticId`]. Deduplicated on (place, message, help) so
+    /// identical errors collapse to one stored diagnostic, matching the effect
+    /// interning key. Takes `&self` (interior mutability) because some effect-building
+    /// passes only hold `&Environment`.
+    pub fn intern_aliasing_diagnostic(
+        &self,
+        place: IdentifierId,
+        diagnostic: OxcDiagnostic,
+    ) -> DiagnosticId {
+        let key = (place, diagnostic.message.clone(), diagnostic.help.clone());
+        let mut dedup = self.aliasing_diagnostic_dedup.borrow_mut();
+        if let Some(&id) = dedup.get(&key) {
+            return id;
+        }
+        let id = self.aliasing_diagnostics.borrow().next_idx();
+        self.aliasing_diagnostics.borrow_mut().push(diagnostic);
+        dedup.insert(key, id);
+        id
+    }
+
+    /// Clone the interned aliasing-effect diagnostic for `id`, for emission.
+    pub fn aliasing_diagnostic(&self, id: DiagnosticId) -> OxcDiagnostic {
+        self.aliasing_diagnostics.borrow()[id].clone()
     }
 
     pub fn has_errors(&self) -> bool {

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -12,7 +12,6 @@ pub mod visitors;
 use crate::react_compiler_utils::FxIndexMap;
 use crate::react_compiler_utils::FxIndexSet;
 use oxc_ast::ast::*;
-use oxc_diagnostics::OxcDiagnostic;
 use oxc_index::define_nonmax_u32_index_type;
 use oxc_str::{Ident, Str};
 use oxc_syntax::number::ToJsString;
@@ -63,6 +62,12 @@ define_nonmax_u32_index_type! {
 
 define_nonmax_u32_index_type! {
     pub struct MutableRangeId;
+}
+
+define_nonmax_u32_index_type! {
+    /// Index into `Environment`'s interned aliasing-effect diagnostics
+    /// (`intern_aliasing_diagnostic` / `aliasing_diagnostic`).
+    pub struct DiagnosticId;
 }
 
 impl BlockId {
@@ -1276,11 +1281,15 @@ pub enum AliasingEffect {
     /// Function expression creation with captures.
     CreateFunction { captures: Vec<Place>, function_id: FunctionId, into: Place },
     /// Mutation of a value known to be frozen (error).
-    MutateFrozen { place: Place, error: OxcDiagnostic },
-    /// Mutation of a global value (error).
-    MutateGlobal { place: Place, error: OxcDiagnostic },
-    /// Side-effect not safe during render.
-    Impure { place: Place, error: OxcDiagnostic },
+    ///
+    /// `error` indexes the diagnostic interned on `Environment` (see
+    /// [`DiagnosticId`]); the `OxcDiagnostic` itself is held out-of-band so this
+    /// effect stays `Copy`/non-`Drop` and can be arena-allocated.
+    MutateFrozen { place: Place, error: DiagnosticId },
+    /// Mutation of a global value (error). `error` indexes the interned diagnostic.
+    MutateGlobal { place: Place, error: DiagnosticId },
+    /// Side-effect not safe during render. `error` indexes the interned diagnostic.
+    Impure { place: Place, error: DiagnosticId },
     /// Value is accessed during render.
     Render { place: Place },
 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -26,6 +26,7 @@ use crate::react_compiler_hir::ArrayElement;
 use crate::react_compiler_hir::ArrayPatternElement;
 use crate::react_compiler_hir::BlockId;
 use crate::react_compiler_hir::DeclarationId;
+use crate::react_compiler_hir::DiagnosticId;
 use crate::react_compiler_hir::Effect;
 use crate::react_compiler_hir::FunctionId;
 use crate::react_compiler_hir::HirFunction;
@@ -780,13 +781,11 @@ enum EffectKey {
     },
     MutateFrozen {
         place: IdentifierId,
-        message: Cow<'static, str>,
-        help: Option<Cow<'static, str>>,
+        diag: DiagnosticId,
     },
     MutateGlobal {
         place: IdentifierId,
-        message: Cow<'static, str>,
-        help: Option<Cow<'static, str>>,
+        diag: DiagnosticId,
     },
     Mutate {
         value: IdentifierId,
@@ -875,16 +874,12 @@ fn effect_key(effect: &AliasingEffect) -> EffectKey {
         }
         AliasingEffect::Impure { place, .. } => EffectKey::Impure { place: place.identifier },
         AliasingEffect::Render { place } => EffectKey::Render { place: place.identifier },
-        AliasingEffect::MutateFrozen { place, error } => EffectKey::MutateFrozen {
-            place: place.identifier,
-            message: error.message.clone(),
-            help: error.help.clone(),
-        },
-        AliasingEffect::MutateGlobal { place, error } => EffectKey::MutateGlobal {
-            place: place.identifier,
-            message: error.message.clone(),
-            help: error.help.clone(),
-        },
+        AliasingEffect::MutateFrozen { place, error } => {
+            EffectKey::MutateFrozen { place: place.identifier, diag: *error }
+        }
+        AliasingEffect::MutateGlobal { place, error } => {
+            EffectKey::MutateGlobal { place: place.identifier, diag: *error }
+        }
         AliasingEffect::Mutate { value, .. } => EffectKey::Mutate { value: value.identifier },
         AliasingEffect::MutateConditionally { value } => {
             EffectKey::MutateConditionally { value: value.identifier }
@@ -1297,10 +1292,9 @@ fn apply_signature(
                                     .span
                                     .map(|s| s.label(format!("{} cannot be modified", variable))),
                             );
-                        effects.push(AliasingEffect::MutateFrozen {
-                            place: *mutate_value,
-                            error: diagnostic,
-                        });
+                        let error =
+                            env.intern_aliasing_diagnostic(mutate_value.identifier, diagnostic);
+                        effects.push(AliasingEffect::MutateFrozen { place: *mutate_value, error });
                     }
                 }
             }
@@ -1922,10 +1916,11 @@ fn apply_effect(
                             variable.as_deref().unwrap_or("variable")
                         ))
                     }));
+                    let error = env.intern_aliasing_diagnostic(value.identifier, diagnostic);
                     apply_effect(
                         context,
                         state,
-                        AliasingEffect::MutateFrozen { place: *value, error: diagnostic },
+                        AliasingEffect::MutateFrozen { place: *value, error },
                         initialized,
                         effects,
                         env,
@@ -1945,10 +1940,11 @@ fn apply_effect(
                             value.span.map(|s| s.label(format!("{} cannot be modified", variable))),
                         );
 
+                    let error = env.intern_aliasing_diagnostic(value.identifier, diagnostic);
                     let error_kind = if abstract_value.kind == ValueKind::Frozen {
-                        AliasingEffect::MutateFrozen { place: *value, error: diagnostic }
+                        AliasingEffect::MutateFrozen { place: *value, error }
                     } else {
-                        AliasingEffect::MutateGlobal { place: *value, error: diagnostic }
+                        AliasingEffect::MutateGlobal { place: *value, error }
                     };
                     apply_effect(context, state, error_kind, initialized, effects, env)?;
                 }
@@ -2317,7 +2313,8 @@ fn compute_signature_for_instruction(
                 .with_labels(
                     instr.span.map(|s| s.label(format!("{} cannot be reassigned", variable))),
                 );
-            effects.push(AliasingEffect::MutateGlobal { place: *sg_value, error: diagnostic });
+            let error = env.intern_aliasing_diagnostic(sg_value.identifier, diagnostic);
+            effects.push(AliasingEffect::MutateGlobal { place: *sg_value, error });
             effects.push(AliasingEffect::Assign { from: *sg_value, into: *lvalue });
         }
         InstructionValue::TypeCastExpression { value: tc_value, .. } => {
@@ -2403,7 +2400,8 @@ fn compute_effects_for_legacy_signature(
                 }
             ))
             .with_labels(span.copied().map(|s| s.label("Cannot call impure function")));
-        effects.push(AliasingEffect::Impure { place: *receiver, error: diagnostic });
+        let error = env.intern_aliasing_diagnostic(receiver.identifier, diagnostic);
+        effects.push(AliasingEffect::Impure { place: *receiver, error });
     }
 
     // TODO: check signature.known_incompatible and throw (TS line 2351-2370)
@@ -2738,10 +2736,11 @@ fn compute_effects_for_aliasing_signature_config(
             AliasingEffectConfig::Impure { place } => {
                 let values = substitutions.get(*place).cloned().unwrap_or_default();
                 for v in values {
-                    effects.push(AliasingEffect::Impure {
-                        place: v,
-                        error: ErrorCategory::Purity.diagnostic("Impure function call"),
-                    });
+                    let error = env.intern_aliasing_diagnostic(
+                        v.identifier,
+                        ErrorCategory::Purity.diagnostic("Impure function call"),
+                    );
+                    effects.push(AliasingEffect::Impure { place: v, error });
                 }
             }
             AliasingEffectConfig::Mutate { value } => {
@@ -2938,19 +2937,19 @@ fn compute_effects_for_aliasing_signature(
             AliasingEffect::Impure { place, error } => {
                 let values = substitutions.get(&place.identifier).cloned().unwrap_or_default();
                 for v in values {
-                    effects.push(AliasingEffect::Impure { place: v, error: error.clone() });
+                    effects.push(AliasingEffect::Impure { place: v, error: *error });
                 }
             }
             AliasingEffect::MutateFrozen { place, error } => {
                 let values = substitutions.get(&place.identifier).cloned().unwrap_or_default();
                 for v in values {
-                    effects.push(AliasingEffect::MutateFrozen { place: v, error: error.clone() });
+                    effects.push(AliasingEffect::MutateFrozen { place: v, error: *error });
                 }
             }
             AliasingEffect::MutateGlobal { place, error } => {
                 let values = substitutions.get(&place.identifier).cloned().unwrap_or_default();
                 for v in values {
-                    effects.push(AliasingEffect::MutateGlobal { place: v, error: error.clone() });
+                    effects.push(AliasingEffect::MutateGlobal { place: v, error: *error });
                 }
             }
             AliasingEffect::Render { place } => {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
@@ -399,20 +399,23 @@ impl AliasingState {
 
 fn append_function_errors(env: &mut Environment, function_id: FunctionId) {
     let func = &env.functions[function_id];
-    if let Some(ref effects) = func.aliasing_effects {
-        // Collect errors first to avoid borrow conflict
-        let errors: Vec<_> = effects
+    // Collect diagnostic ids first to avoid borrow conflict, then resolve + record.
+    let ids: Vec<_> = if let Some(ref effects) = func.aliasing_effects {
+        effects
             .iter()
             .filter_map(|effect| match effect {
                 AliasingEffect::Impure { error, .. }
                 | AliasingEffect::MutateFrozen { error, .. }
-                | AliasingEffect::MutateGlobal { error, .. } => Some(error.clone()),
+                | AliasingEffect::MutateGlobal { error, .. } => Some(*error),
                 _ => None,
             })
-            .collect();
-        for error in errors {
-            env.record_diagnostic(error);
-        }
+            .collect()
+    } else {
+        Vec::new()
+    };
+    for id in ids {
+        let diagnostic = env.aliasing_diagnostic(id);
+        env.record_diagnostic(diagnostic);
     }
 }
 
@@ -593,7 +596,8 @@ pub fn infer_mutation_aliasing_ranges(
                                 AliasingEffect::MutateFrozen { error, .. }
                                 | AliasingEffect::MutateGlobal { error, .. }
                                 | AliasingEffect::Impure { error, .. } => {
-                                    env.record_diagnostic(error.clone());
+                                    let diagnostic = env.aliasing_diagnostic(*error);
+                                    env.record_diagnostic(diagnostic);
                                 }
                                 _ => unreachable!(),
                             }


### PR DESCRIPTION
The `MutateFrozen`/`MutateGlobal`/`Impure` variants of `AliasingEffect` each held an owned `OxcDiagnostic`. Objects allocated into an oxc arena are never dropped, so `OxcDiagnostic` — which owns `Cow<'static, str>` message/help plus a `Labels` vec — is a `Drop` type that blocks moving the HIR into an arena.

Move the diagnostics into an `Environment`-owned side table and store a `Copy` `DiagnosticId` in the effect instead:

- `Environment::intern_aliasing_diagnostic` interns a diagnostic and returns its id, deduplicated on `(place, message, help)` — the same granularity as the effect interning key (`EffectKey`). Identical errors still collapse to one stored diagnostic, so `EffectKey` can key on the id directly instead of cloning the message/help strings.
- The table uses `RefCell` because two effect-building passes (`compute_signature_for_instruction`, `compute_effects_for_legacy_signature`) only hold `&Environment`. Interning is off the hot path — it happens only when an error effect is produced.
- The range pass resolves the id back to the diagnostic at emit time (`env.record_diagnostic(env.aliasing_diagnostic(id))`), the point at which these errors were already surfaced.

`AliasingEffect` no longer carries any `Drop` diagnostic; its remaining non-arena fields are the `Vec`s, which are the mechanical arena-`Vec` migration tracked separately.

Pure internal change: the fixtures snapshot is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

