### PR TITLE
perf(diagnostics): box OxcDiagnosticInner to reduce binary size

### DIFF
--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -241,9 +241,6 @@ impl ConfigLoadError {
 ///
 /// This groups together failures related to the root configuration file
 /// and to any nested configuration files discovered during loading.
-// `OxcDiagnostic` is intentionally inlined (~176 bytes) to keep its construction
-// allocation-free, so the variant size difference is a deliberate trade-off.
-#[expect(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum CliConfigLoadError {
     /// An error that occurred while loading or parsing the root configuration.

--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -173,7 +173,7 @@ impl<'a> IntoIterator for &'a Diagnostics {
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[must_use]
 pub struct OxcDiagnostic {
-    inner: OxcDiagnosticInner,
+    inner: Box<OxcDiagnosticInner>,
 }
 
 impl Deref for OxcDiagnostic {
@@ -274,31 +274,28 @@ impl Diagnostic for OxcDiagnostic {
 impl OxcDiagnostic {
     /// Create new an error-level [`OxcDiagnostic`].
     pub fn error<T: Into<Cow<'static, str>>>(message: T) -> Self {
-        Self {
-            inner: OxcDiagnosticInner {
-                message: message.into(),
-                labels: Labels::None,
-                note: None,
-                help: None,
-                severity: Severity::Error,
-                code: OxcCode::default(),
-                url: None,
-            },
-        }
+        Self::new(Severity::Error, message.into())
     }
 
     /// Create new a warning-level [`OxcDiagnostic`].
     pub fn warn<T: Into<Cow<'static, str>>>(message: T) -> Self {
+        Self::new(Severity::Warning, message.into())
+    }
+
+    // Outlined so the `Box` allocation + field initialization exists once in the binary
+    // instead of being inlined into every diagnostic construction site.
+    #[inline(never)]
+    fn new(severity: Severity, message: Cow<'static, str>) -> Self {
         Self {
-            inner: OxcDiagnosticInner {
-                message: message.into(),
+            inner: Box::new(OxcDiagnosticInner {
+                message,
                 labels: Labels::None,
                 help: None,
                 note: None,
-                severity: Severity::Warning,
+                severity,
                 code: OxcCode::default(),
                 url: None,
-            },
+            }),
         }
     }
 
@@ -462,6 +459,6 @@ impl OxcDiagnostic {
 
     /// Consumes the diagnostic and returns the inner owned data.
     pub fn inner_owned(self) -> OxcDiagnosticInner {
-        self.inner
+        *self.inner
     }
 }


### PR DESCRIPTION
`OxcDiagnostic` is an unboxed ~300-byte struct constructed at thousands of callsites. Boxing its inner data behind an 8-byte handle means every callsite, every `Result<T, OxcDiagnostic>`, and every move copies 8 bytes instead of ~300, so the compiler emits far less inlined construction/copy code.

## Binary size (stripped, real release builds, aarch64-apple-darwin)

| Binary | Before | After | Delta |
|---|---:|---:|---:|
| `oxlint` | 14,177,616 B | 13,665,680 B | **−499.9 KiB (−3.61%)** |
| napi transform (`.node`) | 3,482,624 B | 3,433,040 B | **−48.4 KiB (−1.42%)** |

Most of the win lands in `oxc_linter`, whose ~1,500 diagnostic-construction sites inline into rule bodies; `oxc_react_compiler` also contributes.

The `error`/`warn` constructors delegate to an outlined `#[inline(never)] fn new`, so the `Box` allocation + field initialization exist once in the binary rather than inlined at every construction site.

This reverses #22406, which unboxed the inner to save a heap allocation. That is now safe: the parser no longer constructs diagnostics on its hot path (#24663).

Supersedes the draft #24656, which additionally carried a now-redundant copy of the parser deferral that has since landed via #24663.
