### PR TITLE
refactor(react_compiler): back HIR ordered maps with Vec + FxHashMap

### DIFF
--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -25,7 +25,6 @@ description = "oxc integration for the Rust port of React Compiler"
 
 [lib]
 doctest = false
-test = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -9,8 +9,8 @@ pub mod reactive;
 pub mod type_config;
 pub mod visitors;
 
-use crate::react_compiler_utils::FxIndexMap;
-use crate::react_compiler_utils::FxIndexSet;
+use crate::react_compiler_utils::OrderedMap;
+use crate::react_compiler_utils::OrderedSet;
 use oxc_ast::ast::*;
 use oxc_index::define_nonmax_u32_index_type;
 use oxc_str::{Ident, Str};
@@ -179,7 +179,7 @@ pub enum ParamPattern {
 #[allow(clippy::upper_case_acronyms)]
 pub struct HIR {
     pub entry: BlockId,
-    pub blocks: FxIndexMap<BlockId, BasicBlock>,
+    pub blocks: OrderedMap<BlockId, BasicBlock>,
 }
 
 /// Block kinds
@@ -211,7 +211,7 @@ pub struct BasicBlock {
     pub id: BlockId,
     pub instructions: Vec<InstructionId>,
     pub terminal: Terminal,
-    pub preds: FxIndexSet<BlockId>,
+    pub preds: OrderedSet<BlockId>,
     pub phis: Vec<Phi>,
 }
 
@@ -219,7 +219,7 @@ pub struct BasicBlock {
 #[derive(Debug, Clone)]
 pub struct Phi {
     pub place: Place,
-    pub operands: FxIndexMap<BlockId, Place>,
+    pub operands: OrderedMap<BlockId, Place>,
 }
 
 // =============================================================================

--- a/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
@@ -21,7 +21,7 @@ use crate::react_compiler_inference::infer_mutation_aliasing_ranges::infer_mutat
 use crate::react_compiler_inference::infer_reactive_scope_variables::infer_reactive_scope_variables;
 use crate::react_compiler_optimization::dead_code_elimination;
 use crate::react_compiler_ssa::rewrite_instruction_kinds_based_on_reassignment;
-use crate::react_compiler_utils::FxIndexMap;
+use crate::react_compiler_utils::OrderedMap;
 use rustc_hash::FxHashSet;
 use std::mem::replace;
 
@@ -206,7 +206,7 @@ fn placeholder_function<'a>() -> HirFunction<'a> {
             span: None,
         },
         context: Vec::new(),
-        body: HIR { entry: BlockId::ENTRY, blocks: FxIndexMap::default() },
+        body: HIR { entry: BlockId::ENTRY, blocks: OrderedMap::default() },
         instructions: Vec::new(),
         generator: false,
         is_async: false,

--- a/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
@@ -13,7 +13,7 @@
 
 use std::cmp::Ordering;
 
-use crate::react_compiler_utils::FxIndexSet;
+use crate::react_compiler_utils::OrderedSet;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
@@ -33,7 +33,7 @@ use crate::react_compiler_hir::visitors::each_terminal_operand_ids;
 use crate::react_compiler_lowering::get_reverse_postordered_blocks;
 use crate::react_compiler_lowering::mark_instruction_ids;
 use crate::react_compiler_lowering::mark_predecessors;
-use crate::react_compiler_utils::FxIndexMap;
+use crate::react_compiler_utils::OrderedMap;
 
 // =============================================================================
 // getScopes
@@ -210,7 +210,7 @@ fn handle_rewrite(
     };
 
     let curr_block_id = context.next_block_id;
-    let mut preds = FxIndexSet::default();
+    let mut preds = OrderedSet::default();
     for &p in &context.next_preds {
         preds.insert(p);
     }
@@ -249,7 +249,7 @@ pub fn build_reactive_scope_terminals_hir(func: &mut HirFunction, env: &mut Envi
 
     // Step 2: Apply rewrites by splitting blocks
     let mut rewritten_final_blocks: FxHashMap<BlockId, BlockId> = FxHashMap::default();
-    let mut next_blocks: FxIndexMap<BlockId, BasicBlock> = FxIndexMap::default();
+    let mut next_blocks: OrderedMap<BlockId, BasicBlock> = OrderedMap::default();
 
     // Reverse so we can pop from the end while traversing in ascending order
     queued_rewrites.reverse();
@@ -284,7 +284,7 @@ pub fn build_reactive_scope_terminals_hir(func: &mut HirFunction, env: &mut Envi
         }
 
         if !context.rewrites.is_empty() {
-            let mut final_preds = FxIndexSet::default();
+            let mut final_preds = OrderedSet::default();
             for &p in &context.next_preds {
                 final_preds.insert(p);
             }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -14,6 +14,7 @@
 use std::borrow::Cow;
 
 use crate::react_compiler_utils::FxIndexMap;
+use crate::react_compiler_utils::OrderedMap;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
@@ -640,7 +641,7 @@ impl InferenceState {
         self.uninitialized_access.set(None);
     }
 
-    fn infer_phi(&mut self, phi_place_id: IdentifierId, phi_operands: &FxIndexMap<BlockId, Place>) {
+    fn infer_phi(&mut self, phi_place_id: IdentifierId, phi_operands: &OrderedMap<BlockId, Place>) {
         let mut values: FxHashSet<ValueId> = FxHashSet::default();
         for (_, operand) in phi_operands {
             if let Some(operand_values) = self.variables.get(&operand.identifier) {
@@ -1140,7 +1141,7 @@ fn infer_block(
     let block = &func.body.blocks[&block_id];
 
     // Process phis
-    let phis: Vec<(IdentifierId, FxIndexMap<BlockId, Place>)> =
+    let phis: Vec<(IdentifierId, OrderedMap<BlockId, Place>)> =
         block.phis.iter().map(|phi| (phi.place.identifier, phi.operands.clone())).collect();
     for (place_id, operands) in &phis {
         state.infer_phi(*place_id, operands);

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -4,8 +4,9 @@ use crate::react_compiler_hir::visitors::each_terminal_successor;
 use crate::react_compiler_hir::visitors::terminal_fallthrough;
 use crate::react_compiler_hir::*;
 use crate::react_compiler_utils::FxIndexMap;
-use crate::react_compiler_utils::FxIndexSet;
 use crate::react_compiler_utils::IdentIndexMap;
+use crate::react_compiler_utils::OrderedMap;
+use crate::react_compiler_utils::OrderedSet;
 use crate::scope::DeclKind;
 use crate::scope::ImportBindingKind;
 use crate::scope::ScopeId;
@@ -124,7 +125,7 @@ fn new_block(id: BlockId, kind: BlockKind) -> WipBlock {
 // ---------------------------------------------------------------------------
 
 pub struct HirBuilder<'a, 'b> {
-    completed: FxIndexMap<BlockId, BasicBlock>,
+    completed: OrderedMap<BlockId, BasicBlock>,
     current: WipBlock,
     entry: BlockId,
     scopes: Vec<Scope<'a>>,
@@ -185,7 +186,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         let entry = env.next_block_id();
         let kind = entry_block_kind.unwrap_or(BlockKind::Block);
         HirBuilder {
-            completed: FxIndexMap::default(),
+            completed: OrderedMap::default(),
             current: new_block(entry, kind),
             entry,
             scopes: Vec::new(),
@@ -345,7 +346,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
                 id: wip.id,
                 instructions: wip.instructions,
                 terminal,
-                preds: FxIndexSet::default(),
+                preds: OrderedSet::default(),
                 phis: Vec::new(),
             },
         );
@@ -890,7 +891,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
 /// Blocks not reachable through successors are removed. Blocks that are
 /// only reachable as fallthroughs (not through real successor edges) are
 /// replaced with empty blocks that have an Unreachable terminal.
-pub fn get_reverse_postordered_blocks(hir: &HIR) -> FxIndexMap<BlockId, BasicBlock> {
+pub fn get_reverse_postordered_blocks(hir: &HIR) -> OrderedMap<BlockId, BasicBlock> {
     let mut visited: FxHashSet<BlockId> = FxHashSet::default();
     let mut used: FxHashSet<BlockId> = FxHashSet::default();
     let mut used_fallthroughs: FxHashSet<BlockId> = FxHashSet::default();
@@ -946,7 +947,7 @@ pub fn get_reverse_postordered_blocks(hir: &HIR) -> FxIndexMap<BlockId, BasicBlo
 
     visit(hir, hir.entry, true, &mut visited, &mut used, &mut used_fallthroughs, &mut postorder);
 
-    let mut blocks = FxIndexMap::default();
+    let mut blocks = OrderedMap::default();
     for block_id in postorder.into_iter().rev() {
         let block = hir.blocks.get(&block_id).unwrap();
         if used.contains(&block_id) {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
@@ -40,7 +40,7 @@
 //!
 //! Analogous to TS `Inference/InlineImmediatelyInvokedFunctionExpressions.ts`.
 
-use crate::react_compiler_utils::FxIndexSet;
+use crate::react_compiler_utils::OrderedSet;
 use oxc_str::format_ident;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -142,7 +142,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                         instructions: continuation_instructions,
                         kind: block_kind,
                         phis: Vec::new(),
-                        preds: FxIndexSet::default(),
+                        preds: OrderedSet::default(),
                         terminal: continuation_terminal,
                     };
                     func.body.blocks.insert(continuation_block_id, continuation_block);

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
@@ -8,7 +8,8 @@
 //! Outlines JSX expressions in callbacks into separate component functions.
 //! This pass is conditional on `env.config.enable_jsx_outlining` (defaults to false).
 
-use crate::react_compiler_utils::FxIndexSet;
+use crate::react_compiler_utils::OrderedMap;
+use crate::react_compiler_utils::OrderedSet;
 use oxc_index::IndexVec;
 use oxc_str::{Ident, IdentHashSet, format_ident};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -422,7 +423,7 @@ fn emit_outlined_fn<'a>(
         kind: BlockKind::Block,
         id: BlockId::ENTRY,
         instructions: instr_ids,
-        preds: FxIndexSet::default(),
+        preds: OrderedSet::default(),
         terminal: Terminal::Return {
             value: last_lvalue,
             return_variant: ReturnVariant::Explicit,
@@ -433,7 +434,7 @@ fn emit_outlined_fn<'a>(
         phis: Vec::new(),
     };
 
-    let mut blocks = FxIndexMap::default();
+    let mut blocks = OrderedMap::default();
     blocks.insert(BlockId::ENTRY, block);
 
     let outlined_fn = HirFunction {

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
@@ -8,7 +8,7 @@ use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::visitors;
 use crate::react_compiler_hir::*;
-use crate::react_compiler_utils::FxIndexMap;
+use crate::react_compiler_utils::OrderedMap;
 
 // =============================================================================
 // SSABuilder
@@ -36,7 +36,7 @@ struct SSABuilder {
 }
 
 impl SSABuilder {
-    fn new(blocks: &FxIndexMap<BlockId, BasicBlock>) -> Self {
+    fn new(blocks: &OrderedMap<BlockId, BasicBlock>) -> Self {
         let mut block_preds = FxHashMap::default();
         for (id, block) in blocks {
             block_preds.insert(*id, block.preds.iter().copied().collect());
@@ -198,7 +198,7 @@ impl SSABuilder {
     ) {
         let preds = self.block_preds.get(&block_id).cloned().unwrap_or_default();
 
-        let mut pred_defs: FxIndexMap<BlockId, Place> = FxIndexMap::default();
+        let mut pred_defs: OrderedMap<BlockId, Place> = OrderedMap::default();
         for pred_block_id in &preds {
             let pred_id = self.get_id_at(old_place, *pred_block_id, env);
             pred_defs.insert(
@@ -449,7 +449,7 @@ pub fn placeholder_function<'a>() -> HirFunction<'a> {
             span: None,
         },
         context: Vec::new(),
-        body: HIR { entry: BlockId::ENTRY, blocks: FxIndexMap::default() },
+        body: HIR { entry: BlockId::ENTRY, blocks: OrderedMap::default() },
         instructions: Vec::new(),
         generator: false,
         is_async: false,

--- a/crates/oxc_react_compiler/src/react_compiler_utils/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_utils/mod.rs
@@ -2,8 +2,10 @@ use indexmap::{IndexMap, IndexSet};
 use rustc_hash::FxBuildHasher;
 
 pub mod disjoint_set;
+pub mod ordered_map;
 
 pub use disjoint_set::DisjointSet;
+pub use ordered_map::{OrderedMap, OrderedSet};
 
 /// `IndexMap` keyed with the fast `FxHasher` (rustc-hash) instead of the default SipHash.
 pub type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;

--- a/crates/oxc_react_compiler/src/react_compiler_utils/ordered_map.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_utils/ordered_map.rs
@@ -1,0 +1,341 @@
+//! Insertion-ordered map and set backed by a `Vec` of entries plus an
+//! `FxHashMap` index for O(1) key lookup.
+//!
+//! These are drop-in replacements for the `indexmap`-based [`FxIndexMap`] /
+//! [`FxIndexSet`] used by the HIR (`HIR.blocks`, `BasicBlock.preds`,
+//! `Phi.operands`). They exist because `indexmap` has no arena-allocator variant,
+//! whereas `Vec` and hash maps do (`oxc_allocator::Vec` / `oxc_allocator::HashMap`).
+//! Rebuilding the ordered map from those primitives is the first step toward
+//! moving the HIR into an arena; the container semantics (insertion order + O(1)
+//! lookup) match `IndexMap`/`IndexSet` so behavior is unchanged.
+//!
+//! [`FxIndexMap`]: crate::react_compiler_utils::FxIndexMap
+//! [`FxIndexSet`]: crate::react_compiler_utils::FxIndexSet
+
+use std::fmt;
+use std::hash::Hash;
+
+use rustc_hash::FxHashMap;
+
+/// Insertion-ordered map with O(1) keyed lookup. Mirrors the subset of the
+/// `IndexMap` API used by the HIR. Keys are `Copy` (all current keys are ids).
+#[derive(Clone)]
+pub struct OrderedMap<K, V> {
+    /// Entries in insertion order.
+    entries: Vec<(K, V)>,
+    /// Maps a key to its position in `entries`.
+    index: FxHashMap<K, usize>,
+}
+
+impl<K, V> Default for OrderedMap<K, V> {
+    fn default() -> Self {
+        Self { entries: Vec::new(), index: FxHashMap::default() }
+    }
+}
+
+impl<K: Copy + Eq + Hash, V> OrderedMap<K, V> {
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.index.clear();
+    }
+
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.index.contains_key(key)
+    }
+
+    /// Position of `key` in insertion order, if present.
+    pub fn get_index_of(&self, key: &K) -> Option<usize> {
+        self.index.get(key).copied()
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.index.get(key).map(|&i| &self.entries[i].1)
+    }
+
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        match self.index.get(key) {
+            Some(&i) => Some(&mut self.entries[i].1),
+            None => None,
+        }
+    }
+
+    /// Insert `value` for `key`. If the key already exists its position is kept
+    /// and the previous value is returned; otherwise the entry is appended.
+    /// Matches `IndexMap::insert`.
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        if let Some(&i) = self.index.get(&key) {
+            Some(std::mem::replace(&mut self.entries[i].1, value))
+        } else {
+            let i = self.entries.len();
+            self.entries.push((key, value));
+            self.index.insert(key, i);
+            None
+        }
+    }
+
+    /// Remove `key`, shifting later entries down to preserve order (O(n)).
+    /// Matches `IndexMap::shift_remove`.
+    pub fn shift_remove(&mut self, key: &K) -> Option<V> {
+        let i = self.index.remove(key)?;
+        let (_, value) = self.entries.remove(i);
+        // Entries after `i` moved down by one; fix their recorded positions.
+        for j in i..self.entries.len() {
+            let k = self.entries[j].0;
+            self.index.insert(k, j);
+        }
+        Some(value)
+    }
+
+    /// Keep only entries for which `keep` returns true, preserving order.
+    /// Matches `IndexMap::retain`.
+    pub fn retain(&mut self, mut keep: impl FnMut(&K, &mut V) -> bool) {
+        self.entries.retain_mut(|(k, v)| keep(k, v));
+        self.index.clear();
+        for (i, (k, _)) in self.entries.iter().enumerate() {
+            self.index.insert(*k, i);
+        }
+    }
+
+    /// Remove and yield all entries (the only range used is `..`).
+    pub fn drain(&mut self, range: std::ops::RangeFull) -> std::vec::Drain<'_, (K, V)> {
+        self.index.clear();
+        self.entries.drain(range)
+    }
+
+    pub fn keys(&self) -> impl DoubleEndedIterator<Item = &K> {
+        self.entries.iter().map(|(k, _)| k)
+    }
+
+    pub fn values(&self) -> impl DoubleEndedIterator<Item = &V> {
+        self.entries.iter().map(|(_, v)| v)
+    }
+
+    pub fn values_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut V> {
+        self.entries.iter_mut().map(|(_, v)| v)
+    }
+
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (&K, &V)> {
+        self.entries.iter().map(|(k, v)| (k, v))
+    }
+
+    pub fn iter_mut(&mut self) -> impl DoubleEndedIterator<Item = (&K, &mut V)> {
+        self.entries.iter_mut().map(|(k, v)| (&*k, v))
+    }
+}
+
+impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for OrderedMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map().entries(self.entries.iter().map(|(k, v)| (k, v))).finish()
+    }
+}
+
+/// Insertion-ordered set with O(1) membership. Mirrors the subset of the
+/// `IndexSet` API used by the HIR.
+#[derive(Clone)]
+pub struct OrderedSet<K> {
+    entries: Vec<K>,
+    index: FxHashMap<K, usize>,
+}
+
+impl<K> Default for OrderedSet<K> {
+    fn default() -> Self {
+        Self { entries: Vec::new(), index: FxHashMap::default() }
+    }
+}
+
+impl<K: Copy + Eq + Hash> OrderedSet<K> {
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.index.clear();
+    }
+
+    pub fn contains(&self, key: &K) -> bool {
+        self.index.contains_key(key)
+    }
+
+    /// Insert `key`; returns true if it was newly added. Matches `IndexSet::insert`.
+    pub fn insert(&mut self, key: K) -> bool {
+        if self.index.contains_key(&key) {
+            return false;
+        }
+        let i = self.entries.len();
+        self.entries.push(key);
+        self.index.insert(key, i);
+        true
+    }
+
+    /// Remove `key`, shifting later entries down to preserve order (O(n)).
+    /// Matches `IndexSet::shift_remove`.
+    pub fn shift_remove(&mut self, key: &K) -> bool {
+        let Some(i) = self.index.remove(key) else {
+            return false;
+        };
+        self.entries.remove(i);
+        for j in i..self.entries.len() {
+            let k = self.entries[j];
+            self.index.insert(k, j);
+        }
+        true
+    }
+
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &K> {
+        self.entries.iter()
+    }
+}
+
+impl<K: fmt::Debug> fmt::Debug for OrderedSet<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(self.entries.iter()).finish()
+    }
+}
+
+/// Borrowing iterator over an [`OrderedMap`], yielding `(&K, &V)` in insertion order.
+pub struct Iter<'a, K, V>(std::slice::Iter<'a, (K, V)>);
+
+impl<'a, K, V> Iterator for Iter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(k, v)| (k, v))
+    }
+}
+
+/// Mutable-borrowing iterator over an [`OrderedMap`], yielding `(&K, &mut V)`.
+pub struct IterMut<'a, K, V>(std::slice::IterMut<'a, (K, V)>);
+
+impl<'a, K, V> Iterator for IterMut<'a, K, V> {
+    type Item = (&'a K, &'a mut V);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(k, v)| (&*k, v))
+    }
+}
+
+impl<K, V> IntoIterator for OrderedMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = std::vec::IntoIter<(K, V)>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.into_iter()
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a OrderedMap<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        Iter(self.entries.iter())
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a mut OrderedMap<K, V> {
+    type Item = (&'a K, &'a mut V);
+    type IntoIter = IterMut<'a, K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        IterMut(self.entries.iter_mut())
+    }
+}
+
+impl<K: Copy + Eq + Hash, V> std::ops::Index<&K> for OrderedMap<K, V> {
+    type Output = V;
+    fn index(&self, key: &K) -> &V {
+        self.get(key).expect("OrderedMap: no entry found for key")
+    }
+}
+
+impl<K> IntoIterator for OrderedSet<K> {
+    type Item = K;
+    type IntoIter = std::vec::IntoIter<K>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.into_iter()
+    }
+}
+
+impl<'a, K> IntoIterator for &'a OrderedSet<K> {
+    type Item = &'a K;
+    type IntoIter = std::slice::Iter<'a, K>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OrderedMap, OrderedSet};
+
+    #[test]
+    fn map_insert_order_and_lookup() {
+        let mut m: OrderedMap<u32, &str> = OrderedMap::default();
+        assert_eq!(m.insert(3, "a"), None);
+        assert_eq!(m.insert(1, "b"), None);
+        assert_eq!(m.insert(2, "c"), None);
+        // Re-insert keeps position, returns old value.
+        assert_eq!(m.insert(1, "B"), Some("b"));
+        assert_eq!(m.keys().copied().collect::<Vec<_>>(), vec![3, 1, 2]);
+        assert_eq!(m.get(&1), Some(&"B"));
+        assert_eq!(m.get_index_of(&2), Some(2));
+        assert_eq!(m.get_index_of(&9), None);
+        assert_eq!(m.len(), 3);
+    }
+
+    #[test]
+    fn map_shift_remove_preserves_order_and_reindexes() {
+        let mut m: OrderedMap<u32, u32> = OrderedMap::default();
+        for k in [10, 20, 30, 40] {
+            m.insert(k, k * 10);
+        }
+        assert_eq!(m.shift_remove(&20), Some(200));
+        assert_eq!(m.shift_remove(&99), None);
+        assert_eq!(m.keys().copied().collect::<Vec<_>>(), vec![10, 30, 40]);
+        // Every surviving key still resolves to the right value after reindexing.
+        assert_eq!(m.get(&10), Some(&100));
+        assert_eq!(m.get(&30), Some(&300));
+        assert_eq!(m.get(&40), Some(&400));
+        assert_eq!(m.get_index_of(&40), Some(2));
+    }
+
+    #[test]
+    fn map_retain_and_drain() {
+        let mut m: OrderedMap<u32, u32> = OrderedMap::default();
+        for k in [1, 2, 3, 4, 5] {
+            m.insert(k, k);
+        }
+        m.retain(|k, _| k % 2 == 1);
+        assert_eq!(
+            m.iter().map(|(k, v)| (*k, *v)).collect::<Vec<_>>(),
+            vec![(1, 1), (3, 3), (5, 5)]
+        );
+        assert_eq!(m.get_index_of(&5), Some(2));
+        let drained: Vec<_> = m.drain(..).collect();
+        assert_eq!(drained, vec![(1, 1), (3, 3), (5, 5)]);
+        assert!(m.is_empty());
+        assert_eq!(m.get(&1), None);
+    }
+
+    #[test]
+    fn set_insert_contains_shift_remove() {
+        let mut s: OrderedSet<u32> = OrderedSet::default();
+        assert!(s.insert(5));
+        assert!(s.insert(1));
+        assert!(!s.insert(5)); // duplicate
+        assert!(s.contains(&1));
+        assert_eq!(s.iter().copied().collect::<Vec<_>>(), vec![5, 1]);
+        assert!(s.shift_remove(&5));
+        assert!(!s.shift_remove(&5));
+        assert_eq!(s.iter().copied().collect::<Vec<_>>(), vec![1]);
+        assert!(!s.contains(&5));
+    }
+}


### PR DESCRIPTION
The HIR's insertion-ordered CFG containers were `indexmap`-based:

- `HIR.blocks: FxIndexMap<BlockId, BasicBlock>` — iteration order is reverse-postorder, which is load-bearing (forward dataflow visits each block after its predecessors).
- `BasicBlock.preds: FxIndexSet<BlockId>` — predecessor order sets phi-operand order.
- `Phi.operands: FxIndexMap<BlockId, Place>` — one operand per predecessor, in that order.

`indexmap` has no arena-allocator variant, which blocks moving the HIR into an arena. `Vec` and hash maps do (`oxc_allocator::Vec` / `oxc_allocator::HashMap`), so this replaces those three fields with `OrderedMap` / `OrderedSet` — ordered containers backed by `Vec<(K, V)>` plus an `FxHashMap<K, usize>` index. They mirror the subset of the `IndexMap` / `IndexSet` API the HIR uses (`get`/`get_mut`/`insert`/`shift_remove`/`retain`/`drain`/`keys`/`values`/`iter[_mut]`/`get_index_of`, `IntoIterator`, `Index`, `DoubleEndedIterator`), preserving insertion order and O(1) lookup, so call sites are unchanged.

This is a preparatory step: the three fields are now composed of arena-convertible primitives, so the eventual arena move is a mechanical `Vec` -> `Vec<'a>` / `FxHashMap` -> arena `HashMap` swap rather than an impossible `indexmap` port.

The `SymbolId`-keyed builder maps and `StabilizeBlockIds`' scratch set stay `FxIndexMap` / `FxIndexSet` — they are pass-local working data, not HIR CFG structures.

Pure internal change: the fixtures snapshot is byte-identical; new unit tests cover the `shift_remove` / `retain` / `drain` reindexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

