### PR TITLE
perf(oxlint/lsp): only invoke lint on code actions when document is not opened

### DIFF
--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -4,13 +4,13 @@ use std::sync::{Arc, OnceLock};
 use ignore::gitignore::Gitignore;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tower_lsp_server::ls_types::{
-    CodeActionContext, CodeActionTriggerKind, DiagnosticOptions, DiagnosticServerCapabilities,
+    CodeActionTriggerKind, DiagnosticOptions, DiagnosticServerCapabilities,
 };
 use tower_lsp_server::{
     jsonrpc::ErrorCode,
     ls_types::{
         CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionProviderCapability,
-        Diagnostic, ExecuteCommandOptions, Pattern, Range, ServerCapabilities, Uri,
+        Diagnostic, ExecuteCommandOptions, Pattern, ServerCapabilities, Uri,
         WorkDoneProgressOptions, WorkspaceEdit,
     },
 };
@@ -23,8 +23,9 @@ use oxc_linter::{
 };
 
 use oxc_language_server::{
-    Capabilities, ConcurrentHashMap, DiagnosticMode, DiagnosticResult, TextDocument, Tool,
-    ToolBuilder, ToolRestartChanges, utils::normalize_user_config_path_to_watch_pattern,
+    Capabilities, CodeActionParams, ConcurrentHashMap, DiagnosticMode, DiagnosticResult,
+    TextDocument, Tool, ToolBuilder, ToolRestartChanges,
+    utils::normalize_user_config_path_to_watch_pattern,
 };
 
 use crate::{
@@ -528,7 +529,10 @@ impl Tool for ServerLinter {
             return Ok(None);
         }
 
-        let actions = self.get_code_actions_for_uri(&uri, Some(CodeActionTriggerKind::INVOKED));
+        // We only run the lint process when the code action is explicitly invoked and the file is not open in the editor.
+        let is_open = None;
+        let actions =
+            self.get_code_actions_for_uri(&uri, Some(CodeActionTriggerKind::INVOKED), is_open);
 
         let Some(actions) = actions else {
             return Ok(None);
@@ -552,13 +556,12 @@ impl Tool for ServerLinter {
         }))
     }
 
-    fn get_code_actions_or_commands(
-        &self,
-        uri: &Uri,
-        range: &Range,
-        context: &CodeActionContext,
-    ) -> Vec<CodeActionOrCommand> {
-        let actions = self.get_code_actions_for_uri(uri, context.trigger_kind);
+    fn get_code_actions_or_commands(&self, params: &CodeActionParams) -> Vec<CodeActionOrCommand> {
+        let actions = self.get_code_actions_for_uri(
+            &params.uri,
+            params.context.trigger_kind,
+            Some(params.is_open_document),
+        );
 
         let Some(actions) = actions else {
             return vec![];
@@ -568,7 +571,7 @@ impl Tool for ServerLinter {
             return vec![];
         }
 
-        let actions = actions.into_iter().filter(|r| range_overlaps(*range, r.range));
+        let actions = actions.into_iter().filter(|r| range_overlaps(params.range, r.range));
 
         // `context.only` is a special case here. ESLint behavior is if `source.fixAll` is the first element in `context.only`,
         // then only return fix all code action, and ignore other code actions, even if they are requested.
@@ -579,7 +582,7 @@ impl Tool for ServerLinter {
         // If no `context.only` is applied, only return the quick fix code actions.
         // If it is provided, we should loop over it and return the actions in the same order.
         // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionContext
-        let applying_kinds = match &context.only {
+        let applying_kinds = match &params.context.only {
             Some(only) => {
                 // `source.fixAll` and `source.fixAll.oxc` should behave the same, filter duplicate out
                 let mut seen = FxHashSet::default();
@@ -611,7 +614,7 @@ impl Tool for ServerLinter {
             if kind == CodeActionKind::SOURCE_FIX_ALL {
                 let Some(fix_all) = apply_all_fix_code_action(
                     actions.clone(),
-                    uri.clone(),
+                    params.uri.clone(),
                     self.rules_customization.as_ref(),
                 ) else {
                     continue;
@@ -626,7 +629,7 @@ impl Tool for ServerLinter {
                 }
                 let Some(fix_all) = apply_dangerous_fix_code_action(
                     actions.clone(),
-                    uri.clone(),
+                    params.uri.clone(),
                     self.rules_customization.as_ref(),
                 ) else {
                     continue;
@@ -634,7 +637,7 @@ impl Tool for ServerLinter {
                 code_actions_vec.push(CodeActionOrCommand::CodeAction(fix_all));
             } else if kind == CodeActionKind::QUICKFIX {
                 for action in actions.clone() {
-                    let fix_actions = apply_fix_code_actions(action, uri);
+                    let fix_actions = apply_fix_code_actions(action, &params.uri);
                     code_actions_vec
                         .extend(fix_actions.into_iter().map(CodeActionOrCommand::CodeAction));
                 }
@@ -707,6 +710,7 @@ impl ServerLinter {
         &self,
         uri: &Uri,
         trigger_kind: Option<CodeActionTriggerKind>,
+        is_open: Option<bool>,
     ) -> Option<Vec<LinterCodeAction>> {
         if let Some(cached_code_actions) = self.code_actions.pin().get(uri) {
             cached_code_actions.clone()
@@ -714,7 +718,9 @@ impl ServerLinter {
         // only run linting and generate code actions when the code action is explicitly invoked,
         // otherwise it will be too heavy to run linting on every file open or cursor move, which will cause performance issues and a bad user experience.
         // It is most likely that the client already sent a request, where we run the lint process and cache the code actions.
-        else if trigger_kind == Some(CodeActionTriggerKind::INVOKED) {
+        // So we only need to run the lint process when the code action is explicitly invoked and the file is not open in the editor.
+        else if trigger_kind == Some(CodeActionTriggerKind::INVOKED) && !is_open.unwrap_or(false)
+        {
             let _ = self.run_file(uri, None);
             self.code_actions.pin().get(uri).and_then(std::clone::Clone::clone)
         } else {
@@ -1103,7 +1109,7 @@ mod test_watchers {
 mod test {
     use std::{fs, path::PathBuf};
 
-    use oxc_language_server::Tool;
+    use oxc_language_server::{CodeActionParams, Tool};
     use oxc_linter::ExternalPluginStore;
     use rustc_hash::FxHashSet;
     use serde_json::json;
@@ -1118,6 +1124,14 @@ mod test {
         server_linter::ServerLinterBuilder,
         tester::{Tester, get_file_path},
     };
+
+    fn code_action_params(
+        uri: &tower_lsp_server::ls_types::Uri,
+        range: Range,
+        context: CodeActionContext,
+    ) -> CodeActionParams {
+        CodeActionParams { uri: uri.clone(), range, context, is_open_document: false }
+    }
 
     #[test]
     fn test_create_nested_configs() {
@@ -1170,25 +1184,25 @@ mod test {
         let _ = linter.run_file(&uri, Some("let a = 1;")).unwrap();
 
         // source.fixAll should only return safe fixes, not dangerous ones
-        let safe_actions = linter.get_code_actions_or_commands(
+        let safe_actions = linter.get_code_actions_or_commands(&code_action_params(
             &uri,
-            &range,
-            &CodeActionContext {
+            range,
+            CodeActionContext {
                 only: Some(vec![CodeActionKind::SOURCE_FIX_ALL]),
                 ..Default::default()
             },
-        );
+        ));
         assert!(safe_actions.is_empty(), "source.fixAll should not apply dangerous fixes");
 
         // source.fixAllDangerous.oxc should return dangerous fix actions when fix_kind is dangerous
-        let dangerous_actions = linter.get_code_actions_or_commands(
+        let dangerous_actions = linter.get_code_actions_or_commands(&code_action_params(
             &uri,
-            &range,
-            &CodeActionContext {
+            range,
+            CodeActionContext {
                 only: Some(vec![CODE_ACTION_KIND_SOURCE_FIX_ALL_DANGEROUS_OXC]),
                 ..Default::default()
             },
-        );
+        ));
         assert!(
             !dangerous_actions.is_empty(),
             "source.fixAllDangerous.oxc should return dangerous fix action when fix_kind is dangerous"
@@ -1203,19 +1217,22 @@ mod test {
         let range = Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX));
         let uri = tester.get_file_uri("quickfix.js");
         let _ = linter.run_file(&uri, Some("if (foo == NaN) {}")).unwrap();
-        let code_actions =
-            linter.get_code_actions_or_commands(&uri, &range, &CodeActionContext::default());
+        let code_actions = linter.get_code_actions_or_commands(&code_action_params(
+            &uri,
+            range,
+            CodeActionContext::default(),
+        ));
         assert_eq!(
             code_actions.len(),
             3,
             "Default Context: Should return 3 code actions: 1 rule fix + 2 ignore actions"
         );
 
-        let code_actions = linter.get_code_actions_or_commands(
+        let code_actions = linter.get_code_actions_or_commands(&code_action_params(
             &uri,
-            &range,
-            &CodeActionContext { only: Some(vec![CodeActionKind::QUICKFIX]), ..Default::default() },
-        );
+            range,
+            CodeActionContext { only: Some(vec![CodeActionKind::QUICKFIX]), ..Default::default() },
+        ));
 
         assert_eq!(
             code_actions.len(),
@@ -1223,14 +1240,14 @@ mod test {
             "Quickfix Context: Should return 3 code actions: 1 rule fix + 2 ignore actions"
         );
 
-        let code_actions = linter.get_code_actions_or_commands(
+        let code_actions = linter.get_code_actions_or_commands(&code_action_params(
             &uri,
-            &range,
-            &CodeActionContext {
+            range,
+            CodeActionContext {
                 only: Some(vec![CodeActionKind::QUICKFIX, CodeActionKind::SOURCE_FIX_ALL]),
                 ..Default::default()
             },
-        );
+        ));
 
         assert_eq!(
             code_actions.len(),
@@ -1238,10 +1255,10 @@ mod test {
             "Quickfix & FixAll Context: Should return 4 code actions: 1 rule fix + 2 ignore actions, and 1 fix all action"
         );
 
-        let code_actions = linter.get_code_actions_or_commands(
+        let code_actions = linter.get_code_actions_or_commands(&code_action_params(
             &uri,
-            &range,
-            &CodeActionContext {
+            range,
+            CodeActionContext {
                 only: Some(vec![
                     CodeActionKind::QUICKFIX,
                     CodeActionKind::SOURCE_FIX_ALL,
@@ -1249,7 +1266,7 @@ mod test {
                 ]),
                 ..Default::default()
             },
-        );
+        ));
 
         assert_eq!(
             code_actions.len(),
@@ -1266,8 +1283,11 @@ mod test {
         let linter = tester.create_linter();
         let range = Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX));
         let uri = tester.get_file_uri("quickfix.js");
-        let code_actions =
-            linter.get_code_actions_or_commands(&uri, &range, &CodeActionContext::default());
+        let code_actions = linter.get_code_actions_or_commands(&code_action_params(
+            &uri,
+            range,
+            CodeActionContext::default(),
+        ));
         assert_eq!(
             code_actions.len(),
             0,
@@ -1275,8 +1295,11 @@ mod test {
         );
 
         let _ = linter.run_file(&uri, Some("debugger;")).unwrap();
-        let code_actions =
-            linter.get_code_actions_or_commands(&uri, &range, &CodeActionContext::default());
+        let code_actions = linter.get_code_actions_or_commands(&code_action_params(
+            &uri,
+            range,
+            CodeActionContext::default(),
+        ));
 
         assert_eq!(
             code_actions.len(),
@@ -1291,14 +1314,14 @@ mod test {
         let linter = tester.create_linter();
         let range = Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX));
         let uri = tester.get_file_uri("trigger-kind-invoked.js");
-        let code_actions = linter.get_code_actions_or_commands(
+        let code_actions = linter.get_code_actions_or_commands(&code_action_params(
             &uri,
-            &range,
-            &CodeActionContext {
+            range,
+            CodeActionContext {
                 trigger_kind: Some(CodeActionTriggerKind::INVOKED),
                 ..Default::default()
             },
-        );
+        ));
         assert_eq!(
             code_actions.len(),
             3,

--- a/apps/oxlint/src/lsp/tester.rs
+++ b/apps/oxlint/src/lsp/tester.rs
@@ -230,9 +230,21 @@ impl Tester<'_> {
                     oxc_language_server::LanguageId::default(),
                     None,
                 )),
-                actions: linter.get_code_actions_or_commands(&uri, &range, &context),
+                actions: linter.get_code_actions_or_commands(
+                    &oxc_language_server::CodeActionParams {
+                        uri: uri.clone(),
+                        range,
+                        context: context.clone(),
+                        is_open_document: false,
+                    },
+                ),
                 fix_all_action: linter
-                    .get_code_actions_or_commands(&uri, &range, &fix_all_context)
+                    .get_code_actions_or_commands(&oxc_language_server::CodeActionParams {
+                        uri: uri.clone(),
+                        range,
+                        context: fix_all_context.clone(),
+                        is_open_document: false,
+                    })
                     .into_iter()
                     .next(),
             };

--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -766,13 +766,21 @@ impl LanguageServer for Backend {
     ///
     /// See: <https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction>
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
-        let uri = &params.text_document.uri;
-        let Some(worker) = self.worker_manager.get_worker_for_uri(uri).await else {
+        let uri = params.text_document.uri;
+        let Some(worker) = self.worker_manager.get_worker_for_uri(&uri).await else {
             return Ok(None);
         };
 
-        let code_actions =
-            worker.get_code_actions_or_commands(uri, &params.range, &params.context).await;
+        let is_open_document = self.file_system.is_open(&uri);
+
+        let params = crate::CodeActionParams {
+            uri,
+            range: params.range,
+            context: params.context,
+            is_open_document,
+        };
+
+        let code_actions = worker.get_code_actions_or_commands(&params).await;
 
         if code_actions.is_empty() {
             return Ok(None);

--- a/crates/oxc_language_server/src/file_system.rs
+++ b/crates/oxc_language_server/src/file_system.rs
@@ -103,6 +103,10 @@ impl LSPFileSystem {
         )
     }
 
+    pub fn is_open(&self, uri: &Uri) -> bool {
+        self.files.pin().contains_key(uri)
+    }
+
     pub fn remove(&self, uri: &Uri) {
         self.files.pin().remove(uri);
     }

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -13,6 +13,7 @@ mod position;
 #[cfg(test)]
 mod tests;
 mod tool;
+mod tool_params;
 pub mod utils;
 mod worker;
 mod worker_manager;
@@ -21,6 +22,7 @@ pub use crate::capabilities::{Capabilities, DiagnosticMode};
 pub use crate::language_id::LanguageId;
 pub use crate::position::offset_to_position;
 pub use crate::tool::{DiagnosticResult, Tool, ToolBuilder, ToolRestartChanges};
+pub use crate::tool_params::CodeActionParams;
 pub use crate::worker::WorkspaceWorker;
 pub use crate::worker_manager::WorkerManager;
 

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -138,11 +138,9 @@ impl Tool for FakeTool {
 
     fn get_code_actions_or_commands(
         &self,
-        uri: &Uri,
-        _range: &Range,
-        _context: &CodeActionContext,
+        params: &crate::CodeActionParams,
     ) -> Vec<CodeActionOrCommand> {
-        if uri.as_str().ends_with("code_action.config") {
+        if params.uri.as_str().ends_with("code_action.config") {
             return vec![CodeActionOrCommand::CodeAction(CodeAction {
                 title: "Code Action title".to_string(),
                 kind: Some(CodeActionKind::QUICKFIX),

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -1,12 +1,11 @@
 use tower_lsp_server::{
     jsonrpc::ErrorCode,
     ls_types::{
-        CodeActionContext, CodeActionOrCommand, Diagnostic, Pattern, Range, ServerCapabilities,
-        TextEdit, Uri, WorkspaceEdit,
+        CodeActionOrCommand, Diagnostic, Pattern, ServerCapabilities, TextEdit, Uri, WorkspaceEdit,
     },
 };
 
-use crate::{TextDocument, capabilities::Capabilities};
+use crate::{CodeActionParams, TextDocument, capabilities::Capabilities};
 
 pub trait ToolBuilder: Send + Sync {
     /// Modify the server capabilities to include capabilities provided by this tool.
@@ -73,16 +72,11 @@ pub trait Tool: Send + Sync {
         Err(ErrorCode::InvalidParams)
     }
 
-    /// Get code actions or commands provided by this tool for the given URI and range.
-    /// The tool should filter the code actions based on the provided range.
+    /// Get code actions or commands provided by this tool.
+    /// The tool should filter the code actions based on the requested range.
     /// The context can be used to further filter the code actions,
     /// for example by the `only` field which indicates that only code actions of certain kinds are requested.
-    fn get_code_actions_or_commands(
-        &self,
-        _uri: &Uri,
-        _range: &Range,
-        _context: &CodeActionContext,
-    ) -> Vec<CodeActionOrCommand> {
+    fn get_code_actions_or_commands(&self, _params: &CodeActionParams) -> Vec<CodeActionOrCommand> {
         Vec::new()
     }
 

--- a/crates/oxc_language_server/src/tool_params.rs
+++ b/crates/oxc_language_server/src/tool_params.rs
@@ -1,0 +1,9 @@
+use tower_lsp_server::ls_types::{CodeActionContext, Range, Uri};
+
+/// Code-action request data passed from the language-server backend to a tool.
+pub struct CodeActionParams {
+    pub uri: Uri,
+    pub range: Range,
+    pub context: CodeActionContext,
+    pub is_open_document: bool,
+}

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -6,16 +6,15 @@ use tokio::sync::{Mutex, RwLock};
 use tower_lsp_server::{
     jsonrpc::ErrorCode,
     ls_types::{
-        CodeActionContext, CodeActionOrCommand, Diagnostic,
-        DidChangeWatchedFilesRegistrationOptions, FileEvent, FileSystemWatcher, GlobPattern, OneOf,
-        Range, Registration, RelativePattern, TextEdit, Unregistration, Uri, WatchKind,
-        WorkspaceEdit,
+        CodeActionOrCommand, Diagnostic, DidChangeWatchedFilesRegistrationOptions, FileEvent,
+        FileSystemWatcher, GlobPattern, OneOf, Registration, RelativePattern, TextEdit,
+        Unregistration, Uri, WatchKind, WorkspaceEdit,
     },
 };
 use tracing::debug;
 
 use crate::{
-    TextDocument, ToolRestartChanges,
+    CodeActionParams, TextDocument, ToolRestartChanges,
     capabilities::DiagnosticMode,
     file_system::LSPFileSystem,
     tool::{DiagnosticResult, Tool, ToolBuilder},
@@ -219,17 +218,15 @@ impl WorkspaceWorker {
         (uris_to_clear_diagnostics, watchers_to_unregister)
     }
 
-    /// Get code actions or commands for the given range.
+    /// Get code actions or commands for the given request.
     /// It calls all tools and collects their code actions or commands.
     pub async fn get_code_actions_or_commands(
         &self,
-        uri: &Uri,
-        range: &Range,
-        context: &CodeActionContext,
+        params: &CodeActionParams,
     ) -> Vec<CodeActionOrCommand> {
         let mut actions = Vec::new();
         if let Some(tool) = self.tool.read().await.as_ref() {
-            actions.extend(tool.get_code_actions_or_commands(uri, range, context));
+            actions.extend(tool.get_code_actions_or_commands(params));
         }
         actions
     }
@@ -433,7 +430,7 @@ mod tests {
     use tower_lsp_server::ls_types::{DidChangeWatchedFilesRegistrationOptions, GlobPattern};
 
     use crate::{
-        LanguageId, TextDocument, ToolBuilder,
+        CodeActionParams, LanguageId, TextDocument, ToolBuilder,
         capabilities::DiagnosticMode,
         file_system::LSPFileSystem,
         tests::{FAKE_COMMAND, FakeToolBuilder},
@@ -698,21 +695,23 @@ mod tests {
         worker.start_worker(serde_json::Value::Null).await;
 
         let actions = worker
-            .get_code_actions_or_commands(
-                &Uri::from_str("file:///root/file.js").unwrap(),
-                &Range::default(),
-                &CodeActionContext::default(),
-            )
+            .get_code_actions_or_commands(&CodeActionParams {
+                uri: Uri::from_str("file:///root/file.js").unwrap(),
+                range: Range::default(),
+                context: CodeActionContext::default(),
+                is_open_document: false,
+            })
             .await;
 
         assert_eq!(actions.len(), 0);
 
         let actions = worker
-            .get_code_actions_or_commands(
-                &Uri::from_str("file:///root/code_action.config").unwrap(),
-                &Range::default(),
-                &CodeActionContext::default(),
-            )
+            .get_code_actions_or_commands(&CodeActionParams {
+                uri: Uri::from_str("file:///root/code_action.config").unwrap(),
+                range: Range::default(),
+                context: CodeActionContext::default(),
+                is_open_document: false,
+            })
             .await;
 
         assert_eq!(actions.len(), 1);


### PR DESCRIPTION
Some clients can send code actions for documents, which are not opened and already analyzed with a lint process.
A good example is the IntelliJ plugin, which allows the "fix all" code action from the file explorer.

> This PR refactors the language-server → tool code-action API to pass a single request struct (including an “is document open” flag), enabling the oxlint LSP linter to avoid re-running lint for code-action requests when the document is already open (and presumably already linted/cached).

This is mostly needed for https://github.com/oxc-project/oxc/pull/23768
