### PR TITLE
perf(linter): skip source text copy for diagnostics that won't be rendered

### DIFF
--- a/apps/oxfmt/src/cli/service.rs
+++ b/apps/oxfmt/src/cli/service.rs
@@ -8,7 +8,7 @@ use std::{
 use cow_utils::CowUtils;
 use rayon::prelude::*;
 
-use oxc_diagnostics::{DiagnosticSender, DiagnosticService};
+use oxc_diagnostics::{DiagnosticSender, DiagnosticService, SourcePolicy};
 
 use super::command::OutputMode;
 use crate::core::{FormatResult, FormatStrategy, SourceFormatter, utils};
@@ -57,6 +57,7 @@ impl FormatService {
                         ))
                         .with_help("This may be due to the file being a binary or inaccessible."),
                     ],
+                    SourcePolicy::Always,
                 );
                 let _ = tx_error.send(diagnostics);
                 return;
@@ -70,6 +71,7 @@ impl FormatService {
                         &path,
                         &source_text,
                         diagnostics,
+                        SourcePolicy::Always,
                     );
                     let _ = tx_error.send(errors);
                     return;
@@ -89,6 +91,7 @@ impl FormatService {
                                 "Failed to save '{}': {err}",
                                 path.display()
                             ))],
+                            SourcePolicy::Always,
                         );
                         let _ = tx_error.send(diagnostics);
                         return;

--- a/apps/oxfmt/src/cli/walk.rs
+++ b/apps/oxfmt/src/cli/walk.rs
@@ -10,7 +10,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::instrument;
 
 use oxc_config::{all_paths_have_vcs_boundary, configure_walk_builder};
-use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic};
+use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic, SourcePolicy};
 
 use super::resolve::{build_global_ignore_matchers, is_ignored};
 #[cfg(feature = "napi")]
@@ -682,6 +682,7 @@ fn resolve_format_strategy(
                     ))
                     .with_help(err),
                 ],
+                SourcePolicy::Always,
             );
             let _ = tx_error.send(diagnostics);
             None

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -11,7 +11,9 @@ use std::{
 use cow_utils::CowUtils;
 use ignore::{gitignore::Gitignore, overrides::OverrideBuilder};
 
-use oxc_diagnostics::{DiagnosticSender, DiagnosticService, GraphicalReportHandler, OxcDiagnostic};
+use oxc_diagnostics::{
+    DiagnosticSender, DiagnosticService, GraphicalReportHandler, OxcDiagnostic, SourcePolicy,
+};
 use oxc_linter::{
     AllowWarnDeny, ConfigBuilderError, ConfigStore, ConfigStoreBuilder, ExternalLinter,
     ExternalPluginStore, InvalidFilterKind, LintFilter, LintOptions, LintRunner,
@@ -363,8 +365,19 @@ impl CliRunner {
         // the same functionality.
         let use_cross_module = lint_config.plugins().has_import()
             || nested_configs.values().any(|config| config.plugins().has_import());
-        let mut options =
-            LintServiceOptions::new(self.cwd.clone()).with_cross_module(use_cross_module);
+        // Skip attaching (copying) source text to diagnostics that will never be rendered:
+        // everything under `--silent`, and warnings under `--quiet`. This must mirror the
+        // severity filtering in `DiagnosticService::run`.
+        let source_policy = if misc_options.silent {
+            SourcePolicy::Never
+        } else if warning_options.quiet {
+            SourcePolicy::ErrorsOnly
+        } else {
+            SourcePolicy::Always
+        };
+        let mut options = LintServiceOptions::new(self.cwd.clone())
+            .with_cross_module(use_cross_module)
+            .with_source_policy(source_policy);
 
         let mut suppression_manager = SuppressionManager::load(
             options.cwd(),

--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -56,7 +56,7 @@ use std::{
 
 pub mod reporter;
 
-pub use crate::service::{DiagnosticSender, DiagnosticService};
+pub use crate::service::{DiagnosticSender, DiagnosticService, SourcePolicy};
 
 pub type Error = miette::Error;
 pub type Severity = miette::Severity;

--- a/crates/oxc_diagnostics/src/service.rs
+++ b/crates/oxc_diagnostics/src/service.rs
@@ -18,6 +18,29 @@ use crate::{
 pub type DiagnosticSender = mpsc::Sender<Vec<Error>>;
 pub type DiagnosticReceiver = mpsc::Receiver<Vec<Error>>;
 
+/// Controls whether [`wrap_diagnostics`](DiagnosticService::wrap_diagnostics) attaches a copy of
+/// the source text to the diagnostics it produces.
+///
+/// Attaching source text requires copying the entire file (`source_text.to_owned()`), so it is
+/// wasteful to do it for diagnostics that will never be rendered. The [`DiagnosticService`] filters
+/// warnings (`--quiet`) and all diagnostics (`--silent`) *after* they are produced, so without a
+/// policy the source of every violating file is copied even when it is immediately dropped.
+///
+/// The severity-based filtering in [`DiagnosticService::run`] still counts warnings even when they
+/// are not rendered, so [`ErrorsOnly`](SourcePolicy::ErrorsOnly)/[`Never`](SourcePolicy::Never) only
+/// skip attaching source — the diagnostics themselves are still returned and counted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SourcePolicy {
+    /// Always attach source text. Use when any diagnostic may be rendered (the default).
+    #[default]
+    Always,
+    /// Never attach source text. Use under `--silent`, where nothing is rendered.
+    Never,
+    /// Attach source text only if at least one diagnostic has [error](Severity::Error) severity.
+    /// Use under `--quiet`, where warnings are counted but never rendered.
+    ErrorsOnly,
+}
+
 /// Listens for diagnostics sent over a [channel](DiagnosticSender) by some job, and
 /// formats/reports them to the user.
 ///
@@ -121,7 +144,22 @@ impl DiagnosticService {
         path: P,
         source_text: &str,
         diagnostics: Vec<OxcDiagnostic>,
+        source_policy: SourcePolicy,
     ) -> Vec<Error> {
+        // Skip copying the source text when none of these diagnostics will be rendered.
+        // The source is shared across all diagnostics of a file, so it is only needed if at least
+        // one of them will actually be printed (see [`SourcePolicy`]).
+        let attach_source = match source_policy {
+            SourcePolicy::Always => true,
+            SourcePolicy::Never => false,
+            SourcePolicy::ErrorsOnly => {
+                diagnostics.iter().any(|diagnostic| diagnostic.severity == Severity::Error)
+            }
+        };
+        if !attach_source {
+            return diagnostics.into_iter().map(Error::from).collect();
+        }
+
         // TODO: This causes snapshots to fail when running tests through a JetBrains terminal.
         let is_jetbrains =
             std::env::var("TERMINAL_EMULATOR").is_ok_and(|x| x.eq("JetBrains-JediTerm"));
@@ -345,16 +383,77 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::{
-        Error, OxcDiagnostic,
+        Error, OxcDiagnostic, Severity,
         reporter::{DiagnosticReporter, DiagnosticResult},
         service::from_file_path,
     };
 
-    use super::DiagnosticService;
+    use super::{DiagnosticService, SourcePolicy};
 
     fn with_schema(path: &str) -> String {
         const EXPECTED_SCHEMA: &str = if cfg!(windows) { "file:///" } else { "file://" };
         format!("{EXPECTED_SCHEMA}{path}")
+    }
+
+    fn wrap(diagnostics: Vec<OxcDiagnostic>, policy: SourcePolicy) -> Vec<Error> {
+        DiagnosticService::wrap_diagnostics(
+            "/cwd",
+            "/cwd/file.js",
+            "source text",
+            diagnostics,
+            policy,
+        )
+    }
+
+    // Whether every diagnostic still carries its severity, so `DiagnosticService::run` can count it
+    // even when the source text was not attached.
+    fn severities(errors: &[Error]) -> Vec<Option<Severity>> {
+        errors.iter().map(|e| e.severity()).collect()
+    }
+
+    #[test]
+    fn source_policy_always_attaches_source() {
+        let errors =
+            wrap(vec![OxcDiagnostic::warn("w"), OxcDiagnostic::error("e")], SourcePolicy::Always);
+        assert_eq!(errors.len(), 2);
+        assert!(errors.iter().all(|e| e.source_code().is_some()));
+        assert_eq!(severities(&errors), vec![Some(Severity::Warning), Some(Severity::Error)]);
+    }
+
+    #[test]
+    fn source_policy_never_skips_source_but_keeps_diagnostics() {
+        // `--silent`: nothing is rendered, so no source is attached even for errors,
+        // but the diagnostics are still returned so they can be counted.
+        let errors =
+            wrap(vec![OxcDiagnostic::warn("w"), OxcDiagnostic::error("e")], SourcePolicy::Never);
+        assert_eq!(errors.len(), 2);
+        assert!(errors.iter().all(|e| e.source_code().is_none()));
+        assert_eq!(severities(&errors), vec![Some(Severity::Warning), Some(Severity::Error)]);
+    }
+
+    #[test]
+    fn source_policy_errors_only_skips_source_when_all_warnings() {
+        // `--quiet` on a warning-only file: warnings are counted but never rendered, so the
+        // expensive `source_text.to_owned()` copy is skipped entirely.
+        let errors = wrap(
+            vec![OxcDiagnostic::warn("w1"), OxcDiagnostic::warn("w2")],
+            SourcePolicy::ErrorsOnly,
+        );
+        assert_eq!(errors.len(), 2);
+        assert!(errors.iter().all(|e| e.source_code().is_none()));
+        assert_eq!(severities(&errors), vec![Some(Severity::Warning), Some(Severity::Warning)]);
+    }
+
+    #[test]
+    fn source_policy_errors_only_attaches_source_when_any_error() {
+        // `--quiet` on a file with at least one error: the error will be rendered, so source is
+        // attached (and shared with the warnings, which are dropped later without extra cost).
+        let errors = wrap(
+            vec![OxcDiagnostic::warn("w"), OxcDiagnostic::error("e")],
+            SourcePolicy::ErrorsOnly,
+        );
+        assert_eq!(errors.len(), 2);
+        assert!(errors.iter().all(|e| e.source_code().is_some()));
     }
 
     #[test]

--- a/crates/oxc_linter/src/lint_runner.rs
+++ b/crates/oxc_linter/src/lint_runner.rs
@@ -6,7 +6,7 @@ use std::{
 
 use rustc_hash::FxHashMap;
 
-use oxc_diagnostics::{DiagnosticSender, DiagnosticService};
+use oxc_diagnostics::{DiagnosticSender, DiagnosticService, SourcePolicy};
 use oxc_span::Span;
 
 use crate::{
@@ -102,6 +102,7 @@ impl DirectivesStore {
                     path.clone(),
                     &source_text,
                     diagnostics,
+                    SourcePolicy::Always,
                 );
                 tx_error.send(wrapped).expect("failed to send unused directive diagnostics");
             }

--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -6,7 +6,7 @@ use std::{
 
 use rustc_hash::FxHashMap;
 
-use oxc_diagnostics::DiagnosticSender;
+use oxc_diagnostics::{DiagnosticSender, SourcePolicy};
 
 use crate::{Linter, RuleTimingStore, suppression::DiffManager};
 
@@ -21,6 +21,12 @@ pub struct LintServiceOptions {
     tsconfig: Option<PathBuf>,
 
     cross_module: bool,
+
+    /// Whether to attach source text to produced diagnostics.
+    ///
+    /// Set from `--quiet`/`--silent` so warning-only (or all, under `--silent`) files skip the
+    /// full `source_text.to_owned()` copy for diagnostics that will never be rendered.
+    source_policy: SourcePolicy,
 }
 
 impl LintServiceOptions {
@@ -29,7 +35,22 @@ impl LintServiceOptions {
     where
         T: Into<Box<Path>>,
     {
-        Self { cwd: cwd.into(), tsconfig: None, cross_module: false }
+        Self {
+            cwd: cwd.into(),
+            tsconfig: None,
+            cross_module: false,
+            source_policy: SourcePolicy::Always,
+        }
+    }
+
+    /// Set the [`SourcePolicy`] controlling whether source text is attached to diagnostics.
+    ///
+    /// Defaults to [`SourcePolicy::Always`].
+    #[inline]
+    #[must_use]
+    pub fn with_source_policy(mut self, source_policy: SourcePolicy) -> Self {
+        self.source_policy = source_policy;
+        self
     }
 
     #[inline]

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -20,7 +20,7 @@ use self_cell::self_cell;
 use smallvec::SmallVec;
 
 use oxc_allocator::{Allocator, AllocatorGuard, AllocatorPool, ArenaBox};
-use oxc_diagnostics::{DiagnosticSender, DiagnosticService, Error, OxcDiagnostic};
+use oxc_diagnostics::{DiagnosticSender, DiagnosticService, Error, OxcDiagnostic, SourcePolicy};
 use oxc_parser::{ParseOptions, Parser, Token, config::RuntimeParserConfig};
 use oxc_resolver::Resolver;
 use oxc_semantic::{Semantic, SemanticBuilder};
@@ -66,6 +66,8 @@ pub struct Runtime {
     modules_by_path: ModulesByPath,
     /// Collected disable directives from linted files
     disable_directives_map: Arc<Mutex<FxHashMap<PathBuf, DisableDirectives>>>,
+    /// Whether to attach source text to produced diagnostics (see [`SourcePolicy`]).
+    source_policy: SourcePolicy,
 }
 
 /// Output of `Runtime::process_path`
@@ -256,6 +258,7 @@ impl Runtime {
         #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
         let allocator_pool = AllocatorPool::new(thread_count);
 
+        let source_policy = options.source_policy;
         let resolver = options.cross_module.then(|| Self::get_resolver(options.tsconfig));
 
         Self {
@@ -270,6 +273,7 @@ impl Runtime {
                 .resize_mode(papaya::ResizeMode::Blocking)
                 .build(),
             disable_directives_map: Arc::new(Mutex::new(FxHashMap::default())),
+            source_policy,
         }
     }
 
@@ -658,6 +662,7 @@ impl Runtime {
                                             path,
                                             dep.source_text,
                                             messages,
+                                            me.source_policy,
                                         );
                                         tx_error.send(diagnostics).unwrap();
                                     }
@@ -719,6 +724,7 @@ impl Runtime {
                                 path,
                                 dep.source_text,
                                 errors,
+                                me.source_policy,
                             );
                             tx_error.send(diagnostics).unwrap();
                         }
@@ -873,6 +879,7 @@ impl Runtime {
                                                 Path::new(&module_to_lint.path),
                                                 source_text,
                                                 diagnostics,
+                                                me.source_policy,
                                             );
                                             tx_error.send(wrapped).unwrap();
                                         }

--- a/crates/oxc_linter/src/suppression/mod.rs
+++ b/crates/oxc_linter/src/suppression/mod.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic};
+use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic, SourcePolicy};
 use rustc_hash::FxHashMap;
 
 mod diff;
@@ -169,8 +169,13 @@ impl SuppressionManager {
             // Read-only mode: report diagnostics for any differences
             let (errors, has_unused) = Self::compute_diagnostics(&static_map, &runtime_map);
             if !errors.is_empty() {
-                let diagnostics =
-                    DiagnosticService::wrap_diagnostics(cwd, Path::new(""), "", errors);
+                let diagnostics = DiagnosticService::wrap_diagnostics(
+                    cwd,
+                    Path::new(""),
+                    "",
+                    errors,
+                    SourcePolicy::Always,
+                );
                 tx_error.send(diagnostics).unwrap();
             }
             if has_unused {

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -13,7 +13,9 @@ use oxc_allocator::Allocator;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
-use oxc_diagnostics::{DiagnosticSender, DiagnosticService, Error, OxcDiagnostic, Severity};
+use oxc_diagnostics::{
+    DiagnosticSender, DiagnosticService, Error, OxcDiagnostic, Severity, SourcePolicy,
+};
 use oxc_span::{SourceType, Span};
 
 use super::{AllowWarnDeny, ConfigStore, DisableDirectives, ResolvedLinterState, read_to_string};
@@ -319,6 +321,7 @@ impl TsGoLintState {
                             &path,
                             source_for_diagnostics,
                             filtered_messages,
+                            SourcePolicy::Always,
                         );
                         sender_for_fixes.send(diagnostics).expect("Failed to send diagnostics");
                     }
@@ -1113,6 +1116,7 @@ impl DiagnosticHandler {
                 file_path,
                 &source_text,
                 vec![oxc_diagnostic],
+                SourcePolicy::Always,
             )
         } else {
             vec![oxc_diagnostic.into()]
@@ -1138,6 +1142,7 @@ impl DiagnosticHandler {
             path,
             &source_text,
             vec![oxc_diagnostic],
+            SourcePolicy::Always,
         );
         self.error_sender.send(diagnostics).expect("Failed to send diagnostics");
     }
@@ -1191,6 +1196,7 @@ impl DiagnosticHandler {
                         &path,
                         source_text.as_str(),
                         filtered_messages,
+                        SourcePolicy::Always,
                     );
                     self.error_sender.send(diagnostics).expect("Failed to send diagnostics");
                 } else if !messages_requiring_fixes.contains_key(&path) {


### PR DESCRIPTION
AI Disclosure: Generated with Claude, reviewed and tested by me.

## What

For every violating file, `DiagnosticService::wrap_diagnostics` copies the file's entire source text out of the arena once (`source_text.to_owned()`, wrapped in a `NamedSource` and `Arc`-shared across that file's diagnostics) — in the producer thread, *before* the `--quiet` / `--silent` severity filter runs in `DiagnosticService::run`. The sharing across diagnostics already keeps memory at one copy per file; the problem is that the per-file copy itself is made even when nothing will be rendered.

As a result, warnings that `--quiet` silences (and everything under `--silent`) still pay for a full-file source copy that is immediately dropped and never rendered. Buffering formatters (`json`, `checkstyle`, `sarif`, `gitlab`, `junit`, `stylish`) additionally retain those copies until the end of the run.

Note that this does not apply to tsgolint-based diagnostics because I figured it'd likely be annoying to thread this change through to tsgolint for the first attempt.

## How

Introduce a `SourcePolicy` (`Always` / `Never` / `ErrorsOnly`) and thread it from the CLI flags through `LintServiceOptions` → `Runtime` → `wrap_diagnostics`:

- `--silent` → `Never`
- `--quiet` → `ErrorsOnly` (copy source only when at least one diagnostic in the
  batch is an error, since the source is shared per file)
- default → `Always`

Diagnostics are still **returned and counted** either way, so warning counts and `--max-warnings` are unaffected — only the source *attachment* is skipped. The policy is derived from the same flags as the render-time filter, so a diagnostic is only ever source-less when it would be filtered before `render_error`. Non-linter callers pass `Always` to preserve their behavior.

## Benchmarks

Measured with an interleaved paired-sample harness (two binaries run back-to-back
each round, order alternating; `paired Δ` = median per-round
`baseline_peak − candidate_peak`, which cancels round-level machine noise).

### Stress corpus — 2000 files × ~80KB, 1 warning/file (peak RSS, median of 8 paired rounds)

| formatter / quiet-mode     | args                   | base med | cand med | paired Δ | reduction |
|----------------------------|------------------------|---------:|---------:|---------:|----------:|
| default(stream) / no-quiet | (none)                 |    211.3 |    211.3 |     -0.0 |       -0% |
| default(stream) / quiet    | --quiet                |    175.5 |     20.8 |    153.4 |       87% |
| default(stream) / silent   | --silent               |    151.5 |     21.1 |    130.7 |       86% |
| json(buffered) / no-quiet  | --format=json          |    186.7 |    193.4 |     -6.8 |       -4% |
| json(buffered) / quiet     | --format=json --quiet  |    162.4 |     20.8 |    141.7 |       87% |
| json(buffered) / silent    | --format=json --silent |    174.5 |     19.9 |    153.9 |       88% |

Under `--quiet`/`--silent` peak RSS drops to the bare parse/lint working set
(~20MB) regardless of formatter — the entire per-file `source_text.to_owned()`
cost is gone. The `no-quiet` rows are unchanged (the fix doesn't touch that path;
the small negative json/no-quiet Δ is allocator jitter).

Wall time from the same run: `no-quiet` unchanged; `--quiet`/`--silent` show a
small but consistently-positive paired delta (~3–6ms, 9–16%) from the avoided
memcpy/frees. It's a large **memory** win and a modest **wall-time** win.

### Normal-size corpus — 400 files × ~4KB (no-regression check)

At realistic project size (1.6MB total source) both binaries sit near the ~2–13MB allocator/parse-lint floor, so per-cell deltas are sub-MB and swing sign run-to-run — i.e. noise, with nothing left to save and nothing to regress. `no-quiet` is identical to baseline, `exit=0/0` everywhere (warnings still counted), and `--quiet`/`--silent` still suppress output. The memory benefit scales with the total source volume of warning-only files, so it's large on the stress corpus and correctly shrinks to nothing on a normal-size one, with no downside at small sizes.

## Test plan

- New unit tests in `oxc_diagnostics` covering all three `SourcePolicy` variants
  (source attached/skipped, diagnostics + severities preserved either way).
- `cargo test -p oxc_diagnostics -p oxc_linter -p oxlint` green.
- Functional smoke test: default renders frames; `--quiet` suppresses but still
  counts; `--format=json` line/col still resolve; `--format=json --quiet` empty
  with counts intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

