### PR TITLE
perf(parser): pre-size cover-grammar assignment target buffers

### DIFF
--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -97,10 +97,10 @@ impl<'a, C: Config> CoverGrammar<'a, ArrayExpression<'a>, C> for ArrayAssignment
     // would otherwise carry this body's large stack frame + callee-saved spills on every call.
     #[inline(never)]
     fn cover(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
-        let mut elements = ArenaVec::new_in(p);
+        let len = expr.elements.len();
+        let mut elements = ArenaVec::with_capacity_in(len, p);
         let mut rest = None;
 
-        let len = expr.elements.len();
         for (i, elem) in expr.elements.into_iter().enumerate() {
             match elem {
                 match_expression!(ArrayExpressionElement) => {
@@ -174,10 +174,10 @@ impl<'a, C: Config> CoverGrammar<'a, ObjectExpression<'a>, C> for ObjectAssignme
     // inlining this large body into the hot `AssignmentTarget::cover` dispatcher.
     #[inline(never)]
     fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
-        let mut properties = ArenaVec::new_in(p);
+        let len = expr.properties.len();
+        let mut properties = ArenaVec::with_capacity_in(len, p);
         let mut rest = None;
 
-        let len = expr.properties.len();
         for (i, elem) in expr.properties.into_iter().enumerate() {
             match elem {
                 ObjectPropertyKind::ObjectProperty(property) => {

--- a/tasks/track_memory_allocations/allocs_parser.yaml
+++ b/tasks/track_memory_allocations/allocs_parser.yaml
@@ -6,7 +6,7 @@ checker.ts:
   sys alloc bytes: 4820 # 4.82 kB
   sys peak growth: 2432 # 2.43 kB
   arena allocs: 264366
-  arena reallocs: 22860
+  arena reallocs: 22858
   arena size: 12985152 # 12.99 MB
 
 App.tsx:
@@ -39,7 +39,7 @@ pdf.mjs:
   sys alloc bytes: 24020 # 24.02 kB
   sys peak growth: 12140 # 12.14 kB
   arena allocs: 90583
-  arena reallocs: 8153
+  arena reallocs: 8136
   arena size: 4559872 # 4.56 MB
 
 antd.js:
@@ -72,6 +72,6 @@ kitchen-sink.tsx:
   sys alloc bytes: 51381 # 51.38 kB
   sys peak growth: 14644 # 14.64 kB
   arena allocs: 138059
-  arena reallocs: 11905
+  arena reallocs: 11898
   arena size: 6495776 # 6.50 MB
 


### PR DESCRIPTION
The array/object destructuring assignment-target cover conversion
(`ArrayAssignmentTarget::cover` / `ObjectAssignmentTarget::cover`) built its
target buffer from empty and let it grow via arena reallocs as targets were
pushed. Each source element or property yields at most one target, so the
final length is a known upper bound — reserve it up front with
`with_capacity_in`.

Removes a handful of arena reallocs on the tracked parser fixtures:

- `checker.ts`: −2
- `pdf.mjs`: −17
- `kitchen-sink.tsx`: −7

No change to arena size or system allocations.
