### PR TITLE
perf(linter/unicorn/prefer-event-target): only run on `Class` and `NewExpression` nodes

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3586,7 +3586,7 @@ impl RuleRunner for crate::rules::unicorn::prefer_dom_node_text_content::PreferD
 
 impl RuleRunner for crate::rules::unicorn::prefer_event_target::PreferEventTarget {
     const NODE_TYPES: Option<&AstTypesBitset> =
-        Some(&AstTypesBitset::from_types(&[AstType::IdentifierReference]));
+        Some(&AstTypesBitset::from_types(&[AstType::Class, AstType::NewExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -1,4 +1,3 @@
-use oxc_allocator::{GetAddress, UnstableAddress};
 use oxc_ast::{
     AstKind,
     ast::{Argument, BindingPattern, Expression, IdentifierReference},
@@ -57,26 +56,24 @@ declare_oxc_lint!(
 
 impl Rule for PreferEventTarget {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::IdentifierReference(ident) = node.kind() else {
-            return;
+        let ident = match node.kind() {
+            AstKind::Class(class) => {
+                let Some(Expression::Identifier(ident)) = &class.super_class else {
+                    return;
+                };
+                ident
+            }
+            AstKind::NewExpression(new_expr) => {
+                let Expression::Identifier(ident) = &new_expr.callee else {
+                    return;
+                };
+                ident
+            }
+            _ => return,
         };
 
         if ident.name.as_str() != "EventEmitter" {
             return;
-        }
-
-        match ctx.nodes().parent_kind(node.id()) {
-            AstKind::Class(_) => {}
-            AstKind::NewExpression(new_expr) => {
-                let Expression::Identifier(callee_ident) = &new_expr.callee else {
-                    return;
-                };
-
-                if ident.unstable_address() != callee_ident.address() {
-                    return;
-                }
-            }
-            _ => return,
         }
 
         if is_event_emitter_from_ignored_package(ident, ctx) {

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -612,7 +612,7 @@ unicorn/prefer-dom-node-append                             |  62606
 unicorn/prefer-dom-node-dataset                            |  62606
 unicorn/prefer-dom-node-remove                             |  62606
 unicorn/prefer-dom-node-text-content                       |  77232
-unicorn/prefer-event-target                                | 209565
+unicorn/prefer-event-target                                |   1721
 unicorn/prefer-export-from                                 |    103
 unicorn/prefer-global-this                                 | 209565
 unicorn/prefer-import-meta-properties                      |      3


### PR DESCRIPTION
Narrow `unicorn/prefer-event-target` dispatch from every `IdentifierReference` to only `Class` and `NewExpression` nodes.

This reduces rule invocations from 209,565 to 1,721 (99.18%) while preserving existing behavior

P.S. found it running oxlint on my work codebase, used chatgpt 5.6 to implement the performance improvement
