### PR TITLE
fix(isolated-declarations): reject `window.Symbol`  as global symbol reference

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -48,22 +48,21 @@ impl<'a> IsolatedDeclarations<'a> {
         }
     }
 
-    /// Check the property key whether it is a `Symbol.iterator` or `global.Symbol.iterator`
+    /// Check whether the property key is `Symbol.iterator` or `globalThis.Symbol.iterator`.
     pub(crate) fn is_global_symbol(key: &PropertyKey<'a>) -> bool {
         let PropertyKey::StaticMemberExpression(member) = key else {
             return false;
         };
 
-        // TODO: Unsupported checking if it is a global Symbol yet
         match &member.object {
             // `Symbol.iterator`
             Expression::Identifier(ident) => ident.name == "Symbol",
-            // `global.Symbol.iterator`
+            // `globalThis.Symbol.iterator`
             Expression::StaticMemberExpression(expr) => {
                 expr.property.name == "Symbol"
                     && matches!(
                         &expr.object, Expression::Identifier(ident)
-                        if matches!(ident.name.as_str(), "window" | "globalThis")
+                        if ident.name == "globalThis"
                     )
             }
             _ => false,

--- a/crates/oxc_isolated_declarations/tests/fixtures/computed-symbol.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/computed-symbol.ts
@@ -1,0 +1,13 @@
+export class SymbolKeys {
+  [Symbol.iterator](): Iterator<unknown> {
+    return [][Symbol.iterator]();
+  }
+
+  [globalThis.Symbol.iterator](): Iterator<unknown> {
+    return [][Symbol.iterator]();
+  }
+
+  [window.Symbol.iterator](): Iterator<unknown> {
+    return [][Symbol.iterator]();
+  }
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/computed-symbol.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/computed-symbol.snap
@@ -1,0 +1,26 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/computed-symbol.ts
+---
+```
+==================== .D.TS ====================
+
+export declare class SymbolKeys {
+	[Symbol.iterator](): Iterator<unknown>;
+	[globalThis.Symbol.iterator](): Iterator<unknown>;
+}
+
+
+==================== Errors ====================
+
+  x TS9038: Computed property names on class or object literals cannot be
+  | inferred with --isolatedDeclarations.
+    ,-[10:4]
+  9 | 
+ 10 |   [window.Symbol.iterator](): Iterator<unknown> {
+    :    ^^^^^^^^^^^^^^^^^^^^^^
+ 11 |     return [][Symbol.iterator]();
+    `----
+
+
+```


### PR DESCRIPTION
## Summary
- Align computed property validation with TypeScript: allow Symbol and globalThis.Symbol keys, but reject window.Symbol keys.
- Add an isolated-declarations regression fixture covering all three forms.


[TS Playground](https://www.typescriptlang.org/play/?isolatedDeclarations=true#code/FAUwHgDg9gTgLgAgMYBsCGBnDCDKBPAWwCMoUBpEPDARgQG9gEEBtfY0gOgEs4QY04sALoAKAJQAuBAEle-QTAA8AVwB2Aa1VQA7qoB89RkwQwQcZTFUshrQiRTc5A4eIDcRgL7Av4aPGToWLh2pBRUAEyGTMwA5ihQRGgoACoAFlwYHGz2jnzOMKKSMk4KKhpaugYMxiZmFlbMNtmcPHkKhe5MXj6QsIiomNjN5JQYAMxRLNpcqgAmOlkhDq3yLkWybbBlmjr6k0ym5pbWtuzLJWudCN1AA)