### PR TITLE
fix(isolated-declarations): normalize accessor keys

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -33,6 +33,17 @@ impl<'a> AccessorAnnotation<'a> {
 }
 
 impl<'a> IsolatedDeclarations<'a> {
+    /// Check whether two accessor keys refer to the same property.
+    ///
+    /// Accessor pairing follows JavaScript property-key semantics, so an identifier,
+    /// string literal, numeric literal, or no-substitution template literal with the
+    /// same static name identifies the same property. Keep structural equality as a
+    /// fallback for supported non-static keys such as `Symbol.iterator`.
+    fn accessor_keys_match(left: &PropertyKey<'a>, right: &PropertyKey<'a>) -> bool {
+        left.static_name().zip(right.static_name()).is_some_and(|(left, right)| left == right)
+            || left.content_eq(right)
+    }
+
     pub(crate) fn is_literal_key(key: &PropertyKey<'a>) -> bool {
         match key {
             PropertyKey::StringLiteral(_) | PropertyKey::NumericLiteral(_) => true,
@@ -387,7 +398,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         {
                             if let Some(entry) = method_annotations
                                 .iter_mut()
-                                .find(|(key, _)| method.key.content_eq(key))
+                                .find(|(key, _)| Self::accessor_keys_match(&method.key, key))
                             {
                                 entry.1.setter = Some(annotation);
                             } else {
@@ -413,7 +424,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         if let Some(annotation) = annotation {
                             if let Some(entry) = method_annotations
                                 .iter_mut()
-                                .find(|(key, _)| method.key.content_eq(key))
+                                .find(|(key, _)| Self::accessor_keys_match(&method.key, key))
                             {
                                 entry.1.getter = Some(annotation);
                             } else {
@@ -499,7 +510,7 @@ impl<'a> IsolatedDeclarations<'a> {
                                 if let Some(param) = params.items.first_mut()
                                     && let Some(annotation) =
                                         accessor_annotations.iter().find_map(|(key, annotation)| {
-                                            if method.key.content_eq(key) {
+                                            if Self::accessor_keys_match(&method.key, key) {
                                                 Some(
                                                     annotation
                                                         .get_setter_annotation(self.allocator()),
@@ -560,7 +571,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         }
                         MethodDefinitionKind::Get => {
                             let rt = accessor_annotations.iter().find_map(|(key, annotation)| {
-                                if method.key.content_eq(key) {
+                                if Self::accessor_keys_match(&method.key, key) {
                                     // No explicit return type for getter, should infer it from the first parameter of setter, if not exists,
                                     // use the inferred return type of getter.
                                     if method.value.return_type.is_none() {

--- a/crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
@@ -68,3 +68,28 @@ class GlobalSymbol4 {
     return GlobalSymbol4;
   }
 }
+
+// Accessor pairs use equivalent JavaScript property keys.
+class ComputedStringGetter {
+  get value() {
+    return "value";
+  }
+  set ["value"](v) {
+  }
+}
+
+class ComputedStringSetter {
+  get ["count"]() {
+    return "not-the-declaration-type";
+  }
+  set count(v: number) {
+  }
+}
+
+class ComputedNumericGetter {
+  get [1]() {
+    return true;
+  }
+  set [`1`](v) {
+  }
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
@@ -39,6 +39,18 @@ declare class GlobalSymbol4 {
 	set [Symbol.toStringTag](v);
 	get [Symbol.toStringTag]();
 }
+declare class ComputedStringGetter {
+	get value(): string;
+	set ["value"](v: string);
+}
+declare class ComputedStringSetter {
+	get ["count"](): number;
+	set count(v: number);
+}
+declare class ComputedNumericGetter {
+	get [1](): boolean;
+	set [`1`](v: boolean);
+}
 
 
 ==================== Errors ====================


### PR DESCRIPTION
## Summary

- normalize equivalent static accessor keys before getter/setter pairing
- retain structural matching for computed symbol keys
- cover identifier/string and numeric/template accessor pairs

## Root cause

Accessor pairing compared the AST key nodes structurally, so equivalent JavaScript property names expressed with different key syntax did not match.

[TS Playground](https://www.typescriptlang.org/play/?isolatedDeclarations=true#code/MYGwhgzhAEDCD2BbADgVwC4FMAmBldATgJYB2A5gOKbpYHQDeAUNNGddAG5giqYAUASgbMW0AtVQES0AERcemGQG4RAXxER2AbTndeMgLp8OQpi3XrGoSDAQoMOfMXK5qtAEzCWbdNB3B4VBJ0Q0EvUXF0SWkZEnh0AFp0AAtMBOxMawIwdCJ4EiSAT2RFFXMNdgCg9GMALmgSVEQAI0wCUzVGS2soOCQ0LGwAOSa2omAqGjaAZnCfPwBGIw7RMQkpaEJeMuh1Fk1fLQADBaOjE3CLRiA)

Current behaviour (oxc is before, ts (correct) is after.

```diff
@@ -1,12 +1,12 @@
 declare class ComputedStringGetter {
        get value(): string;
-       set ["value"](v);
+       set ["value"](v: string);
 }
 declare class ComputedStringSetter2 {
-       get ["count"](): string;
+       get ["count"](): number;
        set count(v: number);
 }
 declare class ComputedNumericGetter3 {
        get [1](): boolean;
-       set [`1`](v);
+       set [`1`](v: boolean);
 }
```

