### PR TITLE
refactor(react_compiler): store ReactiveScope collections in the arena

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -6,7 +6,7 @@ use cow_utils::CowUtils;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
-use oxc_allocator::{Allocator, GetAllocator};
+use oxc_allocator::{Allocator, GetAllocator, Vec as ArenaVec};
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_index::IndexVec;
 use oxc_span::Span;
@@ -267,11 +267,11 @@ impl<'a> Environment<'a> {
         self.scopes.push(ReactiveScope {
             id,
             range,
-            dependencies: Vec::new(),
-            declarations: Vec::new(),
-            reassignments: Vec::new(),
+            dependencies: ArenaVec::new_in(&self.allocator),
+            declarations: ArenaVec::new_in(&self.allocator),
+            reassignments: ArenaVec::new_in(&self.allocator),
             early_return_value: None,
-            merged: Vec::new(),
+            merged: ArenaVec::new_in(&self.allocator),
             span: None,
         });
         id

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -11,6 +11,7 @@ pub mod visitors;
 
 use crate::react_compiler_utils::OrderedMap;
 use crate::react_compiler_utils::OrderedSet;
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds, Vec as ArenaVec};
 use oxc_ast::ast::*;
 use oxc_index::define_nonmax_u32_index_type;
 use oxc_str::{Ident, Str};
@@ -1176,44 +1177,76 @@ pub enum PropertyNameKind<'a> {
 // ReactiveScope
 // =============================================================================
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ReactiveScope<'a> {
     pub id: ScopeId,
     pub range: MutableRange,
 
     /// The inputs to this reactive scope (populated by later passes)
-    pub dependencies: Vec<ReactiveScopeDependency<'a>>,
+    pub dependencies: ArenaVec<'a, ReactiveScopeDependency<'a>>,
 
     /// The set of values produced by this scope (populated by later passes)
-    pub declarations: Vec<(IdentifierId, ReactiveScopeDeclaration)>,
+    pub declarations: ArenaVec<'a, (IdentifierId, ReactiveScopeDeclaration)>,
 
     /// Identifiers which are reassigned by this scope (populated by later passes)
-    pub reassignments: Vec<IdentifierId>,
+    pub reassignments: ArenaVec<'a, IdentifierId>,
 
     /// If the scope contains an early return, this stores info about it (populated by later passes)
     pub early_return_value: Option<ReactiveScopeEarlyReturn>,
 
     /// Scopes that were merged into this one (populated by later passes)
-    pub merged: Vec<ScopeId>,
+    pub merged: ArenaVec<'a, ScopeId>,
 
     /// Source location spanning the scope
     pub span: Option<Span>,
 }
 
 /// A dependency of a reactive scope.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ReactiveScopeDependency<'a> {
     pub identifier: IdentifierId,
     pub reactive: bool,
-    pub path: Vec<DependencyPathEntry<'a>>,
+    pub path: ArenaVec<'a, DependencyPathEntry<'a>>,
     pub span: Option<Span>,
 }
 
 /// A declaration produced by a reactive scope.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ReactiveScopeDeclaration {
     pub identifier: IdentifierId,
     pub scope: ScopeId,
+}
+
+// --- Arena `CloneIn` for the `ReactiveScope` subtree ------------------------
+// Arena `Vec` is not `Clone`. HIR clones are same-arena and `Ident`/leaves borrow
+// the source AST, so `Copy` ids/leaves clone via `*self` and only the arena `Vec`s
+// recurse. Construction (`new_in`/`from_iter_in`) takes `&alloc`; `clone_in` takes
+// `alloc`.
+
+/// Trivial `CloneIn` for `Copy` HIR leaves/ids used inside arena `Vec`s.
+macro_rules! impl_trivial_clone_in {
+    ($($ty:ty),+ $(,)?) => {
+        $(impl<'a> CloneIn<'a> for $ty {
+            type Cloned = $ty;
+            #[inline(always)]
+            fn clone_in_impl(&self, _: CloneInSemanticIds, _: &'a Allocator) -> $ty {
+                *self
+            }
+        })+
+    };
+}
+impl_trivial_clone_in!(DependencyPathEntry<'a>);
+
+impl<'a> CloneIn<'a> for ReactiveScopeDependency<'a> {
+    type Cloned = ReactiveScopeDependency<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        ReactiveScopeDependency {
+            identifier: self.identifier,
+            reactive: self.reactive,
+            path: self.path.clone_in_impl(sem, alloc),
+            span: self.span,
+        }
+    }
 }
 
 /// Early return value info for a reactive scope.

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -13,6 +13,7 @@
 //! - `src/HIR/DeriveMinimalDependenciesHIR.ts`
 
 use crate::react_compiler_utils::FxIndexMap;
+use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
 use oxc_index::IndexVec;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BTreeSet;
@@ -58,8 +59,10 @@ pub fn propagate_scope_dependencies_hir<'a>(func: &mut HirFunction<'a>, env: &mu
             if let Terminal::Scope { scope, block: inner_block, .. } = &block.terminal
                 && let Some(node_indices) = working.get(inner_block)
             {
-                let deps: Vec<ReactiveScopeDependency> =
-                    node_indices.iter().map(|&idx| registry.nodes[idx].full_path.clone()).collect();
+                let deps: Vec<ReactiveScopeDependency> = node_indices
+                    .iter()
+                    .map(|&idx| registry.nodes[idx].full_path.clone_in(env.allocator))
+                    .collect();
                 keyed.insert(*scope, deps);
             }
         }
@@ -90,11 +93,11 @@ pub fn propagate_scope_dependencies_hir<'a>(func: &mut HirFunction<'a>, env: &mu
         // Step 2: Calculate hoistable dependencies using the tree.
         let mut tree = ReactiveScopeDependencyTreeHIR::new(hoistables.iter());
         for dep in deps {
-            tree.add_dependency(dep.clone());
+            tree.add_dependency(dep.clone_in(env.allocator));
         }
 
         // Step 3: Reduce dependencies to a minimal set.
-        let candidates = tree.derive_minimal_dependencies();
+        let candidates = tree.derive_minimal_dependencies(env.allocator);
         let scope = &mut env.scopes[*scope_id];
         for candidate_dep in candidates {
             let already_exists = scope.dependencies.iter().any(|existing_dep| {
@@ -222,7 +225,7 @@ fn collect_temporaries_sidemap<'a>(
     env: &Environment<'a>,
     used_outside_declaring_scope: &FxHashSet<DeclarationId>,
 ) -> TemporariesMap<'a> {
-    let mut temporaries = IndexVec::from_vec(vec![None; env.identifiers.len()]);
+    let mut temporaries = IndexVec::from_vec((0..env.identifiers.len()).map(|_| None).collect());
     collect_temporaries_sidemap_impl(
         func,
         env,
@@ -277,7 +280,14 @@ fn collect_temporaries_sidemap_impl<'a>(
             match &instr.value {
                 InstructionValue::PropertyLoad { object, property, span, .. } if !used_outside => {
                     if inner_fn_context.is_none() || temporaries[object.identifier].is_some() {
-                        let prop = get_property(object, property, false, *span, temporaries);
+                        let prop = get_property(
+                            object,
+                            property,
+                            false,
+                            *span,
+                            temporaries,
+                            env.allocator,
+                        );
                         temporaries[instr.lvalue.identifier] = Some(prop);
                     }
                 }
@@ -292,7 +302,7 @@ fn collect_temporaries_sidemap_impl<'a>(
                         temporaries[instr.lvalue.identifier] = Some(ReactiveScopeDependency {
                             identifier: place.identifier,
                             reactive: place.reactive,
-                            path: vec![],
+                            path: ArenaVec::new_in(&env.allocator),
                             span: *span,
                         });
                     }
@@ -309,7 +319,7 @@ fn collect_temporaries_sidemap_impl<'a>(
                         temporaries[instr.lvalue.identifier] = Some(ReactiveScopeDependency {
                             identifier: place.identifier,
                             reactive: place.reactive,
-                            path: vec![],
+                            path: ArenaVec::new_in(&env.allocator),
                             span: *span,
                         });
                     }
@@ -339,10 +349,11 @@ fn get_property<'a>(
     optional: bool,
     span: Option<Span>,
     temporaries: &TemporariesMap<'a>,
+    alloc: &'a Allocator,
 ) -> ReactiveScopeDependency<'a> {
     let resolved = temporaries[object.identifier].as_ref();
     if let Some(resolved) = resolved {
-        let mut path = resolved.path.clone();
+        let mut path = resolved.path.clone_in(alloc);
         path.push(DependencyPathEntry { property: *property_name, optional, span });
         ReactiveScopeDependency {
             identifier: resolved.identifier,
@@ -354,7 +365,10 @@ fn get_property<'a>(
         ReactiveScopeDependency {
             identifier: object.identifier,
             reactive: object.reactive,
-            path: vec![DependencyPathEntry { property: *property_name, optional, span }],
+            path: ArenaVec::from_array_in(
+                [DependencyPathEntry { property: *property_name, optional, span }],
+                &alloc,
+            ),
             span,
         }
     }
@@ -388,8 +402,11 @@ fn collect_optional_chain_sidemap<'a>(
     let mut ctx = OptionalTraversalContext {
         seen_optionals: FxHashSet::default(),
         processed_instrs_in_optional: FxHashSet::default(),
-        temporaries_read_in_optional: IndexVec::from_vec(vec![None; env.identifiers.len()]),
+        temporaries_read_in_optional: IndexVec::from_vec(
+            (0..env.identifiers.len()).map(|_| None).collect(),
+        ),
         hoistable_objects: FxHashMap::default(),
+        alloc: env.allocator,
     };
 
     traverse_function_optional(func, env, &mut ctx);
@@ -406,6 +423,7 @@ struct OptionalTraversalContext<'a> {
     processed_instrs_in_optional: FxHashSet<ProcessedInstr>,
     temporaries_read_in_optional: TemporariesMap<'a>,
     hoistable_objects: FxHashMap<BlockId, ReactiveScopeDependency<'a>>,
+    alloc: &'a Allocator,
 }
 
 fn traverse_function_optional<'a>(
@@ -538,7 +556,7 @@ fn traverse_optional_block<'a>(
                 return None;
             }
 
-            let mut path: Vec<DependencyPathEntry> = Vec::new();
+            let mut path = ArenaVec::new_in(&ctx.alloc);
             for i in 1..maybe_test_block.instructions.len() {
                 let curr_instr = &func.instructions[maybe_test_block.instructions[i].index()];
                 let prev_instr = &func.instructions[maybe_test_block.instructions[i - 1].index()];
@@ -609,12 +627,14 @@ fn traverse_optional_block<'a>(
             if !is_optional {
                 // Non-optional load: record that PropertyLoads from inner optional are hoistable
                 if let Some(inner_dep) = &ctx.temporaries_read_in_optional[inner_optional_id] {
-                    let inner_dep = inner_dep.clone();
+                    let inner_dep = inner_dep.clone_in(ctx.alloc);
                     ctx.hoistable_objects.insert(optional_block.id, inner_dep);
                 }
             }
 
-            let base = ctx.temporaries_read_in_optional[inner_optional_id].clone()?;
+            let base = ctx.temporaries_read_in_optional[inner_optional_id]
+                .as_ref()
+                .map(|d| d.clone_in(ctx.alloc))?;
             (&test_block.terminal, base)
         }
         _ => return None,
@@ -702,7 +722,7 @@ fn traverse_optional_block<'a>(
         }
         _ => BlockId::from_usize(0),
     }));
-    ctx.temporaries_read_in_optional[match_result.consequent_id] = Some(load.clone());
+    ctx.temporaries_read_in_optional[match_result.consequent_id] = Some(load.clone_in(ctx.alloc));
     ctx.temporaries_read_in_optional[match_result.property_id] = Some(load);
 
     Some(match_result.consequent_id)
@@ -712,7 +732,7 @@ fn traverse_optional_block<'a>(
 // CollectHoistablePropertyLoads
 // =============================================================================
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct PropertyPathNode<'a> {
     properties: FxHashMap<PropertyLiteral<'a>, usize>, // index into registry
     optional_properties: FxHashMap<PropertyLiteral<'a>, usize>, // index into registry
@@ -723,11 +743,12 @@ struct PropertyPathNode<'a> {
 struct PropertyPathRegistry<'a> {
     nodes: Vec<PropertyPathNode<'a>>,
     roots: FxHashMap<IdentifierId, usize>,
+    alloc: &'a Allocator,
 }
 
 impl<'a> PropertyPathRegistry<'a> {
-    fn new() -> Self {
-        Self { nodes: Vec::new(), roots: FxHashMap::default() }
+    fn new(alloc: &'a Allocator) -> Self {
+        Self { nodes: Vec::new(), roots: FxHashMap::default(), alloc }
     }
 
     fn get_or_create_identifier(
@@ -746,7 +767,7 @@ impl<'a> PropertyPathRegistry<'a> {
             full_path: ReactiveScopeDependency {
                 identifier: identifier_id,
                 reactive,
-                path: vec![],
+                path: ArenaVec::new_in(&self.alloc),
                 span,
             },
             has_optional: false,
@@ -769,17 +790,23 @@ impl<'a> PropertyPathRegistry<'a> {
         if let Some(idx) = existing {
             return idx;
         }
-        let parent_full_path = self.nodes[parent_idx].full_path.clone();
-        let parent_has_optional = self.nodes[parent_idx].has_optional;
+        let parent = &self.nodes[parent_idx];
+        let parent_has_optional = parent.has_optional;
+        // `identifier`/`reactive` are `Copy`, and `path` is the only field that
+        // owns an arena allocation — clone it exactly once. Cloning the whole
+        // parent `full_path` first (as `clone_in`) would strand a duplicate path
+        // in the compilation arena that is never reclaimed.
+        let identifier = parent.full_path.identifier;
+        let reactive = parent.full_path.reactive;
+        let mut new_path = parent.full_path.path.clone_in(self.alloc);
         let idx = self.nodes.len();
-        let mut new_path = parent_full_path.path.clone();
         new_path.push(*entry);
         self.nodes.push(PropertyPathNode {
             properties: FxHashMap::default(),
             optional_properties: FxHashMap::default(),
             full_path: ReactiveScopeDependency {
-                identifier: parent_full_path.identifier,
-                reactive: parent_full_path.reactive,
+                identifier,
+                reactive,
                 path: new_path,
                 span: entry.span,
             },
@@ -826,7 +853,7 @@ fn reduce_maybe_optional_chains(nodes: &mut BTreeSet<usize>, registry: &mut Prop
         let to_process: Vec<usize> = optional_chain_nodes.iter().copied().collect();
 
         for original_idx in to_process {
-            let full_path = registry.nodes[original_idx].full_path.clone();
+            let full_path = registry.nodes[original_idx].full_path.clone_in(registry.alloc);
 
             let mut curr_node = registry.get_or_create_identifier(
                 full_path.identifier,
@@ -901,20 +928,25 @@ fn in_range(id: EvaluationOrder, range: &MutableRange) -> bool {
 fn get_maybe_non_null_in_instruction<'a>(
     value: &InstructionValue<'a>,
     temporaries: &TemporariesMap<'a>,
+    alloc: &'a Allocator,
 ) -> Option<ReactiveScopeDependency<'a>> {
     match value {
         InstructionValue::PropertyLoad { object, .. } => {
-            Some(temporaries[object.identifier].clone().unwrap_or_else(|| {
-                ReactiveScopeDependency {
+            Some(temporaries[object.identifier].as_ref().map(|d| d.clone_in(alloc)).unwrap_or_else(
+                || ReactiveScopeDependency {
                     identifier: object.identifier,
                     reactive: object.reactive,
-                    path: vec![],
+                    path: ArenaVec::new_in(&alloc),
                     span: object.span,
-                }
-            }))
+                },
+            ))
         }
-        InstructionValue::Destructure { value: val, .. } => temporaries[val.identifier].clone(),
-        InstructionValue::ComputedLoad { object, .. } => temporaries[object.identifier].clone(),
+        InstructionValue::Destructure { value: val, .. } => {
+            temporaries[val.identifier].as_ref().map(|d| d.clone_in(alloc))
+        }
+        InstructionValue::ComputedLoad { object, .. } => {
+            temporaries[object.identifier].as_ref().map(|d| d.clone_in(alloc))
+        }
         _ => None,
     }
 }
@@ -1086,7 +1118,9 @@ fn collect_non_nulls_in_blocks<'a>(
 
         for &instr_id in &block.instructions {
             let instr = &func.instructions[instr_id.index()];
-            if let Some(path) = get_maybe_non_null_in_instruction(&instr.value, ctx.temporaries) {
+            if let Some(path) =
+                get_maybe_non_null_in_instruction(&instr.value, ctx.temporaries, env.allocator)
+            {
                 let path_ident = path.identifier;
                 if is_immutable_at_instr(path_ident, instr.id, env, ctx) {
                     let node_idx = registry.get_or_create_property(&path);
@@ -1110,7 +1144,10 @@ fn collect_non_nulls_in_blocks<'a>(
                             let sub_dep = ReactiveScopeDependency {
                                 identifier: val.identifier,
                                 reactive: val.reactive,
-                                path: dep.path[..i].to_vec(),
+                                path: ArenaVec::from_iter_in(
+                                    dep.path[..i].iter().copied(),
+                                    &env.allocator,
+                                ),
                                 span: dep.span,
                             };
                             let node_idx = registry.get_or_create_property(&sub_dep);
@@ -1326,7 +1363,7 @@ fn collect_hoistable_and_propagate<'a>(
     temporaries: &TemporariesMap<'a>,
     hoistable_from_optionals: &FxHashMap<BlockId, ReactiveScopeDependency<'a>>,
 ) -> (FxHashMap<BlockId, BTreeSet<usize>>, PropertyPathRegistry<'a>) {
-    let mut registry = PropertyPathRegistry::new();
+    let mut registry = PropertyPathRegistry::new(env.allocator);
     let assumed_invoked_fns = get_assumed_invoked_functions(func, env);
     let known_immutable_identifiers: FxHashSet<IdentifierId> = if func.fn_type
         == ReactFunctionType::Component
@@ -1519,10 +1556,20 @@ impl<'a> ReactiveScopeDependencyTreeHIR<'a> {
             merge_access(dep_cursor.access_type, PropertyAccessType::OptionalDependency);
     }
 
-    fn derive_minimal_dependencies(&self) -> Vec<ReactiveScopeDependency<'a>> {
+    fn derive_minimal_dependencies(
+        &self,
+        alloc: &'a Allocator,
+    ) -> Vec<ReactiveScopeDependency<'a>> {
         let mut results = Vec::new();
         for (&root_id, (root_node, reactive)) in &self.dep_roots {
-            collect_minimal_deps_in_subtree(root_node, *reactive, root_id, &[], &mut results);
+            collect_minimal_deps_in_subtree(
+                root_node,
+                *reactive,
+                root_id,
+                &[],
+                &mut results,
+                alloc,
+            );
         }
         results
     }
@@ -1534,12 +1581,13 @@ fn collect_minimal_deps_in_subtree<'a>(
     root_id: IdentifierId,
     path: &[DependencyPathEntry<'a>],
     results: &mut Vec<ReactiveScopeDependency<'a>>,
+    alloc: &'a Allocator,
 ) {
     if is_dependency_access(node.access_type) {
         results.push(ReactiveScopeDependency {
             identifier: root_id,
             reactive,
-            path: path.to_vec(),
+            path: ArenaVec::from_iter_in(path.iter().copied(), &alloc),
             span: node.span,
         });
     } else {
@@ -1556,6 +1604,7 @@ fn collect_minimal_deps_in_subtree<'a>(
                 root_id,
                 &new_path,
                 results,
+                alloc,
             );
         }
     }
@@ -1610,7 +1659,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
         self.scope_stack.push(scope_id);
     }
 
-    fn exit_scope(&mut self, scope_id: ScopeId, pruned: bool, env: &mut Environment) {
+    fn exit_scope(&mut self, scope_id: ScopeId, pruned: bool, env: &mut Environment<'a>) {
         let scoped_deps =
             self.dep_stack.pop().expect("[PropagateScopeDeps]: Unexpected scope mismatch");
         self.scope_stack.pop();
@@ -1620,7 +1669,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
             if self.check_valid_dependency(dep, env)
                 && let Some(top) = self.dep_stack.last_mut()
             {
-                top.push(dep.clone());
+                top.push(dep.clone_in(env.allocator));
             }
         }
 
@@ -1675,12 +1724,14 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
         false
     }
 
-    fn visit_operand(&mut self, place: &Place, env: &mut Environment) {
-        let dep =
-            self.temporaries[place.identifier].clone().unwrap_or_else(|| ReactiveScopeDependency {
+    fn visit_operand(&mut self, place: &Place, env: &mut Environment<'a>) {
+        let dep = self.temporaries[place.identifier]
+            .as_ref()
+            .map(|d| d.clone_in(env.allocator))
+            .unwrap_or_else(|| ReactiveScopeDependency {
                 identifier: place.identifier,
                 reactive: place.reactive,
-                path: vec![],
+                path: ArenaVec::new_in(&env.allocator),
                 span: place.span,
             });
         self.visit_dependency(dep, env);
@@ -1692,13 +1743,13 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
         property: &PropertyLiteral<'a>,
         optional: bool,
         span: Option<Span>,
-        env: &mut Environment,
+        env: &mut Environment<'a>,
     ) {
-        let dep = get_property(object, property, optional, span, self.temporaries);
+        let dep = get_property(object, property, optional, span, self.temporaries, env.allocator);
         self.visit_dependency(dep, env);
     }
 
-    fn visit_dependency(&mut self, dep: ReactiveScopeDependency<'a>, env: &mut Environment) {
+    fn visit_dependency(&mut self, dep: ReactiveScopeDependency<'a>, env: &mut Environment<'a>) {
         let ident = &env.identifiers[dep.identifier];
         let decl_id = ident.declaration_id;
 
@@ -1734,7 +1785,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
             ReactiveScopeDependency {
                 identifier: dep.identifier,
                 reactive: dep.reactive,
-                path: vec![],
+                path: ArenaVec::new_in(&env.allocator),
                 span: dep.span,
             }
         } else {
@@ -1748,7 +1799,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
         }
     }
 
-    fn visit_reassignment(&mut self, place: &Place, env: &mut Environment) {
+    fn visit_reassignment(&mut self, place: &Place, env: &mut Environment<'a>) {
         if let Some(current_scope) = self.current_scope() {
             let scope = &env.scopes[current_scope];
             let already = scope.reassignments.iter().any(|id| {
@@ -1760,7 +1811,7 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
                     &ReactiveScopeDependency {
                         identifier: place.identifier,
                         reactive: place.reactive,
-                        path: vec![],
+                        path: ArenaVec::new_in(&env.allocator),
                         span: place.span,
                     },
                     env,
@@ -1811,7 +1862,7 @@ fn visit_inner_function_blocks<'a>(
     for (inner_bid, inner_instr_ids, inner_phis, inner_terminal) in &inner_blocks {
         for &(_pred_id, op_id) in inner_phis {
             if let Some(maybe_optional) = &ctx.temporaries[op_id] {
-                let maybe_optional = maybe_optional.clone();
+                let maybe_optional = maybe_optional.clone_in(env.allocator);
                 ctx.visit_dependency(maybe_optional, env);
             }
         }
@@ -1981,7 +2032,7 @@ fn handle_function_deps<'a>(
         for phi in &block.phis {
             for (_pred_id, operand) in &phi.operands {
                 if let Some(maybe_optional_chain) = &ctx.temporaries[operand.identifier] {
-                    let maybe_optional_chain = maybe_optional_chain.clone();
+                    let maybe_optional_chain = maybe_optional_chain.clone_in(env.allocator);
                     ctx.visit_dependency(maybe_optional_chain, env);
                 }
             }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -663,9 +663,10 @@ fn ox_codegen_reactive_scope<'a>(
     scope_id: ScopeId,
     block: &ReactiveBlock<'a>,
 ) -> Result<(), OxcDiagnostic> {
-    let scope_deps = cx.env.scopes[scope_id].dependencies.clone();
-    let scope_decls = cx.env.scopes[scope_id].declarations.clone();
-    let scope_reassignments = cx.env.scopes[scope_id].reassignments.clone();
+    let scope_deps = cx.env.scopes[scope_id].dependencies.clone_in(cx.env.allocator);
+    let scope_decls = cx.env.scopes[scope_id].declarations.iter().copied().collect::<Vec<_>>();
+    let scope_reassignments =
+        cx.env.scopes[scope_id].reassignments.iter().copied().collect::<Vec<_>>();
 
     let mut cache_store_stmts: oxc_allocator::Vec<'a, oxc::Statement<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
@@ -10,6 +10,8 @@
 
 use std::mem::take;
 
+use oxc_allocator::{CloneIn, Vec as ArenaVec};
+
 use rustc_hash::FxHashSet;
 
 use oxc_diagnostics::OxcDiagnostic;
@@ -59,7 +61,7 @@ pub fn merge_reactive_scopes_that_invalidate_together<'a>(
         last_usage,
         temporaries: IndexVec::from_vec(vec![None; num_identifiers]),
     };
-    let mut state: Option<Vec<ReactiveScopeDependency>> = None;
+    let mut state = None;
     transform_reactive_function(func, &mut transform, &mut state)
 }
 
@@ -100,7 +102,7 @@ struct MergeTransform<'a, 'e> {
 }
 
 impl<'a, 'e> ReactiveFunctionTransform<'a> for MergeTransform<'a, 'e> {
-    type State = Option<Vec<ReactiveScopeDependency<'a>>>;
+    type State = Option<ArenaVec<'a, ReactiveScopeDependency<'a>>>;
 
     fn env(&self) -> &Environment<'a> {
         self.env
@@ -112,10 +114,10 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for MergeTransform<'a, 'e> {
         scope: &mut ReactiveScopeBlock<'a>,
         state: &mut Self::State,
     ) -> Result<Transformed<ReactiveStatement<'a>>, OxcDiagnostic> {
-        let scope_deps = self.env.scopes[scope.scope].dependencies.clone();
+        let scope_deps = self.env.scopes[scope.scope].dependencies.clone_in(self.env.allocator);
         // Save parent state and recurse with this scope's deps as state
         let parent_state = state.take();
-        *state = Some(scope_deps.clone());
+        *state = Some(scope_deps.clone_in(self.env.allocator));
         self.visit_scope(scope, state)?;
         // Restore parent state
         *state = parent_state;
@@ -277,7 +279,11 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                                 current_range_end.max(next_range_end);
 
                             // Merge declarations from next into current
-                            let next_decls = self.env.scopes[next_scope_id].declarations.clone();
+                            let next_decls = self.env.scopes[next_scope_id]
+                                .declarations
+                                .iter()
+                                .copied()
+                                .collect::<Vec<_>>();
                             for (key, value) in next_decls {
                                 let current_decls =
                                     &mut self.env.scopes[current_scope_id].declarations;
@@ -456,7 +462,7 @@ fn can_merge_scopes<'a>(
         .map(|(_key, decl)| ReactiveScopeDependency {
             identifier: decl.identifier,
             reactive: true,
-            path: Vec::new(),
+            path: ArenaVec::new_in(&env.allocator),
             span: None,
         })
         .collect();

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
@@ -852,7 +852,7 @@ fn promote_all_instances_scope_identifiers(
     let decl_ids: Vec<IdentifierId> =
         scope_data.declarations.iter().map(|(_, d)| d.identifier).collect();
     let dep_ids: Vec<IdentifierId> = scope_data.dependencies.iter().map(|d| d.identifier).collect();
-    let reassign_ids: Vec<IdentifierId> = scope_data.reassignments.clone();
+    let reassign_ids: Vec<IdentifierId> = scope_data.reassignments.iter().copied().collect();
 
     for id in decl_ids {
         let identifier = &env.identifiers[id];

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
@@ -123,7 +123,8 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                 // Propagate always-invalidating and unmemoized to declarations/reassignments
                 let decl_ids: Vec<IdentifierId> =
                     scope_data.declarations.iter().map(|(_, decl)| decl.identifier).collect();
-                let reassign_ids: Vec<IdentifierId> = scope_data.reassignments.clone();
+                let reassign_ids: Vec<IdentifierId> =
+                    scope_data.reassignments.iter().copied().collect();
 
                 for id in &decl_ids {
                     if self.always_invalidating_values.contains(id) {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
@@ -236,7 +236,8 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneVisitor<'a, 'e> {
             for id in decl_ids {
                 state.insert(id);
             }
-            let reassign_ids: Vec<IdentifierId> = scope_data.reassignments.clone();
+            let reassign_ids: Vec<IdentifierId> =
+                scope_data.reassignments.iter().copied().collect();
             for id in reassign_ids {
                 state.insert(id);
             }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
@@ -9,6 +9,7 @@
 //! accurately preserved, and that no originally memoized values became
 //! unmemoized in the output.
 
+use oxc_allocator::CloneIn;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::diagnostics::ErrorCategory;
@@ -142,7 +143,7 @@ fn visit_scope<'h>(scope_block: &ReactiveScopeBlock<'h>, state: &mut VisitorStat
         && let Some(ref deps_from_source) = memo_state.deps_from_source
     {
         let scope = &state.env.scopes[scope_block.scope];
-        let deps = scope.dependencies.clone();
+        let deps = scope.dependencies.clone_in(state.env.allocator);
         let memo_span = memo_state.span;
         let decls = memo_state.decls.clone();
         let deps_from_source = deps_from_source.clone();
@@ -162,7 +163,7 @@ fn visit_scope<'h>(scope_block: &ReactiveScopeBlock<'h>, state: &mut VisitorStat
 
     // Mark scope and merged scopes as completed
     let scope = &state.env.scopes[scope_block.scope];
-    let merged = scope.merged.clone();
+    let merged = scope.merged.iter().copied().collect::<Vec<_>>();
     state.scopes.insert(scope_block.scope);
     for merged_id in merged {
         state.scopes.insert(merged_id);


### PR DESCRIPTION
Continues the react_compiler HIR-to-arena migration by moving the per-compilation `ReactiveScope` collections off the global heap and into the compilation arena.

## What changed

- `ReactiveScope::{dependencies, declarations, reassignments, merged}` and `ReactiveScopeDependency::path` change from `std::vec::Vec` to `oxc_allocator::Vec<'a>`.
- Arena `Vec` is not `Clone`, so `ReactiveScope`/`ReactiveScopeDependency` drop `#[derive(Clone)]`. `ReactiveScopeDependency` and `DependencyPathEntry` get hand-written same-arena `CloneIn` impls (leaves copy, the arena `Vec` recurses); `ReactiveScopeDeclaration` becomes `Copy`.
- Construction and clone sites across the reactive-scope and inference passes now allocate from `env.allocator` (`clone_in` / `ArenaVec::*_in`); a few dependency-collection helpers take an explicit `&'a Allocator`.

Behavior is unchanged — the snapshot corpus and transform tests remain byte-identical.

## Stack

- #24664
- #24666
- **this PR** — stacked on top of #24666

🤖 This PR was written with the assistance of Claude Code.