### PR TITLE
refactor(react_compiler): drop dead error-plumbing and coercion helpers in globals

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -527,7 +527,7 @@ impl<'a> Environment<'a> {
 
         let module_type = module_config.map(|config| {
             let mut type_errors: Vec<String> = Vec::new();
-            let ty = globals::install_type_config_with_errors(
+            let ty = globals::install_type_config(
                 &mut self.shapes,
                 &config,
                 module_name,

--- a/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
@@ -56,7 +56,7 @@ impl<'a> GlobalRegistry<'a> {
     }
 
     pub fn get(&self, key: &str) -> Option<&Global<'a>> {
-        self.entries.get(key).or_else(|| self.base.and_then(|b| b.get(key).map(shrink_global)))
+        self.entries.get(key).or_else(|| self.base.and_then(|b| b.get(key)))
     }
 
     pub fn insert(&mut self, key: Ident<'a>, value: Global<'a>) {
@@ -85,11 +85,6 @@ impl<'a> GlobalRegistry<'a> {
         debug_assert!(self.base.is_none(), "into_inner() called on overlay-mode GlobalRegistry");
         self.entries
     }
-}
-
-/// Coerce a static global reference to the arena lifetime (covariant).
-fn shrink_global<'a, 'b>(global: &'b Global<'static>) -> &'b Global<'a> {
-    global
 }
 
 impl Default for GlobalRegistry<'_> {
@@ -133,21 +128,13 @@ pub fn base_globals() -> &'static IdentHashMap<'static, Global<'static>> {
 // installTypeConfig — converts TypeConfig to internal Type
 // =============================================================================
 
-/// Like `install_type_config` but collects validation errors.
-pub fn install_type_config_with_errors<'a>(
+/// Convert a `TypeConfig` into an internal `Type`, collecting validation errors.
+/// Ported from TS `installTypeConfig`.
+pub fn install_type_config<'a>(
     shapes: &mut ShapeRegistry<'a>,
     type_config: &TypeConfig,
     module_name: &str,
     errors: &mut Vec<String>,
-) -> Global<'a> {
-    install_type_config_inner(shapes, type_config, module_name, &mut Some(errors))
-}
-
-fn install_type_config_inner<'a>(
-    shapes: &mut ShapeRegistry<'a>,
-    type_config: &TypeConfig,
-    module_name: &str,
-    errors: &mut Option<&mut Vec<String>>,
 ) -> Global<'a> {
     match type_config {
         TypeConfig::TypeReference(TypeReferenceConfig { name }) => match name {
@@ -162,7 +149,7 @@ fn install_type_config_inner<'a>(
         TypeConfig::Function(func_config) => {
             // Compute return type first to avoid double-borrow of shapes
             let return_type =
-                install_type_config_inner(shapes, &func_config.return_type, module_name, errors);
+                install_type_config(shapes, &func_config.return_type, module_name, errors);
             add_function(
                 shapes,
                 Vec::new(),
@@ -189,7 +176,7 @@ fn install_type_config_inner<'a>(
         TypeConfig::Hook(hook_config) => {
             // Compute return type first to avoid double-borrow of shapes
             let return_type =
-                install_type_config_inner(shapes, &hook_config.return_type, module_name, errors);
+                install_type_config(shapes, &hook_config.return_type, module_name, errors);
             add_hook(
                 shapes,
                 HookSignatureBuilder {
@@ -215,32 +202,24 @@ fn install_type_config_inner<'a>(
                     props
                         .iter()
                         .map(|(key, value)| {
-                            let ty = install_type_config_inner(
-                                shapes,
-                                value,
-                                module_name,
-                                errors,
-                            );
+                            let ty = install_type_config(shapes, value, module_name, errors);
                             // Validate hook-name vs hook-type consistency (matching TS installTypeConfig)
-                            if let Some(errs) = errors {
-                                let expect_hook = is_hook_name(key);
-                                let is_hook = match &ty {
-                                    Type::Function { shape_id: Some(id), .. } => {
-                                        shapes.get(id)
-                                            .and_then(|shape| shape.function_type.as_ref())
-                                            .and_then(|ft| ft.hook_kind.as_ref())
-                                            .is_some()
-                                    }
-                                    _ => false,
-                                };
-                                if expect_hook != is_hook {
-                                    errs.push(format!(
-                                        "Expected type for object property '{}' from module '{}' {} based on the property name",
-                                        key,
-                                        module_name,
-                                        if expect_hook { "to be a hook" } else { "not to be a hook" }
-                                    ));
-                                }
+                            let expect_hook = is_hook_name(key);
+                            let is_hook = match &ty {
+                                Type::Function { shape_id: Some(id), .. } => shapes
+                                    .get(id)
+                                    .and_then(|shape| shape.function_type.as_ref())
+                                    .and_then(|ft| ft.hook_kind.as_ref())
+                                    .is_some(),
+                                _ => false,
+                            };
+                            if expect_hook != is_hook {
+                                errors.push(format!(
+                                    "Expected type for object property '{}' from module '{}' {} based on the property name",
+                                    key,
+                                    module_name,
+                                    if expect_hook { "to be a hook" } else { "not to be a hook" }
+                                ));
                             }
                             (shapes.alloc_ident(key), ty)
                         })
@@ -404,7 +383,7 @@ fn add_object_from_def<'a>(
 /// defined at module level in ObjectShape.ts.
 #[cold]
 #[inline(never)]
-pub fn build_builtin_shapes() -> ShapeRegistry<'static> {
+fn build_builtin_shapes() -> ShapeRegistry<'static> {
     let mut shapes = ShapeRegistry::new();
     for def in BUILTIN_SHAPE_DEFS {
         add_object_from_def(&mut shapes, Some(def.id), def.props);
@@ -1271,7 +1250,7 @@ pub fn get_reanimated_module_type<'a>(shapes: &mut ShapeRegistry<'a>) -> Type<'a
 /// (like Object.keys, Array.isArray) register new shapes.
 #[cold]
 #[inline(never)]
-pub fn build_default_globals(shapes: &mut ShapeRegistry<'static>) -> GlobalRegistry<'static> {
+fn build_default_globals(shapes: &mut ShapeRegistry<'static>) -> GlobalRegistry<'static> {
     let mut globals = GlobalRegistry::new();
 
     // React APIs — returns the list so we can reuse them for the React namespace

--- a/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
@@ -165,7 +165,7 @@ impl<'a> ShapeRegistry<'a> {
     }
 
     pub fn get(&self, key: &str) -> Option<&ObjectShape<'a>> {
-        self.entries.get(key).or_else(|| self.base.and_then(|b| b.get(key).map(shrink_shape)))
+        self.entries.get(key).or_else(|| self.base.and_then(|b| b.get(key)))
     }
 
     pub fn insert(&mut self, key: Ident<'a>, value: ObjectShape<'a>) {
@@ -201,11 +201,6 @@ impl<'a> ShapeRegistry<'a> {
             None => Ident::from(&*format!("<generated_{id}>").leak()),
         }
     }
-}
-
-/// Coerce a static shape reference to the arena lifetime (covariant).
-fn shrink_shape<'a, 'b>(shape: &'b ObjectShape<'static>) -> &'b ObjectShape<'a> {
-    shape
 }
 
 impl Default for ShapeRegistry<'_> {


### PR DESCRIPTION
Follow-up cleanup of `globals.rs` (and its two callers) in `oxc_react_compiler`. Removes machinery that no longer earns its keep — no behavior change.

## What

- **Collapse the `install_type_config` split.** `install_type_config_with_errors` wrapped a private `install_type_config_inner` whose `errors: &mut Option<&mut Vec<String>>` was *always* `Some` — the sole caller passed `Some` and the recursion only forwarded it. Vestigial from a non-error variant that no longer exists. Now a single `install_type_config` taking `&mut Vec<String>`.
- **Remove `shrink_global` / `shrink_shape`.** These were `fn(&T<'static>) -> &T<'a> { x }` identity functions; lifetime variance already performs that coercion in `Registry::get`, so they were no-op noise.
- **Tighten visibility.** `build_builtin_shapes` / `build_default_globals` are only used inside the `BASE` initializer, so they no longer need to be `pub`.

Net `3 files changed, 27 insertions(+), 53 deletions(-)`.