### PR TITLE
fix(minifier): guard reordered identifier reads

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1521,13 +1521,25 @@ impl<'a> PeepholeOptimizations {
 
     /// Whether evaluating a member assignment-target part earlier could observe
     /// a different binding value. This includes ordinary mutation and closed-over
-    /// lexicals that could still be in their TDZ (e.g. `v.x = await f()`).
+    /// lexicals that could still be in their TDZ (e.g. `v.x = await f()` or
+    /// `obj[v] = await f()`).
     fn member_part_blocks_reorder(expr: &Expression<'a>, ctx: &TraverseCtx<'a>) -> bool {
         match expr {
             Expression::Identifier(id) => Self::identifier_read_blocks_reorder(id, ctx),
             Expression::ThisExpression(_) => false,
             _ => true,
         }
+    }
+
+    /// Whether evaluating a computed member key before a side-effecting
+    /// replacement could observe a different value.
+    ///
+    /// The key expression and `GetValue` move before the assignment RHS, but
+    /// `ToPropertyKey` still happens afterward. A scope-independent literal or
+    /// a stable simple reference is therefore safe regardless of its value type.
+    /// <https://tc39.es/ecma262/#sec-evaluate-property-access-with-expression-key>
+    fn computed_key_blocks_reorder(key: &Expression<'a>, ctx: &TraverseCtx<'a>) -> bool {
+        !key.is_literal_value(false, ctx) && Self::member_part_blocks_reorder(key, ctx)
     }
 
     /// Returns Some(true) when the expression is successfully replaced.
@@ -1558,6 +1570,8 @@ impl<'a> PeepholeOptimizations {
                 }
                 // If the identifier is not a getter and the identifier is read-only,
                 // we know that the value is same even if we reordered the expression.
+                // Imported names are live bindings, so local read-only status is
+                // insufficient for them.
                 //
                 // But a lexical binding that is closed over from an enclosing
                 // function/module scope may still be in its Temporal Dead Zone
@@ -1693,6 +1707,10 @@ impl<'a> PeepholeOptimizations {
                         AssignmentTarget::AssignmentTargetIdentifier(_) => false,
                         AssignmentTarget::ComputedMemberExpression(member_expr) => {
                             Self::member_part_blocks_reorder(&member_expr.object, ctx)
+                                || Self::computed_key_blocks_reorder(
+                                    &member_expr.expression,
+                                    ctx,
+                                )
                         }
                         AssignmentTarget::PrivateFieldExpression(member_expr) => {
                             Self::member_part_blocks_reorder(&member_expr.object, ctx)

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -153,7 +153,8 @@ impl<'a> PeepholeOptimizations {
     /// Checks if an expression's reference may change due to mutation.
     ///
     /// Returns `true` if the expression references a symbol that may be mutated,
-    /// or if the expression is not a simple identifier/this reference.
+    /// is externally mutable through an ESM import or Script global, or is not a
+    /// simple identifier/this reference.
     pub fn is_expression_that_reference_may_change(
         expr: &Expression<'a>,
         ctx: &TraverseCtx<'a>,
@@ -169,6 +170,8 @@ impl<'a> PeepholeOptimizations {
     }
 
     /// Whether reading a resolved symbol again could produce a different value.
+    /// Imported bindings and Script-root globals can change externally.
+    ///
     /// Uses the O(1) cached reference counts from `SymbolValue` when available,
     /// falling back to the O(num_refs) scan in `Scoping::symbol_is_mutated` for
     /// symbols without cached values.
@@ -177,10 +180,18 @@ impl<'a> PeepholeOptimizations {
     /// `exit_variable_declarator` → `init_symbol_value`); function declarations
     /// and other binding kinds still take the fallback path.
     fn symbol_value_may_change(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
+        let scoping = ctx.scoping();
+        if scoping.symbol_flags(symbol_id).is_import()
+            || (ctx.source_type().is_script()
+                && scoping.symbol_scope_id(symbol_id) == scoping.root_scope_id())
+        {
+            return true;
+        }
+
         if let Some(sv) = ctx.state.symbols.value(symbol_id) {
             sv.references.has_writes()
         } else {
-            ctx.scoping().symbol_is_mutated(symbol_id)
+            scoping.symbol_is_mutated(symbol_id)
         }
     }
 

--- a/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
+++ b/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
@@ -346,6 +346,18 @@ fn test_inline_read_before_await_tdz() {
     // closed-over lexical object must not be reordered either.
     test_same("let v = ext(); export async function init() { let num = await foo(); v.x = num }");
     test_same("let v = ext(); export async function init() { let num = await foo(); v[0] = num }");
+    // A computed member assignment target also evaluates its key before the
+    // right-hand side. Moving the key read before the await would observe its
+    // TDZ, while the original resumes after `key` has been initialized.
+    // `+ext()` gives the key a known primitive type, while the export keeps the
+    // binding read in place so this exercises the TDZ guard itself.
+    test_same(
+        "let p = init({}); export let key = +ext(); async function init(obj) { let num = await foo(); obj[key] = num } export { p }",
+    );
+    // A yielded value has the same ordering hazard.
+    test_same(
+        "let iter = init({}), first = iter.next(); export let key = +ext(); function* init(obj) { let num = yield foo(); obj[key] = num } iter.next(0); export { first }",
+    );
     // `var` / parameter bindings are not TDZ-subject, so reordering the read
     // past the await is safe and still merges.
     test(
@@ -374,6 +386,61 @@ fn test_inline_read_before_await_tdz() {
     // Closed over across two function boundaries.
     test_same(
         "let v = ext(); export function outer(fn) { return async function () { let num = await foo(); fn(v, num) } }",
+    );
+}
+
+#[test]
+fn test_inline_computed_key_before_side_effecting_replacement() {
+    // The RHS can reassign a computed-key binding, so the ordinary
+    // reference-stability guard applies too. This parameter has no TDZ.
+    test_same("export function init(obj, key) { let num = (key = 'y', foo()); obj[key] = num }");
+    // `ToPropertyKey` happens after the assignment RHS. A stable key binding
+    // remains safe to read earlier even if the referenced object is mutated
+    // while the async function is suspended.
+    test(
+        "export async function init(obj, key) { let num = await mutate(key); obj[key] = num }",
+        "export async function init(obj, key) { obj[key] = await mutate(key) }",
+    );
+    // A literal is scope-independent, so the existing optimization remains
+    // available too.
+    test(
+        "export async function init(obj) { let num = await foo(); obj[0] = num }",
+        "export async function init(obj) { obj[0] = await foo() }",
+    );
+    // Module bindings cannot be changed by another module, so the Script-root
+    // guard must not block this safe substitution.
+    test(
+        "var key = 'x'; export function init(obj) { let num = mutate(); obj[key] = num }",
+        "var key = 'x'; export function init(obj) { obj.x = mutate() }",
+    );
+    // Non-simple key expressions remain conservative because evaluating the
+    // expression itself moves before the replacement.
+    test_same(
+        "export function init(obj, key) { let num = (key = 1, value()); obj[key === 0] = num }",
+    );
+    // ESM imports are live bindings. A call in the replacement can update
+    // either assignment-target part even though this module never writes it.
+    test_same(
+        "import { key, mutate } from 'x'; export function init(obj) { let num = mutate(); obj[key] = num }",
+    );
+    test_same(
+        "import { target, mutate } from 'x'; export function init() { let num = mutate(); target.x = num }",
+    );
+    test_same(
+        "import { value, mutate } from 'x'; export function init(consume) { let num = mutate(); consume(value, num) }",
+    );
+    // A pure replacement can move without observing changes to imported
+    // bindings, so it bypasses the reorder-stability walk.
+    test(
+        "import { consume } from 'x'; export function init(value) { let result = !value; consume(result) }",
+        "import { consume } from 'x'; export function init(value) { consume(!value) }",
+    );
+    // A later script can likewise update any binding in this script's global
+    // scope while a call in the replacement runs.
+    test_script_same("var key = 'x'; function init(obj) { let num = mutate(); obj[key] = num }");
+    test_script_same("var target = {}; function init() { let num = mutate(); target.x = num }");
+    test_script_same(
+        "var value = 0; function init(consume) { let num = mutate(); consume(value, num) }",
     );
 }
 

--- a/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
@@ -1136,6 +1136,8 @@ fn test_fold_logical_expression_to_assignment_expression() {
     test_same("var x = {}; x.y || (a, x = {}, x.y = 3)");
     test_same("var x = {}; x.y || (foo(x = {}), x.y = 3)");
     test_same("var x = { y: {} }; x.y.z || (x.y = {}, x.y.z = 3)");
+    // ESM imports are live bindings and can be updated by `mutate`.
+    test_same("import { x, mutate } from 'm'; x.y || (mutate(), x.y = 3)");
     test("x || (a, x = 3)", "x ||= (a, 3)");
     test("var x = {}; x.y || (foo(), x.y = 3)", "var x = {}; x.y ||= (foo(), 3)");
     test("var x = {}; x.y || (new Foo(), x.y = 3)", "var x = {}; x.y ||= (new Foo(), 3)");

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -299,6 +299,10 @@ fn test_logical_expression() {
         "var x = { y: {} }; x.y.z != null || (x.y = {}, x.y.z = 3)",
         "var x = { y: {} }; x.y.z ?? (x.y = {}, x.y.z = 3)",
     );
+    test(
+        "import { x, mutate } from 'm'; x.y != null || (mutate(), x.y = 3)",
+        "import { x, mutate } from 'm'; x.y ?? (mutate(), x.y = 3)",
+    );
     // Safe to transform to ??= when base object is not mutated
     test("var x = {}; x.y != null || (foo(), x.y = 3)", "var x = {}; x.y ??= (foo(), 3)");
     test("var x = {}; x.y != null || (new Foo(), x.y = 3)", "var x = {}; x.y ??= (new Foo(), 3)");

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -23,5 +23,5 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 6.69 MB    | 2.12 MB    | 2.31 MB    | 453.83 kB  | 488.28 kB  |          5 | antd.js    
 
-10.95 MB   | 3.33 MB    | 3.49 MB    | 852.92 kB  | 915.50 kB  |          4 | typescript.js 
+10.95 MB   | 3.33 MB    | 3.49 MB    | 852.95 kB  | 915.50 kB  |          4 | typescript.js 
 

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 152
   sys alloc bytes: 15028748 # 15.03 MB
   sys peak growth: 10203896 # 10.20 MB
-  arena allocs: 152706
-  arena reallocs: 28225
-  arena size: 19309904 # 19.31 MB
+  arena allocs: 152864
+  arena reallocs: 28386
+  arena size: 19330664 # 19.33 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,9 +16,9 @@ App.tsx:
   sys deallocs: 63
   sys alloc bytes: 2136669 # 2.14 MB
   sys peak growth: 1620605 # 1.62 MB
-  arena allocs: 17027
-  arena reallocs: 2700
-  arena size: 2915736 # 2.92 MB
+  arena allocs: 17035
+  arena reallocs: 2714
+  arena size: 2916824 # 2.92 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -60,8 +60,8 @@ binder.ts:
   sys deallocs: 33
   sys alloc bytes: 963614 # 963.61 kB
   sys peak growth: 658042 # 658.04 kB
-  arena allocs: 7082
-  arena reallocs: 838
+  arena allocs: 7079
+  arena reallocs: 841
   arena size: 1169808 # 1.17 MB
 
 kitchen-sink.tsx:
@@ -71,7 +71,7 @@ kitchen-sink.tsx:
   sys deallocs: 1867
   sys alloc bytes: 5346850 # 5.35 MB
   sys peak growth: 3738631 # 3.74 MB
-  arena allocs: 71929
-  arena reallocs: 12244
+  arena allocs: 71932
+  arena reallocs: 12252
   arena size: 9560960 # 9.56 MB
 


### PR DESCRIPTION
A locally read-only identifier is not necessarily stable across a side-effecting call. ESM imports are live bindings, Script-root bindings can be changed by another script, and computed assignment keys bypassed the existing closed-over-TDZ guard. Single-use substitution could therefore move a binding read before a call and change program behavior.

The same incomplete stability query affected logical-assignment folding. A live imported member base could be cached before a call that reassigns the export, making `||=` or `??=` update the old object instead of the current binding.

Builds on the shared reorder predicates from #24699. Imports, Script-root bindings, unresolved references, syntactically mutated symbols, and closed-over block-scoped reads are treated conservatively across ordinary reads, assignment-target objects, computed keys, and member-base folding. Stable module bindings and pure replacements remain optimizable.

## Example

```js
var key = "x";
function init(obj) {
  let value = mutate();
  obj[key] = value;
}
```

The previous substitution could produce:

```js
var key = "x";
function init(obj) {
  obj[key] = mutate();
}
```

That captures `key` before `mutate()` runs, although another script can change the global binding during the call. The declaration is now retained so the read remains after `mutate()`.

For imported member bases, main can rewrite `x.y || (mutate(), x.y = 3)` to `x.y ||= (mutate(), 3)`. When `mutate` reassigns the exported `x`, the original two-module runtime repro produces `3`, while the rewritten program produces `0`. The shared stability guard now prevents that fold.

Plain computed assignments still inline stable identifiers and literals. ECMAScript evaluates the key expression and `GetValue` before the right-hand side, but defers `ToPropertyKey` until the final `PutValue`, so arbitrary key expressions remain conservative without losing safe simple-key substitutions.

This improves the existing reorder guard; it does not add a general TDZ model. Sloppy mapped `arguments` mutation remains a pre-existing unsupported case and is outside this stack.

Verified with the full `oxc_minifier` suite (622 passed, 42 ignored), clippy with warnings denied, formatting, minsize, allocation snapshots, runtime ordering probes, and repeat-compression checks.

Exact guard ablations attribute the total minsize change of +18 raw and +34 gzip bytes to two fixtures, with no iteration-count changes. TypeScript contributes +9 raw/+32 gzip because retaining `nonExports` preserves the Script-global `__spreadArray` lookup after a potentially side-effecting `ts.filter` call; shifted mangled names amplify its gzip delta. ECharts contributes +9 raw/+2 gzip because the computed-key guard conservatively retains `dataIdx` when the loop key has writes. Recovering that ECharts case would require more precise write-location or closure analysis rather than weakening the correctness guard. The import guard changes no minsize fixture because the corpus is parsed as Script. System-allocation metrics are unchanged; arena changes are dominated by retained code with minor fold-path shifts.

## Stack

1. #24699 — centralize reorder stability checks (merged)
2. **#24698 — guard reordered identifier reads**

AI assistance: Codex and Claude were used for implementation, adversarial review, and verification. The contributor remains responsible for reviewing, understanding, and submitting the changes under the repository AI usage policy.
