### PR TITLE
refactor(minifier): centralize reorder stability checks

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1491,38 +1491,43 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    /// Whether reordering this read before a side-effecting replacement could
-    /// observe `symbol_id` in its Temporal Dead Zone.
+    /// Whether the current read closes over a block-scoped binding.
     ///
-    /// The hazard is a block-scoped binding (`let`/`const`/`using`/`class`/`enum`)
-    /// closed over from an enclosing function: the function can suspend at an
-    /// `await`/`yield` while outer code initializes the binding, so the earlier
-    /// (reordered) read hits the TDZ where the original would not. A same-function
-    /// binding can't be initialized mid-suspension, so it stays inlinable.
+    /// This is a structural test, not proof that the binding is currently in its
+    /// Temporal Dead Zone. Moving such a read before an `await`/`yield` can expose
+    /// the TDZ while outer code is still initializing the binding. A same-function
+    /// binding cannot be initialized mid-suspension, so it stays inlinable.
     ///
     /// <https://github.com/rolldown/rolldown/issues/9959>
-    fn is_tdz_closed_over_read(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
-        ctx.scoping().symbol_flags(symbol_id).is_block_scoped()
-            && Self::read_crosses_function_boundary(
-                ctx.current_scope_id(),
-                ctx.scoping().symbol_scope_id(symbol_id),
-                ctx,
-            )
+    fn is_closed_over_block_scoped_read(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
+        let scoping = ctx.scoping();
+        if !scoping.symbol_flags(symbol_id).is_block_scoped() {
+            return false;
+        }
+
+        let binding_scope = scoping.symbol_scope_id(symbol_id);
+        Self::read_crosses_function_boundary(ctx.current_scope_id(), binding_scope, ctx)
     }
 
-    /// Whether reordering a side-effecting replacement past this member
-    /// assignment-target object is unsafe. The object is evaluated before the
-    /// replacement, so it is unsafe if its reference may change, or if it reads
-    /// a closed-over lexical that could be in its TDZ (e.g. `v.x = await f()`
-    /// reading `v` before the await). See [`Self::is_tdz_closed_over_read`].
-    fn member_object_blocks_reorder(object: &Expression<'a>, ctx: &TraverseCtx<'a>) -> bool {
-        Self::is_expression_that_reference_may_change(object, ctx)
-            || matches!(object, Expression::Identifier(id)
-                if ctx
-                    .scoping()
-                    .get_reference(id.reference_id())
-                    .symbol_id()
-                    .is_some_and(|symbol_id| Self::is_tdz_closed_over_read(symbol_id, ctx)))
+    /// Whether moving this identifier read earlier could observe a different
+    /// value or enter a closed-over lexical's TDZ.
+    fn identifier_read_blocks_reorder(id: &IdentifierReference<'a>, ctx: &TraverseCtx<'a>) -> bool {
+        let symbol_id = ctx.scoping().get_reference(id.reference_id()).symbol_id();
+        symbol_id.is_none_or(|symbol_id| {
+            Self::symbol_value_may_change(symbol_id, ctx)
+                || Self::is_closed_over_block_scoped_read(symbol_id, ctx)
+        })
+    }
+
+    /// Whether evaluating a member assignment-target part earlier could observe
+    /// a different binding value. This includes ordinary mutation and closed-over
+    /// lexicals that could still be in their TDZ (e.g. `v.x = await f()`).
+    fn member_part_blocks_reorder(expr: &Expression<'a>, ctx: &TraverseCtx<'a>) -> bool {
+        match expr {
+            Expression::Identifier(id) => Self::identifier_read_blocks_reorder(id, ctx),
+            Expression::ThisExpression(_) => false,
+            _ => true,
+        }
     }
 
     /// Returns Some(true) when the expression is successfully replaced.
@@ -1561,10 +1566,7 @@ impl<'a> PeepholeOptimizations {
                 // in particular before a side-effecting replacement such as an
                 // `await` — can surface a `ReferenceError` that the original order
                 // avoids. https://github.com/rolldown/rolldown/issues/9959
-                if let Some(symbol_id) = ctx.scoping().get_reference(id.reference_id()).symbol_id()
-                    && !Self::is_symbol_mutated(symbol_id, ctx)
-                    && !Self::is_tdz_closed_over_read(symbol_id, ctx)
-                {
+                if !Self::identifier_read_blocks_reorder(id, ctx) {
                     return None;
                 }
             }
@@ -1690,13 +1692,13 @@ impl<'a> PeepholeOptimizations {
                     let may_depend_on_side_effect = match &assign_expr.left {
                         AssignmentTarget::AssignmentTargetIdentifier(_) => false,
                         AssignmentTarget::ComputedMemberExpression(member_expr) => {
-                            Self::member_object_blocks_reorder(&member_expr.object, ctx)
+                            Self::member_part_blocks_reorder(&member_expr.object, ctx)
                         }
                         AssignmentTarget::PrivateFieldExpression(member_expr) => {
-                            Self::member_object_blocks_reorder(&member_expr.object, ctx)
+                            Self::member_part_blocks_reorder(&member_expr.object, ctx)
                         }
                         AssignmentTarget::StaticMemberExpression(member_expr) => {
-                            Self::member_object_blocks_reorder(&member_expr.object, ctx)
+                            Self::member_part_blocks_reorder(&member_expr.object, ctx)
                         }
                         AssignmentTarget::ArrayAssignmentTarget(_)
                         | AssignmentTarget::ObjectAssignmentTarget(_)

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -160,26 +160,23 @@ impl<'a> PeepholeOptimizations {
     ) -> bool {
         match expr {
             Expression::Identifier(id) => {
-                if let Some(symbol_id) = ctx.scoping().get_reference(id.reference_id()).symbol_id()
-                {
-                    Self::is_symbol_mutated(symbol_id, ctx)
-                } else {
-                    true
-                }
+                let symbol_id = ctx.scoping().get_reference(id.reference_id()).symbol_id();
+                symbol_id.is_none_or(|symbol_id| Self::symbol_value_may_change(symbol_id, ctx))
             }
             Expression::ThisExpression(_) => false,
             _ => true,
         }
     }
 
-    /// Check if a symbol is mutated, using the O(1) cached reference counts from
-    /// `SymbolValue` when available, falling back to the O(num_refs) scan in
-    /// `Scoping::symbol_is_mutated` for symbols without cached values.
+    /// Whether reading a resolved symbol again could produce a different value.
+    /// Uses the O(1) cached reference counts from `SymbolValue` when available,
+    /// falling back to the O(num_refs) scan in `Scoping::symbol_is_mutated` for
+    /// symbols without cached values.
     ///
     /// Only variable declarators have cached values (populated during
     /// `exit_variable_declarator` → `init_symbol_value`); function declarations
     /// and other binding kinds still take the fallback path.
-    fn is_symbol_mutated(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
+    fn symbol_value_may_change(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
         if let Some(sv) = ctx.state.symbols.value(symbol_id) {
             sv.references.has_writes()
         } else {
@@ -187,19 +184,19 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    /// True if the scope chain from `read_scope` up to (excluding) `body_scope`
+    /// True if the scope chain from `read_scope` up to (excluding) `stop_scope`
     /// crosses a function boundary — i.e. the read is in a closure relative to
-    /// `body_scope`. Async/generator/arrow scopes are all `Function`.
+    /// `stop_scope`. Async/generator/arrow scopes are all `Function`.
     fn read_crosses_function_boundary(
         read_scope: ScopeId,
-        body_scope: ScopeId,
+        stop_scope: ScopeId,
         ctx: &TraverseCtx<'a>,
     ) -> bool {
         let scoping = ctx.scoping();
         scoping
             .scope_ancestors(read_scope)
-            .take_while(|&s| s != body_scope)
-            .any(|s| scoping.scope_flags(s).is_function())
+            .take_while(|&scope_id| scope_id != stop_scope)
+            .any(|scope_id| scoping.scope_flags(scope_id).is_function())
     }
 }
 

--- a/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
+++ b/crates/oxc_minifier/tests/peephole/inline_single_use_variable.rs
@@ -333,17 +333,15 @@ fn test_inline_read_before_await_tdz() {
     // declaration's initializer (`let p = init(), v = ...`), before `v` is
     // initialized, so `v` is in its TDZ when `init` runs.
     test_same(
-        "import { bar } from 'x'; let p = init(), v = ext(); async function init() { let num = await foo(); bar(v, num) } export { p }",
+        "import { bar } from 'x'; let p = init(bar), v = ext(); async function init(fn) { let num = await foo(); fn(v, num) } export { p }",
     );
     test_same(
-        "import { bar } from 'x'; let v = ext(); export async function init() { let num = await foo(); bar(v, num) }",
+        "let v = ext(); export async function init(fn) { let num = await foo(); fn(v, num) }",
     );
     test_same(
-        "import { bar } from 'x'; const v = ext(); export async function init() { let num = await foo(); bar(v, num) }",
+        "const v = ext(); export async function init(fn) { let num = await foo(); fn(v, num) }",
     );
-    test_same(
-        "import { bar } from 'x'; export async function init() { let num = await foo(); bar(C, num) } class C {}",
-    );
+    test_same("export async function init(fn) { let num = await foo(); fn(C, num) } class C {}");
     // A member assignment target reads the object before the await, so a
     // closed-over lexical object must not be reordered either.
     test_same("let v = ext(); export async function init() { let num = await foo(); v.x = num }");
@@ -351,12 +349,12 @@ fn test_inline_read_before_await_tdz() {
     // `var` / parameter bindings are not TDZ-subject, so reordering the read
     // past the await is safe and still merges.
     test(
-        "import { bar } from 'x'; export async function init(v) { let num = await foo(); bar(v, num) }",
-        "import { bar } from 'x'; export async function init(v) { bar(v, await foo()) }",
+        "export async function init(fn, v) { let num = await foo(); fn(v, num) }",
+        "export async function init(fn, v) { fn(v, await foo()) }",
     );
     test(
-        "import { bar } from 'x'; export async function init() { var v = ext(); let num = await foo(); bar(v, num) }",
-        "import { bar } from 'x'; export async function init() { bar(ext(), await foo()) }",
+        "export async function init(fn) { var v = ext(); let num = await foo(); fn(v, num) }",
+        "export async function init(fn) { fn(ext(), await foo()) }",
     );
     test(
         "export async function init(v) { let num = await foo(); v.x = num }",
@@ -364,20 +362,18 @@ fn test_inline_read_before_await_tdz() {
     );
     // Same-function lexical is always initialized at the read, so it still merges.
     test(
-        "import { bar } from 'x'; export function outer() { const v = ext(); return bar(v, ext2()) }",
-        "import { bar } from 'x'; export function outer() { return bar(ext(), ext2()) }",
+        "export function outer(fn) { const v = ext(); return fn(v, ext2()) }",
+        "export function outer(fn) { return fn(ext(), ext2()) }",
     );
     // `using` is block-scoped too.
     test_same(
-        "import { bar } from 'x'; using v = ext(); export async function init() { let num = await foo(); bar(v, num) }",
+        "using v = ext(); export async function init(fn) { let num = await foo(); fn(v, num) }",
     );
     // `yield` is a suspension point like `await`.
-    test_same(
-        "import { bar } from 'x'; let v = ext(); export function* init() { let num = yield foo(); bar(v, num) }",
-    );
+    test_same("let v = ext(); export function* init(fn) { let num = yield foo(); fn(v, num) }");
     // Closed over across two function boundaries.
     test_same(
-        "import { bar } from 'x'; let v = ext(); export function outer() { return async function () { let num = await foo(); bar(v, num) } }",
+        "let v = ext(); export function outer(fn) { return async function () { let num = await foo(); fn(v, num) } }",
     );
 }
 


### PR DESCRIPTION
Single-use substitution checked the same reorder-safety decision in separate forms for ordinary identifier reads and member assignment targets. That duplication made future stability rules easy to apply to one consumer but miss in another.

Route both consumers through shared resolved-symbol stability and closed-over block-scoped-read predicates. Each identifier reference is resolved once, after which the symbol-level checks share the result. The refactor preserves three non-obvious boundaries: unresolved references remain blocked through `is_none_or`, non-simple member objects remain conservative through the `_ => true` arm, and the inverted ordinary-read condition is equivalent to the previous `resolved && !mutated && !closed_over` check. The closed-over predicate is named for what it structurally proves rather than implying that every such read is currently in the TDZ. TDZ fixtures use parameter callees so future import handling cannot make them pass vacuously.

There is no behavior or output change. Verified with 621 passing `oxc_minifier` tests and 42 ignored tests, clippy with warnings denied, formatting, `just minsize`, and allocation regeneration; minsize and allocation snapshots are byte-identical.

## Stack

1. **#24699 — centralize reorder stability checks**
2. #24698 — guard reordered identifier reads

AI assistance: Codex and Claude were used for implementation, adversarial review, and verification. The contributor remains responsible for reviewing, understanding, and submitting the changes under the repository AI usage policy.
