### PR TITLE
refactor(react_compiler): move the CFG HIR into the arena

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -169,7 +169,7 @@ fn run_pipeline<'a>(
         return Ok(Ok(None));
     }
 
-    prune_maybe_throws(&mut hir, &mut env.functions)?;
+    prune_maybe_throws(&mut hir, &mut env.functions, env.allocator)?;
 
     validate_context_variable_lvalues(&hir, &mut env)?;
 
@@ -180,7 +180,7 @@ fn run_pipeline<'a>(
 
     inline_immediately_invoked_function_expressions(&mut hir, &mut env);
 
-    merge_consecutive_blocks(&mut hir, &mut env.functions);
+    merge_consecutive_blocks(&mut hir, &mut env.functions, env.allocator);
 
     // TODO: port assertConsistentIdentifiers
     // TODO: port assertTerminalSuccessorsExist
@@ -221,7 +221,7 @@ fn run_pipeline<'a>(
 
     dead_code_elimination(&mut hir, &env);
 
-    prune_maybe_throws(&mut hir, &mut env.functions)?;
+    prune_maybe_throws(&mut hir, &mut env.functions, env.allocator)?;
 
     infer_mutation_aliasing_ranges(&mut hir, &mut env, false)?;
 

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -129,7 +129,7 @@ pub struct Environment<'a> {
 
 /// An outlined function entry, stored on Environment during compilation.
 /// Corresponds to TS `{ fn: HIRFunction, type: ReactFunctionType | null }`.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct OutlinedFunctionEntry<'a> {
     pub func: HirFunction<'a>,
     pub fn_type: Option<ReactFunctionType>,

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -10,7 +10,7 @@ pub mod type_config;
 pub mod visitors;
 
 use crate::react_compiler_utils::OrderedMap;
-use crate::react_compiler_utils::OrderedSet;
+use crate::react_compiler_utils::ordered_map::{ArenaOrderedMap, ArenaOrderedSet};
 use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds, Vec as ArenaVec};
 use oxc_ast::ast::*;
 use oxc_index::define_nonmax_u32_index_type;
@@ -145,21 +145,21 @@ impl std::fmt::Display for FloatValue {
 // =============================================================================
 
 /// A function lowered to HIR form
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct HirFunction<'a> {
     pub span: Option<Span>,
     pub id: Option<Ident<'a>>,
     pub name_hint: Option<Ident<'a>>,
     pub fn_type: ReactFunctionType,
-    pub params: Vec<ParamPattern>,
+    pub params: ArenaVec<'a, ParamPattern>,
     pub returns: Place,
-    pub context: Vec<Place>,
-    pub body: HIR,
-    pub instructions: Vec<Instruction<'a>>,
+    pub context: ArenaVec<'a, Place>,
+    pub body: HIR<'a>,
+    pub instructions: ArenaVec<'a, Instruction<'a>>,
     pub generator: bool,
     pub is_async: bool,
-    pub directives: Vec<Str<'a>>,
-    pub aliasing_effects: Option<Vec<AliasingEffect>>,
+    pub directives: ArenaVec<'a, Str<'a>>,
+    pub aliasing_effects: Option<ArenaVec<'a, AliasingEffect<'a>>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -176,11 +176,11 @@ pub enum ParamPattern {
 }
 
 /// The HIR control-flow graph
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[allow(clippy::upper_case_acronyms)]
-pub struct HIR {
+pub struct HIR<'a> {
     pub entry: BlockId,
-    pub blocks: OrderedMap<BlockId, BasicBlock>,
+    pub blocks: OrderedMap<BlockId, BasicBlock<'a>>,
 }
 
 /// Block kinds
@@ -206,29 +206,29 @@ impl std::fmt::Display for BlockKind {
 }
 
 /// A basic block in the CFG
-#[derive(Debug, Clone)]
-pub struct BasicBlock {
+#[derive(Debug)]
+pub struct BasicBlock<'a> {
     pub kind: BlockKind,
     pub id: BlockId,
-    pub instructions: Vec<InstructionId>,
-    pub terminal: Terminal,
-    pub preds: OrderedSet<BlockId>,
-    pub phis: Vec<Phi>,
+    pub instructions: ArenaVec<'a, InstructionId>,
+    pub terminal: Terminal<'a>,
+    pub preds: ArenaOrderedSet<'a, BlockId>,
+    pub phis: ArenaVec<'a, Phi<'a>>,
 }
 
 /// Phi node for SSA
-#[derive(Debug, Clone)]
-pub struct Phi {
+#[derive(Debug)]
+pub struct Phi<'a> {
     pub place: Place,
-    pub operands: OrderedMap<BlockId, Place>,
+    pub operands: ArenaOrderedMap<'a, BlockId, Place>,
 }
 
 // =============================================================================
 // Terminal enum
 // =============================================================================
 
-#[derive(Debug, Clone)]
-pub enum Terminal {
+#[derive(Debug)]
+pub enum Terminal<'a> {
     Unreachable {
         id: EvaluationOrder,
         span: Option<Span>,
@@ -243,7 +243,7 @@ pub enum Terminal {
         return_variant: ReturnVariant,
         id: EvaluationOrder,
         span: Option<Span>,
-        effects: Option<Vec<AliasingEffect>>,
+        effects: Option<ArenaVec<'a, AliasingEffect<'a>>>,
     },
     Goto {
         block: BlockId,
@@ -269,7 +269,7 @@ pub enum Terminal {
     },
     Switch {
         test: Place,
-        cases: Vec<Case>,
+        cases: ArenaVec<'a, Case>,
         fallthrough: BlockId,
         id: EvaluationOrder,
         span: Option<Span>,
@@ -349,7 +349,7 @@ pub enum Terminal {
         handler: Option<BlockId>,
         id: EvaluationOrder,
         span: Option<Span>,
-        effects: Option<Vec<AliasingEffect>>,
+        effects: Option<ArenaVec<'a, AliasingEffect<'a>>>,
     },
     Try {
         block: BlockId,
@@ -375,7 +375,7 @@ pub enum Terminal {
     },
 }
 
-impl Terminal {
+impl<'a> Terminal<'a> {
     /// Get the evaluation order of this terminal
     pub fn evaluation_order(&self) -> EvaluationOrder {
         match self {
@@ -482,13 +482,13 @@ pub struct Case {
 // Instruction types
 // =============================================================================
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Instruction<'a> {
     pub id: EvaluationOrder,
     pub lvalue: Place,
     pub value: InstructionValue<'a>,
     pub span: Option<Span>,
-    pub effects: Option<Vec<AliasingEffect>>,
+    pub effects: Option<ArenaVec<'a, AliasingEffect<'a>>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -509,15 +509,15 @@ pub struct LValue {
     pub kind: InstructionKind,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct LValuePattern<'a> {
     pub pattern: Pattern<'a>,
     pub kind: InstructionKind,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum Pattern<'a> {
-    Array(ArrayPattern),
+    Array(ArrayPattern<'a>),
     Object(ObjectPattern<'a>),
 }
 
@@ -525,7 +525,7 @@ pub enum Pattern<'a> {
 // InstructionValue enum
 // =============================================================================
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum InstructionValue<'a> {
     LoadLocal {
         place: Place,
@@ -574,18 +574,18 @@ pub enum InstructionValue<'a> {
     },
     NewExpression {
         callee: Place,
-        args: Vec<PlaceOrSpread>,
+        args: ArenaVec<'a, PlaceOrSpread>,
         span: Option<Span>,
     },
     CallExpression {
         callee: Place,
-        args: Vec<PlaceOrSpread>,
+        args: ArenaVec<'a, PlaceOrSpread>,
         span: Option<Span>,
     },
     MethodCall {
         receiver: Place,
         property: Place,
-        args: Vec<PlaceOrSpread>,
+        args: ArenaVec<'a, PlaceOrSpread>,
         span: Option<Span>,
     },
     UnaryExpression {
@@ -600,14 +600,14 @@ pub enum InstructionValue<'a> {
     },
     JsxExpression {
         tag: JsxTag<'a>,
-        props: Vec<JsxAttribute<'a>>,
-        children: Option<Vec<Place>>,
+        props: ArenaVec<'a, JsxAttribute<'a>>,
+        children: Option<ArenaVec<'a, Place>>,
         span: Option<Span>,
         opening_span: Option<Span>,
         closing_span: Option<Span>,
     },
     ObjectExpression {
-        properties: Vec<ObjectPropertyOrSpread<'a>>,
+        properties: ArenaVec<'a, ObjectPropertyOrSpread<'a>>,
         span: Option<Span>,
     },
     ObjectMethod {
@@ -615,11 +615,11 @@ pub enum InstructionValue<'a> {
         lowered_func: LoweredFunction,
     },
     ArrayExpression {
-        elements: Vec<ArrayElement>,
+        elements: ArenaVec<'a, ArrayElement>,
         span: Option<Span>,
     },
     JsxFragment {
-        children: Vec<Place>,
+        children: ArenaVec<'a, Place>,
         span: Option<Span>,
     },
     RegExpLiteral {
@@ -686,13 +686,13 @@ pub enum InstructionValue<'a> {
         // Upstream's HIR models only a single quasi with no interpolation; the
         // oxc port extends it to support `tag`-ed templates with `${...}`
         // interpolations (a deliberate divergence from the TS reference).
-        quasis: Vec<TemplateQuasi<'a>>,
-        subexprs: Vec<Place>,
+        quasis: ArenaVec<'a, TemplateQuasi<'a>>,
+        subexprs: ArenaVec<'a, Place>,
         span: Option<Span>,
     },
     TemplateLiteral {
-        subexprs: Vec<Place>,
-        quasis: Vec<TemplateQuasi<'a>>,
+        subexprs: ArenaVec<'a, Place>,
+        quasis: ArenaVec<'a, TemplateQuasi<'a>>,
         span: Option<Span>,
     },
     Await {
@@ -729,7 +729,7 @@ pub enum InstructionValue<'a> {
     },
     StartMemoize {
         manual_memo_id: u32,
-        deps: Option<Vec<ManualMemoDependency<'a>>>,
+        deps: Option<ArenaVec<'a, ManualMemoDependency<'a>>>,
         deps_span: Option<Option<Span>>,
         has_invalid_deps: bool,
         span: Option<Span>,
@@ -851,10 +851,10 @@ pub struct TemplateQuasi<'a> {
     pub cooked: Option<Str<'a>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ManualMemoDependency<'a> {
     pub root: ManualMemoDependencyRoot<'a>,
-    pub path: Vec<DependencyPathEntry<'a>>,
+    pub path: ArenaVec<'a, DependencyPathEntry<'a>>,
     pub span: Option<Span>,
 }
 
@@ -981,9 +981,9 @@ pub struct SpreadPattern {
     pub place: Place,
 }
 
-#[derive(Debug, Clone)]
-pub struct ArrayPattern {
-    pub items: Vec<ArrayPatternElement>,
+#[derive(Debug)]
+pub struct ArrayPattern<'a> {
+    pub items: ArenaVec<'a, ArrayPatternElement>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -993,9 +993,9 @@ pub enum ArrayPatternElement {
     Hole,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ObjectPattern<'a> {
-    pub properties: Vec<ObjectPropertyOrSpread<'a>>,
+    pub properties: ArenaVec<'a, ObjectPropertyOrSpread<'a>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1235,7 +1235,30 @@ macro_rules! impl_trivial_clone_in {
         })+
     };
 }
-impl_trivial_clone_in!(DependencyPathEntry<'a>);
+impl_trivial_clone_in!(
+    DependencyPathEntry<'a>,
+    IdentifierId,
+    ScopeId,
+    BlockId,
+    InstructionId,
+    EvaluationOrder,
+    TypeId,
+    FunctionId,
+    MutableRangeId,
+    DiagnosticId,
+    DeclarationId,
+    Place,
+    Case,
+    PlaceOrSpread,
+    PlaceOrSpreadOrHole,
+    ArrayElement,
+    ArrayPatternElement,
+    ObjectPropertyOrSpread<'a>,
+    JsxAttribute<'a>,
+    TemplateQuasi<'a>,
+    ParamPattern,
+    SpreadPattern,
+);
 
 impl<'a> CloneIn<'a> for ReactiveScopeDependency<'a> {
     type Cloned = ReactiveScopeDependency<'a>;
@@ -1265,15 +1288,15 @@ use crate::react_compiler_hir::type_config::ValueKind;
 use crate::react_compiler_hir::type_config::ValueReason;
 
 /// Reason for a mutation, used for generating hints (e.g. rename to "Ref").
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MutationReason {
     AssignCurrentProperty,
 }
 
 /// Describes the aliasing/mutation/data-flow effects of an instruction or terminal.
 /// Ported from TS `AliasingEffect` in `AliasingEffects.ts`.
-#[derive(Debug, Clone)]
-pub enum AliasingEffect {
+#[derive(Debug)]
+pub enum AliasingEffect<'a> {
     /// Marks the given value and its direct aliases as frozen.
     Freeze { value: Place, reason: ValueReason },
     /// Mutate the value and any direct aliases.
@@ -1303,7 +1326,7 @@ pub enum AliasingEffect {
         receiver: Place,
         function: Place,
         mutates_function: bool,
-        args: Vec<PlaceOrSpreadOrHole>,
+        args: ArenaVec<'a, PlaceOrSpreadOrHole>,
         into: Place,
         /// Callee function `TypeId`, used to resolve the `FunctionSignature` from the
         /// environment on demand. Storing the id (rather than an `Rc<FunctionSignature>`)
@@ -1312,7 +1335,7 @@ pub enum AliasingEffect {
         span: Option<Span>,
     },
     /// Function expression creation with captures.
-    CreateFunction { captures: Vec<Place>, function_id: FunctionId, into: Place },
+    CreateFunction { captures: ArenaVec<'a, Place>, function_id: FunctionId, into: Place },
     /// Mutation of a value known to be frozen (error).
     ///
     /// `error` indexes the diagnostic interned on `Environment` (see
@@ -1328,7 +1351,7 @@ pub enum AliasingEffect {
 }
 
 /// Combined Place/Spread/Hole for Apply args.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum PlaceOrSpreadOrHole {
     Place(Place),
     Spread(SpreadPattern),
@@ -1337,14 +1360,614 @@ pub enum PlaceOrSpreadOrHole {
 
 /// Aliasing signature for function calls.
 /// Ported from TS `AliasingSignature` in `AliasingEffects.ts`.
-#[derive(Debug, Clone)]
-pub struct AliasingSignature {
+#[derive(Debug)]
+pub struct AliasingSignature<'a> {
     pub receiver: IdentifierId,
-    pub params: Vec<IdentifierId>,
+    pub params: ArenaVec<'a, IdentifierId>,
     pub rest: Option<IdentifierId>,
     pub returns: IdentifierId,
-    pub effects: Vec<AliasingEffect>,
-    pub temporaries: Vec<Place>,
+    pub effects: ArenaVec<'a, AliasingEffect<'a>>,
+    pub temporaries: ArenaVec<'a, Place>,
+}
+
+// =============================================================================
+// Arena `CloneIn` for the arena-carrying HIR types (same-arena, `Cloned = Self`)
+// =============================================================================
+// Copy leaves are copied by direct field assignment; only arena `Vec` /
+// `ArenaOrderedMap` / `ArenaOrderedSet` fields recurse via `clone_in_impl`.
+// `Option<ArenaVec<..>>` clones via `self.x.as_ref().map(|v| v.clone_in_impl(..))`.
+
+impl<'a> CloneIn<'a> for HirFunction<'a> {
+    type Cloned = HirFunction<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        HirFunction {
+            span: self.span,
+            id: self.id,
+            name_hint: self.name_hint,
+            fn_type: self.fn_type,
+            params: self.params.clone_in_impl(sem, alloc),
+            returns: self.returns,
+            context: self.context.clone_in_impl(sem, alloc),
+            body: self.body.clone_in_impl(sem, alloc),
+            instructions: self.instructions.clone_in_impl(sem, alloc),
+            generator: self.generator,
+            is_async: self.is_async,
+            directives: self.directives.clone_in_impl(sem, alloc),
+            aliasing_effects: self.aliasing_effects.as_ref().map(|v| v.clone_in_impl(sem, alloc)),
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for HIR<'a> {
+    type Cloned = HIR<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        let mut blocks = OrderedMap::default();
+        for (id, block) in self.blocks.iter() {
+            blocks.insert(*id, block.clone_in_impl(sem, alloc));
+        }
+        HIR { entry: self.entry, blocks }
+    }
+}
+
+impl<'a> CloneIn<'a> for BasicBlock<'a> {
+    type Cloned = BasicBlock<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        BasicBlock {
+            kind: self.kind,
+            id: self.id,
+            instructions: self.instructions.clone_in_impl(sem, alloc),
+            terminal: self.terminal.clone_in_impl(sem, alloc),
+            preds: self.preds.clone_in_impl(sem, alloc),
+            phis: self.phis.clone_in_impl(sem, alloc),
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for Phi<'a> {
+    type Cloned = Phi<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        Phi { place: self.place, operands: self.operands.clone_in_impl(sem, alloc) }
+    }
+}
+
+impl<'a> CloneIn<'a> for Terminal<'a> {
+    type Cloned = Terminal<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        match self {
+            Terminal::Unreachable { id, span } => Terminal::Unreachable { id: *id, span: *span },
+            Terminal::Throw { value, id, span } => {
+                Terminal::Throw { value: *value, id: *id, span: *span }
+            }
+            Terminal::Return { value, return_variant, id, span, effects } => Terminal::Return {
+                value: *value,
+                return_variant: *return_variant,
+                id: *id,
+                span: *span,
+                effects: effects.as_ref().map(|v| v.clone_in_impl(sem, alloc)),
+            },
+            Terminal::Goto { block, variant, id, span } => {
+                Terminal::Goto { block: *block, variant: *variant, id: *id, span: *span }
+            }
+            Terminal::If { test, consequent, alternate, fallthrough, id, span } => Terminal::If {
+                test: *test,
+                consequent: *consequent,
+                alternate: *alternate,
+                fallthrough: *fallthrough,
+                id: *id,
+                span: *span,
+            },
+            Terminal::Branch { test, consequent, alternate, fallthrough, id, span } => {
+                Terminal::Branch {
+                    test: *test,
+                    consequent: *consequent,
+                    alternate: *alternate,
+                    fallthrough: *fallthrough,
+                    id: *id,
+                    span: *span,
+                }
+            }
+            Terminal::Switch { test, cases, fallthrough, id, span } => Terminal::Switch {
+                test: *test,
+                cases: cases.clone_in_impl(sem, alloc),
+                fallthrough: *fallthrough,
+                id: *id,
+                span: *span,
+            },
+            Terminal::DoWhile { loop_block, test, fallthrough, id, span } => Terminal::DoWhile {
+                loop_block: *loop_block,
+                test: *test,
+                fallthrough: *fallthrough,
+                id: *id,
+                span: *span,
+            },
+            Terminal::While { test, loop_block, fallthrough, id, span } => Terminal::While {
+                test: *test,
+                loop_block: *loop_block,
+                fallthrough: *fallthrough,
+                id: *id,
+                span: *span,
+            },
+            Terminal::For { init, test, update, loop_block, fallthrough, id, span } => {
+                Terminal::For {
+                    init: *init,
+                    test: *test,
+                    update: *update,
+                    loop_block: *loop_block,
+                    fallthrough: *fallthrough,
+                    id: *id,
+                    span: *span,
+                }
+            }
+            Terminal::ForOf { init, test, loop_block, fallthrough, id, span } => Terminal::ForOf {
+                init: *init,
+                test: *test,
+                loop_block: *loop_block,
+                fallthrough: *fallthrough,
+                id: *id,
+                span: *span,
+            },
+            Terminal::ForIn { init, loop_block, fallthrough, id, span } => Terminal::ForIn {
+                init: *init,
+                loop_block: *loop_block,
+                fallthrough: *fallthrough,
+                id: *id,
+                span: *span,
+            },
+            Terminal::Logical { operator, test, fallthrough, id, span } => Terminal::Logical {
+                operator: *operator,
+                test: *test,
+                fallthrough: *fallthrough,
+                id: *id,
+                span: *span,
+            },
+            Terminal::Ternary { test, fallthrough, id, span } => {
+                Terminal::Ternary { test: *test, fallthrough: *fallthrough, id: *id, span: *span }
+            }
+            Terminal::Optional { optional, test, fallthrough, id, span } => Terminal::Optional {
+                optional: *optional,
+                test: *test,
+                fallthrough: *fallthrough,
+                id: *id,
+                span: *span,
+            },
+            Terminal::Label { block, fallthrough, id, span } => {
+                Terminal::Label { block: *block, fallthrough: *fallthrough, id: *id, span: *span }
+            }
+            Terminal::Sequence { block, fallthrough, id, span } => Terminal::Sequence {
+                block: *block,
+                fallthrough: *fallthrough,
+                id: *id,
+                span: *span,
+            },
+            Terminal::MaybeThrow { continuation, handler, id, span, effects } => {
+                Terminal::MaybeThrow {
+                    continuation: *continuation,
+                    handler: *handler,
+                    id: *id,
+                    span: *span,
+                    effects: effects.as_ref().map(|v| v.clone_in_impl(sem, alloc)),
+                }
+            }
+            Terminal::Try { block, handler_binding, handler, fallthrough, id, span } => {
+                Terminal::Try {
+                    block: *block,
+                    handler_binding: *handler_binding,
+                    handler: *handler,
+                    fallthrough: *fallthrough,
+                    id: *id,
+                    span: *span,
+                }
+            }
+            Terminal::Scope { fallthrough, block, scope, id, span } => Terminal::Scope {
+                fallthrough: *fallthrough,
+                block: *block,
+                scope: *scope,
+                id: *id,
+                span: *span,
+            },
+            Terminal::PrunedScope { fallthrough, block, scope, id, span } => {
+                Terminal::PrunedScope {
+                    fallthrough: *fallthrough,
+                    block: *block,
+                    scope: *scope,
+                    id: *id,
+                    span: *span,
+                }
+            }
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for Instruction<'a> {
+    type Cloned = Instruction<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        Instruction {
+            id: self.id,
+            lvalue: self.lvalue,
+            value: self.value.clone_in_impl(sem, alloc),
+            span: self.span,
+            effects: self.effects.as_ref().map(|v| v.clone_in_impl(sem, alloc)),
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for InstructionValue<'a> {
+    type Cloned = InstructionValue<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        match self {
+            // --- Copy-only variants: field-copy ---
+            InstructionValue::LoadLocal { place, span } => {
+                InstructionValue::LoadLocal { place: *place, span: *span }
+            }
+            InstructionValue::LoadContext { place, span } => {
+                InstructionValue::LoadContext { place: *place, span: *span }
+            }
+            InstructionValue::DeclareLocal { lvalue, span } => {
+                InstructionValue::DeclareLocal { lvalue: *lvalue, span: *span }
+            }
+            InstructionValue::DeclareContext { lvalue, span } => {
+                InstructionValue::DeclareContext { lvalue: *lvalue, span: *span }
+            }
+            InstructionValue::StoreLocal { lvalue, value, span } => {
+                InstructionValue::StoreLocal { lvalue: *lvalue, value: *value, span: *span }
+            }
+            InstructionValue::StoreContext { lvalue, value, span } => {
+                InstructionValue::StoreContext { lvalue: *lvalue, value: *value, span: *span }
+            }
+            InstructionValue::Primitive { value, span } => {
+                InstructionValue::Primitive { value: *value, span: *span }
+            }
+            InstructionValue::JSXText { value, span } => {
+                InstructionValue::JSXText { value: *value, span: *span }
+            }
+            InstructionValue::BinaryExpression { operator, left, right, span } => {
+                InstructionValue::BinaryExpression {
+                    operator: *operator,
+                    left: *left,
+                    right: *right,
+                    span: *span,
+                }
+            }
+            InstructionValue::UnaryExpression { operator, value, span } => {
+                InstructionValue::UnaryExpression {
+                    operator: *operator,
+                    value: *value,
+                    span: *span,
+                }
+            }
+            InstructionValue::TypeCastExpression { value, cast, span } => {
+                InstructionValue::TypeCastExpression { value: *value, cast: *cast, span: *span }
+            }
+            InstructionValue::ObjectMethod { span, lowered_func } => {
+                InstructionValue::ObjectMethod { span: *span, lowered_func: *lowered_func }
+            }
+            InstructionValue::RegExpLiteral { pattern, flags, span } => {
+                InstructionValue::RegExpLiteral { pattern: *pattern, flags: *flags, span: *span }
+            }
+            InstructionValue::MetaProperty { meta, property, span } => {
+                InstructionValue::MetaProperty { meta: *meta, property: *property, span: *span }
+            }
+            InstructionValue::PropertyStore { object, property, value, span } => {
+                InstructionValue::PropertyStore {
+                    object: *object,
+                    property: *property,
+                    value: *value,
+                    span: *span,
+                }
+            }
+            InstructionValue::PropertyLoad { object, property, span } => {
+                InstructionValue::PropertyLoad { object: *object, property: *property, span: *span }
+            }
+            InstructionValue::PropertyDelete { object, property, span } => {
+                InstructionValue::PropertyDelete {
+                    object: *object,
+                    property: *property,
+                    span: *span,
+                }
+            }
+            InstructionValue::ComputedStore { object, property, value, span } => {
+                InstructionValue::ComputedStore {
+                    object: *object,
+                    property: *property,
+                    value: *value,
+                    span: *span,
+                }
+            }
+            InstructionValue::ComputedLoad { object, property, span } => {
+                InstructionValue::ComputedLoad { object: *object, property: *property, span: *span }
+            }
+            InstructionValue::ComputedDelete { object, property, span } => {
+                InstructionValue::ComputedDelete {
+                    object: *object,
+                    property: *property,
+                    span: *span,
+                }
+            }
+            InstructionValue::LoadGlobal { binding, span } => {
+                InstructionValue::LoadGlobal { binding: *binding, span: *span }
+            }
+            InstructionValue::StoreGlobal { name, value, span } => {
+                InstructionValue::StoreGlobal { name: *name, value: *value, span: *span }
+            }
+            InstructionValue::FunctionExpression {
+                name,
+                name_hint,
+                lowered_func,
+                expr_type,
+                span,
+            } => InstructionValue::FunctionExpression {
+                name: *name,
+                name_hint: *name_hint,
+                lowered_func: *lowered_func,
+                expr_type: *expr_type,
+                span: *span,
+            },
+            InstructionValue::Await { value, span } => {
+                InstructionValue::Await { value: *value, span: *span }
+            }
+            InstructionValue::GetIterator { collection, span } => {
+                InstructionValue::GetIterator { collection: *collection, span: *span }
+            }
+            InstructionValue::IteratorNext { iterator, collection, span } => {
+                InstructionValue::IteratorNext {
+                    iterator: *iterator,
+                    collection: *collection,
+                    span: *span,
+                }
+            }
+            InstructionValue::NextPropertyOf { value, span } => {
+                InstructionValue::NextPropertyOf { value: *value, span: *span }
+            }
+            InstructionValue::PrefixUpdate { lvalue, operation, value, span } => {
+                InstructionValue::PrefixUpdate {
+                    lvalue: *lvalue,
+                    operation: *operation,
+                    value: *value,
+                    span: *span,
+                }
+            }
+            InstructionValue::PostfixUpdate { lvalue, operation, value, span } => {
+                InstructionValue::PostfixUpdate {
+                    lvalue: *lvalue,
+                    operation: *operation,
+                    value: *value,
+                    span: *span,
+                }
+            }
+            InstructionValue::Debugger { span } => InstructionValue::Debugger { span: *span },
+            InstructionValue::FinishMemoize { manual_memo_id, decl, pruned, span } => {
+                InstructionValue::FinishMemoize {
+                    manual_memo_id: *manual_memo_id,
+                    decl: *decl,
+                    pruned: *pruned,
+                    span: *span,
+                }
+            }
+            // --- Arena-carrying variants: recurse ---
+            InstructionValue::Destructure { lvalue, value, span } => {
+                InstructionValue::Destructure {
+                    lvalue: lvalue.clone_in_impl(sem, alloc),
+                    value: *value,
+                    span: *span,
+                }
+            }
+            InstructionValue::NewExpression { callee, args, span } => {
+                InstructionValue::NewExpression {
+                    callee: *callee,
+                    args: args.clone_in_impl(sem, alloc),
+                    span: *span,
+                }
+            }
+            InstructionValue::CallExpression { callee, args, span } => {
+                InstructionValue::CallExpression {
+                    callee: *callee,
+                    args: args.clone_in_impl(sem, alloc),
+                    span: *span,
+                }
+            }
+            InstructionValue::MethodCall { receiver, property, args, span } => {
+                InstructionValue::MethodCall {
+                    receiver: *receiver,
+                    property: *property,
+                    args: args.clone_in_impl(sem, alloc),
+                    span: *span,
+                }
+            }
+            InstructionValue::JsxExpression {
+                tag,
+                props,
+                children,
+                span,
+                opening_span,
+                closing_span,
+            } => InstructionValue::JsxExpression {
+                tag: *tag,
+                props: props.clone_in_impl(sem, alloc),
+                children: children.as_ref().map(|v| v.clone_in_impl(sem, alloc)),
+                span: *span,
+                opening_span: *opening_span,
+                closing_span: *closing_span,
+            },
+            InstructionValue::ObjectExpression { properties, span } => {
+                InstructionValue::ObjectExpression {
+                    properties: properties.clone_in_impl(sem, alloc),
+                    span: *span,
+                }
+            }
+            InstructionValue::ArrayExpression { elements, span } => {
+                InstructionValue::ArrayExpression {
+                    elements: elements.clone_in_impl(sem, alloc),
+                    span: *span,
+                }
+            }
+            InstructionValue::JsxFragment { children, span } => InstructionValue::JsxFragment {
+                children: children.clone_in_impl(sem, alloc),
+                span: *span,
+            },
+            InstructionValue::TaggedTemplateExpression { tag, quasis, subexprs, span } => {
+                InstructionValue::TaggedTemplateExpression {
+                    tag: *tag,
+                    quasis: quasis.clone_in_impl(sem, alloc),
+                    subexprs: subexprs.clone_in_impl(sem, alloc),
+                    span: *span,
+                }
+            }
+            InstructionValue::TemplateLiteral { subexprs, quasis, span } => {
+                InstructionValue::TemplateLiteral {
+                    subexprs: subexprs.clone_in_impl(sem, alloc),
+                    quasis: quasis.clone_in_impl(sem, alloc),
+                    span: *span,
+                }
+            }
+            InstructionValue::StartMemoize {
+                manual_memo_id,
+                deps,
+                deps_span,
+                has_invalid_deps,
+                span,
+            } => InstructionValue::StartMemoize {
+                manual_memo_id: *manual_memo_id,
+                deps: deps.as_ref().map(|v| v.clone_in_impl(sem, alloc)),
+                deps_span: *deps_span,
+                has_invalid_deps: *has_invalid_deps,
+                span: *span,
+            },
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for LValuePattern<'a> {
+    type Cloned = LValuePattern<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        LValuePattern { pattern: self.pattern.clone_in_impl(sem, alloc), kind: self.kind }
+    }
+}
+
+impl<'a> CloneIn<'a> for Pattern<'a> {
+    type Cloned = Pattern<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        match self {
+            Pattern::Array(p) => Pattern::Array(p.clone_in_impl(sem, alloc)),
+            Pattern::Object(p) => Pattern::Object(p.clone_in_impl(sem, alloc)),
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for ArrayPattern<'a> {
+    type Cloned = ArrayPattern<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        ArrayPattern { items: self.items.clone_in_impl(sem, alloc) }
+    }
+}
+
+impl<'a> CloneIn<'a> for ObjectPattern<'a> {
+    type Cloned = ObjectPattern<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        ObjectPattern { properties: self.properties.clone_in_impl(sem, alloc) }
+    }
+}
+
+impl<'a> CloneIn<'a> for ManualMemoDependency<'a> {
+    type Cloned = ManualMemoDependency<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        ManualMemoDependency {
+            root: self.root,
+            path: self.path.clone_in_impl(sem, alloc),
+            span: self.span,
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for AliasingEffect<'a> {
+    type Cloned = AliasingEffect<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        match self {
+            AliasingEffect::Freeze { value, reason } => {
+                AliasingEffect::Freeze { value: *value, reason: *reason }
+            }
+            AliasingEffect::Mutate { value, reason } => {
+                AliasingEffect::Mutate { value: *value, reason: *reason }
+            }
+            AliasingEffect::MutateConditionally { value } => {
+                AliasingEffect::MutateConditionally { value: *value }
+            }
+            AliasingEffect::MutateTransitive { value } => {
+                AliasingEffect::MutateTransitive { value: *value }
+            }
+            AliasingEffect::MutateTransitiveConditionally { value } => {
+                AliasingEffect::MutateTransitiveConditionally { value: *value }
+            }
+            AliasingEffect::Capture { from, into } => {
+                AliasingEffect::Capture { from: *from, into: *into }
+            }
+            AliasingEffect::Alias { from, into } => {
+                AliasingEffect::Alias { from: *from, into: *into }
+            }
+            AliasingEffect::MaybeAlias { from, into } => {
+                AliasingEffect::MaybeAlias { from: *from, into: *into }
+            }
+            AliasingEffect::Assign { from, into } => {
+                AliasingEffect::Assign { from: *from, into: *into }
+            }
+            AliasingEffect::Create { into, value, reason } => {
+                AliasingEffect::Create { into: *into, value: *value, reason: *reason }
+            }
+            AliasingEffect::CreateFrom { from, into } => {
+                AliasingEffect::CreateFrom { from: *from, into: *into }
+            }
+            AliasingEffect::ImmutableCapture { from, into } => {
+                AliasingEffect::ImmutableCapture { from: *from, into: *into }
+            }
+            AliasingEffect::Apply {
+                receiver,
+                function,
+                mutates_function,
+                args,
+                into,
+                signature,
+                span,
+            } => AliasingEffect::Apply {
+                receiver: *receiver,
+                function: *function,
+                mutates_function: *mutates_function,
+                args: args.clone_in_impl(sem, alloc),
+                into: *into,
+                signature: *signature,
+                span: *span,
+            },
+            AliasingEffect::CreateFunction { captures, function_id, into } => {
+                AliasingEffect::CreateFunction {
+                    captures: captures.clone_in_impl(sem, alloc),
+                    function_id: *function_id,
+                    into: *into,
+                }
+            }
+            AliasingEffect::MutateFrozen { place, error } => {
+                AliasingEffect::MutateFrozen { place: *place, error: *error }
+            }
+            AliasingEffect::MutateGlobal { place, error } => {
+                AliasingEffect::MutateGlobal { place: *place, error: *error }
+            }
+            AliasingEffect::Impure { place, error } => {
+                AliasingEffect::Impure { place: *place, error: *error }
+            }
+            AliasingEffect::Render { place } => AliasingEffect::Render { place: *place },
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for AliasingSignature<'a> {
+    type Cloned = AliasingSignature<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        AliasingSignature {
+            receiver: self.receiver,
+            params: self.params.clone_in_impl(sem, alloc),
+            rest: self.rest,
+            returns: self.returns,
+            effects: self.effects.clone_in_impl(sem, alloc),
+            temporaries: self.temporaries.clone_in_impl(sem, alloc),
+        }
+    }
 }
 
 // =============================================================================

--- a/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
@@ -20,6 +20,7 @@ use oxc_str::{Ident, Str};
 use crate::react_compiler_hir::{
     BlockId, EvaluationOrder, InstructionValue, ParamPattern, Place, ScopeId,
 };
+use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds};
 use oxc_ast::ast::LogicalOperator;
 use oxc_span::Span;
 
@@ -29,7 +30,7 @@ use oxc_span::Span;
 
 /// Tree representation of a compiled function, converted from the CFG-based HIR.
 /// TS: ReactiveFunction in HIR.ts
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ReactiveFunction<'a> {
     pub span: Option<Span>,
     pub id: Option<Ident<'a>>,
@@ -50,7 +51,7 @@ pub struct ReactiveFunction<'a> {
 pub type ReactiveBlock<'a> = Vec<ReactiveStatement<'a>>;
 
 /// TS: ReactiveStatement (discriminated union with 'kind' field)
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum ReactiveStatement<'a> {
     Instruction(ReactiveInstruction<'a>),
     Terminal(Box<ReactiveTerminalStatement<'a>>),
@@ -63,7 +64,7 @@ pub enum ReactiveStatement<'a> {
 // =============================================================================
 
 /// TS: ReactiveInstruction
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ReactiveInstruction<'a> {
     pub id: EvaluationOrder,
     pub lvalue: Option<Place>,
@@ -74,7 +75,7 @@ pub struct ReactiveInstruction<'a> {
 /// Extends InstructionValue with compound expression types that were
 /// separate blocks+terminals in HIR but become nested expressions here.
 /// TS: ReactiveValue = InstructionValue | ReactiveLogicalValue | ...
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum ReactiveValue<'a> {
     /// All ~35 base instruction value kinds
     Instruction(InstructionValue<'a>),
@@ -108,7 +109,7 @@ pub enum ReactiveValue<'a> {
 // Terminals
 // =============================================================================
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ReactiveTerminalStatement<'a> {
     pub terminal: ReactiveTerminal<'a>,
     pub label: Option<ReactiveLabel>,
@@ -137,7 +138,7 @@ impl Display for ReactiveTerminalTargetKind {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum ReactiveTerminal<'a> {
     Break {
         target: BlockId,
@@ -210,7 +211,7 @@ pub enum ReactiveTerminal<'a> {
     },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ReactiveSwitchCase<'a> {
     pub test: Option<Place>,
     pub block: Option<ReactiveBlock<'a>>,
@@ -220,14 +221,247 @@ pub struct ReactiveSwitchCase<'a> {
 // Scope Blocks
 // =============================================================================
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ReactiveScopeBlock<'a> {
     pub scope: ScopeId,
     pub instructions: ReactiveBlock<'a>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PrunedReactiveScopeBlock<'a> {
     pub scope: ScopeId,
     pub instructions: ReactiveBlock<'a>,
+}
+
+// =============================================================================
+// Arena `CloneIn` for the reactive subtree
+//
+// The reactive tree is std-`Vec`/`Box` based, but it embeds `InstructionValue`,
+// which is arena-backed and no longer `Clone`. So the reactive types drop
+// `derive(Clone)` and provide same-arena `CloneIn` instead (`Cloned = Self`).
+// The std `Vec`/`Box` fields are cloned by recursing manually; only the embedded
+// `InstructionValue` needs the allocator.
+// =============================================================================
+
+fn clone_reactive_block_in<'a>(
+    block: &[ReactiveStatement<'a>],
+    sem: CloneInSemanticIds,
+    alloc: &'a Allocator,
+) -> Vec<ReactiveStatement<'a>> {
+    block.iter().map(|stmt| stmt.clone_in_impl(sem, alloc)).collect()
+}
+
+fn clone_reactive_instructions_in<'a>(
+    instructions: &[ReactiveInstruction<'a>],
+    sem: CloneInSemanticIds,
+    alloc: &'a Allocator,
+) -> Vec<ReactiveInstruction<'a>> {
+    instructions.iter().map(|instr| instr.clone_in_impl(sem, alloc)).collect()
+}
+
+impl<'a> CloneIn<'a> for ReactiveFunction<'a> {
+    type Cloned = ReactiveFunction<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        ReactiveFunction {
+            span: self.span,
+            id: self.id,
+            name_hint: self.name_hint,
+            params: self.params.clone(),
+            generator: self.generator,
+            is_async: self.is_async,
+            body: clone_reactive_block_in(&self.body, sem, alloc),
+            directives: self.directives.clone(),
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for ReactiveStatement<'a> {
+    type Cloned = ReactiveStatement<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        match self {
+            ReactiveStatement::Instruction(instr) => {
+                ReactiveStatement::Instruction(instr.clone_in_impl(sem, alloc))
+            }
+            ReactiveStatement::Terminal(terminal) => {
+                ReactiveStatement::Terminal(Box::new(terminal.as_ref().clone_in_impl(sem, alloc)))
+            }
+            ReactiveStatement::Scope(scope) => {
+                ReactiveStatement::Scope(scope.clone_in_impl(sem, alloc))
+            }
+            ReactiveStatement::PrunedScope(scope) => {
+                ReactiveStatement::PrunedScope(scope.clone_in_impl(sem, alloc))
+            }
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for ReactiveInstruction<'a> {
+    type Cloned = ReactiveInstruction<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        ReactiveInstruction {
+            id: self.id,
+            lvalue: self.lvalue,
+            value: self.value.clone_in_impl(sem, alloc),
+            span: self.span,
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for ReactiveValue<'a> {
+    type Cloned = ReactiveValue<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        match self {
+            ReactiveValue::Instruction(value) => {
+                ReactiveValue::Instruction(value.clone_in_impl(sem, alloc))
+            }
+            ReactiveValue::LogicalExpression { operator, left, right } => {
+                ReactiveValue::LogicalExpression {
+                    operator: *operator,
+                    left: Box::new(left.as_ref().clone_in_impl(sem, alloc)),
+                    right: Box::new(right.as_ref().clone_in_impl(sem, alloc)),
+                }
+            }
+            ReactiveValue::ConditionalExpression { test, consequent, alternate } => {
+                ReactiveValue::ConditionalExpression {
+                    test: Box::new(test.as_ref().clone_in_impl(sem, alloc)),
+                    consequent: Box::new(consequent.as_ref().clone_in_impl(sem, alloc)),
+                    alternate: Box::new(alternate.as_ref().clone_in_impl(sem, alloc)),
+                }
+            }
+            ReactiveValue::SequenceExpression { instructions, id, value } => {
+                ReactiveValue::SequenceExpression {
+                    instructions: clone_reactive_instructions_in(instructions, sem, alloc),
+                    id: *id,
+                    value: Box::new(value.as_ref().clone_in_impl(sem, alloc)),
+                }
+            }
+            ReactiveValue::OptionalExpression { value, optional } => {
+                ReactiveValue::OptionalExpression {
+                    value: Box::new(value.as_ref().clone_in_impl(sem, alloc)),
+                    optional: *optional,
+                }
+            }
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for ReactiveTerminalStatement<'a> {
+    type Cloned = ReactiveTerminalStatement<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        ReactiveTerminalStatement {
+            terminal: self.terminal.clone_in_impl(sem, alloc),
+            label: self.label.clone(),
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for ReactiveTerminal<'a> {
+    type Cloned = ReactiveTerminal<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        match self {
+            ReactiveTerminal::Break { target, id, target_kind } => ReactiveTerminal::Break {
+                target: *target,
+                id: *id,
+                target_kind: target_kind.clone(),
+            },
+            ReactiveTerminal::Continue { target, id, target_kind } => ReactiveTerminal::Continue {
+                target: *target,
+                id: *id,
+                target_kind: target_kind.clone(),
+            },
+            ReactiveTerminal::Return { value, id } => {
+                ReactiveTerminal::Return { value: *value, id: *id }
+            }
+            ReactiveTerminal::Throw { value, id } => {
+                ReactiveTerminal::Throw { value: *value, id: *id }
+            }
+            ReactiveTerminal::Switch { test, cases, id } => ReactiveTerminal::Switch {
+                test: *test,
+                cases: cases.iter().map(|case| case.clone_in_impl(sem, alloc)).collect(),
+                id: *id,
+            },
+            ReactiveTerminal::DoWhile { loop_block, test, id } => ReactiveTerminal::DoWhile {
+                loop_block: clone_reactive_block_in(loop_block, sem, alloc),
+                test: test.clone_in_impl(sem, alloc),
+                id: *id,
+            },
+            ReactiveTerminal::While { test, loop_block, id } => ReactiveTerminal::While {
+                test: test.clone_in_impl(sem, alloc),
+                loop_block: clone_reactive_block_in(loop_block, sem, alloc),
+                id: *id,
+            },
+            ReactiveTerminal::For { init, test, update, loop_block, id } => ReactiveTerminal::For {
+                init: init.clone_in_impl(sem, alloc),
+                test: test.clone_in_impl(sem, alloc),
+                update: update.as_ref().map(|value| value.clone_in_impl(sem, alloc)),
+                loop_block: clone_reactive_block_in(loop_block, sem, alloc),
+                id: *id,
+            },
+            ReactiveTerminal::ForOf { init, test, loop_block, id, span } => {
+                ReactiveTerminal::ForOf {
+                    init: init.clone_in_impl(sem, alloc),
+                    test: test.clone_in_impl(sem, alloc),
+                    loop_block: clone_reactive_block_in(loop_block, sem, alloc),
+                    id: *id,
+                    span: *span,
+                }
+            }
+            ReactiveTerminal::ForIn { init, loop_block, id, span } => ReactiveTerminal::ForIn {
+                init: init.clone_in_impl(sem, alloc),
+                loop_block: clone_reactive_block_in(loop_block, sem, alloc),
+                id: *id,
+                span: *span,
+            },
+            ReactiveTerminal::If { test, consequent, alternate, id } => ReactiveTerminal::If {
+                test: *test,
+                consequent: clone_reactive_block_in(consequent, sem, alloc),
+                alternate: alternate
+                    .as_ref()
+                    .map(|block| clone_reactive_block_in(block, sem, alloc)),
+                id: *id,
+            },
+            ReactiveTerminal::Label { block, id } => ReactiveTerminal::Label {
+                block: clone_reactive_block_in(block, sem, alloc),
+                id: *id,
+            },
+            ReactiveTerminal::Try { block, handler_binding, handler, id } => {
+                ReactiveTerminal::Try {
+                    block: clone_reactive_block_in(block, sem, alloc),
+                    handler_binding: *handler_binding,
+                    handler: clone_reactive_block_in(handler, sem, alloc),
+                    id: *id,
+                }
+            }
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for ReactiveSwitchCase<'a> {
+    type Cloned = ReactiveSwitchCase<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        ReactiveSwitchCase {
+            test: self.test,
+            block: self.block.as_ref().map(|block| clone_reactive_block_in(block, sem, alloc)),
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for ReactiveScopeBlock<'a> {
+    type Cloned = ReactiveScopeBlock<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        ReactiveScopeBlock {
+            scope: self.scope,
+            instructions: clone_reactive_block_in(&self.instructions, sem, alloc),
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for PrunedReactiveScopeBlock<'a> {
+    type Cloned = PrunedReactiveScopeBlock<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        PrunedReactiveScopeBlock {
+            scope: self.scope,
+            instructions: clone_reactive_block_in(&self.instructions, sem, alloc),
+        }
+    }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
@@ -481,19 +481,15 @@ pub fn each_terminal_operand(terminal: &Terminal) -> PlaceList {
 pub fn map_pattern_operands(pattern: &mut Pattern, f: &mut impl FnMut(Place) -> Place) {
     match pattern {
         Pattern::Array(arr) => {
-            arr.items = arr
-                .items
-                .iter()
-                .map(|item| match item {
-                    ArrayPatternElement::Place(place) => ArrayPatternElement::Place(f(*place)),
+            for item in arr.items.iter_mut() {
+                match item {
+                    ArrayPatternElement::Place(place) => *place = f(*place),
                     ArrayPatternElement::Spread(spread) => {
-                        let mut spread = *spread;
                         spread.place = f(spread.place);
-                        ArrayPatternElement::Spread(spread)
                     }
-                    ArrayPatternElement::Hole => ArrayPatternElement::Hole,
-                })
-                .collect();
+                    ArrayPatternElement::Hole => {}
+                }
+            }
         }
         Pattern::Object(obj) => {
             for property in obj.properties.iter_mut() {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_method_call_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_method_call_scopes.rs
@@ -68,7 +68,7 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
                     // Recurse into inner functions
                     let func_id = lowered_func.func;
                     let mut inner_func =
-                        replace(&mut env.functions[func_id], placeholder_function());
+                        replace(&mut env.functions[func_id], placeholder_function(env.allocator));
                     align_method_call_scopes(&mut inner_func, env);
                     env.functions[func_id] = inner_func;
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
@@ -86,7 +86,7 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
                     let func_id = lowered_func.func;
                     let mut inner_func =
-                        replace(&mut env.functions[func_id], placeholder_function());
+                        replace(&mut env.functions[func_id], placeholder_function(env.allocator));
                     align_object_method_scopes(&mut inner_func, env);
                     env.functions[func_id] = inner_func;
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
@@ -12,6 +12,8 @@
 //! inferMutationAliasingRanges, rewriteInstructionKindsBasedOnReassignment,
 //! and inferReactiveScopeVariables on each inner function.
 
+use oxc_allocator::CloneIn;
+use oxc_allocator::Vec as ArenaVec;
 use oxc_diagnostics::OxcDiagnostic;
 
 use crate::diagnostics::ErrorCategory;
@@ -20,14 +22,14 @@ use crate::react_compiler_inference::infer_mutation_aliasing_effects::infer_muta
 use crate::react_compiler_inference::infer_mutation_aliasing_ranges::infer_mutation_aliasing_ranges;
 use crate::react_compiler_inference::infer_reactive_scope_variables::infer_reactive_scope_variables;
 use crate::react_compiler_optimization::dead_code_elimination;
+use crate::react_compiler_ssa::enter_ssa::placeholder_function;
 use crate::react_compiler_ssa::rewrite_instruction_kinds_based_on_reassignment;
-use crate::react_compiler_utils::OrderedMap;
 use rustc_hash::FxHashSet;
 use std::mem::replace;
 
 use crate::react_compiler_hir::{
-    AliasingEffect, BlockId, Effect, EvaluationOrder, FunctionId, HIR, HirFunction, IdentifierId,
-    InstructionValue, Place, ReactFunctionType,
+    AliasingEffect, Effect, EvaluationOrder, FunctionId, HirFunction, IdentifierId,
+    InstructionValue,
 };
 
 /// Analyse all nested function expressions and object methods in `func`.
@@ -68,7 +70,8 @@ where
     // Process each inner function
     for func_id in inner_func_ids {
         // Take the inner function out of the arena to avoid borrow conflicts
-        let mut inner_func = replace(&mut env.functions[func_id], placeholder_function());
+        let mut inner_func =
+            replace(&mut env.functions[func_id], placeholder_function(env.allocator));
 
         lower_with_mutation_aliasing(&mut inner_func, env, debug_logger)?;
 
@@ -137,7 +140,10 @@ where
     // inferReactiveScopeVariables on the inner function
     infer_reactive_scope_variables(func, env)?;
 
-    func.aliasing_effects = Some(function_effects.clone());
+    func.aliasing_effects = Some(ArenaVec::from_iter_in(
+        function_effects.iter().map(|e| e.clone_in(env.allocator)),
+        &env.allocator,
+    ));
 
     // Phase 2: Populate the Effect of each context variable to use in inferring
     // the outer function. Corresponds to TS Phase 2 in lowerWithMutationAliasing.
@@ -187,30 +193,4 @@ where
     debug_logger(func, env);
 
     Ok(())
-}
-
-/// Create a placeholder HirFunction for temporarily swapping an inner function
-/// out of `env.functions` via `std::mem::replace`. The placeholder is never
-/// read — the real function is swapped back immediately after processing.
-fn placeholder_function<'a>() -> HirFunction<'a> {
-    HirFunction {
-        span: None,
-        id: None,
-        name_hint: None,
-        fn_type: ReactFunctionType::Other,
-        params: Vec::new(),
-        returns: Place {
-            identifier: IdentifierId::from_usize(0),
-            effect: Effect::Unknown,
-            reactive: false,
-            span: None,
-        },
-        context: Vec::new(),
-        body: HIR { entry: BlockId::ENTRY, blocks: OrderedMap::default() },
-        instructions: Vec::new(),
-        generator: false,
-        is_async: false,
-        directives: Vec::new(),
-        aliasing_effects: None,
-    }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
@@ -13,7 +13,9 @@
 
 use std::cmp::Ordering;
 
-use crate::react_compiler_utils::OrderedSet;
+use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
+
+use crate::react_compiler_utils::ordered_map::ArenaOrderedSet;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
@@ -178,18 +180,19 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
 // handleRewrite
 // =============================================================================
 
-struct RewriteContext {
+struct RewriteContext<'a> {
     next_block_id: BlockId,
     next_preds: Vec<BlockId>,
     instr_slice_idx: usize,
-    rewrites: Vec<BasicBlock>,
+    rewrites: Vec<BasicBlock<'a>>,
+    alloc: &'a Allocator,
 }
 
-fn handle_rewrite(
+fn handle_rewrite<'a>(
     terminal_info: &TerminalRewriteInfo,
     idx: usize,
-    source_block: &BasicBlock,
-    context: &mut RewriteContext,
+    source_block: &BasicBlock<'a>,
+    context: &mut RewriteContext<'a>,
 ) {
     let terminal: Terminal = match terminal_info {
         TerminalRewriteInfo::StartScope { block_id, fallthrough_id, instr_id, scope_id } => {
@@ -210,18 +213,28 @@ fn handle_rewrite(
     };
 
     let curr_block_id = context.next_block_id;
-    let mut preds = OrderedSet::default();
+    let mut preds = ArenaOrderedSet::new_in(context.alloc);
     for &p in &context.next_preds {
         preds.insert(p);
     }
 
+    // Only the first rewrite should reuse source block phis
+    let phis = if context.rewrites.is_empty() {
+        source_block.phis.clone_in(context.alloc)
+    } else {
+        ArenaVec::new_in(&context.alloc)
+    };
+    let instructions = ArenaVec::from_iter_in(
+        source_block.instructions[context.instr_slice_idx..idx].iter().copied(),
+        &context.alloc,
+    );
+
     context.rewrites.push(BasicBlock {
         kind: source_block.kind,
         id: curr_block_id,
-        instructions: source_block.instructions[context.instr_slice_idx..idx].to_vec(),
+        instructions,
         preds,
-        // Only the first rewrite should reuse source block phis
-        phis: if context.rewrites.is_empty() { source_block.phis.clone() } else { Vec::new() },
+        phis,
         terminal,
     });
 
@@ -243,13 +256,16 @@ fn handle_rewrite(
 /// to fallthroughs. Given a function whose reactive scope ranges have been
 /// correctly aligned and merged, this pass rewrites blocks to introduce
 /// ReactiveScopeTerminals and their fallthrough blocks.
-pub fn build_reactive_scope_terminals_hir(func: &mut HirFunction, env: &mut Environment) {
+pub fn build_reactive_scope_terminals_hir<'a>(
+    func: &mut HirFunction<'a>,
+    env: &mut Environment<'a>,
+) {
     // Step 1: Collect rewrites
     let mut queued_rewrites = collect_scope_rewrites(func, env);
 
     // Step 2: Apply rewrites by splitting blocks
     let mut rewritten_final_blocks: FxHashMap<BlockId, BlockId> = FxHashMap::default();
-    let mut next_blocks: OrderedMap<BlockId, BasicBlock> = OrderedMap::default();
+    let mut next_blocks: OrderedMap<BlockId, BasicBlock<'a>> = OrderedMap::default();
 
     // Reverse so we can pop from the end while traversing in ascending order
     queued_rewrites.reverse();
@@ -261,6 +277,7 @@ pub fn build_reactive_scope_terminals_hir(func: &mut HirFunction, env: &mut Envi
             rewrites: Vec::new(),
             next_preds: preds_vec,
             instr_slice_idx: 0,
+            alloc: env.allocator,
         };
 
         // Handle queued terminal rewrites at their nearest instruction ID
@@ -284,7 +301,7 @@ pub fn build_reactive_scope_terminals_hir(func: &mut HirFunction, env: &mut Envi
         }
 
         if !context.rewrites.is_empty() {
-            let mut final_preds = OrderedSet::default();
+            let mut final_preds = ArenaOrderedSet::new_in(env.allocator);
             for &p in &context.next_preds {
                 final_preds.insert(p);
             }
@@ -292,9 +309,12 @@ pub fn build_reactive_scope_terminals_hir(func: &mut HirFunction, env: &mut Envi
                 id: context.next_block_id,
                 kind: block.kind,
                 preds: final_preds,
-                terminal: block.terminal.clone(),
-                instructions: block.instructions[context.instr_slice_idx..].to_vec(),
-                phis: Vec::new(),
+                terminal: block.terminal.clone_in(env.allocator),
+                instructions: ArenaVec::from_iter_in(
+                    block.instructions[context.instr_slice_idx..].iter().copied(),
+                    &env.allocator,
+                ),
+                phis: ArenaVec::new_in(&env.allocator),
             };
             let final_block_id = final_block.id;
             context.rewrites.push(final_block);
@@ -303,7 +323,7 @@ pub fn build_reactive_scope_terminals_hir(func: &mut HirFunction, env: &mut Envi
             }
             rewritten_final_blocks.insert(block.id, final_block_id);
         } else {
-            next_blocks.insert(block.id, block.clone());
+            next_blocks.insert(block.id, block.clone_in(env.allocator));
         }
     }
 
@@ -328,7 +348,7 @@ pub fn build_reactive_scope_terminals_hir(func: &mut HirFunction, env: &mut Envi
     }
 
     // Step 4: Fixup HIR to restore RPO, correct predecessors, renumber instructions
-    func.body.blocks = get_reverse_postordered_blocks(&func.body);
+    func.body.blocks = get_reverse_postordered_blocks(&func.body, env.allocator);
     mark_predecessors(&mut func.body);
     mark_instruction_ids(&mut func.body, &mut func.instructions);
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -18,6 +18,9 @@ use crate::react_compiler_utils::OrderedMap;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
+use oxc_allocator::Allocator;
+use oxc_allocator::CloneIn;
+use oxc_allocator::Vec as ArenaVec;
 use oxc_diagnostics::OxcDiagnostic;
 
 use crate::diagnostics::ErrorCategory;
@@ -77,9 +80,9 @@ use std::rc::Rc;
 /// Infers mutation/aliasing effects for all instructions and terminals in `func`.
 ///
 /// Corresponds to TS `inferMutationAliasingEffects(fn, {isFunctionExpression})`.
-pub fn infer_mutation_aliasing_effects(
-    func: &mut HirFunction,
-    env: &mut Environment,
+pub fn infer_mutation_aliasing_effects<'a>(
+    func: &mut HirFunction<'a>,
+    env: &mut Environment<'a>,
     is_function_expression: bool,
 ) -> Result<(), OxcDiagnostic> {
     let mut initial_state = InferenceState::empty(is_function_expression);
@@ -168,6 +171,7 @@ pub fn infer_mutation_aliasing_effects(
     let non_mutating_spreads = find_non_mutated_destructure_spreads(func, env);
 
     let mut context = Context {
+        alloc: env.allocator,
         interned_effects: FxHashMap::default(),
         instruction_signature_cache: FxHashMap::default(),
         catch_handlers: FxHashMap::default(),
@@ -682,11 +686,12 @@ enum MutationResult {
 // Context
 // =============================================================================
 
-struct Context {
-    interned_effects: FxHashMap<EffectKey, AliasingEffect>,
+struct Context<'a> {
+    alloc: &'a Allocator,
+    interned_effects: FxHashMap<EffectKey, AliasingEffect<'a>>,
     /// `Rc` so `apply_signature` can hold the signature while passing the
     /// context on mutably, without deep-cloning the effect list every time.
-    instruction_signature_cache: FxHashMap<u32, Rc<InstructionSignature>>,
+    instruction_signature_cache: FxHashMap<u32, Rc<InstructionSignature<'a>>>,
     catch_handlers: FxHashMap<BlockId, Place>,
     is_function_expression: bool,
     hoisted_context_declarations: FxHashMap<DeclarationId, Option<Place>>,
@@ -698,17 +703,17 @@ struct Context {
     /// locally-declared functions when processing Apply effects.
     function_values: FxHashMap<ValueId, FunctionId>,
     /// Cache of function expression signatures, keyed by FunctionId
-    function_signature_cache: FxHashMap<FunctionId, AliasingSignature>,
+    function_signature_cache: FxHashMap<FunctionId, AliasingSignature<'a>>,
     /// Cache of temporary places created for aliasing signature config temporaries.
     /// Keyed by (lvalue_identifier_id, temp_name) to ensure stable allocation
     /// across fixpoint iterations.
     aliasing_config_temp_cache: FxHashMap<(IdentifierId, String), Place>,
 }
 
-impl Context {
-    fn intern_effect(&mut self, effect: AliasingEffect) -> AliasingEffect {
+impl<'a> Context<'a> {
+    fn intern_effect(&mut self, effect: AliasingEffect<'a>) -> AliasingEffect<'a> {
         let key = effect_key(&effect);
-        self.interned_effects.entry(key).or_insert(effect).clone()
+        self.interned_effects.entry(key).or_insert(effect).clone_in(self.alloc)
     }
 
     /// Get or create a stable ValueId for a given effect, ensuring fixpoint convergence.
@@ -718,8 +723,8 @@ impl Context {
     }
 }
 
-struct InstructionSignature {
-    effects: Vec<AliasingEffect>,
+struct InstructionSignature<'a> {
+    effects: Vec<AliasingEffect<'a>>,
 }
 
 // =============================================================================
@@ -1131,18 +1136,28 @@ fn infer_param(param: &ParamPattern, state: &mut InferenceState, param_kind: &Ab
 // inferBlock
 // =============================================================================
 
-fn infer_block(
-    context: &mut Context,
+fn infer_block<'a>(
+    context: &mut Context<'a>,
     state: &mut InferenceState,
     block_id: BlockId,
-    func: &mut HirFunction,
-    env: &mut Environment,
+    func: &mut HirFunction<'a>,
+    env: &mut Environment<'a>,
 ) -> Result<(), OxcDiagnostic> {
+    let alloc = context.alloc;
     let block = &func.body.blocks[&block_id];
 
     // Process phis
-    let phis: Vec<(IdentifierId, OrderedMap<BlockId, Place>)> =
-        block.phis.iter().map(|phi| (phi.place.identifier, phi.operands.clone())).collect();
+    let phis: Vec<(IdentifierId, OrderedMap<BlockId, Place>)> = block
+        .phis
+        .iter()
+        .map(|phi| {
+            let mut operands = OrderedMap::default();
+            for (k, v) in phi.operands.iter() {
+                operands.insert(*k, *v);
+            }
+            (phi.place.identifier, operands)
+        })
+        .collect();
     for (place_id, operands) in &phis {
         state.infer_phi(*place_id, operands);
     }
@@ -1162,7 +1177,7 @@ fn infer_block(
         // Apply signature
         let effects =
             apply_signature(context, state, *instr_idx, &func.instructions[instr_index], env)?;
-        func.instructions[instr_index].effects = effects;
+        func.instructions[instr_index].effects = effects.map(|e| ArenaVec::from_iter_in(e, &alloc));
     }
 
     // Process terminal
@@ -1195,7 +1210,7 @@ fn infer_block(
             if let Some(handler_param) = context.catch_handlers.get(&handler_id).cloned()
                 && state.is_defined(handler_param.identifier)
             {
-                let mut terminal_effects: Vec<AliasingEffect> = Vec::new();
+                let mut terminal_effects: Vec<AliasingEffect<'a>> = Vec::new();
                 for instr_idx in &instr_ids {
                     let instr = &func.instructions[*instr_idx as usize];
                     match &instr.value {
@@ -1219,8 +1234,11 @@ fn infer_block(
                 if let Terminal::MaybeThrow { effects: ref mut term_effects, .. } =
                     block_mut.terminal
                 {
-                    *term_effects =
-                        if terminal_effects.is_empty() { None } else { Some(terminal_effects) };
+                    *term_effects = if terminal_effects.is_empty() {
+                        None
+                    } else {
+                        Some(ArenaVec::from_iter_in(terminal_effects, &alloc))
+                    };
                 }
             }
         }
@@ -1230,10 +1248,13 @@ fn infer_block(
                 if let Terminal::Return { ref value, effects: ref mut term_effects, .. } =
                     block_mut.terminal
                 {
-                    *term_effects = Some(vec![context.intern_effect(AliasingEffect::Freeze {
-                        value: *value,
-                        reason: ValueReason::JsxCaptured,
-                    })]);
+                    *term_effects = Some(ArenaVec::from_array_in(
+                        [context.intern_effect(AliasingEffect::Freeze {
+                            value: *value,
+                            reason: ValueReason::JsxCaptured,
+                        })],
+                        &alloc,
+                    ));
                 }
             }
         }
@@ -1246,14 +1267,15 @@ fn infer_block(
 // applySignature
 // =============================================================================
 
-fn apply_signature(
-    context: &mut Context,
+fn apply_signature<'a>(
+    context: &mut Context<'a>,
     state: &mut InferenceState,
     instr_idx: u32,
-    instr: &Instruction,
-    env: &mut Environment,
-) -> Result<Option<Vec<AliasingEffect>>, OxcDiagnostic> {
-    let mut effects: Vec<AliasingEffect> = Vec::new();
+    instr: &Instruction<'a>,
+    env: &mut Environment<'a>,
+) -> Result<Option<Vec<AliasingEffect<'a>>>, OxcDiagnostic> {
+    let alloc = context.alloc;
+    let mut effects: Vec<AliasingEffect<'a>> = Vec::new();
 
     // For function instructions, validate frozen mutation
     match &instr.value {
@@ -1310,7 +1332,7 @@ fn apply_signature(
     let sig = Rc::clone(context.instruction_signature_cache.get(&instr_idx).unwrap());
 
     for effect in &sig.effects {
-        apply_effect(context, state, effect.clone(), &mut initialized, &mut effects, env)?;
+        apply_effect(context, state, effect.clone_in(alloc), &mut initialized, &mut effects, env)?;
     }
 
     // If lvalue is not yet defined, initialize it with a default value.
@@ -1377,20 +1399,20 @@ fn freeze_function_captures_transitive(
 // applyEffect
 // =============================================================================
 
-fn apply_effect(
-    context: &mut Context,
+fn apply_effect<'a>(
+    context: &mut Context<'a>,
     state: &mut InferenceState,
-    effect: AliasingEffect,
+    effect: AliasingEffect<'a>,
     initialized: &mut FxHashSet<IdentifierId>,
-    effects: &mut Vec<AliasingEffect>,
-    env: &mut Environment,
+    effects: &mut Vec<AliasingEffect<'a>>,
+    env: &mut Environment<'a>,
 ) -> Result<(), OxcDiagnostic> {
     let effect = context.intern_effect(effect);
     match effect {
         AliasingEffect::Freeze { ref value, reason } => {
             let did_freeze = state.freeze(value.identifier, reason);
             if did_freeze {
-                effects.push(effect.clone());
+                effects.push(effect.clone_in(context.alloc));
                 // Transitively freeze FunctionExpression captures if enabled
                 // (matches TS freezeValue which recurses into func.context)
                 let enable_transitive = env.config.enable_preserve_existing_memoization_guarantees
@@ -1416,7 +1438,7 @@ fn apply_effect(
             let value_id = context.get_or_create_value_id(&effect);
             state.initialize(value_id, AbstractValue { kind, reason: ReasonSet::single(reason) });
             state.define(into.identifier, value_id);
-            effects.push(effect.clone());
+            effects.push(effect.clone_in(context.alloc));
         }
         AliasingEffect::ImmutableCapture { ref from, .. } => {
             let kind = state.kind(from.identifier).kind;
@@ -1425,7 +1447,7 @@ fn apply_effect(
                     // no-op: don't track data flow for copy types
                 }
                 _ => {
-                    effects.push(effect.clone());
+                    effects.push(effect.clone_in(context.alloc));
                 }
             }
         }
@@ -1468,7 +1490,7 @@ fn apply_effect(
                     )?;
                 }
                 _ => {
-                    effects.push(effect.clone());
+                    effects.push(effect.clone_in(context.alloc));
                 }
             }
         }
@@ -1478,7 +1500,7 @@ fn apply_effect(
                 "[InferMutationAliasingEffects] Cannot re-initialize variable within an instruction"
             );
             initialized.insert(into.identifier);
-            effects.push(effect.clone());
+            effects.push(effect.clone_in(context.alloc));
 
             // Check if function is mutable
             let has_captures = captures.iter().any(|capture| {
@@ -1513,7 +1535,7 @@ fn apply_effect(
             let is_mutable = has_captures || has_tracked_side_effects || captures_ref;
 
             // Update context variable effects
-            let context_places: Vec<Place> = inner_func.context.clone();
+            let context_places: Vec<Place> = inner_func.context.iter().copied().collect();
             for operand in &context_places {
                 if operand.effect != Effect::Capture {
                     continue;
@@ -1598,7 +1620,7 @@ fn apply_effect(
             } else if (source_type == Some("mutable") && destination_type == Some("mutable"))
                 || is_maybe_alias
             {
-                effects.push(effect.clone());
+                effects.push(effect.clone_in(context.alloc));
             } else if (source_type == Some("context") && destination_type.is_some())
                 || (source_type == Some("mutable") && destination_type == Some("context"))
             {
@@ -1656,7 +1678,7 @@ fn apply_effect(
                 }
                 _ => {
                     state.assign(into.identifier, from.identifier);
-                    effects.push(effect.clone());
+                    effects.push(effect.clone_in(context.alloc));
                 }
             }
         }
@@ -1682,10 +1704,14 @@ fn apply_effect(
                             context.function_signature_cache.entry(func_id).or_insert_with(|| {
                                 build_signature_from_function_expression(env, func_id)
                             });
-                            let sig =
-                                context.function_signature_cache.get(&func_id).unwrap().clone();
+                            let sig = context
+                                .function_signature_cache
+                                .get(&func_id)
+                                .unwrap()
+                                .clone_in(context.alloc);
                             let inner_func = &env.functions[func_id];
-                            let context_places: Vec<Place> = inner_func.context.clone();
+                            let context_places: Vec<Place> =
+                                inner_func.context.iter().copied().collect();
                             let sig_effects = compute_effects_for_aliasing_signature(
                                 env,
                                 &sig,
@@ -1875,7 +1901,7 @@ fn apply_effect(
             let value = mutate_place;
             let mutation_kind = state.mutate_with_span(variant, value.identifier, env, value.span);
             if mutation_kind == MutationResult::Mutate {
-                effects.push(effect.clone());
+                effects.push(effect.clone_in(context.alloc));
             } else if mutation_kind == MutationResult::MutateRef {
                 // no-op
             } else if mutation_kind != MutationResult::None
@@ -1955,7 +1981,7 @@ fn apply_effect(
         | AliasingEffect::Render { .. }
         | AliasingEffect::MutateFrozen { .. }
         | AliasingEffect::MutateGlobal { .. } => {
-            effects.push(effect.clone());
+            effects.push(effect.clone_in(context.alloc));
         }
     }
     Ok(())
@@ -1965,14 +1991,15 @@ fn apply_effect(
 // computeSignatureForInstruction
 // =============================================================================
 
-fn compute_signature_for_instruction(
-    context: &mut Context,
-    env: &Environment,
-    instr: &Instruction,
-) -> InstructionSignature {
+fn compute_signature_for_instruction<'a>(
+    context: &mut Context<'a>,
+    env: &Environment<'a>,
+    instr: &Instruction<'a>,
+) -> InstructionSignature<'a> {
+    let alloc = env.allocator;
     let lvalue = &instr.lvalue;
     let value = &instr.value;
-    let mut effects: Vec<AliasingEffect> = Vec::new();
+    let mut effects: Vec<AliasingEffect<'a>> = Vec::new();
 
     match value {
         InstructionValue::ArrayExpression { elements, .. } => {
@@ -2028,7 +2055,7 @@ fn compute_signature_for_instruction(
                 receiver: *callee,
                 function: *callee,
                 mutates_function: false,
-                args: args.iter().map(place_or_spread_to_hole).collect(),
+                args: ArenaVec::from_iter_in(args.iter().map(place_or_spread_to_hole), &alloc),
                 into: *lvalue,
                 signature: Some(env.identifiers[callee.identifier].type_),
                 span: *span,
@@ -2039,7 +2066,7 @@ fn compute_signature_for_instruction(
                 receiver: *callee,
                 function: *callee,
                 mutates_function: true,
-                args: args.iter().map(place_or_spread_to_hole).collect(),
+                args: ArenaVec::from_iter_in(args.iter().map(place_or_spread_to_hole), &alloc),
                 into: *lvalue,
                 signature: Some(env.identifiers[callee.identifier].type_),
                 span: *span,
@@ -2050,7 +2077,7 @@ fn compute_signature_for_instruction(
                 receiver: *receiver,
                 function: *property,
                 mutates_function: false,
-                args: args.iter().map(place_or_spread_to_hole).collect(),
+                args: ArenaVec::from_iter_in(args.iter().map(place_or_spread_to_hole), &alloc),
                 into: *lvalue,
                 signature: Some(env.identifiers[property.identifier].type_),
                 span: *span,
@@ -2111,12 +2138,14 @@ fn compute_signature_for_instruction(
         InstructionValue::FunctionExpression { lowered_func, .. }
         | InstructionValue::ObjectMethod { lowered_func, .. } => {
             let inner_func = &env.functions[lowered_func.func];
-            let captures: Vec<Place> = inner_func
-                .context
-                .iter()
-                .filter(|operand| operand.effect == Effect::Capture)
-                .cloned()
-                .collect();
+            let captures = ArenaVec::from_iter_in(
+                inner_func
+                    .context
+                    .iter()
+                    .filter(|operand| operand.effect == Effect::Capture)
+                    .copied(),
+                &alloc,
+            );
             effects.push(AliasingEffect::CreateFunction {
                 into: *lvalue,
                 function_id: lowered_func.func,
@@ -2369,19 +2398,19 @@ fn compute_signature_for_instruction(
 // =============================================================================
 
 #[allow(clippy::too_many_arguments)]
-fn compute_effects_for_legacy_signature(
+fn compute_effects_for_legacy_signature<'a>(
     state: &InferenceState,
     signature: &FunctionSignature,
     lvalue: &Place,
     receiver: &Place,
     args: &[PlaceOrSpreadOrHole],
     span: Option<&Span>,
-    env: &Environment,
+    env: &Environment<'a>,
     function_values: &FxHashMap<ValueId, FunctionId>,
     todo_errors: &mut Vec<OxcDiagnostic>,
-) -> Vec<AliasingEffect> {
+) -> Vec<AliasingEffect<'a>> {
     let return_value_reason = signature.return_value_reason.unwrap_or(ValueReason::Other);
-    let mut effects: Vec<AliasingEffect> = Vec::new();
+    let mut effects: Vec<AliasingEffect<'a>> = Vec::new();
 
     effects.push(AliasingEffect::Create {
         into: *lvalue,
@@ -2608,8 +2637,8 @@ fn is_known_mutable_effect(effect: Effect) -> bool {
 // =============================================================================
 
 #[allow(clippy::too_many_arguments)]
-fn compute_effects_for_aliasing_signature_config(
-    env: &mut Environment,
+fn compute_effects_for_aliasing_signature_config<'a>(
+    env: &mut Environment<'a>,
     config: &AliasingSignatureConfig,
     lvalue: &Place,
     receiver: &Place,
@@ -2617,7 +2646,8 @@ fn compute_effects_for_aliasing_signature_config(
     context: &[Place],
     span: Option<&Span>,
     temp_cache: &mut FxHashMap<(IdentifierId, String), Place>,
-) -> Result<Option<Vec<AliasingEffect>>, OxcDiagnostic> {
+) -> Result<Option<Vec<AliasingEffect<'a>>>, OxcDiagnostic> {
+    let alloc = env.allocator;
     // Build substitutions from config strings to places
     let mut substitutions: FxHashMap<String, Vec<Place>> = FxHashMap::default();
     substitutions.insert(config.receiver.to_string(), vec![*receiver]);
@@ -2767,7 +2797,7 @@ fn compute_effects_for_aliasing_signature_config(
                 let func = substitutions.get(*f).and_then(|v| v.first()).cloned();
                 let into = substitutions.get(*i).and_then(|v| v.first()).cloned();
                 if let (Some(recv), Some(func), Some(into)) = (recv, func, into) {
-                    let mut apply_args: Vec<PlaceOrSpreadOrHole> = Vec::new();
+                    let mut apply_args = ArenaVec::new_in(&alloc);
                     for arg in *a {
                         match arg {
                             ApplyArgConfig::Hole => {
@@ -2807,12 +2837,13 @@ fn compute_effects_for_aliasing_signature_config(
 
 /// Build an AliasingSignature from a function expression's params/returns/aliasing effects.
 /// Corresponds to TS `buildSignatureFromFunctionExpression`.
-fn build_signature_from_function_expression(
-    env: &mut Environment,
+fn build_signature_from_function_expression<'a>(
+    env: &mut Environment<'a>,
     func_id: FunctionId,
-) -> AliasingSignature {
+) -> AliasingSignature<'a> {
+    let alloc = env.allocator;
     let inner_func = &env.functions[func_id];
-    let mut params: Vec<IdentifierId> = Vec::new();
+    let mut params = ArenaVec::new_in(&alloc);
     let mut rest: Option<IdentifierId> = None;
     for param in &inner_func.params {
         match param {
@@ -2821,7 +2852,11 @@ fn build_signature_from_function_expression(
         }
     }
     let returns = inner_func.returns.identifier;
-    let aliasing_effects = inner_func.aliasing_effects.clone().unwrap_or_default();
+    let aliasing_effects = inner_func
+        .aliasing_effects
+        .as_ref()
+        .map(|v| v.clone_in(alloc))
+        .unwrap_or_else(|| ArenaVec::new_in(&alloc));
     let span = inner_func.span;
 
     if rest.is_none() {
@@ -2835,21 +2870,22 @@ fn build_signature_from_function_expression(
         rest,
         returns,
         effects: aliasing_effects,
-        temporaries: Vec::new(),
+        temporaries: ArenaVec::new_in(&alloc),
     }
 }
 
 /// Compute effects by substituting an AliasingSignature (IdentifierId-based)
 /// with actual arguments. Corresponds to TS `computeEffectsForSignature`.
-fn compute_effects_for_aliasing_signature(
-    env: &mut Environment,
-    signature: &AliasingSignature,
+fn compute_effects_for_aliasing_signature<'a>(
+    env: &mut Environment<'a>,
+    signature: &AliasingSignature<'a>,
     lvalue: &Place,
     receiver: &Place,
     args: &[PlaceOrSpreadOrHole],
     context: &[Place],
     span: Option<&Span>,
-) -> Result<Option<Vec<AliasingEffect>>, OxcDiagnostic> {
+) -> Result<Option<Vec<AliasingEffect<'a>>>, OxcDiagnostic> {
+    let alloc = env.allocator;
     if signature.params.len() > args.len()
         || (args.len() > signature.params.len() && signature.rest.is_none())
     {
@@ -2962,7 +2998,7 @@ fn compute_effects_for_aliasing_signature(
             AliasingEffect::Mutate { value, reason } => {
                 let values = substitutions.get(&value.identifier).cloned().unwrap_or_default();
                 for v in values {
-                    effects.push(AliasingEffect::Mutate { value: v, reason: reason.clone() });
+                    effects.push(AliasingEffect::Mutate { value: v, reason: *reason });
                 }
             }
             AliasingEffect::MutateConditionally { value } => {
@@ -3017,7 +3053,7 @@ fn compute_effects_for_aliasing_signature(
                 let func = substitutions.get(&f.identifier).and_then(|v| v.first()).cloned();
                 let apply_into = substitutions.get(&i.identifier).and_then(|v| v.first()).cloned();
                 if let (Some(recv), Some(func), Some(apply_into)) = (recv, func, apply_into) {
-                    let mut apply_args: Vec<PlaceOrSpreadOrHole> = Vec::new();
+                    let mut apply_args = ArenaVec::new_in(&alloc);
                     for arg in a {
                         match arg {
                             PlaceOrSpreadOrHole::Hole => apply_args.push(PlaceOrSpreadOrHole::Hole),
@@ -3107,7 +3143,7 @@ fn get_write_error_reason(abstract_value: &AbstractValue) -> String {
     }
 }
 
-fn conditionally_mutate_iterator(place: &Place, ty: &Type) -> Option<AliasingEffect> {
+fn conditionally_mutate_iterator<'a>(place: &Place, ty: &Type) -> Option<AliasingEffect<'a>> {
     if !is_builtin_collection_type(ty) {
         Some(AliasingEffect::MutateTransitiveConditionally { value: *place })
     } else {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
@@ -14,6 +14,7 @@
 //!   vars, aliasing between params/context-vars/return-value)
 //! - The legacy `Effect` to store on each Place
 
+use oxc_allocator::CloneIn;
 use oxc_diagnostics::OxcDiagnostic;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -264,7 +265,7 @@ impl AliasingState {
             };
 
             if node.mutation_reason.is_none() {
-                node.mutation_reason = reason.clone();
+                node.mutation_reason = reason;
             }
             node.last_mutated = node.last_mutated.max(index);
 
@@ -429,12 +430,12 @@ fn append_function_errors(env: &mut Environment, function_id: FunctionId) {
 /// params/context-vars, aliasing between params/context-vars/return).
 ///
 /// Corresponds to TS `inferMutationAliasingRanges(fn, {isFunctionExpression})`.
-pub fn infer_mutation_aliasing_ranges(
-    func: &mut HirFunction,
-    env: &mut Environment,
+pub fn infer_mutation_aliasing_ranges<'a>(
+    func: &mut HirFunction<'a>,
+    env: &mut Environment<'a>,
     is_function_expression: bool,
-) -> Result<Vec<AliasingEffect>, OxcDiagnostic> {
-    let mut function_effects: Vec<AliasingEffect> = Vec::new();
+) -> Result<Vec<AliasingEffect<'a>>, OxcDiagnostic> {
+    let mut function_effects: Vec<AliasingEffect<'a>> = Vec::new();
 
     // =========================================================================
     // Part 1: Build data flow graph and infer mutable ranges
@@ -509,12 +510,12 @@ pub fn infer_mutation_aliasing_ranges(
         seen_blocks.insert(block_id);
 
         // Process instruction effects
-        let instr_ids: Vec<_> = block.instructions.clone();
+        let instr_ids: Vec<_> = block.instructions.iter().copied().collect();
         for instr_id in &instr_ids {
             let instr = &func.instructions[instr_id.index()];
             let instr_eval_order = instr.id;
-            let effects = match &instr.effects {
-                Some(e) => e.clone(),
+            let effects = match instr.effects.as_ref() {
+                Some(e) => e.clone_in(env.allocator),
                 None => continue,
             };
             for effect in &effects {
@@ -572,7 +573,7 @@ pub fn infer_mutation_aliasing_ranges(
                             id: instr_eval_order,
                             transitive: false,
                             kind: MutationKind::Definite,
-                            reason: reason.clone(),
+                            reason: *reason,
                             place: *value,
                         });
                         index += 1;
@@ -602,12 +603,12 @@ pub fn infer_mutation_aliasing_ranges(
                                 _ => unreachable!(),
                             }
                         }
-                        function_effects.push(effect.clone());
+                        function_effects.push(effect.clone_in(env.allocator));
                     }
                     AliasingEffect::Render { place } => {
                         renders.push(PendingRender { index, place: *place });
                         index += 1;
-                        function_effects.push(effect.clone());
+                        function_effects.push(effect.clone_in(env.allocator));
                     }
                     // Other effects (Freeze, ImmutableCapture, Apply) are no-ops here
                     _ => {}
@@ -633,7 +634,7 @@ pub fn infer_mutation_aliasing_ranges(
         // Handle terminal effects (MaybeThrow and Return)
         let terminal_effects = match terminal {
             Terminal::MaybeThrow { effects, .. } | Terminal::Return { effects, .. } => {
-                effects.clone()
+                effects.as_ref().map(|v| v.clone_in(env.allocator))
             }
             _ => None,
         };
@@ -665,7 +666,7 @@ pub fn infer_mutation_aliasing_ranges(
             mutation.transitive,
             mutation.kind,
             mutation.place.span,
-            mutation.reason.clone(),
+            mutation.reason,
             env,
             should_record_errors,
         );
@@ -786,7 +787,7 @@ pub fn infer_mutation_aliasing_ranges(
         }
 
         let block = &func.body.blocks[&block_id];
-        let instr_ids: Vec<_> = block.instructions.clone();
+        let instr_ids: Vec<_> = block.instructions.iter().copied().collect();
 
         for instr_id in &instr_ids {
             let instr = &func.instructions[instr_id.index()];
@@ -842,7 +843,7 @@ pub fn infer_mutation_aliasing_ranges(
             }
 
             // Compute operand effects from instruction effects
-            let effects = instr.effects.as_ref().unwrap().clone();
+            let effects = instr.effects.as_ref().unwrap().clone_in(env.allocator);
             let mut operand_effects: FxHashMap<IdentifierId, Effect> = FxHashMap::default();
 
             for effect in &effects {
@@ -1056,10 +1057,10 @@ pub fn infer_mutation_aliasing_ranges(
 // Helper: collect param/context mutation effects
 // =============================================================================
 
-fn collect_param_effects(
+fn collect_param_effects<'a>(
     state: &AliasingState,
     place: &Place,
-    function_effects: &mut Vec<AliasingEffect>,
+    function_effects: &mut Vec<AliasingEffect<'a>>,
 ) {
     let node = match state.nodes.get(&place.identifier) {
         Some(n) => n,
@@ -1076,7 +1077,7 @@ fn collect_param_effects(
             MutationKind::Definite => {
                 function_effects.push(AliasingEffect::Mutate {
                     value: Place { span: local.span, ..*place },
-                    reason: node.mutation_reason.clone(),
+                    reason: node.mutation_reason,
                 });
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
@@ -563,7 +563,7 @@ fn apply_reactive_flags_replay(
 
         // 2b. Instructions
         let block = func.body.blocks.get(block_id).unwrap();
-        let instr_ids: Vec<InstructionId> = block.instructions.clone();
+        let instr_ids: Vec<InstructionId> = block.instructions.iter().copied().collect();
 
         for instr_id in &instr_ids {
             let instr = &func.instructions[instr_id.index()];

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -1843,8 +1843,9 @@ fn visit_inner_function_blocks<'a>(
 ) {
     // Clone inner function's instructions and block structure to avoid
     // borrow conflicts when mutating env through handle_instruction.
-    let inner_instrs: Vec<Instruction> = env.functions[func_id].instructions.clone();
-    type InnerBlockSnapshot = (BlockId, Vec<InstructionId>, Vec<(BlockId, IdentifierId)>, Terminal);
+    let inner_instrs = env.functions[func_id].instructions.clone_in(env.allocator);
+    type InnerBlockSnapshot<'a> =
+        (BlockId, Vec<InstructionId>, Vec<(BlockId, IdentifierId)>, Terminal<'a>);
     let inner_blocks: Vec<InnerBlockSnapshot> = env.functions[func_id]
         .body
         .blocks
@@ -1855,7 +1856,12 @@ fn visit_inner_function_blocks<'a>(
                 .iter()
                 .flat_map(|phi| phi.operands.iter().map(|(pred, place)| (*pred, place.identifier)))
                 .collect();
-            (*bid, blk.instructions.clone(), phi_ops, blk.terminal.clone())
+            (
+                *bid,
+                blk.instructions.iter().copied().collect(),
+                phi_ops,
+                blk.terminal.clone_in(env.allocator),
+            )
         })
         .collect();
 

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -15,6 +15,7 @@ use crate::scope::ScopeResolver;
 use crate::scope::SymbolId;
 
 use oxc_allocator::CloneIn;
+use oxc_allocator::Vec as ArenaVec;
 use oxc_ast::ast as oxc;
 use oxc_ast::ast::BinaryOperator;
 use oxc_diagnostics::OxcDiagnostic;
@@ -637,8 +638,10 @@ fn lower_inner<'a>(
         identifier_spans,
     );
 
+    let alloc = builder.environment().allocator;
+
     // Build context places from the captured refs
-    let mut context: Vec<Place> = Vec::new();
+    let mut context = ArenaVec::new_in(&alloc);
     for (&symbol_id, ctx_span) in &context_map {
         let identifier = builder.resolve_binding(scope.symbol_ident(symbol_id), symbol_id)?;
         context.push(Place {
@@ -650,7 +653,7 @@ fn lower_inner<'a>(
     }
 
     // Process parameters.
-    let mut hir_params: Vec<ParamPattern> = Vec::new();
+    let mut hir_params = ArenaVec::new_in(&alloc);
     for param in &params.items {
         if param.initializer.is_none()
             && let oxc::BindingPattern::BindingIdentifier(ident) = &param.pattern
@@ -745,7 +748,7 @@ fn lower_inner<'a>(
     }
 
     // Lower the body
-    let mut directives: Vec<Str<'a>> = Vec::new();
+    let mut directives = ArenaVec::new_in(&alloc);
     match body {
         FunctionBody::Expression(expr) => {
             let fallthrough = builder.reserve(BlockKind::Block);
@@ -762,7 +765,8 @@ fn lower_inner<'a>(
             );
         }
         FunctionBody::Block(block) => {
-            directives = block.directives.iter().map(|d| d.expression.value).collect();
+            directives =
+                ArenaVec::from_iter_in(block.directives.iter().map(|d| d.expression.value), &alloc);
             // A function body shares the function's scope (the scope cell lives on
             // the function node, not the block), so pass it as the scope override.
             lower_block_statement_with_scope(&mut builder, &block.statements, function_scope)?;
@@ -786,6 +790,7 @@ fn lower_inner<'a>(
 
     // Build the HIR
     let (hir_body, instructions, used_names, child_bindings) = builder.build()?;
+    let instructions = ArenaVec::from_iter_in(instructions, &env.allocator);
 
     // Create the returns place
     let returns =
@@ -1131,8 +1136,9 @@ fn lower_member_expression_from_simple_target<'a>(
 fn lower_arguments<'a>(
     builder: &mut HirBuilder<'a, '_>,
     args: &[oxc::Argument<'a>],
-) -> Result<Vec<PlaceOrSpread>, OxcDiagnostic> {
-    let mut result = Vec::new();
+) -> Result<ArenaVec<'a, PlaceOrSpread>, OxcDiagnostic> {
+    let alloc = builder.environment().allocator;
+    let mut result = ArenaVec::new_in(&alloc);
     for arg in args {
         match arg {
             oxc::Argument::SpreadElement(spread) => {
@@ -1307,7 +1313,8 @@ fn lower_binding_assignment<'a>(
             }
         }
         oxc::BindingPattern::ArrayPattern(pattern) => {
-            let mut items: Vec<ArrayPatternElement> = Vec::new();
+            let alloc = builder.environment().allocator;
+            let mut items = ArenaVec::new_in(&alloc);
             let mut followups: Vec<(Place, &oxc::BindingPattern)> = Vec::new();
 
             for element in &pattern.elements {
@@ -1427,7 +1434,8 @@ fn lower_binding_assignment<'a>(
             Ok(Some(temporary))
         }
         oxc::BindingPattern::ObjectPattern(pattern) => {
-            let mut properties: Vec<ObjectPropertyOrSpread> = Vec::new();
+            let alloc = builder.environment().allocator;
+            let mut properties = ArenaVec::new_in(&alloc);
             let mut followups: Vec<(Place, &oxc::BindingPattern)> = Vec::new();
 
             for prop in &pattern.properties {
@@ -1866,7 +1874,8 @@ fn lower_assignment_target<'a>(
             lower_member_assignment_target(builder, span, kind, simple, value)
         }
         oxc::AssignmentTarget::ArrayAssignmentTarget(pattern) => {
-            let mut items: Vec<ArrayPatternElement> = Vec::new();
+            let alloc = builder.environment().allocator;
+            let mut items = ArenaVec::new_in(&alloc);
             let mut followups: Vec<(Place, FollowupTarget)> = Vec::new();
 
             // force_temporaries: when kind is Reassign and any element is
@@ -2014,7 +2023,8 @@ fn lower_assignment_target<'a>(
             Ok(Some(temporary))
         }
         oxc::AssignmentTarget::ObjectAssignmentTarget(pattern) => {
-            let mut properties: Vec<ObjectPropertyOrSpread> = Vec::new();
+            let alloc = builder.environment().allocator;
+            let mut properties = ArenaVec::new_in(&alloc);
             let mut followups: Vec<(Place, FollowupTarget)> = Vec::new();
 
             let force_temporaries = if kind == InstructionKind::Reassign {
@@ -3662,13 +3672,15 @@ fn lower_expression<'a>(
         }
         oxc::Expression::TemplateLiteral(tmpl) => {
             let span = Some(tmpl.span);
+            let alloc = builder.environment().allocator;
             let subexprs: Vec<Place> = tmpl
                 .expressions
                 .iter()
                 .map(|e| lower_expression_to_temporary(builder, e))
                 .collect::<Result<Vec<_>, _>>()?;
-            let quasis: Vec<TemplateQuasi> =
-                tmpl.quasis.iter().map(template_quasi_from_oxc).collect();
+            let subexprs = ArenaVec::from_iter_in(subexprs, &alloc);
+            let quasis =
+                ArenaVec::from_iter_in(tmpl.quasis.iter().map(template_quasi_from_oxc), &alloc);
             Ok(InstructionValue::TemplateLiteral { subexprs, quasis, span })
         }
         oxc::Expression::TaggedTemplateExpression(tagged) => {
@@ -3694,14 +3706,18 @@ fn lower_expression<'a>(
             // Evaluation order: the tag is evaluated first, then each interpolated
             // subexpression left-to-right.
             let tag = lower_expression_to_temporary(builder, &tagged.tag)?;
+            let alloc = builder.environment().allocator;
             let subexprs: Vec<Place> = tagged
                 .quasi
                 .expressions
                 .iter()
                 .map(|e| lower_expression_to_temporary(builder, e))
                 .collect::<Result<Vec<_>, _>>()?;
-            let quasis: Vec<TemplateQuasi> =
-                tagged.quasi.quasis.iter().map(template_quasi_from_oxc).collect();
+            let subexprs = ArenaVec::from_iter_in(subexprs, &alloc);
+            let quasis = ArenaVec::from_iter_in(
+                tagged.quasi.quasis.iter().map(template_quasi_from_oxc),
+                &alloc,
+            );
             Ok(InstructionValue::TaggedTemplateExpression { tag, quasis, subexprs, span })
         }
         oxc::Expression::AwaitExpression(await_expr) => {
@@ -3772,7 +3788,8 @@ fn lower_expression<'a>(
             // the keyword span, matching Babel's `Import` node span.
             let import_keyword_span = Some(oxc_span::Span::new(imp.span.start, imp.span.start + 6));
             let callee = lower_import_keyword_to_temporary(builder, &import_keyword_span)?;
-            let mut args: Vec<PlaceOrSpread> = Vec::new();
+            let alloc = builder.environment().allocator;
+            let mut args = ArenaVec::new_in(&alloc);
             let source = lower_expression_to_temporary(builder, &imp.source)?;
             args.push(PlaceOrSpread::Place(source));
             if let Some(options) = &imp.options {
@@ -3985,7 +4002,8 @@ fn lower_expression<'a>(
         }
         oxc::Expression::ObjectExpression(obj) => {
             let span = Some(obj.span);
-            let mut properties: Vec<ObjectPropertyOrSpread> = Vec::new();
+            let alloc = builder.environment().allocator;
+            let mut properties = ArenaVec::new_in(&alloc);
             for prop in &obj.properties {
                 match prop {
                     oxc::ObjectPropertyKind::ObjectProperty(p) => {
@@ -4023,7 +4041,8 @@ fn lower_expression<'a>(
         }
         oxc::Expression::ArrayExpression(arr) => {
             let span = Some(arr.span);
-            let mut elements: Vec<ArrayElement> = Vec::new();
+            let alloc = builder.environment().allocator;
+            let mut elements = ArenaVec::new_in(&alloc);
             for element in &arr.elements {
                 match element {
                     oxc::ArrayExpressionElement::Elision(_) => {
@@ -4383,7 +4402,8 @@ fn lower_jsx_element_expr<'a>(
     let tag = lower_jsx_element_name(builder, &jsx_element.opening_element.name)?;
 
     // Lower attributes (props)
-    let mut props: Vec<JsxAttribute> = Vec::new();
+    let alloc = builder.environment().allocator;
+    let mut props = ArenaVec::new_in(&alloc);
     for attr_item in &jsx_element.opening_element.attributes {
         match attr_item {
             oxc::JSXAttributeItem::SpreadAttribute(spread) => {
@@ -4548,14 +4568,16 @@ fn lower_jsx_element_expr<'a>(
     }
 
     // Lower children
-    let children: Vec<Place> = jsx_element
-        .children
-        .iter()
-        .map(|child| lower_jsx_element(builder, child))
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .flatten()
-        .collect();
+    let children = ArenaVec::from_iter_in(
+        jsx_element
+            .children
+            .iter()
+            .map(|child| lower_jsx_element(builder, child))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten(),
+        &alloc,
+    );
 
     if is_fbt {
         builder.fbt_depth -= 1;
@@ -4580,14 +4602,17 @@ fn lower_jsx_fragment_expr<'a>(
     let span = Some(jsx_fragment.span);
 
     // Lower children
-    let children: Vec<Place> = jsx_fragment
-        .children
-        .iter()
-        .map(|child| lower_jsx_element(builder, child))
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .flatten()
-        .collect();
+    let alloc = builder.environment().allocator;
+    let children = ArenaVec::from_iter_in(
+        jsx_fragment
+            .children
+            .iter()
+            .map(|child| lower_jsx_element(builder, child))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten(),
+        &alloc,
+    );
 
     Ok(InstructionValue::JsxFragment { children, span })
 }
@@ -5981,7 +6006,8 @@ fn lower_statement<'a>(
             // Iterate through cases in reverse order so that previous blocks can
             // fallthrough to successors
             let mut fallthrough = continuation_id;
-            let mut cases: Vec<Case> = Vec::new();
+            let alloc = builder.environment().allocator;
+            let mut cases = ArenaVec::new_in(&alloc);
             let mut has_default = false;
 
             for ii in (0..switch_stmt.cases.len()).rev() {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -6,7 +6,7 @@ use crate::react_compiler_hir::*;
 use crate::react_compiler_utils::FxIndexMap;
 use crate::react_compiler_utils::IdentIndexMap;
 use crate::react_compiler_utils::OrderedMap;
-use crate::react_compiler_utils::OrderedSet;
+use crate::react_compiler_utils::ordered_map::ArenaOrderedSet;
 use crate::scope::DeclKind;
 use crate::scope::ImportBindingKind;
 use crate::scope::ScopeId;
@@ -14,6 +14,7 @@ use crate::scope::ScopeResolver;
 use crate::scope::SymbolId;
 use rustc_hash::FxHashSet;
 
+use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
 use oxc_str::{Ident, format_ident};
@@ -21,7 +22,12 @@ use oxc_str::{Ident, format_ident};
 use crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex;
 
 type BuildResult<'a> = Result<
-    (HIR, Vec<Instruction<'a>>, IdentIndexMap<'a, SymbolId>, FxIndexMap<SymbolId, IdentifierId>),
+    (
+        HIR<'a>,
+        Vec<Instruction<'a>>,
+        IdentIndexMap<'a, SymbolId>,
+        FxIndexMap<SymbolId, IdentifierId>,
+    ),
     OxcDiagnostic,
 >;
 
@@ -125,7 +131,7 @@ fn new_block(id: BlockId, kind: BlockKind) -> WipBlock {
 // ---------------------------------------------------------------------------
 
 pub struct HirBuilder<'a, 'b> {
-    completed: OrderedMap<BlockId, BasicBlock>,
+    completed: OrderedMap<BlockId, BasicBlock<'a>>,
     current: WipBlock,
     entry: BlockId,
     scopes: Vec<Scope<'a>>,
@@ -338,16 +344,17 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     /// Kept non-generic (and out-of-line) so the block-completion machinery compiles
     /// once instead of being duplicated into every generic `try_enter*` instantiation.
     #[inline(never)]
-    fn complete_block(&mut self, wip: WipBlock, terminal: Terminal) {
+    fn complete_block(&mut self, wip: WipBlock, terminal: Terminal<'a>) {
+        let alloc = self.env.allocator;
         self.completed.insert(
             wip.id,
             BasicBlock {
                 kind: wip.kind,
                 id: wip.id,
-                instructions: wip.instructions,
+                instructions: ArenaVec::from_iter_in(wip.instructions, &alloc),
                 terminal,
-                preds: OrderedSet::default(),
-                phis: Vec::new(),
+                preds: ArenaOrderedSet::new_in(alloc),
+                phis: ArenaVec::new_in(&alloc),
             },
         );
     }
@@ -356,7 +363,11 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     ///
     /// If `next_block_kind` is `Some`, a new current block is created with that kind.
     /// Returns the BlockId of the completed block.
-    pub fn terminate(&mut self, terminal: Terminal, next_block_kind: Option<BlockKind>) -> BlockId {
+    pub fn terminate(
+        &mut self,
+        terminal: Terminal<'a>,
+        next_block_kind: Option<BlockKind>,
+    ) -> BlockId {
         // The placeholder block created here (`BlockId::PLACEHOLDER`) is only used when
         // next_block_kind is None, meaning this is the final terminate() call.
         // It will never be read or completed because build() consumes self
@@ -376,7 +387,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
 
     /// Terminate the current block with the given terminal, and set
     /// a previously reserved block as the new current block.
-    pub fn terminate_with_continuation(&mut self, terminal: Terminal, continuation: WipBlock) {
+    pub fn terminate_with_continuation(&mut self, terminal: Terminal<'a>, continuation: WipBlock) {
         let wip = std::mem::replace(&mut self.current, continuation);
         self.complete_block(wip, terminal);
     }
@@ -393,7 +404,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     pub fn try_enter_reserved(
         &mut self,
         wip: WipBlock,
-        f: impl FnOnce(&mut Self) -> Result<Terminal, OxcDiagnostic>,
+        f: impl FnOnce(&mut Self) -> Result<Terminal<'a>, OxcDiagnostic>,
     ) -> Result<(), OxcDiagnostic> {
         let prev = std::mem::replace(&mut self.current, wip);
         let terminal = f(self)?;
@@ -406,7 +417,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
     pub fn try_enter(
         &mut self,
         kind: BlockKind,
-        f: impl FnOnce(&mut Self, BlockId) -> Result<Terminal, OxcDiagnostic>,
+        f: impl FnOnce(&mut Self, BlockId) -> Result<Terminal<'a>, OxcDiagnostic>,
     ) -> Result<BlockId, OxcDiagnostic> {
         let wip = self.reserve(kind);
         let wip_id = wip.id;
@@ -590,7 +601,7 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
 
         let mut instructions = std::mem::take(&mut self.instruction_table);
 
-        let rpo_blocks = get_reverse_postordered_blocks(&hir);
+        let rpo_blocks = get_reverse_postordered_blocks(&hir, self.env.allocator);
 
         // Check for unreachable blocks that contain FunctionExpression instructions.
         // These could contain hoisted declarations that we can't safely remove.
@@ -891,14 +902,17 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
 /// Blocks not reachable through successors are removed. Blocks that are
 /// only reachable as fallthroughs (not through real successor edges) are
 /// replaced with empty blocks that have an Unreachable terminal.
-pub fn get_reverse_postordered_blocks(hir: &HIR) -> OrderedMap<BlockId, BasicBlock> {
+pub fn get_reverse_postordered_blocks<'a>(
+    hir: &HIR<'a>,
+    alloc: &'a Allocator,
+) -> OrderedMap<BlockId, BasicBlock<'a>> {
     let mut visited: FxHashSet<BlockId> = FxHashSet::default();
     let mut used: FxHashSet<BlockId> = FxHashSet::default();
     let mut used_fallthroughs: FxHashSet<BlockId> = FxHashSet::default();
     let mut postorder: Vec<BlockId> = Vec::new();
 
     fn visit(
-        hir: &HIR,
+        hir: &HIR<'_>,
         block_id: BlockId,
         is_used: bool,
         visited: &mut FxHashSet<BlockId>,
@@ -951,20 +965,20 @@ pub fn get_reverse_postordered_blocks(hir: &HIR) -> OrderedMap<BlockId, BasicBlo
     for block_id in postorder.into_iter().rev() {
         let block = hir.blocks.get(&block_id).unwrap();
         if used.contains(&block_id) {
-            blocks.insert(block_id, block.clone());
+            blocks.insert(block_id, block.clone_in(alloc));
         } else if used_fallthroughs.contains(&block_id) {
             blocks.insert(
                 block_id,
                 BasicBlock {
                     kind: block.kind,
                     id: block_id,
-                    instructions: Vec::new(),
+                    instructions: ArenaVec::new_in(&alloc),
                     terminal: Terminal::Unreachable {
                         id: block.terminal.evaluation_order(),
                         span: block.terminal.span().copied(),
                     },
-                    preds: block.preds.clone(),
-                    phis: Vec::new(),
+                    preds: block.preds.clone_in(alloc),
+                    phis: ArenaVec::new_in(&alloc),
                 },
             );
         }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -102,7 +102,7 @@ fn constant_propagation_impl<'a>(
          * If terminals have changed then blocks may have become newly unreachable.
          * Re-run minification of the graph (incl reordering instruction ids)
          */
-        func.body.blocks = get_reverse_postordered_blocks(&func.body);
+        func.body.blocks = get_reverse_postordered_blocks(&func.body, env.allocator);
         remove_unreachable_for_updates(&mut func.body);
         remove_dead_do_while_statements(&mut func.body);
         remove_unnecessary_try_catch(&mut func.body);
@@ -126,7 +126,7 @@ fn constant_propagation_impl<'a>(
          * Finally, merge together any blocks that are now guaranteed to execute
          * consecutively
          */
-        merge_consecutive_blocks(func, &mut env.functions);
+        merge_consecutive_blocks(func, &mut env.functions, env.allocator);
 
         // TODO: port assertConsistentIdentifiers(fn) and assertTerminalSuccessorsExist(fn)
         // from TS HIR validation. These are debug assertions that verify structural
@@ -159,7 +159,7 @@ fn apply_constant_propagation<'a>(
         }
 
         let block = &func.body.blocks[&block_id];
-        let instr_ids = block.instructions.clone();
+        let instr_ids = block.instructions.iter().copied().collect::<Vec<_>>();
         let block_kind = block.kind;
         let instr_count = instr_ids.len();
 
@@ -624,7 +624,7 @@ fn process_inner_function<'a>(
     env: &mut Environment<'a>,
     constants: &mut Constants<'a>,
 ) {
-    let mut inner = replace(&mut env.functions[func_id], placeholder_function());
+    let mut inner = replace(&mut env.functions[func_id], placeholder_function(env.allocator));
     constant_propagation_impl(&mut inner, env, constants);
     env.functions[func_id] = inner;
 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
@@ -11,6 +11,7 @@
 //!
 //! Ported from TypeScript `src/Optimization/DeadCodeElimination.ts`.
 
+use oxc_allocator::Vec as ArenaVec;
 use oxc_index::IndexSlice;
 use oxc_str::IdentHashSet;
 use rustc_hash::FxHashSet;
@@ -189,11 +190,11 @@ fn find_referenced_identifiers<'a>(func: &HirFunction<'a>, env: &Environment<'a>
 }
 
 /// Rewrite a retained instruction (destructuring cleanup, StoreLocal -> DeclareLocal).
-fn rewrite_instruction(
-    func: &mut HirFunction,
+fn rewrite_instruction<'a>(
+    func: &mut HirFunction<'a>,
     instr_id: InstructionId,
     state: &State,
-    env: &Environment,
+    env: &Environment<'a>,
 ) {
     let instr = &mut func.instructions[instr_id.index()];
 
@@ -245,7 +246,7 @@ fn rewrite_instruction(
                         }
                     }
                     if let Some(props) = next_properties {
-                        obj.properties = props;
+                        obj.properties = ArenaVec::from_iter_in(props, &env.allocator);
                     }
                 }
             }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
@@ -18,6 +18,9 @@ use cow_utils::CowUtils;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
+use oxc_allocator::Allocator;
+use oxc_allocator::CloneIn;
+use oxc_allocator::Vec as ArenaVec;
 use oxc_diagnostics::OxcDiagnostic;
 
 use crate::diagnostics::ErrorCategory;
@@ -122,7 +125,7 @@ pub fn drop_manual_memoization<'a>(
     // Collect all block instruction lists up front to avoid borrowing func immutably
     // while needing to mutate it
     let all_block_instructions: Vec<Vec<InstructionId>> =
-        func.body.blocks.values().map(|block| block.instructions.clone()).collect();
+        func.body.blocks.values().map(|block| block.instructions.to_vec()).collect();
 
     for block_instructions in &all_block_instructions {
         for &instr_id in block_instructions {
@@ -156,14 +159,18 @@ pub fn drop_manual_memoization<'a>(
 
     // Phase 2: Insert manual memoization markers as needed
     if !queued_inserts.is_empty() {
+        let alloc = env.allocator;
         let mut has_changes = false;
         for block in func.body.blocks.values_mut() {
-            let mut next_instructions: Option<Vec<InstructionId>> = None;
+            let mut next_instructions: Option<ArenaVec<'a, InstructionId>> = None;
             for i in 0..block.instructions.len() {
                 let instr_id = block.instructions[i];
                 if let Some(insert_instr) = queued_inserts.remove(&instr_id) {
                     if next_instructions.is_none() {
-                        next_instructions = Some(block.instructions[..i].to_vec());
+                        next_instructions = Some(ArenaVec::from_iter_in(
+                            block.instructions[..i].iter().copied(),
+                            &alloc,
+                        ));
                     }
                     let ni = next_instructions.as_mut().unwrap();
                     ni.push(instr_id);
@@ -217,7 +224,8 @@ fn process_manual_memo_call<'a>(
     let span = func.instructions[instr_id.index()].value.span().cloned();
 
     // Replace the instruction value with the memoization replacement
-    let replacement = get_manual_memoization_replacement(&fn_place, span, manual_memo.kind);
+    let replacement =
+        get_manual_memoization_replacement(&fn_place, span, manual_memo.kind, env.allocator);
     func.instructions[instr_id.index()].value = replacement;
 
     if is_validation_enabled {
@@ -352,7 +360,7 @@ fn collect_temporaries<'a>(
         // matching the TS behavior where collectMaybeMemoDependencies inserts into
         // maybeDeps directly for StoreLocal's target variable.
         if let InstructionValue::StoreLocal { lvalue, .. } = &instr.value {
-            sidemap.maybe_deps.insert(lvalue.place.identifier, dep.clone());
+            sidemap.maybe_deps.insert(lvalue.place.identifier, dep.clone_in(env.allocator));
         }
         sidemap.maybe_deps.insert(lvalue_id, dep);
     }
@@ -373,14 +381,14 @@ fn collect_maybe_memo_dependencies<'a>(
     match value {
         InstructionValue::LoadGlobal { binding, span, .. } => Some(ManualMemoDependency {
             root: ManualMemoDependencyRoot::Global { identifier_name: binding.name() },
-            path: vec![],
+            path: ArenaVec::new_in(&env.allocator),
             span: *span,
         }),
         InstructionValue::PropertyLoad { object, property, span, .. } => {
             maybe_deps.get(&object.identifier).map(|object_dep| ManualMemoDependency {
                 root: object_dep.root,
                 path: {
-                    let mut path = object_dep.path.clone();
+                    let mut path = object_dep.path.clone_in(env.allocator);
                     path.push(DependencyPathEntry { property: *property, optional, span: *span });
                     path
                 },
@@ -389,14 +397,14 @@ fn collect_maybe_memo_dependencies<'a>(
         }
         InstructionValue::LoadLocal { place, .. } | InstructionValue::LoadContext { place, .. } => {
             if let Some(source) = maybe_deps.get(&place.identifier) {
-                Some(source.clone())
+                Some(source.clone_in(env.allocator))
             } else if matches!(
                 &env.identifiers[place.identifier].name,
                 Some(IdentifierName::Named(_))
             ) {
                 Some(ManualMemoDependency {
                     root: ManualMemoDependencyRoot::NamedLocal { value: *place, constant: false },
-                    path: vec![],
+                    path: ArenaVec::new_in(&env.allocator),
                     span: place.span,
                 })
             } else {
@@ -414,7 +422,7 @@ fn collect_maybe_memo_dependencies<'a>(
                 if !matches!(lvalue_name, Some(IdentifierName::Named(_))) {
                     // Note: we can't insert into maybe_deps here since we only have
                     // a shared reference. The caller handles insertion.
-                    return Some(aliased.clone());
+                    return Some(aliased.clone_in(env.allocator));
                 }
             }
             None
@@ -431,10 +439,11 @@ fn get_manual_memoization_replacement<'a>(
     fn_place: &Place,
     span: Option<Span>,
     kind: ManualMemoKind,
+    alloc: &'a Allocator,
 ) -> InstructionValue<'a> {
     if kind == ManualMemoKind::UseMemo {
         // Replace with Call fn() - invoke the memo function directly
-        InstructionValue::CallExpression { callee: *fn_place, args: vec![], span }
+        InstructionValue::CallExpression { callee: *fn_place, args: ArenaVec::new_in(&alloc), span }
     } else {
         // Replace with LoadLocal fn - just reference the function
         InstructionValue::LoadLocal {
@@ -462,7 +471,7 @@ fn make_manual_memoization_markers<'a>(
         lvalue: create_temporary_place(env, fn_expr.span),
         value: InstructionValue::StartMemoize {
             manual_memo_id,
-            deps: deps_list,
+            deps: deps_list.map(|v| ArenaVec::from_iter_in(v, &env.allocator)),
             deps_span: Some(deps_span),
             has_invalid_deps: false,
             span: fn_expr.span,
@@ -489,7 +498,7 @@ fn extract_manual_memoization_args<'a>(
     instr: &Instruction,
     kind: ManualMemoKind,
     sidemap: &IdentifierSidemap<'a>,
-    env: &mut Environment,
+    env: &mut Environment<'a>,
 ) -> Option<ExtractedMemoArgs<'a>> {
     let args: &[PlaceOrSpread] = match &instr.value {
         InstructionValue::CallExpression { args, .. } => args,
@@ -567,7 +576,7 @@ fn extract_manual_memoization_args<'a>(
     for dep in &deps_info.deps {
         let maybe_dep = sidemap.maybe_deps.get(&dep.identifier);
         if let Some(d) = maybe_dep {
-            deps_list.push(d.clone());
+            deps_list.push(d.clone_in(env.allocator));
         } else {
             env.record_diagnostic(
                 ErrorCategory::UseMemo

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
@@ -40,7 +40,8 @@
 //!
 //! Analogous to TS `Inference/InlineImmediatelyInvokedFunctionExpressions.ts`.
 
-use crate::react_compiler_utils::OrderedSet;
+use crate::react_compiler_utils::ordered_map::ArenaOrderedSet;
+use oxc_allocator::{CloneIn, Vec as ArenaVec};
 use oxc_str::format_ident;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -134,15 +135,18 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
 
                     // Create a new block which will contain code following the IIFE call
                     let continuation_block_id = env.next_block_id();
-                    let continuation_instructions: Vec<InstructionId> =
-                        func.body.blocks[&block_id].instructions[ii + 1..].to_vec();
-                    let continuation_terminal = func.body.blocks[&block_id].terminal.clone();
+                    let continuation_instructions: ArenaVec<InstructionId> = ArenaVec::from_iter_in(
+                        func.body.blocks[&block_id].instructions[ii + 1..].iter().copied(),
+                        &env.allocator,
+                    );
+                    let continuation_terminal =
+                        func.body.blocks[&block_id].terminal.clone_in(env.allocator);
                     let continuation_block = BasicBlock {
                         id: continuation_block_id,
                         instructions: continuation_instructions,
                         kind: block_kind,
-                        phis: Vec::new(),
-                        preds: OrderedSet::default(),
+                        phis: ArenaVec::new_in(&env.allocator),
+                        preds: ArenaOrderedSet::new_in(env.allocator),
                         terminal: continuation_terminal,
                     };
                     func.body.blocks.insert(continuation_block_id, continuation_block);
@@ -166,9 +170,9 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
 
                         // Take blocks and instructions from inner function
                         let inner_func = &mut env.functions[inner_func_id];
-                        let inner_blocks: Vec<(BlockId, BasicBlock)> =
+                        let inner_blocks: Vec<(BlockId, BasicBlock<'a>)> =
                             inner_func.body.blocks.drain(..).collect();
-                        let inner_instructions: Vec<Instruction> =
+                        let inner_instructions: Vec<Instruction<'a>> =
                             inner_func.instructions.drain(..).collect();
 
                         // Append inner instructions first, then remap block instruction IDs
@@ -236,9 +240,9 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
 
                         // Take blocks and instructions from inner function
                         let inner_func = &mut env.functions[inner_func_id];
-                        let inner_blocks: Vec<(BlockId, BasicBlock)> =
+                        let inner_blocks: Vec<(BlockId, BasicBlock<'a>)> =
                             inner_func.body.blocks.drain(..).collect();
-                        let inner_instructions: Vec<Instruction> =
+                        let inner_instructions: Vec<Instruction<'a>> =
                             inner_func.instructions.drain(..).collect();
 
                         // Append inner instructions first, then remap block instruction IDs
@@ -292,10 +296,10 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
 
         // If terminals have changed then blocks may have become newly unreachable.
         // Re-run minification of the graph (incl reordering instruction ids).
-        func.body.blocks = get_reverse_postordered_blocks(&func.body);
+        func.body.blocks = get_reverse_postordered_blocks(&func.body, env.allocator);
         mark_instruction_ids(&mut func.body, &mut func.instructions);
         mark_predecessors(&mut func.body);
-        merge_consecutive_blocks(func, &mut env.functions);
+        merge_consecutive_blocks(func, &mut env.functions, env.allocator);
     }
 }
 
@@ -329,8 +333,8 @@ fn has_single_exit_return_terminal(func: &HirFunction<'_>) -> bool {
 /// * Replace the terminal with a Goto to <return_target>
 fn rewrite_block<'a>(
     env: &mut Environment<'a>,
-    instructions: &mut Vec<Instruction<'a>>,
-    block: &mut BasicBlock,
+    instructions: &mut ArenaVec<'a, Instruction<'a>>,
+    block: &mut BasicBlock<'a>,
     return_target: BlockId,
     return_value: &Place,
 ) {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/merge_consecutive_blocks.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/merge_consecutive_blocks.rs
@@ -15,6 +15,7 @@
 
 use std::mem::replace;
 
+use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
 use oxc_index::IndexSlice;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -27,9 +28,10 @@ use crate::react_compiler_lowering::mark_predecessors;
 use crate::react_compiler_ssa::enter_ssa::placeholder_function;
 
 /// Merge consecutive blocks in the function's CFG, including inner functions.
-pub fn merge_consecutive_blocks(
-    func: &mut HirFunction,
-    functions: &mut IndexSlice<FunctionId, [HirFunction]>,
+pub fn merge_consecutive_blocks<'a>(
+    func: &mut HirFunction<'a>,
+    functions: &mut IndexSlice<FunctionId, [HirFunction<'a>]>,
+    alloc: &'a Allocator,
 ) {
     // Collect inner function IDs for recursive processing
     let inner_func_ids: Vec<FunctionId> = func
@@ -51,8 +53,8 @@ pub fn merge_consecutive_blocks(
     for func_id in inner_func_ids {
         // Use std::mem::replace to temporarily take the inner function out,
         // process it, then put it back (standard borrow checker workaround)
-        let mut inner_func = replace(&mut functions[func_id], placeholder_function());
-        merge_consecutive_blocks(&mut inner_func, functions);
+        let mut inner_func = replace(&mut functions[func_id], placeholder_function(alloc));
+        merge_consecutive_blocks(&mut inner_func, functions, alloc);
         functions[func_id] = inner_func;
     }
 
@@ -115,8 +117,8 @@ pub fn merge_consecutive_blocks(
                 (phi.place.identifier, operand)
             })
             .collect();
-        let block_instr_ids = block.instructions.clone();
-        let block_terminal = block.terminal.clone();
+        let block_instr_ids = block.instructions.clone_in(alloc);
+        let block_terminal = block.terminal.clone_in(alloc);
 
         // Create phi instructions and add to instruction table
         let mut new_instr_ids = Vec::new();
@@ -132,7 +134,10 @@ pub fn merge_consecutive_blocks(
                 lvalue,
                 value: InstructionValue::LoadLocal { place: operand, span: GENERATED_SOURCE },
                 span: GENERATED_SOURCE,
-                effects: Some(vec![AliasingEffect::Alias { from: operand, into: lvalue }]),
+                effects: Some(ArenaVec::from_array_in(
+                    [AliasingEffect::Alias { from: operand, into: lvalue }],
+                    &alloc,
+                )),
             };
             let instr_id = InstructionId::from_usize(func.instructions.len());
             func.instructions.push(instr);

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
@@ -12,7 +12,6 @@
 //! Conditional on `env.config.enable_name_anonymous_functions`.
 
 use std::borrow::Cow;
-use std::mem::take;
 
 use rustc_hash::FxHashMap;
 
@@ -81,11 +80,8 @@ pub fn name_anonymous_functions<'a>(func: &mut HirFunction<'a>, env: &mut Enviro
 
     // Update name_hint on FunctionExpression instruction values in all arena functions
     for i in 0..env.functions.len() {
-        // We need to temporarily take the instructions to avoid borrow issues
         let func_id = FunctionId::from_usize(i);
-        let mut instructions = take(&mut env.functions[func_id].instructions);
-        apply_name_hints_to_instructions(&mut instructions, &update_map);
-        env.functions[func_id].instructions = instructions;
+        apply_name_hints_to_instructions(&mut env.functions[func_id].instructions, &update_map);
     }
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
@@ -17,6 +17,7 @@
 //!
 //! Ported from TypeScript `src/Optimization/OptimizeForSSR.ts`.
 
+use oxc_allocator::Vec as ArenaVec;
 use rustc_hash::FxHashMap;
 
 use crate::react_compiler_hir::environment::Environment;
@@ -33,7 +34,7 @@ use oxc_span::Span;
 /// removing event handlers, and stripping known event handler / ref JSX props.
 ///
 /// Corresponds to TS `optimizeForSSR(fn: HIRFunction): void`.
-pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
+pub fn optimize_for_ssr<'a>(func: &mut HirFunction<'a>, env: &Environment<'a>) {
     // Phase 1: Identify useState/useReducer calls that can be safely inlined.
     //
     // For useState(initialValue) where initialValue is primitive/object/array,
@@ -232,7 +233,10 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                         span,
                                     } => InstructionValue::CallExpression {
                                         callee: *callee,
-                                        args: vec![PlaceOrSpread::Place(*arg)],
+                                        args: ArenaVec::from_array_in(
+                                            [PlaceOrSpread::Place(*arg)],
+                                            &env.allocator,
+                                        ),
                                         span: *span,
                                     },
                                 };

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_props_method_calls.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_props_method_calls.rs
@@ -20,7 +20,7 @@ use crate::react_compiler_hir::{HirFunction, InstructionValue, is_props_type};
 
 pub fn optimize_props_method_calls(func: &mut HirFunction, env: &Environment) {
     for (_block_id, block) in &func.body.blocks {
-        let instruction_ids: Vec<_> = block.instructions.clone();
+        let instruction_ids: Vec<_> = block.instructions.iter().copied().collect();
         for instr_id in instruction_ids {
             let instr = &mut func.instructions[instr_id.index()];
             let should_replace = matches!(

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
@@ -15,6 +15,7 @@ use std::mem::replace;
 
 use rustc_hash::FxHashSet;
 
+use oxc_allocator::CloneIn;
 use oxc_str::Ident;
 
 use crate::react_compiler_hir::environment::Environment;
@@ -83,14 +84,14 @@ pub fn outline_functions<'a>(
         match action {
             Action::Recurse(function_id) => {
                 let mut inner_func =
-                    replace(&mut env.functions[function_id], placeholder_function());
+                    replace(&mut env.functions[function_id], placeholder_function(env.allocator));
                 outline_functions(&mut inner_func, env, fbt_operands);
                 env.functions[function_id] = inner_func;
             }
             Action::RecurseAndOutline { instr_idx, function_id } => {
                 // First recurse into the inner function (depth-first)
                 let mut inner_func =
-                    replace(&mut env.functions[function_id], placeholder_function());
+                    replace(&mut env.functions[function_id], placeholder_function(env.allocator));
                 outline_functions(&mut inner_func, env, fbt_operands);
                 env.functions[function_id] = inner_func;
 
@@ -103,7 +104,7 @@ pub fn outline_functions<'a>(
                 env.functions[function_id].id = Some(generated_name);
 
                 // Outline the function
-                let outlined_func = env.functions[function_id].clone();
+                let outlined_func = env.functions[function_id].clone_in(env.allocator);
                 env.outline_function(outlined_func, None);
 
                 // Replace the instruction value with LoadGlobal

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
@@ -9,7 +9,9 @@
 //! This pass is conditional on `env.config.enable_jsx_outlining` (defaults to false).
 
 use crate::react_compiler_utils::OrderedMap;
-use crate::react_compiler_utils::OrderedSet;
+use crate::react_compiler_utils::ordered_map::ArenaOrderedSet;
+use oxc_allocator::CloneIn;
+use oxc_allocator::Vec as ArenaVec;
 use oxc_index::IndexVec;
 use oxc_str::{Ident, IdentHashSet, format_ident};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -69,7 +71,7 @@ fn outline_jsx_impl<'a>(
     let block_ids: Vec<BlockId> = func.body.blocks.keys().copied().collect();
     for block_id in &block_ids {
         let block = &func.body.blocks[block_id];
-        let instr_ids = block.instructions.clone();
+        let instr_ids = block.instructions.iter().copied().collect::<Vec<_>>();
 
         let mut rewrite_instr: FxHashMap<EvaluationOrder, Vec<Instruction<'a>>> =
             FxHashMap::default();
@@ -133,7 +135,7 @@ fn outline_jsx_impl<'a>(
                 }
                 InstrAction::FunctionExpr { func_id } => {
                     let mut inner_func =
-                        replace(&mut env.functions[func_id], placeholder_function());
+                        replace(&mut env.functions[func_id], placeholder_function(env.allocator));
                     outline_jsx_impl(&mut inner_func, env, outlined_fns);
                     env.functions[func_id] = inner_func;
                 }
@@ -169,15 +171,15 @@ fn outline_jsx_impl<'a>(
         );
         if !rewrite_instr.is_empty() {
             let block = func.body.blocks.get_mut(block_id).unwrap();
-            let old_instr_ids = block.instructions.clone();
-            let mut new_instr_ids = Vec::new();
+            let old_instr_ids = block.instructions.iter().copied().collect::<Vec<_>>();
+            let mut new_instr_ids = ArenaVec::new_in(&env.allocator);
             for &iid in &old_instr_ids {
                 let eval_order = func.instructions[iid.index()].id;
                 if let Some(replacement_instrs) = rewrite_instr.get(&eval_order) {
                     // Add replacement instructions to the instruction table and reference them
                     for new_instr in replacement_instrs {
                         let new_idx = func.instructions.len();
-                        func.instructions.push(new_instr.clone());
+                        func.instructions.push(new_instr.clone_in(env.allocator));
                         new_instr_ids.push(InstructionId::from_usize(new_idx));
                     }
                 } else {
@@ -323,10 +325,10 @@ fn emit_outlined_jsx<'a>(
     outlined_props: &[OutlinedJsxAttribute<'a>],
     outlined_tag: Ident<'a>,
 ) -> Option<Vec<Instruction<'a>>> {
-    let props: Vec<JsxAttribute> = outlined_props
-        .iter()
-        .map(|p| JsxAttribute::Attribute { name: p.new_name, place: p.place })
-        .collect();
+    let props = ArenaVec::from_iter_in(
+        outlined_props.iter().map(|p| JsxAttribute::Attribute { name: p.new_name, place: p.place }),
+        &env.allocator,
+    );
 
     // Create LoadGlobal for the outlined component
     let load_id = env.next_identifier_id();
@@ -391,10 +393,10 @@ fn emit_outlined_fn<'a>(
     let destructure_instr = emit_destructure_props(env, &props_obj, &old_to_new_props);
 
     // Emit load globals for JSX tags
-    let load_global_instrs = emit_load_globals(func, jsx_group, globals)?;
+    let load_global_instrs = emit_load_globals(func, jsx_group, globals, env.allocator)?;
 
     // Emit updated JSX instructions
-    let updated_jsx_instrs = emit_updated_jsx(func, jsx_group, &old_to_new_props);
+    let updated_jsx_instrs = emit_updated_jsx(func, jsx_group, &old_to_new_props, env.allocator);
 
     // Build instructions list
     let mut instructions = Vec::new();
@@ -403,8 +405,8 @@ fn emit_outlined_fn<'a>(
     instructions.extend(updated_jsx_instrs);
 
     // Build instruction table and instruction IDs
-    let mut instr_table = Vec::new();
-    let mut instr_ids = Vec::new();
+    let mut instr_table = ArenaVec::new_in(&env.allocator);
+    let mut instr_ids = ArenaVec::new_in(&env.allocator);
     for instr in instructions {
         let idx = instr_table.len();
         instr_table.push(instr);
@@ -423,7 +425,7 @@ fn emit_outlined_fn<'a>(
         kind: BlockKind::Block,
         id: BlockId::ENTRY,
         instructions: instr_ids,
-        preds: OrderedSet::default(),
+        preds: ArenaOrderedSet::new_in(env.allocator),
         terminal: Terminal::Return {
             value: last_lvalue,
             return_variant: ReturnVariant::Explicit,
@@ -431,7 +433,7 @@ fn emit_outlined_fn<'a>(
             span: None,
             effects: None,
         },
-        phis: Vec::new(),
+        phis: ArenaVec::new_in(&env.allocator),
     };
 
     let mut blocks = OrderedMap::default();
@@ -441,15 +443,15 @@ fn emit_outlined_fn<'a>(
         id: None,
         name_hint: None,
         fn_type: ReactFunctionType::Other,
-        params: vec![ParamPattern::Place(props_obj)],
+        params: ArenaVec::from_array_in([ParamPattern::Place(props_obj)], &env.allocator),
         returns: returns_place,
-        context: Vec::new(),
+        context: ArenaVec::new_in(&env.allocator),
         body: HIR { entry: BlockId::ENTRY, blocks },
         instructions: instr_table,
         generator: false,
         is_async: false,
-        directives: Vec::new(),
-        aliasing_effects: Some(vec![]),
+        directives: ArenaVec::new_in(&env.allocator),
+        aliasing_effects: Some(ArenaVec::new_in(&env.allocator)),
         span: None,
     };
 
@@ -460,6 +462,7 @@ fn emit_load_globals<'a>(
     func: &HirFunction<'a>,
     jsx_group: &[JsxInstrInfo],
     globals: &FxHashMap<IdentifierId, usize>,
+    alloc: &'a oxc_allocator::Allocator,
 ) -> Option<Vec<Instruction<'a>>> {
     let mut instructions = Vec::new();
     for info in jsx_group {
@@ -467,7 +470,7 @@ fn emit_load_globals<'a>(
         if let InstructionValue::JsxExpression { tag: JsxTag::Place(tag_place), .. } = &instr.value
         {
             let global_instr_idx = globals.get(&tag_place.identifier)?;
-            instructions.push(func.instructions[*global_instr_idx].clone());
+            instructions.push(func.instructions[*global_instr_idx].clone_in(alloc));
         }
     }
     Some(instructions)
@@ -477,6 +480,7 @@ fn emit_updated_jsx<'a>(
     func: &HirFunction<'a>,
     jsx_group: &[JsxInstrInfo],
     old_to_new_props: &FxIndexMap<IdentifierId, OutlinedJsxAttribute<'a>>,
+    alloc: &'a oxc_allocator::Allocator,
 ) -> Vec<Instruction<'a>> {
     let jsx_ids: FxHashSet<IdentifierId> = jsx_group.iter().map(|j| j.lvalue_id).collect();
     let mut new_instrs = Vec::new();
@@ -492,7 +496,7 @@ fn emit_updated_jsx<'a>(
             closing_span,
         } = &instr.value
         {
-            let mut new_props = Vec::new();
+            let mut new_props = ArenaVec::new_in(&alloc);
             for prop in props {
                 // TS: invariant(prop.kind === 'JsxAttribute', ...)
                 // Spread attributes would have caused collectProps to return null earlier
@@ -516,8 +520,8 @@ fn emit_updated_jsx<'a>(
             }
 
             let new_children = children.as_ref().map(|kids| {
-                kids.iter()
-                    .map(|child| {
+                ArenaVec::from_iter_in(
+                    kids.iter().map(|child| {
                         if jsx_ids.contains(&child.identifier) {
                             *child
                         } else {
@@ -527,8 +531,9 @@ fn emit_updated_jsx<'a>(
                                 .expect("Expected a new prop for child identifier");
                             new_prop.place
                         }
-                    })
-                    .collect()
+                    }),
+                    &alloc,
+                )
             });
 
             new_instrs.push(Instruction {
@@ -543,7 +548,7 @@ fn emit_updated_jsx<'a>(
                     closing_span: *closing_span,
                 },
                 span: instr.span,
-                effects: instr.effects.clone(),
+                effects: instr.effects.as_ref().map(|v| v.clone_in(alloc)),
             });
         }
     }
@@ -586,7 +591,7 @@ fn emit_destructure_props<'a>(
     props_obj: &Place,
     old_to_new_props: &FxIndexMap<IdentifierId, OutlinedJsxAttribute<'a>>,
 ) -> Instruction<'a> {
-    let mut properties = Vec::new();
+    let mut properties = ArenaVec::new_in(&env.allocator);
     for prop in old_to_new_props.values() {
         properties.push(ObjectPropertyOrSpread::Property(ObjectProperty {
             key: ObjectPropertyKey::String { name: prop.new_name },

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
@@ -10,6 +10,7 @@
 //!
 //! Analogous to TS `Optimization/PruneMaybeThrows.ts`.
 
+use oxc_allocator::Allocator;
 use oxc_index::{IndexSlice, IndexVec};
 
 use oxc_diagnostics::OxcDiagnostic;
@@ -26,20 +27,21 @@ use crate::react_compiler_lowering::{
 use crate::react_compiler_optimization::merge_consecutive_blocks::merge_consecutive_blocks;
 
 /// Prune `MaybeThrow` terminals for blocks that cannot throw, then clean up the CFG.
-pub fn prune_maybe_throws(
-    func: &mut HirFunction,
-    functions: &mut IndexSlice<FunctionId, [HirFunction]>,
+pub fn prune_maybe_throws<'a>(
+    func: &mut HirFunction<'a>,
+    functions: &mut IndexSlice<FunctionId, [HirFunction<'a>]>,
+    alloc: &'a Allocator,
 ) -> Result<(), OxcDiagnostic> {
     let terminal_mapping = prune_maybe_throws_impl(func);
     if let Some(terminal_mapping) = terminal_mapping {
         // If terminals have changed then blocks may have become newly unreachable.
         // Re-run minification of the graph (incl reordering instruction ids).
-        func.body.blocks = get_reverse_postordered_blocks(&func.body);
+        func.body.blocks = get_reverse_postordered_blocks(&func.body, alloc);
         remove_unreachable_for_updates(&mut func.body);
         remove_dead_do_while_statements(&mut func.body);
         remove_unnecessary_try_catch(&mut func.body);
         mark_instruction_ids(&mut func.body, &mut func.instructions);
-        merge_consecutive_blocks(func, functions);
+        merge_consecutive_blocks(func, functions, alloc);
 
         // Rewrite phi operands to reference the updated predecessor blocks
         for block in func.body.blocks.values_mut() {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/prune_unused_labels_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/prune_unused_labels_hir.rs
@@ -59,20 +59,16 @@ pub fn prune_unused_labels_hir(func: &mut HirFunction) {
             "Unexpected block predecessors when merging label blocks"
         );
 
-        // Collect instructions from next and fallthrough
-        let next_instructions = func.body.blocks[next_id].instructions.clone();
-        let fallthrough_instructions = func.body.blocks[fallthrough_id].instructions.clone();
-        let fallthrough_terminal = func.body.blocks[fallthrough_id].terminal.clone();
+        // Remove merged blocks, taking ownership of their contents to avoid cloning
+        // the arena-allocated instructions and terminal.
+        let next_block = func.body.blocks.shift_remove(next_id).unwrap();
+        let fallthrough_block = func.body.blocks.shift_remove(fallthrough_id).unwrap();
 
         // Merge into the label block
         let label_block = func.body.blocks.get_mut(&label_id).unwrap();
-        label_block.instructions.extend(next_instructions);
-        label_block.instructions.extend(fallthrough_instructions);
-        label_block.terminal = fallthrough_terminal;
-
-        // Remove merged blocks
-        func.body.blocks.shift_remove(next_id);
-        func.body.blocks.shift_remove(fallthrough_id);
+        label_block.instructions.extend(next_block.instructions);
+        label_block.instructions.extend(fallthrough_block.instructions);
+        label_block.terminal = fallthrough_block.terminal;
 
         rewrites.insert(*fallthrough_id, label_id);
     }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -21,6 +21,7 @@ use crate::react_compiler_hir::{
     ReactiveSwitchCase, ReactiveTerminal, ReactiveTerminalStatement, ReactiveTerminalTargetKind,
     ReactiveValue, Terminal,
 };
+use oxc_allocator::CloneIn;
 use oxc_span::Span;
 
 /// Convert the HIR CFG into a tree-structured ReactiveFunction.
@@ -39,11 +40,11 @@ pub fn build_reactive_function<'a>(
         span: hir.span,
         id: hir.id,
         name_hint: hir.name_hint,
-        params: hir.params.clone(),
+        params: hir.params.iter().copied().collect(),
         generator: hir.generator,
         is_async: hir.is_async,
         body,
-        directives: hir.directives.clone(),
+        directives: hir.directives.iter().copied().collect(),
     })
 }
 
@@ -125,7 +126,7 @@ impl<'a, 'h> Context<'a, 'h> {
         }
     }
 
-    fn block(&self, id: BlockId) -> &BasicBlock {
+    fn block(&self, id: BlockId) -> &BasicBlock<'_> {
         &self.ir.body.blocks[&id]
     }
 
@@ -302,8 +303,8 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
             // Extract data from block before any mutable operations
             let block = &self.hir.body.blocks[&block_id];
             let block_id_val = block.id;
-            let instructions: Vec<_> = block.instructions.clone();
-            let terminal = block.terminal.clone();
+            let instructions: Vec<_> = block.instructions.iter().copied().collect();
+            let terminal = block.terminal.clone_in(self.env.allocator);
 
             if !self.cx.emitted.insert(block_id_val) {
                 return Err(ErrorCategory::Invariant
@@ -316,7 +317,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 block_value.push(ReactiveStatement::Instruction(ReactiveInstruction {
                     id: instr.id,
                     lvalue: Some(instr.lvalue),
-                    value: ReactiveValue::Instruction(instr.value.clone()),
+                    value: ReactiveValue::Instruction(instr.value.clone_in(self.env.allocator)),
                     span: instr.span,
                 }));
             }
@@ -911,8 +912,8 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
     ) -> Result<ValueBlockResult<'a>, OxcDiagnostic> {
         let block = &self.hir.body.blocks[&block_id];
         let block_id_val = block.id;
-        let terminal = block.terminal.clone();
-        let instructions: Vec<_> = block.instructions.clone();
+        let terminal = block.terminal.clone_in(self.env.allocator);
+        let instructions: Vec<_> = block.instructions.iter().copied().collect();
 
         // If we've reached the fallthrough, stop
         if let Some(ft) = fallthrough
@@ -988,7 +989,9 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                         ReactiveInstruction {
                             id: instr.id,
                             lvalue: Some(instr.lvalue),
-                            value: ReactiveValue::Instruction(instr.value.clone()),
+                            value: ReactiveValue::Instruction(
+                                instr.value.clone_in(self.env.allocator),
+                            ),
                             span: instr.span,
                         }
                     })
@@ -1146,7 +1149,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 ReactiveInstruction {
                     id: instr.id,
                     lvalue: Some(instr.lvalue),
-                    value: ReactiveValue::Instruction(instr.value.clone()),
+                    value: ReactiveValue::Instruction(instr.value.clone_in(self.env.allocator)),
                     span: instr.span,
                 }
             })
@@ -1166,10 +1169,16 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                         lvalue.place,
                     )
                 } else {
-                    (ReactiveValue::Instruction(last_instr.value.clone()), last_instr.lvalue)
+                    (
+                        ReactiveValue::Instruction(last_instr.value.clone_in(self.env.allocator)),
+                        last_instr.lvalue,
+                    )
                 }
             }
-            _ => (ReactiveValue::Instruction(last_instr.value.clone()), last_instr.lvalue),
+            _ => (
+                ReactiveValue::Instruction(last_instr.value.clone_in(self.env.allocator)),
+                last_instr.lvalue,
+            ),
         };
         let id = last_instr.id;
 
@@ -1205,7 +1214,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 ReactiveInstruction {
                     id: instr.id,
                     lvalue: Some(instr.lvalue),
-                    value: ReactiveValue::Instruction(instr.value.clone()),
+                    value: ReactiveValue::Instruction(instr.value.clone_in(self.env.allocator)),
                     span: instr.span,
                 }
             })
@@ -1343,7 +1352,7 @@ struct ValueTerminalResult<'a> {
 }
 
 /// Helper to get span from a terminal
-fn terminal_span(terminal: &Terminal) -> &Option<Span> {
+fn terminal_span<'t>(terminal: &'t Terminal<'_>) -> &'t Option<Span> {
     match terminal {
         Terminal::If { span, .. }
         | Terminal::Branch { span, .. }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -1194,8 +1194,10 @@ fn ox_codegen_for_init<'a>(
     init: &ReactiveValue<'a>,
 ) -> Result<Option<oxc::ForStatementInit<'a>>, OxcDiagnostic> {
     if let ReactiveValue::SequenceExpression { instructions, .. } = init {
-        let block_items: Vec<ReactiveStatement> =
-            instructions.iter().map(|i| ReactiveStatement::Instruction(i.clone())).collect();
+        let block_items: Vec<ReactiveStatement> = instructions
+            .iter()
+            .map(|i| ReactiveStatement::Instruction(i.clone_in(cx.env.allocator)))
+            .collect();
         let body = ox_codegen_block(cx, &block_items)?;
         let mut declarators: oxc_allocator::Vec<'a, oxc::VariableDeclarator<'a>> =
             oxc_allocator::ArenaVec::new_in(&cx.ast);
@@ -1309,7 +1311,8 @@ fn ox_codegen_instruction_nullable<'a>(
                     None,
                 )?;
                 let lvalue = instr.lvalue.as_ref().unwrap();
-                cx.object_methods.insert(lvalue.identifier, (value.clone(), *span));
+                cx.object_methods
+                    .insert(lvalue.identifier, (value.clone_in(cx.env.allocator), *span));
                 return Ok(None);
             }
             _ => {}
@@ -1563,8 +1566,10 @@ fn ox_codegen_instruction_value<'a>(
             )))
         }
         ReactiveValue::SequenceExpression { instructions, value, .. } => {
-            let block_items: Vec<ReactiveStatement> =
-                instructions.iter().map(|i| ReactiveStatement::Instruction(i.clone())).collect();
+            let block_items: Vec<ReactiveStatement> = instructions
+                .iter()
+                .map(|i| ReactiveStatement::Instruction(i.clone_in(cx.env.allocator)))
+                .collect();
             let body = ox_codegen_block_no_reset(cx, &block_items)?;
             let mut expressions: oxc_allocator::Vec<'a, oxc::Expression<'a>> =
                 oxc_allocator::ArenaVec::new_in(&cx.ast);
@@ -2499,8 +2504,7 @@ fn ox_codegen_function_expression<'a>(
     lowered_func: &crate::react_compiler_hir::LoweredFunction,
     expr_type: &FunctionExpressionType,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
-    let func = cx.env.functions[lowered_func.func].clone();
-    let mut reactive_fn = build_reactive_function(&func, cx.env)?;
+    let mut reactive_fn = build_reactive_function(&cx.env.functions[lowered_func.func], cx.env)?;
     prune_unused_labels(&mut reactive_fn, cx.env)?;
     prune_unused_lvalues(&mut reactive_fn, cx.env);
     prune_hoisted_contexts(&mut reactive_fn, cx.env)?;
@@ -2659,16 +2663,18 @@ fn ox_codegen_object_expression<'a>(
                         ));
                     }
                     ObjectPropertyType::Method => {
-                        let method_data =
-                            cx.object_methods.get(&obj_prop.place.identifier).cloned();
+                        let method_data = cx
+                            .object_methods
+                            .get(&obj_prop.place.identifier)
+                            .map(|(v, s)| (v.clone_in(cx.env.allocator), *s));
                         let Some((InstructionValue::ObjectMethod { lowered_func, .. }, _)) =
                             method_data
                         else {
                             return Err(invariant_err("Expected ObjectMethod instruction", None));
                         };
 
-                        let func = cx.env.functions[lowered_func.func].clone();
-                        let mut reactive_fn = build_reactive_function(&func, cx.env)?;
+                        let mut reactive_fn =
+                            build_reactive_function(&cx.env.functions[lowered_func.func], cx.env)?;
                         prune_unused_labels(&mut reactive_fn, cx.env)?;
                         prune_unused_lvalues(&mut reactive_fn, cx.env);
 
@@ -2726,7 +2732,7 @@ fn ox_codegen_jsx_expression<'a>(
     cx: &mut OxcContext<'a, '_>,
     tag: &JsxTag,
     props: &[JsxAttribute],
-    children: &Option<Vec<Place>>,
+    children: &Option<oxc_allocator::Vec<'a, Place>>,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
     let mut attributes: oxc_allocator::Vec<'a, oxc::JSXAttributeItem<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
@@ -10,6 +10,7 @@
 
 use rustc_hash::FxHashSet;
 
+use oxc_allocator::CloneIn;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_str::format_ident;
 
@@ -184,7 +185,8 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         if let Some(extras) = extra_instructions {
             // Clone the original instruction and build the replacement list
             let mut all_instructions = Vec::new();
-            all_instructions.push(ReactiveStatement::Instruction(instruction.clone()));
+            all_instructions
+                .push(ReactiveStatement::Instruction(instruction.clone_in(self.env.allocator)));
             for extra in extras {
                 all_instructions.push(ReactiveStatement::Instruction(extra));
             }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
@@ -353,16 +353,17 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
         let mut next_instructions: Vec<ReactiveStatement<'a>> = Vec::new();
         let mut index = 0;
         let all_stmts: Vec<ReactiveStatement> = take(block);
+        let alloc = self.env.allocator;
 
         for entry in &merged {
             // Push everything before the merge range
             while index < entry.from {
-                next_instructions.push(all_stmts[index].clone());
+                next_instructions.push(all_stmts[index].clone_in(alloc));
                 index += 1;
             }
             // The first item in the merge range must be a scope
             let mut merged_scope = match &all_stmts[entry.from] {
-                ReactiveStatement::Scope(s) => s.clone(),
+                ReactiveStatement::Scope(s) => s.clone_in(alloc),
                 _ => {
                     return Err(ErrorCategory::Invariant
                         .diagnostic("MergeConsecutiveScopes: Expected scope at starting index"));
@@ -374,11 +375,13 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
                 index += 1;
                 match stmt {
                     ReactiveStatement::Scope(inner_scope) => {
-                        merged_scope.instructions.extend(inner_scope.instructions.clone());
+                        merged_scope
+                            .instructions
+                            .extend(inner_scope.instructions.iter().map(|s| s.clone_in(alloc)));
                         self.env.scopes[merged_scope.scope].merged.push(inner_scope.scope);
                     }
                     _ => {
-                        merged_scope.instructions.push(stmt.clone());
+                        merged_scope.instructions.push(stmt.clone_in(alloc));
                     }
                 }
             }
@@ -386,7 +389,7 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
         }
         // Push remaining
         while index < all_stmts.len() {
-            next_instructions.push(all_stmts[index].clone());
+            next_instructions.push(all_stmts[index].clone_in(alloc));
             index += 1;
         }
 

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
@@ -12,6 +12,7 @@
 
 use std::mem::take;
 
+use oxc_allocator::Vec as ArenaVec;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_str::{Ident, format_ident};
 
@@ -278,12 +279,15 @@ fn apply_early_return_to_scope<'a>(
                     reactive: false,
                     span: None, // GeneratedSource
                 },
-                args: vec![PlaceOrSpread::Place(Place {
-                    identifier: arg_temp,
-                    effect: Effect::Unknown,
-                    reactive: false,
-                    span: None, // GeneratedSource
-                })],
+                args: ArenaVec::from_array_in(
+                    [PlaceOrSpread::Place(Place {
+                        identifier: arg_temp,
+                        effect: Effect::Unknown,
+                        reactive: false,
+                        span: None, // GeneratedSource
+                    })],
+                    &env.allocator,
+                ),
                 span,
             }),
             span,

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
@@ -9,6 +9,7 @@
 
 use std::mem::replace;
 
+use oxc_allocator::CloneIn;
 use oxc_diagnostics::OxcDiagnostic;
 
 use crate::react_compiler_hir::visitors::{
@@ -62,7 +63,7 @@ pub trait ReactiveFunctionVisitor<'a> {
         for block_id in block_ids {
             let inner_func = &self.env().functions[func_id];
             let block = &inner_func.body.blocks[&block_id];
-            let instr_ids: Vec<_> = block.instructions.clone();
+            let instr_ids: Vec<_> = block.instructions.iter().copied().collect();
             let terminal_operands = each_terminal_operand(&block.terminal);
             let terminal_id = block.terminal.evaluation_order();
 
@@ -73,7 +74,7 @@ pub trait ReactiveFunctionVisitor<'a> {
                 let reactive_instr = ReactiveInstruction {
                     id: instr.id,
                     lvalue: Some(instr.lvalue),
-                    value: ReactiveValue::Instruction(instr.value.clone()),
+                    value: ReactiveValue::Instruction(instr.value.clone_in(self.env().allocator)),
                     span: instr.span,
                 };
                 self.visit_instruction(&reactive_instr, state);
@@ -614,18 +615,24 @@ pub trait ReactiveFunctionTransform<'a> {
                 }
                 Transformed::Remove => {
                     if next_block.is_none() {
-                        next_block = Some(block[..i].to_vec());
+                        next_block = Some(
+                            block[..i].iter().map(|s| s.clone_in(self.env().allocator)).collect(),
+                        );
                     }
                 }
                 Transformed::Replace(replacement) => {
                     if next_block.is_none() {
-                        next_block = Some(block[..i].to_vec());
+                        next_block = Some(
+                            block[..i].iter().map(|s| s.clone_in(self.env().allocator)).collect(),
+                        );
                     }
                     next_block.as_mut().unwrap().push(replacement);
                 }
                 Transformed::ReplaceMany(replacements) => {
                     if next_block.is_none() {
-                        next_block = Some(block[..i].to_vec());
+                        next_block = Some(
+                            block[..i].iter().map(|s| s.clone_in(self.env().allocator)).collect(),
+                        );
                     }
                     next_block.as_mut().unwrap().extend(replacements);
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/eliminate_redundant_phi.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/eliminate_redundant_phi.rs
@@ -116,7 +116,7 @@ fn eliminate_redundant_phi_impl(
 
             // Rewrite instructions
             let instruction_ids: Vec<InstructionId> =
-                ir.blocks.get(&block_id).unwrap().instructions.clone();
+                ir.blocks.get(&block_id).unwrap().instructions.iter().copied().collect();
 
             for instr_id in &instruction_ids {
                 let instr_idx = instr_id.index();
@@ -154,7 +154,8 @@ fn eliminate_redundant_phi_impl(
                     }
 
                     // Take inner function out, process it, put it back
-                    let mut inner_func = replace(&mut env.functions[fid], placeholder_function());
+                    let mut inner_func =
+                        replace(&mut env.functions[fid], placeholder_function(env.allocator));
 
                     eliminate_redundant_phi_impl(&mut inner_func, env, rewrites);
 

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
@@ -1,7 +1,8 @@
-use std::mem::{replace, take};
+use std::mem::replace;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use oxc_allocator::{Allocator, Vec as ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 
 use crate::diagnostics::ErrorCategory;
@@ -9,6 +10,7 @@ use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::visitors;
 use crate::react_compiler_hir::*;
 use crate::react_compiler_utils::OrderedMap;
+use crate::react_compiler_utils::ordered_map::ArenaOrderedMap;
 
 // =============================================================================
 // SSABuilder
@@ -24,19 +26,19 @@ struct State {
     incomplete_phis: Vec<IncompletePhi>,
 }
 
-struct SSABuilder {
+struct SSABuilder<'a> {
     states: FxHashMap<BlockId, State>,
     current: Option<BlockId>,
     unsealed_preds: FxHashMap<BlockId, u32>,
     block_preds: FxHashMap<BlockId, Vec<BlockId>>,
     unknown: FxHashSet<IdentifierId>,
     context: FxHashSet<IdentifierId>,
-    pending_phis: FxHashMap<BlockId, Vec<Phi>>,
+    pending_phis: FxHashMap<BlockId, Vec<Phi<'a>>>,
     processed_functions: Vec<FunctionId>,
 }
 
-impl SSABuilder {
-    fn new(blocks: &OrderedMap<BlockId, BasicBlock>) -> Self {
+impl<'a> SSABuilder<'a> {
+    fn new(blocks: &OrderedMap<BlockId, BasicBlock<'a>>) -> Self {
         let mut block_preds = FxHashMap::default();
         for (id, block) in blocks {
             block_preds.insert(*id, block.preds.iter().copied().collect());
@@ -53,7 +55,7 @@ impl SSABuilder {
         }
     }
 
-    fn define_function(&mut self, func: &HirFunction) {
+    fn define_function(&mut self, func: &HirFunction<'a>) {
         for (id, block) in &func.body.blocks {
             self.block_preds.insert(*id, block.preds.iter().copied().collect());
         }
@@ -64,7 +66,7 @@ impl SSABuilder {
         self.states.get_mut(&current).expect("state not found for current block")
     }
 
-    fn make_id(&mut self, old_id: IdentifierId, env: &mut Environment) -> IdentifierId {
+    fn make_id(&mut self, old_id: IdentifierId, env: &mut Environment<'a>) -> IdentifierId {
         let new_id = env.next_identifier_id();
         let old = &env.identifiers[old_id];
         let declaration_id = old.declaration_id;
@@ -80,7 +82,7 @@ impl SSABuilder {
     fn define_place(
         &mut self,
         old_place: &Place,
-        env: &mut Environment,
+        env: &mut Environment<'a>,
     ) -> Result<Place, OxcDiagnostic> {
         let old_id = old_place.identifier;
 
@@ -125,7 +127,7 @@ impl SSABuilder {
         self.unknown.remove(&id);
     }
 
-    fn get_place(&mut self, old_place: &Place, env: &mut Environment) -> Place {
+    fn get_place(&mut self, old_place: &Place, env: &mut Environment<'a>) -> Place {
         let current_id = self.current.expect("must be in a block");
         let new_id = self.get_id_at(old_place, current_id, env);
         Place {
@@ -140,7 +142,7 @@ impl SSABuilder {
         &mut self,
         old_place: &Place,
         block_id: BlockId,
-        env: &mut Environment,
+        env: &mut Environment<'a>,
     ) -> IdentifierId {
         if let Some(state) = self.states.get(&block_id)
             && let Some(&new_id) = state.defs.get(&old_place.identifier)
@@ -194,11 +196,12 @@ impl SSABuilder {
         block_id: BlockId,
         old_place: &Place,
         new_place: &Place,
-        env: &mut Environment,
+        env: &mut Environment<'a>,
     ) {
         let preds = self.block_preds.get(&block_id).cloned().unwrap_or_default();
 
-        let mut pred_defs: OrderedMap<BlockId, Place> = OrderedMap::default();
+        let mut pred_defs: ArenaOrderedMap<'a, BlockId, Place> =
+            ArenaOrderedMap::new_in(env.allocator);
         for pred_block_id in &preds {
             let pred_id = self.get_id_at(old_place, *pred_block_id, env);
             pred_defs.insert(
@@ -217,7 +220,7 @@ impl SSABuilder {
         self.pending_phis.entry(block_id).or_default().push(phi);
     }
 
-    fn fix_incomplete_phis(&mut self, block_id: BlockId, env: &mut Environment) {
+    fn fix_incomplete_phis(&mut self, block_id: BlockId, env: &mut Environment<'a>) {
         let incomplete_phis: Vec<IncompletePhi> =
             self.states.get_mut(&block_id).unwrap().incomplete_phis.drain(..).collect();
         for phi in &incomplete_phis {
@@ -236,7 +239,10 @@ impl SSABuilder {
 // Public entry point
 // =============================================================================
 
-pub fn enter_ssa(func: &mut HirFunction, env: &mut Environment) -> Result<(), OxcDiagnostic> {
+pub fn enter_ssa<'a>(
+    func: &mut HirFunction<'a>,
+    env: &mut Environment<'a>,
+) -> Result<(), OxcDiagnostic> {
     let mut builder = SSABuilder::new(&func.body.blocks);
     let root_entry = func.body.entry;
     enter_ssa_impl(func, &mut builder, env, root_entry)?;
@@ -247,7 +253,11 @@ pub fn enter_ssa(func: &mut HirFunction, env: &mut Environment) -> Result<(), Ox
     Ok(())
 }
 
-fn apply_pending_phis(func: &mut HirFunction, env: &mut Environment, builder: &mut SSABuilder) {
+fn apply_pending_phis<'a>(
+    func: &mut HirFunction<'a>,
+    env: &mut Environment<'a>,
+    builder: &mut SSABuilder<'a>,
+) {
     for (block_id, block) in func.body.blocks.iter_mut() {
         if let Some(phis) = builder.pending_phis.remove(block_id) {
             block.phis.extend(phis);
@@ -263,10 +273,10 @@ fn apply_pending_phis(func: &mut HirFunction, env: &mut Environment, builder: &m
     }
 }
 
-fn enter_ssa_impl(
-    func: &mut HirFunction,
-    builder: &mut SSABuilder,
-    env: &mut Environment,
+fn enter_ssa_impl<'a>(
+    func: &mut HirFunction<'a>,
+    builder: &mut SSABuilder<'a>,
+    env: &mut Environment<'a>,
     root_entry: BlockId,
 ) -> Result<(), OxcDiagnostic> {
     let mut visited_blocks: FxHashSet<BlockId> = FxHashSet::default();
@@ -290,8 +300,9 @@ fn enter_ssa_impl(
                     "Expected function context to be empty for outer function declarations",
                 ));
             }
-            let params = take(&mut func.params);
-            let mut new_params = Vec::with_capacity(params.len());
+            let alloc = env.allocator;
+            let params = replace(&mut func.params, ArenaVec::new_in(&alloc));
+            let mut new_params = ArenaVec::with_capacity_in(params.len(), &alloc);
             for param in params {
                 new_params.push(match param {
                     ParamPattern::Place(p) => ParamPattern::Place(builder.define_place(&p, env)?),
@@ -305,7 +316,7 @@ fn enter_ssa_impl(
 
         // Process instructions
         let instruction_ids: Vec<InstructionId> =
-            func.body.blocks.get(&block_id).unwrap().instructions.clone();
+            func.body.blocks.get(&block_id).unwrap().instructions.iter().copied().collect();
 
         for instr_id in &instruction_ids {
             let instr_idx = instr_id.index();
@@ -323,9 +334,13 @@ fn enter_ssa_impl(
 
             // Map context places for function expressions before other operands
             if let Some(fid) = func_expr_id {
-                let context = take(&mut env.functions[fid].context);
-                env.functions[fid].context =
-                    context.into_iter().map(|place| builder.get_place(&place, env)).collect();
+                let alloc = env.allocator;
+                let context = replace(&mut env.functions[fid].context, ArenaVec::new_in(&alloc));
+                let new_context = ArenaVec::from_iter_in(
+                    context.into_iter().map(|place| builder.get_place(&place, env)),
+                    &alloc,
+                );
+                env.functions[fid].context = new_context;
             }
 
             // Map non-context operands
@@ -373,8 +388,10 @@ fn enter_ssa_impl(
                 let saved_current = builder.current;
 
                 // Map inner function params
-                let inner_params = take(&mut env.functions[fid].params);
-                let mut new_inner_params = Vec::with_capacity(inner_params.len());
+                let alloc = env.allocator;
+                let inner_params =
+                    replace(&mut env.functions[fid].params, ArenaVec::new_in(&alloc));
+                let mut new_inner_params = ArenaVec::with_capacity_in(inner_params.len(), &alloc);
                 for param in inner_params {
                     new_inner_params.push(match param {
                         ParamPattern::Place(p) => {
@@ -388,7 +405,8 @@ fn enter_ssa_impl(
                 env.functions[fid].params = new_inner_params;
 
                 // Take the inner function out of the arena to process it
-                let mut inner_func = replace(&mut env.functions[fid], placeholder_function());
+                let mut inner_func =
+                    replace(&mut env.functions[fid], placeholder_function(env.allocator));
 
                 enter_ssa_impl(&mut inner_func, builder, env, root_entry)?;
 
@@ -435,25 +453,25 @@ fn enter_ssa_impl(
 /// Create a placeholder HirFunction for temporarily swapping an inner function
 /// out of `env.functions` via `std::mem::replace`. The placeholder is never
 /// read — the real function is swapped back immediately after processing.
-pub fn placeholder_function<'a>() -> HirFunction<'a> {
+pub fn placeholder_function<'a>(alloc: &'a Allocator) -> HirFunction<'a> {
     HirFunction {
         span: None,
         id: None,
         name_hint: None,
         fn_type: ReactFunctionType::Other,
-        params: Vec::new(),
+        params: ArenaVec::new_in(&alloc),
         returns: Place {
             identifier: IdentifierId::from_usize(0),
             effect: Effect::Unknown,
             reactive: false,
             span: None,
         },
-        context: Vec::new(),
+        context: ArenaVec::new_in(&alloc),
         body: HIR { entry: BlockId::ENTRY, blocks: OrderedMap::default() },
-        instructions: Vec::new(),
+        instructions: ArenaVec::new_in(&alloc),
         generator: false,
         is_async: false,
-        directives: Vec::new(),
+        directives: ArenaVec::new_in(&alloc),
         aliasing_effects: None,
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -390,7 +390,7 @@ fn generate_for_function_id<'a>(
     allocator: &'a Allocator,
 ) -> Result<(), OxcDiagnostic> {
     // Take the function out temporarily to avoid borrow conflicts
-    let inner = replace(&mut functions[func_id], placeholder_function());
+    let inner = replace(&mut functions[func_id], placeholder_function(allocator));
 
     // Process params for component inner functions
     if inner.fn_type == ReactFunctionType::Component {

--- a/crates/oxc_react_compiler/src/react_compiler_utils/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_utils/mod.rs
@@ -5,7 +5,7 @@ pub mod disjoint_set;
 pub mod ordered_map;
 
 pub use disjoint_set::DisjointSet;
-pub use ordered_map::{OrderedMap, OrderedSet};
+pub use ordered_map::OrderedMap;
 
 /// `IndexMap` keyed with the fast `FxHasher` (rustc-hash) instead of the default SipHash.
 pub type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;

--- a/crates/oxc_react_compiler/src/react_compiler_utils/ordered_map.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_utils/ordered_map.rs
@@ -15,6 +15,9 @@
 use std::fmt;
 use std::hash::Hash;
 
+use oxc_allocator::{
+    Allocator, CloneIn, CloneInSemanticIds, HashMap as ArenaHashMap, Vec as ArenaVec,
+};
 use rustc_hash::FxHashMap;
 
 /// Insertion-ordered map with O(1) keyed lookup. Mirrors the subset of the
@@ -272,9 +275,278 @@ impl<'a, K> IntoIterator for &'a OrderedSet<K> {
     }
 }
 
+// =============================================================================
+// Arena-backed variants
+// =============================================================================
+//
+// These mirror the [`OrderedMap`] / [`OrderedSet`] container semantics
+// (insertion order + O(1) keyed lookup) but store their entries and index in an
+// arena allocator via [`oxc_allocator::Vec`] / [`oxc_allocator::HashMap`]. They
+// intentionally do **not** implement `Default` or `Clone`: arena containers must
+// be constructed with an allocator (`new_in`) and cloned same-arena via
+// [`CloneIn`]. Used by the HIR (`BasicBlock.preds`, `Phi.operands`) as it moves
+// into the arena.
+
+/// Insertion-ordered map with O(1) keyed lookup, backed by an arena allocator.
+/// Mirrors the subset of the [`OrderedMap`] API used by the HIR.
+pub struct ArenaOrderedMap<'a, K, V> {
+    /// Entries in insertion order.
+    entries: ArenaVec<'a, (K, V)>,
+    /// Maps a key to its position in `entries`.
+    index: ArenaHashMap<'a, K, usize>,
+}
+
+impl<'a, K: Copy + Eq + Hash, V> ArenaOrderedMap<'a, K, V> {
+    pub fn new_in(allocator: &'a Allocator) -> Self {
+        Self { entries: ArenaVec::new_in(&allocator), index: ArenaHashMap::new_in(allocator) }
+    }
+
+    pub fn with_capacity_in(capacity: usize, allocator: &'a Allocator) -> Self {
+        Self {
+            entries: ArenaVec::with_capacity_in(capacity, &allocator),
+            index: ArenaHashMap::with_capacity_in(capacity, allocator),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.index.clear();
+    }
+
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.index.contains_key(key)
+    }
+
+    /// Position of `key` in insertion order, if present.
+    pub fn get_index_of(&self, key: &K) -> Option<usize> {
+        self.index.get(key).copied()
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.index.get(key).map(|&i| &self.entries[i].1)
+    }
+
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        match self.index.get(key) {
+            Some(&i) => Some(&mut self.entries[i].1),
+            None => None,
+        }
+    }
+
+    /// Insert `value` for `key`. If the key already exists its position is kept
+    /// and the previous value is returned; otherwise the entry is appended.
+    /// Matches `IndexMap::insert`.
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        if let Some(&i) = self.index.get(&key) {
+            Some(std::mem::replace(&mut self.entries[i].1, value))
+        } else {
+            let i = self.entries.len();
+            self.entries.push((key, value));
+            self.index.insert(key, i);
+            None
+        }
+    }
+
+    /// Remove `key`, shifting later entries down to preserve order (O(n)).
+    /// Matches `IndexMap::shift_remove`.
+    pub fn shift_remove(&mut self, key: &K) -> Option<V> {
+        let i = self.index.remove(key)?;
+        let (_, value) = self.entries.remove(i);
+        // Entries after `i` moved down by one; fix their recorded positions.
+        for j in i..self.entries.len() {
+            let k = self.entries[j].0;
+            self.index.insert(k, j);
+        }
+        Some(value)
+    }
+
+    /// Keep only entries for which `keep` returns true, preserving order.
+    /// Matches `IndexMap::retain`.
+    pub fn retain(&mut self, mut keep: impl FnMut(&K, &mut V) -> bool) {
+        self.entries.retain_mut(|(k, v)| keep(k, v));
+        self.index.clear();
+        for (i, (k, _)) in self.entries.iter().enumerate() {
+            self.index.insert(*k, i);
+        }
+    }
+
+    pub fn keys(&self) -> impl DoubleEndedIterator<Item = &K> {
+        self.entries.iter().map(|(k, _)| k)
+    }
+
+    pub fn values(&self) -> impl DoubleEndedIterator<Item = &V> {
+        self.entries.iter().map(|(_, v)| v)
+    }
+
+    pub fn values_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut V> {
+        self.entries.iter_mut().map(|(_, v)| v)
+    }
+
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (&K, &V)> {
+        self.entries.iter().map(|(k, v)| (k, v))
+    }
+
+    pub fn iter_mut(&mut self) -> impl DoubleEndedIterator<Item = (&K, &mut V)> {
+        self.entries.iter_mut().map(|(k, v)| (&*k, v))
+    }
+}
+
+impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for ArenaOrderedMap<'_, K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map().entries(self.entries.iter().map(|(k, v)| (k, v))).finish()
+    }
+}
+
+impl<'a, 'i, K, V> IntoIterator for &'i ArenaOrderedMap<'a, K, V> {
+    type Item = (&'i K, &'i V);
+    type IntoIter = Iter<'i, K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        Iter(self.entries.iter())
+    }
+}
+
+impl<'a, 'i, K, V> IntoIterator for &'i mut ArenaOrderedMap<'a, K, V> {
+    type Item = (&'i K, &'i mut V);
+    type IntoIter = IterMut<'i, K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        IterMut(self.entries.iter_mut())
+    }
+}
+
+impl<K: Copy + Eq + Hash, V> std::ops::Index<&K> for ArenaOrderedMap<'_, K, V> {
+    type Output = V;
+    fn index(&self, key: &K) -> &V {
+        self.get(key).expect("ArenaOrderedMap: no entry found for key")
+    }
+}
+
+impl<'a, K, V> CloneIn<'a> for ArenaOrderedMap<'a, K, V>
+where
+    K: Copy + Eq + Hash + 'a,
+    V: CloneIn<'a, Cloned = V>,
+{
+    type Cloned = ArenaOrderedMap<'a, K, V>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        let entries = ArenaVec::from_iter_in(
+            self.entries.iter().map(|(k, v)| (*k, v.clone_in_impl(sem, alloc))),
+            &alloc,
+        );
+        // Rebuild the index from the cloned entries (keys are `Copy`, so no
+        // `CloneIn` is required on `K`).
+        let mut index = ArenaHashMap::with_capacity_in(entries.len(), alloc);
+        for (i, (k, _)) in entries.iter().enumerate() {
+            index.insert(*k, i);
+        }
+        ArenaOrderedMap { entries, index }
+    }
+}
+
+/// Insertion-ordered set with O(1) membership, backed by an arena allocator.
+/// Mirrors the subset of the [`OrderedSet`] API used by the HIR.
+pub struct ArenaOrderedSet<'a, K> {
+    entries: ArenaVec<'a, K>,
+    index: ArenaHashMap<'a, K, usize>,
+}
+
+impl<'a, K: Copy + Eq + Hash> ArenaOrderedSet<'a, K> {
+    pub fn new_in(allocator: &'a Allocator) -> Self {
+        Self { entries: ArenaVec::new_in(&allocator), index: ArenaHashMap::new_in(allocator) }
+    }
+
+    pub fn with_capacity_in(capacity: usize, allocator: &'a Allocator) -> Self {
+        Self {
+            entries: ArenaVec::with_capacity_in(capacity, &allocator),
+            index: ArenaHashMap::with_capacity_in(capacity, allocator),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.index.clear();
+    }
+
+    pub fn contains(&self, key: &K) -> bool {
+        self.index.contains_key(key)
+    }
+
+    /// Insert `key`; returns true if it was newly added. Matches `IndexSet::insert`.
+    pub fn insert(&mut self, key: K) -> bool {
+        if self.index.contains_key(&key) {
+            return false;
+        }
+        let i = self.entries.len();
+        self.entries.push(key);
+        self.index.insert(key, i);
+        true
+    }
+
+    /// Remove `key`, shifting later entries down to preserve order (O(n)).
+    /// Matches `IndexSet::shift_remove`.
+    pub fn shift_remove(&mut self, key: &K) -> bool {
+        let Some(i) = self.index.remove(key) else {
+            return false;
+        };
+        self.entries.remove(i);
+        for j in i..self.entries.len() {
+            let k = self.entries[j];
+            self.index.insert(k, j);
+        }
+        true
+    }
+
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &K> {
+        self.entries.iter()
+    }
+}
+
+impl<K: fmt::Debug> fmt::Debug for ArenaOrderedSet<'_, K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(self.entries.iter()).finish()
+    }
+}
+
+impl<'a, 'i, K> IntoIterator for &'i ArenaOrderedSet<'a, K> {
+    type Item = &'i K;
+    type IntoIter = std::slice::Iter<'i, K>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.iter()
+    }
+}
+
+impl<'a, K> CloneIn<'a> for ArenaOrderedSet<'a, K>
+where
+    K: Copy + Eq + Hash + 'a,
+{
+    type Cloned = ArenaOrderedSet<'a, K>;
+    fn clone_in_impl(&self, _sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        let entries = ArenaVec::from_iter_in(self.entries.iter().copied(), &alloc);
+        let mut index = ArenaHashMap::with_capacity_in(entries.len(), alloc);
+        for (i, k) in entries.iter().enumerate() {
+            index.insert(*k, i);
+        }
+        ArenaOrderedSet { entries, index }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{OrderedMap, OrderedSet};
+    use super::{ArenaOrderedMap, ArenaOrderedSet, OrderedMap, OrderedSet};
 
     #[test]
     fn map_insert_order_and_lookup() {
@@ -337,5 +609,83 @@ mod tests {
         assert!(!s.shift_remove(&5));
         assert_eq!(s.iter().copied().collect::<Vec<_>>(), vec![1]);
         assert!(!s.contains(&5));
+    }
+
+    #[test]
+    fn arena_map_insert_order_and_lookup() {
+        let allocator = oxc_allocator::Allocator::default();
+        let mut m: ArenaOrderedMap<u32, &str> = ArenaOrderedMap::new_in(&allocator);
+        assert!(m.is_empty());
+        assert_eq!(m.insert(3, "a"), None);
+        assert_eq!(m.insert(1, "b"), None);
+        assert_eq!(m.insert(2, "c"), None);
+        // Re-insert keeps position, returns old value.
+        assert_eq!(m.insert(1, "B"), Some("b"));
+        assert_eq!(m.keys().copied().collect::<Vec<_>>(), vec![3, 1, 2]);
+        assert_eq!(m.get(&1), Some(&"B"));
+        assert_eq!(m[&1], "B");
+        assert!(m.contains_key(&2));
+        assert_eq!(m.get_index_of(&2), Some(2));
+        assert_eq!(m.get_index_of(&9), None);
+        assert_eq!(m.len(), 3);
+    }
+
+    #[test]
+    fn arena_map_shift_remove_preserves_order_and_reindexes() {
+        let allocator = oxc_allocator::Allocator::default();
+        let mut m: ArenaOrderedMap<u32, u32> = ArenaOrderedMap::new_in(&allocator);
+        for k in [10, 20, 30, 40] {
+            m.insert(k, k * 10);
+        }
+        assert_eq!(m.shift_remove(&20), Some(200));
+        assert_eq!(m.shift_remove(&99), None);
+        assert_eq!(m.keys().copied().collect::<Vec<_>>(), vec![10, 30, 40]);
+        assert_eq!(m.get(&10), Some(&100));
+        assert_eq!(m.get(&30), Some(&300));
+        assert_eq!(m.get(&40), Some(&400));
+        assert_eq!(m.get_index_of(&40), Some(2));
+    }
+
+    #[test]
+    fn arena_map_retain_iter_and_clear() {
+        let allocator = oxc_allocator::Allocator::default();
+        let mut m: ArenaOrderedMap<u32, u32> = ArenaOrderedMap::with_capacity_in(8, &allocator);
+        for k in [1, 2, 3, 4, 5] {
+            m.insert(k, k);
+        }
+        m.retain(|k, _| k % 2 == 1);
+        assert_eq!(
+            m.iter().map(|(k, v)| (*k, *v)).collect::<Vec<_>>(),
+            vec![(1, 1), (3, 3), (5, 5)]
+        );
+        assert_eq!(m.get_index_of(&5), Some(2));
+        // `&Self` IntoIterator + `values_mut`.
+        for v in m.values_mut() {
+            *v += 100;
+        }
+        assert_eq!(
+            (&m).into_iter().map(|(k, v)| (*k, *v)).collect::<Vec<_>>(),
+            vec![(1, 101), (3, 103), (5, 105)]
+        );
+        m.clear();
+        assert!(m.is_empty());
+        assert_eq!(m.get(&1), None);
+    }
+
+    #[test]
+    fn arena_set_insert_contains_shift_remove() {
+        let allocator = oxc_allocator::Allocator::default();
+        let mut s: ArenaOrderedSet<u32> = ArenaOrderedSet::new_in(&allocator);
+        assert!(s.insert(5));
+        assert!(s.insert(1));
+        assert!(!s.insert(5)); // duplicate
+        assert!(s.contains(&1));
+        assert_eq!(s.iter().copied().collect::<Vec<_>>(), vec![5, 1]);
+        assert_eq!((&s).into_iter().copied().collect::<Vec<_>>(), vec![5, 1]);
+        assert!(s.shift_remove(&5));
+        assert!(!s.shift_remove(&5));
+        assert_eq!(s.iter().copied().collect::<Vec<_>>(), vec![1]);
+        assert!(!s.contains(&5));
+        assert_eq!(s.len(), 1);
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -3,6 +3,7 @@ use std::mem::{replace, take};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_index::IndexSlice;
 use oxc_str::Ident;
@@ -74,6 +75,7 @@ pub fn validate_exhaustive_dependencies(
         &mut temporaries,
         &mut Some(&mut callbacks),
         false,
+        env.allocator,
     )?;
 
     // Set has_invalid_deps on StartMemoize instructions that had validation errors
@@ -447,6 +449,7 @@ fn visit_candidate_dependency<'a>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_dependencies<'a>(
     func: &HirFunction<'a>,
     identifiers: &IndexSlice<IdentifierId, [Identifier<'a>]>,
@@ -455,6 +458,7 @@ fn collect_dependencies<'a>(
     temporaries: &mut FxHashMap<IdentifierId, Temporary<'a>>,
     callbacks: &mut Option<&mut Callbacks<'_, 'a>>,
     is_function_expression: bool,
+    alloc: &'a Allocator,
 ) -> Result<Temporary<'a>, OxcDiagnostic> {
     let optionals = find_optional_places(func);
     let mut locals: FxHashSet<IdentifierId> = FxHashSet::default();
@@ -710,6 +714,7 @@ fn collect_dependencies<'a>(
                         temporaries,
                         &mut None,
                         true,
+                        alloc,
                     )?;
                     temporaries.insert(lvalue_id, function_deps.clone());
                     add_dependency(&function_deps, &mut dependencies, &mut dep_keys, &locals);
@@ -719,7 +724,9 @@ fn collect_dependencies<'a>(
                         // onStartMemoize — mirrors TS behavior of clearing dependencies and locals
                         *cb.start_memo = Some(StartMemoInfo {
                             manual_memo_id: *manual_memo_id,
-                            deps: deps.clone(),
+                            deps: deps
+                                .as_ref()
+                                .map(|v| v.iter().map(|d| d.clone_in(alloc)).collect()),
                             deps_span: *deps_span,
                         });
                         // Save current state and clear, matching TS which clears the shared
@@ -882,7 +889,10 @@ fn collect_dependencies<'a>(
                                                         },
                                                         constant: false,
                                                     },
-                                                    path: path.clone(),
+                                                    path: ArenaVec::from_iter_in(
+                                                        path.iter().copied(),
+                                                        &alloc,
+                                                    ),
                                                     span: *span,
                                                 },
                                                 InferredDependency::Global { binding } => {
@@ -890,7 +900,7 @@ fn collect_dependencies<'a>(
                                                         root: ManualMemoDependencyRoot::Global {
                                                             identifier_name: binding.name(),
                                                         },
-                                                        path: Vec::new(),
+                                                        path: ArenaVec::new_in(&alloc),
                                                         span: None,
                                                     }
                                                 }
@@ -984,7 +994,10 @@ fn collect_dependencies<'a>(
                                                         },
                                                         constant: false,
                                                     },
-                                                    path: path.clone(),
+                                                    path: ArenaVec::from_iter_in(
+                                                        path.iter().copied(),
+                                                        &alloc,
+                                                    ),
                                                     span: *span,
                                                 },
                                                 InferredDependency::Global { binding } => {
@@ -992,7 +1005,7 @@ fn collect_dependencies<'a>(
                                                         root: ManualMemoDependencyRoot::Global {
                                                             identifier_name: binding.name(),
                                                         },
-                                                        path: Vec::new(),
+                                                        path: ArenaVec::new_in(&alloc),
                                                         span: None,
                                                     }
                                                 }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
@@ -9,7 +9,7 @@
 //! accurately preserved, and that no originally memoized values became
 //! unmemoized in the output.
 
-use oxc_allocator::CloneIn;
+use oxc_allocator::{CloneIn, Vec as ArenaVec};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::diagnostics::ErrorCategory;
@@ -36,7 +36,7 @@ struct ManualMemoBlockState<'h> {
     /// Declarations produced within this manual memo block.
     decls: FxHashSet<DeclarationId>,
     /// Normalized deps from source (useMemo/useCallback dep array).
-    deps_from_source: Option<Vec<ManualMemoDependency<'h>>>,
+    deps_from_source: Option<ArenaVec<'h, ManualMemoDependency<'h>>>,
     /// Manual memo id from StartMemoize.
     manual_memo_id: u32,
 }
@@ -142,12 +142,14 @@ fn visit_scope<'h>(scope_block: &ReactiveScopeBlock<'h>, state: &mut VisitorStat
     if let Some(ref memo_state) = state.manual_memo_state
         && let Some(ref deps_from_source) = memo_state.deps_from_source
     {
+        let alloc = state.env.allocator;
         let scope = &state.env.scopes[scope_block.scope];
-        let deps = scope.dependencies.clone_in(state.env.allocator);
+        let deps = scope.dependencies.clone_in(alloc);
         let memo_span = memo_state.span;
         let decls = memo_state.decls.clone();
-        let deps_from_source = deps_from_source.clone();
-        let temporaries = state.temporaries.clone();
+        let deps_from_source = deps_from_source.clone_in(alloc);
+        let temporaries: FxHashMap<IdentifierId, ManualMemoDependency> =
+            state.temporaries.iter().map(|(k, v)| (*k, v.clone_in(alloc))).collect();
         for dep in &deps {
             validate_inferred_dep(
                 dep.identifier,
@@ -196,7 +198,7 @@ fn visit_instruction<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSta
                 return;
             }
 
-            let deps_from_source = deps.clone();
+            let deps_from_source = deps.as_ref().map(|v| v.clone_in(state.env.allocator));
 
             state.manual_memo_state = Some(ManualMemoBlockState {
                 span: instr.span,
@@ -316,6 +318,7 @@ fn record_unmemoized_error(span: Option<Span>, env: &mut Environment) {
 /// Record temporaries from an instruction.
 /// TS: `recordTemporaries`
 fn record_temporaries<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorState<'_, 'h>) {
+    let alloc = state.env.allocator;
     let lvalue = &instr.lvalue;
     let lv_id = lvalue.as_ref().map(|lv| lv.identifier);
     if let Some(id) = lv_id
@@ -342,7 +345,7 @@ fn record_temporaries<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSt
             lvalue.identifier,
             ManualMemoDependency {
                 root: ManualMemoDependencyRoot::NamedLocal { value: *lvalue, constant: false },
-                path: Vec::new(),
+                path: ArenaVec::new_in(&alloc),
                 span: lvalue.span,
             },
         );
@@ -352,6 +355,7 @@ fn record_temporaries<'h>(instr: &ReactiveInstruction<'h>, state: &mut VisitorSt
 /// Record dependencies from a reactive value.
 /// TS: `recordDepsInValue`
 fn record_deps_in_value<'h>(value: &ReactiveValue<'h>, state: &mut VisitorState<'_, 'h>) {
+    let alloc = state.env.allocator;
     match value {
         ReactiveValue::SequenceExpression { instructions, value, .. } => {
             for instr in instructions {
@@ -395,7 +399,7 @@ fn record_deps_in_value<'h>(value: &ReactiveValue<'h>, state: &mut VisitorState<
                                         value: lvalue.place,
                                         constant: false,
                                     },
-                                    path: Vec::new(),
+                                    path: ArenaVec::new_in(&alloc),
                                     span: lvalue.place.span,
                                 },
                             );
@@ -415,7 +419,7 @@ fn record_deps_in_value<'h>(value: &ReactiveValue<'h>, state: &mut VisitorState<
                                             value: *place,
                                             constant: false,
                                         },
-                                        path: Vec::new(),
+                                        path: ArenaVec::new_in(&alloc),
                                         span: place.span,
                                     },
                                 );
@@ -430,7 +434,7 @@ fn record_deps_in_value<'h>(value: &ReactiveValue<'h>, state: &mut VisitorState<
 }
 
 /// Get operand places from a StartMemoize instruction's deps.
-fn start_memoize_operands(deps: &Option<Vec<ManualMemoDependency>>) -> Vec<Place> {
+fn start_memoize_operands(deps: &Option<ArenaVec<'_, ManualMemoDependency<'_>>>) -> Vec<Place> {
     let mut result = Vec::new();
     if let Some(deps) = deps {
         for dep in deps {
@@ -620,12 +624,13 @@ fn validate_inferred_dep<'h>(
     temporaries: &FxHashMap<IdentifierId, ManualMemoDependency<'h>>,
     decls_within_memo_block: &FxHashSet<DeclarationId>,
     valid_deps_in_memo_block: &[ManualMemoDependency<'h>],
-    env: &mut Environment,
+    env: &mut Environment<'h>,
     memo_location: Option<Span>,
 ) {
+    let alloc = env.allocator;
     // Normalize the dependency through temporaries
     let normalized_dep = if let Some(temp) = temporaries.get(&dep_id) {
-        let mut path = temp.path.clone();
+        let mut path = temp.path.clone_in(alloc);
         path.extend_from_slice(dep_path);
         ManualMemoDependency { root: temp.root, path, span: temp.span }
     } else {
@@ -644,7 +649,7 @@ fn validate_inferred_dep<'h>(
                 },
                 constant: false,
             },
-            path: dep_path.to_vec(),
+            path: ArenaVec::from_iter_in(dep_path.iter().copied(), &alloc),
             span: ident.span,
         }
     };


### PR DESCRIPTION
The largest step of the react_compiler HIR-to-arena migration: moves the control-flow-graph HIR and the reactive-function tree off the global heap into the compilation arena, eliminating the per-node `malloc`/`free` churn (block instruction/phi vectors, predecessor sets, phi operand maps, instruction-value vectors) that dominated the compiler's allocation traffic.

## What changed

- `HIR`, `BasicBlock`, `Phi`, `Terminal`, `AliasingEffect`, `ArrayPattern`, and `AliasingSignature` gain an `'a` lifetime; their `Vec` fields become `oxc_allocator::Vec<'a>` (block instructions/phis, terminal effects/cases, all `InstructionValue` vectors, patterns, aliasing args/captures, function params/context/directives/aliasing-effects, ...).
- The two per-node insertion-ordered containers move to the arena: `BasicBlock.preds` → `ArenaOrderedSet<'a, BlockId>` and `Phi.operands` → `ArenaOrderedMap<'a, BlockId, Place>` — new arena-backed variants (`oxc_allocator::Vec` + `oxc_allocator::HashMap`) added alongside the existing std `OrderedMap`/`OrderedSet`, which are kept.
- `HIR.blocks` deliberately stays a std `OrderedMap` (one map per function, no allocation payoff, and `HirFunction` is never arena-boxed — it lives in a std `IndexVec`). This also keeps `get_reverse_postordered_blocks` returning a std map, bounding arena high-water.
- Arena `Vec` is not `Clone`, so the arena-carrying HIR and reactive-tree types drop `#[derive(Clone)]` and get hand-written same-arena `CloneIn` impls; construction/clone sites across ~30 files thread the allocator from `env.allocator`.

Behavior is unchanged — the snapshot corpus and transform tests remain byte-identical.

## Memory

Arena bytes used across the full 1269-fixture corpus (fresh allocator per file, measured after `compile`):

| | total arena used | max single fixture |
|---|---|---|
| before (HIR on heap) | 5.45 MB | 171 KB |
| after (HIR in arena) | 9.93 MB | 228 KB |

The +4.48 MB is the HIR moving from the heap into the arena (offsetting the corresponding heap allocations). No pathological ballooning: RPO-heavy fixtures grow ~2-3× at negligible absolute scale, and arenas free per-file so nothing accumulates across the corpus.

## Stack

- #24664
- #24666
- #24696
- **this PR** — stacked on top of #24696

🤖 This PR was written with the assistance of Claude Code.