### PR TITLE
refactor(react_compiler): remove dead code and tighten visibility

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/dominator.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/dominator.rs
@@ -285,7 +285,7 @@ pub fn post_dominator_frontier(
 }
 
 /// Walks up the post-dominator tree to collect all blocks that post-dominate `target_id`.
-pub fn post_dominators_of(
+fn post_dominators_of(
     func: &HirFunction,
     post_dominators: &PostDominator,
     target_id: BlockId,

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -262,7 +262,7 @@ impl<'a> Environment<'a> {
     }
 
     /// Allocate a new Type in the arena, returns its TypeId.
-    pub fn next_type_id(&mut self) -> TypeId {
+    fn next_type_id(&mut self) -> TypeId {
         let id = self.types.next_idx();
         self.types.push(Type::Var { id });
         id

--- a/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
@@ -20,7 +20,6 @@ use crate::react_compiler_hir::object_shape::*;
 use crate::react_compiler_hir::type_config::AliasingEffectConfig;
 use crate::react_compiler_hir::type_config::AliasingSignatureConfig;
 use crate::react_compiler_hir::type_config::ApplyArgConfig;
-use crate::react_compiler_hir::type_config::ApplyArgHoleKind;
 use crate::react_compiler_hir::type_config::BuiltInTypeRef;
 use crate::react_compiler_hir::type_config::TypeConfig;
 use crate::react_compiler_hir::type_config::TypeReferenceConfig;
@@ -81,7 +80,7 @@ impl<'a> GlobalRegistry<'a> {
 
     /// Consume the registry and return the inner map.
     /// Only valid in builder mode (no base).
-    pub fn into_inner(self) -> IdentHashMap<'a, Global<'a>> {
+    fn into_inner(self) -> IdentHashMap<'a, Global<'a>> {
         debug_assert!(self.base.is_none(), "into_inner() called on overlay-mode GlobalRegistry");
         self.entries
     }
@@ -513,7 +512,7 @@ const BUILTIN_SHAPE_DEFS: &[ShapeDef] = &[
                                 mutates_function: false,
                                 args: &[
                                     ApplyArgConfig::Place("@item"),
-                                    ApplyArgConfig::Hole { kind: ApplyArgHoleKind::Hole },
+                                    ApplyArgConfig::Hole,
                                     ApplyArgConfig::Place("@receiver"),
                                 ],
                                 into: "@callbackReturn",

--- a/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
@@ -174,7 +174,7 @@ impl<'a> ShapeRegistry<'a> {
 
     /// Consume the registry and return the inner map.
     /// Only valid in builder mode (no base).
-    pub fn into_inner(self) -> IdentHashMap<'a, ObjectShape<'a>> {
+    pub(crate) fn into_inner(self) -> IdentHashMap<'a, ObjectShape<'a>> {
         debug_assert!(self.base.is_none(), "into_inner() called on overlay-mode ShapeRegistry");
         self.entries
     }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/type_config.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/type_config.rs
@@ -96,26 +96,6 @@ pub enum AliasingEffectConfig {
 #[derive(Debug, Clone)]
 pub enum ApplyArgConfig {
     Place(&'static str),
-    Spread {
-        #[allow(dead_code)]
-        kind: ApplyArgSpreadKind,
-        place: &'static str,
-    },
-    Hole {
-        #[allow(dead_code)]
-        kind: ApplyArgHoleKind,
-    },
-}
-
-/// Helper enum for tagged serde of `ApplyArgConfig::Spread`.
-#[derive(Debug, Clone)]
-pub enum ApplyArgSpreadKind {
-    Spread,
-}
-
-/// Helper enum for tagged serde of `ApplyArgConfig::Hole`.
-#[derive(Debug, Clone)]
-pub enum ApplyArgHoleKind {
     Hole,
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -2770,7 +2770,7 @@ fn compute_effects_for_aliasing_signature_config(
                     let mut apply_args: Vec<PlaceOrSpreadOrHole> = Vec::new();
                     for arg in *a {
                         match arg {
-                            ApplyArgConfig::Hole { .. } => {
+                            ApplyArgConfig::Hole => {
                                 apply_args.push(PlaceOrSpreadOrHole::Hole);
                             }
                             ApplyArgConfig::Place(name) => {
@@ -2778,15 +2778,6 @@ fn compute_effects_for_aliasing_signature_config(
                                     && let Some(p) = places.first()
                                 {
                                     apply_args.push(PlaceOrSpreadOrHole::Place(*p));
-                                }
-                            }
-                            ApplyArgConfig::Spread { place: name, .. } => {
-                                if let Some(places) = substitutions.get(*name)
-                                    && let Some(p) = places.first()
-                                {
-                                    apply_args.push(PlaceOrSpreadOrHole::Spread(SpreadPattern {
-                                        place: *p,
-                                    }));
                                 }
                             }
                         }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
@@ -364,7 +364,7 @@ fn collect_temporaries<'a>(
 
 /// Collect loads from named variables and property reads into `maybe_deps`.
 /// Returns the variable + property reads represented by the instruction value.
-pub fn collect_maybe_memo_dependencies<'a>(
+fn collect_maybe_memo_dependencies<'a>(
     value: &InstructionValue<'a>,
     maybe_deps: &FxHashMap<IdentifierId, ManualMemoDependency<'a>>,
     optional: bool,

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -280,7 +280,6 @@ impl<'a, 'h> Context<'a, 'h> {
 struct Driver<'a, 'b, 'h> {
     cx: &'b mut Context<'a, 'h>,
     hir: &'h HirFunction<'a>,
-    #[allow(dead_code)]
     env: &'h Environment<'a>,
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -62,7 +62,7 @@ use crate::react_compiler_reactive_scopes::visitors::visit_reactive_function;
 // Public API
 // =============================================================================
 
-pub const MEMO_CACHE_SENTINEL: &str = "react.memo_cache_sentinel";
+const MEMO_CACHE_SENTINEL: &str = "react.memo_cache_sentinel";
 pub const EARLY_RETURN_SENTINEL: &str = "react.early_return_sentinel";
 
 /// FBT tags whose children get special codegen treatment.
@@ -266,7 +266,6 @@ struct OxcContext<'a, 'env> {
     temp: OxcTemporaries<'a>,
     object_methods: FxHashMap<IdentifierId, (InstructionValue<'a>, Option<Span>)>,
     unique_identifiers: IdentHashSet<'a>,
-    #[allow(dead_code)]
     fbt_operands: FxHashSet<IdentifierId>,
     synthesized_names: IdentHashMap<'a, Ident<'a>>,
 }
@@ -323,7 +322,6 @@ impl<'a, 'env> OxcContext<'a, 'env> {
         validated
     }
 
-    #[allow(dead_code)]
     fn record_error(&mut self, diagnostic: OxcDiagnostic) -> Result<(), OxcDiagnostic> {
         self.env.record_error(diagnostic)
     }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
@@ -490,7 +490,7 @@ fn can_merge_scopes<'a>(
 }
 
 /// Check if a type is always invalidating (guaranteed to change when inputs change).
-pub fn is_always_invalidating_type(ty: &Type) -> bool {
+fn is_always_invalidating_type(ty: &Type) -> bool {
     match ty {
         Type::Object { shape_id: Some(id) } => matches!(
             id.as_str(),

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
@@ -199,32 +199,11 @@ pub fn rename_variables<'a>(
     func: &mut ReactiveFunction<'a>,
     env: &mut Environment<'a>,
 ) -> IdentHashSet<'a> {
-    rename_variables_with_parent(func, env, None)
-}
-
-fn rename_variables_with_parent<'a>(
-    func: &mut ReactiveFunction<'a>,
-    env: &mut Environment<'a>,
-    parent_names: Option<&IdentHashSet<'a>>,
-) -> IdentHashSet<'a> {
     let globals = collect_referenced_globals(&func.body, env);
 
     // Phase 1: Use ReactiveFunctionVisitor to compute the rename mapping.
     // This collects DeclarationId -> IdentifierName without mutating env.
     let mut scopes = Scopes::new(globals.clone());
-    // If parent names are provided (for outlined functions), pre-populate
-    // the scope stack so that parameter names don't collide with parent
-    // variables. In the TS compiler, outlined functions are placed in the
-    // parent function body and processed within the parent's scope context.
-    if let Some(parent) = parent_names {
-        scopes.enter();
-        for name in parent {
-            // Sentinel value: `stack` is used purely as a set (only key presence is
-            // read via `lookup().is_some()`), so any id works here.
-            scopes.stack.last_mut().unwrap().insert(*name, DeclarationId::from_usize(0));
-            scopes.names.insert(*name);
-        }
-    }
     rename_variables_impl(func, &Visitor { env }, &mut scopes);
 
     // Phase 2: Apply the computed renames to all identifiers in env.

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -1194,31 +1194,18 @@ impl<'a> Unifier<'a> {
         t_b: Type<'a>,
         shapes: &ShapeRegistry<'a>,
     ) -> Result<(), OxcDiagnostic> {
-        self.unify_impl(t_a, t_b, shapes)
-    }
-
-    fn unify_impl(
-        &mut self,
-        t_a: Type<'a>,
-        t_b: Type<'a>,
-        shapes: &ShapeRegistry<'a>,
-    ) -> Result<(), OxcDiagnostic> {
         // Handle Property in the RHS position
         if let Type::Property { ref object_type, ref object_name, ref property_name } = t_b {
             // Check enableTreatRefLikeIdentifiersAsRefs
             if self.enable_treat_ref_like_identifiers_as_refs
                 && is_ref_like_name(object_name, property_name)
             {
-                self.unify_impl(
+                self.unify(
                     *object_type.clone(),
                     Type::Object { shape_id: Some(BUILT_IN_USE_REF_ID) },
                     shapes,
                 )?;
-                self.unify_impl(
-                    t_a,
-                    Type::Object { shape_id: Some(BUILT_IN_REF_VALUE_ID) },
-                    shapes,
-                )?;
+                self.unify(t_a, Type::Object { shape_id: Some(BUILT_IN_REF_VALUE_ID) }, shapes)?;
                 return Ok(());
             }
 
@@ -1231,7 +1218,7 @@ impl<'a> Unifier<'a> {
                 self.custom_hook_type.as_ref(),
             );
             if let Some(property_type) = property_type {
-                self.unify_impl(t_a, property_type, shapes)?;
+                self.unify(t_a, property_type, shapes)?;
             }
             return Ok(());
         }
@@ -1256,7 +1243,7 @@ impl<'a> Unifier<'a> {
         ) = (&t_a, &t_b)
             && con_a == con_b
         {
-            self.unify_impl(*ret_a.clone(), *ret_b.clone(), shapes)?;
+            self.unify(*ret_a.clone(), *ret_b.clone(), shapes)?;
         }
         Ok(())
     }
@@ -1278,14 +1265,14 @@ impl<'a> Unifier<'a> {
         }
 
         if let Some(existing) = self.substitutions.get(&v_id).cloned() {
-            self.unify_impl(existing, ty, shapes)?;
+            self.unify(existing, ty, shapes)?;
             return Ok(());
         }
 
         if let Type::Var { id: ty_id } = &ty
             && let Some(existing) = self.substitutions.get(ty_id).cloned()
         {
-            self.unify_impl(v, existing, shapes)?;
+            self.unify(v, existing, shapes)?;
             return Ok(());
         }
 
@@ -1319,7 +1306,7 @@ impl<'a> Unifier<'a> {
             }
 
             if let Some(candidate) = candidate_type {
-                self.unify_impl(v, candidate, shapes)?;
+                self.unify(v, candidate, shapes)?;
                 return Ok(());
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
@@ -51,7 +51,7 @@ pub fn validate_context_variable_lvalues(
 /// Like [`validate_context_variable_lvalues`], but writes diagnostics into the
 /// provided `errors` instead of `env.errors`. Useful when the caller wants to
 /// discard the diagnostics (e.g. when lowering is incomplete).
-pub fn validate_context_variable_lvalues_with_errors(
+fn validate_context_variable_lvalues_with_errors(
     func: &HirFunction,
     functions: &IndexSlice<FunctionId, [HirFunction]>,
     identifiers: &IndexSlice<IdentifierId, [Identifier]>,

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -130,7 +130,6 @@ enum InferredDependency<'a> {
     Local {
         identifier: IdentifierId,
         path: Vec<DependencyPathEntry<'a>>,
-        #[allow(dead_code)]
         context: bool,
         span: Option<Span>,
     },


### PR DESCRIPTION
A follow-up dead-code sweep of `oxc_react_compiler`. Everything here is **behavior-preserving** — the removed branch/variant never executed, and the rest is stale attributes, a pass-through merge, and visibility.

## Dead code removed
- **Never-wired branch in `rename_variables`** — `rename_variables_with_parent`'s `parent_names` was always `None` (its only caller passes `None`; it doesn't recurse), so the `Some(..)` "outlined functions" block and the wrapper split were dead. Inlined into `rename_variables`.
- **`ApplyArgConfig::Spread`** — never constructed anywhere (only a defensive match arm); removed the variant, its write-only `kind` field, `Hole.kind`, and the now-orphaned `ApplyArgSpreadKind` / `ApplyArgHoleKind` enums. (`ApplyArgConfig` derives only `Debug, Clone`, so nothing built it via serde either.)

## Stale attributes / redundant machinery
- Delete 4 `#[allow(dead_code)]` markers whose items are actually used now: `OxcContext::{fbt_operands, record_error}`, `Driver.env`, `InferredDependency::Local.context`.
- Merge the pure pass-through `Unifier::unify` into `unify_impl` (identical signature, no accumulator) — a single `unify`.

## Visibility
Tighten 8 items referenced only within their own module to private / `pub(crate)`: `GlobalRegistry`/`ShapeRegistry::into_inner`, `post_dominators_of`, `collect_maybe_memo_dependencies`, `is_always_invalidating_type`, `MEMO_CACHE_SENTINEL`, `next_type_id`, `validate_context_variable_lvalues_with_errors`.

`14 files changed, +17 / -85`. `cargo clippy` clean; unit + transform tests pass.