### PR TITLE
refactor(react_compiler): move the reactive-function tree into the arena

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
@@ -20,7 +20,7 @@ use oxc_str::{Ident, Str};
 use crate::react_compiler_hir::{
     BlockId, EvaluationOrder, InstructionValue, ParamPattern, Place, ScopeId,
 };
-use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds};
+use oxc_allocator::{Allocator, Box as ArenaBox, CloneIn, CloneInSemanticIds, Vec as ArenaVec};
 use oxc_ast::ast::LogicalOperator;
 use oxc_span::Span;
 
@@ -48,13 +48,13 @@ pub struct ReactiveFunction<'a> {
 // =============================================================================
 
 /// TS: ReactiveBlock = Array<ReactiveStatement>
-pub type ReactiveBlock<'a> = Vec<ReactiveStatement<'a>>;
+pub type ReactiveBlock<'a> = oxc_allocator::Vec<'a, ReactiveStatement<'a>>;
 
 /// TS: ReactiveStatement (discriminated union with 'kind' field)
 #[derive(Debug)]
 pub enum ReactiveStatement<'a> {
     Instruction(ReactiveInstruction<'a>),
-    Terminal(Box<ReactiveTerminalStatement<'a>>),
+    Terminal(ArenaBox<'a, ReactiveTerminalStatement<'a>>),
     Scope(ReactiveScopeBlock<'a>),
     PrunedScope(PrunedReactiveScopeBlock<'a>),
 }
@@ -83,26 +83,26 @@ pub enum ReactiveValue<'a> {
     /// TS: ReactiveLogicalValue
     LogicalExpression {
         operator: LogicalOperator,
-        left: Box<ReactiveValue<'a>>,
-        right: Box<ReactiveValue<'a>>,
+        left: ArenaBox<'a, ReactiveValue<'a>>,
+        right: ArenaBox<'a, ReactiveValue<'a>>,
     },
 
     /// TS: ReactiveTernaryValue
     ConditionalExpression {
-        test: Box<ReactiveValue<'a>>,
-        consequent: Box<ReactiveValue<'a>>,
-        alternate: Box<ReactiveValue<'a>>,
+        test: ArenaBox<'a, ReactiveValue<'a>>,
+        consequent: ArenaBox<'a, ReactiveValue<'a>>,
+        alternate: ArenaBox<'a, ReactiveValue<'a>>,
     },
 
     /// TS: ReactiveSequenceValue
     SequenceExpression {
-        instructions: Vec<ReactiveInstruction<'a>>,
+        instructions: ArenaVec<'a, ReactiveInstruction<'a>>,
         id: EvaluationOrder,
-        value: Box<ReactiveValue<'a>>,
+        value: ArenaBox<'a, ReactiveValue<'a>>,
     },
 
     /// TS: ReactiveOptionalCallValue
-    OptionalExpression { value: Box<ReactiveValue<'a>>, optional: bool },
+    OptionalExpression { value: ArenaBox<'a, ReactiveValue<'a>>, optional: bool },
 }
 
 // =============================================================================
@@ -160,7 +160,7 @@ pub enum ReactiveTerminal<'a> {
     },
     Switch {
         test: Place,
-        cases: Vec<ReactiveSwitchCase<'a>>,
+        cases: ArenaVec<'a, ReactiveSwitchCase<'a>>,
         id: EvaluationOrder,
     },
     DoWhile {
@@ -247,16 +247,16 @@ fn clone_reactive_block_in<'a>(
     block: &[ReactiveStatement<'a>],
     sem: CloneInSemanticIds,
     alloc: &'a Allocator,
-) -> Vec<ReactiveStatement<'a>> {
-    block.iter().map(|stmt| stmt.clone_in_impl(sem, alloc)).collect()
+) -> ArenaVec<'a, ReactiveStatement<'a>> {
+    ArenaVec::from_iter_in(block.iter().map(|stmt| stmt.clone_in_impl(sem, alloc)), &alloc)
 }
 
 fn clone_reactive_instructions_in<'a>(
     instructions: &[ReactiveInstruction<'a>],
     sem: CloneInSemanticIds,
     alloc: &'a Allocator,
-) -> Vec<ReactiveInstruction<'a>> {
-    instructions.iter().map(|instr| instr.clone_in_impl(sem, alloc)).collect()
+) -> ArenaVec<'a, ReactiveInstruction<'a>> {
+    ArenaVec::from_iter_in(instructions.iter().map(|instr| instr.clone_in_impl(sem, alloc)), &alloc)
 }
 
 impl<'a> CloneIn<'a> for ReactiveFunction<'a> {
@@ -282,9 +282,10 @@ impl<'a> CloneIn<'a> for ReactiveStatement<'a> {
             ReactiveStatement::Instruction(instr) => {
                 ReactiveStatement::Instruction(instr.clone_in_impl(sem, alloc))
             }
-            ReactiveStatement::Terminal(terminal) => {
-                ReactiveStatement::Terminal(Box::new(terminal.as_ref().clone_in_impl(sem, alloc)))
-            }
+            ReactiveStatement::Terminal(terminal) => ReactiveStatement::Terminal(ArenaBox::new_in(
+                terminal.as_ref().clone_in_impl(sem, alloc),
+                &alloc,
+            )),
             ReactiveStatement::Scope(scope) => {
                 ReactiveStatement::Scope(scope.clone_in_impl(sem, alloc))
             }
@@ -317,27 +318,33 @@ impl<'a> CloneIn<'a> for ReactiveValue<'a> {
             ReactiveValue::LogicalExpression { operator, left, right } => {
                 ReactiveValue::LogicalExpression {
                     operator: *operator,
-                    left: Box::new(left.as_ref().clone_in_impl(sem, alloc)),
-                    right: Box::new(right.as_ref().clone_in_impl(sem, alloc)),
+                    left: ArenaBox::new_in(left.as_ref().clone_in_impl(sem, alloc), &alloc),
+                    right: ArenaBox::new_in(right.as_ref().clone_in_impl(sem, alloc), &alloc),
                 }
             }
             ReactiveValue::ConditionalExpression { test, consequent, alternate } => {
                 ReactiveValue::ConditionalExpression {
-                    test: Box::new(test.as_ref().clone_in_impl(sem, alloc)),
-                    consequent: Box::new(consequent.as_ref().clone_in_impl(sem, alloc)),
-                    alternate: Box::new(alternate.as_ref().clone_in_impl(sem, alloc)),
+                    test: ArenaBox::new_in(test.as_ref().clone_in_impl(sem, alloc), &alloc),
+                    consequent: ArenaBox::new_in(
+                        consequent.as_ref().clone_in_impl(sem, alloc),
+                        &alloc,
+                    ),
+                    alternate: ArenaBox::new_in(
+                        alternate.as_ref().clone_in_impl(sem, alloc),
+                        &alloc,
+                    ),
                 }
             }
             ReactiveValue::SequenceExpression { instructions, id, value } => {
                 ReactiveValue::SequenceExpression {
                     instructions: clone_reactive_instructions_in(instructions, sem, alloc),
                     id: *id,
-                    value: Box::new(value.as_ref().clone_in_impl(sem, alloc)),
+                    value: ArenaBox::new_in(value.as_ref().clone_in_impl(sem, alloc), &alloc),
                 }
             }
             ReactiveValue::OptionalExpression { value, optional } => {
                 ReactiveValue::OptionalExpression {
-                    value: Box::new(value.as_ref().clone_in_impl(sem, alloc)),
+                    value: ArenaBox::new_in(value.as_ref().clone_in_impl(sem, alloc), &alloc),
                     optional: *optional,
                 }
             }
@@ -377,7 +384,10 @@ impl<'a> CloneIn<'a> for ReactiveTerminal<'a> {
             }
             ReactiveTerminal::Switch { test, cases, id } => ReactiveTerminal::Switch {
                 test: *test,
-                cases: cases.iter().map(|case| case.clone_in_impl(sem, alloc)).collect(),
+                cases: ArenaVec::from_iter_in(
+                    cases.iter().map(|case| case.clone_in_impl(sem, alloc)),
+                    &alloc,
+                ),
                 id: *id,
             },
             ReactiveTerminal::DoWhile { loop_block, test, id } => ReactiveTerminal::DoWhile {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -21,7 +21,7 @@ use crate::react_compiler_hir::{
     ReactiveSwitchCase, ReactiveTerminal, ReactiveTerminalStatement, ReactiveTerminalTargetKind,
     ReactiveValue, Terminal,
 };
-use oxc_allocator::CloneIn;
+use oxc_allocator::{Box as ArenaBox, CloneIn, Vec as ArenaVec};
 use oxc_span::Span;
 
 /// Convert the HIR CFG into a tree-structured ReactiveFunction.
@@ -29,11 +29,12 @@ pub fn build_reactive_function<'a>(
     hir: &HirFunction<'a>,
     env: &Environment<'a>,
 ) -> Result<ReactiveFunction<'a>, OxcDiagnostic> {
+    let alloc = env.allocator;
     let mut ctx = Context::new(hir);
     let mut driver = Driver { cx: &mut ctx, hir, env };
 
     let entry_block_id = hir.body.entry;
-    let mut body = Vec::new();
+    let mut body = ArenaVec::new_in(&alloc);
     driver.visit_block(entry_block_id, &mut body)?;
 
     Ok(ReactiveFunction {
@@ -285,8 +286,14 @@ struct Driver<'a, 'b, 'h> {
 }
 
 impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
+    /// Allocate `value` into the arena and wrap it in an arena `Box`.
+    #[inline]
+    fn box_in<T>(&self, value: T) -> ArenaBox<'a, T> {
+        ArenaBox::new_in(value, &self.env.allocator)
+    }
+
     fn traverse_block(&mut self, block_id: BlockId) -> Result<ReactiveBlock<'a>, OxcDiagnostic> {
-        let mut block_value = Vec::new();
+        let mut block_value = ArenaVec::new_in(&self.env.allocator);
         self.visit_block(block_id, &mut block_value)?;
         Ok(block_value)
     }
@@ -366,7 +373,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     };
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                    block_value.push(ReactiveStatement::Terminal(self.box_in(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::If {
                                 test: *test,
@@ -374,8 +381,8 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                                 alternate: alternate_block,
                                 id: *id,
                             },
-                            label: fallthrough_id
-                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            label:
+                                fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
                     )));
 
@@ -397,7 +404,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     // TS processes cases in reverse order, then reverses the result.
                     // This ensures that later cases are scheduled when earlier cases
                     // are traversed, matching fallthrough semantics.
-                    let mut reactive_cases = Vec::new();
+                    let mut reactive_cases = ArenaVec::new_in(&self.env.allocator);
                     for case in cases.iter().rev() {
                         let case_block_id = case.block;
 
@@ -419,15 +426,15 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     reactive_cases.reverse();
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                    block_value.push(ReactiveStatement::Terminal(self.box_in(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::Switch {
                                 test: *test,
                                 cases: reactive_cases,
                                 id: *id,
                             },
-                            label: fallthrough_id
-                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            label:
+                                fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
                     )));
 
@@ -460,15 +467,15 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     let test_result = self.visit_value_block(*test, *span, None)?;
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                    block_value.push(ReactiveStatement::Terminal(self.box_in(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::DoWhile {
                                 loop_block: loop_body,
                                 test: test_result.value,
                                 id: *id,
                             },
-                            label: fallthrough_id
-                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            label:
+                                fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
                     )));
 
@@ -506,15 +513,15 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     };
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                    block_value.push(ReactiveStatement::Terminal(self.box_in(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::While {
                                 test: test_result.value,
                                 loop_block: loop_body,
                                 id: *id,
                             },
-                            label: fallthrough_id
-                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            label:
+                                fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
                     )));
 
@@ -558,7 +565,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     };
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                    block_value.push(ReactiveStatement::Terminal(self.box_in(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::For {
                                 init: init_value,
@@ -567,8 +574,8 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                                 loop_block: loop_body,
                                 id: *id,
                             },
-                            label: fallthrough_id
-                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            label:
+                                fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
                     )));
 
@@ -608,7 +615,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     };
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                    block_value.push(ReactiveStatement::Terminal(self.box_in(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::ForOf {
                                 init: init_value,
@@ -617,8 +624,8 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                                 id: *id,
                                 span: *span,
                             },
-                            label: fallthrough_id
-                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            label:
+                                fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
                     )));
 
@@ -654,7 +661,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     };
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                    block_value.push(ReactiveStatement::Terminal(self.box_in(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::ForIn {
                                 init: init_value,
@@ -662,8 +669,8 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                                 id: *id,
                                 span: *span,
                             },
-                            label: fallthrough_id
-                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            label:
+                                fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
                     )));
 
@@ -690,11 +697,11 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     let label_body = self.traverse_block(*label_block)?;
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                    block_value.push(ReactiveStatement::Terminal(self.box_in(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::Label { block: label_body, id: *id },
-                            label: fallthrough_id
-                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            label:
+                                fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
                     )));
 
@@ -776,7 +783,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     let handler_body = self.traverse_block(*handler)?;
 
                     self.cx.unschedule_all(&schedule_ids)?;
-                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                    block_value.push(ReactiveStatement::Terminal(self.box_in(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::Try {
                                 block: try_body,
@@ -784,8 +791,8 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                                 handler: handler_body,
                                 id: *id,
                             },
-                            label: fallthrough_id
-                                .map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            label:
+                                fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
                         },
                     )));
 
@@ -841,7 +848,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 }
 
                 Terminal::Return { value, id, .. } => {
-                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                    block_value.push(ReactiveStatement::Terminal(self.box_in(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::Return { value: *value, id: *id },
                             label: None,
@@ -850,7 +857,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 }
 
                 Terminal::Throw { value, id, .. } => {
-                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                    block_value.push(ReactiveStatement::Terminal(self.box_in(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::Throw { value: *value, id: *id },
                             label: None,
@@ -863,11 +870,12 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 }
 
                 Terminal::Branch { test, consequent, alternate, id, .. } => {
+                    let alloc = self.env.allocator;
                     let consequent_block = if self.cx.is_scheduled(*consequent) {
                         if let Some(stmt) = self.visit_break(*consequent, *id)? {
-                            vec![stmt]
+                            ArenaVec::from_iter_in([stmt], &alloc)
                         } else {
-                            Vec::new()
+                            ArenaVec::new_in(&alloc)
                         }
                     } else {
                         self.traverse_block(*consequent)?
@@ -880,7 +888,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     }
                     let alternate_block = self.traverse_block(*alternate)?;
 
-                    block_value.push(ReactiveStatement::Terminal(Box::new(
+                    block_value.push(ReactiveStatement::Terminal(self.box_in(
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::If {
                                 test: *test,
@@ -982,20 +990,19 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 let final_result = self.visit_value_block(init_fallthrough, span, None)?;
 
                 // Combine block instructions + init instruction, then wrap
-                let mut all_instrs: Vec<ReactiveInstruction<'a>> = instructions
-                    .iter()
-                    .map(|iid| {
+                let alloc = self.env.allocator;
+                let mut all_instrs: ArenaVec<'a, ReactiveInstruction<'a>> = ArenaVec::from_iter_in(
+                    instructions.iter().map(|iid| {
                         let instr = &self.hir.instructions[iid.index()];
                         ReactiveInstruction {
                             id: instr.id,
                             lvalue: Some(instr.lvalue),
-                            value: ReactiveValue::Instruction(
-                                instr.value.clone_in(self.env.allocator),
-                            ),
+                            value: ReactiveValue::Instruction(instr.value.clone_in(alloc)),
                             span: instr.span,
                         }
-                    })
-                    .collect();
+                    }),
+                    &alloc,
+                );
                 all_instrs.push(init_instr);
 
                 if all_instrs.is_empty() {
@@ -1007,7 +1014,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                         value: ReactiveValue::SequenceExpression {
                             instructions: all_instrs,
                             id: final_result.id,
-                            value: Box::new(final_result.value),
+                            value: self.box_in(final_result.value),
                         },
                         id: final_result.id,
                     })
@@ -1060,20 +1067,23 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 let consequent =
                     self.visit_value_block(test_result.consequent, *span, Some(*fallthrough))?;
                 let call = ReactiveValue::SequenceExpression {
-                    instructions: vec![ReactiveInstruction {
-                        id: test_result.test.id,
-                        lvalue: Some(test_result.test.place),
-                        value: test_result.test.value,
-                        span: test_result.branch_span,
-                    }],
+                    instructions: ArenaVec::from_iter_in(
+                        [ReactiveInstruction {
+                            id: test_result.test.id,
+                            lvalue: Some(test_result.test.place),
+                            value: test_result.test.value,
+                            span: test_result.branch_span,
+                        }],
+                        &self.env.allocator,
+                    ),
                     id: consequent.id,
-                    value: Box::new(consequent.value),
+                    value: self.box_in(consequent.value),
                 };
                 Ok(ValueTerminalResult {
                     place: consequent.place,
                     value: ReactiveValue::OptionalExpression {
                         optional: *optional,
-                        value: Box::new(call),
+                        value: self.box_in(call),
                     },
                     fallthrough: *fallthrough,
                     id: *id,
@@ -1084,14 +1094,17 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 let left_final =
                     self.visit_value_block(test_result.consequent, *span, Some(*fallthrough))?;
                 let left = ReactiveValue::SequenceExpression {
-                    instructions: vec![ReactiveInstruction {
-                        id: test_result.test.id,
-                        lvalue: Some(test_result.test.place),
-                        value: test_result.test.value,
-                        span: *span,
-                    }],
+                    instructions: ArenaVec::from_iter_in(
+                        [ReactiveInstruction {
+                            id: test_result.test.id,
+                            lvalue: Some(test_result.test.place),
+                            value: test_result.test.value,
+                            span: *span,
+                        }],
+                        &self.env.allocator,
+                    ),
                     id: left_final.id,
-                    value: Box::new(left_final.value),
+                    value: self.box_in(left_final.value),
                 };
                 let right =
                     self.visit_value_block(test_result.alternate, *span, Some(*fallthrough))?;
@@ -1099,8 +1112,8 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     place: left_final.place,
                     value: ReactiveValue::LogicalExpression {
                         operator: *operator,
-                        left: Box::new(left),
-                        right: Box::new(right.value),
+                        left: self.box_in(left),
+                        right: self.box_in(right.value),
                     },
                     fallthrough: *fallthrough,
                     id: *id,
@@ -1115,9 +1128,9 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 Ok(ValueTerminalResult {
                     place: consequent.place,
                     value: ReactiveValue::ConditionalExpression {
-                        test: Box::new(test_result.test.value),
-                        consequent: Box::new(consequent.value),
-                        alternate: Box::new(alternate.value),
+                        test: self.box_in(test_result.test.value),
+                        consequent: self.box_in(consequent.value),
+                        alternate: self.box_in(alternate.value),
                     },
                     fallthrough: *fallthrough,
                     id: *id,
@@ -1142,18 +1155,19 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         let last_id = instructions.last().expect("Expected non-empty instructions");
         let last_instr = &self.hir.instructions[last_id.index()];
 
-        let remaining: Vec<ReactiveInstruction<'a>> = instructions[..instructions.len() - 1]
-            .iter()
-            .map(|iid| {
+        let alloc = self.env.allocator;
+        let remaining: ArenaVec<'a, ReactiveInstruction<'a>> = ArenaVec::from_iter_in(
+            instructions[..instructions.len() - 1].iter().map(|iid| {
                 let instr = &self.hir.instructions[iid.index()];
                 ReactiveInstruction {
                     id: instr.id,
                     lvalue: Some(instr.lvalue),
-                    value: ReactiveValue::Instruction(instr.value.clone_in(self.env.allocator)),
+                    value: ReactiveValue::Instruction(instr.value.clone_in(alloc)),
                     span: instr.span,
                 }
-            })
-            .collect();
+            }),
+            &alloc,
+        );
 
         // If the last instruction is a StoreLocal to a temporary (unnamed identifier),
         // convert it to a LoadLocal of the value being stored, matching the TS behavior.
@@ -1191,7 +1205,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 value: ReactiveValue::SequenceExpression {
                     instructions: remaining,
                     id,
-                    value: Box::new(value),
+                    value: self.box_in(value),
                 },
                 id,
             }
@@ -1207,18 +1221,19 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
             return continuation;
         }
 
-        let reactive_instrs: Vec<ReactiveInstruction<'a>> = instructions
-            .iter()
-            .map(|iid| {
+        let alloc = self.env.allocator;
+        let reactive_instrs: ArenaVec<'a, ReactiveInstruction<'a>> = ArenaVec::from_iter_in(
+            instructions.iter().map(|iid| {
                 let instr = &self.hir.instructions[iid.index()];
                 ReactiveInstruction {
                     id: instr.id,
                     lvalue: Some(instr.lvalue),
-                    value: ReactiveValue::Instruction(instr.value.clone_in(self.env.allocator)),
+                    value: ReactiveValue::Instruction(instr.value.clone_in(alloc)),
                     span: instr.span,
                 }
-            })
-            .collect();
+            }),
+            &alloc,
+        );
 
         ValueBlockResult {
             block: continuation.block,
@@ -1226,7 +1241,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
             value: ReactiveValue::SequenceExpression {
                 instructions: reactive_instrs,
                 id: continuation.id,
-                value: Box::new(continuation.value),
+                value: self.box_in(continuation.value),
             },
             id: continuation.id,
         }
@@ -1246,7 +1261,8 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         span: Option<Span>,
     ) -> ReactiveValue<'a> {
         // Collect all instructions from potentially nested SequenceExpressions
-        let mut instructions: Vec<ReactiveInstruction<'a>> = Vec::new();
+        let mut instructions: ArenaVec<'a, ReactiveInstruction<'a>> =
+            ArenaVec::new_in(&self.env.allocator);
         let mut inner_value = result.value;
 
         // Flatten nested SequenceExpressions
@@ -1254,7 +1270,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
             inner_value
         {
             instructions.extend(seq_instrs);
-            inner_value = *value;
+            inner_value = value.unbox();
         }
 
         // Only add the final instruction if the innermost value is not just a LoadLocal
@@ -1278,7 +1294,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         ReactiveValue::SequenceExpression {
             instructions,
             id: result.id,
-            value: Box::new(ReactiveValue::Instruction(InstructionValue::Primitive {
+            value: self.box_in(ReactiveValue::Instruction(InstructionValue::Primitive {
                 value: PrimitiveValue::Undefined,
                 span,
             })),
@@ -1298,7 +1314,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
             }
             return Ok(None);
         }
-        Ok(Some(ReactiveStatement::Terminal(Box::new(ReactiveTerminalStatement {
+        Ok(Some(ReactiveStatement::Terminal(self.box_in(ReactiveTerminalStatement {
             terminal: ReactiveTerminal::Break { target: target_block, id, target_kind },
             label: None,
         }))))
@@ -1319,7 +1335,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
             }
         };
 
-        Ok(ReactiveStatement::Terminal(Box::new(ReactiveTerminalStatement {
+        Ok(ReactiveStatement::Terminal(self.box_in(ReactiveTerminalStatement {
             terminal: ReactiveTerminal::Continue { target: target_block, id, target_kind },
             label: None,
         })))

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -1194,10 +1194,12 @@ fn ox_codegen_for_init<'a>(
     init: &ReactiveValue<'a>,
 ) -> Result<Option<oxc::ForStatementInit<'a>>, OxcDiagnostic> {
     if let ReactiveValue::SequenceExpression { instructions, .. } = init {
-        let block_items: Vec<ReactiveStatement> = instructions
-            .iter()
-            .map(|i| ReactiveStatement::Instruction(i.clone_in(cx.env.allocator)))
-            .collect();
+        let block_items = oxc_allocator::Vec::from_iter_in(
+            instructions
+                .iter()
+                .map(|i| ReactiveStatement::Instruction(i.clone_in(cx.env.allocator))),
+            &cx.env.allocator,
+        );
         let body = ox_codegen_block(cx, &block_items)?;
         let mut declarators: oxc_allocator::Vec<'a, oxc::VariableDeclarator<'a>> =
             oxc_allocator::ArenaVec::new_in(&cx.ast);
@@ -1566,10 +1568,12 @@ fn ox_codegen_instruction_value<'a>(
             )))
         }
         ReactiveValue::SequenceExpression { instructions, value, .. } => {
-            let block_items: Vec<ReactiveStatement> = instructions
-                .iter()
-                .map(|i| ReactiveStatement::Instruction(i.clone_in(cx.env.allocator)))
-                .collect();
+            let block_items = oxc_allocator::Vec::from_iter_in(
+                instructions
+                    .iter()
+                    .map(|i| ReactiveStatement::Instruction(i.clone_in(cx.env.allocator))),
+                &cx.env.allocator,
+            );
             let body = ox_codegen_block_no_reset(cx, &block_items)?;
             let mut expressions: oxc_allocator::Vec<'a, oxc::Expression<'a>> =
                 oxc_allocator::ArenaVec::new_in(&cx.ast);

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
@@ -8,7 +8,7 @@
 //!
 //! Corresponds to `src/ReactiveScopes/MergeReactiveScopesThatInvalidateTogether.ts`.
 
-use std::mem::take;
+use std::mem::replace;
 
 use oxc_allocator::{CloneIn, Vec as ArenaVec};
 
@@ -126,7 +126,8 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for MergeTransform<'a, 'e> {
         if let Some(parent_deps) = state.as_ref()
             && are_equal_dependencies(parent_deps, &scope_deps, self.env)
         {
-            let instructions = take(&mut scope.instructions);
+            // ReplaceMany keeps a std `Vec`; drain the arena block into one.
+            let instructions = scope.instructions.drain(..).collect::<Vec<_>>();
             return Ok(Transformed::ReplaceMany(instructions));
         }
         Ok(Transformed::Keep)
@@ -350,10 +351,10 @@ impl<'a, 'e> MergeTransform<'a, 'e> {
             return Ok(());
         }
 
-        let mut next_instructions: Vec<ReactiveStatement<'a>> = Vec::new();
-        let mut index = 0;
-        let all_stmts: Vec<ReactiveStatement> = take(block);
         let alloc = self.env.allocator;
+        let mut next_instructions: ArenaVec<'a, ReactiveStatement<'a>> = ArenaVec::new_in(&alloc);
+        let mut index = 0;
+        let all_stmts = replace(block, ArenaVec::new_in(&alloc));
 
         for entry in &merged {
             // Push everything before the merge range

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
@@ -10,9 +10,9 @@
 //!
 //! Corresponds to `src/ReactiveScopes/PropagateEarlyReturns.ts`.
 
-use std::mem::take;
+use std::mem::replace;
 
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_str::{Ident, format_ident};
 
@@ -133,6 +133,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
             state.early_return_value = Some(early_return_value.clone());
 
             let return_value = *value;
+            let alloc = self.env.allocator;
 
             return Ok(Transformed::ReplaceMany(vec![
                 // StoreLocal: reassign the early return value
@@ -155,14 +156,17 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                     span,
                 }),
                 // Break to the label
-                ReactiveStatement::Terminal(Box::new(ReactiveTerminalStatement {
-                    terminal: ReactiveTerminal::Break {
-                        target: early_return_value.label,
-                        id: EvaluationOrder::UNSET,
-                        target_kind: ReactiveTerminalTargetKind::Labeled,
+                ReactiveStatement::Terminal(ArenaBox::new_in(
+                    ReactiveTerminalStatement {
+                        terminal: ReactiveTerminal::Break {
+                            target: early_return_value.label,
+                            id: EvaluationOrder::UNSET,
+                            target_kind: ReactiveTerminalTargetKind::Labeled,
+                        },
+                        label: None,
                     },
-                    label: None,
-                })),
+                    &alloc,
+                )),
             ]));
         }
 
@@ -203,128 +207,135 @@ fn apply_early_return_to_scope<'a>(
     let for_temp = create_temporary_place_id(env, span);
     let arg_temp = create_temporary_place_id(env, span);
 
-    let original_instructions = take(&mut scope_block.instructions);
+    let alloc = env.allocator;
+    let original_instructions = replace(&mut scope_block.instructions, ArenaVec::new_in(&alloc));
 
-    scope_block.instructions = vec![
-        // LoadGlobal Symbol
-        ReactiveStatement::Instruction(ReactiveInstruction {
-            id: EvaluationOrder::UNSET,
-            lvalue: Some(Place {
-                identifier: symbol_temp,
-                effect: Effect::Unknown,
-                reactive: false,
-                span: None, // GeneratedSource
-            }),
-            value: ReactiveValue::Instruction(InstructionValue::LoadGlobal {
-                binding: NonLocalBinding::Global { name: Ident::from("Symbol") },
-                span,
-            }),
-            span,
-        }),
-        // PropertyLoad Symbol.for
-        ReactiveStatement::Instruction(ReactiveInstruction {
-            id: EvaluationOrder::UNSET,
-            lvalue: Some(Place {
-                identifier: for_temp,
-                effect: Effect::Unknown,
-                reactive: false,
-                span: None, // GeneratedSource
-            }),
-            value: ReactiveValue::Instruction(InstructionValue::PropertyLoad {
-                object: Place {
+    scope_block.instructions = ArenaVec::from_iter_in(
+        [
+            // LoadGlobal Symbol
+            ReactiveStatement::Instruction(ReactiveInstruction {
+                id: EvaluationOrder::UNSET,
+                lvalue: Some(Place {
                     identifier: symbol_temp,
                     effect: Effect::Unknown,
                     reactive: false,
                     span: None, // GeneratedSource
-                },
-                property: PropertyLiteral::String(Ident::from("for")),
+                }),
+                value: ReactiveValue::Instruction(InstructionValue::LoadGlobal {
+                    binding: NonLocalBinding::Global { name: Ident::from("Symbol") },
+                    span,
+                }),
                 span,
             }),
-            span,
-        }),
-        // Primitive: the sentinel string
-        ReactiveStatement::Instruction(ReactiveInstruction {
-            id: EvaluationOrder::UNSET,
-            lvalue: Some(Place {
-                identifier: arg_temp,
-                effect: Effect::Unknown,
-                reactive: false,
-                span: None, // GeneratedSource
-            }),
-            value: ReactiveValue::Instruction(InstructionValue::Primitive {
-                value: PrimitiveValue::String(EARLY_RETURN_SENTINEL.into()),
-                span,
-            }),
-            span,
-        }),
-        // MethodCall: Symbol.for("react.early_return_sentinel")
-        ReactiveStatement::Instruction(ReactiveInstruction {
-            id: EvaluationOrder::UNSET,
-            lvalue: Some(Place {
-                identifier: sentinel_temp,
-                effect: Effect::Unknown,
-                reactive: false,
-                span: None, // GeneratedSource
-            }),
-            value: ReactiveValue::Instruction(InstructionValue::MethodCall {
-                receiver: Place {
-                    identifier: symbol_temp,
-                    effect: Effect::Unknown,
-                    reactive: false,
-                    span: None, // GeneratedSource
-                },
-                property: Place {
+            // PropertyLoad Symbol.for
+            ReactiveStatement::Instruction(ReactiveInstruction {
+                id: EvaluationOrder::UNSET,
+                lvalue: Some(Place {
                     identifier: for_temp,
                     effect: Effect::Unknown,
                     reactive: false,
                     span: None, // GeneratedSource
-                },
-                args: ArenaVec::from_array_in(
-                    [PlaceOrSpread::Place(Place {
-                        identifier: arg_temp,
+                }),
+                value: ReactiveValue::Instruction(InstructionValue::PropertyLoad {
+                    object: Place {
+                        identifier: symbol_temp,
                         effect: Effect::Unknown,
                         reactive: false,
                         span: None, // GeneratedSource
-                    })],
-                    &env.allocator,
-                ),
+                    },
+                    property: PropertyLiteral::String(Ident::from("for")),
+                    span,
+                }),
                 span,
             }),
-            span,
-        }),
-        // StoreLocal: let earlyReturnValue = sentinel
-        ReactiveStatement::Instruction(ReactiveInstruction {
-            id: EvaluationOrder::UNSET,
-            lvalue: None,
-            value: ReactiveValue::Instruction(InstructionValue::StoreLocal {
-                lvalue: LValue {
-                    kind: InstructionKind::Let,
-                    place: Place {
-                        identifier: early_return.value,
-                        effect: Effect::ConditionallyMutate,
-                        reactive: true,
-                        span,
-                    },
-                },
-                value: Place {
+            // Primitive: the sentinel string
+            ReactiveStatement::Instruction(ReactiveInstruction {
+                id: EvaluationOrder::UNSET,
+                lvalue: Some(Place {
+                    identifier: arg_temp,
+                    effect: Effect::Unknown,
+                    reactive: false,
+                    span: None, // GeneratedSource
+                }),
+                value: ReactiveValue::Instruction(InstructionValue::Primitive {
+                    value: PrimitiveValue::String(EARLY_RETURN_SENTINEL.into()),
+                    span,
+                }),
+                span,
+            }),
+            // MethodCall: Symbol.for("react.early_return_sentinel")
+            ReactiveStatement::Instruction(ReactiveInstruction {
+                id: EvaluationOrder::UNSET,
+                lvalue: Some(Place {
                     identifier: sentinel_temp,
                     effect: Effect::Unknown,
                     reactive: false,
                     span: None, // GeneratedSource
-                },
+                }),
+                value: ReactiveValue::Instruction(InstructionValue::MethodCall {
+                    receiver: Place {
+                        identifier: symbol_temp,
+                        effect: Effect::Unknown,
+                        reactive: false,
+                        span: None, // GeneratedSource
+                    },
+                    property: Place {
+                        identifier: for_temp,
+                        effect: Effect::Unknown,
+                        reactive: false,
+                        span: None, // GeneratedSource
+                    },
+                    args: ArenaVec::from_array_in(
+                        [PlaceOrSpread::Place(Place {
+                            identifier: arg_temp,
+                            effect: Effect::Unknown,
+                            reactive: false,
+                            span: None, // GeneratedSource
+                        })],
+                        &alloc,
+                    ),
+                    span,
+                }),
                 span,
             }),
-            span,
-        }),
-        // Label terminal wrapping the original instructions
-        ReactiveStatement::Terminal(Box::new(ReactiveTerminalStatement {
-            label: Some(ReactiveLabel { id: early_return.label, implicit: false }),
-            terminal: ReactiveTerminal::Label {
-                block: original_instructions,
+            // StoreLocal: let earlyReturnValue = sentinel
+            ReactiveStatement::Instruction(ReactiveInstruction {
                 id: EvaluationOrder::UNSET,
-            },
-        })),
-    ];
+                lvalue: None,
+                value: ReactiveValue::Instruction(InstructionValue::StoreLocal {
+                    lvalue: LValue {
+                        kind: InstructionKind::Let,
+                        place: Place {
+                            identifier: early_return.value,
+                            effect: Effect::ConditionallyMutate,
+                            reactive: true,
+                            span,
+                        },
+                    },
+                    value: Place {
+                        identifier: sentinel_temp,
+                        effect: Effect::Unknown,
+                        reactive: false,
+                        span: None, // GeneratedSource
+                    },
+                    span,
+                }),
+                span,
+            }),
+            // Label terminal wrapping the original instructions
+            ReactiveStatement::Terminal(ArenaBox::new_in(
+                ReactiveTerminalStatement {
+                    label: Some(ReactiveLabel { id: early_return.label, implicit: false }),
+                    terminal: ReactiveTerminal::Label {
+                        block: original_instructions,
+                        id: EvaluationOrder::UNSET,
+                    },
+                },
+                &alloc,
+            )),
+        ],
+        &alloc,
+    );
 }
 
 // =============================================================================

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
@@ -11,8 +11,9 @@
 //!
 //! Corresponds to `src/ReactiveScopes/PruneAlwaysInvalidatingScopes.ts`.
 
-use std::mem::take;
+use std::mem::replace;
 
+use oxc_allocator::Vec as ArenaVec;
 use rustc_hash::FxHashSet;
 
 use oxc_diagnostics::OxcDiagnostic;
@@ -114,6 +115,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         let mut within_scope = true;
         self.visit_scope(scope, &mut within_scope)?;
 
+        let alloc = self.env.allocator;
         let scope_id = scope.scope;
         let scope_data = &self.env.scopes[scope_id];
 
@@ -140,7 +142,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                 return Ok(Transformed::Replace(ReactiveStatement::PrunedScope(
                     PrunedReactiveScopeBlock {
                         scope: scope.scope,
-                        instructions: take(&mut scope.instructions),
+                        instructions: replace(&mut scope.instructions, ArenaVec::new_in(&alloc)),
                     },
                 )));
             }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -8,8 +8,6 @@
 //!
 //! Corresponds to `src/ReactiveScopes/PruneNonEscapingScopes.ts`.
 
-use std::mem::take;
-
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
@@ -1097,7 +1095,8 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for PruneScopesTransform<'a, 'e> {
             Ok(Transformed::Keep)
         } else {
             self.pruned_scopes.insert(scope_id);
-            Ok(Transformed::ReplaceMany(take(&mut scope.instructions)))
+            // ReplaceMany keeps a std `Vec`; drain the arena block into one.
+            Ok(Transformed::ReplaceMany(scope.instructions.drain(..).collect()))
         }
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_labels.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_labels.rs
@@ -8,8 +8,6 @@
 //!
 //! Corresponds to `src/ReactiveScopes/PruneUnusedLabels.ts`.
 
-use std::mem::take;
-
 use rustc_hash::FxHashSet;
 
 use oxc_diagnostics::OxcDiagnostic;
@@ -79,7 +77,8 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
             // Note: In TS, there's a check for `last.terminal.target === null`
             // to pop a trailing break, but since target is always a BlockId (number),
             // that check is always false, so the trailing break is never removed.
-            let flattened = take(block);
+            // ReplaceMany keeps a std `Vec`; drain the arena block into one.
+            let flattened = block.drain(..).collect::<Vec<_>>();
             return Ok(Transformed::ReplaceMany(flattened));
         }
 

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_lvalues.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_lvalues.rs
@@ -12,7 +12,7 @@
 use rustc_hash::FxHashSet;
 
 use crate::react_compiler_hir::{
-    DeclarationId, EvaluationOrder, Place, ReactiveFunction, ReactiveInstruction,
+    DeclarationId, EvaluationOrder, Place, ReactiveBlock, ReactiveFunction, ReactiveInstruction,
     ReactiveStatement, ReactiveTerminal, ReactiveValue, environment::Environment,
 };
 
@@ -85,7 +85,7 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for Visitor<'a, 'e> {
 /// Phase 2: Walk the tree and null out lvalues whose DeclarationId is unused.
 /// This is necessary because Rust's visitor takes immutable references.
 fn null_unused_lvalues<'a>(
-    block: &mut Vec<ReactiveStatement<'a>>,
+    block: &mut ReactiveBlock<'a>,
     env: &Environment<'a>,
     unused: &FxHashSet<DeclarationId>,
 ) {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_scopes.rs
@@ -7,8 +7,9 @@
 //!
 //! Corresponds to `src/ReactiveScopes/PruneUnusedScopes.ts`.
 
-use std::mem::take;
+use std::mem::replace;
 
+use oxc_allocator::Vec as ArenaVec;
 use oxc_diagnostics::OxcDiagnostic;
 
 use crate::react_compiler_hir::{
@@ -67,6 +68,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
         let mut scope_state = State { has_return_statement: false };
         self.visit_scope(scope, &mut scope_state)?;
 
+        let alloc = self.env.allocator;
         let scope_id = scope.scope;
         let scope_data = &self.env.scopes[scope_id];
 
@@ -77,7 +79,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
             // Replace with pruned scope
             Ok(Transformed::Replace(ReactiveStatement::PrunedScope(PrunedReactiveScopeBlock {
                 scope: scope.scope,
-                instructions: take(&mut scope.instructions),
+                instructions: replace(&mut scope.instructions, ArenaVec::new_in(&alloc)),
             })))
         } else {
             Ok(Transformed::Keep)

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
@@ -9,7 +9,7 @@
 
 use std::mem::replace;
 
-use oxc_allocator::CloneIn;
+use oxc_allocator::{CloneIn, Vec as ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 
 use crate::react_compiler_hir::visitors::{
@@ -578,7 +578,8 @@ pub trait ReactiveFunctionTransform<'a> {
         block: &mut ReactiveBlock<'a>,
         state: &mut Self::State,
     ) -> Result<(), OxcDiagnostic> {
-        let mut next_block: Option<Vec<ReactiveStatement<'a>>> = None;
+        let alloc = self.env().allocator;
+        let mut next_block: Option<ArenaVec<'a, ReactiveStatement<'a>>> = None;
         let len = block.len();
         for i in 0..len {
             // Take the statement out temporarily
@@ -615,24 +616,27 @@ pub trait ReactiveFunctionTransform<'a> {
                 }
                 Transformed::Remove => {
                     if next_block.is_none() {
-                        next_block = Some(
-                            block[..i].iter().map(|s| s.clone_in(self.env().allocator)).collect(),
-                        );
+                        next_block = Some(ArenaVec::from_iter_in(
+                            block[..i].iter().map(|s| s.clone_in(alloc)),
+                            &alloc,
+                        ));
                     }
                 }
                 Transformed::Replace(replacement) => {
                     if next_block.is_none() {
-                        next_block = Some(
-                            block[..i].iter().map(|s| s.clone_in(self.env().allocator)).collect(),
-                        );
+                        next_block = Some(ArenaVec::from_iter_in(
+                            block[..i].iter().map(|s| s.clone_in(alloc)),
+                            &alloc,
+                        ));
                     }
                     next_block.as_mut().unwrap().push(replacement);
                 }
                 Transformed::ReplaceMany(replacements) => {
                     if next_block.is_none() {
-                        next_block = Some(
-                            block[..i].iter().map(|s| s.clone_in(self.env().allocator)).collect(),
-                        );
+                        next_block = Some(ArenaVec::from_iter_in(
+                            block[..i].iter().map(|s| s.clone_in(alloc)),
+                            &alloc,
+                        ));
                     }
                     next_block.as_mut().unwrap().extend(replacements);
                 }


### PR DESCRIPTION
The final subtree of the react_compiler HIR-to-arena migration: the ReactiveFunction tree's own structural vectors and boxes move off the heap into the compilation arena, so the reactive tree stops straddling two allocators.

## What changed

- `ReactiveBlock` (`= Vec<ReactiveStatement>`, every block body), `ReactiveValue::SequenceExpression.instructions`, and `ReactiveTerminal::Switch.cases` become `oxc_allocator::Vec<'a>`.
- The tree's `Box` fields (`ReactiveStatement::Terminal`, the boxed `ReactiveValue` sub-expressions, ...) become `oxc_allocator::Box<'a>` — required so the element types are `!needs_drop` and can live in an arena `Vec` (`ReactiveStatement` was `Drop` via its std boxes). This completes the tree's move (Vec + Box) into the arena.
- The transform passes' `std::mem::take` on block bodies (arena `Vec` has no `Default`) become `std::mem::replace(.., Vec::new_in(alloc))`; construction sites allocate from `env.allocator`.
- `Transformed::ReplaceMany` deliberately stays a std `Vec` — a transient replacement list that `traverse_block` drains into the arena block — so the generic visitor enum and every pass's `ReplaceMany` construction are untouched.

Behavior is unchanged — snapshot corpus and transform tests remain byte-identical.

## Memory

Arena bytes across the full 1269-fixture corpus (fresh allocator per file, after `compile`):

| | total arena used | max single fixture |
|---|---|---|
| before (tree on heap) | 9.93 MB | 228 KB |
| after (tree in arena) | 12.97 MB | 297 KB |

The +3.04 MB (+31%) is a relocation of the tree off the heap — smaller than the CFG subtree's +82% shift, and no fixture balloons.

## Follow-up (not in this PR)

The reactive-scopes passes rebuild block bodies with a clone-prefix + take/rebuild pattern; with the arena the abandoned spine isn't freed until the per-file arena drops (a bounded churn tail, included in the +31% above). Rewriting `traverse_block` and the merge Pass-3 to drain/splice the block in place would collapse that churn tail **and** delete a pre-existing wasteful deep-clone (a CPU win). Deferred to its own PR because the in-place splice must be verified byte-identical across the whole corpus.

## Stack

- #24664
- #24666
- #24696
- #24700
- **this PR** — stacked on top of #24700

🤖 This PR was written with the assistance of Claude Code.