### PR TITLE
perf(parser): reuse scratch storage for lists

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -9,6 +9,7 @@ use crate::{
     diagnostics::{self, ParserDiagnostic},
     error_handler::FatalError,
     lexer::{Kind, LexerCheckpoint, Token, cold_branch},
+    scratch::{ScratchElement, ScratchMark},
 };
 
 #[derive(Clone)]
@@ -387,24 +388,26 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> ArenaVec<'a, T>
     where
         F: FnMut(&mut Self) -> T,
+        T: ScratchElement<'a>,
     {
         let opening_span = self.cur_token().span();
         self.expect(open);
-        let mut list = ArenaVec::new_in(self);
-        self.parse_normal_list_into(&mut list, close, f);
+        let mark = self.start_scratch();
+        self.parse_normal_list_into_scratch(&mark, close, f);
         self.expect_closing(close, opening_span);
-        list
+        self.finish_scratch(mark)
     }
 
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    fn parse_normal_list_into<F, T>(
+    fn parse_normal_list_into_scratch<F, T>(
         &mut self,
-        list: &mut ArenaVec<'a, T>,
+        mark: &ScratchMark<T>,
         close: Kind,
         mut parse_element: F,
     ) where
         F: FnMut(&mut Self) -> T,
+        T: ScratchElement<'a>,
     {
         loop {
             let kind = self.cur_kind();
@@ -415,7 +418,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 break;
             }
             let element = parse_element(self);
-            list.push(element);
+            self.scratch_push(mark, element);
         }
     }
 
@@ -427,31 +430,33 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> ArenaVec<'a, T>
     where
         F: Fn(&mut Self) -> Option<T>,
+        T: ScratchElement<'a>,
     {
         let opening_span = self.cur_token().span();
         self.expect(open);
-        let mut list = ArenaVec::new_in(self);
-        self.parse_normal_list_breakable_into(&mut list, close, f);
+        let mark = self.start_scratch();
+        self.parse_normal_list_breakable_into_scratch(&mark, close, f);
         self.expect_closing(close, opening_span);
-        list
+        self.finish_scratch(mark)
     }
 
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    fn parse_normal_list_breakable_into<F, T>(
+    fn parse_normal_list_breakable_into_scratch<F, T>(
         &mut self,
-        list: &mut ArenaVec<'a, T>,
+        mark: &ScratchMark<T>,
         close: Kind,
         parse_element: F,
     ) where
         F: Fn(&mut Self) -> Option<T>,
+        T: ScratchElement<'a>,
     {
         loop {
             if self.at(close) || self.has_fatal_error() {
                 break;
             }
             if let Some(element) = parse_element(self) {
-                list.push(element);
+                self.scratch_push(mark, element);
             } else {
                 break;
             }
@@ -467,23 +472,24 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> (ArenaVec<'a, T>, Option<u32>)
     where
         F: FnMut(&mut Self) -> T,
+        T: ScratchElement<'a>,
     {
-        let mut list = ArenaVec::new_in(self);
-        let trailing_separator = self.parse_delimited_list_into(
-            &mut list,
+        let mark = self.start_scratch();
+        let trailing_separator = self.parse_delimited_list_into_scratch(
+            &mark,
             close,
             separator,
             opening_span,
             parse_element,
         );
+        let list = self.finish_scratch(mark);
         (list, trailing_separator)
     }
 
-    #[expect(clippy::inline_always)]
-    #[inline(always)]
-    pub(crate) fn parse_delimited_list_into<F, T>(
+    #[inline]
+    pub(crate) fn parse_delimited_list_into_scratch<F, T>(
         &mut self,
-        list: &mut ArenaVec<'a, T>,
+        mark: &ScratchMark<T>,
         close: Kind,
         separator: Kind,
         opening_span: Span,
@@ -491,6 +497,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> Option<u32>
     where
         F: FnMut(&mut Self) -> T,
+        T: ScratchElement<'a>,
     {
         // Cache cur_kind() to avoid redundant calls in compound checks
         let kind = self.cur_kind();
@@ -501,7 +508,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return None;
         }
         let element = parse_element(self);
-        list.push(element);
+        self.scratch_push(mark, element);
         loop {
             let kind = self.cur_kind();
             if kind == close
@@ -526,7 +533,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 return Some(trailing_separator);
             }
             let element = parse_element(self);
-            list.push(element);
+            self.scratch_push(mark, element);
         }
     }
 
@@ -542,24 +549,26 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         E: Fn(&mut Self) -> A,
         R: Fn(&mut Self) -> ArenaBox<'a, BindingRestElement<'a>>,
         D: Fn(Span) -> ParserDiagnostic<'a>,
+        A: ScratchElement<'a>,
     {
-        let mut list = ArenaVec::new_in(self);
-        let rest = self.parse_delimited_list_with_rest_into(
-            &mut list,
+        let mark = self.start_scratch();
+        let rest = self.parse_delimited_list_with_rest_into_scratch(
+            &mark,
             close,
             opening_span,
             parse_element,
             parse_rest,
             rest_last_diagnostic,
         );
+        let list = self.finish_scratch(mark);
         (list, rest)
     }
 
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    fn parse_delimited_list_with_rest_into<E, A, R, D>(
+    fn parse_delimited_list_with_rest_into_scratch<E, A, R, D>(
         &mut self,
-        list: &mut ArenaVec<'a, A>,
+        mark: &ScratchMark<A>,
         close: Kind,
         opening_span: Span,
         parse_element: E,
@@ -570,6 +579,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         E: Fn(&mut Self) -> A,
         R: Fn(&mut Self) -> ArenaBox<'a, BindingRestElement<'a>>,
         D: Fn(Span) -> ParserDiagnostic<'a>,
+        A: ScratchElement<'a>,
     {
         let mut rest: Option<ArenaBox<'a, BindingRestElement<'a>>> = None;
         let mut first = true;
@@ -618,7 +628,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 rest.replace(parse_rest(self));
             } else {
                 let element = parse_element(self);
-                list.push(element);
+                self.scratch_push(mark, element);
             }
         }
 

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaBox, ArenaVec};
+use oxc_allocator::ArenaBox;
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 
@@ -83,14 +83,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         decl_parent: VariableDeclarationParent,
         declare: bool,
     ) -> ArenaBox<'a, VariableDeclaration<'a>> {
-        let mut declarations = ArenaVec::new_in(self);
+        let mark = self.start_scratch();
         loop {
             let declaration = self.parse_variable_declarator(decl_parent, kind);
-            declarations.push(declaration);
+            self.scratch_push(&mark, declaration);
             if !self.eat(Kind::Comma) {
                 break;
             }
         }
+        let declarations = self.finish_scratch(mark);
 
         if matches!(decl_parent, VariableDeclarationParent::Statement) {
             self.asi();
@@ -204,7 +205,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         // BindingList[?In, ?Yield, ?Await, ~Pattern]
-        let mut declarations = ArenaVec::new_in(self);
+        let mark = self.start_scratch();
         loop {
             let decl_parent = if matches!(statement_ctx, StatementContext::For) {
                 VariableDeclarationParent::For
@@ -219,11 +220,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 ));
             }
 
-            declarations.push(declaration);
+            self.scratch_push(&mark, declaration);
             if !self.eat(Kind::Comma) {
                 break;
             }
         }
+        let declarations = self.finish_scratch(mark);
 
         VariableDeclaration::boxed(self.end_span(span), kind, declarations, false, self)
     }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1652,12 +1652,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         span: u32,
         first_expression: Expression<'a>,
     ) -> Expression<'a> {
-        let mut expressions = ArenaVec::with_capacity_in(2, self);
-        expressions.push(first_expression);
+        let mark = self.start_scratch();
+        self.scratch_push(&mark, first_expression);
         while self.eat(Kind::Comma) {
             let expression = self.parse_assignment_expression_or_higher();
-            expressions.push(expression);
+            self.scratch_push(&mark, expression);
         }
+        let expressions = self.finish_scratch(mark);
         Expression::new_sequence_expression(self.end_span(span), expressions, self)
     }
 

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -70,16 +70,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         func_kind: FunctionKind,
         opening_span: Span,
     ) -> (ArenaVec<'a, FormalParameter<'a>>, Option<ArenaBox<'a, FormalParameterRest<'a>>>) {
-        let mut list = ArenaVec::new_in(self);
-        let rest = self.parse_formal_parameters_list_into(&mut list, func_kind, opening_span);
+        let mark = self.start_scratch();
+        let rest = self.parse_formal_parameters_list_into_scratch(&mark, func_kind, opening_span);
+        let list = self.finish_scratch(mark);
         (list, rest)
     }
 
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    fn parse_formal_parameters_list_into(
+    fn parse_formal_parameters_list_into_scratch(
         &mut self,
-        list: &mut ArenaVec<'a, FormalParameter<'a>>,
+        mark: &crate::scratch::ScratchMark<FormalParameter<'a>>,
         func_kind: FunctionKind,
         opening_span: Span,
     ) -> Option<ArenaBox<'a, FormalParameterRest<'a>>> {
@@ -165,7 +166,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         param.span,
                     ));
                 }
-                list.push(param);
+                self.scratch_push(mark, param);
             }
         }
 

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -8,6 +8,7 @@ use crate::{
     ParserConfig as Config, ParserImpl, diagnostics,
     lexer::Kind,
     modifiers::{Modifier, ModifierKind, Modifiers},
+    scratch::ScratchMark,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -266,13 +267,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         default_specifier: Option<BindingIdentifier<'a>>,
         import_kind: ImportOrExportKind,
     ) -> ArenaVec<'a, ImportDeclarationSpecifier<'a>> {
-        // If there is a default specifier, create a Vec with the default specifier in it,
-        // otherwise, create an empty Vec.
-        let mut specifiers = if default_specifier.is_some() {
-            ArenaVec::with_capacity_in(1, self)
-        } else {
-            ArenaVec::new_in(self)
-        };
+        let mark = self.start_scratch();
 
         if let Some(default_specifier) = default_specifier {
             let default_span = default_specifier.span;
@@ -281,7 +276,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 default_specifier,
                 self,
             );
-            specifiers.push(specifier);
+            self.scratch_push(&mark, specifier);
             if self.eat(Kind::Comma) {
                 match self.cur_kind() {
                     // import defaultExport, * as name from "module-name";
@@ -292,7 +287,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                             ));
                         }
                         let specifier = self.parse_import_namespace_specifier();
-                        specifiers.push(specifier);
+                        self.scratch_push(&mark, specifier);
                     }
                     // import defaultExport, { export1 [ , [...] ] } from "module-name";
                     Kind::LCurly => {
@@ -301,33 +296,40 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                                 default_span,
                             ));
                         }
-                        self.parse_import_specifiers_into(&mut specifiers, import_kind);
+                        self.parse_import_specifiers_into(&mark, import_kind);
                     }
-                    _ => return self.unexpected(),
+                    _ => {
+                        self.cancel_scratch(mark);
+                        return self.unexpected();
+                    }
                 }
             }
 
             // If the default specifiers name was `type`, and it was not a type import
             // then skip the `from` specifier expect. This is specifically to support an import
             // like: `import type from 'source'`
-            if self.is_ts
-                && import_kind == ImportOrExportKind::Value
-                && specifiers.len() == 1
-                && specifiers[0].name() == "type"
-            {
-                return specifiers;
+            let is_import_type_as_default = {
+                let is_ts = self.is_ts;
+                let specifiers = self.scratch_slice(&mark);
+                is_ts
+                    && import_kind == ImportOrExportKind::Value
+                    && specifiers.len() == 1
+                    && specifiers[0].name() == "type"
+            };
+            if is_import_type_as_default {
+                return self.finish_scratch(mark);
             }
         } else if self.at(Kind::Star) {
             // import * as name from "module-name";
             let specifier = self.parse_import_namespace_specifier();
-            specifiers.push(specifier);
+            self.scratch_push(&mark, specifier);
         } else if self.at(Kind::LCurly) {
             // import { export1 , export2 as alias2 , [...] } from "module-name";
-            self.parse_import_specifiers_into(&mut specifiers, import_kind);
+            self.parse_import_specifiers_into(&mark, import_kind);
         }
 
         self.expect(Kind::From);
-        specifiers
+        self.finish_scratch(mark)
     }
 
     // import * as name from "module-name"
@@ -343,14 +345,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     // import { export1 , export2 as alias2 , [...] } from "module-name";
     fn parse_import_specifiers_into(
         &mut self,
-        specifiers: &mut ArenaVec<'a, ImportDeclarationSpecifier<'a>>,
+        mark: &ScratchMark<ImportDeclarationSpecifier<'a>>,
         import_kind: ImportOrExportKind,
     ) {
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
         self.context_remove(self.ctx, |p| {
-            let _ = p.parse_delimited_list_into(
-                specifiers,
+            let _ = p.parse_delimited_list_into_scratch(
+                mark,
                 Kind::RCurly,
                 Kind::Comma,
                 opening_span,

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -34,8 +34,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         in_ts_namespace_body: bool,
     ) -> (ArenaVec<'a, Directive<'a>>, ArenaVec<'a, Statement<'a>>) {
-        let mut directives = ArenaVec::new_in(self);
-        let mut statements = ArenaVec::new_in(self);
+        // Statements are the outer list so directives can be completed before the first
+        // statement is appended, preserving the scratch stack's LIFO discipline.
+        let statements_mark = self.start_scratch::<Statement<'a>>();
+        let mut directives_mark = Some(self.start_scratch::<Directive<'a>>());
+        let mut directives = None;
+        let mut statements_len = 0;
 
         let is_top_level = self.ctx.has_top_level();
         let stmt_ctx = StatementContext::StatementList;
@@ -62,7 +66,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     None
                 } else {
                     self.state.encountered_await_identifier = false;
-                    Some((statements.len(), self.checkpoint()))
+                    Some((statements_len, self.checkpoint()))
                 }
             } else {
                 None
@@ -95,11 +99,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         let string = string.unbox();
                         let src = &self.source_text
                             [string.span.start as usize + 1..string.span.end as usize - 1];
-                        directives.push(Directive::new(span, string, Str::from(src), self));
+                        let directive = Directive::new(span, string, Str::from(src), self);
+                        self.scratch_push(directives_mark.as_ref().unwrap(), directive);
                         continue;
                     }
                     stmt => {
                         expecting_directives = false;
+                        directives = Some(self.finish_scratch(directives_mark.take().unwrap()));
                         stmt
                     }
                 }
@@ -119,9 +125,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::statement_in_ambient_context(stmt.span()));
                 reported_ambient_statement = true;
             }
-            statements.push(stmt);
+            self.scratch_push(&statements_mark, stmt);
+            statements_len += 1;
         }
 
+        let directives =
+            directives.unwrap_or_else(|| self.finish_scratch(directives_mark.take().unwrap()));
+        let statements = if is_top_level {
+            self.finish_scratch_with_capacity_headroom(statements_mark)
+        } else {
+            self.finish_scratch(statements_mark)
+        };
         (directives, statements)
     }
 
@@ -738,7 +752,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         };
         self.expect(Kind::Colon);
-        let mut consequent = ArenaVec::new_in(self);
+        let mark = self.start_scratch();
         loop {
             let kind = self.cur_kind();
             if matches!(
@@ -752,14 +766,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             if let Statement::VariableDeclaration(var_decl) = &stmt
                 && var_decl.kind.is_using()
             {
-                // It is a Syntax Error if UsingDeclaration is contained directly within the StatementList of either a CaseClause or DefaultClause.
-                // It is a Syntax Error if AwaitUsingDeclaration is contained directly within the StatementList of either a CaseClause or DefaultClause.
+                // `using` declarations cannot appear directly in a switch clause.
                 self.error(diagnostics::using_declaration_not_allowed_in_switch_bare_case(
                     stmt.span(),
                 ));
             }
-            consequent.push(stmt);
+            self.scratch_push(&mark, stmt);
         }
+        let consequent = self.finish_scratch(mark);
         SwitchCase::new(self.end_span(span), test, consequent, self)
     }
 

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -243,16 +243,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         in_jsx_child: bool,
     ) -> (ArenaVec<'a, JSXChild<'a>>, JSXClosing<'a>) {
-        let mut children = ArenaVec::new_in(self);
-        let closing = self.parse_jsx_children_and_closing_into(&mut children, in_jsx_child);
+        let mark = self.start_scratch();
+        let closing = self.parse_jsx_children_and_closing_into_scratch(&mark, in_jsx_child);
+        let children = self.finish_scratch(mark);
         (children, closing)
     }
 
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    fn parse_jsx_children_and_closing_into(
+    fn parse_jsx_children_and_closing_into_scratch(
         &mut self,
-        children: &mut ArenaVec<'a, JSXChild<'a>>,
+        mark: &crate::scratch::ScratchMark<JSXChild<'a>>,
         in_jsx_child: bool,
     ) -> JSXClosing<'a> {
         loop {
@@ -271,14 +272,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     // <> open nested fragment
                     if kind == Kind::RAngle {
                         let child = JSXChild::Fragment(self.parse_jsx_fragment(span, true));
-                        children.push(child);
+                        self.scratch_push(mark, child);
                         continue;
                     }
 
                     // <ident open nested element
                     if kind == Kind::Ident || kind.is_any_keyword() {
                         let child = JSXChild::Element(self.parse_jsx_element(span, true));
-                        children.push(child);
+                        self.scratch_push(mark, child);
                         continue;
                     }
 
@@ -298,7 +299,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     // {...expr}
                     if self.eat(Kind::Dot3) {
                         let child = JSXChild::Spread(self.parse_jsx_spread_child(span_start));
-                        children.push(child);
+                        self.scratch_push(mark, child);
                         continue;
                     }
                     // {expr}
@@ -306,12 +307,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         JSXChild::ExpressionContainer(self.parse_jsx_expression_container(
                             span_start, /* in_jsx_child */ true,
                         ));
-                    children.push(child);
+                    self.scratch_push(mark, child);
                 }
                 // text
                 Kind::JSXText => {
                     let child = JSXChild::Text(self.parse_jsx_text());
-                    children.push(child);
+                    self.scratch_push(mark, child);
                 }
                 _ => {
                     // Unexpected token in JSX children
@@ -405,7 +406,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   `JSXSpreadAttribute` `JSXAttributes_opt`
     ///   `JSXAttribute` `JSXAttributes_opt`
     fn parse_jsx_attributes(&mut self) -> ArenaVec<'a, JSXAttributeItem<'a>> {
-        let mut attributes = ArenaVec::new_in(self);
+        let mark = self.start_scratch();
         loop {
             let kind = self.cur_kind();
             if matches!(kind, Kind::LAngle | Kind::RAngle | Kind::Slash)
@@ -419,9 +420,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
                 _ => JSXAttributeItem::Attribute(self.parse_jsx_attribute()),
             };
-            attributes.push(attribute);
+            self.scratch_push(&mark, attribute);
         }
-        attributes
+        self.finish_scratch(mark)
     }
 
     /// `JSXAttribute` :

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -72,6 +72,7 @@ mod cursor;
 mod error_handler;
 mod modifiers;
 mod module_record;
+mod scratch;
 mod state;
 
 mod js;
@@ -640,6 +641,9 @@ struct ParserImpl<'a, C: ParserConfig> {
     /// Ast builder for creating AST nodes
     ast: AstBuilder<'a>,
 
+    /// Reusable heap storage for AST lists under construction.
+    scratch: scratch::ParserScratch<'a>,
+
     /// Module Record Builder
     module_record_builder: ModuleRecordBuilder<'a>,
 
@@ -675,6 +679,7 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
             state: ParserState::new(),
             ctx: Self::default_context(source_type, options),
             ast: AstBuilder::new(allocator),
+            scratch: scratch::ParserScratch::default(),
             module_record_builder: ModuleRecordBuilder::new(allocator, source_type),
             is_ts: source_type.is_typescript(),
         }
@@ -687,6 +692,7 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     #[inline]
     pub fn parse(mut self) -> ParserReturn<'a> {
         let mut program = self.parse_program();
+        self.scratch.debug_assert_empty();
         let mut panicked = false;
 
         if let Some(fatal_error) = self.fatal_error.take() {
@@ -774,6 +780,7 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
         // initialize cur_token and prev_token by moving onto the first token
         self.bump_any();
         let expr = self.parse_expr();
+        self.scratch.debug_assert_empty();
         if let Some(FatalError { error, .. }) = self.fatal_error.take() {
             return Err(error.into_diagnostic().into());
         }

--- a/crates/oxc_parser/src/scratch.rs
+++ b/crates/oxc_parser/src/scratch.rs
@@ -1,0 +1,352 @@
+//! Reusable parser-owned storage for AST lists under construction.
+
+use std::{marker::PhantomData, mem::needs_drop, ptr};
+
+use oxc_allocator::{Allocator, ArenaVec, GetAllocator};
+use oxc_ast::ast::*;
+
+use crate::{ParserConfig, ParserImpl};
+
+pub struct ScratchStack<T> {
+    items: Vec<T>,
+}
+
+impl<T> Default for ScratchStack<T> {
+    fn default() -> Self {
+        Self { items: Vec::new() }
+    }
+}
+
+/// Position of an active list in parser scratch storage.
+///
+/// This does not borrow [`ParserScratch`], so parsing can recurse while a list is active.
+pub struct ScratchMark<T> {
+    start: usize,
+    #[cfg(debug_assertions)]
+    depth: usize,
+    marker: PhantomData<fn() -> T>,
+}
+
+pub trait ScratchElement<'a>: Sized {
+    /// Preserve the old arena vector's geometric spare capacity when downstream passes grow it.
+    const PRESERVE_CAPACITY_HEADROOM: bool = false;
+
+    const ASSERT_NO_DROP: () = assert!(!needs_drop::<Self>());
+
+    fn stack<'s>(scratch: &'s mut ParserScratch<'a>) -> &'s mut ScratchStack<Self>;
+}
+
+macro_rules! define_parser_scratch {
+    ($($(#[$meta:meta])* $field:ident: $ty:ty $(=> $preserve_headroom:expr)?),+ $(,)?) => {
+        #[derive(Default)]
+        pub struct ParserScratch<'a> {
+            #[cfg(debug_assertions)]
+            active_depth: usize,
+            $($(#[$meta])* $field: ScratchStack<$ty>,)+
+        }
+
+        $(
+            $(#[$meta])*
+            impl<'a> ScratchElement<'a> for $ty {
+                $(const PRESERVE_CAPACITY_HEADROOM: bool = $preserve_headroom;)?
+
+                #[inline]
+                fn stack<'s>(
+                    scratch: &'s mut ParserScratch<'a>,
+                ) -> &'s mut ScratchStack<Self> {
+                    &mut scratch.$field
+                }
+            }
+        )+
+
+        impl ParserScratch<'_> {
+            #[inline]
+            pub(crate) fn debug_assert_empty(&self) {
+                #[cfg(debug_assertions)]
+                {
+                    debug_assert_eq!(self.active_depth, 0, "scratch list was not finished");
+                    $($(#[$meta])*
+                        debug_assert!(
+                            self.$field.items.is_empty(),
+                            "scratch buffer `{}` was not rewound",
+                            stringify!($field),
+                        );
+                    )+
+                }
+            }
+        }
+    };
+}
+
+define_parser_scratch! {
+    statements: Statement<'a>,
+    switch_cases: SwitchCase<'a>,
+    // Transformers insert synthesized elements into parsed class bodies.
+    class_elements: ClassElement<'a> => true,
+    expressions: Expression<'a>,
+    array_expression_elements: ArrayExpressionElement<'a>,
+    object_properties: ObjectPropertyKind<'a>,
+    arguments: Argument<'a>,
+    binding_properties: BindingProperty<'a>,
+    array_binding_elements: Option<BindingPattern<'a>>,
+    ts_enum_members: TSEnumMember<'a>,
+    ts_signatures: TSSignature<'a>,
+    ts_type_parameters: TSTypeParameter<'a>,
+    ts_types: TSType<'a>,
+    ts_tuple_elements: TSTupleElement<'a>,
+    ts_index_signature_names: TSIndexSignatureName<'a>,
+    import_attributes: ImportAttribute<'a>,
+    export_specifiers: ExportSpecifier<'a>,
+    directives: Directive<'a>,
+    variable_declarators: VariableDeclarator<'a>,
+    formal_parameters: FormalParameter<'a>,
+    jsx_children: JSXChild<'a>,
+    jsx_attributes: JSXAttributeItem<'a>,
+    ts_interface_heritage: TSInterfaceHeritage<'a>,
+    import_declaration_specifiers: ImportDeclarationSpecifier<'a>,
+    #[cfg(test)]
+    test_values: u64,
+    #[cfg(test)]
+    test_other_values: i64,
+}
+
+impl<'a> ParserScratch<'a> {
+    #[inline]
+    fn begin<T: ScratchElement<'a>>(&mut self) -> ScratchMark<T> {
+        let () = T::ASSERT_NO_DROP;
+        let start = T::stack(self).items.len();
+
+        #[cfg(debug_assertions)]
+        {
+            self.active_depth += 1;
+            ScratchMark { start, depth: self.active_depth, marker: PhantomData }
+        }
+
+        #[cfg(not(debug_assertions))]
+        ScratchMark { start, marker: PhantomData }
+    }
+
+    #[inline]
+    fn push<T: ScratchElement<'a>>(&mut self, mark: &ScratchMark<T>, value: T) {
+        self.assert_active(mark);
+        T::stack(self).items.push(value);
+    }
+
+    #[inline]
+    fn slice<T: ScratchElement<'a>>(&mut self, mark: &ScratchMark<T>) -> &[T] {
+        self.assert_active(mark);
+        &T::stack(self).items[mark.start..]
+    }
+
+    #[inline]
+    fn finish<T: ScratchElement<'a>>(
+        &mut self,
+        mark: ScratchMark<T>,
+        allocator: &'a Allocator,
+    ) -> ArenaVec<'a, T> {
+        self.finish_with_capacity(mark, allocator, T::PRESERVE_CAPACITY_HEADROOM)
+    }
+
+    #[inline]
+    #[expect(clippy::needless_pass_by_value, reason = "a mark can only be finished once")]
+    fn finish_with_capacity<T: ScratchElement<'a>>(
+        &mut self,
+        mark: ScratchMark<T>,
+        allocator: &'a Allocator,
+        preserve_capacity_headroom: bool,
+    ) -> ArenaVec<'a, T> {
+        self.assert_active(&mark);
+        let items = &mut T::stack(self).items;
+        assert!(mark.start <= items.len(), "scratch mark is outside its typed buffer");
+        let len = items.len() - mark.start;
+        let capacity =
+            if preserve_capacity_headroom && len > 0 { len.next_power_of_two() } else { len };
+        let mut list = ArenaVec::with_capacity_in(capacity, &allocator);
+
+        // Safe element-wise moves regress small-file parsing, so move the initialized tail in bulk.
+        // SAFETY: The typed scratch tail contains `len` initialized `T`s, and the arena vector has
+        // capacity for all of them. `T` cannot require drop, the allocations cannot overlap, and
+        // the scratch length is rewound immediately after the bulk move.
+        unsafe {
+            ptr::copy_nonoverlapping(items.as_ptr().add(mark.start), list.as_mut_ptr(), len);
+            list.set_len(len);
+            items.set_len(mark.start);
+        }
+
+        self.finish_mark(&mark);
+        list
+    }
+
+    #[inline]
+    #[expect(clippy::needless_pass_by_value, reason = "a mark can only be cancelled once")]
+    fn cancel<T: ScratchElement<'a>>(&mut self, mark: ScratchMark<T>) {
+        self.assert_active(&mark);
+        T::stack(self).items.truncate(mark.start);
+        self.finish_mark(&mark);
+    }
+
+    #[inline]
+    fn assert_active<T>(&self, mark: &ScratchMark<T>) {
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            mark.depth, self.active_depth,
+            "scratch lists must be accessed in LIFO order"
+        );
+
+        #[cfg(not(debug_assertions))]
+        let _ = mark;
+    }
+
+    #[inline]
+    fn finish_mark<T>(&mut self, mark: &ScratchMark<T>) {
+        #[cfg(debug_assertions)]
+        {
+            debug_assert_eq!(
+                mark.depth, self.active_depth,
+                "scratch lists must be finished in LIFO order"
+            );
+            self.active_depth -= 1;
+        }
+
+        #[cfg(not(debug_assertions))]
+        let _ = mark;
+    }
+}
+
+impl<'a, C: ParserConfig> ParserImpl<'a, C> {
+    #[inline]
+    pub(crate) fn start_scratch<T: ScratchElement<'a>>(&mut self) -> ScratchMark<T> {
+        self.scratch.begin()
+    }
+
+    #[inline]
+    pub(crate) fn scratch_push<T: ScratchElement<'a>>(&mut self, mark: &ScratchMark<T>, value: T) {
+        self.scratch.push(mark, value);
+    }
+
+    #[inline]
+    pub(crate) fn scratch_slice<T: ScratchElement<'a>>(&mut self, mark: &ScratchMark<T>) -> &[T] {
+        self.scratch.slice(mark)
+    }
+
+    #[inline]
+    pub(crate) fn finish_scratch<T: ScratchElement<'a>>(
+        &mut self,
+        mark: ScratchMark<T>,
+    ) -> ArenaVec<'a, T> {
+        self.scratch.finish(mark, self.ast.allocator())
+    }
+
+    #[inline]
+    pub(crate) fn finish_scratch_with_capacity_headroom<T: ScratchElement<'a>>(
+        &mut self,
+        mark: ScratchMark<T>,
+    ) -> ArenaVec<'a, T> {
+        self.scratch.finish_with_capacity(mark, self.ast.allocator(), true)
+    }
+
+    #[inline]
+    pub(crate) fn cancel_scratch<T: ScratchElement<'a>>(&mut self, mark: ScratchMark<T>) {
+        self.scratch.cancel(mark);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use oxc_allocator::Allocator;
+
+    use super::ParserScratch;
+
+    #[test]
+    fn collects_exact_arena_vector_and_reuses_storage() {
+        let allocator = Allocator::default();
+        let mut scratch = ParserScratch::default();
+
+        let mark = scratch.begin::<u64>();
+        for value in 0..128 {
+            scratch.push(&mark, value);
+        }
+        let capacity = scratch.test_values.items.capacity();
+        let values = scratch.finish(mark, &allocator);
+
+        assert_eq!(values.as_slice(), (0..128).collect::<Vec<_>>());
+        assert_eq!(values.capacity(), values.len());
+        assert!(scratch.test_values.items.is_empty());
+        assert_eq!(scratch.test_values.items.capacity(), capacity);
+    }
+
+    #[test]
+    fn preserves_requested_capacity_headroom() {
+        let allocator = Allocator::default();
+        let mut scratch = ParserScratch::default();
+
+        let mark = scratch.begin::<u64>();
+        scratch.push(&mark, 1);
+        scratch.push(&mark, 2);
+        scratch.push(&mark, 3);
+        let scratch_capacity = scratch.test_values.items.capacity();
+        let values = scratch.finish_with_capacity(mark, &allocator, true);
+
+        assert_eq!(values.as_slice(), &[1, 2, 3]);
+        assert_eq!(values.capacity(), 4);
+        assert!(scratch.test_values.items.is_empty());
+        assert_eq!(scratch.test_values.items.capacity(), scratch_capacity);
+    }
+
+    #[test]
+    fn supports_nested_lists() {
+        let allocator = Allocator::default();
+        let mut scratch = ParserScratch::default();
+
+        let outer = scratch.begin::<u64>();
+        scratch.push(&outer, 1);
+        let inner = scratch.begin::<u64>();
+        scratch.push(&inner, 2);
+        let inner_values = scratch.finish(inner, &allocator);
+        scratch.push(&outer, 3);
+        let outer_values = scratch.finish(outer, &allocator);
+
+        assert_eq!(inner_values.as_slice(), &[2]);
+        assert_eq!(outer_values.as_slice(), &[1, 3]);
+    }
+
+    #[test]
+    fn supports_nested_lists_with_different_types() {
+        let allocator = Allocator::default();
+        let mut scratch = ParserScratch::default();
+
+        let outer = scratch.begin::<u64>();
+        scratch.push(&outer, 1);
+        let inner = scratch.begin::<i64>();
+        scratch.push(&inner, -2);
+        assert_eq!(scratch.finish(inner, &allocator).as_slice(), &[-2]);
+        scratch.push(&outer, 3);
+        assert_eq!(scratch.finish(outer, &allocator).as_slice(), &[1, 3]);
+        scratch.debug_assert_empty();
+    }
+
+    #[test]
+    fn cancel_discards_only_the_active_list() {
+        let allocator = Allocator::default();
+        let mut scratch = ParserScratch::default();
+
+        let outer = scratch.begin::<u64>();
+        scratch.push(&outer, 1);
+        let inner = scratch.begin::<u64>();
+        scratch.push(&inner, 2);
+        scratch.cancel(inner);
+        assert_eq!(scratch.slice(&outer), &[1]);
+        assert_eq!(scratch.finish(outer, &allocator).as_slice(), &[1]);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "scratch lists must be accessed in LIFO order")]
+    fn rejects_non_lifo_access() {
+        let mut scratch = ParserScratch::default();
+
+        let outer = scratch.begin::<u64>();
+        let _inner = scratch.begin::<u64>();
+        scratch.push(&outer, 1);
+    }
+}

--- a/crates/oxc_parser/src/scratch.rs
+++ b/crates/oxc_parser/src/scratch.rs
@@ -1,6 +1,6 @@
 //! Reusable parser-owned storage for AST lists under construction.
 
-use std::{marker::PhantomData, mem::needs_drop, ptr};
+use std::marker::PhantomData;
 
 use oxc_allocator::{Allocator, ArenaVec, GetAllocator};
 use oxc_ast::ast::*;
@@ -30,8 +30,6 @@ pub struct ScratchMark<T> {
 pub trait ScratchElement<'a>: Sized {
     /// Preserve the old arena vector's geometric spare capacity when downstream passes grow it.
     const PRESERVE_CAPACITY_HEADROOM: bool = false;
-
-    const ASSERT_NO_DROP: () = assert!(!needs_drop::<Self>());
 
     fn stack<'s>(scratch: &'s mut ParserScratch<'a>) -> &'s mut ScratchStack<Self>;
 }
@@ -113,7 +111,6 @@ define_parser_scratch! {
 impl<'a> ParserScratch<'a> {
     #[inline]
     fn begin<T: ScratchElement<'a>>(&mut self) -> ScratchMark<T> {
-        let () = T::ASSERT_NO_DROP;
         let start = T::stack(self).items.len();
 
         #[cfg(debug_assertions)]
@@ -162,16 +159,7 @@ impl<'a> ParserScratch<'a> {
         let capacity =
             if preserve_capacity_headroom && len > 0 { len.next_power_of_two() } else { len };
         let mut list = ArenaVec::with_capacity_in(capacity, &allocator);
-
-        // Safe element-wise moves regress small-file parsing, so move the initialized tail in bulk.
-        // SAFETY: The typed scratch tail contains `len` initialized `T`s, and the arena vector has
-        // capacity for all of them. `T` cannot require drop, the allocations cannot overlap, and
-        // the scratch length is rewound immediately after the bulk move.
-        unsafe {
-            ptr::copy_nonoverlapping(items.as_ptr().add(mark.start), list.as_mut_ptr(), len);
-            list.set_len(len);
-            items.set_len(mark.start);
-        }
+        list.extend(items.drain(mark.start..));
 
         self.finish_mark(&mark);
         list

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -271,7 +271,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_ts_interface_extends_clause(&mut self) -> ArenaVec<'a, TSInterfaceHeritage<'a>> {
         self.bump_any(); // bump `extends`
 
-        let mut extends = ArenaVec::with_capacity_in(1, self);
+        let mark = self.start_scratch();
         loop {
             let span = self.start_span();
             let mut extend = self.parse_lhs_expression_or_higher();
@@ -289,14 +289,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
             let heritage =
                 TSInterfaceHeritage::new(self.end_span(span), extend, type_argument, self);
-            extends.push(heritage);
+            self.scratch_push(&mark, heritage);
 
             if !self.eat(Kind::Comma) {
                 break;
             }
         }
 
-        extends
+        self.finish_scratch(mark)
     }
 
     fn parse_ts_interface_body(&mut self) -> ArenaBox<'a, TSInterfaceBody<'a>> {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -277,13 +277,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         /* hasLeadingOperator && parseFunctionOrConstructorTypeToError(isUnionType) ||*/
         let mut ty = parse_constituent_type(self);
         if self.at(kind) || has_leading_operator {
-            let mut types = ArenaVec::from_value_in(ty, self);
+            let mark = self.start_scratch();
+            self.scratch_push(&mark, ty);
             while self.eat(kind) {
                 let ty =
                     /*parseFunctionOrConstructorTypeToError(isUnionType) || */
                     parse_constituent_type(self);
-                types.push(ty);
+                self.scratch_push(&mark, ty);
             }
+            let types = self.finish_scratch(mark);
             let span = self.end_span(span);
             ty = match kind {
                 Kind::Pipe => TSType::new_ts_union_type(span, types, self),
@@ -943,19 +945,28 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         let opening_span = self.cur_token().span();
         self.expect(Kind::LAngle);
-        let (params, _) =
-            self.parse_delimited_list(Kind::RAngle, Kind::Comma, opening_span, Self::parse_ts_type);
+        let params_mark = self.start_scratch::<TSType<'a>>();
+        self.parse_delimited_list_into_scratch(
+            &params_mark,
+            Kind::RAngle,
+            Kind::Comma,
+            opening_span,
+            Self::parse_ts_type,
+        );
         // `a < b> = c` is valid but `a < b >= c` is BinaryExpression
         if matches!(self.re_lex_right_angle(), Kind::GtEq) {
+            self.cancel_scratch(params_mark);
             self.rewind(checkpoint);
             return None;
         }
         self.re_lex_ts_r_angle();
         self.expect(Kind::RAngle);
         if self.fatal_error.is_some() || !self.can_follow_type_arguments_in_expr() {
+            self.cancel_scratch(params_mark);
             self.rewind(checkpoint);
             return None;
         }
+        let params = self.finish_scratch(params_mark);
         let span = self.end_span(span);
         if params.is_empty() {
             self.error(diagnostics::ts_empty_type_argument_list(span));
@@ -1246,7 +1257,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.start_span();
         self.expect(Kind::LCurly);
 
-        let mut properties = ArenaVec::new_in(self);
+        let mark = self.start_scratch();
         let mut first = true;
         while !self.at(Kind::RCurly) && !self.at(Kind::Eof) {
             if first {
@@ -1291,7 +1302,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     true, /* computed */
                     self,
                 );
-                properties.push(property);
+                self.scratch_push(&mark, property);
                 continue;
             }
 
@@ -1317,10 +1328,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 false,
                 self,
             );
-            properties.push(property);
+            self.scratch_push(&mark, property);
         }
 
         self.expect(Kind::RCurly);
+        let properties = self.finish_scratch(mark);
         ObjectExpression::boxed(self.end_span(span), properties, self)
     }
 

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -7,7 +7,7 @@ checker.ts:
   sys peak growth: 2990058 # 2.99 MB
   arena allocs: 1081815
   arena reallocs: 118690
-  arena size: 138513064 # 138.51 MB
+  arena size: 137363096 # 137.36 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -18,7 +18,7 @@ App.tsx:
   sys peak growth: 443550 # 443.55 kB
   arena allocs: 212668
   arena reallocs: 25343
-  arena size: 29608600 # 29.61 MB
+  arena size: 29459376 # 29.46 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -29,7 +29,7 @@ RadixUIAdoptionSection.jsx:
   sys peak growth: 2856 # 2.86 kB
   arena allocs: 1155
   arena reallocs: 157
-  arena size: 210048 # 210.05 kB
+  arena size: 207808 # 207.81 kB
 
 pdf.mjs:
   file size: 567296 # 567.30 kB
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 1164624 # 1.16 MB
   arena allocs: 437639
   arena reallocs: 43489
-  arena size: 44872224 # 44.87 MB
+  arena size: 44466152 # 44.47 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 13841112 # 13.84 MB
   arena allocs: 2586207
   arena reallocs: 302459
-  arena size: 525725120 # 525.73 MB
+  arena size: 522529648 # 522.53 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -62,7 +62,7 @@ binder.ts:
   sys peak growth: 195661 # 195.66 kB
   arena allocs: 64083
   arena reallocs: 6932
-  arena size: 8574752 # 8.57 MB
+  arena size: 8472896 # 8.47 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -73,5 +73,5 @@ kitchen-sink.tsx:
   sys peak growth: 1499988 # 1.50 MB
   arena allocs: 569903
   arena reallocs: 60147
-  arena size: 57887072 # 57.89 MB
+  arena size: 57368392 # 57.37 MB
 

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 19934725 # 19.93 MB
   arena allocs: 371546
   arena reallocs: 76276
-  arena size: 45907176 # 45.91 MB
+  arena size: 45910712 # 45.91 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -7,7 +7,7 @@ checker.ts:
   sys peak growth: 10203896 # 10.20 MB
   arena allocs: 152891
   arena reallocs: 28386
-  arena size: 19331576 # 19.33 MB
+  arena size: 18180712 # 18.18 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -18,7 +18,7 @@ App.tsx:
   sys peak growth: 1620605 # 1.62 MB
   arena allocs: 17035
   arena reallocs: 2714
-  arena size: 2916824 # 2.92 MB
+  arena size: 2767600 # 2.77 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -29,7 +29,7 @@ RadixUIAdoptionSection.jsx:
   sys peak growth: 11628 # 11.63 kB
   arena allocs: 33
   arena reallocs: 6
-  arena size: 35768 # 35.77 kB
+  arena size: 33528 # 33.53 kB
 
 pdf.mjs:
   file size: 567296 # 567.30 kB
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 3707391 # 3.71 MB
   arena allocs: 47436
   arena reallocs: 7715
-  arena size: 6374320 # 6.37 MB
+  arena size: 5967944 # 5.97 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 19934725 # 19.93 MB
   arena allocs: 371546
   arena reallocs: 76276
-  arena size: 49106184 # 49.11 MB
+  arena size: 45907176 # 45.91 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -62,7 +62,7 @@ binder.ts:
   sys peak growth: 658042 # 658.04 kB
   arena allocs: 7078
   arena reallocs: 841
-  arena size: 1169840 # 1.17 MB
+  arena size: 1068000 # 1.07 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -73,5 +73,4 @@ kitchen-sink.tsx:
   sys peak growth: 3737991 # 3.74 MB
   arena allocs: 71838
   arena reallocs: 12252
-  arena size: 9559192 # 9.56 MB
-
+  arena size: 9040896 # 9.04 MB

--- a/tasks/track_memory_allocations/allocs_parser.yaml
+++ b/tasks/track_memory_allocations/allocs_parser.yaml
@@ -1,77 +1,77 @@
 checker.ts:
   file size: 2922154 # 2.92 MB
-  sys allocs: 23
-  sys reallocs: 10
-  sys deallocs: 23
-  sys alloc bytes: 4820 # 4.82 kB
-  sys peak growth: 2432 # 2.43 kB
-  arena allocs: 264366
-  arena reallocs: 22858
-  arena size: 12985152 # 12.99 MB
+  sys allocs: 41
+  sys reallocs: 60
+  sys deallocs: 41
+  sys alloc bytes: 124788 # 124.79 kB
+  sys peak growth: 121360 # 121.36 kB
+  arena allocs: 264054
+  arena reallocs: 135
+  arena size: 11835184 # 11.84 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
-  sys allocs: 23
-  sys reallocs: 13
-  sys deallocs: 23
-  sys alloc bytes: 38116 # 38.12 kB
-  sys peak growth: 26404 # 26.40 kB
-  arena allocs: 44464
-  arena reallocs: 3537
-  arena size: 2244408 # 2.24 MB
+  sys allocs: 42
+  sys reallocs: 52
+  sys deallocs: 42
+  sys alloc bytes: 56356 # 56.36 kB
+  sys peak growth: 43684 # 43.68 kB
+  arena allocs: 44444
+  arena reallocs: 81
+  arena size: 2095184 # 2.10 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
-  sys allocs: 1
-  sys reallocs: 0
-  sys deallocs: 1
+  sys allocs: 8
+  sys reallocs: 5
+  sys deallocs: 8
   sys alloc bytes: 108 # 108 B
   sys peak growth: 108 # 108 B
   arena allocs: 367
-  arena reallocs: 66
-  arena size: 21200 # 21.20 kB
+  arena reallocs: 4
+  arena size: 18960 # 18.96 kB
 
 pdf.mjs:
   file size: 567296 # 567.30 kB
-  sys allocs: 67
-  sys reallocs: 67
-  sys deallocs: 67
-  sys alloc bytes: 24020 # 24.02 kB
-  sys peak growth: 12140 # 12.14 kB
+  sys allocs: 79
+  sys reallocs: 103
+  sys deallocs: 79
+  sys alloc bytes: 47060 # 47.06 kB
+  sys peak growth: 26348 # 26.35 kB
   arena allocs: 90583
-  arena reallocs: 8136
-  arena size: 4559872 # 4.56 MB
+  arena reallocs: 218
+  arena size: 4153800 # 4.15 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
-  sys allocs: 190
-  sys reallocs: 221
-  sys deallocs: 190
-  sys alloc bytes: 109952 # 109.95 kB
-  sys peak growth: 48264 # 48.26 kB
+  sys allocs: 200
+  sys reallocs: 261
+  sys deallocs: 200
+  sys alloc bytes: 206080 # 206.08 kB
+  sys peak growth: 143752 # 143.75 kB
   arena allocs: 528577
-  arena reallocs: 55355
-  arena size: 29421920 # 29.42 MB
+  arena reallocs: 1285
+  arena size: 26226448 # 26.23 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
-  sys allocs: 1
-  sys reallocs: 0
-  sys deallocs: 1
-  sys alloc bytes: 3016 # 3.02 kB
-  sys peak growth: 251 # 251 B
-  arena allocs: 16620
-  arena reallocs: 1476
-  arena size: 917416 # 917.42 kB
+  sys allocs: 15
+  sys reallocs: 25
+  sys deallocs: 15
+  sys alloc bytes: 22252 # 22.25 kB
+  sys peak growth: 22252 # 22.25 kB
+  arena allocs: 16608
+  arena reallocs: 24
+  arena size: 815560 # 815.56 kB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
-  sys allocs: 190
-  sys reallocs: 160
-  sys deallocs: 190
-  sys alloc bytes: 51381 # 51.38 kB
-  sys peak growth: 14644 # 14.64 kB
-  arena allocs: 138059
-  arena reallocs: 11898
-  arena size: 6495776 # 6.50 MB
+  sys allocs: 213
+  sys reallocs: 212
+  sys deallocs: 213
+  sys alloc bytes: 136149 # 136.15 kB
+  sys peak growth: 95632 # 95.63 kB
+  arena allocs: 137773
+  arena reallocs: 658
+  arena size: 5977416 # 5.98 MB
 

--- a/tasks/track_memory_allocations/allocs_semantic.yaml
+++ b/tasks/track_memory_allocations/allocs_semantic.yaml
@@ -7,7 +7,7 @@ checker.ts:
   sys peak growth: 3858362 # 3.86 MB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 12985152 # 12.99 MB
+  arena size: 11835184 # 11.84 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -18,7 +18,7 @@ App.tsx:
   sys peak growth: 360848 # 360.85 kB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 2244408 # 2.24 MB
+  arena size: 2095184 # 2.10 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -29,7 +29,7 @@ RadixUIAdoptionSection.jsx:
   sys peak growth: 2748 # 2.75 kB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 21200 # 21.20 kB
+  arena size: 18960 # 18.96 kB
 
 pdf.mjs:
   file size: 567296 # 567.30 kB
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 832762 # 832.76 kB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 4559872 # 4.56 MB
+  arena size: 4153800 # 4.15 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 5441278 # 5.44 MB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 29421920 # 29.42 MB
+  arena size: 26226448 # 26.23 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -62,7 +62,7 @@ binder.ts:
   sys peak growth: 246886 # 246.89 kB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 917416 # 917.42 kB
+  arena size: 815560 # 815.56 kB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -73,5 +73,5 @@ kitchen-sink.tsx:
   sys peak growth: 1101954 # 1.10 MB
   arena allocs: 0
   arena reallocs: 0
-  arena size: 6495776 # 6.50 MB
+  arena size: 5977416 # 5.98 MB
 

--- a/tasks/track_memory_allocations/allocs_transformer.yaml
+++ b/tasks/track_memory_allocations/allocs_transformer.yaml
@@ -7,7 +7,7 @@ checker.ts:
   sys peak growth: 2243 # 2.24 kB
   arena allocs: 1959
   arena reallocs: 5
-  arena size: 13073848 # 13.07 MB
+  arena size: 11923880 # 11.92 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -18,7 +18,7 @@ App.tsx:
   sys peak growth: 2584 # 2.58 kB
   arena allocs: 618
   arena reallocs: 17
-  arena size: 2277696 # 2.28 MB
+  arena size: 2128472 # 2.13 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -29,7 +29,7 @@ RadixUIAdoptionSection.jsx:
   sys peak growth: 2144 # 2.14 kB
   arena allocs: 258
   arena reallocs: 13
-  arena size: 34616 # 34.62 kB
+  arena size: 32376 # 32.38 kB
 
 pdf.mjs:
   file size: 567296 # 567.30 kB
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 1610 # 1.61 kB
   arena allocs: 2
   arena reallocs: 0
-  arena size: 4559896 # 4.56 MB
+  arena size: 4153824 # 4.15 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 1611 # 1.61 kB
   arena allocs: 2
   arena reallocs: 0
-  arena size: 29421944 # 29.42 MB
+  arena size: 26226472 # 26.23 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -62,7 +62,7 @@ binder.ts:
   sys peak growth: 1625 # 1.62 kB
   arena allocs: 154
   arena reallocs: 0
-  arena size: 924256 # 924.26 kB
+  arena size: 822400 # 822.40 kB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -73,5 +73,5 @@ kitchen-sink.tsx:
   sys peak growth: 3218 # 3.22 kB
   arena allocs: 6132
   arena reallocs: 280
-  arena size: 6829872 # 6.83 MB
+  arena size: 6311512 # 6.31 MB
 


### PR DESCRIPTION
## Summary

- add typed parser-owned LIFO scratch storage for AST lists
- safely drain completed lists into exact-capacity arena storage and cancel speculative lists on rewind
- reduce tracked parser arena reallocations from 103,326 to 2,405 and arena size by 9.8%

Follow-up to #24708.

Validated with parser unit and conformance runs, release checks, and allocation tracking.

AI assistance was used for research, implementation, and validation.