### PR TITLE
refactor(parser): separate list parsing from collection

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -383,7 +383,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         open: Kind,
         close: Kind,
-        mut f: F,
+        f: F,
     ) -> ArenaVec<'a, T>
     where
         F: FnMut(&mut Self) -> T,
@@ -391,6 +391,21 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let opening_span = self.cur_token().span();
         self.expect(open);
         let mut list = ArenaVec::new_in(self);
+        self.parse_normal_list_into(&mut list, close, f);
+        self.expect_closing(close, opening_span);
+        list
+    }
+
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn parse_normal_list_into<F, T>(
+        &mut self,
+        list: &mut ArenaVec<'a, T>,
+        close: Kind,
+        mut parse_element: F,
+    ) where
+        F: FnMut(&mut Self) -> T,
+    {
         loop {
             let kind = self.cur_kind();
             if kind == close
@@ -399,10 +414,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             {
                 break;
             }
-            list.push(f(self));
+            let element = parse_element(self);
+            list.push(element);
         }
-        self.expect_closing(close, opening_span);
-        list
     }
 
     pub(crate) fn parse_normal_list_breakable<F, T>(
@@ -417,18 +431,31 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let opening_span = self.cur_token().span();
         self.expect(open);
         let mut list = ArenaVec::new_in(self);
+        self.parse_normal_list_breakable_into(&mut list, close, f);
+        self.expect_closing(close, opening_span);
+        list
+    }
+
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn parse_normal_list_breakable_into<F, T>(
+        &mut self,
+        list: &mut ArenaVec<'a, T>,
+        close: Kind,
+        parse_element: F,
+    ) where
+        F: Fn(&mut Self) -> Option<T>,
+    {
         loop {
             if self.at(close) || self.has_fatal_error() {
                 break;
             }
-            if let Some(e) = f(self) {
-                list.push(e);
+            if let Some(element) = parse_element(self) {
+                list.push(element);
             } else {
                 break;
             }
         }
-        self.expect_closing(close, opening_span);
-        list
     }
 
     pub(crate) fn parse_delimited_list<F, T>(
@@ -436,55 +463,31 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         close: Kind,
         separator: Kind,
         opening_span: Span,
-        mut f: F,
+        parse_element: F,
     ) -> (ArenaVec<'a, T>, Option<u32>)
     where
         F: FnMut(&mut Self) -> T,
     {
         let mut list = ArenaVec::new_in(self);
-        // Cache cur_kind() to avoid redundant calls in compound checks
-        let kind = self.cur_kind();
-        if kind == close
-            || matches!(kind, Kind::Eof | Kind::Undetermined)
-            || self.fatal_error.is_some()
-        {
-            return (list, None);
-        }
-        list.push(f(self));
-        loop {
-            let kind = self.cur_kind();
-            if kind == close
-                || matches!(kind, Kind::Eof | Kind::Undetermined)
-                || self.fatal_error.is_some()
-            {
-                return (list, None);
-            }
-            if kind != separator {
-                self.set_fatal_error(diagnostics::expect_closing_or_separator(
-                    close.to_str(),
-                    separator.to_str(),
-                    kind.to_str(),
-                    self.cur_token().span(),
-                    opening_span,
-                ));
-                return (list, None);
-            }
-            self.advance(separator);
-            if self.cur_kind() == close {
-                let trailing_separator = self.prev_token_end - 1;
-                return (list, Some(trailing_separator));
-            }
-            list.push(f(self));
-        }
+        let trailing_separator = self.parse_delimited_list_into(
+            &mut list,
+            close,
+            separator,
+            opening_span,
+            parse_element,
+        );
+        (list, trailing_separator)
     }
 
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
     pub(crate) fn parse_delimited_list_into<F, T>(
         &mut self,
         list: &mut ArenaVec<'a, T>,
         close: Kind,
         separator: Kind,
         opening_span: Span,
-        mut f: F,
+        mut parse_element: F,
     ) -> Option<u32>
     where
         F: FnMut(&mut Self) -> T,
@@ -497,7 +500,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         {
             return None;
         }
-        list.push(f(self));
+        let element = parse_element(self);
+        list.push(element);
         loop {
             let kind = self.cur_kind();
             if kind == close
@@ -521,7 +525,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 let trailing_separator = self.prev_token_end - 1;
                 return Some(trailing_separator);
             }
-            list.push(f(self));
+            let element = parse_element(self);
+            list.push(element);
         }
     }
 
@@ -539,6 +544,33 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         D: Fn(Span) -> ParserDiagnostic<'a>,
     {
         let mut list = ArenaVec::new_in(self);
+        let rest = self.parse_delimited_list_with_rest_into(
+            &mut list,
+            close,
+            opening_span,
+            parse_element,
+            parse_rest,
+            rest_last_diagnostic,
+        );
+        (list, rest)
+    }
+
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn parse_delimited_list_with_rest_into<E, A, R, D>(
+        &mut self,
+        list: &mut ArenaVec<'a, A>,
+        close: Kind,
+        opening_span: Span,
+        parse_element: E,
+        parse_rest: R,
+        rest_last_diagnostic: D,
+    ) -> Option<ArenaBox<'a, BindingRestElement<'a>>>
+    where
+        E: Fn(&mut Self) -> A,
+        R: Fn(&mut Self) -> ArenaBox<'a, BindingRestElement<'a>>,
+        D: Fn(Span) -> ParserDiagnostic<'a>,
+    {
         let mut rest: Option<ArenaBox<'a, BindingRestElement<'a>>> = None;
         let mut first = true;
         loop {
@@ -585,10 +617,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             if kind == Kind::Dot3 {
                 rest.replace(parse_rest(self));
             } else {
-                list.push(parse_element(self));
+                let element = parse_element(self);
+                list.push(element);
             }
         }
 
-        (list, rest)
+        rest
     }
 }

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -71,6 +71,18 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         opening_span: Span,
     ) -> (ArenaVec<'a, FormalParameter<'a>>, Option<ArenaBox<'a, FormalParameterRest<'a>>>) {
         let mut list = ArenaVec::new_in(self);
+        let rest = self.parse_formal_parameters_list_into(&mut list, func_kind, opening_span);
+        (list, rest)
+    }
+
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn parse_formal_parameters_list_into(
+        &mut self,
+        list: &mut ArenaVec<'a, FormalParameter<'a>>,
+        func_kind: FunctionKind,
+        opening_span: Span,
+    ) -> Option<ArenaBox<'a, FormalParameterRest<'a>>> {
         let mut rest: Option<ArenaBox<'a, FormalParameterRest<'a>>> = None;
         let mut first = true;
         let mut has_optional = false;
@@ -157,7 +169,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
 
-        (list, rest)
+        rest
     }
 
     fn parse_formal_parameter_with_decorators(

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -276,11 +276,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         if let Some(default_specifier) = default_specifier {
             let default_span = default_specifier.span;
-            specifiers.push(ImportDeclarationSpecifier::new_import_default_specifier(
+            let specifier = ImportDeclarationSpecifier::new_import_default_specifier(
                 default_specifier.span,
                 default_specifier,
                 self,
-            ));
+            );
+            specifiers.push(specifier);
             if self.eat(Kind::Comma) {
                 match self.cur_kind() {
                     // import defaultExport, * as name from "module-name";
@@ -290,7 +291,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                                 default_span,
                             ));
                         }
-                        specifiers.push(self.parse_import_namespace_specifier());
+                        let specifier = self.parse_import_namespace_specifier();
+                        specifiers.push(specifier);
                     }
                     // import defaultExport, { export1 [ , [...] ] } from "module-name";
                     Kind::LCurly => {
@@ -317,7 +319,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         } else if self.at(Kind::Star) {
             // import * as name from "module-name";
-            specifiers.push(self.parse_import_namespace_specifier());
+            let specifier = self.parse_import_namespace_specifier();
+            specifiers.push(specifier);
         } else if self.at(Kind::LCurly) {
             // import { export1 , export2 as alias2 , [...] } from "module-name";
             self.parse_import_specifiers_into(&mut specifiers, import_kind);

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -244,11 +244,22 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         in_jsx_child: bool,
     ) -> (ArenaVec<'a, JSXChild<'a>>, JSXClosing<'a>) {
         let mut children = ArenaVec::new_in(self);
+        let closing = self.parse_jsx_children_and_closing_into(&mut children, in_jsx_child);
+        (children, closing)
+    }
+
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn parse_jsx_children_and_closing_into(
+        &mut self,
+        children: &mut ArenaVec<'a, JSXChild<'a>>,
+        in_jsx_child: bool,
+    ) -> JSXClosing<'a> {
         loop {
             if self.fatal_error.is_some() {
                 // Return dummy closing fragment on fatal error
                 let closing = JSXClosingFragment::new(self.cur_token().span(), self);
-                return (children, JSXClosing::Fragment(closing));
+                return JSXClosing::Fragment(closing);
             }
 
             match self.cur_kind() {
@@ -259,25 +270,26 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
                     // <> open nested fragment
                     if kind == Kind::RAngle {
-                        children.push(JSXChild::Fragment(self.parse_jsx_fragment(span, true)));
+                        let child = JSXChild::Fragment(self.parse_jsx_fragment(span, true));
+                        children.push(child);
                         continue;
                     }
 
                     // <ident open nested element
                     if kind == Kind::Ident || kind.is_any_keyword() {
-                        children.push(JSXChild::Element(self.parse_jsx_element(span, true)));
+                        let child = JSXChild::Element(self.parse_jsx_element(span, true));
+                        children.push(child);
                         continue;
                     }
 
                     // </ closing tag - parse it inline and return
                     if kind == Kind::Slash {
                         self.bump_any(); // bump `/`
-                        let closing = self.parse_jsx_closing_inline(span, in_jsx_child);
-                        return (children, closing);
+                        return self.parse_jsx_closing_inline(span, in_jsx_child);
                     }
 
                     // Unexpected token after `<`
-                    return (children, self.unexpected());
+                    return self.unexpected();
                 }
                 Kind::LCurly => {
                     let span_start = self.start_span();
@@ -285,23 +297,25 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
                     // {...expr}
                     if self.eat(Kind::Dot3) {
-                        children.push(JSXChild::Spread(self.parse_jsx_spread_child(span_start)));
+                        let child = JSXChild::Spread(self.parse_jsx_spread_child(span_start));
+                        children.push(child);
                         continue;
                     }
                     // {expr}
-                    children.push(JSXChild::ExpressionContainer(
-                        self.parse_jsx_expression_container(
+                    let child =
+                        JSXChild::ExpressionContainer(self.parse_jsx_expression_container(
                             span_start, /* in_jsx_child */ true,
-                        ),
-                    ));
+                        ));
+                    children.push(child);
                 }
                 // text
                 Kind::JSXText => {
-                    children.push(JSXChild::Text(self.parse_jsx_text()));
+                    let child = JSXChild::Text(self.parse_jsx_text());
+                    children.push(child);
                 }
                 _ => {
                     // Unexpected token in JSX children
-                    return (children, self.unexpected());
+                    return self.unexpected();
                 }
             }
         }

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -287,12 +287,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 type_argument = self.try_parse_type_arguments();
             }
 
-            extends.push(TSInterfaceHeritage::new(
-                self.end_span(span),
-                extend,
-                type_argument,
-                self,
-            ));
+            let heritage =
+                TSInterfaceHeritage::new(self.end_span(span), extend, type_argument, self);
+            extends.push(heritage);
 
             if !self.eat(Kind::Comma) {
                 break;

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -279,10 +279,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.at(kind) || has_leading_operator {
             let mut types = ArenaVec::from_value_in(ty, self);
             while self.eat(kind) {
-                types.push(
+                let ty =
                     /*parseFunctionOrConstructorTypeToError(isUnionType) || */
-                    parse_constituent_type(self),
-                );
+                    parse_constituent_type(self);
+                types.push(ty);
             }
             let span = self.end_span(span);
             ty = match kind {
@@ -1281,7 +1281,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.expect(Kind::Colon);
                 let value = self.parse_assignment_expression_or_higher();
                 let key = PropertyKey::new_string_literal(bracket_span, "", None, self);
-                properties.push(ObjectPropertyKind::new_object_property(
+                let property = ObjectPropertyKind::new_object_property(
                     self.end_span(prop_span),
                     PropertyKind::Init,
                     key,
@@ -1290,7 +1290,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     false,
                     true, /* computed */
                     self,
-                ));
+                );
+                properties.push(property);
                 continue;
             }
 
@@ -1306,7 +1307,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.expect(Kind::Colon);
             let value = self.parse_assignment_expression_or_higher();
 
-            properties.push(ObjectPropertyKind::new_object_property(
+            let property = ObjectPropertyKind::new_object_property(
                 self.end_span(prop_span),
                 PropertyKind::Init,
                 key,
@@ -1315,7 +1316,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 false,
                 false,
                 self,
-            ));
+            );
+            properties.push(property);
         }
 
         self.expect(Kind::RCurly);


### PR DESCRIPTION
## Summary

- extract ArenaVec-backed `_into` helpers for shared and complex list parsers
- preserve direct pushes, evaluation order, allocation results, and optimized codegen
- separate list parsing from storage before the scratch follow-up

Stack 1 of 2. Follow-up: [#24704](https://github.com/oxc-project/oxc/pull/24704).

Validated with parser unit and conformance runs, Clippy, allocation tracking, and optimized codegen comparison.

AI assistance was used for research, implementation, and validation.