### PR TITLE
fix(isolated-declarations): separate static accessors

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -370,8 +370,9 @@ impl<'a> IsolatedDeclarations<'a> {
     fn collect_accessor_annotations(
         &self,
         decl: &Class<'a>,
-    ) -> Vec<(PropertyKey<'a>, AccessorAnnotation<'a>)> {
-        let mut method_annotations: Vec<(PropertyKey<'_>, AccessorAnnotation<'_>)> = Vec::new();
+    ) -> Vec<(PropertyKey<'a>, bool, AccessorAnnotation<'a>)> {
+        let mut method_annotations: Vec<(PropertyKey<'_>, bool, AccessorAnnotation<'_>)> =
+            Vec::new();
         for element in &decl.body.body {
             if let ClassElement::MethodDefinition(method) = element {
                 // Note: do not skip `private`-modifier accessors. Their types are still
@@ -391,14 +392,17 @@ impl<'a> IsolatedDeclarations<'a> {
                         if let Some(annotation) =
                             first_param.type_annotation.clone_in(self.allocator())
                         {
-                            if let Some(entry) = method_annotations
-                                .iter_mut()
-                                .find(|(key, _)| Self::accessor_keys_match(&method.key, key))
+                            if let Some(entry) =
+                                method_annotations.iter_mut().find(|(key, is_static, _)| {
+                                    method.r#static == *is_static
+                                        && Self::accessor_keys_match(&method.key, key)
+                                })
                             {
-                                entry.1.setter = Some(annotation);
+                                entry.2.setter = Some(annotation);
                             } else {
                                 method_annotations.push((
                                     method.key.clone_in(self.allocator()),
+                                    method.r#static,
                                     AccessorAnnotation { setter: Some(annotation), getter: None },
                                 ));
                             }
@@ -417,14 +421,17 @@ impl<'a> IsolatedDeclarations<'a> {
                                 self.infer_function_return_type(function)
                             };
                         if let Some(annotation) = annotation {
-                            if let Some(entry) = method_annotations
-                                .iter_mut()
-                                .find(|(key, _)| Self::accessor_keys_match(&method.key, key))
+                            if let Some(entry) =
+                                method_annotations.iter_mut().find(|(key, is_static, _)| {
+                                    method.r#static == *is_static
+                                        && Self::accessor_keys_match(&method.key, key)
+                                })
                             {
-                                entry.1.getter = Some(annotation);
+                                entry.2.getter = Some(annotation);
                             } else {
                                 method_annotations.push((
                                     method.key.clone_in(self.allocator()),
+                                    method.r#static,
                                     AccessorAnnotation { setter: None, getter: Some(annotation) },
                                 ));
                             }
@@ -436,6 +443,20 @@ impl<'a> IsolatedDeclarations<'a> {
         }
 
         method_annotations
+    }
+
+    fn has_matching_getter(decl: &Class<'a>, setter: &MethodDefinition<'a>) -> bool {
+        decl.body.body.iter().any(|element| {
+            let ClassElement::MethodDefinition(getter) = element else {
+                return false;
+            };
+            getter.kind == MethodDefinitionKind::Get
+                && getter.r#static == setter.r#static
+                && !getter.key.is_private_identifier()
+                && (Self::is_valid_property_key(&getter.key) || !getter.computed)
+                && Self::accessor_keys_match(&getter.key, &setter.key)
+                && !getter.accessibility.is_some_and(TSAccessibility::is_private)
+        })
     }
 
     pub(crate) fn transform_class(
@@ -502,20 +523,27 @@ impl<'a> IsolatedDeclarations<'a> {
                                 )
                             } else {
                                 let mut params = params.clone_in(self.allocator());
-                                if let Some(param) = params.items.first_mut()
-                                    && let Some(annotation) =
-                                        accessor_annotations.iter().find_map(|(key, annotation)| {
-                                            if Self::accessor_keys_match(&method.key, key) {
-                                                Some(
-                                                    annotation
-                                                        .get_setter_annotation(self.allocator()),
-                                                )
-                                            } else {
-                                                None
-                                            }
-                                        })
-                                {
-                                    param.type_annotation = annotation;
+                                let annotation = accessor_annotations.iter().find_map(
+                                    |(key, is_static, annotation)| {
+                                        if method.r#static == *is_static
+                                            && Self::accessor_keys_match(&method.key, key)
+                                        {
+                                            Some(annotation.get_setter_annotation(self.allocator()))
+                                        } else {
+                                            None
+                                        }
+                                    },
+                                );
+                                if let Some(param) = params.items.first_mut() {
+                                    if let Some(annotation) = annotation {
+                                        param.type_annotation = annotation;
+                                    } else if param.type_annotation.is_none()
+                                        && !Self::has_matching_getter(decl, method)
+                                    {
+                                        self.error(accessor_must_have_explicit_return_type(
+                                            method.key.span(),
+                                        ));
+                                    }
                                 }
                                 params
                             }
@@ -565,19 +593,23 @@ impl<'a> IsolatedDeclarations<'a> {
                             rt
                         }
                         MethodDefinitionKind::Get => {
-                            let rt = accessor_annotations.iter().find_map(|(key, annotation)| {
-                                if Self::accessor_keys_match(&method.key, key) {
-                                    // No explicit return type for getter, should infer it from the first parameter of setter, if not exists,
-                                    // use the inferred return type of getter.
-                                    if method.value.return_type.is_none() {
-                                        annotation.get_setter_annotation(self.allocator())
+                            let rt = accessor_annotations.iter().find_map(
+                                |(key, is_static, annotation)| {
+                                    if method.r#static == *is_static
+                                        && Self::accessor_keys_match(&method.key, key)
+                                    {
+                                        // No explicit return type for getter, should infer it from the first parameter of setter, if not exists,
+                                        // use the inferred return type of getter.
+                                        if method.value.return_type.is_none() {
+                                            annotation.get_setter_annotation(self.allocator())
+                                        } else {
+                                            annotation.get_getter_annotation(self.allocator())
+                                        }
                                     } else {
-                                        annotation.get_getter_annotation(self.allocator())
+                                        None
                                     }
-                                } else {
-                                    None
-                                }
-                            });
+                                },
+                            );
                             if rt.is_none() {
                                 self.error(accessor_must_have_explicit_return_type(
                                     method.key.span(),

--- a/crates/oxc_isolated_declarations/tests/fixtures/static-instance-accessor-pairs.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/static-instance-accessor-pairs.ts
@@ -1,0 +1,31 @@
+// Instance and static accessors with the same key are distinct properties.
+// Their types must not be used to infer each other.
+export class InstanceGetterStaticSetter {
+  get value() {
+    return;
+  }
+
+  static set value(value: string) {}
+}
+
+export class StaticGetterInstanceSetter {
+  static get value() {
+    return;
+  }
+
+  set value(value: number) {}
+}
+
+export class InstanceGetterStaticUntypedSetter {
+  get value(): string {
+    return "";
+  }
+  static set value(value) {}
+}
+
+export class StaticGetterInstanceUntypedSetter {
+  static get value(): number {
+    return 0;
+  }
+  set value(value) {}
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/static-instance-accessor-pairs.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/static-instance-accessor-pairs.snap
@@ -1,0 +1,65 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/static-instance-accessor-pairs.ts
+---
+```
+==================== .D.TS ====================
+
+export declare class InstanceGetterStaticSetter {
+	get value();
+	static set value(value: string);
+}
+export declare class StaticGetterInstanceSetter {
+	static get value();
+	set value(value: number);
+}
+export declare class InstanceGetterStaticUntypedSetter {
+	get value(): string;
+	static set value(value);
+}
+export declare class StaticGetterInstanceUntypedSetter {
+	static get value(): number;
+	set value(value);
+}
+
+
+==================== Errors ====================
+
+  x TS9009: At least one accessor must have an explicit return type annotation
+  | with --isolatedDeclarations.
+   ,-[4:7]
+ 3 | export class InstanceGetterStaticSetter {
+ 4 |   get value() {
+   :       ^^^^^
+ 5 |     return;
+   `----
+
+  x TS9009: At least one accessor must have an explicit return type annotation
+  | with --isolatedDeclarations.
+    ,-[12:14]
+ 11 | export class StaticGetterInstanceSetter {
+ 12 |   static get value() {
+    :              ^^^^^
+ 13 |     return;
+    `----
+
+  x TS9009: At least one accessor must have an explicit return type annotation
+  | with --isolatedDeclarations.
+    ,-[23:14]
+ 22 |   }
+ 23 |   static set value(value) {}
+    :              ^^^^^
+ 24 | }
+    `----
+
+  x TS9009: At least one accessor must have an explicit return type annotation
+  | with --isolatedDeclarations.
+    ,-[30:7]
+ 29 |   }
+ 30 |   set value(value) {}
+    :       ^^^^^
+ 31 | }
+    `----
+
+
+```


### PR DESCRIPTION
## Summary

- keep static and instance accessors with the same key in separate inference pairs
- retain property-key normalization while adding staticness to the pairing identity
- cover both instance-getter/static-setter and static-getter/instance-setter directions

## Root cause

Accessor pairing identified entries by property key alone. A same-named accessor in the opposite staticness domain could therefore provide an inferred type, even though TypeScript treats the static and instance properties independently.

[TS Playground](https://www.typescriptlang.org/play/?isolatedDeclarations=true)

Current behaviour (oxc is before, ts (correct) is after.

```diff
@@ -1,8 +1,8 @@
 declare class InstanceGetterStaticSetter {
-       get value(): string;
+       get value();
        static set value(value: string);
 }
 declare class StaticGetterInstanceSetter {
-       static get value(): number;
+       static get value();
        set value(value: number);
 }
```
