### PR TITLE
feat(str)!: move `IdentBuildHasher` to `oxc_str` crate

### DIFF
--- a/crates/oxc_allocator/src/hash_map.rs
+++ b/crates/oxc_allocator/src/hash_map.rs
@@ -1,12 +1,11 @@
 //! A hash map without `Drop` that stores data in arena allocator.
 //!
-//! By default uses [`FxHasher`] to hash keys. The hasher can be customized via the `S` type
-//! parameter (e.g. [`IdentBuildHasher`] for `Ident` keys).
+//! By default uses [`FxHasher`] to hash keys. The hasher can be customized via the `S` type parameter
+//! (e.g. `IdentBuildHasher` for `Ident` keys).
 //!
 //! See [`HashMap`] for more details.
 //!
 //! [`FxHasher`]: rustc_hash::FxHasher
-//! [`IdentBuildHasher`]: crate::IdentBuildHasher
 
 // All methods which just delegate to `hashbrown::HashMap` methods marked `#[inline(always)]`
 #![expect(clippy::inline_always)]

--- a/crates/oxc_allocator/src/hash_set.rs
+++ b/crates/oxc_allocator/src/hash_set.rs
@@ -1,12 +1,11 @@
 //! A hash set without `Drop` that stores data in arena allocator.
 //!
-//! By default uses [`FxHasher`] to hash keys. The hasher can be customized via the `S` type
-//! parameter (e.g. [`IdentBuildHasher`] for `Ident` keys).
+//! By default uses [`FxHasher`] to hash keys. The hasher can be customized via the `S` type parameter
+//! (e.g. `IdentBuildHasher` for `Ident` keys).
 //!
 //! See [`HashSet`] for more details.
 //!
 //! [`FxHasher`]: rustc_hash::FxHasher
-//! [`IdentBuildHasher`]: crate::IdentBuildHasher
 
 // All methods which just delegate to `hashbrown::HashSet` methods marked `#[inline(always)]`
 #![expect(clippy::inline_always)]

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -52,7 +52,6 @@ mod fixed_size;
 mod from_raw_parts;
 pub mod hash_map;
 pub mod hash_set;
-pub mod ident_hasher;
 #[cfg(feature = "pool")]
 mod pool;
 mod replace_with;
@@ -79,7 +78,6 @@ pub use clone_in::{CloneIn, CloneInSemanticIds};
 pub use convert::{FromIn, IntoIn};
 pub use hash_map::{HashMap, HashMap as ArenaHashMap};
 pub use hash_set::{HashSet, HashSet as ArenaHashSet};
-pub use ident_hasher::{IdentBuildHasher, ident_hash, pack_len_hash};
 #[cfg(feature = "pool")]
 pub use pool::*;
 pub use replace_with::ReplaceWith;

--- a/crates/oxc_react_compiler/src/react_compiler_utils/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_utils/mod.rs
@@ -10,4 +10,4 @@ pub type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 /// `IndexSet` keyed with the fast `FxHasher` (rustc-hash) instead of the default SipHash.
 pub type FxIndexSet<T> = IndexSet<T, FxBuildHasher>;
 /// `IndexMap` keyed by [`oxc_str::Ident`], reusing its precomputed hash.
-pub type IdentIndexMap<'a, V> = IndexMap<oxc_str::Ident<'a>, V, oxc_allocator::IdentBuildHasher>;
+pub type IdentIndexMap<'a, V> = IndexMap<oxc_str::Ident<'a>, V, oxc_str::IdentBuildHasher>;

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
@@ -13,10 +13,9 @@
 use crate::react_compiler_utils::{FxIndexSet, IdentIndexMap};
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use oxc_allocator::IdentBuildHasher;
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_index::IndexSlice;
-use oxc_str::{Ident, IdentHashSet};
+use oxc_str::{Ident, IdentBuildHasher, IdentHashSet};
 
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::BasicBlock;

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -12,14 +12,16 @@ use std::{
 
 use oxc_allocator::{
     Allocator, ArenaStringBuilder, CloneIn, CloneInSemanticIds, Dummy, FromIn, GetAllocator,
-    IdentBuildHasher, ident_hash,
 };
 #[cfg(feature = "serialize")]
 use oxc_estree::{ESTree, JsonSafeString, Serializer as ESTreeSerializer};
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer as SerdeSerializer};
 
-use crate::{CompactStr, Str};
+use crate::{
+    CompactStr, Str,
+    ident_hasher::{IdentBuildHasher, ident_hash},
+};
 
 /// A packed representation of `len` and `hash` for `Ident` - 64-bit platforms version.
 ///

--- a/crates/oxc_str/src/ident_hasher.rs
+++ b/crates/oxc_str/src/ident_hasher.rs
@@ -75,17 +75,6 @@ pub const fn ident_hash(s: &[u8]) -> u32 {
     }
 }
 
-/// Pack length and hash into a single `u64`.
-///
-/// Lower 32 bits = length, upper 32 bits = hash.
-///
-/// This is used as compact precomputed data inside `Ident` and as the
-/// `Ident::hash()` payload passed into [`IdentHasher::write_u64`].
-#[inline]
-pub const fn pack_len_hash(len: u32, hash: u32) -> u64 {
-    (len as u64) | ((hash as u64) << 32)
-}
-
 /// Compose the final hash state used by hashbrown.
 ///
 /// Keep upper bits derived from `hash` (for tag/SIMD filtering), while ensuring
@@ -156,9 +145,12 @@ impl Hasher for IdentHasher {
 mod test {
     use std::hash::{BuildHasher, Hasher};
 
-    use super::{
-        IdentBuildHasher, IdentHasher, hashbrown_state, ident_hash, pack_len_hash, unpack_len_hash,
-    };
+    use super::{IdentBuildHasher, IdentHasher, hashbrown_state, ident_hash, unpack_len_hash};
+
+    /// Pack `len` and `hash` the way `Ident::hash()` does, for driving the `write_u64` path.
+    const fn pack_len_hash(len: u32, hash: u32) -> u64 {
+        (len as u64) | ((hash as u64) << 32)
+    }
 
     // ---- ident_hash quality tests ----
 
@@ -220,17 +212,6 @@ mod test {
             ident_hash(b"privateInterfaceWithPrivatePropertyTypes"),
             ident_hash(b"privateInterfaceWithPrivateParmeterTypes"), // spellchecker:disable-line
         );
-    }
-
-    // ---- pack_len_hash tests ----
-
-    #[test]
-    fn pack_round_trip() {
-        let len = 42u32;
-        let hash = 0xDEAD_BEEFu32;
-        let packed = pack_len_hash(len, hash);
-        assert_eq!((packed & 0xFFFF_FFFF) as u32, len);
-        assert_eq!((packed >> 32) as u32, hash);
     }
 
     // ---- IdentHasher tests ----

--- a/crates/oxc_str/src/lib.rs
+++ b/crates/oxc_str/src/lib.rs
@@ -4,10 +4,12 @@
 
 mod compact_str;
 mod ident;
+mod ident_hasher;
 mod str;
 
 pub use compact_str::{CompactStr, MAX_INLINE_LEN};
 pub use ident::{ArenaIdentHashMap, Ident, IdentHashMap, IdentHashSet};
+pub use ident_hasher::{IdentBuildHasher, IdentHasher};
 pub use str::{Str, Str as ArenaStr};
 
 #[doc(hidden)]

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -201,9 +201,8 @@ use indexmap::IndexMap;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 
-use oxc_allocator::IdentBuildHasher;
 use oxc_ast::ast::*;
-use oxc_str::Ident;
+use oxc_str::{Ident, IdentBuildHasher};
 use oxc_syntax::symbol::SymbolId;
 use oxc_traverse::Traverse;
 


### PR DESCRIPTION
Move all `Ident`\-hashing code from `oxc_allocator` into `oxc_str`, to sit alongside `Ident`'s code.

This feels like the natural place for this code, and reduces the public API surface - we no longer need to expose `Ident`'s internals (`ident_hash`). Now only `IdentHasher` and `IdentBuildHasher` are exposed.

Only change to code is removing `pack_len_hash`, as it was only used in tests.