### PR TITLE
fix(minifier): avoid incorrect logical assignment transformation when base object may be mutated

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_logical_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_logical_expression.rs
@@ -203,6 +203,26 @@ impl<'a> PeepholeOptimizations {
         false
     }
 
+    /// Returns `true` if `read_expr <op> (target = value)` can be compressed to
+    /// `target <op>= value`, where `<op>` is `||`, `&&`, or `??`.
+    ///
+    /// On top of [`Self::has_no_side_effect_for_evaluation_same_target`], this
+    /// requires that `target`'s object binding cannot be mutated. Unlike the
+    /// `a = a + b` -> `a += b` compression (where the target is captured *before*
+    /// the right-hand side runs), the logical form reads `target` first and only
+    /// then evaluates the write target, so `<op>=` — which captures the object
+    /// once — would write to a different object if reading `target` reassigns its
+    /// object (e.g. `x.y || (x.y = 3)` where the getter of `x.y` sets `x`).
+    /// <https://github.com/oxc-project/oxc/issues/16647>
+    pub fn can_compress_to_logical_assignment(
+        assignment_target: &AssignmentTarget<'a>,
+        read_expr: &Expression,
+        ctx: &TraverseCtx<'a>,
+    ) -> bool {
+        Self::has_no_side_effect_for_evaluation_same_target(assignment_target, read_expr, ctx)
+            && !Self::member_object_may_be_mutated(assignment_target, ctx)
+    }
+
     /// Compress `a || (a = b)` to `a ||= b`
     ///
     /// Also `a || (foo, bar, a = b)` to `a ||= (foo, bar, b)`
@@ -223,18 +243,7 @@ impl<'a> PeepholeOptimizations {
             if assignment_expr.operator != AssignmentOperator::Assign {
                 return;
             }
-            if !Self::has_no_side_effect_for_evaluation_same_target(
-                &assignment_expr.left,
-                &e.left,
-                ctx,
-            ) {
-                return;
-            }
-
-            // Don't transform `x.y || (x = {}, x.y = 3)` to `x.y ||= (x = {}, 3)` because
-            // `||=` evaluates `x.y` (capturing `x`) before the RHS reassigns `x`.
-            // https://github.com/oxc-project/oxc/issues/16647
-            if Self::member_object_may_be_mutated(&assignment_expr.left, ctx) {
+            if !Self::can_compress_to_logical_assignment(&assignment_expr.left, &e.left, ctx) {
                 return;
             }
 
@@ -267,8 +276,7 @@ impl<'a> PeepholeOptimizations {
             return;
         }
         let new_op = e.operator.to_assignment_operator();
-        if !Self::has_no_side_effect_for_evaluation_same_target(&assignment_expr.left, &e.left, ctx)
-        {
+        if !Self::can_compress_to_logical_assignment(&assignment_expr.left, &e.left, ctx) {
             return;
         }
 

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -193,18 +193,14 @@ impl<'a> PeepholeOptimizations {
                         };
                         if let Some(new_left_hand_expr) = new_left_hand_expr {
                             if ctx.supports_feature(ESFeature::ES2021LogicalAssignmentOperators)
-                                    && let Expression::AssignmentExpression(assignment_expr) =
-                                        logical_right
-                                    && assignment_expr.operator == AssignmentOperator::Assign
-                                    && Self::has_no_side_effect_for_evaluation_same_target(
-                                        &assignment_expr.left,
-                                        new_left_hand_expr,
-                                        ctx,
-                                    )
-                                    // Don't transform `x.y != null || (x = {}, x.y = 3)` to `x.y ??= (x = {}, 3)` because
-                                    // `??=` evaluates `x.y` (capturing `x`) before the RHS reassigns `x`.
-                                    // https://github.com/oxc-project/oxc/pull/16802#discussion_r2619369597
-                                    && !Self::member_object_may_be_mutated(&assignment_expr.left, ctx)
+                                && let Expression::AssignmentExpression(assignment_expr) =
+                                    logical_right
+                                && assignment_expr.operator == AssignmentOperator::Assign
+                                && Self::can_compress_to_logical_assignment(
+                                    &assignment_expr.left,
+                                    new_left_hand_expr,
+                                    ctx,
+                                )
                             {
                                 assignment_expr.span = *logical_span;
                                 assignment_expr.operator = AssignmentOperator::LogicalNullish;

--- a/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
@@ -1267,6 +1267,14 @@ fn test_fold_logical_expression_to_assignment_expression() {
     test_same("var x = {}; x.y.z.w || (x.y = {}, x.y.z.w = 3)");
     // `x` is not mutated anywhere, and the preceding expression `x.y.z = {}` doesn't affect `x`
     test("var x = {}; x.y || (x.y.z = {}, x.y = 3)", "var x = {}; x.y ||= (x.y.z = {}, 3)");
+
+    // reading `x.y` reassigns `x` via the getter, so the original evaluates
+    // the write target `x.y` against the NEW object, while `x.y ||= 3`
+    // (which captures the object once) would write to the OLD one. Each case
+    // leaves `x.y === 3`; the merged form would leave `x.y === 9`.
+    test_same("var x = { get y() { return x = { y: 9 }, 0 } }; x.y || (x.y = 3)");
+    test_same("var x = { get y() { return x = { y: 9 }, 1 } }; x.y && (x.y = 3)");
+    test_same("var x = { get y() { x = { y: 9 } } }; x.y ?? (x.y = 3)");
 }
 
 #[test]

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -5,23 +5,23 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 173.90 kB  | 59.37 kB   | 59.82 kB   | 19.15 kB   | 19.33 kB   |          2 | moment.js  
 
-287.63 kB  | 89.22 kB   | 90.07 kB   | 30.90 kB   | 31.95 kB   |          2 | jquery.js  
+287.63 kB  | 89.24 kB   | 90.07 kB   | 30.91 kB   | 31.95 kB   |          2 | jquery.js  
 
-342.15 kB  | 116.94 kB  | 118.14 kB  | 43.17 kB   | 44.37 kB   |          2 | vue.js     
+342.15 kB  | 116.98 kB  | 118.14 kB  | 43.19 kB   | 44.37 kB   |          2 | vue.js     
 
 544.10 kB  | 70.91 kB   | 72.48 kB   | 25.73 kB   | 26.20 kB   |          2 | lodash.js  
 
 555.77 kB  | 267.20 kB  | 270.13 kB  | 87.98 kB   | 90.80 kB   |          2 | d3.js      
 
-1.01 MB    | 439.24 kB  | 458.89 kB  | 122.03 kB  | 126.71 kB  |          2 | bundle.min.js 
+1.01 MB    | 439.26 kB  | 458.89 kB  | 122.03 kB  | 126.71 kB  |          2 | bundle.min.js 
 
 1.25 MB    | 642.46 kB  | 646.76 kB  | 159.37 kB  | 163.73 kB  |          2 | three.js   
 
 2.14 MB    | 710.90 kB  | 724.14 kB  | 160.38 kB  | 181.07 kB  |          2 | victory.js 
 
-3.20 MB    | 1.00 MB    | 1.01 MB    | 322.55 kB  | 331.56 kB  |          2 | echarts.js 
+3.20 MB    | 1.00 MB    | 1.01 MB    | 322.57 kB  | 331.56 kB  |          2 | echarts.js 
 
 6.69 MB    | 2.12 MB    | 2.31 MB    | 453.79 kB  | 488.28 kB  |          5 | antd.js    
 
-10.95 MB   | 3.33 MB    | 3.49 MB    | 852.91 kB  | 915.50 kB  |          4 | typescript.js 
+10.95 MB   | 3.33 MB    | 3.49 MB    | 852.93 kB  | 915.50 kB  |          4 | typescript.js 
 

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 152
   sys alloc bytes: 15030872 # 15.03 MB
   sys peak growth: 10203896 # 10.20 MB
-  arena allocs: 152894
+  arena allocs: 152891
   arena reallocs: 28386
-  arena size: 19331624 # 19.33 MB
+  arena size: 19331576 # 19.33 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 1038
   sys alloc bytes: 29975903 # 29.98 MB
   sys peak growth: 19934725 # 19.93 MB
-  arena allocs: 371547
+  arena allocs: 371546
   arena reallocs: 76276
-  arena size: 49105432 # 49.11 MB
+  arena size: 49106184 # 49.11 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,9 +60,9 @@ binder.ts:
   sys deallocs: 33
   sys alloc bytes: 963614 # 963.61 kB
   sys peak growth: 658042 # 658.04 kB
-  arena allocs: 7079
+  arena allocs: 7078
   arena reallocs: 841
-  arena size: 1169856 # 1.17 MB
+  arena size: 1169840 # 1.17 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB


### PR DESCRIPTION
Similar to #16802 but for cases without the returned value.
