### PR TITLE
fix(str): enable `hashbrown` feature `inline-more`

### DIFF
--- a/crates/oxc_str/Cargo.toml
+++ b/crates/oxc_str/Cargo.toml
@@ -24,7 +24,7 @@ oxc_allocator = { workspace = true }
 oxc_estree = { workspace = true }
 
 compact_str = { workspace = true }
-hashbrown = { workspace = true }
+hashbrown = { workspace = true, default-features = false, features = ["inline-more"] }
 
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }


### PR DESCRIPTION
Pure refactor.

`oxc_str` uses `hashbrown` crate. Because `oxc_str` depends on `oxc_allocator`, feature unification enables the `inline-more` Cargo feature for `hashbrown`. Make this explicit by enabling the `inline-more` feature in `oxc_str` crate too.