### PR TITLE
feat(data_structures): add `const_str_eq` function

### DIFF
--- a/crates/oxc_data_structures/Cargo.toml
+++ b/crates/oxc_data_structures/Cargo.toml
@@ -37,6 +37,7 @@ all = [
   "rope",
   "slice_iter",
   "stack",
+  "str",
   "string_ext",
 ]
 assert_unchecked = []
@@ -49,4 +50,5 @@ non_null = []
 rope = ["dep:ropey"]
 slice_iter = ["assert_unchecked"]
 stack = []
+str = []
 string_ext = ["assert_unchecked"]

--- a/crates/oxc_data_structures/README.md
+++ b/crates/oxc_data_structures/README.md
@@ -18,6 +18,7 @@ This crate provides specialized data structures and utilities that are used thro
 - **Non-null pointers**: `NonNullConst<T>` and `NonNullMut<T>` - non-null pointer types with explicit const/mut permissions
 - **Branch prediction hints**: `likely` and `unlikely` functions to hint to the compiler whether a branch is likely to be taken (also re-exports `std::hint::cold_path`)
 - **`StringExt` trait**: Add methods to `String` to push without capacity checks
+- **String utilities**: `const`-compatible string helpers (e.g. `const_str_eq` for comparing strings in a `const` context)
 
 ## Architecture
 

--- a/crates/oxc_data_structures/src/lib.rs
+++ b/crates/oxc_data_structures/src/lib.rs
@@ -30,5 +30,8 @@ pub mod slice_iter;
 #[cfg(feature = "stack")]
 pub mod stack;
 
+#[cfg(feature = "str")]
+pub mod str;
+
 #[cfg(feature = "string_ext")]
 pub mod string_ext;

--- a/crates/oxc_data_structures/src/str.rs
+++ b/crates/oxc_data_structures/src/str.rs
@@ -1,0 +1,68 @@
+//! String utility functions.
+
+/// Compare two strings for equality in a `const` context.
+///
+/// `str`'s `==` operator is not `const` (it goes through the non-`const` [`PartialEq`] impl),
+/// so this byte-for-byte comparison stands in where a compile-time string equality is needed.
+///
+/// Do not use this except in const context - standard `==` ([`PartialEq`]) has much better performance.
+///
+/// ```
+/// use oxc_data_structures::str::const_str_eq;
+///
+/// const _: () = assert!(const_str_eq("foo", "foo"));
+/// const _: () = assert!(!const_str_eq("foo", "bar"));
+/// ```
+pub const fn const_str_eq(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+
+    let len = a.len();
+
+    if b.len() != len {
+        return false;
+    }
+
+    let mut i = 0;
+    while i < len {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::const_str_eq;
+
+    #[test]
+    fn equal_and_unequal() {
+        // Equal
+        assert!(const_str_eq("", ""));
+        assert!(const_str_eq("foo", "foo"));
+        assert!(const_str_eq("foobar", "foobar"));
+
+        // Not equal to empty string
+        assert!(!const_str_eq("", "foo"));
+        assert!(!const_str_eq("foo", ""));
+
+        // Differing lengths
+        assert!(!const_str_eq("f", "foo"));
+        assert!(!const_str_eq("foo", "f"));
+        assert!(!const_str_eq("foo", "foobar"));
+
+        // Same length, differing bytes
+        assert!(!const_str_eq("foo", "for"));
+        assert!(!const_str_eq("foo", "bar"));
+    }
+
+    #[test]
+    fn usable_in_const_context() {
+        const EQ: bool = const_str_eq("foo", "foo");
+        const NE: bool = const_str_eq("foo", "bar");
+        assert_eq!((EQ, NE), (true, false));
+    }
+}


### PR DESCRIPTION
Add a `const_str_eq` function to `oxc_data_structures`, which allows comparing two strings in const context.

```rust
const IS_SAME: bool = const_str_eq("foo", "bar");
const _: () = assert!(!IS_SAME);
```

This is a primitive required for forthcoming `MultiVec` SoA vec type. Putting it in `oxc_data_structures` as it can be useful in other places too.