### PR TITLE
test(allocator, data_structures, str): use `implements!` macro in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "oxc-schemars",
  "oxc_allocator",
+ "oxc_data_structures",
  "oxc_estree",
  "serde",
 ]

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -42,6 +42,7 @@ serde = { workspace = true, optional = true }
 windows-sys = { workspace = true, features = ["Win32_System_Memory"], optional = true }
 
 [dev-dependencies]
+oxc_data_structures = { workspace = true, features = ["types"] }
 oxc_estree = { workspace = true, features = ["serialize"] }
 quickcheck = { workspace = true }
 rand = { workspace = true }

--- a/crates/oxc_allocator/src/arena/tests.rs
+++ b/crates/oxc_allocator/src/arena/tests.rs
@@ -11,17 +11,6 @@ use super::{
     create::{OVERHEAD, TYPICAL_PAGE_SIZE},
 };
 
-/// This function tests that `Arena` isn't `Sync`.
-/// ```compile_fail
-/// use oxc_allocator::arena::Arena;
-/// fn _requires_sync<T: Sync>(_value: T) {}
-/// fn _arena_not_sync(b: Arena) {
-///    _requires_sync(b);
-/// }
-/// ```
-#[cfg(doctest)]
-fn arena_not_sync() {}
-
 // Uses private `DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER`, `OVERHEAD`, and `TYPICAL_PAGE_SIZE`
 #[test]
 fn allocated_and_used_bytes() {

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -449,9 +449,23 @@ impl<T: Debug> Debug for Vec<'_, T> {
 
 #[cfg(test)]
 mod test {
+    use std::cell::Cell;
+
+    use oxc_data_structures::types::implements;
+
     use crate::Allocator;
 
     use super::Vec;
+
+    // `Vec` must not be `Send` - 2 `Vec`s on different threads could then allocate into the same
+    // arena simultaneously, which would be undefined behavior. See `unsafe impl Sync for Vec`.
+    // `Vec` is `Sync` only if `T` is.
+    #[test]
+    fn vec_send_sync() {
+        assert!(implements!(Vec<u32>: !Send));
+        assert!(implements!(Vec<u32>: Sync));
+        assert!(implements!(Vec<Cell<u32>>: !Sync));
+    }
 
     #[test]
     fn vec_with_capacity() {

--- a/crates/oxc_allocator/tests/arena/tests.rs
+++ b/crates/oxc_allocator/tests/arena/tests.rs
@@ -1,6 +1,7 @@
 use std::{alloc::Layout, fmt::Debug, mem, ptr};
 
 use oxc_allocator::arena::Arena;
+use oxc_data_structures::types::implements;
 
 #[test]
 fn can_iterate_over_allocated_things() {
@@ -229,10 +230,11 @@ fn test_chunk_capacity() {
     assert!(b.chunk_capacity() < orig_capacity);
 }
 
+// `Arena` uses `Cell`s internally, so sharing one between threads would be undefined behavior
 #[test]
-fn arena_is_send() {
-    fn assert_send(_: impl Send) {}
-    assert_send(Arena::new());
+fn arena_is_send_but_not_sync() {
+    assert!(implements!(Arena: Send));
+    assert!(implements!(Arena: !Sync));
 }
 
 #[test]

--- a/crates/oxc_data_structures/src/lib.rs
+++ b/crates/oxc_data_structures/src/lib.rs
@@ -36,5 +36,10 @@ pub mod str;
 #[cfg(feature = "string_ext")]
 pub mod string_ext;
 
-#[cfg(feature = "types")]
+// Gated on `any(test, ...)` because `implements!` is used in unit tests for `non_null` and `stack`,
+// and unit tests cannot enable features.
+// This enables:
+// * `cargo test -p oxc_data_structures --features non_null`
+// * `cargo test -p oxc_data_structures --features stack`
+#[cfg(any(test, feature = "types"))]
 pub mod types;

--- a/crates/oxc_data_structures/src/non_null.rs
+++ b/crates/oxc_data_structures/src/non_null.rs
@@ -1725,4 +1725,20 @@ mod tests {
         let mut_ptr = NonNullMut::from_mut(&mut x);
         assert_eq!(hash_of(&const_ptr), hash_of(&mut_ptr));
     }
+
+    // ---------------------------------------------------------------------------------
+    // Send / Sync
+    // ---------------------------------------------------------------------------------
+
+    /// Both types wrap `NonNull`, so inherit its `!Send` / `!Sync`.
+    /// Types containing them have to opt in to `Send` / `Sync` explicitly.
+    #[test]
+    fn not_send_or_sync() {
+        use crate::types::implements;
+
+        assert!(implements!(NonNullConst<u32>: !Send));
+        assert!(implements!(NonNullConst<u32>: !Sync));
+        assert!(implements!(NonNullMut<u32>: !Send));
+        assert!(implements!(NonNullMut<u32>: !Sync));
+    }
 }

--- a/crates/oxc_data_structures/src/stack/non_empty.rs
+++ b/crates/oxc_data_structures/src/stack/non_empty.rs
@@ -993,4 +993,17 @@ mod tests {
 
         assert_eq!(drops(), &[10, 20, 31, 40, 50]);
     }
+
+    /// `NonEmptyStack<T>` is `Send` / `Sync` only if `T` is.
+    #[test]
+    fn send_sync() {
+        use std::rc::Rc;
+
+        use crate::types::implements;
+
+        assert!(implements!(NonEmptyStack<u32>: Send));
+        assert!(implements!(NonEmptyStack<u32>: Sync));
+        assert!(implements!(NonEmptyStack<Rc<u32>>: !Send));
+        assert!(implements!(NonEmptyStack<Rc<u32>>: !Sync));
+    }
 }

--- a/crates/oxc_data_structures/src/stack/standard.rs
+++ b/crates/oxc_data_structures/src/stack/standard.rs
@@ -846,4 +846,17 @@ mod tests {
 
         assert_eq!(drops(), &[10, 20, 31, 40, 50]);
     }
+
+    /// `Stack<T>` is `Send` / `Sync` only if `T` is.
+    #[test]
+    fn send_sync() {
+        use std::rc::Rc;
+
+        use crate::types::implements;
+
+        assert!(implements!(Stack<u32>: Send));
+        assert!(implements!(Stack<u32>: Sync));
+        assert!(implements!(Stack<Rc<u32>>: !Send));
+        assert!(implements!(Stack<Rc<u32>>: !Sync));
+    }
 }

--- a/crates/oxc_str/Cargo.toml
+++ b/crates/oxc_str/Cargo.toml
@@ -29,6 +29,9 @@ hashbrown = { workspace = true, default-features = false, features = ["inline-mo
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
+[dev-dependencies]
+oxc_data_structures = { workspace = true, features = ["types"] }
+
 [features]
 default = []
 serialize = ["compact_str/serde", "dep:serde", "oxc_estree/serialize"]

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -617,6 +617,7 @@ mod test {
     use std::hash::BuildHasher;
 
     use oxc_allocator::Allocator;
+    use oxc_data_structures::types::implements;
 
     use super::*;
 
@@ -630,16 +631,13 @@ mod test {
 
     #[test]
     fn ident_send_sync() {
-        fn assert_send<T: Send>() {}
-        fn assert_sync<T: Sync>() {}
-        assert_send::<Ident<'_>>();
-        assert_sync::<Ident<'_>>();
+        assert!(implements!(Ident: Send));
+        assert!(implements!(Ident: Sync));
     }
 
     #[test]
     fn ident_copy() {
-        fn assert_copy<T: Copy>() {}
-        assert_copy::<Ident<'_>>();
+        assert!(implements!(Ident: Copy));
     }
 
     #[test]


### PR DESCRIPTION
Use `implements!` macro (introduced in #24721) in various tests, including adding some new ones.

The most valuable change is replacing a `compile_fail` doctest which checks that `Arena` is not `Sync`. Using `assert!(implements!(Arena: !Sync));` is more robust.

