### PR TITLE
feat(semantic): add context notes for strict assignments

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -191,6 +191,18 @@ pub fn check_identifier(name: &str, span: Span, ctx: &SemanticBuilder<'_>) {
     }
 }
 
+fn unexpected_identifier_assign_context(
+    ctx: &SemanticBuilder<'_>,
+) -> diagnostics::UnexpectedIdentifierAssignContext {
+    if ctx.ancestry().ancestor_kinds().any(|kind| matches!(kind, AstKind::Class(_))) {
+        diagnostics::UnexpectedIdentifierAssignContext::Class
+    } else if ctx.source_type.is_module() {
+        diagnostics::UnexpectedIdentifierAssignContext::Module
+    } else {
+        diagnostics::UnexpectedIdentifierAssignContext::StrictMode
+    }
+}
+
 pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder<'_>) {
     // `.d.ts` files are allowed to use `eval` and `arguments` as binding identifiers
     if ctx.source_type.is_typescript_definition() {
@@ -231,7 +243,11 @@ pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder
             };
 
             if !is_ok {
-                ctx.error(diagnostics::unexpected_identifier_assign(&ident.name, ident.span));
+                ctx.error(diagnostics::unexpected_identifier_assign(
+                    &ident.name,
+                    ident.span,
+                    unexpected_identifier_assign_context(ctx),
+                ));
             }
         }
         "let" if !ctx.strict_mode() => {
@@ -273,8 +289,11 @@ pub fn check_identifier_reference(ident: &IdentifierReference, ctx: &SemanticBui
                 | AstKind::AssignmentTargetPropertyIdentifier(_)
                 | AstKind::UpdateExpression(_)
                 | AstKind::ArrayAssignmentTarget(_) => {
-                    return ctx
-                        .error(diagnostics::unexpected_identifier_assign(&ident.name, ident.span));
+                    return ctx.error(diagnostics::unexpected_identifier_assign(
+                        &ident.name,
+                        ident.span,
+                        unexpected_identifier_assign_context(ctx),
+                    ));
                 }
                 AstKind::AssignmentExpression(assign_expr) => {
                     // only throw error if arguments or eval are being assigned to
@@ -285,6 +304,7 @@ pub fn check_identifier_reference(ident: &IdentifierReference, ctx: &SemanticBui
                         return ctx.error(diagnostics::unexpected_identifier_assign(
                             &ident.name,
                             ident.span,
+                            unexpected_identifier_assign_context(ctx),
                         ));
                     }
                 }

--- a/crates/oxc_semantic/src/diagnostics.rs
+++ b/crates/oxc_semantic/src/diagnostics.rs
@@ -82,8 +82,31 @@ pub enum ReservedKeywordContext {
 }
 
 #[cold]
-pub fn unexpected_identifier_assign(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("Cannot assign to '{x0}' in strict mode")).with_label(span1)
+pub fn unexpected_identifier_assign(
+    x0: &str,
+    span1: Span,
+    context: UnexpectedIdentifierAssignContext,
+) -> OxcDiagnostic {
+    let diagnostic =
+        OxcDiagnostic::error(format!("Cannot assign to '{x0}' in strict mode")).with_label(span1);
+    match context {
+        UnexpectedIdentifierAssignContext::StrictMode => {
+            diagnostic.with_note("This is strict mode code")
+        }
+        UnexpectedIdentifierAssignContext::Class => {
+            diagnostic.with_note("Classes are always strict mode code")
+        }
+        UnexpectedIdentifierAssignContext::Module => {
+            diagnostic.with_note("Modules are always strict mode code")
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum UnexpectedIdentifierAssignContext {
+    StrictMode,
+    Class,
+    Module,
 }
 
 #[cold]

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -1965,138 +1965,161 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ function hello() {'use strict'; var eval = 10; }
    ·                                     ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/469/input.js:1:37]
  1 │ function hello() {'use strict'; var arguments = 10; }
    ·                                     ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/470/input.js:1:48]
  1 │ function hello() {'use strict'; try { } catch (eval) { } }
    ·                                                ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/471/input.js:1:48]
  1 │ function hello() {'use strict'; try { } catch (arguments) { } }
    ·                                                ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/472/input.js:1:33]
  1 │ function hello() {'use strict'; eval = 10; }
    ·                                 ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/473/input.js:1:33]
  1 │ function hello() {'use strict'; arguments = 10; }
    ·                                 ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/474/input.js:1:35]
  1 │ function hello() {'use strict'; ++eval; }
    ·                                   ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/475/input.js:1:35]
  1 │ function hello() {'use strict'; --eval; }
    ·                                   ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/476/input.js:1:35]
  1 │ function hello() {'use strict'; ++arguments; }
    ·                                   ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/477/input.js:1:35]
  1 │ function hello() {'use strict'; --arguments; }
    ·                                   ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/478/input.js:1:33]
  1 │ function hello() {'use strict'; eval++; }
    ·                                 ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/479/input.js:1:33]
  1 │ function hello() {'use strict'; eval--; }
    ·                                 ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/480/input.js:1:33]
  1 │ function hello() {'use strict'; arguments++; }
    ·                                 ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/481/input.js:1:33]
  1 │ function hello() {'use strict'; arguments--; }
    ·                                 ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/482/input.js:1:42]
  1 │ function hello() {'use strict'; function eval() { } }
    ·                                          ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/483/input.js:1:42]
  1 │ function hello() {'use strict'; function arguments() { } }
    ·                                          ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/484/input.js:1:10]
  1 │ function eval() {'use strict'; }
    ·          ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/485/input.js:1:10]
  1 │ function arguments() {'use strict'; }
    ·          ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/486/input.js:1:43]
  1 │ function hello() {'use strict'; (function eval() { }()) }
    ·                                           ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/487/input.js:1:43]
  1 │ function hello() {'use strict'; (function arguments() { }()) }
    ·                                           ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/488/input.js:1:11]
  1 │ (function eval() {'use strict'; })()
    ·           ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/489/input.js:1:11]
  1 │ (function arguments() {'use strict'; })()
    ·           ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/490/input.js:1:48]
  1 │ function hello() {'use strict'; ({ s: function eval() { } }); }
    ·                                                ────
    ╰────
+  note: This is strict mode code
 
   × The keyword 'package' is reserved
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/491/input.js:1:11]
@@ -2110,42 +2133,49 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ function hello() {'use strict'; ({ i: 10, set s(eval) { } }); }
    ·                                                 ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/493/input.js:1:42]
  1 │ function hello() {'use strict'; ({ set s(eval) { } }); }
    ·                                          ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/494/input.js:1:50]
  1 │ function hello() {'use strict'; ({ s: function s(eval) { } }); }
    ·                                                  ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/495/input.js:1:16]
  1 │ function hello(eval) {'use strict';}
    ·                ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/496/input.js:1:16]
  1 │ function hello(arguments) {'use strict';}
    ·                ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/497/input.js:1:49]
  1 │ function hello() { 'use strict'; function inner(eval) {} }
    ·                                                 ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/498/input.js:1:49]
  1 │ function hello() { 'use strict'; function inner(arguments) {} }
    ·                                                 ─────────
    ╰────
+  note: This is strict mode code
 
   × '0'-prefixed octal literals and octal escape sequences are deprecated
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/500/input.js:1:34]
@@ -2244,6 +2274,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ function a(eval) { "use strict"; }
    ·            ────
    ╰────
+  note: This is strict mode code
 
   × The keyword 'package' is reserved
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/516/input.js:1:12]
@@ -2281,6 +2312,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ (function a(eval) { "use strict"; })
    ·             ────
    ╰────
+  note: This is strict mode code
 
   × The keyword 'package' is reserved
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/521/input.js:1:13]
@@ -2681,6 +2713,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ const { arguments } = foo();
    ·         ─────────
    ╰────
+  note: Modules are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/destructuring/binding-arguments-strict/input.js:2:9]
@@ -2688,12 +2721,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  2 │ const { arguments } = foo();
    ·         ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/destructuring/binding-eval/input.js:1:17]
  1 │ 'use strict'; ({eval = defValue} = obj)
    ·                 ────
    ╰────
+  note: This is strict mode code
 
   × Expected `:` but found `}`
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/destructuring/binding-this/input.js:1:12]
@@ -3947,6 +3982,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ function hello() {'use strict'; ({ i: 10, s(eval) { } }); }
    ·                                             ────
    ╰────
+  note: This is strict mode code
 
   × Identifier `t` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/228/input.js:1:35]
@@ -3985,12 +4021,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ "use strict"; ({ v: eval } = obj)
    ·                     ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/234/input.js:1:21]
  1 │ "use strict"; ({ v: arguments } = obj)
    ·                     ─────────
    ╰────
+  note: This is strict mode code
 
   × for-in loop variable declaration may not have an initializer
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/235/input.js:1:6]
@@ -4025,36 +4063,42 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ "use strict"; (eval = 10) => 42
    ·                ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/243/input.js:1:15]
  1 │ "use strict"; eval => 42
    ·               ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/244/input.js:1:15]
  1 │ "use strict"; arguments => 42
    ·               ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/245/input.js:1:16]
  1 │ "use strict"; (eval, a) => 42
    ·                ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/246/input.js:1:16]
  1 │ "use strict"; (arguments, a) => 42
    ·                ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/247/input.js:1:16]
  1 │ "use strict"; (eval, a = 10) => 42
    ·                ────
    ╰────
+  note: This is strict mode code
 
   × Identifier `a` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/248/input.js:1:16]
@@ -4237,6 +4281,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ ({ t(eval) { "use strict"; } });
    ·      ────
    ╰────
+  note: This is strict mode code
 
   × Bad escape sequence in untagged template literal
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/290/input.js:1:23]
@@ -4274,12 +4319,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ "use strict"; (eval) => 42
    ·                ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/297/input.js:1:2]
  1 │ (eval) => { "use strict"; 42 }
    ·  ────
    ╰────
+  note: This is strict mode code
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/298/input.js:1:21]
@@ -4347,12 +4394,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ 'use strict'; [...eval] = arr
    ·                   ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/334/input.js:1:5]
  1 │ [...eval] = arr
    ·     ────
    ╰────
+  note: Modules are always strict mode code
 
   × Cannot use `yield` as an identifier in a generator context
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/335/input.js:1:14]
@@ -9416,6 +9465,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ eval => {"use strict"};
    · ────
    ╰────
+  note: This is strict mode code
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-arrow-function/non-arrow-param-followed-by-arrow/input.js:1:6]
@@ -9477,6 +9527,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ class A {a(eval){}}
    ·            ────
    ╰────
+  note: Classes are always strict mode code
 
   × Invalid assignment in object literal
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-destructuring-assignment/invalid-cover-grammar/input.js:1:22]
@@ -10961,30 +11012,35 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ "use strict"; (eval = 10) => 42
    ·                ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0088/input.js:1:15]
  1 │ "use strict"; eval => 42
    ·               ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0089/input.js:1:15]
  1 │ "use strict"; arguments => 42
    ·               ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0090/input.js:1:16]
  1 │ "use strict"; (eval, a) => 42
    ·                ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0091/input.js:1:16]
  1 │ "use strict"; (arguments, a) => 42
    ·                ─────────
    ╰────
+  note: This is strict mode code
 
   × Identifier `a` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0092/input.js:1:2]
@@ -11046,12 +11102,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ "use strict"; (eval) => 42
    ·                ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0101/input.js:1:2]
  1 │ (eval) => { "use strict"; 42 }
    ·  ────
    ╰────
+  note: This is strict mode code
 
   × Expected `,` or `}` but found `/`
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0102/input.js:1:8]
@@ -11559,138 +11617,161 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ function hello() {'use strict'; var eval = 10; }
    ·                                     ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0186/input.js:1:37]
  1 │ function hello() {'use strict'; var arguments = 10; }
    ·                                     ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0187/input.js:1:48]
  1 │ function hello() {'use strict'; try { } catch (eval) { } }
    ·                                                ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0188/input.js:1:48]
  1 │ function hello() {'use strict'; try { } catch (arguments) { } }
    ·                                                ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0189/input.js:1:33]
  1 │ function hello() {'use strict'; eval = 10; }
    ·                                 ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0190/input.js:1:33]
  1 │ function hello() {'use strict'; arguments = 10; }
    ·                                 ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0191/input.js:1:35]
  1 │ function hello() {'use strict'; ++eval; }
    ·                                   ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0192/input.js:1:35]
  1 │ function hello() {'use strict'; --eval; }
    ·                                   ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0193/input.js:1:35]
  1 │ function hello() {'use strict'; ++arguments; }
    ·                                   ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0194/input.js:1:35]
  1 │ function hello() {'use strict'; --arguments; }
    ·                                   ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0195/input.js:1:33]
  1 │ function hello() {'use strict'; eval++; }
    ·                                 ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0196/input.js:1:33]
  1 │ function hello() {'use strict'; eval--; }
    ·                                 ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0197/input.js:1:33]
  1 │ function hello() {'use strict'; arguments++; }
    ·                                 ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0198/input.js:1:33]
  1 │ function hello() {'use strict'; arguments--; }
    ·                                 ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0199/input.js:1:42]
  1 │ function hello() {'use strict'; function eval() { } }
    ·                                          ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0200/input.js:1:42]
  1 │ function hello() {'use strict'; function arguments() { } }
    ·                                          ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0201/input.js:1:10]
  1 │ function eval() {'use strict'; }
    ·          ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0202/input.js:1:10]
  1 │ function arguments() {'use strict'; }
    ·          ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0203/input.js:1:43]
  1 │ function hello() {'use strict'; (function eval() { }()) }
    ·                                           ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0204/input.js:1:43]
  1 │ function hello() {'use strict'; (function arguments() { }()) }
    ·                                           ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0205/input.js:1:11]
  1 │ (function eval() {'use strict'; })()
    ·           ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0206/input.js:1:11]
  1 │ (function arguments() {'use strict'; })()
    ·           ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0207/input.js:1:48]
  1 │ function hello() {'use strict'; ({ s: function eval() { } }); }
    ·                                                ────
    ╰────
+  note: This is strict mode code
 
   × The keyword 'package' is reserved
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0208/input.js:1:11]
@@ -11704,42 +11785,49 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ function hello() {'use strict'; ({ i: 10, set s(eval) { } }); }
    ·                                                 ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0210/input.js:1:42]
  1 │ function hello() {'use strict'; ({ set s(eval) { } }); }
    ·                                          ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0211/input.js:1:50]
  1 │ function hello() {'use strict'; ({ s: function s(eval) { } }); }
    ·                                                  ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0212/input.js:1:16]
  1 │ function hello(eval) {'use strict';}
    ·                ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0213/input.js:1:16]
  1 │ function hello(arguments) {'use strict';}
    ·                ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0214/input.js:1:49]
  1 │ function hello() { 'use strict'; function inner(eval) {} }
    ·                                                 ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0215/input.js:1:49]
  1 │ function hello() { 'use strict'; function inner(arguments) {} }
    ·                                                 ─────────
    ╰────
+  note: This is strict mode code
 
   × '0'-prefixed octal literals and octal escape sequences are deprecated
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0216/input.js:1:1]
@@ -11886,12 +11974,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ function eval(a) { "use strict"; }
    ·          ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0236/input.js:1:10]
  1 │ function arguments(a) { "use strict"; }
    ·          ─────────
    ╰────
+  note: This is strict mode code
 
   × The keyword 'static' is reserved
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0239/input.js:1:24]
@@ -11913,6 +12003,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ function a(eval) { "use strict"; }
    ·            ────
    ╰────
+  note: This is strict mode code
 
   × The keyword 'package' is reserved
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0242/input.js:1:12]
@@ -11950,6 +12041,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ (function a(eval) { "use strict"; })
    ·             ────
    ╰────
+  note: This is strict mode code
 
   × The keyword 'package' is reserved
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0247/input.js:1:13]

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -9,6 +9,7 @@ Negative Passed: 153/153 (100.00%)
    ·          ─────────
  2 │ function eval() {}
    ╰────
+  note: Modules are always strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[misc/fail/arguments-eval.ts:2:10]
@@ -17,6 +18,7 @@ Negative Passed: 153/153 (100.00%)
    ·          ────
  3 │ 
    ╰────
+  note: Modules are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:4:16]
@@ -25,6 +27,7 @@ Negative Passed: 153/153 (100.00%)
    ·                ─────────
  5 │ function foo2([arguments]) {}
    ╰────
+  note: Modules are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:5:16]
@@ -33,6 +36,7 @@ Negative Passed: 153/153 (100.00%)
    ·                ─────────
  6 │ function foo3({ eval }) {}
    ╰────
+  note: Modules are always strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[misc/fail/arguments-eval.ts:6:17]
@@ -41,6 +45,7 @@ Negative Passed: 153/153 (100.00%)
    ·                 ────
  7 │ function foo4([eval]) {}
    ╰────
+  note: Modules are always strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[misc/fail/arguments-eval.ts:7:16]
@@ -49,6 +54,7 @@ Negative Passed: 153/153 (100.00%)
    ·                ────
  8 │ 
    ╰────
+  note: Modules are always strict mode code
 
   × Cannot use await in class static initialization block
    ╭─[misc/fail/await-expr-in-block-in-class-static-block.mjs:4:7]

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -1609,6 +1609,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·     ─────────
  19 │ }
     ╰────
+  note: This is strict mode code
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
     ╭─[test262/test/language/asi/S7.9.2_A1_T1.js:17:4]
@@ -3102,6 +3103,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ eval = 42;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/directive-prologue/14.1-5gs.js:19:1]
@@ -3109,6 +3111,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ eval = 42;
     · ────
     ╰────
+  note: This is strict mode code
 
   × The keyword 'static' is reserved
     ╭─[test262/test/language/directive-prologue/func-decl-inside-func-decl-parse.js:22:9]
@@ -3768,6 +3771,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ var af = arguments => 1;
     ·          ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/arrow-function/syntax/early-errors/arrowparameters-bindingidentifier-no-eval.js:21:10]
@@ -3775,6 +3779,7 @@ Negative Passed: 4651/4651 (100.00%)
  21 │ var af = eval => 1;
     ·          ────
     ╰────
+  note: This is strict mode code
 
   × The keyword 'yield' is reserved
     ╭─[test262/test/language/expressions/arrow-function/syntax/early-errors/arrowparameters-bindingidentifier-no-yield.js:21:10]
@@ -3797,6 +3802,7 @@ Negative Passed: 4651/4651 (100.00%)
  25 │ var af = (arguments) => 1;
     ·           ─────────
     ╰────
+  note: This is strict mode code
 
   × Identifier `x` has already been declared
     ╭─[test262/test/language/expressions/arrow-function/syntax/early-errors/arrowparameters-cover-no-duplicates-binding-array-1.js:26:11]
@@ -3903,6 +3909,7 @@ Negative Passed: 4651/4651 (100.00%)
  25 │ var af = (eval) => 1;
     ·           ────
     ╰────
+  note: This is strict mode code
 
   × The keyword 'yield' is reserved
     ╭─[test262/test/language/expressions/arrow-function/syntax/early-errors/arrowparameters-cover-no-yield.js:20:11]
@@ -4006,6 +4013,7 @@ Negative Passed: 4651/4651 (100.00%)
  24 │ 0, [arguments] = [];
     ·     ─────────
     ╰────
+  note: This is strict mode code
 
   × The keyword 'yield' is reserved
     ╭─[test262/test/language/expressions/assignment/dstr/array-elem-target-yield-invalid.js:24:8]
@@ -4121,6 +4129,7 @@ Negative Passed: 4651/4651 (100.00%)
  24 │ 0, { eval = 0 } = {};
     ·      ────
     ╰────
+  note: This is strict mode code
 
   × The keyword 'yield' is reserved
     ╭─[test262/test/language/expressions/assignment/dstr/obj-id-init-yield-ident-invalid.js:24:10]
@@ -4136,6 +4145,7 @@ Negative Passed: 4651/4651 (100.00%)
  24 │ 0, { eval } = {};
     ·      ────
     ╰────
+  note: This is strict mode code
 
   × The keyword 'yield' is reserved
     ╭─[test262/test/language/expressions/assignment/dstr/obj-prop-elem-init-yield-ident-invalid.js:24:13]
@@ -4574,6 +4584,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ (arguments) = 20;
     ·  ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/assignment/id-eval-strict.js:17:2]
@@ -4581,6 +4592,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ (eval) = 20;
     ·  ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/assignment/non-simple-target.js:19:1]
@@ -5049,6 +5061,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ arguments = 1;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/assignmenttargettype/direct-identifierreference-eval-strict.js:17:1]
@@ -5056,6 +5069,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ eval = 1;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Unexpected import.meta expression
     ╭─[test262/test/language/expressions/assignmenttargettype/direct-import.meta.js:21:1]
@@ -6182,6 +6196,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ (arguments) = 1;
     ·  ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/assignmenttargettype/parenthesized-identifierreference-eval-strict.js:20:2]
@@ -6189,6 +6204,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ (eval) = 1;
     ·  ────
     ╰────
+  note: This is strict mode code
 
   × Unexpected import.meta expression
     ╭─[test262/test/language/expressions/assignmenttargettype/parenthesized-import.meta.js:24:2]
@@ -7063,6 +7079,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·       ─────────
  18 │ 
     ╰────
+  note: This is strict mode code
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
     ╭─[test262/test/language/expressions/async-arrow-function/early-errors-arrow-await-in-formals-default.js:15:17]
@@ -7108,6 +7125,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ async(eval) => {  }
     ·       ────
     ╰────
+  note: This is strict mode code
 
   × Identifier `bar` has already been declared
     ╭─[test262/test/language/expressions/async-arrow-function/early-errors-arrow-formals-body-duplicate.js:16:7]
@@ -7253,6 +7271,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·                 ─────────
  18 │ 
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/async-function/early-errors-expression-binding-identifier-eval.js:17:17]
@@ -7260,6 +7279,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ (async function eval () { })
     ·                 ────
     ╰────
+  note: This is strict mode code
 
   × TS(2337): Super calls are not permitted outside constructors or in nested functions inside constructors.
     ╭─[test262/test/language/expressions/async-function/early-errors-expression-body-contains-super-call.js:16:29]
@@ -7282,6 +7302,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ (async function foo (eval) {  })
     ·                      ────
     ╰────
+  note: This is strict mode code
 
   × Identifier `bar` has already been declared
     ╭─[test262/test/language/expressions/async-function/early-errors-expression-formals-body-duplicate.js:16:22]
@@ -7789,6 +7810,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ (async function*(arguments) { });
     ·                  ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot use `await` as an identifier in an async context
     ╭─[test262/test/language/expressions/async-generator/early-errors-expression-await-as-function-binding-identifier.js:18:18]
@@ -7803,6 +7825,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ (async function* arguments() { });
     ·                  ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/async-generator/early-errors-expression-binding-identifier-eval.js:20:18]
@@ -7810,6 +7833,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ (async function* eval() { });
     ·                  ────
     ╰────
+  note: This is strict mode code
 
   × TS(2337): Super calls are not permitted outside constructors or in nested functions inside constructors.
     ╭─[test262/test/language/expressions/async-generator/early-errors-expression-body-contains-super-call.js:18:22]
@@ -7831,6 +7855,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ (async function*(eval) { });
     ·                  ────
     ╰────
+  note: This is strict mode code
 
   × Identifier `a` has already been declared
     ╭─[test262/test/language/expressions/async-generator/early-errors-expression-formals-body-duplicate-const.js:22:18]
@@ -14592,6 +14617,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ eval *= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/add-arguments-strict.js:20:1]
@@ -14599,6 +14625,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ arguments += 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/add-eval-strict.js:19:1]
@@ -14606,6 +14633,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ eval += 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/compound-assignment/add-non-simple.js:18:1]
@@ -14620,6 +14648,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ arguments &= 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/and-eval-strict.js:19:1]
@@ -14627,6 +14656,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ eval &= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/compound-assignment/btws-and-non-simple.js:18:1]
@@ -14655,6 +14685,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ arguments /= 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/div-eval-strict.js:19:1]
@@ -14662,6 +14693,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ eval /= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/compound-assignment/div-non-simple.js:18:1]
@@ -14683,6 +14715,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ arguments <<= 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/lshift-eval-strict.js:20:1]
@@ -14690,6 +14723,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ eval <<= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/mod-arguments-strict.js:20:1]
@@ -14697,6 +14731,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ arguments %= 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/compound-assignment/mod-div-non-simple.js:18:1]
@@ -14711,6 +14746,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ eval %= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/mult-arguments-strict.js:20:1]
@@ -14718,6 +14754,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ arguments *= 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/mult-eval-strict.js:19:1]
@@ -14725,6 +14762,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ eval *= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/compound-assignment/mult-non-simple.js:18:1]
@@ -14739,6 +14777,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ arguments |= 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/or-eval-strict.js:19:1]
@@ -14746,6 +14785,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ eval |= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/compound-assignment/right-shift-non-simple.js:18:1]
@@ -14760,6 +14800,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ arguments >>= 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/srshift-eval-strict.js:20:1]
@@ -14767,6 +14808,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ eval >>= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/sub-arguments-strict.js:20:1]
@@ -14774,6 +14816,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ arguments -= 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/sub-eval-strict.js:19:1]
@@ -14781,6 +14824,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ eval -= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/compound-assignment/subtract-non-simple.js:18:1]
@@ -14802,6 +14846,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ arguments >>>= 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/urshift-eval-strict.js:20:1]
@@ -14809,6 +14854,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ eval >>>= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/xor-arguments-strict.js:20:1]
@@ -14816,6 +14862,7 @@ Negative Passed: 4651/4651 (100.00%)
  20 │ arguments ^= 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/compound-assignment/xor-eval-strict.js:19:1]
@@ -14823,6 +14870,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ eval ^= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/conditional/in-branch-2.js:23:6]
@@ -18193,6 +18241,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ (function arguments() {'use strict';});
     ·           ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/expressions/function/name-arguments-strict.js:18:11]
@@ -18200,6 +18249,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ (function arguments() {});
     ·           ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/function/name-eval-strict-body.js:18:11]
@@ -18207,6 +18257,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ (function eval() {'use strict';});
     ·           ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/function/name-eval-strict.js:18:11]
@@ -18214,6 +18265,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ (function eval() {});
     ·           ────
     ╰────
+  note: This is strict mode code
 
   × Illegal 'use strict' directive in function with non-simple parameter list
      ╭─[test262/test/language/expressions/function/object-destructuring-param-strict-body.js:132:3]
@@ -18311,6 +18363,7 @@ Negative Passed: 4651/4651 (100.00%)
  22 │ (function (eval) { 'use strict'; });
     ·            ────
     ╰────
+  note: This is strict mode code
 
   × Illegal 'use strict' directive in function with non-simple parameter list
      ╭─[test262/test/language/expressions/function/rest-param-strict-body.js:132:3]
@@ -18965,6 +19018,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ arguments &&= 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/logical-assignment/lgcl-and-assignment-operator-non-simple-lhs.js:20:1]
@@ -18979,6 +19033,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ eval &&= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/logical-assignment/lgcl-and-non-simple.js:18:1]
@@ -18993,6 +19048,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ arguments ??= 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/logical-assignment/lgcl-nullish-assignment-operator-non-simple-lhs.js:20:1]
@@ -19007,6 +19063,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ eval ??= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/logical-assignment/lgcl-nullish-non-simple.js:18:1]
@@ -19021,6 +19078,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ arguments ||= 20;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/logical-assignment/lgcl-or-assignment-operator-non-simple-lhs.js:20:1]
@@ -19035,6 +19093,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ eval ||= 20;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/logical-assignment/lgcl-or-non-simple.js:18:1]
@@ -19065,6 +19124,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ var obj = { set _11_1_5_1_fun(eval) {}};
     ·                               ────
     ╰────
+  note: This is strict mode code
 
   × Identifier `__proto__` has already been declared
     ╭─[test262/test/language/expressions/object/__proto__-duplicate.js:21:3]
@@ -19897,6 +19957,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·              ─────────
  19 │ })
     ╰────
+  note: This is strict mode code
 
   × Expected `,` or `}` but found `Identifier`
     ╭─[test262/test/language/expressions/object/method-definition/early-errors-object-method-async-lineterminator.js:22:3]
@@ -19952,6 +20013,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·             ────
  19 │ })
     ╰────
+  note: This is strict mode code
 
   × 'async' modifier cannot be used here.
     ╭─[test262/test/language/expressions/object/method-definition/early-errors-object-method-formals-body-duplicate.js:18:3]
@@ -20611,6 +20673,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·         ─────────
  19 │     "use strict";
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/expressions/object/setter-param-arguments-strict-outside.js:19:9]
@@ -20619,6 +20682,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·         ─────────
  20 │ };
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/object/setter-param-eval-strict-inside.js:18:9]
@@ -20627,6 +20691,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·         ────
  19 │     "use strict";
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/object/setter-param-eval-strict-outside.js:19:9]
@@ -20635,6 +20700,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·         ────
  20 │ };
     ╰────
+  note: This is strict mode code
 
   × 'super' can only be referenced in a derived class.
     ╭─[test262/test/language/expressions/optional-chaining/call-expression-super-no-base.js:20:1]
@@ -20732,6 +20798,7 @@ Negative Passed: 4651/4651 (100.00%)
  27 │ arguments--;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/postfix-decrement/eval.js:27:1]
@@ -20739,6 +20806,7 @@ Negative Passed: 4651/4651 (100.00%)
  27 │ eval--;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Unexpected token
     ╭─[test262/test/language/expressions/postfix-decrement/line-terminator-carriage-return.js:18:3]
@@ -20808,6 +20876,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ arguments++;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/expressions/postfix-increment/arguments.js:23:1]
@@ -20815,6 +20884,7 @@ Negative Passed: 4651/4651 (100.00%)
  23 │ arguments++;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/postfix-increment/eval.js:23:1]
@@ -20822,6 +20892,7 @@ Negative Passed: 4651/4651 (100.00%)
  23 │ eval++;
     · ────
     ╰────
+  note: This is strict mode code
 
   × Unexpected token
     ╭─[test262/test/language/expressions/postfix-increment/line-terminator-carriage-return.js:18:3]
@@ -20891,6 +20962,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ --arguments;
     ·   ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/expressions/prefix-decrement/arguments.js:27:3]
@@ -20898,6 +20970,7 @@ Negative Passed: 4651/4651 (100.00%)
  27 │ --arguments;
     ·   ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/prefix-decrement/eval.js:27:3]
@@ -20905,6 +20978,7 @@ Negative Passed: 4651/4651 (100.00%)
  27 │ --eval;
     ·   ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/prefix-decrement/target-cover-newtarget.js:31:6]
@@ -20943,6 +21017,7 @@ Negative Passed: 4651/4651 (100.00%)
  27 │ ++arguments;
     ·   ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/expressions/prefix-increment/eval.js:28:3]
@@ -20950,6 +21025,7 @@ Negative Passed: 4651/4651 (100.00%)
  28 │ ++eval;
     ·   ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to this expression
     ╭─[test262/test/language/expressions/prefix-increment/target-cover-newtarget.js:31:6]
@@ -25551,6 +25627,7 @@ Negative Passed: 4651/4651 (100.00%)
  35 │ import { arguments } from './early-import-arguments.js';
     ·          ─────────
     ╰────
+  note: Modules are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/module-code/early-import-as-arguments.js:35:15]
@@ -25558,6 +25635,7 @@ Negative Passed: 4651/4651 (100.00%)
  35 │ import { x as arguments } from './early-import-as-arguments.js';
     ·               ─────────
     ╰────
+  note: Modules are always strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/module-code/early-import-as-eval.js:35:15]
@@ -25565,6 +25643,7 @@ Negative Passed: 4651/4651 (100.00%)
  35 │ import { x as eval } from './early-import-as-eval.js';
     ·               ────
     ╰────
+  note: Modules are always strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/module-code/early-import-eval.js:35:10]
@@ -25572,6 +25651,7 @@ Negative Passed: 4651/4651 (100.00%)
  35 │ import { eval } from './early-import-eval.js';
     ·          ────
     ╰────
+  note: Modules are always strict mode code
 
   × Identifier `x` has already been declared
     ╭─[test262/test/language/module-code/early-lex-and-var.js:17:5]
@@ -27081,6 +27161,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·                     ─────────
  18 │ 
     ╰────
+  note: This is strict mode code
 
   × Unexpected token
     ╭─[test262/test/language/statements/async-function/early-errors-declaration-await-in-formals-default.js:15:30]
@@ -27103,6 +27184,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·                ─────────
  18 │ 
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/async-function/early-errors-declaration-binding-identifier-eval.js:17:16]
@@ -27110,6 +27192,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ async function eval () {  }
     ·                ────
     ╰────
+  note: This is strict mode code
 
   × TS(2337): Super calls are not permitted outside constructors or in nested functions inside constructors.
     ╭─[test262/test/language/statements/async-function/early-errors-declaration-body-contains-super-call.js:16:28]
@@ -27140,6 +27223,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ async function foo (eval) {  }
     ·                     ────
     ╰────
+  note: This is strict mode code
 
   × Identifier `bar` has already been declared
     ╭─[test262/test/language/statements/async-function/early-errors-declaration-formals-body-duplicate.js:16:21]
@@ -28878,6 +28962,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·              ─────────
  17 │ }
     ╰────
+  note: Classes are always strict mode code
 
   × Unexpected token
     ╭─[test262/test/language/statements/class/definition/early-errors-class-method-await-in-formals-default.js:16:23]
@@ -28920,6 +29005,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·             ────
  17 │ }
     ╰────
+  note: Classes are always strict mode code
 
   × Expected `;` but found `Identifier`
     ╭─[test262/test/language/statements/class/definition/early-errors-class-method-formals-body-duplicate.js:18:18]
@@ -35733,6 +35819,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·               ─────────
  35 │ }
     ╰────
+  note: This is strict mode code
 
   × The keyword 'yield' is reserved
     ╭─[test262/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-target-yield-invalid.js:34:18]
@@ -36572,6 +36659,7 @@ Negative Passed: 4651/4651 (100.00%)
  33 │ for ([arguments] in [[]]) ;
     ·       ─────────
     ╰────
+  note: This is strict mode code
 
   × The keyword 'yield' is reserved
     ╭─[test262/test/language/statements/for-in/dstr/array-elem-target-yield-invalid.js:33:10]
@@ -36687,6 +36775,7 @@ Negative Passed: 4651/4651 (100.00%)
  33 │ for ({ eval = 0 } in [{}]) ;
     ·        ────
     ╰────
+  note: This is strict mode code
 
   × The keyword 'yield' is reserved
     ╭─[test262/test/language/statements/for-in/dstr/obj-id-init-yield-ident-invalid.js:33:12]
@@ -36702,6 +36791,7 @@ Negative Passed: 4651/4651 (100.00%)
  33 │ for ({ eval } in [{}]) ;
     ·        ────
     ╰────
+  note: This is strict mode code
 
   × The keyword 'yield' is reserved
     ╭─[test262/test/language/statements/for-in/dstr/obj-prop-elem-init-yield-ident-invalid.js:33:15]
@@ -36905,6 +36995,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·            ─────────
  20 │ }
     ╰────
+  note: This is strict mode code
 
   × for-in loop variable declaration may not have an initializer
     ╭─[test262/test/language/statements/for-in/var-arguments-fn-strict-init.js:19:8]
@@ -36921,6 +37012,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·            ─────────
  20 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/for-in/var-arguments-strict-init.js:18:10]
@@ -36928,6 +37020,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ for (var arguments = 42 in null) {}
     ·          ─────────
     ╰────
+  note: This is strict mode code
 
   × for-in loop variable declaration may not have an initializer
     ╭─[test262/test/language/statements/for-in/var-arguments-strict-init.js:18:6]
@@ -36942,6 +37035,7 @@ Negative Passed: 4651/4651 (100.00%)
  16 │ for (var arguments in null) {}
     ·          ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/for-in/var-eval-strict-init.js:16:10]
@@ -36949,6 +37043,7 @@ Negative Passed: 4651/4651 (100.00%)
  16 │ for (var eval = 42 in null) {}
     ·          ────
     ╰────
+  note: This is strict mode code
 
   × for-in loop variable declaration may not have an initializer
     ╭─[test262/test/language/statements/for-in/var-eval-strict-init.js:16:6]
@@ -36963,6 +37058,7 @@ Negative Passed: 4651/4651 (100.00%)
  16 │ for (var eval in null) {}
     ·          ────
     ╰────
+  note: This is strict mode code
 
   × Async functions can only be declared at the top level or inside a block
     ╭─[test262/test/language/statements/for-of/decl-async-fun.js:21:19]
@@ -37102,6 +37198,7 @@ Negative Passed: 4651/4651 (100.00%)
  33 │ for ([arguments] of [[]]) ;
     ·       ─────────
     ╰────
+  note: This is strict mode code
 
   × The keyword 'yield' is reserved
     ╭─[test262/test/language/statements/for-of/dstr/array-elem-target-yield-invalid.js:33:10]
@@ -37341,6 +37438,7 @@ Negative Passed: 4651/4651 (100.00%)
  33 │ for ({ eval = 0 } of [{}]) ;
     ·        ────
     ╰────
+  note: This is strict mode code
 
   × The keyword 'yield' is reserved
     ╭─[test262/test/language/statements/for-of/dstr/obj-id-init-yield-ident-invalid.js:33:12]
@@ -37356,6 +37454,7 @@ Negative Passed: 4651/4651 (100.00%)
  33 │ for ({ eval } of [{}]) ;
     ·        ────
     ╰────
+  note: This is strict mode code
 
   × The keyword 'yield' is reserved
     ╭─[test262/test/language/statements/for-of/dstr/obj-prop-elem-init-yield-ident-invalid.js:33:15]
@@ -37745,6 +37844,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ function _13_0_4_5_fun() { eval = 42; };
     ·                            ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/function/13.1-13gs.js:18:10]
@@ -37752,6 +37852,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ function arguments() { };
     ·          ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/function/13.1-1gs.js:19:22]
@@ -37759,6 +37860,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ function _13_1_1_fun(eval) { }
     ·                      ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/function/13.1-4gs.js:19:29]
@@ -37766,6 +37868,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ var _13_1_4_fun = function (arguments) { };
     ·                             ─────────
     ╰────
+  note: This is strict mode code
 
   × Identifier `param` has already been declared
     ╭─[test262/test/language/statements/function/13.1-5gs.js:18:22]
@@ -37994,6 +38097,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·         ────
  25 │     }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/function/enable-strict-via-outer-body.js:24:9]
@@ -38002,6 +38106,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·         ────
  25 │     }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/function/enable-strict-via-outer-script.js:24:9]
@@ -38010,6 +38115,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·         ────
  25 │     }
     ╰────
+  note: This is strict mode code
 
   × Expected `(` but found `,`
     ╭─[test262/test/language/statements/function/invalid-2-names.js:17:11]
@@ -38070,6 +38176,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ function arguments() { 'use strict'; }
     ·          ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/function/name-arguments-strict.js:18:10]
@@ -38077,6 +38184,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ function arguments() { }
     ·          ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/function/name-eval-strict-body.js:18:10]
@@ -38084,6 +38192,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ function eval() { 'use strict'; }
     ·          ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/function/name-eval-strict.js:18:10]
@@ -38091,6 +38200,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ function eval() { }
     ·          ────
     ╰────
+  note: This is strict mode code
 
   × Illegal 'use strict' directive in function with non-simple parameter list
      ╭─[test262/test/language/statements/function/object-destructuring-param-strict-body.js:133:3]
@@ -38107,6 +38217,7 @@ Negative Passed: 4651/4651 (100.00%)
  22 │ function _13_1_20_fun(arguments) { 'use strict'; }
     ·                       ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/function/param-arguments-strict.js:23:22]
@@ -38114,6 +38225,7 @@ Negative Passed: 4651/4651 (100.00%)
  23 │ function _13_1_3_fun(arguments) { }
     ·                      ─────────
     ╰────
+  note: This is strict mode code
 
   × The keyword 'yield' is reserved
     ╭─[test262/test/language/statements/function/param-dflt-yield-strict.js:23:18]
@@ -38202,6 +38314,7 @@ Negative Passed: 4651/4651 (100.00%)
  22 │ function _13_1_16_fun(eval) { 'use strict'; }
     ·                       ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/function/param-eval-strict.js:23:22]
@@ -38209,6 +38322,7 @@ Negative Passed: 4651/4651 (100.00%)
  23 │ function _13_1_1_fun(eval) { }
     ·                      ────
     ╰────
+  note: This is strict mode code
 
   × Illegal 'use strict' directive in function with non-simple parameter list
      ╭─[test262/test/language/statements/function/rest-param-strict-body.js:133:3]
@@ -40269,6 +40383,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ try { } catch (arguments) { }
     ·                ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/try/catch-parameter-boundnames-restriction-eval-negative-early.js:17:16]
@@ -40276,6 +40391,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ try { } catch (eval) { }
     ·                ────
     ╰────
+  note: This is strict mode code
 
   × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/try/dstr/ary-ptrn-rest-init-ary.js:33:14]
@@ -40727,6 +40843,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ for (var eval in arrObj) { }
     ·          ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/12.2.1-4gs.js:18:5]
@@ -40734,6 +40851,7 @@ Negative Passed: 4651/4651 (100.00%)
  18 │ var arguments;
     ·     ─────────
     ╰────
+  note: This is strict mode code
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
     ╭─[test262/test/language/statements/variable/S12.2_A8_T1.js:18:6]
@@ -40813,6 +40931,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·          ─────────
  21 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-fn-strict-list-final.js:20:15]
@@ -40821,6 +40940,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·               ─────────
  21 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-fn-strict-list-first-init.js:19:7]
@@ -40829,6 +40949,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·       ─────────
  20 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-fn-strict-list-first.js:20:7]
@@ -40837,6 +40958,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·       ─────────
  21 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-fn-strict-list-middle-init.js:19:10]
@@ -40845,6 +40967,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·          ─────────
  20 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-fn-strict-list-middle.js:20:10]
@@ -40853,6 +40976,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·          ─────────
  21 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-fn-strict-list-repeated.js:20:7]
@@ -40861,6 +40985,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·       ─────────
  21 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-fn-strict-list-repeated.js:20:18]
@@ -40869,6 +40994,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·                  ─────────
  21 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-fn-strict-single-init.js:20:7]
@@ -40877,6 +41003,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·       ─────────
  21 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-fn-strict-single.js:20:7]
@@ -40885,6 +41012,7 @@ Negative Passed: 4651/4651 (100.00%)
     ·       ─────────
  21 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-strict-list-final-init.js:19:8]
@@ -40892,6 +41020,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ var a, arguments = 42;
     ·        ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-strict-list-final.js:17:13]
@@ -40899,6 +41028,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ var a = 42, arguments;
     ·             ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-strict-list-first-init.js:16:5]
@@ -40906,6 +41036,7 @@ Negative Passed: 4651/4651 (100.00%)
  16 │ var arguments = 42, a;
     ·     ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-strict-list-first.js:17:5]
@@ -40913,6 +41044,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ var arguments, a;
     ·     ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-strict-list-middle-init.js:16:8]
@@ -40920,6 +41052,7 @@ Negative Passed: 4651/4651 (100.00%)
  16 │ var a, arguments = 42, b;
     ·        ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-strict-list-middle.js:17:8]
@@ -40927,6 +41060,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ var a, arguments, b;
     ·        ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-strict-list-repeated.js:19:5]
@@ -40934,6 +41068,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ var arguments, arguments = 42;
     ·     ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-strict-list-repeated.js:19:16]
@@ -40941,6 +41076,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ var arguments, arguments = 42;
     ·                ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-strict-single-init.js:19:5]
@@ -40948,6 +41084,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ var arguments = 42;
     ·     ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/arguments-strict-single.js:17:5]
@@ -40955,6 +41092,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ var arguments;
     ·     ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot use `await` as an identifier in an async context
     ╭─[test262/test/language/statements/variable/dstr/ary-ptrn-elem-id-static-init-await-invalid.js:25:10]
@@ -41042,6 +41180,7 @@ Negative Passed: 4651/4651 (100.00%)
  16 │ var a, eval = 42;
     ·        ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/variable/eval-strict-list-final.js:17:8]
@@ -41049,6 +41188,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ var a, eval;
     ·        ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/variable/eval-strict-list-first-init.js:19:5]
@@ -41056,6 +41196,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ var eval = 42, a;
     ·     ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/variable/eval-strict-list-first.js:17:5]
@@ -41063,6 +41204,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ var eval, a = 42;
     ·     ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/variable/eval-strict-list-middle-init.js:16:8]
@@ -41070,6 +41212,7 @@ Negative Passed: 4651/4651 (100.00%)
  16 │ var a, eval = 42, b;
     ·        ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/variable/eval-strict-list-middle.js:16:8]
@@ -41077,6 +41220,7 @@ Negative Passed: 4651/4651 (100.00%)
  16 │ var a, eval, b;
     ·        ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/variable/eval-strict-list-repeated.js:19:5]
@@ -41084,6 +41228,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ var eval, eval;
     ·     ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/variable/eval-strict-list-repeated.js:19:11]
@@ -41091,6 +41236,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ var eval, eval;
     ·           ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/variable/eval-strict-single-init.js:19:5]
@@ -41098,6 +41244,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ var eval = 42;
     ·     ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/variable/eval-strict-single.js:19:5]
@@ -41105,6 +41252,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ var eval;
     ·     ────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[test262/test/language/statements/variable/id-arguments-strict.js:17:5]
@@ -41112,6 +41260,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ var arguments;
     ·     ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
     ╭─[test262/test/language/statements/variable/id-eval-strict.js:17:5]
@@ -41119,6 +41268,7 @@ Negative Passed: 4651/4651 (100.00%)
  17 │ var eval;
     ·     ────
     ╰────
+  note: This is strict mode code
 
   × Cannot use `await` as an identifier in an async context
     ╭─[test262/test/language/statements/variable/static-init-await-binding-invalid.js:25:9]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -2430,6 +2430,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  4 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/alwaysStrictES6.ts:3:9]
@@ -2438,6 +2439,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  4 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/alwaysStrictModule.ts:4:13]
@@ -2446,6 +2448,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·             ─────────
  5 │     }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/alwaysStrictModule2.ts:4:13]
@@ -2454,6 +2457,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·             ─────────
  5 │     }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/alwaysStrictNoImplicitUseStrict.ts:4:13]
@@ -2462,6 +2466,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·             ─────────
  5 │     }
    ╰────
+  note: This is strict mode code
 
   × TS(1039): Initializers are not allowed in ambient contexts.
    ╭─[typescript/tests/cases/compiler/ambientErrors1.ts:1:17]
@@ -2578,6 +2583,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·     ─────────
  3 │ function foo(a) {
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/argumentsBindsToFunctionScopeArgumentList.ts:4:5]
@@ -2586,6 +2592,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·     ─────────
  5 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/argumentsReferenceInConstructor4_Js.ts:18:9]
@@ -2594,6 +2601,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·               ─────────
  19 │ 
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/argumentsReferenceInMethod4_Js.ts:16:9]
@@ -2602,6 +2610,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·               ─────────
  17 │ 
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/argumentsReferenceInObjectLiteral_Js.ts:22:11]
@@ -2610,6 +2619,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·           ─────────
  23 │     return {
     ╰────
+  note: This is strict mode code
 
   × 'arguments' is not allowed in class field initializer
    ╭─[typescript/tests/cases/compiler/argumentsUsedInClassFieldInitializerOrStaticInitializationBlock.ts:3:10]
@@ -3524,6 +3534,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                         ─────────
  3 │     var arguments: any[]; // no error
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsArrowFunctions.ts:3:9]
@@ -3532,6 +3543,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  4 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsArrowFunctions.ts:5:12]
@@ -3540,6 +3552,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·            ─────────
  6 │     var arguments = 10; // no error
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsArrowFunctions.ts:6:9]
@@ -3548,6 +3561,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  7 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsArrowFunctions.ts:8:18]
@@ -3556,6 +3570,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                  ─────────
  9 │     var arguments = 10; // no error
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsArrowFunctions.ts:9:9]
@@ -3564,6 +3579,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·         ─────────
  10 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsArrowFunctions.ts:13:9]
@@ -3572,6 +3588,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·         ─────────
  14 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsArrowFunctions.ts:16:9]
@@ -3580,6 +3597,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·         ─────────
  17 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:3:31]
@@ -3588,6 +3606,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                               ─────────
  4 │         var arguments: any[]; // no error
    ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:4:13]
@@ -3596,6 +3615,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·             ─────────
  5 │     }
    ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:8:17]
@@ -3604,6 +3624,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                 ─────────
  9 │         var arguments = 10; // no error
    ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:9:13]
@@ -3612,6 +3633,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  10 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:13:17]
@@ -3620,6 +3642,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  14 │         var arguments = 10; // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:14:13]
@@ -3628,6 +3651,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  15 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:20:13]
@@ -3636,6 +3660,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  21 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:25:13]
@@ -3644,6 +3669,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  26 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:30:24]
@@ -3652,6 +3678,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                        ─────────
  31 │         var arguments = 10; // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:31:13]
@@ -3660,6 +3687,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  32 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:35:24]
@@ -3668,6 +3696,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                        ─────────
  36 │         var arguments = 10; // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:36:13]
@@ -3676,6 +3705,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  37 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:41:31]
@@ -3684,6 +3714,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                               ─────────
  42 │ }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:44:17]
@@ -3692,6 +3723,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  45 │ }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:47:17]
@@ -3700,6 +3732,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  48 │ }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:51:31]
@@ -3708,6 +3741,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                               ─────────
  52 │     constructor(i: string, ...arguments); // no codegen no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:52:31]
@@ -3716,6 +3750,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                               ─────────
  53 │     constructor(i: any, ...arguments) { // error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:53:28]
@@ -3724,6 +3759,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                            ─────────
  54 │         var arguments: any[]; // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:54:13]
@@ -3732,6 +3768,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  55 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:59:17]
@@ -3740,6 +3777,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  60 │     constructor(arguments: string, ...rest); // no codegen no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:60:17]
@@ -3748,6 +3786,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  61 │     constructor(arguments: any, ...rest) { // error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:61:17]
@@ -3756,6 +3795,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  62 │         var arguments: any; // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:62:13]
@@ -3764,6 +3804,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  63 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:67:17]
@@ -3772,6 +3813,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  68 │     constructor(arguments: string); // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:68:17]
@@ -3780,6 +3822,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  69 │     constructor(arguments: any) { // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:69:17]
@@ -3788,6 +3831,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  70 │         var arguments: any; // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:70:13]
@@ -3796,6 +3840,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  71 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:75:31]
@@ -3804,6 +3849,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                               ─────────
  76 │     constructor(i: string, ...arguments); // no codegen no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:76:31]
@@ -3812,6 +3858,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                               ─────────
  77 │ }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:79:17]
@@ -3820,6 +3867,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  80 │     constructor(arguments: string, ...rest); // no codegen no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:80:17]
@@ -3828,6 +3876,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  81 │ }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:84:17]
@@ -3836,6 +3885,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  85 │     constructor(arguments: string); // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:85:17]
@@ -3844,6 +3894,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  86 │ }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:2:30]
@@ -3852,6 +3903,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                              ─────────
  3 │         var arguments: any[]; // no error
    ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:3:13]
@@ -3860,6 +3912,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·             ─────────
  4 │     }
    ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:5:17]
@@ -3868,6 +3921,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                 ─────────
  6 │         var arguments = 10; // no error
    ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:6:13]
@@ -3876,6 +3930,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·             ─────────
  7 │     }
    ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:8:23]
@@ -3884,6 +3939,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                       ─────────
  9 │         var arguments = 10; // no error
    ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:9:13]
@@ -3892,6 +3948,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  10 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:11:29]
@@ -3900,6 +3957,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                             ─────────
  12 │     public f4(i: string, ...arguments); // no codegen no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:12:29]
@@ -3908,6 +3966,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                             ─────────
  13 │     public f4(i: any, ...arguments) { // error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:13:26]
@@ -3916,6 +3975,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                          ─────────
  14 │         var arguments: any[]; // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:14:13]
@@ -3924,6 +3984,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  15 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:16:16]
@@ -3932,6 +3993,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                ─────────
  17 │     public f41(arguments: string, ...rest); // no codegen no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:17:16]
@@ -3940,6 +4002,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                ─────────
  18 │     public f41(arguments: any, ...rest) { // error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:18:16]
@@ -3948,6 +4011,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                ─────────
  19 │         var arguments: any; // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:19:13]
@@ -3956,6 +4020,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  20 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:21:22]
@@ -3964,6 +4029,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                      ─────────
  22 │     public f4NoError(arguments: string); // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:22:22]
@@ -3972,6 +4038,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                      ─────────
  23 │     public f4NoError(arguments: any) { // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:23:22]
@@ -3980,6 +4047,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                      ─────────
  24 │         var arguments: any; // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:24:13]
@@ -3988,6 +4056,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  25 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:29:30]
@@ -3996,6 +4065,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                              ─────────
  30 │     public foo1(arguments: number, ...rest); // No error - no code gen
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:30:17]
@@ -4004,6 +4074,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  31 │     public fooNoError(arguments: number); // No error - no code gen
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:31:23]
@@ -4012,6 +4083,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                       ─────────
  32 │ 
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:33:29]
@@ -4020,6 +4092,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                             ─────────
  34 │     public f4(i: string, ...arguments); // no codegen no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:34:29]
@@ -4028,6 +4101,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                             ─────────
  35 │     public f41(arguments: number, ...rest); // no codegen no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:35:16]
@@ -4036,6 +4110,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                ─────────
  36 │     public f41(arguments: string, ...rest); // no codegen no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:36:16]
@@ -4044,6 +4119,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                ─────────
  37 │     public f4NoError(arguments: number); // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:37:22]
@@ -4052,6 +4128,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                      ─────────
  38 │     public f4NoError(arguments: string); // no error
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:38:22]
@@ -4060,6 +4137,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                      ─────────
  39 │ }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:43:13]
@@ -4068,6 +4146,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  44 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:46:13]
@@ -4076,6 +4155,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  47 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:3:13]
@@ -4084,6 +4164,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·             ─────────
  4 │     var arguments = 10; // no error
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:4:9]
@@ -4092,6 +4173,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  5 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:6:28]
@@ -4100,6 +4182,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                            ─────────
  7 │     var arguments: any[]; // no error
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:7:9]
@@ -4108,6 +4191,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  8 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:9:20]
@@ -4116,6 +4200,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                    ─────────
  10 │     var arguments = 10; // no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:10:9]
@@ -4124,6 +4209,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·         ─────────
  11 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:13:35]
@@ -4132,6 +4218,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                                   ─────────
  14 │ declare function f21(arguments: number, ...rest); // no error - no code gen
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:14:22]
@@ -4140,6 +4227,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                      ─────────
  15 │ declare function f2NoError(arguments: number); // no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:15:28]
@@ -4148,6 +4236,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                            ─────────
  16 │ 
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:18:9]
@@ -4156,6 +4245,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·         ─────────
  19 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:21:9]
@@ -4164,6 +4254,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·         ─────────
  22 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:24:13]
@@ -4172,6 +4263,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  25 │ function f4(arguments: string, ...rest); // no codegen no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:25:13]
@@ -4180,6 +4272,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  26 │ function f4(arguments: any, ...rest) { // error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:26:13]
@@ -4188,6 +4281,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  27 │     var arguments: any; // No error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:27:9]
@@ -4196,6 +4290,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·         ─────────
  28 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:29:28]
@@ -4204,6 +4299,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                            ─────────
  30 │ function f42(i: string, ...arguments); // no codegen no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:30:28]
@@ -4212,6 +4308,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                            ─────────
  31 │ function f42(i: any, ...arguments) { // error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:31:25]
@@ -4220,6 +4317,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                         ─────────
  32 │     var arguments: any[]; // No error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:32:9]
@@ -4228,6 +4326,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·         ─────────
  33 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:34:20]
@@ -4236,6 +4335,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                    ─────────
  35 │ function f4NoError(arguments: string); // no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:35:20]
@@ -4244,6 +4344,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                    ─────────
  36 │ function f4NoError(arguments: any) { // no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:36:20]
@@ -4252,6 +4353,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                    ─────────
  37 │     var arguments: any; // No error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:37:9]
@@ -4260,6 +4362,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·         ─────────
  38 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:40:21]
@@ -4268,6 +4371,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                     ─────────
  41 │ declare function f5(arguments: string, ...rest); // no codegen no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:41:21]
@@ -4276,6 +4380,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                     ─────────
  42 │ declare function f52(i: number, ...arguments); // no codegen no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:42:36]
@@ -4284,6 +4389,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                                    ─────────
  43 │ declare function f52(i: string, ...arguments); // no codegen no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:43:36]
@@ -4292,6 +4398,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                                    ─────────
  44 │ declare function f6(arguments: number); // no codegen no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:44:21]
@@ -4300,6 +4407,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                     ─────────
  45 │ declare function f6(arguments: string); // no codegen no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:45:21]
@@ -4307,6 +4415,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  45 │ declare function f6(arguments: string); // no codegen no error
     ·                     ─────────
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:3:17]
@@ -4315,6 +4424,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                 ─────────
  4 │         var arguments = 10; // no error
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:4:13]
@@ -4323,6 +4433,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·             ─────────
  5 │     }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:6:32]
@@ -4331,6 +4442,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                                ─────────
  7 │         var arguments: any[]; // no error
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:7:13]
@@ -4339,6 +4451,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·             ─────────
  8 │     }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:9:24]
@@ -4347,6 +4460,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                        ─────────
  10 │         var arguments = 10; // no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:10:13]
@@ -4355,6 +4469,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  11 │     }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:14:13]
@@ -4363,6 +4478,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  15 │     }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:17:13]
@@ -4371,6 +4487,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  18 │     }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:20:17]
@@ -4379,6 +4496,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  21 │     function f4(arguments: string, ...rest); // no codegen no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:21:17]
@@ -4387,6 +4505,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  22 │     function f4(arguments: any, ...rest) { // error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:22:17]
@@ -4395,6 +4514,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                 ─────────
  23 │         var arguments: any; // No error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:23:13]
@@ -4403,6 +4523,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  24 │     }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:25:32]
@@ -4411,6 +4532,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                                ─────────
  26 │     function f42(i: string, ...arguments); // no codegen no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:26:32]
@@ -4419,6 +4541,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                                ─────────
  27 │     function f42(i: any, ...arguments) { // error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:27:29]
@@ -4427,6 +4550,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                             ─────────
  28 │         var arguments: any[]; // No error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:28:13]
@@ -4435,6 +4559,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  29 │     }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:30:24]
@@ -4443,6 +4568,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                        ─────────
  31 │     function f4NoError(arguments: string); // no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:31:24]
@@ -4451,6 +4577,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                        ─────────
  32 │     function f4NoError(arguments: any) { // no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:32:24]
@@ -4459,6 +4586,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                        ─────────
  33 │         var arguments: any; // No error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsFunctionExpressions.ts:33:13]
@@ -4467,6 +4595,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  34 │     }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsInType.ts:2:24]
@@ -4475,6 +4604,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                        ─────────
  3 │ var v12: (arguments: number, ...restParameters) => void; // no error - no code gen
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsInType.ts:3:11]
@@ -4483,6 +4613,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·           ─────────
  4 │ var v2: {
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsInType.ts:5:6]
@@ -4491,6 +4622,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·      ─────────
  6 │     new (arguments: number, ...restParameters); // no error - no code gen
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsInType.ts:6:10]
@@ -4499,6 +4631,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·          ─────────
  7 │     foo(arguments: number, ...restParameters); // no error - no code gen
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsInType.ts:7:9]
@@ -4507,6 +4640,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  8 │     prop: (arguments: number, ...restParameters) => void; // no error - no code gen
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsInType.ts:8:12]
@@ -4515,6 +4649,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·            ─────────
  9 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsInType.ts:11:20]
@@ -4523,6 +4658,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                    ─────────
  12 │     new (i: number, ...arguments); // no error - no code gen
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsInType.ts:12:24]
@@ -4531,6 +4667,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                        ─────────
  13 │     foo(i: number, ...arguments); // no error - no code gen
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsInType.ts:13:23]
@@ -4539,6 +4676,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                       ─────────
  14 │     prop: (i: number, ...arguments) => void; // no error - no code gen
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsInType.ts:14:26]
@@ -4547,6 +4685,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                          ─────────
  15 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsInterfaceMembers.ts:4:20]
@@ -4555,6 +4694,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                    ─────────
  5 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/collisionArgumentsInterfaceMembers.ts:7:6]
@@ -4563,6 +4703,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·      ─────────
  8 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsInterfaceMembers.ts:10:6]
@@ -4571,6 +4712,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·      ─────────
  11 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsInterfaceMembers.ts:15:24]
@@ -4579,6 +4721,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                        ─────────
  16 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsInterfaceMembers.ts:18:10]
@@ -4587,6 +4730,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·          ─────────
  19 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsInterfaceMembers.ts:21:10]
@@ -4595,6 +4739,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·          ─────────
  22 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsInterfaceMembers.ts:26:23]
@@ -4603,6 +4748,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                       ─────────
  27 │     foo1(arguments: number, ...rest); // no error - no code gen
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsInterfaceMembers.ts:27:10]
@@ -4611,6 +4757,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·          ─────────
  28 │     fooNoError(arguments: number);  // no error
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsInterfaceMembers.ts:28:16]
@@ -4619,6 +4766,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·                ─────────
  29 │ }
     ╰────
+  note: This is strict mode code
 
   × Expected `=` but found `EOF`
    ╭─[typescript/tests/cases/compiler/commonJsExportTypeDeclarationError.ts:3:1]
@@ -8246,6 +8394,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·         ─────────
  12 │ }
     ╰────
+  note: This is strict mode code
 
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/jsFileCompilationBindMultipleDefaultExports.ts:3:16]
@@ -8287,6 +8436,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·          ────
  11 │ }
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/jsFileCompilationBindStrictModeErrors.ts:12:10]
@@ -8295,6 +8445,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·          ─────────
  13 │ }
     ╰────
+  note: This is strict mode code
 
   × 'with' statements are not allowed
     ╭─[typescript/tests/cases/compiler/jsFileCompilationBindStrictModeErrors.ts:15:1]
@@ -11818,6 +11969,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·             ─────────
  24 │ }
     ╰────
+  note: Modules are always strict mode code
 
   × Identifier `x` has already been declared
    ╭─[typescript/tests/cases/compiler/shadowingViaLocalValue.ts:2:9]
@@ -13639,6 +13791,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·   ────
  4 │ --eval;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[typescript/tests/cases/compiler/unaryOperatorsInStrictMode.ts:4:3]
@@ -13647,6 +13800,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·   ────
  5 │ ++arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/unaryOperatorsInStrictMode.ts:5:3]
@@ -13655,6 +13809,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·   ─────────
  6 │ --arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/compiler/unaryOperatorsInStrictMode.ts:6:3]
@@ -13663,6 +13818,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·   ─────────
  7 │ eval++;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[typescript/tests/cases/compiler/unaryOperatorsInStrictMode.ts:7:1]
@@ -13671,6 +13827,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    · ────
  8 │ eval--;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[typescript/tests/cases/compiler/unaryOperatorsInStrictMode.ts:8:1]
@@ -13679,6 +13836,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    · ────
  9 │ arguments++;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/unaryOperatorsInStrictMode.ts:9:1]
@@ -13687,6 +13845,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     · ─────────
  10 │ arguments--;
     ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/unaryOperatorsInStrictMode.ts:10:1]
@@ -13694,6 +13853,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  10 │ arguments--;
     · ─────────
     ╰────
+  note: This is strict mode code
 
   × Empty parenthesized expression
    ╭─[typescript/tests/cases/compiler/uncaughtCompilerError2.ts:2:4]
@@ -14024,6 +14184,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  2 │ var eval;
    ·     ────
    ╰────
+  note: This is strict mode code
 
   × 'with' statements are not allowed
    ╭─[typescript/tests/cases/compiler/withStatement.ts:3:1]
@@ -18353,6 +18514,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  3 │ function arguments() { }
    ·          ─────────
    ╰────
+  note: This is strict mode code
 
   × Expected `from` but found `import`
    ╭─[typescript/tests/cases/conformance/dynamicImport/importCallExpressionIncorrect1.ts:2:1]
@@ -18653,6 +18815,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·     ─────────
  3 │ var a = () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments03_ES6.ts:2:5]
@@ -18661,6 +18824,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·     ─────────
  3 │ var a = () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments04.ts:3:9]
@@ -18669,6 +18833,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  4 │     var a = () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments04_ES6.ts:3:9]
@@ -18677,6 +18842,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  4 │     var a = () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments05.ts:2:12]
@@ -18685,6 +18851,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·            ─────────
  3 │     var a = () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments05_ES6.ts:2:12]
@@ -18693,6 +18860,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·            ─────────
  3 │     var a = () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments06.ts:2:12]
@@ -18701,6 +18869,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·            ─────────
  3 │     var a = () => () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments06_ES6.ts:2:12]
@@ -18709,6 +18878,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·            ─────────
  3 │     var a = () => () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments07.ts:2:12]
@@ -18717,6 +18887,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·            ─────────
  3 │     var a = (arguments) => () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments07.ts:3:14]
@@ -18725,6 +18896,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·              ─────────
  4 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments07_ES6.ts:2:12]
@@ -18733,6 +18905,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·            ─────────
  3 │     var a = (arguments) => () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments07_ES6.ts:3:14]
@@ -18741,6 +18914,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·              ─────────
  4 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments08.ts:2:12]
@@ -18749,6 +18923,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·            ─────────
  3 │     var a = () => (arguments) => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments08.ts:3:20]
@@ -18757,6 +18932,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                    ─────────
  4 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments08_ES6.ts:2:12]
@@ -18765,6 +18941,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·            ─────────
  3 │     var a = () => (arguments) => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments08_ES6.ts:3:20]
@@ -18773,6 +18950,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                    ─────────
  4 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments11.ts:2:12]
@@ -18781,6 +18959,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·            ─────────
  3 │     var _arguments = 10;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments11_ES6.ts:2:12]
@@ -18789,6 +18968,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·            ─────────
  3 │     var _arguments = 10;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments12.ts:2:7]
@@ -18797,6 +18977,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·       ─────────
  3 │         var a = () => arguments;
    ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments12_ES6.ts:2:7]
@@ -18805,6 +18986,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·       ─────────
  3 │         var a = () => arguments;
    ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments13.ts:4:14]
@@ -18813,6 +18995,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·              ─────────
  5 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments13_ES6.ts:4:14]
@@ -18821,6 +19004,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·              ─────────
  5 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments14.ts:4:15]
@@ -18829,6 +19013,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·               ─────────
  5 │         return () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments14_ES6.ts:4:13]
@@ -18837,6 +19022,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·             ─────────
  5 │         return () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments15.ts:3:9]
@@ -18845,6 +19031,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  4 │     if (Math.random()) {
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments15.ts:5:15]
@@ -18853,6 +19040,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·               ─────────
  6 │         return () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments15_ES6.ts:3:9]
@@ -18861,6 +19049,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  4 │     if (Math.random()) {
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments15_ES6.ts:5:15]
@@ -18869,6 +19058,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·               ─────────
  6 │         return () => arguments;
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments16.ts:3:9]
@@ -18877,6 +19067,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  4 │     if (Math.random()) {
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments16.ts:7:9]
@@ -18885,6 +19076,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  8 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments16_ES6.ts:3:9]
@@ -18893,6 +19085,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  4 │     if (Math.random()) {
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments16_ES6.ts:7:9]
@@ -18901,6 +19094,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  8 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments17.ts:3:11]
@@ -18909,6 +19103,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·           ─────────
  4 │     if (Math.random()) {
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments17.ts:7:9]
@@ -18917,6 +19112,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  8 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments17_ES6.ts:3:11]
@@ -18925,6 +19121,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·           ─────────
  4 │     if (Math.random()) {
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionWhenUsingArguments17_ES6.ts:7:9]
@@ -18933,6 +19130,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  8 │ }
    ╰────
+  note: This is strict mode code
 
   × Invalid characters after number
    ╭─[typescript/tests/cases/conformance/es6/binaryAndOctalIntegerLiteral/binaryIntegerLiteralError.ts:2:17]
@@ -18965,6 +19163,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                ─────────
  5 │     private bar(eval:any) {
    ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/classDeclaration/parseClassDeclarationInStrictModeByDefaultInES6.ts:5:17]
@@ -18973,6 +19172,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                 ────
  6 │         arguments = "hello";
    ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/es6/classDeclaration/parseClassDeclarationInStrictModeByDefaultInES6.ts:6:9]
@@ -18981,6 +19181,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ─────────
  7 │     }
    ╰────
+  note: Classes are always strict mode code
 
   × 'super' can only be referenced in a derived class.
    ╭─[typescript/tests/cases/conformance/es6/classDeclaration/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts:3:1]
@@ -27649,6 +27850,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·            ────
  3 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode11.ts:2:20]
@@ -27657,6 +27859,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                    ────
  3 │ };
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode12.ts:2:19]
@@ -27664,6 +27867,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  2 │ var v = { set foo(eval) { } }
    ·                   ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode13.ts:4:7]
@@ -27672,6 +27876,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·       ────
  5 │ }
    ╰────
+  note: This is strict mode code
 
   × 'with' statements are not allowed
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode14.ts:2:1]
@@ -27702,6 +27907,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  2 │ eval = 1;
    · ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode4.ts:2:1]
@@ -27709,6 +27915,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  2 │ arguments = 1;
    · ─────────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode5.ts:2:1]
@@ -27716,6 +27923,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  2 │ eval += 1;
    · ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode6.ts:2:1]
@@ -27723,6 +27931,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  2 │ eval++;
    · ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode7.ts:2:3]
@@ -27730,6 +27939,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  2 │ ++eval;
    ·   ────
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode8.ts:2:10]
@@ -27738,6 +27948,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·          ────
  3 │ }
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'eval' in strict mode
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode9.ts:2:18]
@@ -27746,6 +27957,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·                  ────
  3 │ };
    ╰────
+  note: This is strict mode code
 
   × 'super' can only be used with function calls or in property accesses
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression2.ts:3:5]
@@ -28274,6 +28486,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·               ────
  23 │         const arguments = 8
     ╰────
+  note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/conformance/salsa/plainJSBinderErrors.ts:23:15]
@@ -28282,6 +28495,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·               ─────────
  24 │     }
     ╰────
+  note: Classes are always strict mode code
 
   × 'with' statements are not allowed
     ╭─[typescript/tests/cases/conformance/salsa/plainJSBinderErrors.ts:27:9]
@@ -28306,6 +28520,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ·       ────
  40 │ const arguments = 10
     ╰────
+  note: Modules are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/conformance/salsa/plainJSBinderErrors.ts:40:7]
@@ -28313,6 +28528,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  40 │ const arguments = 10
     ·       ─────────
     ╰────
+  note: Modules are always strict mode code
 
   × Expected `in` but found `Identifier`
    ╭─[typescript/tests/cases/conformance/salsa/plainJSGrammarErrors.ts:4:5]
@@ -28370,6 +28586,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·       ────
  3 │ const arguments = 2
    ╰────
+  note: This is strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[typescript/tests/cases/conformance/salsa/plainJSReservedStrict.ts:3:7]
@@ -28377,6 +28594,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  3 │ const arguments = 2
    ·       ─────────
    ╰────
+  note: This is strict mode code
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/conformance/scanner/ecmascript3/scannerES3NumericLiteral3.ts:1:3]


### PR DESCRIPTION
## Summary

Adds context notes to `Cannot assign to '{x0}' in strict mode` diagnostics, explaining whether strict mode comes from an explicit directive, class body, or module.

