### PR TITLE
refactor(allocator): `RawVec::from_raw_parts_in` take a `NonNull` pointer

### DIFF
--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -174,8 +174,9 @@ impl<'alloc, T> Vec<'alloc, T> {
 
         let allocator = allocator.allocator();
         let boxed = Box::new_in(value, &allocator);
-        let ptr = Box::into_non_null(boxed).as_ptr();
-        // SAFETY: `ptr` contains a valid `T`.
+        let ptr = Box::into_non_null(boxed);
+
+        // SAFETY: `ptr` contains a valid `T`, allocated in `allocator`'s arena.
         // A `Vec` with length 1, capacity 1 can own the same allocation.
         let vec = unsafe { InnerVec::from_raw_parts_in(ptr, 1, 1, allocator.arena()) };
         Self(vec)
@@ -210,7 +211,8 @@ impl<'alloc, T> Vec<'alloc, T> {
 
         let allocator = allocator.allocator();
         let boxed = Box::new_in(array, &allocator);
-        let ptr = Box::into_non_null(boxed).as_ptr().cast::<T>();
+        let ptr = Box::into_non_null(boxed).cast::<T>();
+
         // SAFETY: `ptr` has correct alignment - it was just allocated as `[T; N]`.
         // `ptr` was allocated with correct size for `[T; N]`.
         // `len` and `capacity` are both `N`.

--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -552,6 +552,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// # Examples
     ///
     /// ```ignore
+    /// use std::ptr::NonNull;
     /// use bumpalo::{Bump, collections::Vec};
     ///
     /// use std::ptr;
@@ -562,7 +563,7 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// let mut v = Vec::from_iter_in([1, 2, 3], &b);
     ///
     /// // Pull out the various important pieces of information about `v`
-    /// let p = v.as_mut_ptr();
+    /// let p = NonNull::new(v.as_mut_ptr()).unwrap();
     /// let len = v.len();
     /// let cap = v.capacity();
     ///
@@ -572,8 +573,8 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     ///     mem::forget(v);
     ///
     ///     // Overwrite memory with 4, 5, 6
-    ///     for i in 0..len as isize {
-    ///         ptr::write(p.offset(i), 4 + i);
+    ///     for i in 0..len {
+    ///         p.add(i).write(4 + i);
     ///     }
     ///
     ///     // Put everything back together into a Vec
@@ -582,12 +583,14 @@ impl<'a, T: 'a, A: Alloc> Vec<'a, T, A> {
     /// }
     /// ```
     pub unsafe fn from_raw_parts_in(
-        ptr: *mut T,
+        ptr: NonNull<T>,
         length: usize,
         capacity: usize,
         alloc: &'a A,
     ) -> Vec<'a, T, A> {
-        Vec { buf: RawVec::from_raw_parts_in(ptr, length, capacity, alloc) }
+        // SAFETY: Caller guarantees `from_raw_parts_in`'s requirements
+        let buf = unsafe { RawVec::from_raw_parts_in(ptr, length, capacity, alloc) };
+        Vec { buf }
     }
 
     /// Returns the number of elements in the vector, also referred to as its 'length'.

--- a/crates/oxc_allocator/src/vec2/raw_vec.rs
+++ b/crates/oxc_allocator/src/vec2/raw_vec.rs
@@ -131,10 +131,7 @@ impl<'a, T, A: Alloc> RawVec<'a, T, A> {
     /// If all these values came from a `Vec` created in allocator `a`, then these requirements
     /// are guaranteed to be fulfilled.
     #[inline(always)]
-    pub unsafe fn from_raw_parts_in(ptr: *mut T, len: usize, cap: usize, alloc: &'a A) -> Self {
-        // SAFETY: Caller guarantees `ptr` was allocated, which implies it's not null
-        let ptr = unsafe { NonNull::new_unchecked(ptr) };
-
+    pub unsafe fn from_raw_parts_in(ptr: NonNull<T>, len: usize, cap: usize, alloc: &'a A) -> Self {
         // Caller guarantees `cap` and `len` are `<= u32::MAX`, so `as u32` cannot truncate them
         #[expect(clippy::cast_possible_truncation)]
         let len = len as u32;


### PR DESCRIPTION
`RawVec::from_raw_parts_in` and `InnerVec::from_raw_parts_in`  take a `NonNull<T>` pointer, instead of a `*mut T` pointer.

`RawVec` ultimately uses `NonNull` internally, and both callers `Vec::from_value_in` and `Vec::from_array_in` have a `NonNull` pointer to start with. So this change avoid converting `NonNull<T>` to `*mut T` only to convert it back to `NonNull<T>` with an unsafe call.