### PR TITLE
feat(ast): add decorators to FormalParameterRest in ESTree AST

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -2379,6 +2379,7 @@ function deserializeFormalParameters(pos) {
         range: [start, end],
         parent: previousParent,
       });
+    rest.decorators = deserializeVecDecorator(pos + 16);
     rest.argument = deserializeBindingPattern(pos + 56);
     rest.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 72);
     if (rest.typeAnnotation !== null) {

--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -673,7 +673,7 @@ export type FunctionType =
 export interface FormalParameterRest extends Span {
   type: "RestElement";
   argument: BindingPattern;
-  decorators?: [];
+  decorators?: Array<Decorator>;
   optional?: boolean;
   typeAnnotation?: TSTypeAnnotation | null;
   value?: null;

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1870,7 +1870,7 @@ pub enum FunctionType {
         interface FormalParameterRest extends Span {
             type: 'RestElement';
             argument: BindingPattern;
-            decorators?: [],
+            decorators?: Array<Decorator>;
             optional?: boolean;
             typeAnnotation?: TSTypeAnnotation | null;
             value?: null;

--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -347,6 +347,9 @@ impl ESTree for CatchParameterConverter<'_, '_> {
                 ...(RANGE && { range: [start, end] }),
                 ...(PARENT && { parent: previousParent }),
             };
+            if (IS_TS) {
+                rest.decorators = DESER[Vec<Decorator>]( POS_OFFSET<FormalParameterRest>.decorators );
+            }
             rest.argument = DESER[BindingPattern]( POS_OFFSET<FormalParameterRest>.rest.argument );
             if (IS_TS) {
                 rest.typeAnnotation = DESER[Option<Box<TSTypeAnnotation>>](
@@ -388,7 +391,7 @@ impl ESTree for FormalParameterRest<'_> {
         let rest = self;
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("RestElement"));
-        state.serialize_ts_field("decorators", &EmptyArray(()));
+        state.serialize_ts_field("decorators", &rest.decorators);
         state.serialize_field("argument", &rest.rest.argument);
         state.serialize_ts_field("optional", &false);
         state.serialize_ts_field("typeAnnotation", &rest.type_annotation);

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -1908,6 +1908,7 @@ function deserializeFormalParameters(pos) {
         start: deserializeI32(pos + 40),
         end: (end = deserializeI32(pos + 44)),
       };
+    rest.decorators = deserializeVecDecorator(pos + 16);
     rest.argument = deserializeBindingPattern(pos + 56);
     rest.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 72);
     if (rest.typeAnnotation !== null) {

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -2112,6 +2112,7 @@ function deserializeFormalParameters(pos) {
         end: (end = deserializeI32(pos + 44)),
         parent: previousParent,
       });
+    rest.decorators = deserializeVecDecorator(pos + 16);
     rest.argument = deserializeBindingPattern(pos + 56);
     rest.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 72);
     if (rest.typeAnnotation !== null) {

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -2115,6 +2115,7 @@ function deserializeFormalParameters(pos) {
         end: (end = deserializeI32(pos + 44)),
         range: [start, end],
       };
+    rest.decorators = deserializeVecDecorator(pos + 16);
     rest.argument = deserializeBindingPattern(pos + 56);
     rest.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 72);
     if (rest.typeAnnotation !== null) {

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -2318,6 +2318,7 @@ function deserializeFormalParameters(pos) {
         range: [start, end],
         parent: previousParent,
       });
+    rest.decorators = deserializeVecDecorator(pos + 16);
     rest.argument = deserializeBindingPattern(pos + 56);
     rest.typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 72);
     if (rest.typeAnnotation !== null) {

--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -240,6 +240,9 @@ describe.concurrent("edge cases", () => {
     // Hashbangs
     "#!/usr/bin/env node\nlet x;",
     "#!/usr/bin/env node\nlet x;\n// foo",
+    // Decorators on rest parameters
+    "class C { constructor(@dec ...args) {} }",
+    "class C { method(@dec ...args) {} }",
   ])("%s", (sourceText) => {
     // oxlint-disable-next-line jest/expect-expect
     it("JS", () => runCaseInWorker(TEST_TYPE_INLINE_FIXTURE, { filename: "dummy.js", sourceText }));

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -666,7 +666,7 @@ export type FunctionType =
 export interface FormalParameterRest extends Span {
   type: "RestElement";
   argument: BindingPattern;
-  decorators?: [];
+  decorators?: Array<Decorator>;
   optional?: boolean;
   typeAnnotation?: TSTypeAnnotation | null;
   value?: null;


### PR DESCRIPTION
Closes #18981

## Summary

PR #18938 added a `decorators` field to the `FormalParameterRest` node in Oxc's Rust AST, so decorators on rest parameters are now parsed:

```ts
class C {
  constructor(@dec ...args) {}
  method(@dec ...args) {}
  set prop(@dec ...args) {}
}
```

However, that field never made it into the TS-ESTree output — both serialization paths hard-coded an empty `decorators` array, so consumers on the JS side lost the decorators. This matches how TS-ESLint already represents the syntax, where the `RestElement` carries its decorators.

## Changes

- **Rust ESTree serializer** (`FormalParameterRest`): serialize the actual `decorators` instead of an empty array.
- **JS raw-transfer deserializer** (`FormalParametersConverter`): deserialize the real decorators (TS mode only), with the correct `parent` link.
- **TS type definition**: `decorators?: []` → `decorators?: Array<Decorator>`.
- Regenerated the derived files (TS deserializers, oxlint deserializer, `.d.ts` types).

Decorators are a TS-only field on `RestElement`, so only the TS serialization paths are affected. The node's span is unchanged (starts at `...`, excluding the decorator), consistent with how decorated non-rest parameters are already serialized.

## Testing

Added two cases to the `edge cases` suite in `napi/parser/test/parse-raw.test.ts`, which asserts the raw-transfer (JS deserialize) output matches the standard (Rust JSON) output. Both the constructor and method forms pass in JS and TS modes, confirming the two serialization paths stay in sync.

---

> **AI disclosure:** this PR was written with the help of an AI assistant (Claude Code) and reviewed by me.