### PR TITLE
feat(linter/unicorn): implement no-duplicate-set-values rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3177,6 +3177,11 @@ impl RuleRunner for crate::rules::unicorn::no_document_cookie::NoDocumentCookie 
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::no_duplicate_set_values::NoDuplicateSetValues {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::no_empty_file::NoEmptyFile {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -629,6 +629,7 @@ pub use crate::rules::unicorn::no_await_in_promise_methods::NoAwaitInPromiseMeth
 pub use crate::rules::unicorn::no_confusing_array_with::NoConfusingArrayWith as UnicornNoConfusingArrayWith;
 pub use crate::rules::unicorn::no_console_spaces::NoConsoleSpaces as UnicornNoConsoleSpaces;
 pub use crate::rules::unicorn::no_document_cookie::NoDocumentCookie as UnicornNoDocumentCookie;
+pub use crate::rules::unicorn::no_duplicate_set_values::NoDuplicateSetValues as UnicornNoDuplicateSetValues;
 pub use crate::rules::unicorn::no_empty_file::NoEmptyFile as UnicornNoEmptyFile;
 pub use crate::rules::unicorn::no_hex_escape::NoHexEscape as UnicornNoHexEscape;
 pub use crate::rules::unicorn::no_immediate_mutation::NoImmediateMutation as UnicornNoImmediateMutation;
@@ -1354,6 +1355,7 @@ pub enum RuleEnum {
     UnicornNoConfusingArrayWith(UnicornNoConfusingArrayWith),
     UnicornNoConsoleSpaces(UnicornNoConsoleSpaces),
     UnicornNoDocumentCookie(UnicornNoDocumentCookie),
+    UnicornNoDuplicateSetValues(UnicornNoDuplicateSetValues),
     UnicornNoEmptyFile(UnicornNoEmptyFile),
     UnicornNoHexEscape(UnicornNoHexEscape),
     UnicornNoImmediateMutation(UnicornNoImmediateMutation),
@@ -2264,7 +2266,8 @@ const UNICORN_NO_AWAIT_IN_PROMISE_METHODS_ID: usize =
 const UNICORN_NO_CONFUSING_ARRAY_WITH_ID: usize = UNICORN_NO_AWAIT_IN_PROMISE_METHODS_ID + 1usize;
 const UNICORN_NO_CONSOLE_SPACES_ID: usize = UNICORN_NO_CONFUSING_ARRAY_WITH_ID + 1usize;
 const UNICORN_NO_DOCUMENT_COOKIE_ID: usize = UNICORN_NO_CONSOLE_SPACES_ID + 1usize;
-const UNICORN_NO_EMPTY_FILE_ID: usize = UNICORN_NO_DOCUMENT_COOKIE_ID + 1usize;
+const UNICORN_NO_DUPLICATE_SET_VALUES_ID: usize = UNICORN_NO_DOCUMENT_COOKIE_ID + 1usize;
+const UNICORN_NO_EMPTY_FILE_ID: usize = UNICORN_NO_DUPLICATE_SET_VALUES_ID + 1usize;
 const UNICORN_NO_HEX_ESCAPE_ID: usize = UNICORN_NO_EMPTY_FILE_ID + 1usize;
 const UNICORN_NO_IMMEDIATE_MUTATION_ID: usize = UNICORN_NO_HEX_ESCAPE_ID + 1usize;
 const UNICORN_NO_INSTANCEOF_ARRAY_ID: usize = UNICORN_NO_IMMEDIATE_MUTATION_ID + 1usize;
@@ -3243,6 +3246,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UNICORN_NO_CONFUSING_ARRAY_WITH_ID,
             Self::UnicornNoConsoleSpaces(_) => UNICORN_NO_CONSOLE_SPACES_ID,
             Self::UnicornNoDocumentCookie(_) => UNICORN_NO_DOCUMENT_COOKIE_ID,
+            Self::UnicornNoDuplicateSetValues(_) => UNICORN_NO_DUPLICATE_SET_VALUES_ID,
             Self::UnicornNoEmptyFile(_) => UNICORN_NO_EMPTY_FILE_ID,
             Self::UnicornNoHexEscape(_) => UNICORN_NO_HEX_ESCAPE_ID,
             Self::UnicornNoImmediateMutation(_) => UNICORN_NO_IMMEDIATE_MUTATION_ID,
@@ -4215,6 +4219,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::NAME,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::NAME,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::NAME,
+            Self::UnicornNoDuplicateSetValues(_) => UnicornNoDuplicateSetValues::NAME,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::NAME,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::NAME,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::NAME,
@@ -5205,6 +5210,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::CATEGORY,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::CATEGORY,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::CATEGORY,
+            Self::UnicornNoDuplicateSetValues(_) => UnicornNoDuplicateSetValues::CATEGORY,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::CATEGORY,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::CATEGORY,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::CATEGORY,
@@ -6198,6 +6204,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::FIX,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::FIX,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::FIX,
+            Self::UnicornNoDuplicateSetValues(_) => UnicornNoDuplicateSetValues::FIX,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::FIX,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::FIX,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::FIX,
@@ -7297,6 +7304,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::documentation(),
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::documentation(),
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::documentation(),
+            Self::UnicornNoDuplicateSetValues(_) => UnicornNoDuplicateSetValues::documentation(),
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::documentation(),
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::documentation(),
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::documentation(),
@@ -9217,6 +9225,10 @@ impl RuleEnum {
                 .or_else(|| UnicornNoConsoleSpaces::schema(generator)),
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::config_schema(generator)
                 .or_else(|| UnicornNoDocumentCookie::schema(generator)),
+            Self::UnicornNoDuplicateSetValues(_) => {
+                UnicornNoDuplicateSetValues::config_schema(generator)
+                    .or_else(|| UnicornNoDuplicateSetValues::schema(generator))
+            }
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::config_schema(generator)
                 .or_else(|| UnicornNoEmptyFile::schema(generator)),
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::config_schema(generator)
@@ -10748,6 +10760,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => "unicorn",
             Self::UnicornNoConsoleSpaces(_) => "unicorn",
             Self::UnicornNoDocumentCookie(_) => "unicorn",
+            Self::UnicornNoDuplicateSetValues(_) => "unicorn",
             Self::UnicornNoEmptyFile(_) => "unicorn",
             Self::UnicornNoHexEscape(_) => "unicorn",
             Self::UnicornNoImmediateMutation(_) => "unicorn",
@@ -12681,6 +12694,9 @@ impl RuleEnum {
             Self::UnicornNoDocumentCookie(_) => Ok(Self::UnicornNoDocumentCookie(
                 UnicornNoDocumentCookie::from_configuration(value)?,
             )),
+            Self::UnicornNoDuplicateSetValues(_) => Ok(Self::UnicornNoDuplicateSetValues(
+                UnicornNoDuplicateSetValues::from_configuration(value)?,
+            )),
             Self::UnicornNoEmptyFile(_) => {
                 Ok(Self::UnicornNoEmptyFile(UnicornNoEmptyFile::from_configuration(value)?))
             }
@@ -14323,6 +14339,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(rule) => rule.to_configuration(),
             Self::UnicornNoConsoleSpaces(rule) => rule.to_configuration(),
             Self::UnicornNoDocumentCookie(rule) => rule.to_configuration(),
+            Self::UnicornNoDuplicateSetValues(rule) => rule.to_configuration(),
             Self::UnicornNoEmptyFile(rule) => rule.to_configuration(),
             Self::UnicornNoHexEscape(rule) => rule.to_configuration(),
             Self::UnicornNoImmediateMutation(rule) => rule.to_configuration(),
@@ -15174,6 +15191,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(rule) => rule.run(node, ctx),
             Self::UnicornNoConsoleSpaces(rule) => rule.run(node, ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run(node, ctx),
+            Self::UnicornNoDuplicateSetValues(rule) => rule.run(node, ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run(node, ctx),
             Self::UnicornNoHexEscape(rule) => rule.run(node, ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run(node, ctx),
@@ -16035,6 +16053,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(rule) => rule.run_once(ctx),
             Self::UnicornNoConsoleSpaces(rule) => rule.run_once(ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run_once(ctx),
+            Self::UnicornNoDuplicateSetValues(rule) => rule.run_once(ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run_once(ctx),
             Self::UnicornNoHexEscape(rule) => rule.run_once(ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run_once(ctx),
@@ -16975,6 +16994,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoConsoleSpaces(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoDuplicateSetValues(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoHexEscape(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17875,6 +17895,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(rule) => rule.should_run(ctx),
             Self::UnicornNoConsoleSpaces(rule) => rule.should_run(ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.should_run(ctx),
+            Self::UnicornNoDuplicateSetValues(rule) => rule.should_run(ctx),
             Self::UnicornNoEmptyFile(rule) => rule.should_run(ctx),
             Self::UnicornNoHexEscape(rule) => rule.should_run(ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.should_run(ctx),
@@ -18935,6 +18956,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::IS_TSGOLINT_RULE,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::IS_TSGOLINT_RULE,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::IS_TSGOLINT_RULE,
+            Self::UnicornNoDuplicateSetValues(_) => UnicornNoDuplicateSetValues::IS_TSGOLINT_RULE,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::IS_TSGOLINT_RULE,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::IS_TSGOLINT_RULE,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::IS_TSGOLINT_RULE,
@@ -20059,6 +20081,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::VERSION,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::VERSION,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::VERSION,
+            Self::UnicornNoDuplicateSetValues(_) => UnicornNoDuplicateSetValues::VERSION,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::VERSION,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::VERSION,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::VERSION,
@@ -21102,6 +21125,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::HAS_CONFIG,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::HAS_CONFIG,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::HAS_CONFIG,
+            Self::UnicornNoDuplicateSetValues(_) => UnicornNoDuplicateSetValues::HAS_CONFIG,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::HAS_CONFIG,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::HAS_CONFIG,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::HAS_CONFIG,
@@ -22114,6 +22138,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::INFO,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::INFO,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::INFO,
+            Self::UnicornNoDuplicateSetValues(_) => UnicornNoDuplicateSetValues::INFO,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::INFO,
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::INFO,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::INFO,
@@ -23005,6 +23030,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(rule) => rule.types_info(),
             Self::UnicornNoConsoleSpaces(rule) => rule.types_info(),
             Self::UnicornNoDocumentCookie(rule) => rule.types_info(),
+            Self::UnicornNoDuplicateSetValues(rule) => rule.types_info(),
             Self::UnicornNoEmptyFile(rule) => rule.types_info(),
             Self::UnicornNoHexEscape(rule) => rule.types_info(),
             Self::UnicornNoImmediateMutation(rule) => rule.types_info(),
@@ -23853,6 +23879,7 @@ impl RuleEnum {
             Self::UnicornNoConfusingArrayWith(rule) => rule.run_info(),
             Self::UnicornNoConsoleSpaces(rule) => rule.run_info(),
             Self::UnicornNoDocumentCookie(rule) => rule.run_info(),
+            Self::UnicornNoDuplicateSetValues(rule) => rule.run_info(),
             Self::UnicornNoEmptyFile(rule) => rule.run_info(),
             Self::UnicornNoHexEscape(rule) => rule.run_info(),
             Self::UnicornNoImmediateMutation(rule) => rule.run_info(),
@@ -24799,6 +24826,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornNoConfusingArrayWith(UnicornNoConfusingArrayWith::default()),
         RuleEnum::UnicornNoConsoleSpaces(UnicornNoConsoleSpaces::default()),
         RuleEnum::UnicornNoDocumentCookie(UnicornNoDocumentCookie::default()),
+        RuleEnum::UnicornNoDuplicateSetValues(UnicornNoDuplicateSetValues::default()),
         RuleEnum::UnicornNoEmptyFile(UnicornNoEmptyFile::default()),
         RuleEnum::UnicornNoHexEscape(UnicornNoHexEscape::default()),
         RuleEnum::UnicornNoImmediateMutation(UnicornNoImmediateMutation::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -485,7 +485,7 @@ pub(crate) mod react_perf {
 
 /// <https://github.com/sindresorhus/eslint-plugin-unicorn>
 pub(crate) mod unicorn {
-    pub mod catch_error_name;
+pub mod catch_error_name;
     pub mod consistent_assert;
     pub mod consistent_date_clone;
     pub mod consistent_empty_array_spread;
@@ -517,6 +517,7 @@ pub(crate) mod unicorn {
     pub mod no_confusing_array_with;
     pub mod no_console_spaces;
     pub mod no_document_cookie;
+    pub mod no_duplicate_set_values;
     pub mod no_empty_file;
     pub mod no_hex_escape;
     pub mod no_immediate_mutation;

--- a/crates/oxc_linter/src/rules/unicorn/no_duplicate_set_values.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_duplicate_set_values.rs
@@ -1,0 +1,292 @@
+use oxc_ast::{
+    AstKind,
+    ast::{
+        ArrayExpressionElement, BinaryOperator, Expression, UnaryOperator, VariableDeclarationKind,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    ast_util::{get_declaration_of_variable, is_new_expression},
+    context::LintContext,
+    rule::Rule,
+    utils::is_same_expression,
+};
+
+fn no_duplicate_set_values_diagnostic(span: Span, value: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Remove duplicate value `{value}` from the Set.")).with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDuplicateSetValues;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow duplicate values in `Set` constructor array literals.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `Set` values are unique, so repeated static values in a `Set` constructor
+    /// array literal are redundant.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// new Set([1, 2, 1]);
+    /// new Set(["foo", "bar", "foo"]);
+    /// new Set([foo.bar, foo.bar]);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// new Set([1, 2, "1"]);
+    /// new Set([{}, {}]);
+    /// new Set([foo.bar, foo.baz]);
+    /// ```
+    NoDuplicateSetValues,
+    unicorn,
+    suspicious,
+    none,
+    version = "next",
+    short_description = "Disallow duplicate values in `Set` constructor array literals.",
+);
+
+impl Rule for NoDuplicateSetValues {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::NewExpression(new_expr) = node.kind() else {
+            return;
+        };
+
+        if !is_new_expression(new_expr, &["Set"], Some(1), Some(1)) {
+            return;
+        }
+
+        let Some(first_arg) = new_expr.arguments.first() else {
+            return;
+        };
+        let Some(Expression::ArrayExpression(array)) = first_arg.as_expression() else {
+            return;
+        };
+
+        let mut seen: Vec<Option<&Expression<'a>>> = Vec::with_capacity(array.elements.len());
+
+        for element in &array.elements {
+            if matches!(element, ArrayExpressionElement::SpreadElement(_)) {
+                continue;
+            }
+
+            if matches!(element, ArrayExpressionElement::Elision(_)) {
+                if seen.iter().any(|prev| is_duplicate_value(*prev, None, ctx)) {
+                    ctx.diagnostic(no_duplicate_set_values_diagnostic(element.span(), "undefined"));
+                }
+                seen.push(None);
+                continue;
+            }
+
+            let Some(expr) = element.as_expression() else {
+                continue;
+            };
+
+            if seen.iter().any(|prev| is_duplicate_value(*prev, Some(expr), ctx)) {
+                let text = ctx.source_range(expr.span());
+                ctx.diagnostic(no_duplicate_set_values_diagnostic(expr.span(), text));
+            }
+            seen.push(Some(expr));
+        }
+    }
+}
+
+fn is_duplicate_value<'a>(
+    left: Option<&Expression<'a>>,
+    right: Option<&Expression<'a>>,
+    ctx: &LintContext<'a>,
+) -> bool {
+    let left_static = comparable_static_value(left, ctx);
+    let right_static = comparable_static_value(right, ctx);
+
+    if let (Some(left_static), Some(right_static)) = (left_static, right_static) {
+        return same_value_zero(&left_static, &right_static);
+    }
+
+    // Upstream: if either side is a Literal (and static comparison failed), do not
+    // fall back to reference equality.
+    if left.is_some_and(is_literal_like) || right.is_some_and(is_literal_like) {
+        return false;
+    }
+
+    match (left, right) {
+        (Some(left), Some(right)) => {
+            is_same_expression(left.get_inner_expression(), right.get_inner_expression(), ctx)
+        }
+        _ => false,
+    }
+}
+
+fn is_literal_like(expr: &Expression<'_>) -> bool {
+    matches!(
+        expr.get_inner_expression(),
+        Expression::NullLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::StringLiteral(_)
+            | Expression::BigIntLiteral(_)
+            | Expression::RegExpLiteral(_)
+    )
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum ComparableStatic<'a> {
+    Null,
+    Undefined,
+    Bool(bool),
+    Number(f64),
+    String(&'a str),
+}
+
+fn same_value_zero(left: &ComparableStatic<'_>, right: &ComparableStatic<'_>) -> bool {
+    match (left, right) {
+        (ComparableStatic::Null, ComparableStatic::Null)
+        | (ComparableStatic::Undefined, ComparableStatic::Undefined) => true,
+        (ComparableStatic::Bool(a), ComparableStatic::Bool(b)) => a == b,
+        (ComparableStatic::String(a), ComparableStatic::String(b)) => a == b,
+        (ComparableStatic::Number(a), ComparableStatic::Number(b)) => {
+            if a.is_nan() && b.is_nan() {
+                true
+            } else {
+                // SameValueZero: +0 === -0
+                *a == *b
+            }
+        }
+        _ => false,
+    }
+}
+
+fn comparable_static_value<'a>(
+    expr: Option<&Expression<'a>>,
+    ctx: &LintContext<'a>,
+) -> Option<ComparableStatic<'a>> {
+    let Some(expr) = expr else {
+        return Some(ComparableStatic::Undefined);
+    };
+    comparable_static_from_expression(expr.get_inner_expression(), ctx)
+}
+
+fn comparable_static_from_expression<'a>(
+    expr: &Expression<'a>,
+    ctx: &LintContext<'a>,
+) -> Option<ComparableStatic<'a>> {
+    match expr {
+        Expression::NullLiteral(_) => Some(ComparableStatic::Null),
+        Expression::BooleanLiteral(b) => Some(ComparableStatic::Bool(b.value)),
+        Expression::NumericLiteral(n) => Some(ComparableStatic::Number(n.value)),
+        Expression::StringLiteral(s) => Some(ComparableStatic::String(s.value.as_str())),
+        Expression::TemplateLiteral(t) => t.single_quasi().map(|q| ComparableStatic::String(q.as_str())),
+        Expression::UnaryExpression(unary) if unary.operator == UnaryOperator::UnaryNegation => {
+            let Expression::NumericLiteral(n) = unary.argument.get_inner_expression() else {
+                return None;
+            };
+            Some(ComparableStatic::Number(-n.value))
+        }
+        Expression::BinaryExpression(bin) => {
+            let left = comparable_static_from_expression(bin.left.get_inner_expression(), ctx)?;
+            let right = comparable_static_from_expression(bin.right.get_inner_expression(), ctx)?;
+            match (left, right, bin.operator) {
+                (
+                    ComparableStatic::Number(a),
+                    ComparableStatic::Number(b),
+                    BinaryOperator::Addition,
+                ) => Some(ComparableStatic::Number(a + b)),
+                (
+                    ComparableStatic::Number(a),
+                    ComparableStatic::Number(b),
+                    BinaryOperator::Subtraction,
+                ) => Some(ComparableStatic::Number(a - b)),
+                (
+                    ComparableStatic::Number(a),
+                    ComparableStatic::Number(b),
+                    BinaryOperator::Multiplication,
+                ) => Some(ComparableStatic::Number(a * b)),
+                (
+                    ComparableStatic::Number(a),
+                    ComparableStatic::Number(b),
+                    BinaryOperator::Division,
+                ) => Some(ComparableStatic::Number(a / b)),
+                _ => None,
+            }
+        }
+        Expression::Identifier(ident) => {
+            if ident.name == "undefined" {
+                return Some(ComparableStatic::Undefined);
+            }
+            if ident.name == "NaN" {
+                return Some(ComparableStatic::Number(f64::NAN));
+            }
+
+            let decl = get_declaration_of_variable(ident, ctx)?;
+            let AstKind::VariableDeclarator(var_decl) = decl.kind() else {
+                return None;
+            };
+            if var_decl.kind != VariableDeclarationKind::Const {
+                return None;
+            }
+            let init = var_decl.init.as_ref()?;
+            comparable_static_from_expression(init.get_inner_expression(), ctx)
+        }
+        _ => None,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("new Set([1, 2, \"1\"])", None),
+        ("new Set([{}, {}])", None),
+        ("new Set([[], []])", None),
+        ("new Set([/foo/, /foo/])", None),
+        ("new Set([Symbol(), Symbol()])", None),
+        ("new Set(foo)", None),
+        ("Set([1, 1])", None),
+        ("new NotSet([1, 1])", None),
+        ("new globalThis.Set([1, 1])", None),
+        ("new Set([foo(), foo()])", None),
+        ("new Set([foo.bar, foo.baz])", None),
+        ("new Set([foo, ...bar, baz])", None),
+        ("const foo = {}; new Set([foo, {}]);", None),
+        ("const foo = 1; const bar = 2; new Set([foo, bar]);", None),
+    ];
+
+    let fail = vec![
+        ("new Set([1, 2, 1])", None),
+        ("new Set([\"foo\", \"bar\", \"foo\"])", None),
+        ("new Set([null, null])", None),
+        ("new Set([undefined, undefined])", None),
+        ("new Set([, undefined])", None),
+        ("new Set([undefined, ,])", None),
+        ("new Set([,,])", None),
+        ("new Set([-1, -1])", None),
+        ("new Set([NaN, NaN])", None),
+        ("new Set([0, -0])", None),
+        ("new Set([1, 1, 2, 2])", None),
+        ("new Set([1 + 1, 2])", None),
+        ("new Set([`foo`, \"foo\"])", None),
+        ("new Set([foo, foo])", None),
+        ("new Set([foo.bar, foo.bar])", None),
+        ("new Set([foo[\"bar\"], foo.bar])", None),
+        ("new Set([this.foo, this.foo])", None),
+        ("new Set([foo, ...bar, foo])", None),
+        ("const foo = 2; new Set([foo, 2]);", None),
+        ("const foo = 'bar'; new Set([foo, 'bar']);", None),
+        ("const foo = undefined; new Set([foo, undefined]);", None),
+        ("const foo = {}; new Set([foo, foo]);", None),
+    ];
+
+    Tester::new(NoDuplicateSetValues::NAME, NoDuplicateSetValues::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_no_duplicate_set_values.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_duplicate_set_values.snap
@@ -1,0 +1,141 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `1` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:16]
+ 1 │ new Set([1, 2, 1])
+   ·                ─
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `"foo"` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:24]
+ 1 │ new Set(["foo", "bar", "foo"])
+   ·                        ─────
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `null` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:16]
+ 1 │ new Set([null, null])
+   ·                ────
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `undefined` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:21]
+ 1 │ new Set([undefined, undefined])
+   ·                     ─────────
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `undefined` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:12]
+ 1 │ new Set([, undefined])
+   ·            ─────────
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `undefined` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:21]
+ 1 │ new Set([undefined, ,])
+   ·                     ─
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `undefined` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:11]
+ 1 │ new Set([,,])
+   ·           ─
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `-1` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:14]
+ 1 │ new Set([-1, -1])
+   ·              ──
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `NaN` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:15]
+ 1 │ new Set([NaN, NaN])
+   ·               ───
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `-0` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:13]
+ 1 │ new Set([0, -0])
+   ·             ──
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `1` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:13]
+ 1 │ new Set([1, 1, 2, 2])
+   ·             ─
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `2` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:19]
+ 1 │ new Set([1, 1, 2, 2])
+   ·                   ─
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `2` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:17]
+ 1 │ new Set([1 + 1, 2])
+   ·                 ─
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `"foo"` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:17]
+ 1 │ new Set([`foo`, "foo"])
+   ·                 ─────
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `foo` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:15]
+ 1 │ new Set([foo, foo])
+   ·               ───
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `foo.bar` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:19]
+ 1 │ new Set([foo.bar, foo.bar])
+   ·                   ───────
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `foo.bar` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:22]
+ 1 │ new Set([foo["bar"], foo.bar])
+   ·                      ───────
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `this.foo` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:20]
+ 1 │ new Set([this.foo, this.foo])
+   ·                    ────────
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `foo` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:23]
+ 1 │ new Set([foo, ...bar, foo])
+   ·                       ───
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `2` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:30]
+ 1 │ const foo = 2; new Set([foo, 2]);
+   ·                              ─
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `'bar'` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:34]
+ 1 │ const foo = 'bar'; new Set([foo, 'bar']);
+   ·                                  ─────
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `undefined` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:38]
+ 1 │ const foo = undefined; new Set([foo, undefined]);
+   ·                                      ─────────
+   ╰────
+
+  ⚠ unicorn(no-duplicate-set-values): Remove duplicate value `foo` from the Set.
+   ╭─[no_duplicate_set_values.tsx:1:31]
+ 1 │ const foo = {}; new Set([foo, foo]);
+   ·                               ───
+   ╰────


### PR DESCRIPTION
## Summary

Implements `unicorn/no-duplicate-set-values` for #684.

Reports duplicate values in `new Set([ ... ])` array literals (static values, same references, SameValueZero for numbers). Does not match `globalThis.Set` or distinct object/array literals.

## Test plan

- [x] `cargo test -p oxc_linter --lib rules::unicorn::no_duplicate_set_values::test`
- [ ] CI

Part of #684