### PR TITLE
fix(formatter): stabilize comment between tagged temaplte tag and quasi

### DIFF
--- a/crates/oxc_formatter/src/print/template/mod.rs
+++ b/crates/oxc_formatter/src/print/template/mod.rs
@@ -55,20 +55,45 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TemplateLiteral<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TaggedTemplateExpression<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        // Format the tag and type arguments
-        write!(f, [self.tag(), self.type_arguments()]);
+        // Format the tag and type arguments.
+        // Comments between the tag (or type arguments) and the quasi always belong to the quasi
+        // as leading comments; suppress the trailing-comment capture on the last node before the quasi
+        // so they reach `comments_before` below.
+        // ```js
+        // foo /* c */
+        // `x`;
+        // ```
+        // Without this, the newline after the comment would make it the tag's trailing comment (end-of-line rule),
+        // printing ``foo /* c */`x`;``.
+        // Unlike the no-newline form which attaches to the quasi, so formatting is not idempotent.
+        if let Some(type_arguments) = self.type_arguments() {
+            write!(f, [self.tag(), FormatNodeWithoutTrailingComments(type_arguments)]);
+        } else {
+            write!(f, [FormatNodeWithoutTrailingComments(self.tag())]);
+        }
 
         let quasi = self.quasi();
 
         let comments = f.context().comments().comments_before(quasi.span.start);
         if !comments.is_empty() {
-            write!(
-                f,
-                [group(&format_args!(
-                    soft_line_break_or_space(),
-                    FormatLeadingComments::Comments(comments)
-                ))]
-            );
+            // The separator before the first comment is a plain space when the comment starts on the same line,
+            // and a soft line break otherwise.
+            // ```js
+            // foo /* a */ `x`; // same line -> space
+            //
+            // foo
+            // /* b */
+            // `x`;             // own line  -> soft line break
+            // ```
+            // No `group` here:
+            // the line elements inside the comments must inherit the enclosing mode,
+            // so a comment followed by a newline in the source keeps its line break.
+            if comments[0].preceded_by_newline() {
+                write!(f, [soft_line_break()]);
+            } else {
+                write!(f, [space()]);
+            }
+            write!(f, [FormatLeadingComments::Comments(comments)]);
         }
 
         write!(f, [line_suffix_boundary()]);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/tagged-template-literal.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/tagged-template-literal.js
@@ -1,0 +1,27 @@
+// Comments between a tagged template's tag and its quasi always attach to the
+// quasi as leading comments, regardless of the surrounding whitespace (prettier#19345).
+foo`` // comment 1
+;
+foo // comment 2
+``;
+foo // comment 3
+`x`;
+foo /* comment 4 */`
+`;
+foo /* comment 5 */
+`
+`;
+foo /* comment 6 */
+`x`;
+foo // comment 7
+`x`;
+foo
+/* comment 8 */
+`x`;
+foo
+// comment 9
+`x`;
+bar(foo // comment 10
+`x`);
+bar(foo /* comment 11 */
+`x`);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/tagged-template-literal.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/tagged-template-literal.js.snap
@@ -1,0 +1,96 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Comments between a tagged template's tag and its quasi always attach to the
+// quasi as leading comments, regardless of the surrounding whitespace (prettier#19345).
+foo`` // comment 1
+;
+foo // comment 2
+``;
+foo // comment 3
+`x`;
+foo /* comment 4 */`
+`;
+foo /* comment 5 */
+`
+`;
+foo /* comment 6 */
+`x`;
+foo // comment 7
+`x`;
+foo
+/* comment 8 */
+`x`;
+foo
+// comment 9
+`x`;
+bar(foo // comment 10
+`x`);
+bar(foo /* comment 11 */
+`x`);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Comments between a tagged template's tag and its quasi always attach to the
+// quasi as leading comments, regardless of the surrounding whitespace (prettier#19345).
+foo``; // comment 1
+foo // comment 2
+``;
+foo // comment 3
+`x`;
+foo /* comment 4 */ `
+`;
+foo /* comment 5 */
+`
+`;
+foo /* comment 6 */
+`x`;
+foo // comment 7
+`x`;
+foo
+/* comment 8 */
+`x`;
+foo
+// comment 9
+`x`;
+bar(
+  foo // comment 10
+  `x`,
+);
+bar(foo /* comment 11 */ `x`);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Comments between a tagged template's tag and its quasi always attach to the
+// quasi as leading comments, regardless of the surrounding whitespace (prettier#19345).
+foo``; // comment 1
+foo // comment 2
+``;
+foo // comment 3
+`x`;
+foo /* comment 4 */ `
+`;
+foo /* comment 5 */
+`
+`;
+foo /* comment 6 */
+`x`;
+foo // comment 7
+`x`;
+foo
+/* comment 8 */
+`x`;
+foo
+// comment 9
+`x`;
+bar(
+  foo // comment 10
+  `x`,
+);
+bar(foo /* comment 11 */ `x`);
+
+===================== End =====================

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 774/809 (95.67%), 23 files skipped
+js compatibility: 773/809 (95.55%), 23 files skipped
 
 # Failed
 
@@ -12,6 +12,7 @@ js compatibility: 774/809 (95.67%), 23 files skipped
 | js/comments/if.js | 💥💥 | 97.99% |
 | js/comments/return-statement-2.js | 💥💥 | 77.78% |
 | js/comments/return-statement.js | 💥💥 | 97.25% |
+| js/comments/tagged-template-literal.js | 💥💥 | 89.66% |
 | js/comments/between-head-and-body/between-head-and-body.js | 💥 | 33.10% |
 | js/comments/between-head-and-body/empty-statement.js | 💥 | 51.25% |
 | js/comments/between-head-and-body/non-block.js | 💥 | 82.86% |


### PR DESCRIPTION
Fixes idempotency.

Prettier will fix this in 3.10 release. So conformance drops a bit for a while.
