### PR TITLE
refactor(ecmascript)!: gate analysis APIs

### DIFF
--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -20,20 +20,27 @@ workspace = true
 test = true
 doctest = false
 
+[features]
+side_effects = ["dep:oxc_allocator", "dep:oxc_regular_expression"]
+constant_evaluation = ["side_effects", "dep:cow-utils", "dep:smallvec"]
+
 [dependencies]
-oxc_allocator = { workspace = true }
+oxc_allocator = { workspace = true, optional = true }
 oxc_ast = { workspace = true }
-oxc_regular_expression = { workspace = true }
+oxc_regular_expression = { workspace = true, optional = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true, features = ["to_js_string"] }
 
-cow-utils = { workspace = true }
+cow-utils = { workspace = true, optional = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
-smallvec = { workspace = true }
+smallvec = { workspace = true, optional = true }
 
 [dev-dependencies]
 # Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
 # If we enabled `disable_old_builder` feature in main dependency, feature unification would
 # cause it to be activated for `oxc_ast` for the user too.
 oxc_ast = { workspace = true, features = ["disable_old_builder"] }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/oxc_ecmascript/README.md
+++ b/crates/oxc_ecmascript/README.md
@@ -2,4 +2,9 @@
 
 ECMAScript Operations defined in the spec https://tc39.es/ecma262/
 
+## Cargo features
+
+- `side_effects`: Enables side-effect analysis.
+- `constant_evaluation`: Enables constant evaluation and implies `side_effects`.
+
 Tests reside in `crates/oxc_minifier/tests/ecmascript` due to cyclic dependency with `oxc_parser`.

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -3,13 +3,10 @@ mod equality_comparison;
 mod is_int32_or_uint32;
 mod is_literal_value;
 mod url_encoding;
-mod value;
-mod value_type;
 
+pub use crate::{ConstantValue, DetermineValueType, ValueType};
 pub use is_int32_or_uint32::IsInt32OrUint32;
 pub use is_literal_value::IsLiteralValue;
-pub use value::ConstantValue;
-pub use value_type::{DetermineValueType, ValueType};
 
 use std::borrow::Cow;
 

--- a/crates/oxc_ecmascript/src/global_context.rs
+++ b/crates/oxc_ecmascript/src/global_context.rs
@@ -1,7 +1,7 @@
 use oxc_ast::ast::{Expression, IdentifierReference};
 use oxc_syntax::reference::ReferenceId;
 
-use crate::constant_evaluation::{ConstantValue, ValueType};
+use crate::{ConstantValue, ValueType};
 
 pub trait GlobalContext<'a>: Sized {
     /// Whether the reference is a global reference.

--- a/crates/oxc_ecmascript/src/lib.rs
+++ b/crates/oxc_ecmascript/src/lib.rs
@@ -1,4 +1,9 @@
 //! Methods defined in the [ECMAScript Language Specification](https://tc39.es/ecma262).
+//!
+//! # Cargo features
+//!
+//! - `side_effects`: Enables side-effect analysis.
+//! - `constant_evaluation`: Enables constant evaluation and implies `side_effects`.
 
 // [Syntax-Directed Operations](https://tc39.es/ecma262/#sec-syntax-directed-operations)
 mod bound_names;
@@ -8,6 +13,7 @@ mod prop_name;
 
 // Abstract Operations
 mod array_join;
+#[cfg(feature = "constant_evaluation")]
 mod is_less_than;
 mod string_char_at;
 mod string_char_code_at;
@@ -24,12 +30,16 @@ mod to_number;
 mod to_numeric;
 mod to_primitive;
 mod to_string;
+mod value;
+mod value_type;
 
 // other
 mod to_integer_index;
 
+#[cfg(feature = "constant_evaluation")]
 pub mod constant_evaluation;
 mod global_context;
+#[cfg(feature = "side_effects")]
 pub mod side_effects;
 
 pub use self::{
@@ -53,4 +63,6 @@ pub use self::{
     to_number::ToNumber,
     to_primitive::ToPrimitive,
     to_string::ToJsString,
+    value::ConstantValue,
+    value_type::{DetermineValueType, ValueType},
 };

--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -1,8 +1,7 @@
 use oxc_ast::ast::*;
 
 use crate::{
-    ToBigInt, ToIntegerIndex,
-    constant_evaluation::{DetermineValueType, ValueType},
+    DetermineValueType, ToBigInt, ToIntegerIndex, ValueType,
     to_numeric::ToNumeric,
     to_primitive::{ToPrimitive, ToPrimitiveResult},
 };

--- a/crates/oxc_ecmascript/src/side_effects/statements.rs
+++ b/crates/oxc_ecmascript/src/side_effects/statements.rs
@@ -1,6 +1,6 @@
 use oxc_ast::ast::*;
 
-use crate::constant_evaluation::DetermineValueType;
+use crate::DetermineValueType;
 
 use super::{MayHaveSideEffects, PropertyReadSideEffects, context::MayHaveSideEffectsContext};
 

--- a/crates/oxc_ecmascript/src/to_primitive.rs
+++ b/crates/oxc_ecmascript/src/to_primitive.rs
@@ -1,9 +1,6 @@
 use oxc_ast::ast::*;
 
-use crate::{
-    GlobalContext,
-    constant_evaluation::{DetermineValueType, ValueType},
-};
+use crate::{DetermineValueType, GlobalContext, ValueType};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToPrimitiveResult {

--- a/crates/oxc_ecmascript/src/to_string.rs
+++ b/crates/oxc_ecmascript/src/to_string.rs
@@ -4,9 +4,7 @@ use oxc_ast::ast::*;
 use oxc_syntax::operator::UnaryOperator;
 
 use crate::{
-    GlobalContext, ToBoolean,
-    array_join::ArrayJoin,
-    constant_evaluation::{DetermineValueType, ValueType},
+    DetermineValueType, GlobalContext, ToBoolean, ValueType, array_join::ArrayJoin,
     to_primitive::maybe_object_with_to_primitive_related_properties_overridden,
 };
 

--- a/crates/oxc_ecmascript/src/value.rs
+++ b/crates/oxc_ecmascript/src/value.rs
@@ -3,8 +3,7 @@ use std::borrow::Cow;
 use num_bigint::BigInt;
 use num_traits::Zero;
 
-use super::value_type::ValueType;
-use crate::{GlobalContext, ToBoolean, ToJsString, ToNumber};
+use crate::{GlobalContext, ToBoolean, ToJsString, ToNumber, ValueType};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum ConstantValue<'a> {

--- a/crates/oxc_ecmascript/src/value_type.rs
+++ b/crates/oxc_ecmascript/src/value_type.rs
@@ -61,7 +61,7 @@ impl ValueType {
 ///
 /// Evaluate the expression and attempt to determine which ValueType it could resolve to.
 /// This function ignores the cases that throws an error, e.g. `foo * 0` can throw an error when `foo` is a bigint.
-/// To detect those cases, use [`crate::side_effects::MayHaveSideEffects`].
+/// To detect those cases, use `MayHaveSideEffects` when the `side_effects` feature is enabled.
 pub trait DetermineValueType<'a> {
     fn value_type(&self, ctx: &impl GlobalContext<'a>) -> ValueType;
 }

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -35,7 +35,7 @@ oxc_config = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["box_macros"] }
 oxc_diagnostics = { workspace = true }
 oxc_estree_tokens = { workspace = true }
-oxc_ecmascript = { workspace = true }
+oxc_ecmascript = { workspace = true, features = ["side_effects"] }
 oxc_index = { workspace = true }
 oxc_macros = { workspace = true, features = ["ruledocs"] }
 oxc_parser = { workspace = true }

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -25,7 +25,7 @@ oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_compat = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["stack"] }
-oxc_ecmascript = { workspace = true }
+oxc_ecmascript = { workspace = true, features = ["constant_evaluation"] }
 oxc_index = { workspace = true }
 oxc_mangler = { workspace = true }
 oxc_parser = { workspace = true }


### PR DESCRIPTION
> **PR stack (1 of 3)**
> 1. **#24739 (this PR)**
> 2. #24742
> 3. #24712
>
> Review and merge in this order.

The `oxc_ecmascript` crate currently compiles constant evaluation and side-effect analysis for every consumer, even when a consumer only needs the small shared ECMAScript value primitives. This makes optional analysis code and its dependencies part of unrelated builds.

This introduces two explicit features:

- `side_effects` enables side-effect analysis and its RegExp support.
- `constant_evaluation` enables constant evaluation and implies `side_effects`, because side-effect analysis uses constant folding for several purity decisions.

`ConstantValue`, `ValueType`, and `DetermineValueType` move to feature-independent root modules so `GlobalContext` remains available without either analysis feature. Existing paths through `constant_evaluation` remain re-exported when that feature is enabled.

This is a prerequisite for #24742, which exposes engine targets to side-effect analysis without making compatibility data part of every `oxc_ecmascript` consumer.

This is a breaking Cargo feature change for direct consumers of `oxc_ecmascript`: code using side-effect analysis or constant evaluation must enable the corresponding feature.

Verified locally with the no-feature, `side_effects`, and `constant_evaluation` configurations, crate tests, dependent linter and minifier tests, rustdoc with warnings denied, and `just ready`. The release oxlint binary on this commit is 13,350,096 bytes.

Implemented with AI assistance (OpenAI Codex and Claude). The contributor remains responsible for reviewing, understanding, and maintaining these changes.