### PR TITLE
feat(napi/minify): expose property name mangling options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,6 +2377,7 @@ dependencies = [
 name = "oxc_minify_napi"
 version = "0.144.0"
 dependencies = [
+ "lazy-regex",
  "mimalloc-safe",
  "napi",
  "napi-build",
@@ -2391,6 +2392,7 @@ dependencies = [
  "oxc_sourcemap",
  "oxc_span",
  "oxc_str",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,6 +2337,7 @@ dependencies = [
 name = "oxc_minify_napi"
 version = "0.142.0"
 dependencies = [
+ "lazy-regex",
  "mimalloc-safe",
  "napi",
  "napi-build",
@@ -2351,6 +2352,7 @@ dependencies = [
  "oxc_sourcemap",
  "oxc_span",
  "oxc_str",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -35,6 +35,8 @@ oxc_span = { workspace = true }
 
 napi = { workspace = true }
 napi-derive = { workspace = true }
+lazy-regex = { workspace = true }
+rustc-hash = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit"] }

--- a/napi/minify/README.md
+++ b/napi/minify/README.md
@@ -67,6 +67,47 @@ console.log(result.code);
 console.log(result.map);
 ```
 
+### Property-name mangling
+
+Property mangling is opt-in and independent from identifier mangling. `include` is a
+[Rust regex](https://docs.rs/regex/latest/regex/#syntax) source string and is required when
+`mangleProps` is present. JavaScript regex flags and look-around are not supported; Rust
+character classes such as `\w` are Unicode-aware by default.
+
+```javascript
+const result = minifySync("component.js", source, {
+  mangle: false,
+  mangleProps: {
+    include: "^_",
+    exclude: "^__public",
+    reserved: ["_externalApi"],
+    quoted: false,
+    cache: previousResult?.mangleCache,
+  },
+});
+
+saveCache(result.mangleCache);
+```
+
+The returned `mangleCache` contains the input cache plus newly assigned names when parsing
+finishes without errors, sorted by original name. A `false` cache value keeps that property
+unchanged. Feeding the cache back keeps recorded mappings stable for later unminified input, but
+the cache does not discover unchanged names that exist only in another input. Callers coordinating
+separate files must pin or reserve those names explicitly. Property mappings are
+single-application: do not minify already-mangled output with the same cache. Custom target names
+may be shared deliberately, but must be valid JavaScript `IdentifierName` values and cannot be
+`__proto__`, `constructor`, or `prototype`. The original name `__proto__` is always reserved and
+cannot be used as a cache key.
+
+With `quoted: false`, quoting is handled per occurrence: `obj._field` is eligible while
+`obj["_field"]` is not. Property mangling assumes matching properties are never accessed through
+arbitrary dynamic strings. Use `/* @__KEY__ */ "_field"` for a string that semantically names a
+property, such as a reflective API argument. Names reached through direct `eval`, the `Function`
+constructor, or `with` must be reserved or excluded explicitly.
+
+Properties owned by unminified code, imported module namespaces, globals, DOM objects, or other
+host APIs must also be excluded or reserved.
+
 ## Assumptions
 
 `oxc-minify` makes some assumptions about the source code.

--- a/napi/minify/README.md
+++ b/napi/minify/README.md
@@ -67,6 +67,43 @@ console.log(result.code);
 console.log(result.map);
 ```
 
+### Property-name mangling
+
+Property mangling is opt-in and independent from identifier mangling. `include` is a
+[Rust regex](https://docs.rs/regex/latest/regex/#syntax) source string and is required when
+`mangleProps` is present. JavaScript regex flags and look-around are not supported; Rust
+character classes such as `\w` are Unicode-aware by default.
+
+```javascript
+const result = minifySync("component.js", source, {
+  mangle: false,
+  mangleProps: {
+    include: "^_",
+    exclude: "^__public",
+    reserved: ["_externalApi"],
+    quoted: false,
+    cache: previousResult?.mangleCache,
+  },
+});
+
+saveCache(result.mangleCache);
+```
+
+The returned `mangleCache` contains the input cache plus newly assigned names when parsing
+finishes without errors, sorted by original name. A `false` cache value keeps that property
+unchanged. Feeding the cache back keeps recorded mappings stable for later unminified input, but
+the cache does not discover unchanged names that exist only in another input. Callers coordinating
+separate files must pin or reserve those names explicitly. Property mappings are
+single-application: do not minify already-mangled output with the same cache. Custom target names
+may be shared deliberately, but must be valid JavaScript `IdentifierName` values and cannot be
+`__proto__`, `constructor`, or `prototype`.
+
+With `quoted: false`, quoting is handled per occurrence: `obj._field` is eligible while
+`obj["_field"]` is not. Property mangling assumes matching properties are never accessed through
+arbitrary dynamic strings. Use `/* @__KEY__ */ "_field"` for a string that semantically names a
+property, such as a reflective API argument. Names reached through direct `eval`, the `Function`
+constructor, or `with` must be reserved or excluded explicitly.
+
 ## Assumptions
 
 `oxc-minify` makes some assumptions about the source code.

--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -167,6 +167,38 @@ export interface MangleOptionsKeepNames {
   class: boolean
 }
 
+export interface ManglePropertiesOptions {
+  /**
+   * Rust-regex source selecting property names to mangle. Matching is unanchored unless the
+   * expression contains anchors. JavaScript regex flags and look-around are not supported.
+   */
+  include: string
+  /** Rust-regex source excluding property names selected by `include`. */
+  exclude?: string
+  /** Exact names that are neither mangled nor emitted as automatic output names. */
+  reserved?: Array<string>
+  /**
+   * Mangle quoted property occurrences in addition to unquoted occurrences.
+   *
+   * @default false
+   */
+  quoted?: boolean
+  /**
+   * Generate readable `_$name$_`-style output names.
+   *
+   * @default false
+   */
+  debug?: boolean
+  /**
+   * Stable mappings from original names to output names. `false` reserves an original name.
+   * Entries that do not match `include`, or that match `exclude`, remain inert but are
+   * preserved in the returned `mangleCache`. String targets must be `IdentifierName` values
+   * other than `__proto__`, `constructor`, or `prototype`. The original name `__proto__` is
+   * always reserved and cannot be used as a cache key.
+   */
+  cache?: Record<string, string | false>
+}
+
 /**
  * Minify asynchronously.
  *
@@ -179,6 +211,12 @@ export interface MinifyOptions {
   module?: boolean
   compress?: boolean | CompressOptions
   mangle?: boolean | MangleOptions
+  /**
+   * Mangle matching property names independently of identifier mangling. Properties owned by
+   * unminified code, imported module namespaces, globals, or host APIs must be excluded or
+   * reserved.
+   */
+  mangleProps?: ManglePropertiesOptions
   codegen?: boolean | CodegenOptions
   sourcemap?: boolean
 }
@@ -192,6 +230,11 @@ export interface MinifyResult {
    * Only populated when `codegen.legalComments` is `"linked"` or `"external"`.
    */
   legalComments: Array<string>
+  /**
+   * Updated property-name cache sorted by original name. Present when `mangleProps` ran on a
+   * parse without errors.
+   */
+  mangleCache?: Record<string, string | false>
 }
 
 /** Minify synchronously. */

--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -167,6 +167,37 @@ export interface MangleOptionsKeepNames {
   class: boolean
 }
 
+export interface ManglePropertiesOptions {
+  /**
+   * Rust-regex source selecting property names to mangle. Matching is unanchored unless the
+   * expression contains anchors. JavaScript regex flags and look-around are not supported.
+   */
+  include: string
+  /** Rust-regex source excluding property names selected by `include`. */
+  exclude?: string
+  /** Exact names that are neither mangled nor emitted as automatic output names. */
+  reserved?: Array<string>
+  /**
+   * Mangle quoted property occurrences in addition to unquoted occurrences.
+   *
+   * @default false
+   */
+  quoted?: boolean
+  /**
+   * Generate readable `_$name$_`-style output names.
+   *
+   * @default false
+   */
+  debug?: boolean
+  /**
+   * Stable mappings from original names to output names. `false` reserves an original name.
+   * Entries that do not match `include`, or that match `exclude`, remain inert but are
+   * preserved in the returned `mangleCache`. String targets must be `IdentifierName` values
+   * other than `__proto__`, `constructor`, or `prototype`.
+   */
+  cache?: Record<string, string | false>
+}
+
 /**
  * Minify asynchronously.
  *
@@ -179,6 +210,8 @@ export interface MinifyOptions {
   module?: boolean
   compress?: boolean | CompressOptions
   mangle?: boolean | MangleOptions
+  /** Mangle matching property names independently of identifier mangling. */
+  mangleProps?: ManglePropertiesOptions
   codegen?: boolean | CodegenOptions
   sourcemap?: boolean
 }
@@ -192,6 +225,11 @@ export interface MinifyResult {
    * Only populated when `codegen.legalComments` is `"linked"` or `"external"`.
    */
   legalComments: Array<string>
+  /**
+   * Updated property-name cache sorted by original name. Present when `mangleProps` ran on a
+   * parse without errors.
+   */
+  mangleCache?: Record<string, string | false>
 }
 
 /** Minify synchronously. */

--- a/napi/minify/minify.wasi.d.cts
+++ b/napi/minify/minify.wasi.d.cts
@@ -167,6 +167,38 @@ export interface MangleOptionsKeepNames {
   class: boolean
 }
 
+export interface ManglePropertiesOptions {
+  /**
+   * Rust-regex source selecting property names to mangle. Matching is unanchored unless the
+   * expression contains anchors. JavaScript regex flags and look-around are not supported.
+   */
+  include: string
+  /** Rust-regex source excluding property names selected by `include`. */
+  exclude?: string
+  /** Exact names that are neither mangled nor emitted as automatic output names. */
+  reserved?: Array<string>
+  /**
+   * Mangle quoted property occurrences in addition to unquoted occurrences.
+   *
+   * @default false
+   */
+  quoted?: boolean
+  /**
+   * Generate readable `_$name$_`-style output names.
+   *
+   * @default false
+   */
+  debug?: boolean
+  /**
+   * Stable mappings from original names to output names. `false` reserves an original name.
+   * Entries that do not match `include`, or that match `exclude`, remain inert but are
+   * preserved in the returned `mangleCache`. String targets must be `IdentifierName` values
+   * other than `__proto__`, `constructor`, or `prototype`. The original name `__proto__` is
+   * always reserved and cannot be used as a cache key.
+   */
+  cache?: Record<string, string | false>
+}
+
 /**
  * Minify asynchronously.
  *
@@ -179,6 +211,12 @@ export interface MinifyOptions {
   module?: boolean
   compress?: boolean | CompressOptions
   mangle?: boolean | MangleOptions
+  /**
+   * Mangle matching property names independently of identifier mangling. Properties owned by
+   * unminified code, imported module namespaces, globals, or host APIs must be excluded or
+   * reserved.
+   */
+  mangleProps?: ManglePropertiesOptions
   codegen?: boolean | CodegenOptions
   sourcemap?: boolean
 }
@@ -192,6 +230,11 @@ export interface MinifyResult {
    * Only populated when `codegen.legalComments` is `"linked"` or `"external"`.
    */
   legalComments: Array<string>
+  /**
+   * Updated property-name cache sorted by original name. Present when `mangleProps` ran on a
+   * parse without errors.
+   */
+  mangleCache?: Record<string, string | false>
 }
 
 /** Minify synchronously. */

--- a/napi/minify/src/lib.rs
+++ b/napi/minify/src/lib.rs
@@ -15,7 +15,7 @@ static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 
 mod options;
 
-use std::path::PathBuf;
+use std::{collections::BTreeMap, path::PathBuf};
 
 use napi::{Either, Task, bindgen_prelude::AsyncTask};
 use napi_derive::napi;
@@ -40,13 +40,29 @@ pub struct MinifyResult {
     /// Legal comments extracted from the source code.
     /// Only populated when `codegen.legalComments` is `"linked"` or `"external"`.
     pub legal_comments: Vec<String>,
+    /// Updated property-name cache sorted by original name. Present when `mangleProps` ran on a
+    /// parse without errors.
+    #[napi(ts_type = "Record<string, string | false>")]
+    pub mangle_cache: Option<BTreeMap<String, Either<String, bool>>>,
+}
+
+fn to_napi_mangle_cache(
+    cache: oxc_minifier::ManglePropertyCache,
+) -> BTreeMap<String, Either<String, bool>> {
+    cache
+        .into_iter()
+        .map(|(original, target)| {
+            let value = target.map_or(Either::B(false), |target| Either::A(target.to_string()));
+            (original.to_string(), value)
+        })
+        .collect()
 }
 
 fn minify_impl(filename: &str, source_text: &str, options: Option<MinifyOptions>) -> MinifyResult {
     use oxc_codegen::CodegenOptions;
     let options = options.unwrap_or_default();
 
-    let minifier_options = match oxc_minifier::MinifierOptions::try_from(&options) {
+    let mut minifier_options = match oxc_minifier::MinifierOptions::try_from(&options) {
         Ok(options) => options,
         Err(error) => {
             return MinifyResult {
@@ -69,9 +85,19 @@ fn minify_impl(filename: &str, source_text: &str, options: Option<MinifyOptions>
     };
 
     let parser_ret = Parser::new(&allocator, source_text, source_type).parse();
+    if !parser_ret.diagnostics.is_empty() {
+        // A recovered AST may be incomplete, so skip property mangling and its cache.
+        minifier_options.mangle_properties = None;
+    }
     let mut program = parser_ret.program;
 
-    let scoping = Minifier::new(minifier_options).minify(&allocator, &mut program).scoping;
+    let minifier_ret = Minifier::new(minifier_options).minify(&allocator, &mut program);
+    let scoping = minifier_ret.scoping;
+    let mangle_cache = parser_ret
+        .diagnostics
+        .is_empty()
+        .then(|| minifier_ret.property_mangle_cache.map(to_napi_mangle_cache))
+        .flatten();
 
     let mut codegen_options = match &options.codegen {
         // Need to remove all comments.
@@ -106,6 +132,7 @@ fn minify_impl(filename: &str, source_text: &str, options: Option<MinifyOptions>
         map: ret.map.map(oxc_sourcemap::napi::SourceMap::from),
         errors: OxcError::from_diagnostics(filename, source_text, parser_ret.diagnostics),
         legal_comments,
+        mangle_cache,
     }
 }
 

--- a/napi/minify/src/lib.rs
+++ b/napi/minify/src/lib.rs
@@ -15,7 +15,7 @@ static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 
 mod options;
 
-use std::path::PathBuf;
+use std::{collections::BTreeMap, path::PathBuf};
 
 use napi::{Either, Task, bindgen_prelude::AsyncTask};
 use napi_derive::napi;
@@ -40,13 +40,29 @@ pub struct MinifyResult {
     /// Legal comments extracted from the source code.
     /// Only populated when `codegen.legalComments` is `"linked"` or `"external"`.
     pub legal_comments: Vec<String>,
+    /// Updated property-name cache sorted by original name. Present when `mangleProps` ran on a
+    /// parse without errors.
+    #[napi(ts_type = "Record<string, string | false>")]
+    pub mangle_cache: Option<BTreeMap<String, Either<String, bool>>>,
+}
+
+fn to_napi_mangle_cache(
+    cache: oxc_minifier::ManglePropertyCache,
+) -> BTreeMap<String, Either<String, bool>> {
+    cache
+        .into_iter()
+        .map(|(original, target)| {
+            let value = target.map_or(Either::B(false), |target| Either::A(target.to_string()));
+            (original.to_string(), value)
+        })
+        .collect()
 }
 
 fn minify_impl(filename: &str, source_text: &str, options: Option<MinifyOptions>) -> MinifyResult {
     use oxc_codegen::CodegenOptions;
     let options = options.unwrap_or_default();
 
-    let minifier_options = match oxc_minifier::MinifierOptions::try_from(&options) {
+    let mut minifier_options = match oxc_minifier::MinifierOptions::try_from(&options) {
         Ok(options) => options,
         Err(error) => {
             return MinifyResult {
@@ -69,9 +85,20 @@ fn minify_impl(filename: &str, source_text: &str, options: Option<MinifyOptions>
     };
 
     let parser_ret = Parser::new(&allocator, source_text, source_type).parse();
+    if !parser_ret.diagnostics.is_empty() {
+        // A recovered AST can be emitted for diagnostics, but its property set is incomplete.
+        // Do not rewrite names unless the corresponding cache can be published safely.
+        minifier_options.mangle_properties = None;
+    }
     let mut program = parser_ret.program;
 
-    let scoping = Minifier::new(minifier_options).minify(&allocator, &mut program).scoping;
+    let minifier_ret = Minifier::new(minifier_options).minify(&allocator, &mut program);
+    let scoping = minifier_ret.scoping;
+    let mangle_cache = parser_ret
+        .diagnostics
+        .is_empty()
+        .then(|| minifier_ret.property_mangle_cache.map(to_napi_mangle_cache))
+        .flatten();
 
     let mut codegen_options = match &options.codegen {
         // Need to remove all comments.
@@ -106,6 +133,7 @@ fn minify_impl(filename: &str, source_text: &str, options: Option<MinifyOptions>
         map: ret.map.map(oxc_sourcemap::napi::SourceMap::from),
         errors: OxcError::from_diagnostics(filename, source_text, parser_ret.diagnostics),
         legal_comments,
+        mangle_cache,
     }
 }
 

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -1,5 +1,6 @@
 use napi::Either;
 use napi_derive::napi;
+use rustc_hash::FxHashMap;
 
 use oxc_compat::EngineTargets;
 use oxc_str::CompactStr;
@@ -274,6 +275,88 @@ impl From<&MangleOptionsKeepNames> for oxc_minifier::MangleOptionsKeepNames {
     }
 }
 
+#[napi(object)]
+pub struct ManglePropertiesOptions {
+    /// Rust-regex source selecting property names to mangle. Matching is unanchored unless the
+    /// expression contains anchors. JavaScript regex flags and look-around are not supported.
+    pub include: String,
+
+    /// Rust-regex source excluding property names selected by `include`.
+    pub exclude: Option<String>,
+
+    /// Exact names that are neither mangled nor emitted as automatic output names.
+    pub reserved: Option<Vec<String>>,
+
+    /// Mangle quoted property occurrences in addition to unquoted occurrences.
+    ///
+    /// @default false
+    pub quoted: Option<bool>,
+
+    /// Generate readable `_$name$_`-style output names.
+    ///
+    /// @default false
+    pub debug: Option<bool>,
+
+    /// Stable mappings from original names to output names. `false` reserves an original name.
+    /// Entries that do not match `include`, or that match `exclude`, remain inert but are
+    /// preserved in the returned `mangleCache`. String targets must be `IdentifierName` values
+    /// other than `__proto__`, `constructor`, or `prototype`. The original name `__proto__` is
+    /// always reserved and cannot be used as a cache key.
+    #[napi(ts_type = "Record<string, string | false>")]
+    pub cache: Option<FxHashMap<String, Either<String, bool>>>,
+}
+
+impl TryFrom<&ManglePropertiesOptions> for oxc_minifier::ManglePropertiesOptions {
+    type Error = String;
+
+    fn try_from(options: &ManglePropertiesOptions) -> Result<Self, Self::Error> {
+        let include = lazy_regex::Regex::new(&options.include)
+            .map_err(|error| format!("Invalid mangleProps.include regex: {error}"))?;
+        let exclude = options
+            .exclude
+            .as_ref()
+            .map(|pattern| {
+                lazy_regex::Regex::new(pattern)
+                    .map_err(|error| format!("Invalid mangleProps.exclude regex: {error}"))
+            })
+            .transpose()?;
+        let mut cache = oxc_minifier::ManglePropertyCache::default();
+        if let Some(entries) = &options.cache {
+            for (original, value) in entries {
+                if original == "__proto__" {
+                    return Err(
+                        "Invalid mangleProps.cache key '__proto__': this original name cannot be used as a cache key"
+                            .to_string(),
+                    );
+                }
+                let target = match value {
+                    Either::A(target) => Some(CompactStr::from(target.as_str())),
+                    Either::B(false) => None,
+                    Either::B(true) => {
+                        return Err(format!(
+                            "Invalid mangleProps.cache value for '{original}': expected a string or false"
+                        ));
+                    }
+                };
+                cache
+                    .insert(CompactStr::from(original.as_str()), target)
+                    .map_err(|error| format!("Invalid mangleProps.cache: {error}"))?;
+            }
+        }
+
+        Ok(Self {
+            include,
+            exclude,
+            reserved: options.reserved.as_ref().map_or_else(Default::default, |names| {
+                names.iter().map(|name| CompactStr::from(name.as_str())).collect()
+            }),
+            mangle_quoted: options.quoted.unwrap_or(false),
+            debug: options.debug.unwrap_or(false),
+            cache,
+        })
+    }
+}
+
 #[napi(string_enum = "lowercase")]
 pub enum LegalCommentsMode {
     /// Do not preserve any legal comments.
@@ -364,6 +447,11 @@ pub struct MinifyOptions {
 
     pub mangle: Option<Either<bool, MangleOptions>>,
 
+    /// Mangle matching property names independently of identifier mangling. Properties owned by
+    /// unminified code, imported module namespaces, globals, or host APIs must be excluded or
+    /// reserved.
+    pub mangle_props: Option<ManglePropertiesOptions>,
+
     pub codegen: Option<Either<bool, CodegenOptions>>,
 
     pub sourcemap: Option<bool>,
@@ -383,6 +471,11 @@ impl TryFrom<&MinifyOptions> for oxc_minifier::MinifierOptions {
             None | Some(Either::A(true)) => Some(oxc_minifier::MangleOptions::default()),
             Some(Either::B(o)) => Some(oxc_minifier::MangleOptions::from(o)),
         };
-        Ok(oxc_minifier::MinifierOptions { compress, mangle, mangle_properties: None })
+        let mangle_properties = o
+            .mangle_props
+            .as_ref()
+            .map(oxc_minifier::ManglePropertiesOptions::try_from)
+            .transpose()?;
+        Ok(oxc_minifier::MinifierOptions { compress, mangle, mangle_properties })
     }
 }

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -1,5 +1,6 @@
 use napi::Either;
 use napi_derive::napi;
+use rustc_hash::FxHashMap;
 
 use oxc_compat::EngineTargets;
 use oxc_str::CompactStr;
@@ -274,6 +275,81 @@ impl From<&MangleOptionsKeepNames> for oxc_minifier::MangleOptionsKeepNames {
     }
 }
 
+#[napi(object)]
+pub struct ManglePropertiesOptions {
+    /// Rust-regex source selecting property names to mangle. Matching is unanchored unless the
+    /// expression contains anchors. JavaScript regex flags and look-around are not supported.
+    pub include: String,
+
+    /// Rust-regex source excluding property names selected by `include`.
+    pub exclude: Option<String>,
+
+    /// Exact names that are neither mangled nor emitted as automatic output names.
+    pub reserved: Option<Vec<String>>,
+
+    /// Mangle quoted property occurrences in addition to unquoted occurrences.
+    ///
+    /// @default false
+    pub quoted: Option<bool>,
+
+    /// Generate readable `_$name$_`-style output names.
+    ///
+    /// @default false
+    pub debug: Option<bool>,
+
+    /// Stable mappings from original names to output names. `false` reserves an original name.
+    /// Entries that do not match `include`, or that match `exclude`, remain inert but are
+    /// preserved in the returned `mangleCache`. String targets must be `IdentifierName` values
+    /// other than `__proto__`, `constructor`, or `prototype`.
+    #[napi(ts_type = "Record<string, string | false>")]
+    pub cache: Option<FxHashMap<String, Either<String, bool>>>,
+}
+
+impl TryFrom<&ManglePropertiesOptions> for oxc_minifier::ManglePropertiesOptions {
+    type Error = String;
+
+    fn try_from(options: &ManglePropertiesOptions) -> Result<Self, Self::Error> {
+        let include = lazy_regex::Regex::new(&options.include)
+            .map_err(|error| format!("Invalid mangleProps.include regex: {error}"))?;
+        let exclude = options
+            .exclude
+            .as_ref()
+            .map(|pattern| {
+                lazy_regex::Regex::new(pattern)
+                    .map_err(|error| format!("Invalid mangleProps.exclude regex: {error}"))
+            })
+            .transpose()?;
+        let mut cache = oxc_minifier::ManglePropertyCache::default();
+        if let Some(entries) = &options.cache {
+            for (original, value) in entries {
+                let target = match value {
+                    Either::A(target) => Some(CompactStr::from(target.as_str())),
+                    Either::B(false) => None,
+                    Either::B(true) => {
+                        return Err(format!(
+                            "Invalid mangleProps.cache value for '{original}': expected a string or false"
+                        ));
+                    }
+                };
+                cache
+                    .insert(CompactStr::from(original.as_str()), target)
+                    .map_err(|error| format!("Invalid mangleProps.cache: {error}"))?;
+            }
+        }
+
+        Ok(Self {
+            include,
+            exclude,
+            reserved: options.reserved.as_ref().map_or_else(Default::default, |names| {
+                names.iter().map(|name| CompactStr::from(name.as_str())).collect()
+            }),
+            mangle_quoted: options.quoted.unwrap_or(false),
+            debug: options.debug.unwrap_or(false),
+            cache,
+        })
+    }
+}
+
 #[napi(string_enum = "lowercase")]
 pub enum LegalCommentsMode {
     /// Do not preserve any legal comments.
@@ -364,6 +440,9 @@ pub struct MinifyOptions {
 
     pub mangle: Option<Either<bool, MangleOptions>>,
 
+    /// Mangle matching property names independently of identifier mangling.
+    pub mangle_props: Option<ManglePropertiesOptions>,
+
     pub codegen: Option<Either<bool, CodegenOptions>>,
 
     pub sourcemap: Option<bool>,
@@ -383,6 +462,11 @@ impl TryFrom<&MinifyOptions> for oxc_minifier::MinifierOptions {
             None | Some(Either::A(true)) => Some(oxc_minifier::MangleOptions::default()),
             Some(Either::B(o)) => Some(oxc_minifier::MangleOptions::from(o)),
         };
-        Ok(oxc_minifier::MinifierOptions { compress, mangle, mangle_properties: None })
+        let mangle_properties = o
+            .mangle_props
+            .as_ref()
+            .map(oxc_minifier::ManglePropertiesOptions::try_from)
+            .transpose()?;
+        Ok(oxc_minifier::MinifierOptions { compress, mangle, mangle_properties })
     }
 }

--- a/napi/minify/test/minify.test.ts
+++ b/napi/minify/test/minify.test.ts
@@ -140,6 +140,158 @@ describe("async minify", () => {
   });
 });
 
+describe("property mangling", () => {
+  it("is independent from identifier mangling and returns a reusable cache", () => {
+    const ret = minifySync("test.js", "let local; obj._often; obj._rare; obj._often;", {
+      compress: false,
+      mangle: false,
+      mangleProps: { include: "^_" },
+    });
+
+    expect(ret.errors).toHaveLength(0);
+    expect(ret.code).toBe("let local;obj.e;obj.t;obj.e;");
+    expect(ret.mangleCache).toEqual({ _often: "e", _rare: "t" });
+  });
+
+  it("keeps quoted occurrences unless quoted is enabled", () => {
+    const source = "obj._field; obj['_field'];";
+    expect(
+      minifySync("test.js", source, {
+        compress: false,
+        mangle: false,
+        mangleProps: { include: "^_" },
+      }).code,
+    ).toBe("obj.e;obj[`_field`];");
+    expect(
+      minifySync("test.js", source, {
+        compress: false,
+        mangle: false,
+        mangleProps: { include: "^_", quoted: true },
+      }).code,
+    ).toBe("obj.e;obj.e;");
+  });
+
+  it("honors false entries and duplicate custom targets", () => {
+    const ret = minifySync("test.js", "obj._first; obj._second; obj._keep;", {
+      compress: false,
+      mangle: false,
+      mangleProps: {
+        include: "^_",
+        cache: { _first: "A", _second: "A", _keep: false },
+      },
+    });
+
+    expect(ret.code).toBe("obj.A;obj.A;obj._keep;");
+    expect(ret.mangleCache).toEqual({ _first: "A", _second: "A", _keep: false });
+  });
+
+  it("keeps cache keys out of automatic targets across round trips", () => {
+    const first = minifySync("test.js", "obj.foo;", {
+      compress: false,
+      mangle: false,
+      mangleProps: { include: ".", cache: { e: false } },
+    });
+    expect(first.code).toBe("obj.t;");
+    expect(first.mangleCache).toEqual({ e: false, foo: "t" });
+
+    const second = minifySync("test.js", "obj.e; obj.foo;", {
+      compress: false,
+      mangle: false,
+      mangleProps: { include: ".", cache: first.mangleCache },
+    });
+    expect(second.code).toBe("obj.e;obj.t;");
+    expect(second.mangleCache).toEqual(first.mangleCache);
+  });
+
+  it("keeps every property readable in debug mode", () => {
+    const ret = minifySync("test.js", "obj._alpha; obj._beta; obj._gamma;", {
+      compress: false,
+      mangle: false,
+      mangleProps: { include: "^_", debug: true },
+    });
+    expect(ret.code).toBe("obj._$_alpha$_;obj._$_beta$_;obj._$_gamma$_;");
+  });
+
+  it("honors exclude and reserved names", () => {
+    const ret = minifySync("test.js", "obj._skipOne; obj._reserved; obj._mangle;", {
+      compress: false,
+      mangle: false,
+      mangleProps: {
+        include: "^_",
+        exclude: "^_skip(?:One|Two)$",
+        reserved: ["_reserved"],
+      },
+    });
+    expect(ret.errors).toHaveLength(0);
+    expect(ret.code).toBe("obj._skipOne;obj._reserved;obj.e;");
+  });
+
+  it("works through the async API", async () => {
+    const ret = await minify("test.js", "obj._field; obj._field;", {
+      compress: false,
+      mangle: false,
+      mangleProps: { include: "^_" },
+    });
+    expect(ret.errors).toHaveLength(0);
+    expect(ret.code).toBe("obj.e;obj.e;");
+    expect(ret.mangleCache).toEqual({ _field: "e" });
+  });
+
+  it("does not mangle properties when parsing has errors", () => {
+    const ret = minifySync("test.js", "const invalid; obj._field;", {
+      compress: false,
+      mangle: false,
+      mangleProps: { include: "^_" },
+    });
+    expect(ret.errors).toHaveLength(1);
+    expect(ret.code).toBe("const invalid;obj._field;");
+    expect(ret.mangleCache).toBeUndefined();
+  });
+
+  it("returns cache entries in stable lexical order", () => {
+    const ret = minifySync(
+      "test.js",
+      "obj._zeta; obj._alpha; obj._middle; obj._beta; obj._omega;",
+      {
+        compress: false,
+        mangle: false,
+        mangleProps: { include: "^_" },
+      },
+    );
+    expect(Object.keys(ret.mangleCache!)).toEqual([
+      "_alpha",
+      "_beta",
+      "_middle",
+      "_omega",
+      "_zeta",
+    ]);
+  });
+
+  it.each([
+    [{ include: "[" }, "Invalid mangleProps.include regex"],
+    [{ include: "^_", cache: { _field: true as any } }, "expected a string or false"],
+    [
+      { include: "^_", cache: { ["__proto__"]: false } },
+      "this original name cannot be used as a cache key",
+    ],
+    [{ include: "^_", cache: { _field: "not-valid" } }, "must be an IdentifierName"],
+    [{ include: "^_", cache: { _field: "__proto__" } }, "must be an IdentifierName"],
+    [
+      { include: "^_", cache: { _field: "constructor" } },
+      "other than '__proto__', 'constructor', or 'prototype'",
+    ],
+    [
+      { include: "^_", cache: { _field: "prototype" } },
+      "other than '__proto__', 'constructor', or 'prototype'",
+    ],
+  ])("rejects invalid options", (mangleProps, message) => {
+    const ret = minifySync("test.js", "obj._field;", { mangleProps: mangleProps as any });
+    expect(ret.errors).toHaveLength(1);
+    expect(ret.errors[0].message).toContain(message);
+    expect(ret.mangleCache).toBeUndefined();
+  });
+});
+
 describe("worker", () => {
   it("should run", async () => {
     const code = await new Promise((resolve, reject) => {

--- a/napi/minify/test/minify.test.ts
+++ b/napi/minify/test/minify.test.ts
@@ -140,6 +140,154 @@ describe("async minify", () => {
   });
 });
 
+describe("property mangling", () => {
+  it("is independent from identifier mangling and returns a reusable cache", () => {
+    const ret = minifySync("test.js", "let local; obj._often; obj._rare; obj._often;", {
+      compress: false,
+      mangle: false,
+      mangleProps: { include: "^_" },
+    });
+
+    expect(ret.errors).toHaveLength(0);
+    expect(ret.code).toBe("let local;obj.e;obj.t;obj.e;");
+    expect(ret.mangleCache).toEqual({ _often: "e", _rare: "t" });
+  });
+
+  it("keeps quoted occurrences unless quoted is enabled", () => {
+    const source = "obj._field; obj['_field'];";
+    expect(
+      minifySync("test.js", source, {
+        compress: false,
+        mangle: false,
+        mangleProps: { include: "^_" },
+      }).code,
+    ).toBe("obj.e;obj[`_field`];");
+    expect(
+      minifySync("test.js", source, {
+        compress: false,
+        mangle: false,
+        mangleProps: { include: "^_", quoted: true },
+      }).code,
+    ).toBe("obj.e;obj.e;");
+  });
+
+  it("honors false entries and duplicate custom targets", () => {
+    const ret = minifySync("test.js", "obj._first; obj._second; obj._keep;", {
+      compress: false,
+      mangle: false,
+      mangleProps: {
+        include: "^_",
+        cache: { _first: "A", _second: "A", _keep: false },
+      },
+    });
+
+    expect(ret.code).toBe("obj.A;obj.A;obj._keep;");
+    expect(ret.mangleCache).toEqual({ _first: "A", _second: "A", _keep: false });
+  });
+
+  it("keeps cache keys out of automatic targets across round trips", () => {
+    const first = minifySync("test.js", "obj.foo;", {
+      compress: false,
+      mangle: false,
+      mangleProps: { include: ".", cache: { e: false } },
+    });
+    expect(first.code).toBe("obj.t;");
+    expect(first.mangleCache).toEqual({ e: false, foo: "t" });
+
+    const second = minifySync("test.js", "obj.e; obj.foo;", {
+      compress: false,
+      mangle: false,
+      mangleProps: { include: ".", cache: first.mangleCache },
+    });
+    expect(second.code).toBe("obj.e;obj.t;");
+    expect(second.mangleCache).toEqual(first.mangleCache);
+  });
+
+  it("keeps every property readable in debug mode", () => {
+    const ret = minifySync("test.js", "obj._alpha; obj._beta; obj._gamma;", {
+      compress: false,
+      mangle: false,
+      mangleProps: { include: "^_", debug: true },
+    });
+    expect(ret.code).toBe("obj._$_alpha$_;obj._$_beta$_;obj._$_gamma$_;");
+  });
+
+  it("honors exclude and reserved names", () => {
+    const ret = minifySync("test.js", "obj._skipOne; obj._reserved; obj._mangle;", {
+      compress: false,
+      mangle: false,
+      mangleProps: {
+        include: "^_",
+        exclude: "^_skip(?:One|Two)$",
+        reserved: ["_reserved"],
+      },
+    });
+    expect(ret.errors).toHaveLength(0);
+    expect(ret.code).toBe("obj._skipOne;obj._reserved;obj.e;");
+  });
+
+  it("works through the async API", async () => {
+    const ret = await minify("test.js", "obj._field; obj._field;", {
+      compress: false,
+      mangle: false,
+      mangleProps: { include: "^_" },
+    });
+    expect(ret.errors).toHaveLength(0);
+    expect(ret.code).toBe("obj.e;obj.e;");
+    expect(ret.mangleCache).toEqual({ _field: "e" });
+  });
+
+  it("does not mangle properties when parsing has errors", () => {
+    const ret = minifySync("test.js", "const invalid; obj._field;", {
+      compress: false,
+      mangle: false,
+      mangleProps: { include: "^_" },
+    });
+    expect(ret.errors).toHaveLength(1);
+    expect(ret.code).toBe("const invalid;obj._field;");
+    expect(ret.mangleCache).toBeUndefined();
+  });
+
+  it("returns cache entries in stable lexical order", () => {
+    const ret = minifySync(
+      "test.js",
+      "obj._zeta; obj._alpha; obj._middle; obj._beta; obj._omega;",
+      {
+        compress: false,
+        mangle: false,
+        mangleProps: { include: "^_" },
+      },
+    );
+    expect(Object.keys(ret.mangleCache!)).toEqual([
+      "_alpha",
+      "_beta",
+      "_middle",
+      "_omega",
+      "_zeta",
+    ]);
+  });
+
+  it.each([
+    [{ include: "[" }, "Invalid mangleProps.include regex"],
+    [{ include: "^_", cache: { _field: true as any } }, "expected a string or false"],
+    [{ include: "^_", cache: { _field: "not-valid" } }, "must be an IdentifierName"],
+    [{ include: "^_", cache: { _field: "__proto__" } }, "must be an IdentifierName"],
+    [
+      { include: "^_", cache: { _field: "constructor" } },
+      "other than '__proto__', 'constructor', or 'prototype'",
+    ],
+    [
+      { include: "^_", cache: { _field: "prototype" } },
+      "other than '__proto__', 'constructor', or 'prototype'",
+    ],
+  ])("rejects invalid options", (mangleProps, message) => {
+    const ret = minifySync("test.js", "obj._field;", { mangleProps: mangleProps as any });
+    expect(ret.errors).toHaveLength(1);
+    expect(ret.errors[0].message).toContain(message);
+    expect(ret.mangleCache).toBeUndefined();
+  });
+});
+
 describe("worker", () => {
   it("should run", async () => {
     const code = await new Promise((resolve, reject) => {


### PR DESCRIPTION
The property mangler added in #24740 is not available through `oxc-minify`. This adds `mangleProps` for configuring it and `mangleCache` for reusing chosen property names.

### Feature

- `include` selects property names to mangle. `exclude` and `reserved` keep names unchanged.
- `quoted` also mangles quoted property names. `debug` produces readable output names.
- `cache` fixes a property to a chosen name. A `false` value keeps the original name.
- Property mangling works in both sync and async APIs. It is separate from identifier mangling.
- When property mangling is enabled and the call succeeds, the result includes the updated `mangleCache`.
- Invalid `mangleProps` regexes and cache entries are returned in `result.errors`.

### Design

The binding converts JavaScript values into core minifier options and results. The core minifier still chooses names and rewrites properties, so both APIs follow the same rules.

A parser error may leave an incomplete AST. In that case, property mangling is skipped and no partial cache is returned.

### Example

```js
const result = minifySync(
  "test.js",
  "let local; obj._often; obj._rare; obj._often;",
  {
    compress: false,
    mangle: false,
    mangleProps: { include: "^_" },
  },
);

result.code; // "let local;obj.e;obj.t;obj.e;"
result.mangleCache; // { _often: "e", _rare: "t" }
```

### Limitation

- `include` and `exclude` use Rust regex syntax. They match anywhere unless the pattern includes anchors.
- Do not reuse the cache on already-mangled output. A mapping is not always safe to apply twice.
- The cache only remembers recorded mappings. It cannot find unchanged names in another input or in external code. Reserve, exclude, or pin those names before the first call.
- String cache targets must be valid JavaScript `IdentifierName` values and cannot be `__proto__`, `constructor`, or `prototype`. The original name `__proto__` cannot be a cache key.

AI assistance: OpenAI Codex and Claude were used for research, implementation, adversarial review, and verification. The contributor remains responsible for reviewing, understanding, and submitting the changes under the repository AI usage policy.
