### PR TITLE
refactor(ecmascript): expose engine targets to side effects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,6 +1992,7 @@ dependencies = [
  "num-traits",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_compat",
  "oxc_regular_expression",
  "oxc_span",
  "oxc_syntax",

--- a/crates/oxc_compat/src/engine_targets.rs
+++ b/crates/oxc_compat/src/engine_targets.rs
@@ -74,6 +74,7 @@ impl EngineTargets {
     ///
     /// Returns `true` if the feature is NOT supported (needs transformation),
     /// `false` if the feature IS supported (can be used natively).
+    /// Use [`Self::supports_es_feature`] for a strict positive capability query.
     pub fn has_feature(&self, feature: ESFeature) -> bool {
         let feature_engine_targets = &features()[&feature];
         for (engine, feature_version) in feature_engine_targets.iter() {
@@ -87,6 +88,27 @@ impl EngineTargets {
             }
         }
         false
+    }
+
+    /// Check whether every target engine is known to support the given ES feature.
+    ///
+    /// Unlike [`Self::has_feature`], this is a strict capability query: an empty target or an
+    /// engine missing from the compatibility table is treated as unsupported.
+    pub fn supports_es_feature(&self, feature: ESFeature) -> bool {
+        if self.is_any_target() {
+            return false;
+        }
+
+        let feature_engine_targets = &features()[&feature];
+        self.iter().all(|(engine, target_version)| {
+            feature_engine_targets.get(engine).is_some_and(|feature_version| {
+                if *engine == Engine::Es {
+                    target_version.0 >= feature_version.0
+                } else {
+                    target_version >= feature_version
+                }
+            })
+        })
     }
 
     /// Parses the value returned from `browserslist`.
@@ -161,4 +183,39 @@ fn test_displayed_value_is_parsable() {
     let s = target.to_string();
     let parsed = EngineTargets::from_target(&s).unwrap();
     assert_eq!(target.0, parsed.0);
+}
+
+#[test]
+fn test_supports_es_feature() {
+    use crate::ESFeature::{ES2015ArrowFunctions, ES2020OptionalChaining};
+
+    assert!(!EngineTargets::default().supports_es_feature(ES2015ArrowFunctions));
+
+    assert!(
+        EngineTargets::from_target("es2015").unwrap().supports_es_feature(ES2015ArrowFunctions)
+    );
+    assert!(
+        EngineTargets::from_target("esnext").unwrap().supports_es_feature(ES2020OptionalChaining)
+    );
+    assert!(
+        !EngineTargets::from_target("es2019").unwrap().supports_es_feature(ES2020OptionalChaining)
+    );
+    assert!(
+        EngineTargets::from_target("es2020").unwrap().supports_es_feature(ES2020OptionalChaining)
+    );
+
+    // Browser targets also contain an implicit `esnext`. All configured engines must support the
+    // feature, regardless of compatibility-table iteration order.
+    assert!(
+        !EngineTargets::from_target("chrome90")
+            .unwrap()
+            .supports_es_feature(ES2020OptionalChaining)
+    );
+    assert!(
+        EngineTargets::from_target("chrome91").unwrap().supports_es_feature(ES2020OptionalChaining)
+    );
+
+    // Missing compatibility data is not proof of support.
+    let rhino = EngineTargets::new(FxHashMap::from_iter([(Engine::Rhino, Version(1, 7, 15))]));
+    assert!(!rhino.supports_es_feature(ES2020OptionalChaining));
 }

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -21,12 +21,13 @@ test = true
 doctest = false
 
 [features]
-side_effects = ["dep:oxc_allocator", "dep:oxc_regular_expression"]
+side_effects = ["dep:oxc_allocator", "dep:oxc_compat", "dep:oxc_regular_expression"]
 constant_evaluation = ["side_effects", "dep:cow-utils", "dep:smallvec"]
 
 [dependencies]
 oxc_allocator = { workspace = true, optional = true }
 oxc_ast = { workspace = true }
+oxc_compat = { workspace = true, optional = true }
 oxc_regular_expression = { workspace = true, optional = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true, features = ["to_js_string"] }

--- a/crates/oxc_ecmascript/src/side_effects/context.rs
+++ b/crates/oxc_ecmascript/src/side_effects/context.rs
@@ -1,4 +1,5 @@
 use oxc_ast::ast::Expression;
+use oxc_compat::EngineTargets;
 
 use crate::GlobalContext;
 
@@ -12,6 +13,15 @@ pub enum PropertyReadSideEffects {
 }
 
 pub trait MayHaveSideEffectsContext<'a>: GlobalContext<'a> {
+    /// Target engines used to decide whether runtime features are supported.
+    ///
+    /// The default returns `None`. This means target information is unavailable; callers must treat
+    /// runtime features as unsupported rather than unconstrained, because unsupported syntax can
+    /// make an otherwise pure expression throw at runtime.
+    fn engine_targets(&self) -> Option<&EngineTargets> {
+        None
+    }
+
     /// Whether to respect the pure annotations.
     ///
     /// Pure annotations are the comments that marks that a expression is pure.

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -1,6 +1,6 @@
 use oxc_allocator::GetAllocator;
 use oxc_ast::ast::*;
-use oxc_compat::ESFeature;
+use oxc_compat::{ESFeature, EngineTargets};
 use oxc_ecmascript::{
     GlobalContext,
     constant_evaluation::{
@@ -81,6 +81,10 @@ impl<'a> GlobalContext<'a> for &mut TraverseCtx<'a, MinifierState<'a>> {
 }
 
 impl<'a> MayHaveSideEffectsContext<'a> for TraverseCtx<'a, MinifierState<'a>> {
+    fn engine_targets(&self) -> Option<&EngineTargets> {
+        Some(&self.options().target)
+    }
+
     fn annotations(&self) -> bool {
         self.options().treeshake.annotations
     }
@@ -107,6 +111,10 @@ impl<'a> MayHaveSideEffectsContext<'a> for TraverseCtx<'a, MinifierState<'a>> {
 }
 
 impl<'a> MayHaveSideEffectsContext<'a> for &TraverseCtx<'a, MinifierState<'a>> {
+    fn engine_targets(&self) -> Option<&EngineTargets> {
+        MayHaveSideEffectsContext::engine_targets(*self)
+    }
+
     fn annotations(&self) -> bool {
         (*self).annotations()
     }
@@ -129,6 +137,10 @@ impl<'a> MayHaveSideEffectsContext<'a> for &TraverseCtx<'a, MinifierState<'a>> {
 }
 
 impl<'a> MayHaveSideEffectsContext<'a> for &mut TraverseCtx<'a, MinifierState<'a>> {
+    fn engine_targets(&self) -> Option<&EngineTargets> {
+        MayHaveSideEffectsContext::engine_targets(&**self)
+    }
+
     fn annotations(&self) -> bool {
         (**self).annotations()
     }
@@ -157,9 +169,10 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         self.state.options()
     }
 
-    /// Check if the target engines supports a feature.
+    /// Loosely check whether target engines support a feature for syntax generation.
     ///
-    /// Returns `true` if the feature is supported.
+    /// This follows [`oxc_compat::EngineTargets::has_feature`] semantics. Side-effect analysis uses
+    /// the stricter [`oxc_compat::EngineTargets::supports_es_feature`] capability query instead.
     pub fn supports_feature(&self, feature: ESFeature) -> bool {
         !self.options().target.has_feature(feature)
     }


### PR DESCRIPTION
> **PR stack (2 of 3)**
> 1. #24739
> 2. **#24742 (this PR)**
> 3. #24712
>
> Review #24739 first. This PR is based on its branch, so GitHub shows only the engine-target plumbing.

Stacked on #24739, which introduces the `side_effects` and `constant_evaluation` feature boundary for `oxc_ecmascript`.

Side-effect analysis sometimes needs to know whether runtime syntax is supported by every configured engine. `MayHaveSideEffectsContext` currently has no access to target information, while `EngineTargets::has_feature` is intentionally permissive about missing compatibility data because it answers whether a transformation is needed.

`MayHaveSideEffectsContext::engine_targets()` exposes the configured targets through a general-purpose accessor. Its default is `None`, so consumers without target information remain conservative, while the minifier supplies its existing `CompressOptions::target`.

`EngineTargets::supports_es_feature` provides the corresponding strict capability query. Every configured engine must have compatibility data and meet the required version; empty targets and missing rows are not treated as proof of support. The existing transformation-oriented `has_feature` behavior remains unchanged.

Because `oxc_linter` enables `side_effects`, this also adds `oxc_compat` to the oxlint and language-server build graphs. It does not change side-effect decisions by itself; #24712 consumes the new capability for target-aware RegExp validation.

Verified with all `oxc_compat` tests, the no-feature/`side_effects`/`constant_evaluation` `oxc_ecmascript` matrix, a minifier check, formatting, and Clippy.

Implemented with AI assistance (OpenAI Codex and Claude). The contributor remains responsible for reviewing, understanding, and maintaining these changes.