### PR TITLE
fix(oxlint,oxfmt): report error for invalid glob patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "fast-glob"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9e81515b0279bf618200fd15d132e7195d2048fb46eed6f0f3c10cbc068266"
+checksum = "3cc9868289ee02952b341465ce66e67adec151227afedacf9137c0adb1e53943"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ criterion2 = { version = "3.0.4", default-features = false } # Benchmarking
 dragonbox_ecma = "0.1.12" # Fast float formatting
 encoding_rs = "0.8.35" # Character encoding
 encoding_rs_io = "0.1.7" # Encoding I/O
-fast-glob = "1.0.1" # Fast glob matching
+fast-glob = "1.1.0" # Fast glob matching
 flate2 = "1.1.9" # Compression
 futures = "0.3.32" # Async utilities
 handlebars = "6.4.2" # Template engine

--- a/apps/oxfmt/src/cli/walk.rs
+++ b/apps/oxfmt/src/cli/walk.rs
@@ -9,7 +9,7 @@ use ignore::gitignore::Gitignore;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::instrument;
 
-use oxc_config::{all_paths_have_vcs_boundary, configure_walk_builder};
+use oxc_config::{all_paths_have_vcs_boundary, configure_walk_builder, validate_glob_pattern};
 use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic};
 
 use super::resolve::{build_global_ignore_matchers, is_ignored};
@@ -50,7 +50,10 @@ impl ScopedWalker {
     /// Create a new `ScopedWalker` by classifying CLI path arguments.
     ///
     /// Paths are split into target paths, glob patterns, and exclude patterns (`!` prefix).
-    pub fn new(cwd: PathBuf, paths: &[PathBuf]) -> Self {
+    ///
+    /// # Errors
+    /// Returns an error when an argument classified as a glob pattern is invalid.
+    pub fn new(cwd: PathBuf, paths: &[PathBuf]) -> Result<Self, String> {
         let mut target_paths = vec![];
         let mut glob_patterns = vec![];
         let mut exclude_patterns = vec![];
@@ -73,6 +76,7 @@ impl ScopedWalker {
             };
 
             if is_glob_pattern(normalized, &cwd) {
+                validate_glob_pattern(normalized)?;
                 glob_patterns.push(normalized.to_string());
                 continue;
             }
@@ -88,7 +92,7 @@ impl ScopedWalker {
             target_paths.push(full_path);
         }
 
-        Self { cwd, paths: target_paths, glob_patterns, exclude_patterns }
+        Ok(Self { cwd, paths: target_paths, glob_patterns, exclude_patterns })
     }
 
     /// Run the walk across all scopes.

--- a/apps/oxfmt/src/cli/walk_runner.rs
+++ b/apps/oxfmt/src/cli/walk_runner.rs
@@ -159,7 +159,16 @@ impl WalkRunner {
 
         // Run scoped walks (root + nested) sends entries to `tx_entry` and errors to `tx_error`.
         // Manually drop after the walk to signal the formatting service that no more entries will be sent.
-        let any_config_found = match ScopedWalker::new(cwd, &paths).run(
+        let walker = match ScopedWalker::new(cwd, &paths) {
+            Ok(walker) => walker,
+            Err(err) => {
+                drop(tx_entry);
+                drop(tx_error);
+                utils::print_and_flush(stderr, &format!("{err}\n"));
+                return CliRunResult::InvalidOptionConfig;
+            }
+        };
+        let any_config_found = match walker.run(
             root_config_resolver,
             &resolved_ignore_paths,
             ignore_options.with_node_modules,

--- a/apps/oxfmt/test/cli/glob_patterns/8.snap.md
+++ b/apps/oxfmt/test/cli/glob_patterns/8.snap.md
@@ -1,0 +1,37 @@
+# Input
+
+## Command
+```
+oxfmt --check src/*.{js,ts
+```
+
+## File tree
+```
+- fixtures/ <CWD>
+  - lib/
+    - util.js
+  - src/
+    - {d}.js
+    - a.js
+    - b.js
+    - c.ts
+```
+
+# Result
+
+## Exit code
+1
+
+## stdout
+```
+Checking formatting...
+
+```
+
+## stderr
+```
+Invalid glob pattern `src/*.{js,ts`: unclosed brace expansion at byte 6; missing '}' (to match a literal '{', escape it as '/{' or '[{]')
+```
+
+## File changes
+No changes

--- a/apps/oxfmt/test/cli/glob_patterns/options.json
+++ b/apps/oxfmt/test/cli/glob_patterns/options.json
@@ -11,5 +11,6 @@
     "gitignore": {
       ".gitignore": "lib/\n"
     }
-  }
+  },
+  { "args": ["--check", "src/*.{js,ts"] }
 ]

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides_invalid/1.snap.md
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides_invalid/1.snap.md
@@ -9,6 +9,7 @@ oxfmt -c invalid_value.json --check test.js
 ```
 - fixtures/ <CWD>
   - cross_field_conflict.json
+  - invalid_glob.json
   - invalid_value.json
   - root_invalid.json
   - test.js

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides_invalid/2.snap.md
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides_invalid/2.snap.md
@@ -9,6 +9,7 @@ oxfmt -c cross_field_conflict.json --check test.js
 ```
 - fixtures/ <CWD>
   - cross_field_conflict.json
+  - invalid_glob.json
   - invalid_value.json
   - root_invalid.json
   - test.js

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides_invalid/3.snap.md
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides_invalid/3.snap.md
@@ -2,7 +2,7 @@
 
 ## Command
 ```
-oxfmt -c root_invalid.json --check test.js
+oxfmt -c invalid_glob.json --check test.js
 ```
 
 ## File tree
@@ -28,8 +28,7 @@ oxfmt -c root_invalid.json --check test.js
 ## stderr
 ```
 Failed to parse configuration.
-Invalid printWidth: The line width should be between 1 and 320
-
+Invalid glob pattern `src/**/*.{js,ts`: unclosed brace expansion at byte 9; missing '}' (to match a literal '{', escape it as '/{' or '[{]')
 ```
 
 ## File changes

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides_invalid/fixtures/invalid_glob.json
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides_invalid/fixtures/invalid_glob.json
@@ -1,0 +1,10 @@
+{
+  "overrides": [
+    {
+      "files": ["src/**/*.{js,ts"],
+      "options": {
+        "semi": false
+      }
+    }
+  ]
+}

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides_invalid/options.json
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides_invalid/options.json
@@ -1,5 +1,6 @@
 [
   { "args": ["-c", "root_invalid.json", "--check", "test.js"] },
   { "args": ["-c", "invalid_value.json", "--check", "test.js"] },
-  { "args": ["-c", "cross_field_conflict.json", "--check", "test.js"] }
+  { "args": ["-c", "cross_field_conflict.json", "--check", "test.js"] },
+  { "args": ["-c", "invalid_glob.json", "--check", "test.js"] }
 ]

--- a/apps/oxlint/fixtures/cli/invalid_glob_in_override/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cli/invalid_glob_in_override/.oxlintrc.json
@@ -1,0 +1,16 @@
+{
+  "rules": {
+    "no-debugger": "error"
+  },
+  "overrides": [
+    {
+      // Invalid glob (unclosed brace expansion) must be reported at config load,
+      // not silently change whether the override applies.
+      // https://github.com/oxc-project/oxc/issues/24612
+      "files": ["src/**/*.{js,ts"],
+      "rules": {
+        "no-debugger": "off"
+      }
+    }
+  ]
+}

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1855,6 +1855,13 @@ export { redundant };
     }
 
     #[test]
+    fn test_invalid_config_invalid_glob_in_override() {
+        Tester::new()
+            .with_cwd("fixtures/cli/invalid_glob_in_override".into())
+            .test_and_snapshot(&[]);
+    }
+
+    #[test]
     fn test_invalid_config_missing_rule_in_override() {
         Tester::new()
             .with_cwd("fixtures/cli/invalid_config_missing_rule_in_override".into())

--- a/apps/oxlint/src/snapshots/fixtures__cli__invalid_glob_in_override_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__invalid_glob_in_override_@oxlint.snap
@@ -1,0 +1,15 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/cli/invalid_glob_in_override
+----------
+Failed to parse oxlint configuration file.
+
+  x Failed to parse config with error Error("Invalid glob pattern `src/**/*.{js,ts`: unclosed brace expansion at byte 9; missing '}' (to match a literal '{', escape it as '\\{' or '[{]')", line: 0,
+  | column: 0)
+
+----------
+CLI result: InvalidOptionConfig
+----------

--- a/crates/oxc_config/src/glob_set.rs
+++ b/crates/oxc_config/src/glob_set.rs
@@ -1,6 +1,17 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 
+/// Validate a single glob pattern.
+///
+/// `fast_glob::glob_match` does not validate patterns,
+/// so user-written patterns must be rejected up front with this.
+///
+/// # Errors
+/// Returns the error message when the pattern is not a valid glob.
+pub fn validate_glob_pattern(pattern: &str) -> Result<(), String> {
+    fast_glob::validate(pattern).map_err(|err| format!("Invalid glob pattern `{pattern}`: {err}"))
+}
+
 /// A set of glob patterns.
 /// Patterns are matched against paths relative to the configuration file's directory.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, JsonSchema)]
@@ -8,7 +19,7 @@ pub struct GlobSet(Vec<String>);
 
 impl<'de> Deserialize<'de> for GlobSet {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Self::new(Vec::<String>::deserialize(deserializer)?))
+        Self::try_new(Vec::<String>::deserialize(deserializer)?).map_err(serde::de::Error::custom)
     }
 }
 
@@ -45,6 +56,16 @@ impl GlobSet {
                 })
                 .collect::<Vec<_>>(),
         )
+    }
+
+    /// Like [`Self::new`], but validates each pattern as written by the user, before normalization.
+    /// Deserialization goes through this.
+    fn try_new<S: AsRef<str>, I: IntoIterator<Item = S>>(patterns: I) -> Result<Self, String> {
+        let patterns = patterns.into_iter().collect::<Vec<_>>();
+        for pattern in &patterns {
+            validate_glob_pattern(pattern.as_ref())?;
+        }
+        Ok(Self::new(patterns))
     }
 
     pub fn is_match(&self, path: &str) -> bool {
@@ -95,5 +116,21 @@ mod test {
         let glob_set: GlobSet = from_value(json!(["../foo.js"])).unwrap();
         assert!(glob_set.is_match("../foo.js"));
         assert!(!glob_set.is_match("foo.js"));
+    }
+
+    #[test]
+    fn test_globset_invalid_pattern() {
+        // Invalid patterns must be rejected at deserialization time.
+        // Fixes https://github.com/oxc-project/oxc/issues/24612
+        let err = from_value::<GlobSet>(json!(["src/**/*.{js,ts"])).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("Invalid glob pattern `src/**/*.{js,ts`"), "{message}");
+        assert!(message.contains("unclosed brace expansion"), "{message}");
+
+        let err = from_value::<GlobSet>(json!(["src/[abpp.js"])).unwrap_err();
+        assert!(err.to_string().contains("unclosed character class"), "{}", err.to_string());
+
+        // One invalid pattern rejects the whole set, even alongside valid ones
+        assert!(from_value::<GlobSet>(json!(["*.ts", "src/**/*.{js,ts"])).is_err());
     }
 }

--- a/crates/oxc_config/src/lib.rs
+++ b/crates/oxc_config/src/lib.rs
@@ -8,6 +8,6 @@ mod walk;
 pub use discovery::{
     ConfigConflict, ConfigDiscovery, ConfigFileNames, DiscoveredConfigFile, is_js_config_path,
 };
-pub use glob_set::GlobSet;
+pub use glob_set::{GlobSet, validate_glob_pattern};
 pub use ignore_patterns::validate_ignore_pattern;
 pub use walk::{all_paths_have_vcs_boundary, configure_walk_builder};


### PR DESCRIPTION
Fixes #24612

- Update `fast-glob` to `1.1.0` which exposes `validate()` api
- Use it in `oxc_config`, apps will be validated through `deserialize`
- Oxfmt supports globs for CLI paths, also validated
