### PR TITLE
test(napi/transform): add React Compiler ecosystem comparator

### DIFF
--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -45,13 +45,16 @@
     "postbuild-dev": "node scripts/patch.js",
     "build-wasm": "pnpm run build-wasm-dev --release",
     "build-wasm-dev": "pnpm run build-dev --target wasm32-wasip1-threads",
+    "compare-react-compiler": "node scripts/compare-react-compiler.mjs",
     "test": "vitest run --dir ./test"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.0",
     "@emnapi/core": "catalog:",
     "@emnapi/runtime": "catalog:",
     "@napi-rs/cli": "catalog:",
     "@types/node": "catalog:",
+    "babel-plugin-react-compiler": "1.0.0",
     "publint": "catalog:",
     "vitest": "catalog:"
   },

--- a/napi/transform/scripts/compare-react-compiler.mjs
+++ b/napi/transform/scripts/compare-react-compiler.mjs
@@ -1,0 +1,632 @@
+#!/usr/bin/env node
+// oxlint-disable no-console -- This is a command-line reporting tool.
+
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { availableParallelism, tmpdir } from "node:os";
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { basename, extname, join, relative, resolve } from "node:path";
+import { isMainThread, parentPort, Worker } from "node:worker_threads";
+
+import babel from "@babel/core";
+import reactCompilerPlugin from "babel-plugin-react-compiler";
+
+import { transformSync as oxcTransformSync } from "../index.js";
+
+const { transformSync: babelTransformSync } = babel;
+const require = createRequire(import.meta.url);
+const babelVersion = require("@babel/core/package.json").version;
+const reactCompilerVersion = require("babel-plugin-react-compiler/package.json").version;
+
+const DEFAULT_ROOT = resolve(import.meta.dirname, "../../../../oxc-ecosystem-ci/repos");
+const DEFAULT_REPORT = join(tmpdir(), "oxc-react-compiler-comparison.json");
+const SOURCE_EXTENSIONS = new Set([".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"]);
+const NON_ISSUE_STATUSES = new Set(["match", "unchanged", "skipped-too-large"]);
+
+function usage() {
+  console.log(`Usage: pnpm run compare-react-compiler -- [root-or-file] [options]
+
+Compare the React Compiler in the local oxc-transform binding with
+babel-plugin-react-compiler using both compilers' default plugin options.
+
+Options:
+  --repo <name>          Only compare a named repository below the root
+  --jobs <number>        Worker count (default: available CPUs, capped at 8)
+  --limit <number>       Compare at most this many files
+  --max-bytes <number>   Skip files larger than this (default: 1048576)
+  --max-details <number> Include details for this many issues (default: 100)
+  --report <path>        JSON report path (default: ${DEFAULT_REPORT})
+  --help                 Show this help
+
+The default root is ${DEFAULT_ROOT}. Declaration files are excluded because they
+are not transform inputs. Repository roots are enumerated with git ls-files.`);
+}
+
+function parsePositiveInteger(value, flag) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} requires a positive integer, received ${value}`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv) {
+  const options = {
+    root: DEFAULT_ROOT,
+    repo: undefined,
+    jobs: Math.min(8, Math.max(1, availableParallelism())),
+    limit: undefined,
+    maxBytes: 1024 * 1024,
+    maxDetails: 100,
+    report: DEFAULT_REPORT,
+  };
+  let rootSet = false;
+
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index];
+    if (argument === "--") continue;
+    if (argument === "--help" || argument === "-h") {
+      usage();
+      process.exit(0);
+    }
+    if (!argument.startsWith("-")) {
+      if (rootSet) throw new Error(`Unexpected positional argument: ${argument}`);
+      options.root = resolve(argument);
+      rootSet = true;
+      continue;
+    }
+
+    const value = argv[++index];
+    if (value === undefined) throw new Error(`${argument} requires a value`);
+    switch (argument) {
+      case "--repo":
+        options.repo = value;
+        break;
+      case "--jobs":
+        options.jobs = parsePositiveInteger(value, argument);
+        break;
+      case "--limit":
+        options.limit = parsePositiveInteger(value, argument);
+        break;
+      case "--max-bytes":
+        options.maxBytes = parsePositiveInteger(value, argument);
+        break;
+      case "--max-details":
+        options.maxDetails = parsePositiveInteger(value, argument);
+        break;
+      case "--report":
+        options.report = resolve(value);
+        break;
+      default:
+        throw new Error(`Unknown option: ${argument}`);
+    }
+  }
+  return options;
+}
+
+function isDeclarationFile(path) {
+  return /\.d\.[cm]?ts$/iu.test(path);
+}
+
+function isSourceFile(path) {
+  return SOURCE_EXTENSIONS.has(extname(path).toLowerCase()) && !isDeclarationFile(path);
+}
+
+function isGitRepository(path) {
+  return existsSync(join(path, ".git"));
+}
+
+function trackedFiles(repository) {
+  const output = execFileSync("git", ["-C", repository, "ls-files", "-z"], {
+    encoding: "utf8",
+    maxBuffer: 128 * 1024 * 1024,
+  });
+  return output
+    .split("\0")
+    .filter(Boolean)
+    .filter(isSourceFile)
+    .map((path) => resolve(repository, path));
+}
+
+function findFiles(root, repositoryName) {
+  if (!existsSync(root)) throw new Error(`Input does not exist: ${root}`);
+  if (statSync(root).isFile()) {
+    if (repositoryName !== undefined) throw new Error("--repo cannot be used with a file input");
+    if (!isSourceFile(root)) throw new Error(`Unsupported source extension: ${root}`);
+    return [root];
+  }
+
+  if (isGitRepository(root)) {
+    if (repositoryName !== undefined && repositoryName !== basename(root)) return [];
+    return trackedFiles(root).sort();
+  }
+
+  const repositories = readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(root, entry.name))
+    .filter(isGitRepository)
+    .filter((path) => repositoryName === undefined || basename(path) === repositoryName)
+    .sort();
+  if (repositories.length === 0) {
+    throw new Error(`No git repositories found below ${root}`);
+  }
+  return repositories.flatMap(trackedFiles).sort();
+}
+
+function sourceKind(filename) {
+  const extension = extname(filename).toLowerCase();
+  const typescript =
+    extension === ".ts" || extension === ".tsx" || extension === ".mts" || extension === ".cts";
+  const jsx = extension === ".tsx" || !typescript;
+  const sourceType =
+    extension === ".mjs" || extension === ".mts"
+      ? "module"
+      : extension === ".cjs" || extension === ".cts"
+        ? "commonjs"
+        : "unambiguous";
+  const lang = typescript ? (jsx ? "tsx" : "ts") : "jsx";
+  return { extension, jsx, lang, sourceType, typescript };
+}
+
+function babelOptions(filename, reactCompiler, comments) {
+  const kind = sourceKind(filename);
+  const parserPlugins = ["decorators"];
+  if (kind.typescript) {
+    parserPlugins.push([
+      "typescript",
+      {
+        disallowAmbiguousJSXLike: kind.extension === ".mts" || kind.extension === ".cts",
+        dts: false,
+        isTSX: kind.jsx,
+      },
+    ]);
+  }
+  if (kind.jsx) parserPlugins.push("jsx");
+
+  return {
+    babelrc: false,
+    cloneInputAst: false,
+    code: true,
+    comments,
+    configFile: false,
+    filename,
+    generatorOpts: { comments, compact: false },
+    parserOpts: {
+      allowAwaitOutsideFunction: true,
+      allowReturnOutsideFunction: kind.sourceType === "commonjs",
+      plugins: parserPlugins,
+      sourceType: kind.sourceType === "commonjs" ? "script" : kind.sourceType,
+    },
+    plugins: reactCompiler ? [[reactCompilerPlugin, {}]] : [],
+    sourceMaps: false,
+    sourceType: kind.sourceType === "commonjs" ? "script" : kind.sourceType,
+  };
+}
+
+function comparisonCleanupPlugin() {
+  return {
+    visitor: {
+      EmptyStatement(path) {
+        path.remove();
+      },
+      Program: {
+        exit(path, state) {
+          if (!state.opts.renameBindings) return;
+
+          const bindings = [];
+          const seen = new Set();
+          function collectBindings(scope) {
+            for (const binding of Object.values(scope.bindings)) {
+              if (!seen.has(binding)) {
+                seen.add(binding);
+                bindings.push(binding);
+              }
+            }
+          }
+
+          collectBindings(path.scope);
+          path.traverse({
+            Scopable(scopePath) {
+              collectBindings(scopePath.scope);
+            },
+          });
+          bindings.sort(
+            (left, right) =>
+              left.identifier.start - right.identifier.start ||
+              left.identifier.end - right.identifier.end,
+          );
+          for (const [index, binding] of bindings.entries()) {
+            binding.scope.rename(binding.identifier.name, `__comparison_binding_${index}__`);
+          }
+        },
+      },
+    },
+  };
+}
+
+function canonicalizeForComparison(filename, source, renameBindings) {
+  const options = babelOptions(filename, false, false);
+  options.generatorOpts = { comments: false, compact: true, minified: true };
+  options.plugins = [[comparisonCleanupPlugin, { renameBindings }]];
+  return babelTransformSync(source, options)?.code;
+}
+
+function cosmeticDifferenceKind(filename, left, right) {
+  try {
+    if (
+      canonicalizeForComparison(filename, left, false) ===
+      canonicalizeForComparison(filename, right, false)
+    ) {
+      return "comments-or-empty-statements";
+    }
+    if (
+      canonicalizeForComparison(filename, left, true) ===
+      canonicalizeForComparison(filename, right, true)
+    ) {
+      return "alpha-renaming-only";
+    }
+  } catch {
+    // Keep the original structural classification if canonicalization cannot parse
+    // an output. The main comparison already records parser failures separately.
+  }
+  return undefined;
+}
+
+function compilerOutputInfo(code) {
+  const runtimeImport = code.match(
+    /import\s*\{(?<specifiers>[^}]*)\}\s*from\s*["']react\/compiler-runtime["']/u,
+  );
+  const cacheSpecifier = runtimeImport?.groups.specifiers.match(
+    /(?:^|,)\s*c(?:\s+as\s+(?<local>[$\w]+))?\s*(?:,|$)/u,
+  );
+  const cacheName = cacheSpecifier?.groups.local ?? (cacheSpecifier ? "c" : undefined);
+  const memoCacheSlots = [];
+  if (cacheName !== undefined) {
+    const escapedName = cacheName.replaceAll(/[$()*+.?[\\\]^{|}]/gu, "\\$&");
+    const callPattern = new RegExp(`(?<![$\\w])${escapedName}\\((\\d+)\\)`, "gu");
+    for (const match of code.matchAll(callPattern)) memoCacheSlots.push(Number(match[1]));
+  }
+  return {
+    emitsMemoCache: runtimeImport !== null,
+    memoCacheSlots,
+  };
+}
+
+function analyzeOutputMismatch(filename, babelOutput, oxcOutput) {
+  const cosmeticKind = cosmeticDifferenceKind(filename, babelOutput, oxcOutput);
+  const babel = compilerOutputInfo(babelOutput);
+  const oxc = compilerOutputInfo(oxcOutput);
+  let differenceKind = cosmeticKind;
+  if (differenceKind === undefined) {
+    if (
+      babel.emitsMemoCache !== oxc.emitsMemoCache ||
+      babel.memoCacheSlots.length !== oxc.memoCacheSlots.length
+    ) {
+      differenceKind = "compile-selection";
+    } else if (babel.memoCacheSlots.some((slots, index) => slots !== oxc.memoCacheSlots[index])) {
+      differenceKind = "cache-layout";
+    } else {
+      differenceKind = "structural";
+    }
+  }
+  return {
+    babelEmitsMemoCache: babel.emitsMemoCache,
+    babelMemoCacheSlots: babel.memoCacheSlots,
+    differenceKind,
+    oxcEmitsMemoCache: oxc.emitsMemoCache,
+    oxcMemoCacheSlots: oxc.memoCacheSlots,
+  };
+}
+
+function runBabel(filename, source, reactCompiler, comments) {
+  const result = babelTransformSync(source, babelOptions(filename, reactCompiler, comments));
+  if (result?.code === undefined || result.code === null) {
+    throw new Error("Babel returned no code");
+  }
+  return result.code;
+}
+
+function runOxc(filename, source, reactCompiler) {
+  const kind = sourceKind(filename);
+  const result = oxcTransformSync(filename, source, {
+    lang: kind.lang,
+    plugins: reactCompiler ? { reactCompiler: true } : undefined,
+    sourceType: kind.sourceType,
+  });
+  const errors = result.errors.filter((error) => error.severity === "Error");
+  const errorText = errors.map((error) => error.message).join("\n");
+  // With panicThreshold="none", React Compiler reports recoverable per-function
+  // bailouts at Error severity while still producing a complete transform. A fatal
+  // compile is distinguishable by the absence of generated code.
+  if (errors.length > 0 && result.code.length === 0) {
+    throw new Error(errorText);
+  }
+  return {
+    code: result.code,
+    errorText,
+    errors: errors.length,
+    warnings: result.errors.filter((error) => error.severity === "Warning").length,
+  };
+}
+
+function oxcDiagnosticInfo(result) {
+  return result.errors === 0
+    ? {}
+    : { oxcDiagnostic: truncate(result.errorText, 4_000), oxcErrors: result.errors };
+}
+
+function errorMessage(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return truncate(message, 4_000);
+}
+
+function truncate(value, maxLength = 20_000) {
+  if (value === undefined || value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}\n/* truncated: ${value.length - maxLength} characters omitted */`;
+}
+
+function compareFile(filename, maxBytes, details = false) {
+  let source;
+  try {
+    const { size } = statSync(filename);
+    if (size > maxBytes) return { status: "skipped-too-large", size };
+    source = readFileSync(filename, "utf8");
+  } catch (error) {
+    return { error: errorMessage(error), status: "read-error" };
+  }
+
+  let normalizedSource;
+  try {
+    // Both compilers receive exactly the same Babel-parsed source. Preserve comments
+    // because the default React Compiler options honor ESLint and Flow suppression
+    // comments. The output classifier ignores comment attachment differences.
+    normalizedSource = runBabel(filename, source, false, true);
+  } catch (error) {
+    return { error: errorMessage(error), status: "babel-parse-error" };
+  }
+
+  let oxcBaseline;
+  try {
+    oxcBaseline = runOxc(filename, normalizedSource, false);
+  } catch (error) {
+    return { error: errorMessage(error), status: "oxc-parse-error" };
+  }
+
+  let oxcCompiled;
+  let oxcError;
+  try {
+    oxcCompiled = runOxc(filename, normalizedSource, true);
+  } catch (error) {
+    oxcError = errorMessage(error);
+  }
+
+  let babelCompiled;
+  let babelError;
+  try {
+    babelCompiled = runBabel(filename, normalizedSource, true, true);
+  } catch (error) {
+    babelError = errorMessage(error);
+  }
+
+  if (oxcError !== undefined || babelError !== undefined) {
+    const status =
+      oxcError !== undefined && babelError !== undefined
+        ? "both-error"
+        : oxcError !== undefined
+          ? "oxc-error"
+          : "babel-error";
+    return { babelError, oxcError, status };
+  }
+
+  let babelOutput;
+  try {
+    // Babel leaves TypeScript and JSX syntax in place. Pass its compiler output
+    // through Oxc without React Compiler so both sides use the same downstream
+    // TypeScript, JSX, and code-generation pipeline. Do this before detecting
+    // changes as well, otherwise Babel's partial removal of TypeScript syntax can
+    // be misclassified as a compiler-only change.
+    babelOutput = runOxc(filename, babelCompiled, false);
+  } catch (error) {
+    return { error: errorMessage(error), status: "babel-output-error" };
+  }
+
+  const oxcChanged = oxcCompiled.code !== oxcBaseline.code;
+  const babelChanged = babelOutput.code !== oxcBaseline.code;
+  if (!oxcChanged && !babelChanged) {
+    return { ...oxcDiagnosticInfo(oxcCompiled), status: "unchanged" };
+  }
+  if (oxcChanged && !babelChanged) {
+    const info = compilerOutputInfo(oxcCompiled.code);
+    return {
+      ...(details
+        ? { normalizedSource: truncate(oxcBaseline.code), oxcOutput: truncate(oxcCompiled.code) }
+        : {}),
+      differenceKind:
+        cosmeticDifferenceKind(filename, oxcBaseline.code, oxcCompiled.code) ??
+        (info.emitsMemoCache ? "compile-selection" : "structural"),
+      oxcEmitsMemoCache: info.emitsMemoCache,
+      ...oxcDiagnosticInfo(oxcCompiled),
+      oxcMemoCacheSlots: info.memoCacheSlots,
+      status: "oxc-only-change",
+    };
+  }
+  if (!oxcChanged && babelChanged) {
+    const info = compilerOutputInfo(babelOutput.code);
+    return {
+      ...(details
+        ? {
+            babelOutput: truncate(babelOutput.code),
+            normalizedSource: truncate(oxcBaseline.code),
+          }
+        : {}),
+      babelEmitsMemoCache: info.emitsMemoCache,
+      babelMemoCacheSlots: info.memoCacheSlots,
+      differenceKind:
+        cosmeticDifferenceKind(filename, oxcBaseline.code, babelOutput.code) ??
+        (info.emitsMemoCache ? "compile-selection" : "structural"),
+      ...oxcDiagnosticInfo(oxcCompiled),
+      status: "babel-only-change",
+    };
+  }
+
+  if (babelOutput.code === oxcCompiled.code) {
+    return {
+      babelWarnings: babelOutput.warnings,
+      ...oxcDiagnosticInfo(oxcCompiled),
+      oxcWarnings: oxcCompiled.warnings,
+      status: "match",
+    };
+  }
+  return {
+    ...(details
+      ? {
+          babelOutput: truncate(babelOutput.code),
+          normalizedSource: truncate(normalizedSource),
+          oxcOutput: truncate(oxcCompiled.code),
+        }
+      : {}),
+    ...analyzeOutputMismatch(filename, babelOutput.code, oxcCompiled.code),
+    babelWarnings: babelOutput.warnings,
+    ...oxcDiagnosticInfo(oxcCompiled),
+    oxcWarnings: oxcCompiled.warnings,
+    status: "output-mismatch",
+  };
+}
+
+function runWorkers(files, jobs, maxBytes, onResult) {
+  return new Promise((resolvePromise, reject) => {
+    let completed = 0;
+    let nextIndex = 0;
+    let stopped = false;
+    const workers = [];
+
+    function stop(error) {
+      if (stopped) return;
+      stopped = true;
+      for (const worker of workers) void worker.terminate();
+      reject(error);
+    }
+
+    function dispatch(worker) {
+      if (nextIndex >= files.length) {
+        if (completed === files.length && !stopped) {
+          stopped = true;
+          for (const activeWorker of workers) void activeWorker.terminate();
+          resolvePromise();
+        }
+        return;
+      }
+      const index = nextIndex++;
+      worker.postMessage({ filename: files[index], index, maxBytes });
+    }
+
+    const workerCount = Math.min(jobs, files.length);
+    for (let index = 0; index < workerCount; index++) {
+      const worker = new Worker(import.meta.filename);
+      workers.push(worker);
+      worker.on("error", stop);
+      worker.on("exit", (code) => {
+        if (!stopped && code !== 0) stop(new Error(`Comparison worker exited with code ${code}`));
+      });
+      worker.on("message", (message) => {
+        completed++;
+        onResult(files[message.index], message.result, completed);
+        dispatch(worker);
+      });
+      dispatch(worker);
+    }
+  });
+}
+
+function increment(record, key) {
+  record[key] = (record[key] ?? 0) + 1;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  let files = findFiles(options.root, options.repo);
+  if (options.limit !== undefined) files = files.slice(0, options.limit);
+  if (files.length === 0) throw new Error("No matching source files found");
+
+  console.log(
+    `Comparing ${files.length.toLocaleString()} files with ${options.jobs} workers ` +
+      `(Babel ${babelVersion}, React Compiler ${reactCompilerVersion})`,
+  );
+
+  const counts = {};
+  const repositoryCounts = {};
+  const issueSummaries = [];
+  const issueFiles = [];
+  let oxcDiagnosticFileCount = 0;
+  const startedAt = Date.now();
+  let lastProgress = startedAt;
+
+  await runWorkers(files, options.jobs, options.maxBytes, (filename, result, completed) => {
+    increment(counts, result.status);
+    const relativePath = relative(options.root, filename) || basename(filename);
+    const repository = /[\\/]/u.test(relativePath)
+      ? relativePath.split(/[\\/]/u, 1)[0]
+      : basename(options.root);
+    repositoryCounts[repository] ??= {};
+    increment(repositoryCounts[repository], result.status);
+    if (result.oxcErrors !== undefined) oxcDiagnosticFileCount++;
+    if (!NON_ISSUE_STATUSES.has(result.status) || result.oxcErrors !== undefined) {
+      issueSummaries.push({ file: relativePath, ...result });
+      if (issueFiles.length < options.maxDetails) issueFiles.push(filename);
+    }
+
+    const now = Date.now();
+    if (now - lastProgress >= 10_000 || completed === files.length) {
+      const rate = completed / ((now - startedAt) / 1000);
+      console.log(
+        `${completed.toLocaleString()}/${files.length.toLocaleString()} ` +
+          `(${rate.toFixed(1)} files/s, ${Object.entries(counts)
+            .map(([status, count]) => `${status}=${count}`)
+            .join(", ")})`,
+      );
+      lastProgress = now;
+    }
+  });
+
+  const issues = issueSummaries.map((issue, index) => {
+    if (index < issueFiles.length) {
+      Object.assign(issue, compareFile(issueFiles[index], options.maxBytes, true));
+    }
+    return issue;
+  });
+  const issueCount = issues.length;
+  const report = {
+    comparedAt: new Date().toISOString(),
+    durationSeconds: Number(((Date.now() - startedAt) / 1000).toFixed(3)),
+    root: options.root,
+    versions: {
+      babel: babelVersion,
+      babelPluginReactCompiler: reactCompilerVersion,
+      oxcTransform: require("../package.json").version,
+    },
+    compilerOptions: {},
+    counts,
+    detailedIssueCount: issueFiles.length,
+    issueCount,
+    issueDetailsTruncated: issueCount > issueFiles.length,
+    issues,
+    oxcDiagnosticFileCount,
+    repositoryCounts,
+    totalFiles: files.length,
+  };
+  writeFileSync(options.report, `${JSON.stringify(report, null, 2)}\n`);
+
+  console.log(`Report: ${options.report}`);
+  console.log(`Issues: ${issueCount.toLocaleString()}`);
+}
+
+if (isMainThread) {
+  main().catch((error) => {
+    console.error(errorMessage(error));
+    process.exitCode = 1;
+  });
+} else {
+  parentPort.on("message", ({ filename, index, maxBytes }) => {
+    parentPort.postMessage({ index, result: compareFile(filename, maxBytes) });
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,9 @@ importers:
 
   napi/transform:
     devDependencies:
+      '@babel/core':
+        specifier: ^7.29.0
+        version: 7.29.7
       '@emnapi/core':
         specifier: 'catalog:'
         version: 1.11.2
@@ -345,6 +348,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.1.0
+      babel-plugin-react-compiler:
+        specifier: 1.0.0
+        version: 1.0.0
       publint:
         specifier: 'catalog:'
         version: 0.3.21
@@ -620,13 +626,25 @@ packages:
     resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@8.0.0':
     resolution: {integrity: sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/core@8.0.1':
     resolution: {integrity: sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/generator@8.0.0':
     resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
@@ -635,6 +653,10 @@ packages:
   '@babel/helper-annotate-as-pure@8.0.0':
     resolution: {integrity: sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@8.0.0':
     resolution: {integrity: sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==}
@@ -646,6 +668,10 @@ packages:
     peerDependencies:
       '@babel/core': ^8.0.0
 
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-globals@8.0.0':
     resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -654,9 +680,19 @@ packages:
     resolution: {integrity: sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-imports@8.0.0':
     resolution: {integrity: sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   '@babel/helper-optimise-call-expression@8.0.0':
     resolution: {integrity: sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==}
@@ -700,6 +736,10 @@ packages:
     resolution: {integrity: sha512-kXxQVZHNOctSJJsqzmcbPSCEkM6oHNnDIkua7g9RCO9xRHj2eCiKvRx2KPdfWR9QxcGWnK/oArrtunmie3rL9g==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@8.0.0':
     resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -707,6 +747,10 @@ packages:
   '@babel/helper-wrap-function@8.0.0':
     resolution: {integrity: sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helpers@8.0.0':
     resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
@@ -822,9 +866,17 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@8.0.0':
     resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/traverse@8.0.0':
     resolution: {integrity: sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw==}
@@ -3651,6 +3703,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -4565,6 +4620,9 @@ packages:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
@@ -5061,6 +5119,10 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -5535,6 +5597,9 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -5640,7 +5705,29 @@ snapshots:
       '@babel/helper-validator-identifier': 8.0.0
       js-tokens: 10.0.0
 
+  '@babel/compat-data@7.29.7': {}
+
   '@babel/compat-data@8.0.0': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/core@8.0.1':
     dependencies:
@@ -5661,6 +5748,14 @@ snapshots:
       obug: 2.1.3
       semver: 7.8.5
 
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/generator@8.0.0':
     dependencies:
       '@babel/parser': 8.0.0
@@ -5673,6 +5768,14 @@ snapshots:
   '@babel/helper-annotate-as-pure@8.0.0':
     dependencies:
       '@babel/types': 8.0.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
 
   '@babel/helper-compilation-targets@8.0.0':
     dependencies:
@@ -5693,6 +5796,8 @@ snapshots:
       '@babel/traverse': 8.0.0
       semver: 7.8.5
 
+  '@babel/helper-globals@7.29.7': {}
+
   '@babel/helper-globals@8.0.0': {}
 
   '@babel/helper-member-expression-to-functions@8.0.0':
@@ -5700,10 +5805,26 @@ snapshots:
       '@babel/traverse': 8.0.0
       '@babel/types': 8.0.0
 
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-imports@8.0.0':
     dependencies:
       '@babel/traverse': 8.0.0
       '@babel/types': 8.0.0
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-optimise-call-expression@8.0.0':
     dependencies:
@@ -5740,6 +5861,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@8.0.0': {}
 
+  '@babel/helper-validator-option@7.29.7': {}
+
   '@babel/helper-validator-option@8.0.0': {}
 
   '@babel/helper-wrap-function@8.0.0':
@@ -5747,6 +5870,11 @@ snapshots:
       '@babel/template': 8.0.0
       '@babel/traverse': 8.0.0
       '@babel/types': 8.0.0
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/helpers@8.0.0':
     dependencies:
@@ -5858,11 +5986,29 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
   '@babel/template@8.0.0':
     dependencies:
       '@babel/code-frame': 8.0.0
       '@babel/parser': 8.0.0
       '@babel/types': 8.0.0
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/traverse@8.0.0':
     dependencies:
@@ -8290,6 +8436,10 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.29.7
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -9199,6 +9349,10 @@ snapshots:
 
   lru-cache@11.5.2: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   luxon@3.7.2: {}
 
   lz-string@1.5.0: {}
@@ -9794,6 +9948,8 @@ snapshots:
   scroll-into-view-if-needed@3.1.0:
     dependencies:
       compute-scroll-into-view: 3.1.1
+
+  semver@6.3.1: {}
 
   semver@7.8.5: {}
 
@@ -10415,6 +10571,8 @@ snapshots:
   ws@8.20.0: {}
 
   xtend@4.0.2: {}
+
+  yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
Adds a default-options differential runner for the local React Compiler NAPI transform and `babel-plugin-react-compiler` across tracked ecosystem sources.

The runner normalizes both paths through the same downstream transform, preserves suppression comments, classifies cosmetic/cache/selection/structural differences, and writes a complete JSON report.

AI assistance was used to implement and analyze this change. The author is responsible for reviewing and validating it.

Validation:

- `pnpm --dir napi/transform test`
- `pnpm exec oxlint --deny-warnings napi/transform/scripts/compare-react-compiler.mjs`
- `pnpm exec oxfmt --check napi/transform/scripts/compare-react-compiler.mjs napi/transform/package.json pnpm-lock.yaml`
- Full 238,432-file ecosystem comparison
