### PR TITLE
fix(react_compiler): honor default suppressions

### DIFF
--- a/crates/oxc_react_compiler/fixtures/default-suppression-eslint-block-range.js
+++ b/crates/oxc_react_compiler/fixtures/default-suppression-eslint-block-range.js
@@ -1,0 +1,6 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+function Component({ value }) {
+  const doubled = value * 2;
+  return <div>{doubled}</div>;
+}
+/* eslint-enable react-hooks/rules-of-hooks */

--- a/crates/oxc_react_compiler/fixtures/default-suppression-eslint-next-line.js
+++ b/crates/oxc_react_compiler/fixtures/default-suppression-eslint-next-line.js
@@ -1,0 +1,5 @@
+function Component({ value }) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const doubled = value * 2;
+  return <div>{doubled}</div>;
+}

--- a/crates/oxc_react_compiler/fixtures/default-suppression-flow.js
+++ b/crates/oxc_react_compiler/fixtures/default-suppression-flow.js
@@ -1,0 +1,5 @@
+function Component({ value }) {
+  // $FlowFixMe[react-rule-hook]
+  const doubled = value * 2;
+  return <div>{doubled}</div>;
+}

--- a/crates/oxc_react_compiler/src/options.rs
+++ b/crates/oxc_react_compiler/src/options.rs
@@ -140,8 +140,7 @@ pub struct PluginOptions {
     /// ESLint rule names whose `eslint-disable` comments make the compiler skip the
     /// function they cover, so it doesn't optimize code the author has already
     /// flagged. `None` uses the defaults (`react-hooks/exhaustive-deps` and
-    /// `react-hooks/rules-of-hooks`). Ignored when both the exhaustive-deps and
-    /// hooks-usage validations are enabled.
+    /// `react-hooks/rules-of-hooks`).
     pub eslint_suppression_rules: Option<Vec<String>>,
 
     /// Whether Flow suppression comments (e.g. `$FlowFixMe`) likewise make the

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -2866,23 +2866,16 @@ pub fn compile_program<'a>(
     // Compute output mode once, up front
     let output_mode = CompilerOutputMode::from_opts(&options);
 
-    let eslint_rules: Option<Vec<String>> =
-        if options.environment.validate_exhaustive_memoization_dependencies
-            && options.environment.validate_hooks_usage
-        {
-            // Don't check for ESLint suppressions if both validations are enabled
-            None
-        } else {
-            Some(options.eslint_suppression_rules.clone().unwrap_or_else(|| {
-                DEFAULT_ESLINT_SUPPRESSIONS.iter().map(|s| s.to_string()).collect()
-            }))
-        };
+    let eslint_rules = options
+        .eslint_suppression_rules
+        .clone()
+        .unwrap_or_else(|| DEFAULT_ESLINT_SUPPRESSIONS.iter().map(|s| s.to_string()).collect());
 
     // Find program-level suppressions from comments
     let suppressions = find_program_suppressions(
         &program.comments,
         program.source_text,
-        eslint_rules.as_deref(),
+        Some(&eslint_rules),
         options.flow_suppressions,
     );
 

--- a/crates/oxc_react_compiler/tests/snapshots/default-suppression-eslint-block-range.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/default-suppression-eslint-block-range.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/default-suppression-eslint-block-range.js
+---
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Suppression: React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled", labels: One([LabeledSpan { label: Some("Found React rule suppression"), span: SourceSpan { offset: SourceOffset(0), length: 47 }, primary: false }]), help: Some("React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior. Found suppression `eslint-disable react-hooks/rules-of-hooks`"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/default-suppression-eslint-next-line.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/default-suppression-eslint-next-line.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/default-suppression-eslint-next-line.js
+---
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Suppression: React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled", labels: One([LabeledSpan { label: Some("Found React rule suppression"), span: SourceSpan { offset: SourceOffset(34), length: 55 }, primary: false }]), help: Some("React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior. Found suppression `eslint-disable-next-line react-hooks/exhaustive-deps`"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/default-suppression-flow.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/default-suppression-flow.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/default-suppression-flow.js
+---
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Suppression: React Compiler has skipped optimizing this component because one or more React rule violations were reported by Flow", labels: One([LabeledSpan { label: Some("Found React rule suppression"), span: SourceSpan { offset: SourceOffset(34), length: 30 }, primary: false }]), help: Some("React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior. Found suppression `$FlowFixMe[react-rule-hook]`"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/exhaustive-deps__compile-files-with-exhaustive-deps-violation-in-effects.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/exhaustive-deps__compile-files-with-exhaustive-deps-violation-in-effects.snap
@@ -2,56 +2,8 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/exhaustive-deps/compile-files-with-exhaustive-deps-violation-in-effects.js
 ---
-import { c as _c } from "react/compiler-runtime";
-// @validateExhaustiveMemoizationDependencies
-import { useMemo } from "react";
-import { ValidateMemoization } from "shared-runtime";
-function Component(t0) {
-	const $ = _c(10);
-	const { x } = t0;
-	let t1;
-	if ($[0] !== x) {
-		t1 = () => {
-			console.log(x);
-		};
-		$[0] = x;
-		$[1] = t1;
-	} else {
-		t1 = $[1];
-	}
-	let t2;
-	if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
-		t2 = [];
-		$[2] = t2;
-	} else {
-		t2 = $[2];
-	}
-	useEffect(t1, t2);
-	let t3;
-	if ($[3] !== x) {
-		t3 = [x];
-		$[3] = x;
-		$[4] = t3;
-	} else {
-		t3 = $[4];
-	}
-	const memo = t3;
-	let t4;
-	if ($[5] !== x) {
-		t4 = [x];
-		$[5] = x;
-		$[6] = t4;
-	} else {
-		t4 = $[6];
-	}
-	let t5;
-	if ($[7] !== memo || $[8] !== t4) {
-		t5 = <ValidateMemoization inputs={t4} output={memo} />;
-		$[7] = memo;
-		$[8] = t4;
-		$[9] = t5;
-	} else {
-		t5 = $[9];
-	}
-	return t5;
-}
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Suppression: React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled", labels: One([LabeledSpan { label: Some("Found React rule suppression"), span: SourceSpan { offset: SourceOffset(210), length: 55 }, primary: false }]), help: Some("React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior. Found suppression `eslint-disable-next-line react-hooks/exhaustive-deps`"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/exhaustive-deps__error.sketchy-code-exhaustive-deps.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/exhaustive-deps__error.sketchy-code-exhaustive-deps.snap
@@ -4,6 +4,6 @@ input_file: crates/oxc_react_compiler/fixtures/exhaustive-deps/error.sketchy-cod
 ---
 Diagnostics:
 
-OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] MemoDependencies: Found missing memoization dependencies", labels: One([LabeledSpan { label: Some("Missing dependency `item`"), span: SourceSpan { offset: SourceOffset(186), length: 4 }, primary: false }]), help: Some("Missing dependencies can cause a value to update less often than it should, resulting in stale UI"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Suppression: React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled", labels: One([LabeledSpan { label: Some("Found React rule suppression"), span: SourceSpan { offset: SourceOffset(203), length: 55 }, primary: false }]), help: Some("React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior. Found suppression `eslint-disable-next-line react-hooks/exhaustive-deps`"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
 No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/use-no-forget-multiple-with-eslint-suppression.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/use-no-forget-multiple-with-eslint-suppression.snap
@@ -4,7 +4,7 @@ input_file: crates/oxc_react_compiler/fixtures/use-no-forget-multiple-with-eslin
 ---
 Diagnostics:
 
-OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Refs: Cannot access refs during render", labels: One([LabeledSpan { label: Some("Cannot update ref during render"), span: SourceSpan { offset: SourceOffset(233), length: 11 }, primary: false }]), help: Some("React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Suppression: React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled", labels: One([LabeledSpan { label: Some("Found React rule suppression"), span: SourceSpan { offset: SourceOffset(176), length: 54 }, primary: false }]), help: Some("React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior. Found suppression `eslint-disable-next-line react-hooks/rules-of-hooks`"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
 import { useRef } from "react";
 const useControllableState = (options) => {};

--- a/crates/oxc_react_compiler/tests/snapshots/use-no-forget-with-eslint-suppression.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/use-no-forget-with-eslint-suppression.snap
@@ -4,6 +4,6 @@ input_file: crates/oxc_react_compiler/fixtures/use-no-forget-with-eslint-suppres
 ---
 Diagnostics:
 
-OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Refs: Cannot access refs during render", labels: One([LabeledSpan { label: Some("Cannot update ref during render"), span: SourceSpan { offset: SourceOffset(160), length: 11 }, primary: false }]), help: Some("React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Suppression: React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled", labels: One([LabeledSpan { label: Some("Found React rule suppression"), span: SourceSpan { offset: SourceOffset(103), length: 54 }, primary: false }]), help: Some("React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior. Found suppression `eslint-disable-next-line react-hooks/rules-of-hooks`"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
 
 No changes.

--- a/crates/oxc_react_compiler/tests/transform.rs
+++ b/crates/oxc_react_compiler/tests/transform.rs
@@ -68,6 +68,43 @@ fn skips_non_react_code() {
     assert!(!result.changed, "non-React code must not be transformed");
 }
 
+#[test]
+fn default_suppressions_bail_out() {
+    let fixtures = [
+        (
+            "eslint-disable-next-line",
+            include_str!("../fixtures/default-suppression-eslint-next-line.js"),
+            1,
+        ),
+        (
+            "eslint-disable block range",
+            include_str!("../fixtures/default-suppression-eslint-block-range.js"),
+            1,
+        ),
+        ("Flow", include_str!("../fixtures/default-suppression-flow.js"), 1),
+    ];
+
+    // Babel 1.0.0 currently treats a block disable as open-ended. The block fixture
+    // therefore covers the disable/enable syntax without asserting post-enable behavior.
+    for (kind, source, expected_errors) in fixtures {
+        let allocator = Allocator::default();
+        let (_program, result) =
+            transform_source(source, SourceType::tsx(), &allocator, PluginOptions::default());
+
+        assert!(!result.changed, "{kind} suppression must prevent compilation");
+        assert!(
+            result.diagnostics.has_errors(),
+            "{kind} suppression must report the compiler bail-out: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(
+            result.diagnostics.len(),
+            expected_errors,
+            "{kind} suppression should affect the same functions as the Babel plugin"
+        );
+    }
+}
+
 /// TypeScript-only constructs (`declare global`, `import =`, `export =`,
 /// overload signatures, `#field in obj`) round-trip without panicking while the
 /// component still compiles.


### PR DESCRIPTION
Honor Babel React Compiler 1.0.0's default ESLint and Flow suppression bailouts even when validation flags are enabled.

Validation:
- `cargo test -p oxc_react_compiler`
- `cargo clippy -p oxc_react_compiler --all-targets -- -D warnings`
- Direct fixture comparison with `babel-plugin-react-compiler@1.0.0`

Caveat: Babel 1.0.0 treats block disables as open-ended; this change preserves that behavior.

AI-assisted.
