### PR TITLE
fix(react_compiler): infer typed forwardRef callbacks

### DIFF
--- a/crates/oxc_react_compiler/fixtures/infer-forward-ref-generic-typed.tsx
+++ b/crates/oxc_react_compiler/fixtures/infer-forward-ref-generic-typed.tsx
@@ -1,0 +1,12 @@
+// @compilationMode:"infer"
+import {forwardRef} from 'react';
+
+type Props = {label: string};
+
+const Card = forwardRef<HTMLDivElement, Props>(
+  ({label}: Props, viewTracker) => (
+    <div ref={viewTracker}>{label}</div>
+  ),
+);
+
+export default Card;

--- a/crates/oxc_react_compiler/fixtures/infer-two-param-component-not-forward-ref.tsx
+++ b/crates/oxc_react_compiler/fixtures/infer-two-param-component-not-forward-ref.tsx
@@ -1,0 +1,8 @@
+// @compilationMode:"infer"
+type Props = {label: string};
+
+const Card = ({label}: Props, viewTracker: unknown) => (
+  <div data-view-tracker={String(viewTracker)}>{label}</div>
+);
+
+export default Card;

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -1274,8 +1274,8 @@ fn get_declarator_name<'ast>(decl: &VariableDeclarator<'ast>) -> Option<&'ast st
 /// - `loop_expression_depth` for loop test/right positions (while.test,
 ///   do-while.test, for-in.right, for-of.right), which Babel treats as
 ///   non-program-scope in 'all' mode;
-/// - parent context: `current_declarator_name` for `const Foo = () => {}` and
-///   `parent_callee_stack` for forwardRef/memo wrappers;
+/// - parent context: `current_declarator_name` for direct `const Foo = () => {}`
+///   initializers and `parent_callee_stack` for forwardRef/memo wrappers;
 /// - in 'all' mode, rejects functions whose scope depth `> 2` (program +
 ///   function) or that sit in a loop expression position.
 ///
@@ -1496,14 +1496,14 @@ impl<'a, 'b, 'ast> DiscoveryWalker<'a, 'b, 'ast> {
 
     fn walk_variable_declaration(&mut self, decl: &'b VariableDeclaration<'ast>) {
         for declarator in &decl.declarations {
-            // Only infer the declarator name when the init is a direct function
-            // expression, arrow, or call expression (for forwardRef/memo wrappers).
+            // Babel's `getFunctionName` infers a declarator name only when the
+            // initializer is the function itself. In particular, the callback in
+            // `const Foo = forwardRef(() => {})` is unnamed and is classified from
+            // its `forwardRef` parent instead.
             if let Some(init) = &declarator.init {
                 if matches!(
                     init,
-                    Expression::FunctionExpression(_)
-                        | Expression::ArrowFunctionExpression(_)
-                        | Expression::CallExpression(_)
+                    Expression::FunctionExpression(_) | Expression::ArrowFunctionExpression(_)
                 ) {
                     self.current_declarator_name = get_declarator_name(declarator);
                 }
@@ -1637,20 +1637,15 @@ impl<'a, 'b, 'ast> DiscoveryWalker<'a, 'b, 'ast> {
             }
             Expression::CallExpression(node) => {
                 let callee_name = get_callee_name_if_react_api(&node.callee);
-                // The declarator name only flows through forwardRef/memo calls; for
-                // any other call, clear it so nested functions don't inherit it.
-                if callee_name.is_none() {
-                    self.current_declarator_name = None;
-                }
+                // Call arguments are never direct variable initializers, so a
+                // nested function must not inherit the surrounding declarator name.
+                self.current_declarator_name = None;
                 self.parent_callee_stack.push(callee_name);
                 self.walk_expression(&node.callee);
                 for arg in &node.arguments {
                     self.walk_argument(arg);
                 }
-                let was_react_api = self.parent_callee_stack.pop().flatten().is_some();
-                if was_react_api {
-                    self.current_declarator_name = None;
-                }
+                self.parent_callee_stack.pop();
             }
             Expression::ChainExpression(node) => self.walk_chain_element(&node.expression),
             Expression::StaticMemberExpression(node) => self.walk_expression(&node.object),

--- a/crates/oxc_react_compiler/tests/snapshots/infer-forward-ref-generic-typed.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/infer-forward-ref-generic-typed.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/infer-forward-ref-generic-typed.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+// @compilationMode:"infer"
+import { forwardRef } from "react";
+type Props = {
+	label: string;
+};
+const Card = forwardRef<HTMLDivElement, Props>((t0, viewTracker) => {
+	const $ = _c(3);
+	const { label } = t0;
+	let t1;
+	if ($[0] !== label || $[1] !== viewTracker) {
+		t1 = <div ref={viewTracker}>{label}</div>;
+		$[0] = label;
+		$[1] = viewTracker;
+		$[2] = t1;
+	} else {
+		t1 = $[2];
+	}
+	return t1;
+});
+export default Card;

--- a/crates/oxc_react_compiler/tests/snapshots/infer-two-param-component-not-forward-ref.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/infer-two-param-component-not-forward-ref.snap
@@ -1,0 +1,10 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/infer-two-param-component-not-forward-ref.tsx
+---
+// @compilationMode:"infer"
+type Props = {
+	label: string;
+};
+const Card = ({ label }: Props, viewTracker: unknown) => <div data-view-tracker={String(viewTracker)}>{label}</div>;
+export default Card;


### PR DESCRIPTION
Align inline `forwardRef` callback discovery with Babel by preventing outer declarator names from leaking through call expressions. Add TSX fixtures for a generic typed callback and an unwrapped two-parameter control.

## Validation

- React Compiler snapshot and integration suites
- Clippy for `oxc_react_compiler` with warnings denied
- Babel 1.0.0 parity for the reduced cases and original Simorgh cache sizes
- `just ready` reached the full suite; four unrelated Oxlint base failures remain (one suppression count and three ANSI-color snapshots)

AI assistance was used to diagnose, implement, and validate this change. The contributor remains responsible for reviewing and understanding it.
