### PR TITLE
fix(transformer): preserve nonfatal React Compiler bailouts

### DIFF
--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -164,12 +164,13 @@ pub trait CompilerInterface {
             let mut transformer_return =
                 self.transform(options, &allocator, &mut program, source_path, scoping);
 
-            // Errors are fatal (e.g. a React Compiler error); warnings are reported
-            // but codegen still runs.
+            // Report all diagnostics, but only stop for diagnostics the transformer
+            // marked fatal. React Compiler can report Error-severity diagnostics for
+            // individual function bailouts without aborting the file.
+            let has_fatal_errors = transformer_return.has_fatal_errors;
             let diagnostics = mem::take(&mut transformer_return.diagnostics);
-            let has_errors = diagnostics.has_errors();
             self.handle_errors(diagnostics);
-            if has_errors {
+            if has_fatal_errors {
                 return;
             }
 

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -15,7 +15,7 @@ mod react_compiler_typeinference;
 mod react_compiler_utils;
 mod react_compiler_validation;
 
-use crate::react_compiler::entrypoint::compile_result::CompileResult;
+use crate::react_compiler::entrypoint::compile_result::CompileResult as InternalCompileResult;
 use crate::react_compiler::entrypoint::imports::{
     get_react_compiler_runtime_module, has_memo_cache_function_import, validate_restricted_imports,
 };
@@ -48,6 +48,19 @@ pub struct LintResult {
     pub diagnostics: Diagnostics,
 }
 
+/// Whether the compiler completed normally or encountered an error that must abort
+/// the surrounding transform pipeline.
+///
+/// A successful compile can still contain diagnostics from functions that were
+/// individually skipped according to [`PluginOptions::panic_threshold`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompileStatus {
+    /// Compilation completed, including when individual functions bailed out.
+    Success,
+    /// Compilation must abort because of a configuration error or panic threshold.
+    Fatal,
+}
+
 /// Run the React Compiler on a pre-parsed program.
 ///
 /// Returns the compiled output — `None` when the compiler has nothing to change
@@ -76,22 +89,41 @@ pub fn compile<'a>(
     allocator: &'a Allocator,
     options: PluginOptions,
 ) -> (Option<CompileOutput<'a>>, Diagnostics) {
+    let (output, diagnostics, _status) = compile_with_status(program, semantic, allocator, options);
+    (output, diagnostics)
+}
+
+/// Run the React Compiler and preserve whether its diagnostics represent a fatal
+/// whole-file error.
+///
+/// Integrations that run additional transforms after React Compiler should use this
+/// entry point instead of inferring fatality from diagnostic severity. With the
+/// default `panicThreshold: "none"`, a failed function is reported as an error but
+/// does not prevent sibling functions or later transform passes from running.
+pub fn compile_with_status<'a>(
+    program: &Program<'a>,
+    semantic: &Semantic<'_>,
+    allocator: &'a Allocator,
+    options: PluginOptions,
+) -> (Option<CompileOutput<'a>>, Diagnostics, CompileStatus) {
     // Check for existing runtime imports (file already compiled).
     if has_memo_cache_function_import(program, &get_react_compiler_runtime_module(&options.target))
     {
-        return (None, Diagnostics::default());
+        return (None, Diagnostics::default(), CompileStatus::Success);
     }
 
     // Blocklisted imports fail the whole file: report and bail without compiling.
     if let Some(diagnostics) =
         validate_restricted_imports(program, &options.environment.validate_blocklisted_imports)
     {
-        return (None, diagnostics);
+        return (None, diagnostics, CompileStatus::Fatal);
     }
 
     match compile_program(allocator, semantic, program, options) {
-        CompileResult::Success { output, diagnostics } => (output.map(|b| *b), diagnostics),
-        CompileResult::Error { diagnostics } => (None, diagnostics),
+        InternalCompileResult::Success { output, diagnostics } => {
+            (output.map(|b| *b), diagnostics, CompileStatus::Success)
+        }
+        InternalCompileResult::Error { diagnostics } => (None, diagnostics, CompileStatus::Fatal),
     }
 }
 

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -11,7 +11,9 @@ use oxc_allocator::{Allocator, ArenaVec, ReplaceWith};
 use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_diagnostics::Diagnostics;
 #[cfg(feature = "react_compiler")]
-use oxc_react_compiler::{PluginOptions, compile as react_compiler_compile};
+use oxc_react_compiler::{
+    CompileStatus, PluginOptions, compile_with_status as react_compiler_compile,
+};
 use oxc_semantic::Scoping;
 #[cfg(feature = "react_compiler")]
 use oxc_semantic::SemanticBuilder;
@@ -92,6 +94,12 @@ pub use crate::{
 pub struct TransformerReturn {
     /// Diagnostics produced during transformation.
     pub diagnostics: Diagnostics,
+    /// Whether transformation produced a diagnostic that must stop code generation.
+    ///
+    /// Error-severity React Compiler diagnostics are recoverable when its panic
+    /// threshold does not escalate them, so consumers must not infer fatality from
+    /// [`diagnostics`](Self::diagnostics) alone.
+    pub has_fatal_errors: bool,
     /// Updated semantic scoping after all transforms have run.
     pub scoping: Scoping,
     /// Helpers used by this transform.
@@ -145,15 +153,21 @@ impl<'a> Transformer<'a> {
         let allocator = self.allocator;
 
         #[cfg(feature = "react_compiler")]
-        let (scoping, react_compiler_diagnostics) = self.run_react_compiler(scoping, program);
+        let (scoping, react_compiler_diagnostics, react_compiler_fatal) =
+            self.run_react_compiler(scoping, program);
         #[cfg(not(feature = "react_compiler"))]
         let react_compiler_diagnostics = Diagnostics::new();
+        #[cfg(not(feature = "react_compiler"))]
+        let react_compiler_fatal = false;
 
-        // A React Compiler error is fatal: stop before the rest of the transform runs.
-        if react_compiler_diagnostics.has_errors() {
+        // Only errors escalated by React Compiler are fatal. With the default panic
+        // threshold, diagnostics can describe a skipped function while sibling
+        // functions and the remaining transform pipeline continue normally.
+        if react_compiler_fatal {
             #[expect(deprecated)]
             return TransformerReturn {
                 diagnostics: react_compiler_diagnostics,
+                has_fatal_errors: true,
                 scoping,
                 helpers_used: FxHashMap::default(),
             };
@@ -213,10 +227,12 @@ impl<'a> Transformer<'a> {
         traverse_mut_with_ctx(&mut transformer, program, &mut reusable_ctx);
         let (mut state, scoping) = reusable_ctx.into_state_and_scoping();
         let helpers_used = state.helper_loader.used_helpers.drain().collect();
+        let transformer_diagnostics = Diagnostics::from(state.take_errors());
+        let has_fatal_errors = transformer_diagnostics.has_errors();
         let mut diagnostics = react_compiler_diagnostics;
-        diagnostics.extend(state.take_errors());
+        diagnostics.extend(transformer_diagnostics);
         #[expect(deprecated)]
-        TransformerReturn { diagnostics, scoping, helpers_used }
+        TransformerReturn { diagnostics, has_fatal_errors, scoping, helpers_used }
     }
 
     #[cfg(feature = "react_compiler")]
@@ -224,21 +240,21 @@ impl<'a> Transformer<'a> {
         &mut self,
         scoping: Scoping,
         program: &mut Program<'a>,
-    ) -> (Scoping, Diagnostics) {
+    ) -> (Scoping, Diagnostics, bool) {
         let Some(options) = self.react_compiler.take() else {
-            return (scoping, Diagnostics::new());
+            return (scoping, Diagnostics::new(), false);
         };
-        let (output, diagnostics) = {
+        let (output, diagnostics, status) = {
             let semantic = SemanticBuilder::new().with_build_nodes(true).build(program).semantic;
             react_compiler_compile(program, &semantic, self.allocator, options)
         };
         let Some(output) = output else {
-            return (scoping, diagnostics);
+            return (scoping, diagnostics, status == CompileStatus::Fatal);
         };
         output.transform(program);
         let scoping =
             SemanticBuilder::new().with_enum_eval(true).build(program).semantic.into_scoping();
-        (scoping, diagnostics)
+        (scoping, diagnostics, status == CompileStatus::Fatal)
     }
 }
 

--- a/crates/oxc_transformer/tests/fixtures/react_compiler/fatal-blocklisted-import.tsx
+++ b/crates/oxc_transformer/tests/fixtures/react_compiler/fatal-blocklisted-import.tsx
@@ -1,0 +1,5 @@
+import blocked from "blocked-module";
+
+export function Component(): JSX.Element {
+  return <div>{blocked}</div>;
+}

--- a/crates/oxc_transformer/tests/fixtures/react_compiler/nonfatal-bailout-continues-tsx.tsx
+++ b/crates/oxc_transformer/tests/fixtures/react_compiler/nonfatal-bailout-continues-tsx.tsx
@@ -1,0 +1,14 @@
+import { useRef } from "react";
+
+type Props = {
+  value: string;
+};
+
+export function InvalidRefAccess(): JSX.Element {
+  const ref = useRef<HTMLDivElement>(null);
+  return <span>{ref.current}</span>;
+}
+
+export function CompilableSibling({ value }: Props): JSX.Element {
+  return <main>{value}</main>;
+}

--- a/crates/oxc_transformer/tests/fixtures/react_compiler/nonfatal-bailout-with-compilable-sibling.jsx
+++ b/crates/oxc_transformer/tests/fixtures/react_compiler/nonfatal-bailout-with-compilable-sibling.jsx
@@ -1,0 +1,10 @@
+import { useRef } from "react";
+
+export function InvalidRefAccess() {
+  const ref = useRef(null);
+  return <span>{ref.current}</span>;
+}
+
+export function CompilableSibling({ value }) {
+  return <div>{value}</div>;
+}

--- a/crates/oxc_transformer/tests/integrations/react_compiler.rs
+++ b/crates/oxc_transformer/tests/integrations/react_compiler.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use oxc_allocator::Allocator;
 use oxc_codegen::Codegen;
 use oxc_parser::Parser;
-use oxc_react_compiler::PluginOptions;
+use oxc_react_compiler::{PanicThreshold, PluginOptions};
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use oxc_transformer::{TransformOptions, Transformer};
@@ -54,4 +54,84 @@ fn keeps_import_used_only_as_computed_key() {
         code.contains("import { CSS_VAR }"),
         "import referenced by the computed key was wrongly elided:\n{code}"
     );
+}
+
+#[test]
+fn nonfatal_bailout_does_not_discard_compilable_sibling() {
+    let allocator = Allocator::default();
+    let source =
+        include_str!("../fixtures/react_compiler/nonfatal-bailout-with-compilable-sibling.jsx");
+    let mut program = Parser::new(&allocator, source, SourceType::jsx()).parse().program;
+    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let options =
+        TransformOptions { react_compiler: Some(PluginOptions::default()), ..Default::default() };
+
+    let ret = Transformer::new(&allocator, Path::new("mixed.jsx"), &options)
+        .build_with_scoping(scoping, &mut program);
+    assert!(ret.diagnostics.has_errors(), "expected the ref-access bailout diagnostic");
+
+    let code = Codegen::new().build(&program).code;
+    assert!(code.contains("ref.current"), "bailed-out function was not preserved:\n{code}");
+    assert!(code.contains("react/compiler-runtime"), "sibling was not compiled:\n{code}");
+    assert!(code.contains("_c("), "sibling did not use the memo cache:\n{code}");
+}
+
+#[test]
+fn nonfatal_bailout_allows_downstream_tsx_transform() {
+    let allocator = Allocator::default();
+    let source = include_str!("../fixtures/react_compiler/nonfatal-bailout-continues-tsx.tsx");
+    let mut program = Parser::new(&allocator, source, SourceType::tsx()).parse().program;
+    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let options =
+        TransformOptions { react_compiler: Some(PluginOptions::default()), ..Default::default() };
+
+    let ret = Transformer::new(&allocator, Path::new("mixed.tsx"), &options)
+        .build_with_scoping(scoping, &mut program);
+    assert!(ret.diagnostics.has_errors(), "expected the ref-access bailout diagnostic");
+
+    let code = Codegen::new().build(&program).code;
+    assert!(code.contains("react/compiler-runtime"), "sibling was not compiled:\n{code}");
+    assert!(!code.contains("type Props"), "TypeScript transform did not run:\n{code}");
+    assert!(!code.contains(": JSX.Element"), "return type was not removed:\n{code}");
+    assert!(!code.contains("<main>"), "JSX transform did not run:\n{code}");
+}
+
+#[test]
+fn all_errors_panic_threshold_still_aborts_downstream_transforms() {
+    let allocator = Allocator::default();
+    let source = include_str!("../fixtures/react_compiler/nonfatal-bailout-continues-tsx.tsx");
+    let mut program = Parser::new(&allocator, source, SourceType::tsx()).parse().program;
+    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let react_compiler =
+        PluginOptions { panic_threshold: PanicThreshold::AllErrors, ..PluginOptions::default() };
+    let options = TransformOptions { react_compiler: Some(react_compiler), ..Default::default() };
+
+    let ret = Transformer::new(&allocator, Path::new("mixed.tsx"), &options)
+        .build_with_scoping(scoping, &mut program);
+    assert!(ret.diagnostics.has_errors(), "expected a fatal ref-access diagnostic");
+
+    let code = Codegen::new().build(&program).code;
+    assert!(code.contains("type Props"), "fatal compile unexpectedly ran TypeScript transform");
+    assert!(code.contains("<main>"), "fatal compile unexpectedly ran JSX transform");
+    assert!(!code.contains("react/compiler-runtime"), "fatal compile emitted compiler output");
+}
+
+#[test]
+fn config_error_still_aborts_downstream_transforms() {
+    let allocator = Allocator::default();
+    let source = include_str!("../fixtures/react_compiler/fatal-blocklisted-import.tsx");
+    let mut program = Parser::new(&allocator, source, SourceType::tsx()).parse().program;
+    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let mut react_compiler = PluginOptions::default();
+    react_compiler.environment.validate_blocklisted_imports =
+        Some(vec!["blocked-module".to_string()]);
+    let options = TransformOptions { react_compiler: Some(react_compiler), ..Default::default() };
+
+    let ret = Transformer::new(&allocator, Path::new("blocked.tsx"), &options)
+        .build_with_scoping(scoping, &mut program);
+    assert!(!ret.diagnostics.is_empty(), "expected a fatal configuration diagnostic");
+
+    let code = Codegen::new().build(&program).code;
+    assert!(code.contains(": JSX.Element"), "config error unexpectedly ran TypeScript transform");
+    assert!(code.contains("<div>"), "config error unexpectedly ran JSX transform");
 }

--- a/napi/transform/test/fixtures/react-compiler/nonfatal-bailout.tsx
+++ b/napi/transform/test/fixtures/react-compiler/nonfatal-bailout.tsx
@@ -1,0 +1,14 @@
+import { useRef } from "react";
+
+type Props = {
+  value: string;
+};
+
+export function InvalidRefAccess(): JSX.Element {
+  const ref = useRef<HTMLDivElement>(null);
+  return <span>{ref.current}</span>;
+}
+
+export function CompilableSibling({ value }: Props): JSX.Element {
+  return <main>{value}</main>;
+}

--- a/napi/transform/test/reactCompiler.test.ts
+++ b/napi/transform/test/reactCompiler.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import { transformSync } from "../index";
@@ -25,6 +27,11 @@ export function Component(props: Props) {
   );
 }
 `;
+
+const nonfatalBailoutFixture = readFileSync(
+  new URL("./fixtures/react-compiler/nonfatal-bailout.tsx", import.meta.url),
+  "utf8",
+);
 
 describe("plugins.reactCompiler", () => {
   it("memoizes, composes with the TS + JSX transforms, and preserves comments", () => {
@@ -174,25 +181,28 @@ function Component() {
     expect(errors.some((error) => error.severity === "Error")).toBe(false);
   });
 
-  it("aborts the transform when React Compiler reports an error", () => {
-    const { code, errors } = transformSync(
-      "Component.jsx",
-      `
-function Component(props) {
-  if (props.cond) {
-    useState(0);
-  }
-  return <div>{props.text}</div>;
-}
-`,
-      {
-        plugins: { reactCompiler: true },
-        jsx: { runtime: "automatic" },
-      },
-    );
+  it("emits fully lowered code for a default nonfatal bailout", () => {
+    const { code, errors } = transformSync("Component.tsx", nonfatalBailoutFixture, {
+      plugins: { reactCompiler: true },
+      jsx: { runtime: "automatic" },
+    });
 
-    // A React Compiler error (Rules of Hooks violation) is fatal: it is surfaced
-    // at error severity and the transform stops, emitting no code.
+    // Upstream logs recoverable compiler errors at their original severity but
+    // does not throw with the default panicThreshold: "none".
+    expect(errors.some((error) => error.severity === "Error")).toBe(true);
+    expect(code).toContain("react/compiler-runtime");
+    expect(code).toContain("_c(");
+    expect(code).not.toContain("type Props");
+    expect(code).not.toContain(": JSX.Element");
+    expect(code).not.toContain("<main>");
+  });
+
+  it("aborts the transform when the panic threshold escalates an error", () => {
+    const { code, errors } = transformSync("Component.tsx", nonfatalBailoutFixture, {
+      plugins: { reactCompiler: { panicThreshold: "all_errors" } },
+      jsx: { runtime: "automatic" },
+    });
+
     expect(errors.some((error) => error.severity === "Error")).toBe(true);
     expect(code).toBe("");
   });


### PR DESCRIPTION
Preserve React Compiler fatality through the transformer and codegen pipeline so default per-function bailouts keep sibling compilation and downstream TSX lowering.

Validation:
- `cargo test -p oxc_transformer --features react_compiler`
- `cargo test -p oxc_react_compiler --test transform`
- `pnpm --dir napi/transform test`
- targeted Clippy with warnings denied
- `just ready` reached an unrelated ANSI-only Oxlint snapshot mismatch in non-TTY execution

AI assistance was used to implement and validate this change.