### PR TITLE
fix(react_compiler): compile inline TypeScript enums

### DIFF
--- a/crates/oxc_react_compiler/fixtures/ts-enum-inline-switch-case.tsx
+++ b/crates/oxc_react_compiler/fixtures/ts-enum-inline-switch-case.tsx
@@ -1,0 +1,17 @@
+function Component(props: {action: string}) {
+  enum Action {
+    Select,
+  }
+
+  switch (props.action) {
+    case String(Action.Select):
+      return <span>selected</span>;
+    default:
+      return <span>unknown</span>;
+  }
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{action: '0'}],
+};

--- a/crates/oxc_react_compiler/fixtures/ts-enum-inline-unused-side-effect.tsx
+++ b/crates/oxc_react_compiler/fixtures/ts-enum-inline-unused-side-effect.tsx
@@ -1,0 +1,16 @@
+function createValue(value: number): number {
+  return value;
+}
+
+function Component(props: {value: number}) {
+  enum Unused {
+    Value = createValue(props.value),
+  }
+
+  return <span>{props.value}</span>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 1}],
+};

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -721,6 +721,13 @@ pub enum InstructionValue<'a> {
     Debugger {
         span: Option<Span>,
     },
+    /// A runtime statement that the HIR does not model, preserved verbatim through
+    /// the optimization pipeline. This mirrors the reference compiler's
+    /// `UnsupportedNode` value for inline TypeScript enums.
+    UnsupportedStatement {
+        statement: &'a oxc_ast::ast::Statement<'a>,
+        span: Option<Span>,
+    },
     StartMemoize {
         manual_memo_id: u32,
         deps: Option<Vec<ManualMemoDependency<'a>>>,
@@ -790,6 +797,7 @@ impl<'a> InstructionValue<'a> {
             | InstructionValue::PrefixUpdate { span, .. }
             | InstructionValue::PostfixUpdate { span, .. }
             | InstructionValue::Debugger { span, .. }
+            | InstructionValue::UnsupportedStatement { span, .. }
             | InstructionValue::StartMemoize { span, .. }
             | InstructionValue::FinishMemoize { span, .. } => span.as_ref(),
         }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
@@ -85,6 +85,7 @@ pub fn each_instruction_value_lvalue(value: &InstructionValue) -> PlaceList {
         | InstructionValue::IteratorNext { .. }
         | InstructionValue::NextPropertyOf { .. }
         | InstructionValue::Debugger { .. }
+        | InstructionValue::UnsupportedStatement { .. }
         | InstructionValue::StartMemoize { .. }
         | InstructionValue::FinishMemoize { .. } => {}
     }
@@ -274,6 +275,7 @@ pub fn each_instruction_value_operand_with_functions(
             result.push(decl.clone());
         }
         InstructionValue::Debugger { .. }
+        | InstructionValue::UnsupportedStatement { .. }
         | InstructionValue::RegExpLiteral { .. }
         | InstructionValue::MetaProperty { .. }
         | InstructionValue::LoadGlobal { .. }
@@ -1020,6 +1022,7 @@ pub fn for_each_instruction_value_operand_mut(
             f(decl);
         }
         InstructionValue::Debugger { .. }
+        | InstructionValue::UnsupportedStatement { .. }
         | InstructionValue::RegExpLiteral { .. }
         | InstructionValue::MetaProperty { .. }
         | InstructionValue::LoadGlobal { .. }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -2381,6 +2381,7 @@ fn compute_signature_for_instruction(
         InstructionValue::TaggedTemplateExpression { .. }
         | InstructionValue::BinaryExpression { .. }
         | InstructionValue::Debugger { .. }
+        | InstructionValue::UnsupportedStatement { .. }
         | InstructionValue::JSXText { .. }
         | InstructionValue::MetaProperty { .. }
         | InstructionValue::Primitive { .. }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
@@ -199,6 +199,7 @@ fn may_allocate(value: &InstructionValue, lvalue_type_is_primitive: bool) -> boo
         | InstructionValue::JsxFragment { .. }
         | InstructionValue::NewExpression { .. }
         | InstructionValue::ObjectExpression { .. }
+        | InstructionValue::UnsupportedStatement { .. }
         | InstructionValue::ObjectMethod { .. }
         | InstructionValue::FunctionExpression { .. } => true,
     }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -5466,8 +5466,12 @@ fn is_reorderable_expression(
                 match builder.scope().resolve_reference(ident) {
                     None => true, // global
                     Some(symbol_id) => {
-                        // Module-scope bindings (ModuleLocal, imports) are safe to reorder
+                        // Module-scope bindings (ModuleLocal, imports) and opaque inline
+                        // enum bindings are safe to reorder. The latter are lowered as
+                        // globals because their declaration is preserved as an
+                        // UnsupportedStatement rather than represented in HIR.
                         builder.scope().symbol_scope(symbol_id) == builder.scope().program_scope()
+                            || builder.scope().decl_kind(symbol_id) == DeclKind::TSEnumDeclaration
                     }
                 }
             } else {
@@ -6337,11 +6341,14 @@ fn lower_statement<'a>(
             )?;
         }
         oxc::Statement::TSEnumDeclaration(_) => {
-            // Inline TS `enum` has runtime semantics but no HIR representation, and
-            // the compiled body is rebuilt from HIR. Flag the function to be skipped
-            // (silently, no diagnostic) once lowering finishes, rather than dropping
-            // the enum from the output. Other functions in the file are unaffected.
-            builder.environment_mut().skip_compilation = true;
+            // Inline enums have runtime semantics. Preserve the whole statement as an
+            // opaque HIR value, matching the reference compiler's `UnsupportedNode`.
+            let allocator = builder.environment().allocator;
+            let statement = allocator.alloc(stmt.clone_in_with_semantic_ids(allocator));
+            lower_value_to_temporary(
+                builder,
+                InstructionValue::UnsupportedStatement { statement, span: Some(stmt.span()) },
+            )?;
         }
         _ => {
             // Remaining statements are skipped: bodyless FunctionDeclaration

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -757,9 +757,8 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         };
         // Treat type-only declarations as globals so the compiler
         // doesn't try to create/initialize HIR bindings for them.
-        // TSEnumDeclaration is included because a function with an inline
-        // enum is skipped (`skip_compilation`) and the enum binding is
-        // never initialized in HIR.
+        // TSEnumDeclaration is included because inline enums are represented by an
+        // opaque statement and their binding is never initialized in HIR.
         if matches!(
             self.scope.decl_kind(symbol_id),
             DeclKind::TSTypeAliasDeclaration

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -611,6 +611,7 @@ fn evaluate_instruction<'a>(
         | InstructionValue::IteratorNext { .. }
         | InstructionValue::NextPropertyOf { .. }
         | InstructionValue::Debugger { .. }
+        | InstructionValue::UnsupportedStatement { .. }
         | InstructionValue::FinishMemoize { .. } => None,
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
@@ -339,6 +339,7 @@ fn pruneable_value(value: &InstructionValue, state: &State, env: &Environment) -
             false
         }
         InstructionValue::NewExpression { .. }
+        | InstructionValue::UnsupportedStatement { .. }
         | InstructionValue::TaggedTemplateExpression { .. } => {
             // Potentially safe to prune, but we conservatively keep them
             false

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -1327,6 +1327,9 @@ fn ox_codegen_instruction_nullable<'a>(
             InstructionValue::Debugger { .. } => {
                 return Ok(Some(oxc_ast::ast::Statement::new_debugger_statement(SPAN, &cx.ast)));
             }
+            InstructionValue::UnsupportedStatement { statement, .. } => {
+                return Ok(Some(statement.clone_in_with_semantic_ids(cx.ast.allocator())));
+            }
             InstructionValue::ObjectMethod { span, .. } => {
                 invariant(
                     instr.lvalue.is_some(),
@@ -2071,6 +2074,7 @@ fn ox_codegen_base_instruction_value<'a>(
         InstructionValue::StartMemoize { .. }
         | InstructionValue::FinishMemoize { .. }
         | InstructionValue::Debugger { .. }
+        | InstructionValue::UnsupportedStatement { .. }
         | InstructionValue::DeclareLocal { .. }
         | InstructionValue::DeclareContext { .. }
         | InstructionValue::Destructure { .. }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -450,6 +450,12 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
                 };
                 (lvalues, rvalues)
             }
+            InstructionValue::UnsupportedStatement { .. } => {
+                let lvalues = lvalue.map_or_else(Vec::new, |place_identifier| {
+                    vec![LValueMemoization { place_identifier, level: MemoizationLevel::Never }]
+                });
+                (lvalues, vec![])
+            }
             InstructionValue::NextPropertyOf { .. }
             | InstructionValue::StartMemoize { .. }
             | InstructionValue::FinishMemoize { .. }

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -814,6 +814,7 @@ fn generate_instruction_types<'a>(
         | InstructionValue::GetIterator { .. }
         | InstructionValue::IteratorNext { .. }
         | InstructionValue::Debugger { .. }
+        | InstructionValue::UnsupportedStatement { .. }
         | InstructionValue::FinishMemoize { .. } => {
             // No type equations for these
         }
@@ -1157,6 +1158,7 @@ fn apply_instruction_operands<'a>(
         | InstructionValue::DeclareContext { .. }
         | InstructionValue::RegExpLiteral { .. }
         | InstructionValue::MetaProperty { .. }
+        | InstructionValue::UnsupportedStatement { .. }
         | InstructionValue::Debugger { .. } => {
             // No operand places
         }

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-switch-case.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-switch-case.snap
@@ -1,0 +1,37 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline-switch-case.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+function Component(props) {
+	const $ = _c(2);
+	enum Action {
+		Select
+	}
+	switch (props.action) {
+		case String(Action.Select): {
+			let t0;
+			if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+				t0 = <span>selected</span>;
+				$[0] = t0;
+			} else {
+				t0 = $[0];
+			}
+			return t0;
+		}
+		default: {
+			let t0;
+			if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+				t0 = <span>unknown</span>;
+				$[1] = t0;
+			} else {
+				t0 = $[1];
+			}
+			return t0;
+		}
+	}
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ action: "0" }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-unused-side-effect.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-unused-side-effect.snap
@@ -1,0 +1,27 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline-unused-side-effect.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+function createValue(value: number): number {
+	return value;
+}
+function Component(props) {
+	const $ = _c(2);
+	enum Unused {
+		Value = createValue(props.value)
+	}
+	let t0;
+	if ($[0] !== props.value) {
+		t0 = <span>{props.value}</span>;
+		$[0] = props.value;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ value: 1 }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline.snap
@@ -2,16 +2,26 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline.tsx
 ---
+import { c as _c } from "react/compiler-runtime";
 function Component(props) {
+	const $ = _c(2);
 	enum Bool {
 		True = "true",
 		False = "false"
 	}
-	let bool: Bool = Bool.False;
+	let bool = Bool.False;
 	if (props.value) {
 		bool = Bool.True;
 	}
-	return <div>{bool}</div>;
+	let t0;
+	if ($[0] !== bool) {
+		t0 = <div>{bool}</div>;
+		$[0] = bool;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
 }
 export const FIXTURE_ENTRYPOINT = {
 	fn: Component,


### PR DESCRIPTION
Preserve inline TypeScript enum statements through React Compiler HIR and treat their member accesses consistently with the Babel compiler.

Adds reduced fixtures for switch-case access and an unused enum with a side-effecting initializer.

## Validation

- `cargo test -p oxc_react_compiler --all-features`
- `cargo test -p oxc_transformer --features react_compiler`
- strict Clippy and formatting checks
- 69 NAPI transform checks
- exact default-option output parity with Babel 1.0.0 for the Bun case, both Kibana cases, and both new fixtures

AI assistance was used to diagnose, implement, and validate this change. The author reviewed the code and generated snapshots.
