### PR TITLE
fix(react_compiler): align object rest memo scopes

### DIFF
--- a/crates/oxc_react_compiler/fixtures/destructure-rest-jsx-only.tsx
+++ b/crates/oxc_react_compiler/fixtures/destructure-rest-jsx-only.tsx
@@ -1,0 +1,3 @@
+function Component({value, ...rest}) {
+  return <Child {...rest} value={value} />;
+}

--- a/crates/oxc_react_compiler/fixtures/merge-consecutive-scopes-destructure-call.tsx
+++ b/crates/oxc_react_compiler/fixtures/merge-consecutive-scopes-destructure-call.tsx
@@ -1,0 +1,18 @@
+declare function createContext(options: {
+  settings: unknown;
+  theme: unknown;
+}): {Provider: React.ComponentType<{children: React.ReactNode}>};
+
+function Component({value, settings, ...rest}) {
+  const {Provider} = createContext({
+    settings,
+    theme: rest.theme,
+  });
+  return (
+    <Outer {...rest}>
+      <Provider>
+        <Child value={value} />
+      </Provider>
+    </Outer>
+  );
+}

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -55,7 +55,6 @@ use crate::react_compiler_hir::object_shape::BUILT_IN_ARRAY_ID;
 use crate::react_compiler_hir::object_shape::BUILT_IN_MAP_ID;
 use crate::react_compiler_hir::object_shape::BUILT_IN_SET_ID;
 use crate::react_compiler_hir::object_shape::FunctionSignature;
-use crate::react_compiler_hir::object_shape::HookKind;
 use crate::react_compiler_hir::type_config::AliasingEffectConfig;
 use crate::react_compiler_hir::type_config::AliasingSignatureConfig;
 use crate::react_compiler_hir::type_config::ApplyArgConfig;
@@ -163,15 +162,12 @@ pub fn infer_mutation_aliasing_effects(
     queue(&mut queued_states, &states_by_block, func.body.entry, initial_state);
 
     let hoisted_context_declarations = find_hoisted_context_declarations(func, env);
-    let non_mutating_spreads = find_non_mutated_destructure_spreads(func, env);
-
     let mut context = Context {
         interned_effects: FxHashMap::default(),
         instruction_signature_cache: FxHashMap::default(),
         catch_handlers: FxHashMap::default(),
         is_function_expression,
         hoisted_context_declarations,
-        non_mutating_spreads,
         effect_value_id_cache: FxHashMap::default(),
         function_values: FxHashMap::default(),
         function_signature_cache: FxHashMap::default(),
@@ -688,7 +684,6 @@ struct Context {
     catch_handlers: FxHashMap<BlockId, Place>,
     is_function_expression: bool,
     hoisted_context_declarations: FxHashMap<DeclarationId, Option<Place>>,
-    non_mutating_spreads: FxHashSet<IdentifierId>,
     /// Cache of ValueIds keyed by effect key, ensuring stable allocation-site identity
     /// across fixpoint iterations. Mirrors TS `effectInstructionValueCache`.
     effect_value_id_cache: FxHashMap<EffectKey, ValueId>,
@@ -997,124 +992,6 @@ fn find_hoisted_context_declarations(
         }
     }
     hoisted
-}
-
-fn find_non_mutated_destructure_spreads(
-    func: &HirFunction,
-    env: &Environment,
-) -> FxHashSet<IdentifierId> {
-    let mut known_frozen: FxHashSet<IdentifierId> = FxHashSet::default();
-    if func.fn_type == ReactFunctionType::Component {
-        if let Some(ParamPattern::Place(p)) = func.params.first() {
-            known_frozen.insert(p.identifier);
-        }
-    } else {
-        for param in &func.params {
-            if let ParamPattern::Place(p) = param {
-                known_frozen.insert(p.identifier);
-            }
-        }
-    }
-
-    let mut candidate_non_mutating_spreads: FxHashMap<IdentifierId, IdentifierId> =
-        FxHashMap::default();
-    for (_block_id, block) in &func.body.blocks {
-        if !candidate_non_mutating_spreads.is_empty() {
-            for phi in &block.phis {
-                for (_, operand) in &phi.operands {
-                    if let Some(spread) =
-                        candidate_non_mutating_spreads.get(&operand.identifier).copied()
-                    {
-                        candidate_non_mutating_spreads.remove(&spread);
-                    }
-                }
-            }
-        }
-        for instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.index()];
-            let lvalue_id = instr.lvalue.identifier;
-            match &instr.value {
-                InstructionValue::Destructure { lvalue, value, .. } => {
-                    if !known_frozen.contains(&value.identifier) {
-                        continue;
-                    }
-                    if !(lvalue.kind == InstructionKind::Let
-                        || lvalue.kind == InstructionKind::Const)
-                    {
-                        continue;
-                    }
-                    match &lvalue.pattern {
-                        Pattern::Object(obj_pat) => {
-                            for prop in &obj_pat.properties {
-                                if let ObjectPropertyOrSpread::Spread(s) = prop {
-                                    candidate_non_mutating_spreads
-                                        .insert(s.place.identifier, s.place.identifier);
-                                }
-                            }
-                        }
-                        _ => continue,
-                    }
-                }
-                InstructionValue::LoadLocal { place, .. } => {
-                    if let Some(spread) =
-                        candidate_non_mutating_spreads.get(&place.identifier).copied()
-                    {
-                        candidate_non_mutating_spreads.insert(lvalue_id, spread);
-                    }
-                }
-                InstructionValue::StoreLocal { lvalue: sl, value: sv, .. } => {
-                    if let Some(spread) =
-                        candidate_non_mutating_spreads.get(&sv.identifier).copied()
-                    {
-                        candidate_non_mutating_spreads.insert(lvalue_id, spread);
-                        candidate_non_mutating_spreads.insert(sl.place.identifier, spread);
-                    }
-                }
-                InstructionValue::JsxFragment { .. } | InstructionValue::JsxExpression { .. } => {
-                    // Passing objects created with spread to jsx can't mutate them
-                }
-                InstructionValue::PropertyLoad { .. } => {
-                    // Properties must be frozen since the original value was frozen
-                }
-                InstructionValue::CallExpression { callee, .. }
-                | InstructionValue::MethodCall { property: callee, .. } => {
-                    let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
-                    if get_hook_kind_for_type(env, callee_ty).ok().flatten().is_some() {
-                        if !is_ref_or_ref_value_for_id(env, lvalue_id) {
-                            known_frozen.insert(lvalue_id);
-                        }
-                    } else if !candidate_non_mutating_spreads.is_empty() {
-                        for operand in visitors::each_instruction_value_operand(&instr.value, env) {
-                            if let Some(spread) =
-                                candidate_non_mutating_spreads.get(&operand.identifier).copied()
-                            {
-                                candidate_non_mutating_spreads.remove(&spread);
-                            }
-                        }
-                    }
-                }
-                _ => {
-                    if !candidate_non_mutating_spreads.is_empty() {
-                        for operand in visitors::each_instruction_value_operand(&instr.value, env) {
-                            if let Some(spread) =
-                                candidate_non_mutating_spreads.get(&operand.identifier).copied()
-                            {
-                                candidate_non_mutating_spreads.remove(&spread);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    let mut non_mutating: FxHashSet<IdentifierId> = FxHashSet::default();
-    for (key, value) in &candidate_non_mutating_spreads {
-        if key == value {
-            non_mutating.insert(*key);
-        }
-    }
-    non_mutating
 }
 
 // =============================================================================
@@ -2255,16 +2132,10 @@ fn compute_signature_for_instruction(
                         }
                     }
                     PatternItem::Spread(place) => {
-                        let value_kind = if context.non_mutating_spreads.contains(&place.identifier)
-                        {
-                            ValueKind::Frozen
-                        } else {
-                            ValueKind::Mutable
-                        };
                         effects.push(AliasingEffect::Create {
                             into: place.clone(),
                             reason: ValueReason::Other,
-                            value: value_kind,
+                            value: ValueKind::Mutable,
                         });
                         effects.push(AliasingEffect::Capture {
                             from: dest_value.clone(),
@@ -3192,13 +3063,6 @@ fn get_function_call_signature(
 fn is_ref_or_ref_value_for_id(env: &Environment, id: IdentifierId) -> bool {
     let ty = &env.types[env.identifiers[id].type_];
     is_ref_or_ref_value(ty)
-}
-
-fn get_hook_kind_for_type<'a>(
-    env: &'a Environment,
-    ty: &Type,
-) -> Result<Option<&'a HookKind>, OxcDiagnostic> {
-    env.get_hook_kind_for_type(ty)
 }
 
 /// Format a Type for printPlace-style output, matching TS's `printType()`.

--- a/crates/oxc_react_compiler/tests/snapshots/destructure-rest-jsx-only.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/destructure-rest-jsx-only.snap
@@ -1,0 +1,29 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/destructure-rest-jsx-only.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+function Component(t0) {
+	const $ = _c(6);
+	let rest;
+	let value;
+	if ($[0] !== t0) {
+		({value, ...rest} = t0);
+		$[0] = t0;
+		$[1] = rest;
+		$[2] = value;
+	} else {
+		rest = $[1];
+		value = $[2];
+	}
+	let t1;
+	if ($[3] !== rest || $[4] !== value) {
+		t1 = <Child {...rest} value={value} />;
+		$[3] = rest;
+		$[4] = value;
+		$[5] = t1;
+	} else {
+		t1 = $[5];
+	}
+	return t1;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/merge-consecutive-scopes-destructure-call.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/merge-consecutive-scopes-destructure-call.snap
@@ -1,0 +1,64 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/merge-consecutive-scopes-destructure-call.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+declare function createContext(options: {
+	settings: unknown;
+	theme: unknown;
+}): {
+	Provider: React.ComponentType<{
+		children: React.ReactNode;
+	}>;
+};
+function Component(t0) {
+	const $ = _c(12);
+	let rest;
+	let t1;
+	let value;
+	if ($[0] !== t0) {
+		const { value: t2, settings, ...t3 } = t0;
+		value = t2;
+		rest = t3;
+		t1 = createContext({
+			settings,
+			theme: rest.theme
+		});
+		$[0] = t0;
+		$[1] = rest;
+		$[2] = t1;
+		$[3] = value;
+	} else {
+		rest = $[1];
+		t1 = $[2];
+		value = $[3];
+	}
+	const { Provider } = t1;
+	let t2;
+	if ($[4] !== value) {
+		t2 = <Child value={value} />;
+		$[4] = value;
+		$[5] = t2;
+	} else {
+		t2 = $[5];
+	}
+	let t3;
+	if ($[6] !== Provider || $[7] !== t2) {
+		t3 = <Provider>{t2}</Provider>;
+		$[6] = Provider;
+		$[7] = t2;
+		$[8] = t3;
+	} else {
+		t3 = $[8];
+	}
+	let t4;
+	if ($[9] !== rest || $[10] !== t3) {
+		t4 = <Outer {...rest}>{t3}</Outer>;
+		$[9] = rest;
+		$[10] = t3;
+		$[11] = t4;
+	} else {
+		t4 = $[11];
+	}
+	return t4;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/nonmutated-spread-hook-return.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/nonmutated-spread-hook-return.snap
@@ -7,19 +7,20 @@ import { identity, Stringify, useIdentity } from "shared-runtime";
 function Component(props) {
 	const $ = _c(6);
 	const t0 = useIdentity(props);
-	let rest;
 	let x;
+	let z;
 	if ($[0] !== t0) {
-		({x, ...rest} = t0);
+		const { x: t1, ...rest } = t0;
+		x = t1;
+		z = rest.z;
+		identity(z);
 		$[0] = t0;
-		$[1] = rest;
-		$[2] = x;
+		$[1] = x;
+		$[2] = z;
 	} else {
-		rest = $[1];
-		x = $[2];
+		x = $[1];
+		z = $[2];
 	}
-	const z = rest.z;
-	identity(z);
 	let t1;
 	if ($[3] !== x || $[4] !== z) {
 		t1 = <Stringify x={x} z={z} />;

--- a/crates/oxc_react_compiler/tests/snapshots/nonmutated-spread-props-local-indirection.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/nonmutated-spread-props-local-indirection.snap
@@ -6,20 +6,21 @@ import { c as _c } from "react/compiler-runtime";
 import { identity, Stringify } from "shared-runtime";
 function Component(t0) {
 	const $ = _c(6);
-	let rest;
 	let x;
+	let z;
 	if ($[0] !== t0) {
-		({x, ...rest} = t0);
+		const { x: t1, ...rest } = t0;
+		x = t1;
+		const restAlias = rest;
+		z = restAlias.z;
+		identity(z);
 		$[0] = t0;
-		$[1] = rest;
-		$[2] = x;
+		$[1] = x;
+		$[2] = z;
 	} else {
-		rest = $[1];
-		x = $[2];
+		x = $[1];
+		z = $[2];
 	}
-	const restAlias = rest;
-	const z = restAlias.z;
-	identity(z);
 	let t1;
 	if ($[3] !== x || $[4] !== z) {
 		t1 = <Stringify x={x} z={z} />;

--- a/crates/oxc_react_compiler/tests/snapshots/nonmutated-spread-props.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/nonmutated-spread-props.snap
@@ -6,19 +6,20 @@ import { c as _c } from "react/compiler-runtime";
 import { identity, Stringify } from "shared-runtime";
 function Component(t0) {
 	const $ = _c(6);
-	let rest;
 	let x;
+	let z;
 	if ($[0] !== t0) {
-		({x, ...rest} = t0);
+		const { x: t1, ...rest } = t0;
+		x = t1;
+		z = rest.z;
+		identity(z);
 		$[0] = t0;
-		$[1] = rest;
-		$[2] = x;
+		$[1] = x;
+		$[2] = z;
 	} else {
-		rest = $[1];
-		x = $[2];
+		x = $[1];
+		z = $[2];
 	}
-	const z = rest.z;
-	identity(z);
 	let t1;
 	if ($[3] !== x || $[4] !== z) {
 		t1 = <Stringify x={x} z={z} />;


### PR DESCRIPTION
Align object-rest aliasing with `babel-plugin-react-compiler` 1.0.0 so dependent calls stay in the same reactive scope. The later frozen-spread shortcut broke the alias chain and allocated extra memo-cache slots.

Adds reduced TSX fixtures for the merged scope and JSX-only control.

## Validation

- `cargo test -p oxc_react_compiler`
- `cargo clippy -p oxc_react_compiler --all-targets -- -D warnings`
- 69 NAPI transform checks
- exact Babel parity for the Kibana reproduction (`_c(24)`) and all five affected fixtures
- `just ready` formatting/check passed; the workspace run reached an unrelated oxlint ANSI-color snapshot mismatch

AI-assisted: Codex helped reduce, implement, and validate this change.
