### PR TITLE
fix(react_compiler): preserve using declarations

### DIFF
--- a/crates/oxc_react_compiler/fixtures/using-declaration-skips-only-that-function.tsx
+++ b/crates/oxc_react_compiler/fixtures/using-declaration-skips-only-that-function.tsx
@@ -1,6 +1,4 @@
-// `using`/`await using` disposal semantics aren't preserved yet, so `WithUsing` is
-// skipped and emitted unchanged, while the structurally identical `Clean` component
-// in the same file is still compiled.
+// A resource declaration is preserved while the component's memoizable work is compiled.
 function WithUsing(props) {
   using resource = props.acquire();
   return <div onClick={() => props.onClick()}>{props.text}</div>;

--- a/crates/oxc_react_compiler/fixtures/using-declarations-preserve-disposal.tsx
+++ b/crates/oxc_react_compiler/fixtures/using-declarations-preserve-disposal.tsx
@@ -1,0 +1,39 @@
+class Disposer {
+  [Symbol.dispose]() {}
+}
+
+class AsyncDisposer {
+  async [Symbol.asyncDispose]() {}
+}
+
+export function UnusedResource() {
+  using resource = new Disposer();
+  return <p>hello world</p>;
+}
+
+export async function AwaitUsingResource(props) {
+  await using resource = await props.acquire();
+  return <p>{props.text}</p>;
+}
+
+export function UsedResource(props) {
+  using resource = props.resource;
+  return <button onClick={() => resource.use()}>{props.text}</button>;
+}
+
+export function BlockScopedResource(props) {
+  if (props.enabled) {
+    using resource = props.acquire();
+    if (props.early) {
+      return <p>{resource.value}</p>;
+    }
+  }
+  return <p>{props.text}</p>;
+}
+
+export function ForUsingResource(props) {
+  for (using resource of props.resources) {
+    resource.use();
+  }
+  return <p>{props.text}</p>;
+}

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -162,9 +162,8 @@ fn run_pipeline<'a>(
         return Ok(Err(env.take_invariant_errors()));
     }
 
-    // Lowering flags this when the function uses `using`/`await using`, whose disposal
-    // semantics aren't preserved yet. Skip compiling it silently — no diagnostic — so
-    // other functions in the file still compile.
+    // Lowering flags unsupported runtime declarations. Skip compiling the function
+    // silently — no diagnostic — so other functions in the file still compile.
     if env.skip_compilation {
         return Ok(Ok(None));
     }

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -1139,8 +1139,8 @@ fn process_fn<'a>(
             }
             Ok(None)
         }
-        // Lowering silently declined to compile this function (e.g. it uses
-        // `using`/`await using`); nothing to emit, and no diagnostic.
+        // Lowering silently declined to compile this function; nothing to emit,
+        // and no diagnostic.
         Ok(None) => Ok(None),
         Ok(Some(codegen_fn)) => {
             // Functions opted out via directive are skipped; nothing to emit.

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -59,10 +59,14 @@ pub struct Environment<'a> {
     pub errors: Diagnostics,
 
     // Set during lowering when the function uses syntax the compiler can't handle
-    // yet (currently `using`/`await using`, whose disposal semantics aren't
-    // preserved). Signals the pipeline to skip compiling this function silently —
-    // no diagnostic — while other functions in the file still compile.
+    // yet. Signals the pipeline to skip compiling this function silently — no
+    // diagnostic — while other functions in the file still compile.
     pub skip_compilation: bool,
+
+    /// Resource-management bindings keyed by their stable declaration ID.
+    /// SSA versions retain the declaration ID, allowing codegen and DCE to
+    /// preserve `using` / `await using` after the normal `const`-like analysis.
+    resource_declarations: FxHashMap<DeclarationId, ResourceDeclarationKind>,
 
     // Function type classification (Component, Hook, Other)
     pub fn_type: ReactFunctionType,
@@ -181,6 +185,7 @@ impl<'a> Environment<'a> {
             functions: IndexVec::new(),
             errors: Diagnostics::new(),
             skip_compilation: false,
+            resource_declarations: FxHashMap::default(),
             fn_type: ReactFunctionType::Other,
             output_mode: OutputMode::Client,
             instrument_fn_name: None,
@@ -241,6 +246,30 @@ impl<'a> Environment<'a> {
             span: None,
         });
         id
+    }
+
+    pub fn register_resource_declaration(
+        &mut self,
+        declaration_id: DeclarationId,
+        kind: ResourceDeclarationKind,
+    ) {
+        self.resource_declarations.insert(declaration_id, kind);
+    }
+
+    pub fn has_resource_declarations(&self) -> bool {
+        !self.resource_declarations.is_empty()
+    }
+
+    pub fn resource_declaration_kind(
+        &self,
+        identifier_id: IdentifierId,
+    ) -> Option<ResourceDeclarationKind> {
+        let declaration_id = self.identifiers[identifier_id].declaration_id;
+        self.resource_declarations.get(&declaration_id).copied()
+    }
+
+    pub fn is_resource_declaration(&self, identifier_id: IdentifierId) -> bool {
+        self.has_resource_declarations() && self.resource_declaration_kind(identifier_id).is_some()
     }
 
     /// Allocate a new ReactiveScope in the arena, returns its ScopeId.

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -497,6 +497,16 @@ pub enum InstructionKind {
     Function,
 }
 
+/// Disposal mode for an explicit resource-management declaration.
+///
+/// The core HIR treats the binding itself like a `const`, while this metadata
+/// preserves the declaration's runtime disposal semantics for codegen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResourceDeclarationKind {
+    Sync,
+    Async,
+}
+
 #[derive(Debug, Clone)]
 pub struct LValue {
     pub place: Place,

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -6370,14 +6370,11 @@ fn lower_variable_declaration<'a>(
         )?;
         // Treat `var` as `let` so references to the variable don't break
     }
-    if matches!(var_decl.kind, VK::Using | VK::AwaitUsing) {
-        // `using`/`await using` disposal semantics aren't preserved yet. Flag the
-        // function to be skipped (silently, no diagnostic) once lowering finishes,
-        // rather than miscompiling it. It's still lowered as `const` below so the HIR
-        // stays valid until the pipeline checks the flag. Other functions in the file
-        // are unaffected.
-        builder.environment_mut().skip_compilation = true;
-    }
+    let resource_kind = match var_decl.kind {
+        VK::Using => Some(ResourceDeclarationKind::Sync),
+        VK::AwaitUsing => Some(ResourceDeclarationKind::Async),
+        _ => None,
+    };
     let kind = match var_decl.kind {
         VK::Let | VK::Var => InstructionKind::Let,
         VK::Const | VK::Using | VK::AwaitUsing => InstructionKind::Const,
@@ -6399,6 +6396,17 @@ fn lower_variable_declaration<'a>(
                 value,
                 assign_style,
             )?;
+            if let Some(resource_kind) = resource_kind
+                && let oxc::BindingPattern::BindingIdentifier(id) = &declarator.id
+                && let Some(symbol_id) = builder.scope().resolve_binding_identifier(id)
+            {
+                let identifier =
+                    builder.resolve_binding_with_span(id.name, symbol_id, Some(id.span))?;
+                let declaration_id = builder.environment().identifiers[identifier].declaration_id;
+                builder
+                    .environment_mut()
+                    .register_resource_declaration(declaration_id, resource_kind);
+            }
         } else if let oxc::BindingPattern::BindingIdentifier(id) = &declarator.id {
             // No init: emit DeclareLocal or DeclareContext
             let id_span = id.span;
@@ -6488,6 +6496,14 @@ fn lower_for_in_of_left<'a>(
 ) -> Result<Option<Place>, OxcDiagnostic> {
     match left {
         oxc::ForStatementLeft::VariableDeclaration(var_decl) => {
+            if matches!(
+                var_decl.kind,
+                oxc::VariableDeclarationKind::Using | oxc::VariableDeclarationKind::AwaitUsing
+            ) {
+                // A for-of resource binding is disposed after every iteration,
+                // which the HIR's generic loop assignment cannot represent yet.
+                builder.environment_mut().skip_compilation = true;
+            }
             if var_decl.declarations.len() != 1 {
                 builder.record_error(
                     ErrorCategory::Invariant

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
@@ -157,7 +157,8 @@ fn find_referenced_identifiers<'a>(func: &HirFunction<'a>, env: &Environment<'a>
                     if let InstructionValue::StoreLocal { lvalue, value, .. } = &instr.value {
                         // If this is a Let/Const declaration, mark the initializer as referenced
                         // only if the SSA'd lval is also referenced
-                        if lvalue.kind == InstructionKind::Reassign
+                        if env.is_resource_declaration(lvalue.place.identifier)
+                            || lvalue.kind == InstructionKind::Reassign
                             || is_id_used(&state, lvalue.place.identifier)
                         {
                             reference(&mut state, &env.identifiers, value.identifier);
@@ -252,6 +253,7 @@ fn rewrite_instruction(
         }
         InstructionValue::StoreLocal { lvalue, span, .. }
             if lvalue.kind != InstructionKind::Reassign
+                && !env.is_resource_declaration(lvalue.place.identifier)
                 && !is_id_used(state, lvalue.place.identifier) =>
         {
             // This is a const/let declaration where the variable is accessed later,
@@ -273,6 +275,9 @@ fn pruneable_value(value: &InstructionValue, state: &State, env: &Environment) -
             !is_id_or_name_used(state, &env.identifiers, lvalue.place.identifier)
         }
         InstructionValue::StoreLocal { lvalue, .. } => {
+            if env.is_resource_declaration(lvalue.place.identifier) {
+                return false;
+            }
             if lvalue.kind == InstructionKind::Reassign {
                 // Reassignments can be pruned if the specific instance being assigned is never read
                 !is_id_used(state, lvalue.place.identifier)

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -35,6 +35,7 @@ use crate::react_compiler_hir::Place;
 use crate::react_compiler_hir::PlaceOrSpread;
 use crate::react_compiler_hir::PrimitiveValue;
 use crate::react_compiler_hir::PropertyLiteral;
+use crate::react_compiler_hir::ResourceDeclarationKind;
 use crate::react_compiler_hir::ScopeId;
 use crate::react_compiler_hir::TypeCast;
 use crate::react_compiler_hir::environment::{Environment, OutputMode};
@@ -1403,7 +1404,19 @@ fn ox_emit_store<'a>(
                 ));
             }
             let lval = ox_codegen_lvalue(cx, lvalue)?;
-            Ok(Some(ox_make_var_decl(cx, oxc::VariableDeclarationKind::Const, lval, value)))
+            let declaration_kind = match lvalue {
+                LvalueRef::Place(place) => {
+                    match cx.env.resource_declaration_kind(place.identifier) {
+                        Some(ResourceDeclarationKind::Sync) => oxc::VariableDeclarationKind::Using,
+                        Some(ResourceDeclarationKind::Async) => {
+                            oxc::VariableDeclarationKind::AwaitUsing
+                        }
+                        None => oxc::VariableDeclarationKind::Const,
+                    }
+                }
+                LvalueRef::Pattern(_) => oxc::VariableDeclarationKind::Const,
+            };
+            Ok(Some(ox_make_var_decl(cx, declaration_kind, lval, value)))
         }
         InstructionKind::Function => {
             let lval = ox_codegen_lvalue(cx, lvalue)?;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
@@ -24,7 +24,8 @@ use crate::react_compiler_hir::{
 };
 
 use crate::react_compiler_reactive_scopes::visitors::{
-    ReactiveFunctionTransform, Transformed, transform_reactive_function,
+    ReactiveFunctionTransform, ReactiveFunctionVisitor, Transformed, transform_reactive_function,
+    visit_reactive_function,
 };
 
 /// Prunes scopes that always invalidate because they depend on unmemoized
@@ -34,17 +35,49 @@ pub fn prune_always_invalidating_scopes<'a>(
     func: &mut ReactiveFunction<'a>,
     env: &Environment<'a>,
 ) -> Result<(), OxcDiagnostic> {
+    let mut resource_initializers = FxHashSet::default();
+    if env.has_resource_declarations() {
+        visit_reactive_function(
+            func,
+            &ResourceInitializerCollector { env },
+            &mut resource_initializers,
+        );
+    }
     let mut transform = Transform {
         env,
-        always_invalidating_values: FxHashSet::default(),
-        unmemoized_values: FxHashSet::default(),
+        resource_initializer_values: resource_initializers.clone(),
+        always_invalidating_values: resource_initializers.clone(),
+        unmemoized_values: resource_initializers,
     };
     let mut state = false; // withinScope
     transform_reactive_function(func, &mut transform, &mut state)
 }
 
+struct ResourceInitializerCollector<'a, 'e> {
+    env: &'e Environment<'a>,
+}
+
+impl<'a, 'e> ReactiveFunctionVisitor<'a> for ResourceInitializerCollector<'a, 'e> {
+    type State = FxHashSet<IdentifierId>;
+
+    fn env(&self) -> &Environment<'a> {
+        self.env
+    }
+
+    fn visit_instruction(&self, instruction: &ReactiveInstruction<'a>, state: &mut Self::State) {
+        if let ReactiveValue::Instruction(InstructionValue::StoreLocal { value, lvalue, .. }) =
+            &instruction.value
+            && self.env.is_resource_declaration(lvalue.place.identifier)
+        {
+            state.insert(value.identifier);
+        }
+        self.traverse_instruction(instruction, state);
+    }
+}
+
 struct Transform<'a, 'e> {
     env: &'e Environment<'a>,
+    resource_initializer_values: FxHashSet<IdentifierId>,
     always_invalidating_values: FxHashSet<IdentifierId>,
     unmemoized_values: FxHashSet<IdentifierId>,
 }
@@ -84,6 +117,15 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                 lvalue: store_lvalue,
                 ..
             }) => {
+                if self.env.is_resource_declaration(store_lvalue.place.identifier) {
+                    // Resource acquisition and registration must happen on every
+                    // execution of the declaration. Mark both sides so a scope
+                    // producing the initializer cannot memoize it independently.
+                    self.always_invalidating_values.insert(store_value.identifier);
+                    self.always_invalidating_values.insert(store_lvalue.place.identifier);
+                    self.unmemoized_values.insert(store_value.identifier);
+                    self.unmemoized_values.insert(store_lvalue.place.identifier);
+                }
                 if self.always_invalidating_values.contains(&store_value.identifier) {
                     self.always_invalidating_values.insert(store_lvalue.place.identifier);
                 }
@@ -116,6 +158,17 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
 
         let scope_id = scope.scope;
         let scope_data = &self.env.scopes[scope_id];
+
+        if scope_data.declarations.iter().any(|(_, declaration)| {
+            self.resource_initializer_values.contains(&declaration.identifier)
+        }) {
+            return Ok(Transformed::Replace(ReactiveStatement::PrunedScope(
+                PrunedReactiveScopeBlock {
+                    scope: scope.scope,
+                    instructions: take(&mut scope.instructions),
+                },
+            )));
+        }
 
         for dep in &scope_data.dependencies {
             if self.unmemoized_values.contains(&dep.identifier) {

--- a/crates/oxc_react_compiler/tests/snapshots/using-declaration-skips-only-that-function.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/using-declaration-skips-only-that-function.snap
@@ -3,12 +3,28 @@ source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/using-declaration-skips-only-that-function.tsx
 ---
 import { c as _c } from "react/compiler-runtime";
-// `using`/`await using` disposal semantics aren't preserved yet, so `WithUsing` is
-// skipped and emitted unchanged, while the structurally identical `Clean` component
-// in the same file is still compiled.
+// A resource declaration is preserved while the component's memoizable work is compiled.
 function WithUsing(props) {
+	const $ = _c(5);
 	using resource = props.acquire();
-	return <div onClick={() => props.onClick()}>{props.text}</div>;
+	let t0;
+	if ($[0] !== props) {
+		t0 = () => props.onClick();
+		$[0] = props;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	let t1;
+	if ($[2] !== props.text || $[3] !== t0) {
+		t1 = <div onClick={t0}>{props.text}</div>;
+		$[2] = props.text;
+		$[3] = t0;
+		$[4] = t1;
+	} else {
+		t1 = $[4];
+	}
+	return t1;
 }
 function Clean(props) {
 	const $ = _c(5);

--- a/crates/oxc_react_compiler/tests/snapshots/using-declarations-preserve-disposal.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/using-declarations-preserve-disposal.snap
@@ -1,0 +1,75 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/using-declarations-preserve-disposal.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+class Disposer {
+	[Symbol.dispose]() {}
+}
+class AsyncDisposer {
+	async [Symbol.asyncDispose]() {}
+}
+export function UnusedResource() {
+	const $ = _c(1);
+	using resource = new Disposer();
+	let t0;
+	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		t0 = <p>hello world</p>;
+		$[0] = t0;
+	} else {
+		t0 = $[0];
+	}
+	return t0;
+}
+export async function AwaitUsingResource(props) {
+	const $ = _c(2);
+	await using resource = await props.acquire();
+	let t0;
+	if ($[0] !== props.text) {
+		t0 = <p>{props.text}</p>;
+		$[0] = props.text;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}
+export function UsedResource(props) {
+	const $ = _c(3);
+	using resource = props.resource;
+	const t0 = () => resource.use();
+	let t1;
+	if ($[0] !== props.text || $[1] !== t0) {
+		t1 = <button onClick={t0}>{props.text}</button>;
+		$[0] = props.text;
+		$[1] = t0;
+		$[2] = t1;
+	} else {
+		t1 = $[2];
+	}
+	return t1;
+}
+export function BlockScopedResource(props) {
+	const $ = _c(2);
+	if (props.enabled) {
+		using resource = props.acquire();
+		if (props.early) {
+			return <p>{resource.value}</p>;
+		}
+	}
+	let t0;
+	if ($[0] !== props.text) {
+		t0 = <p>{props.text}</p>;
+		$[0] = props.text;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}
+export function ForUsingResource(props) {
+	for (using resource of props.resources) {
+		resource.use();
+	}
+	return <p>{props.text}</p>;
+}

--- a/crates/oxc_react_compiler/tests/transform.rs
+++ b/crates/oxc_react_compiler/tests/transform.rs
@@ -289,21 +289,46 @@ function Component(props) {\n\
 }
 
 #[test]
-fn resource_management_declarations_bail_out() {
+fn resource_management_declarations_preserve_their_kind() {
     let cases = [
-        "\
+        (
+            "\
 function Component(props) {\n  using x = sideEffect();\n  return <div>{props.text}</div>;\n}\n",
-        "\
-async function Component(props) {\n  await using x = sideEffect();\n  return <div>{props.text}</div>;\n}\n",
+            "using x = sideEffect();",
+        ),
+        (
+            "\
+async function Component(props) {\n  await using x = await sideEffect();\n  return <div>{props.text}</div>;\n}\n",
+            "await using x = await sideEffect();",
+        ),
     ];
 
-    for source in cases {
+    for (source, expected_declaration) in cases {
         let allocator = Allocator::default();
-        let (_program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
+        let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
 
-        assert!(!result.changed, "resource management should skip React Compiler");
+        assert!(result.changed, "resource management should compile");
         assert!(result.diagnostics.is_empty(), "unexpected diagnostics: {:?}", result.diagnostics);
+        let output = Codegen::new().build(&program).code;
+        assert!(
+            output.contains(expected_declaration),
+            "resource declaration kind was not preserved:\n{output}"
+        );
+        assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
     }
+}
+
+#[test]
+fn for_using_declarations_bail_out() {
+    let source = "\
+function Component(props) {\n  for (using x of props.resources) {\n    x.use();\n  }\n  return <div>{props.text}</div>;\n}\n";
+    let allocator = Allocator::default();
+    let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
+
+    assert!(!result.changed, "for-using disposal is not represented by HIR yet");
+    assert!(result.diagnostics.is_empty(), "unexpected diagnostics: {:?}", result.diagnostics);
+    let output = Codegen::new().build(&program).code;
+    assert!(output.contains("for (using x of props.resources)"), "for-using changed:\n{output}");
 }
 
 #[test]

--- a/crates/oxc_transformer/tests/integrations/react_compiler.rs
+++ b/crates/oxc_transformer/tests/integrations/react_compiler.rs
@@ -26,6 +26,28 @@ fn memoizes_component_through_transformer() {
     assert!(code.contains("_c("), "component was not memoized:\n{code}");
 }
 
+#[test]
+fn preserves_resource_disposal_through_transformer() {
+    let allocator = Allocator::default();
+    let source = "class Disposer { [Symbol.dispose]() {} }\n\
+        export function Page() {\n  using resource = new Disposer();\n  return <p>hello world</p>;\n}\n";
+    let mut program = Parser::new(&allocator, source, SourceType::tsx()).parse().program;
+    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+
+    let options =
+        TransformOptions { react_compiler: Some(PluginOptions::default()), ..Default::default() };
+    let ret = Transformer::new(&allocator, Path::new("page.tsx"), &options)
+        .build_with_scoping(scoping, &mut program);
+    assert!(ret.diagnostics.is_empty(), "{:?}", ret.diagnostics);
+
+    let code = Codegen::new().build(&program).code;
+    assert!(code.contains("_c(1)"), "component was not memoized:\n{code}");
+    assert!(
+        code.contains("using resource = new Disposer()"),
+        "resource disposal was not preserved:\n{code}"
+    );
+}
+
 /// An import referenced only through a computed key (`{ [NAME]: … }`) inside a
 /// memoized block must survive. The compiler hoists the object into a cache slot;
 /// the computed key has to stay an identifier *reference* so semantic analysis


### PR DESCRIPTION
Preserves `using` and `await using` through React Compiler optimization without memoizing resource acquisition. `for (using ... of ...)` remains a per-function bailout until HIR can represent disposal per iteration.

AI assistance was used; the implementation, generated output, and snapshots were manually reviewed.

## Validation

- `cargo test -p oxc_react_compiler`
- `cargo test -p oxc_transformer --features react_compiler`
- Clippy with warnings denied for both crates
- 69 NAPI transform checks
- Direct Babel comparison and runtime disposal probes
