### PR TITLE
fix(minifier): avoid reordering this before super

### DIFF
--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -120,7 +120,7 @@ impl<'a> PeepholeOptimizations {
         // `body_unsafe` is set by a preceding non-declarative statement, and the
         // program root additionally starts unsafe when the module has loaders
         // (see `enter_program`) — so this one check covers the cyclic-import gate.
-        let &(body_scope, body_unsafe) = ctx.state.body_unsafe_stack.last();
+        let &(body_scope, body_unsafe, _) = ctx.state.body_unsafe_stack.last();
         if body_unsafe || ctx.current_scope_id() != body_scope {
             return false;
         }

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -556,18 +556,6 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    /// Whether an expression is or contains a `super()` call at the top level
-    /// (i.e., in a sequence expression, but not nested inside conditionals/functions).
-    fn expression_contains_super_call(expr: &Expression<'a>) -> bool {
-        match expr {
-            _ if expr.is_super_call_expression() => true,
-            Expression::SequenceExpression(seq) => {
-                seq.expressions.iter().any(Expression::is_super_call_expression)
-            }
-            _ => false,
-        }
-    }
-
     fn handle_expression_statement(
         mut expr_stmt: ArenaBox<'a, ExpressionStatement<'a>>,
         result: &mut ArenaVec<'a, Statement<'a>>,

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -124,10 +124,26 @@ impl<'a> PeepholeOptimizations {
     /// prelude. No-op if the flag is already set, or if `current_scope_id` is
     /// some inner scope (a block/for/etc.) — those don't end the prelude.
     fn mark_current_body_unsafe(ctx: &mut TraverseCtx<'a>) {
-        let &(body_scope, body_unsafe) = ctx.state.body_unsafe_stack.last();
+        let &(body_scope, body_unsafe, _) = ctx.state.body_unsafe_stack.last();
         if !body_unsafe && body_scope == ctx.current_scope_id() {
             ctx.state.body_unsafe_stack.last_mut().1 = true;
         }
+    }
+
+    /// End offset of the first unconditional `super()` call in an expression.
+    /// A sequence remains unconditional, but nested conditionals and functions do not.
+    fn unconditional_super_call_end(expr: &Expression<'a>) -> Option<u32> {
+        match expr {
+            Expression::CallExpression(call) if call.callee.is_super() => Some(call.span.end),
+            Expression::SequenceExpression(seq) => {
+                seq.expressions.iter().find_map(Self::unconditional_super_call_end)
+            }
+            _ => None,
+        }
+    }
+
+    fn expression_contains_super_call(expr: &Expression<'a>) -> bool {
+        Self::unconditional_super_call_end(expr).is_some()
     }
 
     /// Checks if a member expression's base object may be mutated.
@@ -231,7 +247,18 @@ impl<'a> PeepholeOptimizations {
     fn member_part_blocks_reorder(expr: &Expression<'a>, ctx: &TraverseCtx<'a>) -> bool {
         match expr {
             Expression::Identifier(id) => Self::identifier_read_blocks_reorder(id, ctx),
-            Expression::ThisExpression(_) => false,
+            Expression::ThisExpression(this_expr) => {
+                // Source offsets stand in for execution order here. This assumes upstream
+                // transforms do not reorder `super()` and `this` without updating their spans;
+                // the current Rolldown and oxc-minify pipelines satisfy this assumption.
+                Self::this_is_inside_derived_constructor(ctx)
+                    && ctx
+                        .state
+                        .body_unsafe_stack
+                        .last()
+                        .2
+                        .is_none_or(|initialized_at| this_expr.span.start < initialized_at)
+            }
             _ => true,
         }
     }
@@ -279,13 +306,23 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         // single program-root entry by the next pass; reset it in place rather
         // than reallocating (matching the `reset`/`clear` above).
         *ctx.state.body_unsafe_stack.last_mut() =
-            (ctx.scoping().root_scope_id(), module_has_loaders);
+            (ctx.scoping().root_scope_id(), module_has_loaders, None);
         // `PassChanges` is managed by pass completion, not reset per
         // traversal.
     }
 
-    fn enter_function_body(&mut self, _body: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {
-        ctx.state.body_unsafe_stack.push((ctx.current_scope_id(), false));
+    fn enter_function_body(&mut self, body: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {
+        let initialized_at = if Self::this_is_inside_derived_constructor(ctx) {
+            body.statements.iter().find_map(|stmt| match stmt {
+                Statement::ExpressionStatement(stmt) => {
+                    Self::unconditional_super_call_end(&stmt.expression)
+                }
+                _ => None,
+            })
+        } else {
+            None
+        };
+        ctx.state.body_unsafe_stack.push((ctx.current_scope_id(), false, initialized_at));
     }
 
     fn exit_function_body(&mut self, _body: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -88,15 +88,18 @@ pub struct MinifierState<'a> {
     pub private_member_usage: PrivateMemberUsageStack<'a>,
 
     /// One frame per enclosing function body (program root at the bottom).
-    /// `(body_scope, body_unsafe)`. While `body_unsafe` is false, the next
-    /// `var x = <literal>;` whose declarator sits at `body_scope` is safe to
-    /// inline despite hoisting. A preceding non-declarative statement sets it;
-    /// the program root additionally starts unsafe when the module has any
-    /// loader (`import` / `export … from` / `export * from`), since a cyclic
+    /// `(body_scope, body_unsafe, this_initialized_at)`. While `body_unsafe` is
+    /// false, the next `var x = <literal>;` whose declarator sits at `body_scope`
+    /// is safe to inline despite hoisting. A preceding non-declarative statement
+    /// sets it; the program root additionally starts unsafe when the module has
+    /// any loader (`import` / `export … from` / `export * from`), since a cyclic
     /// importer could observe a not-yet-assigned binding our exports close over.
     /// Pushed by `enter_function_body`, popped by `exit_function_body`. See
-    /// `init_symbol_value`.
-    pub body_unsafe_stack: NonEmptyStack<(ScopeId, bool)>,
+    /// `init_symbol_value`. `this_initialized_at` is the source offset after the
+    /// first unconditional top-level `super()` call, allowing reorder checks to
+    /// distinguish an uninitialized derived-constructor `this` from `this`
+    /// accesses after `super()`.
+    pub body_unsafe_stack: NonEmptyStack<(ScopeId, bool, Option<u32>)>,
 
     /// Per-pass change accumulator populated by typed mutation helpers and
     /// consumed by `compression_pass` after Normalize and every peephole pass.
@@ -120,7 +123,7 @@ impl<'a> MinifierState<'a> {
             config: CompressionConfig { source_type, options, mode },
             symbols,
             private_member_usage: PrivateMemberUsageStack::new(),
-            body_unsafe_stack: NonEmptyStack::new((scoping.root_scope_id(), false)),
+            body_unsafe_stack: NonEmptyStack::new((scoping.root_scope_id(), false, None)),
             pass_changes: PassChanges::new(scoping.references_len(), allocator),
             concat_scratch: String::new(),
         }

--- a/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
@@ -1035,6 +1035,28 @@ fn test_compress_conditional_expression_inside() {
     ); // both outputs `0, 1`
     test("let a = [], i = 0; x ? a[i] = 0 : a[i] = 1", "let a = [], i = 0; a[0] = +!x");
     test("x ? this.b = 0 : this.b = 1", "this.b = +!x");
+    // The assignment target must not move before `super()` initializes `this`.
+    test_same(
+        "class B extends A {
+            constructor() {
+                super() ? this.b = 0 : this.b = 1;
+            }
+        }",
+    );
+    // An unconditional preceding `super()` makes moving the later `this` safe.
+    test(
+        "class B extends A {
+            constructor() {
+                super();
+                x ? this.b = 0 : this.b = 1;
+            }
+        }",
+        "class B extends A {
+            constructor() {
+                super(), this.b = +!x;
+            }
+        }",
+    );
     test(
         "var a = {};
         async function f(p) {


### PR DESCRIPTION
Conditional assignment merging can move a `this` member target ahead of a `super()` condition. In a derived constructor, that rewrites valid source into an access of uninitialized `this`, causing a `ReferenceError`.

Keep reorder-sensitive `this` targets guarded until the first unconditional top-level `super()` call in a derived constructor. This preserves the optimization after `super()` has initialized `this`, including the real-world Terser fixture that caused the earlier size increase.

## Example

Input:

```js
class B extends A {
  constructor() {
    super() ? (this.b = 0) : (this.b = 1);
  }
}
```

Before:

```js
class B extends A{constructor(){this.b=+!super()}}
```

After:

```js
class B extends A{constructor(){super()?this.b=0:this.b=1}}
```

Verified with the full `oxc_minifier` suite (625 passed, 42 ignored), Clippy with warnings denied, formatting, `just minsize`, allocation regeneration, and byte-for-byte comparison of all 12 minsize outputs against `main`. Minsize and allocation snapshots are unchanged.

Addresses the wrong-code issue raised in https://github.com/oxc-project/oxc/pull/24706#discussion_r3614230970.

Implemented with AI assistance (OpenAI Codex). The contributor remains responsible for reviewing, understanding, and submitting the changes under the repository AI usage policy.