### PR TITLE
fix(react_compiler): preserve aliasing diagnostic locations

### DIFF
--- a/crates/oxc_react_compiler/fixtures/error.mutate-props-in-distinct-callbacks.js
+++ b/crates/oxc_react_compiler/fixtures/error.mutate-props-in-distinct-callbacks.js
@@ -1,0 +1,12 @@
+function useMutate(document) {
+  const updateData = useCallback(() => {
+    document.data = {};
+  }, [document]);
+  const updateTitle = useCallback(() => {
+    document.title = '';
+  }, [document]);
+  const updateIcon = useCallback(() => {
+    document.icon = '';
+  }, [document]);
+  return [updateData, updateTitle, updateIcon];
+}

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -40,9 +40,56 @@ pub enum OutputMode {
     Lint,
 }
 
-/// Dedup key for interned aliasing-effect diagnostics: `(place, message, help)`,
-/// matching the effect interning key granularity so identical errors collapse.
+/// Analysis identity for an aliasing-effect diagnostic, matching the effect
+/// interning key granularity so identical errors collapse.
 type AliasingDiagnosticKey = (IdentifierId, Cow<'static, str>, Option<Cow<'static, str>>);
+
+/// Dedup key for the source-specific diagnostic payload. Keeping this separate
+/// from [`AliasingDiagnosticKey`] lets effect interning collapse equivalent
+/// errors without discarding the location selected for the retained effect.
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct AliasingDiagnosticInstanceKey {
+    identity: DiagnosticId,
+    note: Option<Cow<'static, str>>,
+    severity: u8,
+    code_scope: Option<Cow<'static, str>>,
+    code_number: Option<Cow<'static, str>>,
+    url: Option<Cow<'static, str>>,
+    labels: Vec<AliasingDiagnosticLabelKey>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct AliasingDiagnosticLabelKey {
+    offset: u32,
+    len: u32,
+    primary: bool,
+    text: Option<String>,
+}
+
+impl AliasingDiagnosticInstanceKey {
+    fn new(identity: DiagnosticId, diagnostic: &OxcDiagnostic) -> Self {
+        let labels = diagnostic
+            .labels
+            .iter()
+            .map(|label| AliasingDiagnosticLabelKey {
+                offset: label.offset(),
+                len: label.len(),
+                primary: label.primary(),
+                text: label.label().map(str::to_owned),
+            })
+            .collect();
+
+        Self {
+            identity,
+            note: diagnostic.note.clone(),
+            severity: diagnostic.severity as u8,
+            code_scope: diagnostic.code.scope.clone(),
+            code_number: diagnostic.code.number.clone(),
+            url: diagnostic.url.clone(),
+            labels,
+        }
+    }
+}
 
 pub struct Environment<'a> {
     // Arena allocator for the compilation unit. HIR strings (identifier names,
@@ -65,12 +112,13 @@ pub struct Environment<'a> {
     pub errors: Diagnostics,
 
     // Interned diagnostics for aliasing-effect errors (MutateFrozen/MutateGlobal/
-    // Impure). Those effects store a `DiagnosticId` into this table instead of an
-    // owned `OxcDiagnostic`, so `AliasingEffect` stays `Copy`/non-`Drop` and can be
-    // arena-allocated. Deduplicated on (place, message, help) to mirror the effect
-    // interning key. `RefCell` because some effect-building passes hold `&Environment`.
-    aliasing_diagnostics: RefCell<IndexVec<DiagnosticId, OxcDiagnostic>>,
+    // Impure). Analysis identity is deduplicated separately from source-specific
+    // diagnostic instances so effects stay `Copy` without losing their locations.
+    // `RefCell` is needed because some effect-building passes hold `&Environment`.
     aliasing_diagnostic_dedup: RefCell<FxHashMap<AliasingDiagnosticKey, DiagnosticId>>,
+    aliasing_diagnostic_instances: RefCell<IndexVec<DiagnosticInstanceId, OxcDiagnostic>>,
+    aliasing_diagnostic_instance_dedup:
+        RefCell<FxHashMap<AliasingDiagnosticInstanceKey, DiagnosticInstanceId>>,
 
     // Set during lowering when the function uses syntax the compiler can't handle
     // yet (currently `using`/`await using`, whose disposal semantics aren't
@@ -194,8 +242,9 @@ impl<'a> Environment<'a> {
             scopes: IndexVec::new(),
             functions: IndexVec::new(),
             errors: Diagnostics::new(),
-            aliasing_diagnostics: RefCell::new(IndexVec::new()),
             aliasing_diagnostic_dedup: RefCell::new(FxHashMap::default()),
+            aliasing_diagnostic_instances: RefCell::new(IndexVec::new()),
+            aliasing_diagnostic_instance_dedup: RefCell::new(FxHashMap::default()),
             skip_compilation: false,
             fn_type: ReactFunctionType::Other,
             output_mode: OutputMode::Client,
@@ -308,30 +357,46 @@ impl<'a> Environment<'a> {
         self.errors.push(diagnostic);
     }
 
-    /// Intern an aliasing-effect diagnostic into the environment-owned side table,
-    /// returning a `Copy` [`DiagnosticId`]. Deduplicated on (place, message, help) so
-    /// identical errors collapse to one stored diagnostic, matching the effect
-    /// interning key. Takes `&self` (interior mutability) because some effect-building
-    /// passes only hold `&Environment`.
+    /// Intern an aliasing-effect diagnostic into the environment-owned side tables.
+    /// Analysis-equivalent diagnostics share an identity, while source-specific
+    /// instances retain their own labels. Takes `&self` (interior mutability)
+    /// because some effect-building passes only hold `&Environment`.
     pub fn intern_aliasing_diagnostic(
         &self,
         place: IdentifierId,
         diagnostic: OxcDiagnostic,
-    ) -> DiagnosticId {
+    ) -> AliasingDiagnostic {
         let key = (place, diagnostic.message.clone(), diagnostic.help.clone());
-        let mut dedup = self.aliasing_diagnostic_dedup.borrow_mut();
-        if let Some(&id) = dedup.get(&key) {
-            return id;
-        }
-        let id = self.aliasing_diagnostics.borrow().next_idx();
-        self.aliasing_diagnostics.borrow_mut().push(diagnostic);
-        dedup.insert(key, id);
-        id
+        let identity = {
+            let mut dedup = self.aliasing_diagnostic_dedup.borrow_mut();
+            if let Some(&id) = dedup.get(&key) {
+                id
+            } else {
+                let id = DiagnosticId::from_usize(dedup.len());
+                dedup.insert(key, id);
+                id
+            }
+        };
+
+        let key = AliasingDiagnosticInstanceKey::new(identity, &diagnostic);
+        let instance = {
+            let mut dedup = self.aliasing_diagnostic_instance_dedup.borrow_mut();
+            if let Some(&id) = dedup.get(&key) {
+                id
+            } else {
+                let id = self.aliasing_diagnostic_instances.borrow().next_idx();
+                self.aliasing_diagnostic_instances.borrow_mut().push(diagnostic);
+                dedup.insert(key, id);
+                id
+            }
+        };
+
+        AliasingDiagnostic::new(identity, instance)
     }
 
-    /// Clone the interned aliasing-effect diagnostic for `id`, for emission.
-    pub fn aliasing_diagnostic(&self, id: DiagnosticId) -> OxcDiagnostic {
-        self.aliasing_diagnostics.borrow()[id].clone()
+    /// Clone the source-specific aliasing-effect diagnostic for emission.
+    pub fn aliasing_diagnostic(&self, diagnostic: AliasingDiagnostic) -> OxcDiagnostic {
+        self.aliasing_diagnostic_instances.borrow()[diagnostic.instance()].clone()
     }
 
     pub fn has_errors(&self) -> bool {

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -66,9 +66,35 @@ define_nonmax_u32_index_type! {
 }
 
 define_nonmax_u32_index_type! {
-    /// Index into `Environment`'s interned aliasing-effect diagnostics
-    /// (`intern_aliasing_diagnostic` / `aliasing_diagnostic`).
+    /// Stable identity for an aliasing-effect diagnostic's analysis-relevant fields.
     pub struct DiagnosticId;
+}
+
+define_nonmax_u32_index_type! {
+    /// Index into `Environment`'s source-specific aliasing-effect diagnostics.
+    pub struct DiagnosticInstanceId;
+}
+
+/// Separates an aliasing diagnostic's analysis identity from its source-specific
+/// payload. Effect interning uses `identity`, while emission uses `instance`.
+#[derive(Debug, Clone, Copy)]
+pub struct AliasingDiagnostic {
+    identity: DiagnosticId,
+    instance: DiagnosticInstanceId,
+}
+
+impl AliasingDiagnostic {
+    pub(crate) fn new(identity: DiagnosticId, instance: DiagnosticInstanceId) -> Self {
+        Self { identity, instance }
+    }
+
+    pub(crate) fn identity(self) -> DiagnosticId {
+        self.identity
+    }
+
+    pub(crate) fn instance(self) -> DiagnosticInstanceId {
+        self.instance
+    }
 }
 
 impl BlockId {
@@ -1246,6 +1272,8 @@ impl_trivial_clone_in!(
     FunctionId,
     MutableRangeId,
     DiagnosticId,
+    DiagnosticInstanceId,
+    AliasingDiagnostic,
     DeclarationId,
     Place,
     Case,
@@ -1338,14 +1366,14 @@ pub enum AliasingEffect<'a> {
     CreateFunction { captures: ArenaVec<'a, Place>, function_id: FunctionId, into: Place },
     /// Mutation of a value known to be frozen (error).
     ///
-    /// `error` indexes the diagnostic interned on `Environment` (see
-    /// [`DiagnosticId`]); the `OxcDiagnostic` itself is held out-of-band so this
-    /// effect stays `Copy`/non-`Drop` and can be arena-allocated.
-    MutateFrozen { place: Place, error: DiagnosticId },
-    /// Mutation of a global value (error). `error` indexes the interned diagnostic.
-    MutateGlobal { place: Place, error: DiagnosticId },
-    /// Side-effect not safe during render. `error` indexes the interned diagnostic.
-    Impure { place: Place, error: DiagnosticId },
+    /// `error` references the diagnostic interned on `Environment`; the
+    /// `OxcDiagnostic` itself is held out-of-band so this effect stays
+    /// `Copy`/non-`Drop` and can be arena-allocated.
+    MutateFrozen { place: Place, error: AliasingDiagnostic },
+    /// Mutation of a global value (error).
+    MutateGlobal { place: Place, error: AliasingDiagnostic },
+    /// Side-effect not safe during render.
+    Impure { place: Place, error: AliasingDiagnostic },
     /// Value is accessed during render.
     Render { place: Place },
 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -881,10 +881,10 @@ fn effect_key(effect: &AliasingEffect) -> EffectKey {
         AliasingEffect::Impure { place, .. } => EffectKey::Impure { place: place.identifier },
         AliasingEffect::Render { place } => EffectKey::Render { place: place.identifier },
         AliasingEffect::MutateFrozen { place, error } => {
-            EffectKey::MutateFrozen { place: place.identifier, diag: *error }
+            EffectKey::MutateFrozen { place: place.identifier, diag: error.identity() }
         }
         AliasingEffect::MutateGlobal { place, error } => {
-            EffectKey::MutateGlobal { place: place.identifier, diag: *error }
+            EffectKey::MutateGlobal { place: place.identifier, diag: error.identity() }
         }
         AliasingEffect::Mutate { value, .. } => EffectKey::Mutate { value: value.identifier },
         AliasingEffect::MutateConditionally { value } => {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -712,8 +712,28 @@ struct Context<'a> {
 
 impl<'a> Context<'a> {
     fn intern_effect(&mut self, effect: AliasingEffect<'a>) -> AliasingEffect<'a> {
+        let incoming_diagnostic = match &effect {
+            AliasingEffect::MutateFrozen { error, .. }
+            | AliasingEffect::MutateGlobal { error, .. }
+            | AliasingEffect::Impure { error, .. } => Some(*error),
+            _ => None,
+        };
         let key = effect_key(&effect);
-        self.interned_effects.entry(key).or_insert(effect).clone_in(self.alloc)
+        let mut interned = self.interned_effects.entry(key).or_insert(effect).clone_in(self.alloc);
+
+        // Diagnostics carry source-specific instances that are not part of effect
+        // identity. Keep the canonical analysis effect, but preserve the instance
+        // from this occurrence for later emission.
+        if let Some(incoming_diagnostic) = incoming_diagnostic {
+            match &mut interned {
+                AliasingEffect::MutateFrozen { error, .. }
+                | AliasingEffect::MutateGlobal { error, .. }
+                | AliasingEffect::Impure { error, .. } => *error = incoming_diagnostic,
+                _ => unreachable!(),
+            }
+        }
+
+        interned
     }
 
     /// Get or create a stable ValueId for a given effect, ensuring fixpoint convergence.

--- a/crates/oxc_react_compiler/tests/snapshots/error.mutate-props-in-distinct-callbacks.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.mutate-props-in-distinct-callbacks.snap
@@ -1,0 +1,11 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/error.mutate-props-in-distinct-callbacks.js
+---
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Immutability: This value cannot be modified", labels: One([LabeledSpan { label: Some("`document` cannot be modified"), span: SourceSpan { offset: SourceOffset(76), length: 8 }, primary: false }]), help: Some("Modifying component props or hook arguments is not allowed. Consider using a local variable instead"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Immutability: This value cannot be modified", labels: One([LabeledSpan { label: Some("`document` cannot be modified"), span: SourceSpan { offset: SourceOffset(160), length: 8 }, primary: false }]), help: Some("Modifying component props or hook arguments is not allowed. Consider using a local variable instead"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Immutability: This value cannot be modified", labels: One([LabeledSpan { label: Some("`document` cannot be modified"), span: SourceSpan { offset: SourceOffset(244), length: 8 }, primary: false }]), help: Some("Modifying component props or hook arguments is not allowed. Consider using a local variable instead"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.


### PR DESCRIPTION
Preserve source-specific labels for aliasing diagnostics while retaining their shared analysis identity. Previously, interning by place, message, and help reused the first source location for later effects.

Validated with `just ready` and React ecosystem comparisons.

AI-assisted: Codex was used to implement and validate this change.