### PR TITLE
fix(semantic): allow arguments in ambient declarations

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -204,7 +204,8 @@ fn unexpected_identifier_assign_context(
 }
 
 pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder<'_>) {
-    // `.d.ts` files are allowed to use `eval` and `arguments` as binding identifiers
+    // `.d.ts` files do not generate runtime bindings, so TypeScript permits `eval` and
+    // `arguments` as binding identifiers even when the declaration file is a module.
     if ctx.source_type.is_typescript_definition() {
         return;
     }
@@ -223,24 +224,24 @@ pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder
             // interface Foo { bar(arguments: any[]): void; baz(...arguments: any[]): void; } // OK
             // declare function g({eval, arguments}: {eval: number, arguments: number}): number; // Error
             // declare function h([eval, arguments]: [number, number]): number; // Error
-            let is_declare_function = |kind: &AstKind| {
-                kind.as_function()
-                    .is_some_and(|func| matches!(func.r#type, FunctionType::TSDeclareFunction))
-            };
 
-            // Walk up the ancestor stack: `ancestors.next()` yields the parent,
-            // then the grandparent, and so on.
-            let mut ancestors = ctx.ancestry().ancestor_kinds();
-            let parent = ancestors.next().unwrap();
-            let is_ok = match parent {
-                AstKind::Function(func) => matches!(func.r#type, FunctionType::TSDeclareFunction),
-                AstKind::FormalParameter(_) | AstKind::FormalParameterRest(_) => {
-                    is_declare_function(&ancestors.next().unwrap())
-                }
-                // `nth(1)` skips the `FormalParameter*` grandparent to reach the function.
-                AstKind::BindingRestElement(_) => is_declare_function(&ancestors.nth(1).unwrap()),
-                _ => false,
-            };
+            let parent = ctx.ancestry().parent_kind();
+            // Direct rest parameters and destructuring rest elements share the same AST kind.
+            let is_direct_rest_parameter = matches!(parent, AstKind::BindingRestElement(_))
+                && matches!(
+                    ctx.ancestry().ancestor_kinds().nth(1),
+                    Some(AstKind::FormalParameterRest(_))
+                );
+            let is_ok = ctx.in_ambient_context()
+                && (is_direct_rest_parameter
+                    || !matches!(
+                        parent,
+                        AstKind::VariableDeclarator(_)
+                            | AstKind::BindingProperty(_)
+                            | AstKind::ArrayPattern(_)
+                            | AstKind::AssignmentPattern(_)
+                            | AstKind::BindingRestElement(_)
+                    ));
 
             if !is_ok {
                 ctx.error(diagnostics::unexpected_identifier_assign(

--- a/tasks/coverage/misc/fail/arguments-eval-ambient.ts
+++ b/tasks/coverage/misc/fail/arguments-eval-ambient.ts
@@ -1,0 +1,3 @@
+export {};
+declare var arguments: unknown;
+declare const eval: unknown;

--- a/tasks/coverage/misc/fail/arguments-eval.ts
+++ b/tasks/coverage/misc/fail/arguments-eval.ts
@@ -5,5 +5,14 @@ function foo({ arguments }) {}
 function foo2([arguments]) {}
 function foo3({ eval }) {}
 function foo4([eval]) {}
+declare function foo5({ arguments }: { arguments: number }): void;
+declare function foo6([eval]: [number]): void;
+declare function foo7([arguments = 0]: [number?]): void;
+declare function foo8({ ...arguments }: object): void;
+declare function foo9([...eval]: unknown[]): void;
+declare class C {
+  method({ eval }: { eval: number }): void;
+  constructor([arguments]: [number]);
+}
 
 export {};

--- a/tasks/coverage/misc/pass/arguments-eval-ambient.d.ts
+++ b/tasks/coverage/misc/pass/arguments-eval-ambient.d.ts
@@ -1,0 +1,7 @@
+export {};
+declare var arguments: unknown;
+declare const eval: unknown;
+declare function objectRest({ ...arguments }: object): void;
+declare function arrayRest([...eval]: unknown[]): void;
+declare function objectBinding({ arguments }: { arguments: unknown }): void;
+declare function arrayBinding([eval]: [unknown]): void;

--- a/tasks/coverage/misc/pass/arguments-eval.d.ts
+++ b/tasks/coverage/misc/pass/arguments-eval.d.ts
@@ -6,6 +6,17 @@ interface Foo {
   bar2(...arguments: any[]): void;
 }
 
+declare function arguments(): void;
+declare function eval(): void;
+declare function f(eval: number, arguments: number): number;
+declare function f2(...eval: number[]): number;
+declare function f3(...arguments: number[]): number;
+
+declare class C {
+  constructor(arguments: number);
+  method(eval: number, ...arguments: number[]): void;
+}
+
 declare namespace foo {
   type arguments = {};
   type eval = {};

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 72/72 (100.00%)
-Positive Passed: 72/72 (100.00%)
+AST Parsed     : 73/73 (100.00%)
+Positive Passed: 73/73 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 72/72 (100.00%)
-Positive Passed: 72/72 (100.00%)
+AST Parsed     : 73/73 (100.00%)
+Positive Passed: 73/73 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,24 @@
 parser_misc Summary:
-AST Parsed     : 72/72 (100.00%)
-Positive Passed: 72/72 (100.00%)
-Negative Passed: 153/153 (100.00%)
+AST Parsed     : 73/73 (100.00%)
+Positive Passed: 73/73 (100.00%)
+Negative Passed: 154/154 (100.00%)
+
+  × Cannot assign to 'arguments' in strict mode
+   ╭─[misc/fail/arguments-eval-ambient.ts:2:13]
+ 1 │ export {};
+ 2 │ declare var arguments: unknown;
+   ·             ─────────
+ 3 │ declare const eval: unknown;
+   ╰────
+  note: Modules are always strict mode code
+
+  × Cannot assign to 'eval' in strict mode
+   ╭─[misc/fail/arguments-eval-ambient.ts:3:15]
+ 2 │ declare var arguments: unknown;
+ 3 │ declare const eval: unknown;
+   ·               ────
+   ╰────
+  note: Modules are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -52,9 +69,72 @@ Negative Passed: 153/153 (100.00%)
  6 │ function foo3({ eval }) {}
  7 │ function foo4([eval]) {}
    ·                ────
- 8 │ 
+ 8 │ declare function foo5({ arguments }: { arguments: number }): void;
    ╰────
   note: Modules are always strict mode code
+
+  × Cannot assign to 'arguments' in strict mode
+   ╭─[misc/fail/arguments-eval.ts:8:25]
+ 7 │ function foo4([eval]) {}
+ 8 │ declare function foo5({ arguments }: { arguments: number }): void;
+   ·                         ─────────
+ 9 │ declare function foo6([eval]: [number]): void;
+   ╰────
+  note: Modules are always strict mode code
+
+  × Cannot assign to 'eval' in strict mode
+    ╭─[misc/fail/arguments-eval.ts:9:24]
+  8 │ declare function foo5({ arguments }: { arguments: number }): void;
+  9 │ declare function foo6([eval]: [number]): void;
+    ·                        ────
+ 10 │ declare function foo7([arguments = 0]: [number?]): void;
+    ╰────
+  note: Modules are always strict mode code
+
+  × Cannot assign to 'arguments' in strict mode
+    ╭─[misc/fail/arguments-eval.ts:10:24]
+  9 │ declare function foo6([eval]: [number]): void;
+ 10 │ declare function foo7([arguments = 0]: [number?]): void;
+    ·                        ─────────
+ 11 │ declare function foo8({ ...arguments }: object): void;
+    ╰────
+  note: Modules are always strict mode code
+
+  × Cannot assign to 'arguments' in strict mode
+    ╭─[misc/fail/arguments-eval.ts:11:28]
+ 10 │ declare function foo7([arguments = 0]: [number?]): void;
+ 11 │ declare function foo8({ ...arguments }: object): void;
+    ·                            ─────────
+ 12 │ declare function foo9([...eval]: unknown[]): void;
+    ╰────
+  note: Modules are always strict mode code
+
+  × Cannot assign to 'eval' in strict mode
+    ╭─[misc/fail/arguments-eval.ts:12:27]
+ 11 │ declare function foo8({ ...arguments }: object): void;
+ 12 │ declare function foo9([...eval]: unknown[]): void;
+    ·                           ────
+ 13 │ declare class C {
+    ╰────
+  note: Modules are always strict mode code
+
+  × Cannot assign to 'eval' in strict mode
+    ╭─[misc/fail/arguments-eval.ts:14:12]
+ 13 │ declare class C {
+ 14 │   method({ eval }: { eval: number }): void;
+    ·            ────
+ 15 │   constructor([arguments]: [number]);
+    ╰────
+  note: Classes are always strict mode code
+
+  × Cannot assign to 'arguments' in strict mode
+    ╭─[misc/fail/arguments-eval.ts:15:16]
+ 14 │   method({ eval }: { eval: number }): void;
+ 15 │   constructor([arguments]: [number]);
+    ·                ─────────
+ 16 │ }
+    ╰────
+  note: Classes are always strict mode code
 
   × Cannot use await in class static initialization block
    ╭─[misc/fail/await-expr-in-block-in-class-static-block.mjs:4:7]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3708,33 +3708,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
   note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:41:31]
- 40 │ declare class c4 {
- 41 │     constructor(i: number, ...arguments); // No error - no code gen
-    ·                               ─────────
- 42 │ }
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:44:17]
- 43 │ declare class c42 {
- 44 │     constructor(arguments: number, ...rest); // No error - no code gen
-    ·                 ─────────
- 45 │ }
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:47:17]
- 46 │ declare class c4NoError {
- 47 │     constructor(arguments: number);  // no error
-    ·                 ─────────
- 48 │ }
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:51:31]
  50 │ class c5 {
  51 │     constructor(i: number, ...arguments); // no codegen no error
@@ -3839,60 +3812,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  70 │         var arguments: any; // no error
     ·             ─────────
  71 │     }
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:75:31]
- 74 │ declare class c6 {
- 75 │     constructor(i: number, ...arguments); // no codegen no error
-    ·                               ─────────
- 76 │     constructor(i: string, ...arguments); // no codegen no error
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:76:31]
- 75 │     constructor(i: number, ...arguments); // no codegen no error
- 76 │     constructor(i: string, ...arguments); // no codegen no error
-    ·                               ─────────
- 77 │ }
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:79:17]
- 78 │ declare class c62 {
- 79 │     constructor(arguments: number, ...rest); // no codegen no error
-    ·                 ─────────
- 80 │     constructor(arguments: string, ...rest); // no codegen no error
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:80:17]
- 79 │     constructor(arguments: number, ...rest); // no codegen no error
- 80 │     constructor(arguments: string, ...rest); // no codegen no error
-    ·                 ─────────
- 81 │ }
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:84:17]
- 83 │ declare class c6NoError {
- 84 │     constructor(arguments: number); // no error
-    ·                 ─────────
- 85 │     constructor(arguments: string); // no error
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassConstructor.ts:85:17]
- 84 │     constructor(arguments: number); // no error
- 85 │     constructor(arguments: string); // no error
-    ·                 ─────────
- 86 │ }
     ╰────
   note: Classes are always strict mode code
 
@@ -4059,87 +3978,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
   note: Classes are always strict mode code
 
   × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:29:30]
- 28 │ declare class c2 {
- 29 │     public foo(i: number, ...arguments); // No error - no code gen
-    ·                              ─────────
- 30 │     public foo1(arguments: number, ...rest); // No error - no code gen
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:30:17]
- 29 │     public foo(i: number, ...arguments); // No error - no code gen
- 30 │     public foo1(arguments: number, ...rest); // No error - no code gen
-    ·                 ─────────
- 31 │     public fooNoError(arguments: number); // No error - no code gen
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:31:23]
- 30 │     public foo1(arguments: number, ...rest); // No error - no code gen
- 31 │     public fooNoError(arguments: number); // No error - no code gen
-    ·                       ─────────
- 32 │ 
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:33:29]
- 32 │ 
- 33 │     public f4(i: number, ...arguments); // no codegen no error
-    ·                             ─────────
- 34 │     public f4(i: string, ...arguments); // no codegen no error
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:34:29]
- 33 │     public f4(i: number, ...arguments); // no codegen no error
- 34 │     public f4(i: string, ...arguments); // no codegen no error
-    ·                             ─────────
- 35 │     public f41(arguments: number, ...rest); // no codegen no error
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:35:16]
- 34 │     public f4(i: string, ...arguments); // no codegen no error
- 35 │     public f41(arguments: number, ...rest); // no codegen no error
-    ·                ─────────
- 36 │     public f41(arguments: string, ...rest); // no codegen no error
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:36:16]
- 35 │     public f41(arguments: number, ...rest); // no codegen no error
- 36 │     public f41(arguments: string, ...rest); // no codegen no error
-    ·                ─────────
- 37 │     public f4NoError(arguments: number); // no error
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:37:22]
- 36 │     public f41(arguments: string, ...rest); // no codegen no error
- 37 │     public f4NoError(arguments: number); // no error
-    ·                      ─────────
- 38 │     public f4NoError(arguments: string); // no error
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:38:22]
- 37 │     public f4NoError(arguments: number); // no error
- 38 │     public f4NoError(arguments: string); // no error
-    ·                      ─────────
- 39 │ }
-    ╰────
-  note: Classes are always strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/collisionArgumentsClassMethod.ts:43:13]
  42 │     public foo(...restParameters) {
  43 │         var arguments = 10; // no error
@@ -4208,33 +4046,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  10 │     var arguments = 10; // no error
     ·         ─────────
  11 │ }
-    ╰────
-  note: This is strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:13:35]
- 12 │ 
- 13 │ declare function f2(i: number, ...arguments); // no error - no code gen
-    ·                                   ─────────
- 14 │ declare function f21(arguments: number, ...rest); // no error - no code gen
-    ╰────
-  note: This is strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:14:22]
- 13 │ declare function f2(i: number, ...arguments); // no error - no code gen
- 14 │ declare function f21(arguments: number, ...rest); // no error - no code gen
-    ·                      ─────────
- 15 │ declare function f2NoError(arguments: number); // no error
-    ╰────
-  note: This is strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:15:28]
- 14 │ declare function f21(arguments: number, ...rest); // no error - no code gen
- 15 │ declare function f2NoError(arguments: number); // no error
-    ·                            ─────────
- 16 │ 
     ╰────
   note: This is strict mode code
 
@@ -4361,59 +4172,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  37 │     var arguments: any; // No error
     ·         ─────────
  38 │ }
-    ╰────
-  note: This is strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:40:21]
- 39 │ 
- 40 │ declare function f5(arguments: number, ...rest); // no codegen no error
-    ·                     ─────────
- 41 │ declare function f5(arguments: string, ...rest); // no codegen no error
-    ╰────
-  note: This is strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:41:21]
- 40 │ declare function f5(arguments: number, ...rest); // no codegen no error
- 41 │ declare function f5(arguments: string, ...rest); // no codegen no error
-    ·                     ─────────
- 42 │ declare function f52(i: number, ...arguments); // no codegen no error
-    ╰────
-  note: This is strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:42:36]
- 41 │ declare function f5(arguments: string, ...rest); // no codegen no error
- 42 │ declare function f52(i: number, ...arguments); // no codegen no error
-    ·                                    ─────────
- 43 │ declare function f52(i: string, ...arguments); // no codegen no error
-    ╰────
-  note: This is strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:43:36]
- 42 │ declare function f52(i: number, ...arguments); // no codegen no error
- 43 │ declare function f52(i: string, ...arguments); // no codegen no error
-    ·                                    ─────────
- 44 │ declare function f6(arguments: number); // no codegen no error
-    ╰────
-  note: This is strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:44:21]
- 43 │ declare function f52(i: string, ...arguments); // no codegen no error
- 44 │ declare function f6(arguments: number); // no codegen no error
-    ·                     ─────────
- 45 │ declare function f6(arguments: string); // no codegen no error
-    ╰────
-  note: This is strict mode code
-
-  × Cannot assign to 'arguments' in strict mode
-    ╭─[typescript/tests/cases/compiler/collisionArgumentsFunction.ts:45:21]
- 44 │ declare function f6(arguments: number); // no codegen no error
- 45 │ declare function f6(arguments: string); // no codegen no error
-    ·                     ─────────
     ╰────
   note: This is strict mode code
 

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 72/72 (100.00%)
-Positive Passed: 67/72 (93.06%)
+AST Parsed     : 73/73 (100.00%)
+Positive Passed: 68/73 (93.15%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 72/72 (100.00%)
-Positive Passed: 72/72 (100.00%)
+AST Parsed     : 73/73 (100.00%)
+Positive Passed: 73/73 (100.00%)


### PR DESCRIPTION
## Summary

- allow `eval` and `arguments` as direct bindings in ambient declarations
- continue reporting strict-mode errors for destructured ambient bindings
- add focused coverage for declared functions, classes, object patterns, and array patterns

## Why

The semantic checker previously identified allowed bindings by walking to a `TSDeclareFunction`. That missed other ambient declarations, including declared class constructors and methods, and produced diagnostics for TypeScript cases that require no runtime code generation.

The check now uses the existing ambient-context state and rejects only destructuring binding shapes.
