### PR TITLE
refactor(ast_tools): rename `BuilderMethodsGenerator` to `AstBuilderGenerator`

### DIFF
--- a/crates/oxc_ast/src/generated/builder_methods.rs
+++ b/crates/oxc_ast/src/generated/builder_methods.rs
@@ -1,5 +1,5 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
-// To edit this generated file you have to edit `tasks/ast_tools/src/generators/builder_methods.rs`.
+// To edit this generated file you have to edit `tasks/ast_tools/src/generators/ast_builder.rs`.
 
 //! AST node builder methods.
 

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -1,4 +1,4 @@
-//! Generator for builder methods defined directly on AST types.
+//! Generator for AST builder methods defined directly on AST types.
 //!
 //! A node is built with `BindingRestElement::new(span, argument, builder)`, where `builder` is
 //! anything which implements `GetAstBuilder` (e.g. an `AstBuilder`, or a parser/traversal context).
@@ -20,11 +20,11 @@ use crate::{
 use super::{AttrLocation, AttrPart, AttrPositions, attr_positions, define_generator};
 
 /// Generator for builder methods defined directly on AST types.
-pub struct BuilderMethodsGenerator;
+pub struct AstBuilderGenerator;
 
-define_generator!(BuilderMethodsGenerator);
+define_generator!(AstBuilderGenerator);
 
-impl Generator for BuilderMethodsGenerator {
+impl Generator for AstBuilderGenerator {
     /// Register that accept `#[builder]` attr on structs, enums, or struct fields.
     fn attrs(&self) -> &[(&'static str, AttrPositions)] {
         &[("builder", attr_positions!(Struct | Enum | StructField))]

--- a/tasks/ast_tools/src/generators/mod.rs
+++ b/tasks/ast_tools/src/generators/mod.rs
@@ -5,8 +5,8 @@ use crate::{
 };
 
 mod assert_layouts;
+mod ast_builder;
 mod ast_kind;
-mod builder_methods;
 #[cfg(feature = "generate-js")]
 mod estree_visit;
 mod formatter;
@@ -28,8 +28,8 @@ mod visit;
 mod visit_js;
 
 pub use assert_layouts::AssertLayoutsGenerator;
+pub use ast_builder::AstBuilderGenerator;
 pub use ast_kind::AstKindGenerator;
-pub use builder_methods::BuilderMethodsGenerator;
 #[cfg(feature = "generate-js")]
 pub use estree_visit::ESTreeVisitGenerator;
 pub use formatter::{FormatterAstNodesGenerator, FormatterFormatGenerator};

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -261,7 +261,7 @@ const DERIVES: &[&(dyn Derive + Sync)] = &[
 const GENERATORS: &[&(dyn Generator + Sync)] = &[
     &generators::AssertLayoutsGenerator,
     &generators::AstKindGenerator,
-    &generators::BuilderMethodsGenerator,
+    &generators::AstBuilderGenerator,
     &generators::GetIdGenerator,
     &generators::InheritVariantsGenerator,
     &generators::VisitGenerator,


### PR DESCRIPTION
Pure refactor. #24563 removed the old `AstBuilderGenerator`, so now the new one can take over its rightful name. We may introduce _other_ kinds of builders in future - this name is unambiguous.