### PR TITLE
chore(napi): widen napi req on the no-tokio-rt patch branch for rolldown alpha testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,9 +171,9 @@ oxc_tasks_transform_checker = { path = "tasks/transform_checker" } # Transform v
 oxlint = { path = "apps/oxlint" } # Linter CLI
 
 # Relaxed version so the user can decide which version to use.
-napi = { version = "3" } # Node.js native bindings
+napi = { version = ">=3.12.0-alpha.0, <4" } # Node.js native bindings
 napi-build = "2" # NAPI build tool
-napi-derive = "3" # NAPI proc macros
+napi-derive = ">=3.7.0-alpha.0, <4" # NAPI proc macros
 
 # Relaxed version so the user can decide which version to use.
 indexmap = "2" # Ordered hash map

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ oxc_tasks_transform_checker = { path = "tasks/transform_checker" } # Transform v
 oxlint = { path = "apps/oxlint" } # Linter CLI
 
 # Relaxed version so the user can decide which version to use.
-napi = { version = "3", features = ["tokio_rt"] } # Node.js native bindings
+napi = { version = "3" } # Node.js native bindings
 napi-build = "2" # NAPI build tool
 napi-derive = "3" # NAPI proc macros
 

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -31,7 +31,7 @@ oxc_str = { workspace = true }
 
 rustc-hash = { workspace = true }
 
-napi = { workspace = true, features = ["async"] }
+napi = { workspace = true }
 napi-derive = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
**Draft — not for merge.** This is the long-lived `patch/oxc-0.140.0-no-tokio-rt` branch rolldown consumes via `[patch.crates-io]` (the 0.140.0 backport of the `no-tokio-rt` change, #24475). The latest commit additionally widens the workspace `napi` / `napi-derive` requirement to `>=3.12.0-alpha.0, <4` / `>=3.7.0-alpha.0, <4` (all `oxc_*_napi` crates inherit it) so rolldown/rolldown#10350 can unify on the published napi `3.12.0-alpha.0` bundle — Cargo excludes prereleases from a plain `^3.x`.

Draft while the napi alphas are validated in rolldown CI; not intended to merge into `main`.
