### PR TITLE
fix(ecmascript): detect side effects of `foo().#bar` correctly when PropertyReadSideEffects::None

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -408,8 +408,9 @@ impl<'a> MayHaveSideEffects<'a> for MemberExpression<'a> {
         match self {
             MemberExpression::ComputedMemberExpression(e) => e.may_have_side_effects(ctx),
             MemberExpression::StaticMemberExpression(e) => e.may_have_side_effects(ctx),
-            MemberExpression::PrivateFieldExpression(_) => {
+            MemberExpression::PrivateFieldExpression(e) => {
                 ctx.property_read_side_effects() != PropertyReadSideEffects::None
+                    || e.object.may_have_side_effects(ctx)
             }
         }
     }

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -1477,6 +1477,8 @@ fn test_property_read_side_effects_support() {
     test_with_ctx("foo[bar()]", &none_ctx, true); // bar() itself has side effects
     test_with_ctx("foo.#bar", &all_ctx, true);
     test_with_ctx("foo.#bar", &none_ctx, false);
+    test_with_ctx("foo().#bar", &all_ctx, true);
+    test_with_ctx("foo().#bar", &none_ctx, true); // foo() itself has side effects
     test_with_ctx("({ bar } = foo)", &all_ctx, true);
     // test_with_ctx("({ bar } = foo)", &none_ctx, false);
 


### PR DESCRIPTION
Side effects of`foo().#bar` was not detected correctly when PropertyReadSideEffects::None is used.



Repro: https://stackblitz.com/edit/oxc-project-website-l6tidw4j?file=src%2Fmain.js

refs https://github.com/oxc-project/oxc/pull/24707#discussion_r3614105531