### PR TITLE
refactor(estree): re-order serializer code for `ImportMeta` and `NewTarget`

### DIFF
--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -17,10 +17,6 @@ use super::{EmptyArray, Null};
 // Meta properties
 // ----------------------------------------
 
-fn serialize_meta_property_identifier<S: Serializer>(serializer: S, span: Span, name: Ident<'_>) {
-    IdentifierName { node_id: Cell::new(NodeId::DUMMY), span, name }.serialize(serializer);
-}
-
 #[ast_meta]
 #[estree(
     ts_type = "IdentifierName",
@@ -147,6 +143,10 @@ impl ESTree for NewTargetProperty<'_> {
 
         serialize_meta_property_identifier(serializer, span, static_ident!("target"));
     }
+}
+
+fn serialize_meta_property_identifier<S: Serializer>(serializer: S, span: Span, name: Ident<'_>) {
+    IdentifierName { node_id: Cell::new(NodeId::DUMMY), span, name }.serialize(serializer);
 }
 
 // ----------------------------------------


### PR DESCRIPTION
Follow-on after #24557. Pure refactor.

Personally, I think it's clearer to have helper function below the main code, so it reads top-to-bottom.

It's a matter of taste, but it's consistent with other serializers (since it happens to be my taste, and I wrote most of the serializers).