### PR TITLE
feat(linter): implement unicorn/prefer-includes-over-repeated-comparisons

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1590,6 +1590,8 @@ export interface DummyRuleMap {
   "unicorn/prefer-global-this"?: RuleNoConfig;
   "unicorn/prefer-import-meta-properties"?: RuleNoConfig;
   "unicorn/prefer-includes"?: RuleNoConfig;
+  "unicorn/prefer-includes-over-repeated-comparisons"?:
+    RuleNoConfig | [AllowWarnDeny, PreferIncludesOverRepeatedComparisonsConfig];
   "unicorn/prefer-keyboard-event-key"?: RuleNoConfig;
   "unicorn/prefer-logical-operator-over-ternary"?: RuleNoConfig;
   "unicorn/prefer-math-min-max"?: RuleNoConfig;
@@ -6327,6 +6329,12 @@ export interface PreferExportFrom {
    * When false, if any import binding is used somewhere other than a re-export, all variables in the import declaration are ignored.
    */
   checkUsedVariables?: boolean;
+}
+export interface PreferIncludesOverRepeatedComparisonsConfig {
+  /**
+   * The minimum number of equality comparisons before reporting.
+   */
+  minimumComparisons?: number;
 }
 export interface PreferNumberPropertiesConfig {
   /**

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2958,6 +2958,11 @@ impl RuleRunner for crate::rules::react_perf::jsx_no_new_object_as_prop::JsxNoNe
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::prefer_includes_over_repeated_comparisons::PreferIncludesOverRepeatedComparisons {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::catch_error_name::CatchErrorName {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::CatchParameter]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -693,6 +693,7 @@ pub use crate::rules::unicorn::prefer_export_from::PreferExportFrom as UnicornPr
 pub use crate::rules::unicorn::prefer_global_this::PreferGlobalThis as UnicornPreferGlobalThis;
 pub use crate::rules::unicorn::prefer_import_meta_properties::PreferImportMetaProperties as UnicornPreferImportMetaProperties;
 pub use crate::rules::unicorn::prefer_includes::PreferIncludes as UnicornPreferIncludes;
+pub use crate::rules::unicorn::prefer_includes_over_repeated_comparisons::PreferIncludesOverRepeatedComparisons as UnicornPreferIncludesOverRepeatedComparisons;
 pub use crate::rules::unicorn::prefer_keyboard_event_key::PreferKeyboardEventKey as UnicornPreferKeyboardEventKey;
 pub use crate::rules::unicorn::prefer_logical_operator_over_ternary::PreferLogicalOperatorOverTernary as UnicornPreferLogicalOperatorOverTernary;
 pub use crate::rules::unicorn::prefer_math_min_max::PreferMathMinMax as UnicornPreferMathMinMax;
@@ -1322,6 +1323,7 @@ pub enum RuleEnum {
     ReactPerfJsxNoNewArrayAsProp(ReactPerfJsxNoNewArrayAsProp),
     ReactPerfJsxNoNewFunctionAsProp(ReactPerfJsxNoNewFunctionAsProp),
     ReactPerfJsxNoNewObjectAsProp(ReactPerfJsxNoNewObjectAsProp),
+    UnicornPreferIncludesOverRepeatedComparisons(UnicornPreferIncludesOverRepeatedComparisons),
     UnicornCatchErrorName(UnicornCatchErrorName),
     UnicornConsistentAssert(UnicornConsistentAssert),
     UnicornConsistentDateClone(UnicornConsistentDateClone),
@@ -2225,7 +2227,10 @@ const REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID: usize =
     REACT_PERF_JSX_NO_NEW_ARRAY_AS_PROP_ID + 1usize;
 const REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID: usize =
     REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID + 1usize;
-const UNICORN_CATCH_ERROR_NAME_ID: usize = REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID + 1usize;
+const UNICORN_PREFER_INCLUDES_OVER_REPEATED_COMPARISONS_ID: usize =
+    REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID + 1usize;
+const UNICORN_CATCH_ERROR_NAME_ID: usize =
+    UNICORN_PREFER_INCLUDES_OVER_REPEATED_COMPARISONS_ID + 1usize;
 const UNICORN_CONSISTENT_ASSERT_ID: usize = UNICORN_CATCH_ERROR_NAME_ID + 1usize;
 const UNICORN_CONSISTENT_DATE_CLONE_ID: usize = UNICORN_CONSISTENT_ASSERT_ID + 1usize;
 const UNICORN_CONSISTENT_EMPTY_ARRAY_SPREAD_ID: usize = UNICORN_CONSISTENT_DATE_CLONE_ID + 1usize;
@@ -3205,6 +3210,9 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => REACT_PERF_JSX_NO_NEW_ARRAY_AS_PROP_ID,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID,
+            Self::UnicornPreferIncludesOverRepeatedComparisons(_) => {
+                UNICORN_PREFER_INCLUDES_OVER_REPEATED_COMPARISONS_ID
+            }
             Self::UnicornCatchErrorName(_) => UNICORN_CATCH_ERROR_NAME_ID,
             Self::UnicornConsistentAssert(_) => UNICORN_CONSISTENT_ASSERT_ID,
             Self::UnicornConsistentDateClone(_) => UNICORN_CONSISTENT_DATE_CLONE_ID,
@@ -4177,6 +4185,9 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::NAME,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::NAME,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::NAME,
+            Self::UnicornPreferIncludesOverRepeatedComparisons(_) => {
+                UnicornPreferIncludesOverRepeatedComparisons::NAME
+            }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::NAME,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::NAME,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::NAME,
@@ -5165,6 +5176,9 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::CATEGORY,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::CATEGORY,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::CATEGORY,
+            Self::UnicornPreferIncludesOverRepeatedComparisons(_) => {
+                UnicornPreferIncludesOverRepeatedComparisons::CATEGORY
+            }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::CATEGORY,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::CATEGORY,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::CATEGORY,
@@ -6160,6 +6174,9 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::FIX,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::FIX,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::FIX,
+            Self::UnicornPreferIncludesOverRepeatedComparisons(_) => {
+                UnicornPreferIncludesOverRepeatedComparisons::FIX
+            }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::FIX,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::FIX,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::FIX,
@@ -7242,6 +7259,9 @@ impl RuleEnum {
             }
             Self::ReactPerfJsxNoNewObjectAsProp(_) => {
                 ReactPerfJsxNoNewObjectAsProp::documentation()
+            }
+            Self::UnicornPreferIncludesOverRepeatedComparisons(_) => {
+                UnicornPreferIncludesOverRepeatedComparisons::documentation()
             }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::documentation(),
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::documentation(),
@@ -9119,6 +9139,10 @@ impl RuleEnum {
                 ReactPerfJsxNoNewObjectAsProp::config_schema(generator)
                     .or_else(|| ReactPerfJsxNoNewObjectAsProp::schema(generator))
             }
+            Self::UnicornPreferIncludesOverRepeatedComparisons(_) => {
+                UnicornPreferIncludesOverRepeatedComparisons::config_schema(generator)
+                    .or_else(|| UnicornPreferIncludesOverRepeatedComparisons::schema(generator))
+            }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::config_schema(generator)
                 .or_else(|| UnicornCatchErrorName::schema(generator)),
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::config_schema(generator)
@@ -10716,6 +10740,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => "react_perf",
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => "react_perf",
             Self::ReactPerfJsxNoNewObjectAsProp(_) => "react_perf",
+            Self::UnicornPreferIncludesOverRepeatedComparisons(_) => "unicorn",
             Self::UnicornCatchErrorName(_) => "unicorn",
             Self::UnicornConsistentAssert(_) => "unicorn",
             Self::UnicornConsistentDateClone(_) => "unicorn",
@@ -12573,6 +12598,11 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewObjectAsProp(_) => Ok(Self::ReactPerfJsxNoNewObjectAsProp(
                 ReactPerfJsxNoNewObjectAsProp::from_configuration(value)?,
             )),
+            Self::UnicornPreferIncludesOverRepeatedComparisons(_) => {
+                Ok(Self::UnicornPreferIncludesOverRepeatedComparisons(
+                    UnicornPreferIncludesOverRepeatedComparisons::from_configuration(value)?,
+                ))
+            }
             Self::UnicornCatchErrorName(_) => {
                 Ok(Self::UnicornCatchErrorName(UnicornCatchErrorName::from_configuration(value)?))
             }
@@ -14291,6 +14321,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.to_configuration(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.to_configuration(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.to_configuration(),
+            Self::UnicornPreferIncludesOverRepeatedComparisons(rule) => rule.to_configuration(),
             Self::UnicornCatchErrorName(rule) => rule.to_configuration(),
             Self::UnicornConsistentAssert(rule) => rule.to_configuration(),
             Self::UnicornConsistentDateClone(rule) => rule.to_configuration(),
@@ -15142,6 +15173,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run(node, ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run(node, ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run(node, ctx),
+            Self::UnicornPreferIncludesOverRepeatedComparisons(rule) => rule.run(node, ctx),
             Self::UnicornCatchErrorName(rule) => rule.run(node, ctx),
             Self::UnicornConsistentAssert(rule) => rule.run(node, ctx),
             Self::UnicornConsistentDateClone(rule) => rule.run(node, ctx),
@@ -16003,6 +16035,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_once(ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_once(ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_once(ctx),
+            Self::UnicornPreferIncludesOverRepeatedComparisons(rule) => rule.run_once(ctx),
             Self::UnicornCatchErrorName(rule) => rule.run_once(ctx),
             Self::UnicornConsistentAssert(rule) => rule.run_once(ctx),
             Self::UnicornConsistentDateClone(rule) => rule.run_once(ctx),
@@ -16937,6 +16970,9 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornPreferIncludesOverRepeatedComparisons(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
             Self::UnicornCatchErrorName(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornConsistentAssert(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornConsistentDateClone(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17843,6 +17879,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.should_run(ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.should_run(ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.should_run(ctx),
+            Self::UnicornPreferIncludesOverRepeatedComparisons(rule) => rule.should_run(ctx),
             Self::UnicornCatchErrorName(rule) => rule.should_run(ctx),
             Self::UnicornConsistentAssert(rule) => rule.should_run(ctx),
             Self::UnicornConsistentDateClone(rule) => rule.should_run(ctx),
@@ -18880,6 +18917,9 @@ impl RuleEnum {
             }
             Self::ReactPerfJsxNoNewObjectAsProp(_) => {
                 ReactPerfJsxNoNewObjectAsProp::IS_TSGOLINT_RULE
+            }
+            Self::UnicornPreferIncludesOverRepeatedComparisons(_) => {
+                UnicornPreferIncludesOverRepeatedComparisons::IS_TSGOLINT_RULE
             }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::IS_TSGOLINT_RULE,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::IS_TSGOLINT_RULE,
@@ -20019,6 +20059,9 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::VERSION,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::VERSION,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::VERSION,
+            Self::UnicornPreferIncludesOverRepeatedComparisons(_) => {
+                UnicornPreferIncludesOverRepeatedComparisons::VERSION
+            }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::VERSION,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::VERSION,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::VERSION,
@@ -21058,6 +21101,9 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::HAS_CONFIG,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::HAS_CONFIG,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::HAS_CONFIG,
+            Self::UnicornPreferIncludesOverRepeatedComparisons(_) => {
+                UnicornPreferIncludesOverRepeatedComparisons::HAS_CONFIG
+            }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::HAS_CONFIG,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::HAS_CONFIG,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::HAS_CONFIG,
@@ -22076,6 +22122,9 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::INFO,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::INFO,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::INFO,
+            Self::UnicornPreferIncludesOverRepeatedComparisons(_) => {
+                UnicornPreferIncludesOverRepeatedComparisons::INFO
+            }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::INFO,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::INFO,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::INFO,
@@ -22973,6 +23022,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.types_info(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.types_info(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.types_info(),
+            Self::UnicornPreferIncludesOverRepeatedComparisons(rule) => rule.types_info(),
             Self::UnicornCatchErrorName(rule) => rule.types_info(),
             Self::UnicornConsistentAssert(rule) => rule.types_info(),
             Self::UnicornConsistentDateClone(rule) => rule.types_info(),
@@ -23821,6 +23871,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_info(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_info(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_info(),
+            Self::UnicornPreferIncludesOverRepeatedComparisons(rule) => rule.run_info(),
             Self::UnicornCatchErrorName(rule) => rule.run_info(),
             Self::UnicornConsistentAssert(rule) => rule.run_info(),
             Self::UnicornConsistentDateClone(rule) => rule.run_info(),
@@ -24761,6 +24812,9 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactPerfJsxNoNewArrayAsProp(ReactPerfJsxNoNewArrayAsProp::default()),
         RuleEnum::ReactPerfJsxNoNewFunctionAsProp(ReactPerfJsxNoNewFunctionAsProp::default()),
         RuleEnum::ReactPerfJsxNoNewObjectAsProp(ReactPerfJsxNoNewObjectAsProp::default()),
+        RuleEnum::UnicornPreferIncludesOverRepeatedComparisons(
+            UnicornPreferIncludesOverRepeatedComparisons::default(),
+        ),
         RuleEnum::UnicornCatchErrorName(UnicornCatchErrorName::default()),
         RuleEnum::UnicornConsistentAssert(UnicornConsistentAssert::default()),
         RuleEnum::UnicornConsistentDateClone(UnicornConsistentDateClone::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -485,8 +485,7 @@ pub(crate) mod react_perf {
 
 /// <https://github.com/sindresorhus/eslint-plugin-unicorn>
 pub(crate) mod unicorn {
-        pub mod prefer_includes_over_repeated_comparisons;
-pub mod catch_error_name;
+    pub mod catch_error_name;
     pub mod consistent_assert;
     pub mod consistent_date_clone;
     pub mod consistent_empty_array_spread;
@@ -582,6 +581,7 @@ pub mod catch_error_name;
     pub mod prefer_global_this;
     pub mod prefer_import_meta_properties;
     pub mod prefer_includes;
+    pub mod prefer_includes_over_repeated_comparisons;
     pub mod prefer_keyboard_event_key;
     pub mod prefer_logical_operator_over_ternary;
     pub mod prefer_math_min_max;

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -485,7 +485,8 @@ pub(crate) mod react_perf {
 
 /// <https://github.com/sindresorhus/eslint-plugin-unicorn>
 pub(crate) mod unicorn {
-    pub mod catch_error_name;
+        pub mod prefer_includes_over_repeated_comparisons;
+pub mod catch_error_name;
     pub mod consistent_assert;
     pub mod consistent_date_clone;
     pub mod consistent_empty_array_spread;

--- a/crates/oxc_linter/src/rules/unicorn/prefer_includes_over_repeated_comparisons.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_includes_over_repeated_comparisons.rs
@@ -97,19 +97,13 @@ declare_oxc_lint!(
 
 impl Rule for PreferIncludesOverRepeatedComparisons {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        let config = value
-            .as_array()
-            .and_then(|arr| arr.first())
-            .cloned()
-            .map_or_else(
-                || Ok(PreferIncludesOverRepeatedComparisonsConfig::default()),
-                serde_json::from_value,
-            )?;
+        let config = value.as_array().and_then(|arr| arr.first()).cloned().map_or_else(
+            || Ok(PreferIncludesOverRepeatedComparisonsConfig::default()),
+            serde_json::from_value,
+        )?;
 
         let minimum_comparisons = config.minimum_comparisons.max(2);
-        Ok(Self(Box::new(PreferIncludesOverRepeatedComparisonsConfig {
-            minimum_comparisons,
-        })))
+        Ok(Self(Box::new(PreferIncludesOverRepeatedComparisonsConfig { minimum_comparisons })))
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -309,9 +303,10 @@ fn contains_optional_chain(expr: &Expression<'_>) -> bool {
         Expression::CallExpression(call) => {
             call.optional
                 || contains_optional_chain(&call.callee)
-                || call.arguments.iter().any(|arg| {
-                    arg.as_expression().is_some_and(contains_optional_chain)
-                })
+                || call
+                    .arguments
+                    .iter()
+                    .any(|arg| arg.as_expression().is_some_and(contains_optional_chain))
         }
         _ => false,
     }
@@ -396,10 +391,7 @@ fn test() {
         ("undefined === a || undefined === b || undefined === c;", None),
         ("a === null || b === null || c === null;", None),
         (r#"a === undefined || a === "x" || b === undefined;"#, None),
-        (
-            "a === (undefined as any) || b === (undefined as any) || c === (undefined as any);",
-            None,
-        ),
+        ("a === (undefined as any) || b === (undefined as any) || c === (undefined as any);", None),
         (
             r#"value === "a" || value === "b";"#,
             Some(serde_json::json!([{"minimumComparisons": 4}])),

--- a/crates/oxc_linter/src/rules/unicorn/prefer_includes_over_repeated_comparisons.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_includes_over_repeated_comparisons.rs
@@ -1,0 +1,487 @@
+use oxc_ast::{
+    AstKind,
+    ast::{BinaryExpression, Expression, IdentifierReference, LogicalExpression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_ecmascript::{
+    GlobalContext,
+    side_effects::{MayHaveSideEffects, MayHaveSideEffectsContext, PropertyReadSideEffects},
+};
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::IsGlobalReference;
+use oxc_span::Span;
+use oxc_syntax::operator::{BinaryOperator, LogicalOperator};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{is_same_expression, is_same_member_expression},
+};
+
+fn prefer_includes_over_repeated_comparisons_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `.includes()` instead of repeated equality checks.")
+        .with_help("Rewrite the repeated `===` comparisons as a single `.includes()` call.")
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct PreferIncludesOverRepeatedComparisonsConfig {
+    /// The minimum number of equality comparisons before reporting.
+    #[serde(default = "default_minimum_comparisons")]
+    minimum_comparisons: u32,
+}
+
+fn default_minimum_comparisons() -> u32 {
+    3
+}
+
+impl Default for PreferIncludesOverRepeatedComparisonsConfig {
+    fn default() -> Self {
+        Self { minimum_comparisons: default_minimum_comparisons() }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferIncludesOverRepeatedComparisons(Box<PreferIncludesOverRepeatedComparisonsConfig>);
+
+impl std::ops::Deref for PreferIncludesOverRepeatedComparisons {
+    type Target = PreferIncludesOverRepeatedComparisonsConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Prefers `.includes()` over repeated strict equality comparisons joined by `||`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Comparing the same expression against multiple values is easier to scan as a
+    /// membership check. An `Array#includes()` rewrite communicates intent more clearly.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// value === 'a' || value === 'b' || value === 'c';
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// ['a', 'b', 'c'].includes(value);
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// #### minimumComparisons
+    ///
+    /// `{ type: integer, minimum: 2, default: 3 }`
+    ///
+    /// The minimum number of equality comparisons before reporting.
+    PreferIncludesOverRepeatedComparisons,
+    unicorn,
+    style,
+    none,
+    config = PreferIncludesOverRepeatedComparisonsConfig,
+    version = "next",
+    short_description = "Prefer `.includes()` over repeated equality comparisons.",
+);
+
+impl Rule for PreferIncludesOverRepeatedComparisons {
+    fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
+        let config = value
+            .as_array()
+            .and_then(|arr| arr.first())
+            .cloned()
+            .map_or_else(
+                || Ok(PreferIncludesOverRepeatedComparisonsConfig::default()),
+                serde_json::from_value,
+            )?;
+
+        let minimum_comparisons = config.minimum_comparisons.max(2);
+        Ok(Self(Box::new(PreferIncludesOverRepeatedComparisonsConfig {
+            minimum_comparisons,
+        })))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::LogicalExpression(logical_expr) = node.kind() else {
+            return;
+        };
+
+        if logical_expr.operator != LogicalOperator::Or {
+            return;
+        }
+
+        // Only handle the outermost `||` expression in a chain.
+        if let AstKind::LogicalExpression(parent) = ctx.nodes().parent_kind(node.id())
+            && parent.operator == LogicalOperator::Or
+        {
+            return;
+        }
+
+        let Some(comparisons) = get_logical_or_operands(logical_expr) else {
+            return;
+        };
+        if comparisons.len() < self.minimum_comparisons as usize {
+            return;
+        }
+
+        if comparisons.iter().any(|comparison| {
+            !matches!(comparison.operator, BinaryOperator::StrictEquality)
+                || contains_optional_chain(&comparison.left)
+                || contains_optional_chain(&comparison.right)
+        }) {
+            return;
+        }
+
+        let Some(shared_reference) = get_shared_reference(&comparisons, ctx) else {
+            return;
+        };
+
+        if is_nan_value(shared_reference, ctx) {
+            return;
+        }
+
+        let side_effects_ctx = SideEffectsContext { ctx };
+        if !comparisons.iter().all(|comparison| {
+            get_compared_value(comparison, shared_reference, ctx).is_some_and(|compared_value| {
+                !compared_value.may_have_side_effects(&side_effects_ctx)
+                    && !is_nan_value(compared_value, ctx)
+            })
+        }) {
+            return;
+        }
+
+        ctx.diagnostic(prefer_includes_over_repeated_comparisons_diagnostic(logical_expr.span));
+    }
+}
+
+fn get_logical_or_operands<'a, 'b>(
+    node: &'b LogicalExpression<'a>,
+) -> Option<Vec<&'b BinaryExpression<'a>>> {
+    let mut operands = Vec::new();
+    collect_logical_or_operands(node, &mut operands)?;
+    Some(operands)
+}
+
+fn collect_logical_or_operands<'a, 'b>(
+    node: &'b LogicalExpression<'a>,
+    out: &mut Vec<&'b BinaryExpression<'a>>,
+) -> Option<()> {
+    for child in [&node.left, &node.right] {
+        match child.without_parentheses() {
+            Expression::LogicalExpression(logical_expr)
+                if logical_expr.operator == LogicalOperator::Or =>
+            {
+                collect_logical_or_operands(logical_expr, out)?;
+            }
+            Expression::BinaryExpression(bin_expr) => out.push(bin_expr),
+            _ => return None,
+        }
+    }
+    Some(())
+}
+
+fn get_shared_reference<'a, 'b>(
+    comparisons: &[&'b BinaryExpression<'a>],
+    ctx: &LintContext<'a>,
+) -> Option<&'b Expression<'a>> {
+    let first = comparisons.first()?;
+    let mut candidates: Vec<&Expression<'a>> = [&first.left, &first.right]
+        .into_iter()
+        .filter(|expr| is_reference(expr) && !is_undefined(expr, ctx))
+        .collect();
+
+    for comparison in comparisons.iter().skip(1) {
+        candidates.retain(|candidate| {
+            is_same_reference(candidate, &comparison.left, ctx)
+                || is_same_reference(candidate, &comparison.right, ctx)
+        });
+        if candidates.is_empty() {
+            return None;
+        }
+    }
+
+    if candidates.len() == 1 { Some(candidates[0]) } else { None }
+}
+
+fn get_compared_value<'a, 'b>(
+    comparison: &'b BinaryExpression<'a>,
+    shared_reference: &Expression<'a>,
+    ctx: &LintContext<'a>,
+) -> Option<&'b Expression<'a>> {
+    let left_is_shared = is_same_reference(&comparison.left, shared_reference, ctx);
+    let right_is_shared = is_same_reference(&comparison.right, shared_reference, ctx);
+
+    match (left_is_shared, right_is_shared) {
+        (true, false) => Some(&comparison.right),
+        (false, true) => Some(&comparison.left),
+        _ => None,
+    }
+}
+
+fn is_reference(expr: &Expression<'_>) -> bool {
+    matches!(
+        expr.get_inner_expression(),
+        Expression::Identifier(_)
+            | Expression::Super(_)
+            | Expression::ThisExpression(_)
+            | Expression::StaticMemberExpression(_)
+            | Expression::ComputedMemberExpression(_)
+            | Expression::PrivateFieldExpression(_)
+    )
+}
+
+fn is_same_reference<'a>(
+    left: &Expression<'a>,
+    right: &Expression<'a>,
+    ctx: &LintContext<'a>,
+) -> bool {
+    let left = left.get_inner_expression();
+    let right = right.get_inner_expression();
+
+    if let (Some(left_member), Some(right_member)) =
+        (left.as_member_expression(), right.as_member_expression())
+    {
+        return is_same_member_expression(left_member, right_member, ctx);
+    }
+
+    is_same_expression(left, right, ctx)
+}
+
+fn is_undefined<'a>(expr: &Expression<'a>, ctx: &LintContext<'a>) -> bool {
+    match expr.get_inner_expression() {
+        Expression::Identifier(ident) if ident.name == "undefined" => {
+            ident.is_global_reference(ctx.scoping())
+        }
+        _ => false,
+    }
+}
+
+fn is_nan_value<'a>(expr: &Expression<'a>, ctx: &LintContext<'a>) -> bool {
+    match expr.get_inner_expression() {
+        Expression::Identifier(ident) if ident.name == "NaN" => {
+            ident.is_global_reference(ctx.scoping())
+        }
+        Expression::StaticMemberExpression(member)
+            if member.property.name == "NaN"
+                && matches!(
+                    member.object.get_inner_expression(),
+                    Expression::Identifier(ident)
+                        if ident.name == "Number" && ident.is_global_reference(ctx.scoping())
+                ) =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+
+fn contains_optional_chain(expr: &Expression<'_>) -> bool {
+    match expr {
+        Expression::ChainExpression(_) => true,
+        Expression::ParenthesizedExpression(paren) => contains_optional_chain(&paren.expression),
+        Expression::TSAsExpression(expr) => contains_optional_chain(&expr.expression),
+        Expression::TSSatisfiesExpression(expr) => contains_optional_chain(&expr.expression),
+        Expression::TSTypeAssertion(expr) => contains_optional_chain(&expr.expression),
+        Expression::TSNonNullExpression(expr) => contains_optional_chain(&expr.expression),
+        Expression::TSInstantiationExpression(expr) => contains_optional_chain(&expr.expression),
+        Expression::StaticMemberExpression(member) => {
+            member.optional || contains_optional_chain(&member.object)
+        }
+        Expression::ComputedMemberExpression(member) => {
+            member.optional
+                || contains_optional_chain(&member.object)
+                || contains_optional_chain(&member.expression)
+        }
+        Expression::PrivateFieldExpression(member) => {
+            member.optional || contains_optional_chain(&member.object)
+        }
+        Expression::CallExpression(call) => {
+            call.optional
+                || contains_optional_chain(&call.callee)
+                || call.arguments.iter().any(|arg| {
+                    arg.as_expression().is_some_and(contains_optional_chain)
+                })
+        }
+        _ => false,
+    }
+}
+
+struct SideEffectsContext<'a, 'c> {
+    ctx: &'c LintContext<'a>,
+}
+
+impl<'a> GlobalContext<'a> for SideEffectsContext<'_, 'a> {
+    fn is_global_reference(&self, reference: &IdentifierReference<'a>) -> bool {
+        reference.is_global_reference(self.ctx.scoping())
+    }
+}
+
+impl<'a> MayHaveSideEffectsContext<'a> for SideEffectsContext<'_, 'a> {
+    fn annotations(&self) -> bool {
+        false
+    }
+
+    fn manual_pure_functions(&self, _callee: &Expression) -> bool {
+        false
+    }
+
+    fn property_read_side_effects(&self) -> PropertyReadSideEffects {
+        // Match eslint-utils `hasSideEffect`: plain property reads are treated as pure.
+        PropertyReadSideEffects::None
+    }
+
+    fn unknown_global_side_effects(&self) -> bool {
+        false
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"value === "a";"#, None),
+        (r#"value === "a" || otherValue === "b";"#, None),
+        (r#"value == "a" || value == "b";"#, None),
+        (r#"value !== "a" && value !== "b";"#, None),
+        (r#"value === "a" || isValue(value);"#, None),
+        (r#"value === "a" || value !== "b";"#, None),
+        (r#"value === "a" || value === "b" || otherValue === "c";"#, None),
+        (r#"getValue() === "a" || getValue() === "b";"#, None),
+        (r#"getObject().value === "a" || getObject().value === "b";"#, None),
+        (r#"object[getKey()] === "a" || object[getKey()] === "b";"#, None),
+        (r#"value === getValue() || value === "b";"#, None),
+        (r#"value === "a" || value === getValue();"#, None),
+        (r#"value === (otherValue = "a") || value === "b";"#, None),
+        (r#"value === ++otherValue || value === "b";"#, None),
+        ("value === Number.NaN || value === 1;", None),
+        ("value === NaN || value === 1;", None),
+        ("Number.NaN === value || Number.NaN === otherValue;", None),
+        ("NaN === value || NaN === otherValue;", None),
+        (r#"foo?.bar === "a" || foo?.bar === "b";"#, None),
+        (r#"foo?.bar === "a" || foo.bar === "b";"#, None),
+        (r#"foo.bar === "a" || foo?.bar === "b";"#, None),
+        (r#"foo[bar?.baz] === "a" || foo[bar?.baz] === "b";"#, None),
+        (r#"foo[bar?.()] === "a" || foo[bar?.()] === "b";"#, None),
+        (r#"(foo?.bar).baz === "a" || (foo?.bar).baz === "b";"#, None),
+        (r#"value === "a" || value === foo?.bar;"#, None),
+        (r#"value === (foo?.bar ?? "a") || value === "b";"#, None),
+        ("foo === bar || bar === foo;", None),
+        ("foo === foo || foo === foo;", None),
+        ("foo === bar || foo === foo;", None),
+        ("foo === 1 || bar === 1;", None),
+        (r#"value === "a" || value === "b";"#, None),
+        (r#""a" === value || "b" === value;"#, None),
+        (r#"value === "a" || "b" === value;"#, None),
+        ("value === first || value === second;", None),
+        (r#"args[0] === "-h" || args[0] === "--help";"#, None),
+        (r#"object.value === "a" || object.value === "b";"#, None),
+        (r#"object.foo === "a" || object["foo"] === "b";"#, None),
+        (r#"object[key] === "a" || object[key] === "b";"#, None),
+        ("value === object.a || value === object.b;", None),
+        (r#"(value === "a") || (value === "b");"#, None),
+        (r#"(value === "a" || value === "b") && otherValue;"#, None),
+        ("state.a === undefined || state.b === undefined || state.c === undefined;", None),
+        ("undefined === a || undefined === b || undefined === c;", None),
+        ("a === null || b === null || c === null;", None),
+        (r#"a === undefined || a === "x" || b === undefined;"#, None),
+        (
+            "a === (undefined as any) || b === (undefined as any) || c === (undefined as any);",
+            None,
+        ),
+        (
+            r#"value === "a" || value === "b";"#,
+            Some(serde_json::json!([{"minimumComparisons": 4}])),
+        ),
+        (r#"(foo?.bar as Foo).baz === "a" || (foo?.bar as Foo).baz === "b";"#, None),
+    ];
+
+    let fail = vec![
+        (r#"value === "a" || value === "b" || value === "c";"#, None),
+        (r#"value === undefined || value === "a" || value === "b";"#, None),
+        (
+            "value === null || value === undefined;",
+            Some(serde_json::json!([{"minimumComparisons": 2}])),
+        ),
+        (
+            r#"value === "a" || value === "b";"#,
+            Some(serde_json::json!([{"minimumComparisons": 2}])),
+        ),
+        (
+            r#""a" === value || "b" === value;"#,
+            Some(serde_json::json!([{"minimumComparisons": 2}])),
+        ),
+        (
+            r#"value === "a" || "b" === value;"#,
+            Some(serde_json::json!([{"minimumComparisons": 2}])),
+        ),
+        (
+            "value === first || value === second;",
+            Some(serde_json::json!([{"minimumComparisons": 2}])),
+        ),
+        (
+            r#"args[0] === "-h" || args[0] === "--help";"#,
+            Some(serde_json::json!([{"minimumComparisons": 2}])),
+        ),
+        (
+            r#"object.value === "a" || object.value === "b";"#,
+            Some(serde_json::json!([{"minimumComparisons": 2}])),
+        ),
+        (
+            r#"object.foo === "a" || object["foo"] === "b";"#,
+            Some(serde_json::json!([{"minimumComparisons": 2}])),
+        ),
+        (
+            r#"object[key] === "a" || object[key] === "b";"#,
+            Some(serde_json::json!([{"minimumComparisons": 2}])),
+        ),
+        (
+            "value === object.a || value === object.b;",
+            Some(serde_json::json!([{"minimumComparisons": 2}])),
+        ),
+        (
+            r#"(value === "a") || (value === "b");"#,
+            Some(serde_json::json!([{"minimumComparisons": 2}])),
+        ),
+        (
+            r#"(value === "a" || value === "b") && otherValue;"#,
+            Some(serde_json::json!([{"minimumComparisons": 2}])),
+        ),
+        (
+            r#"value === "a" || value === "b" || value === "c";"#,
+            Some(serde_json::json!([{"minimumComparisons": 3}])),
+        ),
+        (r#"value! === "a" || value! === "b" || value! === "c";"#, None),
+        (
+            r#"(value satisfies string) === "a" || (value satisfies string) === "b" || (value satisfies string) === "c";"#,
+            None,
+        ),
+        (
+            r#"(value as {foo?: string}) === "a" || (value as {foo?: string}) === "b" || (value as {foo?: string}) === "c";"#,
+            None,
+        ),
+        (
+            r#"(object satisfies Foo).value === "a" || (object satisfies Foo).value === "b" || (object satisfies Foo).value === "c";"#,
+            None,
+        ),
+    ];
+
+    Tester::new(
+        PreferIncludesOverRepeatedComparisons::NAME,
+        PreferIncludesOverRepeatedComparisons::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_includes_over_repeated_comparisons.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_includes_over_repeated_comparisons.snap
@@ -1,0 +1,137 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ value === "a" || value === "b" || value === "c";
+   · ───────────────────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ value === undefined || value === "a" || value === "b";
+   · ─────────────────────────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ value === null || value === undefined;
+   · ─────────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ value === "a" || value === "b";
+   · ──────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ "a" === value || "b" === value;
+   · ──────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ value === "a" || "b" === value;
+   · ──────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ value === first || value === second;
+   · ───────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ args[0] === "-h" || args[0] === "--help";
+   · ────────────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ object.value === "a" || object.value === "b";
+   · ────────────────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ object.foo === "a" || object["foo"] === "b";
+   · ───────────────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ object[key] === "a" || object[key] === "b";
+   · ──────────────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ value === object.a || value === object.b;
+   · ────────────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ (value === "a") || (value === "b");
+   · ──────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:2]
+ 1 │ (value === "a" || value === "b") && otherValue;
+   ·  ──────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ value === "a" || value === "b" || value === "c";
+   · ───────────────────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ value! === "a" || value! === "b" || value! === "c";
+   · ──────────────────────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ (value satisfies string) === "a" || (value satisfies string) === "b" || (value satisfies string) === "c";
+   · ────────────────────────────────────────────────────────────────────────────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ (value as {foo?: string}) === "a" || (value as {foo?: string}) === "b" || (value as {foo?: string}) === "c";
+   · ───────────────────────────────────────────────────────────────────────────────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.
+
+  ⚠ unicorn(prefer-includes-over-repeated-comparisons): Use `.includes()` instead of repeated equality checks.
+   ╭─[prefer_includes_over_repeated_comparisons.tsx:1:1]
+ 1 │ (object satisfies Foo).value === "a" || (object satisfies Foo).value === "b" || (object satisfies Foo).value === "c";
+   · ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+   ╰────
+  help: Rewrite the repeated `===` comparisons as a single `.includes()` call.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9218,6 +9218,26 @@
         "unicorn/prefer-includes": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/prefer-includes-over-repeated-comparisons": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/PreferIncludesOverRepeatedComparisonsConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "unicorn/prefer-keyboard-event-key": {
           "$ref": "#/definitions/RuleNoConfig"
         },
@@ -17213,6 +17233,20 @@
             "$ref": "#/definitions/JestFnType"
           },
           "markdownDescription": "Jest function types to enforce importing for."
+        }
+      },
+      "additionalProperties": false
+    },
+    "PreferIncludesOverRepeatedComparisonsConfig": {
+      "type": "object",
+      "properties": {
+        "minimumComparisons": {
+          "description": "The minimum number of equality comparisons before reporting.",
+          "default": 3,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "markdownDescription": "The minimum number of equality comparisons before reporting."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

Implements `unicorn/prefer-includes-over-repeated-comparisons` (part of #684).

Suggests rewriting repeated strict-equality checks joined by `||` into a single `.includes()` call when a shared reference is compared against multiple values.

- Supports `minimumComparisons` (default `3`, minimum `2`)
- Skips optional chaining, `NaN`, side-effectful compared values, and `undefined` used as the shared reference
- Report-only (no autofix), matching the initial rule landing pattern

## Testing

- [x] `cargo test -p oxc_linter --lib prefer_includes_over_repeated_comparisons`

## AI disclosure

This contribution was developed with assistance from Cursor (AI coding agent). I reviewed the logic against upstream `eslint-plugin-unicorn` behavior, ran the rule tests, and take responsibility for the change.