### PR TITLE
fix(linter/jsx-a11y/interactive-supports-focus): match eslint behavior for custom components

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/interactive_supports_focus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/interactive_supports_focus.rs
@@ -10,6 +10,7 @@ use crate::{
     AstNode,
     context::LintContext,
     fixer::RuleFixer,
+    globals::HTML_TAG,
     rule::{DefaultRuleConfig, Rule},
     utils::{
         KEYBOARD_EVENT_HANDLERS, MOUSE_EVENT_HANDLERS, get_element_type,
@@ -134,6 +135,12 @@ impl Rule for InteractiveSupportsFocus {
         }
 
         let element_type = get_element_type(ctx, jsx_el);
+
+        // Do not test unresolved custom components because their rendered DOM element is unknown.
+        if !HTML_TAG.contains(element_type.as_ref()) {
+            return;
+        }
+
         if is_interactive_element(&element_type, jsx_el)
             || is_non_interactive_element(&element_type, jsx_el)
         {
@@ -215,6 +222,8 @@ fn test() {
         (r#"<a onClick={() => void 0} href="http://x.y.z" tabIndex={0} />"#, None, None),
         (r#"<a onClick={() => void 0} href="http://x.y.z" role="button" />"#, None, None),
         (r"<TestComponent onClick={doFoo} />", None, None),
+        (r#"<HigherLevelComponent role="button" onClick={() => void 0} />"#, None, None),
+        (r#"<Foo.Bar role="button" onClick={() => void 0} />"#, None, None),
         (r#"<input onClick={() => void 0} type="hidden" />;"#, None, None),
         (r"<span onClick='submitForm();'>Submit</span>", None, None),
         (r"<span onClick='submitForm();' tabIndex={undefined}>Submit</span>", None, None),


### PR DESCRIPTION
## Description

In eslint, `jsx-a11y/interactive-supports-focus` does not report violations in custom components, while Oxlint does. This assumption requires consumer sites of such custom elements to provide a manual `tabindex` property. However, custom components may render to the DOM with `tabindex` defined (e.g. read in `role` as a prop and add `tabindex` based on role). Assuming that they don't requires more verbose code that is not necessarily more correct.

fixes: https://github.com/oxc-project/oxc/issues/24573
repro repo: https://github.com/cellison-figma/interactive-supports-focus-inconsistency

## AI disclosure

I did not use AI to assist in authoring this PR