### PR TITLE
fix(minifier): isolate derived constructor this state

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -574,7 +574,7 @@ impl<'a> PeepholeOptimizations {
         // Only consider top-level expression statements — `super()` inside `if`/loops
         // is conditional and doesn't guarantee `this` is initialized.
         if matches!(expr_stmt.expression, Expression::ThisExpression(_))
-            && Self::this_is_inside_derived_constructor(ctx)
+            && Self::derived_constructor_this_scope(ctx).is_some()
             && result.iter().rev().any(|stmt| {
                 matches!(
                     stmt,

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -248,16 +248,28 @@ impl<'a> PeepholeOptimizations {
         match expr {
             Expression::Identifier(id) => Self::identifier_read_blocks_reorder(id, ctx),
             Expression::ThisExpression(this_expr) => {
+                let Some(this_scope) = Self::derived_constructor_this_scope(ctx) else {
+                    return false;
+                };
+                // Parameter defaults are visited before their function body, so a missing
+                // owner frame means this derived constructor's `this` is uninitialized.
+                let Some(owner_index) = ctx
+                    .state
+                    .body_unsafe_stack
+                    .iter()
+                    .rposition(|(body_scope, _, _)| *body_scope == this_scope)
+                else {
+                    return true;
+                };
                 // Source offsets stand in for execution order here. This assumes upstream
                 // transforms do not reorder `super()` and `this` without updating their spans;
                 // the current Rolldown and oxc-minify pipelines satisfy this assumption.
-                Self::this_is_inside_derived_constructor(ctx)
-                    && ctx
-                        .state
-                        .body_unsafe_stack
-                        .last()
-                        .2
-                        .is_none_or(|initialized_at| this_expr.span.start < initialized_at)
+                // Arrow body frames above the owner share its lexical `this`, so `super()`
+                // in any of those frames initializes the same binding.
+                !ctx.state.body_unsafe_stack[owner_index..].iter().any(|&(_, _, initialized_at)| {
+                    initialized_at
+                        .is_some_and(|initialized_at| this_expr.span.start >= initialized_at)
+                })
             }
             _ => true,
         }
@@ -312,7 +324,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     }
 
     fn enter_function_body(&mut self, body: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {
-        let initialized_at = if Self::this_is_inside_derived_constructor(ctx) {
+        let initialized_at = if Self::derived_constructor_this_scope(ctx).is_some() {
             body.statements.iter().find_map(|stmt| match stmt {
                 Statement::ExpressionStatement(stmt) => {
                     Self::unconditional_super_call_end(&stmt.expression)

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -11,7 +11,7 @@ use oxc_ecmascript::{
     side_effects::{MayHaveSideEffects, MayHaveSideEffectsContext},
 };
 use oxc_span::GetSpan;
-use oxc_syntax::symbol::SymbolId;
+use oxc_syntax::{scope::ScopeId, symbol::SymbolId};
 
 use super::PeepholeOptimizations;
 use super::fold_constants::is_cjs_module_exports_hint;
@@ -40,7 +40,9 @@ impl<'a> PeepholeOptimizations {
                 // In a derived class constructor, accessing `this` before `super()` throws
                 // a `ReferenceError`, so we must keep it. In all other positions (including
                 // non-derived constructors) `this` is always initialized and can be dropped.
-                Expression::ThisExpression(_) => !Self::this_is_inside_derived_constructor(ctx),
+                Expression::ThisExpression(_) => {
+                    Self::derived_constructor_this_scope(ctx).is_none()
+                }
                 _ => unreachable!(
                     "expr_has_specialized_unused_handler is out of sync with this dispatch"
                 ),
@@ -50,27 +52,26 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    /// Whether the nearest non-arrow, non-block function scope is a constructor
-    /// of a class that extends another class (derived class).
+    /// Scope of the derived constructor whose `this` is used at the current position.
     /// Only derived constructors have the TDZ for `this` before `super()`.
-    pub(crate) fn this_is_inside_derived_constructor(ctx: &TraverseCtx<'a>) -> bool {
+    pub(crate) fn derived_constructor_this_scope(ctx: &TraverseCtx<'a>) -> Option<ScopeId> {
         for scope_id in ctx.ancestor_scopes() {
             let flags = ctx.scoping().scope_flags(scope_id);
             if flags.is_block() || flags.is_arrow() {
                 continue;
             }
             if !flags.is_constructor() {
-                return false;
+                return None;
             }
             // Found a constructor — check if the class has `extends`.
             for ancestor in ctx.ancestors() {
                 if let Ancestor::ClassBody(class) = ancestor {
-                    return class.super_class().is_some();
+                    return class.super_class().is_some().then_some(scope_id);
                 }
             }
-            return false;
+            return None;
         }
-        false
+        None
     }
 
     fn remove_unused_unary_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {

--- a/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
@@ -1177,6 +1177,60 @@ fn test_compress_conditional_expression_inside() {
 }
 
 #[test]
+fn test_derived_constructor_parameter_default_does_not_use_outer_super_state() {
+    test_same(
+        "class Outer extends P {
+            constructor() {
+                super();
+                class Inner extends Q {
+                    constructor(a = f() ? this.x = 1 : this.x = 2) {
+                        super();
+                    }
+                }
+                new Inner();
+            }
+        }",
+    );
+}
+
+#[test]
+fn test_derived_constructor_this_captured_by_arrow() {
+    test(
+        "class Outer extends P { constructor() {
+            super();
+            use(() => f() ? this.k = 1 : this.k = 2);
+        } }",
+        "class Outer extends P { constructor() {
+            super(), use(() => this.k = f() ? 1 : 2);
+        } }",
+    );
+
+    test(
+        "class Outer extends P { constructor() {
+            use(() => f() ? this.k = 1 : this.k = 2);
+            super();
+        } }",
+        "class Outer extends P { constructor() {
+            use(() => f() ? this.k = 1 : this.k = 2), super();
+        } }",
+    );
+
+    test(
+        "class Outer extends P { constructor() {
+            use(() => {
+                super();
+                f() ? this.k = 1 : this.k = 2;
+            });
+        } }",
+        "class Outer extends P { constructor() {
+            use(() => {
+                super(), this.k = f() ? 1 : 2;
+            });
+        } }",
+    );
+}
+
+#[test]
 fn test_fold_is_null_or_undefined() {
     test("v = foo === null || foo === undefined", "v = foo == null");
     test("v = foo === undefined || foo === null", "v = foo == null");


### PR DESCRIPTION
> **PR stack (1 of 2)**
> 1. **#24784 (this PR)**
> 2. #24785
>
> Review and merge in this order. #24785 is based on this branch.

Nested derived-constructor parameter defaults can temporarily consult an enclosing function body's `super()` state because parameters are traversed before the inner function body frame is pushed. If the enclosing derived constructor has already called `super()`, conditional assignment merging can treat the inner constructor's uninitialized `this` as safe and move its access before the condition, changing side effects and the thrown error.

Resolve the derived constructor scope whose lexical `this` is used, then find its matching body frame before consulting `super()` source offsets. A missing owner frame identifies constructor parameter evaluation, while body frames belonging to nested arrows continue to share initialization of the same lexical `this`. The span-based ordering and its existing optimization coverage are otherwise unchanged.

## Example

Input:

```js
class Outer extends P {
  constructor() {
    super();
    class Inner extends Q {
      constructor(a = f() ? this.x = 1 : this.x = 2) {
        super();
      }
    }
    new Inner();
  }
}
```

Before:

```js
class Outer extends P{constructor(){super();class Inner extends Q{constructor(a=this.x=f()?1:2){super()}}new Inner}}
```

After:

```js
class Outer extends P{constructor(){super();class Inner extends Q{constructor(a=f()?this.x=1:this.x=2){super()}}new Inner}}
```

Verified with the full `oxc_minifier` suite (633 passed, 42 ignored), Clippy with warnings denied, formatting, `just minsize`, and allocation regeneration. Minsize and allocation snapshots are unchanged.

Follow-up to #24755.

Implemented with AI assistance (OpenAI Codex and Claude). The contributor remains responsible for reviewing, understanding, and submitting these changes under the repository AI usage policy.
