### PR TITLE
fix(minifier): avoid reordering this in nested class keys

### DIFF
--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -63,10 +63,24 @@ impl<'a> PeepholeOptimizations {
             if !flags.is_constructor() {
                 return None;
             }
-            // Found a constructor — check if the class has `extends`.
+            // Found a constructor — check if the class containing that constructor has
+            // `extends`. The nearest class is not necessarily the right one: computed keys
+            // and decorators of a nested class still use the outer lexical `this`.
+            let mut found_constructor_method = false;
             for ancestor in ctx.ancestors() {
-                if let Ancestor::ClassBody(class) = ancestor {
-                    return class.super_class().is_some().then_some(scope_id);
+                match ancestor {
+                    // Field initializers have their own `this`, even though they do not
+                    // introduce a function scope.
+                    Ancestor::PropertyDefinitionValue(_) | Ancestor::AccessorPropertyValue(_) => {
+                        return None;
+                    }
+                    Ancestor::MethodDefinitionValue(method) if method.kind().is_constructor() => {
+                        found_constructor_method = true;
+                    }
+                    Ancestor::ClassBody(class) if found_constructor_method => {
+                        return class.super_class().is_some().then_some(scope_id);
+                    }
+                    _ => {}
                 }
             }
             return None;

--- a/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
@@ -1231,6 +1231,57 @@ fn test_derived_constructor_this_captured_by_arrow() {
 }
 
 #[test]
+fn test_derived_constructor_this_in_nested_class_computed_key() {
+    // Evaluating the computed key calls `f()` before accessing the outer
+    // constructor's uninitialized `this`.
+    test_same(
+        "class Outer extends P { constructor() {
+            class Inner { [f() ? this.k = 1 : this.k = 2]() {} }
+            super();
+        } }",
+    );
+
+    // Once `super()` has initialized the outer `this`, the assignment can
+    // still be merged inside a nested computed key.
+    test(
+        "class Outer extends P { constructor() {
+            super();
+            class Inner { [f() ? this.k = 1 : this.k = 2]() {} }
+        } }",
+        "class Outer extends P { constructor() {
+            super();
+            class Inner { [this.k = f() ? 1 : 2]() {} }
+        } }",
+    );
+
+    // A nested method body has its own initialized `this` binding, so the
+    // assignment can still be merged there.
+    test(
+        "class Outer extends P { constructor() {
+            class Inner { method() { f() ? this.k = 1 : this.k = 2 } }
+            super();
+        } }",
+        "class Outer extends P { constructor() {
+            class Inner { method() { this.k = f() ? 1 : 2 } }
+            super();
+        } }",
+    );
+
+    // A field initializer also has its own initialized `this` binding, despite
+    // not introducing a function scope.
+    test(
+        "class Outer extends P { constructor() {
+            class Inner { field = f() ? this.k = 1 : this.k = 2 }
+            super();
+        } }",
+        "class Outer extends P { constructor() {
+            class Inner { field = this.k = f() ? 1 : 2 }
+            super();
+        } }",
+    );
+}
+
+#[test]
 fn test_fold_is_null_or_undefined() {
     test("v = foo === null || foo === undefined", "v = foo == null");
     test("v = foo === undefined || foo === null", "v = foo == null");

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -87,6 +87,15 @@ fn test_remove_unused_this() {
         "export class A extends B { constructor() { class C { constructor() {} } super(); } }",
     );
 
+    // A nested class's computed key uses the outer constructor's `this`, so a
+    // bare access before `super()` must not be dropped.
+    test_same(
+        "export class A extends B { constructor() {
+            class C { [(this, f())]() {} }
+            super();
+        } }",
+    );
+
     // In all other positions `this` is always initialized and can be dropped.
     test("{ this; }", "");
     test("export class Foo { foo() { this; } }", "export class Foo { foo() {} }");


### PR DESCRIPTION
> **PR stack (2 of 2)**
> 1. #24784
> 2. **#24785 (this PR)**
>
> Review #24784 first. This PR is based on its branch, so GitHub shows only the nested-class fix.

Computed keys of a class nested before `super()` use the enclosing constructor's lexical `this`. The derived-constructor check found that outer constructor scope but paired it with the nearest class body. When the nested class did not extend another class, conditional assignment merging could therefore treat pre-`super()` `this` as initialized and move its access ahead of side effects.

The check now locates the class that owns the constructor method. Computed keys and decorators continue through nested classes to the outer lexical `this`, while method bodies and field initializers keep their own initialized `this` bindings.

## Example

Input:

```js
class Outer extends P {
  constructor() {
    class Inner {
      [f() ? this.k = 1 : this.k = 2]() {}
    }
    super();
  }
}
```

Before:

```js
class Outer extends P {
  constructor() {
    class Inner {
      [this.k = f() ? 1 : 2]() {}
    }
    super();
  }
}
```

After:

```js
class Outer extends P {
  constructor() {
    class Inner {
      [f() ? this.k = 1 : this.k = 2]() {}
    }
    super();
  }
}
```

Verified with the full `oxc_minifier` suite (634 passed, 42 ignored), Clippy with warnings denied, formatting, `just minsize`, and allocation regeneration. Minsize and allocation snapshots are unchanged.

Follow-up to #24784.

Implemented with AI assistance (OpenAI Codex and Claude). The contributor remains responsible for reviewing, understanding, and submitting these changes under the repository AI usage policy.
