### PR TITLE
fix(formatter_css): print nested SCSS map with consistent indent

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -275,6 +275,10 @@ Notable divergences are:
 - SCSS: A function call directly after a `//` comment in nested-args position
   - Prettier double-indents it
   - We print the normal indent (prettier/prettier#19427)
+- SCSS: A nested map value prints at the SAME indent in every block context
+  - Prettier double-indents it (closing `)` floating between levels) when the nearest
+    at-rule ancestor is a control directive (`@if`/`@else`/`@for`/`@each`/`@while`; selector blocks in between don't shield)
+    = identical source, different indent per context
 - SCSS: The map-item break (one element per line + trailing comma) applies ONLY to parens whose contents are already a comma-separated list (semantics)
   - `(x,)` is a single-element list in Sass, so the added comma is a semantic no-op for a comma list and NOWHERE else
   - Prettier 3.9.5 changes `key: ($a + $b)` from a number to a list,
@@ -362,10 +366,10 @@ cargo run -p oxc_prettier_conformance
 cargo run -p oxc_prettier_conformance -- --filter css/atrule
 ```
 
-At the current version (v3.9.5), the divergences of six files have been confirmed and are intentional (see "Known divergences"):
+At the current version (v3.9.5), the divergences of seven files have been confirmed and are intentional (see "Known divergences"):
 
 - CSS: `css/stylefmt-repo/at-media/at-media.css`, `css/stylefmt-repo/cssnext-example/cssnext-example.css`, `css/postcss-plugins/postcss-nesting.css`
-- SCSS: `scss/comments/4878.scss`, `scss/map/function-argument/functional-argument.scss`, `scss/variables/apply-rule.scss`
+- SCSS: `scss/comments/4878.scss`, `scss/map/function-argument/functional-argument.scss`, `scss/parens/issue-16594.scss`, `scss/variables/apply-rule.scss`
 
 Two more files fail with MIXED hunks; they can't pass as files (the intentional hunks alone keep them failing), so the remaining diffs are itemized here:
 

--- a/crates/oxc_formatter_css/src/context.rs
+++ b/crates/oxc_formatter_css/src/context.rs
@@ -16,8 +16,6 @@ pub struct CssFormatContext<'a> {
     /// Inside an ICSS rule (`:import(...)` / `:export`): property names keep
     /// their case (Prettier's `insideIcssRuleNode`).
     in_icss_rule: std::cell::Cell<bool>,
-    /// Current block nesting depth (rules/at-rules).
-    block_depth: std::cell::Cell<u32>,
     /// The source may contain css-in-js `${}` placeholder markers
     /// (embedded entry point only); gates the printer's placeholder handling.
     template_placeholders: bool,
@@ -39,7 +37,6 @@ impl<'a> CssFormatContext<'a> {
             comments: Comments::new(comments),
             in_less_detached: std::cell::Cell::new(false),
             in_icss_rule: std::cell::Cell::new(false),
-            block_depth: std::cell::Cell::new(0),
             template_placeholders,
             tailwind_classes: Vec::new(),
         }
@@ -61,10 +58,6 @@ impl<'a> CssFormatContext<'a> {
     /// Whether the source may contain css-in-js `${}` placeholder markers.
     pub fn template_placeholders(&self) -> bool {
         self.template_placeholders
-    }
-
-    pub fn block_depth(&self) -> &std::cell::Cell<u32> {
-        &self.block_depth
     }
 
     pub fn in_less_detached(&self) -> &std::cell::Cell<bool> {

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -140,6 +140,12 @@ pub(super) fn write_top_level_value<'a>(
     }
 }
 
+/// A paren-delimited map/list value or key: hugs the colon and carries
+/// its own break layout (Prettier's `value-paren_group` checks).
+fn is_paren_block(value: &ComponentValue<'_>) -> bool {
+    matches!(value, ComponentValue::SassMap(_) | ComponentValue::SassParenthesizedExpression(_))
+}
+
 /// `(key: value, ...)`: SCSS maps in map-item positions always break,
 /// one item per line, with a trailing comma per the `trailingComma` option.
 pub(super) fn write_sass_map<'a>(
@@ -277,10 +283,7 @@ pub(super) fn write_sass_map<'a>(
                 ValueContext { map_key: false, paren_break: true, map_break: true, ..ctx };
             // Nested maps / paren lists hug the colon (`key: (`);
             // the pair never breaks after the colon (Prettier dedents these).
-            let value_is_block = matches!(
-                item.value,
-                ComponentValue::SassMap(_) | ComponentValue::SassParenthesizedExpression(_)
-            );
+            let value_is_block = is_paren_block(&item.value);
 
             // Comments between items:
             // block comments join the item when the pair fits on one line (Prettier's fill);
@@ -304,10 +307,7 @@ pub(super) fn write_sass_map<'a>(
             if i == 0 {
                 first_item_has_leading_comment = had_leading_comment;
             }
-            let key_is_block = matches!(
-                item.key,
-                ComponentValue::SassMap(_) | ComponentValue::SassParenthesizedExpression(_)
-            );
+            let key_is_block = is_paren_block(&item.key);
             if i + 1 == map.items.len() {
                 // Suppressed only when the source ALSO had a trailing comma
                 // (the comment lands inside the last comma_group in postcss).
@@ -323,17 +323,17 @@ pub(super) fn write_sass_map<'a>(
             } else if value_is_block {
                 value::write_component_value(&item.key, key_ctx, f);
                 write!(f, [":", space()]);
-                // A paren/map KEY (or a leading comment, or nesting) keeps the pair's indent on the value
+                // A paren/map KEY (or a leading comment) keeps the pair's indent on the value
                 // (Prettier's dedent applies only when the doc is a plain `group(indent(fill))`).
-                let needs_indent =
-                    key_is_block || had_leading_comment || f.context().block_depth().get() > 0;
-                if needs_indent {
-                    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
-                        write_top_level_value(&item.value, val_ctx, f);
-                    });
+                // NOTE: Prettier ALSO skips the dedent inside `@if`/`@each`/... and double-indents the value.
+                // (prettier#16607 crash-guard artifact we deliberately do NOT match)
+                let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    write_top_level_value(&item.value, val_ctx, f);
+                });
+                if key_is_block || had_leading_comment {
                     write!(f, indent(&body));
                 } else {
-                    write_top_level_value(&item.value, val_ctx, f);
+                    write!(f, body);
                 }
             } else {
                 // `key: value` breaks after the colon when too long
@@ -341,11 +341,7 @@ pub(super) fn write_sass_map<'a>(
                     let mut filler = f.fill();
                     let key = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                         // Paren/map keys cancel the pair indent (Prettier's `isKey` → dedent)
-                        if matches!(
-                            item.key,
-                            ComponentValue::SassMap(_)
-                                | ComponentValue::SassParenthesizedExpression(_)
-                        ) {
+                        if key_is_block {
                             let inner = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                                 value::write_component_value(&item.key, key_ctx, f);
                             });

--- a/crates/oxc_formatter_css/src/print/statement.rs
+++ b/crates/oxc_formatter_css/src/print/statement.rs
@@ -646,14 +646,6 @@ fn respace_value_tokens(v: &str) -> String {
 /// Mirrors Prettier's block printing: `{` + indented statements + `}`.
 /// An empty block prints as `{\n}`.
 pub(super) fn write_block<'a>(block: &SimpleBlock<'a>, f: &mut CssFormatter<'_, 'a>) {
-    let depth = f.context().block_depth();
-    depth.set(depth.get() + 1);
-    write_block_inner(block, f);
-    let depth = f.context().block_depth();
-    depth.set(depth.get() - 1);
-}
-
-fn write_block_inner<'a>(block: &SimpleBlock<'a>, f: &mut CssFormatter<'_, 'a>) {
     let block_span = to_span(&block.span);
     let r_curly = block_span.end.saturating_sub(1);
 

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/nested-map-in-block.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/nested-map-in-block.scss
@@ -1,0 +1,47 @@
+// A nested map value prints at the SAME indent in EVERY block context
+// (oxc-project/oxc#24773).
+//
+// ---- Group 1: matches Prettier (its pair-dedent fires -> normal indent) ----
+@function fn() {
+  $in-function: ($k: ($n: $v));
+}
+@mixin mx() {
+  $in-mixin: ($k: ($n: $v));
+}
+.sel {
+  $in-selector: ($k: ($n: $v));
+}
+// Nearest at-rule ancestor wins: @function shields the outer @if
+@if true {
+  @function fn3() {
+    $in-function-under-if: ($k: ($n: $v));
+  }
+}
+
+// ---- Group 2: DELIBERATE DIVERGENCE ----
+// See "SCSS: A nested map value prints at the SAME indent" in AGENTS.md
+// "Known divergences". For every case below Prettier double-indents `$n`
+// and floats the closing `),` between levels:
+//   $in-if: (
+//     $k: (
+//         $n: $v,
+//       ),
+//   );
+// We print the same normal indent as Group 1.
+@if true {
+  $in-if: ($k: ($n: $v));
+}
+@each $i in $list {
+  $in-each: ($k: ($n: $v));
+}
+// Selector blocks do NOT shield the control directive
+@if true {
+  .sel {
+    $in-selector-under-if: ($k: ($n: $v));
+  }
+}
+@function fn2() {
+  @if true {
+    $in-if-under-function: ($k: ($n: $v));
+  }
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/nested-map-in-block.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/nested-map-in-block.scss.snap
@@ -1,0 +1,220 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A nested map value prints at the SAME indent in EVERY block context
+// (oxc-project/oxc#24773).
+//
+// ---- Group 1: matches Prettier (its pair-dedent fires -> normal indent) ----
+@function fn() {
+  $in-function: ($k: ($n: $v));
+}
+@mixin mx() {
+  $in-mixin: ($k: ($n: $v));
+}
+.sel {
+  $in-selector: ($k: ($n: $v));
+}
+// Nearest at-rule ancestor wins: @function shields the outer @if
+@if true {
+  @function fn3() {
+    $in-function-under-if: ($k: ($n: $v));
+  }
+}
+
+// ---- Group 2: DELIBERATE DIVERGENCE ----
+// See "SCSS: A nested map value prints at the SAME indent" in AGENTS.md
+// "Known divergences". For every case below Prettier double-indents `$n`
+// and floats the closing `),` between levels:
+//   $in-if: (
+//     $k: (
+//         $n: $v,
+//       ),
+//   );
+// We print the same normal indent as Group 1.
+@if true {
+  $in-if: ($k: ($n: $v));
+}
+@each $i in $list {
+  $in-each: ($k: ($n: $v));
+}
+// Selector blocks do NOT shield the control directive
+@if true {
+  .sel {
+    $in-selector-under-if: ($k: ($n: $v));
+  }
+}
+@function fn2() {
+  @if true {
+    $in-if-under-function: ($k: ($n: $v));
+  }
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A nested map value prints at the SAME indent in EVERY block context
+// (oxc-project/oxc#24773).
+//
+// ---- Group 1: matches Prettier (its pair-dedent fires -> normal indent) ----
+@function fn() {
+  $in-function: (
+    $k: (
+      $n: $v,
+    ),
+  );
+}
+@mixin mx() {
+  $in-mixin: (
+    $k: (
+      $n: $v,
+    ),
+  );
+}
+.sel {
+  $in-selector: (
+    $k: (
+      $n: $v,
+    ),
+  );
+}
+// Nearest at-rule ancestor wins: @function shields the outer @if
+@if true {
+  @function fn3() {
+    $in-function-under-if: (
+      $k: (
+        $n: $v,
+      ),
+    );
+  }
+}
+
+// ---- Group 2: DELIBERATE DIVERGENCE ----
+// See "SCSS: A nested map value prints at the SAME indent" in AGENTS.md
+// "Known divergences". For every case below Prettier double-indents `$n`
+// and floats the closing `),` between levels:
+//   $in-if: (
+//     $k: (
+//         $n: $v,
+//       ),
+//   );
+// We print the same normal indent as Group 1.
+@if true {
+  $in-if: (
+    $k: (
+      $n: $v,
+    ),
+  );
+}
+@each $i in $list {
+  $in-each: (
+    $k: (
+      $n: $v,
+    ),
+  );
+}
+// Selector blocks do NOT shield the control directive
+@if true {
+  .sel {
+    $in-selector-under-if: (
+      $k: (
+        $n: $v,
+      ),
+    );
+  }
+}
+@function fn2() {
+  @if true {
+    $in-if-under-function: (
+      $k: (
+        $n: $v,
+      ),
+    );
+  }
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A nested map value prints at the SAME indent in EVERY block context
+// (oxc-project/oxc#24773).
+//
+// ---- Group 1: matches Prettier (its pair-dedent fires -> normal indent) ----
+@function fn() {
+  $in-function: (
+    $k: (
+      $n: $v,
+    ),
+  );
+}
+@mixin mx() {
+  $in-mixin: (
+    $k: (
+      $n: $v,
+    ),
+  );
+}
+.sel {
+  $in-selector: (
+    $k: (
+      $n: $v,
+    ),
+  );
+}
+// Nearest at-rule ancestor wins: @function shields the outer @if
+@if true {
+  @function fn3() {
+    $in-function-under-if: (
+      $k: (
+        $n: $v,
+      ),
+    );
+  }
+}
+
+// ---- Group 2: DELIBERATE DIVERGENCE ----
+// See "SCSS: A nested map value prints at the SAME indent" in AGENTS.md
+// "Known divergences". For every case below Prettier double-indents `$n`
+// and floats the closing `),` between levels:
+//   $in-if: (
+//     $k: (
+//         $n: $v,
+//       ),
+//   );
+// We print the same normal indent as Group 1.
+@if true {
+  $in-if: (
+    $k: (
+      $n: $v,
+    ),
+  );
+}
+@each $i in $list {
+  $in-each: (
+    $k: (
+      $n: $v,
+    ),
+  );
+}
+// Selector blocks do NOT shield the control directive
+@if true {
+  .sel {
+    $in-selector-under-if: (
+      $k: (
+        $n: $v,
+      ),
+    );
+  }
+}
+@function fn2() {
+  @if true {
+    $in-if-under-function: (
+      $k: (
+        $n: $v,
+      ),
+    );
+  }
+}
+
+===================== End =====================

--- a/tasks/prettier_conformance/snapshots/prettier.scss.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.scss.snap.md
@@ -1,4 +1,4 @@
-scss compatibility: 87/90 (96.67%), 6 files skipped
+scss compatibility: 86/90 (95.56%), 6 files skipped
 
 # Failed
 
@@ -6,6 +6,7 @@ scss compatibility: 87/90 (96.67%), 6 files skipped
 | :-------- | :--------------: | :---------: |
 | scss/comments/4878.scss | 💥 | 89.39% |
 | scss/map/function-argument/functional-argument.scss | 💥 | 96.00% |
+| scss/parens/issue-16594.scss | 💥 | 71.43% |
 | scss/variables/apply-rule.scss | 💥 | 87.88% |
 
 # Skipped (parse error, TODO: should be ignored or supported)


### PR DESCRIPTION
Fixes #24773
