### PR TITLE
perf(formatter_core): bound the thread-local scratch cache

### DIFF
--- a/crates/oxc_formatter/src/print/jsx/child_list.rs
+++ b/crates/oxc_formatter/src/print/jsx/child_list.rs
@@ -555,13 +555,13 @@ enum MultilineLayout {
 struct MultilineBuilder<'a> {
     layout: MultilineLayout,
     /// Heap accumulator; the flat and multiline builders write alternately,
-    /// so each checks out its own (see [`ScratchBuffer::writer`]).
+    /// so each owns its own (see [`ScratchBuffer::writer`]).
     result: ScratchBuffer<'a>,
 }
 
 impl<'a> MultilineBuilder<'a> {
     fn new(layout: MultilineLayout) -> Self {
-        Self { layout, result: ScratchBuffer::checkout() }
+        Self { layout, result: ScratchBuffer::new() }
     }
 
     /// Formats an element that does not require a separator
@@ -700,9 +700,7 @@ struct FlatBuilder<'a> {
 
 impl<'a> FlatBuilder<'a> {
     fn new(disabled: bool) -> Self {
-        // A builder born disabled never writes; skip the pool checkout
-        let result = if disabled { ScratchBuffer::empty() } else { ScratchBuffer::checkout() };
-        Self { result, disabled }
+        Self { result: ScratchBuffer::new(), disabled }
     }
 
     fn write(
@@ -720,8 +718,7 @@ impl<'a> FlatBuilder<'a> {
 
     fn disable(&mut self) {
         self.disabled = true;
-        // Abandoned content; clear so the scratch returns to the cache empty.
-        self.result.clear();
+        self.result.discard();
     }
 
     fn finish(self) -> FormatFlatChildren<'a> {

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -831,18 +831,18 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AssignmentLike<'a, '_> {
             // can can be known only when it's formatted (it can incur in some transformation,
             // like removing some escapes, etc.).
             //
-            // 1. we check a scratch vector out as a temporary heap buffer
+            // 1. we create a scratch accumulator as a temporary heap buffer
             //    (see `AccumulatorBuffer` for why neither the arena nor the shared scratch fits)
             // 2. we write the left hand side into the buffer and retrieve the `is_left_short` info
             //    which is computed only when we format it
             // 3. we compute the layout
             // 4. we write the left node inside the main buffer based on the layout
-            let mut formatted_left = ScratchBuffer::checkout();
+            let mut formatted_left = ScratchBuffer::new();
             let is_left_short =
                 self.write_left(&mut Formatter::new(&mut formatted_left.writer(f.state_mut())));
             let left_may_break = formatted_left.may_directly_break();
 
-            let left = format_once(move |f| f.write_elements(formatted_left.drain(..)));
+            let left = format_once(move |f| f.write_elements(formatted_left.drain()));
 
             // Compare name only if we are in a position of computing it.
             // If not (for example, left is not an identifier), then let's fallback to false,

--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -35,7 +35,8 @@ Pick by what you're building:
   - it moves into the `Document` for free, and heap-staging it costs an extra copy for no benefit
 - Unknown-length staging that ends interned/sliced: `HeapVecBuffer`
   - a watermarked view over a shared, thread-cached scratch vector; the arena receives one exactly-sized copy (see its rustdoc for the full rationale)
-- Accumulating across interleaved `write()` calls (multiple builders open at once), or staging that must release the state between writes and consumption: check a `ScratchBuffer` out per accumulator and write through `ScratchBuffer::writer`, finish via `Formatter::intern_elements` (or re-emit into the destination buffer)
+  - the per-thread cache has byte and buffer-count limits; oversized staging is released after the format run
+- Accumulating across interleaved `write()` calls (multiple builders open at once), or staging that must release the state between writes and consumption: give each accumulator its own `ScratchBuffer` (pooled capacity is fetched lazily on first write) and write through `ScratchBuffer::writer`, finish via `Formatter::intern_elements` (or re-emit via `ScratchBuffer::drain`, abandon via `ScratchBuffer::discard`)
   - the shared scratch's LIFO rule and its exclusive state borrow rule out `HeapVecBuffer` there (see the JSX child-list builders and `AssignmentLike` in `oxc_formatter`)
 - `BestFitting` variants: `best_fitting_variant` (wraps the entry tags and stages on the heap in one place)
 - Known-length sequences: build exact-sized directly (e.g. `ArenaVec::from_iter_in`)

--- a/crates/oxc_formatter_core/src/buffer.rs
+++ b/crates/oxc_formatter_core/src/buffer.rs
@@ -139,7 +139,10 @@ impl<'ast, C> Buffer<'ast, C> for VecBuffer<'_, 'ast, C> {
     }
 
     fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]) {
-        self.elements.splice(start.., replacement.iter().cloned());
+        // `truncate` silently ignores an out-of-bounds start; fail loudly instead
+        assert!(start <= self.elements.len(), "replace_end start out of bounds");
+        self.elements.truncate(start);
+        self.elements.extend_from_slice(replacement);
     }
 }
 
@@ -185,12 +188,17 @@ impl<'buf, 'ast, C> HeapVecBuffer<'buf, 'ast, C> {
         if self.is_empty() { None } else { self.state.scratch_mut().pop() }
     }
 
+    /// Removes and returns the buffered elements, leaving the buffer empty.
+    pub(crate) fn drain(&mut self) -> std::vec::Drain<'_, FormatElement<'ast>> {
+        let watermark = self.watermark;
+        self.state.scratch_mut().drain(watermark..)
+    }
+
     /// Moves the buffered elements into an exactly-sized arena vector, leaving the buffer empty.
     pub fn take_into_arena_vec(&mut self) -> ArenaVec<'ast, FormatElement<'ast>> {
         let allocator = self.state.allocator();
-        let watermark = self.watermark;
         // `Drain`'s exact size hint makes `from_iter_in` allocate exactly-sized
-        ArenaVec::from_iter_in(self.state.scratch_mut().drain(watermark..), &allocator)
+        ArenaVec::from_iter_in(self.drain(), &allocator)
     }
 
     /// Moves the buffered elements into an exactly-sized arena slice, leaving the buffer empty.
@@ -234,7 +242,11 @@ impl<'ast, C> Buffer<'ast, C> for HeapVecBuffer<'_, 'ast, C> {
 
     fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]) {
         let start = self.watermark + start;
-        self.state.scratch_mut().splice(start.., replacement.iter().cloned());
+        let scratch = self.state.scratch_mut();
+        // `truncate` silently ignores an out-of-bounds start; fail loudly instead
+        assert!(start <= scratch.len(), "replace_end start out of bounds");
+        scratch.truncate(start);
+        scratch.extend_from_slice(replacement);
     }
 }
 
@@ -248,7 +260,7 @@ impl<'ast, C> Buffer<'ast, C> for HeapVecBuffer<'_, 'ast, C> {
 /// Those can't stage in the arena (every growth would strand the grown-out-of allocation, see [`HeapVecBuffer`])
 /// nor share the format run's scratch vector (suspended or interleaved use breaks its LIFO discipline).
 ///
-/// Instead the caller checks its own [`crate::ScratchBuffer`] out of the thread-local cache
+/// Instead the caller owns a [`crate::ScratchBuffer`] (backed lazily by the thread-local cache)
 /// and writes through this adapter (constructed via [`crate::ScratchBuffer::writer`]);
 /// the arena receives one exactly-sized copy when the finished result is interned ([`crate::Formatter::intern_elements`]),
 /// or nothing at all when the elements are re-emitted into a downstream buffer.
@@ -284,7 +296,10 @@ impl<'ast, C> Buffer<'ast, C> for AccumulatorBuffer<'_, 'ast, C> {
     }
 
     fn replace_end(&mut self, start: usize, replacement: &[FormatElement<'ast>]) {
-        self.elements.splice(start.., replacement.iter().cloned());
+        // `truncate` silently ignores an out-of-bounds start; fail loudly instead
+        assert!(start <= self.elements.len(), "replace_end start out of bounds");
+        self.elements.truncate(start);
+        self.elements.extend_from_slice(replacement);
     }
 }
 

--- a/crates/oxc_formatter_core/src/formatter.rs
+++ b/crates/oxc_formatter_core/src/formatter.rs
@@ -5,12 +5,29 @@ use std::borrow::Cow;
 use oxc_allocator::{Allocator, ArenaVec, GetAllocator};
 
 use crate::{
-    Argument, Arguments, Buffer, FormatContext, FormatElement, FormatState,
+    Argument, Arguments, Buffer, FormatContext, FormatElement, FormatState, ScratchBuffer,
     buffer::HeapVecBuffer,
     builders::{FillBuilder, JoinBuilder},
     format::{Format, write},
     format_element::Interned,
 };
+
+/// Interns an exactly-sized element sequence, the single place encoding the interning policy:
+/// the 0/1-element cases return without ever allocating an `ArenaVec`.
+fn intern_exact<'ast>(
+    allocator: &'ast Allocator,
+    mut elements: impl ExactSizeIterator<Item = FormatElement<'ast>>,
+) -> Option<FormatElement<'ast>> {
+    match elements.len() {
+        0 => None,
+        // Doesn't get cheaper than calling clone, use the element directly
+        1 => elements.next(),
+        // The exact size hint makes `from_iter_in` allocate exactly-sized
+        _ => Some(FormatElement::Interned(Interned::new(ArenaVec::from_iter_in(
+            elements, &allocator,
+        )))),
+    }
+}
 
 /// Lifts a `Cow<'ast, str>` to `&'ast str`, allocating in the arena only for the owned case.
 /// Borrowed Cows already point into arena-resident source, so they pass through unchanged.
@@ -66,34 +83,16 @@ impl<'buf, 'ast, C> Formatter<'buf, 'ast, C> {
     pub fn intern(&mut self, content: &dyn Format<'ast, C>) -> Option<FormatElement<'ast>> {
         let mut buffer = HeapVecBuffer::new(self.state_mut());
         write(&mut buffer, Arguments::new(&[Argument::new(&content)]));
-
-        // Dispatching on the heap buffer lets the 0/1-element cases return
-        // without ever allocating an `ArenaVec`.
-        match buffer.len() {
-            0 => None,
-            // Doesn't get cheaper than calling clone, use the element directly
-            1 => buffer.pop(),
-            _ => Some(FormatElement::Interned(Interned::new(buffer.take_into_arena_vec()))),
-        }
+        intern_exact(buffer.state().allocator(), buffer.drain())
     }
 
-    /// Interns a pre-built element sequence (e.g. a builder's heap accumulator),
-    /// moving it into the arena exactly-sized. The source is cleared,
-    /// retaining its capacity for the caller (a [`crate::ScratchBuffer`] returns it to the cache).
+    /// Interns a builder's heap accumulator, moving it into the arena exactly-sized.
+    /// The source is emptied, retaining its capacity (returned to the cache when the scratch drops).
     pub fn intern_elements(
         &self,
-        elements: &mut Vec<FormatElement<'ast>>,
+        elements: &mut ScratchBuffer<'ast>,
     ) -> Option<FormatElement<'ast>> {
-        match elements.len() {
-            0 => None,
-            // Doesn't get cheaper than calling clone, use the element directly
-            1 => elements.pop(),
-            _ => {
-                // `Drain`'s exact size hint makes `from_iter_in` allocate exactly-sized
-                let vec = ArenaVec::from_iter_in(elements.drain(..), &self.allocator());
-                Some(FormatElement::Interned(Interned::new(vec)))
-            }
-        }
+        intern_exact(self.allocator(), elements.drain())
     }
 
     /// Creates a [`JoinBuilder`] that joins entries together without a separator.

--- a/crates/oxc_formatter_core/src/state.rs
+++ b/crates/oxc_formatter_core/src/state.rs
@@ -1,46 +1,126 @@
-use std::{cell::RefCell, mem};
+use std::{cell::RefCell, collections::VecDeque, mem};
+
+use rustc_hash::FxHashMap;
 
 use oxc_allocator::{Allocator, GetAllocator};
-use rustc_hash::FxHashMap;
 
 use crate::{
     FormatElement, GroupId, UniqueGroupIdBuilder, buffer::AccumulatorBuffer,
     format_element::Interned,
 };
 
+/// Maximum total element-storage capacity retained by the scratch cache on each thread.
+///
+/// This bounds only idle capacity between format runs;
+/// a run can still grow beyond it, and the oversized vector is then released at run end instead of cached.
+/// The cache retains only what a run actually grew, so a generous ceiling is near-free,
+/// while a tight one would make every re-format of a large file re-grow its scratch from nothing.
+///
+/// 8 MB keeps every measured non-bundled fixture cached (`checker.ts` included);
+/// only the bundled `antd.js` overflows and re-grows per run
+/// (its elevated sys-alloc numbers in `allocs_formatter.yaml` are this constant at work),
+/// a deliberate trade-off: repeatedly re-formatting bundles is not worth pinning tens of MB per thread.
+const MAX_CACHED_SCRATCH_BYTES: usize = 8 * 1024 * 1024;
+
+/// Maximum number of scratch vectors retained on each thread.
+///
+/// Sized for the concurrent users: nested format runs (embedded languages) plus overlapping accumulators
+/// (nested JSX child lists hold up to two each, so 64 keeps roughly 30 levels of JSX nesting warm).
+/// Low-stakes in both directions: retained memory is already bounded by the byte limit above,
+/// overflow just makes excess accumulators allocate fresh small vectors, and the count mainly keeps the `take_largest` scan short.
+const MAX_CACHED_SCRATCH_BUFFERS: usize = 64;
+
 thread_local! {
-    /// Cache of heap staging vectors, keeping their high-water capacity alive across format runs on the same thread.
-    /// Once a thread is warm, staging performs no heap allocation at all.
-    /// A stack because format runs nest (embedded-language formatting creates a child [`FormatState`] on the same thread).
+    /// Cache of heap staging vectors, reusing capacity across format runs on the same thread.
+    /// Retained memory and buffer count are bounded by the constants above.
+    /// Multiple vectors are kept because format runs can nest
+    /// (embedded-language formatting creates a child [`FormatState`] on the same thread) and accumulators can overlap.
     ///
-    /// INVARIANT: the blind LIFO pop hands each vector back to the role that grew it
-    /// only because returns and takes pair up in reverse order today:
-    /// a run's shared scratch, the largest vector by far on pathological inputs
-    /// (a bundled file can stage most of its document in one `intern`, tens of MB),
-    /// is returned last on [`FormatState`] drop and taken first by the next [`FormatState::new`],
-    /// while the accumulator-sized vectors cycle among themselves in between.
-    /// Anything that changes the return order (e.g. a second [`ScratchBuffer`] field on [`FormatState`] dropping after `scratch`)
-    /// silently mismatches sizes to roles and re-grows the big vector from nothing every run (only visible in the allocation snapshots).
-    /// If you need another long-lived holder, make [`ScratchBuffer::checkout`] pick by capacity instead of relying on this ordering.
-    static SCRATCH_CACHE: RefCell<Vec<Vec<FormatElement<'static>>>> =
-        const { RefCell::new(Vec::new()) };
+    /// Accumulator buffers use LIFO order.
+    /// A [`FormatState`] explicitly takes the largest cached buffer,
+    /// so rejecting an oversized run scratch cannot make the next run start with a small accumulator buffer.
+    /// When a limit is reached, [`ScratchCache::insert`] evicts the oldest buffers first;
+    /// an individually oversized vector is released instead of cached.
+    static SCRATCH_CACHE: RefCell<ScratchCache> = const { RefCell::new(ScratchCache::new()) };
 }
 
-/// A heap staging vector checked out of the thread-local `SCRATCH_CACHE` on creation and returned on drop (panics included),
-/// so its high-water capacity is reused across checkouts.
+struct ScratchCache {
+    buffers: VecDeque<Vec<FormatElement<'static>>>,
+    retained_bytes: usize,
+}
+
+impl ScratchCache {
+    const fn new() -> Self {
+        Self { buffers: VecDeque::new(), retained_bytes: 0 }
+    }
+
+    fn take(&mut self) -> Vec<FormatElement<'static>> {
+        let Some(buffer) = self.buffers.pop_back() else { return Vec::new() };
+        self.retained_bytes -= Self::capacity_in_bytes(buffer.capacity());
+        buffer
+    }
+
+    fn take_largest(&mut self) -> Vec<FormatElement<'static>> {
+        let Some((index, _)) =
+            self.buffers.iter().enumerate().max_by_key(|(_, buffer)| buffer.capacity())
+        else {
+            return Vec::new();
+        };
+        let buffer = self.buffers.remove(index).unwrap();
+        self.retained_bytes -= Self::capacity_in_bytes(buffer.capacity());
+        buffer
+    }
+
+    fn insert(&mut self, buffer: Vec<FormatElement<'static>>) {
+        let buffer_bytes = Self::capacity_in_bytes(buffer.capacity());
+        if buffer_bytes == 0 || buffer_bytes > MAX_CACHED_SCRATCH_BYTES {
+            return;
+        }
+
+        // Evict the least recently returned buffers until both limits have room
+        while self.buffers.len() >= MAX_CACHED_SCRATCH_BUFFERS
+            || self.retained_bytes > MAX_CACHED_SCRATCH_BYTES - buffer_bytes
+        {
+            let Some(evicted) = self.buffers.pop_front() else { break };
+            self.retained_bytes -= Self::capacity_in_bytes(evicted.capacity());
+        }
+
+        self.retained_bytes += buffer_bytes;
+        self.buffers.push_back(buffer);
+    }
+
+    const fn capacity_in_bytes(capacity: usize) -> usize {
+        capacity.saturating_mul(size_of::<FormatElement<'static>>())
+    }
+}
+
+/// A heap staging vector backed by the thread-local `SCRATCH_CACHE`.
+///
+/// Pooled capacity is fetched on first use and returned on drop (panics included),
+/// so its high-water capacity is reused across instances.
 ///
 /// Two users:
 /// - [`FormatState`] holds one per format run, shared by all [`crate::HeapVecBuffer`]s like a stack via watermarks:
 ///   each buffer records the length at creation, pushes its elements, and drains its own tail on completion.
 ///   Sound because IR staging is strictly LIFO (an inner buffer always completes before its enclosing one resumes)
-/// - Accumulators that outlive a single staging scope (interleaved or suspended use, written through [`crate::AccumulatorBuffer`]) check out their own.
-///   The cache itself is an unordered pool with no LIFO requirement
+/// - Accumulators that outlive a single staging scope (interleaved or suspended use, written through [`crate::AccumulatorBuffer`]) each own one.
+///   Accumulators fetch cached vectors in LIFO order; [`FormatState`] takes the largest vector
+///
+/// Content leaves the buffer only through the named consumption paths
+/// ([`crate::Formatter::intern_elements`], [`ScratchBuffer::drain`], or [`ScratchBuffer::discard`])
+/// all of which leave it empty, satisfying the drop-time assertion below.
 #[derive(Debug)]
 pub struct ScratchBuffer<'ast>(Vec<FormatElement<'ast>>);
 
 impl<'ast> ScratchBuffer<'ast> {
-    pub fn checkout() -> Self {
-        let vec = SCRATCH_CACHE.with_borrow_mut(Vec::pop).unwrap_or_default();
+    /// An empty scratch buffer. Costs nothing until written to:
+    /// pooled capacity is fetched lazily by [`ScratchBuffer::writer`],
+    /// so an accumulator that is never written (e.g. a builder born disabled) never touches the cache.
+    pub const fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    fn from_cached(vec: Vec<FormatElement<'static>>) -> Self {
         // SAFETY: cached vectors are always empty (checkin clears them);
         // an empty vector holds no values, so re-branding its element lifetime is sound.
         Self(unsafe {
@@ -48,42 +128,68 @@ impl<'ast> ScratchBuffer<'ast> {
         })
     }
 
-    /// An unpooled, empty scratch buffer, for accumulators that may never be written (e.g. a builder born disabled):
-    /// costs no thread-local access on creation, nor on drop while still empty.
-    pub const fn empty() -> Self {
-        Self(Vec::new())
+    fn checkout() -> Self {
+        Self::from_cached(SCRATCH_CACHE.with_borrow_mut(ScratchCache::take))
     }
 
-    /// Adapts this scratch vector into a [`Buffer`](crate::Buffer) writing into it.
+    fn checkout_largest() -> Self {
+        Self::from_cached(SCRATCH_CACHE.with_borrow_mut(ScratchCache::take_largest))
+    }
+
+    /// Adapts this scratch vector into a [`Buffer`](crate::Buffer) writing into it,
+    /// fetching pooled capacity on the way if the vector has none yet.
     ///
-    /// This is the only way to construct an [`AccumulatorBuffer`],
-    /// so an accumulator always writes into a pooled vector guarded by the drain-before-drop assertion below.
+    /// This is the only way to construct an [`AccumulatorBuffer`] and the only write path into the vector,
+    /// so accumulated content is always guarded by the drain-before-drop assertion below.
     pub fn writer<'buf, C>(
         &'buf mut self,
         state: &'buf mut FormatState<'ast, C>,
     ) -> AccumulatorBuffer<'buf, 'ast, C> {
+        if self.0.capacity() == 0 {
+            *self = Self::checkout();
+        }
         AccumulatorBuffer::new(state, &mut self.0)
+    }
+
+    /// Removes and returns the accumulated elements, leaving the buffer empty (re-emit consumption path).
+    pub fn drain(&mut self) -> std::vec::Drain<'_, FormatElement<'ast>> {
+        self.0.drain(..)
+    }
+
+    /// Inserts an element at `index`, shifting the rest.
+    /// For post-hoc adjustment of already-accumulated content
+    /// (e.g. slipping a separator into the last written entry); new content goes through [`ScratchBuffer::writer`].
+    pub fn insert(&mut self, index: usize, element: FormatElement<'ast>) {
+        self.0.insert(index, element);
+    }
+
+    /// Abandons any accumulated content and returns the pooled capacity to the cache immediately,
+    /// so other accumulators (e.g. nested ones still running) can reuse it.
+    pub fn discard(&mut self) {
+        self.0.clear();
+        // The taken-out buffer's drop checks its capacity back in
+        drop(mem::take(self));
     }
 }
 
 impl<'ast> std::ops::Deref for ScratchBuffer<'ast> {
-    type Target = Vec<FormatElement<'ast>>;
+    type Target = [FormatElement<'ast>];
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl std::ops::DerefMut for ScratchBuffer<'_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+impl Default for ScratchBuffer<'_> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 impl Drop for ScratchBuffer<'_> {
     fn drop(&mut self) {
-        // Every user drains the vector on completion (`HeapVecBuffer`s their own tail,
-        // accumulators via `Formatter::intern_elements`); a leftover means elements leaked.
+        // Every user empties the vector on completion (`HeapVecBuffer`s drain their own tail,
+        // accumulators finish via `intern_elements`/`drain`/`discard`); a leftover means elements leaked.
         // (Skipped mid-unwind: buffers up the stack haven't truncated their tails yet.)
         debug_assert!(
             self.0.is_empty() || std::thread::panicking(),
@@ -98,7 +204,7 @@ impl Drop for ScratchBuffer<'_> {
         // SAFETY: just cleared; see `checkout`
         let vec =
             unsafe { mem::transmute::<Vec<FormatElement<'_>>, Vec<FormatElement<'static>>>(vec) };
-        SCRATCH_CACHE.with_borrow_mut(|cache| cache.push(vec));
+        SCRATCH_CACHE.with_borrow_mut(|cache| cache.insert(vec));
     }
 }
 
@@ -132,7 +238,7 @@ impl<'ast, C> FormatState<'ast, C> {
             allocator,
             group_id_builder: UniqueGroupIdBuilder::default(),
             printed_interned_elements: FxHashMap::default(),
-            scratch: ScratchBuffer::checkout(),
+            scratch: ScratchBuffer::checkout_largest(),
         }
     }
 
@@ -187,5 +293,101 @@ impl<'ast, C> GetAllocator<'ast> for FormatState<'ast, C> {
     #[inline]
     fn allocator(&self) -> &'ast Allocator {
         self.allocator
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buffer_with_capacity(capacity: usize) -> Vec<FormatElement<'static>> {
+        Vec::with_capacity(capacity)
+    }
+
+    fn assert_retained_bytes_consistent(cache: &ScratchCache) {
+        assert_eq!(
+            cache.retained_bytes,
+            cache
+                .buffers
+                .iter()
+                .map(|buffer| ScratchCache::capacity_in_bytes(buffer.capacity()))
+                .sum::<usize>()
+        );
+    }
+
+    #[test]
+    fn scratch_cache_rejects_an_oversized_buffer() {
+        let mut cache = ScratchCache::new();
+        let oversized_capacity = MAX_CACHED_SCRATCH_BYTES / size_of::<FormatElement<'static>>() + 1;
+
+        cache.insert(buffer_with_capacity(oversized_capacity));
+
+        assert!(cache.buffers.is_empty());
+        assert_eq!(cache.retained_bytes, 0);
+    }
+
+    #[test]
+    fn scratch_cache_bounds_total_retained_bytes() {
+        let mut cache = ScratchCache::new();
+        let half_budget_capacity =
+            MAX_CACHED_SCRATCH_BYTES / size_of::<FormatElement<'static>>() / 2;
+
+        for _ in 0..3 {
+            cache.insert(buffer_with_capacity(half_budget_capacity));
+        }
+
+        assert!(cache.retained_bytes <= MAX_CACHED_SCRATCH_BYTES);
+        assert_retained_bytes_consistent(&cache);
+    }
+
+    #[test]
+    fn scratch_cache_bounds_buffer_count() {
+        let mut cache = ScratchCache::new();
+
+        for _ in 0..=MAX_CACHED_SCRATCH_BUFFERS {
+            cache.insert(buffer_with_capacity(1));
+        }
+
+        assert_eq!(cache.buffers.len(), MAX_CACHED_SCRATCH_BUFFERS);
+    }
+
+    #[test]
+    fn scratch_cache_updates_retained_bytes_on_take() {
+        let mut cache = ScratchCache::new();
+        cache.insert(buffer_with_capacity(16));
+        let retained_bytes = cache.retained_bytes;
+
+        let buffer = cache.take();
+
+        assert_eq!(ScratchCache::capacity_in_bytes(buffer.capacity()), retained_bytes);
+        assert_eq!(cache.retained_bytes, 0);
+    }
+
+    #[test]
+    fn scratch_cache_takes_the_largest_buffer_for_format_state() {
+        let mut cache = ScratchCache::new();
+        cache.insert(buffer_with_capacity(8));
+        cache.insert(buffer_with_capacity(32));
+        cache.insert(buffer_with_capacity(16));
+
+        let buffer = cache.take_largest();
+
+        assert_eq!(buffer.capacity(), 32);
+        assert_retained_bytes_consistent(&cache);
+    }
+
+    #[test]
+    fn scratch_cache_evicts_the_oldest_buffer() {
+        let mut cache = ScratchCache::new();
+        cache.insert(buffer_with_capacity(2));
+        for _ in 1..MAX_CACHED_SCRATCH_BUFFERS {
+            cache.insert(buffer_with_capacity(1));
+        }
+
+        cache.insert(buffer_with_capacity(3));
+
+        assert_eq!(cache.buffers.len(), MAX_CACHED_SCRATCH_BUFFERS);
+        assert_eq!(cache.buffers.back().unwrap().capacity(), 3);
+        assert!(!cache.buffers.iter().any(|buffer| buffer.capacity() == 2));
     }
 }

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -12,10 +12,10 @@ checker.ts:
 App.tsx:
   file size: 415342 # 415.34 kB
   sys allocs: 2532
-  sys reallocs: 80
+  sys reallocs: 85
   sys deallocs: 2531
-  sys alloc bytes: 985182 # 985.18 kB
-  sys peak growth: 443550 # 443.55 kB
+  sys alloc bytes: 1302622 # 1.30 MB
+  sys peak growth: 760990 # 760.99 kB
   arena allocs: 209344
   arena reallocs: 364
   arena size: 21592480 # 21.59 MB
@@ -34,10 +34,10 @@ RadixUIAdoptionSection.jsx:
 pdf.mjs:
   file size: 567296 # 567.30 kB
   sys allocs: 4019
-  sys reallocs: 172
+  sys reallocs: 173
   sys deallocs: 4018
-  sys alloc bytes: 2050032 # 2.05 MB
-  sys peak growth: 1164624 # 1.16 MB
+  sys alloc bytes: 2377712 # 2.38 MB
+  sys peak growth: 1492304 # 1.49 MB
   arena allocs: 428857
   arena reallocs: 428
   arena size: 35654864 # 35.65 MB
@@ -45,10 +45,10 @@ pdf.mjs:
 antd.js:
   file size: 6686316 # 6.69 MB
   sys allocs: 34121
-  sys reallocs: 3994
-  sys deallocs: 34120
-  sys alloc bytes: 20850396 # 20.85 MB
-  sys peak growth: 13841112 # 13.84 MB
+  sys reallocs: 4001
+  sys deallocs: 34121
+  sys alloc bytes: 104081116 # 104.08 MB
+  sys peak growth: 83833168 # 83.83 MB
   arena allocs: 2503924
   arena reallocs: 1889
   arena size: 327824560 # 327.82 MB
@@ -66,11 +66,11 @@ binder.ts:
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
-  sys allocs: 9565
-  sys reallocs: 2815
+  sys allocs: 9566
+  sys reallocs: 2822
   sys deallocs: 9564
   sys alloc bytes: 3180244 # 3.18 MB
-  sys peak growth: 1499988 # 1.50 MB
+  sys peak growth: 1520468 # 1.52 MB
   arena allocs: 560401
   arena reallocs: 1041
   arena size: 46408496 # 46.41 MB


### PR DESCRIPTION
Measures to address this.

> NOTE: checked-in vectors keep their high-water capacity for the thread's lifetime

The 8 MB covers the largest file (checker.ts) that is likely to be created and formatted manually.