### PR TITLE
ci(semgrep): add scan workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,26 @@
+name: Semgrep
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+jobs:
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep:1.170.0
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - run: semgrep scan --config auto


### PR DESCRIPTION
## Summary

- add Semgrep CE scans for pull requests and pushes to `main`
- pin Semgrep to v1.170.0
- use the repository's pinned `taiki-e/checkout-action` and concurrency convention

## Testing

- parsed `.github/workflows/semgrep.yml` with Ruby Psych
- checked the staged diff with `git diff --check`

## AI usage

This change was implemented with assistance from OpenAI OpenCode. The contributor remains responsible for reviewing and understanding the change.