### PR TITLE
fix(parser): use correct diagnostic for `await using` in bare switch case

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -747,7 +747,13 @@ parser_diagnostics! {
     };
 
     using_declaration_not_allowed_in_switch_bare_case(span: Span) => {
-        OxcDiagnostic::error("Using declaration cannot appear in the bare case statement.")
+        OxcDiagnostic::error("'using' declaration cannot appear in the bare case statement.")
+            .with_label(span)
+            .with_help("Wrap this declaration in a block statement")
+    };
+
+    await_using_declaration_not_allowed_in_switch_bare_case(span: Span) => {
+        OxcDiagnostic::error("'await using' declaration cannot appear in the bare case statement.")
             .with_label(span)
             .with_help("Wrap this declaration in a block statement")
     };

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -754,9 +754,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             {
                 // It is a Syntax Error if UsingDeclaration is contained directly within the StatementList of either a CaseClause or DefaultClause.
                 // It is a Syntax Error if AwaitUsingDeclaration is contained directly within the StatementList of either a CaseClause or DefaultClause.
-                self.error(diagnostics::using_declaration_not_allowed_in_switch_bare_case(
-                    stmt.span(),
-                ));
+                self.error(if var_decl.kind.is_await() {
+                    diagnostics::await_using_declaration_not_allowed_in_switch_bare_case(
+                        stmt.span(),
+                    )
+                } else {
+                    diagnostics::using_declaration_not_allowed_in_switch_bare_case(stmt.span())
+                });
             }
             consequent.push(stmt);
         }

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -8851,7 +8851,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'await using' declaration cannot appear in the bare case statement.
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-module-bare-case-await-using-binding/input.js:5:7]
  4 │       {}
  5 │       await using x = bar();
@@ -8860,7 +8860,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'await using' declaration cannot appear in the bare case statement.
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-module-bare-case-await-using-binding/input.js:8:7]
  7 │       {}
  8 │       await using y = bar();
@@ -8869,7 +8869,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'await using' declaration cannot appear in the bare case statement.
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-script-bare-case-await-using-binding/input.js:5:7]
  4 │       {}
  5 │       await using x = bar();
@@ -8878,7 +8878,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'await using' declaration cannot appear in the bare case statement.
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/async-explicit-resource-management/invalid-script-bare-case-await-using-binding/input.js:8:7]
  7 │       {}
  8 │       await using y = bar();
@@ -9214,7 +9214,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'using' declaration cannot appear in the bare case statement.
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-module-bare-case-using-binding/input.js:5:7]
  4 │       {}
  5 │       using x = bar();
@@ -9223,7 +9223,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'using' declaration cannot appear in the bare case statement.
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-module-bare-case-using-binding/input.js:8:7]
  7 │       {}
  8 │       using y = bar();
@@ -9232,7 +9232,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'using' declaration cannot appear in the bare case statement.
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-script-bare-case-using-binding/input.js:5:7]
  4 │       {}
  5 │       using x = bar();
@@ -9241,7 +9241,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'using' declaration cannot appear in the bare case statement.
    ╭─[babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-script-bare-case-using-binding/input.js:8:7]
  7 │       {}
  8 │       using y = bar();

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -27692,7 +27692,7 @@ Negative Passed: 4651/4651 (100.00%)
     ╰────
   help: Try inserting a semicolon here
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'await using' declaration cannot appear in the bare case statement.
     ╭─[test262/test/language/statements/await-using/syntax/await-using-invalid-switchstatement-caseclause.js:22:7]
  21 │     case 0:
  22 │       await using _ = null;
@@ -27701,7 +27701,7 @@ Negative Passed: 4651/4651 (100.00%)
     ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'await using' declaration cannot appear in the bare case statement.
     ╭─[test262/test/language/statements/await-using/syntax/await-using-invalid-switchstatement-defaultclause.js:22:7]
  21 │     default:
  22 │       await using _ = null;
@@ -27745,7 +27745,7 @@ Negative Passed: 4651/4651 (100.00%)
     ╰────
   help: Add an initializer (e.g. ` = undefined`) here
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'await using' declaration cannot appear in the bare case statement.
     ╭─[test262/test/language/statements/await-using/syntax/with-initializer-case-expression-statement-list.js:24:32]
  23 │ async function f() {
  24 │     switch (true) { case true: await using x = null; }
@@ -27754,7 +27754,7 @@ Negative Passed: 4651/4651 (100.00%)
     ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'await using' declaration cannot appear in the bare case statement.
     ╭─[test262/test/language/statements/await-using/syntax/with-initializer-default-statement-list.js:24:30]
  23 │ async function f() {
  24 │     switch (true) { default: await using x = null; }
@@ -40579,7 +40579,7 @@ Negative Passed: 4651/4651 (100.00%)
  19 │ }
     ╰────
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'using' declaration cannot appear in the bare case statement.
     ╭─[test262/test/language/statements/using/syntax/using-invalid-switchstatement-caseclause.js:21:5]
  20 │   case 0:
  21 │     using _ = null;
@@ -40588,7 +40588,7 @@ Negative Passed: 4651/4651 (100.00%)
     ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'using' declaration cannot appear in the bare case statement.
     ╭─[test262/test/language/statements/using/syntax/using-invalid-switchstatement-defaultclause.js:21:5]
  20 │   default:
  21 │     using _ = null;
@@ -40605,7 +40605,7 @@ Negative Passed: 4651/4651 (100.00%)
     ╰────
   help: Wrap this code in a block or use a module
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'using' declaration cannot appear in the bare case statement.
     ╭─[test262/test/language/statements/using/syntax/with-initializer-case-expression-statement-list.js:20:28]
  19 │ $DONOTEVALUATE();
  20 │ switch (true) { case true: using x = null; }
@@ -40613,7 +40613,7 @@ Negative Passed: 4651/4651 (100.00%)
     ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'using' declaration cannot appear in the bare case statement.
     ╭─[test262/test/language/statements/using/syntax/with-initializer-default-statement-list.js:21:26]
  20 │ $DONOTEVALUATE();
  21 │ switch (true) { default: using x = null; }

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -28559,7 +28559,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  8 │ }
    ╰────
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'await using' declaration cannot appear in the bare case statement.
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.17.ts:3:9]
  2 │     case 0:
  3 │         await using d20 = { async [Symbol.asyncDispose]() {} };
@@ -28568,7 +28568,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'await using' declaration cannot appear in the bare case statement.
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.17.ts:7:9]
  6 │     case 1:
  7 │         await using d21 = { async [Symbol.asyncDispose]() {} };
@@ -28577,7 +28577,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'await using' declaration cannot appear in the bare case statement.
     ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.17.ts:11:9]
  10 │     default:
  11 │         await using d22 = { async [Symbol.asyncDispose]() {} };
@@ -28586,7 +28586,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'await using' declaration cannot appear in the bare case statement.
     ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.17.ts:17:13]
  16 │         case 0:
  17 │             await using d23 = { async [Symbol.asyncDispose]() {} };
@@ -28595,7 +28595,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'await using' declaration cannot appear in the bare case statement.
     ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.17.ts:21:13]
  20 │         default:
  21 │             await using d24 = { async [Symbol.asyncDispose]() {} };
@@ -28747,7 +28747,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  8 │ }
    ╰────
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'using' declaration cannot appear in the bare case statement.
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.17.ts:3:9]
  2 │     case 0:
  3 │         using d20 = { [Symbol.dispose]() {} };
@@ -28756,7 +28756,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'using' declaration cannot appear in the bare case statement.
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.17.ts:7:9]
  6 │     case 1:
  7 │         using d21 = { [Symbol.dispose]() {} };
@@ -28765,7 +28765,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'using' declaration cannot appear in the bare case statement.
     ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.17.ts:11:9]
  10 │     default:
  11 │         using d22 = { [Symbol.dispose]() {} };
@@ -28774,7 +28774,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'using' declaration cannot appear in the bare case statement.
     ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.17.ts:17:13]
  16 │         case 0:
  17 │             using d23 = { [Symbol.dispose]() {} };
@@ -28783,7 +28783,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ╰────
   help: Wrap this declaration in a block statement
 
-  × Using declaration cannot appear in the bare case statement.
+  × 'using' declaration cannot appear in the bare case statement.
     ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.17.ts:21:13]
  20 │         default:
  21 │             using d24 = { [Symbol.dispose]() {} };


### PR DESCRIPTION
This improve the error diagnostic for await using in bar switch case clauses, as well as aligning more closely with  the behaviour for using/await using in ambient contexts:

https://github.com/oxc-project/oxc/blob/981a9522f5fb658943e89501b35543ff3283eea5/crates/oxc_parser/src/js/declaration.rs#L197-L204