### PR TITLE
chore(linter/eslint/no-case-declarations): disable invalid test case

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
@@ -159,8 +159,8 @@ fn test() {
         ("switch (a) { default: function f() {} break; }"),
         ("switch (a) { case 1: class C {} break; }"),
         ("switch (a) { default: class C {} break; }"),
-        ("switch (a) { default: using x = {}; break; }"),
-        ("switch (a) { default: await using x = {}; break; }"),
+        // ("switch (a) { default: using x = {}; break; }"),
+        // ("switch (a) { default: await using x = {}; break; }"),
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/snapshots/eslint_no_case_declarations.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_case_declarations.snap
@@ -57,17 +57,3 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────
    ╰────
   help: Wrap the case body in braces `{}` to create an explicit block scope for the lexical declaration.
-
-  × Using declaration cannot appear in the bare case statement.
-   ╭─[no_case_declarations.tsx:1:23]
- 1 │ switch (a) { default: using x = {}; break; }
-   ·                       ─────────────
-   ╰────
-  help: Wrap this declaration in a block statement
-
-  × Using declaration cannot appear in the bare case statement.
-   ╭─[no_case_declarations.tsx:1:23]
- 1 │ switch (a) { default: await using x = {}; break; }
-   ·                       ───────────────────
-   ╰────
-  help: Wrap this declaration in a block statement


### PR DESCRIPTION
There's no point testing these - the parser/coverage handles this already