### PR TITLE
fix(linter/typescript/explicit-function-return-type): recognize contextually typed returned objects

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -620,7 +620,17 @@ fn ancestor_has_return_type<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bo
             AstKind::ExpressionStatement(expr)
                 if !matches!(expr.expression, Expression::ArrowFunctionExpression(_)) =>
             {
-                return false;
+                let function_body = ctx.nodes().parent_node(ancestor.id());
+                if !matches!(function_body.kind(), AstKind::FunctionBody(_)) {
+                    return false;
+                }
+                let function = ctx.nodes().parent_node(function_body.id());
+                if !matches!(
+                    function.kind(),
+                    AstKind::ArrowFunctionExpression(func) if func.expression
+                ) {
+                    return false;
+                }
             }
             _ => {}
         }
@@ -851,6 +861,20 @@ fn test() {
             const x: Foo = {
               foo: { bar: () => {} },
             };
+            ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+            interface Repo {
+              count: () => Promise<number>;
+            }
+
+            export const buildRepo = (): Repo => ({
+              count: async () => 0,
+            });
             ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
@@ -1632,6 +1656,17 @@ fn test() {
         ),
         (
             "var arrowFn = () => 'test';",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+            const buildRepo = (): Repo => {
+              const repo = { count: async () => 0 };
+              return repo;
+            };
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -603,6 +603,9 @@ fn ancestor_has_return_type<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bo
         return true;
     }
 
+    let mut is_contextually_typed_return = true;
+    let mut reached_return_boundary = false;
+
     for ancestor in ctx.nodes().ancestors(node.id()) {
         match ancestor.kind() {
             AstKind::SequenceExpression(sequence)
@@ -613,10 +616,10 @@ fn ancestor_has_return_type<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bo
                 return false;
             }
             AstKind::ArrowFunctionExpression(func) if func.return_type.is_some() => {
-                return true;
+                return is_contextually_typed_return;
             }
             AstKind::Function(func) if func.return_type.is_some() => {
-                return true;
+                return is_contextually_typed_return;
             }
             AstKind::VariableDeclarator(decl) => {
                 return decl.type_annotation.is_some();
@@ -624,9 +627,14 @@ fn ancestor_has_return_type<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bo
             AstKind::PropertyDefinition(def) => {
                 return def.type_annotation.is_some();
             }
-            AstKind::ExpressionStatement(expr)
-                if !matches!(expr.expression, Expression::ArrowFunctionExpression(_)) =>
-            {
+            AstKind::FormalParameter(param) => {
+                return param.type_annotation.is_some();
+            }
+            AstKind::FormalParameterRest(param) => {
+                return param.type_annotation.is_some();
+            }
+            AstKind::ReturnStatement(_) => reached_return_boundary = true,
+            AstKind::ExpressionStatement(_) => {
                 let function_body = ctx.nodes().parent_node(ancestor.id());
                 if !matches!(function_body.kind(), AstKind::FunctionBody(_)) {
                     return false;
@@ -638,7 +646,28 @@ fn ancestor_has_return_type<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bo
                 ) {
                     return false;
                 }
+                reached_return_boundary = true;
             }
+            AstKind::ObjectProperty(prop)
+                if !reached_return_boundary
+                    && !prop.value.span().contains_inclusive(node.span()) =>
+            {
+                is_contextually_typed_return = false;
+            }
+            AstKind::ConditionalExpression(conditional)
+                if !reached_return_boundary
+                    && !conditional.consequent.span().contains_inclusive(node.span())
+                    && !conditional.alternate.span().contains_inclusive(node.span()) =>
+            {
+                is_contextually_typed_return = false;
+            }
+            AstKind::ObjectProperty(_)
+            | AstKind::ObjectExpression(_)
+            | AstKind::ParenthesizedExpression(_)
+            | AstKind::SequenceExpression(_)
+            | AstKind::ConditionalExpression(_)
+                if !reached_return_boundary => {}
+            _ if !reached_return_boundary => is_contextually_typed_return = false,
             _ => {}
         }
     }
@@ -887,6 +916,10 @@ fn test() {
               sideEffect(),
               { count: async () => 0 }
             );
+
+            export const buildConditionalRepo = (condition: boolean): Repo => condition
+              ? { count: async () => 0 }
+              : { count: async () => 1 };
             ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
@@ -1689,6 +1722,16 @@ fn test() {
               { count: async () => 0 },
               repo
             );
+            ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+            const buildRepo = (): Repo => [
+              { count: async () => 0 }
+            ][0];
             ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -605,6 +605,13 @@ fn ancestor_has_return_type<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bo
 
     for ancestor in ctx.nodes().ancestors(node.id()) {
         match ancestor.kind() {
+            AstKind::SequenceExpression(sequence)
+                if sequence.expressions.last().is_none_or(|expression| {
+                    !expression.span().contains_inclusive(node.span())
+                }) =>
+            {
+                return false;
+            }
             AstKind::ArrowFunctionExpression(func) if func.return_type.is_some() => {
                 return true;
             }
@@ -875,6 +882,11 @@ fn test() {
             export const buildRepo = (): Repo => ({
               count: async () => 0,
             });
+
+            export const buildRepoAfterSideEffect = (): Repo => (
+              sideEffect(),
+              { count: async () => 0 }
+            );
             ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
@@ -1666,6 +1678,17 @@ fn test() {
               const repo = { count: async () => 0 };
               return repo;
             };
+            ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+            const buildRepo = (): Repo => (
+              { count: async () => 0 },
+              repo
+            );
             ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
@@ -164,6 +164,15 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:30]
+ 2 │             const buildRepo = (): Repo => {
+ 3 │               const repo = { count: async () => 0 };
+   ·                              ─────────────
+ 4 │               return repo;
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript(explicit-function-return-type): Missing return type on function.
    ╭─[explicit_function_return_type.tsx:3:36]
  2 │             function foo(): any {
  3 │               const bar = () => () => console.log('aa');

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
@@ -173,6 +173,15 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:17]
+ 2 │             const buildRepo = (): Repo => (
+ 3 │               { count: async () => 0 },
+   ·                 ─────────────
+ 4 │               repo
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript(explicit-function-return-type): Missing return type on function.
    ╭─[explicit_function_return_type.tsx:3:36]
  2 │             function foo(): any {
  3 │               const bar = () => () => console.log('aa');

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
@@ -182,6 +182,15 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:17]
+ 2 │             const buildRepo = (): Repo => [
+ 3 │               { count: async () => 0 }
+   ·                 ─────────────
+ 4 │             ][0];
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript(explicit-function-return-type): Missing return type on function.
    ╭─[explicit_function_return_type.tsx:3:36]
  2 │             function foo(): any {
  3 │               const bar = () => () => console.log('aa');


### PR DESCRIPTION
## Summary
- treat an object literal in a concise arrow body as covered by the arrow return annotation
- preserve diagnostics for object literals created inside block-bodied functions
- add regression coverage for both cases

Closes #24792