### PR TITLE
fix(linter/node/no-top-level-await): clarify diagnostic

### DIFF
--- a/crates/oxc_linter/src/rules/node/no_top_level_await.rs
+++ b/crates/oxc_linter/src/rules/node/no_top_level_await.rs
@@ -12,8 +12,9 @@ use crate::{
 };
 
 fn no_top_level_await_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Top-level `await` is forbidden in published modules.")
+    OxcDiagnostic::warn("Top-level `await` prevents this module from being loaded with `require(esm)`.")
         .with_help("Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.")
+        .with_note("This rule is intended for published packages. Consider disabling it if this package is private.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/snapshots/node_no_top_level_await.snap
+++ b/crates/oxc_linter/src/snapshots/node_no_top_level_await.snap
@@ -2,73 +2,83 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
-  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+  ⚠ node(no-top-level-await): Top-level `await` prevents this module from being loaded with `require(esm)`.
    ╭─[no_top_level_await.mts:1:13]
  1 │ const foo = await import('foo')
    ·             ───────────────────
    ╰────
   help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+  note: This rule is intended for published packages. Consider disabling it if this package is private.
 
-  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+  ⚠ node(no-top-level-await): Top-level `await` prevents this module from being loaded with `require(esm)`.
    ╭─[no_top_level_await.mts:1:1]
  1 │ await import('foo')
    · ───────────────────
    ╰────
   help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+  note: This rule is intended for published packages. Consider disabling it if this package is private.
 
-  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+  ⚠ node(no-top-level-await): Top-level `await` prevents this module from being loaded with `require(esm)`.
    ╭─[no_top_level_await.mts:1:1]
  1 │ for await (const e of asyncIterate()) { /* ... */ }
    · ───────────────────────────────────────────────────
    ╰────
   help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+  note: This rule is intended for published packages. Consider disabling it if this package is private.
 
-  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+  ⚠ node(no-top-level-await): Top-level `await` prevents this module from being loaded with `require(esm)`.
    ╭─[no_top_level_await.mts:1:1]
  1 │ await using foo = x
    · ───────────────────
    ╰────
   help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+  note: This rule is intended for published packages. Consider disabling it if this package is private.
 
-  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+  ⚠ node(no-top-level-await): Top-level `await` prevents this module from being loaded with `require(esm)`.
    ╭─[no_top_level_await.mts:1:3]
  1 │ { await import('foo') }
    ·   ───────────────────
    ╰────
   help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+  note: This rule is intended for published packages. Consider disabling it if this package is private.
 
-  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+  ⚠ node(no-top-level-await): Top-level `await` prevents this module from being loaded with `require(esm)`.
    ╭─[no_top_level_await.mts:1:13]
  1 │ if (cond) { await import('foo') }
    ·             ───────────────────
    ╰────
   help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+  note: This rule is intended for published packages. Consider disabling it if this package is private.
 
-  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+  ⚠ node(no-top-level-await): Top-level `await` prevents this module from being loaded with `require(esm)`.
    ╭─[no_top_level_await.mts:1:30]
  1 │ for (const e of iterate()) { await handle(e) }
    ·                              ───────────────
    ╰────
   help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+  note: This rule is intended for published packages. Consider disabling it if this package is private.
 
-  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+  ⚠ node(no-top-level-await): Top-level `await` prevents this module from being loaded with `require(esm)`.
    ╭─[no_top_level_await.mts:1:3]
  1 │ { await using foo = x }
    ·   ───────────────────
    ╰────
   help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+  note: This rule is intended for published packages. Consider disabling it if this package is private.
 
-  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+  ⚠ node(no-top-level-await): Top-level `await` prevents this module from being loaded with `require(esm)`.
    ╭─[no_top_level_await.mts:1:13]
  1 │ const foo = await import('foo')
    ·             ───────────────────
    ╰────
   help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+  note: This rule is intended for published packages. Consider disabling it if this package is private.
 
-  ⚠ node(no-top-level-await): Top-level `await` is forbidden in published modules.
+  ⚠ node(no-top-level-await): Top-level `await` prevents this module from being loaded with `require(esm)`.
    ╭─[no_top_level_await.mts:2:13]
  1 │ #!/usr/bin/env node
  2 │ const foo = await import('foo')
    ·             ───────────────────
    ╰────
   help: Move the `await` inside an `async` function, as ES modules with top-level `await` cannot be loaded with `require(esm)`.
+  note: This rule is intended for published packages. Consider disabling it if this package is private.


### PR DESCRIPTION
Clarify that top-level `await` prevents loading a module through `require(esm)`, instead of implying Oxlint has determined that the package is published. Add a note explaining that the rule targets published packages and can be disabled for private packages.

Closes #24795.