### PR TITLE
perf(react_compiler): share codegen temporaries by reference

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -224,10 +224,11 @@ use oxc_span::SPAN;
 
 // Temp value tracking. Maps a temporary's declaration to its emitted oxc value
 // (`None` for params/catch bindings that are declared but have no inlinable value).
-// oxc nodes are not `Clone`; the snapshot/restore in block codegen and the per-place
-// read both clone into the arena via [`CloneIn`] (see `ox_clone_temporaries` /
-// `ox_codegen_place`).
-type OxcTemporaries<'a> = FxHashMap<DeclarationId, Option<OxValue<'a>>>;
+// Values are arena-allocated and shared by reference: entries are only ever
+// replaced, never mutated in place, so the block-codegen snapshot/restore is a
+// plain map clone of `Copy` references, and only the per-place read clones the
+// node into the arena via [`CloneIn`] (see `ox_codegen_place`).
+type OxcTemporaries<'a> = FxHashMap<DeclarationId, Option<&'a OxValue<'a>>>;
 
 use oxc_allocator::CloneIn;
 
@@ -246,16 +247,6 @@ impl<'a> OxValue<'a> {
             OxValue::JsxText(t) => OxValue::JsxText(t.clone_in_with_semantic_ids(allocator)),
         }
     }
-}
-
-/// Clone the temporaries map, cloning each oxc value into the arena.
-fn ox_clone_temporaries<'a>(
-    ast: &oxc_ast::builder::AstBuilder<'a>,
-    temp: &OxcTemporaries<'a>,
-) -> OxcTemporaries<'a> {
-    temp.iter()
-        .map(|(id, v)| (*id, v.as_ref().map(|v| v.clone_in_with_semantic_ids(ast.allocator()))))
-        .collect()
 }
 
 struct OxcContext<'a, 'env> {
@@ -567,7 +558,7 @@ fn ox_codegen_block<'a>(
     cx: &mut OxcContext<'a, '_>,
     block: &ReactiveBlock<'a>,
 ) -> Result<oxc_allocator::Vec<'a, oxc::Statement<'a>>, OxcDiagnostic> {
-    let temp_snapshot = ox_clone_temporaries(&cx.ast, &cx.temp);
+    let temp_snapshot = cx.temp.clone();
     let result = ox_codegen_block_no_reset(cx, block)?;
     cx.temp = temp_snapshot;
     Ok(result)
@@ -591,7 +582,7 @@ fn ox_codegen_block_no_reset<'a>(
                 statements.extend(scope_block);
             }
             ReactiveStatement::Scope(ReactiveScopeBlock { scope, instructions }) => {
-                let temp_snapshot = ox_clone_temporaries(&cx.ast, &cx.temp);
+                let temp_snapshot = cx.temp.clone();
                 ox_codegen_reactive_scope(cx, &mut statements, *scope, instructions)?;
                 cx.temp = temp_snapshot;
             }
@@ -1455,7 +1446,8 @@ fn ox_emit_store<'a>(
                 );
                 if !is_store_context {
                     let ident = &cx.env.identifiers[lvalue_place.identifier];
-                    cx.temp.insert(ident.declaration_id, Some(OxValue::Expression(expr)));
+                    let value = &*cx.ast.allocator().alloc(OxValue::Expression(expr));
+                    cx.temp.insert(ident.declaration_id, Some(value));
                     return Ok(None);
                 }
                 let stmt = ox_codegen_instruction(cx, instr, OxValue::Expression(expr))?;
@@ -1507,6 +1499,7 @@ fn ox_codegen_instruction<'a>(
     };
     let ident = &cx.env.identifiers[lvalue.identifier];
     if ident.name.is_none() {
+        let value = &*cx.ast.allocator().alloc(value);
         cx.temp.insert(ident.declaration_id, Some(value));
         return Ok(oxc_ast::ast::Statement::new_empty_statement(SPAN, &cx.ast));
     }
@@ -2627,7 +2620,7 @@ fn ox_codegen_inner_function<'a>(
         cx.unique_identifiers.clone(),
         cx.fbt_operands.clone(),
     );
-    inner_cx.temp = ox_clone_temporaries(&cx.ast, &cx.temp);
+    inner_cx.temp = cx.temp.clone();
     ox_codegen_reactive_function(&mut inner_cx, reactive_fn)
 }
 


### PR DESCRIPTION
## Context

The reactive-function codegen keeps a map of compiler temporaries and snapshots that map whenever it enters a block, a memoization scope or a nested function, restoring it on the way out. Each snapshot deep-cloned every value collected so far into the arena, so the cost grew with the number of blocks times the size of the accumulated trees. That's cheap on small components and expensive on large ones with a lot of JSX.

## This PR

Store the temporaries as arena-allocated `&OxValue` references instead of owned values. Entries are only ever replaced, never mutated in place, and the one place that reads a temporary (`ox_codegen_place`) already clones the node into the arena. So a snapshot is now just a copy of the map's references, `ox_clone_temporaries` goes away, and the emitted program is unchanged.

### Performance

The effect scales with component size, so it barely shows on typical open-source apps (their largest components compile in tens of milliseconds) and grows on very large components. Two views:

**Size-scaling probe** (reproducible): one function component with N repeated JSX sections, compiled on `main` vs this branch:

| Sections | Source size | main | this branch | Ratio |
| ---: | ---: | ---: | ---: | ---: |
| 25 | 17 KB | 26 ms | 17 ms | 1.51x |
| 50 | 33 KB | 83 ms | 50 ms | 1.66x |
| 100 | 66 KB | 327 ms | 188 ms | 1.74x |
| 200 | 133 KB | 1,663 ms | 1,096 ms | 1.52x |
| 400 | 267 KB | 7,952 ms | 5,692 ms | 1.40x |

Compile time still grows super-linearly with size on both sides: on `main` the remaining hot pass for large components is `infer_reactive_scope_variables`, which this change does not touch.

<details><summary>Probe generator (Node)</summary>

```js
// node gen_scaling.mjs <N> > Big.tsx
const N = Number(process.argv[2]);
const header = `import { useState } from "react";
declare const Child: any;
declare const Footer: any;
declare function cx(...args: any[]): string;
declare function format(v: number): string;

export default function Big({ data, flag, onSelect, onDone }: any) {
  const [count, setCount] = useState(0);
  return (
    <div className="root" onClick={() => setCount(count + 1)}>
`;
const section = (i) => `      <section key="s${i}" className={cx("s${i}", flag ? "on" : "off")} onClick={() => onSelect(${i}, data.items[${i}])}>
        <h2 title={data.titles[${i}]}>
          {data.titles[${i}]} - {count + ${i}}
        </h2>
        {flag && <p className="note">{data.notes[${i}]}</p>}
        <ul>
          {data.items.map((it: any) => (
            <li key={it.id} data-idx={${i}}>
              {it.label} {format(it.value * ${i})}
            </li>
          ))}
        </ul>
        <Child a={data.a} b={{ x: ${i}, y: data.y, nested: { k: "k${i}" } }} onDone={() => onDone(${i}, data.a)} />
        <Footer id={${i}} label={\`row-${i}\`} total={data.total + ${i}} />
      </section>
`;
const footer = `    </div>
  );
}
`;
let body = "";
for (let i = 0; i < N; i++) body += section(i);
process.stdout.write(header + body + footer);
```
</details>

This PR was assisted by Claude Code.