### PR TITLE
fix(parser): parse unary conditional after satisfies

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -601,7 +601,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             | Kind::Object
             | Kind::Star
             | Kind::Question
-            | Kind::Break
+            | Kind::Bang
             | Kind::Dot3
             | Kind::Infer
             | Kind::Import

--- a/tasks/coverage/misc/pass/oxc-24804.ts
+++ b/tasks/coverage/misc/pass/oxc-24804.ts
@@ -1,0 +1,3 @@
+const foo = "foo"
+const bar = "bar"
+foo === "value" satisfies string ? !bar : bar

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 73/73 (100.00%)
-Positive Passed: 73/73 (100.00%)
+AST Parsed     : 74/74 (100.00%)
+Positive Passed: 74/74 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 73/73 (100.00%)
-Positive Passed: 73/73 (100.00%)
+AST Parsed     : 74/74 (100.00%)
+Positive Passed: 74/74 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 73/73 (100.00%)
-Positive Passed: 73/73 (100.00%)
+AST Parsed     : 74/74 (100.00%)
+Positive Passed: 74/74 (100.00%)
 Negative Passed: 154/154 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 73/73 (100.00%)
-Positive Passed: 68/73 (93.15%)
+AST Parsed     : 74/74 (100.00%)
+Positive Passed: 69/74 (93.24%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 73/73 (100.00%)
-Positive Passed: 73/73 (100.00%)
+AST Parsed     : 74/74 (100.00%)
+Positive Passed: 74/74 (100.00%)


### PR DESCRIPTION
Fixes #24804.

Recognize `!` as a type-start token so `?` after `satisfies` remains the conditional-expression operator instead of being consumed as a JSDoc nullable type.

Validated with `just ready`.

AI-assisted.