### PR TITLE
docs(linter/jsx-a11y): document flattened config options

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/no_interactive_element_to_noninteractive_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_interactive_element_to_noninteractive_role.rs
@@ -32,7 +32,16 @@ pub struct NoInteractiveElementToNoninteractiveRole(
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct NoInteractiveElementToNoninteractiveRoleConfig {
     /// A mapping of HTML element names to arrays of ARIA role strings that are
-    /// allowed overrides for that element.
+    /// allowed overrides for that element. For example, `{ "tr": ["none", "presentation"] }`
+    /// permits `<tr role="none" />` without triggering the rule.
+    ///
+    /// Defaults are:
+    /// ```json
+    /// {
+    ///   "tr": ["none", "presentation"],
+    ///   "canvas": ["img"]
+    /// }
+    /// ```
     #[serde(default, flatten)]
     pub allowed_roles: FxHashMap<CompactStr, Vec<CompactStr>>,
 }
@@ -71,6 +80,24 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule:
     /// ```jsx
     /// <div role="img"><button>Save</button></div>
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// This rule takes an object whose keys are HTML element names and whose values
+    /// are arrays of non-interactive ARIA roles allowed on that element. Providing an
+    /// entry overrides the default exceptions for that element.
+    ///
+    /// By default `role="none"` / `role="presentation"` are allowed on `<tr>`, and
+    /// `role="img"` is allowed on `<canvas>`:
+    ///
+    /// ```json
+    /// {
+    ///   "jsx-a11y/no-interactive-element-to-noninteractive-role": [
+    ///     "error",
+    ///     { "tr": ["none", "presentation"], "canvas": ["img"] }
+    ///   ]
+    /// }
     /// ```
     NoInteractiveElementToNoninteractiveRole,
     jsx_a11y,

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_interactive_element_to_noninteractive_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_interactive_element_to_noninteractive_role.rs
@@ -81,24 +81,6 @@ declare_oxc_lint!(
     /// ```jsx
     /// <div role="img"><button>Save</button></div>
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// This rule takes an object whose keys are HTML element names and whose values
-    /// are arrays of non-interactive ARIA roles allowed on that element. Providing an
-    /// entry overrides the default exceptions for that element.
-    ///
-    /// By default `role="none"` / `role="presentation"` are allowed on `<tr>`, and
-    /// `role="img"` is allowed on `<canvas>`:
-    ///
-    /// ```json
-    /// {
-    ///   "jsx-a11y/no-interactive-element-to-noninteractive-role": [
-    ///     "error",
-    ///     { "tr": ["none", "presentation"], "canvas": ["img"] }
-    ///   ]
-    /// }
-    /// ```
     NoInteractiveElementToNoninteractiveRole,
     jsx_a11y,
     correctness,

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_interactions.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_interactions.rs
@@ -154,44 +154,6 @@ declare_oxc_lint!(
     /// <div role="button" onClick={() => {}} />
     /// <div onClick={() => {}} role="presentation" />
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// #### `handlers`
-    ///
-    /// An array of event handler prop names that should trigger this rule. Defaults to
-    /// the recommended handlers from `eslint-plugin-jsx-a11y` (click, keyboard, focus,
-    /// mouse/drag, and `onError` / `onLoad`).
-    ///
-    /// ```json
-    /// {
-    ///   "jsx-a11y/no-noninteractive-element-interactions": [
-    ///     "error",
-    ///     { "handlers": ["onClick", "onKeyDown"] }
-    ///   ]
-    /// }
-    /// ```
-    ///
-    /// #### Element exceptions (flattened object)
-    ///
-    /// Additional object keys are HTML element or ARIA role names whose values are
-    /// arrays of handlers to ignore for that element. Providing an entry overrides the
-    /// default exceptions for that element.
-    ///
-    /// By default keyboard handlers are allowed on `alert` / `dialog`, and
-    /// `onError` / `onLoad` are allowed on `body`, `iframe`, and `img`:
-    ///
-    /// ```json
-    /// {
-    ///   "jsx-a11y/no-noninteractive-element-interactions": [
-    ///     "error",
-    ///     {
-    ///       "handlers": ["onClick"],
-    ///       "main": ["onClick"]
-    ///     }
-    ///   ]
-    /// }
-    /// ```
     NoNoninteractiveElementInteractions,
     jsx_a11y,
     correctness,

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_interactions.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_interactions.rs
@@ -91,9 +91,27 @@ pub struct NoNoninteractiveElementInteractions(Box<NoNoninteractiveElementIntera
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
 pub struct NoNoninteractiveElementInteractionsConfig {
-    /// An array of event handler names that should trigger this rule.
+    /// An array of event handler prop names that should trigger this rule
+    /// (for example `onClick`, `onKeyDown`).
+    ///
+    /// Defaults to the recommended set from `eslint-plugin-jsx-a11y`, including
+    /// `onClick`, `onKeyDown`, `onKeyPress`, `onKeyUp`, `onFocus`, `onBlur`,
+    /// mouse/drag handlers, and `onError` / `onLoad`.
     handlers: Option<Vec<CompactStr>>,
-    /// A mapping of HTML element names to handler names that should be ignored for that element.
+    /// A mapping of HTML element names (or ARIA role names) to handler names that
+    /// should be ignored for that element. For example, `{ "img": ["onError", "onLoad"] }`
+    /// permits `<img onLoad={() => {}} />` without triggering the rule.
+    ///
+    /// Defaults are:
+    /// ```json
+    /// {
+    ///   "alert": ["onKeyUp", "onKeyDown", "onKeyPress"],
+    ///   "body": ["onError", "onLoad"],
+    ///   "dialog": ["onKeyUp", "onKeyDown", "onKeyPress"],
+    ///   "iframe": ["onError", "onLoad"],
+    ///   "img": ["onError", "onLoad"]
+    /// }
+    /// ```
     #[serde(flatten)]
     handler_exceptions: FxHashMap<CompactStr, Vec<CompactStr>>,
 }
@@ -135,6 +153,44 @@ declare_oxc_lint!(
     /// <button onClick={() => {}} />
     /// <div role="button" onClick={() => {}} />
     /// <div onClick={() => {}} role="presentation" />
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// #### `handlers`
+    ///
+    /// An array of event handler prop names that should trigger this rule. Defaults to
+    /// the recommended handlers from `eslint-plugin-jsx-a11y` (click, keyboard, focus,
+    /// mouse/drag, and `onError` / `onLoad`).
+    ///
+    /// ```json
+    /// {
+    ///   "jsx-a11y/no-noninteractive-element-interactions": [
+    ///     "error",
+    ///     { "handlers": ["onClick", "onKeyDown"] }
+    ///   ]
+    /// }
+    /// ```
+    ///
+    /// #### Element exceptions (flattened object)
+    ///
+    /// Additional object keys are HTML element or ARIA role names whose values are
+    /// arrays of handlers to ignore for that element. Providing an entry overrides the
+    /// default exceptions for that element.
+    ///
+    /// By default keyboard handlers are allowed on `alert` / `dialog`, and
+    /// `onError` / `onLoad` are allowed on `body`, `iframe`, and `img`:
+    ///
+    /// ```json
+    /// {
+    ///   "jsx-a11y/no-noninteractive-element-interactions": [
+    ///     "error",
+    ///     {
+    ///       "handlers": ["onClick"],
+    ///       "main": ["onClick"]
+    ///     }
+    ///   ]
+    /// }
     /// ```
     NoNoninteractiveElementInteractions,
     jsx_a11y,

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -14731,7 +14731,7 @@
       "type": "object",
       "properties": {
         "handlers": {
-          "description": "An array of event handler names that should trigger this rule.",
+          "description": "An array of event handler prop names that should trigger this rule\n(for example `onClick`, `onKeyDown`).\n\nDefaults to the recommended set from `eslint-plugin-jsx-a11y`, including\n`onClick`, `onKeyDown`, `onKeyPress`, `onKeyUp`, `onFocus`, `onBlur`,\nmouse/drag handlers, and `onError` / `onLoad`.",
           "default": [
             "onError",
             "onLoad",
@@ -14764,7 +14764,7 @@
           "items": {
             "type": "string"
           },
-          "markdownDescription": "An array of event handler names that should trigger this rule."
+          "markdownDescription": "An array of event handler prop names that should trigger this rule\n(for example `onClick`, `onKeyDown`).\n\nDefaults to the recommended set from `eslint-plugin-jsx-a11y`, including\n`onClick`, `onKeyDown`, `onKeyPress`, `onKeyUp`, `onFocus`, `onBlur`,\nmouse/drag handlers, and `onError` / `onLoad`."
         }
       },
       "additionalProperties": {


### PR DESCRIPTION
## Summary
- Document flattened element/role exception maps and defaults for `jsx-a11y/no-interactive-element-to-noninteractive-role`
- Document `handlers` defaults and flattened element exceptions for `jsx-a11y/no-noninteractive-element-interactions`
- Refresh `configuration_schema.json` descriptions for the `handlers` option

Closes #22533

## Test plan
- [ ] Rule pages show the new Options sections
- [ ] `cargo test -p oxc_linter --lib jsx_a11y::no_interactive_element_to_noninteractive_role`
- [ ] `cargo test -p oxc_linter --lib jsx_a11y::no_noninteractive_element_interactions`

Made with [Cursor](https://cursor.com)