### PR TITLE
fix(codegen): preserve orphaned file coverage comments

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -97,6 +97,13 @@ pub enum CommentContent {
     /// e.g. `/* turbopackOptional: true */`
     /// <https://nextjs.org/docs/app/guides/lazy-loading#turbopackoptional-turbopack-only>
     Turbopack = 10,
+
+    /// File-level code coverage ignore.
+    ///
+    /// `v8 ignore file`, `istanbul ignore file`.
+    /// Classified separately because its meaning remains valid if the next AST
+    /// node is removed, unlike position-sensitive coverage annotations.
+    CoverageIgnoreFile = 11,
 }
 
 bitflags! {
@@ -291,7 +298,14 @@ impl Comment {
     /// Is coverage ignore comment.
     #[inline]
     pub fn is_coverage_ignore(self) -> bool {
-        self.content == CommentContent::CoverageIgnore && self.is_leading()
+        matches!(self.content, CommentContent::CoverageIgnore | CommentContent::CoverageIgnoreFile)
+            && self.is_leading()
+    }
+
+    /// Is a file-level coverage ignore comment.
+    #[inline]
+    pub fn is_coverage_ignore_file(self) -> bool {
+        self.content == CommentContent::CoverageIgnoreFile && self.is_leading()
     }
 
     /// Returns `true` if this comment is preceded by a newline.

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -13,6 +13,11 @@ use crate::{Codegen, LegalComment, options::CommentOptions};
 
 pub type CommentsMap = FxHashMap</* attached_to */ u32, Vec<Comment>>;
 
+/// Whether a comment remains meaningful if its original AST anchor is removed.
+fn preserve_when_orphaned(comment: Comment) -> bool {
+    comment.is_legal() || comment.is_coverage_ignore_file()
+}
+
 /// A `pife`-marked arrow or function expression prints its leading comments
 /// inside its own `(` wrap, so operand emission sites must not consume them.
 fn is_pife_function(expression: &Expression<'_>) -> bool {
@@ -96,10 +101,10 @@ impl Codegen<'_> {
                 }
             }
             if add {
-                if comment.is_legal()
-                    && let Err(idx) = self.legal_comment_keys.binary_search(&comment.attached_to)
+                if preserve_when_orphaned(*comment)
+                    && let Err(idx) = self.orphan_comment_keys.binary_search(&comment.attached_to)
                 {
-                    self.legal_comment_keys.insert(idx, comment.attached_to);
+                    self.orphan_comment_keys.insert(idx, comment.attached_to);
                 }
                 self.comments.entry(comment.attached_to).or_default().push(*comment);
             }
@@ -239,49 +244,50 @@ impl Codegen<'_> {
         }
     }
 
-    /// Whether a legal-comment orphan with `attached_to < end` is still
-    /// pending. Used by block emitters to keep an empty body multi-line.
+    /// Whether an orphan comment with `attached_to < end` is still pending.
+    /// Used by block emitters to keep an empty body multi-line.
     #[inline]
-    pub(crate) fn has_legal_orphans_before(&self, end: u32) -> bool {
-        self.legal_comment_keys
+    pub(crate) fn has_orphan_comments_before(&self, end: u32) -> bool {
+        self.orphan_comment_keys
             .iter()
             .take_while(|&&k| k < end)
             .any(|k| self.comments.contains_key(k))
     }
 
-    /// Drain pending legal-comment orphans with `attached_to < end` and emit
-    /// them in source order. Called at every statement boundary so legal
-    /// comments survive when their original anchor was removed by DCE.
+    /// Drain pending orphan comments with `attached_to < end` and emit them in
+    /// source order. Called at every statement boundary so legal and file-level
+    /// coverage comments survive when their original anchor was removed by an
+    /// upstream pass.
     #[inline]
-    pub(crate) fn print_legal_orphans_before(&mut self, end: u32) {
-        if self.legal_comment_keys.is_empty() {
+    pub(crate) fn print_orphan_comments_before(&mut self, end: u32) {
+        if self.orphan_comment_keys.is_empty() {
             return;
         }
-        let idx = self.legal_comment_keys.partition_point(|&k| k < end);
+        let idx = self.orphan_comment_keys.partition_point(|&k| k < end);
         if idx == 0 {
             return;
         }
         // Concatenate across keys so `print_comments` sees one sequence;
         // per-key calls would leak `print_next_indent_as_space` and produce
         // stray leading spaces.
-        let mut legals: Vec<Comment> = Vec::new();
+        let mut orphans: Vec<Comment> = Vec::new();
         let comments = &mut self.comments;
-        for k in self.legal_comment_keys.drain(..idx) {
+        for k in self.orphan_comment_keys.drain(..idx) {
             let Some(entry) = comments.get_mut(&k) else { continue };
-            debug_assert!(entry.iter().any(|c| c.is_legal()));
-            legals.extend(entry.extract_if(.., |c| c.is_legal()));
+            debug_assert!(entry.iter().any(|c| preserve_when_orphaned(*c)));
+            orphans.extend(entry.extract_if(.., |c| preserve_when_orphaned(*c)));
             if entry.is_empty() {
                 comments.remove(&k);
             }
         }
-        if let Some(last) = legals.last_mut() {
+        if let Some(last) = orphans.last_mut() {
             // Orphans aren't in their original position, so the source's
             // `followed_by_newline` hint no longer applies. Force it on so
             // `print_comments` emits a trailing newline instead of setting
             // `print_next_indent_as_space` — otherwise the next indent (often
             // before `}`) collapses to a space and pass 2 stops matching.
             last.set_followed_by_newline(true);
-            self.print_comments(&legals);
+            self.print_comments(&orphans);
         }
     }
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -572,9 +572,9 @@ impl Gen for SwitchCase<'_> {
         }
         p.print_colon();
 
-        // Force multi-line if a legal orphan is pending; the inline path skips the flush.
+        // Force multi-line if an orphan comment is pending; the inline path skips the flush.
         let single_line = self.consequent.len() == 1
-            && !p.has_legal_orphans_before(self.consequent[0].span().start);
+            && !p.has_orphan_comments_before(self.consequent[0].span().start);
         if single_line {
             p.print_body(&self.consequent[0], ctx);
             return;
@@ -807,7 +807,7 @@ impl Gen for FunctionBody<'_> {
         let span_end = self.span.end;
         let comments_at_end = if span_end > 0 { p.get_comments(span_end - 1) } else { None };
         let single_line = if self.is_empty() {
-            !p.has_legal_orphans_before(self.span.end)
+            !p.has_orphan_comments_before(self.span.end)
                 && comments_at_end
                     .as_ref()
                     .is_none_or(|comments| comments.iter().all(|c| !c.has_newlines_around()))
@@ -2807,7 +2807,7 @@ impl Gen for StaticBlock<'_> {
         p.add_source_mapping(self.span);
         p.print_str("static");
         p.print_soft_space();
-        let single_line = self.body.is_empty() && !p.has_legal_orphans_before(self.span.end);
+        let single_line = self.body.is_empty() && !p.has_orphan_comments_before(self.span.end);
         p.print_curly_braces(self.span, single_line, |p| {
             p.print_stmts_with_orphan_flush(&self.body, self.span.end, ctx);
         });

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -139,9 +139,10 @@ pub struct Codegen<'a> {
     /// or (d) source text isn't available.
     annotation_comments: FxHashMap<u32, Comment>,
 
-    /// Sorted, deduped `attached_to` keys for pending legal comments. Lets
-    /// `print_legal_orphans_before` flush via `partition_point` + `drain`.
-    legal_comment_keys: Vec<u32>,
+    /// Sorted, deduped `attached_to` keys for comments that must survive a
+    /// removed anchor. Lets `print_orphan_comments_before` flush via
+    /// `partition_point` + `drain`.
+    orphan_comment_keys: Vec<u32>,
 
     #[cfg(feature = "sourcemap")]
     sourcemap_builder: Option<SourcemapBuilder<'a>>,
@@ -196,7 +197,7 @@ impl<'a> Codegen<'a> {
             quote: Quote::Double,
             comments: CommentsMap::default(),
             annotation_comments: FxHashMap::default(),
-            legal_comment_keys: Vec::new(),
+            orphan_comment_keys: Vec::new(),
             #[cfg(feature = "sourcemap")]
             sourcemap_builder: None,
         }
@@ -665,14 +666,14 @@ impl<'a> Codegen<'a> {
     }
 
     fn print_block_statement(&mut self, stmt: &BlockStatement<'_>, ctx: Context) {
-        let single_line = stmt.body.is_empty() && !self.has_legal_orphans_before(stmt.span.end);
+        let single_line = stmt.body.is_empty() && !self.has_orphan_comments_before(stmt.span.end);
         self.print_curly_braces(stmt.span, single_line, |p| {
             p.print_stmts_with_orphan_flush(&stmt.body, stmt.span.end, ctx);
         });
         self.needs_semicolon = false;
     }
 
-    /// Print `stmts`, flushing legal-comment orphans before each and at `scope_end`.
+    /// Print `stmts`, flushing orphan comments before each and at `scope_end`.
     fn print_stmts_with_orphan_flush(
         &mut self,
         stmts: &[Statement<'_>],
@@ -680,11 +681,11 @@ impl<'a> Codegen<'a> {
         ctx: Context,
     ) {
         for stmt in stmts {
-            self.print_legal_orphans_before(stmt.span().start);
+            self.print_orphan_comments_before(stmt.span().start);
             self.print_semicolon_if_needed();
             stmt.print(self, ctx);
         }
-        self.print_legal_orphans_before(scope_end);
+        self.print_orphan_comments_before(scope_end);
     }
 
     fn print_directives_and_statements(
@@ -698,11 +699,11 @@ impl<'a> Codegen<'a> {
             directive.print(self, ctx);
         }
         let Some((first, rest)) = stmts.split_first() else {
-            self.print_legal_orphans_before(scope_end);
+            self.print_orphan_comments_before(scope_end);
             return;
         };
 
-        self.print_legal_orphans_before(first.span().start);
+        self.print_orphan_comments_before(first.span().start);
 
         // Ensure first string literal is not a directive.
         let mut first_needs_parens = false;

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -354,7 +354,95 @@ export type TSTypeLiteral = {
 }
 
 pub mod coverage {
+    use oxc_allocator::Allocator;
+    use oxc_codegen::{Codegen, CodegenOptions, CommentOptions};
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
     use crate::snapshot;
+
+    fn codegen_after_removing_first_statement(source_text: &str) -> String {
+        codegen_after_removing_first_statement_with_options(source_text, CodegenOptions::default())
+    }
+
+    fn codegen_after_removing_first_statement_with_options(
+        source_text: &str,
+        options: CodegenOptions,
+    ) -> String {
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, source_text, SourceType::ts()).parse();
+        assert!(ret.diagnostics.is_empty());
+        let mut program = ret.program;
+        program.body.remove(0);
+        Codegen::new().with_options(options).build(&program).code
+    }
+
+    #[test]
+    fn preserve_file_coverage_comment_when_anchor_is_removed() {
+        // https://github.com/oxc-project/oxc/issues/23667
+        for comment in [
+            "/* v8 ignore file */",
+            "// v8 ignore file",
+            "/* v8 ignore file -- @preserve */",
+            "/* istanbul ignore file */",
+            "// istanbul ignore file -- generated",
+        ] {
+            let source_text =
+                format!("{comment}\nimport type {{ Foo }} from './types';\nexport default {{}};");
+            assert_eq!(
+                codegen_after_removing_first_statement(&source_text),
+                format!("{comment}\nexport default {{}};\n")
+            );
+        }
+    }
+
+    #[test]
+    fn preserve_file_coverage_comment_when_only_anchor_is_removed() {
+        for comment in ["/* v8 ignore file */", "// istanbul ignore file -- generated"] {
+            let source_text = format!("{comment}\nconst removed = 1;");
+            assert_eq!(
+                codegen_after_removing_first_statement(&source_text),
+                format!("{comment}\n")
+            );
+        }
+    }
+
+    #[test]
+    fn preserve_file_coverage_comment_after_hashbang_when_anchor_is_removed() {
+        let source_text =
+            "#!/usr/bin/env node\n/* v8 ignore file */\nconst removed = 1;\nsurvivor();";
+        assert_eq!(
+            codegen_after_removing_first_statement(source_text),
+            "#!/usr/bin/env node\n/* v8 ignore file */\nsurvivor();\n"
+        );
+    }
+
+    #[test]
+    fn respect_disabled_annotation_comments_when_anchor_is_removed() {
+        let source_text = "/* v8 ignore file */\nconst removed = 1;\nsurvivor();";
+        let options = CodegenOptions {
+            comments: CommentOptions { annotation: false, ..CommentOptions::default() },
+            ..CodegenOptions::default()
+        };
+        assert_eq!(
+            codegen_after_removing_first_statement_with_options(source_text, options),
+            "survivor();\n"
+        );
+    }
+
+    #[test]
+    fn do_not_preserve_non_file_coverage_comment_when_anchor_is_removed() {
+        for comment in [
+            "/* v8 ignore next */",
+            "/* v8 ignore filename */",
+            "/* c8 ignore next */",
+            "/* istanbul ignore next */",
+            "/* node:coverage disable */",
+        ] {
+            let source_text = format!("{comment}\nconst removed = 1;\nsurvivor();");
+            assert_eq!(codegen_after_removing_first_statement(&source_text), "survivor();\n");
+        }
+    }
 
     #[test]
     fn comment() {

--- a/crates/oxc_lexer/src/comment_meta.rs
+++ b/crates/oxc_lexer/src/comment_meta.rs
@@ -7,6 +7,7 @@ pub const CONTENT_NO_SIDE_EFFECTS: u8 = 5;
 pub const CONTENT_WEBPACK: u8 = 6;
 pub const CONTENT_VITE: u8 = 7;
 pub const CONTENT_COVERAGE_IGNORE: u8 = 8;
+pub const CONTENT_COVERAGE_IGNORE_FILE: u8 = 9;
 pub const META_MULTILINE: u8 = 0x10;
 
 #[inline]
@@ -21,6 +22,7 @@ pub fn content_from_ordinal(o: u8) -> oxc_ast::ast::CommentContent {
         CONTENT_WEBPACK => CommentContent::Webpack,
         CONTENT_VITE => CommentContent::Vite,
         CONTENT_COVERAGE_IGNORE => CommentContent::CoverageIgnore,
+        CONTENT_COVERAGE_IGNORE_FILE => CommentContent::CoverageIgnoreFile,
         _ => CommentContent::None,
     }
 }
@@ -115,7 +117,11 @@ fn classify(bytes: &[u8], is_block: bool, lic: bool) -> u8 {
                 || rest.starts_with(b"node:coverage")
                 || rest.starts_with(b"istanbul ignore")
             {
-                return CONTENT_COVERAGE_IGNORE;
+                return if is_coverage_ignore_file(rest) {
+                    CONTENT_COVERAGE_IGNORE_FILE
+                } else {
+                    CONTENT_COVERAGE_IGNORE
+                };
             }
             return if lic { CONTENT_LEGAL } else { CONTENT_NONE };
         }
@@ -132,6 +138,17 @@ fn classify(bytes: &[u8], is_block: bool, lic: bool) -> u8 {
     }
 
     if lic { CONTENT_LEGAL } else { CONTENT_NONE }
+}
+
+fn is_coverage_ignore_file(source: &[u8]) -> bool {
+    fn starts_with_directive(source: &[u8], directive: &[u8]) -> bool {
+        source
+            .strip_prefix(directive)
+            .is_some_and(|rest| rest.first().is_none_or(u8::is_ascii_whitespace))
+    }
+
+    starts_with_directive(source, b"v8 ignore file")
+        || starts_with_directive(source, b"istanbul ignore file")
 }
 
 #[inline]
@@ -154,4 +171,38 @@ pub fn meta_byte_exact(src: &[u8], start: u32, end: u32, is_block: bool) -> u8 {
     let ord = classify(b, is_block, lic) & 0x0F;
     let ml = is_block && has_nl_cr(b);
     ord | if ml { META_MULTILINE } else { 0 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CONTENT_COVERAGE_IGNORE, CONTENT_COVERAGE_IGNORE_FILE, classify, content_from_ordinal,
+    };
+    use oxc_ast::ast::CommentContent;
+
+    #[test]
+    fn coverage_ignore_file() {
+        for (source, is_block) in [
+            (b"v8 ignore file".as_slice(), true),
+            (b"v8 ignore file".as_slice(), false),
+            (b"v8 ignore file -- @preserve".as_slice(), true),
+            (b"istanbul ignore file".as_slice(), true),
+            (b"istanbul ignore file -- generated".as_slice(), false),
+        ] {
+            assert_eq!(classify(source, is_block, false), CONTENT_COVERAGE_IGNORE_FILE);
+            assert_eq!(
+                content_from_ordinal(CONTENT_COVERAGE_IGNORE_FILE),
+                CommentContent::CoverageIgnoreFile
+            );
+        }
+
+        for source in [
+            b"v8 ignore next".as_slice(),
+            b"v8 ignore filename",
+            b"c8 ignore file",
+            b"istanbul ignore next",
+        ] {
+            assert_eq!(classify(source, true, false), CONTENT_COVERAGE_IGNORE);
+        }
+    }
 }

--- a/crates/oxc_minifier/tests/peephole/normalize.rs
+++ b/crates/oxc_minifier/tests/peephole/normalize.rs
@@ -310,11 +310,11 @@ fn remove_unused_use_strict_directive() {
 }
 
 // Legal comments anchored to a removed `"use strict"` directive are rescued
-// by the same `print_legal_orphans_before` flush used for #19750: the
+// by the same preserved-comment orphan flush used for #19750: the
 // directive's `span.start` is gone, but the orphan re-anchors at the next
 // surviving statement. Pin that for the legal-comment subset of #19748.
-// Non-legal comments above a removed directive are not covered:
-// `print_legal_orphans_before` is gated on `Comment::is_legal()` by design.
+// Normal comments above a removed directive are not covered; only comments
+// with file-level meaning are preserved when their anchor is removed.
 
 #[test]
 fn preserve_legal_comment_above_removed_use_strict() {

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -331,7 +331,11 @@ impl<'a> TriviaBuilder<'a> {
                     || rest.starts_with(b"node:coverage")
                     || rest.starts_with(b"istanbul ignore")
                 {
-                    comment.content = CommentContent::CoverageIgnore;
+                    comment.content = if is_coverage_ignore_file(rest) {
+                        CommentContent::CoverageIgnoreFile
+                    } else {
+                        CommentContent::CoverageIgnore
+                    };
                     return;
                 }
                 // Fall through to check license/preserve
@@ -399,6 +403,17 @@ fn contains_license_or_preserve_comment(s: &str) -> bool {
     }
 
     false
+}
+
+fn is_coverage_ignore_file(source: &[u8]) -> bool {
+    fn starts_with_directive(source: &[u8], directive: &[u8]) -> bool {
+        source
+            .strip_prefix(directive)
+            .is_some_and(|rest| rest.first().is_none_or(u8::is_ascii_whitespace))
+    }
+
+    starts_with_directive(source, b"v8 ignore file")
+        || starts_with_directive(source, b"istanbul ignore file")
 }
 
 #[cfg(test)]
@@ -789,6 +804,14 @@ function bar() {}";
             ("/* #__PURE__ */", CommentContent::Pure),
             ("/* #__NO_SIDE_EFFECTS__ */", CommentContent::NoSideEffects),
             ("/* turbopackOptional: true */", CommentContent::Turbopack),
+            ("/* v8 ignore next */", CommentContent::CoverageIgnore),
+            ("/* v8 ignore filename */", CommentContent::CoverageIgnore),
+            ("/* c8 ignore file */", CommentContent::CoverageIgnore),
+            ("/* v8 ignore file */", CommentContent::CoverageIgnoreFile),
+            ("// v8 ignore file", CommentContent::CoverageIgnoreFile),
+            ("/* v8 ignore file -- @preserve */", CommentContent::CoverageIgnoreFile),
+            ("/* istanbul ignore file */", CommentContent::CoverageIgnoreFile),
+            ("// istanbul ignore file -- generated", CommentContent::CoverageIgnoreFile),
         ];
 
         for (source_text, expected) in data {

--- a/crates/oxc_transformer/tests/integrations/comments.rs
+++ b/crates/oxc_transformer/tests/integrations/comments.rs
@@ -1,0 +1,28 @@
+use oxc_span::SourceType;
+use oxc_transformer::TransformOptions;
+
+use crate::test_with_source_type;
+
+#[test]
+fn preserve_file_coverage_comment_when_typescript_import_is_removed() {
+    // https://github.com/oxc-project/oxc/issues/23667
+    // Transform conformance clears comments before codegen, so this cross-cutting
+    // parser + transformer + codegen behavior needs the integration harness.
+    let cases = [
+        (
+            "/* v8 ignore file */\nimport unusedDefault, { unusedNamed } from './side-effects';\nexport default {};",
+            "/* v8 ignore file */\nexport default {};\n",
+        ),
+        (
+            "/* v8 ignore file */\nimport type { Foo } from './types';\nexport default { typed: 'stuff' } satisfies Foo;",
+            "/* v8 ignore file */\nexport default { typed: 'stuff' };\n",
+        ),
+    ];
+
+    for (source_text, expected) in cases {
+        let output =
+            test_with_source_type(source_text, SourceType::ts(), &TransformOptions::default())
+                .expect("transform should succeed");
+        assert_eq!(output, expected);
+    }
+}

--- a/crates/oxc_transformer/tests/integrations/main.rs
+++ b/crates/oxc_transformer/tests/integrations/main.rs
@@ -1,3 +1,4 @@
+mod comments;
 mod enum_eval;
 mod es_target;
 mod helper_call;
@@ -28,7 +29,14 @@ pub fn codegen(source_text: &str, source_type: SourceType) -> String {
 }
 
 pub(crate) fn test(source_text: &str, options: &TransformOptions) -> Result<String, Diagnostics> {
-    let source_type = SourceType::default();
+    test_with_source_type(source_text, SourceType::default(), options)
+}
+
+pub(crate) fn test_with_source_type(
+    source_text: &str,
+    source_type: SourceType,
+    options: &TransformOptions,
+) -> Result<String, Diagnostics> {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let mut program = ret.program;


### PR DESCRIPTION
File-level V8 and Istanbul coverage directives attach to the first AST statement. When TypeScript import removal or another upstream pass deletes that statement, codegen never visits the comment attachment position and silently drops the directive. Coverage tooling then instruments a file that was explicitly excluded.

The lexer now classifies `v8 ignore file` and `istanbul ignore file` separately, including line-comment forms and explanatory suffixes. Codegen lets those directives share the existing legal-comment orphan flush, preserving source order without scanning source text during printing. Position-sensitive directives such as `ignore next`, `start`, and `stop` remain unchanged.

The recovery path is named and documented around orphaned attachments. Hashbang ordering remains intact, and disabling annotation comments still suppresses these directives. The transformer regression stays in the Rust integration harness because transform conformance deliberately clears comments before codegen.

## Example

Input:

```ts
/* v8 ignore file */
import type { Foo } from "./types";

export default { typed: "stuff" } satisfies Foo;
```

Before:

```js
export default { typed: "stuff" };
```

After:

```js
/* v8 ignore file */
export default { typed: "stuff" };
```

Covered by direct codegen regressions for removed anchors, hashbang ordering, disabled annotation comments, and position-sensitive negative cases, plus a TypeScript transformer integration test. Verified with `env -u NO_COLOR just ready`, including all-feature tests, linting, documentation, generated-code checks, formatting, and a clean-tree check.

closes #23667

This PR was assisted by OpenAI Codex.