### PR TITLE
refactor(minifier): name function body state

### DIFF
--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -117,20 +117,20 @@ impl<'a> PeepholeOptimizations {
         {
             return false;
         }
-        // `body_unsafe` is set by a preceding non-declarative statement, and the
-        // program root additionally starts unsafe when the module has loaders
-        // (see `enter_program`) — so this one check covers the cyclic-import gate.
-        let &(body_scope, body_unsafe, _) = ctx.state.body_unsafe_stack.last();
-        if body_unsafe || ctx.current_scope_id() != body_scope {
+        // `hoisted_var_inlining_unsafe` is set by a preceding non-declarative
+        // statement. The program root additionally starts unsafe when the module
+        // has loaders (see `enter_program`), covering the cyclic-import gate.
+        let frame = ctx.state.body_frames.last();
+        if frame.hoisted_var_inlining_unsafe || ctx.current_scope_id() != frame.scope_id {
             return false;
         }
         // At least one read, and every read crosses a function boundary.
         let mut reads = ctx.scoping().get_resolved_references(symbol_id).filter(|r| r.is_read());
         let Some(first) = reads.next() else { return false };
-        if !Self::read_crosses_function_boundary(first.scope_id(), body_scope, ctx) {
+        if !Self::read_crosses_function_boundary(first.scope_id(), frame.scope_id, ctx) {
             return false;
         }
-        reads.all(|read| Self::read_crosses_function_boundary(read.scope_id(), body_scope, ctx))
+        reads.all(|read| Self::read_crosses_function_boundary(read.scope_id(), frame.scope_id, ctx))
     }
 
     /// Classify the fresh value an expression creates (a value that cannot alias

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -23,7 +23,7 @@ use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_ecmascript::constant_evaluation::IsLiteralValue;
 
-use crate::{Traverse, TraverseCtx};
+use crate::{Traverse, TraverseCtx, state::BodyFrame};
 
 pub use self::normalize::{Normalize, NormalizeOptions};
 
@@ -124,9 +124,10 @@ impl<'a> PeepholeOptimizations {
     /// prelude. No-op if the flag is already set, or if `current_scope_id` is
     /// some inner scope (a block/for/etc.) — those don't end the prelude.
     fn mark_current_body_unsafe(ctx: &mut TraverseCtx<'a>) {
-        let &(body_scope, body_unsafe, _) = ctx.state.body_unsafe_stack.last();
-        if !body_unsafe && body_scope == ctx.current_scope_id() {
-            ctx.state.body_unsafe_stack.last_mut().1 = true;
+        let current_scope_id = ctx.current_scope_id();
+        let frame = ctx.state.body_frames.last_mut();
+        if !frame.hoisted_var_inlining_unsafe && frame.scope_id == current_scope_id {
+            frame.hoisted_var_inlining_unsafe = true;
         }
     }
 
@@ -253,11 +254,8 @@ impl<'a> PeepholeOptimizations {
                 };
                 // Parameter defaults are visited before their function body, so a missing
                 // owner frame means this derived constructor's `this` is uninitialized.
-                let Some(owner_index) = ctx
-                    .state
-                    .body_unsafe_stack
-                    .iter()
-                    .rposition(|(body_scope, _, _)| *body_scope == this_scope)
+                let Some(owner_index) =
+                    ctx.state.body_frames.iter().rposition(|frame| frame.scope_id == this_scope)
                 else {
                     return true;
                 };
@@ -266,8 +264,9 @@ impl<'a> PeepholeOptimizations {
                 // the current Rolldown and oxc-minify pipelines satisfy this assumption.
                 // Arrow body frames above the owner share its lexical `this`, so `super()`
                 // in any of those frames initializes the same binding.
-                !ctx.state.body_unsafe_stack[owner_index..].iter().any(|&(_, _, initialized_at)| {
-                    initialized_at
+                !ctx.state.body_frames[owner_index..].iter().any(|frame| {
+                    frame
+                        .this_initialized_at
                         .is_some_and(|initialized_at| this_expr.span.start >= initialized_at)
                 })
             }
@@ -317,8 +316,11 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         // `enter`/`exit_function_body` are balanced, so the stack is back to its
         // single program-root entry by the next pass; reset it in place rather
         // than reallocating (matching the `reset`/`clear` above).
-        *ctx.state.body_unsafe_stack.last_mut() =
-            (ctx.scoping().root_scope_id(), module_has_loaders, None);
+        *ctx.state.body_frames.last_mut() = BodyFrame {
+            scope_id: ctx.scoping().root_scope_id(),
+            hoisted_var_inlining_unsafe: module_has_loaders,
+            this_initialized_at: None,
+        };
         // `PassChanges` is managed by pass completion, not reset per
         // traversal.
     }
@@ -334,11 +336,15 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         } else {
             None
         };
-        ctx.state.body_unsafe_stack.push((ctx.current_scope_id(), false, initialized_at));
+        ctx.state.body_frames.push(BodyFrame {
+            scope_id: ctx.current_scope_id(),
+            hoisted_var_inlining_unsafe: false,
+            this_initialized_at: initialized_at,
+        });
     }
 
     fn exit_function_body(&mut self, _body: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {
-        ctx.state.body_unsafe_stack.pop();
+        ctx.state.body_frames.pop();
     }
 
     fn exit_program(&mut self, _program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -73,6 +73,22 @@ impl<'a> PassChanges<'a> {
     }
 }
 
+/// State associated with one enclosing function body or the program root.
+pub struct BodyFrame {
+    /// Semantic scope containing the body's top-level statements.
+    pub scope_id: ScopeId,
+
+    /// Whether a preceding statement could observe a later hoisted variable
+    /// before its initializer runs. The program root also starts unsafe when a
+    /// module loader could expose its bindings through a cycle.
+    pub hoisted_var_inlining_unsafe: bool,
+
+    /// Source offset after the first unconditional top-level `super()` call,
+    /// used to distinguish initialized and uninitialized derived-constructor
+    /// `this` accesses.
+    pub this_initialized_at: Option<u32>,
+}
+
 pub struct MinifierState<'a> {
     /// Source semantics, compression options, and pipeline selection fixed for
     /// the lifetime of this run.
@@ -88,18 +104,8 @@ pub struct MinifierState<'a> {
     pub private_member_usage: PrivateMemberUsageStack<'a>,
 
     /// One frame per enclosing function body (program root at the bottom).
-    /// `(body_scope, body_unsafe, this_initialized_at)`. While `body_unsafe` is
-    /// false, the next `var x = <literal>;` whose declarator sits at `body_scope`
-    /// is safe to inline despite hoisting. A preceding non-declarative statement
-    /// sets it; the program root additionally starts unsafe when the module has
-    /// any loader (`import` / `export … from` / `export * from`), since a cyclic
-    /// importer could observe a not-yet-assigned binding our exports close over.
-    /// Pushed by `enter_function_body`, popped by `exit_function_body`. See
-    /// `init_symbol_value`. `this_initialized_at` is the source offset after the
-    /// first unconditional top-level `super()` call, allowing reorder checks to
-    /// distinguish an uninitialized derived-constructor `this` from `this`
-    /// accesses after `super()`.
-    pub body_unsafe_stack: NonEmptyStack<(ScopeId, bool, Option<u32>)>,
+    /// Pushed by `enter_function_body` and popped by `exit_function_body`.
+    pub body_frames: NonEmptyStack<BodyFrame>,
 
     /// Per-pass change accumulator populated by typed mutation helpers and
     /// consumed by `compression_pass` after Normalize and every peephole pass.
@@ -123,7 +129,11 @@ impl<'a> MinifierState<'a> {
             config: CompressionConfig { source_type, options, mode },
             symbols,
             private_member_usage: PrivateMemberUsageStack::new(),
-            body_unsafe_stack: NonEmptyStack::new((scoping.root_scope_id(), false, None)),
+            body_frames: NonEmptyStack::new(BodyFrame {
+                scope_id: scoping.root_scope_id(),
+                hoisted_var_inlining_unsafe: false,
+                this_initialized_at: None,
+            }),
             pass_changes: PassChanges::new(scoping.references_len(), allocator),
             concat_scratch: String::new(),
         }


### PR DESCRIPTION
#24784 and #24785 left function-body traversal state as a three-element tuple. The two optimizations share the same stack lifecycle, but numeric field access and tuple destructuring obscure which invariant each call site reads or mutates.

Replace the tuple with a named `BodyFrame` containing the body scope, hoisted-variable inlining safety, and derived-constructor `this` initialization offset. The root reset and function-body push/pop behavior remain unchanged.

Verified with `cargo test -p oxc_minifier`, `just minsize` (including allocation tracking), `cargo clippy -p oxc_minifier -- -D warnings`, and `just fmt`. Minsize and allocation snapshots are unchanged.

Implemented with AI assistance (OpenAI Codex). The contributor remains responsible for reviewing, understanding, and submitting these changes under the repository AI usage policy.
