### PR TITLE
test(formatter_core): assert fixture idempotency in test harness

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter/tests/fixtures/mod.rs
@@ -16,6 +16,11 @@ struct JsHarness;
 impl FixtureFormatter for JsHarness {
     type Options = JsFormatOptions;
 
+    // TODO: Enable once the 10 known non-idempotent fixtures are fixed
+    // (comment × paren/semicolon placement, blank-line-driven argument
+    // expansion, union/intersection leading comments, jsdoc @example fences).
+    const CHECK_IDEMPOTENCY: bool = false;
+
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = JsFormatOptions::default();
 

--- a/crates/oxc_formatter_core/src/test_support/harness.rs
+++ b/crates/oxc_formatter_core/src/test_support/harness.rs
@@ -27,6 +27,11 @@ pub trait FixtureFormatter {
     /// The typed format-option struct for this language.
     type Options: Clone;
 
+    /// When `true` (default), every fixture also asserts idempotency:
+    /// formatting the first pass's output must reproduce it byte-for-byte.
+    /// Opt out only while known non-idempotent fixtures are being fixed.
+    const CHECK_IDEMPOTENCY: bool = true;
+
     /// Build typed options from a parsed `options.json` fragment.
     fn parse_options(json: &OptionSet) -> Self::Options;
 
@@ -140,6 +145,21 @@ fn generate_snapshot<F: FixtureFormatter>(path: &Path, source_text: &str) -> Str
 
         let options = F::parse_options(&option_json);
         let formatted = F::format(source_text, path, &options);
+
+        // Idempotency: formatting the formatter's own output must be a no-op.
+        if F::CHECK_IDEMPOTENCY {
+            let reformatted = F::format(&formatted, path, &options);
+            assert_eq!(
+                reformatted,
+                formatted,
+                "\n💥 Formatting is not idempotent!\n\
+                 fixture: {}\noptions: {options_line}\n\
+                 ============ first pass ============\n{formatted}\n\
+                 ============ second pass ===========\n{reformatted}",
+                path.display()
+            );
+        }
+
         snapshot.push_str(&formatted);
         snapshot.push('\n');
     }

--- a/crates/oxc_formatter_css/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_css/tests/fixtures/mod.rs
@@ -17,6 +17,10 @@ struct CssHarness;
 impl FixtureFormatter for CssHarness {
     type Options = CssFormatOptions;
 
+    // TODO: Enable once the known non-idempotent output is fixed:
+    // nth-an-plus-b.css (`+ 3n` — invalid An+B whitespace, second pass fails to parse)
+    const CHECK_IDEMPOTENCY: bool = false;
+
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = CssFormatOptions::default();
 


### PR DESCRIPTION
Automatically test idempotency with fixture tests.

Currently, JS and CSS formatter have the issue, will fix later to enable.
