### PR TITLE
refactor(formatter_core): remove thread-local scratch cache

### DIFF
--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -34,11 +34,12 @@ Pick by what you're building:
 - Root document (feeds `Document::new` / `EmbeddedIr`): `VecBuffer` (arena)
   - it moves into the `Document` for free, and heap-staging it costs an extra copy for no benefit
 - Unknown-length staging that ends interned/sliced: `HeapVecBuffer`
-  - a watermarked view over a shared, thread-cached scratch vector; the arena receives one exactly-sized copy (see its rustdoc for the full rationale)
-  - the per-thread cache has byte and buffer-count limits; oversized staging is released after the format run
-- Accumulating across interleaved `write()` calls (multiple builders open at once), or staging that must release the state between writes and consumption: give each accumulator its own `ScratchBuffer` (pooled capacity is fetched lazily on first write) and write through `ScratchBuffer::writer`, finish via `Formatter::intern_elements` (or re-emit via `ScratchBuffer::drain`, abandon via `ScratchBuffer::discard`)
+  - a watermarked view over one scratch vector owned by the format run
+  - the arena receives one exactly-sized copy (see its rustdoc for the full rationale)
+  - for `BestFitting` variants, `best_fitting_variant` already wraps this (entry tags + staging in one place)
+- Accumulating across interleaved `write()` calls (multiple builders open at once), or staging that must release the state between writes and consumption: `ScratchBuffer` (one per accumulator)
+  - write through `ScratchBuffer::writer`, finish via `Formatter::intern_elements` (or re-emit via `ScratchBuffer::drain`, abandon via `ScratchBuffer::discard`)
   - the shared scratch's LIFO rule and its exclusive state borrow rule out `HeapVecBuffer` there (see the JSX child-list builders and `AssignmentLike` in `oxc_formatter`)
-- `BestFitting` variants: `best_fitting_variant` (wraps the entry tags and stages on the heap in one place)
 - Known-length sequences: build exact-sized directly (e.g. `ArenaVec::from_iter_in`)
 
 `Formatter::intern` and `BestFitting` already stage on the heap; consumer crates get this for free.

--- a/crates/oxc_formatter_core/src/buffer.rs
+++ b/crates/oxc_formatter_core/src/buffer.rs
@@ -157,9 +157,10 @@ impl<'ast, C> Buffer<'ast, C> for VecBuffer<'_, 'ast, C> {
 /// growth can reuse the allocation only when nothing else was bumped in between, which practically never holds while formatting).
 /// Heap growth is reclaimed by the system allocator, and the arena receives only the final, exactly-sized copy.
 ///
-/// The buffer is a watermarked view over the format run's single shared staging vector:
-/// its content is the vector's tail past the length recorded at creation, drained on completion (or on drop).
-/// See `ScratchBuffer` in `state.rs` for the sharing scheme and the LIFO discipline it relies on.
+/// The buffer is a watermarked view over the format run's single shared staging vector ([`FormatState`]'s scratch):
+/// its content is the vector's tail past the length recorded at creation,
+/// drained on completion (or on drop). Multiple buffers share the vector like a stack,
+/// sound because IR staging is strictly LIFO (an inner buffer always completes before its enclosing one resumes).
 pub struct HeapVecBuffer<'buf, 'ast, C> {
     state: &'buf mut FormatState<'ast, C>,
     watermark: usize,
@@ -233,6 +234,72 @@ impl<'ast, C> Buffer<'ast, C> for HeapVecBuffer<'_, 'ast, C> {
     }
 }
 
+/// An owned heap staging vector for accumulators that outlive a single staging scope.
+///
+/// See [`AccumulatorBuffer`] for why interleaved or suspended accumulators can use
+/// neither the arena nor the format run's shared scratch vector.
+///
+/// Content leaves the buffer only through the named consumption paths ([`crate::Formatter::intern_elements`],
+/// [`ScratchBuffer::drain`], or [`ScratchBuffer::discard`]) all of which leave it empty,
+/// satisfying the drop-time assertion below.
+#[derive(Debug, Default)]
+pub struct ScratchBuffer<'ast>(Vec<FormatElement<'ast>>);
+
+impl<'ast> ScratchBuffer<'ast> {
+    /// An empty scratch buffer.
+    pub const fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Adapts this scratch vector into a [`Buffer`] writing into it.
+    ///
+    /// This is the only way to construct an [`AccumulatorBuffer`] and the only write path into the vector,
+    /// so accumulated content is always guarded by the drain-before-drop assertion below.
+    pub fn writer<'buf, C>(
+        &'buf mut self,
+        state: &'buf mut FormatState<'ast, C>,
+    ) -> AccumulatorBuffer<'buf, 'ast, C> {
+        AccumulatorBuffer::new(state, &mut self.0)
+    }
+
+    /// Removes and returns the accumulated elements, leaving the buffer empty (re-emit consumption path).
+    pub fn drain(&mut self) -> std::vec::Drain<'_, FormatElement<'ast>> {
+        self.0.drain(..)
+    }
+
+    /// Inserts an element at `index`, shifting the rest.
+    /// For post-hoc adjustment of already-accumulated content
+    /// (e.g. slipping a separator into the last written entry); new content goes through [`ScratchBuffer::writer`].
+    pub fn insert(&mut self, index: usize, element: FormatElement<'ast>) {
+        self.0.insert(index, element);
+    }
+
+    /// Abandons any accumulated content, releasing the allocation immediately
+    /// (no caller writes again after a discard, so holding the capacity until drop would only pin peak memory).
+    pub fn discard(&mut self) {
+        self.0 = Vec::new();
+    }
+}
+
+impl<'ast> Deref for ScratchBuffer<'ast> {
+    type Target = [FormatElement<'ast>];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Drop for ScratchBuffer<'_> {
+    fn drop(&mut self) {
+        // Accumulators finish via `intern_elements`/`drain`/`discard`; a leftover means elements leaked.
+        // (Skipped mid-unwind: the owner may unwind while content is still staged.)
+        debug_assert!(
+            self.0.is_empty() || std::thread::panicking(),
+            "scratch buffer dropped before being fully drained"
+        );
+    }
+}
+
 /// Heap accumulator [`Buffer`] over a caller-owned element vector.
 ///
 /// For element sequences that outlive a single exclusive borrow of the [`FormatState`]:
@@ -243,8 +310,7 @@ impl<'ast, C> Buffer<'ast, C> for HeapVecBuffer<'_, 'ast, C> {
 /// Those can't stage in the arena (every growth would strand the grown-out-of allocation, see [`HeapVecBuffer`])
 /// nor share the format run's scratch vector (suspended or interleaved use breaks its LIFO discipline).
 ///
-/// Instead the caller owns a [`crate::ScratchBuffer`] (backed lazily by the thread-local cache)
-/// and writes through this adapter (constructed via [`crate::ScratchBuffer::writer`]);
+/// Instead the caller owns a [`ScratchBuffer`] and writes through this adapter (constructed via [`ScratchBuffer::writer`]);
 /// the arena receives one exactly-sized copy when the finished result is interned ([`crate::Formatter::intern_elements`]),
 /// or nothing at all when the elements are re-emitted into a downstream buffer.
 pub struct AccumulatorBuffer<'buf, 'ast, C> {

--- a/crates/oxc_formatter_core/src/formatter.rs
+++ b/crates/oxc_formatter_core/src/formatter.rs
@@ -87,7 +87,7 @@ impl<'buf, 'ast, C> Formatter<'buf, 'ast, C> {
     }
 
     /// Interns a builder's heap accumulator, moving it into the arena exactly-sized.
-    /// The source is emptied, retaining its capacity (returned to the cache when the scratch drops).
+    /// The source is emptied.
     pub fn intern_elements(
         &self,
         elements: &mut ScratchBuffer<'ast>,

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -40,7 +40,7 @@ pub mod test_support;
 pub use arguments::{Argument, Arguments};
 pub use buffer::{
     AccumulatorBuffer, Buffer, BufferExtensions, HeapVecBuffer, Inspect, PreambleBuffer, Recorded,
-    Recording, RemoveSoftLinesBuffer, VecBuffer,
+    Recording, RemoveSoftLinesBuffer, ScratchBuffer, VecBuffer,
 };
 pub use diagnostics::{ActualStart, FormatError, InvalidDocumentError, PrintError};
 pub use embedded::{
@@ -67,7 +67,7 @@ pub use options::{
 pub use printer::{PrintResult, PrintWidth, Printed, Printer, PrinterOptions};
 pub(crate) use simple_context::SimpleFormatContext;
 pub use source_text::SourceText;
-pub use state::{FormatState, ScratchBuffer};
+pub use state::FormatState;
 pub use text_range::TextRange;
 pub use traits::{FormatContext, FormatOptions};
 

--- a/crates/oxc_formatter_core/src/state.rs
+++ b/crates/oxc_formatter_core/src/state.rs
@@ -1,212 +1,8 @@
-use std::{cell::RefCell, collections::VecDeque, mem};
-
 use rustc_hash::FxHashMap;
 
 use oxc_allocator::{Allocator, GetAllocator};
 
-use crate::{
-    FormatElement, GroupId, UniqueGroupIdBuilder, buffer::AccumulatorBuffer,
-    format_element::Interned,
-};
-
-/// Maximum total element-storage capacity retained by the scratch cache on each thread.
-///
-/// This bounds only idle capacity between format runs;
-/// a run can still grow beyond it, and the oversized vector is then released at run end instead of cached.
-/// The cache retains only what a run actually grew, so a generous ceiling is near-free,
-/// while a tight one would make every re-format of a large file re-grow its scratch from nothing.
-///
-/// 8 MB keeps every measured non-bundled fixture cached (`checker.ts` included);
-/// only the bundled `antd.js` overflows and re-grows per run
-/// (its elevated sys-alloc numbers in `allocs_formatter.yaml` are this constant at work),
-/// a deliberate trade-off: repeatedly re-formatting bundles is not worth pinning tens of MB per thread.
-const MAX_CACHED_SCRATCH_BYTES: usize = 8 * 1024 * 1024;
-
-/// Maximum number of scratch vectors retained on each thread.
-///
-/// Sized for the concurrent users: nested format runs (embedded languages) plus overlapping accumulators
-/// (nested JSX child lists hold up to two each, so 64 keeps roughly 30 levels of JSX nesting warm).
-/// Low-stakes in both directions: retained memory is already bounded by the byte limit above,
-/// overflow just makes excess accumulators allocate fresh small vectors, and the count mainly keeps the `take_largest` scan short.
-const MAX_CACHED_SCRATCH_BUFFERS: usize = 64;
-
-thread_local! {
-    /// Cache of heap staging vectors, reusing capacity across format runs on the same thread.
-    /// Retained memory and buffer count are bounded by the constants above.
-    /// Multiple vectors are kept because format runs can nest
-    /// (embedded-language formatting creates a child [`FormatState`] on the same thread) and accumulators can overlap.
-    ///
-    /// Accumulator buffers use LIFO order.
-    /// A [`FormatState`] explicitly takes the largest cached buffer,
-    /// so rejecting an oversized run scratch cannot make the next run start with a small accumulator buffer.
-    /// When a limit is reached, [`ScratchCache::insert`] evicts the oldest buffers first;
-    /// an individually oversized vector is released instead of cached.
-    static SCRATCH_CACHE: RefCell<ScratchCache> = const { RefCell::new(ScratchCache::new()) };
-}
-
-struct ScratchCache {
-    buffers: VecDeque<Vec<FormatElement<'static>>>,
-    retained_bytes: usize,
-}
-
-impl ScratchCache {
-    const fn new() -> Self {
-        Self { buffers: VecDeque::new(), retained_bytes: 0 }
-    }
-
-    fn take(&mut self) -> Vec<FormatElement<'static>> {
-        let Some(buffer) = self.buffers.pop_back() else { return Vec::new() };
-        self.retained_bytes -= Self::capacity_in_bytes(buffer.capacity());
-        buffer
-    }
-
-    fn take_largest(&mut self) -> Vec<FormatElement<'static>> {
-        let Some((index, _)) =
-            self.buffers.iter().enumerate().max_by_key(|(_, buffer)| buffer.capacity())
-        else {
-            return Vec::new();
-        };
-        let buffer = self.buffers.remove(index).unwrap();
-        self.retained_bytes -= Self::capacity_in_bytes(buffer.capacity());
-        buffer
-    }
-
-    fn insert(&mut self, buffer: Vec<FormatElement<'static>>) {
-        let buffer_bytes = Self::capacity_in_bytes(buffer.capacity());
-        if buffer_bytes == 0 || buffer_bytes > MAX_CACHED_SCRATCH_BYTES {
-            return;
-        }
-
-        // Evict the least recently returned buffers until both limits have room
-        while self.buffers.len() >= MAX_CACHED_SCRATCH_BUFFERS
-            || self.retained_bytes > MAX_CACHED_SCRATCH_BYTES - buffer_bytes
-        {
-            let Some(evicted) = self.buffers.pop_front() else { break };
-            self.retained_bytes -= Self::capacity_in_bytes(evicted.capacity());
-        }
-
-        self.retained_bytes += buffer_bytes;
-        self.buffers.push_back(buffer);
-    }
-
-    const fn capacity_in_bytes(capacity: usize) -> usize {
-        capacity.saturating_mul(size_of::<FormatElement<'static>>())
-    }
-}
-
-/// A heap staging vector backed by the thread-local `SCRATCH_CACHE`.
-///
-/// Pooled capacity is fetched on first use and returned on drop (panics included),
-/// so its high-water capacity is reused across instances.
-///
-/// Two users:
-/// - [`FormatState`] holds one per format run, shared by all [`crate::HeapVecBuffer`]s like a stack via watermarks:
-///   each buffer records the length at creation, pushes its elements, and drains its own tail on completion.
-///   Sound because IR staging is strictly LIFO (an inner buffer always completes before its enclosing one resumes)
-/// - Accumulators that outlive a single staging scope (interleaved or suspended use, written through [`crate::AccumulatorBuffer`]) each own one.
-///   Accumulators fetch cached vectors in LIFO order; [`FormatState`] takes the largest vector
-///
-/// Content leaves the buffer only through the named consumption paths
-/// ([`crate::Formatter::intern_elements`], [`ScratchBuffer::drain`], or [`ScratchBuffer::discard`])
-/// all of which leave it empty, satisfying the drop-time assertion below.
-#[derive(Debug)]
-pub struct ScratchBuffer<'ast>(Vec<FormatElement<'ast>>);
-
-impl<'ast> ScratchBuffer<'ast> {
-    /// An empty scratch buffer. Costs nothing until written to:
-    /// pooled capacity is fetched lazily by [`ScratchBuffer::writer`],
-    /// so an accumulator that is never written (e.g. a builder born disabled) never touches the cache.
-    pub const fn new() -> Self {
-        Self(Vec::new())
-    }
-
-    fn from_cached(vec: Vec<FormatElement<'static>>) -> Self {
-        // SAFETY: cached vectors are always empty (checkin clears them);
-        // an empty vector holds no values, so re-branding its element lifetime is sound.
-        Self(unsafe {
-            mem::transmute::<Vec<FormatElement<'static>>, Vec<FormatElement<'ast>>>(vec)
-        })
-    }
-
-    fn checkout() -> Self {
-        Self::from_cached(SCRATCH_CACHE.with_borrow_mut(ScratchCache::take))
-    }
-
-    fn checkout_largest() -> Self {
-        Self::from_cached(SCRATCH_CACHE.with_borrow_mut(ScratchCache::take_largest))
-    }
-
-    /// Adapts this scratch vector into a [`Buffer`](crate::Buffer) writing into it,
-    /// fetching pooled capacity on the way if the vector has none yet.
-    ///
-    /// This is the only way to construct an [`AccumulatorBuffer`] and the only write path into the vector,
-    /// so accumulated content is always guarded by the drain-before-drop assertion below.
-    pub fn writer<'buf, C>(
-        &'buf mut self,
-        state: &'buf mut FormatState<'ast, C>,
-    ) -> AccumulatorBuffer<'buf, 'ast, C> {
-        if self.0.capacity() == 0 {
-            *self = Self::checkout();
-        }
-        AccumulatorBuffer::new(state, &mut self.0)
-    }
-
-    /// Removes and returns the accumulated elements, leaving the buffer empty (re-emit consumption path).
-    pub fn drain(&mut self) -> std::vec::Drain<'_, FormatElement<'ast>> {
-        self.0.drain(..)
-    }
-
-    /// Inserts an element at `index`, shifting the rest.
-    /// For post-hoc adjustment of already-accumulated content
-    /// (e.g. slipping a separator into the last written entry); new content goes through [`ScratchBuffer::writer`].
-    pub fn insert(&mut self, index: usize, element: FormatElement<'ast>) {
-        self.0.insert(index, element);
-    }
-
-    /// Abandons any accumulated content and returns the pooled capacity to the cache immediately,
-    /// so other accumulators (e.g. nested ones still running) can reuse it.
-    pub fn discard(&mut self) {
-        self.0.clear();
-        // The taken-out buffer's drop checks its capacity back in
-        drop(mem::take(self));
-    }
-}
-
-impl<'ast> std::ops::Deref for ScratchBuffer<'ast> {
-    type Target = [FormatElement<'ast>];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl Default for ScratchBuffer<'_> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Drop for ScratchBuffer<'_> {
-    fn drop(&mut self) {
-        // Every user empties the vector on completion (`HeapVecBuffer`s drain their own tail,
-        // accumulators finish via `intern_elements`/`drain`/`discard`); a leftover means elements leaked.
-        // (Skipped mid-unwind: buffers up the stack haven't truncated their tails yet.)
-        debug_assert!(
-            self.0.is_empty() || std::thread::panicking(),
-            "scratch buffer returned to the cache before being fully drained"
-        );
-        let mut vec = mem::take(&mut self.0);
-        // A buffer that never grew has nothing worth caching
-        if vec.capacity() == 0 {
-            return;
-        }
-        vec.clear();
-        // SAFETY: just cleared; see `checkout`
-        let vec =
-            unsafe { mem::transmute::<Vec<FormatElement<'_>>, Vec<FormatElement<'static>>>(vec) };
-        SCRATCH_CACHE.with_borrow_mut(|cache| cache.insert(vec));
-    }
-}
+use crate::{FormatElement, GroupId, UniqueGroupIdBuilder, format_element::Interned};
 
 /// This structure stores the state that is relevant for the formatting of the whole document.
 ///
@@ -220,8 +16,9 @@ pub struct FormatState<'ast, C> {
     // For the document IR printing process
     /// The interned elements that have been printed to this point
     printed_interned_elements: FxHashMap<Interned<'ast>, usize>,
-    /// Heap staging vector for [`crate::HeapVecBuffer`]; see [`ScratchBuffer`].
-    scratch: ScratchBuffer<'ast>,
+    /// Heap staging vector shared by all [`crate::HeapVecBuffer`]s of this format run;
+    /// see [`crate::HeapVecBuffer`] for the watermark scheme keeping their views disjoint.
+    scratch: Vec<FormatElement<'ast>>,
 }
 
 impl<C: std::fmt::Debug> std::fmt::Debug for FormatState<'_, C> {
@@ -238,18 +35,18 @@ impl<'ast, C> FormatState<'ast, C> {
             allocator,
             group_id_builder: UniqueGroupIdBuilder::default(),
             printed_interned_elements: FxHashMap::default(),
-            scratch: ScratchBuffer::checkout_largest(),
+            scratch: Vec::new(),
         }
     }
 
     /// The heap staging vector shared by all [`crate::HeapVecBuffer`]s of this format run.
     pub(crate) fn scratch(&self) -> &[FormatElement<'ast>] {
-        &self.scratch.0
+        &self.scratch
     }
 
     /// Mutable access to the heap staging vector; see [`FormatState::scratch`].
     pub(crate) fn scratch_mut(&mut self) -> &mut Vec<FormatElement<'ast>> {
-        &mut self.scratch.0
+        &mut self.scratch
     }
 
     /// Returns the allocator used for arena-allocating format elements.
@@ -293,101 +90,5 @@ impl<'ast, C> GetAllocator<'ast> for FormatState<'ast, C> {
     #[inline]
     fn allocator(&self) -> &'ast Allocator {
         self.allocator
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn buffer_with_capacity(capacity: usize) -> Vec<FormatElement<'static>> {
-        Vec::with_capacity(capacity)
-    }
-
-    fn assert_retained_bytes_consistent(cache: &ScratchCache) {
-        assert_eq!(
-            cache.retained_bytes,
-            cache
-                .buffers
-                .iter()
-                .map(|buffer| ScratchCache::capacity_in_bytes(buffer.capacity()))
-                .sum::<usize>()
-        );
-    }
-
-    #[test]
-    fn scratch_cache_rejects_an_oversized_buffer() {
-        let mut cache = ScratchCache::new();
-        let oversized_capacity = MAX_CACHED_SCRATCH_BYTES / size_of::<FormatElement<'static>>() + 1;
-
-        cache.insert(buffer_with_capacity(oversized_capacity));
-
-        assert!(cache.buffers.is_empty());
-        assert_eq!(cache.retained_bytes, 0);
-    }
-
-    #[test]
-    fn scratch_cache_bounds_total_retained_bytes() {
-        let mut cache = ScratchCache::new();
-        let half_budget_capacity =
-            MAX_CACHED_SCRATCH_BYTES / size_of::<FormatElement<'static>>() / 2;
-
-        for _ in 0..3 {
-            cache.insert(buffer_with_capacity(half_budget_capacity));
-        }
-
-        assert!(cache.retained_bytes <= MAX_CACHED_SCRATCH_BYTES);
-        assert_retained_bytes_consistent(&cache);
-    }
-
-    #[test]
-    fn scratch_cache_bounds_buffer_count() {
-        let mut cache = ScratchCache::new();
-
-        for _ in 0..=MAX_CACHED_SCRATCH_BUFFERS {
-            cache.insert(buffer_with_capacity(1));
-        }
-
-        assert_eq!(cache.buffers.len(), MAX_CACHED_SCRATCH_BUFFERS);
-    }
-
-    #[test]
-    fn scratch_cache_updates_retained_bytes_on_take() {
-        let mut cache = ScratchCache::new();
-        cache.insert(buffer_with_capacity(16));
-        let retained_bytes = cache.retained_bytes;
-
-        let buffer = cache.take();
-
-        assert_eq!(ScratchCache::capacity_in_bytes(buffer.capacity()), retained_bytes);
-        assert_eq!(cache.retained_bytes, 0);
-    }
-
-    #[test]
-    fn scratch_cache_takes_the_largest_buffer_for_format_state() {
-        let mut cache = ScratchCache::new();
-        cache.insert(buffer_with_capacity(8));
-        cache.insert(buffer_with_capacity(32));
-        cache.insert(buffer_with_capacity(16));
-
-        let buffer = cache.take_largest();
-
-        assert_eq!(buffer.capacity(), 32);
-        assert_retained_bytes_consistent(&cache);
-    }
-
-    #[test]
-    fn scratch_cache_evicts_the_oldest_buffer() {
-        let mut cache = ScratchCache::new();
-        cache.insert(buffer_with_capacity(2));
-        for _ in 1..MAX_CACHED_SCRATCH_BUFFERS {
-            cache.insert(buffer_with_capacity(1));
-        }
-
-        cache.insert(buffer_with_capacity(3));
-
-        assert_eq!(cache.buffers.len(), MAX_CACHED_SCRATCH_BUFFERS);
-        assert_eq!(cache.buffers.back().unwrap().capacity(), 3);
-        assert!(!cache.buffers.iter().any(|buffer| buffer.capacity() == 2));
     }
 }

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -1,9 +1,9 @@
 checker.ts:
   file size: 2922154 # 2.92 MB
-  sys allocs: 11013
-  sys reallocs: 492
-  sys deallocs: 11012
-  sys alloc bytes: 5918285 # 5.92 MB
+  sys allocs: 19378
+  sys reallocs: 1166
+  sys deallocs: 19377
+  sys alloc bytes: 7510125 # 7.51 MB
   sys peak growth: 2990058 # 2.99 MB
   arena allocs: 1070955
   arena reallocs: 927
@@ -11,43 +11,43 @@ checker.ts:
 
 App.tsx:
   file size: 415342 # 415.34 kB
-  sys allocs: 2532
-  sys reallocs: 85
-  sys deallocs: 2531
-  sys alloc bytes: 1302622 # 1.30 MB
-  sys peak growth: 760990 # 760.99 kB
+  sys allocs: 5191
+  sys reallocs: 524
+  sys deallocs: 5190
+  sys alloc bytes: 2065982 # 2.07 MB
+  sys peak growth: 443550 # 443.55 kB
   arena allocs: 209344
   arena reallocs: 364
   arena size: 21592480 # 21.59 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
-  sys allocs: 54
-  sys reallocs: 26
-  sys deallocs: 53
-  sys alloc bytes: 10116 # 10.12 kB
-  sys peak growth: 2856 # 2.86 kB
+  sys allocs: 89
+  sys reallocs: 74
+  sys deallocs: 88
+  sys alloc bytes: 53476 # 53.48 kB
+  sys peak growth: 19104 # 19.10 kB
   arena allocs: 1134
   arena reallocs: 0
   arena size: 154768 # 154.77 kB
 
 pdf.mjs:
   file size: 567296 # 567.30 kB
-  sys allocs: 4019
-  sys reallocs: 173
-  sys deallocs: 4018
-  sys alloc bytes: 2377712 # 2.38 MB
-  sys peak growth: 1492304 # 1.49 MB
+  sys allocs: 9775
+  sys reallocs: 1327
+  sys deallocs: 9774
+  sys alloc bytes: 3968912 # 3.97 MB
+  sys peak growth: 1164624 # 1.16 MB
   arena allocs: 428857
   arena reallocs: 428
   arena size: 35654864 # 35.65 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
-  sys allocs: 34121
-  sys reallocs: 4001
-  sys deallocs: 34121
-  sys alloc bytes: 104081116 # 104.08 MB
+  sys allocs: 90042
+  sys reallocs: 7663
+  sys deallocs: 90041
+  sys alloc bytes: 114590556 # 114.59 MB
   sys peak growth: 83833168 # 83.83 MB
   arena allocs: 2503924
   arena reallocs: 1889
@@ -55,10 +55,10 @@ antd.js:
 
 binder.ts:
   file size: 193077 # 193.08 kB
-  sys allocs: 457
-  sys reallocs: 35
-  sys deallocs: 456
-  sys alloc bytes: 291781 # 291.78 kB
+  sys allocs: 972
+  sys reallocs: 97
+  sys deallocs: 971
+  sys alloc bytes: 404901 # 404.90 kB
   sys peak growth: 195661 # 195.66 kB
   arena allocs: 63509
   arena reallocs: 38
@@ -66,11 +66,11 @@ binder.ts:
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
-  sys allocs: 9566
-  sys reallocs: 2822
-  sys deallocs: 9564
-  sys alloc bytes: 3180244 # 3.18 MB
-  sys peak growth: 1520468 # 1.52 MB
+  sys allocs: 17087
+  sys reallocs: 4956
+  sys deallocs: 17086
+  sys alloc bytes: 5405684 # 5.41 MB
+  sys peak growth: 1499988 # 1.50 MB
   arena allocs: 560401
   arena reallocs: 1041
   arena size: 46408496 # 46.41 MB


### PR DESCRIPTION
Revert #24583.

After re-measuring, I found no significant improvement. It is not worth the amount of code required.

Also, the fundamental issue is that the end-side formatter, rather than Oxfmt itself, is performing cross-file caching, which is an undesirable side effect.
