### PR TITLE
fix(linter/typescript/no-confusing-non-null-assertion): report `in` and `instanceof`

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -23,7 +23,10 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// Using a non-null assertion (!) next to an assign or equals check (= or == or ===) creates code that is confusing as it looks similar to a not equals check (!= !==).
+    /// Using a non-null assertion (`!`) next to an assignment or equality check (`=` or `==` or
+    /// `===`) creates code that is confusing as it looks similar to an inequality check (`!=` or
+    /// `!==`). Using one next to an `in` or `instanceof` check is also confusing because it may
+    /// look like the operator is negated.
     ///
     /// ### Examples
     ///
@@ -32,6 +35,8 @@ declare_oxc_lint!(
     ///    a! == b; // a non-null assertions(`!`) and an equals test(`==`)
     ///    a !== b; // not equals test(`!==`)
     ///    a! === b; // a non-null assertions(`!`) and an triple equals test(`===`)
+    ///    a! in b;
+    ///    a! instanceof b;
     /// ```
     ///
     /// Examples of **correct** code for this rule:
@@ -74,6 +79,14 @@ fn confusing_non_null_assignment_assertion_diagnostic(op_str: &str, span: Span) 
     .with_label(span)
 }
 
+fn confusing_non_null_operator_diagnostic(op_str: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Confusing combination of non-null assertion and `{op_str}` operator like `a! {op_str} b`, which might be misinterpreted as `!(a {op_str} b)`."
+    ))
+    .with_help("Remove the `!`, or wrap the left-hand side in parentheses.")
+    .with_label(span)
+}
+
 fn get_depth_ends_in_bang(expr: &Expression<'_>) -> Option<u32> {
     match expr {
         Expression::TSNonNullExpression(_) => Some(0),
@@ -91,7 +104,13 @@ fn get_depth_ends_in_bang(expr: &Expression<'_>) -> Option<u32> {
 }
 
 fn is_confusable_operator(operator: BinaryOperator) -> bool {
-    matches!(operator, BinaryOperator::Equality | BinaryOperator::StrictEquality)
+    matches!(
+        operator,
+        BinaryOperator::Equality
+            | BinaryOperator::StrictEquality
+            | BinaryOperator::In
+            | BinaryOperator::Instanceof
+    )
 }
 
 impl Rule for NoConfusingNonNullAssertion {
@@ -103,7 +122,12 @@ impl Rule for NoConfusingNonNullAssertion {
                 let Some(bang_depth) = get_depth_ends_in_bang(&binary_expr.left) else {
                     return;
                 };
-                if bang_depth == 0 {
+                if matches!(binary_expr.operator, BinaryOperator::In | BinaryOperator::Instanceof) {
+                    ctx.diagnostic(confusing_non_null_operator_diagnostic(
+                        binary_expr.operator.as_str(),
+                        binary_expr.span,
+                    ));
+                } else if bang_depth == 0 {
                     ctx.diagnostic(not_need_no_confusing_non_null_assertion_diagnostic(
                         binary_expr.operator.as_str(),
                         binary_expr.span,
@@ -146,6 +170,8 @@ fn test() {
         "a !== b;",
         "a != b;",
         "(a + b!) == c;",
+        "(a + b!) in c;",
+        "(a || b!) instanceof c;",
         "a! + b;",
         "a! += b;",
         "a! - b;",
@@ -168,6 +194,9 @@ fn test() {
         "(a==b)! ==c;",
         "a! = b;",
         "(obj = new new OuterObj().InnerObj).Name! = c;",
+        "a! in b;",
+        "a !in b;",
+        "a! instanceof b;",
     ];
 
     // let fix = vec![

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -1,6 +1,6 @@
 use oxc_ast::{
     AstKind,
-    ast::{Expression, SimpleAssignmentTarget},
+    ast::{ChainElement, Expression, SimpleAssignmentTarget},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -90,6 +90,9 @@ fn confusing_non_null_operator_diagnostic(op_str: &str, span: Span) -> OxcDiagno
 fn get_depth_ends_in_bang(expr: &Expression<'_>) -> Option<u32> {
     match expr {
         Expression::TSNonNullExpression(_) => Some(0),
+        Expression::ChainExpression(chain_expr) => {
+            matches!(&chain_expr.expression, ChainElement::TSNonNullExpression(_)).then_some(0)
+        }
         Expression::BinaryExpression(binary_expr) => {
             get_depth_ends_in_bang(&binary_expr.right).map(|x| x + 1)
         }
@@ -197,6 +200,8 @@ fn test() {
         "a! in b;",
         "a !in b;",
         "a! instanceof b;",
+        "foo?.bar! in obj;",
+        "foo?.bar! instanceof C;",
     ];
 
     // let fix = vec![

--- a/crates/oxc_linter/src/snapshots/typescript_no_confusing_non_null_assertion.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_confusing_non_null_assertion.snap
@@ -50,3 +50,24 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────────────────────────────────
    ╰────
   help: Remove the `!`, or wrap the left-hand side in parentheses.
+
+  ⚠ typescript(no-confusing-non-null-assertion): Confusing combination of non-null assertion and `in` operator like `a! in b`, which might be misinterpreted as `!(a in b)`.
+   ╭─[no_confusing_non_null_assertion.tsx:1:1]
+ 1 │ a! in b;
+   · ───────
+   ╰────
+  help: Remove the `!`, or wrap the left-hand side in parentheses.
+
+  ⚠ typescript(no-confusing-non-null-assertion): Confusing combination of non-null assertion and `in` operator like `a! in b`, which might be misinterpreted as `!(a in b)`.
+   ╭─[no_confusing_non_null_assertion.tsx:1:1]
+ 1 │ a !in b;
+   · ───────
+   ╰────
+  help: Remove the `!`, or wrap the left-hand side in parentheses.
+
+  ⚠ typescript(no-confusing-non-null-assertion): Confusing combination of non-null assertion and `instanceof` operator like `a! instanceof b`, which might be misinterpreted as `!(a instanceof b)`.
+   ╭─[no_confusing_non_null_assertion.tsx:1:1]
+ 1 │ a! instanceof b;
+   · ───────────────
+   ╰────
+  help: Remove the `!`, or wrap the left-hand side in parentheses.

--- a/crates/oxc_linter/src/snapshots/typescript_no_confusing_non_null_assertion.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_confusing_non_null_assertion.snap
@@ -71,3 +71,17 @@ source: crates/oxc_linter/src/tester.rs
    · ───────────────
    ╰────
   help: Remove the `!`, or wrap the left-hand side in parentheses.
+
+  ⚠ typescript(no-confusing-non-null-assertion): Confusing combination of non-null assertion and `in` operator like `a! in b`, which might be misinterpreted as `!(a in b)`.
+   ╭─[no_confusing_non_null_assertion.tsx:1:1]
+ 1 │ foo?.bar! in obj;
+   · ────────────────
+   ╰────
+  help: Remove the `!`, or wrap the left-hand side in parentheses.
+
+  ⚠ typescript(no-confusing-non-null-assertion): Confusing combination of non-null assertion and `instanceof` operator like `a! instanceof b`, which might be misinterpreted as `!(a instanceof b)`.
+   ╭─[no_confusing_non_null_assertion.tsx:1:1]
+ 1 │ foo?.bar! instanceof C;
+   · ──────────────────────
+   ╰────
+  help: Remove the `!`, or wrap the left-hand side in parentheses.


### PR DESCRIPTION
report `in` and `instanceof` in `typescript-eslint/no-confusing-non-null-assertion` rule, ported PR from upstream https://github.com/typescript-eslint/typescript-eslint/pull/9994