### PR TITLE
refactor(formatter_core): move debug names out of `(Group|Label)Id` to unify `debug|release` layout

### DIFF
--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -108,13 +108,15 @@ fn transform<'a>(
     // and any `Line(_)` inside is for output positioning, not a real line boundary.
     // e.g. ```import "a"; <StartLineSuffix> Line(Empty) Text("// trailing") <EndLineSuffix>```
     let mut inside_line_suffix = false;
+    let comment_label = LabelId::of(JsLabels::Comment);
+    let import_label = LabelId::of(JsLabels::ImportDeclaration);
     for (idx, el) in prev_elements.iter().enumerate() {
         if let FormatElement::Tag(tag) = el {
             match tag {
                 Tag::StartLabelled(id) => {
-                    if *id == LabelId::of(JsLabels::Comment) {
+                    if *id == comment_label {
                         inside_comment = true;
-                    } else if *id == LabelId::of(JsLabels::ImportDeclaration) {
+                    } else if *id == import_label {
                         inside_multiline_import = true;
                     }
                 }

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
@@ -50,12 +50,13 @@ impl<'a> SourceLine<'a> {
         let mut has_namespace_specifier = false;
         let mut has_named_specifier = false;
 
+        let import_label = LabelId::of(JsLabels::ImportDeclaration);
         for idx in range.clone() {
             let element = &elements[idx];
 
             // Special marker for `ImportDeclaration`
             if let FormatElement::Tag(Tag::StartLabelled(id)) = element {
-                if *id == LabelId::of(JsLabels::ImportDeclaration) {
+                if *id == import_label {
                     has_import = true;
                 }
                 continue;

--- a/crates/oxc_formatter_core/src/format_element/mod.rs
+++ b/crates/oxc_formatter_core/src/format_element/mod.rs
@@ -16,26 +16,10 @@ use crate::IndentWidth;
 
 use self::tag::{LabelId, Tag, TagKind};
 
-#[cfg(debug_assertions)]
-const _: () = {
-    if cfg!(target_pointer_width = "64") {
-        assert!(
-            size_of::<FormatElement>() == 40,
-            "`FormatElement` size exceeds 40 bytes, expected 40 bytes in 64-bit platforms"
-        );
-    } else if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
-        // Some 32-bit platforms have 8-byte alignment for `u64` and `f64`, while others have 4-byte alignment.
-        //
-        // Skip these assertions on 32-bit platforms where `u64` / `f64` have 4-byte alignment, because
-        // some layout calculations may be incorrect. https://github.com/oxc-project/oxc/pull/13716
-        assert!(
-            size_of::<FormatElement>() == 24,
-            "`FormatElement` size exceeds 24 bytes, expected 24 bytes in 32-bit platforms"
-        );
-    }
-};
-
-#[cfg(not(debug_assertions))]
+// `FormatElement` must have the same layout in debug and release builds.
+//
+// So that memory measurements taken with `debug-assertions` enabled (`cargo allocs` runs with the `coverage` profile) reflect release layouts.
+// That is why `GroupId` and `LabelId` keep their debug names in side tables instead of inline fields.
 const _: () = {
     if cfg!(target_pointer_width = "64") {
         assert!(
@@ -45,8 +29,8 @@ const _: () = {
     } else if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
         // Some 32-bit platforms have 8-byte alignment for `u64` and `f64`, while others have 4-byte alignment.
         //
-        // Skip these assertions on 32-bit platforms where `u64` / `f64` have 4-byte alignment, because
-        // some layout calculations may be incorrect. https://github.com/oxc-project/oxc/pull/13716
+        // Skip these assertions on 32-bit platforms where `u64` / `f64` have 4-byte alignment,
+        // because some layout calculations may be incorrect. https://github.com/oxc-project/oxc/pull/13716
         assert!(
             size_of::<FormatElement>() == 16,
             "`FormatElement` size exceeds 16 bytes, expected 16 bytes in 32-bit platforms"

--- a/crates/oxc_formatter_core/src/format_element/tag.rs
+++ b/crates/oxc_formatter_core/src/format_element/tag.rs
@@ -249,39 +249,63 @@ impl Align {
     }
 }
 
-#[derive(Debug, Eq, Copy, Clone)]
+/// Identifies a label applied via [crate::builders::labelled].
+///
+/// The label's debug name lives in a side table, not an inline field,
+/// to keep the layout of [crate::FormatElement] (which embeds `LabelId` through [`Tag::StartLabelled`]) identical
+/// in debug and release builds. (See the size assertion in `format_element/mod.rs`.)
+/// Registering the name also asserts that no two labels share a `value`.
+#[derive(Eq, PartialEq, Copy, Clone)]
 pub struct LabelId {
     value: u64,
-    #[cfg(debug_assertions)]
-    name: &'static str,
 }
 
-impl PartialEq for LabelId {
-    fn eq(&self, other: &Self) -> bool {
-        let is_equal = self.value == other.value;
-
+impl std::fmt::Debug for LabelId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[cfg(debug_assertions)]
-        {
-            if is_equal {
-                assert_eq!(
-                    self.name, other.name,
-                    "Two `LabelId`s with different names have the same `value`. Are you mixing labels of two different `LabelDefinition` or are the values returned by the `LabelDefinition` not unique?"
-                );
-            }
+        if let Some(name) = debug_names::lookup(self.value) {
+            return f.write_str(name);
         }
-
-        is_equal
+        write!(f, "#{}", self.value)
     }
 }
 
 impl LabelId {
     #[expect(clippy::needless_pass_by_value)] // The `Label` trait is unnecessary, would refactor it later.
     pub fn of<T: Label>(label: T) -> Self {
-        Self {
-            value: label.id(),
-            #[cfg(debug_assertions)]
-            name: label.debug_name(),
+        let value = label.id();
+        #[cfg(debug_assertions)]
+        debug_names::record(value, label.debug_name());
+        Self { value }
+    }
+}
+
+#[cfg(debug_assertions)]
+mod debug_names {
+    use std::sync::Mutex;
+
+    /// All `(value, name)` pairs ever registered.
+    /// Labels are few (one `Label` impl per language with a handful of variants), so a linear scan is fine.
+    static NAMES: Mutex<Vec<(u64, &'static str)>> = Mutex::new(Vec::new());
+
+    pub(super) fn record(value: u64, name: &'static str) {
+        let mut names = NAMES.lock().unwrap();
+        if let Some((_, existing_name)) = names.iter().find(|(existing, _)| *existing == value) {
+            assert_eq!(
+                *existing_name, name,
+                "Two labels with different names have the same `value` ({value}). Are you mixing labels of two different `LabelDefinition` or are the values returned by the `LabelDefinition` not unique?"
+            );
+        } else {
+            names.push((value, name));
         }
+    }
+
+    pub(super) fn lookup(value: u64) -> Option<&'static str> {
+        NAMES
+            .lock()
+            .unwrap()
+            .iter()
+            .find_map(|&(existing, name)| (existing == value).then_some(name))
     }
 }
 

--- a/crates/oxc_formatter_core/src/group_id.rs
+++ b/crates/oxc_formatter_core/src/group_id.rs
@@ -3,61 +3,63 @@ use std::{
     sync::atomic::{AtomicU32, Ordering},
 };
 
-#[cfg(debug_assertions)]
-mod debug {
-    use super::*;
+/// Unique identification for a group.
+///
+/// See [crate::Formatter::group_id] on how to get a unique id.
+///
+/// The debug name lives in a side table (see `debug_names` below),
+/// not an inline field, to keep the layout of [crate::FormatElement] (which embeds `GroupId` through `Tag`) identical in debug and release builds.
+/// (See the size assertion in `format_element/mod.rs`.)
+#[repr(transparent)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+pub struct GroupId {
+    value: NonZeroU32,
+}
 
-    #[derive(Clone, Copy, Eq, PartialEq, Hash)]
-    pub struct GroupId {
-        pub(super) value: NonZeroU32,
-        name: &'static str,
-    }
-
-    impl GroupId {
-        pub(super) fn new(value: NonZeroU32, debug_name: &'static str) -> Self {
-            Self { value, name: debug_name }
-        }
-    }
-
-    impl std::fmt::Debug for GroupId {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "#{}-{}", self.name, self.value)
-        }
+impl GroupId {
+    #[cfg_attr(not(debug_assertions), expect(unused_variables))]
+    fn new(value: NonZeroU32, debug_name: &'static str) -> Self {
+        #[cfg(debug_assertions)]
+        debug_names::record(value, debug_name);
+        Self { value }
     }
 }
 
-#[cfg(not(debug_assertions))]
-mod release {
-    use super::*;
-
-    /// Unique identification for a group.
-    ///
-    /// See [crate::Formatter::group_id] on how to get a unique id.
-    #[repr(transparent)]
-    #[derive(Clone, Copy, Eq, PartialEq, Hash)]
-    pub struct GroupId {
-        pub(super) value: NonZeroU32,
-    }
-
-    impl GroupId {
-        /// Creates a new unique group id with the given debug name (only stored in debug builds)
-        #[cfg_attr(debug_assertions, expect(unused))]
-        pub(super) fn new(value: NonZeroU32, _: &'static str) -> Self {
-            Self { value }
+impl std::fmt::Debug for GroupId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[cfg(debug_assertions)]
+        if let Some(name) = debug_names::lookup(self.value) {
+            return write!(f, "#{name}-{}", self.value);
         }
-    }
-
-    impl std::fmt::Debug for GroupId {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "#{}", self.value)
-        }
+        write!(f, "#{}", self.value)
     }
 }
 
-#[cfg(not(debug_assertions))]
-pub type GroupId = release::GroupId;
+/// Side table mapping `GroupId` values to their debug names.
+///
+/// Ids restart from 1 for every [`UniqueGroupIdBuilder`] (one per format run),
+/// so concurrent or successive runs overwrite each other's entries,
+/// the table is best-effort debug info for IR dumps, not authoritative.
 #[cfg(debug_assertions)]
-pub type GroupId = debug::GroupId;
+mod debug_names {
+    use std::{num::NonZeroU32, sync::Mutex};
+
+    /// Names indexed by `GroupId` value - 1
+    static NAMES: Mutex<Vec<Option<&'static str>>> = Mutex::new(Vec::new());
+
+    pub(super) fn record(value: NonZeroU32, name: &'static str) {
+        let index = value.get() as usize - 1;
+        let mut names = NAMES.lock().unwrap();
+        if names.len() <= index {
+            names.resize(index + 1, None);
+        }
+        names[index] = Some(name);
+    }
+
+    pub(super) fn lookup(value: NonZeroU32) -> Option<&'static str> {
+        NAMES.lock().unwrap().get(value.get() as usize - 1).copied().flatten()
+    }
+}
 
 impl From<GroupId> for u32 {
     fn from(id: GroupId) -> Self {

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -3,75 +3,75 @@ checker.ts:
   sys allocs: 19378
   sys reallocs: 1166
   sys deallocs: 19377
-  sys alloc bytes: 7510125 # 7.51 MB
+  sys alloc bytes: 6767245 # 6.77 MB
   sys peak growth: 2990058 # 2.99 MB
   arena allocs: 1070955
   arena reallocs: 927
-  arena size: 115790968 # 115.79 MB
+  arena size: 90302024 # 90.30 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
   sys allocs: 5191
   sys reallocs: 524
   sys deallocs: 5190
-  sys alloc bytes: 2065982 # 2.07 MB
-  sys peak growth: 443550 # 443.55 kB
+  sys alloc bytes: 1564670 # 1.56 MB
+  sys peak growth: 435358 # 435.36 kB
   arena allocs: 209344
   arena reallocs: 364
-  arena size: 21592480 # 21.59 MB
+  arena size: 16866400 # 16.87 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
   sys allocs: 89
   sys reallocs: 74
   sys deallocs: 88
-  sys alloc bytes: 53476 # 53.48 kB
-  sys peak growth: 19104 # 19.10 kB
+  sys alloc bytes: 36132 # 36.13 kB
+  sys peak growth: 12192 # 12.19 kB
   arena allocs: 1134
   arena reallocs: 0
-  arena size: 154768 # 154.77 kB
+  arena size: 118096 # 118.10 kB
 
 pdf.mjs:
   file size: 567296 # 567.30 kB
   sys allocs: 9775
   sys reallocs: 1327
   sys deallocs: 9774
-  sys alloc bytes: 3968912 # 3.97 MB
+  sys alloc bytes: 3141552 # 3.14 MB
   sys peak growth: 1164624 # 1.16 MB
   arena allocs: 428857
   arena reallocs: 428
-  arena size: 35654864 # 35.65 MB
+  arena size: 29434928 # 29.43 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
   sys allocs: 90042
   sys reallocs: 7663
   sys deallocs: 90041
-  sys alloc bytes: 114590556 # 114.59 MB
-  sys peak growth: 83833168 # 83.83 MB
+  sys alloc bytes: 76472316 # 76.47 MB
+  sys peak growth: 50737424 # 50.74 MB
   arena allocs: 2503924
   arena reallocs: 1889
-  arena size: 327824560 # 327.82 MB
+  arena size: 244471376 # 244.47 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
   sys allocs: 972
   sys reallocs: 97
   sys deallocs: 971
-  sys alloc bytes: 404901 # 404.90 kB
+  sys alloc bytes: 356005 # 356.00 kB
   sys peak growth: 195661 # 195.66 kB
   arena allocs: 63509
   arena reallocs: 38
-  arena size: 7297672 # 7.30 MB
+  arena size: 5682472 # 5.68 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
   sys allocs: 17087
   sys reallocs: 4956
   sys deallocs: 17086
-  sys alloc bytes: 5405684 # 5.41 MB
+  sys alloc bytes: 4436340 # 4.44 MB
   sys peak growth: 1499988 # 1.50 MB
   arena allocs: 560401
   arena reallocs: 1041
-  arena size: 46408496 # 46.41 MB
+  arena size: 38533664 # 38.53 MB
 


### PR DESCRIPTION
In #24558, a large amount of arena memory usage was discovered, but this snapshot was taken with `debug_assertion = true`.

Since `FormatElement` is 40B when this is enabled, but typically 24B, it means the actual usage was not being measured accurately.

In this PR, I have adjusted it so that the size is always consistent regardless of whether `debug_assertion` is enabled or not.
