### PR TITLE
refactor(linter/plugins): add debug asserts

### DIFF
--- a/apps/oxlint/src-js/plugins/comments.ts
+++ b/apps/oxlint/src-js/plugins/comments.ts
@@ -328,28 +328,32 @@ export function getComment(index: number): CommentType {
  * @returns `Comment` object if newly deserialized, or `null` if already deserialized
  */
 function deserializeCommentIfNeeded(index: number): Comment | null {
+  debugAssertIsNonNull(commentsUint8, "Comment buffers should be initialized");
+  debugAssertIsNonNull(commentsInt32, "Comment buffers should be initialized");
+  debugAssertIsNonNull(sourceText, "Source text should be initialized");
+
   const pos = index << COMMENT_SIZE_SHIFT;
 
   // Fast path: If already deserialized, exit
   const flagPos = pos + DESERIALIZED_FLAG_OFFSET;
-  if (commentsUint8![flagPos] !== FLAG_NOT_DESERIALIZED) return null;
+  if (commentsUint8[flagPos] !== FLAG_NOT_DESERIALIZED) return null;
 
   // Mark comment as deserialized, so it won't be deserialized again
-  commentsUint8![flagPos] = FLAG_DESERIALIZED;
+  commentsUint8[flagPos] = FLAG_DESERIALIZED;
 
   // Deserialize comment into a cached `Comment` object
   const comment = cachedComments[index];
 
-  const isBlock = commentsUint8![pos + COMMENT_KIND_OFFSET] !== COMMENT_LINE_KIND;
+  const isBlock = commentsUint8[pos + COMMENT_KIND_OFFSET] !== COMMENT_LINE_KIND;
 
   const pos32 = pos >> 2,
-    start = commentsInt32![pos32],
-    end = commentsInt32![pos32 + 1];
+    start = commentsInt32[pos32],
+    end = commentsInt32[pos32 + 1];
 
   comment.type = isBlock ? "Block" : "Line";
   // Line comments: `// text` -> slice `start + 2..end`
   // Block comments: `/* text */` -> slice `start + 2..end - 2`
-  comment.value = sourceText!.slice(start + 2, end - (+isBlock << 1));
+  comment.value = sourceText.slice(start + 2, end - (+isBlock << 1));
   comment.range[0] = comment.start = start;
   comment.range[1] = comment.end = end;
 

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -413,31 +413,35 @@ export function getToken(index: number): TokenType {
  * @returns `Token` object if newly deserialized, or `null` if already deserialized
  */
 function deserializeTokenIfNeeded(index: number): Token | null {
+  debugAssertIsNonNull(tokensUint8, "Token buffers should be initialized");
+  debugAssertIsNonNull(tokensInt32, "Token buffers should be initialized");
+  debugAssertIsNonNull(sourceText, "Source text should be initialized");
+
   const pos = index << TOKEN_SIZE_SHIFT;
 
   // Fast path: If already deserialized, exit
   const flagPos = pos + DESERIALIZED_FLAG_OFFSET;
-  if (tokensUint8![flagPos] !== FLAG_NOT_DESERIALIZED) return null;
+  if (tokensUint8[flagPos] !== FLAG_NOT_DESERIALIZED) return null;
 
   // Mark token as deserialized, so it won't be deserialized again
-  tokensUint8![flagPos] = FLAG_DESERIALIZED;
+  tokensUint8[flagPos] = FLAG_DESERIALIZED;
 
   // Deserialize token into a cached `Token` object
   const token = cachedTokens[index];
 
-  const kind = tokensUint8![pos + KIND_FIELD_OFFSET];
+  const kind = tokensUint8[pos + KIND_FIELD_OFFSET];
 
   const pos32 = pos >> 2,
-    start = tokensInt32![pos32],
-    end = tokensInt32![pos32 + 1];
+    start = tokensInt32[pos32],
+    end = tokensInt32[pos32 + 1];
 
   // Get `value` as slice of source text `start..end`.
   // Slice `start + 1..end` for private identifiers, to strip leading `#`.
-  let value = sourceText!.slice(start + +(kind === PRIVATE_IDENTIFIER_KIND), end);
+  let value = sourceText.slice(start + +(kind === PRIVATE_IDENTIFIER_KIND), end);
 
   if (kind <= PRIVATE_IDENTIFIER_KIND) {
     // Unescape if `escaped` flag is set
-    if (tokensUint8![pos + IS_ESCAPED_FIELD_OFFSET] === 1) {
+    if (tokensUint8[pos + IS_ESCAPED_FIELD_OFFSET] === 1) {
       value = unescapeIdentifier(value);
     }
   } else if (kind === REGEXP_KIND) {


### PR DESCRIPTION
Pure refactor. Use debug asserts instead of type assertions in code for deserializing comments and tokns. This gives better error messages if we break the invariants in tests. Makes no difference in release build.