### PR TITLE
perf(linter/plugins): test booleans with explicit `=== false`

### DIFF
--- a/apps/oxlint/src-js/plugins/comments.ts
+++ b/apps/oxlint/src-js/plugins/comments.ts
@@ -171,7 +171,7 @@ const resetCommentLoc = resetCommentLocTemp!;
 export function initComments(): void {
   debugAssert(comments === null, "Comments already deserialized");
 
-  if (!allCommentsDeserialized) deserializeComments();
+  if (allCommentsDeserialized === false) deserializeComments();
 
   // `initCommentsBuffer` (called by `deserializeComments`) sets `comments` for zero-comment files
   if (comments !== null) return;
@@ -198,7 +198,7 @@ export function initComments(): void {
  * Does NOT build the `comments` array - use `initComments` for that.
  */
 export function deserializeComments(): void {
-  debugAssert(!allCommentsDeserialized, "Comments already deserialized");
+  debugAssert(allCommentsDeserialized === false, "Comments already deserialized");
 
   if (commentsInt32 === null) initCommentsBuffer();
 
@@ -301,7 +301,7 @@ export function initCommentsBuffer(): void {
  */
 export function getComment(index: number): CommentType {
   // Skip all other checks if all comments have been deserialized
-  if (!allCommentsDeserialized) {
+  if (allCommentsDeserialized === false) {
     const comment = deserializeCommentIfNeeded(index);
 
     if (comment !== null) {

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -284,7 +284,7 @@ export const FLAG_DESERIALIZED = 1;
 export function initTokens(): void {
   debugAssert(tokens === null, "Tokens already initialized");
 
-  if (!allTokensDeserialized) deserializeTokens();
+  if (allTokensDeserialized === false) deserializeTokens();
 
   // Create `tokens` array as a slice of `cachedTokens` array.
   //
@@ -308,7 +308,7 @@ export function initTokens(): void {
  * Does NOT build the `tokens` array - use `initTokens` for that.
  */
 export function deserializeTokens(): void {
-  debugAssert(!allTokensDeserialized, "Tokens already deserialized");
+  debugAssert(allTokensDeserialized === false, "Tokens already deserialized");
 
   if (tokensInt32 === null) initTokensBuffer();
 
@@ -386,7 +386,7 @@ export function initTokensBuffer(): void {
  */
 export function getToken(index: number): TokenType {
   // Skip all other checks if all tokens have been deserialized
-  if (!allTokensDeserialized) {
+  if (allTokensDeserialized === false) {
     const token = deserializeTokenIfNeeded(index);
 
     if (token !== null) {

--- a/apps/oxlint/src-js/plugins/tokens_and_comments.ts
+++ b/apps/oxlint/src-js/plugins/tokens_and_comments.ts
@@ -334,8 +334,8 @@ export function getTokensAndComments(): TokenOrComment[] {
 
   // General case: Deserialize all entries into `cachedTokens` / `cachedComments`,
   // but skip building the `tokens` and `comments` arrays (they aren't needed here)
-  if (!allTokensDeserialized) deserializeTokens();
-  if (!allCommentsDeserialized) deserializeComments();
+  if (allTokensDeserialized === false) deserializeTokens();
+  if (allCommentsDeserialized === false) deserializeComments();
 
   // Ensure merged buffer is built
   if (tokensAndCommentsInt32 === null) initTokensAndCommentsBuffer();


### PR DESCRIPTION
Tiny perf optimization to linter plugins.

`if (x === false)` is longer than `if (!x)`, but is more performant. The 1st compiles down to a simple equality check between `<value x>` and `kFalse` constant, whereas the 2nd is more like `coerceToBoolean(<value x>) === kFalse` - a more expensive operation.

This follows our convention in all JS plugins code of always using explicit `=== false` / `=== true` comparisons.