### PR TITLE
refactor(linter/plugins): remove unnecessary type asserts

### DIFF
--- a/apps/oxlint/src-js/plugins/comments.ts
+++ b/apps/oxlint/src-js/plugins/comments.ts
@@ -161,8 +161,8 @@ class Comment implements Span {
 }
 
 // Copied into consts here to avoid checks at call site (`let` binding could be re-assigned)
-const getCommentLoc = getCommentLocTemp!;
-const resetCommentLoc = resetCommentLocTemp!;
+const getCommentLoc = getCommentLocTemp;
+const resetCommentLoc = resetCommentLocTemp;
 
 /**
  * Deserialize all comments and build the `comments` array.

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -237,8 +237,8 @@ class Token {
 }
 
 // Copied into consts here to avoid checks at call site (`let` binding could be re-assigned)
-const getTokenLoc = getTokenLocTemp!;
-const resetLoc = resetLocTemp!;
+const getTokenLoc = getTokenLocTemp;
+const resetLoc = resetLocTemp;
 
 // `ESTreeKind` discriminants (set by Rust side)
 const PRIVATE_IDENTIFIER_KIND = 2;


### PR DESCRIPTION
Pure refactor. Remove some type assertions which were unnecessary - TS already knows these vars can't be `null`.