### PR TITLE
test(linter/plugins): check comments and tokens within bounds of source text

### DIFF
--- a/apps/oxlint/src-js/plugins/comments.ts
+++ b/apps/oxlint/src-js/plugins/comments.ts
@@ -361,12 +361,14 @@ function deserializeCommentIfNeeded(index: number): Comment | null {
 }
 
 /**
- * Check comments buffer has valid ranges and ascending order.
+ * Check all comments in buffer have valid ranges, are in ascending order, and are within the source text.
  *
  * Only runs in debug build (tests). In release build, this function is entirely removed by minifier.
  */
 function debugCheckValidRanges(): void {
   if (!DEBUG) return;
+
+  debugAssertIsNonNull(sourceText, "`sourceText` should be initialized");
 
   let lastEnd = 0;
   for (let i = 0; i < commentsLen; i++) {
@@ -380,18 +382,20 @@ function debugCheckValidRanges(): void {
     lastEnd = end;
   }
 
-  if (lastEnd > sourceText!.length) {
-    throw new Error(`Comments end beyond source text length: ${lastEnd} > ${sourceText!.length}`);
+  if (lastEnd > sourceText.length) {
+    throw new Error(`Comments end beyond source text length: ${lastEnd} > ${sourceText.length}`);
   }
 }
 
 /**
- * Check all deserialized comments are in ascending order.
+ * Check all deserialized comments have valid ranges, are in ascending order, and are within the source text.
  *
  * Only runs in debug build (tests). In release build, this function is entirely removed by minifier.
  */
 function debugCheckDeserializedComments(): void {
   if (!DEBUG) return;
+
+  debugAssertIsNonNull(sourceText, "`sourceText` should be initialized");
 
   let lastEnd = 0;
   for (let i = 0; i < commentsLen; i++) {
@@ -410,6 +414,10 @@ function debugCheckDeserializedComments(): void {
       );
     }
     lastEnd = end;
+  }
+
+  if (lastEnd > sourceText.length) {
+    throw new Error(`Comments end beyond source text length: ${lastEnd} > ${sourceText.length}`);
   }
 }
 

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -502,12 +502,14 @@ function unescapeIdentifier(name: string): string {
 }
 
 /**
- * Check tokens buffer has valid ranges and ascending order.
+ * Check all tokens in buffer have valid ranges, are in ascending order, and are within the source text.
  *
  * Only runs in debug build (tests). In release build, this function is entirely removed by minifier.
  */
 function debugCheckValidRanges(): void {
   if (!DEBUG) return;
+
+  debugAssertIsNonNull(sourceText, "`sourceText` should be initialized");
 
   let lastEnd = 0;
   for (let i = 0; i < tokensLen; i++) {
@@ -520,15 +522,21 @@ function debugCheckValidRanges(): void {
     }
     lastEnd = end;
   }
+
+  if (lastEnd > sourceText.length) {
+    throw new Error(`Tokens end beyond source text length: ${lastEnd} > ${sourceText.length}`);
+  }
 }
 
 /**
- * Check all deserialized tokens are in ascending order.
+ * Check all deserialized tokens have valid ranges, are in ascending order, and are within the source text.
  *
  * Only runs in debug build (tests). In release build, this function is entirely removed by minifier.
  */
 function debugCheckDeserializedTokens(): void {
   if (!DEBUG) return;
+
+  debugAssertIsNonNull(sourceText, "`sourceText` should be initialized");
 
   let lastEnd = 0;
   for (let i = 0; i < tokensLen; i++) {
@@ -545,6 +553,10 @@ function debugCheckDeserializedTokens(): void {
       );
     }
     lastEnd = end;
+  }
+
+  if (lastEnd > sourceText.length) {
+    throw new Error(`Tokens end beyond source text length: ${lastEnd} > ${sourceText.length}`);
   }
 }
 


### PR DESCRIPTION
Add more debug assertions to debug build-only code which checks the validity of comments and tokens.

Make sure all comments and tokens have spans which are wihin bounds of source text. In particular, this will surface any problems where the source text contains a BOM, which causes us to adjust spans on Rust side when trimming off the BOM.