### PR TITLE
docs(linter): expand overrides.files and ignorePatterns examples

### DIFF
--- a/crates/oxc_config/src/glob_set.rs
+++ b/crates/oxc_config/src/glob_set.rs
@@ -12,8 +12,19 @@ pub fn validate_glob_pattern(pattern: &str) -> Result<(), String> {
     fast_glob::validate(pattern).map_err(|err| format!("Invalid glob pattern `{pattern}`: {err}"))
 }
 
-/// A set of glob patterns.
+/// A set of glob patterns matched with [`fast_glob`](https://crates.io/crates/fast-glob).
+///
 /// Patterns are matched against paths relative to the configuration file's directory.
+/// Patterns without a `/` are treated as recursive (for example `*.ts` matches
+/// `src/foo.ts` as well as `foo.ts`).
+///
+/// ## Examples
+///
+/// ```json
+/// ["*.test.ts", "*.spec.ts"]
+/// ["src/**/*.{ts,tsx}", "scripts/*.mjs"]
+/// ["lib/*.js"]
+/// ```
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, JsonSchema)]
 pub struct GlobSet(Vec<String>);
 

--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -81,19 +81,32 @@ impl JsonSchema for OxlintOverrides {
 #[non_exhaustive]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct OxlintOverride {
-    /// A list of glob patterns to override.
+    /// Glob patterns selecting which files this override applies to.
     ///
-    /// ## Example
-    /// `[ "*.test.ts", "*.spec.ts" ]`
+    /// Patterns use [`fast_glob`](https://crates.io/crates/fast-glob) syntax and are
+    /// matched against paths relative to the configuration file's directory.
+    /// A pattern without `/` is recursive (`*.ts` matches nested files).
+    ///
+    /// ## Examples
+    ///
+    /// ```json
+    /// ["*.test.ts", "*.spec.ts"]
+    /// ["src/**/*.{ts,tsx}"]
+    /// ["scripts/*.mjs"]
+    /// ```
     pub files: GlobSet,
 
-    /// A list of glob patterns to exclude from this override.
+    /// Glob patterns to exclude from this override.
     ///
     /// Files matching these patterns are not globally ignored; this override
-    /// simply does not apply to them.
+    /// simply does not apply to them. Uses the same [`fast_glob`](https://crates.io/crates/fast-glob)
+    /// syntax and relative-path rules as [`Self::files`].
     ///
-    /// ## Example
-    /// `[ "*.generated.ts", "fixtures/**" ]`
+    /// ## Examples
+    ///
+    /// ```json
+    /// ["*.generated.ts", "fixtures/**"]
+    /// ```
     #[serde(default, skip_serializing_if = "GlobSet::is_empty")]
     pub exclude_files: GlobSet,
 

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -276,10 +276,23 @@ pub struct Oxlintrc {
     /// Absolute path to the configuration file.
     #[serde(skip)]
     pub path: PathBuf,
-    /// Globs to ignore during linting. Patterns use gitignore-style matching,
-    /// rooted at the directory containing the configuration file.
-    /// Files outside that directory cannot be matched; patterns containing `..`
-    /// are rejected as a configuration error.
+    /// Globs to ignore during linting.
+    ///
+    /// Patterns use **gitignore-style** matching (not `fast-glob`), rooted at the
+    /// directory containing the configuration file. Prefer this field over a separate
+    /// ignore file so IDE integrations and the CLI share the same ignores.
+    ///
+    /// Files outside the config directory cannot be matched; patterns containing `..`
+    /// are rejected as a configuration error. Negation with `!` is supported.
+    ///
+    /// ## Examples
+    ///
+    /// ```json
+    /// ["dist/**", "coverage/**", "vendor/**", "**/__snapshots__/**"]
+    /// ["build/**/*", "!build/keep.js"]
+    /// ```
+    ///
+    /// See also the [Ignore files](https://oxc.rs/docs/guide/usage/linter/ignore-files.html) guide.
     #[serde(rename = "ignorePatterns")]
     pub ignore_patterns: Vec<String>,
     /// Paths of configuration files that this configuration file extends (inherits from). The files

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -48,13 +48,13 @@
       "markdownDescription": "Enabled or disabled specific global variables."
     },
     "ignorePatterns": {
-      "description": "Globs to ignore during linting. Patterns use gitignore-style matching,\nrooted at the directory containing the configuration file.\nFiles outside that directory cannot be matched; patterns containing `..`\nare rejected as a configuration error.",
+      "description": "Globs to ignore during linting.\n\nPatterns use **gitignore-style** matching (not `fast-glob`), rooted at the\ndirectory containing the configuration file. Prefer this field over a separate\nignore file so IDE integrations and the CLI share the same ignores.\n\nFiles outside the config directory cannot be matched; patterns containing `..`\nare rejected as a configuration error. Negation with `!` is supported.\n\n## Examples\n\n```json\n[\"dist/**\", \"coverage/**\", \"vendor/**\", \"**/__snapshots__/**\"]\n[\"build/**/*\", \"!build/keep.js\"]\n```\n\nSee also the [Ignore files](https://oxc.rs/docs/guide/usage/linter/ignore-files.html) guide.",
       "default": [],
       "type": "array",
       "items": {
         "type": "string"
       },
-      "markdownDescription": "Globs to ignore during linting. Patterns use gitignore-style matching,\nrooted at the directory containing the configuration file.\nFiles outside that directory cannot be matched; patterns containing `..`\nare rejected as a configuration error."
+      "markdownDescription": "Globs to ignore during linting.\n\nPatterns use **gitignore-style** matching (not `fast-glob`), rooted at the\ndirectory containing the configuration file. Prefer this field over a separate\nignore file so IDE integrations and the CLI share the same ignores.\n\nFiles outside the config directory cannot be matched; patterns containing `..`\nare rejected as a configuration error. Negation with `!` is supported.\n\n## Examples\n\n```json\n[\"dist/**\", \"coverage/**\", \"vendor/**\", \"**/__snapshots__/**\"]\n[\"build/**/*\", \"!build/keep.js\"]\n```\n\nSee also the [Ignore files](https://oxc.rs/docs/guide/usage/linter/ignore-files.html) guide."
     },
     "jsPlugins": {
       "description": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are in alpha and not subject to semver.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nBasic usage with a TypeScript plugin and a local plugin path.\n\nTypeScript plugin files are supported in the following environments:\n- Deno and Bun: TypeScript files are supported natively.\n- Node.js >=22.18.0 and Node.js ^20.19.0: TypeScript files are supported natively with built-in\ntype-stripping enabled by default.\n\nFor older Node.js versions, TypeScript plugins are not supported. Please use JavaScript plugins or upgrade your Node version.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.ts\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```",
@@ -11291,12 +11291,12 @@
       "additionalProperties": false
     },
     "GlobSet": {
-      "description": "A set of glob patterns.\nPatterns are matched against paths relative to the configuration file's directory.",
+      "description": "A set of glob patterns matched with [`fast_glob`](https://crates.io/crates/fast-glob).\n\nPatterns are matched against paths relative to the configuration file's directory.\nPatterns without a `/` are treated as recursive (for example `*.ts` matches\n`src/foo.ts` as well as `foo.ts`).\n\n## Examples\n\n```json\n[\"*.test.ts\", \"*.spec.ts\"]\n[\"src/**/*.{ts,tsx}\", \"scripts/*.mjs\"]\n[\"lib/*.js\"]\n```",
       "type": "array",
       "items": {
         "type": "string"
       },
-      "markdownDescription": "A set of glob patterns.\nPatterns are matched against paths relative to the configuration file's directory."
+      "markdownDescription": "A set of glob patterns matched with [`fast_glob`](https://crates.io/crates/fast-glob).\n\nPatterns are matched against paths relative to the configuration file's directory.\nPatterns without a `/` are treated as recursive (for example `*.ts` matches\n`src/foo.ts` as well as `foo.ts`).\n\n## Examples\n\n```json\n[\"*.test.ts\", \"*.spec.ts\"]\n[\"src/**/*.{ts,tsx}\", \"scripts/*.mjs\"]\n[\"lib/*.js\"]\n```"
     },
     "GlobalValue": {
       "type": "string",
@@ -16558,22 +16558,22 @@
           "markdownDescription": "Environments enable and disable collections of global variables."
         },
         "excludeFiles": {
-          "description": "A list of glob patterns to exclude from this override.\n\nFiles matching these patterns are not globally ignored; this override\nsimply does not apply to them.\n\n## Example\n`[ \"*.generated.ts\", \"fixtures/**\" ]`",
+          "description": "Glob patterns to exclude from this override.\n\nFiles matching these patterns are not globally ignored; this override\nsimply does not apply to them. Uses the same [`fast_glob`](https://crates.io/crates/fast-glob)\nsyntax and relative-path rules as [`Self::files`].\n\n## Examples\n\n```json\n[\"*.generated.ts\", \"fixtures/**\"]\n```",
           "allOf": [
             {
               "$ref": "#/definitions/GlobSet"
             }
           ],
-          "markdownDescription": "A list of glob patterns to exclude from this override.\n\nFiles matching these patterns are not globally ignored; this override\nsimply does not apply to them.\n\n## Example\n`[ \"*.generated.ts\", \"fixtures/**\" ]`"
+          "markdownDescription": "Glob patterns to exclude from this override.\n\nFiles matching these patterns are not globally ignored; this override\nsimply does not apply to them. Uses the same [`fast_glob`](https://crates.io/crates/fast-glob)\nsyntax and relative-path rules as [`Self::files`].\n\n## Examples\n\n```json\n[\"*.generated.ts\", \"fixtures/**\"]\n```"
         },
         "files": {
-          "description": "A list of glob patterns to override.\n\n## Example\n`[ \"*.test.ts\", \"*.spec.ts\" ]`",
+          "description": "Glob patterns selecting which files this override applies to.\n\nPatterns use [`fast_glob`](https://crates.io/crates/fast-glob) syntax and are\nmatched against paths relative to the configuration file's directory.\nA pattern without `/` is recursive (`*.ts` matches nested files).\n\n## Examples\n\n```json\n[\"*.test.ts\", \"*.spec.ts\"]\n[\"src/**/*.{ts,tsx}\"]\n[\"scripts/*.mjs\"]\n```",
           "allOf": [
             {
               "$ref": "#/definitions/GlobSet"
             }
           ],
-          "markdownDescription": "A list of glob patterns to override.\n\n## Example\n`[ \"*.test.ts\", \"*.spec.ts\" ]`"
+          "markdownDescription": "Glob patterns selecting which files this override applies to.\n\nPatterns use [`fast_glob`](https://crates.io/crates/fast-glob) syntax and are\nmatched against paths relative to the configuration file's directory.\nA pattern without `/` is recursive (`*.ts` matches nested files).\n\n## Examples\n\n```json\n[\"*.test.ts\", \"*.spec.ts\"]\n[\"src/**/*.{ts,tsx}\"]\n[\"scripts/*.mjs\"]\n```"
         },
         "globals": {
           "description": "Enabled or disabled specific global variables.",


### PR DESCRIPTION
## Summary
- Document that `overrides.files` / `excludeFiles` use `fast-glob`, with concrete pattern examples
- Expand `ignorePatterns` docs (gitignore-style, negation, examples) and link the Ignore files guide
- Regenerate `configuration_schema.json`

Closes #16586

## Test plan
- [ ] Config file reference shows richer descriptions for these fields
- [ ] `just linter-schema-json` output matches the committed schema

Made with [Cursor](https://cursor.com)