### PR TITLE
feat(oxc): add bad-match-all-arg rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4165,6 +4165,12 @@ impl RuleRunner for crate::rules::oxc::bad_comparison_sequence::BadComparisonSeq
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::oxc::bad_match_all_arg::BadMatchAllArg {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::oxc::bad_min_max_func::BadMinMaxFunc {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -384,6 +384,7 @@ pub use crate::rules::oxc::bad_array_method_on_arguments::BadArrayMethodOnArgume
 pub use crate::rules::oxc::bad_bitwise_operator::BadBitwiseOperator as OxcBadBitwiseOperator;
 pub use crate::rules::oxc::bad_char_at_comparison::BadCharAtComparison as OxcBadCharAtComparison;
 pub use crate::rules::oxc::bad_comparison_sequence::BadComparisonSequence as OxcBadComparisonSequence;
+pub use crate::rules::oxc::bad_match_all_arg::BadMatchAllArg as OxcBadMatchAllArg;
 pub use crate::rules::oxc::bad_min_max_func::BadMinMaxFunc as OxcBadMinMaxFunc;
 pub use crate::rules::oxc::bad_object_literal_comparison::BadObjectLiteralComparison as OxcBadObjectLiteralComparison;
 pub use crate::rules::oxc::bad_replace_all_arg::BadReplaceAllArg as OxcBadReplaceAllArg;
@@ -1508,6 +1509,7 @@ pub enum RuleEnum {
     OxcBadBitwiseOperator(OxcBadBitwiseOperator),
     OxcBadCharAtComparison(OxcBadCharAtComparison),
     OxcBadComparisonSequence(OxcBadComparisonSequence),
+    OxcBadMatchAllArg(OxcBadMatchAllArg),
     OxcBadMinMaxFunc(OxcBadMinMaxFunc),
     OxcBadObjectLiteralComparison(OxcBadObjectLiteralComparison),
     OxcBadReplaceAllArg(OxcBadReplaceAllArg),
@@ -2448,7 +2450,8 @@ const OXC_BAD_ARRAY_METHOD_ON_ARGUMENTS_ID: usize = OXC_APPROX_CONSTANT_ID + 1us
 const OXC_BAD_BITWISE_OPERATOR_ID: usize = OXC_BAD_ARRAY_METHOD_ON_ARGUMENTS_ID + 1usize;
 const OXC_BAD_CHAR_AT_COMPARISON_ID: usize = OXC_BAD_BITWISE_OPERATOR_ID + 1usize;
 const OXC_BAD_COMPARISON_SEQUENCE_ID: usize = OXC_BAD_CHAR_AT_COMPARISON_ID + 1usize;
-const OXC_BAD_MIN_MAX_FUNC_ID: usize = OXC_BAD_COMPARISON_SEQUENCE_ID + 1usize;
+const OXC_BAD_MATCH_ALL_ARG_ID: usize = OXC_BAD_COMPARISON_SEQUENCE_ID + 1usize;
+const OXC_BAD_MIN_MAX_FUNC_ID: usize = OXC_BAD_MATCH_ALL_ARG_ID + 1usize;
 const OXC_BAD_OBJECT_LITERAL_COMPARISON_ID: usize = OXC_BAD_MIN_MAX_FUNC_ID + 1usize;
 const OXC_BAD_REPLACE_ALL_ARG_ID: usize = OXC_BAD_OBJECT_LITERAL_COMPARISON_ID + 1usize;
 const OXC_BRANCHES_SHARING_CODE_ID: usize = OXC_BAD_REPLACE_ALL_ARG_ID + 1usize;
@@ -3431,6 +3434,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OXC_BAD_BITWISE_OPERATOR_ID,
             Self::OxcBadCharAtComparison(_) => OXC_BAD_CHAR_AT_COMPARISON_ID,
             Self::OxcBadComparisonSequence(_) => OXC_BAD_COMPARISON_SEQUENCE_ID,
+            Self::OxcBadMatchAllArg(_) => OXC_BAD_MATCH_ALL_ARG_ID,
             Self::OxcBadMinMaxFunc(_) => OXC_BAD_MIN_MAX_FUNC_ID,
             Self::OxcBadObjectLiteralComparison(_) => OXC_BAD_OBJECT_LITERAL_COMPARISON_ID,
             Self::OxcBadReplaceAllArg(_) => OXC_BAD_REPLACE_ALL_ARG_ID,
@@ -4399,6 +4403,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::NAME,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::NAME,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::NAME,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::NAME,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::NAME,
             Self::OxcBadObjectLiteralComparison(_) => OxcBadObjectLiteralComparison::NAME,
             Self::OxcBadReplaceAllArg(_) => OxcBadReplaceAllArg::NAME,
@@ -5407,6 +5412,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::CATEGORY,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::CATEGORY,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::CATEGORY,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::CATEGORY,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::CATEGORY,
             Self::OxcBadObjectLiteralComparison(_) => OxcBadObjectLiteralComparison::CATEGORY,
             Self::OxcBadReplaceAllArg(_) => OxcBadReplaceAllArg::CATEGORY,
@@ -6386,6 +6392,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::FIX,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::FIX,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::FIX,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::FIX,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::FIX,
             Self::OxcBadObjectLiteralComparison(_) => OxcBadObjectLiteralComparison::FIX,
             Self::OxcBadReplaceAllArg(_) => OxcBadReplaceAllArg::FIX,
@@ -7559,6 +7566,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::documentation(),
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::documentation(),
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::documentation(),
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::documentation(),
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::documentation(),
             Self::OxcBadObjectLiteralComparison(_) => {
                 OxcBadObjectLiteralComparison::documentation()
@@ -9696,6 +9704,8 @@ impl RuleEnum {
                 .or_else(|| OxcBadCharAtComparison::schema(generator)),
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::config_schema(generator)
                 .or_else(|| OxcBadComparisonSequence::schema(generator)),
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::config_schema(generator)
+                .or_else(|| OxcBadMatchAllArg::schema(generator)),
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::config_schema(generator)
                 .or_else(|| OxcBadMinMaxFunc::schema(generator)),
             Self::OxcBadObjectLiteralComparison(_) => {
@@ -10916,6 +10926,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => "oxc",
             Self::OxcBadCharAtComparison(_) => "oxc",
             Self::OxcBadComparisonSequence(_) => "oxc",
+            Self::OxcBadMatchAllArg(_) => "oxc",
             Self::OxcBadMinMaxFunc(_) => "oxc",
             Self::OxcBadObjectLiteralComparison(_) => "oxc",
             Self::OxcBadReplaceAllArg(_) => "oxc",
@@ -13199,6 +13210,9 @@ impl RuleEnum {
             Self::OxcBadComparisonSequence(_) => Ok(Self::OxcBadComparisonSequence(
                 OxcBadComparisonSequence::from_configuration(value)?,
             )),
+            Self::OxcBadMatchAllArg(_) => {
+                Ok(Self::OxcBadMatchAllArg(OxcBadMatchAllArg::from_configuration(value)?))
+            }
             Self::OxcBadMinMaxFunc(_) => {
                 Ok(Self::OxcBadMinMaxFunc(OxcBadMinMaxFunc::from_configuration(value)?))
             }
@@ -14499,6 +14513,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.to_configuration(),
             Self::OxcBadCharAtComparison(rule) => rule.to_configuration(),
             Self::OxcBadComparisonSequence(rule) => rule.to_configuration(),
+            Self::OxcBadMatchAllArg(rule) => rule.to_configuration(),
             Self::OxcBadMinMaxFunc(rule) => rule.to_configuration(),
             Self::OxcBadObjectLiteralComparison(rule) => rule.to_configuration(),
             Self::OxcBadReplaceAllArg(rule) => rule.to_configuration(),
@@ -15352,6 +15367,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.run(node, ctx),
             Self::OxcBadCharAtComparison(rule) => rule.run(node, ctx),
             Self::OxcBadComparisonSequence(rule) => rule.run(node, ctx),
+            Self::OxcBadMatchAllArg(rule) => rule.run(node, ctx),
             Self::OxcBadMinMaxFunc(rule) => rule.run(node, ctx),
             Self::OxcBadObjectLiteralComparison(rule) => rule.run(node, ctx),
             Self::OxcBadReplaceAllArg(rule) => rule.run(node, ctx),
@@ -16215,6 +16231,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.run_once(ctx),
             Self::OxcBadCharAtComparison(rule) => rule.run_once(ctx),
             Self::OxcBadComparisonSequence(rule) => rule.run_once(ctx),
+            Self::OxcBadMatchAllArg(rule) => rule.run_once(ctx),
             Self::OxcBadMinMaxFunc(rule) => rule.run_once(ctx),
             Self::OxcBadObjectLiteralComparison(rule) => rule.run_once(ctx),
             Self::OxcBadReplaceAllArg(rule) => rule.run_once(ctx),
@@ -17185,6 +17202,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcBadCharAtComparison(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcBadComparisonSequence(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcBadMatchAllArg(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcBadMinMaxFunc(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcBadObjectLiteralComparison(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcBadReplaceAllArg(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18059,6 +18077,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.should_run(ctx),
             Self::OxcBadCharAtComparison(rule) => rule.should_run(ctx),
             Self::OxcBadComparisonSequence(rule) => rule.should_run(ctx),
+            Self::OxcBadMatchAllArg(rule) => rule.should_run(ctx),
             Self::OxcBadMinMaxFunc(rule) => rule.should_run(ctx),
             Self::OxcBadObjectLiteralComparison(rule) => rule.should_run(ctx),
             Self::OxcBadReplaceAllArg(rule) => rule.should_run(ctx),
@@ -19221,6 +19240,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::IS_TSGOLINT_RULE,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::IS_TSGOLINT_RULE,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::IS_TSGOLINT_RULE,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::IS_TSGOLINT_RULE,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::IS_TSGOLINT_RULE,
             Self::OxcBadObjectLiteralComparison(_) => {
                 OxcBadObjectLiteralComparison::IS_TSGOLINT_RULE
@@ -20291,6 +20311,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::VERSION,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::VERSION,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::VERSION,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::VERSION,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::VERSION,
             Self::OxcBadObjectLiteralComparison(_) => OxcBadObjectLiteralComparison::VERSION,
             Self::OxcBadReplaceAllArg(_) => OxcBadReplaceAllArg::VERSION,
@@ -21346,6 +21367,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::HAS_CONFIG,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::HAS_CONFIG,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::HAS_CONFIG,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::HAS_CONFIG,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::HAS_CONFIG,
             Self::OxcBadObjectLiteralComparison(_) => OxcBadObjectLiteralComparison::HAS_CONFIG,
             Self::OxcBadReplaceAllArg(_) => OxcBadReplaceAllArg::HAS_CONFIG,
@@ -22334,6 +22356,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::INFO,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::INFO,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::INFO,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::INFO,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::INFO,
             Self::OxcBadObjectLiteralComparison(_) => OxcBadObjectLiteralComparison::INFO,
             Self::OxcBadReplaceAllArg(_) => OxcBadReplaceAllArg::INFO,
@@ -23199,6 +23222,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.types_info(),
             Self::OxcBadCharAtComparison(rule) => rule.types_info(),
             Self::OxcBadComparisonSequence(rule) => rule.types_info(),
+            Self::OxcBadMatchAllArg(rule) => rule.types_info(),
             Self::OxcBadMinMaxFunc(rule) => rule.types_info(),
             Self::OxcBadObjectLiteralComparison(rule) => rule.types_info(),
             Self::OxcBadReplaceAllArg(rule) => rule.types_info(),
@@ -24049,6 +24073,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.run_info(),
             Self::OxcBadCharAtComparison(rule) => rule.run_info(),
             Self::OxcBadComparisonSequence(rule) => rule.run_info(),
+            Self::OxcBadMatchAllArg(rule) => rule.run_info(),
             Self::OxcBadMinMaxFunc(rule) => rule.run_info(),
             Self::OxcBadObjectLiteralComparison(rule) => rule.run_info(),
             Self::OxcBadReplaceAllArg(rule) => rule.run_info(),
@@ -25025,6 +25050,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::OxcBadBitwiseOperator(OxcBadBitwiseOperator::default()),
         RuleEnum::OxcBadCharAtComparison(OxcBadCharAtComparison::default()),
         RuleEnum::OxcBadComparisonSequence(OxcBadComparisonSequence::default()),
+        RuleEnum::OxcBadMatchAllArg(OxcBadMatchAllArg::default()),
         RuleEnum::OxcBadMinMaxFunc(OxcBadMinMaxFunc::default()),
         RuleEnum::OxcBadObjectLiteralComparison(OxcBadObjectLiteralComparison::default()),
         RuleEnum::OxcBadReplaceAllArg(OxcBadReplaceAllArg::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -672,6 +672,7 @@ pub(crate) mod oxc {
     pub mod bad_bitwise_operator;
     pub mod bad_char_at_comparison;
     pub mod bad_comparison_sequence;
+    pub mod bad_match_all_arg;
     pub mod bad_min_max_func;
     pub mod bad_object_literal_comparison;
     pub mod bad_replace_all_arg;

--- a/crates/oxc_linter/src/rules/oxc/bad_match_all_arg.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_match_all_arg.rs
@@ -1,0 +1,165 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, RegExpFlags},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    ast_util::{extract_regex_flags, get_declaration_of_variable, is_method_call},
+    context::LintContext,
+    rule::Rule,
+};
+
+fn bad_match_all_arg_diagnostic(match_all_span: Span, regex_span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Global flag (g) is missing in the regular expression supplied to the `matchAll` method.")
+        .with_help("To match all occurrences, use the `matchAll` method with the global flag (g) in the regular expression.")
+        .with_note("Unlike `match`, `matchAll` throws a `TypeError` when passed a non-global regular expression instead of returning an iterator over all matches.")
+        .with_labels([
+            match_all_span.label("`matchAll` called here"),
+            regex_span.label("RegExp supplied here"),
+        ])
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct BadMatchAllArg;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule warns when the `matchAll` method is called with a regular expression that does not have the global flag (g).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// When called with a regular expression, the `matchAll` method requires the global flag (g).
+    /// Otherwise, it throws a `TypeError` at runtime instead of returning an iterator.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// str.matchAll(/abc/);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// str.matchAll(/abc/g);
+    /// ```
+    BadMatchAllArg,
+    oxc,
+    correctness,
+    version = "1.76.0",
+    short_description = "This rule warns when the `matchAll` method is called with a regular expression that does not have the global flag (g).",
+);
+
+impl Rule for BadMatchAllArg {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        if !is_method_call(call_expr, None, Some(&["matchAll"]), Some(1), None) {
+            return;
+        }
+
+        let Some(regexp_argument) = call_expr.arguments[0].as_expression() else {
+            return;
+        };
+
+        let Some((flags, regex_span)) = resolve_flags(regexp_argument, ctx) else {
+            return;
+        };
+
+        if !flags.contains(RegExpFlags::G) {
+            let Some(call_expr_callee) = call_expr.callee.as_member_expression() else {
+                return;
+            };
+            let Some((match_all_span, _)) = call_expr_callee.static_property_info() else {
+                return;
+            };
+
+            ctx.diagnostic(bad_match_all_arg_diagnostic(match_all_span, regex_span));
+        }
+    }
+}
+
+fn resolve_flags<'a>(
+    expr: &'a Expression<'a>,
+    ctx: &LintContext<'a>,
+) -> Option<(RegExpFlags, Span)> {
+    match expr.without_parentheses() {
+        Expression::RegExpLiteral(regexp_literal) => {
+            Some((regexp_literal.regex.flags, regexp_literal.span))
+        }
+        Expression::NewExpression(new_expr) => {
+            if new_expr.callee.is_specific_id("RegExp") {
+                extract_regex_flags(&new_expr.arguments).map(|flags| (flags, new_expr.span))
+            } else {
+                None
+            }
+        }
+        Expression::Identifier(ident) => {
+            let decl = get_declaration_of_variable(ident, ctx)?;
+            let var_decl = decl.kind().as_variable_declarator()?;
+            if let Some(init) = &var_decl.init {
+                return resolve_flags(init, ctx);
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // valid call with global flag
+        r"str.matchAll(/abc/g);",
+        // incorrect number of arguments
+        r"str.matchAll();",
+        // not a method call
+        r"matchAll(/abc/, 'flags');",
+        // not a method call
+        r"str();",
+        // new RegExp with global flag
+        r"str.matchAll(new RegExp('abc', 'g'));",
+        // new matchAll
+        r"new matchAll(/abc/);",
+        // resolved vars - string
+        r#"const foo = "string"; str.matchAll(foo);"#,
+        // resolved vars - regex with global flag
+        r"const foo = /abc/g; str.matchAll(foo);",
+        // resolved vars - new RegExp with global flag
+        r"const foo = new RegExp('abc', 'g'); str.matchAll(foo);",
+        r"const foo = new RegExp('abc', isWindows ? 'g' : 'gi'); str.matchAll(foo);",
+    ];
+
+    let fail = vec![
+        r"str.matchAll(/abc/);",
+        r"str.matchAll(/abc/i);",
+        r"str.matchAll(new RegExp('abc'));",
+        r"str.matchAll(new RegExp('abc','i'));",
+        // resolved vars
+        r"
+            const foo = /abc/;
+
+            str.matchAll(foo);
+        ",
+        r"
+            const foo = /abc/i;
+
+            str.matchAll(foo);
+        ",
+        r"
+            const foo = new RegExp('abc');
+
+            str.matchAll(foo);
+        ",
+    ];
+
+    Tester::new(BadMatchAllArg::NAME, BadMatchAllArg::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/oxc_bad_match_all_arg.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_bad_match_all_arg.snap
@@ -1,0 +1,88 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:5]
+ 1 │ str.matchAll(/abc/);
+   ·     ────┬─── ──┬──
+   ·         │      ╰── RegExp supplied here
+   ·         ╰── `matchAll` called here
+   ╰────
+  help: To match all occurrences, use the `matchAll` method with the global flag (g) in the regular expression.
+  note: Unlike `match`, `matchAll` throws a `TypeError` when passed a non-global regular expression instead of returning an iterator over all matches.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:5]
+ 1 │ str.matchAll(/abc/i);
+   ·     ────┬─── ───┬──
+   ·         │       ╰── RegExp supplied here
+   ·         ╰── `matchAll` called here
+   ╰────
+  help: To match all occurrences, use the `matchAll` method with the global flag (g) in the regular expression.
+  note: Unlike `match`, `matchAll` throws a `TypeError` when passed a non-global regular expression instead of returning an iterator over all matches.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:5]
+ 1 │ str.matchAll(new RegExp('abc'));
+   ·     ────┬─── ────────┬────────
+   ·         │            ╰── RegExp supplied here
+   ·         ╰── `matchAll` called here
+   ╰────
+  help: To match all occurrences, use the `matchAll` method with the global flag (g) in the regular expression.
+  note: Unlike `match`, `matchAll` throws a `TypeError` when passed a non-global regular expression instead of returning an iterator over all matches.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:5]
+ 1 │ str.matchAll(new RegExp('abc','i'));
+   ·     ────┬─── ──────────┬──────────
+   ·         │              ╰── RegExp supplied here
+   ·         ╰── `matchAll` called here
+   ╰────
+  help: To match all occurrences, use the `matchAll` method with the global flag (g) in the regular expression.
+  note: Unlike `match`, `matchAll` throws a `TypeError` when passed a non-global regular expression instead of returning an iterator over all matches.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:2:25]
+ 1 │ 
+ 2 │             const foo = /abc/;
+   ·                         ──┬──
+   ·                           ╰── RegExp supplied here
+ 3 │ 
+ 4 │             str.matchAll(foo);
+   ·                 ────┬───
+   ·                     ╰── `matchAll` called here
+ 5 │         
+   ╰────
+  help: To match all occurrences, use the `matchAll` method with the global flag (g) in the regular expression.
+  note: Unlike `match`, `matchAll` throws a `TypeError` when passed a non-global regular expression instead of returning an iterator over all matches.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:2:25]
+ 1 │ 
+ 2 │             const foo = /abc/i;
+   ·                         ───┬──
+   ·                            ╰── RegExp supplied here
+ 3 │ 
+ 4 │             str.matchAll(foo);
+   ·                 ────┬───
+   ·                     ╰── `matchAll` called here
+ 5 │         
+   ╰────
+  help: To match all occurrences, use the `matchAll` method with the global flag (g) in the regular expression.
+  note: Unlike `match`, `matchAll` throws a `TypeError` when passed a non-global regular expression instead of returning an iterator over all matches.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:2:25]
+ 1 │ 
+ 2 │             const foo = new RegExp('abc');
+   ·                         ────────┬────────
+   ·                                 ╰── RegExp supplied here
+ 3 │ 
+ 4 │             str.matchAll(foo);
+   ·                 ────┬───
+   ·                     ╰── `matchAll` called here
+ 5 │         
+   ╰────
+  help: To match all occurrences, use the `matchAll` method with the global flag (g) in the regular expression.
+  note: Unlike `match`, `matchAll` throws a `TypeError` when passed a non-global regular expression instead of returning an iterator over all matches.


### PR DESCRIPTION
Implements `oxc/bad-match-all-arg`, a new rule that warns when `String.prototype.matchAll` is called with a regular expression that does not have the global flag (`g`). Like `replaceAll`, `matchAll` requires the `g` flag and throws a `TypeError` otherwise.

Detects:
- RegExp literals without `g`: `str.matchAll(/pattern/)` → error
- `new RegExp(...)` constructors without `g`
- Variable tracking across declarations

Passing cases ensure:
- `str.matchAll(/pattern/g)` → no error
- `new RegExp(...)` with `g` flag → no error
- Non-method calls and wrong arg counts are ignored

Fixes #24823

**AI disclosure:** This contribution was developed with assistance from an AI coding agent. The changes were reviewed, tested, and validated before submission.