### PR TITLE
refactor(react_compiler): shorten AST builder method calls

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -2137,18 +2137,16 @@ fn ox_build_compiled_expression<'a>(
     original_kind: OriginalFnKind,
 ) -> Expression<'a> {
     match original_kind {
-        OriginalFnKind::ArrowFunctionExpression => {
-            Expression::ArrowFunctionExpression(ArrowFunctionExpression::boxed(
-                SPAN,
-                false,
-                codegen.is_async,
-                NONE,
-                codegen.params.clone_in_with_semantic_ids(ast.allocator()),
-                NONE,
-                codegen.body.clone_in_with_semantic_ids(ast.allocator()),
-                ast,
-            ))
-        }
+        OriginalFnKind::ArrowFunctionExpression => Expression::new_arrow_function_expression(
+            SPAN,
+            false,
+            codegen.is_async,
+            NONE,
+            codegen.params.clone_in_with_semantic_ids(ast.allocator()),
+            NONE,
+            codegen.body.clone_in_with_semantic_ids(ast.allocator()),
+            ast,
+        ),
         _ => Expression::FunctionExpression(ox_build_function(
             ast,
             codegen,
@@ -2223,13 +2221,13 @@ fn ox_build_gated_const_decl<'a>(
         false,
         ast,
     );
-    Statement::VariableDeclaration(VariableDeclaration::boxed(
+    Statement::new_variable_declaration(
         SPAN,
         VariableDeclarationKind::Const,
         [declarator],
         false,
         ast,
-    ))
+    )
 }
 
 /// The one visitor type behind every oxc-AST traversal of the transform phase,
@@ -2314,7 +2312,7 @@ impl<'a> OxcVisitor<'a, '_> {
                     Statement::VariableDeclaration(d) => Declaration::VariableDeclaration(d),
                     _ => unreachable!(),
                 };
-                *stmt = Statement::ExportNamedDeclaration(ExportNamedDeclaration::boxed(
+                *stmt = Statement::new_export_named_declaration(
                     SPAN,
                     Some(decl),
                     [],
@@ -2322,7 +2320,7 @@ impl<'a> OxcVisitor<'a, '_> {
                     ImportOrExportKind::Value,
                     NONE,
                     ast,
-                ));
+                );
             } else {
                 *stmt = const_decl;
             }
@@ -2338,13 +2336,13 @@ impl<'a> OxcVisitor<'a, '_> {
                 *stmt = ox_build_gated_const_decl(ast, gating_expression, id.as_str());
                 *export_default_name = Some(id);
             } else {
-                *stmt = Statement::ExportDefaultDeclaration(ExportDefaultDeclaration::boxed(
+                *stmt = Statement::new_export_default_declaration(
                     SPAN,
                     ExportDefaultDeclarationKind::from(
                         gating_expression.clone_in_with_semantic_ids(ast.allocator()),
                     ),
                     ast,
-                ));
+                );
             }
             *done = true;
             return true;
@@ -2451,11 +2449,11 @@ impl<'a> oxc_ast_visit::VisitMut<'a> for OxcVisitor<'a, '_> {
             && let Some(name) = export_default_name.take()
         {
             let ident = Expression::new_identifier(SPAN, name, self.ast);
-            let export = Statement::ExportDefaultDeclaration(ExportDefaultDeclaration::boxed(
+            let export = Statement::new_export_default_declaration(
                 SPAN,
                 ExportDefaultDeclarationKind::from(ident),
                 self.ast,
-            ));
+            );
             // Find the const decl we just inserted (it has name `name`); insert after.
             let pos = stmts.iter().position(|s| {
                 matches!(s, Statement::VariableDeclaration(d)
@@ -2765,12 +2763,7 @@ fn ox_add_imports_to_program<'a>(
                 SPAN,
                 Expression::new_identifier(SPAN, "require", ast),
                 NONE,
-                [Argument::from(Expression::new_string_literal(
-                    SPAN,
-                    ox_atom(ast, module_name),
-                    None,
-                    ast,
-                ))],
+                [Argument::new_string_literal(SPAN, ox_atom(ast, module_name), None, ast)],
                 false,
                 ast,
             );
@@ -2806,19 +2799,15 @@ fn ox_make_import_specifier<'a>(
     ast: &AstBuilder<'a>,
     spec: &super::imports::NonLocalImportSpecifier,
 ) -> ImportDeclarationSpecifier<'a> {
-    let imported = ModuleExportName::IdentifierName(IdentifierName::new(
-        SPAN,
-        ox_atom(ast, &spec.imported),
-        ast,
-    ));
+    let imported = ModuleExportName::new_identifier_name(SPAN, ox_atom(ast, &spec.imported), ast);
     let local = BindingIdentifier::new(SPAN, ox_atom(ast, &spec.name), ast);
-    ImportDeclarationSpecifier::ImportSpecifier(ImportSpecifier::boxed(
+    ImportDeclarationSpecifier::new_import_specifier(
         SPAN,
         imported,
         local,
         ImportOrExportKind::Value,
         ast,
-    ))
+    )
 }
 
 /// Whether an import declaration is a non-namespaced value import. Mirrors


### PR DESCRIPTION
Shorten AST builder calls in React Compiler, by collapsing multiple calls into one.

I came across these while testing the codemod.