### PR TITLE
fix(ecmascript): detect side effects in unused arguments to `charCodeAt`

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -231,6 +231,13 @@ fn try_fold_string_char_code_at<'a>(
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
+    if args
+        .iter()
+        .skip(1)
+        .any(|arg| arg.as_expression().is_none_or(|e| e.may_have_side_effects(ctx)))
+    {
+        return None;
+    }
     let Expression::StringLiteral(s) = object else { return None };
     let char_at_index = match args.first() {
         Some(Argument::SpreadElement(_)) => return None,

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -266,7 +266,8 @@ fn test_fold_string_char_code_at() {
     test_same("x = 'abcde'.charCodeAt(...foo)");
     test_same("x = 'abcde'.charCodeAt(y)");
     test("x = 'abcde'.charCodeAt()", "x = 97");
-    test("x = 'abcde'.charCodeAt(0, ++z)", "x = 97");
+    test_same("x = 'abcde'.charCodeAt(0, ++z)");
+    test_same("x = 'abcde'.charCodeAt(0, f())");
     test("x = 'abcde'.charCodeAt(null)", "x = 97");
     test("x = 'abcde'.charCodeAt(true)", "x = 98");
     test("x = '\\ud834\\udd1e'.charCodeAt(0)", "x = 55348");


### PR DESCRIPTION
Detect the side effect of`f()` in `'abcde'.charCodeAt(0, f())`.