### PR TITLE
fix(ecmascript): keep side effects in parent of `toString` calls

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -371,7 +371,7 @@ fn try_fold_to_string<'a>(
         Expression::RegExpLiteral(lit) if args.is_empty() => {
             lit.to_js_string(ctx).map(ConstantValue::String)
         }
-        e if args.is_empty() => e
+        e if args.is_empty() && !e.may_have_side_effects(ctx) => e
             .evaluate_value(ctx)
             // `null` and `undefined` returns type errors
             .filter(|v| !v.is_undefined() && !v.is_null())

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -959,6 +959,8 @@ fn test_to_string() {
     test_same("254n.toString(16);"); // unimplemented
     // test("/a\\\\b/ig.toString()", "'/a\\\\\\\\b/ig';");
     test_same("null.toString()"); // type error
+    test_same("x = (f(), 5).toString()");
+    test_same("async function t(p) { x = (await p, 5).toString(); } t(p)");
 
     test("x = 100 .toString(0)", "x = 100 .toString(0)");
     test("x = 100 .toString(1)", "x = 100 .toString(1)");


### PR DESCRIPTION
Detect the side effect of`f()` in `(f(), 5).toString()`.