### PR TITLE
fix(linter): unicorn/no-array-reverse and no-array-sort replacements should be suggestions

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_array_reverse.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reverse.rs
@@ -64,7 +64,7 @@ declare_oxc_lint!(
     NoArrayReverse,
     unicorn,
     suspicious,
-    fix,
+    suggestion,
     config = NoArrayReverse,
     version = "1.15.0",
     short_description = "Prefer using `Array#toReversed()` over `Array#reverse()`.",
@@ -112,7 +112,14 @@ impl Rule for NoArrayReverse {
                 return;
             }
         }
-        ctx.diagnostic_with_fix(no_array_reverse_diagnostic(span), |fixer| {
+        // The replacement is a suggestion, not an auto-fix, matching upstream
+        // eslint-plugin-unicorn (`hasSuggestions: true`, not `fixable`): the
+        // receiver is not statically known to be an array, and non-array
+        // fluent APIs with a `reverse()` method (e.g. Dexie's
+        // `Collection#reverse()`) have no `toReversed()`, so applying the
+        // replacement blindly under `--fix` turns working code into a
+        // runtime `TypeError`.
+        ctx.diagnostic_with_suggestion(no_array_reverse_diagnostic(span), |fixer| {
             fixer.replace(span, "toReversed")
         });
     }

--- a/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
@@ -76,7 +76,7 @@ declare_oxc_lint!(
     NoArraySort,
     unicorn,
     suspicious,
-    fix,
+    suggestion,
     config = NoArraySort,
     version = "1.15.0",
     short_description = "Prefer using `Array#toSorted()` over `Array#sort()`.",
@@ -154,7 +154,14 @@ impl Rule for NoArraySort {
             }
         }
 
-        ctx.diagnostic_with_fix(no_array_sort_diagnostic(span), |fixer| {
+        // The replacement is a suggestion, not an auto-fix, matching upstream
+        // eslint-plugin-unicorn (`hasSuggestions: true`, not `fixable`): the
+        // receiver is not statically known to be an array — the compareFn
+        // heuristic above catches many query-builder receivers, but not
+        // zero-argument ones — and non-array receivers have no `toSorted()`,
+        // so applying the replacement blindly under `--fix` turns working
+        // code into a runtime `TypeError`.
+        ctx.diagnostic_with_suggestion(no_array_sort_diagnostic(span), |fixer| {
             fixer.replace(span, "toSorted")
         });
     }


### PR DESCRIPTION
Fixes #24847.

`unicorn/no-array-reverse` and `unicorn/no-array-sort` declared their `toReversed()` / `toSorted()` replacements as plain auto-fixes, so `oxlint --fix` rewrote receivers that are not arrays and broke working code at runtime:

```js
const rows = await db.table.orderBy("created_at").reverse().toArray();
// --fix → .toReversed().toArray()
// TypeError: ....toReversed is not a function
```

Dexie's [`Collection#reverse()`](https://dexie.org/docs/Collection/Collection.reverse()) (the documented newest-first IndexedDB query pattern) is a real-world receiver with no `toReversed()`; the same shape exists in other fluent APIs, which is why `no-array-sort` already carries the non-`compareFn` heuristic from #22487. That heuristic can't cover zero-argument calls, and the receiver's type is unknowable syntactically — which is exactly why upstream eslint-plugin-unicorn ships **both rules as suggestion-only** (v72.0.0: `meta.fixable: undefined`, `meta.hasSuggestions: true`) and `eslint --fix` never applies the rewrite.

This PR aligns the fix kind with upstream: `fix` → `suggestion` in both rules (declaration + `diagnostic_with_suggestion`), with a comment explaining why. The diagnostics themselves are unchanged; the rewrite now applies only under `--fix-suggestions`, whose help text already warns "May change program behavior".

Tested:
- `cargo test -p oxc_linter --lib no_array` — all 9 matching tests pass, snapshots unchanged (existing `expect_fix` cases still pass; the tester applies suggestions).
- End-to-end with the patched binary: plain `--fix` reports the diagnostics but leaves the repro untouched; `--fix-suggestions` applies the rewrites.

*Disclosure per the AI usage policy: prepared with AI assistance (Claude Code); behavior verified against oxlint 1.75.0 and eslint-plugin-unicorn 72.0.0 side by side.*
