### PR TITLE
refactor(ast_visit): migrate JS-only mutable visitors

### DIFF
--- a/crates/oxc_isolated_declarations/src/formal_parameter_binding_pattern.rs
+++ b/crates/oxc_isolated_declarations/src/formal_parameter_binding_pattern.rs
@@ -1,10 +1,10 @@
 use oxc_allocator::ReplaceWith;
 use oxc_ast::ast::BindingPattern;
-use oxc_ast_visit::{VisitMut, walk_mut::walk_binding_pattern};
+use oxc_ast_visit::{VisitJsMut, walk_js_mut::walk_binding_pattern};
 
 pub struct FormalParameterBindingPattern;
 
-impl<'a> VisitMut<'a> for FormalParameterBindingPattern {
+impl<'a> VisitJsMut<'a> for FormalParameterBindingPattern {
     fn visit_binding_pattern(&mut self, pattern: &mut BindingPattern<'a>) {
         if matches!(pattern, BindingPattern::AssignmentPattern(_)) {
             pattern.replace_with(|pattern| {

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -93,7 +93,7 @@ use rustc_hash::{FxBuildHasher, FxHashSet};
 
 use oxc_allocator::{ArenaBox, ArenaVec, ReplaceWith, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
-use oxc_ast_visit::{VisitMut, walk_mut::walk_expression};
+use oxc_ast_visit::{VisitJsMut, walk_js_mut::walk_expression};
 use oxc_data_structures::stack::{NonEmptyStack, SparseStack};
 use oxc_semantic::{ReferenceFlags, SymbolId};
 use oxc_span::{GetSpan, SPAN};
@@ -1267,7 +1267,7 @@ impl<'a, 'v> ConstructorBodyThisAfterSuperInserter<'a, 'v> {
     }
 }
 
-impl<'a> VisitMut<'a> for ConstructorBodyThisAfterSuperInserter<'a, '_> {
+impl<'a> VisitJsMut<'a> for ConstructorBodyThisAfterSuperInserter<'a, '_> {
     fn visit_class(&mut self, class: &mut Class<'a>) {
         // Only need to transform `super()` in:
         //

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -105,7 +105,7 @@ use oxc_allocator::{ArenaVec, ReplaceWith};
 use rustc_hash::FxHashMap;
 
 use oxc_ast::{ast::*, builder::NONE};
-use oxc_ast_visit::{VisitMut, walk_mut};
+use oxc_ast_visit::{VisitJsMut, VisitMut, walk_js_mut};
 use oxc_span::SPAN;
 use oxc_str::Ident;
 use oxc_syntax::{
@@ -515,7 +515,7 @@ impl<'a, 'ctx> ConstructorParamsSuperReplacer<'a, 'ctx> {
     }
 }
 
-impl<'a> VisitMut<'a> for ConstructorParamsSuperReplacer<'a, '_> {
+impl<'a> VisitJsMut<'a> for ConstructorParamsSuperReplacer<'a, '_> {
     /// Replace `super()` with `_super.call(super())`.
     // `#[inline]` to make hot path for all other expressions as cheap as possible.
     #[inline]
@@ -532,7 +532,7 @@ impl<'a> VisitMut<'a> for ConstructorParamsSuperReplacer<'a, '_> {
             return;
         }
 
-        walk_mut::walk_expression(self, expr);
+        walk_js_mut::walk_expression(self, expr);
     }
 
     // Stop traversing where scope of current `super` ends
@@ -708,7 +708,7 @@ impl<'a, 'ctx> ConstructorBodySuperReplacer<'a, 'ctx> {
     }
 }
 
-impl<'a> VisitMut<'a> for ConstructorBodySuperReplacer<'a, '_> {
+impl<'a> VisitJsMut<'a> for ConstructorBodySuperReplacer<'a, '_> {
     /// Replace `super()` with `_super()`.
     // `#[inline]` to make hot path for all other function calls as cheap as possible.
     #[inline]
@@ -718,7 +718,7 @@ impl<'a> VisitMut<'a> for ConstructorBodySuperReplacer<'a, '_> {
             self.replace_super(call_expr, span);
         }
 
-        walk_mut::walk_call_expression(self, call_expr);
+        walk_js_mut::walk_call_expression(self, call_expr);
     }
 
     // Stop traversing where scope of current `super` ends

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -2,7 +2,7 @@ use std::cell::Cell;
 
 use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
-use oxc_ast_visit::{VisitMut, walk_mut};
+use oxc_ast_visit::{VisitJsMut, walk_js_mut};
 use oxc_data_structures::stack::NonEmptyStack;
 use oxc_semantic::{ScopeFlags, ScopeId};
 use oxc_span::{SPAN, Span};
@@ -698,7 +698,7 @@ impl IdentifierReferenceRename<'_, '_> {
     }
 }
 
-impl<'a> VisitMut<'a> for IdentifierReferenceRename<'a, '_> {
+impl<'a> VisitJsMut<'a> for IdentifierReferenceRename<'a, '_> {
     fn enter_scope(&mut self, _flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {
         self.scope_stack.push(scope_id.get().unwrap());
     }
@@ -718,7 +718,7 @@ impl<'a> VisitMut<'a> for IdentifierReferenceRename<'a, '_> {
                 .into();
             }
             _ => {
-                walk_mut::walk_expression(self, expr);
+                walk_js_mut::walk_expression(self, expr);
             }
         }
     }

--- a/crates/oxc_transformer_plugins/src/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/src/replace_global_defines.rs
@@ -31,7 +31,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::{Address, Allocator, ArenaBox, GetAddress, ReplaceWith, UnstableAddress};
 use oxc_ast::ast::*;
-use oxc_ast_visit::{VisitMut, walk_mut};
+use oxc_ast_visit::{VisitJsMut, walk_js_mut};
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_parser::Parser;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, Scoping};
@@ -329,7 +329,7 @@ pub struct ReplaceGlobalDefines<'a> {
     destructuring_keys: Option<FxHashSet<CompactStr>>,
 }
 
-impl<'a> VisitMut<'a> for ReplaceGlobalDefines<'a> {
+impl<'a> VisitJsMut<'a> for ReplaceGlobalDefines<'a> {
     fn visit_expression(&mut self, expr: &mut Expression<'a>) {
         if self.ast_node_lock.is_some() {
             return;
@@ -348,7 +348,7 @@ impl<'a> VisitMut<'a> for ReplaceGlobalDefines<'a> {
             self.mark_as_changed();
             self.ast_node_lock = Some(expr.address());
         }
-        walk_mut::walk_expression(self, expr);
+        walk_js_mut::walk_expression(self, expr);
         if self.ast_node_lock == Some(expr.address()) {
             self.ast_node_lock = None;
         }
@@ -370,7 +370,7 @@ impl<'a> VisitMut<'a> for ReplaceGlobalDefines<'a> {
             // `AssignmentExpression` is stored in a `Box`, so has a stable memory location
             self.ast_node_lock = Some(node.unstable_address());
         }
-        walk_mut::walk_assignment_expression(self, node);
+        walk_js_mut::walk_assignment_expression(self, node);
         // `AssignmentExpression` is stored in a `Box`, so has a stable memory location
         if self.ast_node_lock == Some(node.unstable_address()) {
             self.ast_node_lock = None;
@@ -379,16 +379,13 @@ impl<'a> VisitMut<'a> for ReplaceGlobalDefines<'a> {
 
     fn visit_function(&mut self, func: &mut Function<'a>, flags: ScopeFlags) {
         self.non_arrow_function_depth += 1;
-        walk_mut::walk_function(self, func, flags);
+        walk_js_mut::walk_function(self, func, flags);
         self.non_arrow_function_depth -= 1;
     }
 
     fn visit_property_definition(&mut self, property: &mut PropertyDefinition<'a>) {
         self.visit_decorators(&mut property.decorators);
         self.visit_property_key(&mut property.key);
-        if let Some(type_annotation) = &mut property.type_annotation {
-            self.visit_ts_type_annotation(type_annotation);
-        }
         if let Some(value) = &mut property.value {
             self.class_this_depth += 1;
             self.visit_expression(value);
@@ -398,16 +395,13 @@ impl<'a> VisitMut<'a> for ReplaceGlobalDefines<'a> {
 
     fn visit_static_block(&mut self, block: &mut StaticBlock<'a>) {
         self.class_this_depth += 1;
-        walk_mut::walk_static_block(self, block);
+        walk_js_mut::walk_static_block(self, block);
         self.class_this_depth -= 1;
     }
 
     fn visit_accessor_property(&mut self, property: &mut AccessorProperty<'a>) {
         self.visit_decorators(&mut property.decorators);
         self.visit_property_key(&mut property.key);
-        if let Some(type_annotation) = &mut property.type_annotation {
-            self.visit_ts_type_annotation(type_annotation);
-        }
         if let Some(value) = &mut property.value {
             self.class_this_depth += 1;
             self.visit_expression(value);
@@ -434,7 +428,7 @@ impl<'a> VisitMut<'a> for ReplaceGlobalDefines<'a> {
                 self.destructuring_keys = Some(keys);
             }
         }
-        walk_mut::walk_variable_declarator(self, declarator);
+        walk_js_mut::walk_variable_declarator(self, declarator);
     }
 }
 
@@ -1134,14 +1128,14 @@ struct UpdateReplacedExpression<'a> {
     scoping: &'a mut Scoping,
 }
 
-impl VisitMut<'_> for UpdateReplacedExpression<'_> {
+impl VisitJsMut<'_> for UpdateReplacedExpression<'_> {
     fn visit_identifier_reference(&mut self, ident: &mut IdentifierReference<'_>) {
         let reference =
             Reference::new(NodeId::DUMMY, self.scoping.root_scope_id(), ReferenceFlags::Read);
         let reference_id = self.scoping.create_reference(reference);
         self.scoping.add_root_unresolved_reference(ident.name, reference_id);
         ident.set_reference_id(reference_id);
-        walk_mut::walk_identifier_reference(self, ident);
+        walk_js_mut::walk_identifier_reference(self, ident);
     }
 
     fn visit_span(&mut self, span: &mut Span) {

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
 AST Parsed     : 74/74 (100.00%)
-Positive Passed: 69/74 (93.24%)
+Positive Passed: 70/74 (94.59%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]
@@ -84,11 +84,6 @@ rebuilt        : [ReferenceId(187), ReferenceId(193), ReferenceId(300), Referenc
 Unresolved reference IDs mismatch for "Object":
 after transform: [ReferenceId(166), ReferenceId(170), ReferenceId(174), ReferenceId(185), ReferenceId(226), ReferenceId(228), ReferenceId(265), ReferenceId(267), ReferenceId(304), ReferenceId(306), ReferenceId(343), ReferenceId(345), ReferenceId(382), ReferenceId(386), ReferenceId(425), ReferenceId(427), ReferenceId(464), ReferenceId(468), ReferenceId(507), ReferenceId(509), ReferenceId(546), ReferenceId(550), ReferenceId(589), ReferenceId(591), ReferenceId(628), ReferenceId(632), ReferenceId(671), ReferenceId(673), ReferenceId(839), ReferenceId(843), ReferenceId(876), ReferenceId(880), ReferenceId(891), ReferenceId(895)]
 rebuilt        : [ReferenceId(169), ReferenceId(173), ReferenceId(177), ReferenceId(182), ReferenceId(291), ReferenceId(295), ReferenceId(364), ReferenceId(368), ReferenceId(437), ReferenceId(441), ReferenceId(625), ReferenceId(632), ReferenceId(777), ReferenceId(781), ReferenceId(810), ReferenceId(814), ReferenceId(819), ReferenceId(823)]
-
-semantic Error: tasks/coverage/misc/pass/oxc-13284.ts
-Symbol reference IDs mismatch for "_super":
-after transform: SymbolId(18): [ReferenceId(14)]
-rebuilt        : SymbolId(9): []
 
 semantic Error: tasks/coverage/misc/pass/reserved-kw-ambient-context.ts
 Bindings mismatch:


### PR DESCRIPTION
## Summary

Migrate seven runtime-only `VisitMut` implementations to `VisitJsMut`.

This avoids monomorphizing pure TypeScript type-space traversal for these consumers.

## Binary size

On arm64 macOS, `cargo build --release -p oxc_transform_napi` produces a stripped dylib that changes from 3,365,584 to 3,332,480 bytes: **-33,104 bytes (-0.98%)**. Its Mach-O `__text` section changes from 2,909,108 to 2,876,892 bytes: **-32,216 bytes (-1.11%)**.

AI assistance was used to implement this change. I reviewed and take responsibility for the result.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>