### PR TITLE
refactor(linter/plugins): remove dead code in `getDisableDirectives`

### DIFF
--- a/apps/oxlint/src-js/plugins/directives.ts
+++ b/apps/oxlint/src-js/plugins/directives.ts
@@ -33,7 +33,6 @@ interface Directive {
 
 const LABEL_PATTERN =
   /^\s*(?<label>(?:eslint|oxlint)-(?:disable(?:(?:-next)?-line)?|enable))(?:\s|$)/u;
-const LINE_DIRECTIVE_PATTERN = /^(?:eslint|oxlint)-disable-(?:-next)?-line$/u;
 const JUSTIFICATION_SEP_PATTERN = /\s-{2,}\s/u;
 
 export function getDisableDirectives(): { problems: Problem[]; directives: Directive[] } {
@@ -50,9 +49,6 @@ export function getDisableDirectives(): { problems: Problem[]; directives: Direc
 
     let match = LABEL_PATTERN.exec(comment.value);
     if (!match?.groups?.label) continue;
-
-    // Only some comment types are supported as line comments
-    if (comment.type === "Line" && LINE_DIRECTIVE_PATTERN.test(match.groups.label)) continue;
 
     const { label } = match.groups;
 


### PR DESCRIPTION
`LINE_DIRECTIVE_PATTERN` had a stray hyphen (`disable-(?:-next)?-line`), so it only matched
`disable--line` / `disable--next-line` - strings `LABEL_PATTERN` can never produce. Therefore it was dead code - remove it.

If the regex _was_ correctly written, the behavior would be wrong. Looks like this is a hangover from the code being taken from ESLint.