### PR TITLE
perf(linter/plugins): faster copying comments to JS allocator

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -640,7 +640,7 @@ impl Linter {
                 hashbang.span.end,
                 CommentKind::Line,
             ));
-            comments_with_hashbang.extend(original_program.comments.iter().copied());
+            comments_with_hashbang.extend_from_slice_copy(&original_program.comments);
 
             original_program.comments.clear();
 


### PR DESCRIPTION
`ArenaVec::extend_from_slice_copy` is faster than `ArenaVec::extend` as it can specialize based on being passed a slice of `Copy` types.

Here, it replaces item-by-item iteration with a single bulk `memcpy` call.