### PR TITLE
feat(ast_visit): add `Utf8ToUtf16::convert_program_and_comments`

### DIFF
--- a/crates/oxc_ast_visit/src/utf8_to_utf16/mod.rs
+++ b/crates/oxc_ast_visit/src/utf8_to_utf16/mod.rs
@@ -105,6 +105,19 @@ impl Utf8ToUtf16 {
         converter.convert_program(program);
     }
 
+    /// Convert all spans in AST and comments to UTF-16.
+    pub fn convert_program_and_comments(&self, program: &mut Program<'_>) {
+        if let Some(mut converter) = self.converter() {
+            converter.convert_program(program);
+
+            converter.reset();
+
+            for comment in &mut program.comments {
+                converter.convert_span(&mut comment.span);
+            }
+        }
+    }
+
     /// Convert all spans in comments to UTF-16.
     pub fn convert_comments(&self, comments: &mut [Comment]) {
         if let Some(mut converter) = self.converter() {

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -266,7 +266,6 @@ unsafe fn parse_raw_impl(
         // Parse
         let ret = parse_impl(allocator, source_type, source_text, &options);
         let mut program = ret.program;
-        let mut comments = mem::replace(&mut program.comments, ArenaVec::new_in(&allocator));
         let mut module_record = ret.module_record;
 
         // Convert errors.
@@ -314,8 +313,7 @@ unsafe fn parse_raw_impl(
         let (tokens_offset, tokens_len) = (0, 0);
 
         // Convert spans to UTF-16
-        span_converter.convert_program(&mut program);
-        span_converter.convert_comments(&mut comments);
+        span_converter.convert_program_and_comments(&mut program);
         span_converter.convert_module_record(&mut module_record);
         if let Some(mut converter) = span_converter.converter() {
             for error in &mut errors {
@@ -324,6 +322,8 @@ unsafe fn parse_raw_impl(
                 }
             }
         }
+
+        let comments = mem::replace(&mut program.comments, ArenaVec::new_in(&allocator));
 
         // Convert module record
         let module = EcmaScriptModule::from_in(module_record, allocator);

--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -57,8 +57,7 @@ fn bench_estree(criterion: &mut Criterion) {
 
                 runner.run(|| {
                     let span_converter = Utf8ToUtf16::new(program.source_text);
-                    span_converter.convert_program(&mut program);
-                    span_converter.convert_comments(&mut program.comments);
+                    span_converter.convert_program_and_comments(&mut program);
 
                     black_box(program.to_estree_json_with_fixes(true, false));
                     program


### PR DESCRIPTION
Add a method `Utf8ToUtf16::convert_program_and_comments`, and use it in a couple of places.

This is marginally faster than `convert_program` followed by `convert_comments`, as it avoids branching on the same condition twice.