### PR TITLE
feat(oxc): re-export `oxc_str` types from `oxc` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,6 +1662,7 @@ dependencies = [
  "oxc_regular_expression",
  "oxc_semantic",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
  "oxc_transformer",
  "oxc_transformer_plugins",

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -39,6 +39,7 @@ oxc_parser = { workspace = true, features = [] }
 oxc_regular_expression = { workspace = true, optional = true }
 oxc_semantic = { workspace = true, optional = true }
 oxc_span = { workspace = true }
+oxc_str = { workspace = true }
 oxc_syntax = { workspace = true }
 oxc_transformer = { workspace = true, optional = true }
 oxc_transformer_plugins = { workspace = true, optional = true }

--- a/crates/oxc/src/lib.rs
+++ b/crates/oxc/src/lib.rs
@@ -46,11 +46,19 @@ pub mod regular_expression {
 }
 
 pub mod span {
-    //! Source text Span and string types.
+    //! Source text Span.
     //!
     //! See the [`oxc_span` module-level documentation](oxc_span) for more information.
     #[doc(inline)]
     pub use oxc_span::*;
+}
+
+pub mod str {
+    //! String types.
+    //!
+    //! See the [`oxc_str` module-level documentation](oxc_str) for more information.
+    #[doc(inline)]
+    pub use oxc_str::*;
 }
 
 pub mod syntax {


### PR DESCRIPTION
`oxc_str` contains some of our core types - notably `Ident` and `Str`. Re-export it from `oxc` crate.