### PR TITLE
refactor(formatter_core): introduce `exact_line_breaks` builder

### DIFF
--- a/apps/oxfmt/src/core/embed/ir_channel.rs
+++ b/apps/oxfmt/src/core/embed/ir_channel.rs
@@ -14,8 +14,8 @@ use tracing::{debug, debug_span};
 use oxc_allocator::{Allocator, ArenaStringBuilder, ArenaVec};
 use oxc_formatter::HtmlEmbedMeta;
 use oxc_formatter_core::{
-    DispatchResult, EmbeddedContext, EmbeddedIr, FormatDispatcher, FormatElement, IndentWidth,
-    LineMode, TextWidth, UniqueGroupIdBuilder,
+    DispatchResult, EmbeddedContext, EmbeddedIr, FormatDispatcher, FormatElement, LineMode,
+    UniqueGroupIdBuilder,
 };
 use oxc_formatter_css::CssFormatOptions;
 use oxc_formatter_graphql::GraphqlFormatOptions;
@@ -210,6 +210,13 @@ fn to_format_elements_for_template<'a>(
 /// - strip trailing hardline (useless for embedded parts)
 /// - collapse double-hardlines `[Hard, ExpandParent, Hard, ExpandParent]` → `[Empty, ExpandParent]`
 /// - merge consecutive Text nodes (the Prettier Doc path can emit adjacent `Text`s)
+/// - trim a Text's trailing spaces/tabs when a hard/empty line follows:
+///   Prettier's own printer trims at every line break,
+///   so a Doc can rightfully carry them, but the core printer does not.
+///   Untrimmed they would leak into the output verbatim.
+///   (A single trailing space before a MAY-break line is already mapped to `Space` at conversion,
+///   see `convert_doc`'s String arm; this pass covers the statically-known hard breaks,
+///   where full runs and tabs can be dropped.)
 fn postprocess<'a>(ir: &mut ArenaVec<'a, FormatElement<'a>>, allocator: &'a Allocator) {
     // Strip trailing hardline
     if ir.len() >= 2
@@ -241,11 +248,10 @@ fn postprocess<'a>(ir: &mut ArenaVec<'a, FormatElement<'a>>, allocator: &'a Allo
             while read < ir.len() && matches!(ir[read], FormatElement::Text { .. }) {
                 read += 1;
             }
-
-            if read - run_start == 1 {
-                if write != run_start {
-                    ir[write] = ir[run_start].clone();
-                }
+            let single = read - run_start == 1;
+            let text: &str = if single {
+                let FormatElement::Text { text, .. } = ir[run_start] else { unreachable!() };
+                text
             } else {
                 let mut sb = ArenaStringBuilder::new_in(allocator);
                 for element in &ir[run_start..read] {
@@ -253,9 +259,28 @@ fn postprocess<'a>(ir: &mut ArenaVec<'a, FormatElement<'a>>, allocator: &'a Allo
                         sb.push_str(text);
                     }
                 }
-                let text = sb.into_str();
-                let width = TextWidth::from_text(text, IndentWidth::default());
-                ir[write] = FormatElement::Text { text, width };
+                sb.into_str()
+            };
+            // Prettier's own printer trims at every line break regardless of the doc structure around it,
+            // so a break hiding behind tags (`Text("a  "), StartIndent, Hard` from `["a  ", indent([hardline, ..])]`) still trims,
+            // look through tag/expand-parent markers for it (only when there is anything to trim in the first place).
+            let trimmed = if text.ends_with([' ', '\t'])
+                && ir[read..]
+                    .iter()
+                    .find(|el| !matches!(el, FormatElement::Tag(_) | FormatElement::ExpandParent))
+                    .is_some_and(|el| {
+                        matches!(el, FormatElement::Line(LineMode::Hard | LineMode::Empty))
+                    }) {
+                text.trim_end_matches([' ', '\t'])
+            } else {
+                text
+            };
+            if single && trimmed.len() == text.len() {
+                if write != run_start {
+                    ir[write] = ir[run_start].clone();
+                }
+            } else {
+                ir[write] = from_prettier_doc::text_element(trimmed);
             }
             write += 1;
         } else {

--- a/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
@@ -69,6 +69,17 @@ impl<'a, 'b> FmtCtx<'a, 'b> {
     }
 }
 
+/// A `Text` element measured with the default `IndentWidth`.
+///
+/// NOTE: `IndentWidth` only affects tab character width calculation.
+/// If the text contained `\t` (e.g. inside a string literal like `"\t"`?),
+/// the width could be miscalculated when `options.indent_width` != 2.
+/// However, the default value is sufficient in practice.
+pub fn text_element(text: &str) -> FormatElement<'_> {
+    let width = TextWidth::from_text(text, IndentWidth::default());
+    FormatElement::Text { text, width }
+}
+
 fn convert_doc<'a>(
     doc: &Value,
     out: &mut ArenaVec<'a, FormatElement<'a>>,
@@ -76,14 +87,21 @@ fn convert_doc<'a>(
 ) -> Result<(), String> {
     match doc {
         Value::String(s) => {
-            if !s.is_empty() {
-                let text = ctx.allocator.alloc_str(s);
-                // NOTE: `IndentWidth` only affects tab character width calculation.
-                // If a `Doc = string` node contained `\t` (e.g. inside a string literal like `"\t"`?),
-                // the width could be miscalculated when `options.indent_width` != 2.
-                // However, the default value is sufficient in practice.
-                let width = TextWidth::from_text(text, IndentWidth::default());
-                out.push(FormatElement::Text { text, width });
+            // A trailing space maps to `Space` (pending space), not text:
+            // Prettier's printer trims trailing whitespace at every line break,
+            // so a Doc string's trailing space is semantically "a space only if content follows on the same line".
+            // Exactly the core printer's pending-space.
+            // Kept as text it would leak before a soft break (the core printer never trims);
+            // e.g. css-in-html `prop: ` before an `indent([softline, ...])` value.
+            let (content, trailing_space) = match s.strip_suffix(' ') {
+                Some(content) => (content, true),
+                None => (s.as_str(), false),
+            };
+            if !content.is_empty() {
+                out.push(text_element(ctx.allocator.alloc_str(content)));
+            }
+            if trailing_space {
+                out.push(FormatElement::Space);
             }
             Ok(())
         }

--- a/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
@@ -106,22 +106,32 @@ struct PrinterState {
     /// Boolean semantics naturally deduplicates consecutive spaces.
     pending_space: bool,
 
-    /// Mirrors the printer's `line_width > 0` guard for hardline emission
-    /// and `has_empty_line` flag for empty line deduplication.
-    /// See: `Printer::print_line()` in printer/mod.rs
+    /// Mirrors the printer's end-of-line state for hardline collapsing:
+    /// its `line_width > 0` guard (`Content` vs the rest) and its `has_empty_line` cap (`Blank`).
+    /// See the `Line` arm of `Printer::print_element` in `printer/mod.rs`.
     ///
-    /// When true, consecutive `Hard` lines are suppressed (the line is already broken).
-    /// `Empty` after a hardline emits only one additional `Hard` (the second newline).
-    ///
-    /// NOTE: Consecutive `Empty, Empty` won't fully collapse to a single empty line,
-    /// but such sequences don't occur in practice since the IR generators already
-    /// control line emission.
-    last_was_hardline: bool,
+    /// NOTE: the state resets to `Content` at `Interned` / `BestFitting` boundaries,
+    /// so element sequences crossing them are approximated;
+    /// the real IR shapes (straight-line emission) are what this mirrors faithfully.
+    line: LineState,
+}
+
+/// End-of-line state for [PrinterState::line].
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum LineState {
+    /// Content was emitted since the last line break.
+    Content,
+    /// A line break was just emitted:
+    /// further `Hard`s are suppressed (the line is already broken),
+    /// an `Empty` emits only its second newline.
+    Hardline,
+    /// A blank line was just emitted: further `Empty`s emit nothing at all.
+    Blank,
 }
 
 impl PrinterState {
     fn new() -> Self {
-        Self { pending_space: false, last_was_hardline: false }
+        Self { pending_space: false, line: LineState::Content }
     }
 
     /// Flushes the pending space (if any) by appending `" "` to the current scope's children.
@@ -146,17 +156,17 @@ fn convert_elements(
         match element {
             FormatElement::Space => {
                 printer.pending_space = true;
-                printer.last_was_hardline = false;
+                printer.line = LineState::Content;
             }
             FormatElement::Token { text } => {
                 printer.flush_pending_space(&mut stack)?;
                 concat_string(current_children_mut(&mut stack)?, text);
-                printer.last_was_hardline = false;
+                printer.line = LineState::Content;
             }
             FormatElement::Text { text, .. } => {
                 printer.flush_pending_space(&mut stack)?;
                 push_text(current_children_mut(&mut stack)?, text);
-                printer.last_was_hardline = false;
+                printer.line = LineState::Content;
             }
             FormatElement::Line(mode) => {
                 match mode {
@@ -166,48 +176,79 @@ fn convert_elements(
                         // `SoftOrSpace` subsumes it (just like the printer's boolean idempotency).
                         printer.pending_space = false;
                         push_line(current_children_mut(&mut stack)?, *mode);
+                        printer.line = LineState::Content;
                     }
                     LineMode::Soft => {
                         // Soft produces nothing in flat mode, newline in expanded.
                         // Keep `pending_space` as-is (mirroring the printer).
                         push_line(current_children_mut(&mut stack)?, *mode);
+                        printer.line = LineState::Content;
                     }
                     LineMode::Hard | LineMode::Empty => {
                         printer.flush_pending_space(&mut stack)?;
-                        // Mimic the printer's `line_width > 0` guard and `has_empty_line` dedup:
-                        // - The printer only emits a newline when the line has content (`line_width > 0`).
-                        //   Consecutive `Hard, Hard` produces only one newline.
-                        // - For `Empty` after a hardline, only the second newline of `Empty` is emitted
-                        //   (the first is redundant since the line is already broken).
-                        if printer.last_was_hardline {
-                            if *mode == LineMode::Empty {
-                                push_line(current_children_mut(&mut stack)?, LineMode::Hard);
+                        // Mimic the printer's `line_width > 0` guard and `has_empty_line` cap:
+                        // the printer only emits a newline when the line has content,
+                        // so consecutive `Hard, Hard` produces only one newline;
+                        // for `Empty` after a hardline only the second newline is emitted
+                        // (the first is redundant since the line is already broken),
+                        // and nothing at all when a blank line was already emitted.
+                        match printer.line {
+                            LineState::Content => {
+                                push_line(current_children_mut(&mut stack)?, *mode);
+                                printer.line = if *mode == LineMode::Empty {
+                                    LineState::Blank
+                                } else {
+                                    LineState::Hardline
+                                };
                             }
-                            // `Hard` after `Hard` → skip (line already broken)
-                        } else {
-                            push_line(current_children_mut(&mut stack)?, *mode);
+                            LineState::Hardline => {
+                                if *mode == LineMode::Empty {
+                                    push_line(current_children_mut(&mut stack)?, LineMode::Hard);
+                                    printer.line = LineState::Blank;
+                                }
+                                // `Hard` after `Hard` → skip (line already broken)
+                            }
+                            LineState::Blank => {}
                         }
                     }
+                    LineMode::ExactLineBreaks(count) => {
+                        printer.flush_pending_space(&mut stack)?;
+                        // Exactly `count` breaks, exempt from the collapsing above
+                        // (mirrors the printer's `ExactLineBreaks` arm; `push_line`
+                        // expands this to `count` hardlines, which Prettier's own
+                        // printer never collapses).
+                        push_line(current_children_mut(&mut stack)?, *mode);
+                        // A blank is left behind from the start of a line always,
+                        // mid-line only when a break remains after the line-ending one.
+                        // NOTE: `line != Content` approximates the printer's `line_width == 0`,
+                        // they diverge at the document start and right after a `Literal` (blank there, mid-line here).
+                        // Real IR always emits `ExactLineBreaks` after content, where they agree.
+                        printer.line = if printer.line != LineState::Content || count.get() > 1 {
+                            LineState::Blank
+                        } else {
+                            LineState::Hardline
+                        };
+                    }
                     LineMode::Literal => {
-                        // A literal line always prints (no `last_was_hardline` dedup) and
+                        // A literal line always prints (no hardline dedup) and
                         // preserves the pending space (the printer never trims it away),
                         // matching a `\n` embedded in `FormatElement::Text` below.
                         printer.flush_pending_space(&mut stack)?;
                         push_line(current_children_mut(&mut stack)?, *mode);
+                        printer.line = LineState::Content;
                     }
                 }
-                printer.last_was_hardline = matches!(mode, LineMode::Hard | LineMode::Empty);
             }
             // `ExpandParent` is a directive (not visible content) — it forces the parent group
             // to break. The printer treats it as a no-op (expansion is propagated at IR level).
-            // Neither `pending_space` nor `last_was_hardline` should be affected.
+            // Neither `pending_space` nor `line` should be affected.
             FormatElement::ExpandParent => {
                 current_children_mut(&mut stack)?.push(json!({"type": "break-parent"}));
             }
             FormatElement::LineSuffixBoundary => {
                 printer.flush_pending_space(&mut stack)?;
                 current_children_mut(&mut stack)?.push(json!({"type": "line-suffix-boundary"}));
-                printer.last_was_hardline = false;
+                printer.line = LineState::Content;
             }
             FormatElement::Tag(tag) => {
                 if tag.is_start() {
@@ -310,20 +351,20 @@ fn convert_elements(
                     id
                 };
                 current_children_mut(&mut stack)?.push(json!({ "_REF": id }));
-                printer.last_was_hardline = false;
+                printer.line = LineState::Content;
             }
             FormatElement::BestFitting(best_fitting) => {
                 printer.flush_pending_space(&mut stack)?;
                 let doc = convert_best_fitting(best_fitting, state)?;
                 current_children_mut(&mut stack)?.push(doc);
-                printer.last_was_hardline = false;
+                printer.line = LineState::Content;
             }
             FormatElement::TailwindClass(index) => {
                 printer.flush_pending_space(&mut stack)?;
                 if let Some(class) = state.sorted_tailwind_classes.get(*index) {
                     concat_string(current_children_mut(&mut stack)?, class);
                 }
-                printer.last_was_hardline = false;
+                printer.line = LineState::Content;
             }
             FormatElement::EmbedPlaceholder(index) => {
                 // The host splices `${expr}` for each marker before the IR is finalized,
@@ -427,6 +468,14 @@ fn push_line(children: &mut Vec<Value>, mode: LineMode) {
             children.push(json!({"type": "break-parent"}));
             children.push(json!({"type": "line", "hard": true}));
             children.push(json!({"type": "break-parent"}));
+        }
+        LineMode::ExactLineBreaks(count) => {
+            // hardline x count: Prettier's own printer never collapses hardlines,
+            // so this reproduces exactly `count` breaks.
+            for _ in 0..count.get() {
+                children.push(json!({"type": "line", "hard": true}));
+                children.push(json!({"type": "break-parent"}));
+            }
         }
         LineMode::Literal => {
             push_literal_line(children);
@@ -648,5 +697,69 @@ fn normalize_array(mut arr: Vec<Value>) -> Value {
         0 => Value::String(String::new()),
         1 => arr.pop().unwrap(),
         _ => Value::Array(arr),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use oxc_formatter_core::{FormatElement, LineMode};
+    use serde_json::Value;
+
+    use super::format_elements_to_prettier_doc;
+
+    /// Counts `{"type": "line", "hard": true}` nodes (excluding literal lines) in the Doc.
+    fn count_hardlines(doc: &Value) -> usize {
+        match doc {
+            Value::Array(items) => items.iter().map(count_hardlines).sum(),
+            Value::Object(map) => {
+                let own = usize::from(
+                    map.get("type").and_then(Value::as_str) == Some("line")
+                        && map.get("hard").and_then(Value::as_bool) == Some(true)
+                        && !map.contains_key("literal"),
+                );
+                own + map.values().map(count_hardlines).sum::<usize>()
+            }
+            _ => 0,
+        }
+    }
+
+    fn exact(count: u32) -> FormatElement<'static> {
+        FormatElement::Line(LineMode::ExactLineBreaks(NonZeroU32::new(count).unwrap()))
+    }
+    const A: FormatElement<'static> = FormatElement::Token { text: "a" };
+    const HARD: FormatElement<'static> = FormatElement::Line(LineMode::Hard);
+    const EMPTY: FormatElement<'static> = FormatElement::Line(LineMode::Empty);
+
+    #[test]
+    fn exact_line_breaks_expand_to_that_many_hardlines() {
+        let doc = format_elements_to_prettier_doc(&[A, exact(3), A], &[]).unwrap();
+        assert_eq!(count_hardlines(&doc), 3);
+    }
+
+    #[test]
+    fn empty_after_mid_line_single_exact_break_adds_a_blank() {
+        // Mid-line count=1 leaves no blank behind: the following Empty may still add one.
+        let doc = format_elements_to_prettier_doc(&[A, exact(1), EMPTY, A], &[]).unwrap();
+        assert_eq!(count_hardlines(&doc), 2);
+    }
+
+    #[test]
+    fn empty_after_blank_leaving_exact_breaks_is_capped() {
+        // Mid-line count=2 leaves a blank: the following Empty adds nothing.
+        let doc = format_elements_to_prettier_doc(&[A, exact(2), EMPTY, A], &[]).unwrap();
+        assert_eq!(count_hardlines(&doc), 2);
+
+        // From the start of a line even count=1 leaves a blank
+        // (no break is consumed as a line ending), capping the Empty too.
+        let doc = format_elements_to_prettier_doc(&[A, HARD, exact(1), EMPTY, A], &[]).unwrap();
+        assert_eq!(count_hardlines(&doc), 2);
+    }
+
+    #[test]
+    fn hard_after_exact_line_breaks_is_absorbed() {
+        let doc = format_elements_to_prettier_doc(&[A, exact(2), HARD, A], &[]).unwrap();
+        assert_eq!(count_hardlines(&doc), 2);
     }
 }

--- a/apps/oxfmt/test/api/__snapshots__/embedded_languages.test.ts.snap
+++ b/apps/oxfmt/test/api/__snapshots__/embedded_languages.test.ts.snap
@@ -111,6 +111,20 @@ var(--color),
 "
 `;
 
+exports[`Embedded languages > Misc > should not leak a trailing space when a css-in-html declaration value breaks 1`] = `
+"export const BaseStyles = html\`
+  <style>
+    :root {
+      --ln-font-fallback:
+        -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif,
+        Apple Color Emoji, Segoe UI Emoji;
+      --ln-font-body: "Geist", var(--ln-font-fallback);
+    }
+  </style>
+\`;
+"
+`;
+
 exports[`Embedded languages > should format angular.ts (auto) 1`] = `
 "// Angular @Component decorator - direct template and styles
 // Uses Angular-specific syntax: interpolation, directives, bindings

--- a/apps/oxfmt/test/api/__snapshots__/js-in-vue.test.ts.snap
+++ b/apps/oxfmt/test/api/__snapshots__/js-in-vue.test.ts.snap
@@ -57,3 +57,20 @@ exports[`Format js-in-vue with prettier-plugin-oxfmt > should format .vue w/ tem
 </template>
 "
 `;
+
+exports[`Format js-in-vue with prettier-plugin-oxfmt > should preserve gql block-string blank lines through a .vue script 1`] = `
+"<script setup>
+const q = graphql\`
+  """
+  First paragraph.
+
+
+  Second paragraph after two blanks.
+  """
+  type Query {
+    hello: String
+  }
+\`;
+</script>
+"
+`;

--- a/apps/oxfmt/test/api/embedded_languages.test.ts
+++ b/apps/oxfmt/test/api/embedded_languages.test.ts
@@ -262,5 +262,27 @@ describe("Embedded languages", () => {
       expect(result.errors).toStrictEqual([]);
       expect(result.code).toMatchSnapshot();
     });
+
+    // (css-in-html)-in-js: For now, HTML is handled by Prettier, so CSS is also handled by Prettier too.
+    // The CSS `Doc` carries a trailing space after `prop: ` that only materializes when the value fits flat;
+    // when the value breaks, it must not leak (the Doc→IR conversion maps it to a pending space, dropped at the break).
+    it("should not leak a trailing space when a css-in-html declaration value breaks", async () => {
+      const input = `\
+export const BaseStyles = html\`
+  <style>
+    :root {
+      --ln-font-fallback:
+        -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif,
+        Apple Color Emoji, Segoe UI Emoji;
+      --ln-font-body: "Geist", var(--ln-font-fallback);
+    }
+  </style>
+\`;
+`;
+      const result = await format("styles.ts", input);
+      expect(result.errors).toStrictEqual([]);
+      expect(result.code).not.toMatch(/[ \t]+$/m);
+      expect(result.code).toMatchSnapshot();
+    });
   });
 });

--- a/apps/oxfmt/test/api/js-in-vue.test.ts
+++ b/apps/oxfmt/test/api/js-in-vue.test.ts
@@ -103,4 +103,35 @@ const a = \`
     expect(result2.code).toBe(result.code);
     expect(result2.errors).toStrictEqual([]);
   });
+
+  // gql-in-js-in-vue: the `oxc_formatter_graphql` IR's blank runs
+  // (`exact_line_breaks`, part of the block string's VALUE) must survive the IR→Doc conversion
+  // back to the Prettier host (encoded as that many hardlines, which Prettier never collapses).
+  it("should preserve gql block-string blank lines through a .vue script", async () => {
+    const input = `
+<script setup>
+const q = graphql\`
+  """
+  First paragraph.
+
+
+  Second paragraph after two blanks.
+  """
+  type Query {
+    hello: String
+  }
+\`;
+</script>
+`;
+    const result = await format("a.vue", input);
+
+    // Format again to verify idempotency
+    const result2 = await format("a.vue", result.code);
+
+    expect(result.code).toContain("First paragraph.\n\n\n  Second paragraph after two blanks.");
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+    expect(result2.code).toBe(result.code);
+    expect(result2.errors).toStrictEqual([]);
+  });
 });

--- a/crates/oxc_data_structures/src/code_buffer.rs
+++ b/crates/oxc_data_structures/src/code_buffer.rs
@@ -673,17 +673,6 @@ impl CodeBuffer {
         unsafe { self.buf.set_len(len + bytes) };
     }
 
-    /// Remove trailing whitespace (spaces and tabs) from the buffer.
-    ///
-    /// This trims trailing whitespace before line breaks, matching Prettier's `trimEnd(out)` behavior.
-    /// <https://github.com/prettier/prettier/blob/90983f40dce5e20beea4e5618b5e0426a6a7f4f0/src/document/printer/printer.js#L535>
-    #[inline]
-    pub fn trim_trailing_ascii_whitespace(&mut self) {
-        while self.buf.last().is_some_and(|&b| b == b' ' || b == b'\t') {
-            self.buf.pop();
-        }
-    }
-
     /// Get contents of buffer as a byte slice.
     ///
     /// # Example

--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -17,14 +17,18 @@ Formatting is two stages:
 Key IR pieces are all exported from the crate root.
 
 The semantics of each building block live in the `builders.rs` rustdocs.
-e.g. the three mechanisms for verbatim multi-line content
-(`literal_line_break()`, multiline `text()`, `text(..).without_expand_parent()`, and `mark_as_root` / `dedent_to_root`),
-with the non-obvious behaviors pinned by printer tests verified against Prettier's `printDocToString`.
+e.g. the mechanisms for verbatim multi-line content (`exact_line_breaks()` for blank runs exempt from newline collapsing, `literal_line_break()`, multiline `text()`, `text(..).without_expand_parent()`, and `mark_as_root` / `dedent_to_root`), with the non-obvious behaviors pinned by printer tests verified against Prettier's `printDocToString`.
 
 Prettier doc primitives are ported on demand; still missing:
 
 - `hardlineWithoutBreakParent` (markdown tables)
 - and the `trim` doc
+
+### The printer never trims
+
+Unlike Prettier's `printDocToString`, this printer emits exactly what was written:
+end-of-line whitespace never appearing in the output is guaranteed by construction (pending space/indention, no indention on blank lines), not by a trimming pass.
+Text/Token content is the emitter's responsibility, language crates write their values pre-trimmed.
 
 ### Choosing a staging buffer
 

--- a/crates/oxc_formatter_core/src/builders.rs
+++ b/crates/oxc_formatter_core/src/builders.rs
@@ -52,22 +52,51 @@ pub const fn soft_line_break_or_space() -> Line {
     Line::new(LineMode::SoftOrSpace)
 }
 
+/// Exactly `count` line breaks (`count >= 1`), exempt from the printer's newline collapsing.
+///
+/// For blank runs inside verbatim values (block scalars, block strings),
+/// where the number of line breaks IS the value and must not be normalized.
+/// From a mid-line position the first break ends the current line, leaving `count - 1` blank lines;
+/// from the start of a line all `count` breaks become blank lines.
+///
+/// Unlike [hard_line_break]:
+/// - the breaks always print, regardless of the current line or a preceding blank line
+/// - consecutive calls accumulate, nothing is collapsed or capped
+///
+/// The blank lines themselves carry no indention;
+/// the NEXT line starts at the current indention (same re-arming as [hard_line_break]).
+///
+/// # Panics
+/// When `count == 0` or `count > u32::MAX`.
+/// Both are unreachable from source-derived callers: a source of N bytes cannot hold more than N line breaks,
+/// and sources are capped at `u32::MAX` by `oxc_span::Span`.
+#[inline]
+pub fn exact_line_breaks(count: usize) -> Line {
+    let count = u32::try_from(count).expect("line break count must fit in u32");
+    let count = std::num::NonZeroU32::new(count).expect("line break count must be >= 1");
+    Line::new(LineMode::ExactLineBreaks(count))
+}
+
 /// A forced line break that starts the next line at the marked root indention (Prettier's `literalline`).
 ///
 /// Unlike [hard_line_break]:
-/// - trailing whitespace on the current line is preserved (never trimmed)
+/// - pending whitespace on the current line materializes as-is (never dropped)
 /// - the newline always prints, even on an empty line
 /// - the next line starts at the [mark_as_root] indention (column 0 when unmarked)
 ///   instead of the current indention
 ///
-/// Used for verbatim multi-line content whose line structure is built element by element
-/// (e.g. YAML block scalars). For verbatim content held as ONE string,
+/// Used for verbatim multi-line content whose line structure is built element by element (e.g. YAML block scalars).
+/// For verbatim content held as ONE string,
 /// a multiline [text] already prints its embedded newlines with these semantics.
 ///
 /// Known divergence from Prettier:
-/// a [hard_line_break] directly after a COLUMN-0 literal line is absorbed
-/// by the printer's "only print a newline if the line isn't already empty" rule (Prettier prints both newlines).
-/// Use [empty_line] when the extra structural newline is required, it prints exactly one newline in this state.
+/// a [hard_line_break] directly after a literal line is absorbed by
+/// the printer's "only print a newline if the line isn't already empty" rule
+/// (the root indention stays pending until content claims it, so the line counts as empty;
+/// Prettier writes the indention eagerly and prints both newlines, relying on its end-of-line trimming,
+/// which this printer does not have — to drop the indention again).
+/// Use [empty_line] when the extra structural newline is required (it prints exactly one newline in this state),
+/// or [exact_line_breaks] for a precise verbatim run.
 #[inline]
 pub const fn literal_line_break() -> Line {
     Line::new(LineMode::Literal)

--- a/crates/oxc_formatter_core/src/format_element/debug.rs
+++ b/crates/oxc_formatter_core/src/format_element/debug.rs
@@ -170,6 +170,15 @@ where
                     LineMode::Empty => {
                         w!(f, [token("empty_line")]);
                     }
+                    LineMode::ExactLineBreaks(count) => {
+                        w!(
+                            f,
+                            [text(
+                                f.allocator()
+                                    .alloc_str(&std::format!("exact_line_breaks({count})"))
+                            )]
+                        );
+                    }
                     LineMode::Literal => {
                         w!(f, [token("literal_line_break")]);
                     }

--- a/crates/oxc_formatter_core/src/format_element/mod.rs
+++ b/crates/oxc_formatter_core/src/format_element/mod.rs
@@ -118,6 +118,8 @@ pub enum LineMode {
     Hard,
     /// See [crate::builders::empty_line] for documentation.
     Empty,
+    /// See [crate::builders::exact_line_breaks] for documentation.
+    ExactLineBreaks(std::num::NonZeroU32),
     /// See [crate::builders::literal_line_break] for documentation.
     Literal,
 }
@@ -128,7 +130,10 @@ impl LineMode {
     }
 
     pub const fn will_break(self) -> bool {
-        matches!(self, LineMode::Hard | LineMode::Empty | LineMode::Literal)
+        matches!(
+            self,
+            LineMode::Hard | LineMode::Empty | LineMode::ExactLineBreaks(_) | LineMode::Literal
+        )
     }
 }
 

--- a/crates/oxc_formatter_core/src/printer/mod.rs
+++ b/crates/oxc_formatter_core/src/printer/mod.rs
@@ -164,7 +164,10 @@ impl<'a> Printer<'a> {
                             }
                             return Ok(());
                         }
-                        LineMode::Hard | LineMode::Empty | LineMode::Literal => {
+                        LineMode::Hard
+                        | LineMode::Empty
+                        | LineMode::ExactLineBreaks(_)
+                        | LineMode::Literal => {
                             self.state.measured_group_fits = false;
                         }
                     }
@@ -175,23 +178,44 @@ impl<'a> Printer<'a> {
                     return Ok(());
                 }
 
+                if let LineMode::ExactLineBreaks(count) = line_mode {
+                    // Exactly `count` breaks, exempt from the collapsing and capping below (see `exact_line_breaks`).
+                    // From mid-line the first break ends the current line;
+                    // the rest (all of them from the start of a line) are blank lines, which carry no indention of their own.
+                    let count = count.get();
+                    // A blank line is left behind from the start of a line always,
+                    // mid-line only when a break remains after the line-ending one.
+                    let leaves_blank = count > 1 || self.state.line_width == 0;
+                    for _ in 0..count {
+                        self.print_char('\n');
+                    }
+                    self.state.has_empty_line = leaves_blank;
+                    self.state.pending_space = false;
+                    self.state.pending_indent = indent_stack.indention();
+                    return Ok(());
+                }
+
                 if line_mode == &LineMode::Literal {
                     // Prettier's literal line (`doc.literal` in `printDocToString`):
                     // pending indention/space materialize as-is (a literal line never trims),
-                    // the newline always prints (even on an empty line),
-                    // and the next line starts at the marked root indention,
-                    // written eagerly (Prettier writes `indent.root.value` together with the newline)
-                    // so that a following hard line still sees a non-empty line to trim and break.
+                    // the newline always prints (even on an empty line), and the next line starts at the marked root indention.
+                    // The root indention stays PENDING.
+                    // (Prettier writes it eagerly and relies on its end-of-line trimming to drop it again
+                    // when a line break follows; this printer never trims, so it must not write indention that no content claims.
+                    // See the [literal_line_break] divergence note)
                     self.flush_pending_indention_and_space();
                     self.print_char('\n');
-                    self.print_indention(indent_stack.root());
+                    self.state.pending_indent = indent_stack.root();
                     self.state.has_empty_line = false;
                     return Ok(());
                 }
 
-                // Only print a newline if the current line isn't already empty
+                // Only print a newline if the current line isn't already empty.
+                //
+                // NOTE: no end-of-line trimming happens here (unlike Prettier's `printDocToString`):
+                // the pending space/indent mechanisms never materialize at a line end,
+                // and Text/Token content is the emitter's responsibility to keep trimmed.
                 if self.state.line_width > 0 {
-                    self.state.buffer.trim_trailing_ascii_whitespace();
                     self.print_char('\n');
                     self.state.has_empty_line = false;
                 }
@@ -1097,7 +1121,10 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                             self.state.pending_space = true;
                         }
                         LineMode::Soft => {}
-                        LineMode::Hard | LineMode::Empty | LineMode::Literal => {
+                        LineMode::Hard
+                        | LineMode::Empty
+                        | LineMode::ExactLineBreaks(_)
+                        | LineMode::Literal => {
                             // Even in flat mode, content that _directly_ contains a hard or empty
                             // line is considered to fit when a hard break is reached, since that
                             // break is always going to exist, regardless of the print mode.
@@ -1458,10 +1485,10 @@ mod tests {
         Argument, Arguments, Buffer, Document, Format, FormatState, IndentStyle, LineEnding,
         Printed, Printer, PrinterOptions, SimpleFormatContext, VecBuffer,
         builders::{
-            align, block_indent, dedent_to_root, empty_line, group, hard_line_break,
-            if_group_breaks, if_group_fits_on_line, indent, line_suffix, literal_line_break,
-            mark_as_root, soft_block_indent, soft_line_break, soft_line_break_or_space, space,
-            text, token,
+            align, block_indent, dedent_to_root, empty_line, exact_line_breaks, group,
+            hard_line_break, if_group_breaks, if_group_fits_on_line, indent, line_suffix,
+            literal_line_break, mark_as_root, soft_block_indent, soft_line_break,
+            soft_line_break_or_space, space, text, token,
         },
         format_args,
         printer::PrintWidth,
@@ -1504,6 +1531,125 @@ mod tests {
         let document = Document::new(elements, Vec::default());
         document.propagate_expand();
         Printer::new(options, &[]).print(document.elements()).expect("Document to be valid")
+    }
+
+    #[test]
+    fn exact_line_breaks_are_never_collapsed() {
+        let allocator = Allocator::default();
+        // Mid-line: the first break ends the line, the rest are blank lines
+        let formatted =
+            format_simple(&allocator, &format_args!(token("a"), exact_line_breaks(3), token("b")));
+        assert_eq!("a\n\n\nb", formatted.as_code());
+    }
+
+    #[test]
+    fn exact_line_breaks_print_from_the_start_of_a_line() {
+        let allocator = Allocator::default();
+        // From the start of a line every break becomes a blank line
+        // (a hard_line_break would print nothing in this state).
+        let formatted = format_simple(
+            &allocator,
+            &format_args!(token("a"), hard_line_break(), exact_line_breaks(1), token("b")),
+        );
+        assert_eq!("a\n\nb", formatted.as_code());
+    }
+
+    #[test]
+    fn consecutive_exact_line_breaks_accumulate() {
+        let allocator = Allocator::default();
+        let formatted = format_simple(
+            &allocator,
+            &format_args!(token("a"), exact_line_breaks(2), exact_line_breaks(2), token("b")),
+        );
+        // 2 breaks (line ending + 1 blank), then 2 more blanks.
+        assert_eq!("a\n\n\n\nb", formatted.as_code());
+    }
+
+    #[test]
+    fn exact_line_breaks_clear_the_pending_space() {
+        let allocator = Allocator::default();
+        let formatted = format_simple(
+            &allocator,
+            &format_args!(token("a"), space(), exact_line_breaks(1), token("b")),
+        );
+        assert_eq!("a\nb", formatted.as_code());
+    }
+
+    #[test]
+    fn empty_line_after_mid_line_single_exact_break_adds_a_blank() {
+        let allocator = Allocator::default();
+        // Mid-line count=1 leaves no blank behind: the empty_line may still add one.
+        let formatted = format_simple(
+            &allocator,
+            &format_args!(token("a"), exact_line_breaks(1), empty_line(), token("b")),
+        );
+        assert_eq!("a\n\nb", formatted.as_code());
+    }
+
+    #[test]
+    fn empty_line_after_blank_leaving_exact_breaks_is_capped() {
+        let allocator = Allocator::default();
+        // Mid-line count=2 leaves a blank: the empty_line is capped.
+        let formatted = format_simple(
+            &allocator,
+            &format_args!(token("a"), exact_line_breaks(2), empty_line(), token("b")),
+        );
+        assert_eq!("a\n\nb", formatted.as_code());
+
+        // From the start of a line even count=1 leaves a blank
+        // (no break is consumed as a line ending), so the empty_line is capped too.
+        let formatted = format_simple(
+            &allocator,
+            &format_args!(
+                token("a"),
+                hard_line_break(),
+                exact_line_breaks(1),
+                empty_line(),
+                token("b")
+            ),
+        );
+        assert_eq!("a\n\nb", formatted.as_code());
+    }
+
+    #[test]
+    fn exact_line_breaks_flush_pending_line_suffixes() {
+        let allocator = Allocator::default();
+        // The YAML shape `key: | # comment` + a blank-run block scalar: the pending
+        // line suffix must flush onto the current line, not leak past the breaks.
+        let formatted = format_simple(
+            &allocator,
+            &format_args!(
+                token("a"),
+                line_suffix(&format_args!(space(), token("# c"))),
+                exact_line_breaks(2),
+                token("b")
+            ),
+        );
+        assert_eq!("a # c\n\nb", formatted.as_code());
+    }
+
+    #[test]
+    fn hard_line_break_after_exact_line_breaks_is_absorbed() {
+        let allocator = Allocator::default();
+        let formatted = format_simple(
+            &allocator,
+            &format_args!(token("a"), exact_line_breaks(2), hard_line_break(), token("b")),
+        );
+        assert_eq!("a\n\nb", formatted.as_code());
+    }
+
+    #[test]
+    fn exact_line_breaks_blank_lines_carry_no_indention() {
+        let allocator = Allocator::default();
+        let formatted = format_simple(
+            &allocator,
+            &format_args!(
+                token("a"),
+                block_indent(&format_args!(token("b"), exact_line_breaks(2), token("c"))),
+                token("d")
+            ),
+        );
+        assert_eq!("a\n  b\n\n  c\nd", formatted.as_code());
     }
 
     #[test]
@@ -1680,9 +1826,10 @@ a",
 
     /// Composes the document shape of Prettier's YAML block scalar printing
     /// (`language-yaml/print/block.js`): content indented via `align`,
-    /// line boundaries as `mark_as_root(&literal_line_break())` so continuation lines
-    /// keep the block's base indention, an empty content line as a hard line,
-    /// and the keep-chomping (`|+`) trailing newline as `dedent_to_root(&literal_line_break())`.
+    /// non-blank line boundaries as `mark_as_root(&literal_line_break())`,
+    /// so continuation lines keep the block's base indention,
+    /// blank runs as `exact_line_breaks` (no indention on the blank line),
+    /// and the keep-chomping (`|+`) trailing newline as raw verbatim text.
     #[test]
     fn yaml_block_scalar_shaped_document() {
         let allocator = Allocator::default();
@@ -1695,10 +1842,9 @@ a",
                     &format_args!(
                         hard_line_break(),
                         token("hello world"),
-                        mark_as_root(&literal_line_break()),
-                        hard_line_break(),
+                        exact_line_breaks(2),
                         token("next"),
-                        dedent_to_root(&literal_line_break())
+                        dedent_to_root(&text("\n"))
                     )
                 )
             ),

--- a/crates/oxc_formatter_graphql/AGENTS.md
+++ b/crates/oxc_formatter_graphql/AGENTS.md
@@ -63,8 +63,7 @@ Prettier prints `StringValue` from `graphql-js`'s _cooked_ value and re-encodes 
 - escape decoding for regular strings (incl. surrogate pairs)
 - Prettier's re-encoding (`"`/`\` escaped, newline as `\n`, `"""` as `\"""`)
 
-Blank-line runs inside block strings are part of the string VALUE;
-the printer collapses consecutive line breaks, so they are emitted as raw `\n` text plus a `hard_line_break()` that only re-arms indentation (see `write_block_string_break`).
+Blank-line runs inside block strings are part of the string VALUE and are emitted with `exact_line_breaks()`. Values are written pre-trimmed, the core printer never trims.
 
 ### Notable layout rules
 

--- a/crates/oxc_formatter_graphql/src/print/string.rs
+++ b/crates/oxc_formatter_graphql/src/print/string.rs
@@ -12,7 +12,7 @@ use cow_utils::CowUtils;
 
 use oxc_formatter_core::{
     Buffer,
-    builders::{hard_line_break, text},
+    builders::{exact_line_breaks, hard_line_break, text},
     write,
 };
 use oxc_graphql_parser::ast::StringValue;
@@ -38,12 +38,8 @@ fn write_block_string(body: &str, f: &mut GraphqlFormatter<'_, '_>) {
     let unescaped = body.cow_replace("\\\"\"\"", "\"\"\"");
     let cooked_lines = cook_block_string_lines(&unescaped);
 
-    // Prettier: re-escape, then `lines.length === 1` → trim,
-    // all-blank → drop everything.
-    // Trailing spaces/tabs are trimmed per line: Prettier's doc printer trims
-    // them at every hardline. The core printer does the same, but a line
-    // followed by a blank-line run gets its break from raw `\n` text (see
-    // `write_block_string_break`), which bypasses that trim — so trim here.
+    // Prettier: re-escape, then `lines.length === 1` → trim, all-blank → drop everything.
+    // Trailing spaces/tabs are trimmed per line.
     let mut lines: Vec<String> = cooked_lines
         .iter()
         .map(|l| l.trim_end_matches([' ', '\t']).cow_replace("\"\"\"", "\\\"\"\"").into_owned())
@@ -56,12 +52,9 @@ fn write_block_string(body: &str, f: &mut GraphqlFormatter<'_, '_>) {
     }
 
     write!(f, "\"\"\"");
-    // Join with line breaks, preserving runs of blank lines exactly.
-    // Consecutive `hard_line_break()`s collapse in the printer (and `empty_line()` caps
-    // at one blank), but blank lines inside a block string are part of its VALUE.
-    // So a run of `k` blank lines is emitted as `k + 1` raw newlines in a `text()`,
-    // followed by a `hard_line_break()` that prints nothing (the line is already empty)
-    // but re-arms the pending indent for the next line.
+    // Join with line breaks, preserving runs of blank lines exactly:
+    // blank lines inside a block string are part of its VALUE,
+    // so a run of `k` blank lines is emitted as `exact_line_breaks(k + 1)`.
     let mut pending_blanks = 0usize;
     for line in &lines {
         if line.is_empty() {
@@ -80,8 +73,7 @@ fn write_block_string_break(blank_lines: usize, f: &mut GraphqlFormatter<'_, '_>
     if blank_lines == 0 {
         write!(f, hard_line_break());
     } else {
-        write!(f, text(f.allocator().alloc_str(&"\n".repeat(blank_lines + 1))));
-        write!(f, hard_line_break());
+        write!(f, exact_line_breaks(blank_lines + 1));
     }
 }
 

--- a/crates/oxc_formatter_yaml/src/comments.rs
+++ b/crates/oxc_formatter_yaml/src/comments.rs
@@ -58,21 +58,17 @@ impl<'a> Comments<'a> {
         self.inner[start..].iter().copied().take_while(move |c| c.end <= upper_bound)
     }
 
-    /// The end of the most recently consumed comment (`None` before any).
-    pub fn last_consumed_end(&self) -> Option<u32> {
-        self.cursor.get().checked_sub(1).map(|i| self.inner[i].end)
+    /// `anchor`, moved past the most recently consumed comment when that lies beyond it.
+    ///
+    /// A nested container's end-comment flush consumes comments PAST the outer caller's anchor
+    /// (a deeper-indented run belongs to the inner container),
+    /// reproducing the vertical spacing in front of them as it prints.
+    /// Gap measurement resuming from the unmoved anchor would observe that same spacing again
+    /// and emit a second blank line.
+    pub fn gap_anchor_after_consumed(&self, anchor: u32) -> u32 {
+        let last_consumed_end = self.cursor.get().checked_sub(1).map(|i| self.inner[i].end);
+        last_consumed_end.map_or(anchor, |end| anchor.max(end))
     }
-}
-
-/// `anchor`, moved past the most recently printed comment when that lies beyond it.
-///
-/// A nested container's end-comment flush consumes comments PAST the outer
-/// caller's anchor (a deeper-indented run belongs to the inner container),
-/// reproducing the vertical spacing in front of them as it prints.
-/// Gap measurement resuming from the unmoved anchor would observe that
-/// same spacing again and emit a second blank line.
-pub fn gap_anchor_after_consumed(anchor: u32, f: &YamlFormatter<'_, '_>) -> u32 {
-    f.context().comments().last_consumed_end().map_or(anchor, |end| anchor.max(end))
 }
 
 /// Vertical spacing implied by an inter-token source gap.
@@ -162,7 +158,7 @@ pub fn write_blank_preserving_break(
     upper_bound: u32,
     f: &mut YamlFormatter<'_, '_>,
 ) {
-    let prev_end = gap_anchor_after_consumed(prev_end, f);
+    let prev_end = f.context().comments().gap_anchor_after_consumed(prev_end);
     if prev_end < upper_bound
         && classify_gap(f.context().source_text().bytes_range(prev_end, upper_bound)) == Gap::Blank
     {
@@ -206,6 +202,27 @@ pub fn flush_leading_comments(value_start: u32, f: &mut YamlFormatter<'_, '_>) {
     write_leading_comments(leading, value_start, f);
 }
 
+/// The next pending comment when it sits on the same line after `pos`
+/// (nothing but spaces/tabs between), without consuming it.
+pub fn pending_same_line_comment(pos: u32, f: &YamlFormatter<'_, '_>) -> Option<Span> {
+    pending_same_line_comment_over(pos, &[], f)
+}
+
+/// [pending_same_line_comment], additionally allowing the caller's
+/// `gap_punctuation` bytes in the gap (see [write_trailing_same_line_comment]).
+fn pending_same_line_comment_over(
+    pos: u32,
+    gap_punctuation: &[u8],
+    f: &YamlFormatter<'_, '_>,
+) -> Option<Span> {
+    f.context().comments().peek().filter(|span| {
+        span.start >= pos
+            && f.context().source_text().all_bytes_match(pos, span.start, |b| {
+                matches!(b, b' ' | b'\t') || gap_punctuation.contains(&b)
+            })
+    })
+}
+
 /// If the next pending comment sits on the same line as `prev_end`,
 /// drain it and emit it as a trailing line-suffix comment (` # ...`).
 /// `expand_parent()` keeps the enclosing container multi-line.
@@ -220,15 +237,7 @@ pub fn write_trailing_same_line_comment<'a>(
     gap_punctuation: &[u8],
     f: &mut YamlFormatter<'_, 'a>,
 ) {
-    let Some(span) = f.context().comments().peek() else { return };
-    let source = f.context().source_text();
-    if span.start < prev_end
-        || !source.all_bytes_match(prev_end, span.start, |b| {
-            matches!(b, b' ' | b'\t') || gap_punctuation.contains(&b)
-        })
-    {
-        return;
-    }
+    let Some(span) = pending_same_line_comment_over(prev_end, gap_punctuation, f) else { return };
     f.context().comments().take_before(span.end);
     let content = format_with(move |f: &mut YamlFormatter<'_, 'a>| {
         write!(f, space());
@@ -310,7 +319,7 @@ pub fn flush_container_end_comments(
 ) -> u32 {
     let source = f.context().source_text();
     let tab_width = f.options().indent_width.value();
-    let mut prev_end = gap_anchor_after_consumed(prev_end, f);
+    let mut prev_end = f.context().comments().gap_anchor_after_consumed(prev_end);
     loop {
         let Some(span) = f.context().comments().peek() else { return prev_end };
         if span.end > upper_bound

--- a/crates/oxc_formatter_yaml/src/print/block.rs
+++ b/crates/oxc_formatter_yaml/src/print/block.rs
@@ -3,8 +3,8 @@ use std::borrow::Cow;
 use oxc_formatter_core::{
     Buffer,
     builders::{
-        align, dedent, dedent_to_root, hard_line_break, literal_line_break, mark_as_root,
-        soft_line_break_or_space, space, text,
+        align, dedent, dedent_to_root, exact_line_breaks, hard_line_break, literal_line_break,
+        mark_as_root, soft_line_break_or_space, space, text,
     },
     write,
 };
@@ -13,8 +13,24 @@ use oxc_yaml_parser::ast::{BlockScalar, Chomping, Content, MappingItem, Node, Ro
 use crate::{
     comments::{Gap, classify_gap, write_single_comment},
     options::ProseWrap,
-    print::{YamlFormatter, format_with, scalar::split_with_single_space, to_span},
+    print::{
+        YamlFormatter, format_with,
+        scalar::{join_lines_for_never_wrap, split_with_single_space},
+        to_span,
+    },
 };
+
+/// A run of `count` newlines with the arena lifetime, for the keep-chomping tail.
+/// Small runs (the overwhelming case) slice a static string,
+/// instead of building a `String` and copying it into the arena.
+fn arena_newlines<'a>(count: usize, f: &YamlFormatter<'_, 'a>) -> &'a str {
+    const NEWLINES: &str = "\n\n\n\n\n\n\n\n";
+    if count <= NEWLINES.len() {
+        &NEWLINES[..count]
+    } else {
+        f.allocator().alloc_str(&"\n".repeat(count))
+    }
+}
 
 /// How many of a block scalar's trailing source newlines its own OUTPUT consumes
 /// (the effect of [`remove_unnecessary_trailing_newlines`]):
@@ -94,9 +110,7 @@ pub fn write_block_scalar<'a>(
             })
             .collect();
 
-    // Blank runs are emitted as raw `\n` text followed by a hardline that only re-arms indentation
-    // (consecutive hard lines would otherwise be collapsed by the printer,
-    // same technique as `oxc_formatter_graphql`'s `write_block_string_break`).
+    // Blank runs are the scalar's VALUE
     let chomping_keep = block.chomping == Chomping::Keep;
     let contents = format_with(move |f: &mut YamlFormatter<'_, 'a>| {
         let mut blanks = 0usize;
@@ -109,8 +123,7 @@ pub fn write_block_scalar<'a>(
             if blanks > 0 {
                 // One newline entering this segment
                 // (after the header for the first, the separator otherwise) + one per blank line.
-                write!(f, text(crate::print::arena_newlines(blanks + 1, f)));
-                write!(f, hard_line_break());
+                write!(f, exact_line_breaks(blanks + 1));
             } else if wrote_any {
                 write!(f, mark_as_root(&literal_line_break()));
             } else {
@@ -124,11 +137,18 @@ pub fn write_block_scalar<'a>(
             }
             fill.finish();
         }
-        // Trailing blank lines (kept by chomping / blank-line preservation),
-        // plus the final newline for a keep-chomped last descendant.
-        // The extra `\n` also covers the following hardline being collapsed.
-        if blanks > 0 || (chomping_keep && is_last_descendant && wrote_any) {
-            write!(f, dedent_to_root(&text(crate::print::arena_newlines(blanks + 1, f))));
+        if chomping_keep {
+            // Keep chomping: the trailing newlines are the VALUE
+            // (plus the final newline for a last descendant, which `FormatYamlRoot` skips after a keep tail).
+            // Raw text keeps them exempt from EVERY layout normalization,
+            // including the state effects a line element would have on the following separator.
+            // NOT `exact_line_breaks`: the tail may hold space-only lines, which are part of the value too.
+            if blanks > 0 || (is_last_descendant && wrote_any) {
+                write!(f, dedent_to_root(&text(arena_newlines(blanks + 1, f))));
+            }
+        } else if blanks > 0 {
+            // The trailing blank preserved by blank-line preservation
+            write!(f, exact_line_breaks(blanks + 1));
         }
     });
 
@@ -196,22 +216,22 @@ fn block_value_line_contents<'s>(
     let mut lines = remove_unnecessary_trailing_newlines(block, content, is_last_descendant, lines);
     // Trailing spaces on the LAST content line are dropped (Prettier does the same);
     // intermediate lines keep theirs, they are part of the value under every chomping mode.
-    // The printer's own end-of-line trimming only covers the no-trailing-blank case:
-    // a kept trailing blank run is emitted as raw `\n` text, which does not trim what precedes it.
+    // The core printer never trims, so drop them here.
     if block.chomping != Chomping::Keep {
         trim_trailing_spaces_of_last_content_line(&mut lines);
     }
     lines
 }
 
+/// A block-scalar line with no non-whitespace content (no words, or spaces/tabs only).
+fn is_blank_line(words: &[Cow<'_, str>]) -> bool {
+    words.iter().all(|w| w.trim_end_matches([' ', '\t']).is_empty())
+}
+
 /// Trims the trailing spaces/tabs of the last line holding non-whitespace content.
 /// Whitespace-only lines after it (a preserved trailing blank) are left as-is.
 fn trim_trailing_spaces_of_last_content_line(lines: &mut [Vec<Cow<'_, str>>]) {
-    let Some(words) = lines
-        .iter_mut()
-        .rev()
-        .find(|words| words.iter().any(|w| !w.trim_end_matches([' ', '\t']).is_empty()))
-    else {
+    let Some(words) = lines.iter_mut().rev().find(|words| !is_blank_line(words)) else {
         return;
     };
     if let Some(last) = words.last_mut() {
@@ -273,7 +293,7 @@ fn fold_lines<'s>(stripped: &[&'s str], prose_wrap: ProseWrap) -> Vec<Vec<Cow<'s
         .collect();
 
     if prose_wrap == ProseWrap::Never {
-        merged = merged.into_iter().map(|words| vec![Cow::Owned(words.join(" "))]).collect();
+        merged = join_lines_for_never_wrap(merged);
     }
     merged
 }
@@ -292,11 +312,8 @@ fn remove_unnecessary_trailing_newlines<'s>(
         return lines;
     }
 
-    let trailing_newline_count = lines
-        .iter()
-        .rev()
-        .take_while(|words| words.iter().all(|w| w.trim_end_matches([' ', '\t']).is_empty()))
-        .count();
+    let trailing_newline_count =
+        lines.iter().rev().take_while(|words| is_blank_line(words)).count();
 
     if trailing_newline_count == 0 {
         return lines;

--- a/crates/oxc_formatter_yaml/src/print/block_collection.rs
+++ b/crates/oxc_formatter_yaml/src/print/block_collection.rs
@@ -8,8 +8,8 @@ use oxc_yaml_parser::ast::{Mapping, Sequence};
 use crate::{
     comments::{
         flush_container_end_comments, flush_leading_comments, gap_upper_bound,
-        is_suppressed_last_before, write_blank_preserving_break, write_suppressed_node,
-        write_trailing_same_line_comment,
+        is_suppressed_last_before, pending_same_line_comment, write_blank_preserving_break,
+        write_suppressed_node, write_trailing_same_line_comment,
     },
     print::{
         YamlFormatter,
@@ -122,7 +122,15 @@ pub fn write_sequence<'a>(sequence: &'a Sequence<'a>, f: &mut YamlFormatter<'_, 
             continue;
         }
         flush_leading_comments(item.span.start, f);
-        write!(f, "- ");
+        // The content-area space stays when something follows it:
+        // the content, or a same-line comment
+        // (whose own line-suffix space makes it `-  # c`, two spaces, Prettier's shape).
+        // For a bare null item don't leave it at the line end.
+        if item.content.is_some() || pending_same_line_comment(item.span.end, f).is_some() {
+            write!(f, "- ");
+        } else {
+            write!(f, "-");
+        }
         if let Some(node) = &item.content {
             write!(f, align(2, &format_with(|f| write_node(node, f))));
         }

--- a/crates/oxc_formatter_yaml/src/print/document.rs
+++ b/crates/oxc_formatter_yaml/src/print/document.rs
@@ -7,9 +7,9 @@ use oxc_yaml_parser::ast::{Directive, Document, Root};
 
 use crate::{
     comments::{
-        Gap, classify_gap, flush_leading_comments, gap_anchor_after_consumed, gap_upper_bound,
-        is_suppressed_last_before, write_blank_preserving_break, write_single_comment,
-        write_suppressed_node, write_trailing_same_line_comment,
+        Gap, classify_gap, flush_leading_comments, gap_upper_bound, is_suppressed_last_before,
+        write_blank_preserving_break, write_single_comment, write_suppressed_node,
+        write_trailing_same_line_comment,
     },
     print::{
         YamlFormatter,
@@ -66,7 +66,7 @@ pub fn write_root<'a>(root: &'a Root<'a>, f: &mut YamlFormatter<'_, 'a>) -> bool
 /// Must be taken BEFORE the end comments themselves are drained,
 /// that take advances the consumed cursor past them, corrupting the clamp.
 fn document_end_comment_anchor(document: &Document<'_>, f: &YamlFormatter<'_, '_>) -> u32 {
-    gap_anchor_after_consumed(document_gap_anchor(document, f), f)
+    f.context().comments().gap_anchor_after_consumed(document_gap_anchor(document, f))
 }
 
 /// The gap-measurement anchor after a document: its `...` marker,

--- a/crates/oxc_formatter_yaml/src/print/mapping_item.rs
+++ b/crates/oxc_formatter_yaml/src/print/mapping_item.rs
@@ -7,8 +7,8 @@ use oxc_yaml_parser::ast::{Content, MappingItem, Node};
 
 use crate::{
     comments::{
-        Gap, classify_gap, flush_leading_comments, is_own_line, write_single_comment,
-        write_trailing_same_line_comment,
+        Gap, classify_gap, flush_leading_comments, is_own_line, pending_same_line_comment,
+        write_single_comment, write_trailing_same_line_comment,
     },
     options::ProseWrap,
     print::{YamlFormatter, column_of, format_with, to_span, write_node, write_node_or_suppressed},
@@ -40,15 +40,18 @@ pub fn write_mapping_item<'a>(
     let is_empty_value = value_content.is_none();
 
     if is_empty_key && is_empty_value {
-        write!(f, ": ");
-        // A same-line comment follows WITHOUT another space (`: # c`):
-        // Prettier suppresses the line-suffix space for an empty mappingValue.
-        if let Some(span) = f.context().comments().peek()
-            && span.start >= item.span.end
-            && f.context()
-                .source_text()
-                .all_bytes_match(item.span.end, span.start, |b| matches!(b, b' ' | b'\t'))
-        {
+        // The `: `'s own space is the separation for what follows:
+        // a same-line comment
+        // (`: # c`, Prettier suppresses the line-suffix space for an empty mappingValue)
+        // or the rest of a flow collection (`{ : }`).
+        // In a block mapping with no comment nothing follows, don't leave it at the line end.
+        let same_line_comment = pending_same_line_comment(item.span.end, f);
+        if in_flow != FlowParent::No || same_line_comment.is_some() {
+            write!(f, ": ");
+        } else {
+            write!(f, ":");
+        }
+        if let Some(span) = same_line_comment {
             f.context().comments().take_before(span.end);
             let comment = format_with(move |f: &mut YamlFormatter<'_, 'a>| {
                 write_single_comment(span, f);
@@ -72,12 +75,7 @@ pub fn write_mapping_item<'a>(
         // with no `:`, a same-line comment (`? key # c`, whitespace-only gap) attaches to the key content and keeps the explicit form.
         // After `key:` the gap contains the `:`, the comment belongs to the value side, and the implicit form stays
         // (the caller emits it as a line suffix).
-        let key_content_trailing_comment = f.context().comments().peek().is_some_and(|span| {
-            span.start >= key_end
-                && f.context()
-                    .source_text()
-                    .all_bytes_match(key_end, span.start, |b| matches!(b, b' ' | b'\t'))
-        });
+        let key_content_trailing_comment = pending_same_line_comment(key_end, f).is_some();
         if in_flow == FlowParent::No
             && is_absolutely_single_line(key_content, f)
             && !parent_tag_is_set

--- a/crates/oxc_formatter_yaml/src/print/mod.rs
+++ b/crates/oxc_formatter_yaml/src/print/mod.rs
@@ -55,18 +55,6 @@ pub fn column_of(source: &str, offset: u32) -> u32 {
     u32::try_from(count).unwrap_or(u32::MAX)
 }
 
-/// A run of `count` newlines with the arena lifetime.
-/// Small runs (the overwhelming case: blank-line counts) slice a static string
-/// instead of building a `String` and copying it into the arena.
-pub fn arena_newlines<'a>(count: usize, f: &YamlFormatter<'_, 'a>) -> &'a str {
-    const NEWLINES: &str = "\n\n\n\n\n\n\n\n";
-    if count <= NEWLINES.len() {
-        &NEWLINES[..count]
-    } else {
-        f.allocator().alloc_str(&"\n".repeat(count))
-    }
-}
-
 /// Emits a node's properties (anchor/tag) in their source order.
 /// NOTE: Prettier 3.9.5 normalizes to `tag anchor` order; we keep the source order instead.
 ///

--- a/crates/oxc_formatter_yaml/src/print/scalar.rs
+++ b/crates/oxc_formatter_yaml/src/print/scalar.rs
@@ -4,15 +4,12 @@ use cow_utils::CowUtils;
 
 use oxc_formatter_core::{
     Buffer, arena_cow_str,
-    builders::{hard_line_break, soft_line_break_or_space, text},
+    builders::{exact_line_breaks, hard_line_break, soft_line_break_or_space, text},
     write,
 };
 use oxc_span::Span;
 
-use crate::{
-    options::ProseWrap,
-    print::{YamlFormatter, arena_newlines},
-};
+use crate::{options::ProseWrap, print::YamlFormatter};
 
 /// Which flow scalar shape is being folded (affects word-merge rules and quoting).
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -90,10 +87,6 @@ pub fn write_quoted(kind: FlowScalarKind, span: Span, f: &mut YamlFormatter<'_, 
 
 /// Prettier's `printFlowScalarContent`:
 /// each reflow group becomes a `fill(join(line, words))`, groups joined by hardlines.
-///
-/// Empty groups (blank lines) are emitted as raw `\n` text,
-/// so consecutive breaks survive the printer's newline collapsing (same technique as block scalars);
-/// a following hardline only re-arms indentation.
 pub fn write_flow_scalar_content<'a>(
     kind: FlowScalarKind,
     content: &'a str,
@@ -134,8 +127,7 @@ pub fn write_flow_scalar_content<'a>(
         if blanks > 0 {
             // N blank groups = N separators before this group
             // (plus the one separating it from the previous non-empty group, if any).
-            write!(f, text(arena_newlines(blanks + usize::from(wrote_any), f)));
-            write!(f, hard_line_break());
+            write!(f, exact_line_breaks(blanks + usize::from(wrote_any)));
         } else if wrote_any {
             write!(f, hard_line_break());
         }
@@ -153,8 +145,7 @@ pub fn write_flow_scalar_content<'a>(
         // (a single empty group — e.g. the empty string `""` — emits nothing).
         let separators = if wrote_any { blanks } else { blanks - 1 };
         if separators > 0 {
-            write!(f, text(arena_newlines(separators, f)));
-            write!(f, hard_line_break());
+            write!(f, exact_line_breaks(separators));
         }
     }
 }
@@ -212,7 +203,7 @@ fn flow_scalar_line_contents<'s>(
     }
 
     if prose_wrap == ProseWrap::Never {
-        lines = lines.into_iter().map(|words| vec![Cow::Owned(words.join(" "))]).collect();
+        lines = join_lines_for_never_wrap(lines);
     }
     lines
 }
@@ -221,6 +212,18 @@ fn flow_scalar_line_contents<'s>(
 /// split on single spaces that are not at a boundary and not adjacent to another space,
 /// so multi-space runs stay inside one "word".
 /// Empty input yields no words; anything else yields at least one.
+///
+/// `proseWrap: never`: each line's words join into one unbreakable word.
+/// A blank line stays an EMPTY group, joining would turn it into a one-word `""` group,
+/// whose fill materializes the pending indention on the blank line (nothing trims it away).
+/// (Zero- and one-word lines pass through unchanged, sparing the rebuild.)
+pub fn join_lines_for_never_wrap(lines: Vec<Vec<Cow<'_, str>>>) -> Vec<Vec<Cow<'_, str>>> {
+    lines
+        .into_iter()
+        .map(|words| if words.len() <= 1 { words } else { vec![Cow::Owned(words.join(" "))] })
+        .collect()
+}
+
 pub fn split_with_single_space(text: &str) -> impl Iterator<Item = &str> {
     let bytes = text.as_bytes();
     let mut start = 0;


### PR DESCRIPTION
Introduce `exact_line_breaks(count)` IR builder.

This produces a line element that prints exactly `count` line breaks, exempt from the printer's hardline collapsing / empty-line capping.

Blank runs inside verbatim values (YAML block/flow scalars, GraphQL block strings) are the value itself and must not be normalized.
Previously this was emulated by emitting raw `\n` text followed by a re-arming `hard_line_break()`..., hack.

Also removed the printer behavior that trims end of line whitespaces.
