### PR TITLE
perf(linter): avoid allocations in jest/no-deprecated-functions

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2275,7 +2275,6 @@ impl RuleRunner for crate::rules::jest::no_confusing_set_timeout::NoConfusingSet
 impl RuleRunner for crate::rules::jest::no_deprecated_functions::NoDeprecatedFunctions {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::ComputedMemberExpression,
-        AstType::PrivateFieldExpression,
         AstType::StaticMemberExpression,
     ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -1,9 +1,7 @@
-use std::borrow::Cow;
-
-use oxc_ast::ast::Expression;
+use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Span};
+use oxc_span::Span;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -118,14 +116,23 @@ declare_oxc_lint!(
     short_description = "Disallow Jest functions that have been deprecated, renamed, or replaced.",
 );
 
-fn deprecated_functions_map(deprecated_fn: &str) -> Option<(usize, &'static str)> {
-    match deprecated_fn {
-        "jest.resetModuleRegistry" => Some((15, "jest.resetModules")),
-        "jest.addMatchers" => Some((17, "expect.extend")),
-        "require.requireMock" => Some((21, "jest.requireMock")),
-        "require.requireActual" => Some((21, "jest.requireActual")),
-        "jest.runTimersToTime" => Some((22, "jest.advanceTimersByTime")),
-        "jest.genMockFromModule" => Some((26, "jest.createMockFromModule")),
+fn deprecated_functions_map(
+    object: &str,
+    property: &str,
+) -> Option<(usize, &'static str, &'static str)> {
+    match (object, property) {
+        ("jest", "resetModuleRegistry") => {
+            Some((15, "jest.resetModuleRegistry", "jest.resetModules"))
+        }
+        ("jest", "addMatchers") => Some((17, "jest.addMatchers", "expect.extend")),
+        ("require", "requireMock") => Some((21, "require.requireMock", "jest.requireMock")),
+        ("require", "requireActual") => Some((21, "require.requireActual", "jest.requireActual")),
+        ("jest", "runTimersToTime") => {
+            Some((22, "jest.runTimersToTime", "jest.advanceTimersByTime"))
+        }
+        ("jest", "genMockFromModule") => {
+            Some((26, "jest.genMockFromModule", "jest.createMockFromModule"))
+        }
         _ => None,
     }
 }
@@ -151,32 +158,43 @@ impl Rule for NoDeprecatedFunctions {
     }
 
     fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
-        let Some(mem_expr) = node.kind().as_member_expression_kind() else {
+        // Only `jest.*` / `require.*` member accesses with a statically-known
+        // property name can match, so bail before any further work otherwise.
+        let (object, property, span) = match node.kind() {
+            AstKind::StaticMemberExpression(mem_expr) => {
+                let Expression::Identifier(ident) = &mem_expr.object else {
+                    return;
+                };
+                (ident.name.as_str(), mem_expr.property.name.as_str(), mem_expr.span)
+            }
+            AstKind::ComputedMemberExpression(mem_expr) => {
+                let Expression::Identifier(ident) = &mem_expr.object else {
+                    return;
+                };
+                let Some(name) = mem_expr.static_property_name() else {
+                    return;
+                };
+                (ident.name.as_str(), name.as_str(), mem_expr.span)
+            }
+            _ => return,
+        };
+
+        let Some((base_version, deprecated, replacement)) =
+            deprecated_functions_map(object, property)
+        else {
             return;
         };
-        let mut chain: Vec<Cow<'a, str>> = Vec::new();
-        if let Expression::Identifier(ident) = mem_expr.object() {
-            chain.push(Cow::Borrowed(ident.name.as_str()));
-        }
 
-        if let Some(name) = mem_expr.static_property_name() {
-            chain.push(Cow::Borrowed(name.as_str()));
-        }
-
-        let node_name = chain.join(".");
         let jest_version_num: usize = if let Some(jest_version) = ctx.settings().jest.version {
             jest_version
         } else {
             self.jest.version
         };
 
-        if let Some((base_version, replacement)) = deprecated_functions_map(&node_name)
-            && jest_version_num >= base_version
-        {
-            ctx.diagnostic_with_fix(
-                deprecated_function(&node_name, replacement, mem_expr.span()),
-                |fixer| fixer.replace(mem_expr.span(), replacement),
-            );
+        if jest_version_num >= base_version {
+            ctx.diagnostic_with_fix(deprecated_function(deprecated, replacement, span), |fixer| {
+                fixer.replace(span, replacement)
+            });
         }
     }
 }

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -225,7 +225,7 @@ jest/no-commented-out-tests                                |      7
 jest/no-conditional-expect                                 |      0
 jest/no-conditional-in-test                                |  30315
 jest/no-confusing-set-timeout                              |      7
-jest/no-deprecated-functions                               |  95297
+jest/no-deprecated-functions                               |  94090
 jest/no-disabled-tests                                     |      0
 jest/no-done-callback                                      |      0
 jest/no-duplicate-hooks                                    |      7


### PR DESCRIPTION
## What

`jest/no-deprecated-functions` allocated a `Vec<Cow>` and a joined `String` for **every member expression in every linted file** (no `should_run` gate) before checking the 6-entry deprecated-function map.

This PR:
- Bails immediately unless the member object is an `Identifier` (only `jest.*` / `require.*` can ever match)
- Matches the map on `(object, property)` name pairs and returns `&'static str` names, so the hot path allocates nothing
- Matches `StaticMemberExpression` / `ComputedMemberExpression` explicitly instead of `as_member_expression_kind()`, which also drops the dead `PrivateFieldExpression` registration from the generated `NODE_TYPES` (`static_property_name()` is always `None` for private fields, so that arm could never fire)

## Benchmark

Single-threaded paired benchmark (interleaved, order-alternating, N=30) on the n8n TypeScript corpus (18,316 files, 3.37M lines), rule enabled alone:

| | baseline | optimized |
|---|---|---|
| rule-on | 903 ms | 867 ms |
| parse-only control | 842 ms | 842 ms |

Rule-attributable time drops **61 ms → 25 ms** (paired Δ +35.3 ms ± 13.3, t = 14.5, 29/30 wins; control Δ +0.3 ms). Multithreaded wall clock is unchanged (absorbed by parallelism) but user CPU time drops ~6.5%.

## Behavior

No change. Diagnostics verified byte-identical on the same corpus plus a canary covering the computed-literal forms (`jest["addMatchers"]`, ``jest[`runTimersToTime`]``) and near-miss lookalikes (`foo.requireActual`, `(jest).addMatchers`, `jest[dynamicKey]`, `myjest.addMatchers`). Existing test suites (`tests`, `test_version_from_config`, `test_override`) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Allocations

Instrumented builds with a counting global allocator (`--no-default-features`, system allocator + counter). Rule-attributed = single-rule run minus parse-only run (jest plugin enabled, zero rules), `--threads=1`. All counts run-to-run stable:

| Corpus | Allocs before | after | Δ allocs | Bytes before | after | Δ bytes |
|---|---|---|---|---|---|---|
| n8n (TS, flattened, 18,317 files) | 1,949,840 | 14,252 | **−99.3%** | 110.4 MB | 4.1 MB | **−96.3%** |
| vscode `src/` (7,849 files) | 2,310,741 | 6,524 | **−99.7%** | 129.9 MB | 1.9 MB | **−98.6%** |

The old implementation allocated a `Cow<str>` (via `static_property_name`) plus a `format!`-built `String` for essentially every member expression it dispatched on; the new tuple-match implementation is allocation-free on the non-matching path.
