### PR TITLE
perf(lexer): pair-compose compress with quad-grouped stores

### DIFF
--- a/crates/oxc_lexer/src/pipeline/compress.rs
+++ b/crates/oxc_lexer/src/pipeline/compress.rs
@@ -10,6 +10,7 @@ use super::find::{eqm, load8};
 use super::{BIGINT, IDENT_ESC, NUM, PRIV_IDENT_ESC};
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+#[inline(never)]
 pub(super) unsafe fn compress(
     t: &Tables,
     st: *const u64,
@@ -18,6 +19,9 @@ pub(super) unsafe fn compress(
     starts: *mut u32,
     kinds: *mut u8,
 ) -> usize {
+    let lut0z = t.pair_luts.lut0z.as_ptr().cast::<u8>();
+    let lutpad = t.pair_luts.lutpad.as_ptr().cast::<u8>();
+    let step16 = _mm256_set1_epi32(16);
     let mut m = 0usize;
     for b in 0..nb {
         let mword = *st.add(b);
@@ -26,35 +30,37 @@ pub(super) unsafe fn compress(
         }
         let base = b * 64;
         let o0: u32 = 0;
-        let o1 = o0 + (mword & 0xff).count_ones();
-        let o2 = o1 + (mword & 0xff00).count_ones();
-        let o3 = o2 + (mword & 0xff_0000).count_ones();
-        let o4 = o3 + (mword & 0xff00_0000).count_ones();
-        let o5 = o4 + (mword & 0xff_0000_0000).count_ones();
-        let o6 = o5 + (mword & 0xff00_0000_0000).count_ones();
-        let o7 = o6 + (mword & 0xff_0000_0000_0000).count_ones();
-        let o8 = o7 + (mword >> 56).count_ones();
-        macro_rules! chunk {
-            ($ch:expr, $off:expr) => {{
-                let sub = ((mword >> (8 * $ch)) & 0xff) as usize;
-                let row = &t.comp_lut[sub];
-                let lut = _mm256_load_si256(row.lanes.as_ptr() as *const __m256i);
-                let cs = _mm256_add_epi32(_mm256_set1_epi32((base + 8 * $ch) as i32), lut);
-                _mm256_storeu_si256(starts.add(m + $off as usize) as *mut __m256i, cs);
-                let kb = _mm_loadl_epi64(kind.add(base + 8 * $ch) as *const __m128i);
-                let ck = _mm_shuffle_epi8(kb, _mm_load_si128(row.bytes.as_ptr() as *const __m128i));
-                _mm_storel_epi64(kinds.add(m + $off as usize) as *mut __m128i, ck);
+        let o1 = o0 + (mword & 0xffff).count_ones();
+        let o2 = o1 + ((mword >> 16) & 0xffff).count_ones();
+        let o3 = o2 + ((mword >> 32) & 0xffff).count_ones();
+        let o4 = o3 + (mword >> 48).count_ones();
+        let mut basev = _mm256_set1_epi32(base as i32);
+        macro_rules! pair {
+            ($p:expr, $off:expr) => {{
+                let sub0 = ((mword >> (16 * $p)) & 0xff) as usize;
+                let sub1 = ((mword >> (16 * $p + 8)) & 0xff) as usize;
+                let pc0 = sub0.count_ones() as usize;
+                let row0 = _mm_loadl_epi64(lut0z.add(sub0 * 8) as *const __m128i);
+                let row1 = _mm_loadu_si128(lutpad.add(sub1 * 32 + 8 - pc0) as *const __m128i);
+                let ctrl = _mm_or_si128(row0, row1);
+                let kw = _mm_loadu_si128(kind.add(base + 16 * $p) as *const __m128i);
+                let lo = _mm256_add_epi32(basev, _mm256_cvtepu8_epi32(ctrl));
+                _mm256_storeu_si256(starts.add(m + $off as usize) as *mut __m256i, lo);
+                let hi = _mm256_add_epi32(basev, _mm256_cvtepu8_epi32(_mm_srli_si128(ctrl, 8)));
+                _mm256_storeu_si256(starts.add(m + $off as usize + 8) as *mut __m256i, hi);
+                basev = _mm256_add_epi32(basev, step16);
+                _mm_shuffle_epi8(kw, ctrl)
             }};
         }
-        chunk!(0, o0);
-        chunk!(1, o1);
-        chunk!(2, o2);
-        chunk!(3, o3);
-        chunk!(4, o4);
-        chunk!(5, o5);
-        chunk!(6, o6);
-        chunk!(7, o7);
-        m += o8 as usize;
+        let ka = pair!(0, o0);
+        let kb = pair!(1, o1);
+        _mm_storeu_si128(kinds.add(m + o0 as usize) as *mut __m128i, ka);
+        _mm_storeu_si128(kinds.add(m + o1 as usize) as *mut __m128i, kb);
+        let kc = pair!(2, o2);
+        let kd = pair!(3, o3);
+        _mm_storeu_si128(kinds.add(m + o2 as usize) as *mut __m128i, kc);
+        _mm_storeu_si128(kinds.add(m + o3 as usize) as *mut __m128i, kd);
+        m += o4 as usize;
     }
     m
 }
@@ -248,5 +254,85 @@ pub(super) unsafe fn lanes_post(
     }
     if inv_dirty {
         invalid_diags(src, out_kinds, out_starts, m, lanes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compress;
+    use crate::tables::Tables;
+
+    fn xorshift(s: &mut u64) -> u64 {
+        *s ^= *s << 13;
+        *s ^= *s >> 7;
+        *s ^= *s << 17;
+        *s
+    }
+
+    #[test]
+    fn compress_matches_scalar_reference() {
+        let t = Tables::new();
+        let mut cases: Vec<Vec<u64>> = Vec::new();
+        let all_pairs: Vec<u64> = (0..65536u64)
+            .collect::<Vec<_>>()
+            .chunks(4)
+            .map(|c| c.iter().enumerate().fold(0u64, |w, (i, v)| w | (v << (16 * i))))
+            .collect();
+        cases.push(all_pairs);
+        let mut s = 0x9e37_79b9_7f4a_7c15u64;
+        for _ in 0..3 {
+            cases.push(core::iter::repeat_with(|| xorshift(&mut s)).take(512).collect());
+        }
+        cases.push(
+            core::iter::repeat_with(|| xorshift(&mut s) & xorshift(&mut s) & xorshift(&mut s))
+                .take(512)
+                .collect(),
+        );
+        cases.push(
+            core::iter::repeat_with(|| xorshift(&mut s) | xorshift(&mut s) | xorshift(&mut s))
+                .take(512)
+                .collect(),
+        );
+        cases.push(vec![!0u64; 64]);
+        cases.push({
+            let mut v = vec![0u64; 64];
+            v[63] = 1u64 << 63;
+            v
+        });
+        for st in &cases {
+            let nb = st.len();
+            let n = nb * 64;
+            let mut kind = vec![0u8; n];
+            let mut ks = 0xdead_beef_cafe_f00du64;
+            for b in kind.iter_mut() {
+                *b = (xorshift(&mut ks) & 0xff) as u8;
+            }
+            let mut starts = vec![0u32; n + 64];
+            let mut kinds = vec![0u8; n + 64];
+            let m = unsafe {
+                compress(
+                    &t,
+                    st.as_ptr(),
+                    kind.as_ptr(),
+                    nb,
+                    starts.as_mut_ptr(),
+                    kinds.as_mut_ptr(),
+                )
+            };
+            let mut rs: Vec<u32> = Vec::new();
+            let mut rk: Vec<u8> = Vec::new();
+            for (b, &w0) in st.iter().enumerate() {
+                let mut w = w0;
+                while w != 0 {
+                    let bit = w.trailing_zeros() as usize;
+                    w &= w - 1;
+                    rs.push((b * 64 + bit) as u32);
+                    rk.push(kind[b * 64 + bit]);
+                }
+            }
+            assert_eq!(m, rs.len(), "token count mismatch (nb={nb})");
+            assert_eq!(&starts[..m], &rs[..], "starts mismatch");
+            assert_eq!(&kinds[..m], &rk[..], "kinds mismatch");
+        }
     }
 }

--- a/crates/oxc_lexer/src/tables.rs
+++ b/crates/oxc_lexer/src/tables.rs
@@ -77,17 +77,13 @@ pub fn punct1_hash(c: u8) -> u8 {
     if h < 16 { PH_T0[h as usize] } else { PH_T1[(h & 15) as usize] }
 }
 
-/// One 64-byte cache line per `st`-mask byte for `compress`: the 8
-/// left-packed set-bit positions as u32 lanes, then the same as a 16-byte
-/// pshufb control. Fused so each mask byte touches one line, not two tables.
 #[repr(C, align(64))]
-pub struct CompressRow {
-    pub lanes: [u32; 8],
-    pub bytes: [u8; 16],
-    pad: [u8; 16],
+pub struct PairLuts {
+    pub lut0z: [[u8; 8]; 256],
+    pub lutpad: [[u8; 32]; 256],
 }
 
-const _: () = assert!(core::mem::size_of::<CompressRow>() == 64);
+const _: () = assert!(core::mem::size_of::<[[u8; 8]; 256]>().is_multiple_of(64));
 
 pub struct Tables {
     pub op: OpMap,
@@ -101,7 +97,7 @@ pub struct Tables {
     pub wb_hi: [u8; 16],
     pub op2_pack: [u32; 256],
     pub op3_pack: [u64; 256],
-    pub comp_lut: [CompressRow; 256],
+    pub pair_luts: PairLuts,
 }
 
 impl Tables {
@@ -123,12 +119,12 @@ impl Tables {
             wb_hi: [0; 16],
             op2_pack: [0; 256],
             op3_pack: [0; 256],
-            comp_lut: [const { CompressRow { lanes: [0; 8], bytes: [0; 16], pad: [0; 16] } }; 256],
+            pair_luts: PairLuts { lut0z: [[0; 8]; 256], lutpad: [[0; 32]; 256] },
         };
         t.build_regex_kw_mask();
         t.build_op_pack();
         t.build_merged_luts();
-        t.build_lane_lut();
+        t.build_pair_luts();
         kwinit_selfcheck();
         opch_selfcheck();
         t.merged_selfcheck();
@@ -258,22 +254,18 @@ impl Tables {
         }
     }
 
-    fn build_lane_lut(&mut self) {
+    fn build_pair_luts(&mut self) {
         for m in 0..256usize {
-            let row = &mut self.comp_lut[m];
             let mut k = 0usize;
             for bit in 0..8usize {
                 if (m >> bit) & 1 != 0 {
-                    row.lanes[k] = bit as u32;
-                    row.bytes[k] = bit as u8;
+                    self.pair_luts.lut0z[m][k] = bit as u8;
+                    self.pair_luts.lutpad[m][8 + k] = (bit + 8) as u8;
                     k += 1;
                 }
             }
             for j in k..8 {
-                row.lanes[j] = 0;
-            }
-            for j in k..16 {
-                row.bytes[j] = 0x80;
+                self.pair_luts.lutpad[m][8 + j] = 0x80;
             }
         }
     }


### PR DESCRIPTION
compress compacts the st/kind bitmaps into the dense starts/kinds streams. It emitted each 8-bit chunk as an interleaved pair of stores, one into starts and one into kinds. On Zen 3 a store that partially overlaps the previous one serializes to commit whenever another stream's store sits between them, so interleaving the two streams paid that penalty on every block.

This composes two 8-bit chunks into a single 16-lane shuffle and groups the stores so the overlapping starts writes land back to back, dropping the serialized seams from 16 to 4 per block. The control comes from a new pair-composed lookup table replacing the old per-chunk one, and compress stays inline(never) so the store order survives LLVM's aliasing analysis. Output is identical and a new exhaustive test checks it against a scalar reference over every lookup-pair combination. This is the larger of the two wins, moving the big files by roughly 0.25 to 0.3 cyc/byte (checker.js and all the minified bundles), since it is per-block work rather than a once-per-file cost.
