### PR TITLE
perf(linter/eslint/no-this-before-super): skip files without classes

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -64,7 +64,8 @@ enum DefinitelyCallsThisBeforeSuper {
 }
 
 /// Node types that should be in the file in order to run this analysis. Otherwise, the AST
-/// will be skipped for linting.
+/// will be skipped for linting. A violation can only occur in the constructor of a class
+/// with a superclass, so a `Class` node must be present alongside `this`/`super`.
 const NEEDED_NODE_TYPES: &AstTypesBitset =
     &AstTypesBitset::from_types(&[AstType::ThisExpression, AstType::Super]);
 
@@ -144,7 +145,8 @@ impl Rule for NoThisBeforeSuper {
     }
 
     fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
-        ctx.semantic().nodes().contains_any(NEEDED_NODE_TYPES)
+        let nodes = ctx.semantic().nodes();
+        nodes.contains(AstType::Class) && nodes.contains_any(NEEDED_NODE_TYPES)
     }
 }
 

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -122,7 +122,7 @@ eslint/no-shadow-restricted-names                          |      7
 eslint/no-sparse-arrays                                    |   4115
 eslint/no-template-curly-in-string                         |  62460
 eslint/no-ternary                                          |   4722
-eslint/no-this-before-super                                |      5
+eslint/no-this-before-super                                |      4
 eslint/no-throw-literal                                    |    224
 eslint/no-unassigned-vars                                  |  37499
 eslint/no-undef                                            |      7


### PR DESCRIPTION
A violation of `no-this-before-super` can only occur in the constructor of a class with a superclass, so `should_run` now also requires an `AstType::Class` node to be present alongside `this`/`super`. This skips the rule's full-AST `run_once` scan (and CFG walking) in files that use `this` outside of any class — which is the majority of files that merely mention `this`.

### Benchmark

Single-rule config, `--threads=1`, `--debug=timings`, real-world corpora. Rule times are means of 6 interleaved paired runs per binary:

| Corpus | Files | Calls before | Calls after | Δ calls | Rule time before | after | Δ time |
|---|---|---|---|---|---|---|---|
| n8n (TS, flattened) | 18,317 | 3,941 | 2,693 | −31.7% | 6.32 ms | 4.97 ms | **−21.4%** (t=16.2, 6/6 wins) |
| vscode `src/` | 7,849 | 4,273 | 4,202 | −1.7% | 18.20 ms | 17.92 ms | −1.5% (t=0.8, not significant) |

vscode is a heavily class-based codebase, so the new gate rarely fires there; n8n-style codebases skip about a third of calls. Diagnostics are byte-identical on both corpora (16 real hits in vscode `src/`, 0 in the n8n corpus).

The `linter_timings.snap` change (5 → 4 calls) reflects the same gating on the timing fixture set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)