### PR TITLE
perf(linter): speed up jest/vitest prefer-each

### DIFF
--- a/crates/oxc_linter/src/rules/jest/prefer_each.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_each.rs
@@ -17,6 +17,10 @@ impl Rule for PreferEach {
     fn run_once(&self, ctx: &LintContext<'_>) {
         SharedPreferEach::PreferEachConfig::run_once(ctx);
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        SharedPreferEach::PreferEachConfig::should_run(ctx)
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_each.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_each.rs
@@ -84,39 +84,37 @@ impl PreferEachConfig {
     }
 
     fn run<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>, skip: &mut FxHashSet<NodeId>) {
-        let kind = node.kind();
-
-        let AstKind::CallExpression(call_expr) = kind else { return };
+        let AstKind::CallExpression(call_expr) = node.kind() else { return };
 
         // Walking up to the nearest enclosing loop is much cheaper than
         // `parse_jest_fn_call`, so find it first: only calls sitting directly in a
         // loop (not nested in another call) can be reported.
-        let Some(loop_node) = ctx
-            .nodes()
-            .ancestors(node.id())
-            .find_map(|parent_node| match parent_node.kind() {
-                AstKind::CallExpression(_) => Some(None),
+        let mut enclosing_loop = None;
+        for parent_node in ctx.nodes().ancestors(node.id()) {
+            match parent_node.kind() {
+                AstKind::CallExpression(_) => return,
                 AstKind::ForStatement(_)
                 | AstKind::ForInStatement(_)
-                | AstKind::ForOfStatement(_) => Some(Some(parent_node)),
-                _ => None,
-            })
-            .flatten()
-        else {
-            return;
-        };
+                | AstKind::ForOfStatement(_) => {
+                    enclosing_loop = Some(parent_node);
+                    break;
+                }
+                _ => {}
+            }
+        }
+        let Some(loop_node) = enclosing_loop else { return };
 
         if skip.contains(&loop_node.id()) {
             return;
         }
 
-        let Some(vitest_fn_call) =
+        let Some(jest_fn_call) =
             parse_jest_fn_call(call_expr, &PossibleJestNode { node, original: None }, ctx)
         else {
             return;
         };
 
-        let fn_name = match vitest_fn_call.kind() {
+        let fn_name = match jest_fn_call.kind() {
             JestFnKind::General(JestGeneralFnKind::Test) => "it",
             JestFnKind::General(JestGeneralFnKind::Describe | JestGeneralFnKind::Hook) => {
                 "describe"
@@ -128,20 +126,14 @@ impl PreferEachConfig {
             return;
         }
 
-        let span = match loop_node.kind() {
-            AstKind::ForStatement(statement) => {
-                Span::new(statement.span.start, statement.body.span().start)
-            }
-            AstKind::ForInStatement(statement) => {
-                Span::new(statement.span.start, statement.body.span().start)
-            }
-            AstKind::ForOfStatement(statement) => {
-                Span::new(statement.span.start, statement.body.span().start)
-            }
+        let (loop_span, body) = match loop_node.kind() {
+            AstKind::ForStatement(statement) => (statement.span, &statement.body),
+            AstKind::ForInStatement(statement) => (statement.span, &statement.body),
+            AstKind::ForOfStatement(statement) => (statement.span, &statement.body),
             _ => unreachable!(),
         };
 
         skip.insert(loop_node.id());
-        ctx.diagnostic(use_prefer_each(span, fn_name));
+        ctx.diagnostic(use_prefer_each(Span::new(loop_span.start, body.span().start), fn_name));
     }
 }

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_each.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_each.rs
@@ -1,11 +1,11 @@
-use oxc_ast::AstKind;
+use oxc_ast::{AstKind, AstType};
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_semantic::{AstNode, NodeId};
+use oxc_semantic::{AstNode, AstTypesBitset, NodeId};
 use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashSet;
 
 use crate::{
-    context::LintContext,
+    context::{ContextHost, LintContext},
     utils::{JestFnKind, JestGeneralFnKind, PossibleJestNode, parse_jest_fn_call},
 };
 
@@ -59,10 +59,23 @@ describe.each(items)('item', (item) => {
 ```
 ";
 
+/// A diagnostic requires a test call directly inside a `for`/`for-in`/`for-of` loop,
+/// so files without any loop statement (or without any call) can be skipped entirely.
+const LOOP_NODE_TYPES: &AstTypesBitset = &AstTypesBitset::from_types(&[
+    AstType::ForStatement,
+    AstType::ForInStatement,
+    AstType::ForOfStatement,
+]);
+
 #[derive(Debug, Default, Clone)]
 pub struct PreferEachConfig;
 
 impl PreferEachConfig {
+    pub fn should_run(ctx: &ContextHost) -> bool {
+        let nodes = ctx.semantic().nodes();
+        nodes.contains_any(LOOP_NODE_TYPES) && nodes.contains(AstType::CallExpression)
+    }
+
     pub fn run_once(ctx: &LintContext<'_>) {
         let mut skip = FxHashSet::<NodeId>::default();
         ctx.nodes().iter().for_each(|node| {
@@ -75,60 +88,60 @@ impl PreferEachConfig {
 
         let AstKind::CallExpression(call_expr) = kind else { return };
 
+        // Walking up to the nearest enclosing loop is much cheaper than
+        // `parse_jest_fn_call`, so find it first: only calls sitting directly in a
+        // loop (not nested in another call) can be reported.
+        let Some(loop_node) = ctx
+            .nodes()
+            .ancestors(node.id())
+            .find_map(|parent_node| match parent_node.kind() {
+                AstKind::CallExpression(_) => Some(None),
+                AstKind::ForStatement(_)
+                | AstKind::ForInStatement(_)
+                | AstKind::ForOfStatement(_) => Some(Some(parent_node)),
+                _ => None,
+            })
+            .flatten()
+        else {
+            return;
+        };
+
+        if skip.contains(&loop_node.id()) {
+            return;
+        }
+
         let Some(vitest_fn_call) =
             parse_jest_fn_call(call_expr, &PossibleJestNode { node, original: None }, ctx)
         else {
             return;
         };
 
-        if !matches!(
-            vitest_fn_call.kind(),
-            JestFnKind::General(
-                JestGeneralFnKind::Describe | JestGeneralFnKind::Hook | JestGeneralFnKind::Test
-            )
-        ) {
+        let fn_name = match vitest_fn_call.kind() {
+            JestFnKind::General(JestGeneralFnKind::Test) => "it",
+            JestFnKind::General(JestGeneralFnKind::Describe | JestGeneralFnKind::Hook) => {
+                "describe"
+            }
+            _ => return,
+        };
+
+        if is_in_test(ctx, loop_node.id()) {
             return;
         }
 
-        for parent_node in ctx.nodes().ancestors(node.id()) {
-            match parent_node.kind() {
-                AstKind::CallExpression(_) => return,
-                AstKind::ForStatement(_)
-                | AstKind::ForInStatement(_)
-                | AstKind::ForOfStatement(_) => {
-                    if skip.contains(&parent_node.id()) || is_in_test(ctx, parent_node.id()) {
-                        return;
-                    }
-
-                    let fn_name = if matches!(
-                        vitest_fn_call.kind(),
-                        JestFnKind::General(JestGeneralFnKind::Test)
-                    ) {
-                        "it"
-                    } else {
-                        "describe"
-                    };
-
-                    let span = match parent_node.kind() {
-                        AstKind::ForStatement(statement) => {
-                            Span::new(statement.span.start, statement.body.span().start)
-                        }
-                        AstKind::ForInStatement(statement) => {
-                            Span::new(statement.span.start, statement.body.span().start)
-                        }
-                        AstKind::ForOfStatement(statement) => {
-                            Span::new(statement.span.start, statement.body.span().start)
-                        }
-                        _ => unreachable!(),
-                    };
-
-                    skip.insert(parent_node.id());
-                    ctx.diagnostic(use_prefer_each(span, fn_name));
-
-                    break;
-                }
-                _ => {}
+        let span = match loop_node.kind() {
+            AstKind::ForStatement(statement) => {
+                Span::new(statement.span.start, statement.body.span().start)
             }
-        }
+            AstKind::ForInStatement(statement) => {
+                Span::new(statement.span.start, statement.body.span().start)
+            }
+            AstKind::ForOfStatement(statement) => {
+                Span::new(statement.span.start, statement.body.span().start)
+            }
+            _ => unreachable!(),
+        };
+
+        skip.insert(loop_node.id());
+        ctx.diagnostic(use_prefer_each(span, fn_name));
     }
 }

--- a/crates/oxc_linter/src/rules/vitest/prefer_each.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_each.rs
@@ -17,6 +17,10 @@ impl Rule for PreferEach {
     fn run_once(&self, ctx: &LintContext<'_>) {
         SharedPreferEach::PreferEachConfig::run_once(ctx);
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        SharedPreferEach::PreferEachConfig::should_run(ctx)
+    }
 }
 
 #[test]

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -248,7 +248,7 @@ jest/padding-around-after-all-blocks                       |      0
 jest/padding-around-test-blocks                            |      0
 jest/prefer-called-with                                    |      0
 jest/prefer-comparison-matcher                             |      0
-jest/prefer-each                                           |      7
+jest/prefer-each                                           |      6
 jest/prefer-ending-with-an-expect                          |      0
 jest/prefer-equality-matcher                               |      0
 jest/prefer-expect-assertions                              |      7
@@ -697,7 +697,7 @@ vitest/prefer-called-times                                 |      0
 vitest/prefer-called-with                                  |      0
 vitest/prefer-comparison-matcher                           |      0
 vitest/prefer-describe-function-title                      |      0
-vitest/prefer-each                                         |      7
+vitest/prefer-each                                         |      6
 vitest/prefer-equality-matcher                             |      0
 vitest/prefer-expect-assertions                            |      7
 vitest/prefer-expect-resolves                              |      0


### PR DESCRIPTION
Two changes to the shared `prefer-each` implementation (covers both `jest/prefer-each` and `vitest/prefer-each`), preserving behavior exactly:

- **`should_run` gate**: the rule now requires a `for`/`for-in`/`for-of` statement *and* a call expression in the file, since a diagnostic needs a test call directly inside a loop. Most test files contain no loops, so the whole `run_once` pass is skipped. (Previously the rule had no `should_run` at all and ran on every file.)
- **Reordered checks in `run`**: walk up to the nearest enclosing loop *before* calling the allocating `parse_jest_fn_call`, which previously ran for every call expression in the file. Calls not directly inside a loop — the overwhelmingly common case — now bail after a cheap ancestor walk that was already being performed anyway.

### Benchmark

Single rule `jest/prefer-each`, `--threads=1`, `--debug=timings`, real-world corpora. Rule times are means of 6 interleaved paired runs per binary:

| Corpus | Files | Calls before | Calls after | Δ calls | Rule time before | after | Δ time |
|---|---|---|---|---|---|---|---|
| n8n (TS, flattened) | 18,317 | 18,317 | 3,018 | −83.5% | 40.81 ms | 7.60 ms | **−81.4%** (t=86.7, 6/6 wins) |
| vscode `src/` | 7,849 | 7,841 | 2,849 | −63.7% | 35.83 ms | 13.09 ms | **−63.5%** (t=154.3, 6/6 wins) |

Diagnostics are byte-identical between the two binaries on both corpora, with real hits exercising the rule's paths (46 on the n8n corpus, 64 in vscode `src/`).

The `linter_timings.snap` change (7 → 6 calls for both rules) reflects the new gating on the timing fixture set.

This PR was written by Claude Code, reviewed by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)