### PR TITLE
perf(linter/eslint/prefer-rest-params): run once per file

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1385,9 +1385,8 @@ impl RuleRunner for crate::rules::eslint::prefer_regex_literals::PreferRegexLite
 }
 
 impl RuleRunner for crate::rules::eslint::prefer_rest_params::PreferRestParams {
-    const NODE_TYPES: Option<&AstTypesBitset> =
-        Some(&AstTypesBitset::from_types(&[AstType::Function]));
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
 impl RuleRunner for crate::rules::eslint::prefer_spread::PreferSpread {

--- a/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
@@ -80,11 +80,11 @@ impl Rule for PreferRestParams {
 
             // Only references to the implicit `arguments` object are relevant, i.e.
             // those inside a (non-arrow) function.
-            let in_function = ctx
+            if !ctx
                 .nodes()
                 .ancestors(reference_node.id())
-                .any(|ancestor| matches!(ancestor.kind(), AstKind::Function(_)));
-            if !in_function {
+                .any(|ancestor| matches!(ancestor.kind(), AstKind::Function(_)))
+            {
                 continue;
             }
 

--- a/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
@@ -1,5 +1,5 @@
 use crate::{AstNode, context::LintContext, rule::Rule};
-use oxc_ast::AstKind;
+use oxc_ast::{AstKind, AstType};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
@@ -69,11 +69,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferRestParams {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::Function(_) = node.kind() else {
-            return;
-        };
-
+    fn run_once(&self, ctx: &LintContext) {
         let Some(references) = ctx.scoping().root_unresolved_references().get("arguments") else {
             return;
         };
@@ -81,29 +77,29 @@ impl Rule for PreferRestParams {
         for &reference_id in references {
             let reference = ctx.scoping().get_reference(reference_id);
             let reference_node = ctx.nodes().get_node(reference.node_id());
-            if !is_owned_by_function(reference_node, node, ctx) {
+
+            // Only references to the implicit `arguments` object are relevant, i.e.
+            // those inside a (non-arrow) function.
+            let in_function = ctx
+                .nodes()
+                .ancestors(reference_node.id())
+                .any(|ancestor| matches!(ancestor.kind(), AstKind::Function(_)));
+            if !in_function {
                 continue;
             }
 
-            if !is_not_normal_member_access(reference_node, ctx) {
+            if !is_normal_member_access(reference_node, ctx) {
                 ctx.diagnostic(prefer_rest_params_diagnostic(reference_node.span()));
             }
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.semantic().nodes().contains(AstType::Function)
+    }
 }
 
-fn is_owned_by_function(
-    reference_node: &AstNode,
-    function_node: &AstNode,
-    ctx: &LintContext,
-) -> bool {
-    ctx.nodes()
-        .ancestors(reference_node.id())
-        .find(|ancestor| matches!(ancestor.kind(), AstKind::Function(_)))
-        .is_some_and(|ancestor| ancestor.id() == function_node.id())
-}
-
-fn is_not_normal_member_access(identifier: &AstNode, ctx: &LintContext) -> bool {
+fn is_normal_member_access(identifier: &AstNode, ctx: &LintContext) -> bool {
     if let AstKind::StaticMemberExpression(member) = ctx.nodes().parent_kind(identifier.id()) {
         return member.object.span() == identifier.span();
     }

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -166,7 +166,7 @@ eslint/prefer-object-has-own                               |  62606
 eslint/prefer-object-spread                                |  62606
 eslint/prefer-promise-reject-errors                        |  64027
 eslint/prefer-regex-literals                               |  64027
-eslint/prefer-rest-params                                  |  14283
+eslint/prefer-rest-params                                  |      6
 eslint/prefer-spread                                       |  62606
 eslint/prefer-template                                     |  20604
 eslint/preserve-caught-error                               |    151


### PR DESCRIPTION
The rule previously ran per `Function` node and, for each one, rescanned every unresolved `arguments` reference with an ancestor walk to check whether the reference belonged to that function — O(functions × references) ancestor walks per file.

This PR inverts the iteration:

- A single `run_once` iterates the unresolved `arguments` references, and each reference walks to its nearest enclosing function exactly once. (The old per-function union visited exactly the references that have *some* enclosing `Function`, so a `.any()` check over ancestors is equivalent.)
- A `should_run` gate skips files with no `Function` node at all.
- The pre-existing `is_not_normal_member_access` helper is renamed to `is_normal_member_access` — its logic returned `true` for a *normal* (static, non-computed) member access like `arguments.length`, so the old name meant the opposite of what it did. Logic unchanged.

### Benchmark

Single rule, `--threads=1`, `--debug=timings`, real-world corpora. Rule times are means of 6 interleaved paired runs per binary:

| Corpus | Files | Calls before | Calls after | Rule time before | after | Δ time |
|---|---|---|---|---|---|---|
| n8n (TS, flattened) | 18,317 | 40,672 | 8,575 | 0.69 ms | 0.17 ms | **−75.7%** (t=28.7, 6/6 wins) |
| vscode `src/` | 7,849 | 91,939 | 6,021 | 1.43 ms | 0.12 ms | **−91.7%** (t=463, 6/6 wins) |

The absolute cost was already small on these corpora since most files have no `arguments` references — the stronger motivation is removing the quadratic pattern, where a legacy-heavy file with many functions *and* many `arguments` uses paid O(functions × references) walks.

Diagnostics are byte-identical between the two binaries on both corpora (10 hits on the n8n corpus, 44 in vscode `src/`).

The `linter_timings.snap` change (14,283 → 6) reflects the per-function → per-file call collapse on the timing fixture set.

This PR was written by Claude Code, reviewed by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)