### PR TITLE
refactor(ecmascript): share number literal serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,12 +1892,11 @@ version = "0.141.0"
 dependencies = [
  "bitflags",
  "cow-utils",
- "dragonbox_ecma",
  "insta",
- "itoa",
  "oxc_allocator",
  "oxc_ast",
  "oxc_data_structures",
+ "oxc_ecmascript",
  "oxc_index",
  "oxc_parser",
  "oxc_semantic",
@@ -1996,6 +1995,8 @@ name = "oxc_ecmascript"
 version = "0.141.0"
 dependencies = [
  "cow-utils",
+ "dragonbox_ecma",
+ "itoa",
  "num-bigint",
  "num-traits",
  "oxc_allocator",

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -23,6 +23,7 @@ doctest = true
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["code_buffer", "slice_iter", "stack"] }
+oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_sourcemap = { workspace = true, optional = true }
@@ -32,8 +33,6 @@ oxc_syntax = { workspace = true }
 
 bitflags = { workspace = true }
 cow-utils = { workspace = true }
-dragonbox_ecma = { workspace = true }
-itoa = { workspace = true }
 rustc-hash = { workspace = true }
 
 [dev-dependencies]

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -9,6 +9,7 @@ use std::{borrow::Cow, cmp, slice};
 
 use oxc_ast::ast::*;
 use oxc_data_structures::{code_buffer::CodeBuffer, stack::Stack};
+use oxc_ecmascript::with_number_literal;
 use oxc_index::IndexVec;
 use oxc_semantic::Scoping;
 use oxc_span::{GetSpan, SourceType, Span};
@@ -26,7 +27,6 @@ mod cjs_module_lexer;
 mod comment;
 mod context;
 mod r#gen;
-mod number_literal;
 mod operator;
 mod options;
 #[cfg(feature = "sourcemap")]
@@ -35,7 +35,6 @@ mod str;
 
 use binary_expr_visitor::BinaryExpressionVisitor;
 use comment::CommentsMap;
-use number_literal::with_number_literal;
 use operator::Operator;
 #[cfg(feature = "sourcemap")]
 use sourcemap_builder::SourcemapBuilder;

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 
 [features]
 side_effects = ["dep:oxc_allocator", "dep:oxc_compat", "dep:oxc_regular_expression"]
-constant_evaluation = ["side_effects", "dep:cow-utils", "dep:smallvec"]
+constant_evaluation = ["side_effects", "dep:smallvec"]
 
 [dependencies]
 oxc_allocator = { workspace = true, optional = true }
@@ -32,7 +32,9 @@ oxc_regular_expression = { workspace = true, optional = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true, features = ["to_js_string"] }
 
-cow-utils = { workspace = true, optional = true }
+cow-utils = { workspace = true }
+dragonbox_ecma = { workspace = true }
+itoa = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
 smallvec = { workspace = true, optional = true }

--- a/crates/oxc_ecmascript/src/lib.rs
+++ b/crates/oxc_ecmascript/src/lib.rs
@@ -39,6 +39,7 @@ mod to_integer_index;
 #[cfg(feature = "constant_evaluation")]
 pub mod constant_evaluation;
 mod global_context;
+mod number_literal;
 #[cfg(feature = "side_effects")]
 pub mod side_effects;
 
@@ -47,6 +48,7 @@ pub use self::{
     bound_names::BoundNames,
     global_context::{GlobalContext, WithoutGlobalReferenceInformation},
     is_simple_parameter_list::IsSimpleParameterList,
+    number_literal::with_number_literal,
     private_bound_identifiers::PrivateBoundIdentifiers,
     prop_name::PropName,
     string_char_at::{StringCharAt, StringCharAtResult},

--- a/crates/oxc_ecmascript/src/number_literal.rs
+++ b/crates/oxc_ecmascript/src/number_literal.rs
@@ -1,6 +1,10 @@
 use cow_utils::CowUtils;
 
 /// Call `f` with the shortest JavaScript source representation of a non-negative finite number.
+///
+/// # Panics
+///
+/// Panics if the float formatter produces malformed scientific notation.
 // Adapted from Terser's `get_minified_number`:
 // https://github.com/terser/terser/blob/c5315c3fd6321d6b2e076af35a70ef532f498505/lib/output.js#L2418
 #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]


### PR DESCRIPTION
Codegen is not the only consumer that needs the exact emitted form of a number, but the serializer currently lives in the codegen crate. Other consumers would otherwise need to duplicate its formatting policy or depend on codegen.

Move the callback helper extracted in #24888 from `oxc_codegen` to `oxc_ecmascript`, then reuse it from codegen. The serialization algorithm is unchanged; this PR only makes the helper public and relocates its dependencies.

This PR depends on #24888. #24889 handles allocation-free candidate construction, and #24875 adds the minifier consumer.

Verified independently with `cargo test -p oxc_ecmascript -p oxc_codegen`, Clippy, and formatting.

AI assistance: Codex was used to implement and verify this change.
