### PR TITLE
chore(prettier_conformance): ignore ambiguous top-level await

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 774/811 (95.44%), 23 files skipped
+js compatibility: 774/810 (95.56%), 23 files skipped
 
 # Failed
 
@@ -6,7 +6,6 @@ js compatibility: 774/811 (95.44%), 23 files skipped
 | :-------- | :--------------: | :---------: |
 | js/arrows/issue-17421.js | 💥💥 | 90.43% |
 | js/assignment-comments/indentable-block-comment.js | 💥 | 12.50% |
-| js/await/like-call.js | 💥 | 0.00% |
 | js/call/no-argument/no-arguments.js | 💥 | 57.53% |
 | js/comments/15661.js | 💥💥 | 43.53% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |

--- a/tasks/prettier_conformance/src/ignore_list.rs
+++ b/tasks/prettier_conformance/src/ignore_list.rs
@@ -110,6 +110,9 @@ pub const IGNORE_TESTS: &[&str] = &[
     "jsx/top-level-await",
     "typescript/top-level-await",
     "js/ternaries/parenthesis/await-expression.js",
+    // Top-level `await (1)` with no import/export: Prettier always parses `.js` as ESM (await expression),
+    // while our unambiguous detection leans to script (call expression), whose output is valid under both
+    "js/await/like-call.js",
     // ES5 vs ES6+ identifier: Prettier uses ES5 validation, OXC uses ES6+
     // Characters outside BMP (like U+102A7) are valid ES6+ identifiers but not ES5
     "js/quotes/objects.js",


### PR DESCRIPTION
We are script by default, Prettier is module by default.