### PR TITLE
fix(formatter): align quoted `new` signature

### DIFF
--- a/crates/oxc_formatter/src/utils/object.rs
+++ b/crates/oxc_formatter/src/utils/object.rs
@@ -92,12 +92,11 @@ pub fn write_member_name<'a>(
 }
 
 /// Determine if this is a method signature named `"new"` via a quoted key, which must keep its quotes.
-/// Unquoted `new(...)` in an interface or type literal is a construct signature, not a method.
-/// Optional (`new?()`), getter/setter, and property forms stay a member named `new` and are safe to unquote.
+/// Unquoting `new(...)` in an interface or type literal would turn it into a construct signature.
+/// Optional (`new?()`) and getter/setter forms would stay a member named `new` even unquoted,
+/// but Prettier keeps the quotes for every method-signature form; only the property form is unquoted.
 pub fn is_quoted_new_method_signature(method: &TSMethodSignature<'_>) -> bool {
-    method.kind == TSMethodSignatureKind::Method
-        && !method.computed
-        && !method.optional
+    !method.computed
         && matches!(&method.key, PropertyKey::StringLiteral(string) if string.value == "new")
 }
 

--- a/crates/oxc_formatter/tests/fixtures/ts/quote-props/new-method-signature.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/quote-props/new-method-signature.ts
@@ -1,6 +1,5 @@
 // Unquoting a method signature named "new" would turn it into a construct signature,
 // so its quotes must be preserved.
-// Prettier 3.9.5 still removes them;
 // https://github.com/prettier/prettier/issues/19618
 interface Container {
   'new'(id: string): number;
@@ -16,11 +15,16 @@ interface WithSiblings {
   foo: string;
 }
 
-// These are all safe to unquote: they stay a member named "new".
-interface SafeToUnquote {
+// Optional, getter, and setter forms would stay a member named "new" even unquoted,
+// but Prettier keeps the quotes for every method-signature form.
+interface OtherSignatureForms {
   'new'?(id: string): number;
   get 'new'(): number;
   set 'new'(value: number);
+}
+
+// These are all safe to unquote: they stay a member named "new".
+interface SafeToUnquote {
   'new': (id: string) => number;
 }
 class NewMethod {

--- a/crates/oxc_formatter/tests/fixtures/ts/quote-props/new-method-signature.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/quote-props/new-method-signature.ts.snap
@@ -4,7 +4,6 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
 ==================== Input ====================
 // Unquoting a method signature named "new" would turn it into a construct signature,
 // so its quotes must be preserved.
-// Prettier 3.9.5 still removes them;
 // https://github.com/prettier/prettier/issues/19618
 interface Container {
   'new'(id: string): number;
@@ -20,11 +19,16 @@ interface WithSiblings {
   foo: string;
 }
 
-// These are all safe to unquote: they stay a member named "new".
-interface SafeToUnquote {
+// Optional, getter, and setter forms would stay a member named "new" even unquoted,
+// but Prettier keeps the quotes for every method-signature form.
+interface OtherSignatureForms {
   'new'?(id: string): number;
   get 'new'(): number;
   set 'new'(value: number);
+}
+
+// These are all safe to unquote: they stay a member named "new".
+interface SafeToUnquote {
   'new': (id: string) => number;
 }
 class NewMethod {
@@ -40,7 +44,6 @@ const newMethod = {
 -------------------------------------------
 // Unquoting a method signature named "new" would turn it into a construct signature,
 // so its quotes must be preserved.
-// Prettier 3.9.5 still removes them;
 // https://github.com/prettier/prettier/issues/19618
 interface Container {
   "new"(id: string): number;
@@ -56,11 +59,16 @@ interface WithSiblings {
   foo: string;
 }
 
+// Optional, getter, and setter forms would stay a member named "new" even unquoted,
+// but Prettier keeps the quotes for every method-signature form.
+interface OtherSignatureForms {
+  "new"?(id: string): number;
+  get "new"(): number;
+  set "new"(value: number);
+}
+
 // These are all safe to unquote: they stay a member named "new".
 interface SafeToUnquote {
-  new?(id: string): number;
-  get new(): number;
-  set new(value: number);
   new: (id: string) => number;
 }
 class NewMethod {
@@ -75,7 +83,6 @@ const newMethod = {
 --------------------------------------------
 // Unquoting a method signature named "new" would turn it into a construct signature,
 // so its quotes must be preserved.
-// Prettier 3.9.5 still removes them;
 // https://github.com/prettier/prettier/issues/19618
 interface Container {
   "new"(id: string): number;
@@ -91,11 +98,16 @@ interface WithSiblings {
   foo: string;
 }
 
+// Optional, getter, and setter forms would stay a member named "new" even unquoted,
+// but Prettier keeps the quotes for every method-signature form.
+interface OtherSignatureForms {
+  "new"?(id: string): number;
+  get "new"(): number;
+  set "new"(value: number);
+}
+
 // These are all safe to unquote: they stay a member named "new".
 interface SafeToUnquote {
-  new?(id: string): number;
-  get new(): number;
-  set new(value: number);
   new: (id: string) => number;
 }
 class NewMethod {
@@ -110,7 +122,6 @@ const newMethod = {
 ------------------------------------------
 // Unquoting a method signature named "new" would turn it into a construct signature,
 // so its quotes must be preserved.
-// Prettier 3.9.5 still removes them;
 // https://github.com/prettier/prettier/issues/19618
 interface Container {
   "new"(id: string): number;
@@ -126,11 +137,16 @@ interface WithSiblings {
   foo: string;
 }
 
-// These are all safe to unquote: they stay a member named "new".
-interface SafeToUnquote {
+// Optional, getter, and setter forms would stay a member named "new" even unquoted,
+// but Prettier keeps the quotes for every method-signature form.
+interface OtherSignatureForms {
   "new"?(id: string): number;
   get "new"(): number;
   set "new"(value: number);
+}
+
+// These are all safe to unquote: they stay a member named "new".
+interface SafeToUnquote {
   "new": (id: string) => number;
 }
 class NewMethod {
@@ -145,7 +161,6 @@ const newMethod = {
 -------------------------------------------
 // Unquoting a method signature named "new" would turn it into a construct signature,
 // so its quotes must be preserved.
-// Prettier 3.9.5 still removes them;
 // https://github.com/prettier/prettier/issues/19618
 interface Container {
   "new"(id: string): number;
@@ -161,11 +176,16 @@ interface WithSiblings {
   foo: string;
 }
 
-// These are all safe to unquote: they stay a member named "new".
-interface SafeToUnquote {
+// Optional, getter, and setter forms would stay a member named "new" even unquoted,
+// but Prettier keeps the quotes for every method-signature form.
+interface OtherSignatureForms {
   "new"?(id: string): number;
   get "new"(): number;
   set "new"(value: number);
+}
+
+// These are all safe to unquote: they stay a member named "new".
+interface SafeToUnquote {
   "new": (id: string) => number;
 }
 class NewMethod {
@@ -180,7 +200,6 @@ const newMethod = {
 --------------------------------------------
 // Unquoting a method signature named "new" would turn it into a construct signature,
 // so its quotes must be preserved.
-// Prettier 3.9.5 still removes them;
 // https://github.com/prettier/prettier/issues/19618
 interface Container {
   "new"(id: string): number;
@@ -196,11 +215,16 @@ interface WithSiblings {
   "foo": string;
 }
 
+// Optional, getter, and setter forms would stay a member named "new" even unquoted,
+// but Prettier keeps the quotes for every method-signature form.
+interface OtherSignatureForms {
+  "new"?(id: string): number;
+  get "new"(): number;
+  set "new"(value: number);
+}
+
 // These are all safe to unquote: they stay a member named "new".
 interface SafeToUnquote {
-  new?(id: string): number;
-  get new(): number;
-  set new(value: number);
   new: (id: string) => number;
 }
 class NewMethod {
@@ -215,7 +239,6 @@ const newMethod = {
 ---------------------------------------------
 // Unquoting a method signature named "new" would turn it into a construct signature,
 // so its quotes must be preserved.
-// Prettier 3.9.5 still removes them;
 // https://github.com/prettier/prettier/issues/19618
 interface Container {
   "new"(id: string): number;
@@ -231,11 +254,16 @@ interface WithSiblings {
   "foo": string;
 }
 
+// Optional, getter, and setter forms would stay a member named "new" even unquoted,
+// but Prettier keeps the quotes for every method-signature form.
+interface OtherSignatureForms {
+  "new"?(id: string): number;
+  get "new"(): number;
+  set "new"(value: number);
+}
+
 // These are all safe to unquote: they stay a member named "new".
 interface SafeToUnquote {
-  new?(id: string): number;
-  get new(): number;
-  set new(value: number);
   new: (id: string) => number;
 }
 class NewMethod {
@@ -250,7 +278,6 @@ const newMethod = {
 ---------------------------------------------------------------
 // Unquoting a method signature named "new" would turn it into a construct signature,
 // so its quotes must be preserved.
-// Prettier 3.9.5 still removes them;
 // https://github.com/prettier/prettier/issues/19618
 interface Container {
   'new'(id: string): number;
@@ -266,11 +293,16 @@ interface WithSiblings {
   'foo': string;
 }
 
+// Optional, getter, and setter forms would stay a member named "new" even unquoted,
+// but Prettier keeps the quotes for every method-signature form.
+interface OtherSignatureForms {
+  'new'?(id: string): number;
+  get 'new'(): number;
+  set 'new'(value: number);
+}
+
 // These are all safe to unquote: they stay a member named "new".
 interface SafeToUnquote {
-  new?(id: string): number;
-  get new(): number;
-  set new(value: number);
   new: (id: string) => number;
 }
 class NewMethod {
@@ -285,7 +317,6 @@ const newMethod = {
 ----------------------------------------------------------------
 // Unquoting a method signature named "new" would turn it into a construct signature,
 // so its quotes must be preserved.
-// Prettier 3.9.5 still removes them;
 // https://github.com/prettier/prettier/issues/19618
 interface Container {
   'new'(id: string): number;
@@ -301,11 +332,16 @@ interface WithSiblings {
   'foo': string;
 }
 
+// Optional, getter, and setter forms would stay a member named "new" even unquoted,
+// but Prettier keeps the quotes for every method-signature form.
+interface OtherSignatureForms {
+  'new'?(id: string): number;
+  get 'new'(): number;
+  set 'new'(value: number);
+}
+
 // These are all safe to unquote: they stay a member named "new".
 interface SafeToUnquote {
-  new?(id: string): number;
-  get new(): number;
-  set new(value: number);
   new: (id: string) => number;
 }
 class NewMethod {


### PR DESCRIPTION
Relax our conversion, preserve optional, getter/setter.