### PR TITLE
feat(oxfmt)!: Format parser:yaml files by oxc_formatter_yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,13 +292,13 @@ jobs:
       - uses: ./.github/actions/check-changes
         id: filter
         with:
-          paths: apps/oxfmt/,apps/shared/,npm/oxfmt/,crates/oxc_formatter/,crates/oxc_formatter_core/,crates/oxc_formatter_css/,crates/oxc_formatter_graphql/,crates/oxc_formatter_json/,crates/oxc_config/,pnpm-lock.yaml,package.json
+          paths: apps/oxfmt/,apps/shared/,npm/oxfmt/,crates/oxc_formatter/,crates/oxc_formatter_core/,crates/oxc_formatter_css/,crates/oxc_formatter_graphql/,crates/oxc_formatter_json/,crates/oxc_formatter_yaml/,crates/oxc_config/,pnpm-lock.yaml,package.json
           token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
       - uses: ./.github/actions/check-changes
         id: filter-conformance
         with:
-          paths: apps/oxfmt/,npm/oxfmt/,crates/oxc_formatter/,crates/oxc_formatter_core/,crates/oxc_formatter_css/,crates/oxc_formatter_graphql/,crates/oxc_formatter_json/,pnpm-lock.yaml,package.json
+          paths: apps/oxfmt/,npm/oxfmt/,crates/oxc_formatter/,crates/oxc_formatter_core/,crates/oxc_formatter_css/,crates/oxc_formatter_graphql/,crates/oxc_formatter_json/,crates/oxc_formatter_yaml/,pnpm-lock.yaml,package.json
           token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
       - uses: oxc-project/setup-node@4c588e9266bd930b6ddc34307df0659ed511d187 # v1.3.1
@@ -437,7 +437,7 @@ jobs:
       - uses: ./.github/actions/check-changes
         id: filter
         with:
-          paths: apps/oxfmt/,apps/shared/,npm/oxfmt/,crates/oxc_formatter/,crates/oxc_formatter_core/,crates/oxc_formatter_css/,crates/oxc_formatter_graphql/,crates/oxc_formatter_json/,crates/oxc_config/,pnpm-lock.yaml,package.json
+          paths: apps/oxfmt/,apps/shared/,npm/oxfmt/,crates/oxc_formatter/,crates/oxc_formatter_core/,crates/oxc_formatter_css/,crates/oxc_formatter_graphql/,crates/oxc_formatter_json/,crates/oxc_formatter_yaml/,crates/oxc_config/,pnpm-lock.yaml,package.json
           token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
       - uses: oxc-project/setup-node@4c588e9266bd930b6ddc34307df0659ed511d187 # v1.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2843,6 +2843,7 @@ dependencies = [
  "oxc_formatter_css",
  "oxc_formatter_graphql",
  "oxc_formatter_json",
+ "oxc_formatter_yaml",
  "oxc_language_server",
  "oxc_napi",
  "oxc_span",

--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -6,7 +6,7 @@ The `oxfmt` implemented under this directory serves several purposes.
 
 - Pure Rust CLI
   - Minimum feature set, CLI usage only, no LSP, no Stdin support
-  - Formats JS/TS, JSON, GraphQL and TOML files, no xxx-in-js support
+  - Formats JS/TS, JSON, CSS, GraphQL, YAML and TOML files, no xxx-in-js support
   - Entry point: `main()` in `src/main.rs`
   - Build with `cargo build --no-default-features`
 - JS/Rust hybrid CLI using `napi-rs`

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -35,6 +35,7 @@ oxc_formatter_core = { workspace = true }
 oxc_formatter_css = { workspace = true }
 oxc_formatter_graphql = { workspace = true }
 oxc_formatter_json = { workspace = true }
+oxc_formatter_yaml = { workspace = true }
 oxc_language_server = { workspace = true }
 oxc_napi = { workspace = true }
 oxc_span = { workspace = true }

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -10,6 +10,7 @@ use oxc_formatter_css::CssFormatOptions;
 use oxc_formatter_css::CssVariant;
 use oxc_formatter_graphql::GraphqlFormatOptions;
 use oxc_formatter_json::{JsonFormatOptions, JsonVariant};
+use oxc_formatter_yaml::YamlFormatOptions;
 use oxc_span::SourceType;
 use oxc_toml::Options as TomlFormatterOptions;
 
@@ -21,7 +22,7 @@ use super::options::{
 use super::{
     options::{
         to_oxc_formatter, to_oxc_formatter_css, to_oxc_formatter_graphql, to_oxc_formatter_json,
-        to_oxc_toml, to_sort_package_json,
+        to_oxc_formatter_yaml, to_oxc_toml, to_sort_package_json,
     },
     oxfmtrc::FormatConfig,
     support::FileKind,
@@ -76,6 +77,21 @@ pub enum FormatStrategy {
         config: Box<FormatConfig>,
         insert_final_newline: bool,
     },
+    /// For YAML files formatted by `oxc_formatter_yaml`.
+    OxcFormatterYaml {
+        path: Arc<Path>,
+        format_options: Box<YamlFormatOptions>,
+        insert_final_newline: bool,
+    },
+    /// For `.prettierrc` and friends: mirroring Prettier's yaml embed,
+    /// formatted by `oxc_formatter_json` when the whole text parses as JSON,
+    /// and by `oxc_formatter_yaml` otherwise.
+    OxcFormatterYamlRc {
+        path: Arc<Path>,
+        yaml_format_options: Box<YamlFormatOptions>,
+        json_format_options: Box<JsonFormatOptions>,
+        insert_final_newline: bool,
+    },
     /// For TOML files.
     OxfmtToml { path: Arc<Path>, toml_options: TomlFormatterOptions, insert_final_newline: bool },
     /// For non-JS files formatted by external formatter (Prettier).
@@ -106,6 +122,8 @@ impl FormatStrategy {
             | Self::OxcFormatterJsonPackageJson { path, .. }
             | Self::OxcFormatterGraphql { path, .. }
             | Self::OxcFormatterCss { path, .. }
+            | Self::OxcFormatterYaml { path, .. }
+            | Self::OxcFormatterYamlRc { path, .. }
             | Self::OxfmtToml { path, .. } => path,
             #[cfg(feature = "napi")]
             Self::ExternalFormatter { path, .. } => path,
@@ -163,6 +181,17 @@ impl FormatStrategy {
                 format_options: Box::new(to_oxc_formatter_css(&config, variant)?),
                 #[cfg(feature = "napi")]
                 config: Box::new(config),
+                insert_final_newline,
+            },
+            FileKind::OxcFormatterYaml { path } => Self::OxcFormatterYaml {
+                path,
+                format_options: Box::new(to_oxc_formatter_yaml(&config)?),
+                insert_final_newline,
+            },
+            FileKind::OxcFormatterYamlRc { path } => Self::OxcFormatterYamlRc {
+                path,
+                yaml_format_options: Box::new(to_oxc_formatter_yaml(&config)?),
+                json_format_options: Box::new(to_oxc_formatter_json(&config, JsonVariant::Json)?),
                 insert_final_newline,
             },
             FileKind::OxfmtToml { path } => {
@@ -278,6 +307,24 @@ impl SourceFormatter {
                     *format_options,
                     #[cfg(feature = "napi")]
                     &config,
+                ),
+                insert_final_newline,
+            ),
+            FormatStrategy::OxcFormatterYaml { path, format_options, insert_final_newline } => (
+                self.format_by_oxc_formatter_yaml(source_text, &path, *format_options),
+                insert_final_newline,
+            ),
+            FormatStrategy::OxcFormatterYamlRc {
+                path,
+                yaml_format_options,
+                json_format_options,
+                insert_final_newline,
+            } => (
+                self.format_by_oxc_formatter_yaml_rc(
+                    source_text,
+                    &path,
+                    *yaml_format_options,
+                    *json_format_options,
                 ),
                 insert_final_newline,
             ),
@@ -473,6 +520,42 @@ impl SourceFormatter {
             ))
         })?;
         Ok(printed.into_code())
+    }
+
+    /// Format YAML source using `oxc_formatter_yaml`.
+    #[instrument(level = "debug", name = "oxfmt::format::oxc_formatter_yaml", skip_all)]
+    fn format_by_oxc_formatter_yaml(
+        &self,
+        source_text: &str,
+        path: &Path,
+        format_options: YamlFormatOptions,
+    ) -> Result<String, OxcDiagnostic> {
+        let allocator = self.allocator_pool.get();
+        let formatted = oxc_formatter_yaml::format(&allocator, source_text, format_options)?;
+        let printed = formatted.print().map_err(|err| {
+            OxcDiagnostic::error(format!(
+                "Failed to print formatted YAML: {}\n{err}",
+                path.display()
+            ))
+        })?;
+        Ok(printed.into_code())
+    }
+
+    /// Format `.prettierrc` and friends the way Prettier's yaml embed does.
+    #[instrument(level = "debug", name = "oxfmt::format::oxc_formatter_yaml_rc", skip_all)]
+    fn format_by_oxc_formatter_yaml_rc(
+        &self,
+        source_text: &str,
+        path: &Path,
+        yaml_format_options: YamlFormatOptions,
+        json_format_options: JsonFormatOptions,
+    ) -> Result<String, OxcDiagnostic> {
+        if let Ok(printed) =
+            self.format_by_oxc_formatter_json(source_text, path, json_format_options)
+        {
+            return Ok(printed);
+        }
+        self.format_by_oxc_formatter_yaml(source_text, path, yaml_format_options)
     }
 
     /// Format TOML file using `oxc_toml`.

--- a/apps/oxfmt/src/core/options/mod.rs
+++ b/apps/oxfmt/src/core/options/mod.rs
@@ -6,6 +6,7 @@
 //!     for `package.json`'s sorting pre-process
 //! - [`to_oxc_formatter_css()`]: `oxc_formatter_css::CssFormatOptions` for CSS/SCSS/Less formatting
 //! - [`to_oxc_formatter_graphql()`]: `oxc_formatter_graphql::GraphqlFormatOptions` for GraphQL formatting
+//! - [`to_oxc_formatter_yaml()`]: `oxc_formatter_yaml::YamlFormatOptions` for YAML formatting
 //! - [`to_oxc_toml()`]: `oxc_toml::Options` for TOML formatting
 //! - `to_prettier`(NAPI-only): Prettier-compatible JSON, plus `inject_*` helpers for
 //!   layering in `parser` / `filepath` / plugin payloads at the format step
@@ -16,6 +17,7 @@ mod to_oxc_formatter;
 mod to_oxc_formatter_css;
 mod to_oxc_formatter_graphql;
 mod to_oxc_formatter_json;
+mod to_oxc_formatter_yaml;
 mod to_oxc_toml;
 #[cfg(feature = "napi")]
 mod to_prettier;
@@ -25,6 +27,7 @@ pub use to_oxc_formatter::to_oxc_formatter;
 pub use to_oxc_formatter_css::to_oxc_formatter_css;
 pub use to_oxc_formatter_graphql::to_oxc_formatter_graphql;
 pub use to_oxc_formatter_json::{to_oxc_formatter_json, to_sort_package_json};
+pub use to_oxc_formatter_yaml::to_oxc_formatter_yaml;
 pub use to_oxc_toml::to_oxc_toml;
 #[cfg(feature = "napi")]
 pub use to_prettier::{

--- a/apps/oxfmt/src/core/options/to_oxc_formatter_yaml.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter_yaml.rs
@@ -1,0 +1,54 @@
+use oxc_formatter_yaml::{
+    BracketSpacing, ProseWrap, SingleQuote, TrailingCommas, YamlFormatOptions,
+};
+
+use super::{
+    super::oxfmtrc::{FormatConfig, ProseWrapConfig, TrailingCommaConfig},
+    to_core_options::to_core_options,
+};
+
+/// Convert `FormatConfig` into validated `YamlFormatOptions` for `oxc_formatter_yaml`.
+///
+/// Prettier's `yaml` language consumes the shared layout options plus
+/// `proseWrap`, `singleQuote`, `bracketSpacing`, and `trailingComma`.
+///
+/// # Errors
+/// Returns error if any option value is invalid.
+pub fn to_oxc_formatter_yaml(config: &FormatConfig) -> Result<YamlFormatOptions, String> {
+    let core = to_core_options(config)?;
+
+    let mut options = YamlFormatOptions {
+        indent_style: core.indent_style,
+        indent_width: core.indent_width,
+        line_width: core.line_width,
+        line_ending: core.line_ending,
+        ..YamlFormatOptions::default()
+    };
+
+    // [Prettier] proseWrap: "preserve" | "always" | "never"
+    if let Some(prose_wrap) = config.prose_wrap {
+        options.prose_wrap = match prose_wrap {
+            ProseWrapConfig::Preserve => ProseWrap::Preserve,
+            ProseWrapConfig::Always => ProseWrap::Always,
+            ProseWrapConfig::Never => ProseWrap::Never,
+        };
+    }
+    // [Prettier] singleQuote: boolean
+    if let Some(single_quote) = config.single_quote {
+        options.single_quote = SingleQuote::from(single_quote);
+    }
+    // [Prettier] bracketSpacing: boolean
+    if let Some(spacing) = config.bracket_spacing {
+        options.bracket_spacing = BracketSpacing::from(spacing);
+    }
+    // [Prettier] trailingComma: "all" | "es5" | "none"
+    // `all`/`es5` are indistinguishable for YAML (flow collections only check "not none")
+    if let Some(trailing_comma) = config.trailing_comma {
+        options.trailing_commas = match trailing_comma {
+            TrailingCommaConfig::All | TrailingCommaConfig::Es5 => TrailingCommas::Always,
+            TrailingCommaConfig::None => TrailingCommas::Never,
+        };
+    }
+
+    Ok(options)
+}

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -63,6 +63,13 @@ pub fn classify_file_kind(path: Arc<Path>) -> Option<FileKind> {
     if let Some(variant) = classify_css_variant(extension) {
         return Some(FileKind::OxcFormatterCss { path, variant });
     }
+    // Check these before generic YAML check, because Prettier tries to format them as JSON(-in-YAML) first
+    if YAML_RC_FILENAMES.contains(file_name) {
+        return Some(FileKind::OxcFormatterYamlRc { path });
+    }
+    if is_yaml_file(file_name, extension) {
+        return Some(FileKind::OxcFormatterYaml { path });
+    }
 
     // External formatter files are only supported with the `napi` feature
     #[cfg(feature = "napi")]
@@ -101,6 +108,11 @@ pub enum FileKind {
     OxcFormatterGraphql { path: Arc<Path> },
     /// CSS/SCSS/Less files formatted by `oxc_formatter_css`.
     OxcFormatterCss { path: Arc<Path>, variant: CssVariant },
+    /// YAML files formatted by `oxc_formatter_yaml`.
+    OxcFormatterYaml { path: Arc<Path> },
+    /// Files like `.prettierrc`:
+    /// mirroring Prettier's yaml embed, they are formatted as JSON first, then fall back to YAML if that fails.
+    OxcFormatterYamlRc { path: Arc<Path> },
     /// TOML files formatted by taplo (Pure Rust).
     OxfmtToml { path: Arc<Path> },
     /// Files formatted by external formatter (Prettier).
@@ -127,6 +139,8 @@ impl FileKind {
             | Self::OxcFormatterJsonPackageJson { path }
             | Self::OxcFormatterGraphql { path }
             | Self::OxcFormatterCss { path, .. }
+            | Self::OxcFormatterYaml { path }
+            | Self::OxcFormatterYamlRc { path }
             | Self::OxfmtToml { path } => path,
             #[cfg(feature = "napi")]
             Self::ExternalFormatter { path, .. } => path,
@@ -362,20 +376,48 @@ static CSS_EXTENSIONS: phf::Set<&'static str> = phf_set! {
 
 // ---
 
+/// Prettier tries to format these as JSON first, and falls back to YAML when that fails.
+static YAML_RC_FILENAMES: phf::Set<&'static str> = phf_set! {
+    ".prettierrc",
+    ".stylelintrc",
+    ".lintstagedrc",
+};
+
+/// Returns `true` if this is a YAML file (handled by `oxc_formatter_yaml`).
+fn is_yaml_file(file_name: &str, extension: Option<&str>) -> bool {
+    if YAML_FILENAMES.contains(file_name) {
+        return true;
+    }
+    extension.is_some_and(|ext| YAML_EXTENSIONS.contains(ext))
+}
+
+static YAML_FILENAMES: phf::Set<&'static str> = phf_set! {
+    ".clang-format",
+    ".clang-tidy",
+    ".clangd",
+    ".gemrc",
+    "CITATION.cff",
+    "glide.lock",
+    "pixi.lock",
+};
+
+static YAML_EXTENSIONS: phf::Set<&'static str> = phf_set! {
+    "yml",
+    "mir",
+    "reek",
+    "rviz",
+    "sublime-syntax",
+    "syntax",
+    "yaml",
+    "yaml-tmlanguage",
+};
+
+// ---
+
 /// Returns parser name for external formatter, if supported.
 /// See also `prettier --support-info | jq '.languages[]'`
 #[cfg(feature = "napi")]
 fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<&'static str> {
-    // YAML
-    if YAML_FILENAMES.contains(file_name) {
-        return Some("yaml");
-    }
-    if let Some(ext) = extension
-        && YAML_EXTENSIONS.contains(ext)
-    {
-        return Some("yaml");
-    }
-
     // Markdown and variants
     if MARKDOWN_FILENAMES.contains(file_name) {
         return Some("markdown");
@@ -457,32 +499,6 @@ static MARKDOWN_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "ronn",
     "scd",
     "workbook",
-};
-
-#[cfg(feature = "napi")]
-static YAML_FILENAMES: phf::Set<&'static str> = phf_set! {
-    ".clang-format",
-    ".clang-tidy",
-    ".clangd",
-    ".gemrc",
-    "CITATION.cff",
-    "glide.lock",
-    "pixi.lock",
-    ".prettierrc",
-    ".stylelintrc",
-    ".lintstagedrc",
-};
-
-#[cfg(feature = "napi")]
-static YAML_EXTENSIONS: phf::Set<&'static str> = phf_set! {
-    "yml",
-    "mir",
-    "reek",
-    "rviz",
-    "sublime-syntax",
-    "syntax",
-    "yaml",
-    "yaml-tmlanguage",
 };
 
 // ---
@@ -652,12 +668,13 @@ mod tests {
             ("guide.markdown", Some("markdown")),
             ("notes.mdown", Some("markdown")),
             ("page.mdx", Some("mdx")),
-            // YAML
-            (".clang-format", Some("yaml")),
-            (".prettierrc", Some("yaml")),
-            ("config.yml", Some("yaml")),
-            ("settings.yaml", Some("yaml")),
-            ("grammar.sublime-syntax", Some("yaml")),
+            // YAML files are routed to `oxc_formatter_yaml` in `classify_file_kind`
+            // and excluded from this map.
+            (".clang-format", None),
+            (".prettierrc", None),
+            ("config.yml", None),
+            ("settings.yaml", None),
+            ("grammar.sublime-syntax", None),
             // Unknown
             ("unknown.txt", None),
             ("prof.png", None),
@@ -738,6 +755,37 @@ mod tests {
                 "`{file_name}` should be routed to oxc_formatter_css ({expected:?})"
             );
         }
+    }
+
+    #[test]
+    fn test_yaml_files_route_to_oxc_formatter_yaml() {
+        // YAML_EXTENSIONS and YAML_FILENAMES
+        for file_name in [
+            "config.yml",
+            "settings.yaml",
+            "grammar.sublime-syntax",
+            ".clang-format",
+            "CITATION.cff",
+        ] {
+            let result = classify_file_kind(Arc::from(Path::new(file_name)));
+            assert!(
+                matches!(result, Some(FileKind::OxcFormatterYaml { .. })),
+                "`{file_name}` should be routed to oxc_formatter_yaml"
+            );
+        }
+
+        // rc files Prettier tries as JSON first
+        for file_name in [".prettierrc", ".stylelintrc", ".lintstagedrc"] {
+            let result = classify_file_kind(Arc::from(Path::new(file_name)));
+            assert!(
+                matches!(result, Some(FileKind::OxcFormatterYamlRc { .. })),
+                "`{file_name}` should be routed to the JSON-first YAML rc kind"
+            );
+        }
+
+        // YAML lock files are excluded, not formatted
+        let result = classify_file_kind(Arc::from(Path::new("pnpm-lock.yaml")));
+        assert!(result.is_none(), "`pnpm-lock.yaml` should be excluded");
     }
 
     #[test]

--- a/apps/oxfmt/test/api/yaml.test.ts
+++ b/apps/oxfmt/test/api/yaml.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { format } from "../../dist/index.js";
+
+describe("YAML files (oxc_formatter_yaml)", () => {
+  it("should format standalone YAML files in Rust", async () => {
+    const source = `a:   1\nlist:\n  - "x"\n  -   y\nflow: {a: 1, b: [1,2]}\n`;
+    const result = await format("config.yaml", source);
+    expect(result.code).toMatchInlineSnapshot(`
+      "a: 1
+      list:
+        - "x"
+        - y
+      flow: { a: 1, b: [1, 2] }
+      "
+    `);
+  });
+
+  it("should format .yml and other extensions and filenames as YAML", async () => {
+    const source = `key:   value\n`;
+    for (const filename of [
+      "config.yml",
+      "grammar.sublime-syntax",
+      ".clang-format",
+      "CITATION.cff",
+    ]) {
+      // oxlint-disable-next-line no-await-in-loop
+      const result = await format(filename, source);
+      expect(result.code).toBe("key: value\n");
+    }
+  });
+
+  it("should respect singleQuote and proseWrap", async () => {
+    const quoted = await format("config.yaml", `q: 'single'\n`, {
+      singleQuote: true,
+    });
+    expect(quoted.code).toBe("q: 'single'\n");
+
+    const wrapped = await format("config.yaml", `text: aaa bbb ccc\n`, {
+      proseWrap: "always",
+      printWidth: 8,
+    });
+    expect(wrapped.code).toBe("text:\n  aaa\n  bbb\n  ccc\n");
+  });
+
+  it("should format rc files as JSON when the whole text parses as JSON", async () => {
+    const source = `{\n  "singleQuote":true,   "semi": false\n}\n`;
+    const result = await format(".stylelintrc", source);
+    expect(result.code).toBe(`{\n  "singleQuote": true,\n  "semi": false\n}\n`);
+  });
+
+  it("should format rc files as YAML when the text is not JSON", async () => {
+    const source = `singleQuote:   true\nsemi: false\n`;
+    const result = await format(".prettierrc", source);
+    expect(result.code).toBe("singleQuote: true\nsemi: false\n");
+  });
+
+  it("should report a diagnostic for broken input (no Prettier fallback)", async () => {
+    // Unclosed flow sequence; the parser is fail-fast, so the error is surfaced as-is.
+    // Prettier 3.9 (yaml@2) rejects this input as well.
+    const source = `a: [1, 2\n`;
+    const result = await format("broken.yaml", source);
+    expect(result.code).toBe(source);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toMatch(/Syntax error/);
+  });
+});

--- a/apps/oxfmt/test/cli/error_reports/1.snap.md
+++ b/apps/oxfmt/test/cli/error_reports/1.snap.md
@@ -26,11 +26,11 @@ Checking formatting...
 ## stderr
 ```
 
-  x SyntaxError: Nested mappings are not allowed in compact mappings (1:6)
-  | [invalid.yaml]
-  | > 1 | key: val: nested
-  |     |      ^
-  |   2 |
+  x Syntax error: mapping values are not allowed in this context
+   ,-[invalid.yaml:1:9]
+ 1 | key: val: nested
+   :         ^
+   `----
 Error occurred when checking code style in the above files.
 ```
 


### PR DESCRIPTION
Format `.yaml`, `.yml` and others by `oxc_formatter_yaml`.

Also handle maybe-json-or-yaml files like `.prettierrc`.