### PR TITLE
test(oxfmt): remove unicode-ascii replaces

### DIFF
--- a/apps/oxfmt/test/cli/utils.ts
+++ b/apps/oxfmt/test/cli/utils.ts
@@ -91,6 +91,10 @@ export async function runFixture(fixture: Fixture, testCase: TestCaseOptions): P
       input = await fs.readFile(join(fixture.fixturesPath, testCase.stdin), "utf8");
     }
 
+    // Drop `CI` and `FORCE_COLOR` so oxc-miette always renders with the ASCII theme;
+    // otherwise CI runs emit unicode markers that diverge from locally generated snapshots
+    const { CI: _ci, FORCE_COLOR: _forceColor, ...inheritedEnv } = process.env;
+
     // Execute
     const { stdout, stderr, exitCode } = await execa(
       "node",
@@ -100,7 +104,9 @@ export async function runFixture(fixture: Fixture, testCase: TestCaseOptions): P
         reject: false,
         timeout: 5000,
         input,
-        env: { ...process.env, ...testCase.env },
+        // `extendEnv: false` prevents execa from merging `process.env` back in
+        env: { ...inheritedEnv, ...testCase.env },
+        extendEnv: false,
       },
     );
 
@@ -324,13 +330,6 @@ function normalizeOutput(output: string, cwd: string): string {
       .replace(/\\/g, "/")
       .replace(new RegExp(RegExp.escape(cwdPath), "g"), "<cwd>")
       .replace(new RegExp(RegExp.escape(rootPath), "g"), "<root>")
-      .replace(/×/g, "x")
-      .replace(/╭/g, ",")
-      .replace(/─/g, "-")
-      .replace(/│/g, "|")
-      .replace(/·/g, ":")
-      .replace(/┬/g, "|")
-      .replace(/╰/g, "`")
       .replace(/[^\S\n]+$/gm, "")
   );
 }


### PR DESCRIPTION
Now it is forced by env var.
