### PR TITLE
feat(parser): emit error for type args in JS files

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -1140,6 +1140,11 @@ parser_diagnostics! {
             .with_help("Move this after all the overloads")
     };
 
+    type_arguments_in_ts(span: Span) => {
+        ts_error("8011", "Type arguments can only be used in TypeScript files.")
+            .with_label(span)
+    };
+
     as_in_ts(span: Span) => {
         ts_error("8016", "Type assertion expressions can only be used in TypeScript files.")
             .with_label(span)

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -890,6 +890,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             if params.is_empty() {
                 self.error(diagnostics::ts_empty_type_argument_list(span));
             }
+            if !self.is_ts {
+                self.error(diagnostics::type_arguments_in_ts(span));
+            }
             return Some(TSTypeParameterInstantiation::boxed(span, params, self));
         }
         None

--- a/tasks/coverage/misc/fail/type-arguments-in-js.js
+++ b/tasks/coverage/misc/fail/type-arguments-in-js.js
@@ -1,0 +1,1 @@
+class A extends B<C> {}

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 74/74 (100.00%)
 Positive Passed: 74/74 (100.00%)
-Negative Passed: 154/154 (100.00%)
+Negative Passed: 155/155 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval-ambient.ts:2:13]
@@ -4205,3 +4205,9 @@ Negative Passed: 154/154 (100.00%)
    ·                                 ▲
    ╰────
   help: Try inserting a semicolon here
+
+  × TS(8011): Type arguments can only be used in TypeScript files.
+   ╭─[misc/fail/type-arguments-in-js.js:1:18]
+ 1 │ class A extends B<C> {}
+   ·                  ───
+   ╰────


### PR DESCRIPTION
## Summary

- Emit TS8011 when a JavaScript class heritage clause uses TypeScript type arguments.
- Cover the diagnostic with a misc parser failure fixture and snapshot.