### PR TITLE
fix(formatter_yaml): let ancestor collection values claim end comments after block scalars

### DIFF
--- a/crates/oxc_formatter_yaml/AGENTS.md
+++ b/crates/oxc_formatter_yaml/AGENTS.md
@@ -61,7 +61,9 @@ Current divergences:
 - blank lines (prettier#15528): one unified rule:
   a blank line right after a node is preserved (normalized to one) if the source had one, never invented, identical for every node kind and context.
   Prettier's matrix (block collections only between documents; mappings only before end comments; unconditional insertion after block scalars) is not ported.
-  This also keeps `proseWrap: never` idempotent where Prettier is not (prettier#10776)
+  This also keeps `proseWrap: never` idempotent where Prettier is not (prettier#10776),
+  and covers the blank DOUBLED in front of stream-end comments when the last item carries a trailing comment
+  (the prettier#9130 shape, resurfaced: one source blank comes out as two)
 - folded scalar more-indented lines (prettier#16126): never re-flowed under `proseWrap: always`, their line breaks are literal per YAML folding,
   so Prettier's wrapping at the print width changes the parsed value and breaks idempotency
 - "broken but not broken" flow collections: Prettier sometimes emits a newline inside flow brackets while keeping them flat (no trailing comma, `]`/`}` on the content line).

--- a/crates/oxc_formatter_yaml/src/comments.rs
+++ b/crates/oxc_formatter_yaml/src/comments.rs
@@ -311,6 +311,7 @@ pub fn write_suppressed_node(span: Span, f: &mut YamlFormatter<'_, '_>) {
 /// printed at the container's item-content column: `align_width` in from the items,
 /// the tab width for block mappings, the `- ` width (2) for block sequences
 /// (the placement effect of Prettier's `shouldOwnEndComment` + `mappingValue.endComments`, re-derived positionally).
+/// Its direct-block-scalar exclusion is the caller's gate: `ItemTail` in `print/block_collection.rs`.
 /// Returns the position after the last claimed comment so the caller can keep measuring gaps from it.
 pub fn flush_container_end_comments(
     item_column: u32,

--- a/crates/oxc_formatter_yaml/src/print/block.rs
+++ b/crates/oxc_formatter_yaml/src/print/block.rs
@@ -377,8 +377,11 @@ pub fn last_descendant_end(root: &Root<'_>) -> u32 {
 /// a block scalar's span consumes its trailing line breaks (they are part of its VALUE under keep chomping),
 /// so blank-line detection must start after the last content character,
 /// otherwise the blank line separating it from the next item is invisible.
-pub fn item_gap_anchor(content: Option<&Node<'_>>, end: u32, f: &YamlFormatter<'_, '_>) -> u32 {
-    let Some(block) = content.and_then(last_descendant_block_scalar) else {
+///
+/// `block` is the item's resolved [`last_descendant_block_scalar`];
+/// callers that need the walk's result themselves pass it in instead of paying for it twice.
+pub fn item_gap_anchor(block: Option<&BlockScalar>, end: u32, f: &YamlFormatter<'_, '_>) -> u32 {
+    let Some(block) = block else {
         return end;
     };
     // Under keep chomping every trailing newline IS the value; the span end is the correct anchor

--- a/crates/oxc_formatter_yaml/src/print/block_collection.rs
+++ b/crates/oxc_formatter_yaml/src/print/block_collection.rs
@@ -3,7 +3,7 @@ use oxc_formatter_core::{
     builders::{align, group},
     write,
 };
-use oxc_yaml_parser::ast::{Mapping, Sequence};
+use oxc_yaml_parser::ast::{Content, Mapping, Sequence};
 
 use crate::{
     comments::{
@@ -27,37 +27,48 @@ fn write_item_separator(prev_end: u32, next_start: u32, f: &mut YamlFormatter<'_
     write_blank_preserving_break(prev_end, upper_bound, f);
 }
 
-/// Emits the previous item's same-line trailing comment and container end comments,
-/// then the separator to the next item (when one follows).
+/// How an item's tail interacts with the comments that follow it.
+#[derive(Clone, Copy, PartialEq)]
+enum ItemTail {
+    /// No block scalar: same-line trailing comment, then container end comments.
+    Plain,
+    /// The item ends in a block scalar at SOME depth, whose span consumes the trailing line breaks:
+    /// a following own-line comment would LOOK same-line,
+    /// and absorbing it onto the header would change the parsed value, skip the same-line check, still claim end comments.
+    /// Also every sequence-item block scalar, direct or not
+    /// (Prettier's `shouldOwnEndComment` has no block-scalar exclusion for sequence items).
+    EndsInBlockScalar,
+    /// The item's VALUE is a block scalar (mapping only):
+    /// it cannot own end comments either
+    /// (Prettier's `shouldOwnEndComment` exclusion, an ancestor whose value is a collection still can);
+    /// skip both, the comments fall through to the enclosing container or the next node's leading position.
+    ValueIsBlockScalar,
+}
+
+/// Emits the previous item's same-line trailing comment and container end comments
+/// (as far as its [`ItemTail`] allows), then the separator to the next item (when one follows).
 ///
-/// `align_width` is forwarded to [`flush_container_end_comments`]
-/// (see its doc for the per-container value).
-///
-/// Both are skipped after a block scalar value:
-/// its span consumes the trailing line breaks
-/// (a comment on the following line would LOOK same-line, and none can follow one),
-/// and comments under its content region lead the next item instead
-/// (Prettier's `shouldOwnEndComment` exclusion).
+/// `align_width` is forwarded to [`flush_container_end_comments`] (see its doc for the per-container value).
 fn finish_previous_item(
     item_column: u32,
     align_width: u8,
-    prev_end: u32,
-    prev_blocks_end_comments: bool,
+    mut prev_end: u32,
+    prev_tail: ItemTail,
     next_start: Option<u32>,
     f: &mut YamlFormatter<'_, '_>,
 ) {
-    let prev_end = if prev_blocks_end_comments {
-        prev_end
-    } else {
+    if prev_tail == ItemTail::Plain {
         write_trailing_same_line_comment(prev_end, &[], f);
-        flush_container_end_comments(
+    }
+    if prev_tail != ItemTail::ValueIsBlockScalar {
+        prev_end = flush_container_end_comments(
             item_column,
             align_width,
             prev_end,
             next_start.unwrap_or(u32::MAX),
             f,
-        )
-    };
+        );
+    }
     if let Some(next_start) = next_start {
         write_item_separator(prev_end, next_start, f);
     }
@@ -73,26 +84,22 @@ pub fn write_mapping<'a>(
     let item_column = column_of(&f.context().source_text(), mapping.span.start);
     let align_width = f.options().indent_width.value();
     let mut prev_end: Option<u32> = None;
-    let mut prev_blocks_end_comments = false;
+    let mut prev_tail = ItemTail::Plain;
     for item in &mapping.children {
         let start = item.span.start;
         if let Some(prev_end) = prev_end {
-            finish_previous_item(
-                item_column,
-                align_width,
-                prev_end,
-                prev_blocks_end_comments,
-                Some(start),
-                f,
-            );
+            finish_previous_item(item_column, align_width, prev_end, prev_tail, Some(start), f);
         }
         let value_node = item.value_content();
-        prev_end = Some(item_gap_anchor(value_node, item.span.end, f));
-        // Descendant-aware, like `item_gap_anchor`:
-        // a block scalar ending the item at ANY depth consumes the trailing line breaks,
-        // so a following own-line comment would otherwise classify as same-line
-        // and be absorbed into the scalar's content (changing the parsed value).
-        prev_blocks_end_comments = value_node.and_then(last_descendant_block_scalar).is_some();
+        let last_block = value_node.and_then(last_descendant_block_scalar);
+        prev_end = Some(item_gap_anchor(last_block, item.span.end, f));
+        prev_tail = match value_node.map(|node| &node.content) {
+            Some(Content::BlockLiteral(_) | Content::BlockFolded(_)) => {
+                ItemTail::ValueIsBlockScalar
+            }
+            _ if last_block.is_some() => ItemTail::EndsInBlockScalar,
+            _ => ItemTail::Plain,
+        };
 
         if is_suppressed_last_before(f, start) {
             write_suppressed_node(to_span(item.span), f);
@@ -110,7 +117,7 @@ pub fn write_mapping<'a>(
         write!(f, group(&entry));
     }
     if let Some(prev_end) = prev_end {
-        finish_previous_item(item_column, align_width, prev_end, prev_blocks_end_comments, None, f);
+        finish_previous_item(item_column, align_width, prev_end, prev_tail, None, f);
     }
     let depth = f.context().collection_depth();
     depth.set(depth.get() - 1);
@@ -125,22 +132,23 @@ pub fn write_sequence<'a>(sequence: &'a Sequence<'a>, f: &mut YamlFormatter<'_, 
 
     let item_column = column_of(&f.context().source_text(), sequence.span.start);
     let mut prev_end: Option<u32> = None;
-    let mut prev_blocks_end_comments = false;
+    let mut prev_tail = ItemTail::Plain;
     for item in &sequence.children {
         if let Some(prev_end) = prev_end {
             finish_previous_item(
                 item_column,
                 SEQ_CONTENT_ALIGN,
                 prev_end,
-                prev_blocks_end_comments,
+                prev_tail,
                 Some(item.span.start),
                 f,
             );
         }
-        prev_end = Some(item_gap_anchor(item.content.as_deref(), item.span.end, f));
-        // Descendant-aware for the same reason as in `write_mapping`
-        prev_blocks_end_comments =
-            item.content.as_deref().and_then(last_descendant_block_scalar).is_some();
+        let last_block = item.content.as_deref().and_then(last_descendant_block_scalar);
+        prev_end = Some(item_gap_anchor(last_block, item.span.end, f));
+        // Never `ValueIsBlockScalar` here: see its doc on [`ItemTail`]
+        prev_tail =
+            if last_block.is_some() { ItemTail::EndsInBlockScalar } else { ItemTail::Plain };
 
         if is_suppressed_last_before(f, item.span.start) {
             write_suppressed_node(to_span(item.span), f);
@@ -161,14 +169,7 @@ pub fn write_sequence<'a>(sequence: &'a Sequence<'a>, f: &mut YamlFormatter<'_, 
         }
     }
     if let Some(prev_end) = prev_end {
-        finish_previous_item(
-            item_column,
-            SEQ_CONTENT_ALIGN,
-            prev_end,
-            prev_blocks_end_comments,
-            None,
-            f,
-        );
+        finish_previous_item(item_column, SEQ_CONTENT_ALIGN, prev_end, prev_tail, None, f);
     }
     let depth = f.context().collection_depth();
     depth.set(depth.get() - 1);

--- a/crates/oxc_formatter_yaml/src/print/document.rs
+++ b/crates/oxc_formatter_yaml/src/print/document.rs
@@ -73,7 +73,10 @@ fn document_end_comment_anchor(document: &Document<'_>, f: &YamlFormatter<'_, '_
 /// or the end of its body (adjusted for a block scalar tail, whose span consumes the trailing line breaks).
 fn document_gap_anchor(document: &Document<'_>, f: &YamlFormatter<'_, '_>) -> u32 {
     document.document_end_marker.map_or_else(
-        || item_gap_anchor(document.body.content.as_deref(), document.body.span.end, f),
+        || {
+            let block = document.body.content.as_deref().and_then(last_descendant_block_scalar);
+            item_gap_anchor(block, document.body.span.end, f)
+        },
         |marker| marker.end,
     )
 }

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/blank-lines.yaml
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/blank-lines.yaml
@@ -18,3 +18,8 @@ scalar doc
 literal: |
   text
 # no blank is invented between a block scalar and this comment
+---
+last: value # trailing
+
+# one blank stays one; Prettier doubles it when the final item
+# has a trailing comment (the prettier#9130 shape, still alive there)

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/blank-lines.yaml.snap
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/blank-lines.yaml.snap
@@ -22,6 +22,11 @@ scalar doc
 literal: |
   text
 # no blank is invented between a block scalar and this comment
+---
+last: value # trailing
+
+# one blank stays one; Prettier doubles it when the final item
+# has a trailing comment (the prettier#9130 shape, still alive there)
 
 ==================== Output ====================
 ------------------
@@ -44,6 +49,11 @@ scalar doc
 literal: |
   text
 # no blank is invented between a block scalar and this comment
+---
+last: value # trailing
+
+# one blank stays one; Prettier doubles it when the final item
+# has a trailing comment (the prettier#9130 shape, still alive there)
 
 -------------------
 { printWidth: 100 }
@@ -65,5 +75,10 @@ scalar doc
 literal: |
   text
 # no blank is invented between a block scalar and this comment
+---
+last: value # trailing
+
+# one blank stays one; Prettier doubles it when the final item
+# has a trailing comment (the prettier#9130 shape, still alive there)
 
 ===================== End =====================

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/block-scalar-comments.yaml
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/block-scalar-comments.yaml
@@ -1,6 +1,7 @@
-# An own-line comment after an item whose LAST DESCENDANT (not direct content)
-# is a block scalar must lead the next item — never be absorbed into the
-# scalar's content as a same-line comment (that would change the parsed value).
+# An own-line comment after an item ending in a block scalar must never be
+# absorbed into the scalar's content as a same-line comment (that would change
+# the parsed value). At the item's own column it leads the next item;
+# a deeper one becomes a container end comment (see end-comment-align/).
 steps:
   - restore-keys: |
       store-

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/block-scalar-comments.yaml.snap
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/block-scalar-comments.yaml.snap
@@ -2,9 +2,10 @@
 source: crates/oxc_formatter_yaml/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
-# An own-line comment after an item whose LAST DESCENDANT (not direct content)
-# is a block scalar must lead the next item — never be absorbed into the
-# scalar's content as a same-line comment (that would change the parsed value).
+# An own-line comment after an item ending in a block scalar must never be
+# absorbed into the scalar's content as a same-line comment (that would change
+# the parsed value). At the item's own column it leads the next item;
+# a deeper one becomes a container end comment (see end-comment-align/).
 steps:
   - restore-keys: |
       store-
@@ -20,9 +21,10 @@ after: 1
 ------------------
 { printWidth: 80 }
 ------------------
-# An own-line comment after an item whose LAST DESCENDANT (not direct content)
-# is a block scalar must lead the next item — never be absorbed into the
-# scalar's content as a same-line comment (that would change the parsed value).
+# An own-line comment after an item ending in a block scalar must never be
+# absorbed into the scalar's content as a same-line comment (that would change
+# the parsed value). At the item's own column it leads the next item;
+# a deeper one becomes a container end comment (see end-comment-align/).
 steps:
   - restore-keys: |
       store-
@@ -37,9 +39,10 @@ after: 1
 -------------------
 { printWidth: 100 }
 -------------------
-# An own-line comment after an item whose LAST DESCENDANT (not direct content)
-# is a block scalar must lead the next item — never be absorbed into the
-# scalar's content as a same-line comment (that would change the parsed value).
+# An own-line comment after an item ending in a block scalar must never be
+# absorbed into the scalar's content as a same-line comment (that would change
+# the parsed value). At the item's own column it leads the next item;
+# a deeper one becomes a container end comment (see end-comment-align/).
 steps:
   - restore-keys: |
       store-

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/block-scalar-header-comment-width.yaml
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/block-scalar-header-comment-width.yaml
@@ -1,0 +1,8 @@
+# DIVERGENCE (AGENTS.md "trailing comment width"): a same-line trailing comment
+# is a line_suffix and never counts toward the fits measurement, so the header
+# stays on the key line; Prettier measures it inline and breaks the pair
+# (`run:` / `| # ...`) once the comment overflows the print width.
+run: | # this trailing comment is long enough to push the header line far beyond every print width
+  set -euo pipefail
+short: | # fits
+  ok

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/block-scalar-header-comment-width.yaml.snap
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/block-scalar-header-comment-width.yaml.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_formatter_yaml/tests/fixtures/mod.rs
+---
+==================== Input ====================
+# DIVERGENCE (AGENTS.md "trailing comment width"): a same-line trailing comment
+# is a line_suffix and never counts toward the fits measurement, so the header
+# stays on the key line; Prettier measures it inline and breaks the pair
+# (`run:` / `| # ...`) once the comment overflows the print width.
+run: | # this trailing comment is long enough to push the header line far beyond every print width
+  set -euo pipefail
+short: | # fits
+  ok
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+# DIVERGENCE (AGENTS.md "trailing comment width"): a same-line trailing comment
+# is a line_suffix and never counts toward the fits measurement, so the header
+# stays on the key line; Prettier measures it inline and breaks the pair
+# (`run:` / `| # ...`) once the comment overflows the print width.
+run: | # this trailing comment is long enough to push the header line far beyond every print width
+  set -euo pipefail
+short: | # fits
+  ok
+
+-------------------
+{ printWidth: 100 }
+-------------------
+# DIVERGENCE (AGENTS.md "trailing comment width"): a same-line trailing comment
+# is a line_suffix and never counts toward the fits measurement, so the header
+# stays on the key line; Prettier measures it inline and breaks the pair
+# (`run:` / `| # ...`) once the comment overflows the print width.
+run: | # this trailing comment is long enough to push the header line far beyond every print width
+  set -euo pipefail
+short: | # fits
+  ok
+
+===================== End =====================

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/end-comment-align/after-block-scalar.yaml
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/end-comment-align/after-block-scalar.yaml
@@ -1,0 +1,24 @@
+nested:
+  steps:
+    - with:
+        permissions: |
+          actions: read
+
+        # ancestor collection value claims these
+        # at its content column
+top: |-
+  text
+
+# a direct block scalar value owns no end comments,
+# these lead the next key instead
+next: 1
+seq:
+  - |
+    content
+
+  # a sequence item claims even over a direct block scalar
+  - after
+last: |
+  tail
+
+ # under-indented at eof, dedents to the stream tail

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/end-comment-align/after-block-scalar.yaml.snap
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/end-comment-align/after-block-scalar.yaml.snap
@@ -1,0 +1,143 @@
+---
+source: crates/oxc_formatter_yaml/tests/fixtures/mod.rs
+---
+==================== Input ====================
+nested:
+  steps:
+    - with:
+        permissions: |
+          actions: read
+
+        # ancestor collection value claims these
+        # at its content column
+top: |-
+  text
+
+# a direct block scalar value owns no end comments,
+# these lead the next key instead
+next: 1
+seq:
+  - |
+    content
+
+  # a sequence item claims even over a direct block scalar
+  - after
+last: |
+  tail
+
+ # under-indented at eof, dedents to the stream tail
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+nested:
+  steps:
+    - with:
+        permissions: |
+          actions: read
+
+        # ancestor collection value claims these
+        # at its content column
+top: |-
+  text
+
+# a direct block scalar value owns no end comments,
+# these lead the next key instead
+next: 1
+seq:
+  - |
+    content
+
+  # a sequence item claims even over a direct block scalar
+  - after
+last: |
+  tail
+
+# under-indented at eof, dedents to the stream tail
+
+-------------------
+{ printWidth: 100 }
+-------------------
+nested:
+  steps:
+    - with:
+        permissions: |
+          actions: read
+
+        # ancestor collection value claims these
+        # at its content column
+top: |-
+  text
+
+# a direct block scalar value owns no end comments,
+# these lead the next key instead
+next: 1
+seq:
+  - |
+    content
+
+  # a sequence item claims even over a direct block scalar
+  - after
+last: |
+  tail
+
+# under-indented at eof, dedents to the stream tail
+
+-------------------------------
+{ printWidth: 80, tabWidth: 4 }
+-------------------------------
+nested:
+    steps:
+        - with:
+              permissions: |
+                  actions: read
+
+              # ancestor collection value claims these
+              # at its content column
+top: |-
+    text
+
+# a direct block scalar value owns no end comments,
+# these lead the next key instead
+next: 1
+seq:
+    - |
+        content
+
+    # a sequence item claims even over a direct block scalar
+    - after
+last: |
+    tail
+
+# under-indented at eof, dedents to the stream tail
+
+--------------------------------
+{ printWidth: 100, tabWidth: 4 }
+--------------------------------
+nested:
+    steps:
+        - with:
+              permissions: |
+                  actions: read
+
+              # ancestor collection value claims these
+              # at its content column
+top: |-
+    text
+
+# a direct block scalar value owns no end comments,
+# these lead the next key instead
+next: 1
+seq:
+    - |
+        content
+
+    # a sequence item claims even over a direct block scalar
+    - after
+last: |
+    tail
+
+# under-indented at eof, dedents to the stream tail
+
+===================== End =====================


### PR DESCRIPTION
```yaml
    with:
      additional_permissions: |
        actions: read

      # Keep this comment indented
```