### PR TITLE
fix(ci): reduce code coverage memory usage

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,8 +43,10 @@ jobs:
 
       - name: Run
         env:
-          # Increase stack size to 10MB, avoid `oxc_formatter` from stack overflowing when printing long assignment expressions.
-          RUST_MIN_STACK: 104857600
+          # Increase stack size to 10MiB, avoid `oxc_formatter` from stack overflowing when printing long assignment expressions.
+          RUST_MIN_STACK: 10485760
+          # Limit concurrent compiler processes to avoid exhausting the 8GiB runner.
+          CARGO_BUILD_JOBS: 2
         run: cargo codecov --lcov --output-path lcov.info
 
       - name: Upload Artifact


### PR DESCRIPTION
## Summary

- limit Cargo coverage builds to two concurrent compiler processes on the 8 GiB runner
- correct RUST_MIN_STACK from 100 MiB to the documented 10 MiB

## Why

Recent Code Coverage runs intermittently kill rustc with SIGKILL while compiling the coverage-instrumented oxc_linter test binary. The same binary succeeds on reruns, which is consistent with runner memory exhaustion rather than a source or test failure.
