### PR TITLE
fix(parser): clarify return in class static blocks

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -722,6 +722,11 @@ parser_diagnostics! {
             .with_label(span)
     };
 
+    return_statement_in_class_static_block(span: Span) => {
+        ts_error("18041", "A 'return' statement cannot be used inside a class static block.")
+            .with_label(span)
+    };
+
     invalid_identifier_in_using_declaration(span: Span) => {
         OxcDiagnostic::error("Using declarations may not have binding patterns.").with_label(span)
     };

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -686,7 +686,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Some(expr)
         };
         if !self.ctx.has_return() {
-            self.error(diagnostics::return_statement_only_in_function_body(Span::sized(span, 6)));
+            let span = Span::sized(span, 6);
+            // Class static blocks enable `NewTarget` but disable `Return`.
+            // Other contexts that allow `new.target` cannot directly contain
+            // a return statement without entering a function body first.
+            if self.ctx.has_new_target() {
+                self.error(diagnostics::return_statement_in_class_static_block(span));
+            } else {
+                self.error(diagnostics::return_statement_only_in_function_body(span));
+            }
         }
         Statement::new_return_statement(self.end_span(span), argument, self)
     }

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -785,7 +785,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: new.target is only allowed in constructors, functions, and class field initializers
 
-  × TS(1108): A 'return' statement can only be used within a function body.
+  × TS(18041): A 'return' statement cannot be used inside a class static block.
    ╭─[babel/packages/babel-parser/test/fixtures/core/opts/allowReturnOutsideFunction-true-invalid-in-static-block/input.js:3:5]
  2 │   static {
  3 │     return 0;
@@ -8389,7 +8389,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: for octal literals use the '0o' prefix instead
 
-  × TS(1108): A 'return' statement can only be used within a function body.
+  × TS(18041): A 'return' statement cannot be used inside a class static block.
    ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-static-block/invalid-return/input.js:4:5]
  3 │   static {
  4 │     return this;

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -34668,7 +34668,7 @@ Negative Passed: 4651/4651 (100.00%)
  25 │   }
     ╰────
 
-  × TS(1108): A 'return' statement can only be used within a function body.
+  × TS(18041): A 'return' statement cannot be used inside a class static block.
     ╭─[test262/test/language/statements/class/static-init-invalid-return.js:25:7]
  24 │     static {
  25 │       return;

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -15217,7 +15217,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╰────
   help: Either remove this `yield` or change the enclosing function to a generator function (`function*`)
 
-  × TS(1108): A 'return' statement can only be used within a function body.
+  × TS(18041): A 'return' statement cannot be used inside a class static block.
    ╭─[typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock7.ts:5:9]
  4 │         yield 1;
  5 │         return 1;
@@ -15234,7 +15234,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ╰────
   help: Either remove this `yield` or change the enclosing function to a generator function (`function*`)
 
-  × TS(1108): A 'return' statement can only be used within a function body.
+  × TS(18041): A 'return' statement cannot be used inside a class static block.
     ╭─[typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock7.ts:36:13]
  35 │         static {
  36 │             return 1;


### PR DESCRIPTION
## Summary

- report TypeScript diagnostic TS18041 for `return` statements in class static initialization blocks
- reuse the existing `NewTarget`/`Return` parser-context invariant without adding a new context flag
- update the TypeScript, Babel, and Test262 parser snapshots

## Root cause

Class static blocks disable the parser's `Return` context, so their `return` statements previously fell through to the generic top-level TS1108 diagnostic. Static blocks already enable `NewTarget`, which distinguishes this case when `Return` is absent.