### PR TITLE
feat(linter/oxc): add bad-match-all-arg rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1247,6 +1247,7 @@ export interface DummyRuleMap {
   "oxc/bad-bitwise-operator"?: RuleNoConfig;
   "oxc/bad-char-at-comparison"?: RuleNoConfig;
   "oxc/bad-comparison-sequence"?: RuleNoConfig;
+  "oxc/bad-match-all-arg"?: RuleNoConfig;
   "oxc/bad-min-max-func"?: RuleNoConfig;
   "oxc/bad-object-literal-comparison"?: RuleNoConfig;
   "oxc/bad-replace-all-arg"?: RuleNoConfig;

--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__cli__linter__.customignore --no-ignore fixtures__cli__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__cli__linter__.customignore --no-ignore fixtures__cli__linter__nan.js@oxlint.snap
@@ -21,7 +21,7 @@ working directory:
   help: Use the `isNaN` function to compare with NaN.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__cli__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__cli__linter@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --ignore-pattern **/*.js --ignore-pattern **/*.vue fixtures/cli/linte
 working directory: 
 ----------
 No files found to lint. Please check your paths and ignore patterns.
-Finished in <variable>ms on 0 files with 95 rules using 1 threads.
+Finished in <variable>ms on 0 files with 96 rules using 1 threads.
 ----------
 CLI result: LintNoFilesFound
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__cli__flow__@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__cli__flow__@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin -A all -D no-cycle fixtures/cli/flow/
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 97 rules using 1 threads.
+Finished in <variable>ms on 2 files with 98 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin fixtures__cli__flow__index.mjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin fixtures__cli__flow__index.mjs@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin fixtures/cli/flow/index.mjs
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 97 rules using 1 threads.
+Finished in <variable>ms on 1 file with 98 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--no-error-on-unmatched-pattern foo.asdf@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--no-error-on-unmatched-pattern foo.asdf@oxlint.snap
@@ -5,7 +5,7 @@ source: apps/oxlint/src/tester.rs
 arguments: --no-error-on-unmatched-pattern foo.asdf
 working directory: 
 ----------
-Finished in <variable>ms on 0 files with 95 rules using 1 threads.
+Finished in <variable>ms on 0 files with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-D correctness fixtures__cli__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-D correctness fixtures__cli__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__cli__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__cli__linter__debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -W correctness -A no-debugger fixtures/cli/linter/debugger.js
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 94 rules using 1 threads.
+Finished in <variable>ms on 1 file with 95 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__cli__eslintrc_env__eslintrc_no_env.json fixtures__cli__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__cli__eslintrc_env__eslintrc_no_env.json fixtures__cli__eslintrc_env__test.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Either define 'console' or remove the reference to it. If 'console' is a global variable, add it to the 'globals' configuration.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 96 rules using 1 threads.
+Finished in <variable>ms on 1 file with 97 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__cli__no_undef__eslintrc.json fixtures__cli__no_undef__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__cli__no_undef__eslintrc.json fixtures__cli__no_undef__test.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Either define 'console' or remove the reference to it. If 'console' is a global variable, add it to the 'globals' configuration.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 96 rules using 1 threads.
+Finished in <variable>ms on 1 file with 97 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__eslintrc_env__eslintrc_env_browser.json fixtures__cli__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__eslintrc_env__eslintrc_env_browser.json fixtures__cli__eslintrc_env__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/cli/eslintrc_env/eslintrc_env_browser.json fixtures/cli/e
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 96 rules using 1 threads.
+Finished in <variable>ms on 1 file with 97 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__eslintrc_off__eslintrc.json fixtures__cli__eslintrc_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__eslintrc_off__eslintrc.json fixtures__cli__eslintrc_off__test.js@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__linter__eslintrc.json fixtures__cli__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__linter__eslintrc.json fixtures__cli__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__no_console_off__eslintrc.json fixtures__cli__no_console_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__no_console_off__eslintrc.json fixtures__cli__no_console_off__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/cli/no_console_off/eslintrc.json fixtures/cli/no_console_
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__overrides__directories-config.json fixtures__cli__overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__overrides__directories-config.json fixtures__cli__overrides@oxlint.snap
@@ -35,7 +35,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 7 files with 95 rules using 1 threads.
+Finished in <variable>ms on 7 files with 96 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__astro__debugger.astro@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__astro__debugger.astro@oxlint.snap
@@ -43,7 +43,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__linter@oxlint.snap
@@ -36,7 +36,7 @@ working directory:
   help: Use the `isNaN` function to compare with NaN.
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 95 rules using 1 threads.
+Finished in <variable>ms on 3 files with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__linter__debugger.js fixtures__cli__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__linter__debugger.js fixtures__cli__linter__nan.js@oxlint.snap
@@ -28,7 +28,7 @@ working directory:
   help: Use the `isNaN` function to compare with NaN.
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 95 rules using 1 threads.
+Finished in <variable>ms on 2 files with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__linter__js_as_jsx.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__linter__js_as_jsx.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__svelte__debugger.svelte@oxlint.snap
@@ -34,7 +34,7 @@ working directory:
   help: Variable declared without assignment. Either assign a value or remove the declaration.
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__vue__debugger.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__vue__debugger.vue@oxlint.snap
@@ -25,7 +25,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__vue__empty.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__vue__empty.vue@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/cli/vue/empty.vue
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__cli__vue__invalid.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__vue__invalid.vue@oxlint.snap
@@ -16,7 +16,7 @@ working directory:
   help: Add an initializer (e.g. ` = undefined`) here
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
@@ -6,7 +6,7 @@ arguments: foo.asdf
 working directory: 
 ----------
 No files found to lint. Please check your paths and ignore patterns.
-Finished in <variable>ms on 0 files with 95 rules using 1 threads.
+Finished in <variable>ms on 0 files with 96 rules using 1 threads.
 ----------
 CLI result: LintNoFilesFound
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/config_ignore_patterns/ignore_directory
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
@@ -12,7 +12,7 @@ working directory: fixtures/cli/config_ignore_patterns/with_oxlintrc
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__dot_folder_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__dot_folder_@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/dot_folder
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__extends_config_--config extends_rules_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__extends_config_--config extends_rules_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 96 rules using 1 threads.
+Finished in <variable>ms on 1 file with 97 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 96 rules using 1 threads.
+Finished in <variable>ms on 1 file with 97 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__extends_config_--disable-nested-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__extends_config_--disable-nested-config@oxlint.snap
@@ -31,7 +31,7 @@ working directory: fixtures/cli/extends_config
   help: Remove the debugger statement
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 4 files with 95 rules using 1 threads.
+Finished in <variable>ms on 4 files with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__ignore_patterns_ancestor_config_-c .__packages__..__.oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__ignore_patterns_ancestor_config_-c .__packages__..__.oxlintrc.json .@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/ignore_patterns_ancestor_config
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__ignore_patterns_ancestor_config__packages__foo_.@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__ignore_patterns_ancestor_config__packages__foo_.@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/ignore_patterns_ancestor_config/packages/foo
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
@@ -33,7 +33,7 @@ working directory: fixtures/cli/import-cycle
            ╰─────────╯ imports the current file
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 98 rules using 1 threads.
+Finished in <variable>ms on 2 files with 99 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__issue_10394_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__issue_10394_-c .oxlintrc.json@oxlint.snap
@@ -23,7 +23,7 @@ working directory: fixtures/cli/issue_10394
   help: Write a meaningful title for your test
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__linter_--deny-warnings -c config-deny-warnings-false.json debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__linter_--deny-warnings -c config-deny-warnings-false.json debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/linter
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintNoWarningsAllowed
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__linter_--max-warnings 1 -c config-max-warnings.json debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__linter_--max-warnings 1 -c config-max-warnings.json debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/linter
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__linter_-c config-deny-warnings.json debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__linter_-c config-deny-warnings.json debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/linter
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintNoWarningsAllowed
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__linter_-c config-max-warnings.json debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__linter_-c config-max-warnings.json debugger.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/cli/linter
 
 Found 1 warning and 0 errors.
 Exceeded maximum number of warnings. Found 1.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintMaxWarningsExceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__linter_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__linter_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/cli/linter
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__nested_config__package4-as-cwd_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__nested_config__package4-as-cwd_@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/cli/nested_config/package4-as-cwd
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__overrides_-c .oxlintrc.json other.jsx@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__overrides_-c .oxlintrc.json other.jsx@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/cli/overrides
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 97 rules using 1 threads.
+Finished in <variable>ms on 1 file with 98 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__overrides_-c .oxlintrc.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__overrides_-c .oxlintrc.json test.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/cli/overrides
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 97 rules using 1 threads.
+Finished in <variable>ms on 1 file with 98 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__overrides_-c .oxlintrc.json test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__overrides_-c .oxlintrc.json test.ts@oxlint.snap
@@ -23,7 +23,7 @@ working directory: fixtures/cli/overrides
   help: Delete this console statement.
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 97 rules using 1 threads.
+Finished in <variable>ms on 1 file with 98 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
@@ -68,7 +68,7 @@ working directory: fixtures/cli/overrides_with_plugin
   help: Consider removing this declaration.
 
 Found 3 warnings and 4 errors.
-Finished in <variable>ms on 2 files with 97 rules using 1 threads.
+Finished in <variable>ms on 2 files with 98 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__report_unused_directives_-c .oxlintrc-with-rudd.json --report-unused-disable-directives-severity=off@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__report_unused_directives_-c .oxlintrc-with-rudd.json --report-unused-disable-directives-severity=off@oxlint.snap
@@ -106,7 +106,7 @@ working directory: fixtures/cli/report_unused_directives
   help: Delete this console statement.
 
 Found 11 warnings and 0 errors.
-Finished in <variable>ms on 5 files with 96 rules using 1 threads.
+Finished in <variable>ms on 5 files with 97 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__report_unused_directives_-c .oxlintrc-with-rudd.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__report_unused_directives_-c .oxlintrc-with-rudd.json@oxlint.snap
@@ -321,7 +321,7 @@ working directory: fixtures/cli/report_unused_directives
     `----
 
 Found 38 warnings and 0 errors.
-Finished in <variable>ms on 5 files with 96 rules using 1 threads.
+Finished in <variable>ms on 5 files with 97 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives@oxlint.snap
@@ -321,7 +321,7 @@ working directory: fixtures/cli/report_unused_directives
     `----
 
 Found 38 warnings and 0 errors.
-Finished in <variable>ms on 5 files with 96 rules using 1 threads.
+Finished in <variable>ms on 5 files with 97 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__root_config_ancestor__cwd_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__root_config_ancestor__cwd_@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/cli/root_config_ancestor/cwd
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 94 rules using 1 threads.
+Finished in <variable>ms on 1 file with 95 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_--type-aware -c config-type-aware-false.json no-floating-promises.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_--type-aware -c config-type-aware-false.json no-floating-promises.ts@oxlint.snap
@@ -26,7 +26,7 @@ working directory: fixtures/cli/tsgolint
   help: Consider using this expression or removing it
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 110 rules using 1 threads.
+Finished in <variable>ms on 1 file with 111 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_-c config-type-aware-false-with-overrides.json no-floating-promises.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_-c config-type-aware-false-with-overrides.json no-floating-promises.ts@oxlint.snap
@@ -16,7 +16,7 @@ working directory: fixtures/cli/tsgolint
   help: Consider using this expression or removing it
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_-c config-type-aware-false.json no-floating-promises.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_-c config-type-aware-false.json no-floating-promises.ts@oxlint.snap
@@ -16,7 +16,7 @@ working directory: fixtures/cli/tsgolint
   help: Consider using this expression or removing it
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 95 rules using 1 threads.
+Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_-c config-type-aware-with-overrides.json no-floating-promises.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_-c config-type-aware-with-overrides.json no-floating-promises.ts@oxlint.snap
@@ -26,7 +26,7 @@ working directory: fixtures/cli/tsgolint
   help: Consider using this expression or removing it
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 110 rules using 1 threads.
+Finished in <variable>ms on 1 file with 111 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_config_error_--type-aware@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_config_error_--type-aware@oxlint.snap
@@ -17,7 +17,7 @@ working directory: fixtures/cli/tsgolint_config_error
         See https://github.com/oxc-project/tsgolint/issues/351 for more information.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 110 rules using 1 threads.
+Finished in <variable>ms on 1 file with 111 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_disable_directives_--type-aware --report-unused-disable-directives unused.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_disable_directives_--type-aware --report-unused-disable-directives unused.ts@oxlint.snap
@@ -78,7 +78,7 @@ working directory: fixtures/cli/tsgolint_disable_directives
     `----
 
 Found 8 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 110 rules using 1 threads.
+Finished in <variable>ms on 1 file with 111 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_disable_directives_--type-aware@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_disable_directives_--type-aware@oxlint.snap
@@ -145,7 +145,7 @@ working directory: fixtures/cli/tsgolint_disable_directives
   help: Consider removing this declaration.
 
 Found 15 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 110 rules using 1 threads.
+Finished in <variable>ms on 3 files with 111 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_tsconfig_extends_config_err_--type-aware -D no-floating-promises@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_tsconfig_extends_config_err_--type-aware -D no-floating-promises@oxlint.snap
@@ -11,7 +11,7 @@ working directory: fixtures/cli/tsgolint_tsconfig_extends_config_err
         See https://github.com/oxc-project/tsgolint/issues/351 for more information.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 110 rules using 1 threads.
+Finished in <variable>ms on 1 file with 111 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_--type-check -c config-type-check-false.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_--type-check -c config-type-check-false.json@oxlint.snap
@@ -30,7 +30,7 @@ working directory: fixtures/cli/tsgolint_type_error
    `----
 
 Found 2 warnings and 1 error.
-Finished in <variable>ms on 2 files with 110 rules using 1 threads.
+Finished in <variable>ms on 2 files with 111 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_-c config-type-check-false.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_-c config-type-check-false.json@oxlint.snap
@@ -24,7 +24,7 @@ working directory: fixtures/cli/tsgolint_type_error
   help: Consider removing this declaration.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 110 rules using 1 threads.
+Finished in <variable>ms on 2 files with 111 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_-c config-type-check.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_-c config-type-check.json@oxlint.snap
@@ -30,7 +30,7 @@ working directory: fixtures/cli/tsgolint_type_error
    `----
 
 Found 2 warnings and 1 error.
-Finished in <variable>ms on 2 files with 110 rules using 1 threads.
+Finished in <variable>ms on 2 files with 111 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/test/fixtures/basic/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic/output.snap.md
@@ -17,7 +17,7 @@
   help: Remove the debugger statement
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 96 rules using X threads.
+Finished in Xms on 1 file with 97 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/getDisableDirectives/output.snap.md
+++ b/apps/oxlint/test/fixtures/getDisableDirectives/output.snap.md
@@ -39,7 +39,7 @@
     `----
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 96 rules using X threads.
+Finished in Xms on 1 file with 97 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_basic/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_basic/output.snap.md
@@ -21,7 +21,7 @@
   help: Prefer === operator
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 96 rules using X threads.
+Finished in Xms on 1 file with 97 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_basic_cli_arg/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_basic_cli_arg/output.snap.md
@@ -21,7 +21,7 @@
   help: Prefer === operator
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 96 rules using X threads.
+Finished in Xms on 1 file with 97 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_define_config/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_define_config/output.snap.md
@@ -21,7 +21,7 @@
   help: Prefer === operator
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 96 rules using X threads.
+Finished in Xms on 1 file with 97 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_extends_multiple/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_extends_multiple/output.snap.md
@@ -12,7 +12,7 @@
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 95 rules using X threads.
+Finished in Xms on 1 file with 96 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_extends_print_config/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_extends_print_config/output.snap.md
@@ -4,7 +4,7 @@
 # stdout
 ```
 No files found to lint. Please check your paths and ignore patterns.
-Finished in Xms on 0 files with 95 rules using X threads.
+Finished in Xms on 0 files with 96 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_extends_rules/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_extends_rules/output.snap.md
@@ -21,7 +21,7 @@
   help: Prefer === operator
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 96 rules using X threads.
+Finished in Xms on 1 file with 97 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_mts/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_mts/output.snap.md
@@ -11,7 +11,7 @@
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 95 rules using X threads.
+Finished in Xms on 1 file with 96 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_overrides/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_overrides/output.snap.md
@@ -12,7 +12,7 @@
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in Xms on 2 files with 95 rules using X threads.
+Finished in Xms on 2 files with 96 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/report_legacy_positional_args/output.snap.md
+++ b/apps/oxlint/test/fixtures/report_legacy_positional_args/output.snap.md
@@ -17,7 +17,7 @@
    `----
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 96 rules using X threads.
+Finished in Xms on 1 file with 97 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/suppression_js_plugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/suppression_js_plugin/output.snap.md
@@ -5,7 +5,7 @@
 ```
 Found 0 warnings and 0 errors.
 Updated 'oxlint-suppressions.json'.
-Finished in Xms on 1 file with 94 rules using X threads.
+Finished in Xms on 1 file with 95 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/vite_config_ignored/output.snap.md
+++ b/apps/oxlint/test/fixtures/vite_config_ignored/output.snap.md
@@ -12,7 +12,7 @@
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in Xms on 1 file with 95 rules using X threads.
+Finished in Xms on 1 file with 96 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/vite_config_monorepo/output.snap.md
+++ b/apps/oxlint/test/fixtures/vite_config_monorepo/output.snap.md
@@ -11,7 +11,7 @@
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 95 rules using X threads.
+Finished in Xms on 1 file with 96 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/vite_plus_basic/output.snap.md
+++ b/apps/oxlint/test/fixtures/vite_plus_basic/output.snap.md
@@ -21,7 +21,7 @@
   help: Prefer === operator
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 96 rules using X threads.
+Finished in Xms on 1 file with 97 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/vite_plus_fn_export/output.snap.md
+++ b/apps/oxlint/test/fixtures/vite_plus_fn_export/output.snap.md
@@ -11,7 +11,7 @@
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in Xms on 1 file with 95 rules using X threads.
+Finished in Xms on 1 file with 96 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/vite_plus_no_lint_field/output.snap.md
+++ b/apps/oxlint/test/fixtures/vite_plus_no_lint_field/output.snap.md
@@ -11,7 +11,7 @@
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in Xms on 1 file with 95 rules using X threads.
+Finished in Xms on 1 file with 96 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/vite_plus_priority/output.snap.md
+++ b/apps/oxlint/test/fixtures/vite_plus_priority/output.snap.md
@@ -21,7 +21,7 @@
   help: Prefer === operator
 
 Found 2 warnings and 0 errors.
-Finished in Xms on 1 file with 96 rules using X threads.
+Finished in Xms on 1 file with 97 rules using X threads.
 ```
 
 # stderr

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use rustc_hash::FxHashSet;
+use smallvec::SmallVec;
 
 use oxc_allocator::{ArenaVec, GetAddress};
 use oxc_ast::{
@@ -16,7 +17,10 @@ use oxc_syntax::{
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
 };
 
-use crate::{LintContext, utils::get_function_nearest_jsdoc_node};
+use crate::{
+    LintContext,
+    utils::{get_function_nearest_jsdoc_node, is_regexp_callee},
+};
 
 /// Test if an AST node is a boolean value that never changes. Specifically we
 /// test for:
@@ -311,6 +315,57 @@ pub fn extract_regex_flags<'a>(args: &'a ArenaVec<'a, Argument<'a>>) -> Option<R
         flags |= flag;
     }
     Some(flags)
+}
+
+pub fn resolve_regex_flags<'a>(
+    expr: &'a Expression<'a>,
+    ctx: &LintContext<'a>,
+) -> Option<(RegExpFlags, Span)> {
+    resolve_regex_flags_impl(expr, ctx, &mut SmallVec::new())
+}
+
+fn resolve_regex_flags_impl<'a>(
+    expr: &'a Expression<'a>,
+    ctx: &LintContext<'a>,
+    resolved_symbols: &mut SmallVec<[SymbolId; 4]>,
+) -> Option<(RegExpFlags, Span)> {
+    match expr.without_parentheses() {
+        Expression::RegExpLiteral(regexp_literal) => {
+            Some((regexp_literal.regex.flags, regexp_literal.span))
+        }
+        Expression::NewExpression(new_expr) => {
+            if is_regexp_callee(&new_expr.callee, ctx) {
+                extract_regex_flags(&new_expr.arguments).map(|flags| (flags, new_expr.span))
+            } else {
+                None
+            }
+        }
+        Expression::CallExpression(call_expr) => {
+            if is_regexp_callee(&call_expr.callee, ctx) {
+                extract_regex_flags(&call_expr.arguments).map(|flags| (flags, call_expr.span))
+            } else {
+                None
+            }
+        }
+        Expression::Identifier(ident) => {
+            let symbol_id = get_symbol_id_of_variable(ident, ctx)?;
+            if resolved_symbols.contains(&symbol_id) {
+                return None;
+            }
+
+            resolved_symbols.push(symbol_id);
+            let declaration_id = ctx.scoping().symbol_declaration(symbol_id);
+            let decl = ctx.nodes().get_node(declaration_id);
+            let result = decl
+                .kind()
+                .as_variable_declarator()
+                .and_then(|var_decl| var_decl.init.as_ref())
+                .and_then(|init| resolve_regex_flags_impl(init, ctx, resolved_symbols));
+            resolved_symbols.pop();
+            result
+        }
+        _ => None,
+    }
 }
 
 pub fn is_method_call<'a>(

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4163,6 +4163,12 @@ impl RuleRunner for crate::rules::oxc::bad_comparison_sequence::BadComparisonSeq
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::oxc::bad_match_all_arg::BadMatchAllArg {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::oxc::bad_min_max_func::BadMinMaxFunc {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -384,6 +384,7 @@ pub use crate::rules::oxc::bad_array_method_on_arguments::BadArrayMethodOnArgume
 pub use crate::rules::oxc::bad_bitwise_operator::BadBitwiseOperator as OxcBadBitwiseOperator;
 pub use crate::rules::oxc::bad_char_at_comparison::BadCharAtComparison as OxcBadCharAtComparison;
 pub use crate::rules::oxc::bad_comparison_sequence::BadComparisonSequence as OxcBadComparisonSequence;
+pub use crate::rules::oxc::bad_match_all_arg::BadMatchAllArg as OxcBadMatchAllArg;
 pub use crate::rules::oxc::bad_min_max_func::BadMinMaxFunc as OxcBadMinMaxFunc;
 pub use crate::rules::oxc::bad_object_literal_comparison::BadObjectLiteralComparison as OxcBadObjectLiteralComparison;
 pub use crate::rules::oxc::bad_replace_all_arg::BadReplaceAllArg as OxcBadReplaceAllArg;
@@ -1508,6 +1509,7 @@ pub enum RuleEnum {
     OxcBadBitwiseOperator(OxcBadBitwiseOperator),
     OxcBadCharAtComparison(OxcBadCharAtComparison),
     OxcBadComparisonSequence(OxcBadComparisonSequence),
+    OxcBadMatchAllArg(OxcBadMatchAllArg),
     OxcBadMinMaxFunc(OxcBadMinMaxFunc),
     OxcBadObjectLiteralComparison(OxcBadObjectLiteralComparison),
     OxcBadReplaceAllArg(OxcBadReplaceAllArg),
@@ -2448,7 +2450,8 @@ const OXC_BAD_ARRAY_METHOD_ON_ARGUMENTS_ID: usize = OXC_APPROX_CONSTANT_ID + 1us
 const OXC_BAD_BITWISE_OPERATOR_ID: usize = OXC_BAD_ARRAY_METHOD_ON_ARGUMENTS_ID + 1usize;
 const OXC_BAD_CHAR_AT_COMPARISON_ID: usize = OXC_BAD_BITWISE_OPERATOR_ID + 1usize;
 const OXC_BAD_COMPARISON_SEQUENCE_ID: usize = OXC_BAD_CHAR_AT_COMPARISON_ID + 1usize;
-const OXC_BAD_MIN_MAX_FUNC_ID: usize = OXC_BAD_COMPARISON_SEQUENCE_ID + 1usize;
+const OXC_BAD_MATCH_ALL_ARG_ID: usize = OXC_BAD_COMPARISON_SEQUENCE_ID + 1usize;
+const OXC_BAD_MIN_MAX_FUNC_ID: usize = OXC_BAD_MATCH_ALL_ARG_ID + 1usize;
 const OXC_BAD_OBJECT_LITERAL_COMPARISON_ID: usize = OXC_BAD_MIN_MAX_FUNC_ID + 1usize;
 const OXC_BAD_REPLACE_ALL_ARG_ID: usize = OXC_BAD_OBJECT_LITERAL_COMPARISON_ID + 1usize;
 const OXC_BRANCHES_SHARING_CODE_ID: usize = OXC_BAD_REPLACE_ALL_ARG_ID + 1usize;
@@ -3431,6 +3434,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OXC_BAD_BITWISE_OPERATOR_ID,
             Self::OxcBadCharAtComparison(_) => OXC_BAD_CHAR_AT_COMPARISON_ID,
             Self::OxcBadComparisonSequence(_) => OXC_BAD_COMPARISON_SEQUENCE_ID,
+            Self::OxcBadMatchAllArg(_) => OXC_BAD_MATCH_ALL_ARG_ID,
             Self::OxcBadMinMaxFunc(_) => OXC_BAD_MIN_MAX_FUNC_ID,
             Self::OxcBadObjectLiteralComparison(_) => OXC_BAD_OBJECT_LITERAL_COMPARISON_ID,
             Self::OxcBadReplaceAllArg(_) => OXC_BAD_REPLACE_ALL_ARG_ID,
@@ -4399,6 +4403,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::NAME,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::NAME,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::NAME,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::NAME,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::NAME,
             Self::OxcBadObjectLiteralComparison(_) => OxcBadObjectLiteralComparison::NAME,
             Self::OxcBadReplaceAllArg(_) => OxcBadReplaceAllArg::NAME,
@@ -5407,6 +5412,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::CATEGORY,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::CATEGORY,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::CATEGORY,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::CATEGORY,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::CATEGORY,
             Self::OxcBadObjectLiteralComparison(_) => OxcBadObjectLiteralComparison::CATEGORY,
             Self::OxcBadReplaceAllArg(_) => OxcBadReplaceAllArg::CATEGORY,
@@ -6386,6 +6392,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::FIX,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::FIX,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::FIX,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::FIX,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::FIX,
             Self::OxcBadObjectLiteralComparison(_) => OxcBadObjectLiteralComparison::FIX,
             Self::OxcBadReplaceAllArg(_) => OxcBadReplaceAllArg::FIX,
@@ -7559,6 +7566,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::documentation(),
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::documentation(),
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::documentation(),
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::documentation(),
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::documentation(),
             Self::OxcBadObjectLiteralComparison(_) => {
                 OxcBadObjectLiteralComparison::documentation()
@@ -9696,6 +9704,8 @@ impl RuleEnum {
                 .or_else(|| OxcBadCharAtComparison::schema(generator)),
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::config_schema(generator)
                 .or_else(|| OxcBadComparisonSequence::schema(generator)),
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::config_schema(generator)
+                .or_else(|| OxcBadMatchAllArg::schema(generator)),
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::config_schema(generator)
                 .or_else(|| OxcBadMinMaxFunc::schema(generator)),
             Self::OxcBadObjectLiteralComparison(_) => {
@@ -10916,6 +10926,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => "oxc",
             Self::OxcBadCharAtComparison(_) => "oxc",
             Self::OxcBadComparisonSequence(_) => "oxc",
+            Self::OxcBadMatchAllArg(_) => "oxc",
             Self::OxcBadMinMaxFunc(_) => "oxc",
             Self::OxcBadObjectLiteralComparison(_) => "oxc",
             Self::OxcBadReplaceAllArg(_) => "oxc",
@@ -13199,6 +13210,9 @@ impl RuleEnum {
             Self::OxcBadComparisonSequence(_) => Ok(Self::OxcBadComparisonSequence(
                 OxcBadComparisonSequence::from_configuration(value)?,
             )),
+            Self::OxcBadMatchAllArg(_) => {
+                Ok(Self::OxcBadMatchAllArg(OxcBadMatchAllArg::from_configuration(value)?))
+            }
             Self::OxcBadMinMaxFunc(_) => {
                 Ok(Self::OxcBadMinMaxFunc(OxcBadMinMaxFunc::from_configuration(value)?))
             }
@@ -14499,6 +14513,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.to_configuration(),
             Self::OxcBadCharAtComparison(rule) => rule.to_configuration(),
             Self::OxcBadComparisonSequence(rule) => rule.to_configuration(),
+            Self::OxcBadMatchAllArg(rule) => rule.to_configuration(),
             Self::OxcBadMinMaxFunc(rule) => rule.to_configuration(),
             Self::OxcBadObjectLiteralComparison(rule) => rule.to_configuration(),
             Self::OxcBadReplaceAllArg(rule) => rule.to_configuration(),
@@ -15352,6 +15367,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.run(node, ctx),
             Self::OxcBadCharAtComparison(rule) => rule.run(node, ctx),
             Self::OxcBadComparisonSequence(rule) => rule.run(node, ctx),
+            Self::OxcBadMatchAllArg(rule) => rule.run(node, ctx),
             Self::OxcBadMinMaxFunc(rule) => rule.run(node, ctx),
             Self::OxcBadObjectLiteralComparison(rule) => rule.run(node, ctx),
             Self::OxcBadReplaceAllArg(rule) => rule.run(node, ctx),
@@ -16215,6 +16231,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.run_once(ctx),
             Self::OxcBadCharAtComparison(rule) => rule.run_once(ctx),
             Self::OxcBadComparisonSequence(rule) => rule.run_once(ctx),
+            Self::OxcBadMatchAllArg(rule) => rule.run_once(ctx),
             Self::OxcBadMinMaxFunc(rule) => rule.run_once(ctx),
             Self::OxcBadObjectLiteralComparison(rule) => rule.run_once(ctx),
             Self::OxcBadReplaceAllArg(rule) => rule.run_once(ctx),
@@ -17185,6 +17202,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcBadCharAtComparison(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcBadComparisonSequence(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcBadMatchAllArg(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcBadMinMaxFunc(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcBadObjectLiteralComparison(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcBadReplaceAllArg(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18059,6 +18077,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.should_run(ctx),
             Self::OxcBadCharAtComparison(rule) => rule.should_run(ctx),
             Self::OxcBadComparisonSequence(rule) => rule.should_run(ctx),
+            Self::OxcBadMatchAllArg(rule) => rule.should_run(ctx),
             Self::OxcBadMinMaxFunc(rule) => rule.should_run(ctx),
             Self::OxcBadObjectLiteralComparison(rule) => rule.should_run(ctx),
             Self::OxcBadReplaceAllArg(rule) => rule.should_run(ctx),
@@ -19221,6 +19240,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::IS_TSGOLINT_RULE,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::IS_TSGOLINT_RULE,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::IS_TSGOLINT_RULE,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::IS_TSGOLINT_RULE,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::IS_TSGOLINT_RULE,
             Self::OxcBadObjectLiteralComparison(_) => {
                 OxcBadObjectLiteralComparison::IS_TSGOLINT_RULE
@@ -20291,6 +20311,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::VERSION,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::VERSION,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::VERSION,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::VERSION,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::VERSION,
             Self::OxcBadObjectLiteralComparison(_) => OxcBadObjectLiteralComparison::VERSION,
             Self::OxcBadReplaceAllArg(_) => OxcBadReplaceAllArg::VERSION,
@@ -21346,6 +21367,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::HAS_CONFIG,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::HAS_CONFIG,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::HAS_CONFIG,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::HAS_CONFIG,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::HAS_CONFIG,
             Self::OxcBadObjectLiteralComparison(_) => OxcBadObjectLiteralComparison::HAS_CONFIG,
             Self::OxcBadReplaceAllArg(_) => OxcBadReplaceAllArg::HAS_CONFIG,
@@ -22334,6 +22356,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(_) => OxcBadBitwiseOperator::INFO,
             Self::OxcBadCharAtComparison(_) => OxcBadCharAtComparison::INFO,
             Self::OxcBadComparisonSequence(_) => OxcBadComparisonSequence::INFO,
+            Self::OxcBadMatchAllArg(_) => OxcBadMatchAllArg::INFO,
             Self::OxcBadMinMaxFunc(_) => OxcBadMinMaxFunc::INFO,
             Self::OxcBadObjectLiteralComparison(_) => OxcBadObjectLiteralComparison::INFO,
             Self::OxcBadReplaceAllArg(_) => OxcBadReplaceAllArg::INFO,
@@ -23199,6 +23222,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.types_info(),
             Self::OxcBadCharAtComparison(rule) => rule.types_info(),
             Self::OxcBadComparisonSequence(rule) => rule.types_info(),
+            Self::OxcBadMatchAllArg(rule) => rule.types_info(),
             Self::OxcBadMinMaxFunc(rule) => rule.types_info(),
             Self::OxcBadObjectLiteralComparison(rule) => rule.types_info(),
             Self::OxcBadReplaceAllArg(rule) => rule.types_info(),
@@ -24049,6 +24073,7 @@ impl RuleEnum {
             Self::OxcBadBitwiseOperator(rule) => rule.run_info(),
             Self::OxcBadCharAtComparison(rule) => rule.run_info(),
             Self::OxcBadComparisonSequence(rule) => rule.run_info(),
+            Self::OxcBadMatchAllArg(rule) => rule.run_info(),
             Self::OxcBadMinMaxFunc(rule) => rule.run_info(),
             Self::OxcBadObjectLiteralComparison(rule) => rule.run_info(),
             Self::OxcBadReplaceAllArg(rule) => rule.run_info(),
@@ -25025,6 +25050,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::OxcBadBitwiseOperator(OxcBadBitwiseOperator::default()),
         RuleEnum::OxcBadCharAtComparison(OxcBadCharAtComparison::default()),
         RuleEnum::OxcBadComparisonSequence(OxcBadComparisonSequence::default()),
+        RuleEnum::OxcBadMatchAllArg(OxcBadMatchAllArg::default()),
         RuleEnum::OxcBadMinMaxFunc(OxcBadMinMaxFunc::default()),
         RuleEnum::OxcBadObjectLiteralComparison(OxcBadObjectLiteralComparison::default()),
         RuleEnum::OxcBadReplaceAllArg(OxcBadReplaceAllArg::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -672,6 +672,7 @@ pub(crate) mod oxc {
     pub mod bad_bitwise_operator;
     pub mod bad_char_at_comparison;
     pub mod bad_comparison_sequence;
+    pub mod bad_match_all_arg;
     pub mod bad_min_max_func;
     pub mod bad_object_literal_comparison;
     pub mod bad_replace_all_arg;

--- a/crates/oxc_linter/src/rules/oxc/bad_match_all_arg.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_match_all_arg.rs
@@ -1,0 +1,113 @@
+use oxc_ast::{AstKind, ast::RegExpFlags};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    ast_util::{is_method_call, resolve_regex_flags},
+    context::LintContext,
+    rule::Rule,
+};
+
+fn bad_match_all_arg_diagnostic(match_all_span: Span, regex_span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "Global flag (g) is missing in the regular expression supplied to the `matchAll` method.",
+    )
+    .with_help("Add the global flag (g) to the regular expression.")
+    .with_note("`matchAll` throws a `TypeError` when passed a non-global regular expression.")
+    .with_labels([
+        match_all_span.label("`matchAll` called here"),
+        regex_span.label("RegExp supplied here"),
+    ])
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct BadMatchAllArg;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule warns when the `matchAll` method is called with a regular expression that does
+    /// not have the global flag (g).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// When called with a regular expression, the `matchAll` method requires the global flag (g).
+    /// Otherwise, it throws a `TypeError` at runtime instead of returning an iterator.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// text.matchAll(/pattern/);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// text.matchAll(/pattern/g);
+    /// ```
+    BadMatchAllArg,
+    oxc,
+    correctness,
+    version = "next",
+    short_description = "Warn when `matchAll` is called with a non-global regular expression.",
+);
+
+impl Rule for BadMatchAllArg {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if let AstKind::CallExpression(call_expr) = node.kind()
+            && is_method_call(call_expr, None, Some(&["matchAll"]), Some(1), None)
+            && let Some(regexp_argument) = call_expr.arguments[0].as_expression()
+            && let Some((flags, regex_span)) = resolve_regex_flags(regexp_argument, ctx)
+            && !flags.contains(RegExpFlags::G)
+            && let Some(call_expr_callee) = call_expr.callee.as_member_expression()
+            && let Some((match_all_span, _)) = call_expr_callee.static_property_info()
+        {
+            ctx.diagnostic(bad_match_all_arg_diagnostic(match_all_span, regex_span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Global regular expressions.
+        r#""".matchAll(/a/g);"#,
+        r#""".matchAll(/a/giu);"#,
+        r#""".matchAll(new RegExp("a", "g"));"#,
+        r#""".matchAll(RegExp("a", "g"));"#,
+        r#""".matchAll(globalThis.RegExp("a", "g"));"#,
+        // Calls that cannot throw for a known non-global regular expression.
+        r#""".matchAll("a");"#,
+        r#""".matchAll();"#,
+        r"matchAll(/a/);",
+        r"new matchAll(/a/);",
+        r#"function RegExp() {} "".matchAll(new RegExp("a"));"#,
+        // Resolved variables.
+        r#"const pattern = "a"; "".matchAll(pattern);"#,
+        r#"const pattern = /a/g; "".matchAll(pattern);"#,
+        r#"const pattern = new RegExp("a", "g"); "".matchAll(pattern);"#,
+        r#"const pattern = new RegExp("a", condition ? "g" : "gi"); "".matchAll(pattern);"#,
+        r#"const pattern = pattern; "".matchAll(pattern);"#,
+        r#"const a = b; const b = a; "".matchAll(a);"#,
+    ];
+
+    let fail = vec![
+        r#""".matchAll(/a/);"#,
+        r#""".matchAll(/a/u);"#,
+        r#""".matchAll(new RegExp("a"));"#,
+        r#""".matchAll(new RegExp("a", "i"));"#,
+        r#""".matchAll(RegExp("a"));"#,
+        r#""".matchAll(globalThis.RegExp("a", "i"));"#,
+        r#"""["matchAll"](/a/);"#,
+        // Resolved variables.
+        r#"const pattern = /a/; "".matchAll(pattern);"#,
+        r#"const pattern = /a/i; "".matchAll(pattern);"#,
+        r#"const pattern = new RegExp("a"); "".matchAll(pattern);"#,
+    ];
+
+    Tester::new(BadMatchAllArg::NAME, BadMatchAllArg::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_replace_all_arg.rs
@@ -1,14 +1,11 @@
-use oxc_ast::{
-    AstKind,
-    ast::{Expression, RegExpFlags},
-};
+use oxc_ast::{AstKind, ast::RegExpFlags};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
 use crate::{
     AstNode,
-    ast_util::{extract_regex_flags, get_declaration_of_variable, is_method_call},
+    ast_util::{is_method_call, resolve_regex_flags},
     context::LintContext,
     rule::Rule,
 };
@@ -68,7 +65,7 @@ impl Rule for BadReplaceAllArg {
             return;
         };
 
-        let Some((flags, regex_span)) = resolve_flags(regexp_argument, ctx) else {
+        let Some((flags, regex_span)) = resolve_regex_flags(regexp_argument, ctx) else {
             return;
         };
 
@@ -82,33 +79,6 @@ impl Rule for BadReplaceAllArg {
 
             ctx.diagnostic(bad_replace_all_arg_diagnostic(replace_all_span, regex_span));
         }
-    }
-}
-
-fn resolve_flags<'a>(
-    expr: &'a Expression<'a>,
-    ctx: &LintContext<'a>,
-) -> Option<(RegExpFlags, Span)> {
-    match expr.without_parentheses() {
-        Expression::RegExpLiteral(regexp_literal) => {
-            Some((regexp_literal.regex.flags, regexp_literal.span))
-        }
-        Expression::NewExpression(new_expr) => {
-            if new_expr.callee.is_specific_id("RegExp") {
-                extract_regex_flags(&new_expr.arguments).map(|flags| (flags, new_expr.span))
-            } else {
-                None
-            }
-        }
-        Expression::Identifier(ident) => {
-            let decl = get_declaration_of_variable(ident, ctx)?;
-            let var_decl = decl.kind().as_variable_declarator()?;
-            if let Some(init) = &var_decl.init {
-                return resolve_flags(init, ctx);
-            }
-            None
-        }
-        _ => None,
     }
 }
 

--- a/crates/oxc_linter/src/snapshots/oxc_bad_match_all_arg.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_bad_match_all_arg.snap
@@ -1,0 +1,103 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:4]
+ 1 │ "".matchAll(/a/);
+   ·    ────┬─── ─┬─
+   ·        │     ╰── RegExp supplied here
+   ·        ╰── `matchAll` called here
+   ╰────
+  help: Add the global flag (g) to the regular expression.
+  note: `matchAll` throws a `TypeError` when passed a non-global regular expression.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:4]
+ 1 │ "".matchAll(/a/u);
+   ·    ────┬─── ──┬─
+   ·        │      ╰── RegExp supplied here
+   ·        ╰── `matchAll` called here
+   ╰────
+  help: Add the global flag (g) to the regular expression.
+  note: `matchAll` throws a `TypeError` when passed a non-global regular expression.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:4]
+ 1 │ "".matchAll(new RegExp("a"));
+   ·    ────┬─── ───────┬───────
+   ·        │           ╰── RegExp supplied here
+   ·        ╰── `matchAll` called here
+   ╰────
+  help: Add the global flag (g) to the regular expression.
+  note: `matchAll` throws a `TypeError` when passed a non-global regular expression.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:4]
+ 1 │ "".matchAll(new RegExp("a", "i"));
+   ·    ────┬─── ──────────┬─────────
+   ·        │              ╰── RegExp supplied here
+   ·        ╰── `matchAll` called here
+   ╰────
+  help: Add the global flag (g) to the regular expression.
+  note: `matchAll` throws a `TypeError` when passed a non-global regular expression.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:4]
+ 1 │ "".matchAll(RegExp("a"));
+   ·    ────┬─── ─────┬─────
+   ·        │         ╰── RegExp supplied here
+   ·        ╰── `matchAll` called here
+   ╰────
+  help: Add the global flag (g) to the regular expression.
+  note: `matchAll` throws a `TypeError` when passed a non-global regular expression.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:4]
+ 1 │ "".matchAll(globalThis.RegExp("a", "i"));
+   ·    ────┬─── ─────────────┬─────────────
+   ·        │                 ╰── RegExp supplied here
+   ·        ╰── `matchAll` called here
+   ╰────
+  help: Add the global flag (g) to the regular expression.
+  note: `matchAll` throws a `TypeError` when passed a non-global regular expression.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:4]
+ 1 │ ""["matchAll"](/a/);
+   ·    ─────┬────  ─┬─
+   ·         │       ╰── RegExp supplied here
+   ·         ╰── `matchAll` called here
+   ╰────
+  help: Add the global flag (g) to the regular expression.
+  note: `matchAll` throws a `TypeError` when passed a non-global regular expression.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:17]
+ 1 │ const pattern = /a/; "".matchAll(pattern);
+   ·                 ─┬─     ────┬───
+   ·                  │          ╰── `matchAll` called here
+   ·                  ╰── RegExp supplied here
+   ╰────
+  help: Add the global flag (g) to the regular expression.
+  note: `matchAll` throws a `TypeError` when passed a non-global regular expression.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:17]
+ 1 │ const pattern = /a/i; "".matchAll(pattern);
+   ·                 ──┬─     ────┬───
+   ·                   │          ╰── `matchAll` called here
+   ·                   ╰── RegExp supplied here
+   ╰────
+  help: Add the global flag (g) to the regular expression.
+  note: `matchAll` throws a `TypeError` when passed a non-global regular expression.
+
+  ⚠ oxc(bad-match-all-arg): Global flag (g) is missing in the regular expression supplied to the `matchAll` method.
+   ╭─[bad_match_all_arg.tsx:1:17]
+ 1 │ const pattern = new RegExp("a"); "".matchAll(pattern);
+   ·                 ───────┬───────     ────┬───
+   ·                        │                ╰── `matchAll` called here
+   ·                        ╰── RegExp supplied here
+   ╰────
+  help: Add the global flag (g) to the regular expression.
+  note: `matchAll` throws a `TypeError` when passed a non-global regular expression.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -5850,6 +5850,9 @@
         "oxc/bad-comparison-sequence": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "oxc/bad-match-all-arg": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "oxc/bad-min-max-func": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -369,6 +369,7 @@ oxc/bad-array-method-on-arguments                          |  94090
 oxc/bad-bitwise-operator                                   |  33609
 oxc/bad-char-at-comparison                                 |  62606
 oxc/bad-comparison-sequence                                |  20604
+oxc/bad-match-all-arg                                      |  62606
 oxc/bad-min-max-func                                       |  62606
 oxc/bad-object-literal-comparison                          |  20604
 oxc/bad-replace-all-arg                                    |  62606


### PR DESCRIPTION
## Summary

- add oxc/bad-match-all-arg for non-global regular expressions passed to matchAll
- share cycle-safe RegExp flag resolution with bad-replace-all-arg
- support callable and global-qualified RegExp constructors
- update generated metadata, diagnostics, timings, and CLI rule-count snapshots

Closes #24823.