### PR TITLE
fix(ci): restore code coverage stack size

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Run
         env:
-          # Increase stack size to 10MiB, avoid `oxc_formatter` from stack overflowing when printing long assignment expressions.
-          RUST_MIN_STACK: 10485760
+          # Increase stack size to 100MiB, avoid `oxc_formatter` from stack overflowing when printing long assignment expressions.
+          RUST_MIN_STACK: 104857600
           # Limit concurrent compiler processes to avoid exhausting the 8GiB runner.
           CARGO_BUILD_JOBS: 2
         run: cargo codecov --lcov --output-path lcov.info


### PR DESCRIPTION
## Summary

- restore RUST_MIN_STACK to the previously working 100 MiB value
- keep CARGO_BUILD_JOBS at two to limit compile-time memory pressure

## Why

Follow-up to #24898. The two-job limit allowed the coverage build to complete without the previous oxc_linter SIGKILL, but reducing the stack to 10 MiB caused the oxc_coverage test to abort with a stack overflow in run 30101454727.

The original numeric value was intentional even though its comment incorrectly said 10 MB.
