### PR TITLE
fix(react_compiler): treat hook used as tagged template tag as a call

### DIFF
--- a/crates/oxc_react_compiler/fixtures/validate-hooks-usage-tagged-template.js
+++ b/crates/oxc_react_compiler/fixtures/validate-hooks-usage-tagged-template.js
@@ -1,0 +1,11 @@
+// Regression test: a hook used as a tagged template tag is a *call*, not a
+// value reference, so it must not trigger "Hooks may not be referenced as
+// normal values". Idiomatic framer-motion `useMotionTemplate` usage.
+// https://github.com/oxc-project/oxc/issues/24473
+import {useMotionValue, useMotionTemplate} from 'framer-motion';
+
+function Transform() {
+  const x = useMotionValue(100);
+  const transform = useMotionTemplate`transform(${x}px)`;
+  return <div style={{transform}} />;
+}

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
@@ -307,6 +307,28 @@ pub fn validate_hooks_usage(
                         visit_place(place, &value_kinds, &mut errors_by_span, env)?;
                     }
                 }
+                InstructionValue::TaggedTemplateExpression { tag, subexprs, .. } => {
+                    // A tagged template `tag`...`` invokes `tag` as a function,
+                    // so the tag is a call site (not a value reference). Mirror
+                    // the `CallExpression` handling for the callee.
+                    let callee_kind = get_kind_for_place(tag, &value_kinds, &env.identifiers);
+                    let is_hook_callee =
+                        callee_kind == Kind::KnownHook || callee_kind == Kind::PotentialHook;
+                    if is_hook_callee && !unconditional_blocks.contains(&block.id) {
+                        record_conditional_hook_error(
+                            tag,
+                            &mut value_kinds,
+                            &mut errors_by_span,
+                            env,
+                        )?;
+                    } else if callee_kind == Kind::PotentialHook {
+                        record_dynamic_hook_usage_error(tag, &mut errors_by_span, env)?;
+                    }
+                    // Visit all subexpression operands (not the tag).
+                    for subexpr in subexprs {
+                        visit_place(subexpr, &value_kinds, &mut errors_by_span, env)?;
+                    }
+                }
                 InstructionValue::Destructure { lvalue, value, .. } => {
                     visit_place(value, &value_kinds, &mut errors_by_span, env)?;
                     let object_kind = get_kind_for_place(value, &value_kinds, &env.identifiers);

--- a/crates/oxc_react_compiler/tests/snapshots/validate-hooks-usage-tagged-template.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/validate-hooks-usage-tagged-template.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/validate-hooks-usage-tagged-template.js
+---
+import { c as _c } from "react/compiler-runtime";
+// Regression test: a hook used as a tagged template tag is a *call*, not a
+// value reference, so it must not trigger "Hooks may not be referenced as
+// normal values". Idiomatic framer-motion `useMotionTemplate` usage.
+// https://github.com/oxc-project/oxc/issues/24473
+import { useMotionValue, useMotionTemplate } from "framer-motion";
+function Transform() {
+	const $ = _c(4);
+	const x = useMotionValue(100);
+	let t0;
+	if ($[0] !== x) {
+		t0 = useMotionTemplate`transform(${x}px)`;
+		$[0] = x;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	const transform = t0;
+	let t1;
+	if ($[2] !== transform) {
+		t1 = <div style={{ transform }} />;
+		$[2] = transform;
+		$[3] = t1;
+	} else {
+		t1 = $[3];
+	}
+	return t1;
+}


### PR DESCRIPTION
Fixes #24473

`react/react-compiler` started flagging perfectly valid framer-motion code with "Hooks may not be referenced as normal values, they must be called". This is the idiomatic `useMotionTemplate` usage straight from the Motion docs:

```tsx
import { useMotionValue, useMotionTemplate } from 'framer-motion';

function Transform() {
  const x = useMotionValue(100);
  const transform = useMotionTemplate`transform(${x}px)`;
  return <motion.div style={{ transform }} />;
}
```

It was fine in oxlint 1.72.0 and started erroring in 1.73.0.

Turns out the hooks-usage validator has special handling for `CallExpression` and `MethodCall` — their callee is a call site, so a hook there is being called, not passed around as a value. Tagged templates didn't have that, so `useMotionTemplate` in `` useMotionTemplate`...` `` fell into the generic operand-visiting path and got reported as if the hook were being referenced as a value. But a tagged template obviously *calls* its tag, same as `useMotionTemplate(...)` would.

So I gave `TaggedTemplateExpression` its own arm that mirrors `CallExpression`: the tag is the callee (conditional/dynamic-hook checks still run against it, so real violations are still caught), and the `${...}` interpolations are visited as regular operands. No more false positive.

Added a regression fixture from the repro; it now compiles and memoizes the hook call with no diagnostics. `cargo test -p oxc_react_compiler` is green, clippy clean.

---

_AI disclosure: I used an AI assistant (Claude) while investigating and writing this fix. I reviewed, tested, and understand all of the changes._
