### PR TITLE
fix(linter): keep directories ignored when they contain a nested config

### DIFF
--- a/apps/oxlint/fixtures/cli/ignore_patterns_nested_config_in_ignored_dir/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cli/ignore_patterns_nested_config_in_ignored_dir/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "no-debugger": "error"
+  },
+  "ignorePatterns": ["repos", "repos/**"]
+}

--- a/apps/oxlint/fixtures/cli/ignore_patterns_nested_config_in_ignored_dir/index.ts
+++ b/apps/oxlint/fixtures/cli/ignore_patterns_nested_config_in_ignored_dir/index.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/fixtures/cli/ignore_patterns_nested_config_in_ignored_dir/repos/effect-smol/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cli/ignore_patterns_nested_config_in_ignored_dir/repos/effect-smol/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-debugger": "error"
+  }
+}

--- a/apps/oxlint/fixtures/cli/ignore_patterns_nested_config_in_ignored_dir/repos/effect-smol/src/vendored.ts
+++ b/apps/oxlint/fixtures/cli/ignore_patterns_nested_config_in_ignored_dir/repos/effect-smol/src/vendored.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -885,6 +885,18 @@ mod test {
     }
 
     #[test]
+    // https://github.com/oxc-project/oxc/issues/23182
+    fn ignore_patterns_nested_config_in_ignored_dir() {
+        // A root config's `ignorePatterns` that excludes a directory must keep that
+        // directory ignored even when it contains its own nested oxlint config.
+        let args1 = &[];
+        let args2 = &["."];
+        Tester::new()
+            .with_cwd("fixtures/cli/ignore_patterns_nested_config_in_ignored_dir".into())
+            .test_and_snapshot_multiple(&[args1, args2]);
+    }
+
+    #[test]
     fn ignore_patterns_with_symlink() {
         let args1 = &[];
         let args2 = &["."];

--- a/apps/oxlint/src/snapshots/fixtures__cli__ignore_patterns_nested_config_in_ignored_dir_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__ignore_patterns_nested_config_in_ignored_dir_ .@oxlint.snap
@@ -1,0 +1,38 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/cli/ignore_patterns_nested_config_in_ignored_dir
+----------
+
+  x eslint(no-debugger): `debugger` statement is not allowed
+   ,-[index.ts:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 1 file using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------
+
+########## 
+arguments: .
+working directory: fixtures/cli/ignore_patterns_nested_config_in_ignored_dir
+----------
+
+  x eslint(no-debugger): `debugger` statement is not allowed
+   ,-[index.ts:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 1 file using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------

--- a/crates/oxc_linter/src/config/ignore_matcher.rs
+++ b/crates/oxc_linter/src/config/ignore_matcher.rs
@@ -52,11 +52,34 @@ impl LintIgnoreMatcher {
     }
 
     /// Returns true if the path should be ignored by any config.
-    /// Checks nested configs deepest-to-shallowest, so deepest config wins.
+    /// Checks nested configs deepest-to-shallowest, so the deepest config wins.
     pub fn should_ignore(&self, path: &Path) -> bool {
-        // If a nested config matches, only use its ignore patterns (do not fall back to base)
+        self.evaluate(path, true)
+    }
+
+    /// Core ignore evaluation.
+    ///
+    /// Finds the deepest nested config whose directory is an ancestor of `path`
+    /// (or equal to it, when `include_equal` is `true`). That config's
+    /// `ignorePatterns` govern `path` exclusively, *unless* the nested config's
+    /// own directory is itself ignored by a shallower config — in that case the
+    /// nested config never takes effect and `path` stays ignored. When no nested
+    /// config applies, the base (root) config decides.
+    ///
+    /// This makes a root config's directory-level `ignorePatterns` (e.g.
+    /// `"vendored"`) exclude a whole subtree even when that subtree contains its
+    /// own nested config, while still letting a nested config in a *non-ignored*
+    /// directory override the root's patterns for its own files.
+    /// See <https://github.com/oxc-project/oxc/issues/23182>.
+    fn evaluate(&self, path: &Path, include_equal: bool) -> bool {
         for (ignore, root) in &self.nested {
-            if path.starts_with(root) {
+            let covers = path.starts_with(root) && (include_equal || path != root);
+            if covers {
+                // If this nested config's own directory is excluded by a shallower
+                // config, the nested config must not "un-ignore" its subtree.
+                if self.evaluate(root, false) {
+                    return true;
+                }
                 return ignore
                     .as_ref()
                     .is_some_and(|gi| gi.matched_path_or_any_parents(path, false).is_ignore());
@@ -102,6 +125,45 @@ mod tests {
         // Path outside any nested config, only base applies
         assert!(matcher.should_ignore(Path::new("/repo/file.js")));
         assert!(!matcher.should_ignore(Path::new("/repo/file.ts")));
+    }
+
+    #[test]
+    fn test_base_ignores_directory_with_nested_config() {
+        // Root config ignores the whole `vendored` directory. A nested config
+        // living *inside* that ignored directory must not resurrect it.
+        // https://github.com/oxc-project/oxc/issues/23182
+        let base_patterns = vec!["vendored".to_string(), "vendored/**".to_string()];
+        let base_root = Path::new("/repo");
+
+        // Nested config inside the ignored directory, with no ignore patterns.
+        let nested = (vec![], PathBuf::from("/repo/vendored/pkg"));
+
+        let matcher = LintIgnoreMatcher::new(&base_patterns, base_root, vec![nested]);
+
+        // Files under the ignored directory stay ignored despite the nested config.
+        assert!(matcher.should_ignore(Path::new("/repo/vendored/pkg/src/file.ts")));
+        assert!(matcher.should_ignore(Path::new("/repo/vendored/pkg/index.ts")));
+
+        // Files outside the ignored directory are unaffected.
+        assert!(!matcher.should_ignore(Path::new("/repo/src/file.ts")));
+    }
+
+    #[test]
+    fn test_nested_config_in_non_ignored_dir_overrides_base() {
+        // Root ignores all `*.ts`, but a nested config in a directory that is
+        // itself *not* ignored may un-ignore its own files.
+        let base_patterns = vec!["**/*.ts".to_string()];
+        let base_root = Path::new("/repo");
+
+        let nested = (vec![], PathBuf::from("/repo/pkg"));
+
+        let matcher = LintIgnoreMatcher::new(&base_patterns, base_root, vec![nested]);
+
+        // `pkg` directory itself is not matched by `**/*.ts`, so its nested config
+        // takes effect and un-ignores the `.ts` files within it.
+        assert!(!matcher.should_ignore(Path::new("/repo/pkg/file.ts")));
+        // Files outside the nested config are still ignored by the base.
+        assert!(matcher.should_ignore(Path::new("/repo/file.ts")));
     }
 
     #[test]


### PR DESCRIPTION
Closes #23182

I have a vendored package under `repos/` that ships its own `.oxlintrc.json`, and I wanted to exclude it from linting via the root config:

```json
{ "ignorePatterns": ["repos", "repos/**"], ... }
```

This didn't work — files under `repos/` were still linted. Oddly, the CLI equivalent `oxlint --ignore-pattern repos` did work, so the config file and the flag disagreed.

The cause is in `LintIgnoreMatcher::should_ignore`. When a path is covered by a nested config, it only consults that nested config's `ignorePatterns` and never falls back to the root config. So a nested config sitting inside an ignored directory quietly re-enables linting for the whole directory. The CLI flag avoids this because it's applied during the file walk, before nested configs are discovered.

The fix makes the check recursive: a nested config only governs its subtree if its own directory isn't already ignored by a config above it. If the root ignores the directory the nested config lives in, the subtree stays ignored.

This still keeps the existing behavior where a nested config in a directory that *isn't* ignored can override the root's patterns for its own files (e.g. the root ignoring `**/*.ts` while a subpackage opts back in). Verified against the existing `ignore_patterns_empty_nested` test.

## Tests

- Two unit tests in `ignore_matcher.rs` covering both directions (ignored dir with a nested config, and a nested config in a non-ignored dir).
- A CLI test + fixture reproducing the reported `repos/effect-smol` layout — the snapshot shows only the root file gets linted now.

The rest of the `ignore_patterns_*` and `nested_config` tests still pass.

---

Disclosure: I used AI (Claude) while working on this. I've reviewed and tested the change myself.