### PR TITLE
feat(lexer): emit trivia-free spans in place of token starts

### DIFF
--- a/crates/oxc_lexer/Cargo.toml
+++ b/crates/oxc_lexer/Cargo.toml
@@ -21,11 +21,11 @@ doctest = false
 
 [dependencies]
 oxc_ast = { workspace = true }
+oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 memchr = { workspace = true }
 
 oxc_diagnostics = { workspace = true, optional = true }
-oxc_span = { workspace = true, optional = true }
 
 [features]
-oxc_diagnostics = ["dep:oxc_diagnostics", "dep:oxc_span"]
+oxc_diagnostics = ["dep:oxc_diagnostics"]

--- a/crates/oxc_lexer/src/arena.rs
+++ b/crates/oxc_lexer/src/arena.rs
@@ -1,6 +1,9 @@
 use core::ptr;
 
+use oxc_span::Span;
+
 use crate::error::Diagnostic;
+use crate::token::SPAN_SENTINELS;
 
 #[repr(C)]
 #[derive(Clone, Copy, Default, Debug)]
@@ -52,17 +55,24 @@ impl LexResult {
         unsafe { core::slice::from_raw_parts(self.diagnostics, self.diagnostic_count as usize) }
     }
 
-    lane_accessor!(tok_kinds, tok_kinds, token_count, u8);
-
     #[must_use]
-    pub fn tok_starts<'a>(&'a self, arena: &'a Arena) -> &'a [u32] {
-        if arena.tok_starts.is_null() {
+    pub fn tok_kinds<'a>(&'a self, arena: &'a Arena) -> &'a [u8] {
+        if arena.tok_kinds.is_null() {
             return &[];
         }
         let n = self.token_count as usize;
-        let len_with_sentinel = if n == 0 { 0 } else { n + 1 };
-        // SAFETY: the lexer wrote `token_count` starts plus the sentinel.
-        unsafe { core::slice::from_raw_parts(arena.tok_starts, len_with_sentinel) }
+        // SAFETY: the lexer wrote `token_count` kinds plus the EOF sentinels.
+        unsafe { core::slice::from_raw_parts(arena.tok_kinds, n + SPAN_SENTINELS) }
+    }
+
+    #[must_use]
+    pub fn tok_spans<'a>(&'a self, arena: &'a Arena) -> &'a [Span] {
+        if arena.tok_spans.is_null() {
+            return &[];
+        }
+        let n = self.token_count as usize;
+        // SAFETY: the lexer wrote `token_count` spans plus the EOF sentinels.
+        unsafe { core::slice::from_raw_parts(arena.tok_spans, n + SPAN_SENTINELS) }
     }
 
     lane_accessor!(numbers, numbers, numbers_count, f64);
@@ -85,8 +95,8 @@ pub struct Arena {
 
     pub tok_kinds: *mut u8,
     pub tok_kinds_capacity: u32,
-    pub tok_starts: *mut u32,
-    pub tok_starts_capacity: u32,
+    pub tok_spans: *mut Span,
+    pub tok_spans_capacity: u32,
     pub numbers: *mut f64,
     pub numbers_capacity: u32,
     pub atoms: *mut crate::token::StringSpan,
@@ -116,8 +126,8 @@ impl Arena {
             lines_capacity,
             tok_kinds: ptr::null_mut(),
             tok_kinds_capacity: 0,
-            tok_starts: ptr::null_mut(),
-            tok_starts_capacity: 0,
+            tok_spans: ptr::null_mut(),
+            tok_spans_capacity: 0,
             numbers: ptr::null_mut(),
             numbers_capacity: 0,
             atoms: ptr::null_mut(),
@@ -147,8 +157,8 @@ impl Arena {
         }
         self.tok_kinds = alloc_uninit::<u8>(cap);
         self.tok_kinds_capacity = cap;
-        self.tok_starts = alloc_uninit::<u32>(cap + 1);
-        self.tok_starts_capacity = cap + 1;
+        self.tok_spans = alloc_uninit::<Span>(cap + 1);
+        self.tok_spans_capacity = cap + 1;
 
         self.numbers = alloc_uninit::<f64>((cap / 2) + 64);
         self.numbers_capacity = (cap / 2) + 64;
@@ -198,7 +208,7 @@ impl Drop for Arena {
             free_uninit::<Diagnostic>(self.diags, self.diags_capacity);
             free_uninit::<LineEntry>(self.lines, self.lines_capacity);
             free_uninit::<u8>(self.tok_kinds, self.tok_kinds_capacity);
-            free_uninit::<u32>(self.tok_starts, self.tok_starts_capacity);
+            free_uninit::<Span>(self.tok_spans, self.tok_spans_capacity);
             free_uninit::<f64>(self.numbers, self.numbers_capacity);
             free_uninit::<crate::token::StringSpan>(self.atoms, self.atoms_capacity);
             free_uninit::<crate::token::StringSpan>(self.strings, self.strings_capacity);
@@ -211,7 +221,7 @@ impl Drop for Arena {
         self.diags = ptr::null_mut();
         self.lines = ptr::null_mut();
         self.tok_kinds = ptr::null_mut();
-        self.tok_starts = ptr::null_mut();
+        self.tok_spans = ptr::null_mut();
         self.numbers = ptr::null_mut();
         self.atoms = ptr::null_mut();
         self.strings = ptr::null_mut();

--- a/crates/oxc_lexer/src/lib.rs
+++ b/crates/oxc_lexer/src/lib.rs
@@ -62,11 +62,11 @@ fn lex_into_arena(src: &[u8], len: u32, options: LexOptions, arena: &mut Arena) 
     }
     assert!(
         arena.tok_kinds_capacity as usize >= n + PAD
-            && arena.tok_starts_capacity as usize >= n + PAD,
-        "lexer: arena token capacity too small for source len {n} (tok_kinds={}, tok_starts={}); need >= n + {PAD} \
-         — compress writes a full 8-lane group past the last token and the pipeline appends an EOF sentinel",
+            && arena.tok_spans_capacity as usize >= n + PAD,
+        "lexer: arena token capacity too small for source len {n} (tok_kinds={}, tok_spans={}); need >= n + {PAD} \
+         — build_spans writes a full 4-lane group past the last token and the pipeline appends EOF sentinels",
         arena.tok_kinds_capacity,
-        arena.tok_starts_capacity
+        arena.tok_spans_capacity
     );
 
     assert!(
@@ -83,7 +83,7 @@ fn lex_into_arena(src: &[u8], len: u32, options: LexOptions, arena: &mut Arena) 
                 src,
                 n,
                 arena.tok_kinds,
-                arena.tok_starts,
+                arena.tok_spans,
                 options.jsx,
                 options.ts,
                 options.source_type_module,
@@ -92,14 +92,14 @@ fn lex_into_arena(src: &[u8], len: u32, options: LexOptions, arena: &mut Arena) 
         };
 
         if !lx.lanes.unicode_leads.is_empty() && k > 0 {
-            // SAFETY: `lex_raw` wrote `k` kinds and `k + 1` starts.
-            let (kinds_all, starts_all) = unsafe {
+            // SAFETY: `lex_raw` wrote `k` kinds and `k` spans.
+            let (kinds_all, spans_all) = unsafe {
                 (
                     core::slice::from_raw_parts(arena.tok_kinds, k),
-                    core::slice::from_raw_parts(arena.tok_starts, k + 1),
+                    core::slice::from_raw_parts(arena.tok_spans, k),
                 )
             };
-            resolve_unicode_leads(&mut lx.lanes, &src[..n], kinds_all, starts_all);
+            resolve_unicode_leads(&mut lx.lanes, &src[..n], kinds_all, spans_all);
         }
 
         if !lx.lanes.diag_suppress.is_empty() {
@@ -139,15 +139,23 @@ fn lex_into_arena(src: &[u8], len: u32, options: LexOptions, arena: &mut Arena) 
 }
 
 #[expect(clippy::cast_possible_truncation, reason = "char lengths are 1..=4")]
-fn resolve_unicode_leads(lanes: &mut Lanes, src: &[u8], kinds_all: &[u8], starts_all: &[u32]) {
+fn resolve_unicode_leads(
+    lanes: &mut Lanes,
+    src: &[u8],
+    kinds_all: &[u8],
+    spans_all: &[oxc_span::Span],
+) {
     let k = kinds_all.len();
     let mut leads = core::mem::take(&mut lanes.unicode_leads);
     let mut ti = 0usize;
     for &off in &leads {
-        while ti + 1 < k && token::offset(starts_all[ti + 1]) <= off {
+        while ti + 1 < k && spans_all[ti].end <= off {
             ti += 1;
         }
-        if !candidate_is_code_level(kinds_all[ti]) {
+        if off < spans_all[ti].start
+            || off >= spans_all[ti].end
+            || !candidate_is_code_level(kinds_all[ti])
+        {
             continue;
         }
         let Some(ch) = lanes::decode_char_at(src, off as usize) else { continue };

--- a/crates/oxc_lexer/src/pipeline/compress.rs
+++ b/crates/oxc_lexer/src/pipeline/compress.rs
@@ -1,13 +1,127 @@
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 use core::arch::x86_64::*;
 
+use oxc_span::Span;
+
 use crate::error::diag_code;
 use crate::lanes::Lanes;
 use crate::tables::Tables;
+use crate::token::{SPAN_SENTINELS, is_trivia};
 
 #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
 use super::find::{eqm, load8};
-use super::{BIGINT, IDENT_ESC, NUM, PRIV_IDENT_ESC};
+use super::{BIGINT, EOF, HASHBANG, IDENT_ESC, NUM, PRIV_IDENT_ESC};
+
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+const fn qcompact() -> [[u32; 8]; 16] {
+    let mut t = [[0u32; 8]; 16];
+    let mut mask = 0usize;
+    while mask < 16 {
+        let (mut q, mut k) = (0usize, 0usize);
+        while q < 4 {
+            if mask & (1 << q) != 0 {
+                t[mask][2 * k] = (2 * q) as u32;
+                t[mask][2 * k + 1] = (2 * q + 1) as u32;
+                k += 1;
+            }
+            q += 1;
+        }
+        mask += 1;
+    }
+    t
+}
+
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+const fn bcompact() -> [[u8; 16]; 256] {
+    let mut t = [[0x80u8; 16]; 256];
+    let mut mask = 0usize;
+    while mask < 256 {
+        let (mut b, mut k) = (0usize, 0usize);
+        while b < 8 {
+            if mask & (1 << b) != 0 {
+                t[mask][k] = b as u8;
+                k += 1;
+            }
+            b += 1;
+        }
+        mask += 1;
+    }
+    t
+}
+
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+static QCOMPACT: [[u32; 8]; 16] = qcompact();
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+static BCOMPACT: [[u8; 16]; 256] = bcompact();
+
+pub(super) unsafe fn build_spans(
+    stage_kind: *const u8,
+    stage_pos: *const u32,
+    m: usize,
+    spans: *mut Span,
+    sig_kinds: *mut u8,
+) -> usize {
+    let sp = spans.cast::<u64>();
+    let mut w = 0usize;
+    let mut j = 0usize;
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
+    {
+        let v_min = _mm_set1_epi8(crate::token::TRIVIA_MIN as i8);
+        let v_span = _mm_set1_epi8((crate::token::TRIVIA_MAX - crate::token::TRIVIA_MIN) as i8);
+        let v_hb = _mm_set1_epi8(HASHBANG as i8);
+        let zero = _mm_setzero_si128();
+        while j + 8 <= m {
+            let k8 = _mm_loadl_epi64(stage_kind.add(j) as *const __m128i);
+            let triv = _mm_cmpeq_epi8(_mm_subs_epu8(_mm_sub_epi8(k8, v_min), v_span), zero);
+            let drop = _mm_andnot_si128(_mm_cmpeq_epi8(k8, v_hb), triv);
+            let sig = (!(_mm_movemask_epi8(drop) as u32)) & 0xff;
+
+            let v0 = _mm256_loadu_si256(stage_pos.add(j) as *const __m256i);
+            let v1 = _mm256_loadu_si256(stage_pos.add(j + 1) as *const __m256i);
+            let lo = _mm256_unpacklo_epi32(v0, v1);
+            let hi = _mm256_unpackhi_epi32(v0, v1);
+            let a = _mm256_permute2x128_si256(lo, hi, 0x20);
+            let b = _mm256_permute2x128_si256(lo, hi, 0x31);
+
+            let ma = (sig & 0xf) as usize;
+            let mb = (sig >> 4) as usize;
+            let ca = _mm256_permutevar8x32_epi32(
+                a,
+                _mm256_loadu_si256(QCOMPACT[ma].as_ptr() as *const __m256i),
+            );
+            _mm256_storeu_si256(sp.add(w) as *mut __m256i, ca);
+            let cb = _mm256_permutevar8x32_epi32(
+                b,
+                _mm256_loadu_si256(QCOMPACT[mb].as_ptr() as *const __m256i),
+            );
+            _mm256_storeu_si256(sp.add(w + ma.count_ones() as usize) as *mut __m256i, cb);
+
+            let kc = _mm_shuffle_epi8(
+                k8,
+                _mm_loadu_si128(BCOMPACT[sig as usize].as_ptr() as *const __m128i),
+            );
+            _mm_storel_epi64(sig_kinds.add(w) as *mut __m128i, kc);
+            w += sig.count_ones() as usize;
+            j += 8;
+        }
+    }
+    while j < m {
+        let k = *stage_kind.add(j);
+        *sp.add(w) = stage_pos.add(j).cast::<u64>().read_unaligned();
+        *sig_kinds.add(w) = k;
+        w += usize::from(!is_trivia(k) || k == HASHBANG);
+        j += 1;
+    }
+    w
+}
+
+pub(super) unsafe fn write_sentinels(n: u32, spans: *mut Span, sig_kinds: *mut u8) {
+    let eof = u64::from(n) | (u64::from(n) << 32);
+    for s in 0..SPAN_SENTINELS {
+        *spans.cast::<u64>().add(s) = eof;
+        *sig_kinds.add(s) = EOF;
+    }
+}
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2"))]
 #[inline(never)]
@@ -15,7 +129,8 @@ pub(super) unsafe fn compress(
     t: &Tables,
     st: *const u64,
     kind: *const u8,
-    nb: usize,
+    b0: usize,
+    b1: usize,
     starts: *mut u32,
     kinds: *mut u8,
 ) -> usize {
@@ -23,7 +138,7 @@ pub(super) unsafe fn compress(
     let lutpad = t.pair_luts.lutpad.as_ptr().cast::<u8>();
     let step16 = _mm256_set1_epi32(16);
     let mut m = 0usize;
-    for b in 0..nb {
+    for b in b0..b1 {
         let mword = *st.add(b);
         if mword == 0 {
             continue;
@@ -69,12 +184,13 @@ pub(super) unsafe fn compress(
     _t: &Tables,
     st: *const u64,
     kind: *const u8,
-    nb: usize,
+    b0: usize,
+    b1: usize,
     starts: *mut u32,
     kinds: *mut u8,
 ) -> usize {
     let mut m = 0usize;
-    for b in 0..nb {
+    for b in b0..b1 {
         let mut w = *st.add(b);
         if w == 0 {
             continue;
@@ -94,12 +210,13 @@ pub(super) unsafe fn compress(
 unsafe fn emit_value(
     src: &[u8],
     out_kinds: *const u8,
-    out_starts: *const u32,
+    out_spans: *const Span,
     j: usize,
     lanes: &mut Lanes,
 ) {
-    let s = *out_starts.add(j) as usize;
-    let e = *out_starts.add(j + 1) as usize;
+    let sp = *out_spans.add(j);
+    let s = sp.start as usize;
+    let e = sp.end as usize;
     let k = *out_kinds.add(j);
     if k < IDENT_ESC {
         lanes.push_number_swar(src, s, e);
@@ -113,11 +230,11 @@ unsafe fn emit_value(
 unsafe fn invalid_diags(
     src: &[u8],
     out_kinds: *const u8,
-    out_starts: *const u32,
+    out_spans: *const Span,
     m: usize,
+    nn: u32,
     lanes: &mut Lanes,
 ) {
-    let nn = *out_starts.add(m);
     let char_after = |cs: u32| -> u32 {
         if cs >= nn {
             return 0;
@@ -138,8 +255,8 @@ unsafe fn invalid_diags(
     };
     for j in 0..m {
         if *out_kinds.add(j) == 255 {
-            let s = *out_starts.add(j);
-            let e = *out_starts.add(j + 1);
+            let sp = *out_spans.add(j);
+            let (s, e) = (sp.start, sp.end);
             let b0 = src[s as usize];
             if b0 == b'\\' {
                 lanes.push_diag(s + 1, char_after(s + 1), diag_code::INVALID_IDENTIFIER_ESCAPE);
@@ -155,8 +272,9 @@ unsafe fn invalid_diags(
 pub(super) unsafe fn lanes_post(
     src: &[u8],
     out_kinds: *const u8,
-    out_starts: *const u32,
+    out_spans: *const Span,
     m: usize,
+    nn: u32,
     lanes: &mut Lanes,
 ) {
     let v_num = _mm256_set1_epi8(NUM as i8);
@@ -190,7 +308,7 @@ pub(super) unsafe fn lanes_post(
         let mut mask = (_mm256_movemask_epi8(h0) as u32 as u64)
             | ((_mm256_movemask_epi8(h1) as u32 as u64) << 32);
         while mask != 0 {
-            emit_value(src, out_kinds, out_starts, i + mask.trailing_zeros() as usize, lanes);
+            emit_value(src, out_kinds, out_spans, i + mask.trailing_zeros() as usize, lanes);
             mask &= mask - 1;
         }
         i += 64;
@@ -208,21 +326,22 @@ pub(super) unsafe fn lanes_post(
         }
         inv_dirty |= invm != 0;
         while mask != 0 {
-            emit_value(src, out_kinds, out_starts, i + mask.trailing_zeros() as usize, lanes);
+            emit_value(src, out_kinds, out_spans, i + mask.trailing_zeros() as usize, lanes);
             mask &= mask - 1;
         }
         i += 32;
     }
     if inv_dirty {
-        invalid_diags(src, out_kinds, out_starts, m, lanes);
+        invalid_diags(src, out_kinds, out_spans, m, nn, lanes);
     }
 }
 #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
 pub(super) unsafe fn lanes_post(
     src: &[u8],
     out_kinds: *const u8,
-    out_starts: *const u32,
+    out_spans: *const Span,
     m: usize,
+    nn: u32,
     lanes: &mut Lanes,
 ) {
     let mut inv = 0u64;
@@ -232,13 +351,7 @@ pub(super) unsafe fn lanes_post(
         let mut hits = eqm(x, NUM) | eqm(x, BIGINT) | eqm(x, IDENT_ESC) | eqm(x, PRIV_IDENT_ESC);
         inv |= eqm(x, 255);
         while hits != 0 {
-            emit_value(
-                src,
-                out_kinds,
-                out_starts,
-                i + (hits.trailing_zeros() >> 3) as usize,
-                lanes,
-            );
+            emit_value(src, out_kinds, out_spans, i + (hits.trailing_zeros() >> 3) as usize, lanes);
             hits &= hits - 1;
         }
         i += 8;
@@ -247,13 +360,13 @@ pub(super) unsafe fn lanes_post(
     while i < m {
         let k = *out_kinds.add(i);
         if k == NUM || k == BIGINT || k == IDENT_ESC || k == PRIV_IDENT_ESC {
-            emit_value(src, out_kinds, out_starts, i, lanes);
+            emit_value(src, out_kinds, out_spans, i, lanes);
         }
         inv_dirty |= k == 255;
         i += 1;
     }
     if inv_dirty {
-        invalid_diags(src, out_kinds, out_starts, m, lanes);
+        invalid_diags(src, out_kinds, out_spans, m, nn, lanes);
     }
 }
 
@@ -314,6 +427,7 @@ mod tests {
                     &t,
                     st.as_ptr(),
                     kind.as_ptr(),
+                    0,
                     nb,
                     starts.as_mut_ptr(),
                     kinds.as_mut_ptr(),

--- a/crates/oxc_lexer/src/pipeline/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/mod.rs
@@ -20,19 +20,25 @@ mod keywords;
 mod regex_div;
 mod replay;
 
+use oxc_span::Span;
+
 use crate::PAD;
 use crate::lanes::Lanes;
 use crate::options::LexOptions;
 use crate::tables::Tables;
+use crate::token::SPAN_SENTINELS;
 
 use bitmap::bm_any;
 use carve::{carve, carve_jsx};
 use classify::{classify, misc_post, misc_pre};
 use coalesce::coalesce;
-use compress::{compress, lanes_post};
+use compress::{build_spans, compress, lanes_post, write_sentinels};
 use keywords::KWB;
 
 use crate::token::token_kind;
+
+const STAGE_BLOCKS: usize = 32;
+const STAGE_CAP: usize = STAGE_BLOCKS * 64 + 128;
 
 // Short kind aliases for the pipeline, tied to `token_kind` so they can't drift.
 pub(crate) const WS: u8 = token_kind::WHITESPACE;
@@ -73,8 +79,11 @@ pub struct Lexer {
     kind: Vec<u8>,
     kwpos: Vec<u32>,
     nb_cap: usize,
-    pub starts: Vec<u32>,
-    pub kinds: Vec<u8>,
+    stage_pos: Vec<u32>,
+    stage_kind: Vec<u8>,
+    pub spans: Vec<Span>,
+    pub sig_kinds: Vec<u8>,
+    pub sig_len: usize,
     out_cap: usize,
     pub lanes: Lanes,
     tables: Box<Tables>,
@@ -99,8 +108,11 @@ impl Lexer {
             kind: Vec::new(),
             kwpos: Vec::new(),
             nb_cap: 0,
-            starts: Vec::new(),
-            kinds: Vec::new(),
+            stage_pos: vec![0; STAGE_CAP],
+            stage_kind: vec![0; STAGE_CAP],
+            spans: Vec::new(),
+            sig_kinds: Vec::new(),
+            sig_len: 0,
             out_cap: 0,
             lanes: Lanes::default(),
             tables: Box::new(Tables::new()),
@@ -125,28 +137,31 @@ impl Lexer {
         }
         let need = n + PAD;
         if self.out_cap < need {
-            self.starts.resize(need, 0);
-            self.kinds.resize(need, 0);
+            self.spans.resize(need + SPAN_SENTINELS, Span::new(0, 0));
+            self.sig_kinds.resize(need + SPAN_SENTINELS, 0);
             self.out_cap = need;
         }
     }
 
-    /// Run the full pipeline over `src[..n]`, writing the token stream into
-    /// `out_kinds`/`out_starts` (EOF sentinel last) and the value lanes and
-    /// diagnostics into `self.lanes`. Returns the token count including EOF.
+    /// Run the full pipeline over `src[..n]`, writing the trivia-free token
+    /// stream into `out_kinds`/`out_spans` ([`SPAN_SENTINELS`] EOF entries
+    /// spanning `(n, n)` follow the last token) and the value lanes and
+    /// diagnostics into `self.lanes`. Returns the significant token count,
+    /// excluding the sentinels.
     ///
     /// # Safety
     ///
     /// - `src` must extend at least [`PAD`] zeroed bytes past `n`.
-    /// - `out_kinds` must be valid for `n + PAD` byte writes and `out_starts`
-    ///   for `n + PAD` u32 writes: `compress` stores full 8-lane groups past
-    ///   the last token, and the EOF sentinel follows it.
+    /// - `out_kinds` must be valid for `n + PAD + SPAN_SENTINELS` byte writes
+    ///   and `out_spans` for the same number of [`Span`] writes: `build_spans`
+    ///   stores full 4-lane groups past the last token, and the sentinels
+    ///   follow it.
     pub unsafe fn lex_raw(
         &mut self,
         src: &[u8],
         n: usize,
         out_kinds: *mut u8,
-        out_starts: *mut u32,
+        out_spans: *mut Span,
         jsx: bool,
         ts: bool,
         module: bool,
@@ -157,10 +172,9 @@ impl Lexer {
         self.lanes.clear();
         self.lanes.module = module;
         if n == 0 {
-            *out_kinds = EOF;
-            *out_starts = 0;
-            *out_starts.add(1) = 0;
-            return 1;
+            write_sentinels(0, out_spans, out_kinds);
+            self.sig_len = 0;
+            return 0;
         }
         let nb = n.div_ceil(64);
         let sp = src.as_ptr();
@@ -205,17 +219,35 @@ impl Lexer {
         if nesc != 0 {
             misc_post(sp, n, st, word, misc, kind);
         }
-        let m = compress(t, st, kind, nb, out_starts, out_kinds);
-        *out_kinds.add(m) = EOF;
-        *out_starts.add(m) = n as u32;
-        *out_starts.add(m + 1) = n as u32;
-        lanes_post(src, out_kinds, out_starts, m, &mut self.lanes);
-        m + 1
+        let stage_pos = self.stage_pos.as_mut_ptr();
+        let stage_kind = self.stage_kind.as_mut_ptr();
+        let mut c = 0usize;
+        let mut w = 0usize;
+        let mut b = 0usize;
+        while b < nb {
+            let b1 = (b + STAGE_BLOCKS).min(nb);
+            c += compress(t, st, kind, b, b1, stage_pos.add(c), stage_kind.add(c));
+            b = b1;
+            if c > 1 {
+                w += build_spans(stage_kind, stage_pos, c - 1, out_spans.add(w), out_kinds.add(w));
+                *stage_pos = *stage_pos.add(c - 1);
+                *stage_kind = *stage_kind.add(c - 1);
+                c = 1;
+            }
+        }
+        if c == 1 {
+            *stage_pos.add(1) = n as u32;
+            w += build_spans(stage_kind, stage_pos, 1, out_spans.add(w), out_kinds.add(w));
+        }
+        write_sentinels(n as u32, out_spans.add(w), out_kinds.add(w));
+        lanes_post(src, out_kinds, out_spans, w, n as u32, &mut self.lanes);
+        self.sig_len = w;
+        w
     }
 
-    /// Lex `src[..n]` into the internal `starts`/`kinds` buffers (mode from
-    /// `options`), returning the token count including EOF. Test/bench
-    /// entry; the arena API is [`crate::lex_utf8`].
+    /// Lex `src[..n]` into the internal `spans`/`sig_kinds` buffers (mode from
+    /// `options`), returning the significant token count. Test/bench entry;
+    /// the arena API is [`crate::lex_utf8`].
     ///
     /// # Panics
     ///
@@ -227,14 +259,14 @@ impl Lexer {
             src.len()
         );
         self.ensure(n);
-        let kinds = self.kinds.as_mut_ptr();
-        let starts = self.starts.as_mut_ptr();
+        let kinds = self.sig_kinds.as_mut_ptr();
+        let spans = self.spans.as_mut_ptr();
         unsafe {
             self.lex_raw(
                 src,
                 n,
                 kinds,
-                starts,
+                spans,
                 options.jsx,
                 options.ts,
                 options.source_type_module,

--- a/crates/oxc_lexer/src/pipeline/regex_div.rs
+++ b/crates/oxc_lexer/src/pipeline/regex_div.rs
@@ -1230,7 +1230,7 @@ mod tests {
         opts.jsx = jsx;
         let mut lx = Lexer::new();
         let count = lx.lex(&buf, n, opts);
-        lx.kinds[..count - 1].iter().copied().filter(|&kk| !crate::is_trivia(kk)).collect()
+        lx.sig_kinds[..count].iter().copied().filter(|&kk| !crate::is_trivia(kk)).collect()
     }
 
     #[track_caller]

--- a/crates/oxc_lexer/src/pipeline/replay.rs
+++ b/crates/oxc_lexer/src/pipeline/replay.rs
@@ -676,7 +676,7 @@ mod tests {
         opts.source_type_module = module;
         let mut lx = Lexer::new();
         let count = lx.lex(&buf, n, opts);
-        lx.kinds[..count - 1].iter().copied().filter(|&kk| !crate::is_trivia(kk)).collect()
+        lx.sig_kinds[..count].iter().copied().filter(|&kk| !crate::is_trivia(kk)).collect()
     }
 
     #[track_caller]

--- a/crates/oxc_lexer/src/token.rs
+++ b/crates/oxc_lexer/src/token.rs
@@ -178,6 +178,8 @@ pub mod token_kind {
     pub const INVALID: u8 = 255;
 }
 
+pub const SPAN_SENTINELS: usize = 8;
+
 pub const TRIVIA_MIN: u8 = token_kind::LINE_COMMENT;
 pub const TRIVIA_MAX: u8 = token_kind::LINE_TERMINATOR;
 

--- a/crates/oxc_lexer/tests/module_goal.rs
+++ b/crates/oxc_lexer/tests/module_goal.rs
@@ -11,7 +11,7 @@ fn kinds_of(code: &str, module: bool) -> Vec<u8> {
     opts.source_type_module = module;
     let mut lx = Lexer::new();
     let count = lx.lex(&buf, n, opts);
-    lx.kinds[..count - 1].iter().copied().filter(|&kk| !oxc_lexer::is_trivia(kk)).collect()
+    lx.sig_kinds[..count].iter().copied().filter(|&kk| !oxc_lexer::is_trivia(kk)).collect()
 }
 
 fn diag_codes(code: &str, module: bool) -> Vec<u16> {

--- a/crates/oxc_lexer/tests/regex_div.rs
+++ b/crates/oxc_lexer/tests/regex_div.rs
@@ -16,7 +16,7 @@ fn kinds_of(code: &str, ts: bool, jsx: bool) -> Vec<u8> {
     opts.jsx = jsx;
     let mut lx = Lexer::new();
     let count = lx.lex(&buf, n, opts);
-    lx.kinds[..count - 1].iter().copied().filter(|&kk| !oxc_lexer::is_trivia(kk)).collect()
+    lx.sig_kinds[..count].iter().copied().filter(|&kk| !oxc_lexer::is_trivia(kk)).collect()
 }
 
 #[test]

--- a/crates/oxc_lexer/tests/ts_keywords.rs
+++ b/crates/oxc_lexer/tests/ts_keywords.rs
@@ -55,7 +55,7 @@ fn kinds(code: &str, ts: bool, jsx: bool) -> Vec<u8> {
     opts.jsx = jsx;
     let mut lx = Lexer::new();
     let count = lx.lex(&buf, n, opts);
-    lx.kinds[..count - 1].iter().copied().filter(|&kk| !oxc_lexer::is_trivia(kk)).collect()
+    lx.sig_kinds[..count].iter().copied().filter(|&kk| !oxc_lexer::is_trivia(kk)).collect()
 }
 
 fn first_kind(code: &str, ts: bool) -> u8 {

--- a/tasks/coverage/src/lexer_diff.rs
+++ b/tasks/coverage/src/lexer_diff.rs
@@ -29,22 +29,17 @@ fn lexer_stream(
     options.source_type_module = source_type.is_module();
     options.jsx = source_type.is_jsx();
     options.ts = source_type.is_typescript();
-    // Keep the stream fully contiguous so `starts[i + 1]` is token `i`'s true end.
-    options.emit_whitespace = true;
-    options.emit_comments = true;
 
     let (result, arena) = oxc_lexer::lex_utf8(&buf, n as u32, options);
     let kinds = result.tok_kinds(&arena);
-    let starts = result.tok_starts(&arena);
+    let token_spans = result.tok_spans(&arena);
 
     let mut spans = Vec::with_capacity(kinds.len());
     for (i, &kind) in kinds.iter().enumerate() {
         if kind == oxc_lexer::token_kind::EOF || oxc_lexer::is_trivia(kind) {
             continue;
         }
-        let start = oxc_lexer::token::offset(starts[i]);
-        let end = oxc_lexer::token::offset(starts[i + 1]);
-        spans.push((start, end));
+        spans.push((token_spans[i].start, token_spans[i].end));
     }
     let mut diags = result.diagnostics().to_vec();
     diags.sort_by_key(|d| d.off);


### PR DESCRIPTION
The token tape carried a u32 start per entry and kept whitespace and comments on it as ordinary tokens, so anything reconstructing a token's end had to reach for the next entry and every consumer had to step over trivia. Because whitespace was itself a token, the end of each significant token was already in the array as the start of the following entry, just stored under a different name and then discarded. This publishes one oxc_span::Span per significant token instead, start in the low half and end in the high half, bit-identical to the AST's own Span, with trivia gone from the tape entirely. A span turns out to be a misaligned eight-byte window onto positions the pipeline already had, so build_spans widens and compacts them with a qword permute and a byte shuffle rather than recomputing anything, and compress now fills a fixed staging buffer a chunk of blocks at a time instead of a full-length array, carrying one entry across chunks so the last token of a chunk can still see its end. Eight EOF sentinels spanning (n, n) follow the last token so a consumer can peek a short way past the end without a bounds check, and the hashbang stays on the tape, since its kind sits inside the trivia range and the drop mask excludes it explicitly.

Value lanes, cooked bytes, comment records and diagnostics are byte-identical across both fixture corpora, and the span stream was checked against a scalar reference on every fixture. It costs about 0.22 cyc/byte, roughly 1.0 to 1.5 cycles per significant token, because the tape writes nine bytes per token where it used to write five per entry across about a third more entries than there are real tokens. Worth saying plainly that this one costs throughput rather than winning it. It is a contract change that moves work out of the consumer, and it only pays off once the consumer stops reconstructing ends, skipping trivia and scanning for token boundaries.
