### PR TITLE
fix(lexer): normalize CRLF in template cooked values

### DIFF
--- a/crates/oxc_lexer/src/lanes.rs
+++ b/crates/oxc_lexer/src/lanes.rs
@@ -214,11 +214,7 @@ impl Lanes {
 
     #[inline]
     pub fn push_template(&mut self, src: &[u8], bs: usize, be: usize) {
-        // CRLF normalization is implemented and tested but wired off: the
-        // extra `\r` needle costs ~2% on template-heavy sources, and the
-        // parser facade cooks CR-bearing templates itself, so end-to-end
-        // values are exact either way.
-        let (sp, nes) = self.cook::<false, false>(src, bs as u32, be as u32);
+        let (sp, nes) = self.cook::<false, true>(src, bs as u32, be as u32);
         // A NotEscapeSequence means cooked = None per the grammar; legality
         // depends on tagged-ness (parser context), so the span carries a
         // marker instead of a diagnostic.
@@ -1175,6 +1171,32 @@ unsafe fn cook_decode<const EMIT: bool, const CRLF: bool>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn push_tpl(body: &[u8]) -> Vec<u8> {
+        let mut padded = body.to_vec();
+        padded.extend_from_slice(&[0u8; 64]);
+        let mut l = Lanes::default();
+        l.push_template(&padded, 0, body.len());
+        let sp = l.templates[0];
+        let s = (sp.start & StringSpan::START_MASK) as usize;
+        let e = (sp.end_and_flags & StringSpan::END_MASK) as usize;
+        l.cooked[s..e].to_vec()
+    }
+
+    #[test]
+    fn push_template_normalizes_raw_cr() {
+        assert_eq!(push_tpl(b"a\r\nb"), b"a\nb");
+        assert_eq!(push_tpl(b"a\rb"), b"a\nb");
+        assert_eq!(push_tpl(br"a\r\nb\`c"), b"a\r\nb`c");
+        assert_eq!(push_tpl(b"a\r\nb\\`c"), b"a\nb`c");
+    }
+
+    #[test]
+    fn push_template_keeps_escaped_cr_lf() {
+        assert_eq!(push_tpl(br"\r\n"), b"\r\n");
+        assert_eq!(push_tpl(br"\r"), b"\r");
+        assert_eq!(push_tpl(b"\r\n"), b"\n");
+    }
 
     fn cook(body: &[u8]) -> (Vec<u8>, bool) {
         let mut padded = body.to_vec();


### PR DESCRIPTION
A template body's line terminator sequences are normalized in both the TRV and the TV, so a raw CRLF or a lone CR in the source becomes a single LF in the cooked value. push_template was cooking with normalization switched off, on the reasoning that a consumer could redo it from the raw text, so on a CRLF checkout every multi-line template cooked to bytes the grammar says it should not have. oxc_parser does the normalization itself in template_literal_carriage_return, so the two disagreed.

Redoing it afterwards is not possible, which is the part worth spelling out. Once escapes are decoded a CR in the cooked bytes is ambiguous: it may have come from a raw CRLF, which has to collapse, or from a \r escape, which has to survive, and a template of \r\n must cook to CR LF while any blanket pass over the cooked bytes would flatten it to LF. The decision has to be made on the raw text before escapes are decoded, which is inside cook, so this flips the existing const-generic on rather than adding machinery. Only push_template changes, since identifier atoms cannot contain a raw CR and a raw CR in a string literal is already an error. The new tests go through push_template rather than cook_decode, because the decoder was always correct and already had a passing test while the wiring was what was wrong. No measurable cost, and across both corpora exactly one file's output changes, nanoplotx_components.tsx, by one byte, the single CRLF it has inside a template collapsing to LF.
