### PR TITLE
perf(lexer): cheaper per-comment work in carve

### DIFF
--- a/crates/oxc_lexer/src/lanes.rs
+++ b/crates/oxc_lexer/src/lanes.rs
@@ -437,10 +437,19 @@ impl Lanes {
 
         let s_ = (start as usize).min(sl);
         let mut q = s_;
-        while q > 0 && is_lex_ws(src[q - 1]) {
+        let pre = loop {
+            if q == 0 {
+                break true;
+            }
+            let b = src[q - 1];
+            if b == b'\n' || b == b'\r' {
+                break true;
+            }
+            if !is_lex_ws(b) {
+                break false;
+            }
             q -= 1;
-        }
-        let pre = q == 0 || src[q..s_].iter().any(|&b| b == b'\n' || b == b'\r');
+        };
         c.set_preceded_by_newline(pre);
 
         if !blk {

--- a/crates/oxc_lexer/src/pipeline/find.rs
+++ b/crates/oxc_lexer/src/pipeline/find.rs
@@ -385,8 +385,8 @@ pub(super) unsafe fn scan_block_comment(
         let v = load256(src, i);
         let vn = load256(src, i + 1);
         let term = mm(_mm256_and_si256(veq(v, b'*'), veq(vn, b'/')));
-        let nl = mm(_mm256_or_si256(veq(v, b'\n'), veq(v, b'\r')));
-        let at = mm(veq(v, b'@'));
+        let nl = if saw_nl { 0 } else { mm(_mm256_or_si256(veq(v, b'\n'), veq(v, b'\r'))) };
+        let at = if lic_q < 0 { mm(veq(v, b'@')) } else { 0 };
         if term != 0 {
             let j = term.trailing_zeros() as usize;
             let bodymask: u32 = if j > 0 { (1u32 << j) - 1 } else { 0 };


### PR DESCRIPTION
Two shaves on the comment path in carve. push_comment_record decided preceded_by_newline by walking back over the whole run of whitespace before the comment and then re-scanning that same run forward looking for a line terminator, so it touched those bytes twice. It now walks back once and stops at the first newline, which is the answer it was looking for anyway. Separately, scan_block_comment recomputed the newline mask and the at-sign mask on every 32-byte block of the comment body even after saw_nl was already true and the license marker had already been found, so both are now skipped once they can no longer change the result, which on a long JSDoc block is nearly the whole body.

Comment records are field-exact across both fixture corpora and the token stream and every value lane are unchanged. This is worth about 8% of the per-comment cost and 12 to 15% on an all-comment file. Corpus-weighted it comes out neutral, since comments are a small share of the work almost everywhere, so it is aimed at comment-heavy real source rather than at the average.
