### PR TITLE
fix(linter/react): no only-export-components false positive on nested components

### DIFF
--- a/crates/oxc_linter/src/rules/react/only_export_components.rs
+++ b/crates/oxc_linter/src/rules/react/only_export_components.rs
@@ -1,7 +1,6 @@
 use oxc_ast::{AstKind, ast::*};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::NodeId;
 use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
@@ -244,25 +243,6 @@ impl OnlyExportComponents {
         }
     }
 
-    fn is_exported(ctx: &LintContext, node_id: NodeId) -> bool {
-        let semantic = ctx.semantic();
-        let nodes = semantic.nodes();
-
-        std::iter::successors(Some(node_id), |&id| {
-            let parent = nodes.parent_id(id);
-            if parent == id { None } else { Some(parent) }
-        })
-        .any(|id| {
-            matches!(
-                nodes.get_node(id).kind(),
-                AstKind::ExportDefaultDeclaration(_)
-                    | AstKind::ExportDeclaration(_)
-                    | AstKind::ExportFromDeclaration(_)
-                    | AstKind::ExportNamedDeclaration(_)
-            )
-        })
-    }
-
     fn analyze_exports(&self, ctx: &LintContext) -> ExportAnalysis {
         let mut analysis = ExportAnalysis::default();
         let module_record = ctx.module_record();
@@ -315,13 +295,16 @@ impl OnlyExportComponents {
         ctx.semantic()
             .nodes()
             .iter()
+            // Only top-level declarations can affect Fast Refresh. The reference implementation
+            // (`eslint-plugin-react-refresh`) only scans `program.body`, so nested components
+            // (e.g. a `PascalCase` function returned from a factory) must not be flagged.
+            .filter(|node| matches!(ctx.nodes().parent_kind(node.id()), AstKind::Program(_)))
             .filter_map(|node| match node.kind() {
                 AstKind::VariableDeclaration(var_decl) => {
                     var_decl.declarations.iter().find_map(|declarator| {
                         if let BindingPattern::BindingIdentifier(binding_id) = &declarator.id
                             && is_react_component_name(&binding_id.name)
                             && self.can_be_react_function_component(declarator.init.as_ref())
-                            && !Self::is_exported(ctx, node.id())
                         {
                             return Some(binding_id.span);
                         }
@@ -329,11 +312,7 @@ impl OnlyExportComponents {
                     })
                 }
                 AstKind::Function(func) => func.id.as_ref().and_then(|id| {
-                    if is_react_component_name(&id.name) && !Self::is_exported(ctx, node.id()) {
-                        Some(id.span)
-                    } else {
-                        None
-                    }
+                    if is_react_component_name(&id.name) { Some(id.span) } else { None }
                 }),
                 _ => None,
             })
@@ -899,6 +878,16 @@ export function Button(props: PropsWithChildren): ReactNode {
         ),
         // Named HOC export with anonymous arrow function argument
         ("export const Foo = React.memo(() => <div/>); export const Bar = () => null;", None),
+        // Non-exported nested PascalCase component must not be flagged as a local component,
+        // since only top-level declarations affect Fast Refresh (#24854).
+        (
+            "export const helper = 1; function factory() { return function Inner() { return <span />; }; }",
+            None,
+        ),
+        (
+            "export const helper = 1; function factory() { const Inner = () => <span />; return Inner; }",
+            None,
+        ),
     ];
 
     let fail = vec![


### PR DESCRIPTION
## What this does

Fixes a false positive in `react/only-export-components` where a non-exported, nested PascalCase function was flagged as a Fast Refresh violation.

Closes #24854

## The problem

Given code like this, oxlint incorrectly warned about `Inner`:

```tsx
export const helper = 1;

function factory() {
  return function Inner() {
    return <span />;
  };
}
```

`Inner` is never exported, so it can't possibly affect Fast Refresh, and the upstream `eslint-plugin-react-refresh` correctly stays silent here. The pattern shows up in real code, for example factory helpers that build Recharts components.

## The cause

`find_local_components` was iterating over every node in the semantic tree, which meant it also picked up components declared deep inside other functions. The reference implementation only ever looks at `program.body`, so it never considers anything below the top level.

## The fix

I limited local component detection to top-level declarations by keeping only nodes whose parent is the `Program`. Nested function expressions and declarations live under a `ReturnStatement`, `BlockStatement`, etc., so they're no longer collected.

Once that filter is in place the old `is_exported` helper becomes redundant: a node whose parent is the `Program` can't sit under an `export` declaration, since inline exports always wrap their declaration in an `ExportNamedDeclaration` or `ExportDefaultDeclaration`. So I dropped that helper and its now-unused `NodeId` import.

I also added a couple of pass tests covering the reproduction from the issue, both with a nested named function expression and a nested arrow function.

## AI disclosure

This change was written with the help of an AI assistant, and I've reviewed and tested it myself before submitting.
