### PR TITLE
refactor(lexer): replace token kind constants with a TokenKind enum

### DIFF
--- a/crates/oxc_lexer/src/arena.rs
+++ b/crates/oxc_lexer/src/arena.rs
@@ -56,13 +56,16 @@ impl LexResult {
     }
 
     #[must_use]
-    pub fn tok_kinds<'a>(&'a self, arena: &'a Arena) -> &'a [u8] {
+    pub fn tok_kinds<'a>(&'a self, arena: &'a Arena) -> &'a [crate::token::TokenKind] {
         if arena.tok_kinds.is_null() {
             return &[];
         }
         let n = self.token_count as usize;
         // SAFETY: the lexer wrote `token_count` kinds plus the EOF sentinels.
-        unsafe { core::slice::from_raw_parts(arena.tok_kinds, n + SPAN_SENTINELS) }
+        let bytes = unsafe { core::slice::from_raw_parts(arena.tok_kinds, n + SPAN_SENTINELS) };
+        crate::token::debug_assert_kind_bytes(bytes);
+        // SAFETY: every kind the pipeline writes is a declared discriminant.
+        unsafe { crate::token::kinds_from_bytes(bytes) }
     }
 
     #[must_use]

--- a/crates/oxc_lexer/src/lib.rs
+++ b/crates/oxc_lexer/src/lib.rs
@@ -18,9 +18,7 @@ pub use error::{Diagnostic, diag_code, diag_severity};
 pub use lanes::Lanes;
 pub use options::{LexOptions, default_options};
 pub use pipeline::Lexer;
-pub use token::{
-    TRIVIA_MAX, TRIVIA_MIN, is_string_kind, is_trivia, token_flags, token_kind, token_kind_name,
-};
+pub use token::{KW_BASE, TRIVIA_MAX, TRIVIA_MIN, TokenKind, token_flags};
 
 use core::cell::RefCell;
 
@@ -93,12 +91,15 @@ fn lex_into_arena(src: &[u8], len: u32, options: LexOptions, arena: &mut Arena) 
 
         if !lx.lanes.unicode_leads.is_empty() && k > 0 {
             // SAFETY: `lex_raw` wrote `k` kinds and `k` spans.
-            let (kinds_all, spans_all) = unsafe {
+            let (kind_bytes, spans_all) = unsafe {
                 (
                     core::slice::from_raw_parts(arena.tok_kinds, k),
                     core::slice::from_raw_parts(arena.tok_spans, k),
                 )
             };
+            token::debug_assert_kind_bytes(kind_bytes);
+            // SAFETY: every kind the pipeline writes is a declared discriminant.
+            let kinds_all = unsafe { token::kinds_from_bytes(kind_bytes) };
             resolve_unicode_leads(&mut lx.lanes, &src[..n], kinds_all, spans_all);
         }
 
@@ -142,7 +143,7 @@ fn lex_into_arena(src: &[u8], len: u32, options: LexOptions, arena: &mut Arena) 
 fn resolve_unicode_leads(
     lanes: &mut Lanes,
     src: &[u8],
-    kinds_all: &[u8],
+    kinds_all: &[TokenKind],
     spans_all: &[oxc_span::Span],
 ) {
     let k = kinds_all.len();
@@ -180,14 +181,13 @@ fn resolve_unicode_leads(
 }
 
 /// Literal interiors, trivia, and JSX text may legally contain any char; only candidates landing in code-level tokens are worth checking.
-fn candidate_is_code_level(kind: u8) -> bool {
-    use token::token_kind as T;
-    !(is_trivia(kind)
-        || is_string_kind(kind)
-        || kind == T::REGEXP
-        || (T::TEMPLATE_NO_SUB..=T::TEMPLATE_TAIL).contains(&kind)
-        || (T::TEMPLATE_NO_SUB_COOKED..=T::TEMPLATE_TAIL_COOKED).contains(&kind)
-        || kind == T::JSX_TEXT)
+fn candidate_is_code_level(kind: TokenKind) -> bool {
+    !(kind.is_trivia()
+        || kind.is_string()
+        || kind == TokenKind::RegExp
+        || (TokenKind::TemplateNoSub..=TokenKind::TemplateTail).contains(&kind)
+        || (TokenKind::TemplateNoSubCooked..=TokenKind::TemplateTailCooked).contains(&kind)
+        || kind == TokenKind::JsxText)
 }
 
 fn empty_result(arena: &Arena) -> LexResult {

--- a/crates/oxc_lexer/src/opmap.rs
+++ b/crates/oxc_lexer/src/opmap.rs
@@ -8,106 +8,106 @@
     clippy::collapsible_match
 )]
 
-use crate::token::token_kind;
+use crate::token::TokenKind;
 
 pub const KW_COUNT_JS: usize = 46;
 pub const KW_COUNT_TS: usize = 81;
-pub const KW_KIND_BASE: u8 = token_kind::KW_BASE;
+pub const KW_KIND_BASE: u8 = crate::token::KW_BASE;
 
 /// Keyword spellings and the token kind each rewrites to (the JS set).
 /// `get`/`set` map to IDENT (contextual, never keywords at lex time) but
 /// stay in the table so the perfect hash keeps its shape.
-pub const KEYWORDS: [(&str, u8); KW_COUNT_JS] = [
-    ("await", token_kind::KW_AWAIT),
-    ("break", token_kind::KW_BREAK),
-    ("case", token_kind::KW_CASE),
-    ("catch", token_kind::KW_CATCH),
-    ("class", token_kind::KW_CLASS),
-    ("const", token_kind::KW_CONST),
-    ("continue", token_kind::KW_CONTINUE),
-    ("debugger", token_kind::KW_DEBUGGER),
-    ("default", token_kind::KW_DEFAULT),
-    ("delete", token_kind::KW_DELETE),
-    ("do", token_kind::KW_DO),
-    ("else", token_kind::KW_ELSE),
-    ("enum", token_kind::KW_ENUM),
-    ("export", token_kind::KW_EXPORT),
-    ("extends", token_kind::KW_EXTENDS),
-    ("finally", token_kind::KW_FINALLY),
-    ("for", token_kind::KW_FOR),
-    ("function", token_kind::KW_FUNCTION),
-    ("if", token_kind::KW_IF),
-    ("import", token_kind::KW_IMPORT),
-    ("in", token_kind::KW_IN),
-    ("instanceof", token_kind::KW_INSTANCEOF),
-    ("new", token_kind::KW_NEW),
-    ("of", token_kind::KW_OF),
-    ("return", token_kind::KW_RETURN),
-    ("super", token_kind::KW_SUPER),
-    ("switch", token_kind::KW_SWITCH),
-    ("this", token_kind::KW_THIS),
-    ("throw", token_kind::KW_THROW),
-    ("try", token_kind::KW_TRY),
-    ("typeof", token_kind::KW_TYPEOF),
-    ("var", token_kind::KW_VAR),
-    ("void", token_kind::KW_VOID),
-    ("while", token_kind::KW_WHILE),
-    ("with", token_kind::KW_WITH),
-    ("yield", token_kind::KW_YIELD),
-    ("let", token_kind::KW_LET),
-    ("static", token_kind::KW_STATIC),
-    ("async", token_kind::KW_ASYNC),
-    ("get", token_kind::IDENT),
-    ("set", token_kind::IDENT),
-    ("as", token_kind::KW_AS),
-    ("from", token_kind::KW_FROM),
-    ("true", token_kind::KW_TRUE),
-    ("false", token_kind::KW_FALSE),
-    ("null", token_kind::KW_NULL),
+pub const KEYWORDS: [(&str, TokenKind); KW_COUNT_JS] = [
+    ("await", TokenKind::KwAwait),
+    ("break", TokenKind::KwBreak),
+    ("case", TokenKind::KwCase),
+    ("catch", TokenKind::KwCatch),
+    ("class", TokenKind::KwClass),
+    ("const", TokenKind::KwConst),
+    ("continue", TokenKind::KwContinue),
+    ("debugger", TokenKind::KwDebugger),
+    ("default", TokenKind::KwDefault),
+    ("delete", TokenKind::KwDelete),
+    ("do", TokenKind::KwDo),
+    ("else", TokenKind::KwElse),
+    ("enum", TokenKind::KwEnum),
+    ("export", TokenKind::KwExport),
+    ("extends", TokenKind::KwExtends),
+    ("finally", TokenKind::KwFinally),
+    ("for", TokenKind::KwFor),
+    ("function", TokenKind::KwFunction),
+    ("if", TokenKind::KwIf),
+    ("import", TokenKind::KwImport),
+    ("in", TokenKind::KwIn),
+    ("instanceof", TokenKind::KwInstanceof),
+    ("new", TokenKind::KwNew),
+    ("of", TokenKind::KwOf),
+    ("return", TokenKind::KwReturn),
+    ("super", TokenKind::KwSuper),
+    ("switch", TokenKind::KwSwitch),
+    ("this", TokenKind::KwThis),
+    ("throw", TokenKind::KwThrow),
+    ("try", TokenKind::KwTry),
+    ("typeof", TokenKind::KwTypeof),
+    ("var", TokenKind::KwVar),
+    ("void", TokenKind::KwVoid),
+    ("while", TokenKind::KwWhile),
+    ("with", TokenKind::KwWith),
+    ("yield", TokenKind::KwYield),
+    ("let", TokenKind::KwLet),
+    ("static", TokenKind::KwStatic),
+    ("async", TokenKind::KwAsync),
+    ("get", TokenKind::Ident),
+    ("set", TokenKind::Ident),
+    ("as", TokenKind::KwAs),
+    ("from", TokenKind::KwFrom),
+    ("true", TokenKind::KwTrue),
+    ("false", TokenKind::KwFalse),
+    ("null", TokenKind::KwNull),
 ];
 
 /// TS-mode additions: TypeScript's contextual keywords plus the strict-mode
 /// reserved words. JS mode lexes every one of these spellings as IDENT.
-pub const KEYWORDS_TS_EXTRA: [(&str, u8); KW_COUNT_TS - KW_COUNT_JS] = [
-    ("abstract", token_kind::KW_ABSTRACT),
-    ("accessor", token_kind::KW_ACCESSOR),
-    ("any", token_kind::KW_ANY),
-    ("asserts", token_kind::KW_ASSERTS),
-    ("bigint", token_kind::KW_BIGINT),
-    ("boolean", token_kind::KW_BOOLEAN),
-    ("declare", token_kind::KW_DECLARE),
-    ("global", token_kind::KW_GLOBAL),
-    ("implements", token_kind::KW_IMPLEMENTS),
-    ("infer", token_kind::KW_INFER),
-    ("interface", token_kind::KW_INTERFACE),
-    ("intrinsic", token_kind::KW_INTRINSIC),
-    ("is", token_kind::KW_IS),
-    ("keyof", token_kind::KW_KEYOF),
-    ("module", token_kind::KW_MODULE),
-    ("namespace", token_kind::KW_NAMESPACE),
-    ("never", token_kind::KW_NEVER),
-    ("number", token_kind::KW_NUMBER),
-    ("object", token_kind::KW_OBJECT),
-    ("out", token_kind::KW_OUT),
-    ("override", token_kind::KW_OVERRIDE),
-    ("package", token_kind::KW_PACKAGE),
-    ("private", token_kind::KW_PRIVATE),
-    ("protected", token_kind::KW_PROTECTED),
-    ("public", token_kind::KW_PUBLIC),
-    ("readonly", token_kind::KW_READONLY),
-    ("require", token_kind::KW_REQUIRE),
-    ("satisfies", token_kind::KW_SATISFIES),
-    ("string", token_kind::KW_STRING),
-    ("symbol", token_kind::KW_SYMBOL),
-    ("type", token_kind::KW_TYPE),
-    ("undefined", token_kind::KW_UNDEFINED),
-    ("unique", token_kind::KW_UNIQUE),
-    ("unknown", token_kind::KW_UNKNOWN),
-    ("using", token_kind::KW_USING),
+pub const KEYWORDS_TS_EXTRA: [(&str, TokenKind); KW_COUNT_TS - KW_COUNT_JS] = [
+    ("abstract", TokenKind::KwAbstract),
+    ("accessor", TokenKind::KwAccessor),
+    ("any", TokenKind::KwAny),
+    ("asserts", TokenKind::KwAsserts),
+    ("bigint", TokenKind::KwBigInt),
+    ("boolean", TokenKind::KwBoolean),
+    ("declare", TokenKind::KwDeclare),
+    ("global", TokenKind::KwGlobal),
+    ("implements", TokenKind::KwImplements),
+    ("infer", TokenKind::KwInfer),
+    ("interface", TokenKind::KwInterface),
+    ("intrinsic", TokenKind::KwIntrinsic),
+    ("is", TokenKind::KwIs),
+    ("keyof", TokenKind::KwKeyof),
+    ("module", TokenKind::KwModule),
+    ("namespace", TokenKind::KwNamespace),
+    ("never", TokenKind::KwNever),
+    ("number", TokenKind::KwNumber),
+    ("object", TokenKind::KwObject),
+    ("out", TokenKind::KwOut),
+    ("override", TokenKind::KwOverride),
+    ("package", TokenKind::KwPackage),
+    ("private", TokenKind::KwPrivate),
+    ("protected", TokenKind::KwProtected),
+    ("public", TokenKind::KwPublic),
+    ("readonly", TokenKind::KwReadonly),
+    ("require", TokenKind::KwRequire),
+    ("satisfies", TokenKind::KwSatisfies),
+    ("string", TokenKind::KwString),
+    ("symbol", TokenKind::KwSymbol),
+    ("type", TokenKind::KwType),
+    ("undefined", TokenKind::KwUndefined),
+    ("unique", TokenKind::KwUnique),
+    ("unknown", TokenKind::KwUnknown),
+    ("using", TokenKind::KwUsing),
 ];
 
-const fn keywords_ts() -> [(&'static str, u8); KW_COUNT_TS] {
-    let mut out = [("", 0u8); KW_COUNT_TS];
+const fn keywords_ts() -> [(&'static str, TokenKind); KW_COUNT_TS] {
+    let mut out = [("", TokenKind::Eof); KW_COUNT_TS];
     let mut i = 0;
     while i < KW_COUNT_JS {
         out[i] = KEYWORDS[i];
@@ -121,16 +121,16 @@ const fn keywords_ts() -> [(&'static str, u8); KW_COUNT_TS] {
 }
 
 /// The TS-mode keyword set: [`KEYWORDS`] followed by [`KEYWORDS_TS_EXTRA`].
-pub static KEYWORDS_TS: [(&str, u8); KW_COUNT_TS] = keywords_ts();
+pub static KEYWORDS_TS: [(&str, TokenKind); KW_COUNT_TS] = keywords_ts();
 
 /// First punctuator kind — the token-kind space reserves [32, 128) for them.
-pub const OP_KIND_BASE: u8 = token_kind::LBRACE;
+pub const OP_KIND_BASE: u8 = TokenKind::LBrace as u8;
 pub const OPMAP_NOPS: usize = 33;
 
 pub struct OpDef {
     pub txt: &'static [u8],
     pub len: u8,
-    pub kind: u8,
+    pub kind: TokenKind,
 }
 
 macro_rules! op {
@@ -140,76 +140,76 @@ macro_rules! op {
 }
 
 pub static OPMAP_OPS: [OpDef; OPMAP_NOPS] = [
-    op!(b"<=", token_kind::LE),
-    op!(b">=", token_kind::GE),
-    op!(b"==", token_kind::EQ_EQ),
-    op!(b"!=", token_kind::BANG_EQ),
-    op!(b"===", token_kind::EQ_EQ_EQ),
-    op!(b"!==", token_kind::BANG_EQ_EQ),
-    op!(b"**", token_kind::STAR_STAR),
-    op!(b"++", token_kind::PLUS_PLUS),
-    op!(b"--", token_kind::MINUS_MINUS),
-    op!(b"<<", token_kind::LSHIFT),
-    op!(b">>", token_kind::RSHIFT),
-    op!(b">>>", token_kind::URSHIFT),
-    op!(b"&&", token_kind::AMP_AMP),
-    op!(b"||", token_kind::PIPE_PIPE),
-    op!(b"??", token_kind::NULLISH),
-    op!(b"?.", token_kind::OPTIONAL_CHAIN),
-    op!(b"=>", token_kind::ARROW),
-    op!(b"+=", token_kind::PLUS_EQ),
-    op!(b"-=", token_kind::MINUS_EQ),
-    op!(b"*=", token_kind::STAR_EQ),
-    op!(b"%=", token_kind::PERCENT_EQ),
-    op!(b"<<=", token_kind::LSHIFT_EQ),
-    op!(b">>=", token_kind::RSHIFT_EQ),
-    op!(b">>>=", token_kind::URSHIFT_EQ),
-    op!(b"&=", token_kind::AMP_EQ),
-    op!(b"|=", token_kind::PIPE_EQ),
-    op!(b"^=", token_kind::CARET_EQ),
-    op!(b"&&=", token_kind::AMP_AMP_EQ),
-    op!(b"||=", token_kind::PIPE_PIPE_EQ),
-    op!(b"??=", token_kind::NULLISH_EQ),
-    op!(b"**=", token_kind::STAR_STAR_EQ),
-    op!(b"...", token_kind::ELLIPSIS),
-    op!(b"/=", token_kind::SLASH_EQ),
+    op!(b"<=", TokenKind::Le),
+    op!(b">=", TokenKind::Ge),
+    op!(b"==", TokenKind::EqEq),
+    op!(b"!=", TokenKind::BangEq),
+    op!(b"===", TokenKind::EqEqEq),
+    op!(b"!==", TokenKind::BangEqEq),
+    op!(b"**", TokenKind::StarStar),
+    op!(b"++", TokenKind::PlusPlus),
+    op!(b"--", TokenKind::MinusMinus),
+    op!(b"<<", TokenKind::LShift),
+    op!(b">>", TokenKind::RShift),
+    op!(b">>>", TokenKind::URShift),
+    op!(b"&&", TokenKind::AmpAmp),
+    op!(b"||", TokenKind::PipePipe),
+    op!(b"??", TokenKind::Nullish),
+    op!(b"?.", TokenKind::OptionalChain),
+    op!(b"=>", TokenKind::Arrow),
+    op!(b"+=", TokenKind::PlusEq),
+    op!(b"-=", TokenKind::MinusEq),
+    op!(b"*=", TokenKind::StarEq),
+    op!(b"%=", TokenKind::PercentEq),
+    op!(b"<<=", TokenKind::LShiftEq),
+    op!(b">>=", TokenKind::RShiftEq),
+    op!(b">>>=", TokenKind::URShiftEq),
+    op!(b"&=", TokenKind::AmpEq),
+    op!(b"|=", TokenKind::PipeEq),
+    op!(b"^=", TokenKind::CaretEq),
+    op!(b"&&=", TokenKind::AmpAmpEq),
+    op!(b"||=", TokenKind::PipePipeEq),
+    op!(b"??=", TokenKind::NullishEq),
+    op!(b"**=", TokenKind::StarStarEq),
+    op!(b"...", TokenKind::Ellipsis),
+    op!(b"/=", TokenKind::SlashEq),
 ];
 
-pub const OP_QDOT: u8 = token_kind::OPTIONAL_CHAIN;
-pub const OP_SLASH_EQ: u8 = token_kind::SLASH_EQ;
+pub const OP_QDOT: u8 = TokenKind::OptionalChain as u8;
+pub const OP_SLASH_EQ: u8 = TokenKind::SlashEq as u8;
 
-pub const PUNCT1_KIND_UNKNOWN: u8 = 255;
+pub const PUNCT1_KIND_UNKNOWN: u8 = TokenKind::Invalid as u8;
 pub const PUNCT1_NKNOWN: usize = 26;
 
 /// Single-char punctuators and their kinds. `#` maps to UNKNOWN: a bare `#`
 /// is invalid on its own (private names and hashbangs are resolved earlier).
-pub const PUNCT1: [(u8, u8); PUNCT1_NKNOWN] = [
-    (b'(', token_kind::LPAREN),
-    (b')', token_kind::RPAREN),
-    (b'[', token_kind::LBRACKET),
-    (b']', token_kind::RBRACKET),
-    (b'{', token_kind::LBRACE),
-    (b'}', token_kind::RBRACE),
-    (b';', token_kind::SEMI),
-    (b',', token_kind::COMMA),
-    (b'.', token_kind::DOT),
-    (b'<', token_kind::LT),
-    (b'>', token_kind::GT),
-    (b'+', token_kind::PLUS),
-    (b'-', token_kind::MINUS),
-    (b'*', token_kind::STAR),
-    (b'/', token_kind::SLASH),
-    (b'%', token_kind::PERCENT),
-    (b'&', token_kind::AMP),
-    (b'|', token_kind::PIPE),
-    (b'^', token_kind::CARET),
-    (b'!', token_kind::BANG),
-    (b'~', token_kind::TILDE),
-    (b'?', token_kind::QUESTION),
-    (b':', token_kind::COLON),
-    (b'=', token_kind::EQ),
-    (b'@', token_kind::AT),
-    (b'#', PUNCT1_KIND_UNKNOWN),
+pub const PUNCT1: [(u8, TokenKind); PUNCT1_NKNOWN] = [
+    (b'(', TokenKind::LParen),
+    (b')', TokenKind::RParen),
+    (b'[', TokenKind::LBracket),
+    (b']', TokenKind::RBracket),
+    (b'{', TokenKind::LBrace),
+    (b'}', TokenKind::RBrace),
+    (b';', TokenKind::Semi),
+    (b',', TokenKind::Comma),
+    (b'.', TokenKind::Dot),
+    (b'<', TokenKind::Lt),
+    (b'>', TokenKind::Gt),
+    (b'+', TokenKind::Plus),
+    (b'-', TokenKind::Minus),
+    (b'*', TokenKind::Star),
+    (b'/', TokenKind::Slash),
+    (b'%', TokenKind::Percent),
+    (b'&', TokenKind::Amp),
+    (b'|', TokenKind::Pipe),
+    (b'^', TokenKind::Caret),
+    (b'!', TokenKind::Bang),
+    (b'~', TokenKind::Tilde),
+    (b'?', TokenKind::Question),
+    (b':', TokenKind::Colon),
+    (b'=', TokenKind::Eq),
+    (b'@', TokenKind::At),
+    (b'#', TokenKind::Invalid),
 ];
 
 const fn punct1_list() -> [u8; PUNCT1_NKNOWN] {
@@ -226,7 +226,7 @@ const fn punct1_tok() -> [u8; PUNCT1_NKNOWN] {
     let mut out = [0u8; PUNCT1_NKNOWN];
     let mut i = 0;
     while i < PUNCT1_NKNOWN {
-        out[i] = PUNCT1[i].1;
+        out[i] = PUNCT1[i].1 as u8;
         i += 1;
     }
     out
@@ -293,7 +293,7 @@ pub fn op_key(c0: u8, c1: u8, c2: u8, len: u32) -> u32 {
 
 impl KwSet {
     pub fn build(
-        list: &[(&'static str, u8)],
+        list: &[(&'static str, TokenKind)],
         ts_key: bool,
         shifts: &[u32],
         hint: (u32, u32),
@@ -318,7 +318,7 @@ impl KwSet {
             let len = bytes.len();
             assert!(len >= 2 && len <= 10, "opmap.rs: keyword length out of range");
             s.kw_len[i] = len as u8;
-            s.kw_tok[i] = list[i].1;
+            s.kw_tok[i] = list[i].1 as u8;
             let mut w: u64 = 0;
             let m = if len < 8 { len } else { 8 };
             for k in 0..m {
@@ -422,7 +422,7 @@ impl KwSet {
         self.kw_tok[idx] as u32
     }
 
-    pub fn self_check(&self, list: &[(&'static str, u8)]) {
+    pub fn self_check(&self, list: &[(&'static str, TokenKind)]) {
         for i in 0..list.len() {
             let mut buf = [0u8; 16];
             let bytes = list[i].0.as_bytes();
@@ -485,7 +485,7 @@ impl OpMap {
         for i in 0..OPMAP_NOPS {
             let a = &OPMAP_OPS[i];
             assert!(
-                a.len as usize == a.txt.len() && a.kind >= OP_KIND_BASE && a.kind <= 89,
+                a.len as usize == a.txt.len() && a.kind as u8 >= OP_KIND_BASE && a.kind as u8 <= 89,
                 "opmap.rs: bad OpDef {i}"
             );
             for j in (i + 1)..OPMAP_NOPS {

--- a/crates/oxc_lexer/src/pipeline/carve.rs
+++ b/crates/oxc_lexer/src/pipeline/carve.rs
@@ -631,7 +631,7 @@ pub(super) unsafe fn carve_jsx(
                         {
                             f.kind = JFrameKind::JsxElem;
                         }
-                        jsx_punct(kind, opch, s, crate::token::token_kind::GT);
+                        jsx_punct(kind, opch, s, crate::token::TokenKind::Gt as u8);
                         mode = JMode::Text;
                         text_start = s + 1;
                         i = s + 1;

--- a/crates/oxc_lexer/src/pipeline/classify.rs
+++ b/crates/oxc_lexer/src/pipeline/classify.rs
@@ -180,7 +180,7 @@ const fn cls_table(ts: bool) -> [u16; 256] {
     let mut punct = [PUNCT1_KIND_UNKNOWN; 256];
     let mut i = 0;
     while i < PUNCT1_NKNOWN {
-        punct[PUNCT1[i].0 as usize] = PUNCT1[i].1;
+        punct[PUNCT1[i].0 as usize] = PUNCT1[i].1 as u8;
         i += 1;
     }
     let mut t = [0u16; 256];

--- a/crates/oxc_lexer/src/pipeline/compress.rs
+++ b/crates/oxc_lexer/src/pipeline/compress.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::error::diag_code;
 use crate::lanes::Lanes;
 use crate::tables::Tables;
-use crate::token::{SPAN_SENTINELS, is_trivia};
+use crate::token::{SPAN_SENTINELS, is_trivia_byte};
 
 #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2", target_feature = "bmi2")))]
 use super::find::{eqm, load8};
@@ -109,7 +109,7 @@ pub(super) unsafe fn build_spans(
         let k = *stage_kind.add(j);
         *sp.add(w) = stage_pos.add(j).cast::<u64>().read_unaligned();
         *sig_kinds.add(w) = k;
-        w += usize::from(!is_trivia(k) || k == HASHBANG);
+        w += usize::from(!is_trivia_byte(k) || k == HASHBANG);
         j += 1;
     }
     w

--- a/crates/oxc_lexer/src/pipeline/mod.rs
+++ b/crates/oxc_lexer/src/pipeline/mod.rs
@@ -35,35 +35,35 @@ use coalesce::coalesce;
 use compress::{build_spans, compress, lanes_post, write_sentinels};
 use keywords::KWB;
 
-use crate::token::token_kind;
+use crate::token::TokenKind;
 
 const STAGE_BLOCKS: usize = 32;
 const STAGE_CAP: usize = STAGE_BLOCKS * 64 + 128;
 
 // Short kind aliases for the pipeline, tied to `token_kind` so they can't drift.
-pub(crate) const WS: u8 = token_kind::WHITESPACE;
-pub(crate) const IDENT: u8 = token_kind::IDENT;
-pub(crate) const NUM: u8 = token_kind::NUMBER;
-pub(crate) const BIGINT: u8 = token_kind::BIGINT;
-pub(crate) const STR: u8 = token_kind::STRING;
-pub(crate) const LCOM: u8 = token_kind::LINE_COMMENT;
-pub(crate) const BCOM: u8 = token_kind::BLOCK_COMMENT;
-pub(crate) const REGEX: u8 = token_kind::REGEXP;
-pub(crate) const TMPL_NOSUB: u8 = token_kind::TEMPLATE_NO_SUB;
-pub(crate) const TMPL_HEAD: u8 = token_kind::TEMPLATE_HEAD;
-pub(crate) const TMPL_MIDDLE: u8 = token_kind::TEMPLATE_MIDDLE;
-pub(crate) const TMPL_TAIL: u8 = token_kind::TEMPLATE_TAIL;
-pub(crate) const HASHBANG: u8 = token_kind::HASHBANG;
-pub(crate) const IDENT_ESC: u8 = token_kind::IDENT_ESCAPED;
-pub(crate) const PRIV_IDENT: u8 = token_kind::PRIVATE_IDENT;
-pub(crate) const PRIV_IDENT_ESC: u8 = token_kind::PRIVATE_IDENT_ESCAPED;
-pub(crate) const EOF: u8 = token_kind::EOF;
+pub(crate) const WS: u8 = TokenKind::Whitespace as u8;
+pub(crate) const IDENT: u8 = TokenKind::Ident as u8;
+pub(crate) const NUM: u8 = TokenKind::Number as u8;
+pub(crate) const BIGINT: u8 = TokenKind::BigInt as u8;
+pub(crate) const STR: u8 = TokenKind::String as u8;
+pub(crate) const LCOM: u8 = TokenKind::LineComment as u8;
+pub(crate) const BCOM: u8 = TokenKind::BlockComment as u8;
+pub(crate) const REGEX: u8 = TokenKind::RegExp as u8;
+pub(crate) const TMPL_NOSUB: u8 = TokenKind::TemplateNoSub as u8;
+pub(crate) const TMPL_HEAD: u8 = TokenKind::TemplateHead as u8;
+pub(crate) const TMPL_MIDDLE: u8 = TokenKind::TemplateMiddle as u8;
+pub(crate) const TMPL_TAIL: u8 = TokenKind::TemplateTail as u8;
+pub(crate) const HASHBANG: u8 = TokenKind::Hashbang as u8;
+pub(crate) const IDENT_ESC: u8 = TokenKind::IdentEscaped as u8;
+pub(crate) const PRIV_IDENT: u8 = TokenKind::PrivateIdent as u8;
+pub(crate) const PRIV_IDENT_ESC: u8 = TokenKind::PrivateIdentEscaped as u8;
+pub(crate) const EOF: u8 = TokenKind::Eof as u8;
 
 // JSX coarse kinds, written only by `carve_jsx`. `JEND`/`JSX_LT` read as
 // values in `prev_is_regex` (after a completed element, `/` is division).
-pub(crate) const JTEXT: u8 = token_kind::JSX_TEXT;
-pub(crate) const JEND: u8 = token_kind::JSX_TAG_END;
-pub(crate) const JSX_LT: u8 = token_kind::JSX_LT;
+pub(crate) const JTEXT: u8 = TokenKind::JsxText as u8;
+pub(crate) const JEND: u8 = TokenKind::JsxTagEnd as u8;
+pub(crate) const JSX_LT: u8 = TokenKind::JsxLt as u8;
 
 // `glue_number` computes the kind as `NUM + is_bigint` — keep them adjacent.
 const _: () = assert!(BIGINT == NUM + 1);
@@ -82,7 +82,7 @@ pub struct Lexer {
     stage_pos: Vec<u32>,
     stage_kind: Vec<u8>,
     pub spans: Vec<Span>,
-    pub sig_kinds: Vec<u8>,
+    sig_kinds: Vec<u8>,
     pub sig_len: usize,
     out_cap: usize,
     pub lanes: Lanes,
@@ -117,6 +117,17 @@ impl Lexer {
             lanes: Lanes::default(),
             tables: Box::new(Tables::new()),
         }
+    }
+
+    /// The kinds written by the last [`Lexer::lex`], including the trailing
+    /// [`SPAN_SENTINELS`] EOF entries.
+    #[must_use]
+    pub fn kinds(&self) -> &[TokenKind] {
+        let bytes = &self.sig_kinds[..self.sig_len + SPAN_SENTINELS];
+        crate::token::debug_assert_kind_bytes(bytes);
+        // SAFETY: `lex_raw` wrote `sig_len` kinds plus the sentinels, all of
+        // them declared discriminants.
+        unsafe { crate::token::kinds_from_bytes(bytes) }
     }
 
     fn ensure(&mut self, n: usize) {

--- a/crates/oxc_lexer/src/pipeline/regex_div.rs
+++ b/crates/oxc_lexer/src/pipeline/regex_div.rs
@@ -1218,10 +1218,10 @@ pub(super) unsafe fn prev_is_regex(
 #[cfg(test)]
 mod tests {
     use crate::options::default_options;
-    use crate::token::token_kind as k;
+    use crate::token::TokenKind;
     use crate::{Lexer, PAD};
 
-    fn kinds_of(code: &str, ts: bool, jsx: bool) -> Vec<u8> {
+    fn kinds_of(code: &str, ts: bool, jsx: bool) -> Vec<TokenKind> {
         let mut buf = code.as_bytes().to_vec();
         let n = buf.len();
         buf.resize(n + PAD, 0);
@@ -1230,20 +1230,20 @@ mod tests {
         opts.jsx = jsx;
         let mut lx = Lexer::new();
         let count = lx.lex(&buf, n, opts);
-        lx.sig_kinds[..count].iter().copied().filter(|&kk| !crate::is_trivia(kk)).collect()
+        lx.kinds()[..count].iter().copied().filter(|kk| !kk.is_trivia()).collect()
     }
 
     #[track_caller]
     fn regex(code: &str, ts: bool) {
         let ks = kinds_of(code, ts, false);
-        assert!(ks.contains(&k::REGEXP), "expected regex in {code:?}: kinds {ks:?}");
+        assert!(ks.contains(&TokenKind::RegExp), "expected regex in {code:?}: kinds {ks:?}");
     }
 
     #[track_caller]
     fn division(code: &str, ts: bool) {
         let ks = kinds_of(code, ts, false);
-        assert!(!ks.contains(&k::REGEXP), "expected division in {code:?}: kinds {ks:?}");
-        assert!(ks.contains(&k::SLASH), "expected a `/` in {code:?}: kinds {ks:?}");
+        assert!(!ks.contains(&TokenKind::RegExp), "expected division in {code:?}: kinds {ks:?}");
+        assert!(ks.contains(&TokenKind::Slash), "expected a `/` in {code:?}: kinds {ks:?}");
     }
 
     #[track_caller]
@@ -1411,8 +1411,8 @@ mod tests {
     fn slash_dense_chains() {
         let count = |code: &str, want_re: usize, want_slash: usize| {
             let ks = kinds_of(code, false, false);
-            let re = ks.iter().filter(|&&kk| kk == k::REGEXP).count();
-            let sl = ks.iter().filter(|&&kk| kk == k::SLASH).count();
+            let re = ks.iter().filter(|&&kk| kk == TokenKind::RegExp).count();
+            let sl = ks.iter().filter(|&&kk| kk == TokenKind::Slash).count();
             assert_eq!(
                 (re, sl),
                 (want_re, want_slash),
@@ -1567,7 +1567,7 @@ mod tests {
     #[test]
     fn ts_postfix_bang_unchanged() {
         let ks = kinds_of("x! / 2;", true, false);
-        assert!(!ks.contains(&k::REGEXP), "x! / 2 must stay division: {ks:?}");
+        assert!(!ks.contains(&TokenKind::RegExp), "x! / 2 must stay division: {ks:?}");
     }
 
     #[test]
@@ -1589,9 +1589,9 @@ mod tests {
     #[test]
     fn ts_angle_close_resolved() {
         let ks = kinds_of("class C<T> {} /re/.test(x);", true, false);
-        assert!(ks.contains(&k::REGEXP), "TS class decl with type params: {ks:?}");
+        assert!(ks.contains(&TokenKind::RegExp), "TS class decl with type params: {ks:?}");
         let ks = kinds_of("x = f < T > {} / re / g;", true, false);
-        assert!(!ks.contains(&k::REGEXP), "TS relational re-read must divide: {ks:?}");
+        assert!(!ks.contains(&TokenKind::RegExp), "TS relational re-read must divide: {ks:?}");
     }
 
     #[test]
@@ -1611,31 +1611,31 @@ mod tests {
     fn jsx_operand_positions() {
         let jsx = |code: &str| kinds_of(code, false, true);
         let ks = jsx("export default <App/>;");
-        assert!(ks.contains(&k::JSX_LT), "export default <App/> must open JSX: {ks:?}");
+        assert!(ks.contains(&TokenKind::JsxLt), "export default <App/> must open JSX: {ks:?}");
         let ks = jsx("if (x) <App/>;");
-        assert!(ks.contains(&k::JSX_LT), "if (x) <App/> must open JSX: {ks:?}");
+        assert!(ks.contains(&TokenKind::JsxLt), "if (x) <App/> must open JSX: {ks:?}");
         let ks = jsx("x = a < b;");
-        assert!(!ks.contains(&k::JSX_LT), "a < b is a comparison: {ks:?}");
+        assert!(!ks.contains(&TokenKind::JsxLt), "a < b is a comparison: {ks:?}");
         let ks = jsx("f(x) < y;");
-        assert!(!ks.contains(&k::JSX_LT), "f(x) < y is a comparison: {ks:?}");
+        assert!(!ks.contains(&TokenKind::JsxLt), "f(x) < y is a comparison: {ks:?}");
         let ks = jsx("a++ < b;");
-        assert!(!ks.contains(&k::JSX_LT), "a++ < b is a comparison: {ks:?}");
+        assert!(!ks.contains(&TokenKind::JsxLt), "a++ < b is a comparison: {ks:?}");
         let ks = jsx("x = a > {} < b;");
-        assert!(!ks.contains(&k::JSX_LT), "a > {{}} < b is a comparison chain: {ks:?}");
+        assert!(!ks.contains(&TokenKind::JsxLt), "a > {{}} < b is a comparison chain: {ks:?}");
     }
 
     #[test]
     fn jsx_replay_oracle() {
         let jsx = |code: &str| kinds_of(code, false, true);
         let ks = jsx("function* items(d) { for (const x of d) yield <li id={x}/>; }");
-        assert!(ks.contains(&k::JSX_LT), "yielded JSX element must frame: {ks:?}");
+        assert!(ks.contains(&TokenKind::JsxLt), "yielded JSX element must frame: {ks:?}");
         let ks = jsx("var await = 1, max = 10;\nif (await < max) done();");
-        assert!(!ks.contains(&k::JSX_LT), "await < max is a comparison: {ks:?}");
-        assert!(ks.contains(&k::LT), "expected a plain `<`: {ks:?}");
+        assert!(!ks.contains(&TokenKind::JsxLt), "await < max is a comparison: {ks:?}");
+        assert!(ks.contains(&TokenKind::Lt), "expected a plain `<`: {ks:?}");
         let ks = jsx("async function f() { return await <Spinner/>; }");
-        assert!(ks.contains(&k::JSX_LT), "awaited JSX element must frame: {ks:?}");
+        assert!(ks.contains(&TokenKind::JsxLt), "awaited JSX element must frame: {ks:?}");
         let ks =
             jsx("var await = 1, g = 2;\nvar el = <a b={async () => await 1} c={await /2/g}/>;");
-        assert!(!ks.contains(&k::REGEXP), "container leak, expected division: {ks:?}");
+        assert!(!ks.contains(&TokenKind::RegExp), "container leak, expected division: {ks:?}");
     }
 }

--- a/crates/oxc_lexer/src/pipeline/replay.rs
+++ b/crates/oxc_lexer/src/pipeline/replay.rs
@@ -665,10 +665,10 @@ pub(super) unsafe fn replay_is_keyword(
 #[cfg(test)]
 mod tests {
     use crate::options::default_options;
-    use crate::token::token_kind as k;
+    use crate::token::TokenKind;
     use crate::{Lexer, PAD};
 
-    fn kinds_of(code: &str, module: bool) -> Vec<u8> {
+    fn kinds_of(code: &str, module: bool) -> Vec<TokenKind> {
         let mut buf = code.as_bytes().to_vec();
         let n = buf.len();
         buf.resize(n + PAD, 0);
@@ -676,20 +676,20 @@ mod tests {
         opts.source_type_module = module;
         let mut lx = Lexer::new();
         let count = lx.lex(&buf, n, opts);
-        lx.sig_kinds[..count].iter().copied().filter(|&kk| !crate::is_trivia(kk)).collect()
+        lx.kinds()[..count].iter().copied().filter(|kk| !kk.is_trivia()).collect()
     }
 
     #[track_caller]
     fn regex(code: &str) {
         let ks = kinds_of(code, false);
-        assert!(ks.contains(&k::REGEXP), "expected regex in {code:?}: kinds {ks:?}");
+        assert!(ks.contains(&TokenKind::RegExp), "expected regex in {code:?}: kinds {ks:?}");
     }
 
     #[track_caller]
     fn division(code: &str) {
         let ks = kinds_of(code, false);
-        assert!(!ks.contains(&k::REGEXP), "expected division in {code:?}: kinds {ks:?}");
-        assert!(ks.contains(&k::SLASH), "expected a `/` in {code:?}: kinds {ks:?}");
+        assert!(!ks.contains(&TokenKind::RegExp), "expected division in {code:?}: kinds {ks:?}");
+        assert!(ks.contains(&TokenKind::Slash), "expected a `/` in {code:?}: kinds {ks:?}");
     }
 
     #[test]
@@ -759,9 +759,9 @@ mod tests {
     #[test]
     fn module_gate_skips_replay() {
         let ks = kinds_of("var r = await /re/.test(x);", true);
-        assert!(ks.contains(&k::REGEXP), "module keeps await reserved: {ks:?}");
+        assert!(ks.contains(&TokenKind::RegExp), "module keeps await reserved: {ks:?}");
         let ks = kinds_of("var r = yield /re/;", true);
-        assert!(ks.contains(&k::REGEXP), "module keeps yield reserved: {ks:?}");
+        assert!(ks.contains(&TokenKind::RegExp), "module keeps yield reserved: {ks:?}");
     }
 
     #[test]

--- a/crates/oxc_lexer/src/tables.rs
+++ b/crates/oxc_lexer/src/tables.rs
@@ -161,7 +161,7 @@ impl Tables {
             let mut found: i32 = -1;
             for kw in KEYWORDS.iter() {
                 if kw.0 == *r {
-                    found = (kw.1 - KW_KIND_BASE) as i32;
+                    found = (kw.1 as u8 - KW_KIND_BASE) as i32;
                     break;
                 }
             }

--- a/crates/oxc_lexer/src/token.rs
+++ b/crates/oxc_lexer/src/token.rs
@@ -1,245 +1,354 @@
-/// Token kinds are plain `u8`s the pipeline computes them arithmetically and blends them in SIMD registers.
-pub mod token_kind {
-    pub const EOF: u8 = 0;
+macro_rules! define_token_kind {
+    ($( $variant:ident = $value:literal => $name:literal ),+ $(,)?) => {
+        /// A lexed token kind.
+        ///
+        /// The discriminants are load-bearing: `[32, 128)` is reserved for
+        /// punctuators and `>= 128` for keywords, so the pipeline can classify
+        /// with range checks and SIMD compares. They are *not* dense â€” the
+        /// pipeline computes kinds arithmetically and blends them in SIMD
+        /// registers, so it works on the raw `u8` and only the crate boundary
+        /// is typed.
+        #[repr(u8)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub enum TokenKind {
+            $( $variant = $value, )+
+        }
 
-    pub const IDENT: u8 = 1;
-    pub const PRIVATE_IDENT: u8 = 2;
-    pub const NUMBER: u8 = 3;
-    pub const BIGINT: u8 = 4;
-    pub const STRING: u8 = 5;
-    pub const REGEXP: u8 = 6;
-    pub const TEMPLATE_NO_SUB: u8 = 7;
-    pub const TEMPLATE_HEAD: u8 = 8;
-    pub const TEMPLATE_MIDDLE: u8 = 9;
-    pub const TEMPLATE_TAIL: u8 = 10;
+        impl TokenKind {
+            /// Every declared kind, in discriminant order.
+            pub const VARIANTS: &'static [TokenKind] = &[ $( TokenKind::$variant, )+ ];
 
-    pub const LINE_COMMENT: u8 = 11;
-    pub const BLOCK_COMMENT: u8 = 12;
-    pub const HASHBANG: u8 = 13;
-    pub const WHITESPACE: u8 = 14;
-    pub const LINE_TERMINATOR: u8 = 15;
+            /// The kind `byte` denotes, or `None` if it is not a declared discriminant.
+            #[inline]
+            #[must_use]
+            pub const fn from_u8(byte: u8) -> Option<Self> {
+                match byte {
+                    $( $value => Some(Self::$variant), )+
+                    _ => None,
+                }
+            }
 
-    pub const STRING_COOKED: u8 = 16;
-    pub const IDENT_ESCAPED: u8 = 17;
-    pub const PRIVATE_IDENT_ESCAPED: u8 = 18;
-    pub const TEMPLATE_NO_SUB_COOKED: u8 = 19;
-    pub const TEMPLATE_HEAD_COOKED: u8 = 20;
-    pub const TEMPLATE_MIDDLE_COOKED: u8 = 21;
-    pub const TEMPLATE_TAIL_COOKED: u8 = 22;
-    pub const DECIMAL: u8 = 23;
-    pub const FLOAT: u8 = 24;
-    pub const BINARY: u8 = 25;
-    pub const OCTAL: u8 = 26;
-    pub const HEX: u8 = 27;
-    pub const JSX_TEXT: u8 = 28;
-    pub const JSX_TAG_END: u8 = 29;
-    pub const JSX_LT: u8 = 30;
-    pub const LBRACE: u8 = 32;
-    pub const RBRACE: u8 = 33;
-    pub const LPAREN: u8 = 34;
-    pub const RPAREN: u8 = 35;
-    pub const LBRACKET: u8 = 36;
-    pub const RBRACKET: u8 = 37;
-    pub const DOT: u8 = 38;
-    pub const ELLIPSIS: u8 = 39;
-    pub const SEMI: u8 = 40;
-    pub const COMMA: u8 = 41;
-    pub const COLON: u8 = 42;
-    pub const QUESTION: u8 = 43;
-    pub const OPTIONAL_CHAIN: u8 = 44;
-    pub const NULLISH: u8 = 45;
-    pub const NULLISH_EQ: u8 = 46;
-    pub const ARROW: u8 = 47;
-    pub const LT: u8 = 48;
-    pub const LE: u8 = 49;
-    pub const GT: u8 = 50;
-    pub const GE: u8 = 51;
-    pub const EQ: u8 = 52;
-    pub const EQ_EQ: u8 = 53;
-    pub const EQ_EQ_EQ: u8 = 54;
-    pub const BANG: u8 = 55;
-    pub const BANG_EQ: u8 = 56;
-    pub const BANG_EQ_EQ: u8 = 57;
-    pub const PLUS: u8 = 58;
-    pub const PLUS_PLUS: u8 = 59;
-    pub const PLUS_EQ: u8 = 60;
-    pub const MINUS: u8 = 61;
-    pub const MINUS_MINUS: u8 = 62;
-    pub const MINUS_EQ: u8 = 63;
-    pub const STAR: u8 = 64;
-    pub const STAR_STAR: u8 = 65;
-    pub const STAR_EQ: u8 = 66;
-    pub const STAR_STAR_EQ: u8 = 67;
-    pub const SLASH: u8 = 68;
-    pub const SLASH_EQ: u8 = 69;
-    pub const PERCENT: u8 = 70;
-    pub const PERCENT_EQ: u8 = 71;
-    pub const AMP: u8 = 72;
-    pub const AMP_AMP: u8 = 73;
-    pub const AMP_EQ: u8 = 74;
-    pub const AMP_AMP_EQ: u8 = 75;
-    pub const PIPE: u8 = 76;
-    pub const PIPE_PIPE: u8 = 77;
-    pub const PIPE_EQ: u8 = 78;
-    pub const PIPE_PIPE_EQ: u8 = 79;
-    pub const CARET: u8 = 80;
-    pub const CARET_EQ: u8 = 81;
-    pub const TILDE: u8 = 82;
-    pub const LSHIFT: u8 = 83;
-    pub const LSHIFT_EQ: u8 = 84;
-    pub const RSHIFT: u8 = 85;
-    pub const RSHIFT_EQ: u8 = 86;
-    pub const URSHIFT: u8 = 87;
-    pub const URSHIFT_EQ: u8 = 88;
-    pub const AT: u8 = 89;
-    pub const KW_BASE: u8 = 128;
-    pub const KW_BREAK: u8 = 128;
-    pub const KW_CASE: u8 = 129;
-    pub const KW_CATCH: u8 = 130;
-    pub const KW_CLASS: u8 = 131;
-    pub const KW_CONST: u8 = 132;
-    pub const KW_CONTINUE: u8 = 133;
-    pub const KW_DEBUGGER: u8 = 134;
-    pub const KW_DEFAULT: u8 = 135;
-    pub const KW_DELETE: u8 = 136;
-    pub const KW_DO: u8 = 137;
-    pub const KW_ELSE: u8 = 138;
-    pub const KW_ENUM: u8 = 139;
-    pub const KW_EXPORT: u8 = 140;
-    pub const KW_EXTENDS: u8 = 141;
-    pub const KW_FALSE: u8 = 142;
-    pub const KW_FINALLY: u8 = 143;
-    pub const KW_FOR: u8 = 144;
-    pub const KW_FUNCTION: u8 = 145;
-    pub const KW_IF: u8 = 146;
-    pub const KW_IMPORT: u8 = 147;
-    pub const KW_IN: u8 = 148;
-    pub const KW_INSTANCEOF: u8 = 149;
-    pub const KW_NEW: u8 = 150;
-    pub const KW_NULL: u8 = 151;
-    pub const KW_RETURN: u8 = 152;
-    pub const KW_SUPER: u8 = 153;
-    pub const KW_SWITCH: u8 = 154;
-    pub const KW_THIS: u8 = 155;
-    pub const KW_THROW: u8 = 156;
-    pub const KW_TRUE: u8 = 157;
-    pub const KW_TRY: u8 = 158;
-    pub const KW_TYPEOF: u8 = 159;
-    pub const KW_VAR: u8 = 160;
-    pub const KW_VOID: u8 = 161;
-    pub const KW_WHILE: u8 = 162;
-    pub const KW_WITH: u8 = 163;
-    pub const KW_YIELD: u8 = 164;
-    pub const KW_LET: u8 = 165;
-    pub const KW_STATIC: u8 = 166;
-    pub const KW_ASYNC: u8 = 167;
-    pub const KW_AWAIT: u8 = 168;
-    pub const KW_OF: u8 = 169;
-    pub const KW_FROM: u8 = 170;
-    pub const KW_AS: u8 = 171;
+            /// The token's spelling for punctuators and keywords, else the kind's name.
+            #[inline]
+            #[must_use]
+            pub const fn name(self) -> &'static str {
+                match self {
+                    $( Self::$variant => $name, )+
+                }
+            }
+        }
+    };
+}
+
+define_token_kind! {
+    Eof = 0 => "EOF",
+
+    Ident = 1 => "IDENT",
+    PrivateIdent = 2 => "PRIVATE_IDENT",
+    Number = 3 => "NUMBER",
+    BigInt = 4 => "BIGINT",
+    String = 5 => "STRING",
+    RegExp = 6 => "REGEXP",
+    TemplateNoSub = 7 => "TEMPLATE_NO_SUB",
+    TemplateHead = 8 => "TEMPLATE_HEAD",
+    TemplateMiddle = 9 => "TEMPLATE_MIDDLE",
+    TemplateTail = 10 => "TEMPLATE_TAIL",
+
+    LineComment = 11 => "LINE_COMMENT",
+    BlockComment = 12 => "BLOCK_COMMENT",
+    Hashbang = 13 => "HASHBANG",
+    Whitespace = 14 => "WHITESPACE",
+    LineTerminator = 15 => "LINE_TERMINATOR",
+
+    StringCooked = 16 => "STRING_COOKED",
+    IdentEscaped = 17 => "IDENT_ESCAPED",
+    PrivateIdentEscaped = 18 => "PRIVATE_IDENT_ESCAPED",
+    TemplateNoSubCooked = 19 => "TEMPLATE_NO_SUB_COOKED",
+    TemplateHeadCooked = 20 => "TEMPLATE_HEAD_COOKED",
+    TemplateMiddleCooked = 21 => "TEMPLATE_MIDDLE_COOKED",
+    TemplateTailCooked = 22 => "TEMPLATE_TAIL_COOKED",
+    Decimal = 23 => "DECIMAL",
+    Float = 24 => "FLOAT",
+    Binary = 25 => "BINARY",
+    Octal = 26 => "OCTAL",
+    Hex = 27 => "HEX",
+    JsxText = 28 => "JSX_TEXT",
+    JsxTagEnd = 29 => "JSX_TAG_END",
+    JsxLt = 30 => "JSX_LT",
+
+    LBrace = 32 => "{",
+    RBrace = 33 => "}",
+    LParen = 34 => "(",
+    RParen = 35 => ")",
+    LBracket = 36 => "[",
+    RBracket = 37 => "]",
+    Dot = 38 => ".",
+    Ellipsis = 39 => "...",
+    Semi = 40 => ";",
+    Comma = 41 => ",",
+    Colon = 42 => ":",
+    Question = 43 => "?",
+    OptionalChain = 44 => "?.",
+    Nullish = 45 => "??",
+    NullishEq = 46 => "??=",
+    Arrow = 47 => "=>",
+    Lt = 48 => "<",
+    Le = 49 => "<=",
+    Gt = 50 => ">",
+    Ge = 51 => ">=",
+    Eq = 52 => "=",
+    EqEq = 53 => "==",
+    EqEqEq = 54 => "===",
+    Bang = 55 => "!",
+    BangEq = 56 => "!=",
+    BangEqEq = 57 => "!==",
+    Plus = 58 => "+",
+    PlusPlus = 59 => "++",
+    PlusEq = 60 => "+=",
+    Minus = 61 => "-",
+    MinusMinus = 62 => "--",
+    MinusEq = 63 => "-=",
+    Star = 64 => "*",
+    StarStar = 65 => "**",
+    StarEq = 66 => "*=",
+    StarStarEq = 67 => "**=",
+    Slash = 68 => "/",
+    SlashEq = 69 => "/=",
+    Percent = 70 => "%",
+    PercentEq = 71 => "%=",
+    Amp = 72 => "&",
+    AmpAmp = 73 => "&&",
+    AmpEq = 74 => "&=",
+    AmpAmpEq = 75 => "&&=",
+    Pipe = 76 => "|",
+    PipePipe = 77 => "||",
+    PipeEq = 78 => "|=",
+    PipePipeEq = 79 => "||=",
+    Caret = 80 => "^",
+    CaretEq = 81 => "^=",
+    Tilde = 82 => "~",
+    LShift = 83 => "<<",
+    LShiftEq = 84 => "<<=",
+    RShift = 85 => ">>",
+    RShiftEq = 86 => ">>=",
+    URShift = 87 => ">>>",
+    URShiftEq = 88 => ">>>=",
+    At = 89 => "@",
+
+    KwBreak = 128 => "break",
+    KwCase = 129 => "case",
+    KwCatch = 130 => "catch",
+    KwClass = 131 => "class",
+    KwConst = 132 => "const",
+    KwContinue = 133 => "continue",
+    KwDebugger = 134 => "debugger",
+    KwDefault = 135 => "default",
+    KwDelete = 136 => "delete",
+    KwDo = 137 => "do",
+    KwElse = 138 => "else",
+    KwEnum = 139 => "enum",
+    KwExport = 140 => "export",
+    KwExtends = 141 => "extends",
+    KwFalse = 142 => "false",
+    KwFinally = 143 => "finally",
+    KwFor = 144 => "for",
+    KwFunction = 145 => "function",
+    KwIf = 146 => "if",
+    KwImport = 147 => "import",
+    KwIn = 148 => "in",
+    KwInstanceof = 149 => "instanceof",
+    KwNew = 150 => "new",
+    KwNull = 151 => "null",
+    KwReturn = 152 => "return",
+    KwSuper = 153 => "super",
+    KwSwitch = 154 => "switch",
+    KwThis = 155 => "this",
+    KwThrow = 156 => "throw",
+    KwTrue = 157 => "true",
+    KwTry = 158 => "try",
+    KwTypeof = 159 => "typeof",
+    KwVar = 160 => "var",
+    KwVoid = 161 => "void",
+    KwWhile = 162 => "while",
+    KwWith = 163 => "with",
+    KwYield = 164 => "yield",
+    KwLet = 165 => "let",
+    KwStatic = 166 => "static",
+    KwAsync = 167 => "async",
+    KwAwait = 168 => "await",
+    KwOf = 169 => "of",
+    KwFrom = 170 => "from",
+    KwAs = 171 => "as",
+
     // TS-mode contextual keywords (`LexOptions::ts`) plus the strict-mode
     // reserved words; JS mode lexes all of these spellings as IDENT.
     // Contiguous after the JS block so `>= KW_BASE` range checks cover both.
-    pub const KW_ABSTRACT: u8 = 172;
-    pub const KW_ACCESSOR: u8 = 173;
-    pub const KW_ANY: u8 = 174;
-    pub const KW_ASSERTS: u8 = 175;
-    pub const KW_BIGINT: u8 = 176;
-    pub const KW_BOOLEAN: u8 = 177;
-    pub const KW_DECLARE: u8 = 178;
-    pub const KW_GLOBAL: u8 = 179;
-    pub const KW_IMPLEMENTS: u8 = 180;
-    pub const KW_INFER: u8 = 181;
-    pub const KW_INTERFACE: u8 = 182;
-    pub const KW_INTRINSIC: u8 = 183;
-    pub const KW_IS: u8 = 184;
-    pub const KW_KEYOF: u8 = 185;
-    pub const KW_MODULE: u8 = 186;
-    pub const KW_NAMESPACE: u8 = 187;
-    pub const KW_NEVER: u8 = 188;
-    pub const KW_NUMBER: u8 = 189;
-    pub const KW_OBJECT: u8 = 190;
-    pub const KW_OUT: u8 = 191;
-    pub const KW_OVERRIDE: u8 = 192;
-    pub const KW_PACKAGE: u8 = 193;
-    pub const KW_PRIVATE: u8 = 194;
-    pub const KW_PROTECTED: u8 = 195;
-    pub const KW_PUBLIC: u8 = 196;
-    pub const KW_READONLY: u8 = 197;
-    pub const KW_REQUIRE: u8 = 198;
-    pub const KW_SATISFIES: u8 = 199;
-    pub const KW_STRING: u8 = 200;
-    pub const KW_SYMBOL: u8 = 201;
-    pub const KW_TYPE: u8 = 202;
-    pub const KW_UNDEFINED: u8 = 203;
-    pub const KW_UNIQUE: u8 = 204;
-    pub const KW_UNKNOWN: u8 = 205;
-    pub const KW_USING: u8 = 206;
-    pub const INVALID: u8 = 255;
+    KwAbstract = 172 => "abstract",
+    KwAccessor = 173 => "accessor",
+    KwAny = 174 => "any",
+    KwAsserts = 175 => "asserts",
+    KwBigInt = 176 => "bigint",
+    KwBoolean = 177 => "boolean",
+    KwDeclare = 178 => "declare",
+    KwGlobal = 179 => "global",
+    KwImplements = 180 => "implements",
+    KwInfer = 181 => "infer",
+    KwInterface = 182 => "interface",
+    KwIntrinsic = 183 => "intrinsic",
+    KwIs = 184 => "is",
+    KwKeyof = 185 => "keyof",
+    KwModule = 186 => "module",
+    KwNamespace = 187 => "namespace",
+    KwNever = 188 => "never",
+    KwNumber = 189 => "number",
+    KwObject = 190 => "object",
+    KwOut = 191 => "out",
+    KwOverride = 192 => "override",
+    KwPackage = 193 => "package",
+    KwPrivate = 194 => "private",
+    KwProtected = 195 => "protected",
+    KwPublic = 196 => "public",
+    KwReadonly = 197 => "readonly",
+    KwRequire = 198 => "require",
+    KwSatisfies = 199 => "satisfies",
+    KwString = 200 => "string",
+    KwSymbol = 201 => "symbol",
+    KwType = 202 => "type",
+    KwUndefined = 203 => "undefined",
+    KwUnique = 204 => "unique",
+    KwUnknown = 205 => "unknown",
+    KwUsing = 206 => "using",
+
+    Invalid = 255 => "INVALID",
+}
+
+/// First keyword kind: every kind `>= KW_BASE` other than [`TokenKind::Invalid`] is a keyword.
+pub const KW_BASE: u8 = TokenKind::KwBreak as u8;
+const KW_MAX: u8 = TokenKind::KwUsing as u8;
+
+impl TokenKind {
+    #[inline]
+    #[must_use]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// # Safety
+    ///
+    /// `byte` must be a declared discriminant, i.e. `TokenKind::from_u8(byte).is_some()`.
+    #[inline]
+    #[must_use]
+    pub const unsafe fn from_u8_unchecked(byte: u8) -> Self {
+        debug_assert!(Self::from_u8(byte).is_some(), "not a declared TokenKind discriminant");
+        // SAFETY: the caller guarantees `byte` is a declared discriminant, and
+        // `TokenKind` is `#[repr(u8)]`, so it shares `u8`'s layout.
+        unsafe { core::mem::transmute::<u8, Self>(byte) }
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_trivia(self) -> bool {
+        is_trivia_byte(self as u8)
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_keyword(self) -> bool {
+        (self as u8) >= KW_BASE && (self as u8) <= KW_MAX
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_string(self) -> bool {
+        matches!(self, Self::String | Self::StringCooked)
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_template_no_sub(self) -> bool {
+        matches!(self, Self::TemplateNoSub | Self::TemplateNoSubCooked)
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_template_head(self) -> bool {
+        matches!(self, Self::TemplateHead | Self::TemplateHeadCooked)
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_template_middle(self) -> bool {
+        matches!(self, Self::TemplateMiddle | Self::TemplateMiddleCooked)
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_template_tail(self) -> bool {
+        matches!(self, Self::TemplateTail | Self::TemplateTailCooked)
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_ident(self) -> bool {
+        matches!(self, Self::Ident | Self::IdentEscaped)
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_private_ident(self) -> bool {
+        matches!(self, Self::PrivateIdent | Self::PrivateIdentEscaped)
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_numeric(self) -> bool {
+        matches!(
+            self,
+            Self::Number | Self::Decimal | Self::Float | Self::Binary | Self::Octal | Self::Hex
+        )
+    }
+}
+
+impl core::fmt::Display for TokenKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+/// Reinterpret raw kind bytes written by the pipeline as [`TokenKind`]s.
+///
+/// # Safety
+///
+/// Every byte in `bytes` must be a declared [`TokenKind`] discriminant. The
+/// pipeline only ever writes kinds that came from [`crate::opmap`]'s tables or
+/// from the named constants in `pipeline`, so this holds for any range the
+/// lexer has written; it does *not* hold for uninitialised arena memory.
+#[inline]
+pub(crate) const unsafe fn kinds_from_bytes(bytes: &[u8]) -> &[TokenKind] {
+    // SAFETY: `TokenKind` is `#[repr(u8)]` so it has the same size and
+    // alignment as `u8`, and the caller guarantees every byte is a declared
+    // discriminant.
+    unsafe { core::slice::from_raw_parts(bytes.as_ptr().cast::<TokenKind>(), bytes.len()) }
+}
+
+#[inline]
+pub(crate) fn debug_assert_kind_bytes(bytes: &[u8]) {
+    debug_assert!(
+        bytes.iter().all(|&b| TokenKind::from_u8(b).is_some()),
+        "lexer wrote a byte that is not a declared TokenKind discriminant"
+    );
 }
 
 pub const SPAN_SENTINELS: usize = 8;
 
-pub const TRIVIA_MIN: u8 = token_kind::LINE_COMMENT;
-pub const TRIVIA_MAX: u8 = token_kind::LINE_TERMINATOR;
+pub const TRIVIA_MIN: u8 = TokenKind::LineComment as u8;
+pub const TRIVIA_MAX: u8 = TokenKind::LineTerminator as u8;
 
+/// [`TokenKind::is_trivia`] on a raw kind byte, for the pipeline's `u8` lanes.
 #[inline]
 #[must_use]
-pub const fn is_trivia(kind: u8) -> bool {
+pub(crate) const fn is_trivia_byte(kind: u8) -> bool {
     kind.wrapping_sub(TRIVIA_MIN) <= TRIVIA_MAX - TRIVIA_MIN
-}
-
-#[inline]
-#[must_use]
-pub const fn is_string_kind(kind: u8) -> bool {
-    kind == token_kind::STRING || kind == token_kind::STRING_COOKED
-}
-
-#[inline]
-#[must_use]
-pub const fn is_template_no_sub_kind(kind: u8) -> bool {
-    kind == token_kind::TEMPLATE_NO_SUB || kind == token_kind::TEMPLATE_NO_SUB_COOKED
-}
-
-#[inline]
-#[must_use]
-pub const fn is_template_head_kind(kind: u8) -> bool {
-    kind == token_kind::TEMPLATE_HEAD || kind == token_kind::TEMPLATE_HEAD_COOKED
-}
-
-#[inline]
-#[must_use]
-pub const fn is_template_middle_kind(kind: u8) -> bool {
-    kind == token_kind::TEMPLATE_MIDDLE || kind == token_kind::TEMPLATE_MIDDLE_COOKED
-}
-
-#[inline]
-#[must_use]
-pub const fn is_template_tail_kind(kind: u8) -> bool {
-    kind == token_kind::TEMPLATE_TAIL || kind == token_kind::TEMPLATE_TAIL_COOKED
-}
-
-#[inline]
-#[must_use]
-pub const fn is_ident_kind(kind: u8) -> bool {
-    kind == token_kind::IDENT || kind == token_kind::IDENT_ESCAPED
-}
-
-#[inline]
-#[must_use]
-pub const fn is_private_ident_kind(kind: u8) -> bool {
-    kind == token_kind::PRIVATE_IDENT || kind == token_kind::PRIVATE_IDENT_ESCAPED
-}
-
-#[inline]
-#[must_use]
-pub const fn is_numeric_kind(kind: u8) -> bool {
-    kind == token_kind::NUMBER
-        || kind == token_kind::DECIMAL
-        || kind == token_kind::FLOAT
-        || kind == token_kind::BINARY
-        || kind == token_kind::OCTAL
-        || kind == token_kind::HEX
 }
 
 pub mod token_flags {
@@ -256,184 +365,8 @@ pub mod token_flags {
     pub const ASI_RESTRICTED: u16 = 1 << 10;
 }
 
-const _: () = assert!(token_kind::HASHBANG > token_kind::LINE_COMMENT);
-const _: () = assert!(token_kind::HASHBANG < token_kind::LINE_TERMINATOR);
-
-pub fn token_kind_name(kind: u8) -> &'static str {
-    use token_kind::*;
-    match kind {
-        EOF => "EOF",
-        IDENT => "IDENT",
-        PRIVATE_IDENT => "PRIVATE_IDENT",
-        NUMBER => "NUMBER",
-        BIGINT => "BIGINT",
-        STRING => "STRING",
-        STRING_COOKED => "STRING_COOKED",
-        IDENT_ESCAPED => "IDENT_ESCAPED",
-        PRIVATE_IDENT_ESCAPED => "PRIVATE_IDENT_ESCAPED",
-        TEMPLATE_NO_SUB_COOKED => "TEMPLATE_NO_SUB_COOKED",
-        TEMPLATE_HEAD_COOKED => "TEMPLATE_HEAD_COOKED",
-        TEMPLATE_MIDDLE_COOKED => "TEMPLATE_MIDDLE_COOKED",
-        TEMPLATE_TAIL_COOKED => "TEMPLATE_TAIL_COOKED",
-        DECIMAL => "DECIMAL",
-        FLOAT => "FLOAT",
-        BINARY => "BINARY",
-        OCTAL => "OCTAL",
-        HEX => "HEX",
-        JSX_TEXT => "JSX_TEXT",
-        JSX_TAG_END => "JSX_TAG_END",
-        JSX_LT => "JSX_LT",
-        REGEXP => "REGEXP",
-        TEMPLATE_NO_SUB => "TEMPLATE_NO_SUB",
-        TEMPLATE_HEAD => "TEMPLATE_HEAD",
-        TEMPLATE_MIDDLE => "TEMPLATE_MIDDLE",
-        TEMPLATE_TAIL => "TEMPLATE_TAIL",
-        LINE_COMMENT => "LINE_COMMENT",
-        BLOCK_COMMENT => "BLOCK_COMMENT",
-        HASHBANG => "HASHBANG",
-        WHITESPACE => "WHITESPACE",
-        LINE_TERMINATOR => "LINE_TERMINATOR",
-        LBRACE => "{",
-        RBRACE => "}",
-        LPAREN => "(",
-        RPAREN => ")",
-        LBRACKET => "[",
-        RBRACKET => "]",
-        DOT => ".",
-        ELLIPSIS => "...",
-        SEMI => ";",
-        COMMA => ",",
-        COLON => ":",
-        QUESTION => "?",
-        OPTIONAL_CHAIN => "?.",
-        NULLISH => "??",
-        NULLISH_EQ => "??=",
-        ARROW => "=>",
-        LT => "<",
-        LE => "<=",
-        GT => ">",
-        GE => ">=",
-        EQ => "=",
-        EQ_EQ => "==",
-        EQ_EQ_EQ => "===",
-        BANG => "!",
-        BANG_EQ => "!=",
-        BANG_EQ_EQ => "!==",
-        PLUS => "+",
-        PLUS_PLUS => "++",
-        PLUS_EQ => "+=",
-        MINUS => "-",
-        MINUS_MINUS => "--",
-        MINUS_EQ => "-=",
-        STAR => "*",
-        STAR_STAR => "**",
-        STAR_EQ => "*=",
-        STAR_STAR_EQ => "**=",
-        SLASH => "/",
-        SLASH_EQ => "/=",
-        PERCENT => "%",
-        PERCENT_EQ => "%=",
-        AMP => "&",
-        AMP_AMP => "&&",
-        AMP_EQ => "&=",
-        AMP_AMP_EQ => "&&=",
-        PIPE => "|",
-        PIPE_PIPE => "||",
-        PIPE_EQ => "|=",
-        PIPE_PIPE_EQ => "||=",
-        CARET => "^",
-        CARET_EQ => "^=",
-        TILDE => "~",
-        LSHIFT => "<<",
-        LSHIFT_EQ => "<<=",
-        RSHIFT => ">>",
-        RSHIFT_EQ => ">>=",
-        URSHIFT => ">>>",
-        URSHIFT_EQ => ">>>=",
-        AT => "@",
-        KW_BREAK => "break",
-        KW_CASE => "case",
-        KW_CATCH => "catch",
-        KW_CLASS => "class",
-        KW_CONST => "const",
-        KW_CONTINUE => "continue",
-        KW_DEBUGGER => "debugger",
-        KW_DEFAULT => "default",
-        KW_DELETE => "delete",
-        KW_DO => "do",
-        KW_ELSE => "else",
-        KW_ENUM => "enum",
-        KW_EXPORT => "export",
-        KW_EXTENDS => "extends",
-        KW_FALSE => "false",
-        KW_FINALLY => "finally",
-        KW_FOR => "for",
-        KW_FUNCTION => "function",
-        KW_IF => "if",
-        KW_IMPORT => "import",
-        KW_IN => "in",
-        KW_INSTANCEOF => "instanceof",
-        KW_NEW => "new",
-        KW_NULL => "null",
-        KW_RETURN => "return",
-        KW_SUPER => "super",
-        KW_SWITCH => "switch",
-        KW_THIS => "this",
-        KW_THROW => "throw",
-        KW_TRUE => "true",
-        KW_TRY => "try",
-        KW_TYPEOF => "typeof",
-        KW_VAR => "var",
-        KW_VOID => "void",
-        KW_WHILE => "while",
-        KW_WITH => "with",
-        KW_YIELD => "yield",
-        KW_LET => "let",
-        KW_STATIC => "static",
-        KW_ASYNC => "async",
-        KW_AWAIT => "await",
-        KW_OF => "of",
-        KW_FROM => "from",
-        KW_AS => "as",
-        KW_ABSTRACT => "abstract",
-        KW_ACCESSOR => "accessor",
-        KW_ANY => "any",
-        KW_ASSERTS => "asserts",
-        KW_BIGINT => "bigint",
-        KW_BOOLEAN => "boolean",
-        KW_DECLARE => "declare",
-        KW_GLOBAL => "global",
-        KW_IMPLEMENTS => "implements",
-        KW_INFER => "infer",
-        KW_INTERFACE => "interface",
-        KW_INTRINSIC => "intrinsic",
-        KW_IS => "is",
-        KW_KEYOF => "keyof",
-        KW_MODULE => "module",
-        KW_NAMESPACE => "namespace",
-        KW_NEVER => "never",
-        KW_NUMBER => "number",
-        KW_OBJECT => "object",
-        KW_OUT => "out",
-        KW_OVERRIDE => "override",
-        KW_PACKAGE => "package",
-        KW_PRIVATE => "private",
-        KW_PROTECTED => "protected",
-        KW_PUBLIC => "public",
-        KW_READONLY => "readonly",
-        KW_REQUIRE => "require",
-        KW_SATISFIES => "satisfies",
-        KW_STRING => "string",
-        KW_SYMBOL => "symbol",
-        KW_TYPE => "type",
-        KW_UNDEFINED => "undefined",
-        KW_UNIQUE => "unique",
-        KW_UNKNOWN => "unknown",
-        KW_USING => "using",
-        INVALID => "INVALID",
-        _ => "<unknown>",
-    }
-}
+const _: () = assert!(TokenKind::Hashbang as u8 > TokenKind::LineComment as u8);
+const _: () = assert!((TokenKind::Hashbang as u8) < TokenKind::LineTerminator as u8);
 
 /// Bit 31 of a `starts` entry: reserved "newline before this token" flag.
 /// The lexer does not set it yet, but consumers must still read offsets
@@ -515,5 +448,94 @@ impl StringSpan {
     #[must_use]
     pub const fn lone_surrogates(self) -> bool {
         (self.end_and_flags & Self::LONE_SURROGATES_MASK) != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{KW_BASE, TRIVIA_MAX, TRIVIA_MIN, TokenKind};
+    use crate::{Lexer, PAD, default_options};
+
+    #[test]
+    fn from_u8_round_trips_every_variant() {
+        for &kind in TokenKind::VARIANTS {
+            assert_eq!(TokenKind::from_u8(kind as u8), Some(kind), "{}", kind.name());
+        }
+    }
+
+    #[test]
+    fn from_u8_agrees_with_the_discriminant_for_all_256_bytes() {
+        let declared: Vec<u8> = TokenKind::VARIANTS.iter().map(|k| *k as u8).collect();
+        for byte in 0..=u8::MAX {
+            match TokenKind::from_u8(byte) {
+                Some(kind) => {
+                    assert_eq!(kind as u8, byte);
+                    assert!(declared.contains(&byte));
+                }
+                None => assert!(!declared.contains(&byte), "byte {byte} is declared but unmapped"),
+            }
+        }
+    }
+
+    #[test]
+    fn discriminants_are_unique() {
+        let mut seen = [false; 256];
+        for &kind in TokenKind::VARIANTS {
+            let byte = kind as usize;
+            assert!(!seen[byte], "duplicate discriminant {byte}");
+            seen[byte] = true;
+        }
+    }
+
+    /// The pipeline classifies by range, so the punctuator and keyword blocks
+    /// must stay where `compress` and `opmap` expect them.
+    #[test]
+    fn kind_space_layout_holds() {
+        for &kind in TokenKind::VARIANTS {
+            let byte = kind as u8;
+            if kind.is_keyword() {
+                assert!(byte >= KW_BASE, "{} below KW_BASE", kind.name());
+            }
+            if kind.is_trivia() {
+                assert!((TRIVIA_MIN..=TRIVIA_MAX).contains(&byte), "{}", kind.name());
+            }
+        }
+        assert!(TokenKind::LBrace as u8 >= 32 && (TokenKind::At as u8) < KW_BASE);
+        assert!(!TokenKind::Invalid.is_keyword());
+        assert!(TokenKind::Hashbang.is_trivia());
+    }
+
+    /// Backs the safety invariant of [`super::kinds_from_bytes`]: the lexer
+    /// never emits a byte outside the declared discriminants.
+    #[test]
+    fn every_emitted_kind_is_declared() {
+        const SOURCES: [&str; 6] = [
+            "#!/usr/bin/env node\nlet x = 0b1_0 + 0o7 + 0xFF + 1.5e3 + 9n;",
+            "class A { #p = 1; static { this.#p ??= 2; } get x() { return `a${1}b${2}c`; } }",
+            "a?.b?.[c] ?? d ||= e &&= f >>>= g; /re/gu.test('s\\u00e9'); // line\n/* block */",
+            "export default async function* f(...a) { yield* await import('m'); }",
+            "type T = { readonly [K in keyof U]?: U[K] extends infer V ? V : never };",
+            "const el = <div a='1' {...r}>text {x} <br/></div>;",
+        ];
+        for src in SOURCES {
+            let mut bytes = src.as_bytes().to_vec();
+            let n = bytes.len();
+            bytes.extend_from_slice(&[0u8; PAD]);
+            for (jsx, ts) in [(false, false), (true, false), (false, true), (true, true)] {
+                let mut opts = default_options();
+                opts.jsx = jsx;
+                opts.ts = ts;
+                let mut lexer = Lexer::new();
+                lexer.lex(&bytes, n, opts);
+                for kind in lexer.kinds() {
+                    assert_eq!(
+                        TokenKind::from_u8(*kind as u8),
+                        Some(*kind),
+                        "undeclared kind {} from {src:?}",
+                        *kind as u8
+                    );
+                }
+            }
+        }
     }
 }

--- a/crates/oxc_lexer/tests/module_goal.rs
+++ b/crates/oxc_lexer/tests/module_goal.rs
@@ -1,9 +1,9 @@
 #![cfg(target_endian = "little")]
 #![expect(clippy::cast_possible_truncation, reason = "test helpers: lengths fit u32")]
 
-use oxc_lexer::{Lexer, PAD, default_options, diag_code, lex_utf8, token_kind as k};
+use oxc_lexer::{Lexer, PAD, TokenKind, default_options, diag_code, lex_utf8};
 
-fn kinds_of(code: &str, module: bool) -> Vec<u8> {
+fn kinds_of(code: &str, module: bool) -> Vec<TokenKind> {
     let mut buf = code.as_bytes().to_vec();
     let n = buf.len();
     buf.resize(n + PAD, 0);
@@ -11,7 +11,7 @@ fn kinds_of(code: &str, module: bool) -> Vec<u8> {
     opts.source_type_module = module;
     let mut lx = Lexer::new();
     let count = lx.lex(&buf, n, opts);
-    lx.sig_kinds[..count].iter().copied().filter(|&kk| !oxc_lexer::is_trivia(kk)).collect()
+    lx.kinds()[..count].iter().copied().filter(|kk| !kk.is_trivia()).collect()
 }
 
 fn diag_codes(code: &str, module: bool) -> Vec<u16> {
@@ -27,16 +27,19 @@ fn diag_codes(code: &str, module: bool) -> Vec<u16> {
 #[test]
 fn script_html_open_comment_anywhere() {
     let ks = kinds_of("x <!-- y\nz;", false);
-    assert!(!ks.contains(&k::LT) && !ks.contains(&k::BANG), "script comment: {ks:?}");
+    assert!(
+        !ks.contains(&TokenKind::Lt) && !ks.contains(&TokenKind::Bang),
+        "script comment: {ks:?}"
+    );
     assert!(diag_codes("x <!-- y\nz;", false).is_empty());
 }
 
 #[test]
 fn module_html_open_comment_mid_expression_is_lt() {
     let ks = kinds_of("x <!-- y;", true);
-    assert!(ks.contains(&k::LT), "expected `<` operator: {ks:?}");
-    assert!(ks.contains(&k::BANG), "expected `!` operator: {ks:?}");
-    assert!(ks.contains(&k::MINUS_MINUS), "expected `--` operator: {ks:?}");
+    assert!(ks.contains(&TokenKind::Lt), "expected `<` operator: {ks:?}");
+    assert!(ks.contains(&TokenKind::Bang), "expected `!` operator: {ks:?}");
+    assert!(ks.contains(&TokenKind::MinusMinus), "expected `--` operator: {ks:?}");
     assert!(diag_codes("x <!-- y;", true).is_empty());
 }
 
@@ -44,7 +47,7 @@ fn module_html_open_comment_mid_expression_is_lt() {
 fn module_html_open_comment_at_line_start_diagnosed() {
     let src = "<!-- c\nx;";
     let ks = kinds_of(src, true);
-    assert!(!ks.contains(&k::LT), "line-start form stays a comment: {ks:?}");
+    assert!(!ks.contains(&TokenKind::Lt), "line-start form stays a comment: {ks:?}");
     assert_eq!(diag_codes(src, true), vec![diag_code::HTML_COMMENT_IN_MODULE]);
     let src = "x;\n<!-- c\ny;";
     assert_eq!(diag_codes(src, true), vec![diag_code::HTML_COMMENT_IN_MODULE]);
@@ -55,10 +58,10 @@ fn module_html_open_comment_at_line_start_diagnosed() {
 fn module_html_close_comment_is_operators() {
     let src = "a;\n--> b;";
     let script = kinds_of(src, false);
-    assert!(!script.contains(&k::MINUS_MINUS), "script comment: {script:?}");
+    assert!(!script.contains(&TokenKind::MinusMinus), "script comment: {script:?}");
     let module = kinds_of(src, true);
-    assert!(module.contains(&k::MINUS_MINUS), "expected `--`: {module:?}");
-    assert!(module.contains(&k::GT), "expected `>`: {module:?}");
+    assert!(module.contains(&TokenKind::MinusMinus), "expected `--`: {module:?}");
+    assert!(module.contains(&TokenKind::Gt), "expected `>`: {module:?}");
     assert!(diag_codes(src, true).is_empty());
 }
 
@@ -66,7 +69,7 @@ fn module_html_close_comment_is_operators() {
 fn mid_line_close_comment_unchanged() {
     for module in [false, true] {
         let ks = kinds_of("a --> b;", module);
-        assert!(ks.contains(&k::MINUS_MINUS), "module={module}: {ks:?}");
-        assert!(ks.contains(&k::GT), "module={module}: {ks:?}");
+        assert!(ks.contains(&TokenKind::MinusMinus), "module={module}: {ks:?}");
+        assert!(ks.contains(&TokenKind::Gt), "module={module}: {ks:?}");
     }
 }

--- a/crates/oxc_lexer/tests/regex_div.rs
+++ b/crates/oxc_lexer/tests/regex_div.rs
@@ -1,13 +1,9 @@
 #![cfg(target_endian = "little")]
-#![expect(
-    clippy::cast_possible_truncation,
-    clippy::naive_bytecount,
-    reason = "test helpers: lengths fit u32; counting a tiny kind buffer"
-)]
+#![expect(clippy::cast_possible_truncation, reason = "test helpers: lengths fit u32")]
 
-use oxc_lexer::{Lexer, PAD, default_options, lex_utf8, token_kind as k};
+use oxc_lexer::{Lexer, PAD, TokenKind, default_options, lex_utf8};
 
-fn kinds_of(code: &str, ts: bool, jsx: bool) -> Vec<u8> {
+fn kinds_of(code: &str, ts: bool, jsx: bool) -> Vec<TokenKind> {
     let mut buf = code.as_bytes().to_vec();
     let n = buf.len();
     buf.resize(n + PAD, 0);
@@ -16,29 +12,29 @@ fn kinds_of(code: &str, ts: bool, jsx: bool) -> Vec<u8> {
     opts.jsx = jsx;
     let mut lx = Lexer::new();
     let count = lx.lex(&buf, n, opts);
-    lx.sig_kinds[..count].iter().copied().filter(|&kk| !oxc_lexer::is_trivia(kk)).collect()
+    lx.kinds()[..count].iter().copied().filter(|kk| !kk.is_trivia()).collect()
 }
 
 #[test]
 fn one_probe_per_family() {
     let ks = kinds_of("a++ / b;", false, false);
-    assert!(!ks.contains(&k::REGEXP) && ks.contains(&k::SLASH), "{ks:?}");
+    assert!(!ks.contains(&TokenKind::RegExp) && ks.contains(&TokenKind::Slash), "{ks:?}");
     let ks = kinds_of("x = ++/re/.lastIndex;", false, false);
-    assert!(ks.contains(&k::REGEXP), "{ks:?}");
+    assert!(ks.contains(&TokenKind::RegExp), "{ks:?}");
     let ks = kinds_of("export default /^x$/;", false, false);
-    assert!(ks.contains(&k::REGEXP), "{ks:?}");
+    assert!(ks.contains(&TokenKind::RegExp), "{ks:?}");
     let ks = kinds_of("if (x) /re/.test(y);", false, false);
-    assert!(ks.contains(&k::REGEXP), "{ks:?}");
+    assert!(ks.contains(&TokenKind::RegExp), "{ks:?}");
     let ks = kinds_of("(a + b) / 2;", false, false);
-    assert!(!ks.contains(&k::REGEXP), "{ks:?}");
+    assert!(!ks.contains(&TokenKind::RegExp), "{ks:?}");
     let ks = kinds_of("(class {} / 2);", false, false);
-    assert!(!ks.contains(&k::REGEXP), "{ks:?}");
+    assert!(!ks.contains(&TokenKind::RegExp), "{ks:?}");
     let ks = kinds_of("var yield = 1; var r = yield /2/g;", false, false);
-    assert!(!ks.contains(&k::REGEXP), "{ks:?}");
+    assert!(!ks.contains(&TokenKind::RegExp), "{ks:?}");
     let ks = kinds_of("function* g() { yield /re/; }", false, false);
-    assert!(ks.contains(&k::REGEXP), "{ks:?}");
+    assert!(ks.contains(&TokenKind::RegExp), "{ks:?}");
     let ks = kinds_of("export default <App/>;", false, true);
-    assert!(ks.contains(&k::JSX_LT), "{ks:?}");
+    assert!(ks.contains(&TokenKind::JsxLt), "{ks:?}");
 }
 
 #[test]
@@ -50,8 +46,7 @@ fn arena_api_matches_and_stays_clean() {
     let (res, arena) = lex_utf8(&buf, n, default_options());
     assert!(res.diagnostics().is_empty(), "{:?}", res.diagnostics());
     let count = res.token_count as usize;
-    // SAFETY: `arena.tok_kinds` points to `token_count` kinds written by `lex_utf8`.
-    let kinds = unsafe { core::slice::from_raw_parts(arena.tok_kinds, count) }.to_vec();
-    let re = kinds.iter().filter(|&&kk| kk == k::REGEXP).count();
+    let kinds = res.tok_kinds(&arena)[..count].to_vec();
+    let re = kinds.iter().filter(|&&kk| kk == TokenKind::RegExp).count();
     assert_eq!(re, 3, "two regex literals and one regex argument: {kinds:?}");
 }

--- a/crates/oxc_lexer/tests/ts_keywords.rs
+++ b/crates/oxc_lexer/tests/ts_keywords.rs
@@ -3,50 +3,50 @@
 //! must separate the pairs the JS key cannot.
 #![cfg(target_endian = "little")]
 
-use oxc_lexer::{Lexer, PAD, default_options, token_kind as k};
+use oxc_lexer::{Lexer, PAD, TokenKind, default_options};
 
 /// All 35 TS-mode additions, mirroring `KEYWORDS_TS_EXTRA` (kept literal so
 /// a table typo cannot hide behind shared constants).
-const TS_WORDS: [(&str, u8); 35] = [
-    ("abstract", k::KW_ABSTRACT),
-    ("accessor", k::KW_ACCESSOR),
-    ("any", k::KW_ANY),
-    ("asserts", k::KW_ASSERTS),
-    ("bigint", k::KW_BIGINT),
-    ("boolean", k::KW_BOOLEAN),
-    ("declare", k::KW_DECLARE),
-    ("global", k::KW_GLOBAL),
-    ("implements", k::KW_IMPLEMENTS),
-    ("infer", k::KW_INFER),
-    ("interface", k::KW_INTERFACE),
-    ("intrinsic", k::KW_INTRINSIC),
-    ("is", k::KW_IS),
-    ("keyof", k::KW_KEYOF),
-    ("module", k::KW_MODULE),
-    ("namespace", k::KW_NAMESPACE),
-    ("never", k::KW_NEVER),
-    ("number", k::KW_NUMBER),
-    ("object", k::KW_OBJECT),
-    ("out", k::KW_OUT),
-    ("override", k::KW_OVERRIDE),
-    ("package", k::KW_PACKAGE),
-    ("private", k::KW_PRIVATE),
-    ("protected", k::KW_PROTECTED),
-    ("public", k::KW_PUBLIC),
-    ("readonly", k::KW_READONLY),
-    ("require", k::KW_REQUIRE),
-    ("satisfies", k::KW_SATISFIES),
-    ("string", k::KW_STRING),
-    ("symbol", k::KW_SYMBOL),
-    ("type", k::KW_TYPE),
-    ("undefined", k::KW_UNDEFINED),
-    ("unique", k::KW_UNIQUE),
-    ("unknown", k::KW_UNKNOWN),
-    ("using", k::KW_USING),
+const TS_WORDS: [(&str, TokenKind); 35] = [
+    ("abstract", TokenKind::KwAbstract),
+    ("accessor", TokenKind::KwAccessor),
+    ("any", TokenKind::KwAny),
+    ("asserts", TokenKind::KwAsserts),
+    ("bigint", TokenKind::KwBigInt),
+    ("boolean", TokenKind::KwBoolean),
+    ("declare", TokenKind::KwDeclare),
+    ("global", TokenKind::KwGlobal),
+    ("implements", TokenKind::KwImplements),
+    ("infer", TokenKind::KwInfer),
+    ("interface", TokenKind::KwInterface),
+    ("intrinsic", TokenKind::KwIntrinsic),
+    ("is", TokenKind::KwIs),
+    ("keyof", TokenKind::KwKeyof),
+    ("module", TokenKind::KwModule),
+    ("namespace", TokenKind::KwNamespace),
+    ("never", TokenKind::KwNever),
+    ("number", TokenKind::KwNumber),
+    ("object", TokenKind::KwObject),
+    ("out", TokenKind::KwOut),
+    ("override", TokenKind::KwOverride),
+    ("package", TokenKind::KwPackage),
+    ("private", TokenKind::KwPrivate),
+    ("protected", TokenKind::KwProtected),
+    ("public", TokenKind::KwPublic),
+    ("readonly", TokenKind::KwReadonly),
+    ("require", TokenKind::KwRequire),
+    ("satisfies", TokenKind::KwSatisfies),
+    ("string", TokenKind::KwString),
+    ("symbol", TokenKind::KwSymbol),
+    ("type", TokenKind::KwType),
+    ("undefined", TokenKind::KwUndefined),
+    ("unique", TokenKind::KwUnique),
+    ("unknown", TokenKind::KwUnknown),
+    ("using", TokenKind::KwUsing),
 ];
 
 /// Lex and return the non-trivia kinds (EOF dropped).
-fn kinds(code: &str, ts: bool, jsx: bool) -> Vec<u8> {
+fn kinds(code: &str, ts: bool, jsx: bool) -> Vec<TokenKind> {
     let mut buf = code.as_bytes().to_vec();
     let n = buf.len();
     buf.resize(n + PAD, 0);
@@ -55,10 +55,10 @@ fn kinds(code: &str, ts: bool, jsx: bool) -> Vec<u8> {
     opts.jsx = jsx;
     let mut lx = Lexer::new();
     let count = lx.lex(&buf, n, opts);
-    lx.sig_kinds[..count].iter().copied().filter(|&kk| !oxc_lexer::is_trivia(kk)).collect()
+    lx.kinds()[..count].iter().copied().filter(|kk| !kk.is_trivia()).collect()
 }
 
-fn first_kind(code: &str, ts: bool) -> u8 {
+fn first_kind(code: &str, ts: bool) -> TokenKind {
     kinds(code, ts, false)[0]
 }
 
@@ -66,29 +66,29 @@ fn first_kind(code: &str, ts: bool) -> u8 {
 fn ts_words_resolve_in_ts_mode_only() {
     for (w, tok) in TS_WORDS {
         assert_eq!(first_kind(w, true), tok, "ts mode: {w}");
-        assert_eq!(first_kind(w, false), k::IDENT, "js mode: {w}");
+        assert_eq!(first_kind(w, false), TokenKind::Ident, "js mode: {w}");
     }
 }
 
 #[test]
 fn js_keywords_identical_in_both_modes() {
     for (w, tok) in [
-        ("return", k::KW_RETURN),
-        ("instanceof", k::KW_INSTANCEOF),
-        ("await", k::KW_AWAIT),
-        ("let", k::KW_LET),
-        ("static", k::KW_STATIC),
-        ("as", k::KW_AS),
-        ("of", k::KW_OF),
-        ("null", k::KW_NULL),
+        ("return", TokenKind::KwReturn),
+        ("instanceof", TokenKind::KwInstanceof),
+        ("await", TokenKind::KwAwait),
+        ("let", TokenKind::KwLet),
+        ("static", TokenKind::KwStatic),
+        ("as", TokenKind::KwAs),
+        ("of", TokenKind::KwOf),
+        ("null", TokenKind::KwNull),
     ] {
         assert_eq!(first_kind(w, false), tok, "js mode: {w}");
         assert_eq!(first_kind(w, true), tok, "ts mode: {w}");
     }
     // get/set are in-table placeholders and stay IDENT everywhere.
     for w in ["get", "set"] {
-        assert_eq!(first_kind(w, false), k::IDENT);
-        assert_eq!(first_kind(w, true), k::IDENT);
+        assert_eq!(first_kind(w, false), TokenKind::Ident);
+        assert_eq!(first_kind(w, true), TokenKind::Ident);
     }
 }
 
@@ -96,17 +96,17 @@ fn js_keywords_identical_in_both_modes() {
 fn ts_key_separates_narrow_key_collisions() {
     // These pairs share (c0, c1, len) — the JS key cannot tell them apart,
     // the TS (c0, c1, last, len) key must.
-    assert_eq!(first_kind("static", true), k::KW_STATIC);
-    assert_eq!(first_kind("string", true), k::KW_STRING);
-    assert_eq!(first_kind("declare", true), k::KW_DECLARE);
-    assert_eq!(first_kind("default", true), k::KW_DEFAULT);
-    assert_eq!(first_kind("interface", true), k::KW_INTERFACE);
-    assert_eq!(first_kind("intrinsic", true), k::KW_INTRINSIC);
+    assert_eq!(first_kind("static", true), TokenKind::KwStatic);
+    assert_eq!(first_kind("string", true), TokenKind::KwString);
+    assert_eq!(first_kind("declare", true), TokenKind::KwDeclare);
+    assert_eq!(first_kind("default", true), TokenKind::KwDefault);
+    assert_eq!(first_kind("interface", true), TokenKind::KwInterface);
+    assert_eq!(first_kind("intrinsic", true), TokenKind::KwIntrinsic);
     // (c0, last, len) and (c1, last, len) degenerate pairs, for key hygiene.
-    assert_eq!(first_kind("true", true), k::KW_TRUE);
-    assert_eq!(first_kind("type", true), k::KW_TYPE);
-    assert_eq!(first_kind("if", true), k::KW_IF);
-    assert_eq!(first_kind("of", true), k::KW_OF);
+    assert_eq!(first_kind("true", true), TokenKind::KwTrue);
+    assert_eq!(first_kind("type", true), TokenKind::KwType);
+    assert_eq!(first_kind("if", true), TokenKind::KwIf);
+    assert_eq!(first_kind("of", true), TokenKind::KwOf);
 }
 
 #[test]
@@ -131,46 +131,61 @@ fn near_misses_stay_ident() {
         "String",
         // spellchecker:on
     ] {
-        assert_eq!(first_kind(w, true), k::IDENT, "ts near-miss: {w}");
-        assert_eq!(first_kind(w, false), k::IDENT, "js near-miss: {w}");
+        assert_eq!(first_kind(w, true), TokenKind::Ident, "ts near-miss: {w}");
+        assert_eq!(first_kind(w, false), TokenKind::Ident, "js near-miss: {w}");
     }
 }
 
 #[test]
 fn member_access_words_stay_ident() {
     // The candidate filter drops words right after a member dot.
-    assert_eq!(kinds("a.type", true, false), vec![k::IDENT, k::DOT, k::IDENT]);
-    assert_eq!(kinds("a?.string", true, false), vec![k::IDENT, k::OPTIONAL_CHAIN, k::IDENT]);
-    assert_eq!(kinds("module.exports", true, false), vec![k::KW_MODULE, k::DOT, k::IDENT]);
+    assert_eq!(
+        kinds("a.type", true, false),
+        vec![TokenKind::Ident, TokenKind::Dot, TokenKind::Ident]
+    );
+    assert_eq!(
+        kinds("a?.string", true, false),
+        vec![TokenKind::Ident, TokenKind::OptionalChain, TokenKind::Ident]
+    );
+    assert_eq!(
+        kinds("module.exports", true, false),
+        vec![TokenKind::KwModule, TokenKind::Dot, TokenKind::Ident]
+    );
 }
 
 #[test]
 fn ts_statement_shapes() {
     assert_eq!(
         kinds("type X = string;", true, false),
-        vec![k::KW_TYPE, k::IDENT, k::EQ, k::KW_STRING, k::SEMI]
+        vec![
+            TokenKind::KwType,
+            TokenKind::Ident,
+            TokenKind::Eq,
+            TokenKind::KwString,
+            TokenKind::Semi
+        ]
     );
     assert_eq!(
         kinds("interface I { readonly x: number }", true, false),
         vec![
-            k::KW_INTERFACE,
-            k::IDENT,
-            k::LBRACE,
-            k::KW_READONLY,
-            k::IDENT,
-            k::COLON,
-            k::KW_NUMBER,
-            k::RBRACE
+            TokenKind::KwInterface,
+            TokenKind::Ident,
+            TokenKind::LBrace,
+            TokenKind::KwReadonly,
+            TokenKind::Ident,
+            TokenKind::Colon,
+            TokenKind::KwNumber,
+            TokenKind::RBrace
         ]
     );
     assert_eq!(
         kinds("declare module 'x';", true, false),
-        vec![k::KW_DECLARE, k::KW_MODULE, k::STRING, k::SEMI]
+        vec![TokenKind::KwDeclare, TokenKind::KwModule, TokenKind::String, TokenKind::Semi]
     );
     // Same input in JS mode: every TS spelling is a plain identifier.
     assert_eq!(
         kinds("type X = string;", false, false),
-        vec![k::IDENT, k::IDENT, k::EQ, k::IDENT, k::SEMI]
+        vec![TokenKind::Ident, TokenKind::Ident, TokenKind::Eq, TokenKind::Ident, TokenKind::Semi]
     );
 }
 
@@ -179,15 +194,15 @@ fn tsx_mode_uses_ts_set() {
     assert_eq!(
         kinds("type P = { x: number };", true, true),
         vec![
-            k::KW_TYPE,
-            k::IDENT,
-            k::EQ,
-            k::LBRACE,
-            k::IDENT,
-            k::COLON,
-            k::KW_NUMBER,
-            k::RBRACE,
-            k::SEMI
+            TokenKind::KwType,
+            TokenKind::Ident,
+            TokenKind::Eq,
+            TokenKind::LBrace,
+            TokenKind::Ident,
+            TokenKind::Colon,
+            TokenKind::KwNumber,
+            TokenKind::RBrace,
+            TokenKind::Semi
         ]
     );
 }
@@ -197,20 +212,20 @@ fn number_adjacency_resolves_with_active_set() {
     // glue_number's cold arm resolves the abutting word inline; it must use
     // the mode's set. (`3in` is invalid input; spans still tokenize.)
     let js = kinds("3in x", false, false);
-    assert_eq!(js[0], k::NUMBER);
-    assert_eq!(js[1], k::KW_IN);
+    assert_eq!(js[0], TokenKind::Number);
+    assert_eq!(js[1], TokenKind::KwIn);
     let ts = kinds("3is x", true, false);
-    assert_eq!(ts[0], k::NUMBER);
-    assert_eq!(ts[1], k::KW_IS);
+    assert_eq!(ts[0], TokenKind::Number);
+    assert_eq!(ts[1], TokenKind::KwIs);
     let js2 = kinds("3is x", false, false);
-    assert_eq!(js2[1], k::IDENT);
+    assert_eq!(js2[1], TokenKind::Ident);
 }
 
 #[test]
 fn escape_continuation_demotes_ts_keyword() {
     // `types` is one escaped identifier, not KW_TYPE + escape.
     let got = kinds("type\\u0073 x", true, false);
-    assert_eq!(got[0], k::IDENT_ESCAPED);
+    assert_eq!(got[0], TokenKind::IdentEscaped);
 }
 
 #[test]
@@ -218,10 +233,10 @@ fn regex_vs_division_untouched_by_ts_kinds() {
     // Keyword-kind rewriting happens after the regex decision; `type` is
     // not a regex-preceding keyword in either mode.
     let ts = kinds("type/x/g", true, false);
-    assert_eq!(ts[0], k::KW_TYPE);
-    assert_eq!(ts[1], k::SLASH, "ts: `/` after `type` must be division");
+    assert_eq!(ts[0], TokenKind::KwType);
+    assert_eq!(ts[1], TokenKind::Slash, "ts: `/` after `type` must be division");
     let js = kinds("type/x/g", false, false);
-    assert_eq!(js[1], k::SLASH, "js: `/` after `type` must be division");
+    assert_eq!(js[1], TokenKind::Slash, "js: `/` after `type` must be division");
     // Control: after a real RX keyword it is a regex in both modes.
-    assert_eq!(kinds("return /x/g", true, false)[1], k::REGEXP);
+    assert_eq!(kinds("return /x/g", true, false)[1], TokenKind::RegExp);
 }

--- a/tasks/coverage/src/lexer_diff.rs
+++ b/tasks/coverage/src/lexer_diff.rs
@@ -36,7 +36,7 @@ fn lexer_stream(
 
     let mut spans = Vec::with_capacity(kinds.len());
     for (i, &kind) in kinds.iter().enumerate() {
-        if kind == oxc_lexer::token_kind::EOF || oxc_lexer::is_trivia(kind) {
+        if kind == oxc_lexer::TokenKind::Eof || kind.is_trivia() {
             continue;
         }
         spans.push((token_spans[i].start, token_spans[i].end));


### PR DESCRIPTION
Review feedback was that the token kinds should be a real enum rather than a module of u8 constants. The values were listed twice, once as the constants and again in the token_kind_name match, so they now come from one declaration, and tok_kinds and the new Lexer::kinds hand out &[TokenKind] instead of raw bytes.

The discriminants do not move. The pipeline computes kinds arithmetically and blends them in SIMD registers, so it keeps working on u8. Only the aliases in pipeline and the compile-time tables in opmap are re-expressed in terms of the enum, and those fold away at compile time. Reading the bytes back as TokenKind assumes every kind written is a declared discriminant, which a debug assertion checks on every accessor. Output is identical across both corpora and an interleaved A/B against the branch below lands inside the noise floor.
