### PR TITLE
chore(oxc_react_compiler): exclude testonly files from published crate

### DIFF
--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -22,6 +22,7 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 description = "oxc integration for the Rust port of React Compiler"
+include = ["src/**/*", "examples/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 [lib]
 doctest = false


### PR DESCRIPTION
Adds explicit includes for `oxc_react_compiler` to omit 2.2MB of files (49% of total) under `/tests` and `/fixtures` from the published package. I included the examples directory, but that can also be excluded if desired

[The full list of removed files are included in this text file](https://github.com/user-attachments/files/30380492/oxc_react_removed.txt). Today I learned there is a size limit in GitHub PR descriptions

For the record, I checked all other published crates in the workspace, and none of them included any extraneous files 😃 