### PR TITLE
docs(linter): clarify config extends types

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -540,9 +540,23 @@ export interface Oxlintrc {
    */
   env?: OxlintEnv;
   /**
-   * Paths of configuration files that this configuration file extends (inherits from). The files
-   * are resolved relative to the location of the configuration file that contains the `extends`
-   * property. The configuration files are merged from the first to the last, with the last file
+   * Configurations that this configuration file extends (inherits from).
+   *
+   * In `.oxlintrc.json`, `extends` has type `string[]`. Each string is a path to a configuration
+   * file, resolved relative to the location of the configuration file that contains the
+   * `extends` property.
+   *
+   * In `oxlint.config.ts`, `extends` has type `OxlintConfig[]`. Import each configuration and
+   * pass the configuration object directly:
+   *
+   * ```ts
+   * import { defineConfig } from "oxlint";
+   * import baseConfig from "./base-config.ts";
+   *
+   * export default defineConfig({ extends: [baseConfig] });
+   * ```
+   *
+   * Configurations are merged from the first to the last, with the last configuration
    * overriding the previous ones.
    */
   extends?: string[];

--- a/apps/oxlint/src-js/package/config.ts
+++ b/apps/oxlint/src-js/package/config.ts
@@ -31,6 +31,11 @@ export type {
 export type ExternalPluginsConfig = Exclude<Oxlintrc["jsPlugins"], undefined | null>;
 
 export interface OxlintConfig extends Oxlintrc {
+  /**
+   * Configuration objects to extend.
+   *
+   * Import configurations and pass them directly instead of using file paths.
+   */
   extends?: OxlintConfig[];
 }
 

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -282,9 +282,23 @@ pub struct Oxlintrc {
     /// are rejected as a configuration error.
     #[serde(rename = "ignorePatterns")]
     pub ignore_patterns: Vec<String>,
-    /// Paths of configuration files that this configuration file extends (inherits from). The files
-    /// are resolved relative to the location of the configuration file that contains the `extends`
-    /// property. The configuration files are merged from the first to the last, with the last file
+    /// Configurations that this configuration file extends (inherits from).
+    ///
+    /// In `.oxlintrc.json`, `extends` has type `string[]`. Each string is a path to a configuration
+    /// file, resolved relative to the location of the configuration file that contains the
+    /// `extends` property.
+    ///
+    /// In `oxlint.config.ts`, `extends` has type `OxlintConfig[]`. Import each configuration and
+    /// pass the configuration object directly:
+    ///
+    /// ```ts
+    /// import { defineConfig } from "oxlint";
+    /// import baseConfig from "./base-config.ts";
+    ///
+    /// export default defineConfig({ extends: [baseConfig] });
+    /// ```
+    ///
+    /// Configurations are merged from the first to the last, with the last configuration
     /// overriding the previous ones.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extends: Vec<PathBuf>,

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -30,12 +30,12 @@
       "markdownDescription": "Environments enable and disable collections of global variables."
     },
     "extends": {
-      "description": "Paths of configuration files that this configuration file extends (inherits from). The files\nare resolved relative to the location of the configuration file that contains the `extends`\nproperty. The configuration files are merged from the first to the last, with the last file\noverriding the previous ones.",
+      "description": "Configurations that this configuration file extends (inherits from).\n\nIn `.oxlintrc.json`, `extends` has type `string[]`. Each string is a path to a configuration\nfile, resolved relative to the location of the configuration file that contains the\n`extends` property.\n\nIn `oxlint.config.ts`, `extends` has type `OxlintConfig[]`. Import each configuration and\npass the configuration object directly:\n\n```ts\nimport { defineConfig } from \"oxlint\";\nimport baseConfig from \"./base-config.ts\";\n\nexport default defineConfig({ extends: [baseConfig] });\n```\n\nConfigurations are merged from the first to the last, with the last configuration\noverriding the previous ones.",
       "type": "array",
       "items": {
         "type": "string"
       },
-      "markdownDescription": "Paths of configuration files that this configuration file extends (inherits from). The files\nare resolved relative to the location of the configuration file that contains the `extends`\nproperty. The configuration files are merged from the first to the last, with the last file\noverriding the previous ones."
+      "markdownDescription": "Configurations that this configuration file extends (inherits from).\n\nIn `.oxlintrc.json`, `extends` has type `string[]`. Each string is a path to a configuration\nfile, resolved relative to the location of the configuration file that contains the\n`extends` property.\n\nIn `oxlint.config.ts`, `extends` has type `OxlintConfig[]`. Import each configuration and\npass the configuration object directly:\n\n```ts\nimport { defineConfig } from \"oxlint\";\nimport baseConfig from \"./base-config.ts\";\n\nexport default defineConfig({ extends: [baseConfig] });\n```\n\nConfigurations are merged from the first to the last, with the last configuration\noverriding the previous ones."
     },
     "globals": {
       "description": "Enabled or disabled specific global variables.",

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -239,9 +239,23 @@ Available environments:
 type: `string[]`
 
 
-Paths of configuration files that this configuration file extends (inherits from). The files
-are resolved relative to the location of the configuration file that contains the `extends`
-property. The configuration files are merged from the first to the last, with the last file
+Configurations that this configuration file extends (inherits from).
+
+In `.oxlintrc.json`, `extends` has type `string[]`. Each string is a path to a configuration
+file, resolved relative to the location of the configuration file that contains the
+`extends` property.
+
+In `oxlint.config.ts`, `extends` has type `OxlintConfig[]`. Import each configuration and
+pass the configuration object directly:
+
+```ts
+import { defineConfig } from "oxlint";
+import baseConfig from "./base-config.ts";
+
+export default defineConfig({ extends: [baseConfig] });
+```
+
+Configurations are merged from the first to the last, with the last configuration
 overriding the previous ones.
 
 


### PR DESCRIPTION
The generated config reference only described the JSON schema's `string[]` form. Clarify that `oxlint.config.ts` accepts imported `OxlintConfig[]`, add an example and public JSDoc, and regenerate the derived artifacts.

Closes #20238.

Validated with the website generator suite, targeted TypeScript checks, and the relevant Oxlint tests. The full `just ready` run reached an unrelated parallel suppression-fixture cleanup race; the failing test passes in isolation.

AI-assisted.