### PR TITLE
fix(minifier): keep side effects when folding `Number` call

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1136,10 +1136,12 @@ impl<'a> PeepholeOptimizations {
                 span,
                 match arg {
                     None => 0.0,
-                    Some(arg) => match arg.to_number(ctx) {
-                        Some(n) => n,
-                        None => return,
-                    },
+                    Some(arg) => {
+                        match arg.to_number(ctx).filter(|_| !arg.may_have_side_effects(ctx)) {
+                            Some(n) => n,
+                            None => return,
+                        }
+                    }
                 },
                 None,
                 NumberBase::Decimal,

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -757,6 +757,8 @@ fn test_fold_number_constructor() {
     test("x = Number(true)", "x = 1");
     test("x = Number(false)", "x = 0");
     test("x = Number('foo')", "x = NaN");
+    test_same("x = Number(void f())");
+    test_same("x = Number([f(), 1])");
 }
 
 #[test]


### PR DESCRIPTION
Avoid compressing `Number([f(), 1])` to `NaN`.