### PR TITLE
fix(minifier): keep side effects values in template literals

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1396,7 +1396,9 @@ impl<'a> PeepholeOptimizations {
 
     pub fn substitute_template_literal(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::TemplateLiteral(t) = expr else { return };
-        let Some(val) = t.to_js_string(ctx) else { return };
+        let Some(val) = t.to_js_string(ctx).filter(|_| !t.may_have_side_effects(ctx)) else {
+            return;
+        };
         let new_value =
             Expression::new_string_literal(t.span(), Str::from_cow_in(&val, ctx), None, ctx);
         ctx.replace_expression(expr, new_value);

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -335,6 +335,7 @@ fn test_template_string_to_string() {
     test("x = `hello ${'foo'}`", "x = 'hello foo'");
     test("x = `${2} bananas`", "x = '2 bananas'");
     test("x = `This is ${true}`", "x = 'This is true'");
+    test_same("x = `a${void f()}b`");
 }
 
 #[test]


### PR DESCRIPTION
Avoid compressing `a${void f()}b` to `'aundefinedb'.`