### PR TITLE
fix(minifier): keep side effects in typeof comparisons

### DIFF
--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -662,10 +662,14 @@ impl<'a> PeepholeOptimizations {
         if let Expression::UnaryExpression(left) = &e.left
             && left.operator.is_typeof()
             && e.operator.is_equality()
+            && !e.left.may_have_side_effects(ctx)
         {
             let right_ty = e.right.value_type(ctx);
 
-            if !right_ty.is_undetermined() && right_ty != ValueType::String {
+            if !right_ty.is_undetermined()
+                && right_ty != ValueType::String
+                && !e.right.may_have_side_effects(ctx)
+            {
                 let new_expr = Expression::new_boolean_literal(
                     e.span,
                     e.operator == BinaryOperator::Inequality

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1304,6 +1304,13 @@ fn test_fold_invalid_typeof_comparison() {
 }
 
 #[test]
+fn test_fold_keep_side_effects_in_typeof_comparison() {
+    fold_same("typeof f() == 1");
+    fold("typeof f() === 'asd'", "typeof f() == 'asd'");
+    fold_same("typeof x === [f()]");
+}
+
+#[test]
 fn test_issue_8782() {
     fold("+(void unknown())", "+void unknown()");
 }


### PR DESCRIPTION
Avoid removing `typeof f() == 1`.