### PR TITLE
fix(minifier): keep `typeof foo == ['object']` as-is

### DIFF
--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -768,6 +768,13 @@ impl<'a> PeepholeOptimizations {
 
             if !right_ty.is_undetermined()
                 && right_ty != ValueType::String
+                // a loose comparison with an object can be `true` via ToPrimitive
+                // (e.g. `typeof foo == ['object']` is true when `foo` is an object)
+                && (right_ty != ValueType::Object
+                    || matches!(
+                        e.operator,
+                        BinaryOperator::StrictEquality | BinaryOperator::StrictInequality
+                    ))
                 && !e.right.may_have_side_effects(ctx)
             {
                 let new_expr = Expression::new_boolean_literal(

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1364,6 +1364,15 @@ fn test_fold_invalid_typeof_comparison() {
     fold("typeof foo != undefined", "!0");
     fold("typeof foo === 'string'", "typeof foo == 'string'");
     fold("typeof foo === 'number'", "typeof foo == 'number'");
+
+    // strict equality with an object is always false
+    fold("typeof foo === [1]", "!1");
+    fold("typeof foo !== [1]", "!0");
+    // but loose equality with an object can be true via ToPrimitive:
+    // `typeof foo == ['object']` is true when foo is an object
+    fold_same("typeof foo == ['object']");
+    fold_same("typeof foo != ['object']");
+    fold_same("typeof foo == [1]");
 }
 
 #[test]


### PR DESCRIPTION
Keep `typeof foo == ['object']` as-is as it may be `true`(when `foo` is `{}`) or `false`.