### PR TITLE
fix(linter): report no-redeclare in ESM/CJS scopes

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -7,7 +7,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::{
-    context::{ContextHost, LintContext},
+    context::LintContext,
     rule::{DefaultRuleConfig, Rule},
 };
 
@@ -77,7 +77,15 @@ impl Rule for NoRedeclare {
     }
 
     fn run_once(&self, ctx: &LintContext) {
-        let builtin_globals = if self.builtin_globals { Some(&GLOBALS_BUILTIN) } else { None };
+        // Identical to `no-implicit-globals`: ESM and CommonJS run in their own scope, so
+        // name clashes with host/env built-ins are not possible. Classic scripts share the
+        // global object, so those clashes still matter there.
+        // Redeclarations within the same scope must still be reported in every module kind
+        // (see https://github.com/oxc-project/oxc/issues/18253).
+        let check_builtin_globals = self.builtin_globals
+            && !ctx.source_type().is_module()
+            && !ctx.source_type().is_commonjs();
+        let builtin_globals = if check_builtin_globals { Some(&GLOBALS_BUILTIN) } else { None };
 
         for symbol_id in ctx.scoping().symbol_ids() {
             let name = ctx.scoping().symbol_name(symbol_id);
@@ -126,11 +134,6 @@ impl Rule for NoRedeclare {
             }
         }
     }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        // ES modules run in their own scope, and don't conflict with existing globals
-        !ctx.source_type().is_module()
-    }
 }
 
 #[test]
@@ -167,6 +170,9 @@ fn test() {
         // Issue: <https://github.com/oxc-project/oxc/issues/10396>
         ("export function foo(): void; export function foo() { }", None),
         ("function foo(arg: string): void; function foo(arg: number): any {}", None),
+        // Module/CJS: binding a built-in name is allowed (own scope). Overload +
+        // implementation of `undefined` is not a same-scope redeclare.
+        ("export function undefined(): void; export function undefined() { }", None),
     ];
 
     let fail = vec![
@@ -191,28 +197,54 @@ fn test() {
         ("function f(a, b = 1) { var a; var b;}", None),
         ("function f() { var a; if (test) { var a; } }", None),
         ("for (var a, a;;);", None),
+        // Classic script only: built-in global name without ESM/CJS scope wrap
+        ("function undefined() {}", None),
+        ("var undefined = 1;", None),
         // Issue: <https://github.com/oxc-project/oxc/issues/10396>
-        ("export function undefined(): void; export function undefined() { }", None),
         ("type foo = 1; export function foo(): void; export function foo() { }", None),
     ];
 
+    // TypeScript script (.ts, no import/export) so built-in global checks still run.
+    // `.cts` is CommonJS since #18089 and must not flag env built-in clashes.
     Tester::new(NoRedeclare::NAME, NoRedeclare::PLUGIN, pass, fail)
-        .change_rule_path_extension(".cts")
+        .change_rule_path_extension("ts")
         .test_and_snapshot();
 
+    // Built-in / configured-global clashes only apply to classic scripts.
     let fail = vec![("var foo;", None, Some(serde_json::json!({ "globals": { "foo": false }})))];
 
     Tester::new(NoRedeclare::NAME, NoRedeclare::PLUGIN, vec![], fail)
-        .change_rule_path_extension(".cts")
+        .change_rule_path_extension("ts")
         .test();
 
-    let pass = vec![(
-        "import { performance } from 'node:perf_hooks'; (() => { performance })",
-        None,
-        Some(serde_json::json!({ "globals": { "performance": "readonly" }})),
-    )];
+    // Same-scope redeclarations must still fire in ESM (issue #18253).
+    let fail_module = vec![
+        ("var a = 3; var a = 10;", None),
+        ("export var a; var a;", None),
+        ("function a() {} function a() {}", None),
+    ];
+    Tester::new(NoRedeclare::NAME, NoRedeclare::PLUGIN, vec![], fail_module)
+        .change_rule_path_extension("mjs")
+        .test();
 
-    Tester::new(NoRedeclare::NAME, NoRedeclare::PLUGIN, pass, vec![])
-        .change_rule_path_extension(".ts")
+    // ESM/CJS: binding an env built-in name is fine (own scope); only true
+    // same-scope redeclares still report.
+    let pass_module = vec![
+        (
+            "import { performance } from 'node:perf_hooks'; (() => { performance })",
+            None,
+            Some(serde_json::json!({ "globals": { "performance": "readonly" }})),
+        ),
+        ("var Object = 0;", None, None),
+        ("var Object = 0;", None, Some(serde_json::json!({ "globals": { "Object": "readonly" }}))),
+    ];
+    Tester::new(NoRedeclare::NAME, NoRedeclare::PLUGIN, pass_module, vec![])
+        .change_rule_path_extension("mjs")
+        .test();
+
+    let pass_cjs = vec![("var Object = 0;", None)];
+    let fail_cjs = vec![("var Object = 0; var Object = 1;", None)];
+    Tester::new(NoRedeclare::NAME, NoRedeclare::PLUGIN, pass_cjs, fail_cjs)
+        .change_rule_path_extension("cjs")
         .test();
 }

--- a/crates/oxc_linter/src/snapshots/eslint_no_redeclare.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_redeclare.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
 ---
 
   ⚠ eslint(no-redeclare): 'b' is already defined.
-   ╭─[no_redeclare..cts:1:27]
+   ╭─[no_redeclare.ts:1:27]
  1 │ switch(foo) { case a: var b = 3;
    ·                           ┬
    ·                           ╰── 'b' is already defined.
@@ -14,7 +15,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:5]
+   ╭─[no_redeclare.ts:1:5]
  1 │ var a = 3; var a = 10;
    ·     ┬          ┬
    ·     │          ╰── It can not be redeclared here.
@@ -23,7 +24,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:5]
+   ╭─[no_redeclare.ts:1:5]
  1 │ var a = {}; var a = [];
    ·     ┬           ┬
    ·     │           ╰── It can not be redeclared here.
@@ -32,7 +33,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   × Identifier `a` has already been declared
-   ╭─[no_redeclare..cts:1:5]
+   ╭─[no_redeclare.ts:1:5]
  1 │ var a; function a() {}
    ·     ┬           ┬
    ·     │           ╰── It can not be redeclared here
@@ -40,7 +41,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:10]
+   ╭─[no_redeclare.ts:1:10]
  1 │ function a() {} function a() {}
    ·          ┬               ┬
    ·          │               ╰── It can not be redeclared here.
@@ -49,7 +50,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:5]
+   ╭─[no_redeclare.ts:1:5]
  1 │ var a = function() { }; var a = function() { }
    ·     ┬                       ┬
    ·     │                       ╰── It can not be redeclared here.
@@ -58,7 +59,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:5]
+   ╭─[no_redeclare.ts:1:5]
  1 │ var a = function() { }; var a = new Date();
    ·     ┬                       ┬
    ·     │                       ╰── It can not be redeclared here.
@@ -67,7 +68,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:5]
+   ╭─[no_redeclare.ts:1:5]
  1 │ var a = 3; var a = 10; var a = 15;
    ·     ┬          ┬
    ·     │          ╰── It can not be redeclared here.
@@ -76,7 +77,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:16]
+   ╭─[no_redeclare.ts:1:16]
  1 │ var a = 3; var a = 10; var a = 15;
    ·                ┬           ┬
    ·                │           ╰── It can not be redeclared here.
@@ -85,7 +86,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:5]
+   ╭─[no_redeclare.ts:1:5]
  1 │ var a; var a;
    ·     ┬      ┬
    ·     │      ╰── It can not be redeclared here.
@@ -94,7 +95,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:12]
+   ╭─[no_redeclare.ts:1:12]
  1 │ export var a; var a;
    ·            ┬      ┬
    ·            │      ╰── It can not be redeclared here.
@@ -103,7 +104,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:24]
+   ╭─[no_redeclare.ts:1:24]
  1 │ class C { static { var a; var a; } }
    ·                        ┬      ┬
    ·                        │      ╰── It can not be redeclared here.
@@ -112,7 +113,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:24]
+   ╭─[no_redeclare.ts:1:24]
  1 │ class C { static { var a; { var a; } } }
    ·                        ┬        ┬
    ·                        │        ╰── It can not be redeclared here.
@@ -121,7 +122,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:26]
+   ╭─[no_redeclare.ts:1:26]
  1 │ class C { static { { var a; } var a; } }
    ·                          ┬        ┬
    ·                          │        ╰── It can not be redeclared here.
@@ -130,7 +131,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:26]
+   ╭─[no_redeclare.ts:1:26]
  1 │ class C { static { { var a; } { var a; } } }
    ·                          ┬          ┬
    ·                          │          ╰── It can not be redeclared here.
@@ -139,28 +140,28 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'Object' is already defined as a built-in global variable.
-   ╭─[no_redeclare..cts:1:5]
+   ╭─[no_redeclare.ts:1:5]
  1 │ var Object = 0; var Object = 0; var globalThis = 0;
    ·     ──────
    ╰────
   help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'Object' is already defined as a built-in global variable.
-   ╭─[no_redeclare..cts:1:21]
+   ╭─[no_redeclare.ts:1:21]
  1 │ var Object = 0; var Object = 0; var globalThis = 0;
    ·                     ──────
    ╰────
   help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'globalThis' is already defined as a built-in global variable.
-   ╭─[no_redeclare..cts:1:37]
+   ╭─[no_redeclare.ts:1:37]
  1 │ var Object = 0; var Object = 0; var globalThis = 0;
    ·                                     ──────────
    ╰────
   help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:5]
+   ╭─[no_redeclare.ts:1:5]
  1 │ var a; var {a = 0, b: Object = 0} = {};
    ·     ┬       ┬
    ·     │       ╰── It can not be redeclared here.
@@ -169,14 +170,14 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'Object' is already defined as a built-in global variable.
-   ╭─[no_redeclare..cts:1:23]
+   ╭─[no_redeclare.ts:1:23]
  1 │ var a; var {a = 0, b: Object = 0} = {};
    ·                       ──────
    ╰────
   help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:5]
+   ╭─[no_redeclare.ts:1:5]
  1 │ var a; var {a = 0, b: globalThis = 0} = {};
    ·     ┬       ┬
    ·     │       ╰── It can not be redeclared here.
@@ -185,14 +186,14 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'globalThis' is already defined as a built-in global variable.
-   ╭─[no_redeclare..cts:1:23]
+   ╭─[no_redeclare.ts:1:23]
  1 │ var a; var {a = 0, b: globalThis = 0} = {};
    ·                       ──────────
    ╰────
   help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:20]
+   ╭─[no_redeclare.ts:1:20]
  1 │ function f() { var a; var a; }
    ·                    ┬      ┬
    ·                    │      ╰── It can not be redeclared here.
@@ -201,7 +202,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:12]
+   ╭─[no_redeclare.ts:1:12]
  1 │ function f(a, b = 1) { var a; var b;}
    ·            ┬               ┬
    ·            │               ╰── It can not be redeclared here.
@@ -210,7 +211,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'b' is already defined.
-   ╭─[no_redeclare..cts:1:15]
+   ╭─[no_redeclare.ts:1:15]
  1 │ function f(a, b = 1) { var a; var b;}
    ·               ┬                   ┬
    ·               │                   ╰── It can not be redeclared here.
@@ -219,7 +220,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:20]
+   ╭─[no_redeclare.ts:1:20]
  1 │ function f() { var a; if (test) { var a; } }
    ·                    ┬                  ┬
    ·                    │                  ╰── It can not be redeclared here.
@@ -228,7 +229,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
-   ╭─[no_redeclare..cts:1:10]
+   ╭─[no_redeclare.ts:1:10]
  1 │ for (var a, a;;);
    ·          ┬  ┬
    ·          │  ╰── It can not be redeclared here.
@@ -237,21 +238,21 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'undefined' is already defined as a built-in global variable.
-   ╭─[no_redeclare..cts:1:17]
- 1 │ export function undefined(): void; export function undefined() { }
-   ·                 ─────────
+   ╭─[no_redeclare.ts:1:10]
+ 1 │ function undefined() {}
+   ·          ─────────
    ╰────
   help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'undefined' is already defined as a built-in global variable.
-   ╭─[no_redeclare..cts:1:52]
- 1 │ export function undefined(): void; export function undefined() { }
-   ·                                                    ─────────
+   ╭─[no_redeclare.ts:1:5]
+ 1 │ var undefined = 1;
+   ·     ─────────
    ╰────
   help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'foo' is already defined.
-   ╭─[no_redeclare..cts:1:6]
+   ╭─[no_redeclare.ts:1:6]
  1 │ type foo = 1; export function foo(): void; export function foo() { }
    ·      ─┬─                                                   ─┬─
    ·       │                                                     ╰── It can not be redeclared here.

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -105,7 +105,7 @@ eslint/no-plusplus                                         |    769
 eslint/no-promise-executor-return                          |   1421
 eslint/no-proto                                            |  95297
 eslint/no-prototype-builtins                               |  62606
-eslint/no-redeclare                                        |      1
+eslint/no-redeclare                                        |      7
 eslint/no-regex-spaces                                     |  64236
 eslint/no-restricted-exports                               |     70
 eslint/no-restricted-globals                               |      7


### PR DESCRIPTION
## Summary

- `eslint/no-redeclare` again reports same-scope redeclarations in ESM and CommonJS.
- Built-in / configured global clash checks stay limited to classic scripts (same idea as `no-implicit-globals`).

## Motivation

Closes #18253.

`should_run` previously skipped the whole rule for modules so env built-ins would not clash with module scope. That also dropped real same-scope redeclarations such as `var a = 3; var a = 10;` in ESM, which ESLint still reports.

Fix: always run the rule; only gate the built-in global check on “not module and not CommonJS”. Updated tests cover ESM fails, CJS single-`Object` pass + double-`Object` fail, and script built-in checks via `.ts` scripts (`.cts` is CommonJS since #18089).

## Verification

- `cargo test -p oxc_linter --lib no_redeclare` — passed
- Snapshot `eslint_no_redeclare.snap` regenerated for the path/semantics change
- Did not change: redeclaration detection logic inside a given scope (only when the rule runs + when built-in checks apply)

## AI disclosure

Assisted by AI (Hermes/Sera). I reviewed #18253 against current `no_redeclare` / `no_implicit_globals` behavior, applied the scoped fix, expanded tests, and ran the rule tests above.

---
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera`

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 48h
