### PR TITLE
refactor(linter/import/no-relative-parent-imports): use `Expression::is_commonjs_require`

### DIFF
--- a/crates/oxc_linter/src/rules/import/no_relative_parent_imports.rs
+++ b/crates/oxc_linter/src/rules/import/no_relative_parent_imports.rs
@@ -1,7 +1,4 @@
-use oxc_ast::{
-    AstKind,
-    ast::{Argument, Expression},
-};
+use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -87,10 +84,7 @@ impl Rule for NoRelativeParentImports {
             }
             // CommonJS require() calls
             AstKind::CallExpression(call_expr) => {
-                if let Expression::Identifier(ident) = &call_expr.callee
-                    && ident.name == "require"
-                    && call_expr.arguments.len() == 1
-                    && let Argument::StringLiteral(str_literal) = &call_expr.arguments[0]
+                if let Some(str_literal) = call_expr.common_js_require()
                     && is_parent_import(str_literal.value.as_str())
                 {
                     ctx.diagnostic(no_relative_parent_imports_diagnostic(str_literal.span));
@@ -150,6 +144,8 @@ fn test() {
         r#"export * from "../parent""#,
         r#"export { foo } from "./..""#,
         r#"export * from "./..""#,
+        // Parenthesized callee still resolves to `require`
+        r#"(require)("../plugin.js")"#,
     ];
 
     Tester::new(NoRelativeParentImports::NAME, NoRelativeParentImports::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/import_no_relative_parent_imports.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_relative_parent_imports.snap
@@ -92,3 +92,10 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────
    ╰────
   help: Move the file to the same directory, use dependency injection, or convert to a package.
+
+  ⚠ import(no-relative-parent-imports): Relative imports from parent directories are not allowed
+   ╭─[index.js:1:11]
+ 1 │ (require)("../plugin.js")
+   ·           ──────────────
+   ╰────
+  help: Move the file to the same directory, use dependency injection, or convert to a package.


### PR DESCRIPTION
Also add a test case for one new place where the `require` is caught that wasn't caught before.

Refactor candidate found with Claude Code, new test case generated by Claude Code.

One thing that may be worth noting is that this rule doesn't (and didn't before this PR) catch a `require` using a template literal. the eslint-plugin-import rule doesn't either, but maybe we should update the rule to handle that as well?

```js
// This should maybe be caught by the rule but currently is not:
require(`../foo.js`);
```