### PR TITLE
docs(ast): fix incorrect return value in `common_js_require` docs

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -792,13 +792,18 @@ impl CallExpression<'_> {
         }
     }
 
-    /// Returns `true` if this looks like a call to `require` in CommonJS (has a single string argument):
+    /// Returns the required module's [`StringLiteral`] if this looks like a call to `require` in
+    /// CommonJS (a single string literal argument), or [`None`] otherwise.
+    ///
     /// ```js
-    /// require('string') // => true
-    /// require('string', 'string') // => false
-    /// require() // => false
-    /// require(123) // => false
+    /// require('string') // => Some("string")
+    /// require('string', 'string') // => None
+    /// require() // => None
+    /// require(123) // => None
     /// ```
+    ///
+    /// The callee is matched with [`Expression::is_specific_id`], which looks through parentheses
+    /// and TypeScript wrappers such as `as`, `satisfies`, and `!`.
     pub fn common_js_require(&self) -> Option<&StringLiteral<'_>> {
         if !(self.callee.is_specific_id("require") && self.arguments.len() == 1) {
             return None;


### PR DESCRIPTION
The doc comment for `common_js_require` said it returned a boolean, which is untrue. It returns an `Option<&StringLiteral>`. I think this was a copy-paste mistake, and it's fixed now.

Also added a note that the callee is matched with `is_specific_id`, so it looks through parentheses and TypeScript wrappers, this may be excessive and can be removed to simplify the docs if preferred.

Generated with Claude Code, reviewed and modified by me.