### PR TITLE
refactor(linter/unicorn/throw-new-error): Use `Expression::is_specific_member_access`.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
@@ -88,11 +88,7 @@ impl Rule for ThrowNewError {
 }
 
 fn is_data_tagged_error(callee: &Expression<'_>) -> bool {
-    let Expression::StaticMemberExpression(member) = callee else {
-        return false;
-    };
-
-    member.property.name == "TaggedError" && member.object.is_specific_id("Data")
+    callee.is_specific_member_access("Data", "TaggedError")
 }
 
 #[test]


### PR DESCRIPTION
Found via a scan by Claude Code, use the existing and fully equivalent helper method for this check.