### PR TITLE
fix(linter): mark missing suggestions as pending

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -88,6 +88,7 @@ declare_oxc_lint!(
     NoUnusedPrivateClassMembers,
     eslint,
     correctness,
+    pending,
     version = "0.1.1",
     short_description = "Disallow unused private class members.",
 );

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -64,6 +64,7 @@ declare_oxc_lint!(
     PreferNamedCaptureGroup,
     eslint,
     style,
+    pending,
     version = "1.68.0",
     short_description = "Enforces the use of named capture groups in regular expressions.",
 );

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_condition.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_condition.rs
@@ -94,6 +94,7 @@ declare_oxc_lint!(
     NoUnnecessaryCondition(tsgolint),
     typescript,
     nursery, // TODO(camc314): move to correctness
+    pending,
     config = NoUnnecessaryConditionConfig,
     version = "1.48.0",
     short_description = "Disallow conditions that are always truthy, always falsy, or always nullish based on TypeScript's type information.",

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_conversion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_conversion.rs
@@ -29,6 +29,7 @@ declare_oxc_lint!(
     NoUnnecessaryTypeConversion(tsgolint),
     typescript,
     suspicious,
+    pending,
     version = "1.49.0",
     short_description = "Disallow unnecessary type conversion expressions.",
 );

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_parameters.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_parameters.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     NoUnnecessaryTypeParameters(tsgolint),
     typescript,
     suspicious,
+    pending,
     version = "1.49.0",
     short_description = "Disallow type parameters that are declared but not meaningfully used.",
 );

--- a/crates/oxc_linter/src/rules/typescript/prefer_find.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_find.rs
@@ -29,6 +29,7 @@ declare_oxc_lint!(
     PreferFind(tsgolint),
     typescript,
     style,
+    pending,
     version = "1.49.0",
     short_description = "Prefer `.find(...)` over `.filter(...)[0]` for retrieving a single element.",
 );

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
@@ -58,6 +58,7 @@ declare_oxc_lint!(
     NoArrayReduce,
     unicorn,
     restriction,
+    pending,
     config = NoArrayReduce,
     version = "0.0.19",
     short_description = "Disallow `Array#reduce()` and `Array#reduceRight()`.",

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     NoUnreadableIife,
     unicorn,
     pedantic,
+    pending,
     version = "0.0.19",
     short_description = "This rule disallows IIFEs with a parenthesized arrow function body.",
 );


### PR DESCRIPTION
found some rules that provide suggestions upstream but were missing the `pending` status:

typescript/no-unnecessary-condition - [upstream](https://github.com/typescript-eslint/typescript-eslint/blob/3b71948c6c5d6bbe0f96346b280fafaee467cc6b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts)
typescript/no-unnecessary-type-conversion - [upstream](https://github.com/typescript-eslint/typescript-eslint/blob/3b71948c6c5d6bbe0f96346b280fafaee467cc6b/packages/eslint-plugin/src/rules/no-unnecessary-type-conversion.ts)
typescript/no-unnecessary-type-parameters - [upstream](https://github.com/typescript-eslint/typescript-eslint/blob/3b71948c6c5d6bbe0f96346b280fafaee467cc6b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts)
typescript/prefer-find - [upstream](https://github.com/typescript-eslint/typescript-eslint/blob/3b71948c6c5d6bbe0f96346b280fafaee467cc6b/packages/eslint-plugin/src/rules/prefer-find.ts)
eslint/no-unused-private-class-members - [upstream](https://github.com/eslint/eslint/blob/d08629382b0a6aaa042823b796e5100e60053b54/lib/rules/no-unused-private-class-members.js)
eslint/prefer-named-capture-group - [upstream](https://github.com/eslint/eslint/blob/d08629382b0a6aaa042823b796e5100e60053b54/lib/rules/prefer-named-capture-group.js)
unicorn/no-array-reduce - [upstream](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/a33b1c1e207b37f5c6f4ea8f3e66dad9a9d1ad43/rules/no-array-reduce.js)
unicorn/no-unreadable-iife - [upstream](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/a33b1c1e207b37f5c6f4ea8f3e66dad9a9d1ad43/rules/no-unreadable-iife.js)