### PR TITLE
refactor(oxlint/linter/lsp): extend "ignore fixes" on diagnostic creation

### DIFF
--- a/apps/oxlint/src/lsp/code_actions.rs
+++ b/apps/oxlint/src/lsp/code_actions.rs
@@ -48,11 +48,7 @@ pub fn apply_fix_code_actions(action: LinterCodeAction, uri: &Uri) -> Vec<CodeAc
     let mut preferred_possible = true;
     for fixed in action.fixed_content {
         // only rule fixes and unused directive fixes can be preferred, ignore fixes are not preferred.
-        let preferred = preferred_possible
-            && matches!(
-                fixed.lsp_kind,
-                FixedContentKind::LintRule(_) | FixedContentKind::UnusedDirective
-            );
+        let preferred = preferred_possible && !matches!(fixed.kind, FixKind::IgnoreFix);
         if preferred {
             // only the first fix can be preferred, if there are multiple fixes available.
             preferred_possible = false;
@@ -160,12 +156,7 @@ pub fn fix_all_text_edit(actions: impl Iterator<Item = LinterCodeAction>) -> Vec
     for action in actions {
         // Applying all possible fixes at once is not possible in this context.
         // Search for the first "real" fix for the rule, and ignore the rest of the fixes for the same rule.
-        let Some(fixed_content) = action.fixed_content.into_iter().find(|fixed| {
-            matches!(
-                fixed.lsp_kind,
-                FixedContentKind::LintRule(_) | FixedContentKind::UnusedDirective
-            )
-        }) else {
+        let Some(fixed_content) = action.fixed_content.into_iter().next() else {
             continue;
         };
 
@@ -186,12 +177,7 @@ fn dangerous_fix_all_text_edit(actions: impl Iterator<Item = LinterCodeAction>) 
     let mut text_edits: Vec<TextEdit> = vec![];
 
     for action in actions {
-        let Some(fixed_content) = action.fixed_content.into_iter().find(|fixed| {
-            matches!(
-                fixed.lsp_kind,
-                FixedContentKind::LintRule(_) | FixedContentKind::UnusedDirective
-            )
-        }) else {
+        let Some(fixed_content) = action.fixed_content.into_iter().next() else {
             continue;
         };
 

--- a/apps/oxlint/src/lsp/error_with_position.rs
+++ b/apps/oxlint/src/lsp/error_with_position.rs
@@ -10,7 +10,6 @@ use oxc_diagnostics::{OxcCode, Severity};
 use oxc_language_server::offset_to_position as lsp_offset_to_position;
 use oxc_linter::{
     AllowWarnDeny, DisableDirectives, Fix, FixKind, Message, PossibleFixes, RuleCommentType,
-    disable_for_this_line, disable_for_this_section,
 };
 
 use crate::lsp::{
@@ -42,8 +41,6 @@ pub struct FixedContent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FixedContentKind {
     LintRule(OxcCode),
-    IgnoreLintRuleLine,
-    IgnoreLintRuleSection,
     UnusedDirective,
 }
 
@@ -199,28 +196,6 @@ pub fn message_to_lsp_diagnostic(
             }));
         }
     }
-
-    // Add ignore fixes
-    let error_offset = message.span.start;
-    let section_offset = message.section_offset;
-
-    // If the error is exactly at the section offset and has 0 span length, it means that the file is the problem
-    // and attaching a ignore comment would not ignore the error.
-    // This is because the ignore comment would need to be placed before the error offset, which is not possible.
-    if error_offset == section_offset && message.span.end == section_offset {
-        return Some(DiagnosticReport {
-            diagnostic,
-            code_action: Some(LinterCodeAction { range, fixed_content }),
-        });
-    }
-
-    add_ignore_fixes(
-        &mut fixed_content,
-        &message.error.code,
-        error_offset,
-        section_offset,
-        source_text,
-    );
 
     let code_action = if fixed_content.is_empty() {
         None
@@ -394,43 +369,9 @@ pub fn offset_to_position(offset: u32, source_text: &str) -> Position {
     lsp_offset_to_position(source_text, offset)
 }
 
-/// Add "ignore this line" and "ignore this rule" fixes to the existing fixes.
-/// These fixes will be added to the end of the existing fixes.
-/// If the existing fixes already contain an "remove unused disable directive" fix,
-/// then no ignore fixes will be added.
-fn add_ignore_fixes(
-    fixes: &mut Vec<FixedContent>,
-    code: &OxcCode,
-    error_offset: u32,
-    section_offset: u32,
-    source_text: &str,
-) {
-    debug_assert!(
-        !fixes.iter().any(|fix| fix.message.starts_with("remove unused disable directive")),
-        "Unused disable directives should never pass pass this point, as they should be handled separately in `create_unused_directives_messages`."
-    );
-
-    let Some(rule_name_with_plugin) = get_full_rule_name(code) else {
-        return;
-    };
-    fixes.push(fix_to_fixed_content(
-        &disable_for_this_line(&rule_name_with_plugin, error_offset, section_offset, source_text),
-        source_text,
-        FixedContentKind::IgnoreLintRuleLine,
-    ));
-
-    fixes.push(fix_to_fixed_content(
-        &disable_for_this_section(&rule_name_with_plugin, section_offset, source_text),
-        source_text,
-        FixedContentKind::IgnoreLintRuleSection,
-    ));
-}
-
 #[cfg(test)]
 #[expect(clippy::cast_possible_truncation)]
 mod test {
-    use oxc_diagnostics::OxcCode;
-
     use super::offset_to_position;
 
     #[test]
@@ -474,18 +415,6 @@ mod test {
     #[should_panic(expected = "out of bounds")]
     fn out_of_bounds() {
         offset_to_position(100, "foo");
-    }
-
-    #[test]
-    fn add_ignore_fixes_uses_user_facing_plugin_names() {
-        let source = "foo();";
-        let code = OxcCode { scope: Some("jsx-a11y".into()), number: Some("alt-text".into()) };
-        let mut fixes = vec![];
-
-        super::add_ignore_fixes(&mut fixes, &code, 0, 0, source);
-
-        assert_eq!(fixes[0].code, "// oxlint-disable-next-line jsx-a11y/alt-text\n");
-        assert_eq!(fixes[1].code, "// oxlint-disable jsx-a11y/alt-text\n");
     }
 
     fn assert_position(source: &str, offset: u32, expected: (u32, u32)) {

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -180,6 +180,7 @@ impl ServerLinterBuilder {
                     _ => None,
                 },
             },
+            with_ignore_fixes: true,
             ..Default::default()
         };
 
@@ -214,6 +215,7 @@ impl ServerLinterBuilder {
         let runner = match LintRunnerBuilder::new(lint_service_options.clone(), linter)
             .with_type_aware(type_aware)
             .with_fix_kind(fix_kind)
+            .with_ignore_fixes(true)
             .build()
         {
             Ok(runner) => runner,
@@ -225,6 +227,7 @@ impl ServerLinterBuilder {
                 LintRunnerBuilder::new(lint_service_options, linter)
                     .with_type_aware(false)
                     .with_fix_kind(fix_kind)
+                    .with_ignore_fixes(true)
                     .build()
                     .expect("Failed to build LintRunner without type-aware linting")
             }

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -169,6 +169,8 @@ pub struct ContextHost<'a> {
     pub(super) config: Arc<LintConfig>,
     /// Front-end frameworks that might be in use in the target file.
     pub(super) frameworks: FrameworkFlags,
+    /// If true, the linter will create "ignore this section / line" fixes for all diagnostics
+    with_ignore_fixes: bool,
 }
 
 impl std::fmt::Debug for ContextHost<'_> {
@@ -207,6 +209,7 @@ impl<'a> ContextHost<'a> {
             file_extension,
             config,
             frameworks: options.framework_hints,
+            with_ignore_fixes: options.with_ignore_fixes,
         }
         .sniff_for_frameworks()
     }
@@ -311,6 +314,10 @@ impl<'a> ContextHost<'a> {
     /// by any rule to report issues.
     #[inline]
     pub(crate) fn push_diagnostic(&self, mut diagnostic: Message) {
+        if self.with_ignore_fixes {
+            let source_text = self.semantic().source_text();
+            diagnostic.add_ignore_fix(self.current_sub_host().source_text_offset, source_text);
+        }
         if self.current_sub_host().source_text_offset != 0 {
             diagnostic.move_offset(self.current_sub_host().source_text_offset);
         }
@@ -319,6 +326,12 @@ impl<'a> ContextHost<'a> {
 
     // Append a list of diagnostics. Only used in report_unused_directives.
     fn append_diagnostics(&self, mut diagnostics: Vec<Message>) {
+        if self.with_ignore_fixes {
+            let source_text = self.semantic().source_text();
+            for diagnostic in &mut diagnostics {
+                diagnostic.add_ignore_fix(self.current_sub_host().source_text_offset, source_text);
+            }
+        }
         if self.current_sub_host().source_text_offset != 0 {
             let offset = self.current_sub_host().source_text_offset;
             for diagnostic in &mut diagnostics {

--- a/crates/oxc_linter/src/fixer/disable_fix.rs
+++ b/crates/oxc_linter/src/fixer/disable_fix.rs
@@ -1,6 +1,6 @@
 use oxc_span::Span;
 
-use crate::{Fix, FixKind};
+use crate::{Fix, FixKind, Message};
 use std::borrow::Cow;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10,13 +10,32 @@ enum DisableDirective {
     Section,
 }
 
-pub fn disable_for_this_line(
+impl Message {
+    pub(crate) fn add_ignore_fix(&mut self, section_offset: u32, section_source_text: &str) {
+        let Some(message_rule) = &self.rule else { return };
+        // If the error is exactly at the section offset and has 0 span length, it means that the file is the problem
+        // and attaching a ignore comment would not ignore the error.
+        // This is because the ignore comment would need to be placed before the error offset, which is not possible.
+        if self.span.start == 0 && self.span.end == 0 {
+            return;
+        }
+
+        let rule_name = message_rule.short_canonical_name();
+
+        self.fixes.extend_fix(vec![
+            disable_for_this_line(&rule_name, self.span.start, section_offset, section_source_text),
+            disable_for_this_section(&rule_name, section_offset, section_source_text),
+        ]);
+    }
+}
+
+fn disable_for_this_line(
     rule_name: &str,
     error_offset: u32,
     section_offset: u32,
-    source_text: &str,
+    section_source_text: &str,
 ) -> Fix {
-    let bytes = source_text.as_bytes();
+    let bytes = section_source_text.as_bytes();
     let message = format!("Disable {rule_name} for this line");
 
     // Reuse an inline disable-line comment on the same line when present.
@@ -25,22 +44,17 @@ pub fn disable_for_this_line(
             message: Some(Cow::Owned(message)),
             content: Cow::Owned(format!(" {rule_name}")),
             span: Span::empty(existing_comment_end),
-            kind: FixKind::SafeFix,
+            kind: FixKind::IgnoreFix,
         };
     }
 
     // Find the line break before the error
     let mut line_break_offset = error_offset;
-    for byte in bytes[section_offset as usize..error_offset as usize].iter().rev() {
+    for byte in bytes[..error_offset as usize].iter().rev() {
         if *byte == b'\n' || *byte == b'\r' {
             break;
         }
         line_break_offset -= 1;
-    }
-
-    // For framework files, ensure we don't go before the section start
-    if section_offset > 0 && line_break_offset < section_offset {
-        line_break_offset = section_offset;
     }
 
     let (content_prefix, insert_offset) =
@@ -54,7 +68,7 @@ pub fn disable_for_this_line(
             message: Some(Cow::Owned(message)),
             content: Cow::Owned(format!(" {rule_name}")),
             span: Span::empty(existing_comment_end),
-            kind: FixKind::SafeFix,
+            kind: FixKind::IgnoreFix,
         };
     }
 
@@ -77,16 +91,19 @@ pub fn disable_for_this_line(
             "{content_prefix}{whitespace_string}// oxlint-disable-next-line {rule_name}\n"
         )),
         span: Span::empty(insert_offset),
-        kind: FixKind::SafeFix,
+        kind: FixKind::IgnoreFix,
     }
 }
 
-pub fn disable_for_this_section(rule_name: &str, section_offset: u32, source_text: &str) -> Fix {
-    let bytes = source_text.as_bytes();
+fn disable_for_this_section(
+    rule_name: &str,
+    section_offset: u32,
+    section_source_text: &str,
+) -> Fix {
+    let bytes = section_source_text.as_bytes();
     let message = format!("Disable {rule_name} for this whole file");
 
-    let (content_prefix, insert_offset) =
-        get_section_insert_position(section_offset, section_offset, bytes);
+    let (content_prefix, insert_offset) = get_section_insert_position(section_offset, 0, bytes);
 
     // Reuse an existing section disable comment when present by appending the rule.
     if let Some(existing_comment_end) =
@@ -96,7 +113,7 @@ pub fn disable_for_this_section(rule_name: &str, section_offset: u32, source_tex
             message: Some(Cow::Owned(message)),
             content: Cow::Owned(format!(" {rule_name}")),
             span: Span::empty(existing_comment_end),
-            kind: FixKind::SafeFix,
+            kind: FixKind::IgnoreFix,
         };
     }
 
@@ -106,14 +123,14 @@ pub fn disable_for_this_section(rule_name: &str, section_offset: u32, source_tex
         message: Some(Cow::Owned(message)),
         content: Cow::Owned(content),
         span: Span::empty(insert_offset),
-        kind: FixKind::SafeFix,
+        kind: FixKind::IgnoreFix,
     }
 }
 
 /// Get the insert position and content prefix for section-based insertions.
 ///
-/// For framework files (section_offset > 0), this handles proper line break detection.
-/// For regular JS files (section_offset == 0), this handles shebang lines.
+/// The section source is already sliced at section offset, so offset 0 is the section start.
+/// This handles section-start line break detection and shebang lines at the section start.
 ///
 /// Returns (content_prefix, insert_offset) where:
 /// - content_prefix: "\n" if we need to add a line break, "" otherwise
@@ -124,9 +141,9 @@ fn get_section_insert_position(
     target_offset: u32,
     bytes: &[u8],
 ) -> (&'static str, u32) {
-    if section_offset == 0 && target_offset == 0 {
+    if target_offset == 0 {
         if bytes.starts_with(b"#!") {
-            // Shebang present, insert after the first line
+            // Shebang present, insert after the first line.
             let mut shebang_end = 0;
             for (i, &byte) in bytes.iter().enumerate() {
                 if byte == b'\n' {
@@ -136,29 +153,24 @@ fn get_section_insert_position(
             }
             return ("", shebang_end as u32);
         }
-        // Regular JS file without shebang, insert at start
-        ("", target_offset)
-    } else if target_offset == section_offset {
-        // Framework files - check for line breaks at section_offset
-        let current = bytes.get(section_offset as usize);
-        let next = bytes.get((section_offset + 1) as usize);
 
-        match (current, next) {
-            (Some(b'\n'), _) => {
-                // LF at offset, insert after it
-                ("", section_offset + 1)
-            }
-            (Some(b'\r'), Some(b'\n')) => {
-                // CRLF at offset, insert after both
-                ("", section_offset + 2)
-            }
-            _ => {
-                // Not at line start, prepend newline
-                ("\n", section_offset)
-            }
+        if section_offset == 0 {
+            // Full file starts at offset 0, insert before first byte with no extra newline.
+            return ("", 0);
         }
+
+        // Section starts at a line break, insert after it.
+        if bytes.first() == Some(&b'\n') {
+            return ("", 1);
+        }
+        if bytes.first() == Some(&b'\r') && bytes.get(1) == Some(&b'\n') {
+            return ("", 2);
+        }
+
+        // Section starts in the middle of a line, prepend a newline.
+        ("\n", 0)
     } else {
-        // Framework files where target_offset != section_offset (line was found)
+        // Insertion point was derived from a line start in the section slice.
         ("", target_offset)
     }
 }
@@ -362,19 +374,25 @@ mod tests {
     #[test]
     fn disable_for_section_after_lf() {
         let source = "<script>\nconsole.log('hello');";
-        let fix = super::disable_for_this_section("no-console", 8, source);
+        let section_offset = 8;
+        let section_source_text = &source[8..];
+        let fix =
+            super::disable_for_this_section("no-console", section_offset, section_source_text);
 
         assert_eq!(fix.content, "// oxlint-disable no-console\n");
-        assert_eq!(fix.span, Span::empty(9));
+        assert_eq!(fix.span, Span::empty(1));
     }
 
     #[test]
     fn disable_for_section_after_crlf() {
         let source = "<script>\r\nconsole.log('hello');";
-        let fix = super::disable_for_this_section("no-console", 8, source);
+        let section_offset = 8;
+        let section_source_text = &source[8..];
+        let fix =
+            super::disable_for_this_section("no-console", section_offset, section_source_text);
 
         assert_eq!(fix.content, "// oxlint-disable no-console\n");
-        assert_eq!(fix.span, Span::empty(10));
+        assert_eq!(fix.span, Span::empty(2));
     }
 
     #[test]
@@ -398,10 +416,13 @@ mod tests {
     #[test]
     fn disable_for_section_mid_line() {
         let source = "const x = 5;";
-        let fix = super::disable_for_this_section("no-unused-vars", 6, source);
+        let section_offset = 6;
+        let section_source_text = &source[6..];
+        let fix =
+            super::disable_for_this_section("no-unused-vars", section_offset, section_source_text);
 
         assert_eq!(fix.content, "\n// oxlint-disable no-unused-vars\n");
-        assert_eq!(fix.span, Span::empty(6));
+        assert_eq!(fix.span, Span::empty(0));
     }
 
     #[test]
@@ -409,30 +430,36 @@ mod tests {
         let source =
             "<template>\n  <div />\n</template>\n<script>\nconsole.log('hello');\n</script>";
         let section_offset = source.find("<script>").unwrap() as u32 + "<script>".len() as u32;
-        let fix = super::disable_for_this_section("no-console", section_offset, source);
+        let section_source_text = &source[section_offset as usize..];
+        let fix =
+            super::disable_for_this_section("no-console", section_offset, section_source_text);
 
         assert_eq!(fix.content, "// oxlint-disable no-console\n");
-        assert_eq!(fix.span, Span::empty(42));
+        assert_eq!(fix.span, Span::empty(1));
     }
 
     #[test]
     fn disable_for_section_vue_script_block_after_template_crlf() {
         let source = "<template>\r\n  <div />\r\n</template>\r\n<script>\r\nconsole.log('hello');\r\n</script>";
         let section_offset = source.find("<script>").unwrap() as u32 + "<script>".len() as u32;
-        let fix = super::disable_for_this_section("no-console", section_offset, source);
+        let section_source_text = &source[section_offset as usize..];
+        let fix =
+            super::disable_for_this_section("no-console", section_offset, section_source_text);
 
         assert_eq!(fix.content, "// oxlint-disable no-console\n");
-        assert_eq!(fix.span, Span::empty(46));
+        assert_eq!(fix.span, Span::empty(2));
     }
 
     #[test]
     fn disable_for_section_vue_script_setup_mid_line() {
         let source = "<template><div /></template>\n<script setup>const x = 1;\n</script>";
         let section_offset = source.find("const x").unwrap() as u32;
-        let fix = super::disable_for_this_section("no-unused-vars", section_offset, source);
+        let section_source_text = &source[section_offset as usize..];
+        let fix =
+            super::disable_for_this_section("no-unused-vars", section_offset, section_source_text);
 
         assert_eq!(fix.content, "\n// oxlint-disable no-unused-vars\n");
-        assert_eq!(fix.span, Span::empty(43));
+        assert_eq!(fix.span, Span::empty(0));
     }
 
     #[test]
@@ -442,11 +469,13 @@ mod tests {
             "<template>\n</template>\n<script>\n{existing}\nconsole.log('hello');\n</script>"
         );
         let section_offset = source.find(existing).unwrap() as u32;
+        let section_source_text = &source[section_offset as usize..];
 
-        let fix = super::disable_for_this_section("no-console", section_offset, &source);
+        let fix =
+            super::disable_for_this_section("no-console", section_offset, section_source_text);
 
         assert_eq!(fix.content, " no-console");
-        assert_eq!(fix.span, Span::empty(58));
+        assert_eq!(fix.span, Span::empty(26));
     }
 
     #[test]
@@ -566,10 +595,17 @@ mod tests {
         let source = "<script>\nconsole.log('hello');\n</script>";
         let section_offset = 8; // At the \n after "<script>"
         let error_offset = 17; // At 'console'
-        let fix = super::disable_for_this_line("no-console", error_offset, section_offset, source);
+        let section_source_text = &source[section_offset as usize..];
+        let error_offset_in_section = error_offset - section_offset;
+        let fix = super::disable_for_this_line(
+            "no-console",
+            error_offset_in_section,
+            section_offset,
+            section_source_text,
+        );
 
         assert_eq!(fix.content, "// oxlint-disable-next-line no-console\n");
-        assert_eq!(fix.span, Span::empty(9));
+        assert_eq!(fix.span, Span::empty(1));
     }
 
     #[test]
@@ -578,10 +614,17 @@ mod tests {
         let source = "<script>console.log('hello');\n</script>";
         let section_offset = 8; // After "<script>"
         let error_offset = 16; // At 'console'
-        let fix = super::disable_for_this_line("no-console", error_offset, section_offset, source);
+        let section_source_text = &source[section_offset as usize..];
+        let error_offset_in_section = error_offset - section_offset;
+        let fix = super::disable_for_this_line(
+            "no-console",
+            error_offset_in_section,
+            section_offset,
+            section_source_text,
+        );
 
         assert_eq!(fix.content, "\n// oxlint-disable-next-line no-console\n");
-        assert_eq!(fix.span, Span::empty(8));
+        assert_eq!(fix.span, Span::empty(0));
     }
 
     #[test]
@@ -590,10 +633,17 @@ mod tests {
         let source = "<template>\n</template>\n<script>\n  console.log('hello');\n</script>";
         let section_offset = 31; // At \n after "<script>"
         let error_offset = 36; // At 'console' (after "  ")
-        let fix = super::disable_for_this_line("no-console", error_offset, section_offset, source);
+        let section_source_text = &source[section_offset as usize..];
+        let error_offset_in_section = error_offset - section_offset;
+        let fix = super::disable_for_this_line(
+            "no-console",
+            error_offset_in_section,
+            section_offset,
+            section_source_text,
+        );
 
         assert_eq!(fix.content, "  // oxlint-disable-next-line no-console\n");
-        assert_eq!(fix.span, Span::empty(32));
+        assert_eq!(fix.span, Span::empty(1));
     }
 
     #[test]
@@ -602,10 +652,17 @@ mod tests {
         let source = "<script>\nconsole.log('hello');\n</script>";
         let section_offset = 8; // At the \n after "<script>"
         let error_offset = 8; // Error exactly at section offset
-        let fix = super::disable_for_this_line("no-console", error_offset, section_offset, source);
+        let section_source_text = &source[section_offset as usize..];
+        let error_offset_in_section = error_offset - section_offset;
+        let fix = super::disable_for_this_line(
+            "no-console",
+            error_offset_in_section,
+            section_offset,
+            section_source_text,
+        );
 
         assert_eq!(fix.content, "// oxlint-disable-next-line no-console\n");
-        assert_eq!(fix.span, Span::empty(9));
+        assert_eq!(fix.span, Span::empty(1));
     }
 
     #[test]
@@ -716,9 +773,11 @@ mod tests {
     fn disable_for_this_section_merges_with_existing_ignore_comment_above() {
         let existing = "// oxlint-disable no-alert";
         let source = format!("{existing}\nconsole.log('hello');");
-        let section_offset = source.find("console").unwrap() as u32;
+        let section_offset = source.find(existing).unwrap() as u32;
+        let section_source_text = &source[section_offset as usize..];
 
-        let fix = super::disable_for_this_section("no-console", section_offset, &source);
+        let fix =
+            super::disable_for_this_section("no-console", section_offset, section_source_text);
 
         assert_eq!(fix.content, " no-console");
         assert_eq!(fix.span, Span::empty(26));
@@ -728,9 +787,11 @@ mod tests {
     fn disable_for_this_section_merges_with_eslint_disable_comment_above() {
         let existing = "// eslint-disable no-alert";
         let source = format!("{existing}\nconsole.log('hello');");
-        let section_offset = source.find("console").unwrap() as u32;
+        let section_offset = source.find(existing).unwrap() as u32;
+        let section_source_text = &source[section_offset as usize..];
 
-        let fix = super::disable_for_this_section("no-console", section_offset, &source);
+        let fix =
+            super::disable_for_this_section("no-console", section_offset, section_source_text);
 
         assert_eq!(fix.content, " no-console");
         assert_eq!(fix.span, Span::empty(26));
@@ -760,8 +821,10 @@ mod tests {
     fn disable_for_this_section_does_not_merge_with_non_disable_comment_above() {
         let source = "// tslint:disable no-alert\nconsole.log('hello');";
         let section_offset = source.find("console").unwrap() as u32;
+        let section_source_text = &source[section_offset as usize..];
 
-        let fix = super::disable_for_this_section("no-console", section_offset, source);
+        let fix =
+            super::disable_for_this_section("no-console", section_offset, section_source_text);
 
         assert_eq!(fix.content, "\n// oxlint-disable no-console\n");
     }

--- a/crates/oxc_linter/src/fixer/fix.rs
+++ b/crates/oxc_linter/src/fixer/fix.rs
@@ -35,6 +35,11 @@ bitflags! {
         ///   rule category.
         const Dangerous = 1 << 2;
 
+        /// Mark a fix or suggestion as an "ignore this section / line" fix. These are
+        /// used to automatically add `// oxc-disable` comments to the source code.
+        /// Only used by `--lsp`.
+        const IgnoreFix = 1 << 3;
+
         const SafeFix = Self::Fix.bits();
         const SafeFixOrSuggestion = Self::Fix.bits() | Self::Suggestion.bits();
         const DangerousFix = Self::Dangerous.bits() | Self::Fix.bits();
@@ -384,6 +389,22 @@ impl PossibleFixes {
             PossibleFixes::Single(fix) => fix.span,
             PossibleFixes::Multiple(fixes) => {
                 fixes.iter().map(|fix| fix.span).reduce(Span::merge).unwrap_or(SPAN)
+            }
+        }
+    }
+
+    pub(crate) fn extend_fix(&mut self, fix: Vec<Fix>) {
+        match self {
+            PossibleFixes::None => {
+                *self = PossibleFixes::Multiple(fix);
+            }
+            PossibleFixes::Single(fix1) => {
+                let mut fixes = vec![std::mem::take(fix1)];
+                fixes.extend(fix);
+                *self = PossibleFixes::Multiple(fixes);
+            }
+            PossibleFixes::Multiple(fixes1) => {
+                fixes1.extend(fix);
             }
         }
     }

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -29,7 +29,6 @@ use crate::LintContext;
 
 mod disable_fix;
 mod fix;
-pub use disable_fix::{disable_for_this_line, disable_for_this_section};
 pub use fix::{CompositeFix, Fix, FixKind, MergeFixesError, PossibleFixes, RuleFix};
 
 /// Produces [`RuleFix`] instances. Inspired by ESLint's [`RuleFixer`].

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -81,10 +81,7 @@ pub use crate::{
         JsFix, LintFileResult, LoadPluginResult, convert_and_merge_js_fixes,
     },
     external_plugin_store::{ExternalOptionsId, ExternalPluginStore, ExternalRuleId},
-    fixer::{
-        Fix, FixKind, Fixer, Message, MessageRule, PossibleFixes, disable_for_this_line,
-        disable_for_this_section,
-    },
+    fixer::{Fix, FixKind, Fixer, Message, MessageRule, PossibleFixes},
     frameworks::FrameworkFlags,
     lint_runner::{DirectivesStore, LintRunner, LintRunnerBuilder},
     loader::LINTABLE_EXTENSIONS,

--- a/crates/oxc_linter/src/lint_runner.rs
+++ b/crates/oxc_linter/src/lint_runner.rs
@@ -145,6 +145,7 @@ pub struct LintRunnerBuilder {
     fix_kind: FixKind,
     type_check_only: bool,
     timings: bool,
+    with_ignore_fixes: bool,
 }
 
 impl LintRunnerBuilder {
@@ -158,6 +159,7 @@ impl LintRunnerBuilder {
             fix_kind: FixKind::None,
             type_check_only: false,
             timings: false,
+            with_ignore_fixes: false,
         }
     }
 
@@ -197,6 +199,12 @@ impl LintRunnerBuilder {
         self
     }
 
+    #[must_use]
+    pub fn with_ignore_fixes(mut self, with_ignore_fixes: bool) -> Self {
+        self.with_ignore_fixes = with_ignore_fixes;
+        self
+    }
+
     /// # Errors
     /// Returns an error if the type-aware linter fails to initialize.
     pub fn build(self) -> Result<LintRunner, String> {
@@ -212,7 +220,8 @@ impl LintRunnerBuilder {
                     state
                         .with_silent(self.silent)
                         .with_type_check(self.type_check)
-                        .with_timings(self.timings),
+                        .with_timings(self.timings)
+                        .with_ignore_fixes(self.with_ignore_fixes),
                 ),
                 Err(e) => return Err(e),
             }

--- a/crates/oxc_linter/src/options/mod.rs
+++ b/crates/oxc_linter/src/options/mod.rs
@@ -13,4 +13,6 @@ pub struct LintOptions {
     pub fix: FixKind,
     pub framework_hints: FrameworkFlags,
     pub report_unused_directive: Option<AllowWarnDeny>,
+    // If true, the linter will create "ignore this section / line" fixes for all diagnostics
+    pub with_ignore_fixes: bool,
 }

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -43,6 +43,8 @@ pub struct TsGoLintState {
     type_check: bool,
     /// If `true`, request that per-rule debug timings be returned from `tsgolint`.
     timings: bool,
+    /// If `true`, the linter will create "ignore this section / line" fixes for all diagnostics
+    with_ignore_fixes: bool,
 }
 
 impl TsGoLintState {
@@ -59,6 +61,7 @@ impl TsGoLintState {
             fix_suggestions: fix_kind.contains(FixKind::Suggestion),
             type_check: false,
             timings: false,
+            with_ignore_fixes: false,
         }
     }
 
@@ -82,6 +85,7 @@ impl TsGoLintState {
             fix_suggestions: fix_kind.contains(FixKind::Suggestion),
             type_check: false,
             timings: false,
+            with_ignore_fixes: false,
         })
     }
 
@@ -110,6 +114,12 @@ impl TsGoLintState {
     #[must_use]
     pub fn with_timings(mut self, yes: bool) -> Self {
         self.timings = yes;
+        self
+    }
+
+    #[must_use]
+    pub fn with_ignore_fixes(mut self, yes: bool) -> Self {
+        self.with_ignore_fixes = yes;
         self
     }
 
@@ -483,6 +493,10 @@ impl TsGoLintState {
                                     tsgolint_diagnostic,
                                     &source_text_owned,
                                 );
+
+                                if self.with_ignore_fixes {
+                                    message.add_ignore_fix(0, &source_text_owned);
+                                }
 
                                 message.error.severity = if severity == AllowWarnDeny::Deny {
                                     Severity::Error


### PR DESCRIPTION
This PR refactors the "ignore fixes" code, to be created on diagnostic creation. 
With an extra flag in `LintOptions` and `LintRunner`, the caller can include automatically the fix for ignoring the diagnostic.
This flag is only enabled on `oxlint --lsp` side and is not effected by normal CLI usage.

Important changes:
- The "fixes" are working now with `Spans` instead of `Position`
- The calculation of the right span is not depending on the partial source text, instead of the full source text
- new `FixKind` for the `ignore` fixes.

Generated by GPT-5.3-Codex 🤖 Reviewed by myself