### PR TITLE
perf(linter): avoid `Vec` allocations via `bound_names`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
@@ -4,6 +4,7 @@ use oxc_ast::{
     ast::{BindingPattern, VariableDeclarationKind},
 };
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_ecmascript::BoundNames;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::Scoping;
 use oxc_span::{GetSpan, Span};
@@ -200,10 +201,10 @@ fn run_for_all_redeclarations(
 
 fn run_for_declaration(pattern: &BindingPattern, node_scope_id: ScopeId, ctx: &LintContext) {
     // e.g. "var [a, b] = [1, 2]"
-    for ident in pattern.get_binding_identifiers() {
+    pattern.bound_names(&mut |ident| {
         let name = ident.name;
         let Some(symbol) = ctx.scoping().find_binding(node_scope_id, name) else {
-            continue;
+            return;
         };
 
         let binding = (pattern, name, &symbol);
@@ -215,7 +216,7 @@ fn run_for_declaration(pattern: &BindingPattern, node_scope_id: ScopeId, ctx: &L
 
         // e.g. "var a = 4; console.log(a);"
         run_for_all_references(binding, node_scope_id, ctx);
-    }
+    });
 }
 
 /// Returns true if the reference is outside the declaration scope

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -1,5 +1,6 @@
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_ecmascript::BoundNames;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNode;
 use oxc_span::Span;
@@ -61,9 +62,8 @@ impl Rule for NoExAssign {
             return;
         };
 
-        let idents = catch_param.pattern.get_binding_identifiers();
         let symbol_table = ctx.scoping();
-        for ident in idents {
+        catch_param.pattern.bound_names(&mut |ident| {
             let symbol_id = ident.symbol_id();
             // This symbol _should_ always be considered a catch variable (since we got it from a catch param),
             // but we check in debug mode just to be sure.
@@ -75,7 +75,7 @@ impl Rule for NoExAssign {
                     ));
                 }
             }
-        }
+        });
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_param_reassign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_param_reassign.rs
@@ -4,6 +4,7 @@ use schemars::JsonSchema;
 
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_ecmascript::BoundNames;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{AstNode, NodeId};
 use oxc_span::Span;
@@ -122,7 +123,7 @@ impl Rule for NoParamReassign {
         };
 
         let symbol_table = ctx.scoping();
-        for ident in param.pattern.get_binding_identifiers() {
+        param.pattern.bound_names(&mut |ident| {
             let symbol_id = ident.symbol_id();
 
             let declaration_id = symbol_table.symbol_declaration(symbol_id);
@@ -154,7 +155,7 @@ impl Rule for NoParamReassign {
                     ctx.diagnostic(assignment_to_param_property_diagnostic(name, span));
                 }
             }
-        }
+        });
     }
 }
 

--- a/crates/oxc_linter/src/rules/oxc/branches_sharing_code.rs
+++ b/crates/oxc_linter/src/rules/oxc/branches_sharing_code.rs
@@ -5,6 +5,7 @@ use oxc_ast::{
 };
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_ecmascript::BoundNames;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{ReferenceId, SymbolId};
 use oxc_span::{ContentEq, GetSpan, Span};
@@ -263,7 +264,9 @@ fn collect_lexical_declaration_symbols(stmt: &Statement, symbols: &mut FxHashSet
     if let Statement::VariableDeclaration(decl) = stmt
         && decl.kind.is_lexical()
     {
-        symbols.extend(decl.declarations.iter().flat_map(|decl| decl.id.get_symbol_ids()));
+        decl.bound_names(&mut |ident| {
+            symbols.insert(ident.symbol_id());
+        });
     }
 }
 


### PR DESCRIPTION
AI disclosure: Generated with Claude Code and reviewed by me. This is the same change as #24953, but for a few other rules. Two of the rules are definitely worth making the change on, the other two barely move things, and I'd be fine to remove them from this PR if we don't think it's worth the change.

`BindingPattern::get_binding_identifiers` and `get_symbol_ids` each allocate a `std::Vec` through the global allocator (not the arena) on every call. Four rules only iterated that result once, so the `Vec` was pure overhead. `oxc_ecmascript::BoundNames` already performs the same recursive traversal through a callback with no allocation.

`branches_sharing_code` collapses a little further: `VariableDeclaration` implements `BoundNames` itself, so the manual declarator iteration goes away too.

## Allocations

vscode `src` (7325 files), release build, single-threaded, counting every global allocation. Arena bump allocations never reach the global allocator, so AST nodes are excluded and what remains is malloc traffic. Each rule is isolated with `-A all -D <rule>`, with an all-rules-off baseline (1,686,744) subtracted.

| rule                    | category    |   before |   after | delta                 |    bytes |
| ----------------------- | ----------- | -------: | ------: | --------------------- | -------: |
| `no-param-reassign`     | restriction |  381,168 | 200,663 | **-180,505 (-47.4%)** | -5.78 MB |
| `no-ex-assign`          | correctness |    4,067 |   1,340 | **-2,727 (-67.1%)**   | -87.2 KB |
| `block-scoped-var`      | suspicious  |    6,886 |   6,692 | -194 (-2.8%)          | -6.19 KB |
| `branches-sharing-code` | pedantic    |  179,962 | 179,854 | -108 (-0.1%)          | -1.72 KB |
| **total**               |             |          |         | **-183,534**          | -5.87 MB |

**`no-ex-assign` is the only `correctness` rule here**, so a full default lint run improves by only **-2,727 allocations (-0.109%)**. The large number belongs to `no-param-reassign`, which is `restriction` and off unless configured — this is a win for people who enable these rules, not a default-path speedup.

Two independent checks on the numbers:

- The four isolated deltas sum to -183,534, and measuring all four enabled together also gives -183,534.
- `no-ex-assign` is the only default-on rule of the four, so the full default run's delta should equal its isolated delta alone. Both are -2,727.

Bytes per saved allocation comes out at **32.00** for the three rules that used `get_binding_identifiers` (a `Vec` of 8-byte references, initial capacity 4) and **15.96** for `branches-sharing-code`, which used `get_symbol_ids` (a `Vec` of 4-byte `SymbolId`, capacity 4). The removed allocation matches the size each type implies.

`no-param-reassign` drops 47% rather than ~96% because it also allocates an `FxHashSet<NodeId>` per binding identifier for reference dedup; that accounts for most of the remaining 200,663. Reusing that set across identifiers looks like a bigger win, but it changes the dedup scope rather than being a mechanical swap, so it is left for separate work.

Wall-clock effect was below this machine's noise floor and is not claimed.

## Correctness

Output is byte-identical between binaries across 13 configurations — each rule alone, all four together, `no-param-reassign` with `props: true`, `-W all`, and the default config — on both the vscode corpus and a purpose-built stress file that puts a destructuring pattern in every catch parameter, function parameter, `var` declaration, and shared `if`/`else` lexical declaration (nested rest, elisions, defaults, triple nesting, and 8-binding patterns to grow past the old `Vec`'s inline capacity). Every configuration produced a non-zero diagnostic count, so none of the comparisons were vacuous.

`block-scoped-var` is the only conversion with control flow in the converted loop; its `continue` became a `return` from the callback, which is the equivalent early-exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
