### PR TITLE
perf(linter/import/no-cycle): reduce allocations

### DIFF
--- a/crates/oxc_linter/src/module_graph_visitor.rs
+++ b/crates/oxc_linter/src/module_graph_visitor.rs
@@ -1,6 +1,5 @@
 use std::{
     marker::PhantomData,
-    path::PathBuf,
     sync::{Arc, Weak},
 };
 
@@ -100,6 +99,9 @@ impl<'a, T> ModuleGraphVisitorBuilder<'a, T> {
     ) -> ModuleGraphVisitResult<T> {
         let mut visitor = ModuleGraphVisitor {
             traversed: FxHashSet::default(),
+            #[cfg(debug_assertions)]
+            traversed_paths: FxHashSet::default(),
+            scratch: Vec::new(),
             depth: 0,
             max_depth: self.max_depth,
         };
@@ -129,7 +131,7 @@ impl<T> Default for ModuleGraphVisitorBuilder<'_, T> {
 
 pub struct ModuleGraphVisitResult<T> {
     pub result: T,
-    pub _traversed: FxHashSet<PathBuf>,
+    pub _traversed: FxHashSet<usize>,
     pub _max_depth: u32,
 }
 
@@ -141,7 +143,24 @@ impl<T> ModuleGraphVisitResult<T> {
 
 #[derive(Debug)]
 struct ModuleGraphVisitor {
-    traversed: FxHashSet<PathBuf>,
+    /// Modules already visited, keyed on `Arc` pointer identity.
+    ///
+    /// This is equivalent to keying on `resolved_absolute_path`, but costs no allocation. Linking
+    /// resolves every `loaded_modules` edge to `modules_by_path[path].last()` (see `Runtime::run`),
+    /// so every record reachable through the graph is the single record for its path. Keying on
+    /// the path instead would clone a `PathBuf` for every node visited, which dominated this
+    /// walk's allocation count.
+    ///
+    /// `traversed_paths` re-checks that invariant in debug builds.
+    traversed: FxHashSet<usize>,
+    /// Debug-only mirror of [`Self::traversed`] keyed on the resolved path, so a future change to
+    /// how `loaded_modules` edges are linked cannot silently make pointer identity disagree with
+    /// path identity.
+    #[cfg(debug_assertions)]
+    traversed_paths: FxHashSet<std::path::PathBuf>,
+    /// Scratch stack reused for every node's child list, so the depth-first walk allocates a
+    /// single buffer instead of one `Vec` per visited node.
+    scratch: Vec<(CompactStr, Weak<ModuleRecord>)>,
     depth: u32,
     max_depth: u32,
 }
@@ -198,17 +217,29 @@ impl ModuleGraphVisitor {
         // which causes non-deterministic insertion order into FxHashMap.
         // Different iteration orders can cause cycle detection to find or miss cycles
         // depending on which path reaches a node first (due to the `traversed` set).
-        let mut entries: Vec<_> = module_record
-            .loaded_modules()
-            .iter()
-            .map(|(k, v)| (k.clone(), Weak::clone(v)))
-            .collect();
-        entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        //
+        // The child list is staged on a scratch stack shared by the whole walk: this frame owns
+        // `scratch[start..end]`, deeper frames push and truncate above `end`, and this frame
+        // truncates back to `start` on the way out.
+        let start = self.scratch.len();
+        self.scratch.extend(
+            module_record.loaded_modules().iter().map(|(k, v)| (k.clone(), Weak::clone(v))),
+        );
+        self.scratch[start..].sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        let end = self.scratch.len();
 
-        for (key, weak_module_record) in entries {
+        for index in start..end {
             if self.depth > self.max_depth {
+                self.scratch.truncate(start);
                 return VisitFoldWhile::Stop(accumulator.into_inner());
             }
+
+            // Move the entry out rather than cloning it — the scratch slot is not read again,
+            // and the recursive call below needs `self.scratch` borrowed mutably.
+            let (key, weak_module_record) = std::mem::replace(
+                &mut self.scratch[index],
+                (CompactStr::new_const(""), Weak::new()),
+            );
 
             let loaded_module_record = weak_module_record.upgrade().unwrap();
 
@@ -218,8 +249,24 @@ impl ModuleGraphVisitor {
                 continue;
             }
 
-            let path = &loaded_module_record.resolved_absolute_path;
-            if !self.traversed.insert(path.clone()) {
+            let is_new = self.traversed.insert(Arc::as_ptr(&loaded_module_record) as usize);
+
+            #[cfg(debug_assertions)]
+            {
+                let is_new_path = self
+                    .traversed_paths
+                    .insert(loaded_module_record.resolved_absolute_path.clone());
+                debug_assert_eq!(
+                    is_new,
+                    is_new_path,
+                    "`ModuleGraphVisitor` keys `traversed` on `Arc` pointer identity, which assumes \
+                     one `ModuleRecord` per resolved path in the linked graph. That no longer holds \
+                     for {} — key `traversed` on the path instead.",
+                    loaded_module_record.resolved_absolute_path.display(),
+                );
+            }
+
+            if !is_new {
                 continue;
             }
 
@@ -244,6 +291,8 @@ impl ModuleGraphVisitor {
 
             self.depth -= 1;
         }
+
+        self.scratch.truncate(start);
 
         accumulator
     }

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::OsStr,
-    path::{Component, Path, PathBuf},
+    path::{Component, Path},
     sync::Arc,
 };
 
@@ -19,7 +19,11 @@ use crate::{
     rule::{DefaultRuleConfig, Rule},
 };
 
-fn no_cycle_diagnostic(span: Span, stack: &[(CompactStr, PathBuf)], cwd: &Path) -> OxcDiagnostic {
+fn no_cycle_diagnostic(
+    span: Span,
+    stack: &[(CompactStr, Arc<ModuleRecord>)],
+    cwd: &Path,
+) -> OxcDiagnostic {
     let cycle_description = format_cycle(stack, cwd);
     OxcDiagnostic::warn("Dependency cycle detected")
         .with_help("Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.")
@@ -37,13 +41,14 @@ fn self_referencing_cycle_diagnostic(span: Span, is_import: bool) -> OxcDiagnost
         .with_label(span.primary_label("this module references itself"))
 }
 
-fn format_cycle(stack: &[(CompactStr, PathBuf)], cwd: &Path) -> String {
+fn format_cycle(stack: &[(CompactStr, Arc<ModuleRecord>)], cwd: &Path) -> String {
     let mut lines = Vec::with_capacity(stack.len() * 2 + 1);
 
-    for (i, (specifier, path)) in stack.iter().enumerate() {
-        let relative_path = path
+    for (i, (specifier, module)) in stack.iter().enumerate() {
+        let relative_path = module
+            .resolved_absolute_path
             .strip_prefix(cwd)
-            .unwrap_or(path)
+            .unwrap_or(&module.resolved_absolute_path)
             .to_string_lossy()
             .cow_replace('\\', "/")
             .into_owned();
@@ -145,6 +150,7 @@ impl Rule for NoCycle {
 
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
+        let cwd = std::env::current_dir().unwrap();
 
         let needle = &module_record.resolved_absolute_path;
         let mut direct_imports = module_record
@@ -161,8 +167,7 @@ impl Rule for NoCycle {
 
             let requested_module = module_record.requested_modules[&key][0];
             let span = requested_module.span;
-            let mut stack =
-                vec![(key.clone(), loaded_module_record.resolved_absolute_path.clone())];
+            let mut stack = vec![(key.clone(), Arc::clone(&loaded_module_record))];
 
             if loaded_module_record.resolved_absolute_path == *needle {
                 ctx.diagnostic(self_referencing_cycle_diagnostic(span, requested_module.is_import));
@@ -174,7 +179,7 @@ impl Rule for NoCycle {
                 .filter(|(key, val), parent| self.should_traverse_module(key, val, parent))
                 .event(|event, (key, val), _| match event {
                     ModuleGraphVisitorEvent::Enter => {
-                        stack.push((key.clone(), val.resolved_absolute_path.clone()));
+                        stack.push((key.clone(), Arc::clone(val)));
                     }
                     ModuleGraphVisitorEvent::Leave => {
                         stack.pop();
@@ -189,11 +194,7 @@ impl Rule for NoCycle {
                 });
 
             if visitor_result.result {
-                ctx.diagnostic(no_cycle_diagnostic(
-                    span,
-                    &stack,
-                    &std::env::current_dir().unwrap(),
-                ));
+                ctx.diagnostic(no_cycle_diagnostic(span, &stack, &cwd));
             }
         }
     }
@@ -217,27 +218,37 @@ impl NoCycle {
         }
 
         if self.ignore_types {
-            let import_entries = parent
-                .import_entries
-                .iter()
-                .filter(|entry| entry.module_request.name() == key)
-                .collect::<Vec<_>>();
+            // Equivalent to collecting both entry lists and testing `!is_empty() && all(is_type)`,
+            // without materializing either `Vec`. This runs once per graph edge considered.
+            let mut has_entry = false;
+            let mut all_types = true;
 
-            let indirect_export_entries = parent
-                .indirect_export_entries
-                .iter()
-                .filter(|entry| {
+            for entry in
+                parent.import_entries.iter().filter(|entry| entry.module_request.name() == key)
+            {
+                has_entry = true;
+                if !entry.is_type {
+                    all_types = false;
+                    break;
+                }
+            }
+
+            if all_types {
+                for entry in parent.indirect_export_entries.iter().filter(|entry| {
                     entry
                         .module_request
                         .as_ref()
                         .is_some_and(|module_request| module_request.name() == key)
-                })
-                .collect::<Vec<_>>();
+                }) {
+                    has_entry = true;
+                    if !entry.is_type {
+                        all_types = false;
+                        break;
+                    }
+                }
+            }
 
-            if (!import_entries.is_empty() || !indirect_export_entries.is_empty())
-                && import_entries.iter().all(|entry| entry.is_type)
-                && indirect_export_entries.iter().all(|entry| entry.is_type)
-            {
+            if has_entry && all_types {
                 return false;
             }
         }

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -1,7 +1,7 @@
 use std::{
     ffi::OsStr,
-    path::{Component, Path},
-    sync::Arc,
+    path::{Component, Path, PathBuf},
+    sync::{Arc, LazyLock},
 };
 
 use cow_utils::CowUtils;
@@ -18,6 +18,14 @@ use crate::{
     module_graph_visitor::{ModuleGraphVisitorBuilder, ModuleGraphVisitorEvent, VisitFoldWhile},
     rule::{DefaultRuleConfig, Rule},
 };
+
+/// The working directory, used to relativize the paths in a cycle description.
+///
+/// `std::env::current_dir` is a `getcwd` syscall, which is not cheap (on macOS it reconstructs the
+/// path by walking up the vnode chain). The working directory does not change during a lint run, so
+/// resolve it once for the process, and only on the first `no-cycle` diagnostic — a run that reports
+/// no cycles never pays for it, and never panics if the directory is unreadable.
+static CWD: LazyLock<PathBuf> = LazyLock::new(|| std::env::current_dir().unwrap());
 
 fn no_cycle_diagnostic(
     span: Span,
@@ -150,7 +158,6 @@ impl Rule for NoCycle {
 
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
-        let cwd = std::env::current_dir().unwrap();
 
         let needle = &module_record.resolved_absolute_path;
         let mut direct_imports = module_record
@@ -194,7 +201,7 @@ impl Rule for NoCycle {
                 });
 
             if visitor_result.result {
-                ctx.diagnostic(no_cycle_diagnostic(span, &stack, &cwd));
+                ctx.diagnostic(no_cycle_diagnostic(span, &stack, &CWD));
             }
         }
     }


### PR DESCRIPTION
> [!WARNING]
> **This is a PROOF OF CONCEPT, not a merge-ready change.**
>
> It is opened as a draft to get people smarter than me to confirm whether this change makes sense and whether there are downsides to this improvement. The `traversed` change in particular relies on an invariant that needs confirmation (see *Open questions*). Please review the approach and whether this PR makes sense.

AI Disclosure: This was generated using Claude Code w/ Opus 5. I have reviewed it to the best of my ability and confirmed to the best of my ability that it does not break anything (at least not obviously) in the vscode codebase. But it probably needs further testing. If we want to close this PR and have someone else push this change forward, that'd be fine by me.

## What this shows

`import/no-cycle` walks the module graph once per direct import of every linted file, and nearly
every node and edge of that walk allocates. On the vscode codebase (`src`, 7,368 files) the rule
accounts for **330M of oxlint's 383M heap allocations** and ~86% of total rule time when it is
enabled.

Removing four hot-path allocations cuts that substantially.

## Changes

- **`should_traverse_module`** collected two `Vec`s per graph *edge*, only to test `is_empty()` and
  `all(is_type)`. Now iterates with an early break.
- **Visitor child list** allocated a fresh `Vec` per visited node. Now staged on one scratch stack
  shared by the whole walk; each frame owns `scratch[start..end]` and truncates on the way out.
  Entries are moved out with `mem::replace` rather than cloned.
- **`traversed` set** cloned a `PathBuf` per visited node. Now keyed on `Arc` pointer identity.
- **Cycle stack** cloned a `PathBuf` per node entered. Now holds an `Arc<ModuleRecord>`.
- `std::env::current_dir()` is resolved once per file rather than once per emitted diagnostic.

## Measurements

vscode `src`, 7,368 files, all 785 non-type-aware rules enabled, release build with `mimalloc`:

| metric      | before | after  | delta      |
| ----------- | ------ | ------ | ---------- |
| allocations | 383.4M | 134.1M | **-65.0%** |
| bytes       | 29.0GB | 12.5GB | -57.0%     |
| wall clock  | 3635ms | 2719ms | **-25.2%** |
| CPU time    | 56.8s  | 42.5s  | -25.2%     |

With only `import/no-cycle` enabled, allocations go from 332.6M to 83.4M (**-74.9%**).

Wall clock and CPU are paired interleaved measurements (alternating binary order to cancel thermal
drift), n=20, t=30.9 and t=71.3, patched build faster in 20/20 runs. These are measured from the
exact commit on this branch, not from a prototype. Allocation counts come from a
counting global allocator, 2-3 reps, run-to-run spread <0.001%.

## Correctness so far

- The 1,566 `no-cycle` diagnostics on vscode are byte-identical before and after when sorted.
- A full 785-rule run reports the same 1,252,020 warnings and 16 errors.
- All 41 `import::*` and `oxc/no_barrel_file` unit tests pass. Clippy is clean.

## Open questions

1. **Is the `Arc` pointer key acceptable?** It is equivalent to keying on the path only because
   linking resolves every `loaded_modules` edge to `modules_by_path[path].last()`. That is true
   today, but it is implicit, and it sits next to a `TODO: revise how to store multiple sections in
   loaded_modules`. I added a `debug_assert` that re-checks pointer identity against path identity,
   but interning paths to a `u32` id would remove the coupling entirely. Preference?

2. **`Arc<PathBuf>` was tried and is worse.** Changing `resolved_absolute_path` to `Arc<PathBuf>`
   reaches the same allocation count with exact path semantics, but benchmarks *slower than the
   unpatched baseline* (3027ms vs 2893ms) — cloning an `Arc` shared across 18 rayon threads turns a
   malloc into a contended atomic increment. Recording this so nobody repeats it.

3. **The algorithmic cost is untouched.** `no-cycle` is still O(files x graph size), with a fresh
   `traversed` set per direct import. The remaining 83M allocations are mostly `CompactStr`
   specifier clones in the scratch `extend`. Making `loaded_modules` a pre-sorted immutable list
   after graph construction would let the walk borrow instead of clone, and is probably the larger
   remaining win. Worth pursuing?

## Not done

- Only benchmarked on vscode. A repo with a shallower import graph will show less.
- No new tests locking in the behaviour; existing coverage is what passed.