### PR TITLE
perf(linter/import/no-cycle): skip the graph walk for acyclic modules

### DIFF
--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -9,6 +9,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_str::CompactStr;
+use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -159,6 +160,17 @@ impl Rule for NoCycle {
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
 
+        // Almost every module in a real codebase is in no cycle at all, and answering that for the
+        // whole module costs one traversal instead of one per direct import. See `can_be_in_cycle`.
+        //
+        // Only worth it when `max_depth` is unbounded, which is the default: the per-import walks
+        // then explore the whole reachable subgraph anyway, so the prefilter replaces work rather
+        // than adding to it. With a small `max_depth` the walks are shallow and an unbounded
+        // prefilter could cost more than it saves.
+        if self.max_depth == u32::MAX && !self.can_be_in_cycle(module_record) {
+            return;
+        }
+
         let needle = &module_record.resolved_absolute_path;
         let mut direct_imports = module_record
             .loaded_modules()
@@ -208,6 +220,62 @@ impl Rule for NoCycle {
 }
 
 impl NoCycle {
+    /// Can `root` be part of a dependency cycle at all?
+    ///
+    /// `run_once` runs one full graph walk per direct import, and on real codebases nearly every
+    /// one of those walks explores `root`'s entire reachable subgraph only to conclude "no cycle".
+    /// But `root` is in a cycle if and only if *some* module reachable from it imports it back, so
+    /// a single traversal of that subgraph answers the question for every direct import at once.
+    /// Where the walks visit the union of their subgraphs once per import, this visits it once.
+    ///
+    /// Returning `true` only gates the existing walks, which still decide what is reported and
+    /// reconstruct the path for the diagnostic. So this must never return `false` when a walk would
+    /// have found a cycle, and it doesn't: it traverses the same edges under the same filter, and
+    /// is unbounded where the walks are bounded by `max_depth`.
+    fn can_be_in_cycle(&self, root: &ModuleRecord) -> bool {
+        // Keyed on `Arc` pointer identity, like `ModuleGraphVisitor::traversed`, to avoid cloning a
+        // `PathBuf` per node. `root` is deliberately absent: an edge back to it is the answer, not
+        // a node to expand.
+        let mut visited = FxHashSet::<usize>::default();
+        let mut stack = Vec::<Arc<ModuleRecord>>::new();
+
+        if self.visit_dependencies(root, root, &mut visited, &mut stack) {
+            return true;
+        }
+        while let Some(module_record) = stack.pop() {
+            if self.visit_dependencies(&module_record, root, &mut visited, &mut stack) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Push `module_record`'s not-yet-visited traversable dependencies onto `stack`, returning
+    /// `true` if any of them is `root` itself — i.e. if this module closes a cycle back to `root`.
+    fn visit_dependencies(
+        &self,
+        module_record: &ModuleRecord,
+        root: &ModuleRecord,
+        visited: &mut FxHashSet<usize>,
+        stack: &mut Vec<Arc<ModuleRecord>>,
+    ) -> bool {
+        for (specifier, weak_module_record) in module_record.loaded_modules().iter() {
+            let loaded_module_record = weak_module_record.upgrade().unwrap();
+            if !self.should_traverse_module(specifier, &loaded_module_record, module_record) {
+                continue;
+            }
+            // Compared by path, not pointer, because that is what the walks report a cycle on:
+            // a file split into multiple sections has one record per section but one path.
+            if loaded_module_record.resolved_absolute_path == root.resolved_absolute_path {
+                return true;
+            }
+            if visited.insert(Arc::as_ptr(&loaded_module_record) as usize) {
+                stack.push(loaded_module_record);
+            }
+        }
+        false
+    }
+
     fn should_traverse_module(
         &self,
         key: &CompactStr,


### PR DESCRIPTION
Stacked on #24961 — this PR targets `perf/no-cycle-allocations`, so it shows only the one commit on top. Review #24961 first.

Where #24961 makes each graph walk cheaper, this one stops running almost all of them.

## What

`run_once` walks the module graph once per direct import, and each walk explores the module's whole reachable subgraph before concluding "no cycle". On `vscode/src` that is ~81k walks producing 1,566 diagnostics, so over 98% of them are pure overhead.

A module is in a cycle **if and only if** some module reachable from it imports it back. So one traversal of that subgraph answers the question for every direct import at once. When it says no, skip all the walks.

## Why it can't change what's reported

The prefilter only gates the walks — they still decide what is reported and reconstruct the cycle path for the diagnostic. It cannot skip a cycle a walk would have found:

- it traverses the same edges under the same `should_traverse_module` filter;
- it is unbounded where the walks are bounded by `max_depth`, so its reachable set is a strict superset;
- it compares by resolved path, not `Arc` identity, matching what the walks report a cycle on — a file split into multiple sections has one record per section but one path.

It runs only under the default unbounded `max_depth`, where the walks cover the whole subgraph anyway and the prefilter replaces work rather than adding to it. With a small `max_depth` the walks are shallow enough that an unbounded prefilter could cost more than it saves, so behaviour there is exactly as before.

## Measurements

`vscode/src` (7,327 files, ~81k direct imports), `import/no-cycle` as the only enabled rule, paired interleaved runs with order alternation, n=15.

### vs. the base branch (`perf/no-cycle-allocations`, this PR's diff alone)

| | wall clock | rule allocations | rule bytes |
| --- | --- | --- | --- |
| before | 2242.1 ms | 81.7M | 5.85 GB |
| after | 946.1 ms | 15.3M | 2.03 GB |
| | **−1296.1 ms (−58%)** | **−81%** | **−65%** |

Paired delta sd 24.1, t = +208, faster in 15/15 rounds.

### vs. `main` (the whole stack)

| | wall clock | rule allocations | rule bytes |
| --- | --- | --- | --- |
| `main` | 3330.5 ms | 331.0M | 22.46 GB |
| this PR | 966.3 ms | 15.3M | 2.02 GB |
| | **−2364.2 ms (−71%)** | **−95.4% (21.7×)** | **−91.0% (11.1×)** |

Paired delta sd 97.3, t = +94.1, faster in 15/15 rounds. Subtracting the parse-only baseline, rule-attributable time goes 3182 ms → 818 ms, **3.9× faster**.

In both cases a parse-only control run (same binaries, no rules) is flat — +0.3 ms, t = +0.29 vs `main` — so the delta is attributable to the rule and not to the harness. Allocation figures are likewise rule-attributable: total minus a parse-only run on the same binary, counted with a global allocator shim. The parse-only baselines across separately-built binaries agree to within 0.04%, which is what makes that subtraction meaningful.

## Correctness

- 1,566 diagnostics on `main`, 1,566 on this branch, **byte-identical** after sorting by `(filename, labels, message, code)`.
- Full `oxc_linter` test suite passes with no snapshot changes; `cargo clippy --all-features -D warnings` clean.

## What's left

The remaining 15.3M allocations are concentrated in the minority of files that genuinely sit in a cycle — those are exactly the ones in the large SCC, with the biggest reachable closures, and they still run the full walks. Freezing `loaded_modules` into a pre-sorted immutable slice after linking would remove the per-edge `CompactStr` clone and the per-node sort for those, but it touches `ModuleRecord`'s shape and the runtime's linking phase, so it belongs in a separate PR.

---

AI disclosure: this change was written with Claude Code. I reviewed the implementation, the soundness argument, and ran the benchmarks and parity checks myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
