### PR TITLE
feat(oxfmt/lsp): support `oxc.fmt.disableNestedConfig`

### DIFF
--- a/apps/oxfmt/src/lsp/options.rs
+++ b/apps/oxfmt/src/lsp/options.rs
@@ -5,6 +5,21 @@ use serde_json::Value;
 #[serde(rename_all = "camelCase")]
 pub struct FormatOptions {
     pub config_path: Option<String>,
+    pub disable_nested_config: bool,
+}
+
+impl FormatOptions {
+    /// `fmt.configPath` with the empty string treated as unset.
+    pub fn explicit_config_path(&self) -> Option<&str> {
+        self.config_path.as_deref().filter(|s| !s.is_empty())
+    }
+
+    /// Whether to search for nested config files per file.
+    /// An explicit `fmt.configPath` takes absolute precedence,
+    /// and `fmt.disableNestedConfig` opts out explicitly.
+    pub fn use_nested_configs(&self) -> bool {
+        !self.disable_nested_config && self.explicit_config_path().is_none()
+    }
 }
 
 impl<'de> Deserialize<'de> for FormatOptions {
@@ -32,6 +47,10 @@ impl TryFrom<Value> for FormatOptions {
 
         Ok(Self {
             config_path: object.get("fmt.configPath").and_then(Value::as_str).map(str::to_owned),
+            disable_nested_config: object
+                .get("fmt.disableNestedConfig")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
         })
     }
 }
@@ -45,11 +64,13 @@ mod test {
     #[test]
     fn test_valid_options_json() {
         let json = json!({
-            "fmt.configPath": "./.oxfmtrc.json"
+            "fmt.configPath": "./.oxfmtrc.json",
+            "fmt.disableNestedConfig": true
         });
 
         let options = FormatOptions::try_from(json).unwrap();
         assert_eq!(options.config_path.unwrap(), "./.oxfmtrc.json");
+        assert!(options.disable_nested_config);
     }
 
     #[test]
@@ -58,6 +79,7 @@ mod test {
 
         let options = FormatOptions::try_from(json).unwrap();
         assert!(options.config_path.is_none());
+        assert!(!options.disable_nested_config);
     }
 
     #[test]
@@ -70,11 +92,13 @@ mod test {
     #[test]
     fn test_invalid_options_json() {
         let json = json!({
-            "fmt.configPath": true // should be a string
+            "fmt.configPath": true, // should be a string
+            "fmt.disableNestedConfig": "true" // should be a boolean
         });
 
         let options = FormatOptions::try_from(json).unwrap();
         assert!(options.config_path.is_none());
+        assert!(!options.disable_nested_config);
     }
 
     #[test]
@@ -85,5 +109,23 @@ mod test {
 
         let options = FormatOptions::try_from(json).unwrap();
         assert_eq!(options.config_path, Some(String::new()));
+        assert!(options.explicit_config_path().is_none());
+    }
+
+    #[test]
+    fn test_use_nested_configs() {
+        let options = FormatOptions::default();
+        assert!(options.use_nested_configs());
+
+        let options =
+            FormatOptions { config_path: Some("config.json".into()), ..Default::default() };
+        assert!(!options.use_nested_configs());
+
+        let options = FormatOptions { disable_nested_config: true, ..Default::default() };
+        assert!(!options.use_nested_configs());
+
+        // Empty `fmt.configPath` is treated as unset
+        let options = FormatOptions { config_path: Some(String::new()), ..Default::default() };
+        assert!(options.use_nested_configs());
     }
 }

--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -61,7 +61,8 @@ impl ServerFormatterBuilder {
         };
 
         // If `configPath` is explicitly set, load it eagerly as the single config for all files.
-        let explicit_config_path = options.config_path.filter(|s| !s.is_empty()).map(PathBuf::from);
+        let use_nested_config = options.use_nested_configs();
+        let explicit_config_path = options.explicit_config_path().map(PathBuf::from);
 
         let num_of_threads = 1; // Single threaded for LSP
         // Use `block_in_place()` to avoid nested async runtime access
@@ -79,6 +80,7 @@ impl ServerFormatterBuilder {
             JsConfigLoaderCb::clone(&self.js_config_loader),
             prettierignore_glob,
             explicit_config_path,
+            use_nested_config,
         )
     }
 }
@@ -134,9 +136,12 @@ pub struct ServerFormatter {
     js_config_loader: JsConfigLoaderCb,
     /// `.prettierignore` glob (workspace-level, shared across all scopes).
     prettierignore_glob: Option<Gitignore>,
-    /// Explicit `fmt.configPath` from LSP settings. When set, disables nested
-    /// config discovery; all files use this single config.
+    /// Explicit `fmt.configPath` from LSP settings.
+    /// When set, all files use this single config.
     explicit_config_path: Option<PathBuf>,
+    /// Whether nested config discovery is active.
+    /// Disabled by an explicit `fmt.configPath` or `fmt.disableNestedConfig` in LSP settings.
+    use_nested_config: bool,
     /// Current config snapshot. Swapped wholesale on watched-file changes.
     state: RwLock<Arc<FormatterState>>,
 }
@@ -167,17 +172,18 @@ impl Tool for ServerFormatter {
     fn get_watcher_patterns(&self, options: serde_json::Value) -> Vec<Pattern> {
         let options = deserialize_lsp_options(options);
 
-        let mut patterns: Vec<Pattern> =
-            if let Some(config_path) = options.config_path.as_ref().filter(|s| !s.is_empty()) {
-                vec![normalize_user_config_path_to_watch_pattern(config_path)]
-            } else {
-                // Watch for config files in all subdirectories (nested config support)
-                config_discovery()
-                    .config_file_names()
-                    .into_iter()
-                    .map(|name| format!("**/{name}"))
-                    .collect()
-            };
+        let mut patterns: Vec<Pattern> = if let Some(config_path) = options.explicit_config_path() {
+            vec![normalize_user_config_path_to_watch_pattern(config_path)]
+        } else {
+            // Watch subdirectories too for nested config support;
+            // with `disableNestedConfig`, only the workspace-root config is used
+            let prefix = if options.use_nested_configs() { "**/" } else { "" };
+            config_discovery()
+                .config_file_names()
+                .into_iter()
+                .map(|name| format!("{prefix}{name}"))
+                .collect()
+        };
 
         patterns.push(".editorconfig".to_string());
         patterns
@@ -273,6 +279,7 @@ impl ServerFormatter {
         js_config_loader: JsConfigLoaderCb,
         prettierignore_glob: Option<Gitignore>,
         explicit_config_path: Option<PathBuf>,
+        use_nested_config: bool,
     ) -> Self {
         let state =
             Self::build_state(&root_path, explicit_config_path.as_deref(), &js_config_loader);
@@ -282,6 +289,7 @@ impl ServerFormatter {
             js_config_loader,
             prettierignore_glob,
             explicit_config_path,
+            use_nested_config,
             state: RwLock::new(Arc::new(state)),
         }
     }
@@ -353,9 +361,8 @@ impl ServerFormatter {
         // In-flight reads survive a concurrent rebuild because the old `Arc` keeps the previous snapshot alive.
         let state = Arc::clone(&self.state.read().expect("state rwlock poisoned"));
 
-        // Explicit config path applies uniformly to every file;
-        // passing `None` tells `resolve_file_scope_config` to bypass nested probing.
-        let nested_ctx = self.explicit_config_path.is_none().then_some(&state.nested_ctx);
+        // Passing `None` tells `resolve_file_scope_config` to bypass nested probing
+        let nested_ctx = self.use_nested_config.then_some(&state.nested_ctx);
         let resolver = match resolve_file_scope_config(path, &state.root_resolver, nested_ctx) {
             Ok(r) => r,
             Err(err) => {

--- a/apps/oxfmt/test/lsp/nested_config/__snapshots__/nested_config.test.ts.snap
+++ b/apps/oxfmt/test/lsp/nested_config/__snapshots__/nested_config.test.ts.snap
@@ -36,6 +36,30 @@ const x = '1';
 --------------------"
 `;
 
+exports[`LSP nested config > should ignore nested config when disableNestedConfig is set 1`] = `
+"--- URI -----------
+file://<fixture>/nested-config/sub/test.ts
+--- BEFORE ---------
+const x = "1";
+
+--- AFTER ----------
+const x = '1';
+
+--------------------"
+`;
+
+exports[`LSP nested config > should ignore nested config when disableNestedConfig is set 2`] = `
+"--- URI -----------
+file://<fixture>/nested-config/sub/ignored.generated.ts
+--- BEFORE ---------
+const   x   =   "1";
+
+--- AFTER ----------
+const x = '1';
+
+--------------------"
+`;
+
 exports[`LSP nested config > should ignore nested config when explicit configPath is set 1`] = `
 "--- URI -----------
 file://<fixture>/nested-config-explicit/sub/test.ts

--- a/apps/oxfmt/test/lsp/nested_config/nested_config.test.ts
+++ b/apps/oxfmt/test/lsp/nested_config/nested_config.test.ts
@@ -60,6 +60,29 @@ describe("LSP nested config", () => {
     ).toMatchSnapshot();
   });
 
+  it("should ignore nested config when disableNestedConfig is set", async () => {
+    const rootDir = join(FIXTURES_DIR, "nested-config");
+    const rootUri = pathToFileURL(rootDir).href;
+    await using client = createLspConnection();
+    await client.initialize([{ uri: rootUri, name: "test" }], {}, [
+      { workspaceUri: rootUri, options: { "fmt.disableNestedConfig": true } },
+    ]);
+
+    // sub/test.ts: root config applies (semi: true, singleQuote: true), nested config is ignored
+    expect(
+      await formatFixture(FIXTURES_DIR, "nested-config/sub/test.ts", "typescript", client),
+    ).toMatchSnapshot();
+    // sub/ignored.generated.ts: nested ignorePatterns no longer applies, formatted with root config
+    expect(
+      await formatFixture(
+        FIXTURES_DIR,
+        "nested-config/sub/ignored.generated.ts",
+        "typescript",
+        client,
+      ),
+    ).toMatchSnapshot();
+  });
+
   it("should ignore nested config when explicit configPath is set", async () => {
     const rootDir = join(FIXTURES_DIR, "nested-config-explicit");
     const rootUri = pathToFileURL(rootDir).href;

--- a/apps/oxfmt/test/lsp/utils.ts
+++ b/apps/oxfmt/test/lsp/utils.ts
@@ -274,6 +274,7 @@ ${formatted2}
 // aligned with https://github.com/oxc-project/oxc/blob/7e6c15baaebf206ab540191da0e4e103e4fabf06/apps/oxfmt/src/lsp/options.rs
 type OxfmtLSPConfig = {
   "fmt.configPath"?: string | null;
+  "fmt.disableNestedConfig"?: boolean;
 };
 
 function applyEdits(content: string, edits: TextEdit[] | null, languageId: string): string {


### PR DESCRIPTION
Refs: voidzero-dev/vite-plus#2245

(I had assumed Oxlint didn't have an option for LSP either, but that wasn't the case.)
