### PR TITLE
feat(formatter): add jsdoc.tableAlignment option

### DIFF
--- a/apps/oxfmt/src-js/config.generated.ts
+++ b/apps/oxfmt/src-js/config.generated.ts
@@ -341,6 +341,28 @@ export interface JsdocConfig {
    * - Default: `false`
    */
   separateTagGroups?: boolean;
+  /**
+   * When to pad Markdown table columns so the `|` characters line up.
+   *
+   * - `"always"` — Always pad cells and stretch the separator row to the column width.
+   * - `"auto"` — Pad only when every padded row fits within `tableAlignmentMaxWidth`, otherwise emit that table unpadded (`|a|b|`) with a minimal separator row (`|---|---|`).
+   * - `"never"` — Never pad; every table uses the unpadded form.
+   *
+   * The `"auto"` decision is made per table, so a narrow and a wide table in the same comment can come out differently.
+   *
+   * - Default: `"always"`
+   */
+  tableAlignment?: string;
+  /**
+   * Row width budget used by `tableAlignment: "auto"`.
+   *
+   * Measured on the comment's content — the rendered row plus the Markdown indent it sits at,
+   * but not the surrounding ` * ` gutter. Independent of `printWidth`, since tables are usually
+   * allowed to run wider than prose. Ignored by the other `tableAlignment` modes.
+   *
+   * - Default: `120`
+   */
+  tableAlignmentMaxWidth?: number;
   [k: string]: unknown;
 }
 export interface OxfmtOverrideConfig {

--- a/apps/oxfmt/src/core/options/to_oxc_formatter.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter.rs
@@ -277,7 +277,8 @@ pub(super) fn to_sort_imports(config: &FormatConfig) -> Result<Option<SortImport
 /// Shared by both [`to_oxc_formatter()`] (build) and [`super::validate::validate()`] (gate).
 ///
 /// # Errors
-/// Returns an error if `lineWrappingStyle` / `commentLineStrategy` is invalid.
+/// Returns an error if `lineWrappingStyle` / `commentLineStrategy` / `tableAlignment` /
+/// `tableAlignmentMaxWidth` is invalid.
 pub(super) fn to_jsdoc(
     config: &FormatConfig,
 ) -> Result<Option<oxc_formatter::JsdocOptions>, String> {
@@ -335,6 +336,26 @@ pub(super) fn to_jsdoc(
     }
     if let Some(v) = jsdoc_config.keep_unparsable_example_indent {
         opts.keep_unparsable_example_indent = v;
+    }
+    if let Some(ref v) = jsdoc_config.table_alignment {
+        opts.table_alignment = match v.as_str() {
+            "always" => oxc_formatter::TableAlignment::Always,
+            "auto" => oxc_formatter::TableAlignment::Auto,
+            "never" => oxc_formatter::TableAlignment::Never,
+            other => {
+                return Err(format!(
+                    "Invalid jsdoc tableAlignment: {other:?}. Expected \"always\", \"auto\", or \"never\"."
+                ));
+            }
+        };
+    }
+    if let Some(v) = jsdoc_config.table_alignment_max_width {
+        if v == 0 {
+            return Err(
+                "Invalid jsdoc tableAlignmentMaxWidth: 0. Expected a positive integer.".to_string()
+            );
+        }
+        opts.table_alignment_max_width = v;
     }
 
     Ok(Some(opts))
@@ -675,5 +696,36 @@ mod tests {
         let config: FormatConfig =
             serde_json::from_str(r#"{ "jsdoc": { "lineWrappingStyle": "bogus" } }"#).unwrap();
         assert!(validate(&config).is_err_and(|e| e.contains("lineWrappingStyle")));
+
+        let config: FormatConfig =
+            serde_json::from_str(r#"{ "jsdoc": { "tableAlignment": "bogus" } }"#).unwrap();
+        assert!(validate(&config).is_err_and(|e| e.contains("tableAlignment")));
+
+        let config: FormatConfig =
+            serde_json::from_str(r#"{ "jsdoc": { "tableAlignmentMaxWidth": 0 } }"#).unwrap();
+        assert!(validate(&config).is_err_and(|e| e.contains("tableAlignmentMaxWidth")));
+    }
+
+    #[test]
+    fn test_jsdoc_table_alignment() {
+        use oxc_formatter::TableAlignment;
+
+        // Defaults preserve the existing always-align behavior.
+        let config: FormatConfig = serde_json::from_str(r#"{ "jsdoc": true }"#).unwrap();
+        let jsdoc = to_jsdoc(&config).unwrap().unwrap();
+        assert_eq!(jsdoc.table_alignment, TableAlignment::Always);
+        assert_eq!(jsdoc.table_alignment_max_width, 120);
+
+        let config: FormatConfig = serde_json::from_str(
+            r#"{ "jsdoc": { "tableAlignment": "auto", "tableAlignmentMaxWidth": 60 } }"#,
+        )
+        .unwrap();
+        let jsdoc = to_jsdoc(&config).unwrap().unwrap();
+        assert_eq!(jsdoc.table_alignment, TableAlignment::Auto);
+        assert_eq!(jsdoc.table_alignment_max_width, 60);
+
+        let config: FormatConfig =
+            serde_json::from_str(r#"{ "jsdoc": { "tableAlignment": "never" } }"#).unwrap();
+        assert_eq!(to_jsdoc(&config).unwrap().unwrap().table_alignment, TableAlignment::Never);
     }
 }

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -826,6 +826,26 @@ pub struct JsdocConfig {
     /// - Default: `false`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keep_unparsable_example_indent: Option<bool>,
+    /// When to pad Markdown table columns so the `|` characters line up.
+    ///
+    /// - `"always"` — Always pad cells and stretch the separator row to the column width.
+    /// - `"auto"` — Pad only when every padded row fits within `tableAlignmentMaxWidth`, otherwise emit that table unpadded (`|a|b|`) with a minimal separator row (`|---|---|`).
+    /// - `"never"` — Never pad; every table uses the unpadded form.
+    ///
+    /// The `"auto"` decision is made per table, so a narrow and a wide table in the same comment can come out differently.
+    ///
+    /// - Default: `"always"`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table_alignment: Option<String>,
+    /// Row width budget used by `tableAlignment: "auto"`.
+    ///
+    /// Measured on the comment's content — the rendered row plus the Markdown indent it sits at,
+    /// but not the surrounding ` * ` gutter. Independent of `printWidth`, since tables are usually
+    /// allowed to run wider than prose. Ignored by the other `tableAlignment` modes.
+    ///
+    /// - Default: `120`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table_alignment_max_width: Option<u16>,
 }
 
 // ---

--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -41,6 +41,14 @@ After changing AST shapes or the generators, regenerate with `just ast`, never h
 
 - Derived from `prettier-plugin-jsdoc`, but not fully compatible
 - See `prettier_conformance/jsdoc` for the covered behavior
+- `jsdoc.tableAlignment` has no upstream counterpart. Upstream always pads Markdown table
+  columns; `"auto"` keeps the padding only while a table's rendered rows stay within
+  `jsdoc.tableAlignmentMaxWidth` (default 120), and otherwise emits that table unpadded with
+  a minimal separator row. The budget is measured on comment content — the row plus its
+  Markdown indent, not the leading `*` gutter — and the choice is made per table inside
+  `wrap::format_table_block`, so one comment can mix both forms. Defaults to `"always"`, so
+  conformance against upstream is unaffected; cover new behavior with
+  `tests/fixtures/js/jsdoc/table-alignment-auto/`, not the conformance fixtures.
 
 ### Sort Tailwind CSS
 

--- a/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/mod.rs
+++ b/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/mod.rs
@@ -46,6 +46,11 @@ pub fn format_description_mdast(
     let prefer_code_fences = jsdoc_opts.is_some_and(|o| o.prefer_code_fences);
     let line_wrapping_style =
         jsdoc_opts.map_or(crate::LineWrappingStyle::default(), |o| o.line_wrapping_style);
+    let table_alignment =
+        jsdoc_opts.map_or(crate::TableAlignment::default(), |o| o.table_alignment);
+    let table_alignment_max_width = jsdoc_opts
+        .map_or(crate::DEFAULT_TABLE_ALIGNMENT_MAX_WIDTH, |o| o.table_alignment_max_width)
+        as usize;
 
     // Fast path: if text has no markdown constructs requiring AST parsing,
     // use lightweight wrap_plain_paragraphs() directly.
@@ -141,6 +146,8 @@ pub fn format_description_mdast(
         description_with_dot,
         prefer_code_fences,
         line_wrapping_style,
+        table_alignment,
+        table_alignment_max_width,
         source: &protected,
         format_options,
         allocator,
@@ -159,6 +166,10 @@ pub(super) struct SerializeOptions<'a> {
     pub(super) description_with_dot: bool,
     pub(super) prefer_code_fences: bool,
     pub(super) line_wrapping_style: crate::LineWrappingStyle,
+    pub(super) table_alignment: crate::TableAlignment,
+    /// Row width budget for [`crate::TableAlignment::Auto`], measured on comment content
+    /// (the ` * ` gutter is not counted). Each table subtracts its own indent from this.
+    pub(super) table_alignment_max_width: usize,
     pub(super) source: &'a str,
     pub(super) format_options: Option<&'a JsFormatOptions>,
     pub(super) allocator: Option<&'a Allocator>,

--- a/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/nodes.rs
+++ b/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/nodes.rs
@@ -484,7 +484,11 @@ fn serialize_pipe_prefixed_paragraph(
                 index += 1;
             }
 
-            let block_lines = format_table_block(&raw_lines[start..index]);
+            let block_lines = format_table_block(
+                &raw_lines[start..index],
+                opts.table_alignment,
+                opts.table_alignment_max_width.saturating_sub(indent),
+            );
 
             for line in block_lines {
                 if indent > 0 && !line.is_empty() {

--- a/crates/oxc_formatter/src/formatter/jsdoc/wrap.rs
+++ b/crates/oxc_formatter/src/formatter/jsdoc/wrap.rs
@@ -1,3 +1,5 @@
+use crate::TableAlignment;
+
 /// Compute the width of a string matching JavaScript's `.length` (UTF-16 code units).
 /// This intentionally does NOT use `unicode_width::UnicodeWidthStr` because Prettier
 /// measures `printWidth` in JS string length (UTF-16 code units), not terminal columns.
@@ -56,11 +58,80 @@ fn parse_table_cells(line: &str) -> Vec<&str> {
     inner.split('|').map(str::trim).collect()
 }
 
+/// Render a separator cell at its minimal width: the alignment colons the source
+/// had, plus exactly three dashes. Used by the unaligned output.
+fn push_minimal_separator_cell(row: &mut String, cell: &str) {
+    if cell.starts_with(':') {
+        row.push(':');
+    }
+    row.push_str("---");
+    if cell.ends_with(':') {
+        row.push(':');
+    }
+}
+
+/// Emit a table without any column padding: cells carry their raw (trimmed) content
+/// and the separator row stays minimal (`|---|---|---|`).
+///
+/// Short rows are still filled out to `num_cols` empty cells so every row keeps the
+/// same column count, matching what the aligned path does.
+fn format_table_block_unaligned(
+    table_lines: &[&str],
+    separator_idx: usize,
+    all_cells: &[Vec<&str>],
+    num_cols: usize,
+) -> Vec<String> {
+    // Widest possible row: every cell at its longest, plus a `|` per column and one more
+    // to open the row. The separator row needs 5 per column at most (`:---:`).
+    let widest_cells: usize = (0..num_cols)
+        .map(|j| {
+            all_cells.iter().filter_map(|row| row.get(j)).map(|c| c.len()).max().unwrap_or(0).max(5)
+        })
+        .sum();
+    let row_capacity = widest_cells + num_cols + 1;
+
+    let mut lines = Vec::with_capacity(table_lines.len());
+    let mut data_row_idx = 0;
+    for idx in 0..table_lines.len() {
+        let mut row = String::with_capacity(row_capacity);
+        row.push('|');
+        if idx == separator_idx {
+            let sep_cells = parse_table_cells(table_lines[separator_idx]);
+            for j in 0..num_cols {
+                push_minimal_separator_cell(&mut row, sep_cells.get(j).copied().unwrap_or("---"));
+                row.push('|');
+            }
+        } else {
+            let cells = &all_cells[data_row_idx];
+            data_row_idx += 1;
+            for j in 0..num_cols {
+                row.push_str(cells.get(j).copied().unwrap_or(""));
+                row.push('|');
+            }
+            // A single empty column collapses to `||`, which the table-row detector
+            // rejects (it requires more than two chars), so the next format pass would
+            // break the table apart. Keep one space to stay round-trippable.
+            if row == "||" {
+                row = String::from("| |");
+            }
+        }
+        lines.push(row);
+    }
+    lines
+}
+
 /// Format a block of consecutive table lines.
-/// If the table has a valid separator row, format with column padding.
+/// If the table has a valid separator row, format according to `alignment`.
 /// Otherwise, output as-is.
 ///
-pub fn format_table_block(table_lines: &[&str]) -> Vec<String> {
+/// `max_width` is the row width budget consulted by [`TableAlignment::Auto`]; callers
+/// pass it already reduced by the indent the table will be printed at. It is ignored
+/// by the other modes.
+pub fn format_table_block(
+    table_lines: &[&str],
+    alignment: TableAlignment,
+    max_width: usize,
+) -> Vec<String> {
     let to_owned = || table_lines.iter().map(|l| String::from(*l)).collect();
 
     // Find separator row
@@ -94,6 +165,19 @@ pub fn format_table_block(table_lines: &[&str]) -> Vec<String> {
                 col_widths[j] = col_widths[j].max(str_width(cell));
             }
         }
+    }
+
+    // A padded row renders as `"| " + cell + (" | " + cell)* + " |"`, so the separators
+    // cost `2 + 3 * (num_cols - 1) + 2` and every row comes out the same width.
+    let aligned_row_width: usize = col_widths.iter().sum::<usize>() + 3 * num_cols + 1;
+
+    let align = match alignment {
+        TableAlignment::Always => true,
+        TableAlignment::Never => false,
+        TableAlignment::Auto => aligned_row_width <= max_width,
+    };
+    if !align {
+        return format_table_block_unaligned(table_lines, separator_idx, &all_cells, num_cols);
     }
 
     // Total width per row: "| " + (cell_width + " | ") * num_cols
@@ -482,6 +566,123 @@ pub fn wrap_text(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const TABLE: &[&str] = &[
+        "| Name | Description | Default |",
+        "|---|---|---|",
+        "| verbose | Print every step the resolver takes | false |",
+        "| cwd | Directory the resolver starts from | process.cwd() |",
+    ];
+
+    /// Width every padded row of `TABLE` comes out at: `7 + 35 + 13` of cell content
+    /// plus `3 * 3 + 1` of `|`/space separators.
+    const TABLE_ALIGNED_WIDTH: usize = 65;
+
+    #[test]
+    fn test_table_always_aligns_regardless_of_width() {
+        // `max_width` is ignored in `Always` mode, even when the table blows past it.
+        let result = format_table_block(TABLE, TableAlignment::Always, 10);
+        assert_eq!(
+            result,
+            vec![
+                "| Name    | Description                         | Default       |",
+                "| ------- | ----------------------------------- | ------------- |",
+                "| verbose | Print every step the resolver takes | false         |",
+                "| cwd     | Directory the resolver starts from  | process.cwd() |",
+            ]
+        );
+        assert!(result.iter().all(|l| str_width(l) == TABLE_ALIGNED_WIDTH));
+    }
+
+    #[test]
+    fn test_table_never_drops_alignment_regardless_of_width() {
+        // `max_width` is ignored in `Never` mode, even when the table would fit.
+        assert_eq!(
+            format_table_block(TABLE, TableAlignment::Never, 1000),
+            vec![
+                "|Name|Description|Default|",
+                "|---|---|---|",
+                "|verbose|Print every step the resolver takes|false|",
+                "|cwd|Directory the resolver starts from|process.cwd()|",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_table_auto_aligns_when_every_row_fits() {
+        let aligned = format_table_block(TABLE, TableAlignment::Always, 0);
+        // Exactly at the budget still counts as fitting.
+        assert_eq!(format_table_block(TABLE, TableAlignment::Auto, TABLE_ALIGNED_WIDTH), aligned);
+        assert_eq!(format_table_block(TABLE, TableAlignment::Auto, 120), aligned);
+    }
+
+    #[test]
+    fn test_table_auto_drops_alignment_when_a_row_overflows() {
+        let unaligned = format_table_block(TABLE, TableAlignment::Never, 0);
+        // One char under the budget is enough to give up alignment.
+        assert_eq!(
+            format_table_block(TABLE, TableAlignment::Auto, TABLE_ALIGNED_WIDTH - 1),
+            unaligned
+        );
+        assert_eq!(format_table_block(TABLE, TableAlignment::Auto, 40), unaligned);
+    }
+
+    #[test]
+    fn test_table_auto_is_decided_per_table() {
+        let narrow: &[&str] = &["| a | b |", "|---|---|", "| 1 | 2 |"];
+        assert_eq!(
+            format_table_block(narrow, TableAlignment::Auto, 40),
+            vec!["| a   | b   |", "| --- | --- |", "| 1   | 2   |"]
+        );
+        // Same options, wider table -> the other branch.
+        assert_eq!(
+            format_table_block(TABLE, TableAlignment::Auto, 40),
+            format_table_block(TABLE, TableAlignment::Never, 0)
+        );
+    }
+
+    #[test]
+    fn test_table_unaligned_keeps_alignment_markers_minimal() {
+        let table: &[&str] =
+            &["| Left | Center | Right |", "| :--- | :----: | ----: |", "| a | b | c |"];
+        assert_eq!(
+            format_table_block(table, TableAlignment::Never, 0),
+            vec!["|Left|Center|Right|", "|:---|:---:|---:|", "|a|b|c|"]
+        );
+    }
+
+    #[test]
+    fn test_table_unaligned_pads_short_rows_with_empty_cells() {
+        // Column count is normalized the same way the aligned path does it.
+        let table: &[&str] = &["| a | b | c |", "|---|---|---|", "| 1 |"];
+        assert_eq!(
+            format_table_block(table, TableAlignment::Never, 0),
+            vec!["|a|b|c|", "|---|---|---|", "|1|||"]
+        );
+    }
+
+    #[test]
+    fn test_table_unaligned_single_empty_column_stays_round_trippable() {
+        // `||` would be too short for the table-row detector, so the next pass would
+        // stop treating the block as a table.
+        let table: &[&str] = &["| Header |", "|---|", "|  |", "| x |"];
+        let out = format_table_block(table, TableAlignment::Never, 0);
+        assert_eq!(out, vec!["|Header|", "|---|", "| |", "|x|"]);
+        // Re-running over the emitted rows is a fixed point.
+        let reparsed: Vec<&str> = out.iter().map(String::as_str).collect();
+        assert_eq!(format_table_block(&reparsed, TableAlignment::Never, 0), out);
+    }
+
+    #[test]
+    fn test_table_without_separator_is_left_alone_in_every_mode() {
+        let not_a_table: &[&str] = &["| a | b |", "| c | d |"];
+        for alignment in [TableAlignment::Always, TableAlignment::Auto, TableAlignment::Never] {
+            assert_eq!(
+                format_table_block(not_a_table, alignment, 0),
+                vec!["| a | b |", "| c | d |"]
+            );
+        }
+    }
 
     #[test]
     fn test_wrap_simple_text() {

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -117,6 +117,24 @@ pub enum LineWrappingStyle {
     Balance,
 }
 
+/// When to pad Markdown table columns so the `|` characters line up.
+///
+/// Oxfmt specific, no upstream `prettier-plugin-jsdoc` counterpart.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TableAlignment {
+    /// Always pad cells and stretch the separator row to the column width.
+    #[default]
+    Always,
+    /// Align only when every padded row fits within [`JsdocOptions::table_alignment_max_width`];
+    /// otherwise drop the padding for that table. Decided per table, not per file.
+    Auto,
+    /// Never pad. Cells hold their raw content and the separator row stays minimal.
+    Never,
+}
+
+/// Default value of [`JsdocOptions::table_alignment_max_width`].
+pub const DEFAULT_TABLE_ALIGNMENT_MAX_WIDTH: u16 = 120;
+
 /// Options for JSDoc comment formatting.
 #[derive(Debug, Clone)]
 pub struct JsdocOptions {
@@ -153,6 +171,15 @@ pub struct JsdocOptions {
     /// Preserve indentation in unparsable @example code. Default: false.
     /// Maps to upstream's `jsdocKeepUnParseAbleExampleIndent`.
     pub keep_unparsable_example_indent: bool,
+    /// When to pad Markdown table columns. Default: Always.
+    /// Oxfmt specific.
+    pub table_alignment: TableAlignment,
+    /// Row width budget used by [`TableAlignment::Auto`]. Default: 120.
+    ///
+    /// Measured on the comment's content: the rendered row plus the Markdown indent it
+    /// sits at, but NOT the surrounding ` * ` gutter (the same basis the rest of the
+    /// JSDoc wrapping uses).
+    pub table_alignment_max_width: u16,
 }
 
 impl Default for JsdocOptions {
@@ -169,6 +196,8 @@ impl Default for JsdocOptions {
             line_wrapping_style: LineWrappingStyle::default(),
             description_tag: false,
             keep_unparsable_example_indent: false,
+            table_alignment: TableAlignment::default(),
+            table_alignment_max_width: DEFAULT_TABLE_ALIGNMENT_MAX_WIDTH,
         }
     }
 }

--- a/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/all-rows-fit.js
+++ b/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/all-rows-fit.js
@@ -1,0 +1,10 @@
+/**
+ * Every padded row of this table is 30 chars wide, well under the 60 char
+ * budget, so `auto` pads it exactly like `always` does.
+ *
+ * | Option | Type | Default |
+ * | --- | --- | --- |
+ * | depth | number | 2 |
+ * | strict | boolean | false |
+ */
+const narrow = 1;

--- a/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/all-rows-fit.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/all-rows-fit.js.snap
@@ -1,0 +1,101 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/**
+ * Every padded row of this table is 30 chars wide, well under the 60 char
+ * budget, so `auto` pads it exactly like `always` does.
+ *
+ * | Option | Type | Default |
+ * | --- | --- | --- |
+ * | depth | number | 2 |
+ * | strict | boolean | false |
+ */
+const narrow = 1;
+
+==================== Output ====================
+--------------------------------------------------------------------------------
+{ jsdoc: {"tableAlignment":"auto","tableAlignmentMaxWidth":60}, printWidth: 80 }
+--------------------------------------------------------------------------------
+/**
+ * Every padded row of this table is 30 chars wide, well under the 60 char
+ * budget, so `auto` pads it exactly like `always` does.
+ *
+ * | Option | Type    | Default |
+ * | ------ | ------- | ------- |
+ * | depth  | number  | 2       |
+ * | strict | boolean | false   |
+ */
+const narrow = 1;
+
+---------------------------------------------------------------------------------
+{ jsdoc: {"tableAlignment":"auto","tableAlignmentMaxWidth":60}, printWidth: 100 }
+---------------------------------------------------------------------------------
+/**
+ * Every padded row of this table is 30 chars wide, well under the 60 char budget, so `auto` pads it
+ * exactly like `always` does.
+ *
+ * | Option | Type    | Default |
+ * | ------ | ------- | ------- |
+ * | depth  | number  | 2       |
+ * | strict | boolean | false   |
+ */
+const narrow = 1;
+
+------------------------------------------------------
+{ jsdoc: {"tableAlignment":"always"}, printWidth: 80 }
+------------------------------------------------------
+/**
+ * Every padded row of this table is 30 chars wide, well under the 60 char
+ * budget, so `auto` pads it exactly like `always` does.
+ *
+ * | Option | Type    | Default |
+ * | ------ | ------- | ------- |
+ * | depth  | number  | 2       |
+ * | strict | boolean | false   |
+ */
+const narrow = 1;
+
+-------------------------------------------------------
+{ jsdoc: {"tableAlignment":"always"}, printWidth: 100 }
+-------------------------------------------------------
+/**
+ * Every padded row of this table is 30 chars wide, well under the 60 char budget, so `auto` pads it
+ * exactly like `always` does.
+ *
+ * | Option | Type    | Default |
+ * | ------ | ------- | ------- |
+ * | depth  | number  | 2       |
+ * | strict | boolean | false   |
+ */
+const narrow = 1;
+
+-----------------------------------------------------
+{ jsdoc: {"tableAlignment":"never"}, printWidth: 80 }
+-----------------------------------------------------
+/**
+ * Every padded row of this table is 30 chars wide, well under the 60 char
+ * budget, so `auto` pads it exactly like `always` does.
+ *
+ * |Option|Type|Default|
+ * |---|---|---|
+ * |depth|number|2|
+ * |strict|boolean|false|
+ */
+const narrow = 1;
+
+------------------------------------------------------
+{ jsdoc: {"tableAlignment":"never"}, printWidth: 100 }
+------------------------------------------------------
+/**
+ * Every padded row of this table is 30 chars wide, well under the 60 char budget, so `auto` pads it
+ * exactly like `always` does.
+ *
+ * |Option|Type|Default|
+ * |---|---|---|
+ * |depth|number|2|
+ * |strict|boolean|false|
+ */
+const narrow = 1;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/empty-cells.js
+++ b/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/empty-cells.js
@@ -1,0 +1,18 @@
+/**
+ * Unpadded rows must stay long enough to be re-detected as table rows on the next
+ * format pass, so a lone empty column keeps one space instead of collapsing to `||`.
+ *
+ * | Header |
+ * | --- |
+ * |  |
+ * | x |
+ *
+ * Wider rows can hold empty cells as-is, and short rows are filled out to the
+ * table's column count.
+ *
+ * | A | B | C |
+ * | :-: | :-- | --: |
+ * | 1 |
+ * | 1 | 2 | 3 |
+ */
+const sparse = 1;

--- a/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/empty-cells.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/empty-cells.js.snap
@@ -1,0 +1,157 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/**
+ * Unpadded rows must stay long enough to be re-detected as table rows on the next
+ * format pass, so a lone empty column keeps one space instead of collapsing to `||`.
+ *
+ * | Header |
+ * | --- |
+ * |  |
+ * | x |
+ *
+ * Wider rows can hold empty cells as-is, and short rows are filled out to the
+ * table's column count.
+ *
+ * | A | B | C |
+ * | :-: | :-- | --: |
+ * | 1 |
+ * | 1 | 2 | 3 |
+ */
+const sparse = 1;
+
+==================== Output ====================
+--------------------------------------------------------------------------------
+{ jsdoc: {"tableAlignment":"auto","tableAlignmentMaxWidth":60}, printWidth: 80 }
+--------------------------------------------------------------------------------
+/**
+ * Unpadded rows must stay long enough to be re-detected as table rows on the
+ * next format pass, so a lone empty column keeps one space instead of
+ * collapsing to `||`.
+ *
+ * | Header |
+ * | ------ |
+ * |        |
+ * | x      |
+ *
+ * Wider rows can hold empty cells as-is, and short rows are filled out to the
+ * table's column count.
+ *
+ * | A   | B   | C   |
+ * | :-: | :-- | --: |
+ * | 1   |     |     |
+ * | 1   | 2   | 3   |
+ */
+const sparse = 1;
+
+---------------------------------------------------------------------------------
+{ jsdoc: {"tableAlignment":"auto","tableAlignmentMaxWidth":60}, printWidth: 100 }
+---------------------------------------------------------------------------------
+/**
+ * Unpadded rows must stay long enough to be re-detected as table rows on the next format pass, so a
+ * lone empty column keeps one space instead of collapsing to `||`.
+ *
+ * | Header |
+ * | ------ |
+ * |        |
+ * | x      |
+ *
+ * Wider rows can hold empty cells as-is, and short rows are filled out to the table's column count.
+ *
+ * | A   | B   | C   |
+ * | :-: | :-- | --: |
+ * | 1   |     |     |
+ * | 1   | 2   | 3   |
+ */
+const sparse = 1;
+
+------------------------------------------------------
+{ jsdoc: {"tableAlignment":"always"}, printWidth: 80 }
+------------------------------------------------------
+/**
+ * Unpadded rows must stay long enough to be re-detected as table rows on the
+ * next format pass, so a lone empty column keeps one space instead of
+ * collapsing to `||`.
+ *
+ * | Header |
+ * | ------ |
+ * |        |
+ * | x      |
+ *
+ * Wider rows can hold empty cells as-is, and short rows are filled out to the
+ * table's column count.
+ *
+ * | A   | B   | C   |
+ * | :-: | :-- | --: |
+ * | 1   |     |     |
+ * | 1   | 2   | 3   |
+ */
+const sparse = 1;
+
+-------------------------------------------------------
+{ jsdoc: {"tableAlignment":"always"}, printWidth: 100 }
+-------------------------------------------------------
+/**
+ * Unpadded rows must stay long enough to be re-detected as table rows on the next format pass, so a
+ * lone empty column keeps one space instead of collapsing to `||`.
+ *
+ * | Header |
+ * | ------ |
+ * |        |
+ * | x      |
+ *
+ * Wider rows can hold empty cells as-is, and short rows are filled out to the table's column count.
+ *
+ * | A   | B   | C   |
+ * | :-: | :-- | --: |
+ * | 1   |     |     |
+ * | 1   | 2   | 3   |
+ */
+const sparse = 1;
+
+-----------------------------------------------------
+{ jsdoc: {"tableAlignment":"never"}, printWidth: 80 }
+-----------------------------------------------------
+/**
+ * Unpadded rows must stay long enough to be re-detected as table rows on the
+ * next format pass, so a lone empty column keeps one space instead of
+ * collapsing to `||`.
+ *
+ * |Header|
+ * |---|
+ * | |
+ * |x|
+ *
+ * Wider rows can hold empty cells as-is, and short rows are filled out to the
+ * table's column count.
+ *
+ * |A|B|C|
+ * |:---:|:---|---:|
+ * |1|||
+ * |1|2|3|
+ */
+const sparse = 1;
+
+------------------------------------------------------
+{ jsdoc: {"tableAlignment":"never"}, printWidth: 100 }
+------------------------------------------------------
+/**
+ * Unpadded rows must stay long enough to be re-detected as table rows on the next format pass, so a
+ * lone empty column keeps one space instead of collapsing to `||`.
+ *
+ * |Header|
+ * |---|
+ * | |
+ * |x|
+ *
+ * Wider rows can hold empty cells as-is, and short rows are filled out to the table's column count.
+ *
+ * |A|B|C|
+ * |:---:|:---|---:|
+ * |1|||
+ * |1|2|3|
+ */
+const sparse = 1;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/mixed-tables.js
+++ b/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/mixed-tables.js
@@ -1,0 +1,26 @@
+/**
+ * The alignment decision is per table, not per file: the narrow table below
+ * gets padded while the wide one in the same comment does not.
+ *
+ * | Option | Type | Default |
+ * | --- | --- | --- |
+ * | depth | number | 2 |
+ * | strict | boolean | false |
+ *
+ * And the wide one:
+ *
+ * | Option | Description | Default |
+ * | --- | --- | --- |
+ * | resolveExtensions | List of file extensions the resolver will try in order | [".ts", ".js"] |
+ * | preserveSymlinks | Keep symlinked paths as written instead of resolving them | false |
+ */
+const both = 1;
+
+/**
+ * A separate comment in the same file, narrow again.
+ *
+ * | Left | Center | Right |
+ * | :--- | :----: | ----: |
+ * | a | b | c |
+ */
+const alsoNarrow = 2;

--- a/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/mixed-tables.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/mixed-tables.js.snap
@@ -1,0 +1,213 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/**
+ * The alignment decision is per table, not per file: the narrow table below
+ * gets padded while the wide one in the same comment does not.
+ *
+ * | Option | Type | Default |
+ * | --- | --- | --- |
+ * | depth | number | 2 |
+ * | strict | boolean | false |
+ *
+ * And the wide one:
+ *
+ * | Option | Description | Default |
+ * | --- | --- | --- |
+ * | resolveExtensions | List of file extensions the resolver will try in order | [".ts", ".js"] |
+ * | preserveSymlinks | Keep symlinked paths as written instead of resolving them | false |
+ */
+const both = 1;
+
+/**
+ * A separate comment in the same file, narrow again.
+ *
+ * | Left | Center | Right |
+ * | :--- | :----: | ----: |
+ * | a | b | c |
+ */
+const alsoNarrow = 2;
+
+==================== Output ====================
+--------------------------------------------------------------------------------
+{ jsdoc: {"tableAlignment":"auto","tableAlignmentMaxWidth":60}, printWidth: 80 }
+--------------------------------------------------------------------------------
+/**
+ * The alignment decision is per table, not per file: the narrow table below
+ * gets padded while the wide one in the same comment does not.
+ *
+ * | Option | Type    | Default |
+ * | ------ | ------- | ------- |
+ * | depth  | number  | 2       |
+ * | strict | boolean | false   |
+ *
+ * And the wide one:
+ *
+ * |Option|Description|Default|
+ * |---|---|---|
+ * |resolveExtensions|List of file extensions the resolver will try in order|[".ts", ".js"]|
+ * |preserveSymlinks|Keep symlinked paths as written instead of resolving them|false|
+ */
+const both = 1;
+
+/**
+ * A separate comment in the same file, narrow again.
+ *
+ * | Left | Center | Right |
+ * | :--- | :----: | ----: |
+ * | a    | b      | c     |
+ */
+const alsoNarrow = 2;
+
+---------------------------------------------------------------------------------
+{ jsdoc: {"tableAlignment":"auto","tableAlignmentMaxWidth":60}, printWidth: 100 }
+---------------------------------------------------------------------------------
+/**
+ * The alignment decision is per table, not per file: the narrow table below gets padded while the
+ * wide one in the same comment does not.
+ *
+ * | Option | Type    | Default |
+ * | ------ | ------- | ------- |
+ * | depth  | number  | 2       |
+ * | strict | boolean | false   |
+ *
+ * And the wide one:
+ *
+ * |Option|Description|Default|
+ * |---|---|---|
+ * |resolveExtensions|List of file extensions the resolver will try in order|[".ts", ".js"]|
+ * |preserveSymlinks|Keep symlinked paths as written instead of resolving them|false|
+ */
+const both = 1;
+
+/**
+ * A separate comment in the same file, narrow again.
+ *
+ * | Left | Center | Right |
+ * | :--- | :----: | ----: |
+ * | a    | b      | c     |
+ */
+const alsoNarrow = 2;
+
+------------------------------------------------------
+{ jsdoc: {"tableAlignment":"always"}, printWidth: 80 }
+------------------------------------------------------
+/**
+ * The alignment decision is per table, not per file: the narrow table below
+ * gets padded while the wide one in the same comment does not.
+ *
+ * | Option | Type    | Default |
+ * | ------ | ------- | ------- |
+ * | depth  | number  | 2       |
+ * | strict | boolean | false   |
+ *
+ * And the wide one:
+ *
+ * | Option            | Description                                               | Default        |
+ * | ----------------- | --------------------------------------------------------- | -------------- |
+ * | resolveExtensions | List of file extensions the resolver will try in order    | [".ts", ".js"] |
+ * | preserveSymlinks  | Keep symlinked paths as written instead of resolving them | false          |
+ */
+const both = 1;
+
+/**
+ * A separate comment in the same file, narrow again.
+ *
+ * | Left | Center | Right |
+ * | :--- | :----: | ----: |
+ * | a    | b      | c     |
+ */
+const alsoNarrow = 2;
+
+-------------------------------------------------------
+{ jsdoc: {"tableAlignment":"always"}, printWidth: 100 }
+-------------------------------------------------------
+/**
+ * The alignment decision is per table, not per file: the narrow table below gets padded while the
+ * wide one in the same comment does not.
+ *
+ * | Option | Type    | Default |
+ * | ------ | ------- | ------- |
+ * | depth  | number  | 2       |
+ * | strict | boolean | false   |
+ *
+ * And the wide one:
+ *
+ * | Option            | Description                                               | Default        |
+ * | ----------------- | --------------------------------------------------------- | -------------- |
+ * | resolveExtensions | List of file extensions the resolver will try in order    | [".ts", ".js"] |
+ * | preserveSymlinks  | Keep symlinked paths as written instead of resolving them | false          |
+ */
+const both = 1;
+
+/**
+ * A separate comment in the same file, narrow again.
+ *
+ * | Left | Center | Right |
+ * | :--- | :----: | ----: |
+ * | a    | b      | c     |
+ */
+const alsoNarrow = 2;
+
+-----------------------------------------------------
+{ jsdoc: {"tableAlignment":"never"}, printWidth: 80 }
+-----------------------------------------------------
+/**
+ * The alignment decision is per table, not per file: the narrow table below
+ * gets padded while the wide one in the same comment does not.
+ *
+ * |Option|Type|Default|
+ * |---|---|---|
+ * |depth|number|2|
+ * |strict|boolean|false|
+ *
+ * And the wide one:
+ *
+ * |Option|Description|Default|
+ * |---|---|---|
+ * |resolveExtensions|List of file extensions the resolver will try in order|[".ts", ".js"]|
+ * |preserveSymlinks|Keep symlinked paths as written instead of resolving them|false|
+ */
+const both = 1;
+
+/**
+ * A separate comment in the same file, narrow again.
+ *
+ * |Left|Center|Right|
+ * |:---|:---:|---:|
+ * |a|b|c|
+ */
+const alsoNarrow = 2;
+
+------------------------------------------------------
+{ jsdoc: {"tableAlignment":"never"}, printWidth: 100 }
+------------------------------------------------------
+/**
+ * The alignment decision is per table, not per file: the narrow table below gets padded while the
+ * wide one in the same comment does not.
+ *
+ * |Option|Type|Default|
+ * |---|---|---|
+ * |depth|number|2|
+ * |strict|boolean|false|
+ *
+ * And the wide one:
+ *
+ * |Option|Description|Default|
+ * |---|---|---|
+ * |resolveExtensions|List of file extensions the resolver will try in order|[".ts", ".js"]|
+ * |preserveSymlinks|Keep symlinked paths as written instead of resolving them|false|
+ */
+const both = 1;
+
+/**
+ * A separate comment in the same file, narrow again.
+ *
+ * |Left|Center|Right|
+ * |:---|:---:|---:|
+ * |a|b|c|
+ */
+const alsoNarrow = 2;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/options.json
+++ b/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/options.json
@@ -1,0 +1,5 @@
+[
+  { "jsdoc": { "tableAlignment": "auto", "tableAlignmentMaxWidth": 60 } },
+  { "jsdoc": { "tableAlignment": "always" } },
+  { "jsdoc": { "tableAlignment": "never" } }
+]

--- a/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/row-exceeds-limit.js
+++ b/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/row-exceeds-limit.js
@@ -1,0 +1,10 @@
+/**
+ * Padding this table would make every row 98 chars wide, over the 60 char
+ * budget, so `auto` drops the padding and emits a minimal separator row.
+ *
+ * | Option | Description | Default |
+ * | --- | --- | --- |
+ * | resolveExtensions | List of file extensions the resolver will try in order | [".ts", ".js"] |
+ * | preserveSymlinks | Keep symlinked paths as written instead of resolving them | false |
+ */
+const wide = 1;

--- a/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/row-exceeds-limit.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/row-exceeds-limit.js.snap
@@ -1,0 +1,101 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/**
+ * Padding this table would make every row 98 chars wide, over the 60 char
+ * budget, so `auto` drops the padding and emits a minimal separator row.
+ *
+ * | Option | Description | Default |
+ * | --- | --- | --- |
+ * | resolveExtensions | List of file extensions the resolver will try in order | [".ts", ".js"] |
+ * | preserveSymlinks | Keep symlinked paths as written instead of resolving them | false |
+ */
+const wide = 1;
+
+==================== Output ====================
+--------------------------------------------------------------------------------
+{ jsdoc: {"tableAlignment":"auto","tableAlignmentMaxWidth":60}, printWidth: 80 }
+--------------------------------------------------------------------------------
+/**
+ * Padding this table would make every row 98 chars wide, over the 60 char
+ * budget, so `auto` drops the padding and emits a minimal separator row.
+ *
+ * |Option|Description|Default|
+ * |---|---|---|
+ * |resolveExtensions|List of file extensions the resolver will try in order|[".ts", ".js"]|
+ * |preserveSymlinks|Keep symlinked paths as written instead of resolving them|false|
+ */
+const wide = 1;
+
+---------------------------------------------------------------------------------
+{ jsdoc: {"tableAlignment":"auto","tableAlignmentMaxWidth":60}, printWidth: 100 }
+---------------------------------------------------------------------------------
+/**
+ * Padding this table would make every row 98 chars wide, over the 60 char budget, so `auto` drops
+ * the padding and emits a minimal separator row.
+ *
+ * |Option|Description|Default|
+ * |---|---|---|
+ * |resolveExtensions|List of file extensions the resolver will try in order|[".ts", ".js"]|
+ * |preserveSymlinks|Keep symlinked paths as written instead of resolving them|false|
+ */
+const wide = 1;
+
+------------------------------------------------------
+{ jsdoc: {"tableAlignment":"always"}, printWidth: 80 }
+------------------------------------------------------
+/**
+ * Padding this table would make every row 98 chars wide, over the 60 char
+ * budget, so `auto` drops the padding and emits a minimal separator row.
+ *
+ * | Option            | Description                                               | Default        |
+ * | ----------------- | --------------------------------------------------------- | -------------- |
+ * | resolveExtensions | List of file extensions the resolver will try in order    | [".ts", ".js"] |
+ * | preserveSymlinks  | Keep symlinked paths as written instead of resolving them | false          |
+ */
+const wide = 1;
+
+-------------------------------------------------------
+{ jsdoc: {"tableAlignment":"always"}, printWidth: 100 }
+-------------------------------------------------------
+/**
+ * Padding this table would make every row 98 chars wide, over the 60 char budget, so `auto` drops
+ * the padding and emits a minimal separator row.
+ *
+ * | Option            | Description                                               | Default        |
+ * | ----------------- | --------------------------------------------------------- | -------------- |
+ * | resolveExtensions | List of file extensions the resolver will try in order    | [".ts", ".js"] |
+ * | preserveSymlinks  | Keep symlinked paths as written instead of resolving them | false          |
+ */
+const wide = 1;
+
+-----------------------------------------------------
+{ jsdoc: {"tableAlignment":"never"}, printWidth: 80 }
+-----------------------------------------------------
+/**
+ * Padding this table would make every row 98 chars wide, over the 60 char
+ * budget, so `auto` drops the padding and emits a minimal separator row.
+ *
+ * |Option|Description|Default|
+ * |---|---|---|
+ * |resolveExtensions|List of file extensions the resolver will try in order|[".ts", ".js"]|
+ * |preserveSymlinks|Keep symlinked paths as written instead of resolving them|false|
+ */
+const wide = 1;
+
+------------------------------------------------------
+{ jsdoc: {"tableAlignment":"never"}, printWidth: 100 }
+------------------------------------------------------
+/**
+ * Padding this table would make every row 98 chars wide, over the 60 char budget, so `auto` drops
+ * the padding and emits a minimal separator row.
+ *
+ * |Option|Description|Default|
+ * |---|---|---|
+ * |resolveExtensions|List of file extensions the resolver will try in order|[".ts", ".js"]|
+ * |preserveSymlinks|Keep symlinked paths as written instead of resolving them|false|
+ */
+const wide = 1;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter/tests/fixtures/mod.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use oxc_allocator::Allocator;
 use oxc_formatter::{
     ArrowParentheses, BracketSameLine, BracketSpacing, JsFormatOptions, JsdocOptions,
-    QuoteProperties, QuoteStyle, Semicolons, TrailingCommas,
+    QuoteProperties, QuoteStyle, Semicolons, TableAlignment, TrailingCommas,
 };
 use oxc_formatter_core::{
     IndentStyle, IndentWidth, LineEnding, LineWidth,
@@ -114,7 +114,21 @@ impl FixtureFormatter for JsHarness {
                     }
                 }
                 "jsdoc" if value.is_object() => {
-                    options.jsdoc = Some(JsdocOptions::default());
+                    let mut jsdoc = JsdocOptions::default();
+                    if let Some(s) = value.get("tableAlignment").and_then(|v| v.as_str()) {
+                        jsdoc.table_alignment = match s {
+                            "auto" => TableAlignment::Auto,
+                            "never" => TableAlignment::Never,
+                            _ => TableAlignment::Always,
+                        };
+                    }
+                    if let Some(n) =
+                        value.get("tableAlignmentMaxWidth").and_then(serde_json::Value::as_u64)
+                        && let Ok(width) = u16::try_from(n)
+                    {
+                        jsdoc.table_alignment_max_width = width;
+                    }
+                    options.jsdoc = Some(jsdoc);
                 }
                 _ => {}
             }

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -509,6 +509,18 @@
           "description": "Add blank lines between different tag groups (e.g. between `@param` and `@returns`).\n\n- Default: `false`",
           "type": "boolean",
           "markdownDescription": "Add blank lines between different tag groups (e.g. between `@param` and `@returns`).\n\n- Default: `false`"
+        },
+        "tableAlignment": {
+          "description": "When to pad Markdown table columns so the `|` characters line up.\n\n- `\"always\"` — Always pad cells and stretch the separator row to the column width.\n- `\"auto\"` — Pad only when every padded row fits within `tableAlignmentMaxWidth`, otherwise emit that table unpadded (`|a|b|`) with a minimal separator row (`|---|---|`).\n- `\"never\"` — Never pad; every table uses the unpadded form.\n\nThe `\"auto\"` decision is made per table, so a narrow and a wide table in the same comment can come out differently.\n\n- Default: `\"always\"`",
+          "type": "string",
+          "markdownDescription": "When to pad Markdown table columns so the `|` characters line up.\n\n- `\"always\"` — Always pad cells and stretch the separator row to the column width.\n- `\"auto\"` — Pad only when every padded row fits within `tableAlignmentMaxWidth`, otherwise emit that table unpadded (`|a|b|`) with a minimal separator row (`|---|---|`).\n- `\"never\"` — Never pad; every table uses the unpadded form.\n\nThe `\"auto\"` decision is made per table, so a narrow and a wide table in the same comment can come out differently.\n\n- Default: `\"always\"`"
+        },
+        "tableAlignmentMaxWidth": {
+          "description": "Row width budget used by `tableAlignment: \"auto\"`.\n\nMeasured on the comment's content — the rendered row plus the Markdown indent it sits at,\nbut not the surrounding ` * ` gutter. Independent of `printWidth`, since tables are usually\nallowed to run wider than prose. Ignored by the other `tableAlignment` modes.\n\n- Default: `120`",
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0,
+          "markdownDescription": "Row width budget used by `tableAlignment: \"auto\"`.\n\nMeasured on the comment's content — the rendered row plus the Markdown indent it sits at,\nbut not the surrounding ` * ` gutter. Independent of `printWidth`, since tables are usually\nallowed to run wider than prose. Ignored by the other `tableAlignment` modes.\n\n- Default: `120`"
         }
       }
     },

--- a/tasks/prettier_conformance/src/jsdoc.rs
+++ b/tasks/prettier_conformance/src/jsdoc.rs
@@ -264,6 +264,18 @@ impl JsdocTestRunner {
         {
             options.keep_unparsable_example_indent = true;
         }
+        if let Some(alignment) = json.get("table_alignment").and_then(serde_json::Value::as_str) {
+            options.table_alignment = match alignment {
+                "auto" => oxc_formatter::TableAlignment::Auto,
+                "never" => oxc_formatter::TableAlignment::Never,
+                _ => oxc_formatter::TableAlignment::Always,
+            };
+        }
+        if let Some(w) = json.get("table_alignment_max_width").and_then(serde_json::Value::as_u64)
+            && let Ok(w) = u16::try_from(w)
+        {
+            options.table_alignment_max_width = w;
+        }
         if json.get("single_quote").and_then(serde_json::Value::as_bool) == Some(true) {
             quote_style = QuoteStyle::Single;
         }

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -240,6 +240,36 @@ Add blank lines between different tag groups (e.g. between `@param` and `@return
 - Default: `false`
 
 
+### jsdoc.tableAlignment
+
+type: `string`
+
+
+When to pad Markdown table columns so the `|` characters line up.
+
+- `"always"` — Always pad cells and stretch the separator row to the column width.
+- `"auto"` — Pad only when every padded row fits within `tableAlignmentMaxWidth`, otherwise emit that table unpadded (`|a|b|`) with a minimal separator row (`|---|---|`).
+- `"never"` — Never pad; every table uses the unpadded form.
+
+The `"auto"` decision is made per table, so a narrow and a wide table in the same comment can come out differently.
+
+- Default: `"always"`
+
+
+### jsdoc.tableAlignmentMaxWidth
+
+type: `integer`
+
+
+Row width budget used by `tableAlignment: "auto"`.
+
+Measured on the comment's content — the rendered row plus the Markdown indent it sits at,
+but not the surrounding ` * ` gutter. Independent of `printWidth`, since tables are usually
+allowed to run wider than prose. Ignored by the other `tableAlignment` modes.
+
+- Default: `120`
+
+
 ## jsxSingleQuote
 
 type: `boolean`
@@ -528,6 +558,36 @@ type: `boolean`
 Add blank lines between different tag groups (e.g. between `@param` and `@returns`).
 
 - Default: `false`
+
+
+###### overrides[n].options.jsdoc.tableAlignment
+
+type: `string`
+
+
+When to pad Markdown table columns so the `|` characters line up.
+
+- `"always"` — Always pad cells and stretch the separator row to the column width.
+- `"auto"` — Pad only when every padded row fits within `tableAlignmentMaxWidth`, otherwise emit that table unpadded (`|a|b|`) with a minimal separator row (`|---|---|`).
+- `"never"` — Never pad; every table uses the unpadded form.
+
+The `"auto"` decision is made per table, so a narrow and a wide table in the same comment can come out differently.
+
+- Default: `"always"`
+
+
+###### overrides[n].options.jsdoc.tableAlignmentMaxWidth
+
+type: `integer`
+
+
+Row width budget used by `tableAlignment: "auto"`.
+
+Measured on the comment's content — the rendered row plus the Markdown indent it sits at,
+but not the surrounding ` * ` gutter. Independent of `printWidth`, since tables are usually
+allowed to run wider than prose. Ignored by the other `tableAlignment` modes.
+
+- Default: `120`
 
 
 ##### overrides[n].options.jsxSingleQuote


### PR DESCRIPTION
## What

Adds `jsdoc.tableAlignment`, a width-gated mode for padding Markdown tables inside JSDoc comments.

Today `format_table_block` always pads cells and stretches the separator row so the `|` characters line up. That is nice for narrow tables, but a table with a long description column is forced hundreds of columns wide with no way to opt out.

| Mode | Behavior |
| :-- | :-- |
| `"always"` | Pad cells and stretch the separator row. **Current behavior, and still the default.** |
| `"auto"` | Pad only while the table's rendered rows stay within `jsdoc.tableAlignmentMaxWidth` (default `120`); otherwise emit that table unpadded with a minimal separator row. |
| `"never"` | Always emit the unpadded form. |

With `{ "jsdoc": { "tableAlignment": "auto" } }`, the decision is made **per table**, so both forms can appear in one comment:

```js
/**
 * | Option | Type    | Default |
 * | ------ | ------- | ------- |
 * | depth  | number  | 2       |
 * | strict | boolean | false   |
 *
 * |Option|Description|Default|
 * |---|---|---|
 * |resolveExtensions|List of file extensions the resolver will try in order|[".ts", ".js"]|
 * |preserveSymlinks|Keep symlinked paths as written instead of resolving them|false|
 */
```

## Notes on the implementation

- A padded table renders **every** row at the same width, so the fit check is one comparison against `sum(col_widths) + 3 * num_cols + 1` rather than a per-row scan.
- The budget is measured on comment *content* — the row plus its Markdown indent, but not the leading `*` gutter — which is the same basis `wrap_width` (`available_width - LINE_PREFIX_LEN`) already uses for every other wrap decision. A table at 120 therefore occupies 123 source columns.
- It is deliberately independent of `printWidth`: tables are usually allowed to run wider than prose, and coupling them would make the default behavior change with `printWidth`.
- Unpadded rows keep one space when a lone empty column would otherwise collapse to `||`. That is only two characters, which the table-row detector rejects, so without the guard the next format pass would break the table apart. There is a fixture and a round-trip unit test for this.

## Scope

This only touches the **JSDoc** Markdown path. Standalone `.md` / `.mdx` files are Tier 3 (delegated to Prettier) and are untouched.

## Compatibility

The default is `"always"`, so existing output is byte-identical. `prettier-plugin-jsdoc` has no counterpart to this option, so the new behavior is covered by `crates/oxc_formatter/tests/fixtures/js/jsdoc/table-alignment-auto/` rather than the conformance fixtures — adding it there would register as a permanent failure.

## Testing

- `cargo test -p oxc_formatter` — 321 fixtures + 60 unit tests pass (16 new unit tests, 4 new fixtures × 3 modes × 2 print widths)
- `cargo test -p oxfmt` and `cargo test -p oxfmt --no-default-features` pass
- `cargo run -p oxc_prettier_conformance -- jsdoc` — **145/145 (100%)**, unchanged
- `cargo clippy` clean for `oxc_formatter`, `oxc_formatter --features detect_code_removal`, `oxfmt`, `oxfmt --no-default-features`, and `oxc_prettier_conformance`
- `cargo fmt --all --check` clean
- Regenerated `npm/oxfmt/configuration_schema.json`, `apps/oxfmt/src-js/config.generated.ts`, and the `website_formatter` schema snapshot per `apps/oxfmt/AGENTS.md`
- Idempotency swept manually across 9 table shapes × 3 modes × 3 width budgets (81 runs), including CJK cells, alignment markers, ragged rows, and empty cells — all stable

## Open questions for maintainers

1. **Unpadded cell spacing.** This emits `|a|b|c|` with no spaces. `| a | b | c |` (dropping only the alignment padding) would be more readable but saves less width. Happy to switch.
2. **Option naming.** `tableAlignment` / `tableAlignmentMaxWidth` follows the existing `lineWrappingStyle` / `commentLineStrategy` convention, but I'm not attached to the names.
3. **Default.** Kept as `"always"` to avoid changing anyone's output. If you'd prefer `"auto"` as the default for `jsdoc: true`, that's a one-line change.

## AI usage disclosure

Per the [AI Usage Policy](https://github.com/oxc-project/oxc/blob/main/CONTRIBUTING.md#ai-usage-policy): this change was written with AI assistance (Claude). I have reviewed, tested, and validated it, and I take responsibility for it. Happy to rework anything that doesn't fit the project's direction.
