### PR TITLE
fix(formatter_css): keep leading `+` in An+B to enable idempotency check

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -230,6 +230,11 @@ Notable divergences are:
     - An artifact of its generic at-rule params indent
   - Ours matches how selector lists indent everywhere else
     - This is layout-only, deprecated syntax, triggers only on width overflow
+- A leading `+` in an `An+B` argument stays glued to its term (`:nth-child(+3n - 2)` keeps `+3n`)
+  - Prettier prints `+ 3n` (postcss-selector-parser tokenizes every `+` as a combinator),
+    but the An+B grammar forbids whitespace between a leading sign and its term,
+    so Prettier's output no longer parses as a selector
+    (= a semantics-breaking artifact, it also breaks formatter idempotency: the second pass fails to parse)
 - SCSS: `@forward` with `show`/`hide` members AND a `with (...)` config
   - Prettier parses the whole prelude as ONE comma list, so the config's forced break spills into the member commas
     (`show b,\n  c with (` even when the head fits) and the config body lands one level deeper (+4 body / +2 `)`)

--- a/crates/oxc_formatter_css/src/print/selector.rs
+++ b/crates/oxc_formatter_css/src/print/selector.rs
@@ -531,8 +531,11 @@ fn write_nth<'a>(nth: &Nth<'a>, f: &mut CssFormatter<'_, 'a>) {
 }
 
 /// Normalize an `An+B` expression:
-/// exactly one space around each `+` (none before a leading `+`),
+/// exactly one space around each `+` between terms,
 /// digit-led segments lowercased, all other whitespace kept as-is (a glued `-` stays glued).
+///
+/// NOTE: We keep a leading sign stays glued, since the An+B grammar forbids whitespace after it.
+/// But Prettier formats as `+ 3n`, output is a semantics-breaking artifact.
 fn normalize_an_plus_b(raw: &str) -> Cow<'_, str> {
     let bytes = raw.as_bytes();
     if !bytes.iter().any(|&b| b == b'+' || b.is_ascii_uppercase()) {
@@ -540,6 +543,7 @@ fn normalize_an_plus_b(raw: &str) -> Cow<'_, str> {
     }
 
     let mut out = String::with_capacity(raw.len() + 4);
+    let mut seen_term = false;
     let mut i = 0;
     while i < bytes.len() {
         let b = bytes[i];
@@ -547,7 +551,7 @@ fn normalize_an_plus_b(raw: &str) -> Cow<'_, str> {
             while out.ends_with(' ') {
                 out.pop();
             }
-            if !out.is_empty() {
+            if seen_term {
                 out.push(' ');
             }
             out.push('+');
@@ -555,13 +559,14 @@ fn normalize_an_plus_b(raw: &str) -> Cow<'_, str> {
             while i < bytes.len() && bytes[i].is_ascii_whitespace() {
                 i += 1;
             }
-            if i < bytes.len() {
+            if seen_term && i < bytes.len() {
                 out.push(' ');
             }
         } else if b.is_ascii_whitespace() {
             out.push(b as char);
             i += 1;
         } else {
+            seen_term = true;
             let start = i;
             while i < bytes.len() && !bytes[i].is_ascii_whitespace() && bytes[i] != b'+' {
                 i += 1;

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/nth-an-plus-b.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/nth-an-plus-b.css
@@ -4,6 +4,11 @@ c:nth-child(-n+3) { color: red; }
 d:nth-child(2n-1) { color: red; }
 e:nth-child(odd) { color: red; }
 f:nth-child(2n) { color: red; }
+/*
+ * Deliberate divergence (see "Known divergences" in AGENTS.md): the leading `+` stays glued (`+3n`).
+ * Prettier prints `+ 3n`, but the An+B grammar forbids whitespace between a leading sign and its term,
+ * so Prettier's output no longer parses as a selector.
+ */
 g:nth-child( +3n - 2 ) { color: red; }
 h:nth-child(5) { color: red; }
 i:nth-of-type(2N+1) { color: red; }

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/nth-an-plus-b.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/nth-an-plus-b.css.snap
@@ -8,6 +8,11 @@ c:nth-child(-n+3) { color: red; }
 d:nth-child(2n-1) { color: red; }
 e:nth-child(odd) { color: red; }
 f:nth-child(2n) { color: red; }
+/*
+ * Deliberate divergence (see "Known divergences" in AGENTS.md): the leading `+` stays glued (`+3n`).
+ * Prettier prints `+ 3n`, but the An+B grammar forbids whitespace between a leading sign and its term,
+ * so Prettier's output no longer parses as a selector.
+ */
 g:nth-child( +3n - 2 ) { color: red; }
 h:nth-child(5) { color: red; }
 i:nth-of-type(2N+1) { color: red; }
@@ -44,7 +49,12 @@ e:nth-child(odd) {
 f:nth-child(2n) {
   color: red;
 }
-g:nth-child(+ 3n - 2) {
+/*
+ * Deliberate divergence (see "Known divergences" in AGENTS.md): the leading `+` stays glued (`+3n`).
+ * Prettier prints `+ 3n`, but the An+B grammar forbids whitespace between a leading sign and its term,
+ * so Prettier's output no longer parses as a selector.
+ */
+g:nth-child(+3n - 2) {
   color: red;
 }
 h:nth-child(5) {
@@ -105,7 +115,12 @@ e:nth-child(odd) {
 f:nth-child(2n) {
   color: red;
 }
-g:nth-child(+ 3n - 2) {
+/*
+ * Deliberate divergence (see "Known divergences" in AGENTS.md): the leading `+` stays glued (`+3n`).
+ * Prettier prints `+ 3n`, but the An+B grammar forbids whitespace between a leading sign and its term,
+ * so Prettier's output no longer parses as a selector.
+ */
+g:nth-child(+3n - 2) {
   color: red;
 }
 h:nth-child(5) {

--- a/crates/oxc_formatter_css/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_css/tests/fixtures/mod.rs
@@ -17,10 +17,6 @@ struct CssHarness;
 impl FixtureFormatter for CssHarness {
     type Options = CssFormatOptions;
 
-    // TODO: Enable once the known non-idempotent output is fixed:
-    // nth-an-plus-b.css (`+ 3n` — invalid An+B whitespace, second pass fails to parse)
-    const CHECK_IDEMPOTENCY: bool = false;
-
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = CssFormatOptions::default();
 


### PR DESCRIPTION
Keep `:nth-child(+3n + 1)` as-is, NOT `:nth(+ 3n + 1)` which is not allowed.