### PR TITLE
refactor(linter/oxc/number-arg-out-of-range): simplify rule

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
+++ b/crates/oxc_linter/src/rules/oxc/number_arg_out_of_range.rs
@@ -57,14 +57,10 @@ declare_oxc_lint!(
 
 impl Rule for NumberArgOutOfRange {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::CallExpression(expr) = node.kind() else {
-            return;
-        };
-        let Some(member) = expr.callee.get_member_expr() else {
-            return;
-        };
-
-        if let Some(Argument::NumericLiteral(literal)) = expr.arguments.first() {
+        if let AstKind::CallExpression(expr) = node.kind()
+            && let Some(member) = expr.callee.get_member_expr()
+            && let Some(Argument::NumericLiteral(literal)) = expr.arguments.first()
+        {
             let value = literal.value;
             match member.static_property_name() {
                 Some(name @ "toString") if !(2.0_f64..=36.0_f64).contains(&value) => {


### PR DESCRIPTION
## Summary

- combine call-expression, member-expression, and numeric-argument checks into one if-let condition chain
- preserve the existing method-specific range diagnostics
