### PR TITLE
fix(linter): accept boolean values in globals schema (close #24982)

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -4,7 +4,7 @@
  */
 
 export type AllowWarnDeny = ("allow" | "off" | "warn" | "error" | "deny") | number;
-export type GlobalValue = ("readonly" | "writable" | "off") | undefined;
+export type GlobalValue = (("readonly" | "writable" | "off") | boolean) | undefined;
 export type ExternalPluginEntry =
   | string
   | {

--- a/crates/oxc_linter/src/config/globals.rs
+++ b/crates/oxc_linter/src/config/globals.rs
@@ -1,7 +1,7 @@
 use std::{borrow, fmt, hash, ops::Deref};
 
 use rustc_hash::FxHashMap;
-use schemars::JsonSchema;
+use schemars::{JsonSchema, schema::SchemaObject};
 use serde::{Deserialize, Serialize, de::Visitor};
 
 /// Add or remove global variables.
@@ -57,12 +57,29 @@ impl OxlintGlobals {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum GlobalValue {
     Readonly,
     Writable,
     Off,
+}
+
+impl JsonSchema for GlobalValue {
+    fn schema_name() -> String {
+        "GlobalValue".to_string()
+    }
+
+    fn json_schema(r#gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        let mut string_schema = <String as JsonSchema>::json_schema(r#gen).into_object();
+        string_schema.enum_values =
+            Some(vec!["readonly".into(), "writable".into(), "off".into()]);
+
+        let mut schema = SchemaObject::default();
+        schema.subschemas().any_of =
+            Some(vec![string_schema.into(), <bool as JsonSchema>::json_schema(r#gen)]);
+        schema.into()
+    }
 }
 
 impl GlobalValue {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -11463,11 +11463,18 @@
       ]
     },
     "GlobalValue": {
-      "type": "string",
-      "enum": [
-        "readonly",
-        "writable",
-        "off"
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "readonly",
+            "writable",
+            "off"
+          ]
+        },
+        {
+          "type": "boolean"
+        }
       ]
     },
     "GroupedAccessorPairs": {


### PR DESCRIPTION
Fixes #24982

The `GlobalValue` deserializer already accepts boolean values, mapping `true` to `writable` and `false` to `readonly`. However, its generated JSON Schema only allowed the string values `"readonly"`, `"writable"`, and `"off"`.

This PR:

- updates the `GlobalValue` schema to also accept booleans
- regenerates `npm/oxlint/configuration_schema.json`
- updates the generated TypeScript configuration type to include `boolean`
