### PR TITLE
refactor(linter/eslint/no-unused-vars): use `ArrowFunction::expression` flag

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -150,7 +150,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
     }
 }
 
-impl<'a> Symbol<'_, 'a> {
+impl Symbol<'_, '_> {
     /// Collect local names that are re-exported, for O(1) export checks per symbol.
     pub fn collect_exported_local_names(module_record: &ModuleRecord) -> FxHashSet<&str> {
         let mut names = FxHashSet::default();
@@ -212,11 +212,6 @@ impl<'a> Symbol<'_, 'a> {
     #[inline]
     pub fn is_in_ts(&self) -> bool {
         self.semantic.source_type().is_typescript()
-    }
-
-    #[inline]
-    pub fn get_snippet(&self, span: Span) -> &'a str {
-        span.source_text(self.semantic.source_text())
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -579,9 +579,7 @@ impl<'a> Symbol<'_, 'a> {
                 }
                 AstKind::Function(f) if f.is_declaration() => break,
                 // implicit return in an arrow function
-                AstKind::ArrowFunctionExpression(f)
-                    if f.body.statements.len() == 1
-                        && !self.get_snippet(f.body.span).starts_with('{') =>
+                AstKind::ArrowFunctionExpression(f) if f.expression =>
                 {
                     return false;
                 }
@@ -671,10 +669,7 @@ impl<'a> Symbol<'_, 'a> {
                 // `Some` even if
                 // 1. there are more than one statements
                 // 2. the expression is surrounded by braces
-                AstKind::ArrowFunctionExpression(f)
-                    if f.body.statements.len() == 1
-                        && !self.get_snippet(f.body.span).starts_with('{') =>
-                {
+                AstKind::ArrowFunctionExpression(f) if f.expression => {
                     return true;
                 }
                 x if x.is_statement() => return false,


### PR DESCRIPTION
## Summary

- use the parsed arrow function expression flag instead of inspecting source text
- remove the now-unused source snippet helper
