### PR TITLE
feat(linter/typescript): implement prefer-destructuring rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2037,6 +2037,14 @@ impl RuleRunner for crate::rules::typescript::prefer_as_const::PreferAsConst {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::typescript::prefer_destructuring::PreferDestructuring {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AssignmentExpression,
+        AstType::VariableDeclarator,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::typescript::prefer_enum_initializers::PreferEnumInitializers {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::TSEnumBody]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -569,6 +569,7 @@ pub use crate::rules::typescript::non_nullable_type_assertion_style::NonNullable
 pub use crate::rules::typescript::only_throw_error::OnlyThrowError as TypescriptOnlyThrowError;
 pub use crate::rules::typescript::parameter_properties::ParameterProperties as TypescriptParameterProperties;
 pub use crate::rules::typescript::prefer_as_const::PreferAsConst as TypescriptPreferAsConst;
+pub use crate::rules::typescript::prefer_destructuring::PreferDestructuring as TypescriptPreferDestructuring;
 pub use crate::rules::typescript::prefer_enum_initializers::PreferEnumInitializers as TypescriptPreferEnumInitializers;
 pub use crate::rules::typescript::prefer_find::PreferFind as TypescriptPreferFind;
 pub use crate::rules::typescript::prefer_for_of::PreferForOf as TypescriptPreferForOf;
@@ -1167,6 +1168,7 @@ pub enum RuleEnum {
     TypescriptOnlyThrowError(TypescriptOnlyThrowError),
     TypescriptParameterProperties(TypescriptParameterProperties),
     TypescriptPreferAsConst(TypescriptPreferAsConst),
+    TypescriptPreferDestructuring(TypescriptPreferDestructuring),
     TypescriptPreferEnumInitializers(TypescriptPreferEnumInitializers),
     TypescriptPreferFind(TypescriptPreferFind),
     TypescriptPreferForOf(TypescriptPreferForOf),
@@ -2057,7 +2059,8 @@ const TYPESCRIPT_ONLY_THROW_ERROR_ID: usize =
     TYPESCRIPT_NON_NULLABLE_TYPE_ASSERTION_STYLE_ID + 1usize;
 const TYPESCRIPT_PARAMETER_PROPERTIES_ID: usize = TYPESCRIPT_ONLY_THROW_ERROR_ID + 1usize;
 const TYPESCRIPT_PREFER_AS_CONST_ID: usize = TYPESCRIPT_PARAMETER_PROPERTIES_ID + 1usize;
-const TYPESCRIPT_PREFER_ENUM_INITIALIZERS_ID: usize = TYPESCRIPT_PREFER_AS_CONST_ID + 1usize;
+const TYPESCRIPT_PREFER_DESTRUCTURING_ID: usize = TYPESCRIPT_PREFER_AS_CONST_ID + 1usize;
+const TYPESCRIPT_PREFER_ENUM_INITIALIZERS_ID: usize = TYPESCRIPT_PREFER_DESTRUCTURING_ID + 1usize;
 const TYPESCRIPT_PREFER_FIND_ID: usize = TYPESCRIPT_PREFER_ENUM_INITIALIZERS_ID + 1usize;
 const TYPESCRIPT_PREFER_FOR_OF_ID: usize = TYPESCRIPT_PREFER_FIND_ID + 1usize;
 const TYPESCRIPT_PREFER_FUNCTION_TYPE_ID: usize = TYPESCRIPT_PREFER_FOR_OF_ID + 1usize;
@@ -3034,6 +3037,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TYPESCRIPT_ONLY_THROW_ERROR_ID,
             Self::TypescriptParameterProperties(_) => TYPESCRIPT_PARAMETER_PROPERTIES_ID,
             Self::TypescriptPreferAsConst(_) => TYPESCRIPT_PREFER_AS_CONST_ID,
+            Self::TypescriptPreferDestructuring(_) => TYPESCRIPT_PREFER_DESTRUCTURING_ID,
             Self::TypescriptPreferEnumInitializers(_) => TYPESCRIPT_PREFER_ENUM_INITIALIZERS_ID,
             Self::TypescriptPreferFind(_) => TYPESCRIPT_PREFER_FIND_ID,
             Self::TypescriptPreferForOf(_) => TYPESCRIPT_PREFER_FOR_OF_ID,
@@ -4013,6 +4017,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TypescriptOnlyThrowError::NAME,
             Self::TypescriptParameterProperties(_) => TypescriptParameterProperties::NAME,
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::NAME,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::NAME,
             Self::TypescriptPreferEnumInitializers(_) => TypescriptPreferEnumInitializers::NAME,
             Self::TypescriptPreferFind(_) => TypescriptPreferFind::NAME,
             Self::TypescriptPreferForOf(_) => TypescriptPreferForOf::NAME,
@@ -4990,6 +4995,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TypescriptOnlyThrowError::CATEGORY,
             Self::TypescriptParameterProperties(_) => TypescriptParameterProperties::CATEGORY,
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::CATEGORY,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::CATEGORY,
             Self::TypescriptPreferEnumInitializers(_) => TypescriptPreferEnumInitializers::CATEGORY,
             Self::TypescriptPreferFind(_) => TypescriptPreferFind::CATEGORY,
             Self::TypescriptPreferForOf(_) => TypescriptPreferForOf::CATEGORY,
@@ -6002,6 +6008,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TypescriptOnlyThrowError::FIX,
             Self::TypescriptParameterProperties(_) => TypescriptParameterProperties::FIX,
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::FIX,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::FIX,
             Self::TypescriptPreferEnumInitializers(_) => TypescriptPreferEnumInitializers::FIX,
             Self::TypescriptPreferFind(_) => TypescriptPreferFind::FIX,
             Self::TypescriptPreferForOf(_) => TypescriptPreferForOf::FIX,
@@ -7034,6 +7041,9 @@ impl RuleEnum {
                 TypescriptParameterProperties::documentation()
             }
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::documentation(),
+            Self::TypescriptPreferDestructuring(_) => {
+                TypescriptPreferDestructuring::documentation()
+            }
             Self::TypescriptPreferEnumInitializers(_) => {
                 TypescriptPreferEnumInitializers::documentation()
             }
@@ -8690,6 +8700,10 @@ impl RuleEnum {
             }
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::config_schema(generator)
                 .or_else(|| TypescriptPreferAsConst::schema(generator)),
+            Self::TypescriptPreferDestructuring(_) => {
+                TypescriptPreferDestructuring::config_schema(generator)
+                    .or_else(|| TypescriptPreferDestructuring::schema(generator))
+            }
             Self::TypescriptPreferEnumInitializers(_) => {
                 TypescriptPreferEnumInitializers::config_schema(generator)
                     .or_else(|| TypescriptPreferEnumInitializers::schema(generator))
@@ -10588,6 +10602,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => "typescript",
             Self::TypescriptParameterProperties(_) => "typescript",
             Self::TypescriptPreferAsConst(_) => "typescript",
+            Self::TypescriptPreferDestructuring(_) => "typescript",
             Self::TypescriptPreferEnumInitializers(_) => "typescript",
             Self::TypescriptPreferFind(_) => "typescript",
             Self::TypescriptPreferForOf(_) => "typescript",
@@ -12097,6 +12112,9 @@ impl RuleEnum {
             )),
             Self::TypescriptPreferAsConst(_) => Ok(Self::TypescriptPreferAsConst(
                 TypescriptPreferAsConst::from_configuration(value)?,
+            )),
+            Self::TypescriptPreferDestructuring(_) => Ok(Self::TypescriptPreferDestructuring(
+                TypescriptPreferDestructuring::from_configuration(value)?,
             )),
             Self::TypescriptPreferEnumInitializers(_) => {
                 Ok(Self::TypescriptPreferEnumInitializers(
@@ -14175,6 +14193,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.to_configuration(),
             Self::TypescriptParameterProperties(rule) => rule.to_configuration(),
             Self::TypescriptPreferAsConst(rule) => rule.to_configuration(),
+            Self::TypescriptPreferDestructuring(rule) => rule.to_configuration(),
             Self::TypescriptPreferEnumInitializers(rule) => rule.to_configuration(),
             Self::TypescriptPreferFind(rule) => rule.to_configuration(),
             Self::TypescriptPreferForOf(rule) => rule.to_configuration(),
@@ -15029,6 +15048,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.run(node, ctx),
             Self::TypescriptParameterProperties(rule) => rule.run(node, ctx),
             Self::TypescriptPreferAsConst(rule) => rule.run(node, ctx),
+            Self::TypescriptPreferDestructuring(rule) => rule.run(node, ctx),
             Self::TypescriptPreferEnumInitializers(rule) => rule.run(node, ctx),
             Self::TypescriptPreferFind(rule) => rule.run(node, ctx),
             Self::TypescriptPreferForOf(rule) => rule.run(node, ctx),
@@ -15893,6 +15913,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.run_once(ctx),
             Self::TypescriptParameterProperties(rule) => rule.run_once(ctx),
             Self::TypescriptPreferAsConst(rule) => rule.run_once(ctx),
+            Self::TypescriptPreferDestructuring(rule) => rule.run_once(ctx),
             Self::TypescriptPreferEnumInitializers(rule) => rule.run_once(ctx),
             Self::TypescriptPreferFind(rule) => rule.run_once(ctx),
             Self::TypescriptPreferForOf(rule) => rule.run_once(ctx),
@@ -16812,6 +16833,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptParameterProperties(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptPreferAsConst(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::TypescriptPreferDestructuring(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptPreferEnumInitializers(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptPreferFind(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::TypescriptPreferForOf(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17739,6 +17761,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.should_run(ctx),
             Self::TypescriptParameterProperties(rule) => rule.should_run(ctx),
             Self::TypescriptPreferAsConst(rule) => rule.should_run(ctx),
+            Self::TypescriptPreferDestructuring(rule) => rule.should_run(ctx),
             Self::TypescriptPreferEnumInitializers(rule) => rule.should_run(ctx),
             Self::TypescriptPreferFind(rule) => rule.should_run(ctx),
             Self::TypescriptPreferForOf(rule) => rule.should_run(ctx),
@@ -18708,6 +18731,9 @@ impl RuleEnum {
                 TypescriptParameterProperties::IS_TSGOLINT_RULE
             }
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::IS_TSGOLINT_RULE,
+            Self::TypescriptPreferDestructuring(_) => {
+                TypescriptPreferDestructuring::IS_TSGOLINT_RULE
+            }
             Self::TypescriptPreferEnumInitializers(_) => {
                 TypescriptPreferEnumInitializers::IS_TSGOLINT_RULE
             }
@@ -19889,6 +19915,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TypescriptOnlyThrowError::VERSION,
             Self::TypescriptParameterProperties(_) => TypescriptParameterProperties::VERSION,
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::VERSION,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::VERSION,
             Self::TypescriptPreferEnumInitializers(_) => TypescriptPreferEnumInitializers::VERSION,
             Self::TypescriptPreferFind(_) => TypescriptPreferFind::VERSION,
             Self::TypescriptPreferForOf(_) => TypescriptPreferForOf::VERSION,
@@ -20925,6 +20952,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TypescriptOnlyThrowError::HAS_CONFIG,
             Self::TypescriptParameterProperties(_) => TypescriptParameterProperties::HAS_CONFIG,
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::HAS_CONFIG,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::HAS_CONFIG,
             Self::TypescriptPreferEnumInitializers(_) => {
                 TypescriptPreferEnumInitializers::HAS_CONFIG
             }
@@ -21966,6 +21994,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(_) => TypescriptOnlyThrowError::INFO,
             Self::TypescriptParameterProperties(_) => TypescriptParameterProperties::INFO,
             Self::TypescriptPreferAsConst(_) => TypescriptPreferAsConst::INFO,
+            Self::TypescriptPreferDestructuring(_) => TypescriptPreferDestructuring::INFO,
             Self::TypescriptPreferEnumInitializers(_) => TypescriptPreferEnumInitializers::INFO,
             Self::TypescriptPreferFind(_) => TypescriptPreferFind::INFO,
             Self::TypescriptPreferForOf(_) => TypescriptPreferForOf::INFO,
@@ -22884,6 +22913,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.types_info(),
             Self::TypescriptParameterProperties(rule) => rule.types_info(),
             Self::TypescriptPreferAsConst(rule) => rule.types_info(),
+            Self::TypescriptPreferDestructuring(rule) => rule.types_info(),
             Self::TypescriptPreferEnumInitializers(rule) => rule.types_info(),
             Self::TypescriptPreferFind(rule) => rule.types_info(),
             Self::TypescriptPreferForOf(rule) => rule.types_info(),
@@ -23735,6 +23765,7 @@ impl RuleEnum {
             Self::TypescriptOnlyThrowError(rule) => rule.run_info(),
             Self::TypescriptParameterProperties(rule) => rule.run_info(),
             Self::TypescriptPreferAsConst(rule) => rule.run_info(),
+            Self::TypescriptPreferDestructuring(rule) => rule.run_info(),
             Self::TypescriptPreferEnumInitializers(rule) => rule.run_info(),
             Self::TypescriptPreferFind(rule) => rule.run_info(),
             Self::TypescriptPreferForOf(rule) => rule.run_info(),
@@ -24660,6 +24691,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::TypescriptOnlyThrowError(TypescriptOnlyThrowError::default()),
         RuleEnum::TypescriptParameterProperties(TypescriptParameterProperties::default()),
         RuleEnum::TypescriptPreferAsConst(TypescriptPreferAsConst::default()),
+        RuleEnum::TypescriptPreferDestructuring(TypescriptPreferDestructuring::default()),
         RuleEnum::TypescriptPreferEnumInitializers(TypescriptPreferEnumInitializers::default()),
         RuleEnum::TypescriptPreferFind(TypescriptPreferFind::default()),
         RuleEnum::TypescriptPreferForOf(TypescriptPreferForOf::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -311,6 +311,7 @@ pub(crate) mod typescript {
     pub mod only_throw_error;
     pub mod parameter_properties;
     pub mod prefer_as_const;
+    pub mod prefer_destructuring;
     pub mod prefer_enum_initializers;
     pub mod prefer_find;
     pub mod prefer_for_of;

--- a/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
@@ -1,389 +1,45 @@
-use oxc_ast::{
-    AstKind,
-    ast::{
-        AssignmentTarget, BindingPattern, Expression, MemberExpression, VariableDeclarationKind,
-    },
-};
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Span};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,
     context::LintContext,
-    rule::{Rule, TupleRuleConfig},
+    rule::Rule,
+    rules::shared::prefer_destructuring::{
+        DOCUMENTATION, PreferDestructuring as PreferDestructuringInner, PreferDestructuringConfig,
+    },
 };
 
-fn prefer_object_destructuring(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Use Object destructuring.")
-        .with_help("Use object destructuring rather than direct member access.")
-        .with_label(span)
-}
-
-fn prefer_array_destructuring(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Use Array destructuring.")
-        .with_help("Use array destructuring rather than direct member access.")
-        .with_label(span)
-}
-
-#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-struct PreferDestructuringTargetConfig {
-    array: bool,
-    object: bool,
-}
-
-impl Default for PreferDestructuringTargetConfig {
-    fn default() -> Self {
-        Self { array: true, object: true }
-    }
-}
-
-impl PreferDestructuringTargetConfig {
-    fn disabled() -> Self {
-        Self { array: false, object: false }
-    }
-}
-
-#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct PreferDestructuringTargetOption {
-    array: Option<bool>,
-    object: Option<bool>,
-}
-
-impl PreferDestructuringTargetOption {
-    fn enabled_by_default() -> Self {
-        Self { array: Some(true), object: Some(true) }
-    }
-
-    fn into_config(self) -> PreferDestructuringTargetConfig {
-        PreferDestructuringTargetConfig {
-            array: self.array.unwrap_or(false),
-            object: self.object.unwrap_or(false),
-        }
-    }
-}
-
-#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(rename_all = "PascalCase", deny_unknown_fields)]
-struct PreferDestructuringAssignmentConfig {
-    variable_declarator: Option<PreferDestructuringTargetOption>,
-    assignment_expression: Option<PreferDestructuringTargetOption>,
-}
-
-impl PreferDestructuringAssignmentConfig {
-    fn into_configs(self) -> (PreferDestructuringTargetConfig, PreferDestructuringTargetConfig) {
-        let variable_declarator = self.variable_declarator.map_or_else(
-            PreferDestructuringTargetConfig::disabled,
-            PreferDestructuringTargetOption::into_config,
-        );
-        let assignment_expression = self.assignment_expression.map_or_else(
-            PreferDestructuringTargetConfig::disabled,
-            PreferDestructuringTargetOption::into_config,
-        );
-
-        (variable_declarator, assignment_expression)
-    }
-}
-
-#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(untagged)]
-enum PreferDestructuringOption {
-    Target(PreferDestructuringTargetOption),
-    Assignment(PreferDestructuringAssignmentConfig),
-}
-
-impl Default for PreferDestructuringOption {
-    fn default() -> Self {
-        Self::Target(PreferDestructuringTargetOption::enabled_by_default())
-    }
-}
-
-impl PreferDestructuringOption {
-    fn into_configs(self) -> (PreferDestructuringTargetConfig, PreferDestructuringTargetConfig) {
-        match self {
-            Self::Target(config) => {
-                let config = config.into_config();
-                (config.clone(), config)
-            }
-            Self::Assignment(config) => config.into_configs(),
-        }
-    }
-}
-
-#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-struct PreferDestructuringEnforcementConfig {
-    enforce_for_renamed_properties: bool,
-    enforce_for_declaration_with_type_annotation: bool,
-}
-
-#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(default)]
-struct PreferDestructuringConfig(PreferDestructuringOption, PreferDestructuringEnforcementConfig);
-
-impl PreferDestructuringConfig {
-    fn into_rule(self) -> PreferDestructuring {
-        let (variable_declarator, assignment_expression) = self.0.into_configs();
-
-        PreferDestructuring {
-            variable_declarator,
-            assignment_expression,
-            enforce_for_renamed_properties: self.1.enforce_for_renamed_properties,
-            enforce_for_declaration_with_type_annotation: self
-                .1
-                .enforce_for_declaration_with_type_annotation,
-        }
-    }
-}
-
-#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-pub struct PreferDestructuring {
-    /// Configuration for destructuring in variable declarations, configured for arrays and objects independently.
-    #[serde(rename = "VariableDeclarator")]
-    variable_declarator: PreferDestructuringTargetConfig,
-    /// Configuration for destructuring in assignment expressions, configured for arrays and objects independently.
-    #[serde(rename = "AssignmentExpression")]
-    assignment_expression: PreferDestructuringTargetConfig,
-    /// Determines whether the object destructuring rule applies to renamed variables.
-    enforce_for_renamed_properties: bool,
-    /// Determines whether the rule applies to variable declarations with type annotations.
-    enforce_for_declaration_with_type_annotation: bool,
-}
+#[derive(Debug, Default, Clone)]
+pub struct PreferDestructuring(PreferDestructuringInner);
 
 declare_oxc_lint!(
-    /// ### What it does
-    ///
-    /// Require destructuring from arrays and/or objects.
-    ///
-    /// ### Why is this bad?
-    ///
-    /// With JavaScript ES2015, a new syntax was added for creating variables from an array index or object property,
-    /// called destructuring. This rule enforces usage of destructuring
-    /// instead of accessing a property through a member expression.
-    ///
-    /// ### Examples
-    ///
-    /// Examples of **incorrect** code for this rule:
-    /// ```js
-    /// // With `array` enabled
-    /// const foo = array[0];
-    /// bar.baz = array[0];
-    /// // With `object` enabled
-    /// const qux = object.qux;
-    /// const quux = object['quux'];
-    /// ```
-    ///
-    /// Examples of **correct** code for this rule:
-    /// ```js
-    /// // With `array` enabled
-    /// const [ foo ] = array;
-    /// const arr = array[someIndex];
-    /// [bar.baz] = array;
-    ///
-    /// // With `object` enabled
-    /// const { baz } = object;
-    /// const obj = object.bar;
-    /// ```
     PreferDestructuring,
     eslint,
     style,
     conditional_fix,
     config = PreferDestructuringConfig,
+    docs = DOCUMENTATION,
     version = "1.10.0",
     short_description = "Require destructuring from arrays and/or objects.",
 );
 
 impl Rule for PreferDestructuring {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        serde_json::from_value::<TupleRuleConfig<PreferDestructuringConfig>>(value)
-            .map(|config| config.into_inner().into_rule())
+        PreferDestructuringInner::from_configuration(value).map(Self)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::AssignmentExpression(assign_expr) if assign_expr.operator.is_assign() => {
-                let Some(right) = assign_expr.right.without_parentheses().as_member_expression()
-                else {
-                    return;
-                };
-                if !check_expr(right) {
-                    return;
-                }
-                match right {
-                    MemberExpression::ComputedMemberExpression(comp_expr) => {
-                        if matches!(comp_expr.expression, Expression::TemplateLiteral(_)) {
-                            return;
-                        }
-                        if matches!(comp_expr.expression, Expression::NumericLiteral(_)) {
-                            if self.assignment_expression.array {
-                                ctx.diagnostic(prefer_array_destructuring(assign_expr.span));
-                            }
-                        } else {
-                            if self.enforce_for_renamed_properties
-                                && self.assignment_expression.object
-                            {
-                                ctx.diagnostic(prefer_object_destructuring(assign_expr.span));
-                            }
-                            if let Expression::StringLiteral(string_literal) = &comp_expr.expression
-                                && get_target_name(&assign_expr.left)
-                                    .is_some_and(|v| v == string_literal.value)
-                            {
-                                ctx.diagnostic(prefer_object_destructuring(assign_expr.span));
-                            }
-                        }
-                    }
-                    MemberExpression::StaticMemberExpression(static_expr)
-                        if self.assignment_expression.object
-                            && get_target_name(&assign_expr.left)
-                                .is_some_and(|name| name == static_expr.property.name.as_str()) =>
-                    {
-                        ctx.diagnostic(prefer_object_destructuring(assign_expr.span));
-                    }
-                    _ => {}
-                }
+                self.0.run_on_assignment_expression(assign_expr, ctx);
             }
             AstKind::VariableDeclarator(declarator) => {
-                let has_type_annotation = declarator.type_annotation.is_some();
-                if has_type_annotation && !self.enforce_for_declaration_with_type_annotation {
-                    return;
-                }
-
-                // Skip `using` and `await using` declarations - destructuring doesn't apply to them
-                if matches!(
-                    declarator.kind,
-                    VariableDeclarationKind::Using | VariableDeclarationKind::AwaitUsing
-                ) {
-                    return;
-                }
-                if let Some(init) = &declarator.init
-                    && let Some(right) = init.without_parentheses().as_member_expression()
-                {
-                    if !check_expr(right) {
-                        return;
-                    }
-                    let name = if matches!(declarator.id, BindingPattern::BindingIdentifier(_)) {
-                        declarator.id.get_identifier_name().map(|v| v.as_str())
-                    } else {
-                        None
-                    };
-                    match right {
-                        MemberExpression::ComputedMemberExpression(comp_expr) => {
-                            if matches!(comp_expr.expression, Expression::TemplateLiteral(_)) {
-                                return;
-                            }
-                            if matches!(comp_expr.expression, Expression::NumericLiteral(_)) {
-                                if self.variable_declarator.array {
-                                    ctx.diagnostic(prefer_array_destructuring(init.span()));
-                                }
-                            } else if self.variable_declarator.object {
-                                if let Expression::StringLiteral(string_literal) =
-                                    &comp_expr.expression
-                                    && name.is_some_and(|v| v == string_literal.value)
-                                {
-                                    if has_type_annotation {
-                                        ctx.diagnostic(prefer_object_destructuring(init.span()));
-                                    } else {
-                                        ctx.diagnostic_with_fix(
-                                            prefer_object_destructuring(init.span()),
-                                            |fixer| {
-                                                generate_fix(
-                                                    &fixer,
-                                                    string_literal.span.shrink(1),
-                                                    get_object_span_without_redundant_parentheses(
-                                                        &comp_expr.object,
-                                                    ),
-                                                    declarator.span(),
-                                                )
-                                            },
-                                        );
-                                    }
-                                } else if self.enforce_for_renamed_properties {
-                                    ctx.diagnostic(prefer_object_destructuring(right.span()));
-                                }
-                            }
-                        }
-                        MemberExpression::StaticMemberExpression(static_expr)
-                            if self.variable_declarator.object =>
-                        {
-                            if name.is_some_and(|name| name == static_expr.property.name.as_str()) {
-                                if has_type_annotation {
-                                    ctx.diagnostic(prefer_object_destructuring(init.span()));
-                                } else {
-                                    ctx.diagnostic_with_fix(
-                                        prefer_object_destructuring(init.span()),
-                                        |fixer| {
-                                            generate_fix(
-                                                &fixer,
-                                                static_expr.property.span,
-                                                get_object_span_without_redundant_parentheses(
-                                                    &static_expr.object,
-                                                ),
-                                                declarator.span(),
-                                            )
-                                        },
-                                    );
-                                }
-                            } else if self.enforce_for_renamed_properties {
-                                ctx.diagnostic(prefer_object_destructuring(right.span()));
-                            }
-                        }
-                        _ => {}
-                    }
-                }
+                self.0.run_on_variable_declarator(declarator, ctx);
             }
             _ => {}
         }
     }
-}
-
-fn get_target_name<'a>(target: &'a AssignmentTarget<'a>) -> Option<&'a str> {
-    if let AssignmentTarget::AssignmentTargetIdentifier(ident) = target {
-        return Some(ident.name.as_str());
-    }
-    None
-}
-
-fn check_expr(expr: &MemberExpression) -> bool {
-    if matches!(expr, MemberExpression::PrivateFieldExpression(_))
-        || matches!(expr.object(), Expression::Super(_))
-    {
-        return false;
-    }
-    true
-}
-
-/// Returns the span of the object expression, stripping redundant parentheses for expressions
-/// where they are unnecessary in the destructuring context.
-///
-/// For example: `(bar[baz]).foo` -> uses span of `bar[baz]` (without parens)
-/// But: `(a, b).foo` -> uses span of `(a, b)` (keeps parens, comma operator needs them)
-fn get_object_span_without_redundant_parentheses(object: &Expression) -> Span {
-    match object.without_parentheses() {
-        Expression::CallExpression(_)
-        | Expression::Identifier(_)
-        | Expression::StaticMemberExpression(_)
-        | Expression::ComputedMemberExpression(_)
-        | Expression::ThisExpression(_) => object.without_parentheses().span(),
-        _ => object.span(),
-    }
-}
-
-/// Generate the fix for object destructuring in a variable declaration.
-fn generate_fix(
-    fixer: &crate::fixer::RuleFixer<'_, '_>,
-    prop_span: Span,
-    object_span: Span,
-    replacement_span: Span,
-) -> crate::fixer::RuleFix {
-    let prop = fixer.source_range(prop_span);
-    let object_text = fixer.source_range(object_span);
-    let replacement = format!("{{{prop}}} = {object_text}");
-    fixer.replace(replacement_span, replacement)
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/shared/eslint_typescript/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_typescript/mod.rs
@@ -1,0 +1,1 @@
+pub mod prefer_destructuring;

--- a/crates/oxc_linter/src/rules/shared/eslint_typescript/prefer_destructuring.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_typescript/prefer_destructuring.rs
@@ -1,0 +1,372 @@
+use oxc_ast::ast::{
+    AssignmentExpression, AssignmentTarget, BindingPattern, Expression, MemberExpression,
+    VariableDeclarationKind, VariableDeclarator,
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    context::LintContext,
+    fixer::{RuleFix, RuleFixer},
+    rule::TupleRuleConfig,
+};
+
+pub const DOCUMENTATION: &str = r"### What it does
+
+Require destructuring from arrays and/or objects.
+
+### Why is this bad?
+
+With JavaScript ES2015, a new syntax was added for creating variables from an array index or object property,
+called destructuring. This rule enforces usage of destructuring
+instead of accessing a property through a member expression.
+
+### Examples
+
+Examples of **incorrect** code for this rule:
+```js
+// With `array` enabled
+const foo = array[0];
+bar.baz = array[0];
+// With `object` enabled
+const qux = object.qux;
+const quux = object['quux'];
+```
+
+Examples of **correct** code for this rule:
+```js
+// With `array` enabled
+const [ foo ] = array;
+const arr = array[someIndex];
+[bar.baz] = array;
+
+// With `object` enabled
+const { baz } = object;
+const obj = object.bar;
+```";
+
+fn prefer_object_destructuring(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use Object destructuring.")
+        .with_help("Use object destructuring rather than direct member access.")
+        .with_label(span)
+}
+
+fn prefer_array_destructuring(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use Array destructuring.")
+        .with_help("Use array destructuring rather than direct member access.")
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct PreferDestructuringTargetConfig {
+    array: bool,
+    object: bool,
+}
+
+impl Default for PreferDestructuringTargetConfig {
+    fn default() -> Self {
+        Self { array: true, object: true }
+    }
+}
+
+impl PreferDestructuringTargetConfig {
+    fn disabled() -> Self {
+        Self { array: false, object: false }
+    }
+}
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PreferDestructuringTargetOption {
+    array: Option<bool>,
+    object: Option<bool>,
+}
+
+impl PreferDestructuringTargetOption {
+    fn enabled_by_default() -> Self {
+        Self { array: Some(true), object: Some(true) }
+    }
+
+    fn into_config(self) -> PreferDestructuringTargetConfig {
+        PreferDestructuringTargetConfig {
+            array: self.array.unwrap_or(false),
+            object: self.object.unwrap_or(false),
+        }
+    }
+}
+
+#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase", deny_unknown_fields)]
+struct PreferDestructuringAssignmentConfig {
+    variable_declarator: Option<PreferDestructuringTargetOption>,
+    assignment_expression: Option<PreferDestructuringTargetOption>,
+}
+
+impl PreferDestructuringAssignmentConfig {
+    fn into_configs(self) -> (PreferDestructuringTargetConfig, PreferDestructuringTargetConfig) {
+        let variable_declarator = self.variable_declarator.map_or_else(
+            PreferDestructuringTargetConfig::disabled,
+            PreferDestructuringTargetOption::into_config,
+        );
+        let assignment_expression = self.assignment_expression.map_or_else(
+            PreferDestructuringTargetConfig::disabled,
+            PreferDestructuringTargetOption::into_config,
+        );
+
+        (variable_declarator, assignment_expression)
+    }
+}
+
+#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(untagged)]
+enum PreferDestructuringOption {
+    Target(PreferDestructuringTargetOption),
+    Assignment(PreferDestructuringAssignmentConfig),
+}
+
+impl Default for PreferDestructuringOption {
+    fn default() -> Self {
+        Self::Target(PreferDestructuringTargetOption::enabled_by_default())
+    }
+}
+
+impl PreferDestructuringOption {
+    fn into_configs(self) -> (PreferDestructuringTargetConfig, PreferDestructuringTargetConfig) {
+        match self {
+            Self::Target(config) => {
+                let config = config.into_config();
+                (config.clone(), config)
+            }
+            Self::Assignment(config) => config.into_configs(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct PreferDestructuringEnforcementConfig {
+    enforce_for_renamed_properties: bool,
+    enforce_for_declaration_with_type_annotation: bool,
+}
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(default)]
+pub struct PreferDestructuringConfig(
+    PreferDestructuringOption,
+    PreferDestructuringEnforcementConfig,
+);
+
+impl PreferDestructuringConfig {
+    fn into_rule(self) -> PreferDestructuring {
+        let (variable_declarator, assignment_expression) = self.0.into_configs();
+
+        PreferDestructuring {
+            variable_declarator,
+            assignment_expression,
+            enforce_for_renamed_properties: self.1.enforce_for_renamed_properties,
+            enforce_for_declaration_with_type_annotation: self
+                .1
+                .enforce_for_declaration_with_type_annotation,
+        }
+    }
+}
+
+/// Parsed state shared by the `eslint` and `typescript` variants of the rule.
+#[derive(Debug, Default, Clone)]
+pub struct PreferDestructuring {
+    variable_declarator: PreferDestructuringTargetConfig,
+    assignment_expression: PreferDestructuringTargetConfig,
+    enforce_for_renamed_properties: bool,
+    enforce_for_declaration_with_type_annotation: bool,
+}
+
+impl PreferDestructuring {
+    pub fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<TupleRuleConfig<PreferDestructuringConfig>>(value)
+            .map(|config| config.into_inner().into_rule())
+    }
+
+    pub fn run_on_assignment_expression<'a>(
+        &self,
+        assign_expr: &AssignmentExpression<'a>,
+        ctx: &LintContext<'a>,
+    ) {
+        let Some(right) = assign_expr.right.without_parentheses().as_member_expression() else {
+            return;
+        };
+        if !check_expr(right) {
+            return;
+        }
+        match right {
+            MemberExpression::ComputedMemberExpression(comp_expr) => {
+                if matches!(comp_expr.expression, Expression::TemplateLiteral(_)) {
+                    return;
+                }
+                if matches!(comp_expr.expression, Expression::NumericLiteral(_)) {
+                    if self.assignment_expression.array {
+                        ctx.diagnostic(prefer_array_destructuring(assign_expr.span));
+                    }
+                } else {
+                    if self.enforce_for_renamed_properties && self.assignment_expression.object {
+                        ctx.diagnostic(prefer_object_destructuring(assign_expr.span));
+                    }
+                    if let Expression::StringLiteral(string_literal) = &comp_expr.expression
+                        && get_target_name(&assign_expr.left)
+                            .is_some_and(|v| v == string_literal.value)
+                    {
+                        ctx.diagnostic(prefer_object_destructuring(assign_expr.span));
+                    }
+                }
+            }
+            MemberExpression::StaticMemberExpression(static_expr)
+                if self.assignment_expression.object
+                    && get_target_name(&assign_expr.left)
+                        .is_some_and(|name| name == static_expr.property.name.as_str()) =>
+            {
+                ctx.diagnostic(prefer_object_destructuring(assign_expr.span));
+            }
+            _ => {}
+        }
+    }
+
+    pub fn run_on_variable_declarator<'a>(
+        &self,
+        declarator: &VariableDeclarator<'a>,
+        ctx: &LintContext<'a>,
+    ) {
+        let has_type_annotation = declarator.type_annotation.is_some();
+        if has_type_annotation && !self.enforce_for_declaration_with_type_annotation {
+            return;
+        }
+
+        // Skip `using` and `await using` declarations - destructuring doesn't apply to them
+        if matches!(
+            declarator.kind,
+            VariableDeclarationKind::Using | VariableDeclarationKind::AwaitUsing
+        ) {
+            return;
+        }
+        if let Some(init) = &declarator.init
+            && let Some(right) = init.without_parentheses().as_member_expression()
+        {
+            if !check_expr(right) {
+                return;
+            }
+            let name = if matches!(declarator.id, BindingPattern::BindingIdentifier(_)) {
+                declarator.id.get_identifier_name().map(|v| v.as_str())
+            } else {
+                None
+            };
+            match right {
+                MemberExpression::ComputedMemberExpression(comp_expr) => {
+                    if matches!(comp_expr.expression, Expression::TemplateLiteral(_)) {
+                        return;
+                    }
+                    if matches!(comp_expr.expression, Expression::NumericLiteral(_)) {
+                        if self.variable_declarator.array {
+                            ctx.diagnostic(prefer_array_destructuring(init.span()));
+                        }
+                    } else if self.variable_declarator.object {
+                        if let Expression::StringLiteral(string_literal) = &comp_expr.expression
+                            && name.is_some_and(|v| v == string_literal.value)
+                        {
+                            if has_type_annotation {
+                                ctx.diagnostic(prefer_object_destructuring(init.span()));
+                            } else {
+                                ctx.diagnostic_with_fix(
+                                    prefer_object_destructuring(init.span()),
+                                    |fixer| {
+                                        generate_fix(
+                                            &fixer,
+                                            string_literal.span.shrink(1),
+                                            get_object_span_without_redundant_parentheses(
+                                                &comp_expr.object,
+                                            ),
+                                            declarator.span(),
+                                        )
+                                    },
+                                );
+                            }
+                        } else if self.enforce_for_renamed_properties {
+                            ctx.diagnostic(prefer_object_destructuring(right.span()));
+                        }
+                    }
+                }
+                MemberExpression::StaticMemberExpression(static_expr)
+                    if self.variable_declarator.object =>
+                {
+                    if name.is_some_and(|name| name == static_expr.property.name.as_str()) {
+                        if has_type_annotation {
+                            ctx.diagnostic(prefer_object_destructuring(init.span()));
+                        } else {
+                            ctx.diagnostic_with_fix(
+                                prefer_object_destructuring(init.span()),
+                                |fixer| {
+                                    generate_fix(
+                                        &fixer,
+                                        static_expr.property.span,
+                                        get_object_span_without_redundant_parentheses(
+                                            &static_expr.object,
+                                        ),
+                                        declarator.span(),
+                                    )
+                                },
+                            );
+                        }
+                    } else if self.enforce_for_renamed_properties {
+                        ctx.diagnostic(prefer_object_destructuring(right.span()));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn get_target_name<'a>(target: &'a AssignmentTarget<'a>) -> Option<&'a str> {
+    if let AssignmentTarget::AssignmentTargetIdentifier(ident) = target {
+        return Some(ident.name.as_str());
+    }
+    None
+}
+
+fn check_expr(expr: &MemberExpression) -> bool {
+    if matches!(expr, MemberExpression::PrivateFieldExpression(_))
+        || matches!(expr.object(), Expression::Super(_))
+    {
+        return false;
+    }
+    true
+}
+
+/// Returns the span of the object expression, stripping redundant parentheses for expressions
+/// where they are unnecessary in the destructuring context.
+///
+/// For example: `(bar[baz]).foo` -> uses span of `bar[baz]` (without parens)
+/// But: `(a, b).foo` -> uses span of `(a, b)` (keeps parens, comma operator needs them)
+fn get_object_span_without_redundant_parentheses(object: &Expression) -> Span {
+    match object.without_parentheses() {
+        Expression::CallExpression(_)
+        | Expression::Identifier(_)
+        | Expression::StaticMemberExpression(_)
+        | Expression::ComputedMemberExpression(_)
+        | Expression::ThisExpression(_) => object.without_parentheses().span(),
+        _ => object.span(),
+    }
+}
+
+/// Generate the fix for object destructuring in a variable declaration.
+fn generate_fix(
+    fixer: &RuleFixer<'_, '_>,
+    prop_span: Span,
+    object_span: Span,
+    replacement_span: Span,
+) -> RuleFix {
+    let prop = fixer.source_range(prop_span);
+    let object_text = fixer.source_range(object_span);
+    let replacement = format!("{{{prop}}} = {object_text}");
+    fixer.replace(replacement_span, replacement)
+}

--- a/crates/oxc_linter/src/rules/shared/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/mod.rs
@@ -1,5 +1,7 @@
+mod eslint_typescript;
 mod eslint_unicorn;
 mod jest_vitest;
 
+pub use eslint_typescript::*;
 pub use eslint_unicorn::*;
 pub use jest_vitest::*;

--- a/crates/oxc_linter/src/rules/typescript/prefer_destructuring.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_destructuring.rs
@@ -1,0 +1,117 @@
+use oxc_ast::AstKind;
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    rules::shared::prefer_destructuring::{
+        DOCUMENTATION, PreferDestructuring as PreferDestructuringInner, PreferDestructuringConfig,
+    },
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferDestructuring(PreferDestructuringInner);
+
+declare_oxc_lint!(
+    PreferDestructuring,
+    typescript,
+    style,
+    conditional_fix,
+    config = PreferDestructuringConfig,
+    docs = DOCUMENTATION,
+    version = "next",
+    short_description = "Require destructuring from arrays and/or objects.",
+);
+
+impl Rule for PreferDestructuring {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        PreferDestructuringInner::from_configuration(value).map(Self)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::AssignmentExpression(assign_expr) if assign_expr.operator.is_assign() => {
+                self.0.run_on_assignment_expression(assign_expr, ctx);
+            }
+            AstKind::VariableDeclarator(declarator) => {
+                self.0.run_on_variable_declarator(declarator, ctx);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("var [foo] = array;", None),
+        ("var { foo } = object;", None),
+        // Declarations with a type annotation are ignored unless explicitly enforced.
+        ("const foo: string = object.foo;", None),
+        ("const foo: string = object['foo'];", None),
+        ("const foo: string = array[0];", None),
+        ("var foo = array[someIndex];", None),
+        ("var foo = object.bar;", Some(serde_json::json!([{ "object": false }]))),
+        ("var foo = array[0];", Some(serde_json::json!([{ "array": false }]))),
+        ("({ foo } = object);", None),
+        ("[foo] = array;", None),
+        ("class Foo extends Bar { static foo() {var foo = super.foo} }", None),
+        ("var foo = object?.foo;", None),
+        ("var foo = array?.[0];", None),
+        (
+            "const foo: string = object.foo;",
+            Some(
+                serde_json::json!([{ "object": true }, { "enforceForDeclarationWithTypeAnnotation": false }]),
+            ),
+        ),
+    ];
+
+    let fail = vec![
+        ("var foo = array[0];", None),
+        ("foo = array[0];", None),
+        ("var foo = object.foo;", None),
+        ("var foo = object['foo'];", None),
+        (
+            "var foo: string = object.foo;",
+            Some(
+                serde_json::json!([{ "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }]),
+            ),
+        ),
+        (
+            "var foo: string = object['foo'];",
+            Some(
+                serde_json::json!([{ "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }]),
+            ),
+        ),
+        (
+            "var foo: string = array[0];",
+            Some(
+                serde_json::json!([{ "array": true }, { "enforceForDeclarationWithTypeAnnotation": true }]),
+            ),
+        ),
+        (
+            "var foobar = object.bar;",
+            Some(serde_json::json!([{ "object": true }, { "enforceForRenamedProperties": true }])),
+        ),
+    ];
+
+    let fix: Vec<(&str, &str, Option<serde_json::Value>)> = vec![
+        ("var foo = object.foo;", "var {foo} = object;", None),
+        ("var foo = object['foo'];", "var {foo} = object;", None),
+        // Type annotations disable the autofix even when the rule is enforced for them.
+        (
+            "var foo: string = object.foo;",
+            "var foo: string = object.foo;",
+            Some(
+                serde_json::json!([{ "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }]),
+            ),
+        ),
+    ];
+
+    Tester::new(PreferDestructuring::NAME, PreferDestructuring::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/typescript_prefer_destructuring.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_prefer_destructuring.snap
@@ -1,0 +1,59 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:1:11]
+ 1 │ var foo = array[0];
+   ·           ────────
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:1:1]
+ 1 │ foo = array[0];
+   · ──────────────
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:1:11]
+ 1 │ var foo = object.foo;
+   ·           ──────────
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:1:11]
+ 1 │ var foo = object['foo'];
+   ·           ─────────────
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:1:19]
+ 1 │ var foo: string = object.foo;
+   ·                   ──────────
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:1:19]
+ 1 │ var foo: string = object['foo'];
+   ·                   ─────────────
+   ╰────
+  help: Use object destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Array destructuring.
+   ╭─[prefer_destructuring.tsx:1:19]
+ 1 │ var foo: string = array[0];
+   ·                   ────────
+   ╰────
+  help: Use array destructuring rather than direct member access.
+
+  ⚠ typescript(prefer-destructuring): Use Object destructuring.
+   ╭─[prefer_destructuring.tsx:1:14]
+ 1 │ var foobar = object.bar;
+   ·              ──────────
+   ╰────
+  help: Use object destructuring rather than direct member access.

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -515,6 +515,7 @@ typescript/no-var-requires                                 |  24652
 typescript/no-wrapper-object-types                         |  13199
 typescript/parameter-properties                            |   1070
 typescript/prefer-as-const                                 |  12866
+typescript/prefer-destructuring                            |  50504
 typescript/prefer-enum-initializers                        |     23
 typescript/prefer-for-of                                   |    557
 typescript/prefer-function-type                            |  14798


### PR DESCRIPTION
# feat(linter/typescript): implement prefer-destructuring rule

Adds the `typescript/prefer-destructuring` rule, which ports `@typescript-eslint/prefer-destructuring` to oxlint.

Part of #2180.

## What it does

The rule requires destructuring from arrays and objects instead of reaching into them through member access, so `const foo = object.foo` becomes `const { foo } = object` and `const foo = array[0]` becomes `const [foo] = array`.

The TypeScript variant behaves like the base ESLint rule but also honors the `enforceForDeclarationWithTypeAnnotation` option, so declarations that carry an explicit type annotation are left alone unless you opt in.

## Implementation notes

Most of the logic already lived in `eslint/prefer-destructuring`, including the TypeScript-specific type-annotation handling, so rather than copy it I pulled the shared parts into a new `shared/eslint_typescript` module (the same approach already used for `shared/eslint_unicorn` and `shared/jest_vitest`). Both the `eslint` and `typescript` rules are now thin wrappers over that shared state.

I kept an explicit `match node.kind()` in each wrapper instead of blindly delegating, so `cargo lintgen` can still infer the `NODE_TYPES` (`AssignmentExpression`, `VariableDeclarator`) and the rule only runs on the nodes it cares about. The existing `eslint/prefer-destructuring` tests were left untouched and still pass, which confirms the refactor didn't change any behavior.

One caveat worth calling out: the upstream typescript-eslint rule leans on type information for a few cases (for example, suppressing array suggestions on non-array types). oxlint has no type checker, so this runs purely on the AST — matching how the other type-aware rules are ported here.

---

AI disclosure: this change was written with the help of an AI assistant (Claude). I reviewed, tested, and understand the code, as required by the contributing guidelines.
