### PR TITLE
test(formatter): cover concise arrow parent contexts

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/ts/arrow-function/parent-context.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/arrow-function/parent-context.ts
@@ -1,0 +1,12 @@
+const nestedAwait = async () =>
+  void (await consume(async () =>
+    (await import("a-very-long-module-name-that-forces-the-expression-to-break")).default(),
+  ));
+
+const assignmentChain = () =>
+  firstVeryLongIdentifier = secondVeryLongIdentifier = thirdVeryLongIdentifier;
+
+const amd = () =>
+  define("a-very-long-module-name", ["first-long-dependency", "second-long-dependency"], () => {
+    return value;
+  });

--- a/crates/oxc_formatter/tests/fixtures/ts/arrow-function/parent-context.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/arrow-function/parent-context.ts.snap
@@ -1,0 +1,57 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+const nestedAwait = async () =>
+  void (await consume(async () =>
+    (await import("a-very-long-module-name-that-forces-the-expression-to-break")).default(),
+  ));
+
+const assignmentChain = () =>
+  firstVeryLongIdentifier = secondVeryLongIdentifier = thirdVeryLongIdentifier;
+
+const amd = () =>
+  define("a-very-long-module-name", ["first-long-dependency", "second-long-dependency"], () => {
+    return value;
+  });
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+const nestedAwait = async () =>
+  void (await consume(async () =>
+    (
+      await import("a-very-long-module-name-that-forces-the-expression-to-break")
+    ).default(),
+  ));
+
+const assignmentChain = () =>
+  (firstVeryLongIdentifier = secondVeryLongIdentifier =
+    thirdVeryLongIdentifier);
+
+const amd = () =>
+  define("a-very-long-module-name", [
+    "first-long-dependency",
+    "second-long-dependency",
+  ], () => {
+    return value;
+  });
+
+-------------------
+{ printWidth: 100 }
+-------------------
+const nestedAwait = async () =>
+  void (await consume(async () =>
+    (await import("a-very-long-module-name-that-forces-the-expression-to-break")).default(),
+  ));
+
+const assignmentChain = () =>
+  (firstVeryLongIdentifier = secondVeryLongIdentifier = thirdVeryLongIdentifier);
+
+const amd = () =>
+  define("a-very-long-module-name", ["first-long-dependency", "second-long-dependency"], () => {
+    return value;
+  });
+
+===================== End =====================


### PR DESCRIPTION
Adds formatter regression coverage for concise arrow bodies involving nested `await` expressions, assignment chains, and AMD `define()` calls. This locks existing parent-context behavior ahead of the `ArrowFunctionBody` AST migration.

I may have caused a regression in #24987, so this PR adds test coverage to make sure I don't break it.

