### PR TITLE
fix(minifier): preserve if-chain idempotency

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
@@ -4,7 +4,7 @@ use oxc_ast::ast::*;
 use oxc_semantic::ScopeFlags;
 use oxc_span::GetSpan;
 
-use crate::TraverseCtx;
+use crate::{TraverseCtx, is_terminated::IsTerminated};
 
 use super::PeepholeOptimizations;
 
@@ -128,7 +128,7 @@ impl<'a> PeepholeOptimizations {
     /// `if (foo) if (bar) baz else quaz` ->  `if (foo) { if (bar) baz else quaz }`
     fn wrap_to_avoid_ambiguous_else(if_stmt: &mut IfStatement<'a>, ctx: &mut TraverseCtx<'a>) {
         if let Statement::IfStatement(if2) = &mut if_stmt.consequent
-            && if2.consequent.is_jump_statement()
+            && if2.consequent.is_terminated()
             && if2.alternate.is_some()
         {
             let scope_id = ctx.create_child_scope_of_current(ScopeFlags::empty());

--- a/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
@@ -49,6 +49,10 @@ fn test_function_return_optimization() {
         "function f(){if(a()){if(b()){d();return;}else{return;}}else{return;} c();}",
         "function f(){if(a()){if(b()){d();return}return}}",
     ); // function f(){a()&&b()&&d()}
+    test(
+        "function f(a,b,c){if(a){}else if(b){x();return}else if(c){y();return}z()}",
+        "function f(a,b,c){if(!a){if(b){x();return}if(c){y();return}}z()}",
+    );
     test("function f(){if(a()){b();return;}else;}", "function f(){if(a()){b();return}}"); // function f(){a()&&b()}
     test("function f(){if(a()){return;}else{return;} return;}", "function f(){a();}");
     test("function f(){if(a()){return;}else{return;} b();}", "function f(){a()}");


### PR DESCRIPTION
## Summary
- use termination-aware dangling-else wrapping in the minifier AST
- stabilize terminating else-if chains before codegen and reparse
- add a regression test based on the monitor-oxc compressor failure

Failure: https://github.com/oxc-project/monitor-oxc/actions/runs/30278269292/job/90018363822

