### PR TITLE
perf(minifier): cache engine feature support in a bitset

### DIFF
--- a/crates/oxc_compat/src/engine_targets.rs
+++ b/crates/oxc_compat/src/engine_targets.rs
@@ -90,6 +90,22 @@ impl EngineTargets {
         false
     }
 
+    /// Precompute the answer of [`Self::has_feature`] for every feature in the
+    /// compatibility table.
+    ///
+    /// [`Self::has_feature`] performs a hash lookup and an engine-table walk per call; callers
+    /// that query features repeatedly (e.g. the minifier, per AST node) can compute this cache
+    /// once and answer each query with a single bit test via [`FeatureSupportCache::has_feature`].
+    pub fn feature_support_cache(&self) -> FeatureSupportCache {
+        let mut unsupported = 0u128;
+        for &feature in features().keys() {
+            if self.has_feature(feature) {
+                unsupported |= FeatureSupportCache::bit(feature);
+            }
+        }
+        FeatureSupportCache { unsupported }
+    }
+
     /// Check whether every target engine is known to support the given ES feature.
     ///
     /// Unlike [`Self::has_feature`], this is a strict capability query: an empty target or an
@@ -170,6 +186,66 @@ impl EngineTargets {
         }
         engine_targets.insert(Engine::Es, es_target.unwrap_or(ESTarget::default()).version());
         Ok(engine_targets)
+    }
+}
+
+/// Precomputed answers to [`EngineTargets::has_feature`], built by
+/// [`EngineTargets::feature_support_cache`].
+///
+/// Internally a bitset over [`ESFeature`] discriminants. The representation is private so the
+/// discriminant-to-bit mapping never crosses a crate boundary; `test_feature_bits_fit` pins the
+/// invariant that every table feature fits in the bitset.
+#[derive(Debug, Clone, Copy)]
+pub struct FeatureSupportCache {
+    unsupported: u128,
+}
+
+impl FeatureSupportCache {
+    fn bit(feature: ESFeature) -> u128 {
+        let bit = feature as u32;
+        // At call sites `feature` is a literal variant, so this check constant-folds away.
+        // A feature that would not fit is a codegen-time error caught by `test_feature_bits_fit`;
+        // panicking here (rather than masking the shift) keeps release builds from silently
+        // querying the wrong bit if the generated enum ever outgrows the bitset.
+        assert!(bit < 128, "ESFeature discriminant must fit in the feature bitset");
+        1u128 << bit
+    }
+
+    /// Same answer as [`EngineTargets::has_feature`] on the targets this cache was built from:
+    /// `true` if the feature is NOT supported by all target engines (needs transformation).
+    pub fn has_feature(self, feature: ESFeature) -> bool {
+        self.unsupported & Self::bit(feature) != 0
+    }
+}
+
+/// Pin [`FeatureSupportCache`]'s invariant: every feature in the (generated) compatibility
+/// table maps to a distinct bit inside the bitset. Fails loudly if `ESFeature` outgrows it.
+#[test]
+fn test_feature_bits_fit() {
+    for &feature in features().keys() {
+        assert!(
+            (feature as u32) < 128,
+            "ESFeature::{feature:?} discriminant does not fit in FeatureSupportCache"
+        );
+    }
+}
+
+/// The cache must agree with [`EngineTargets::has_feature`] for every feature, for any target.
+#[test]
+fn test_feature_support_cache_matches_has_feature() {
+    for target in [
+        EngineTargets::default(),
+        EngineTargets::from_target("es2015").unwrap(),
+        EngineTargets::from_target("chrome90").unwrap(),
+    ] {
+        let cache = target.feature_support_cache();
+        for &feature in features().keys() {
+            assert_eq!(
+                cache.has_feature(feature),
+                target.has_feature(feature),
+                "cache disagrees with has_feature for {feature:?} on target {target}"
+            );
+        }
     }
 }
 

--- a/crates/oxc_compat/src/lib.rs
+++ b/crates/oxc_compat/src/lib.rs
@@ -14,6 +14,6 @@ mod es_target;
 pub use babel_targets::BabelTargets;
 pub use browserslist_query::BrowserslistQuery;
 pub use engine::Engine;
-pub use engine_targets::{EngineTargets, Version};
+pub use engine_targets::{EngineTargets, FeatureSupportCache, Version};
 pub use es_features::{ESFeature, features};
 pub use es_target::ESVersion;

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -26,6 +26,9 @@ struct CompressionConfig {
     source_type: SourceType,
     options: CompressOptions,
     mode: CompressionMode,
+    /// Cached [`oxc_compat::EngineTargets::feature_support_cache`] of `options.target`,
+    /// so per-node feature queries are a bit test instead of a hash lookup.
+    feature_support: oxc_compat::FeatureSupportCache,
 }
 
 /// Changes accumulated between two pass-completion boundaries. Live from
@@ -125,8 +128,9 @@ impl<'a> MinifierState<'a> {
         allocator: &'a Allocator,
     ) -> Self {
         let symbols = SymbolState::new(source_type, &options, scoping, allocator);
+        let feature_support = options.target.feature_support_cache();
         Self {
-            config: CompressionConfig { source_type, options, mode },
+            config: CompressionConfig { source_type, options, mode, feature_support },
             symbols,
             private_member_usage: PrivateMemberUsageStack::new(),
             body_frames: NonEmptyStack::new(BodyFrame {
@@ -153,6 +157,12 @@ impl<'a> MinifierState<'a> {
 
     pub(crate) fn options(&self) -> &CompressOptions {
         &self.config.options
+    }
+
+    /// Whether the target engines support `feature`, answered from the cached
+    /// [`CompressionConfig::feature_support`] bitset.
+    pub(crate) fn supports_feature(&self, feature: oxc_compat::ESFeature) -> bool {
+        !self.config.feature_support.has_feature(feature)
     }
 
     pub(crate) fn source_type(&self) -> SourceType {

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -171,10 +171,11 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
 
     /// Loosely check whether target engines support a feature for syntax generation.
     ///
-    /// This follows [`oxc_compat::EngineTargets::has_feature`] semantics. Side-effect analysis uses
-    /// the stricter [`oxc_compat::EngineTargets::supports_es_feature`] capability query instead.
+    /// This follows [`oxc_compat::EngineTargets::has_feature`] semantics, answered from a
+    /// bitmask computed once per run. Side-effect analysis uses the stricter
+    /// [`oxc_compat::EngineTargets::supports_es_feature`] capability query instead.
     pub fn supports_feature(&self, feature: ESFeature) -> bool {
-        !self.options().target.has_feature(feature)
+        self.state.supports_feature(feature)
     }
 
     pub fn source_type(&self) -> SourceType {


### PR DESCRIPTION
## Summary

`EngineTargets::has_feature` performs an `FxHashMap` lookup into the compatibility table plus a walk over the feature's engine-version list on every call. The minifier's peephole passes call it per AST node via `ctx.supports_feature(...)` (`minimize_conditions`, `minimize_conditional_expression`, `minimize_logical_expression`, `replace_known_methods`, `remove_unused_expression`, `substitute_alternate_syntax`), so the same handful of answers is recomputed millions of times per compression run. Profiling (callgrind) showed `has_feature` at ~2% of total compress-phase instructions.

This PR precomputes the answer for every feature in the compatibility table once per compression run:

- `oxc_compat`: new `EngineTargets::feature_support_cache()` returning an opaque `FeatureSupportCache` (internally a `u128` bitset over `ESFeature` discriminants). The representation is private to `oxc_compat` so the discriminant-to-bit mapping never crosses a crate boundary.
- `oxc_minifier`: `CompressionConfig` stores the cache, built in `MinifierState::new`; `TraverseCtx::supports_feature` becomes a single bit test.

## Why it's safe

- The bit computation uses a hard `assert!` (constant-folded away at call sites, which pass literal variants), so if the generated `ESFeature` enum ever outgrows the bitset, release builds panic instead of silently querying an aliased bit.
- `test_feature_bits_fit` fails the moment a regenerated compat table doesn't fit (52 features today, 128-bit headroom).
- `test_feature_support_cache_matches_has_feature` asserts the cache agrees with `has_feature` for **every** feature across representative targets (empty, `es2015`, `chrome90`).
- `CompressOptions` is immutable for the lifetime of a run, so the cache cannot go stale.

## Benchmarks

Instruction counts (cachegrind, compress phase of the `minifier` benchmark, per iteration):

| File | main | this PR | Δ |
|---|---|---|---|
| react.development.js | 4,695,962 | 4,532,521 | **−3.48%** |
| App.tsx | 23,507,638 | 22,740,349 | **−3.26%** |
| binder.ts | 7,287,831 | 7,046,284 | **−3.31%** |
| kitchen-sink.tsx | 87,841,113 | 85,933,200 | **−2.17%** |

Local criterion wall time improved −1.5% to −5.3% across two independent build pairs (scatter is local binary-layout noise; instruction counts above are the stable metric and match what CodSpeed measures). The `mangler` benchmarks execute no code changed by this PR.

## Testing

- `cargo test -p oxc_minifier`: 640 passed
- `cargo test -p oxc_compat`: 6 passed (includes the two new invariant tests)
- `cargo minsize`: size snapshots unchanged (output byte-identical)
- clippy and rustfmt clean

---

*Disclosure per the contributing policy: this change was developed with AI assistance (Claude); it has been reviewed, tested, and benchmarked as described above.*
