### PR TITLE
perf(linter/import/no-cycle): drop two Vec allocations per graph edge

### DIFF
--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -274,27 +274,28 @@ impl NoCycle {
         }
 
         if self.ignore_types {
-            let import_entries = parent
+            // Equivalent to collecting both entry lists and testing `!is_empty() && all(is_type)`,
+            // without materializing either `Vec`. This runs once per graph edge considered.
+            let mut types = parent
                 .import_entries
                 .iter()
                 .filter(|entry| entry.module_request.name() == key)
-                .collect::<Vec<_>>();
+                .map(|entry| entry.is_type)
+                .chain(
+                    parent
+                        .indirect_export_entries
+                        .iter()
+                        .filter(|entry| {
+                            entry
+                                .module_request
+                                .as_ref()
+                                .is_some_and(|module_request| module_request.name() == key)
+                        })
+                        .map(|entry| entry.is_type),
+                )
+                .peekable();
 
-            let indirect_export_entries = parent
-                .indirect_export_entries
-                .iter()
-                .filter(|entry| {
-                    entry
-                        .module_request
-                        .as_ref()
-                        .is_some_and(|module_request| module_request.name() == key)
-                })
-                .collect::<Vec<_>>();
-
-            if (!import_entries.is_empty() || !indirect_export_entries.is_empty())
-                && import_entries.iter().all(|entry| entry.is_type)
-                && indirect_export_entries.iter().all(|entry| entry.is_type)
-            {
+            if types.peek().is_some() && types.all(|is_type| is_type) {
                 return false;
             }
         }


### PR DESCRIPTION
AI Disclosure: generated using Claude Code w/ Opus 5. It has been reviewed and tested manually to ensure parity and that the improvement is real and makes sense.

## What this does

`should_traverse_module` collected both matching entry lists into `Vec`s only to test `!is_empty()` and `all(is_type)`. `ignoreTypes` defaults to `true`, so this ran on every graph edge considered — and since the acyclic prefilter in #25003 traverses each file's whole reachable subgraph, it is now the hottest allocation site in the rule. Chaining the two `is_type` iterators and peeking is the same predicate with nothing materialized.

## Measurements

vscode `src`, 7,368 files, `import/no-cycle` as the only enabled rule, release build. Note that the baseline is the target PR's HEAD, not `main`.

| metric                  | before    | after    | delta      |
| ----------------------- | --------- | -------- | ---------- |
| rule allocations        | 86.78M    | 38.61M   | **-55.5%** |
| rule bytes              | 6.00 GB   | 4.29 GB  | -28.6%     |
| wall clock              | 1182.8 ms | 1063.0 ms | **-119.8 ms** |
| rule-attributable time  | 1083.0 ms | 963.8 ms | **-11.0%** |

Wall clock is paired interleaved runs with order alternation, n=20: paired sd 14.7 ms, t=+36.4, faster in 20/20 rounds. The parse-only control is flat (+0.6 ms, t=+1.45), so the delta is attributable to the rule rather than to binary layout. Allocation counts come from a counting global allocator, 2 reps, run-to-run spread 0.003%; both metrics subtract the parse-only baseline.

## Correctness

- 1,566 `no-cycle` diagnostics on vscode, identical before and after when sorted.
- All 41 `import::*` tests, the three `no_cycle` tests, and `oxc/no_barrel_file` pass. Clippy clean.

Short-circuiting differs from the original — `all` stops at the first `false` where the old code built both `Vec`s first — but only the return value is observable, and the predicate is unchanged: the old code required `all(is_type)` over each list separately, which is the same as over the concatenation.

This change was taken out of #24961 as it was the most promising/best change in that PR and was the most likely to still have an impact after the acyclic fix in the target PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
