### PR TITLE
refactor(formatter_yaml): read `comment.own_line_columns`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -696,7 +696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1523,7 +1523,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1756,9 +1756,9 @@ checksum = "d3b207530da2a077e5cd464ac2c22c7b0c11b7802330d9c742704420b0e21a6f"
 
 [[package]]
 name = "oxc-yaml-parser"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7329e669b41469a5f0a6fa5b1735f97521e2ba3e0a677a2314039e2dd61cd13a"
+checksum = "3beb95e6d6a3d7217cbcf85e7bf88be7f0c8b6f4c697efe6ff21e3e5d4a44ef5"
 dependencies = [
  "oxc_allocator",
 ]
@@ -3306,7 +3306,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3433,7 +3433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3728,7 +3728,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4215,7 +4215,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,7 +240,7 @@ num-traits = "0.2.19" # Numeric traits
 oxc-css-parser = "0.0.9" # CSS/SCSS/Less parser (raffia 0.12.3 fork: adds `template_placeholder` typed placeholders for css-in-js + valid-syntax coverage fixes (see crates/oxc_formatter_css/AGENTS.md))
 oxc-graphql-parser = "0.0.9" # GraphQL parser (direct AST; apollo-parser 0.8.6 fork aligned with graphql-js 17 syntax)
 oxc-toml = "0.14.5" # TOML formatter
-oxc-yaml-parser = "0.0.3" # YAML 1.2 parser (comment-preserving typed AST, node naming from `yaml-unist-parser`)
+oxc-yaml-parser = "0.0.4" # YAML 1.2 parser (comment-preserving typed AST, node naming from `yaml-unist-parser`)
 papaya = "0.2.4" # Concurrent hash map
 percent-encoding = "2.3.2" # URL encoding
 petgraph = { version = "0.8.3", default-features = false } # Graph data structures

--- a/crates/oxc_formatter_yaml/src/comments.rs
+++ b/crates/oxc_formatter_yaml/src/comments.rs
@@ -10,34 +10,44 @@ use oxc_span::Span;
 
 use crate::print::{YamlFormatter, format_with};
 
-/// Cursor over a sorted comment-span list that hands out unprinted slices in span order.
+/// A comment bridged from the parser: its span in the arena source,
+/// plus the parser-recorded layout fact print sites branch on.
+#[derive(Clone, Copy, Debug)]
+pub struct SourceComment {
+    pub span: Span,
+    /// The `#`'s 0-based column when only whitespace precedes it on its line;
+    /// `None` when the comment trails other content (see the parser's `Comment`).
+    pub own_line_column: Option<u32>,
+}
+
+/// Cursor over a sorted comment list that hands out unprinted slices in span order.
 ///
 /// YAML comments are always single-line (`# ...` to end of line);
-/// the parser collects them into a flat, source-ordered list and `format()` bridges them to [`Span`]s.
+/// the parser collects them into a flat, source-ordered list and `format()` bridges them to [`SourceComment`]s.
 /// Comment placement (leading / trailing / end) is decided positionally at print sites.
 ///
 /// `cursor` is a [`Cell`] so the API works through `&self`.
 pub struct Comments<'a> {
-    inner: &'a [Span],
+    inner: &'a [SourceComment],
     cursor: Cell<usize>,
 }
 
 impl<'a> Comments<'a> {
-    pub fn new(comments: &'a [Span]) -> Self {
+    pub fn new(comments: &'a [SourceComment]) -> Self {
         Self { inner: comments, cursor: Cell::new(0) }
     }
 
     /// Returns the next unprinted comment without consuming it.
-    pub fn peek(&self) -> Option<Span> {
+    pub fn peek(&self) -> Option<SourceComment> {
         self.inner.get(self.cursor.get()).copied()
     }
 
     /// Returns unprinted comments whose `span.end <= upper_bound`,
     /// and advances the cursor past them so they won't be returned again.
-    pub fn take_before(&self, upper_bound: u32) -> &'a [Span] {
+    pub fn take_before(&self, upper_bound: u32) -> &'a [SourceComment] {
         let start = self.cursor.get();
         let mut end = start;
-        while end < self.inner.len() && self.inner[end].end <= upper_bound {
+        while end < self.inner.len() && self.inner[end].span.end <= upper_bound {
             end += 1;
         }
         self.cursor.set(end);
@@ -45,7 +55,7 @@ impl<'a> Comments<'a> {
     }
 
     /// Drains all remaining unprinted comments and returns them.
-    pub fn take_remaining(&self) -> &'a [Span] {
+    pub fn take_remaining(&self) -> &'a [SourceComment] {
         let start = self.cursor.get();
         self.cursor.set(self.inner.len());
         &self.inner[start..]
@@ -53,9 +63,9 @@ impl<'a> Comments<'a> {
 
     /// Iterator over unprinted comments whose `span.end <= upper_bound`.
     /// Does NOT advance the cursor.
-    pub fn iter_before(&self, upper_bound: u32) -> impl Iterator<Item = Span> {
+    pub fn iter_before(&self, upper_bound: u32) -> impl Iterator<Item = SourceComment> {
         let start = self.cursor.get();
-        self.inner[start..].iter().copied().take_while(move |c| c.end <= upper_bound)
+        self.inner[start..].iter().copied().take_while(move |c| c.span.end <= upper_bound)
     }
 
     /// `anchor`, moved past the most recently consumed comment when that lies beyond it.
@@ -66,7 +76,7 @@ impl<'a> Comments<'a> {
     /// Gap measurement resuming from the unmoved anchor would observe that same spacing again
     /// and emit a second blank line.
     pub fn gap_anchor_after_consumed(&self, anchor: u32) -> u32 {
-        let last_consumed_end = self.cursor.get().checked_sub(1).map(|i| self.inner[i].end);
+        let last_consumed_end = self.cursor.get().checked_sub(1).map(|i| self.inner[i].span.end);
         last_consumed_end.map_or(anchor, |end| anchor.max(end))
     }
 }
@@ -132,26 +142,6 @@ fn gap_is_trivia_only(source: &str, from: u32, to: u32) -> bool {
     })
 }
 
-/// `true` when only whitespace precedes `offset` on its line
-/// (an own-line comment, as opposed to one trailing other content).
-pub fn is_own_line(source: &str, offset: u32) -> bool {
-    own_line_column(source, offset).is_some()
-}
-
-/// The 0-based column of `offset` when only whitespace precedes it on its line,
-/// in a single backward scan; `None` when other content does.
-fn own_line_column(source: &str, offset: u32) -> Option<u32> {
-    let mut column = 0u32;
-    for &byte in source.as_bytes()[..offset as usize].iter().rev() {
-        match byte {
-            b'\n' => break,
-            b' ' | b'\t' => column += 1,
-            _ => return None,
-        }
-    }
-    Some(column)
-}
-
 /// One line break, widened to a blank line when the source gap holds one.
 pub fn write_blank_preserving_break(
     prev_end: u32,
@@ -187,12 +177,16 @@ fn write_gap(gap: &[u8], f: &mut YamlFormatter<'_, '_>) {
 
 /// Emit comments that precede a node,
 /// preserving the source's vertical spacing (0/1/blank) between each comment and the next position.
-fn write_leading_comments(comments: &[Span], value_start: u32, f: &mut YamlFormatter<'_, '_>) {
+fn write_leading_comments(
+    comments: &[SourceComment],
+    value_start: u32,
+    f: &mut YamlFormatter<'_, '_>,
+) {
     let source = f.context().source_text();
-    for (i, &span) in comments.iter().enumerate() {
-        write_single_comment(span, f);
-        let next_pos = comments.get(i + 1).map_or(value_start, |c| c.start);
-        write_gap(source.bytes_range(span.end, next_pos), f);
+    for (i, comment) in comments.iter().enumerate() {
+        write_single_comment(comment.span, f);
+        let next_pos = comments.get(i + 1).map_or(value_start, |c| c.span.start);
+        write_gap(source.bytes_range(comment.span.end, next_pos), f);
     }
 }
 
@@ -204,7 +198,7 @@ pub fn flush_leading_comments(value_start: u32, f: &mut YamlFormatter<'_, '_>) {
 
 /// The next pending comment when it sits on the same line after `pos`
 /// (nothing but spaces/tabs between), without consuming it.
-pub fn pending_same_line_comment(pos: u32, f: &YamlFormatter<'_, '_>) -> Option<Span> {
+pub fn pending_same_line_comment(pos: u32, f: &YamlFormatter<'_, '_>) -> Option<SourceComment> {
     pending_same_line_comment_over(pos, &[], f)
 }
 
@@ -214,10 +208,10 @@ fn pending_same_line_comment_over(
     pos: u32,
     gap_punctuation: &[u8],
     f: &YamlFormatter<'_, '_>,
-) -> Option<Span> {
-    f.context().comments().peek().filter(|span| {
-        span.start >= pos
-            && f.context().source_text().all_bytes_match(pos, span.start, |b| {
+) -> Option<SourceComment> {
+    f.context().comments().peek().filter(|comment| {
+        comment.span.start >= pos
+            && f.context().source_text().all_bytes_match(pos, comment.span.start, |b| {
                 matches!(b, b' ' | b'\t') || gap_punctuation.contains(&b)
             })
     })
@@ -237,11 +231,13 @@ pub fn write_trailing_same_line_comment<'a>(
     gap_punctuation: &[u8],
     f: &mut YamlFormatter<'_, 'a>,
 ) {
-    let Some(span) = pending_same_line_comment_over(prev_end, gap_punctuation, f) else { return };
-    f.context().comments().take_before(span.end);
+    let Some(comment) = pending_same_line_comment_over(prev_end, gap_punctuation, f) else {
+        return;
+    };
+    f.context().comments().take_before(comment.span.end);
     let content = format_with(move |f: &mut YamlFormatter<'_, 'a>| {
         write!(f, space());
-        write_single_comment(span, f);
+        write_single_comment(comment.span, f);
     });
     write!(f, [line_suffix(&content), expand_parent()]);
 }
@@ -262,7 +258,11 @@ pub fn is_suppressed_last_before(f: &YamlFormatter<'_, '_>, before: u32) -> bool
 /// comment when it precedes it (so a blank line in front of a leading comment
 /// is still measured), else `next_start` itself.
 pub fn gap_upper_bound(next_start: u32, f: &YamlFormatter<'_, '_>) -> u32 {
-    f.context().comments().peek().filter(|c| c.start < next_start).map_or(next_start, |c| c.start)
+    f.context()
+        .comments()
+        .peek()
+        .filter(|c| c.span.start < next_start)
+        .map_or(next_start, |c| c.span.start)
 }
 
 /// The start of the LAST pending comment up to `before`, when it is a suppression marker.
@@ -272,8 +272,8 @@ fn suppression_marker_start_before(f: &YamlFormatter<'_, '_>, before: u32) -> Op
         .comments()
         .iter_before(before)
         .last()
-        .filter(|c| is_suppression_comment(source, *c))
-        .map(|c| c.start)
+        .filter(|c| is_suppression_comment(source, c.span))
+        .map(|c| c.span.start)
 }
 
 /// Flush bound for a block collection's leading comments:
@@ -323,9 +323,10 @@ pub fn flush_container_end_comments(
     let source = f.context().source_text();
     let mut prev_end = f.context().comments().gap_anchor_after_consumed(prev_end);
     loop {
-        let Some(span) = f.context().comments().peek() else { return prev_end };
+        let Some(comment) = f.context().comments().peek() else { return prev_end };
+        let span = comment.span;
         if span.end > upper_bound
-            || own_line_column(&source, span.start).is_none_or(|column| column <= item_column)
+            || comment.own_line_column.is_none_or(|column| column <= item_column)
             // An end-comment run directly follows its container;
             // other tokens in between mean the comment belongs to a LATER node
             // (a nested collection's unbounded tail flush must not jump over the parent's following items).

--- a/crates/oxc_formatter_yaml/src/context.rs
+++ b/crates/oxc_formatter_yaml/src/context.rs
@@ -1,9 +1,11 @@
 use std::cell::Cell;
 
 use oxc_formatter_core::{FormatContext, SourceText};
-use oxc_span::Span;
 
-use crate::{comments::Comments, options::YamlFormatOptions};
+use crate::{
+    comments::{Comments, SourceComment},
+    options::YamlFormatOptions,
+};
 
 /// Formatting context for YAML.
 pub struct YamlFormatContext<'a> {
@@ -22,7 +24,7 @@ impl<'a> YamlFormatContext<'a> {
     pub fn new(
         options: YamlFormatOptions,
         source_code: &'a str,
-        comments: &'a [Span],
+        comments: &'a [SourceComment],
         last_descendant_end: u32,
     ) -> Self {
         Self {

--- a/crates/oxc_formatter_yaml/src/format.rs
+++ b/crates/oxc_formatter_yaml/src/format.rs
@@ -5,10 +5,10 @@ use oxc_formatter_core::{
     builders::{hard_line_break, text},
     write,
 };
-use oxc_span::Span;
 use oxc_yaml_parser::{Parser, ast::Root};
 
 use crate::{
+    comments::SourceComment,
     context::YamlFormatContext,
     options::YamlFormatOptions,
     print::{self, YamlFormatter, to_span},
@@ -81,7 +81,7 @@ pub fn format_to_ir<'a>(
 fn parse_root<'a>(
     allocator: &'a Allocator,
     source_text: &str,
-) -> Result<(&'a Root<'a>, &'a str, &'a [Span]), OxcDiagnostic> {
+) -> Result<(&'a Root<'a>, &'a str, &'a [SourceComment]), OxcDiagnostic> {
     let source_text = source_text.strip_prefix('\u{feff}').unwrap_or(source_text);
     // NOTE: Normalize line endings BEFORE parsing like Prettier, unlike other `oxc_formatter_xxx`.
     // For YAML formatter, the printer slices verbatim text from the source in many places.
@@ -97,9 +97,13 @@ fn parse_root<'a>(
 
     let root = allocator.alloc(root);
 
-    let comments: &'a [Span] =
-        ArenaVec::from_iter_in(root.comments.iter().map(|c| to_span(c.span)), &allocator)
-            .into_arena_slice();
+    let comments: &'a [SourceComment] = ArenaVec::from_iter_in(
+        root.comments
+            .iter()
+            .map(|c| SourceComment { span: to_span(c.span), own_line_column: c.own_line_column }),
+        &allocator,
+    )
+    .into_arena_slice();
 
     Ok((root, source, comments))
 }

--- a/crates/oxc_formatter_yaml/src/print/block.rs
+++ b/crates/oxc_formatter_yaml/src/print/block.rs
@@ -11,7 +11,7 @@ use oxc_formatter_core::{
 use oxc_yaml_parser::ast::{BlockScalar, Chomping, Content, MappingItem, Node, Root};
 
 use crate::{
-    comments::{Gap, classify_gap, write_single_comment},
+    comments::write_single_comment,
     options::ProseWrap,
     print::{
         YamlFormatter, format_with,
@@ -80,19 +80,18 @@ pub fn write_block_scalar<'a>(
         Chomping::Strip => write!(f, "-"),
         Chomping::Clip => {}
     }
-    // Indicator comment: same line as the header (`| # comment`)
-    if let Some(span) = f.context().comments().peek()
-        && span.end <= block.content_start
-        && classify_gap(f.context().source_text().bytes_range(block.span.start, span.start))
-            == Gap::None
+    // Indicator comment: same line as the header (`| # comment`).
+    // The parser guarantees it is the ONLY comment within the scalar's span
+    // (see the guarantee on `BlockScalar`), so nothing else needs draining here;
+    // trailing-ness (`own_line_column: None`) pins it to the header line.
+    if let Some(comment) = f.context().comments().peek()
+        && comment.span.end <= block.content_start
+        && comment.own_line_column.is_none()
     {
-        f.context().comments().take_before(span.end);
+        f.context().comments().take_before(comment.span.end);
         write!(f, space());
-        write_single_comment(span, f);
+        write_single_comment(comment.span, f);
     }
-    // Any other comments inside the header region are consumed silently
-    // (they cannot be represented in a block scalar).
-    let _ = f.context().comments().take_before(block.content_start);
 
     // Words fold to the arena lifetime: borrowed words already slice the arena-backed source,
     // only owned (merged) words need an arena copy.
@@ -159,9 +158,6 @@ pub fn write_block_scalar<'a>(
         let tab_width = f.options().indent_width.value();
         write!(f, dedent(&align(tab_width, &contents)));
     }
-
-    // Claim any comments the scanner collected inside the scalar's range
-    let _ = f.context().comments().take_before(block.span.end);
 }
 
 /// Ports Prettier's `getBlockValueLineContents`.

--- a/crates/oxc_formatter_yaml/src/print/document.rs
+++ b/crates/oxc_formatter_yaml/src/print/document.rs
@@ -7,9 +7,9 @@ use oxc_yaml_parser::ast::{Directive, Document, Root};
 
 use crate::{
     comments::{
-        Gap, classify_gap, flush_leading_comments, gap_upper_bound, is_suppressed_last_before,
-        write_blank_preserving_break, write_single_comment, write_suppressed_node,
-        write_trailing_same_line_comment,
+        Gap, SourceComment, classify_gap, flush_leading_comments, gap_upper_bound,
+        is_suppressed_last_before, write_blank_preserving_break, write_single_comment,
+        write_suppressed_node, write_trailing_same_line_comment,
     },
     print::{
         YamlFormatter,
@@ -102,12 +102,13 @@ fn write_document_separator<'a>(
 /// See [`write_document_separator`] for the deliberate non-follow.
 fn write_end_comments(
     anchor: Option<u32>,
-    comments: &[oxc_span::Span],
+    comments: &[SourceComment],
     f: &mut YamlFormatter<'_, '_>,
 ) {
     let source = f.context().source_text();
-    for (i, &span) in comments.iter().enumerate() {
-        let prev_end = if i == 0 { anchor } else { Some(comments[i - 1].end) };
+    for (i, comment) in comments.iter().enumerate() {
+        let span = comment.span;
+        let prev_end = if i == 0 { anchor } else { Some(comments[i - 1].span.end) };
         let blank = prev_end.is_some_and(|prev_end| {
             prev_end < span.start
                 && classify_gap(source.bytes_range(prev_end, span.start)) == Gap::Blank

--- a/crates/oxc_formatter_yaml/src/print/flow.rs
+++ b/crates/oxc_formatter_yaml/src/print/flow.rs
@@ -145,8 +145,8 @@ fn write_trailing_comma_and_end_comments(close_end: u32, f: &mut YamlFormatter<'
     // Comments inside the brackets after the last entry
     let close_start = close_end.saturating_sub(1);
     let comments = f.context().comments().take_before(close_start);
-    for &span in comments {
+    for comment in comments {
         write!(f, hard_line_break());
-        write_single_comment(span, f);
+        write_single_comment(comment.span, f);
     }
 }

--- a/crates/oxc_formatter_yaml/src/print/mapping_item.rs
+++ b/crates/oxc_formatter_yaml/src/print/mapping_item.rs
@@ -7,8 +7,8 @@ use oxc_yaml_parser::ast::{Content, MappingItem, Node};
 
 use crate::{
     comments::{
-        Gap, classify_gap, flush_leading_comments, is_own_line, pending_same_line_comment,
-        write_single_comment, write_trailing_same_line_comment,
+        Gap, classify_gap, flush_leading_comments, pending_same_line_comment, write_single_comment,
+        write_trailing_same_line_comment,
     },
     options::ProseWrap,
     print::{YamlFormatter, column_of, format_with, to_span, write_node, write_node_or_suppressed},
@@ -51,12 +51,12 @@ pub fn write_mapping_item<'a>(
         } else {
             write!(f, ":");
         }
-        if let Some(span) = same_line_comment {
-            f.context().comments().take_before(span.end);
-            let comment = format_with(move |f: &mut YamlFormatter<'_, 'a>| {
-                write_single_comment(span, f);
+        if let Some(comment) = same_line_comment {
+            f.context().comments().take_before(comment.span.end);
+            let content = format_with(move |f: &mut YamlFormatter<'_, 'a>| {
+                write_single_comment(comment.span, f);
             });
-            write!(f, [line_suffix(&comment), expand_parent()]);
+            write!(f, [line_suffix(&content), expand_parent()]);
         }
         return;
     }
@@ -110,11 +110,11 @@ pub fn write_mapping_item<'a>(
     // the key isn't an inline node, or the source was already explicit with a comment between `?` and the key, or between the key and `:`
     // (an implicit `key:` with a comment above the value keeps the implicit form,
     // the comment becomes the value's leading comment instead).
-    let explicit_comment_before_key =
-        key.explicit && f.context().comments().peek().is_some_and(|c| c.end <= key_node.span.start);
+    let explicit_comment_before_key = key.explicit
+        && f.context().comments().peek().is_some_and(|c| c.span.end <= key_node.span.start);
     if !is_inline(key_content)
         || explicit_comment_before_key
-        || (key.explicit && has_own_line_comment_before_value(key.span.end, value_node, f))
+        || (key.explicit && has_own_line_comment_before_value(value_node, f))
     {
         write!(f, "? ");
         // Comments between the key and `:` that are indented DEEPER than the item are the key's end comments (inside the key's align);
@@ -125,9 +125,11 @@ pub fn write_mapping_item<'a>(
         let colon = value.span.start;
         let key_and_comments = format_with(move |f: &mut YamlFormatter<'_, 'a>| {
             write_key(item, f);
-            let source = f.context().source_text();
-            while let Some(span) = f.context().comments().peek() {
-                if span.end > colon || column_of(&source, span.start) <= item_column {
+            while let Some(comment) = f.context().comments().peek() {
+                let span = comment.span;
+                if span.end > colon
+                    || comment.own_line_column.is_none_or(|column| column <= item_column)
+                {
                     break;
                 }
                 f.context().comments().take_before(span.end);
@@ -138,8 +140,8 @@ pub fn write_mapping_item<'a>(
         write!(f, align(2, &key_and_comments));
         write!(f, hard_line_break());
         let comments = f.context().comments().take_before(colon);
-        for &span in comments {
-            write_single_comment(span, f);
+        for comment in comments {
+            write_single_comment(comment.span, f);
             write!(f, hard_line_break());
         }
         write!(f, ": ");
@@ -390,7 +392,8 @@ fn has_forced_break_when_folded(node: Option<&Node<'_>>, f: &YamlFormatter<'_, '
 /// (`key: # comment` with the value on the next line,
 /// a comment after the value like `key: value # comment` is the value's trailing comment instead.)
 fn key_has_trailing_comment(key_end: u32, value_start: u32, f: &YamlFormatter<'_, '_>) -> bool {
-    let Some(span) = f.context().comments().peek() else { return false };
+    let Some(comment) = f.context().comments().peek() else { return false };
+    let span = comment.span;
     let source = f.context().source_text();
     span.start >= key_end
         && span.end <= value_start
@@ -399,22 +402,15 @@ fn key_has_trailing_comment(key_end: u32, value_start: u32, f: &YamlFormatter<'_
 
 /// Is there any pending comment before `bound` (a leading comment of the value)?
 fn has_pending_comment_before(bound: u32, f: &YamlFormatter<'_, '_>) -> bool {
-    f.context().comments().peek().is_some_and(|c| c.end <= bound)
+    f.context().comments().peek().is_some_and(|c| c.span.end <= bound)
 }
 
 /// Own-line comment between the key and the value forces the explicit form.
-/// A comment trailing the `:` (`key: # comment`) does NOT — it leads the value.
-fn has_own_line_comment_before_value(
-    key_end: u32,
-    value: &Node<'_>,
-    f: &YamlFormatter<'_, '_>,
-) -> bool {
-    let Some(span) = f.context().comments().peek() else { return false };
-    if span.end > value.span.start {
-        return false;
-    }
-    let source = f.context().source_text();
-    // Same-line-after-key comments are trailing, not leading-of-value
-    classify_gap(source.bytes_range(key_end, span.start)) != Gap::None
-        && is_own_line(&source, span.start)
+/// A comment trailing the key's line (`? key # comment`) does NOT.
+/// It is a trailing comment (`own_line_column: None`), not leading-of-value.
+fn has_own_line_comment_before_value(value: &Node<'_>, f: &YamlFormatter<'_, '_>) -> bool {
+    f.context()
+        .comments()
+        .peek()
+        .is_some_and(|c| c.span.end <= value.span.start && c.own_line_column.is_some())
 }

--- a/crates/oxc_formatter_yaml/src/print/mod.rs
+++ b/crates/oxc_formatter_yaml/src/print/mod.rs
@@ -49,6 +49,10 @@ where
 }
 
 /// 0-based column of `offset` in `source` (bytes since the preceding newline).
+///
+/// Comparisons against the parser's character-counted `own_line_column` are sound:
+/// both sides' line prefixes are whitespace and ASCII indicators (`- `, `? `),
+/// where bytes == characters.
 pub fn column_of(source: &str, offset: u32) -> u32 {
     let count =
         source.as_bytes()[..offset as usize].iter().rev().take_while(|&&b| b != b'\n').count();
@@ -108,7 +112,8 @@ pub fn write_node<'a>(node: &'a Node<'a>, f: &mut YamlFormatter<'_, 'a>) {
     let is_block_collection = matches!(content, Content::Mapping(_) | Content::Sequence(_));
     // Middle comments (between the props and the node body, `&a # c`)
     // keep the props separator a space even for block collections.
-    let has_middle_comments = f.context().comments().peek().is_some_and(|c| c.end <= content_start);
+    let has_middle_comments =
+        f.context().comments().peek().is_some_and(|c| c.span.end <= content_start);
     write_props(&node.props, is_block_collection && !has_middle_comments, f);
 
     // Prettier: `[middles.len() == 1 ? "" : hardline, join(hardline, middles), hardline]`.
@@ -118,11 +123,11 @@ pub fn write_node<'a>(node: &'a Node<'a>, f: &mut YamlFormatter<'_, 'a>) {
     let middles = f.context().comments().take_before(middles_bound);
     // `i > 0` is subsumed: any later iteration implies more than one middle.
     let multiple_middles = middles.len() > 1;
-    for &span in middles {
+    for comment in middles {
         if multiple_middles {
             write!(f, hard_line_break());
         }
-        write_single_comment(span, f);
+        write_single_comment(comment.span, f);
     }
     if !middles.is_empty() {
         write!(f, hard_line_break());

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/explicit-keys.yaml
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/explicit-keys.yaml
@@ -15,3 +15,5 @@ plain: separator
 ? bare-no-value # same-line comment keeps the explicit form
 ? normalized
 : implicit stays
+? trailed # a key-line trailing comment with a value present
+: goes implicit

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/explicit-keys.yaml.snap
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/explicit-keys.yaml.snap
@@ -19,6 +19,8 @@ plain: separator
 ? bare-no-value # same-line comment keeps the explicit form
 ? normalized
 : implicit stays
+? trailed # a key-line trailing comment with a value present
+: goes implicit
 
 ==================== Output ====================
 ------------------
@@ -40,6 +42,8 @@ plain: separator
 : 2
 ? bare-no-value # same-line comment keeps the explicit form
 normalized: implicit stays
+trailed: # a key-line trailing comment with a value present
+  goes implicit
 
 -------------------
 { printWidth: 100 }
@@ -60,5 +64,7 @@ plain: separator
 : 2
 ? bare-no-value # same-line comment keeps the explicit form
 normalized: implicit stays
+trailed: # a key-line trailing comment with a value present
+  goes implicit
 
 ===================== End =====================


### PR DESCRIPTION
Also bump `oxc-yaml-parser` for it.

Now, `is_own_line` comment check has been gone.