### PR TITLE
feat(minifier): fold singleton object property reads

### DIFF
--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -38,16 +38,20 @@ impl<'a> PeepholeOptimizations {
     }
 
     pub fn fold_static_member_expr(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        let can_fold_object_property = !ctx.is_tree_shake_only()
-            && matches!(
-                expr,
-                Expression::StaticMemberExpression(member)
-                    if !member.optional && matches!(member.object, Expression::ObjectExpression(_))
-            )
-            && !Self::should_keep_indirect_access(expr, ctx)
-            && !matches!(ctx.parent(), Ancestor::NewExpressionCallee(_));
         let Expression::StaticMemberExpression(e) = expr else { return };
-        let StaticMemberExpression { object, property, .. } = e.as_mut();
+        let StaticMemberExpression { object, property, optional, .. } = e.as_mut();
+        let can_fold_object_property = !ctx.is_tree_shake_only()
+            && !*optional
+            && matches!(object, Expression::ObjectExpression(_))
+            && !match ctx.parent() {
+                Ancestor::CallExpressionCallee(_)
+                | Ancestor::TaggedTemplateExpressionTag(_)
+                | Ancestor::NewExpressionCallee(_) => true,
+                Ancestor::UnaryExpressionArgument(unary) => {
+                    *unary.operator() == UnaryOperator::Delete
+                }
+                _ => false,
+            };
         if can_fold_object_property
             && let Some(changed) =
                 Self::try_fold_singleton_object_property(object, property.name.as_str(), ctx)
@@ -92,19 +96,13 @@ impl<'a> PeepholeOptimizations {
         else {
             return None;
         };
-        let value_is_primitive = matches!(
-            property.value,
-            Expression::BooleanLiteral(_)
-                | Expression::NullLiteral(_)
-                | Expression::NumericLiteral(_)
-                | Expression::BigIntLiteral(_)
-                | Expression::StringLiteral(_)
-        ) || matches!(
-            &property.value,
-            Expression::UnaryExpression(unary)
-                if unary.operator == UnaryOperator::LogicalNot
-                    && matches!(&unary.argument, Expression::NumericLiteral(_))
-        );
+        let value_is_literal = property.value.is_literal()
+            || matches!(
+                &property.value,
+                Expression::UnaryExpression(unary)
+                    if unary.operator == UnaryOperator::LogicalNot
+                        && matches!(&unary.argument, Expression::NumericLiteral(_))
+            );
 
         if property.kind != PropertyKind::Init
             || property.method
@@ -112,7 +110,7 @@ impl<'a> PeepholeOptimizations {
             || property.computed
             || accessed_name == "__proto__"
             || !property.key.is_specific_static_name(accessed_name)
-            || !value_is_primitive
+            || !value_is_literal
         {
             return None;
         }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -9,7 +9,7 @@ use oxc_ecmascript::{
 use oxc_span::{GetSpan, SPAN};
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, LogicalOperator};
 
-use crate::TraverseCtx;
+use crate::{TraverseCtx, generated::ancestor::Ancestor};
 
 use super::PeepholeOptimizations;
 
@@ -38,8 +38,24 @@ impl<'a> PeepholeOptimizations {
     }
 
     pub fn fold_static_member_expr(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
+        let can_fold_object_property = !ctx.is_tree_shake_only()
+            && matches!(
+                expr,
+                Expression::StaticMemberExpression(member)
+                    if !member.optional && matches!(member.object, Expression::ObjectExpression(_))
+            )
+            && !Self::should_keep_indirect_access(expr, ctx)
+            && !matches!(ctx.parent(), Ancestor::NewExpressionCallee(_));
         let Expression::StaticMemberExpression(e) = expr else { return };
-        // TODO: tryFoldObjectPropAccess(n, left, name)
+        let StaticMemberExpression { object, property, .. } = e.as_mut();
+        if can_fold_object_property
+            && let Some(changed) =
+                Self::try_fold_singleton_object_property(object, property.name.as_str(), ctx)
+        {
+            ctx.replace_expression(expr, changed);
+            return;
+        }
+
         // `evaluate_value` only folds a narrow set of member accesses (currently
         // `.length` on constant strings/arrays) and bails cheaply otherwise.
         // Evaluate it first so the overwhelmingly common non-foldable access
@@ -64,6 +80,44 @@ impl<'a> PeepholeOptimizations {
         }
         let changed = ctx.value_to_expr(e.span, value);
         ctx.replace_expression(expr, changed);
+    }
+
+    fn try_fold_singleton_object_property(
+        object: &mut Expression<'a>,
+        accessed_name: &str,
+        ctx: &TraverseCtx<'a>,
+    ) -> Option<Expression<'a>> {
+        let Expression::ObjectExpression(object) = object else { return None };
+        let [ObjectPropertyKind::ObjectProperty(property)] = object.properties.as_mut_slice()
+        else {
+            return None;
+        };
+        let value_is_primitive = matches!(
+            property.value,
+            Expression::BooleanLiteral(_)
+                | Expression::NullLiteral(_)
+                | Expression::NumericLiteral(_)
+                | Expression::BigIntLiteral(_)
+                | Expression::StringLiteral(_)
+        ) || matches!(
+            &property.value,
+            Expression::UnaryExpression(unary)
+                if unary.operator == UnaryOperator::LogicalNot
+                    && matches!(&unary.argument, Expression::NumericLiteral(_))
+        );
+
+        if property.kind != PropertyKind::Init
+            || property.method
+            || property.shorthand
+            || property.computed
+            || accessed_name == "__proto__"
+            || !property.key.is_specific_static_name(accessed_name)
+            || !value_is_primitive
+        {
+            return None;
+        }
+
+        Some(property.value.take_in(ctx))
     }
 
     pub fn fold_logical_expr(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1166,6 +1166,32 @@ fn test_fold_non_finite_result_with_shadowed_global() {
 }
 
 #[test]
+fn test_fold_singleton_object_property_access() {
+    fold("v = ({ a: 1 }).a", "v = 1");
+    fold("v = ({ 'a': 'value' })['a']", "v = 'value'");
+    fold("v = ({ ['a']: 2 }).a", "v = 2");
+    fold("v = ({ a: true }).a", "v = !0");
+    fold("v = ({ a: null }).a", "v = null");
+    fold("v = ({ a: 1n }).a", "v = 1n");
+    fold("v = ({ a: -0 }).a", "v = -0");
+
+    fold_same("v = ({ a: 1 }).b");
+    fold_same("v = ({ a: 1, b: 2 }).a");
+    fold_same("v = ({ [key]: 1 }).a");
+    fold_same("v = ({ get a() { return 1 } }).a");
+    fold_same("v = ({ a() { return 1 } }).a");
+    fold_same("v = ({ __proto__: 1 }).__proto__");
+    fold_same("v = ({ a: value }).a");
+    test_same("({ a: 1 }).a()");
+    test_same("new ({ a: 1 }).a()");
+    test_same("({ a: 'tag' }).a``");
+    test_same("delete ({ a: 1 }).a");
+    test_same("({ a: 1 }).a = 2");
+    test_same("({ a: 1 }).a++");
+    fold("v = ({ /*! @license */ a: 1 }).a", "v = /*! @license */ 1");
+}
+
+#[test]
 fn test_fold_shift_left() {
     fold("1 << 3", "8");
     fold("1.2345 << 0", "1");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1173,6 +1173,7 @@ fn test_fold_singleton_object_property_access() {
     fold("v = ({ a: true }).a", "v = !0");
     fold("v = ({ a: null }).a", "v = null");
     fold("v = ({ a: 1n }).a", "v = 1n");
+    fold("v = ({ a: /x/g }).a", "v = /x/g");
     fold("v = ({ a: -0 }).a", "v = -0");
 
     fold_same("v = ({ a: 1 }).b");
@@ -1183,6 +1184,7 @@ fn test_fold_singleton_object_property_access() {
     fold_same("v = ({ __proto__: 1 }).__proto__");
     fold_same("v = ({ a: value }).a");
     test_same("({ a: 1 }).a()");
+    test_same("({ a: /x/ }).a()");
     test_same("new ({ a: 1 }).a()");
     test_same("({ a: 'tag' }).a``");
     test_same("delete ({ a: 1 }).a");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1174,6 +1174,32 @@ fn test_fold_non_finite_result_with_shadowed_global() {
 }
 
 #[test]
+fn test_fold_singleton_object_property_access() {
+    fold("v = ({ a: 1 }).a", "v = 1");
+    fold("v = ({ 'a': 'value' })['a']", "v = 'value'");
+    fold("v = ({ ['a']: 2 }).a", "v = 2");
+    fold("v = ({ a: true }).a", "v = !0");
+    fold("v = ({ a: null }).a", "v = null");
+    fold("v = ({ a: 1n }).a", "v = 1n");
+    fold("v = ({ a: -0 }).a", "v = -0");
+
+    fold_same("v = ({ a: 1 }).b");
+    fold_same("v = ({ a: 1, b: 2 }).a");
+    fold_same("v = ({ [key]: 1 }).a");
+    fold_same("v = ({ get a() { return 1 } }).a");
+    fold_same("v = ({ a() { return 1 } }).a");
+    fold_same("v = ({ __proto__: 1 }).__proto__");
+    fold_same("v = ({ a: value }).a");
+    test_same("({ a: 1 }).a()");
+    test_same("new ({ a: 1 }).a()");
+    test_same("({ a: 'tag' }).a``");
+    test_same("delete ({ a: 1 }).a");
+    test_same("({ a: 1 }).a = 2");
+    test_same("({ a: 1 }).a++");
+    fold("v = ({ /*! @license */ a: 1 }).a", "v = /*! @license */ 1");
+}
+
+#[test]
 fn test_fold_shift_left() {
     fold("1 << 3", "8");
     fold("1.2345 << 0", "1");

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1181,6 +1181,7 @@ fn test_fold_singleton_object_property_access() {
     fold("v = ({ a: true }).a", "v = !0");
     fold("v = ({ a: null }).a", "v = null");
     fold("v = ({ a: 1n }).a", "v = 1n");
+    fold("v = ({ a: /x/g }).a", "v = /x/g");
     fold("v = ({ a: -0 }).a", "v = -0");
 
     fold_same("v = ({ a: 1 }).b");
@@ -1191,6 +1192,7 @@ fn test_fold_singleton_object_property_access() {
     fold_same("v = ({ __proto__: 1 }).__proto__");
     fold_same("v = ({ a: value }).a");
     test_same("({ a: 1 }).a()");
+    test_same("({ a: /x/ }).a()");
     test_same("new ({ a: 1 }).a()");
     test_same("({ a: 'tag' }).a``");
     test_same("delete ({ a: 1 }).a");


### PR DESCRIPTION
Singleton object-literal property reads remain uncompressed even when the object has exactly one ordinary data property containing a literal value. The temporary object and property lookup can be removed without changing observable behavior.

Fold only non-optional value reads whose static key matches the sole non-computed initializer. Values are limited to literals and the boolean form produced by normalization. RegExp literals are safe because the rewrite preserves their single fresh-object evaluation. Reject `__proto__`, accessors, methods, dynamic keys, additional properties, reference-sensitive contexts, and other values.

## Example

Input:

```js
use(({ a: 1 }).a);
```

Before:

```js
use({ a: 1 }.a);
```

After:

```js
use(1);
```

The 12-file minsize corpus contains no matching cases: exact minified outputs and gzip sizes are unchanged, so no size snapshot update is needed.

Verified with the full `oxc_minifier` test suite, `just minsize`, Clippy with warnings denied, formatting, and `git diff --check`.

Implemented with AI assistance (OpenAI Codex). The contributor remains responsible for reviewing, understanding, and submitting the changes under the repository AI usage policy.