### PR TITLE
fix(formatter_yaml): break long keys off a block scalar header

### DIFF
--- a/crates/oxc_formatter_yaml/AGENTS.md
+++ b/crates/oxc_formatter_yaml/AGENTS.md
@@ -72,9 +72,9 @@ Current divergences:
 - comment position (spec-example-6-1): a comment stays at its syntactic position; Prettier hoists a comment after `[` onto the `key:` line
 - over-indented comments (`key: value` followed by a deeper-indented comment): the value's layout never changes for a comment;
   Prettier breaks the pair onto two lines (`key:\n  value`) — comment indentation alone must not rewrite the preceding node
-- trailing comment width (`key: | # ...`): a same-line trailing comment is a `line_suffix` and never counts toward the `fits` measurement
-  the same treatment Prettier itself gives JS/JSON line comments and yaml flow collections.
-  Prettier's yaml printer measures the one after a block scalar header inline and breaks the key line (`key:\n  | # ...`); that break is not ported
+- trailing comment width (`key: | # ...`): a same-line trailing comment never counts toward the `fits` measurement
+  the same treatment Prettier itself gives JS/JSON line comments and yaml flow collections, but not for block scalar header
+  The KEY does count: a long key overflowing on `key: |` alone breaks the pair exactly like Prettier
 
 ## Verification
 

--- a/crates/oxc_formatter_yaml/src/comments.rs
+++ b/crates/oxc_formatter_yaml/src/comments.rs
@@ -226,20 +226,28 @@ fn pending_same_line_comment_over(
 /// (`,` between flow entries, `:` after an implicit key), so syntax knowledge stays at the print site.
 /// Any other content means the comment trails a LATER node on the same line
 /// (`[a, b, c # comment` must not attach the comment to `a`).
-pub fn write_trailing_same_line_comment<'a>(
+pub fn write_trailing_same_line_comment(
     prev_end: u32,
     gap_punctuation: &[u8],
-    f: &mut YamlFormatter<'_, 'a>,
+    f: &mut YamlFormatter<'_, '_>,
 ) {
     let Some(comment) = pending_same_line_comment_over(prev_end, gap_punctuation, f) else {
         return;
     };
     f.context().comments().take_before(comment.span.end);
+    write_comment_line_suffix(comment.span, f);
+    write!(f, expand_parent());
+}
+
+/// The ` # ...` emission of a same-line trailing comment: a `line_suffix`,
+/// so it never counts toward the `fits` measurement (see the "trailing comment width" divergence).
+/// Gating and consuming are the caller's.
+pub fn write_comment_line_suffix<'a>(span: Span, f: &mut YamlFormatter<'_, 'a>) {
     let content = format_with(move |f: &mut YamlFormatter<'_, 'a>| {
         write!(f, space());
-        write_single_comment(comment.span, f);
+        write_single_comment(span, f);
     });
-    write!(f, [line_suffix(&content), expand_parent()]);
+    write!(f, line_suffix(&content));
 }
 
 /// Returns `true` if `span` is an ignore marker (`# oxfmt-ignore` / `# prettier-ignore`).

--- a/crates/oxc_formatter_yaml/src/print/block.rs
+++ b/crates/oxc_formatter_yaml/src/print/block.rs
@@ -4,14 +4,14 @@ use oxc_formatter_core::{
     Buffer,
     builders::{
         align, dedent, dedent_to_root, exact_line_breaks, hard_line_break, literal_line_break,
-        mark_as_root, soft_line_break_or_space, space, text,
+        mark_as_root, soft_line_break_or_space, text,
     },
     write,
 };
 use oxc_yaml_parser::ast::{BlockScalar, Chomping, Content, MappingItem, Node, Root};
 
 use crate::{
-    comments::write_single_comment,
+    comments::write_comment_line_suffix,
     options::ProseWrap,
     print::{
         YamlFormatter, format_with,
@@ -84,13 +84,14 @@ pub fn write_block_scalar<'a>(
     // The parser guarantees it is the ONLY comment within the scalar's span
     // (see the guarantee on `BlockScalar`), so nothing else needs draining here;
     // trailing-ness (`own_line_column: None`) pins it to the header line.
+    // No `expand_parent()`: the scalar's leading hardline already breaks the container,
+    // and expansion must not leak into the enclosing `best_fitting` measurement.
     if let Some(comment) = f.context().comments().peek()
         && comment.span.end <= block.content_start
         && comment.own_line_column.is_none()
     {
         f.context().comments().take_before(comment.span.end);
-        write!(f, space());
-        write_single_comment(comment.span, f);
+        write_comment_line_suffix(comment.span, f);
     }
 
     // Words fold to the arena lifetime: borrowed words already slice the arena-backed source,

--- a/crates/oxc_formatter_yaml/src/print/mapping_item.rs
+++ b/crates/oxc_formatter_yaml/src/print/mapping_item.rs
@@ -204,42 +204,36 @@ pub fn write_mapping_item<'a>(
         return;
     }
 
-    // Separator between `:` and the value
+    // Separator between `:` and the value.
+    // A props-carrying block collection is NOT pinned:
+    // like a block scalar it takes the width-based routing below
+    // (Prettier hangs `key:\n  !!tag &a` under an overflowing key too).
     let block_collection_without_props =
         matches!(value_node.content, Content::Mapping(_) | Content::Sequence(_))
             && value_node.props.anchor.is_none()
             && value_node.props.tag.is_none();
-    let hardline_separator = block_collection_without_props
-        || has_pending_comment_before(value_start, f)
-        || (in_flow == FlowParent::No && key_trailing_same_line && is_inline(Some(value_node)));
+    let colon = if space_before_colon { " :" } else { ":" };
+    let hardline_separator =
+        block_collection_without_props || has_pending_comment_before(value_start, f);
 
-    if hardline_separator || !is_inline(Some(value_node)) {
-        // The separator is pinned:
-        // hardline (block collection / comments), or a space (block scalar & friends,
-        // whose hardlines Prettier's `conditionalGroup` keeps from re-flowing the key line).
+    if hardline_separator {
+        // The separator is pinned to a hardline (block collection / comments)
         write_key(item, f);
-        let implicit_value = format_with(move |f: &mut YamlFormatter<'_, 'a>| {
-            if space_before_colon {
-                write!(f, space());
-            }
-            write!(f, ":");
-            if hardline_separator {
-                // Key's same-line comment must be emitted before the line break
-                write_trailing_same_line_comment(key_span_end, b":", f);
-                write!(f, hard_line_break());
-            } else {
-                write!(f, space());
-            }
+        write!(f, colon);
+        // Key's same-line comment must be emitted before the line break
+        write_trailing_same_line_comment(key_span_end, b":", f);
+        let value = format_with(|f| {
             write_node_or_suppressed(value_node, f);
         });
-        write!(f, align(tab_width, &implicit_value));
+        write!(f, align(tab_width, &format_args!(hard_line_break(), value)));
         return;
     }
 
     // Width-dependent layout via `best_fitting!`.
     // Variants are measured flat with early-exit at hardlines, so:
     // - variant 1 fits = the key + `: ` + the value's FIRST line fit
-    //   (a multiline value's own hardlines don't re-flow the key line, Prettier's `conditionalGroup` boundary)
+    //   (a multiline value's own hardlines don't re-flow the key line, Prettier's `conditionalGroup` boundary;
+    //   for a block scalar that first line is just the `| ` / `>` header, sans any line-suffix trailing comment)
     // - variant 2 fits = the key fits (Prettier's groupedKey break check)
     // Content is memoized so the comment cursor advances only once.
     let key = format_with(|f: &mut YamlFormatter<'_, 'a>| write_key(item, f)).memoized();
@@ -254,7 +248,6 @@ pub fn write_mapping_item<'a>(
         write!(f, group(&format_with(|f| write_node(value_node, f))));
     })
     .memoized();
-    let colon = if space_before_colon { " :" } else { ":" };
 
     // A definitely-single-line key never flips to the explicit form, no matter how long
     if key_absolutely_single_line && !key_trailing_same_line {

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/block-scalar-header-comment-width.yaml
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/block-scalar-header-comment-width.yaml
@@ -1,8 +1,18 @@
-# DIVERGENCE (AGENTS.md "trailing comment width"): a same-line trailing comment
-# is a line_suffix and never counts toward the fits measurement, so the header
-# stays on the key line; Prettier measures it inline and breaks the pair
-# (`run:` / `| # ...`) once the comment overflows the print width.
+# DIVERGENCE (AGENTS.md "trailing comment width"):
+# a same-line trailing comment is a line_suffix and never counts toward the fits measurement,
+# so the header stays on the key line. (The same as other our formatters, except for CSS for now)
 run: | # this trailing comment is long enough to push the header line far beyond every print width
   set -euo pipefail
 short: | # fits
   ok
+# The KEY does count: a header that overflows on the key alone breaks the pair
+# (comment excluded, so the same rule composes with the divergence above).
+resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
+  jsonPointers:
+    - /status
+resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscalr: | # trailing
+  jsonPointers:
+    - /status
+# Props-carrying block collections take the same width-based routing.
+resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscale: !!map &m
+  a: 1

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/block-scalar-header-comment-width.yaml.snap
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/block-scalar-header-comment-width.yaml.snap
@@ -2,38 +2,71 @@
 source: crates/oxc_formatter_yaml/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
-# DIVERGENCE (AGENTS.md "trailing comment width"): a same-line trailing comment
-# is a line_suffix and never counts toward the fits measurement, so the header
-# stays on the key line; Prettier measures it inline and breaks the pair
-# (`run:` / `| # ...`) once the comment overflows the print width.
+# DIVERGENCE (AGENTS.md "trailing comment width"):
+# a same-line trailing comment is a line_suffix and never counts toward the fits measurement,
+# so the header stays on the key line. (The same as other our formatters, except for CSS for now)
 run: | # this trailing comment is long enough to push the header line far beyond every print width
   set -euo pipefail
 short: | # fits
   ok
+# The KEY does count: a header that overflows on the key alone breaks the pair
+# (comment excluded, so the same rule composes with the divergence above).
+resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
+  jsonPointers:
+    - /status
+resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscalr: | # trailing
+  jsonPointers:
+    - /status
+# Props-carrying block collections take the same width-based routing.
+resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscale: !!map &m
+  a: 1
 
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
 ------------------
-# DIVERGENCE (AGENTS.md "trailing comment width"): a same-line trailing comment
-# is a line_suffix and never counts toward the fits measurement, so the header
-# stays on the key line; Prettier measures it inline and breaks the pair
-# (`run:` / `| # ...`) once the comment overflows the print width.
+# DIVERGENCE (AGENTS.md "trailing comment width"):
+# a same-line trailing comment is a line_suffix and never counts toward the fits measurement,
+# so the header stays on the key line. (The same as other our formatters, except for CSS for now)
 run: | # this trailing comment is long enough to push the header line far beyond every print width
   set -euo pipefail
 short: | # fits
   ok
+# The KEY does count: a header that overflows on the key alone breaks the pair
+# (comment excluded, so the same rule composes with the divergence above).
+resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler:
+  |
+  jsonPointers:
+    - /status
+resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscalr:
+  | # trailing
+  jsonPointers:
+    - /status
+# Props-carrying block collections take the same width-based routing.
+resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscale:
+  !!map &m
+  a: 1
 
 -------------------
 { printWidth: 100 }
 -------------------
-# DIVERGENCE (AGENTS.md "trailing comment width"): a same-line trailing comment
-# is a line_suffix and never counts toward the fits measurement, so the header
-# stays on the key line; Prettier measures it inline and breaks the pair
-# (`run:` / `| # ...`) once the comment overflows the print width.
+# DIVERGENCE (AGENTS.md "trailing comment width"):
+# a same-line trailing comment is a line_suffix and never counts toward the fits measurement,
+# so the header stays on the key line. (The same as other our formatters, except for CSS for now)
 run: | # this trailing comment is long enough to push the header line far beyond every print width
   set -euo pipefail
 short: | # fits
   ok
+# The KEY does count: a header that overflows on the key alone breaks the pair
+# (comment excluded, so the same rule composes with the divergence above).
+resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
+  jsonPointers:
+    - /status
+resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscalr: | # trailing
+  jsonPointers:
+    - /status
+# Props-carrying block collections take the same width-based routing.
+resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscale: !!map &m
+  a: 1
 
 ===================== End =====================


### PR DESCRIPTION
```yaml
short: | # fits
  ok
long: | # this trailing comment is long enough to push the header line far beyond every print width
  but keep line

# However, the KEY does count: a header that overflows on the key alone breaks the pair
resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler:
  |
  This breaks

```
