### PR TITLE
refactor(minifier): restructure typeof comparison folding

### DIFF
--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -764,31 +764,9 @@ impl<'a> PeepholeOptimizations {
             && e.operator.is_equality()
             && !e.left.may_have_side_effects(ctx)
         {
-            let right_ty = e.right.value_type(ctx);
-
-            if !right_ty.is_undetermined()
-                && right_ty != ValueType::String
-                // a loose comparison with an object can be `true` via ToPrimitive
-                // (e.g. `typeof foo == ['object']` is true when `foo` is an object)
-                && (right_ty != ValueType::Object
-                    || matches!(
-                        e.operator,
-                        BinaryOperator::StrictEquality | BinaryOperator::StrictInequality
-                    ))
-                && !e.right.may_have_side_effects(ctx)
-            {
-                let new_expr = Expression::new_boolean_literal(
-                    e.span,
-                    e.operator == BinaryOperator::Inequality
-                        || e.operator == BinaryOperator::StrictInequality,
-                    ctx,
-                );
-                ctx.replace_expression(expr, new_expr);
-                return;
-            }
-            if let Expression::StringLiteral(string_lit) = &e.right
-                && !matches!(
-                    string_lit.value.as_str(),
+            fn is_typeof_string(s: &str) -> bool {
+                matches!(
+                    s,
                     "string"
                         | "number"
                         | "bigint"
@@ -799,15 +777,35 @@ impl<'a> PeepholeOptimizations {
                         | "function"
                         | "unknown" // IE
                 )
-            {
-                let new_expr = Expression::new_boolean_literal(
-                    e.span,
-                    e.operator == BinaryOperator::Inequality
-                        || e.operator == BinaryOperator::StrictInequality,
-                    ctx,
-                );
-                ctx.replace_expression(expr, new_expr);
             }
+
+            let is_strict = matches!(
+                e.operator,
+                BinaryOperator::StrictEquality | BinaryOperator::StrictInequality
+            );
+
+            let may_be_equal = match &e.right {
+                Expression::StringLiteral(string_lit) => is_typeof_string(&string_lit.value),
+                right => {
+                    let ty = right.value_type(ctx);
+                    matches!(ty, ValueType::Undetermined | ValueType::String)
+                        // a loose comparison with an object can be `true` via ToPrimitive
+                        // (e.g. `typeof foo == ['object']` is true when `foo` is an object)
+                        || (ty == ValueType::Object && !is_strict)
+                }
+            };
+
+            if may_be_equal || e.right.may_have_side_effects(ctx) {
+                return;
+            }
+
+            let new_expr = Expression::new_boolean_literal(
+                e.span,
+                e.operator == BinaryOperator::Inequality
+                    || e.operator == BinaryOperator::StrictInequality,
+                ctx,
+            );
+            ctx.replace_expression(expr, new_expr);
         }
     }
 


### PR DESCRIPTION
Simplify handling, reduce repeated boolean literal creativity, and make the code cleaner.