### PR TITLE
perf(linter): answer module identity and type-only questions once, not per graph edge

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -85,7 +85,7 @@ pub use crate::{
     frameworks::FrameworkFlags,
     lint_runner::{DirectivesStore, LintRunner, LintRunnerBuilder},
     loader::LINTABLE_EXTENSIONS,
-    module_record::ModuleRecord,
+    module_record::{LoadedModule, ModuleRecord},
     options::LintOptions,
     options::{AllowWarnDeny, InvalidFilterKind, LintFilter, LintFilterKind},
     rule::{RuleCategory, RuleFixMeta, RuleMeta, RuleRunFunctionsImplemented, RuleRunner},

--- a/crates/oxc_linter/src/module_graph_visitor.rs
+++ b/crates/oxc_linter/src/module_graph_visitor.rs
@@ -1,6 +1,5 @@
 use std::{
     marker::PhantomData,
-    path::PathBuf,
     sync::{Arc, Weak},
 };
 
@@ -129,7 +128,7 @@ impl<T> Default for ModuleGraphVisitorBuilder<'_, T> {
 
 pub struct ModuleGraphVisitResult<T> {
     pub result: T,
-    pub _traversed: FxHashSet<PathBuf>,
+    pub _traversed: FxHashSet<u32>,
     pub _max_depth: u32,
 }
 
@@ -141,7 +140,9 @@ impl<T> ModuleGraphVisitResult<T> {
 
 #[derive(Debug)]
 struct ModuleGraphVisitor {
-    traversed: FxHashSet<PathBuf>,
+    /// Modules already visited, keyed on [`ModuleRecord::path_id`] — same semantics as keying on
+    /// the resolved path, without cloning and hashing a `PathBuf` for every node visited.
+    traversed: FxHashSet<u32>,
     depth: u32,
     max_depth: u32,
 }
@@ -218,8 +219,7 @@ impl ModuleGraphVisitor {
                 continue;
             }
 
-            let path = &loaded_module_record.resolved_absolute_path;
-            if !self.traversed.insert(path.clone()) {
+            if !self.traversed.insert(loaded_module_record.path_id) {
                 continue;
             }
 

--- a/crates/oxc_linter/src/module_graph_visitor.rs
+++ b/crates/oxc_linter/src/module_graph_visitor.rs
@@ -1,15 +1,10 @@
-use std::{
-    marker::PhantomData,
-    sync::{Arc, Weak},
-};
+use std::{marker::PhantomData, sync::Arc};
 
 use rustc_hash::FxHashSet;
 
-use oxc_str::CompactStr;
+use crate::{ModuleRecord, module_record::LoadedModule};
 
-use crate::ModuleRecord;
-
-type ModulePair<'a> = (&'a CompactStr, &'a Arc<ModuleRecord>);
+type ModulePair<'a> = (&'a LoadedModule, &'a Arc<ModuleRecord>);
 
 type FilterFn<'a> = dyn Fn(ModulePair, &ModuleRecord) -> bool + 'a;
 type EventFn<'a> = dyn FnMut(ModuleGraphVisitorEvent, ModulePair, &ModuleRecord) + 'a;
@@ -194,26 +189,18 @@ impl ModuleGraphVisitor {
         enter: &mut EnterMod,
         leave: &mut LeaveMod,
     ) -> VisitFoldWhile<T> {
-        // Sort entries to ensure deterministic iteration order.
-        // The module graph is populated via parallel insertion (par_drain in runtime.rs),
-        // which causes non-deterministic insertion order into FxHashMap.
-        // Different iteration orders can cause cycle detection to find or miss cycles
-        // depending on which path reaches a node first (due to the `traversed` set).
-        let mut entries: Vec<_> = module_record
-            .loaded_modules()
-            .iter()
-            .map(|(k, v)| (k.clone(), Weak::clone(v)))
-            .collect();
-        entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-
-        for (key, weak_module_record) in entries {
+        // `loaded_modules` is sorted by specifier, which is what makes this walk deterministic:
+        // the graph is populated by parallel insertion (`par_drain` in runtime.rs), and different
+        // iteration orders can cause cycle detection to find or miss cycles depending on which
+        // path reaches a node first (due to the `traversed` set).
+        for entry in module_record.loaded_modules() {
             if self.depth > self.max_depth {
                 return VisitFoldWhile::Stop(accumulator.into_inner());
             }
 
-            let loaded_module_record = weak_module_record.upgrade().unwrap();
+            let loaded_module_record = entry.module_record();
 
-            let pair = (&key, &loaded_module_record);
+            let pair = (entry, &loaded_module_record);
 
             if !filter(pair, module_record) {
                 continue;

--- a/crates/oxc_linter/src/module_record.rs
+++ b/crates/oxc_linter/src/module_record.rs
@@ -5,7 +5,7 @@ use std::{
     fmt,
     path::{Component, Path, PathBuf},
     sync::{
-        Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak,
+        Arc, OnceLock, Weak,
         atomic::{AtomicU32, Ordering},
     },
 };
@@ -31,6 +31,30 @@ fn path_is_node_module(path: &Path) -> bool {
         && path
             .components()
             .any(|c| matches!(c, Component::Normal(p) if p == OsStr::new("node_modules")))
+}
+
+/// One entry of a [`ModuleRecord`]'s `[[LoadedModules]]`.
+#[derive(Debug)]
+pub struct LoadedModule {
+    /// Specifier the importing module used to request this one.
+    pub specifier: CompactStr,
+
+    /// Every import entry and indirect export entry naming [`Self::specifier`] is type-only.
+    ///
+    /// False when there are no such entries. Answered once when the graph is linked, rather than
+    /// by scanning the importing module's entries at each use.
+    pub is_type_only: bool,
+
+    module_record: Weak<ModuleRecord>,
+}
+
+impl LoadedModule {
+    /// # Panics
+    ///
+    /// * If the [`ModuleRecord`] has been dropped (fails to `Weak::upgrade`).
+    pub fn module_record(&self) -> Arc<ModuleRecord> {
+        Weak::upgrade(&self.module_record).unwrap()
+    }
 }
 
 /// ESM Module Record
@@ -76,15 +100,17 @@ pub struct ModuleRecord {
 
     /// `[[LoadedModules]]`
     ///
-    /// A map from the specifier strings used by the module represented by this record to request
-    /// the importation of a module to the resolved Module Record. The list does not contain two
-    /// different Records with the same `[[Specifier]]`.
+    /// The specifier strings used by the module represented by this record to request the
+    /// importation of a module, paired with the resolved Module Record. The list does not contain
+    /// two different Records with the same `[[Specifier]]`.
     ///
-    /// Note that Oxc does not support cross-file analysis, so this map will be empty after
-    /// [`ModuleRecord`] is created. You must link the module records yourself.
+    /// Sorted by specifier, so that graph walks iterate a module's edges in a deterministic order
+    /// without re-sorting at each visit, and [`ModuleRecord::get_loaded_module`] can binary search.
     ///
-    /// Use [ModuleRecord::get_loaded_module] to get a `ModuleRecord`.
-    loaded_modules: RwLock<FxHashMap<CompactStr, Weak<ModuleRecord>>>,
+    /// Written once, by [`ModuleRecord::set_loaded_modules`], when the graph is linked. Note that
+    /// Oxc does not support cross-file analysis, so this is empty after [`ModuleRecord`] is
+    /// created; you must link the module records yourself.
+    loaded_modules: OnceLock<Box<[LoadedModule]>>,
 
     /// `[[ImportEntries]]`
     ///
@@ -127,12 +153,10 @@ impl fmt::Debug for ModuleRecord {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         // recursively formatting loaded modules can crash when the module graph is cyclic
         let loaded_modules = self
-            .loaded_modules
-            .read()
-            .unwrap()
-            .keys()
-            .map(ToString::to_string)
-            .reduce(|acc, key| format!("{acc}, {key}"))
+            .loaded_modules()
+            .iter()
+            .map(|module| module.specifier.to_string())
+            .reduce(|acc, specifier| format!("{acc}, {specifier}"))
             .unwrap_or_default();
         let loaded_modules = format!("{{ {loaded_modules} }}");
         f.debug_struct("ModuleRecord")
@@ -550,32 +574,57 @@ impl ModuleRecord {
         }
     }
 
-    /// # Panics
-    ///
-    /// * If the RwLock is poisoned (which only happens if a thread panicked while holding the lock).
-    pub fn loaded_modules(&self) -> RwLockReadGuard<'_, FxHashMap<CompactStr, Weak<ModuleRecord>>> {
-        self.loaded_modules.read().unwrap()
+    /// This module's `[[LoadedModules]]`, sorted by specifier. Empty until the graph is linked.
+    pub fn loaded_modules(&self) -> &[LoadedModule] {
+        self.loaded_modules.get().map_or(&[], |modules| modules)
     }
 
-    /// # Panics
+    /// Link this module to the records its specifiers resolved to.
     ///
-    /// * If the RwLock is poisoned (which only happens if a thread panicked while holding the lock).
-    pub fn write_loaded_modules(
-        &self,
-    ) -> RwLockWriteGuard<'_, FxHashMap<CompactStr, Weak<ModuleRecord>>> {
-        self.loaded_modules.write().unwrap()
+    /// Sorts by specifier and answers each entry's [`LoadedModule::is_type_only`] here, so that
+    /// consumers walking the graph pay for neither. Duplicate specifiers are collapsed; they
+    /// resolve to the same record.
+    ///
+    /// Called once per record. A second call is ignored.
+    pub fn set_loaded_modules(&self, modules: Vec<(CompactStr, Weak<ModuleRecord>)>) {
+        // One pass over the entries rather than a scan per specifier: a specifier is type-only when
+        // it is named by at least one entry and every entry naming it is type-only.
+        let mut type_only = FxHashMap::<&str, bool>::default();
+        let entries =
+            self.import_entries
+                .iter()
+                .map(|entry| (entry.module_request.name(), entry.is_type))
+                .chain(self.indirect_export_entries.iter().filter_map(|entry| {
+                    Some((entry.module_request.as_ref()?.name(), entry.is_type))
+                }));
+        for (name, is_type) in entries {
+            type_only.entry(name).and_modify(|all| *all &= is_type).or_insert(is_type);
+        }
+
+        let mut modules = modules
+            .into_iter()
+            .map(|(specifier, module_record)| LoadedModule {
+                is_type_only: type_only.get(specifier.as_str()).copied().unwrap_or(false),
+                specifier,
+                module_record,
+            })
+            .collect::<Vec<_>>();
+        modules.sort_unstable_by(|a, b| a.specifier.cmp(&b.specifier));
+        modules.dedup_by(|a, b| a.specifier == b.specifier);
+
+        let _ = self.loaded_modules.set(modules.into_boxed_slice());
     }
 
     /// Get a loaded module by upgrading the weak reference to an Arc.
-    /// Returns None if the module has been dropped or not found.
+    /// Returns None if not found.
     ///
     /// # Panics
     ///
-    /// * If the RwLock is poisoned (which only happens if a thread panicked while holding the lock).
     /// * If `ModuleRecord` is dropped (fails to Weak::upgrade).
     pub fn get_loaded_module(&self, key: &str) -> Option<Arc<ModuleRecord>> {
-        let loaded_modules = self.loaded_modules();
-        loaded_modules.get(key).map(|weak| Weak::upgrade(weak).unwrap())
+        let modules = self.loaded_modules();
+        let index = modules.binary_search_by(|module| module.specifier.as_str().cmp(key)).ok()?;
+        Some(modules[index].module_record())
     }
 
     pub(crate) fn exported_bindings_from_star_export(

--- a/crates/oxc_linter/src/module_record.rs
+++ b/crates/oxc_linter/src/module_record.rs
@@ -1,9 +1,13 @@
 //! [ECMAScript Module Record](https://tc39.es/ecma262/#sec-abstract-module-records)
 
 use std::{
+    ffi::OsStr,
     fmt,
-    path::{Path, PathBuf},
-    sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak},
+    path::{Component, Path, PathBuf},
+    sync::{
+        Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak,
+        atomic::{AtomicU32, Ordering},
+    },
 };
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -12,6 +16,22 @@ use oxc_semantic::Semantic;
 use oxc_span::Span;
 use oxc_str::CompactStr;
 pub use oxc_syntax::module_record::RequestedModule;
+
+/// Ids for records built outside a lint run, counting down from `u32::MAX` so they never collide
+/// with the ids `Runtime` interns (which count up from 1). Such records are not part of a linked
+/// graph, so they only need to be distinct from each other.
+static NEXT_UNSHARED_PATH_ID: AtomicU32 = AtomicU32::new(u32::MAX);
+
+/// Is `path` inside a `node_modules` directory?
+///
+/// `Path::components` parses the path one component at a time, so rule out the overwhelmingly
+/// common case with a byte search and only parse components for paths that could match.
+fn path_is_node_module(path: &Path) -> bool {
+    memchr::memmem::find(path.as_os_str().as_encoded_bytes(), b"node_modules").is_some()
+        && path
+            .components()
+            .any(|c| matches!(c, Component::Normal(p) if p == OsStr::new("node_modules")))
+}
 
 /// ESM Module Record
 ///
@@ -27,6 +47,21 @@ pub struct ModuleRecord {
 
     /// Resolved absolute path to this module record
     pub resolved_absolute_path: PathBuf,
+
+    /// Identifies [`Self::resolved_absolute_path`] within a lint run: two records have the same
+    /// id if and only if they have the same resolved path.
+    ///
+    /// Cross-module analysis compares modules constantly, and `Path`'s `PartialEq` and `Hash` both
+    /// walk the path component by component — the same reason `Runtime` keys its maps on `OsStr`.
+    /// Comparing ids instead makes that a `u32` compare. Set by `Runtime` when the record is
+    /// created; records [`ModuleRecord::new`] builds outside a lint run get a distinct id each, so
+    /// they never compare equal to one another.
+    pub path_id: u32,
+
+    /// Is [`Self::resolved_absolute_path`] inside a `node_modules` directory?
+    ///
+    /// Answered once here rather than by walking the path's components at each use.
+    pub is_node_module: bool,
 
     /// `[[RequestedModules]]`
     ///
@@ -103,6 +138,8 @@ impl fmt::Debug for ModuleRecord {
         f.debug_struct("ModuleRecord")
             .field("has_module_syntax", &self.has_module_syntax)
             .field("resolved_absolute_path", &self.resolved_absolute_path)
+            .field("path_id", &self.path_id)
+            .field("is_node_module", &self.is_node_module)
             .field("requested_modules", &self.requested_modules)
             .field("loaded_modules", &loaded_modules)
             .field("import_entries", &self.import_entries)
@@ -468,6 +505,8 @@ impl ModuleRecord {
         Self {
             has_module_syntax: other.has_module_syntax,
             resolved_absolute_path: path.to_path_buf(),
+            path_id: NEXT_UNSHARED_PATH_ID.fetch_sub(1, Ordering::Relaxed),
+            is_node_module: path_is_node_module(path),
             requested_modules: other
                 .requested_modules
                 .iter()

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -1,6 +1,5 @@
 use std::{
-    ffi::OsStr,
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
@@ -154,7 +153,7 @@ impl Rule for NoCycle {
             return;
         }
 
-        let needle = &module_record.resolved_absolute_path;
+        let needle = module_record.path_id;
         let mut direct_imports = module_record
             .loaded_modules()
             .iter()
@@ -172,7 +171,7 @@ impl Rule for NoCycle {
             let mut stack =
                 vec![(key.clone(), loaded_module_record.resolved_absolute_path.clone())];
 
-            if loaded_module_record.resolved_absolute_path == *needle {
+            if loaded_module_record.path_id == needle {
                 ctx.diagnostic(self_referencing_cycle_diagnostic(span, requested_module.is_import));
                 continue;
             }
@@ -189,7 +188,7 @@ impl Rule for NoCycle {
                     }
                 })
                 .visit_fold(false, &loaded_module_record, |_, (_, val), _| {
-                    if val.resolved_absolute_path == *needle {
+                    if val.path_id == needle {
                         VisitFoldWhile::Stop(true)
                     } else {
                         VisitFoldWhile::Next(false)
@@ -245,9 +244,9 @@ impl NoCycle {
             if !self.should_traverse_module(specifier, &loaded_module_record, module_record) {
                 continue;
             }
-            // By path, not pointer: that is what the walks report on, and one file can have
+            // By path id, not pointer: that is what the walks report on, and one file can have
             // several records (one per section).
-            if loaded_module_record.resolved_absolute_path == root.resolved_absolute_path {
+            if loaded_module_record.path_id == root.path_id {
                 return true;
             }
             if visited.insert(Arc::as_ptr(&loaded_module_record) as usize) {
@@ -263,13 +262,7 @@ impl NoCycle {
         module: &Arc<ModuleRecord>,
         parent: &ModuleRecord,
     ) -> bool {
-        let path = &module.resolved_absolute_path;
-
-        let is_node_module = path
-            .components()
-            .any(|c| matches!(c, Component::Normal(p) if p == OsStr::new("node_modules")));
-
-        if is_node_module {
+        if module.is_node_module {
             return false;
         }
 
@@ -306,7 +299,7 @@ impl NoCycle {
         // export function example1() { }
         // export * as Example from './test.js';
         // ```
-        if path == &parent.resolved_absolute_path
+        if module.path_id == parent.path_id
             && let Some(e) = module
                 .indirect_export_entries
                 .iter()

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -1,7 +1,4 @@
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{path::Path, sync::Arc};
 
 use cow_utils::CowUtils;
 use oxc_diagnostics::OxcDiagnostic;
@@ -16,10 +13,14 @@ use crate::{
     ModuleRecord,
     context::LintContext,
     module_graph_visitor::{ModuleGraphVisitorBuilder, ModuleGraphVisitorEvent, VisitFoldWhile},
+    module_record::LoadedModule,
     rule::{DefaultRuleConfig, Rule},
 };
 
-fn no_cycle_diagnostic(span: Span, stack: &[(CompactStr, PathBuf)], cwd: &Path) -> OxcDiagnostic {
+/// One hop of a reported cycle: the specifier used, and the module it resolved to.
+type CycleStep = (CompactStr, Arc<ModuleRecord>);
+
+fn no_cycle_diagnostic(span: Span, stack: &[CycleStep], cwd: &Path) -> OxcDiagnostic {
     let cycle_description = format_cycle(stack, cwd);
     OxcDiagnostic::warn("Dependency cycle detected")
         .with_help("Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.")
@@ -37,10 +38,11 @@ fn self_referencing_cycle_diagnostic(span: Span, is_import: bool) -> OxcDiagnost
         .with_label(span.primary_label("this module references itself"))
 }
 
-fn format_cycle(stack: &[(CompactStr, PathBuf)], cwd: &Path) -> String {
+fn format_cycle(stack: &[CycleStep], cwd: &Path) -> String {
     let mut lines = Vec::with_capacity(stack.len() * 2 + 1);
 
-    for (i, (specifier, path)) in stack.iter().enumerate() {
+    for (i, (specifier, module_record)) in stack.iter().enumerate() {
+        let path = &module_record.resolved_absolute_path;
         let relative_path = path
             .strip_prefix(cwd)
             .unwrap_or(path)
@@ -154,22 +156,18 @@ impl Rule for NoCycle {
         }
 
         let needle = module_record.path_id;
-        let mut direct_imports = module_record
-            .loaded_modules()
-            .iter()
-            .map(|(key, weak_module_record)| (key.clone(), weak_module_record.upgrade().unwrap()))
-            .collect::<Vec<_>>();
-        direct_imports.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
-        for (key, loaded_module_record) in direct_imports {
-            if !self.should_traverse_module(&key, &loaded_module_record, module_record) {
+        // Already sorted by specifier, so the order the cycles are reported in is deterministic.
+        for entry in module_record.loaded_modules() {
+            let loaded_module_record = entry.module_record();
+            if !self.should_traverse_module(entry, &loaded_module_record, module_record) {
                 continue;
             }
 
-            let requested_module = module_record.requested_modules[&key][0];
+            let requested_module = module_record.requested_modules[&entry.specifier][0];
             let span = requested_module.span;
-            let mut stack =
-                vec![(key.clone(), loaded_module_record.resolved_absolute_path.clone())];
+            let mut stack: Vec<CycleStep> =
+                vec![(entry.specifier.clone(), Arc::clone(&loaded_module_record))];
 
             if loaded_module_record.path_id == needle {
                 ctx.diagnostic(self_referencing_cycle_diagnostic(span, requested_module.is_import));
@@ -178,10 +176,10 @@ impl Rule for NoCycle {
 
             let visitor_result = ModuleGraphVisitorBuilder::default()
                 .max_depth(self.max_depth.saturating_sub(1))
-                .filter(|(key, val), parent| self.should_traverse_module(key, val, parent))
-                .event(|event, (key, val), _| match event {
+                .filter(|(entry, val), parent| self.should_traverse_module(entry, val, parent))
+                .event(|event, (entry, val), _| match event {
                     ModuleGraphVisitorEvent::Enter => {
-                        stack.push((key.clone(), val.resolved_absolute_path.clone()));
+                        stack.push((entry.specifier.clone(), Arc::clone(val)));
                     }
                     ModuleGraphVisitorEvent::Leave => {
                         stack.pop();
@@ -239,9 +237,9 @@ impl NoCycle {
         visited: &mut FxHashSet<usize>,
         stack: &mut Vec<Arc<ModuleRecord>>,
     ) -> bool {
-        for (specifier, weak_module_record) in module_record.loaded_modules().iter() {
-            let loaded_module_record = weak_module_record.upgrade().unwrap();
-            if !self.should_traverse_module(specifier, &loaded_module_record, module_record) {
+        for entry in module_record.loaded_modules() {
+            let loaded_module_record = entry.module_record();
+            if !self.should_traverse_module(entry, &loaded_module_record, module_record) {
                 continue;
             }
             // By path id, not pointer: that is what the walks report on, and one file can have
@@ -258,7 +256,7 @@ impl NoCycle {
 
     fn should_traverse_module(
         &self,
-        key: &CompactStr,
+        entry: &LoadedModule,
         module: &Arc<ModuleRecord>,
         parent: &ModuleRecord,
     ) -> bool {
@@ -266,31 +264,8 @@ impl NoCycle {
             return false;
         }
 
-        if self.ignore_types {
-            // Equivalent to collecting both entry lists and testing `!is_empty() && all(is_type)`,
-            // without materializing either `Vec`. This runs once per graph edge considered.
-            let mut types = parent
-                .import_entries
-                .iter()
-                .filter(|entry| entry.module_request.name() == key)
-                .map(|entry| entry.is_type)
-                .chain(
-                    parent
-                        .indirect_export_entries
-                        .iter()
-                        .filter(|entry| {
-                            entry
-                                .module_request
-                                .as_ref()
-                                .is_some_and(|module_request| module_request.name() == key)
-                        })
-                        .map(|entry| entry.is_type),
-                )
-                .peekable();
-
-            if types.peek().is_some() && types.all(|is_type| is_type) {
-                return false;
-            }
+        if self.ignore_types && entry.is_type_only {
+            return false;
         }
 
         // Allow self referencing named export.
@@ -303,7 +278,7 @@ impl NoCycle {
             && let Some(e) = module
                 .indirect_export_entries
                 .iter()
-                .find(|e| e.module_request.as_ref().is_some_and(|r| r.name.as_str() == key))
+                .find(|e| e.module_request.as_ref().is_some_and(|r| r.name == entry.specifier))
             && e.export_name.is_name()
         {
             return false;

--- a/crates/oxc_linter/src/rules/import/no_self_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_self_import.rs
@@ -48,12 +48,12 @@ declare_oxc_lint!(
 impl Rule for NoSelfImport {
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
-        let resolved_absolute_path = &module_record.resolved_absolute_path;
+        let path_id = module_record.path_id;
         for (request, requested_modules) in &module_record.requested_modules {
             let Some(remote_module_record) = module_record.get_loaded_module(request) else {
                 continue;
             };
-            if remote_module_record.resolved_absolute_path == *resolved_absolute_path {
+            if remote_module_record.path_id == path_id {
                 for requested_module in requested_modules {
                     ctx.diagnostic(no_self_import_diagnostic(requested_module.span));
                 }

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -64,6 +64,11 @@ pub struct Runtime {
     /// To make sure all `ModuleRecord` gets dropped after `Runtime` is dropped,
     /// `modules_by_path` must own `ModuleRecord` with `Arc`, all other references must use `Weak<ModuleRecord>`.
     modules_by_path: ModulesByPath,
+    /// Interned ids for resolved module paths, so that cross-module analysis can compare modules
+    /// with a `u32` compare instead of a `Path` one. See [`ModuleRecord::path_id`].
+    ///
+    /// Taken once per created record, not per comparison, so the lock is uncontended in practice.
+    path_ids: Mutex<(FxHashMap<PathBuf, u32>, u32)>,
     /// Collected disable directives from linted files
     disable_directives_map: Arc<Mutex<FxHashMap<PathBuf, DisableDirectives>>>,
 }
@@ -269,8 +274,26 @@ impl Runtime {
                 .hasher(BuildHasherDefault::default())
                 .resize_mode(papaya::ResizeMode::Blocking)
                 .build(),
+            path_ids: Mutex::new((FxHashMap::default(), 1)),
             disable_directives_map: Arc::new(Mutex::new(FxHashMap::default())),
         }
+    }
+
+    /// Id for `path`, shared by every [`ModuleRecord`] resolving to it. See
+    /// [`ModuleRecord::path_id`].
+    ///
+    /// # Panics
+    ///
+    /// * If the mutex is poisoned (which only happens if a thread panicked while holding it).
+    fn intern_path(&self, path: &Path) -> u32 {
+        let (ids, next) = &mut *self.path_ids.lock().unwrap();
+        if let Some(id) = ids.get(path) {
+            return *id;
+        }
+        let id = *next;
+        *next += 1;
+        ids.insert(path.to_path_buf(), id);
+        id
     }
 
     /// Get [`AllocatorPool`] for copying ASTs to fixed-size allocators, if one is required.
@@ -1155,7 +1178,9 @@ impl Runtime {
         let mut semantic = semantic_ret.semantic;
         semantic.set_irregular_whitespaces(ret.irregular_whitespaces);
 
-        let module_record = Arc::new(ModuleRecord::new(path, &ret.module_record, &semantic));
+        let mut module_record = ModuleRecord::new(path, &ret.module_record, &semantic);
+        module_record.path_id = self.intern_path(path);
+        let module_record = Arc::new(module_record);
 
         let tokens = ret.tokens.into_boxed_slice();
 

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -1181,7 +1181,12 @@ impl Runtime {
         semantic.set_irregular_whitespaces(ret.irregular_whitespaces);
 
         let mut module_record = ModuleRecord::new(path, &ret.module_record, &semantic);
-        module_record.path_id = self.intern_path(path);
+        // Only worth interning when the module graph is built: without a resolver nothing links
+        // these records together, so the distinct id `ModuleRecord::new` assigns is enough, and
+        // every run — including ones with no cross-module rules — skips the lock.
+        if self.resolver.is_some() {
+            module_record.path_id = self.intern_path(path);
+        }
         let module_record = Arc::new(module_record);
 
         let tokens = ret.tokens.into_boxed_slice();

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -591,7 +591,7 @@ impl Runtime {
                 for (record, requested_module_paths) in
                     records.iter().zip(requested_module_paths)
                 {
-                    let mut loaded_modules = record.write_loaded_modules();
+                    let mut loaded_modules = Vec::with_capacity(requested_module_paths.len());
                     for request in requested_module_paths {
                         // TODO: revise how to store multiple sections in loaded_modules
                         let Some(dep_module_record) =
@@ -599,8 +599,10 @@ impl Runtime {
                         else {
                             continue;
                         };
-                        loaded_modules.insert(request.specifier, Arc::downgrade(dep_module_record));
+                        loaded_modules
+                            .push((request.specifier, Arc::downgrade(dep_module_record)));
                     }
+                    record.set_loaded_modules(loaded_modules);
                 }
             });
             #[expect(clippy::iter_with_drain)]


### PR DESCRIPTION
AI Disclosure: generated using Claude Code w/ Opus 5. Reviewed and tested by me. This is a PR to show what we've managed to come up with to gain another large speedup for the rule after the previous changesets. It's best to review it per-commit. I would like feedback on whether we think these changes are worth it, and/or which parts are worth it. It changes linter module data modeling a bit, so I'm hesitant to push forward without further feedback.

Follow-up to #25003 and #25004. Those two removed redundant *work* from `import/no-cycle`; this one removes what the remaining work spends its time on. Baseline for every number below is `main` at 6f2b933 (i.e. with both of those already merged).

## What

Profiling the rule on `vscode/src` after #25004 showed it was no longer bound by graph traversal at all. Roughly 61% of its samples were in `std::path`, and most of the rest was rebuilding data that never changes:

| cost | share of rule samples |
| --- | --: |
| `should_traverse_module` parsing path components for its `node_modules` check, once per edge | 27.6% |
| `Path`'s `PartialEq`, which compares components back to front | 21.9% |
| cloning and hashing a `PathBuf` into the visitor's `traversed` set, once per node | 11.7% |
| rebuilding + re-sorting a module's edge list at every node of every walk | ~46% (after the above were fixed) |
| `should_traverse_module` scanning all entries to answer "is this specifier type-only?", once per edge | ~30% (after the above were fixed) |

Each of these is a question about a module that has one answer for the whole run, so `ModuleRecord` now answers them once.

### 1. `is_node_module` and `path_id` (commit 1)

- `is_node_module` is computed when the record is built, with a `memmem` byte search short-circuiting the component walk for the overwhelmingly common non-match.
- `path_id` is a `u32` interned per resolved path, so the identity comparisons cross-module analysis does constantly become integer compares, and `ModuleGraphVisitor::traversed` becomes an `FxHashSet<u32>` that allocates nothing per node. Records built outside a lint run get a distinct id each, so they never compare equal to one another.

`import/no-self-import` gets the cheaper comparison for free.

### 2. `loaded_modules` as a sorted slice (commit 2)

`ModuleGraphVisitor::filter_fold_recursive` rebuilt a module's edge list at every node of every walk — cloning each specifier, cloning each `Weak`, and re-sorting — purely to get a deterministic iteration order that is identical on every visit. So:

- `loaded_modules` becomes a `Box<[LoadedModule]>` sorted by specifier. The walk iterates a borrowed slice and allocates nothing per node; `get_loaded_module` binary searches.
- `LoadedModule::is_type_only` is computed in one pass over the entries, so `should_traverse_module` reads a field instead of scanning.

It is written exactly once, by `Runtime`, so it becomes a `OnceLock` and the `RwLock` goes away with it.

### 3. Gate the interner (commit 3)

`ModuleRecord::new` runs for every file regardless of configuration, so the `intern_path` call from commit 1 charged a mutex acquire, a `PathBuf` clone and a hash to *every* oxlint run — including runs with no import plugin and no rules at all. Without a resolver nothing links these records together, so the id `ModuleRecord::new` already assigns is sufficient and the interner is skipped. See the regression table below for why this was needed.

## Measurements

`vscode/src` — 7,368 files, 81,512 direct imports — release build with `--features allocator`, 18 threads. Wall clock and peak RSS are paired interleaved runs with per-round order alternation, n=21. Allocations come from a counting global allocator, and both allocation columns subtract a parse-only run on the same binary.

### `import/no-cycle`

| metric | `main` | this PR | delta |
| --- | --: | --: | --: |
| wall clock | 974.3 ms | 407.4 ms | **−58.2%** |
| peak RSS | 1400.2 MB | 852.2 MB | **−39.1%** |
| rule-attributable allocations | 38.61 M | 2.29 M | **−94.1%** |
| rule-attributable bytes | 4.31 GB | 1.09 GB | **−74.7%** |

t = +359.3, faster in 21/21 paired rounds.

The walk is now essentially allocation-free: 2.29 M allocations against 81,512 direct imports, down from ~474 per import.

### No regression for everything else

These changes touch `ModuleRecord`, which every cross-module rule reads, and sorting + answering `is_type_only` at link time is work that rules which never walk the graph now pay for. Checked against four configurations that exclude `no-cycle` entirely:

| config | diagnostics | `main` | this PR | delta | t |
| --- | --: | --: | --: | --: | --: |
| parse only (no rules, no graph) | 0 | 97.8 ms | 97.2 ms | +0.6 ms (+0.6%) | +1.74 |
| default (no import plugin) | 7,280 | 111.6 ms | 110.6 ms | +0.9 ms (+0.8%) | +1.93 |
| import rules only, `no-cycle` off | 22 | 211.4 ms | 213.0 ms | −1.6 ms (−0.8%) | −1.09 |
| all categories + import, `no-cycle` off | 643,697 | 470.4 ms | 471.4 ms | −1.0 ms (−0.2%) | −0.49 |

No configuration is distinguishable from `main` (every |t| < 2).

Commit 3 exists because of this table. Before gating the interner, the same benchmark showed a *statistically significant* slowdown on three of these four:

| config | before gating | after gating |
| --- | --- | --- |
| parse only | −1.7 ms, **t = −2.98** | −0.5 ms, t = −1.70 |
| default | −1.3 ms, **t = −3.66** | −0.9 ms, t = −1.82 |
| import rules only | −3.4 ms, **t = −2.79** | −1.1 ms, t = −1.14 |
| all categories + import | −2.3 ms, t = −0.82 | −3.8 ms, t = −1.74 |

The tell was that the offset was roughly constant (~1.5 ms) while the workload varied 5×, and that it appeared even in the parse-only run that builds no module graph at all — but vanished on a single-file run (+0.17 ms, t = +0.92 at n=41), so it was not process startup either. That pointed at a fixed per-file cost paid unconditionally, which is exactly what `intern_path` before the resolver check was.

## Correctness

- Diagnostics are **identical to `main`** on all five configurations above, compared element-wise after sorting: 1,566 lines for `no-cycle` (1,550 cycle diagnostics + 16 parse errors), 7,280 for the default config, 22 for import-rules-only, and 643,697 for all-categories-plus-import.
- Full `oxc_linter` test suite passes with no snapshot changes; `cargo clippy -p oxc_linter --all-features --all-targets -- -D warnings` is clean.

### A note on the build configuration

`allocator` is not a default feature of `oxlint` (`apps/oxlint/Cargo.toml`), so a plain `cargo build --release -p oxlint` links the system allocator rather than mimalloc. Everything above was built with `--features allocator` to match what ships. For reference, the same comparison on system-allocator builds gives −57.4% wall clock rather than −58.2%, so the conclusion does not depend on the allocator — but note this means the figures in #25003, which stated they used `--features allocator`, were in fact system-allocator numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
