### PR TITLE
fix(linter/react/hook-use-state): allow underscore-prefixed useState bindings

### DIFF
--- a/crates/oxc_linter/src/rules/react/hook_use_state.rs
+++ b/crates/oxc_linter/src/rules/react/hook_use_state.rs
@@ -149,6 +149,10 @@ impl Rule for HookUseState {
             return;
         };
 
+        if value_variable_name.starts_with('_') || setter_variable_name.starts_with('_') {
+            return;
+        }
+
         let Some((lowercase_prefix, suffix)) =
             split_leading_lowercase(value_variable_name.as_str())
         else {
@@ -222,6 +226,42 @@ fn test() {
             import React from 'react';
             export default function useColor() {
                 return React.useState('');
+            }",
+            None,
+        ),
+        (
+            r"
+            import React from 'react';
+            export default function useId() {
+                const [_, id] = useState(1);
+                return id;
+            }",
+            None,
+        ),
+        (
+            r"
+            import React from 'react';
+            export default function useId() {
+                const [id, _] = useState(1);
+                return id;
+            }",
+            None,
+        ),
+        (
+            r"
+            import React from 'react';
+            export default function useId() {
+                const [_unusedValue, id] = useState(1);
+                return id;
+            }",
+            None,
+        ),
+        (
+            r"
+            import React from 'react';
+            export default function useId() {
+                const [id, _unusedSetter] = useState(1);
+                return id;
             }",
             None,
         ),


### PR DESCRIPTION
## Summary

- treat an underscore-prefixed `useState` getter or setter as intentionally unused
- skip the pair-name convention when either binding is intentionally unused
- cover both exact `_` placeholders and descriptive `_unused...` names on both tuple positions

Fixes #24952.

## Proof

- exact unpatched base reproduced all four false positives
- focused `react/hook-use-state` rule test passed
- `cargo test -p oxc_linter`: 1,175 passed, 0 failed, 1 ignored, plus integration tests and doctests
- linter crate lint passed
- formatting check passed
- linter code generation completed without changing generated files
- production-only revert made the four new cases fail; restoring the final tree returned the focused test to green
- `git diff --check` passed

AI assistance: I used Codex during implementation and test iteration. I reviewed the final one-file diff, the rule behavior, and the complete proof above before submission.
