### PR TITLE
fix(isolated-declarations): handle ambient expando properties

### DIFF
--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -533,9 +533,13 @@ impl<'a> IsolatedDeclarations<'a> {
         let TSModuleDeclarationName::Identifier(ident) = &decl.id else { return };
         let Some(TSModuleDeclarationBody::TSModuleBlock(block)) = &decl.body else { return };
         for stmt in &block.body {
-            let Statement::ExportDeclaration(decl) = stmt else { continue };
-            match &decl.declaration {
-                Declaration::VariableDeclaration(var) => {
+            let declaration = match stmt {
+                Statement::ExportDeclaration(decl) => Some(&decl.declaration),
+                _ if decl.declare => stmt.as_declaration(),
+                _ => None,
+            };
+            match declaration {
+                Some(Declaration::VariableDeclaration(var)) => {
                     for declarator in &var.declarations {
                         if let Some(name) = declarator.id.get_identifier_name() {
                             assignable_properties
@@ -545,7 +549,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         }
                     }
                 }
-                Declaration::FunctionDeclaration(func) => {
+                Some(Declaration::FunctionDeclaration(func)) => {
                     if let Some(name) = func.name() {
                         assignable_properties
                             .entry(ident.name.as_str())
@@ -553,7 +557,7 @@ impl<'a> IsolatedDeclarations<'a> {
                             .insert(name.into());
                     }
                 }
-                Declaration::ClassDeclaration(cls) => {
+                Some(Declaration::ClassDeclaration(cls)) => {
                     if let Some(id) = cls.id.as_ref() {
                         assignable_properties
                             .entry(ident.name.as_str())
@@ -561,7 +565,7 @@ impl<'a> IsolatedDeclarations<'a> {
                             .insert(id.name.into());
                     }
                 }
-                Declaration::TSEnumDeclaration(decl) => {
+                Some(Declaration::TSEnumDeclaration(decl)) => {
                     assignable_properties
                         .entry(ident.name.as_str())
                         .or_default()

--- a/crates/oxc_isolated_declarations/tests/fixtures/issue-24975.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/issue-24975.ts
@@ -1,0 +1,7 @@
+export function foo(): void {}
+
+export declare namespace foo {
+  let bar: number;
+}
+
+foo.bar = 42;

--- a/crates/oxc_isolated_declarations/tests/snapshots/issue-24975.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/issue-24975.snap
@@ -1,0 +1,11 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/issue-24975.ts
+---
+```
+==================== .D.TS ====================
+
+export declare function foo(): void;
+export declare namespace foo {
+	let bar: number;
+}


### PR DESCRIPTION
Closes #24975.

Treat direct declarations in ambient namespaces as exported when validating properties assigned to expando functions. This preserves the explicit `export` requirement for ordinary namespaces.

Added an isolated declarations regression fixture and snapshot.

AI usage: Codex assisted with issue analysis.