### PR TITLE
fix(linter): allow undefined in React useRef

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -113,6 +113,8 @@ static FUNCTION_NAMES: &[&str] = &[
     "toEqual",
     "toHaveBeenCalledWith",
     "unshift",
+    // `React.useRef(undefined)`
+    "useRef",
 ];
 
 fn is_match_ignore_func_name(name: &str) -> bool {
@@ -406,6 +408,8 @@ fn test() {
         ("array.unshift(undefined);", None),
         ("createContext(undefined);", None),
         ("React.createContext(undefined);", None),
+        ("useRef(undefined);", None),
+        ("React.useRef(undefined);", None),
         ("setState(undefined)", None),
         ("setState?.(undefined)", None),
         ("props.setState(undefined)", None),
@@ -544,6 +548,8 @@ fn test() {
         ),
         ("createContext<T>(undefined);", None),
         ("React.createContext<T>(undefined);", None),
+        ("useRef<T>(undefined);", None),
+        ("React.useRef<T>(undefined);", None),
         (
             "
             const y: any = {}

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -113,6 +113,8 @@ static FUNCTION_NAMES: &[&str] = &[
     "toEqual",
     "toHaveBeenCalledWith",
     "unshift",
+    // `React.useRef(undefined)`
+    "useRef",
 ];
 
 fn is_match_ignore_func_name(name: &str) -> bool {
@@ -418,6 +420,8 @@ fn test() {
         ("array.unshift(undefined);", None),
         ("createContext(undefined);", None),
         ("React.createContext(undefined);", None),
+        ("useRef(undefined);", None),
+        ("React.useRef(undefined);", None),
         ("setState(undefined)", None),
         ("setState?.(undefined)", None),
         ("props.setState(undefined)", None),
@@ -556,6 +560,8 @@ fn test() {
         ),
         ("createContext<T>(undefined);", None),
         ("React.createContext<T>(undefined);", None),
+        ("useRef<T>(undefined);", None),
+        ("React.useRef<T>(undefined);", None),
         (
             "
             const y: any = {}


### PR DESCRIPTION
## Problem
React 19 requires `useRef` to receive an argument, so `useRef(undefined)` is valid while `useRef()` is a TypeScript error. [eslint-plugin-unicorn #2463](https://github.com/sindresorhus/eslint-plugin-unicorn/pull/2463) made the parallel fix, but Oxc's independent Rust port never picked up that behavior.

## Solution
Add `useRef` to the existing ignored function names and cover direct, namespace, and generic TypeScript calls.

## Test plan
`cargo test -p oxc_linter no_useless_undefined`
`just ready`

Validated against `@types/react@19.2.17`: `useRef(undefined)` passes and `useRef()` fails with TS2554. See the [React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#useref-requires-an-argument).

AI-assisted change. I reviewed the implementation and test results and take responsibility for the contribution.