### PR TITLE
refactor(linter): remove `Message.section_offset` property

### DIFF
--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -305,10 +305,7 @@ impl<'a> LintContext<'a> {
     /// Use [`LintContext::diagnostic_with_fix`] to provide an automatic fix.
     #[inline]
     pub fn diagnostic(&self, diagnostic: OxcDiagnostic) {
-        self.add_diagnostic(
-            Message::new(diagnostic, PossibleFixes::None)
-                .with_section_offset(self.parent.current_sub_host().source_text_offset),
-        );
+        self.add_diagnostic(Message::new(diagnostic, PossibleFixes::None));
     }
 
     /// Report a lint rule violation and provide an automatic fix.
@@ -426,10 +423,7 @@ impl<'a> LintContext<'a> {
     /// monomorphized at every rule call site.
     fn emit_single_fix(&self, diagnostic: OxcDiagnostic, fix: Option<Fix>) {
         if let Some(fix) = fix {
-            self.add_diagnostic(
-                Message::new(diagnostic, PossibleFixes::Single(fix))
-                    .with_section_offset(self.parent.current_sub_host().source_text_offset),
-            );
+            self.add_diagnostic(Message::new(diagnostic, PossibleFixes::Single(fix)));
         } else {
             self.diagnostic(diagnostic);
         }
@@ -458,10 +452,7 @@ impl<'a> LintContext<'a> {
         if fixes_result.is_empty() {
             self.diagnostic(diagnostic);
         } else {
-            self.add_diagnostic(
-                Message::new(diagnostic, PossibleFixes::Multiple(fixes_result))
-                    .with_section_offset(self.parent.current_sub_host().source_text_offset),
-            );
+            self.add_diagnostic(Message::new(diagnostic, PossibleFixes::Multiple(fixes_result)));
         }
     }
 
@@ -499,10 +490,7 @@ impl<'a> LintContext<'a> {
         if fixes_result.is_empty() {
             self.diagnostic(diagnostic);
         } else {
-            self.add_diagnostic(
-                Message::new(diagnostic, PossibleFixes::Multiple(fixes_result))
-                    .with_section_offset(self.parent.current_sub_host().source_text_offset),
-            );
+            self.add_diagnostic(Message::new(diagnostic, PossibleFixes::Multiple(fixes_result)));
         }
     }
 

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -268,7 +268,6 @@ pub struct Message {
     pub fixes: PossibleFixes,
     pub span: Span,
     fixed: bool,
-    pub section_offset: u32,
     /// The lint rule that produced this message, if any. Only defined for lint rule errors, and `None` otherwise.
     pub rule: Option<MessageRule>,
 }
@@ -283,18 +282,12 @@ impl Message {
             .map(|span| Span::new(span.offset(), span.offset() + span.len()))
             .unwrap_or_default();
 
-        Self { error, span, fixes, fixed: false, section_offset: 0, rule: None }
+        Self { error, span, fixes, fixed: false, rule: None }
     }
 
     #[must_use]
     pub fn with_rule(mut self, rule: MessageRule) -> Self {
         self.rule = Some(rule);
-        self
-    }
-
-    #[must_use]
-    pub fn with_section_offset(mut self, section_offset: u32) -> Self {
-        self.section_offset = section_offset;
         self
     }
 

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -145,7 +145,6 @@ fn cmp_diagnostics_for_runtime_optimization_assertion(
         .then_with(|| left.error.url.cmp(&right.error.url))
         .then_with(|| left.span.cmp(&right.span))
         .then_with(|| left.fixes.cmp_fix_sequence(&right.fixes))
-        .then_with(|| left.section_offset.cmp(&right.section_offset))
         .then_with(|| {
             left.rule.as_ref().map(|rule| (rule.plugin_name.as_ref(), rule.rule_name.as_ref())).cmp(
                 &right


### PR DESCRIPTION
With moving the ignore logic into `oxc_linter`, nobody is now interested in `Message.section_offset`.
The last PR https://github.com/oxc-project/oxc/pull/24958 did remove the last/only dependency of this property.

