### PR TITLE
perf(parser): avoid large types on stack

### DIFF
--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -46,7 +46,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         func_kind: FunctionKind,
         params_kind: FormalParameterKind,
-    ) -> (Option<TSThisParameter<'a>>, ArenaBox<'a, FormalParameters<'a>>) {
+    ) -> (Option<ArenaBox<'a, TSThisParameter<'a>>>, ArenaBox<'a, FormalParameters<'a>>) {
         let span = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LParen);
@@ -219,7 +219,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     pattern.span(),
                 ));
             }
-            Some(init)
+            Some(ArenaBox::new_in(init, self))
         } else {
             None
         };

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -361,7 +361,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     /// [Import Attributes](https://tc39.es/proposal-import-attributes)
-    fn parse_import_attributes(&mut self) -> Option<WithClause<'a>> {
+    fn parse_import_attributes(&mut self) -> Option<ArenaBox<'a, WithClause<'a>>> {
         let keyword_kind = self.cur_kind();
         let keyword = match keyword_kind {
             Kind::With => WithClauseKeyword::With,
@@ -392,7 +392,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
 
-        Some(WithClause::new(self.end_span(span), keyword, with_entries, self))
+        Some(WithClause::boxed(self.end_span(span), keyword, with_entries, self))
     }
 
     fn parse_import_attribute(&mut self) -> ImportAttribute<'a> {

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -796,13 +796,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
     }
 
-    pub(crate) fn parse_ts_this_parameter(&mut self) -> TSThisParameter<'a> {
+    pub(crate) fn parse_ts_this_parameter(&mut self) -> ArenaBox<'a, TSThisParameter<'a>> {
         let span = self.start_span();
         self.bump_any();
         let this_span = self.end_span(span);
 
         let type_annotation = self.parse_ts_type_annotation();
-        TSThisParameter::new(self.end_span(span), this_span, type_annotation, self)
+        TSThisParameter::boxed(self.end_span(span), this_span, type_annotation, self)
     }
 
     pub(crate) fn at_start_of_ts_declaration(&mut self) -> bool {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -54,7 +54,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let return_type = {
             let return_type_span = self.start_span();
             let return_type = self.parse_return_type();
-            TSTypeAnnotation::new(self.end_span(return_type_span), return_type, self)
+            TSTypeAnnotation::boxed(self.end_span(return_type_span), return_type, self)
         };
 
         let span = self.end_span(span);
@@ -742,7 +742,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> TSType<'a> {
         self.bump_any(); // bump `is`
         let ty = self.parse_ts_type();
-        let type_annotation = Some(TSTypeAnnotation::new(ty.span(), ty, self));
+        let type_annotation = Some(TSTypeAnnotation::boxed(ty.span(), ty, self));
         TSType::new_ts_type_predicate(
             self.end_span(span),
             TSTypePredicateName::This(this_ty),
@@ -823,7 +823,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.eat(Kind::Is) {
             let type_span = self.start_span();
             let ty = self.parse_ts_type();
-            type_annotation = Some(TSTypeAnnotation::new(self.end_span(type_span), ty, self));
+            type_annotation = Some(TSTypeAnnotation::boxed(self.end_span(type_span), ty, self));
         }
         TSType::new_ts_type_predicate(
             self.end_span(asserts_start_span),
@@ -1349,7 +1349,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let ty = self.parse_ts_type();
         if let Some(parameter_name) = type_predicate_variable {
-            let type_annotation = Some(TSTypeAnnotation::new(ty.span(), ty, self));
+            let type_annotation = Some(TSTypeAnnotation::boxed(ty.span(), ty, self));
             return TSType::new_ts_type_predicate(
                 self.end_span(span),
                 parameter_name,


### PR DESCRIPTION
In parser, move some allocations to happen earlier.

When we need an `ArenaBox<T>` for later method calls, it's preferable to allocate it into arena as swiftly as possible, so only hold an 8-byte `ArenaBox` on stack, instead of the whole `T`, which is much larger. This reduces stack and register pressure.