### PR TITLE
perf(isolated_declarations): avoid large types on stack

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -711,7 +711,7 @@ impl<'a> IsolatedDeclarations<'a> {
             elements.insert(0, element);
         }
 
-        let body = ClassBody::new(decl.body.span, elements, self);
+        let body = ClassBody::boxed(decl.body.span, elements, self);
 
         Class::boxed(
             decl.span,

--- a/crates/oxc_isolated_declarations/src/declaration.rs
+++ b/crates/oxc_isolated_declarations/src/declaration.rs
@@ -99,7 +99,7 @@ impl<'a> IsolatedDeclarations<'a> {
         }
 
         let type_annotation =
-            binding_type.map(|ts_type| TSTypeAnnotation::new(SPAN, ts_type, self));
+            binding_type.map(|ts_type| TSTypeAnnotation::boxed(SPAN, ts_type, self));
 
         Some(VariableDeclarator::new(
             decl.span,

--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -92,7 +92,7 @@ impl<'a> IsolatedDeclarations<'a> {
                             self.error(implicitly_adding_undefined_to_type(param.span));
                         } else if !ts_type.is_maybe_undefined() {
                             // union with `undefined`
-                            return TSTypeAnnotation::new(
+                            return TSTypeAnnotation::boxed(
                                 SPAN,
                                 TSType::new_ts_union_type(
                                     SPAN,
@@ -104,7 +104,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         }
                     }
 
-                    TSTypeAnnotation::new(SPAN, ts_type, self)
+                    TSTypeAnnotation::boxed(SPAN, ts_type, self)
                 });
 
             let optional =

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -100,7 +100,7 @@ impl<'a> IsolatedDeclarations<'a> {
             let id = BindingPattern::new_binding_identifier(SPAN, name, self);
             let type_annotation = self
                 .infer_type_from_expression(expr)
-                .map(|ts_type| TSTypeAnnotation::new(SPAN, ts_type, self));
+                .map(|ts_type| TSTypeAnnotation::boxed(SPAN, ts_type, self));
 
             if type_annotation.is_none() {
                 self.error(default_export_inferred(expr.span()));


### PR DESCRIPTION
Continuation of #25034.

In isolated declarations, move some allocations to happen earlier.

When we need an `ArenaBox<T>` for later method calls, it's preferable to allocate it into arena as swiftly as possible, so only hold an 8-byte `ArenaBox` on stack, instead of the whole `T`, which is much larger. This reduces stack and register pressure.