### PR TITLE
feat(ast)!: remove conversion to `Box` from AST builder methods

### DIFF
--- a/crates/oxc_ast/src/builder/custom.rs
+++ b/crates/oxc_ast/src/builder/custom.rs
@@ -18,7 +18,7 @@ use oxc_syntax::{number::NumberBase, operator::UnaryOperator, scope::ScopeId};
 
 use crate::ast::*;
 
-use super::{GetAstBuilder, NONE};
+use super::GetAstBuilder;
 
 impl<'a> Expression<'a> {
     /// Build an [`Expression`] representing the number `0`.
@@ -78,7 +78,7 @@ impl<'a> FormalParameter<'a> {
         builder: &B,
     ) -> Self {
         let builder = builder.builder();
-        FormalParameter::new(span, [], pattern, NONE, NONE, false, None, false, false, builder)
+        FormalParameter::new(span, [], pattern, None, None, false, None, false, false, builder)
     }
 }
 
@@ -95,19 +95,15 @@ impl<'a> Function<'a> {
     /// * `body`: The function body.
     /// * `scope_id`
     #[inline]
-    pub fn boxed_plain_with_scope_id<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed_plain_with_scope_id<B: GetAstBuilder<'a>>(
         r#type: FunctionType,
         span: Span,
         id: Option<BindingIdentifier<'a>>,
-        params: T1,
-        body: T2,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         Function::boxed_with_scope_id_and_pure_and_pife(
             span,
@@ -116,11 +112,11 @@ impl<'a> Function<'a> {
             false,
             false,
             false,
-            NONE,
-            NONE,
+            None,
+            None,
             params,
-            NONE,
-            Some(body.into_in(builder.allocator())),
+            None,
+            Some(body),
             scope_id,
             false,
             false,
@@ -145,28 +141,21 @@ impl<'a> Function<'a> {
     /// * `body`: The function body.
     /// * `scope_id`
     #[inline]
-    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         Function::boxed_with_scope_id_and_pure_and_pife(
             span,
@@ -213,7 +202,7 @@ impl<'a> ExportNamedDeclaration<'a> {
             specifiers,
             source,
             ImportOrExportKind::Value,
-            NONE,
+            None,
             builder,
         )
     }
@@ -237,7 +226,7 @@ impl<'a> ExportNamedDeclaration<'a> {
             [],
             None,
             ImportOrExportKind::Value,
-            NONE,
+            None,
             builder,
         )
     }

--- a/crates/oxc_ast/src/builder/mod.rs
+++ b/crates/oxc_ast/src/builder/mod.rs
@@ -70,12 +70,12 @@
 //! (e.g. `builder.statement_expression(span, expr)`) and primitives (e.g. `builder.vec()`,`builder.ident(str)`).
 //! Those methods have now been removed. Use the AST type builder methods described above instead.
 //!
-//! [`AstBuilder`] and [`NONE`] are no longer re-exported from the crate root either -
-//! import them from this module instead.
+//! [`AstBuilder`] is no longer re-exported from the crate root either -
+//! import it from this module instead.
 //!
 //! Explanation of the motivation for this change here: <https://github.com/oxc-project/oxc/issues/23043>.
 
-use oxc_allocator::{Allocator, ArenaBox, ArenaVec, FromIn, GetAllocator};
+use oxc_allocator::{Allocator, GetAllocator};
 use oxc_syntax::node::NodeId;
 
 mod custom;
@@ -161,26 +161,5 @@ impl<'a> GetAllocator<'a> for AstBuilder<'a> {
     #[inline]
     fn allocator(&self) -> &'a Allocator {
         self.allocator
-    }
-}
-
-/// Type that can be used in any AST builder method call which requires either:
-///
-/// * `IntoIn<'a, Option<Box<'a, T>>`.
-/// * `IntoIn<'a, Option<Vec<'a, T>>`.
-///
-/// Pass `NONE` instead of `None::<Box<'a, T>>`.
-#[expect(clippy::upper_case_acronyms)]
-pub struct NONE;
-
-impl<'a, T> FromIn<'a, NONE> for Option<ArenaBox<'a, T>> {
-    fn from_in(_: NONE, _: &'a Allocator) -> Self {
-        None
-    }
-}
-
-impl<'a, T> FromIn<'a, NONE> for Option<ArenaVec<'a, T>> {
-    fn from_in(_: NONE, _: &'a Allocator) -> Self {
-        None
     }
 }

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -349,22 +349,16 @@ impl<'a> Expression<'a> {
     /// * `return_type`
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
-    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(ArrowFunctionExpression::boxed(
             span,
             expression,
@@ -393,31 +387,19 @@ impl<'a> Expression<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-    >(
+    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(
             ArrowFunctionExpression::boxed_with_scope_id_and_pure_and_pife(
                 span,
@@ -514,17 +496,16 @@ impl<'a> Expression<'a> {
     /// * `arguments`
     /// * `optional`
     #[inline]
-    pub fn new_call_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed(
             span,
@@ -548,18 +529,17 @@ impl<'a> Expression<'a> {
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed_with_pure(
             span,
@@ -605,26 +585,23 @@ impl<'a> Expression<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
-    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed(
             span,
@@ -660,16 +637,16 @@ impl<'a> Expression<'a> {
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
-    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
@@ -677,10 +654,7 @@ impl<'a> Expression<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed_with_scope_id(
             span,
@@ -742,27 +716,20 @@ impl<'a> Expression<'a> {
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
     #[inline]
-    pub fn new_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed(
             span,
             r#type,
@@ -799,37 +766,23 @@ impl<'a> Expression<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-    >(
+    pub fn new_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed_with_scope_id_and_pure_and_pife(
             span,
             r#type,
@@ -911,16 +864,15 @@ impl<'a> Expression<'a> {
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_new_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed(
             span,
@@ -942,17 +894,16 @@ impl<'a> Expression<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     /// * `pure`
     #[inline]
-    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed_with_pure(
             span,
@@ -1032,16 +983,13 @@ impl<'a> Expression<'a> {
     /// * `type_arguments`
     /// * `quasi`
     #[inline]
-    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>>(
         span: Span,
         tag: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         quasi: TemplateLiteral<'a>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TaggedTemplateExpression(TaggedTemplateExpression::boxed(
             span,
             tag,
@@ -1174,17 +1122,15 @@ impl<'a> Expression<'a> {
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
     #[inline]
-    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1>(
         span: Span,
-        opening_element: T1,
-        children: T2,
-        closing_element: T3,
+        opening_element: ArenaBox<'a, JSXOpeningElement<'a>>,
+        children: T1,
+        closing_element: Option<ArenaBox<'a, JSXClosingElement<'a>>>,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
     {
         Self::JSXElement(JSXElement::boxed(
             span,
@@ -1318,15 +1264,12 @@ impl<'a> Expression<'a> {
     /// * `expression`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: ArenaBox<'a, TSTypeParameterInstantiation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
-    {
+    ) -> Self {
         Self::TSInstantiationExpression(TSInstantiationExpression::boxed(
             span,
             expression,
@@ -2022,22 +1965,16 @@ impl<'a> ArrayExpressionElement<'a> {
     /// * `return_type`
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
-    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(ArrowFunctionExpression::boxed(
             span,
             expression,
@@ -2066,31 +2003,19 @@ impl<'a> ArrayExpressionElement<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-    >(
+    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(
             ArrowFunctionExpression::boxed_with_scope_id_and_pure_and_pife(
                 span,
@@ -2187,17 +2112,16 @@ impl<'a> ArrayExpressionElement<'a> {
     /// * `arguments`
     /// * `optional`
     #[inline]
-    pub fn new_call_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed(
             span,
@@ -2221,18 +2145,17 @@ impl<'a> ArrayExpressionElement<'a> {
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed_with_pure(
             span,
@@ -2278,26 +2201,23 @@ impl<'a> ArrayExpressionElement<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
-    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed(
             span,
@@ -2333,16 +2253,16 @@ impl<'a> ArrayExpressionElement<'a> {
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
-    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
@@ -2350,10 +2270,7 @@ impl<'a> ArrayExpressionElement<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed_with_scope_id(
             span,
@@ -2415,27 +2332,20 @@ impl<'a> ArrayExpressionElement<'a> {
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
     #[inline]
-    pub fn new_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed(
             span,
             r#type,
@@ -2472,37 +2382,23 @@ impl<'a> ArrayExpressionElement<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-    >(
+    pub fn new_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed_with_scope_id_and_pure_and_pife(
             span,
             r#type,
@@ -2584,16 +2480,15 @@ impl<'a> ArrayExpressionElement<'a> {
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_new_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed(
             span,
@@ -2615,17 +2510,16 @@ impl<'a> ArrayExpressionElement<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     /// * `pure`
     #[inline]
-    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed_with_pure(
             span,
@@ -2705,16 +2599,13 @@ impl<'a> ArrayExpressionElement<'a> {
     /// * `type_arguments`
     /// * `quasi`
     #[inline]
-    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>>(
         span: Span,
         tag: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         quasi: TemplateLiteral<'a>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TaggedTemplateExpression(TaggedTemplateExpression::boxed(
             span,
             tag,
@@ -2847,17 +2738,15 @@ impl<'a> ArrayExpressionElement<'a> {
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
     #[inline]
-    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1>(
         span: Span,
-        opening_element: T1,
-        children: T2,
-        closing_element: T3,
+        opening_element: ArenaBox<'a, JSXOpeningElement<'a>>,
+        children: T1,
+        closing_element: Option<ArenaBox<'a, JSXClosingElement<'a>>>,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
     {
         Self::JSXElement(JSXElement::boxed(
             span,
@@ -2991,15 +2880,12 @@ impl<'a> ArrayExpressionElement<'a> {
     /// * `expression`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: ArenaBox<'a, TSTypeParameterInstantiation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
-    {
+    ) -> Self {
         Self::TSInstantiationExpression(TSInstantiationExpression::boxed(
             span,
             expression,
@@ -3587,22 +3473,16 @@ impl<'a> PropertyKey<'a> {
     /// * `return_type`
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
-    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(ArrowFunctionExpression::boxed(
             span,
             expression,
@@ -3631,31 +3511,19 @@ impl<'a> PropertyKey<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-    >(
+    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(
             ArrowFunctionExpression::boxed_with_scope_id_and_pure_and_pife(
                 span,
@@ -3752,17 +3620,16 @@ impl<'a> PropertyKey<'a> {
     /// * `arguments`
     /// * `optional`
     #[inline]
-    pub fn new_call_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed(
             span,
@@ -3786,18 +3653,17 @@ impl<'a> PropertyKey<'a> {
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed_with_pure(
             span,
@@ -3843,26 +3709,23 @@ impl<'a> PropertyKey<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
-    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed(
             span,
@@ -3898,16 +3761,16 @@ impl<'a> PropertyKey<'a> {
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
-    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
@@ -3915,10 +3778,7 @@ impl<'a> PropertyKey<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed_with_scope_id(
             span,
@@ -3980,27 +3840,20 @@ impl<'a> PropertyKey<'a> {
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
     #[inline]
-    pub fn new_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed(
             span,
             r#type,
@@ -4037,37 +3890,23 @@ impl<'a> PropertyKey<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-    >(
+    pub fn new_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed_with_scope_id_and_pure_and_pife(
             span,
             r#type,
@@ -4149,16 +3988,15 @@ impl<'a> PropertyKey<'a> {
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_new_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed(
             span,
@@ -4180,17 +4018,16 @@ impl<'a> PropertyKey<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     /// * `pure`
     #[inline]
-    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed_with_pure(
             span,
@@ -4270,16 +4107,13 @@ impl<'a> PropertyKey<'a> {
     /// * `type_arguments`
     /// * `quasi`
     #[inline]
-    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>>(
         span: Span,
         tag: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         quasi: TemplateLiteral<'a>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TaggedTemplateExpression(TaggedTemplateExpression::boxed(
             span,
             tag,
@@ -4412,17 +4246,15 @@ impl<'a> PropertyKey<'a> {
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
     #[inline]
-    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1>(
         span: Span,
-        opening_element: T1,
-        children: T2,
-        closing_element: T3,
+        opening_element: ArenaBox<'a, JSXOpeningElement<'a>>,
+        children: T1,
+        closing_element: Option<ArenaBox<'a, JSXClosingElement<'a>>>,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
     {
         Self::JSXElement(JSXElement::boxed(
             span,
@@ -4556,15 +4388,12 @@ impl<'a> PropertyKey<'a> {
     /// * `expression`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: ArenaBox<'a, TSTypeParameterInstantiation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
-    {
+    ) -> Self {
         Self::TSInstantiationExpression(TSInstantiationExpression::boxed(
             span,
             expression,
@@ -4745,22 +4574,19 @@ impl<'a> TaggedTemplateExpression<'a> {
     /// * `type_arguments`
     /// * `quasi`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         tag: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         quasi: TemplateLiteral<'a>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TaggedTemplateExpression {
             node_id: Cell::new(builder.node_id()),
             span,
             tag,
-            type_arguments: type_arguments.into_in(builder.allocator()),
+            type_arguments,
             quasi,
         }
     }
@@ -4776,16 +4602,13 @@ impl<'a> TaggedTemplateExpression<'a> {
     /// * `type_arguments`
     /// * `quasi`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         tag: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         quasi: TemplateLiteral<'a>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, tag, type_arguments, quasi, builder), &builder.allocator())
     }
@@ -5093,24 +4916,23 @@ impl<'a> CallExpression<'a> {
     /// * `arguments`
     /// * `optional`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         let builder = builder.builder();
         CallExpression {
             node_id: Cell::new(builder.node_id()),
             span,
             callee,
-            type_arguments: type_arguments.into_in(builder.allocator()),
+            type_arguments,
             arguments: arguments.into_in(builder.allocator()),
             optional,
             pure: Default::default(),
@@ -5129,17 +4951,16 @@ impl<'a> CallExpression<'a> {
     /// * `arguments`
     /// * `optional`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -5161,25 +4982,24 @@ impl<'a> CallExpression<'a> {
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         let builder = builder.builder();
         CallExpression {
             node_id: Cell::new(builder.node_id()),
             span,
             callee,
-            type_arguments: type_arguments.into_in(builder.allocator()),
+            type_arguments,
             arguments: arguments.into_in(builder.allocator()),
             optional,
             pure,
@@ -5199,18 +5019,17 @@ impl<'a> CallExpression<'a> {
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn boxed_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         pure: bool,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -5232,23 +5051,22 @@ impl<'a> NewExpression<'a> {
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         let builder = builder.builder();
         NewExpression {
             node_id: Cell::new(builder.node_id()),
             span,
             callee,
-            type_arguments: type_arguments.into_in(builder.allocator()),
+            type_arguments,
             arguments: arguments.into_in(builder.allocator()),
             pure: Default::default(),
         }
@@ -5265,16 +5083,15 @@ impl<'a> NewExpression<'a> {
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -5295,24 +5112,23 @@ impl<'a> NewExpression<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     /// * `pure`
     #[inline]
-    pub fn new_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         let builder = builder.builder();
         NewExpression {
             node_id: Cell::new(builder.node_id()),
             span,
             callee,
-            type_arguments: type_arguments.into_in(builder.allocator()),
+            type_arguments,
             arguments: arguments.into_in(builder.allocator()),
             pure,
         }
@@ -5330,17 +5146,16 @@ impl<'a> NewExpression<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     /// * `pure`
     #[inline]
-    pub fn boxed_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         pure: bool,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -5697,22 +5512,16 @@ impl<'a> Argument<'a> {
     /// * `return_type`
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
-    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(ArrowFunctionExpression::boxed(
             span,
             expression,
@@ -5741,31 +5550,19 @@ impl<'a> Argument<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-    >(
+    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(
             ArrowFunctionExpression::boxed_with_scope_id_and_pure_and_pife(
                 span,
@@ -5862,17 +5659,16 @@ impl<'a> Argument<'a> {
     /// * `arguments`
     /// * `optional`
     #[inline]
-    pub fn new_call_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed(
             span,
@@ -5896,18 +5692,17 @@ impl<'a> Argument<'a> {
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed_with_pure(
             span,
@@ -5953,26 +5748,23 @@ impl<'a> Argument<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
-    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed(
             span,
@@ -6008,16 +5800,16 @@ impl<'a> Argument<'a> {
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
-    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
@@ -6025,10 +5817,7 @@ impl<'a> Argument<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed_with_scope_id(
             span,
@@ -6090,27 +5879,20 @@ impl<'a> Argument<'a> {
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
     #[inline]
-    pub fn new_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed(
             span,
             r#type,
@@ -6147,37 +5929,23 @@ impl<'a> Argument<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-    >(
+    pub fn new_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed_with_scope_id_and_pure_and_pife(
             span,
             r#type,
@@ -6259,16 +6027,15 @@ impl<'a> Argument<'a> {
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_new_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed(
             span,
@@ -6290,17 +6057,16 @@ impl<'a> Argument<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     /// * `pure`
     #[inline]
-    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed_with_pure(
             span,
@@ -6380,16 +6146,13 @@ impl<'a> Argument<'a> {
     /// * `type_arguments`
     /// * `quasi`
     #[inline]
-    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>>(
         span: Span,
         tag: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         quasi: TemplateLiteral<'a>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TaggedTemplateExpression(TaggedTemplateExpression::boxed(
             span,
             tag,
@@ -6522,17 +6285,15 @@ impl<'a> Argument<'a> {
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
     #[inline]
-    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1>(
         span: Span,
-        opening_element: T1,
-        children: T2,
-        closing_element: T3,
+        opening_element: ArenaBox<'a, JSXOpeningElement<'a>>,
+        children: T1,
+        closing_element: Option<ArenaBox<'a, JSXClosingElement<'a>>>,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
     {
         Self::JSXElement(JSXElement::boxed(
             span,
@@ -6666,15 +6427,12 @@ impl<'a> Argument<'a> {
     /// * `expression`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: ArenaBox<'a, TSTypeParameterInstantiation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
-    {
+    ) -> Self {
         Self::TSInstantiationExpression(TSInstantiationExpression::boxed(
             span,
             expression,
@@ -7329,15 +7087,14 @@ impl<'a> AssignmentTarget<'a> {
     /// * `elements`
     /// * `rest`
     #[inline]
-    pub fn new_array_assignment_target<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_array_assignment_target<B: GetAstBuilder<'a>, T1>(
         span: Span,
         elements: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, AssignmentTargetRest<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         Self::ArrayAssignmentTarget(ArrayAssignmentTarget::boxed(
             span,
@@ -7356,15 +7113,14 @@ impl<'a> AssignmentTarget<'a> {
     /// * `properties`
     /// * `rest`
     #[inline]
-    pub fn new_object_assignment_target<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_object_assignment_target<B: GetAstBuilder<'a>, T1>(
         span: Span,
         properties: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, AssignmentTargetRest<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, AssignmentTargetProperty<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         Self::ObjectAssignmentTarget(ObjectAssignmentTarget::boxed(
             span,
@@ -7595,15 +7351,14 @@ impl<'a> AssignmentTargetPattern<'a> {
     /// * `elements`
     /// * `rest`
     #[inline]
-    pub fn new_array_assignment_target<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_array_assignment_target<B: GetAstBuilder<'a>, T1>(
         span: Span,
         elements: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, AssignmentTargetRest<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         Self::ArrayAssignmentTarget(ArrayAssignmentTarget::boxed(
             span,
@@ -7622,15 +7377,14 @@ impl<'a> AssignmentTargetPattern<'a> {
     /// * `properties`
     /// * `rest`
     #[inline]
-    pub fn new_object_assignment_target<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_object_assignment_target<B: GetAstBuilder<'a>, T1>(
         span: Span,
         properties: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, AssignmentTargetRest<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, AssignmentTargetProperty<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         Self::ObjectAssignmentTarget(ObjectAssignmentTarget::boxed(
             span,
@@ -7652,22 +7406,21 @@ impl<'a> ArrayAssignmentTarget<'a> {
     /// * `elements`
     /// * `rest`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         elements: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, AssignmentTargetRest<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         let builder = builder.builder();
         ArrayAssignmentTarget {
             node_id: Cell::new(builder.node_id()),
             span,
             elements: elements.into_in(builder.allocator()),
-            rest: rest.into_in(builder.allocator()),
+            rest,
         }
     }
 
@@ -7681,15 +7434,14 @@ impl<'a> ArrayAssignmentTarget<'a> {
     /// * `elements`
     /// * `rest`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         elements: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, AssignmentTargetRest<'a>>>,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
         T1: IntoIn<'a, ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, elements, rest, builder), &builder.allocator())
@@ -7707,22 +7459,21 @@ impl<'a> ObjectAssignmentTarget<'a> {
     /// * `properties`
     /// * `rest`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         properties: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, AssignmentTargetRest<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, AssignmentTargetProperty<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         let builder = builder.builder();
         ObjectAssignmentTarget {
             node_id: Cell::new(builder.node_id()),
             span,
             properties: properties.into_in(builder.allocator()),
-            rest: rest.into_in(builder.allocator()),
+            rest,
         }
     }
 
@@ -7736,15 +7487,14 @@ impl<'a> ObjectAssignmentTarget<'a> {
     /// * `properties`
     /// * `rest`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         properties: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, AssignmentTargetRest<'a>>>,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
         T1: IntoIn<'a, ArenaVec<'a, AssignmentTargetProperty<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, properties, rest, builder), &builder.allocator())
@@ -8030,15 +7780,14 @@ impl<'a> AssignmentTargetMaybeDefault<'a> {
     /// * `elements`
     /// * `rest`
     #[inline]
-    pub fn new_array_assignment_target<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_array_assignment_target<B: GetAstBuilder<'a>, T1>(
         span: Span,
         elements: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, AssignmentTargetRest<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         Self::ArrayAssignmentTarget(ArrayAssignmentTarget::boxed(
             span,
@@ -8057,15 +7806,14 @@ impl<'a> AssignmentTargetMaybeDefault<'a> {
     /// * `properties`
     /// * `rest`
     #[inline]
-    pub fn new_object_assignment_target<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_object_assignment_target<B: GetAstBuilder<'a>, T1>(
         span: Span,
         properties: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, AssignmentTargetRest<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, AssignmentTargetProperty<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         Self::ObjectAssignmentTarget(ObjectAssignmentTarget::boxed(
             span,
@@ -8424,17 +8172,16 @@ impl<'a> ChainElement<'a> {
     /// * `arguments`
     /// * `optional`
     #[inline]
-    pub fn new_call_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed(
             span,
@@ -8458,18 +8205,17 @@ impl<'a> ChainElement<'a> {
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed_with_pure(
             span,
@@ -9035,18 +8781,13 @@ impl<'a> Statement<'a> {
     /// * `handler`: The `catch` clause, including the parameter and the block statement
     /// * `finalizer`: The `finally` clause
     #[inline]
-    pub fn new_try_statement<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_try_statement<B: GetAstBuilder<'a>>(
         span: Span,
-        block: T1,
-        handler: T2,
-        finalizer: T3,
+        block: ArenaBox<'a, BlockStatement<'a>>,
+        handler: Option<ArenaBox<'a, CatchClause<'a>>>,
+        finalizer: Option<ArenaBox<'a, BlockStatement<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, CatchClause<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, BlockStatement<'a>>>>,
-    {
+    ) -> Self {
         Self::TryStatement(TryStatement::boxed(span, block, handler, finalizer, builder.builder()))
     }
 
@@ -9158,27 +8899,20 @@ impl<'a> Statement<'a> {
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
     #[inline]
-    pub fn new_function_declaration<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_function_declaration<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionDeclaration(Function::boxed(
             span,
             r#type,
@@ -9215,37 +8949,23 @@ impl<'a> Statement<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_function_declaration_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-    >(
+    pub fn new_function_declaration_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionDeclaration(Function::boxed_with_scope_id_and_pure_and_pife(
             span,
             r#type,
@@ -9282,26 +9002,23 @@ impl<'a> Statement<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
-    pub fn new_class_declaration<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_declaration<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassDeclaration(Class::boxed(
             span,
@@ -9337,16 +9054,16 @@ impl<'a> Statement<'a> {
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
-    pub fn new_class_declaration_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_declaration_with_scope_id<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
@@ -9354,10 +9071,7 @@ impl<'a> Statement<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassDeclaration(Class::boxed_with_scope_id(
             span,
@@ -9387,17 +9101,14 @@ impl<'a> Statement<'a> {
     /// * `type_annotation`
     /// * `declare`
     #[inline]
-    pub fn new_ts_type_alias_declaration<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_type_alias_declaration<B: GetAstBuilder<'a>>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         type_annotation: TSType<'a>,
         declare: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-    {
+    ) -> Self {
         Self::TSTypeAliasDeclaration(TSTypeAliasDeclaration::boxed(
             span,
             id,
@@ -9420,18 +9131,15 @@ impl<'a> Statement<'a> {
     /// * `declare`
     /// * `scope_id`
     #[inline]
-    pub fn new_ts_type_alias_declaration_with_scope_id<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_type_alias_declaration_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         type_annotation: TSType<'a>,
         declare: bool,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-    {
+    ) -> Self {
         Self::TSTypeAliasDeclaration(TSTypeAliasDeclaration::boxed_with_scope_id(
             span,
             id,
@@ -9455,19 +9163,17 @@ impl<'a> Statement<'a> {
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
-    pub fn new_ts_interface_declaration<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_ts_interface_declaration<B: GetAstBuilder<'a>, T1>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
-        extends: T2,
-        body: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        extends: T1,
+        body: ArenaBox<'a, TSInterfaceBody<'a>>,
         declare: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
     {
         Self::TSInterfaceDeclaration(TSInterfaceDeclaration::boxed(
             span,
@@ -9493,20 +9199,18 @@ impl<'a> Statement<'a> {
     /// * `declare`: `true` for `declare interface Foo {}`
     /// * `scope_id`
     #[inline]
-    pub fn new_ts_interface_declaration_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_ts_interface_declaration_with_scope_id<B: GetAstBuilder<'a>, T1>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
-        extends: T2,
-        body: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        extends: T1,
+        body: ArenaBox<'a, TSInterfaceBody<'a>>,
         declare: bool,
         scope_id: ScopeId,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
     {
         Self::TSInterfaceDeclaration(TSInterfaceDeclaration::boxed_with_scope_id(
             span,
@@ -9703,18 +9407,15 @@ impl<'a> Statement<'a> {
     /// * `with_clause`: Some(vec![]) for empty assertion
     /// * `import_kind`: `import type { foo } from 'bar'`
     #[inline]
-    pub fn new_import_declaration<B: GetAstBuilder<'a>, T1>(
+    pub fn new_import_declaration<B: GetAstBuilder<'a>>(
         span: Span,
         specifiers: Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
         phase: Option<ImportPhase>,
-        with_clause: T1,
+        with_clause: Option<ArenaBox<'a, WithClause<'a>>>,
         import_kind: ImportOrExportKind,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
-    {
+    ) -> Self {
         Self::ImportDeclaration(ImportDeclaration::boxed(
             span,
             specifiers,
@@ -9737,17 +9438,14 @@ impl<'a> Statement<'a> {
     /// * `with_clause`: Will be `Some(vec![])` for empty assertion
     /// * `export_kind`
     #[inline]
-    pub fn new_export_all_declaration<B: GetAstBuilder<'a>, T1>(
+    pub fn new_export_all_declaration<B: GetAstBuilder<'a>>(
         span: Span,
         exported: Option<ModuleExportName<'a>>,
         source: StringLiteral<'a>,
-        with_clause: T1,
+        with_clause: Option<ArenaBox<'a, WithClause<'a>>>,
         export_kind: ImportOrExportKind,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
-    {
+    ) -> Self {
         Self::ExportAllDeclaration(ExportAllDeclaration::boxed(
             span,
             exported,
@@ -9790,18 +9488,17 @@ impl<'a> Statement<'a> {
     /// * `export_kind`: `export type { foo }`
     /// * `with_clause`: Some(vec![]) for empty assertion
     #[inline]
-    pub fn new_export_named_declaration<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_export_named_declaration<B: GetAstBuilder<'a>, T1>(
         span: Span,
         declaration: Option<Declaration<'a>>,
         specifiers: T1,
         source: Option<StringLiteral<'a>>,
         export_kind: ImportOrExportKind,
-        with_clause: T2,
+        with_clause: Option<ArenaBox<'a, WithClause<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, ExportSpecifier<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
     {
         Self::ExportNamedDeclaration(ExportNamedDeclaration::boxed(
             span,
@@ -10036,27 +9733,20 @@ impl<'a> Declaration<'a> {
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
     #[inline]
-    pub fn new_function_declaration<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_function_declaration<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionDeclaration(Function::boxed(
             span,
             r#type,
@@ -10093,37 +9783,23 @@ impl<'a> Declaration<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_function_declaration_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-    >(
+    pub fn new_function_declaration_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionDeclaration(Function::boxed_with_scope_id_and_pure_and_pife(
             span,
             r#type,
@@ -10160,26 +9836,23 @@ impl<'a> Declaration<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
-    pub fn new_class_declaration<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_declaration<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassDeclaration(Class::boxed(
             span,
@@ -10215,16 +9888,16 @@ impl<'a> Declaration<'a> {
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
-    pub fn new_class_declaration_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_declaration_with_scope_id<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
@@ -10232,10 +9905,7 @@ impl<'a> Declaration<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassDeclaration(Class::boxed_with_scope_id(
             span,
@@ -10265,17 +9935,14 @@ impl<'a> Declaration<'a> {
     /// * `type_annotation`
     /// * `declare`
     #[inline]
-    pub fn new_ts_type_alias_declaration<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_type_alias_declaration<B: GetAstBuilder<'a>>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         type_annotation: TSType<'a>,
         declare: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-    {
+    ) -> Self {
         Self::TSTypeAliasDeclaration(TSTypeAliasDeclaration::boxed(
             span,
             id,
@@ -10298,18 +9965,15 @@ impl<'a> Declaration<'a> {
     /// * `declare`
     /// * `scope_id`
     #[inline]
-    pub fn new_ts_type_alias_declaration_with_scope_id<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_type_alias_declaration_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         type_annotation: TSType<'a>,
         declare: bool,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-    {
+    ) -> Self {
         Self::TSTypeAliasDeclaration(TSTypeAliasDeclaration::boxed_with_scope_id(
             span,
             id,
@@ -10333,19 +9997,17 @@ impl<'a> Declaration<'a> {
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
-    pub fn new_ts_interface_declaration<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_ts_interface_declaration<B: GetAstBuilder<'a>, T1>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
-        extends: T2,
-        body: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        extends: T1,
+        body: ArenaBox<'a, TSInterfaceBody<'a>>,
         declare: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
     {
         Self::TSInterfaceDeclaration(TSInterfaceDeclaration::boxed(
             span,
@@ -10371,20 +10033,18 @@ impl<'a> Declaration<'a> {
     /// * `declare`: `true` for `declare interface Foo {}`
     /// * `scope_id`
     #[inline]
-    pub fn new_ts_interface_declaration_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_ts_interface_declaration_with_scope_id<B: GetAstBuilder<'a>, T1>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
-        extends: T2,
-        body: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        extends: T1,
+        body: ArenaBox<'a, TSInterfaceBody<'a>>,
         declare: bool,
         scope_id: ScopeId,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
     {
         Self::TSInterfaceDeclaration(TSInterfaceDeclaration::boxed_with_scope_id(
             span,
@@ -10642,25 +10302,22 @@ impl<'a> VariableDeclarator<'a> {
     /// * `init`
     /// * `definite`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         kind: VariableDeclarationKind,
         id: BindingPattern<'a>,
-        type_annotation: T1,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         init: Option<Expression<'a>>,
         definite: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         VariableDeclarator {
             node_id: Cell::new(builder.node_id()),
             span,
             kind,
             id,
-            type_annotation: type_annotation.into_in(builder.allocator()),
+            type_annotation,
             init,
             definite,
         }
@@ -11253,22 +10910,16 @@ impl<'a> ForStatementInit<'a> {
     /// * `return_type`
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
-    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(ArrowFunctionExpression::boxed(
             span,
             expression,
@@ -11297,31 +10948,19 @@ impl<'a> ForStatementInit<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-    >(
+    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(
             ArrowFunctionExpression::boxed_with_scope_id_and_pure_and_pife(
                 span,
@@ -11418,17 +11057,16 @@ impl<'a> ForStatementInit<'a> {
     /// * `arguments`
     /// * `optional`
     #[inline]
-    pub fn new_call_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed(
             span,
@@ -11452,18 +11090,17 @@ impl<'a> ForStatementInit<'a> {
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed_with_pure(
             span,
@@ -11509,26 +11146,23 @@ impl<'a> ForStatementInit<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
-    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed(
             span,
@@ -11564,16 +11198,16 @@ impl<'a> ForStatementInit<'a> {
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
-    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
@@ -11581,10 +11215,7 @@ impl<'a> ForStatementInit<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed_with_scope_id(
             span,
@@ -11646,27 +11277,20 @@ impl<'a> ForStatementInit<'a> {
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
     #[inline]
-    pub fn new_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed(
             span,
             r#type,
@@ -11703,37 +11327,23 @@ impl<'a> ForStatementInit<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-    >(
+    pub fn new_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed_with_scope_id_and_pure_and_pife(
             span,
             r#type,
@@ -11815,16 +11425,15 @@ impl<'a> ForStatementInit<'a> {
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_new_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed(
             span,
@@ -11846,17 +11455,16 @@ impl<'a> ForStatementInit<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     /// * `pure`
     #[inline]
-    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed_with_pure(
             span,
@@ -11936,16 +11544,13 @@ impl<'a> ForStatementInit<'a> {
     /// * `type_arguments`
     /// * `quasi`
     #[inline]
-    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>>(
         span: Span,
         tag: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         quasi: TemplateLiteral<'a>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TaggedTemplateExpression(TaggedTemplateExpression::boxed(
             span,
             tag,
@@ -12078,17 +11683,15 @@ impl<'a> ForStatementInit<'a> {
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
     #[inline]
-    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1>(
         span: Span,
-        opening_element: T1,
-        children: T2,
-        closing_element: T3,
+        opening_element: ArenaBox<'a, JSXOpeningElement<'a>>,
+        children: T1,
+        closing_element: Option<ArenaBox<'a, JSXClosingElement<'a>>>,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
     {
         Self::JSXElement(JSXElement::boxed(
             span,
@@ -12222,15 +11825,12 @@ impl<'a> ForStatementInit<'a> {
     /// * `expression`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: ArenaBox<'a, TSTypeParameterInstantiation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
-    {
+    ) -> Self {
         Self::TSInstantiationExpression(TSInstantiationExpression::boxed(
             span,
             expression,
@@ -12702,15 +12302,14 @@ impl<'a> ForStatementLeft<'a> {
     /// * `elements`
     /// * `rest`
     #[inline]
-    pub fn new_array_assignment_target<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_array_assignment_target<B: GetAstBuilder<'a>, T1>(
         span: Span,
         elements: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, AssignmentTargetRest<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         Self::ArrayAssignmentTarget(ArrayAssignmentTarget::boxed(
             span,
@@ -12729,15 +12328,14 @@ impl<'a> ForStatementLeft<'a> {
     /// * `properties`
     /// * `rest`
     #[inline]
-    pub fn new_object_assignment_target<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_object_assignment_target<B: GetAstBuilder<'a>, T1>(
         span: Span,
         properties: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, AssignmentTargetRest<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, AssignmentTargetProperty<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         Self::ObjectAssignmentTarget(ObjectAssignmentTarget::boxed(
             span,
@@ -13312,26 +12910,15 @@ impl<'a> TryStatement<'a> {
     /// * `handler`: The `catch` clause, including the parameter and the block statement
     /// * `finalizer`: The `finally` clause
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
-        block: T1,
-        handler: T2,
-        finalizer: T3,
+        block: ArenaBox<'a, BlockStatement<'a>>,
+        handler: Option<ArenaBox<'a, CatchClause<'a>>>,
+        finalizer: Option<ArenaBox<'a, BlockStatement<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, CatchClause<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, BlockStatement<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
-        TryStatement {
-            node_id: Cell::new(builder.node_id()),
-            span,
-            block: block.into_in(builder.allocator()),
-            handler: handler.into_in(builder.allocator()),
-            finalizer: finalizer.into_in(builder.allocator()),
-        }
+        TryStatement { node_id: Cell::new(builder.node_id()), span, block, handler, finalizer }
     }
 
     /// Build a [`TryStatement`], and store it in the memory arena.
@@ -13345,18 +12932,13 @@ impl<'a> TryStatement<'a> {
     /// * `handler`: The `catch` clause, including the parameter and the block statement
     /// * `finalizer`: The `finally` clause
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
-        block: T1,
-        handler: T2,
-        finalizer: T3,
+        block: ArenaBox<'a, BlockStatement<'a>>,
+        handler: Option<ArenaBox<'a, CatchClause<'a>>>,
+        finalizer: Option<ArenaBox<'a, BlockStatement<'a>>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, CatchClause<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, BlockStatement<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, block, handler, finalizer, builder), &builder.allocator())
     }
@@ -13373,21 +12955,18 @@ impl<'a> CatchClause<'a> {
     /// * `param`: The caught error parameter, e.g. `e` in `catch (e) {}`
     /// * `body`: The statements run when an error is caught
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         param: Option<CatchParameter<'a>>,
-        body: T1,
+        body: ArenaBox<'a, BlockStatement<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         CatchClause {
             node_id: Cell::new(builder.node_id()),
             span,
             param,
-            body: body.into_in(builder.allocator()),
+            body,
             scope_id: Default::default(),
         }
     }
@@ -13402,15 +12981,12 @@ impl<'a> CatchClause<'a> {
     /// * `param`: The caught error parameter, e.g. `e` in `catch (e) {}`
     /// * `body`: The statements run when an error is caught
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         param: Option<CatchParameter<'a>>,
-        body: T1,
+        body: ArenaBox<'a, BlockStatement<'a>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, param, body, builder), &builder.allocator())
     }
@@ -13426,22 +13002,19 @@ impl<'a> CatchClause<'a> {
     /// * `body`: The statements run when an error is caught
     /// * `scope_id`
     #[inline]
-    pub fn new_with_scope_id<B: GetAstBuilder<'a>, T1>(
+    pub fn new_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         param: Option<CatchParameter<'a>>,
-        body: T1,
+        body: ArenaBox<'a, BlockStatement<'a>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         CatchClause {
             node_id: Cell::new(builder.node_id()),
             span,
             param,
-            body: body.into_in(builder.allocator()),
+            body,
             scope_id: Cell::new(Some(scope_id)),
         }
     }
@@ -13457,16 +13030,13 @@ impl<'a> CatchClause<'a> {
     /// * `body`: The statements run when an error is caught
     /// * `scope_id`
     #[inline]
-    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         param: Option<CatchParameter<'a>>,
-        body: T1,
+        body: ArenaBox<'a, BlockStatement<'a>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new_with_scope_id(span, param, body, scope_id, builder),
@@ -13483,22 +13053,14 @@ impl<'a> CatchParameter<'a> {
     /// * `pattern`: The bound error
     /// * `type_annotation`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         pattern: BindingPattern<'a>,
-        type_annotation: T1,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
-        CatchParameter {
-            node_id: Cell::new(builder.node_id()),
-            span,
-            pattern,
-            type_annotation: type_annotation.into_in(builder.allocator()),
-        }
+        CatchParameter { node_id: Cell::new(builder.node_id()), span, pattern, type_annotation }
     }
 }
 
@@ -13585,15 +13147,14 @@ impl<'a> BindingPattern<'a> {
     /// * `properties`
     /// * `rest`
     #[inline]
-    pub fn new_object_pattern<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_object_pattern<B: GetAstBuilder<'a>, T1>(
         span: Span,
         properties: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, BindingRestElement<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, BindingProperty<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
         Self::ObjectPattern(ObjectPattern::boxed(span, properties, rest, builder.builder()))
     }
@@ -13607,15 +13168,14 @@ impl<'a> BindingPattern<'a> {
     /// * `elements`
     /// * `rest`
     #[inline]
-    pub fn new_array_pattern<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_array_pattern<B: GetAstBuilder<'a>, T1>(
         span: Span,
         elements: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, BindingRestElement<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Option<BindingPattern<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
         Self::ArrayPattern(ArrayPattern::boxed(span, elements, rest, builder.builder()))
     }
@@ -13692,22 +13252,21 @@ impl<'a> ObjectPattern<'a> {
     /// * `properties`
     /// * `rest`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         properties: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, BindingRestElement<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, BindingProperty<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
         let builder = builder.builder();
         ObjectPattern {
             node_id: Cell::new(builder.node_id()),
             span,
             properties: properties.into_in(builder.allocator()),
-            rest: rest.into_in(builder.allocator()),
+            rest,
         }
     }
 
@@ -13721,15 +13280,14 @@ impl<'a> ObjectPattern<'a> {
     /// * `properties`
     /// * `rest`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         properties: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, BindingRestElement<'a>>>,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
         T1: IntoIn<'a, ArenaVec<'a, BindingProperty<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, properties, rest, builder), &builder.allocator())
@@ -13777,22 +13335,21 @@ impl<'a> ArrayPattern<'a> {
     /// * `elements`
     /// * `rest`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         elements: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, BindingRestElement<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Option<BindingPattern<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
         let builder = builder.builder();
         ArrayPattern {
             node_id: Cell::new(builder.node_id()),
             span,
             elements: elements.into_in(builder.allocator()),
-            rest: rest.into_in(builder.allocator()),
+            rest,
         }
     }
 
@@ -13806,15 +13363,14 @@ impl<'a> ArrayPattern<'a> {
     /// * `elements`
     /// * `rest`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         elements: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, BindingRestElement<'a>>>,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
         T1: IntoIn<'a, ArenaVec<'a, Option<BindingPattern<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, elements, rest, builder), &builder.allocator())
@@ -13878,27 +13434,20 @@ impl<'a> Function<'a> {
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         Function {
             node_id: Cell::new(builder.node_id()),
@@ -13908,11 +13457,11 @@ impl<'a> Function<'a> {
             generator,
             r#async,
             declare,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            this_param: this_param.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
-            body: body.into_in(builder.allocator()),
+            type_parameters,
+            this_param,
+            params,
+            return_type,
+            body,
             scope_id: Default::default(),
             pure: Default::default(),
             pife: Default::default(),
@@ -13937,27 +13486,20 @@ impl<'a> Function<'a> {
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new(
@@ -13999,30 +13541,23 @@ impl<'a> Function<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         Function {
             node_id: Cell::new(builder.node_id()),
@@ -14032,11 +13567,11 @@ impl<'a> Function<'a> {
             generator,
             r#async,
             declare,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            this_param: this_param.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
-            body: body.into_in(builder.allocator()),
+            type_parameters,
+            this_param,
+            params,
+            return_type,
+            body,
             scope_id: Cell::new(Some(scope_id)),
             pure,
             pife,
@@ -14064,30 +13599,23 @@ impl<'a> Function<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn boxed_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn boxed_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new_with_scope_id_and_pure_and_pife(
@@ -14124,16 +13652,15 @@ impl<'a> FormalParameters<'a> {
     /// * `items`
     /// * `rest`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         kind: FormalParameterKind,
         items: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, FormalParameterRest<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, FormalParameter<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, FormalParameterRest<'a>>>>,
     {
         let builder = builder.builder();
         FormalParameters {
@@ -14141,7 +13668,7 @@ impl<'a> FormalParameters<'a> {
             span,
             kind,
             items: items.into_in(builder.allocator()),
-            rest: rest.into_in(builder.allocator()),
+            rest,
         }
     }
 
@@ -14156,16 +13683,15 @@ impl<'a> FormalParameters<'a> {
     /// * `items`
     /// * `rest`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         kind: FormalParameterKind,
         items: T1,
-        rest: T2,
+        rest: Option<ArenaBox<'a, FormalParameterRest<'a>>>,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
         T1: IntoIn<'a, ArenaVec<'a, FormalParameter<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, FormalParameterRest<'a>>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, kind, items, rest, builder), &builder.allocator())
@@ -14186,12 +13712,12 @@ impl<'a> FormalParameter<'a> {
     /// * `readonly`
     /// * `override`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         decorators: T1,
         pattern: BindingPattern<'a>,
-        type_annotation: T2,
-        initializer: T3,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        initializer: Option<ArenaBox<'a, Expression<'a>>>,
         optional: bool,
         accessibility: Option<TSAccessibility>,
         readonly: bool,
@@ -14200,8 +13726,6 @@ impl<'a> FormalParameter<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, Expression<'a>>>>,
     {
         let builder = builder.builder();
         FormalParameter {
@@ -14209,8 +13733,8 @@ impl<'a> FormalParameter<'a> {
             span,
             decorators: decorators.into_in(builder.allocator()),
             pattern,
-            type_annotation: type_annotation.into_in(builder.allocator()),
-            initializer: initializer.into_in(builder.allocator()),
+            type_annotation,
+            initializer,
             optional,
             accessibility,
             readonly,
@@ -14231,16 +13755,15 @@ impl<'a> FormalParameterRest<'a> {
     /// * `rest`
     /// * `type_annotation`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         decorators: T1,
         rest: BindingRestElement<'a>,
-        type_annotation: T2,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         let builder = builder.builder();
         FormalParameterRest {
@@ -14248,7 +13771,7 @@ impl<'a> FormalParameterRest<'a> {
             span,
             decorators: decorators.into_in(builder.allocator()),
             rest,
-            type_annotation: type_annotation.into_in(builder.allocator()),
+            type_annotation,
         }
     }
 
@@ -14263,16 +13786,15 @@ impl<'a> FormalParameterRest<'a> {
     /// * `rest`
     /// * `type_annotation`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         decorators: T1,
         rest: BindingRestElement<'a>,
-        type_annotation: T2,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -14352,32 +13874,26 @@ impl<'a> ArrowFunctionExpression<'a> {
     /// * `return_type`
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         ArrowFunctionExpression {
             node_id: Cell::new(builder.node_id()),
             span,
             expression,
             r#async,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
-            body: body.into_in(builder.allocator()),
+            type_parameters,
+            params,
+            return_type,
+            body,
             scope_id: Default::default(),
             pure: Default::default(),
             pife: Default::default(),
@@ -14398,22 +13914,16 @@ impl<'a> ArrowFunctionExpression<'a> {
     /// * `return_type`
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new(
@@ -14447,35 +13957,29 @@ impl<'a> ArrowFunctionExpression<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         ArrowFunctionExpression {
             node_id: Cell::new(builder.node_id()),
             span,
             expression,
             r#async,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
-            body: body.into_in(builder.allocator()),
+            type_parameters,
+            params,
+            return_type,
+            body,
             scope_id: Cell::new(Some(scope_id)),
             pure,
             pife,
@@ -14499,25 +14003,19 @@ impl<'a> ArrowFunctionExpression<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn boxed_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn boxed_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new_with_scope_id_and_pure_and_pife(
@@ -14599,26 +14097,23 @@ impl<'a> Class<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         let builder = builder.builder();
         Class {
@@ -14627,11 +14122,11 @@ impl<'a> Class<'a> {
             r#type,
             decorators: decorators.into_in(builder.allocator()),
             id,
-            type_parameters: type_parameters.into_in(builder.allocator()),
+            type_parameters,
             super_class,
-            super_type_arguments: super_type_arguments.into_in(builder.allocator()),
+            super_type_arguments,
             implements: implements.into_in(builder.allocator()),
-            body: body.into_in(builder.allocator()),
+            body,
             r#abstract,
             declare,
             scope_id: Default::default(),
@@ -14656,26 +14151,23 @@ impl<'a> Class<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -14716,16 +14208,16 @@ impl<'a> Class<'a> {
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
-    pub fn new_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_with_scope_id<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
@@ -14733,10 +14225,7 @@ impl<'a> Class<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         let builder = builder.builder();
         Class {
@@ -14745,11 +14234,11 @@ impl<'a> Class<'a> {
             r#type,
             decorators: decorators.into_in(builder.allocator()),
             id,
-            type_parameters: type_parameters.into_in(builder.allocator()),
+            type_parameters,
             super_class,
-            super_type_arguments: super_type_arguments.into_in(builder.allocator()),
+            super_type_arguments,
             implements: implements.into_in(builder.allocator()),
-            body: body.into_in(builder.allocator()),
+            body,
             r#abstract,
             declare,
             scope_id: Cell::new(Some(scope_id)),
@@ -14775,16 +14264,16 @@ impl<'a> Class<'a> {
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
-    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
@@ -14792,10 +14281,7 @@ impl<'a> Class<'a> {
     ) -> ArenaBox<'a, Self>
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -14913,12 +14399,12 @@ impl<'a> ClassElement<'a> {
     /// * `optional`
     /// * `accessibility`
     #[inline]
-    pub fn new_method_definition<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_method_definition<B: GetAstBuilder<'a>, T1>(
         span: Span,
         r#type: MethodDefinitionType,
         decorators: T1,
         key: PropertyKey<'a>,
-        value: T2,
+        value: ArenaBox<'a, Function<'a>>,
         kind: MethodDefinitionKind,
         computed: bool,
         r#static: bool,
@@ -14929,7 +14415,6 @@ impl<'a> ClassElement<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, ArenaBox<'a, Function<'a>>>,
     {
         Self::MethodDefinition(MethodDefinition::boxed(
             span,
@@ -14967,12 +14452,12 @@ impl<'a> ClassElement<'a> {
     /// * `readonly`: `true` when declared with a `readonly` modifier
     /// * `accessibility`: Accessibility modifier.
     #[inline]
-    pub fn new_property_definition<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_property_definition<B: GetAstBuilder<'a>, T1>(
         span: Span,
         r#type: PropertyDefinitionType,
         decorators: T1,
         key: PropertyKey<'a>,
-        type_annotation: T2,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         value: Option<Expression<'a>>,
         computed: bool,
         r#static: bool,
@@ -14986,7 +14471,6 @@ impl<'a> ClassElement<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         Self::PropertyDefinition(PropertyDefinition::boxed(
             span,
@@ -15024,12 +14508,12 @@ impl<'a> ClassElement<'a> {
     /// * `definite`: Property has a `!` after its key.
     /// * `accessibility`: Accessibility modifier.
     #[inline]
-    pub fn new_accessor_property<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_accessor_property<B: GetAstBuilder<'a>, T1>(
         span: Span,
         r#type: AccessorPropertyType,
         decorators: T1,
         key: PropertyKey<'a>,
-        type_annotation: T2,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         value: Option<Expression<'a>>,
         computed: bool,
         r#static: bool,
@@ -15040,7 +14524,6 @@ impl<'a> ClassElement<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         Self::AccessorProperty(AccessorProperty::boxed(
             span,
@@ -15069,17 +14552,16 @@ impl<'a> ClassElement<'a> {
     /// * `readonly`
     /// * `static`
     #[inline]
-    pub fn new_ts_index_signature<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_ts_index_signature<B: GetAstBuilder<'a>, T1>(
         span: Span,
         parameters: T1,
-        type_annotation: T2,
+        type_annotation: ArenaBox<'a, TSTypeAnnotation<'a>>,
         readonly: bool,
         r#static: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, TSIndexSignatureName<'a>>>,
-        T2: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         Self::TSIndexSignature(TSIndexSignature::boxed(
             span,
@@ -15111,12 +14593,12 @@ impl<'a> MethodDefinition<'a> {
     /// * `optional`
     /// * `accessibility`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         r#type: MethodDefinitionType,
         decorators: T1,
         key: PropertyKey<'a>,
-        value: T2,
+        value: ArenaBox<'a, Function<'a>>,
         kind: MethodDefinitionKind,
         computed: bool,
         r#static: bool,
@@ -15127,7 +14609,6 @@ impl<'a> MethodDefinition<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, ArenaBox<'a, Function<'a>>>,
     {
         let builder = builder.builder();
         MethodDefinition {
@@ -15136,7 +14617,7 @@ impl<'a> MethodDefinition<'a> {
             r#type,
             decorators: decorators.into_in(builder.allocator()),
             key,
-            value: value.into_in(builder.allocator()),
+            value,
             kind,
             computed,
             r#static,
@@ -15164,12 +14645,12 @@ impl<'a> MethodDefinition<'a> {
     /// * `optional`
     /// * `accessibility`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         r#type: MethodDefinitionType,
         decorators: T1,
         key: PropertyKey<'a>,
-        value: T2,
+        value: ArenaBox<'a, Function<'a>>,
         kind: MethodDefinitionKind,
         computed: bool,
         r#static: bool,
@@ -15180,7 +14661,6 @@ impl<'a> MethodDefinition<'a> {
     ) -> ArenaBox<'a, Self>
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, ArenaBox<'a, Function<'a>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -15225,12 +14705,12 @@ impl<'a> PropertyDefinition<'a> {
     /// * `readonly`: `true` when declared with a `readonly` modifier
     /// * `accessibility`: Accessibility modifier.
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         r#type: PropertyDefinitionType,
         decorators: T1,
         key: PropertyKey<'a>,
-        type_annotation: T2,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         value: Option<Expression<'a>>,
         computed: bool,
         r#static: bool,
@@ -15244,7 +14724,6 @@ impl<'a> PropertyDefinition<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         let builder = builder.builder();
         PropertyDefinition {
@@ -15253,7 +14732,7 @@ impl<'a> PropertyDefinition<'a> {
             r#type,
             decorators: decorators.into_in(builder.allocator()),
             key,
-            type_annotation: type_annotation.into_in(builder.allocator()),
+            type_annotation,
             value,
             computed,
             r#static,
@@ -15287,12 +14766,12 @@ impl<'a> PropertyDefinition<'a> {
     /// * `readonly`: `true` when declared with a `readonly` modifier
     /// * `accessibility`: Accessibility modifier.
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         r#type: PropertyDefinitionType,
         decorators: T1,
         key: PropertyKey<'a>,
-        type_annotation: T2,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         value: Option<Expression<'a>>,
         computed: bool,
         r#static: bool,
@@ -15306,7 +14785,6 @@ impl<'a> PropertyDefinition<'a> {
     ) -> ArenaBox<'a, Self>
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -15476,18 +14954,15 @@ impl<'a> ModuleDeclaration<'a> {
     /// * `with_clause`: Some(vec![]) for empty assertion
     /// * `import_kind`: `import type { foo } from 'bar'`
     #[inline]
-    pub fn new_import_declaration<B: GetAstBuilder<'a>, T1>(
+    pub fn new_import_declaration<B: GetAstBuilder<'a>>(
         span: Span,
         specifiers: Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
         phase: Option<ImportPhase>,
-        with_clause: T1,
+        with_clause: Option<ArenaBox<'a, WithClause<'a>>>,
         import_kind: ImportOrExportKind,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
-    {
+    ) -> Self {
         Self::ImportDeclaration(ImportDeclaration::boxed(
             span,
             specifiers,
@@ -15510,17 +14985,14 @@ impl<'a> ModuleDeclaration<'a> {
     /// * `with_clause`: Will be `Some(vec![])` for empty assertion
     /// * `export_kind`
     #[inline]
-    pub fn new_export_all_declaration<B: GetAstBuilder<'a>, T1>(
+    pub fn new_export_all_declaration<B: GetAstBuilder<'a>>(
         span: Span,
         exported: Option<ModuleExportName<'a>>,
         source: StringLiteral<'a>,
-        with_clause: T1,
+        with_clause: Option<ArenaBox<'a, WithClause<'a>>>,
         export_kind: ImportOrExportKind,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
-    {
+    ) -> Self {
         Self::ExportAllDeclaration(ExportAllDeclaration::boxed(
             span,
             exported,
@@ -15563,18 +15035,17 @@ impl<'a> ModuleDeclaration<'a> {
     /// * `export_kind`: `export type { foo }`
     /// * `with_clause`: Some(vec![]) for empty assertion
     #[inline]
-    pub fn new_export_named_declaration<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_export_named_declaration<B: GetAstBuilder<'a>, T1>(
         span: Span,
         declaration: Option<Declaration<'a>>,
         specifiers: T1,
         source: Option<StringLiteral<'a>>,
         export_kind: ImportOrExportKind,
-        with_clause: T2,
+        with_clause: Option<ArenaBox<'a, WithClause<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, ExportSpecifier<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
     {
         Self::ExportNamedDeclaration(ExportNamedDeclaration::boxed(
             span,
@@ -15643,12 +15114,12 @@ impl<'a> AccessorProperty<'a> {
     /// * `definite`: Property has a `!` after its key.
     /// * `accessibility`: Accessibility modifier.
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         r#type: AccessorPropertyType,
         decorators: T1,
         key: PropertyKey<'a>,
-        type_annotation: T2,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         value: Option<Expression<'a>>,
         computed: bool,
         r#static: bool,
@@ -15659,7 +15130,6 @@ impl<'a> AccessorProperty<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         let builder = builder.builder();
         AccessorProperty {
@@ -15668,7 +15138,7 @@ impl<'a> AccessorProperty<'a> {
             r#type,
             decorators: decorators.into_in(builder.allocator()),
             key,
-            type_annotation: type_annotation.into_in(builder.allocator()),
+            type_annotation,
             value,
             computed,
             r#static,
@@ -15696,12 +15166,12 @@ impl<'a> AccessorProperty<'a> {
     /// * `definite`: Property has a `!` after its key.
     /// * `accessibility`: Accessibility modifier.
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         r#type: AccessorPropertyType,
         decorators: T1,
         key: PropertyKey<'a>,
-        type_annotation: T2,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         value: Option<Expression<'a>>,
         computed: bool,
         r#static: bool,
@@ -15712,7 +15182,6 @@ impl<'a> AccessorProperty<'a> {
     ) -> ArenaBox<'a, Self>
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -15795,18 +15264,15 @@ impl<'a> ImportDeclaration<'a> {
     /// * `with_clause`: Some(vec![]) for empty assertion
     /// * `import_kind`: `import type { foo } from 'bar'`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         specifiers: Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
         phase: Option<ImportPhase>,
-        with_clause: T1,
+        with_clause: Option<ArenaBox<'a, WithClause<'a>>>,
         import_kind: ImportOrExportKind,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         ImportDeclaration {
             node_id: Cell::new(builder.node_id()),
@@ -15814,7 +15280,7 @@ impl<'a> ImportDeclaration<'a> {
             specifiers,
             source,
             phase,
-            with_clause: with_clause.into_in(builder.allocator()),
+            with_clause,
             import_kind,
         }
     }
@@ -15832,18 +15298,15 @@ impl<'a> ImportDeclaration<'a> {
     /// * `with_clause`: Some(vec![]) for empty assertion
     /// * `import_kind`: `import type { foo } from 'bar'`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         specifiers: Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
         phase: Option<ImportPhase>,
-        with_clause: T1,
+        with_clause: Option<ArenaBox<'a, WithClause<'a>>>,
         import_kind: ImportOrExportKind,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new(span, specifiers, source, phase, with_clause, import_kind, builder),
@@ -16194,18 +15657,17 @@ impl<'a> ExportNamedDeclaration<'a> {
     /// * `export_kind`: `export type { foo }`
     /// * `with_clause`: Some(vec![]) for empty assertion
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         declaration: Option<Declaration<'a>>,
         specifiers: T1,
         source: Option<StringLiteral<'a>>,
         export_kind: ImportOrExportKind,
-        with_clause: T2,
+        with_clause: Option<ArenaBox<'a, WithClause<'a>>>,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, ExportSpecifier<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
     {
         let builder = builder.builder();
         ExportNamedDeclaration {
@@ -16215,7 +15677,7 @@ impl<'a> ExportNamedDeclaration<'a> {
             specifiers: specifiers.into_in(builder.allocator()),
             source,
             export_kind,
-            with_clause: with_clause.into_in(builder.allocator()),
+            with_clause,
         }
     }
 
@@ -16232,18 +15694,17 @@ impl<'a> ExportNamedDeclaration<'a> {
     /// * `export_kind`: `export type { foo }`
     /// * `with_clause`: Some(vec![]) for empty assertion
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         declaration: Option<Declaration<'a>>,
         specifiers: T1,
         source: Option<StringLiteral<'a>>,
         export_kind: ImportOrExportKind,
-        with_clause: T2,
+        with_clause: Option<ArenaBox<'a, WithClause<'a>>>,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
         T1: IntoIn<'a, ArenaVec<'a, ExportSpecifier<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -16304,24 +15765,21 @@ impl<'a> ExportAllDeclaration<'a> {
     /// * `with_clause`: Will be `Some(vec![])` for empty assertion
     /// * `export_kind`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         exported: Option<ModuleExportName<'a>>,
         source: StringLiteral<'a>,
-        with_clause: T1,
+        with_clause: Option<ArenaBox<'a, WithClause<'a>>>,
         export_kind: ImportOrExportKind,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         ExportAllDeclaration {
             node_id: Cell::new(builder.node_id()),
             span,
             exported,
             source,
-            with_clause: with_clause.into_in(builder.allocator()),
+            with_clause,
             export_kind,
         }
     }
@@ -16338,17 +15796,14 @@ impl<'a> ExportAllDeclaration<'a> {
     /// * `with_clause`: Will be `Some(vec![])` for empty assertion
     /// * `export_kind`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         exported: Option<ModuleExportName<'a>>,
         source: StringLiteral<'a>,
-        with_clause: T1,
+        with_clause: Option<ArenaBox<'a, WithClause<'a>>>,
         export_kind: ImportOrExportKind,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new(span, exported, source, with_clause, export_kind, builder),
@@ -16402,27 +15857,20 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
     #[inline]
-    pub fn new_function_declaration<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_function_declaration<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionDeclaration(Function::boxed(
             span,
             r#type,
@@ -16459,37 +15907,23 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_function_declaration_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-    >(
+    pub fn new_function_declaration_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionDeclaration(Function::boxed_with_scope_id_and_pure_and_pife(
             span,
             r#type,
@@ -16526,26 +15960,23 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
-    pub fn new_class_declaration<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_declaration<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassDeclaration(Class::boxed(
             span,
@@ -16581,16 +16012,16 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
-    pub fn new_class_declaration_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_declaration_with_scope_id<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
@@ -16598,10 +16029,7 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassDeclaration(Class::boxed_with_scope_id(
             span,
@@ -16632,19 +16060,17 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
-    pub fn new_ts_interface_declaration<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_ts_interface_declaration<B: GetAstBuilder<'a>, T1>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
-        extends: T2,
-        body: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        extends: T1,
+        body: ArenaBox<'a, TSInterfaceBody<'a>>,
         declare: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
     {
         Self::TSInterfaceDeclaration(TSInterfaceDeclaration::boxed(
             span,
@@ -16670,20 +16096,18 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `declare`: `true` for `declare interface Foo {}`
     /// * `scope_id`
     #[inline]
-    pub fn new_ts_interface_declaration_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_ts_interface_declaration_with_scope_id<B: GetAstBuilder<'a>, T1>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
-        extends: T2,
-        body: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        extends: T1,
+        body: ArenaBox<'a, TSInterfaceBody<'a>>,
         declare: bool,
         scope_id: ScopeId,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
     {
         Self::TSInterfaceDeclaration(TSInterfaceDeclaration::boxed_with_scope_id(
             span,
@@ -16937,22 +16361,16 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `return_type`
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
-    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(ArrowFunctionExpression::boxed(
             span,
             expression,
@@ -16981,31 +16399,19 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-    >(
+    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(
             ArrowFunctionExpression::boxed_with_scope_id_and_pure_and_pife(
                 span,
@@ -17102,17 +16508,16 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `arguments`
     /// * `optional`
     #[inline]
-    pub fn new_call_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed(
             span,
@@ -17136,18 +16541,17 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed_with_pure(
             span,
@@ -17193,26 +16597,23 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
-    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed(
             span,
@@ -17248,16 +16649,16 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
-    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
@@ -17265,10 +16666,7 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed_with_scope_id(
             span,
@@ -17330,27 +16728,20 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
     #[inline]
-    pub fn new_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed(
             span,
             r#type,
@@ -17387,37 +16778,23 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-    >(
+    pub fn new_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed_with_scope_id_and_pure_and_pife(
             span,
             r#type,
@@ -17499,16 +16876,15 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_new_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed(
             span,
@@ -17530,17 +16906,16 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     /// * `pure`
     #[inline]
-    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed_with_pure(
             span,
@@ -17620,16 +16995,13 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `type_arguments`
     /// * `quasi`
     #[inline]
-    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>>(
         span: Span,
         tag: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         quasi: TemplateLiteral<'a>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TaggedTemplateExpression(TaggedTemplateExpression::boxed(
             span,
             tag,
@@ -17762,17 +17134,15 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
     #[inline]
-    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1>(
         span: Span,
-        opening_element: T1,
-        children: T2,
-        closing_element: T3,
+        opening_element: ArenaBox<'a, JSXOpeningElement<'a>>,
+        children: T1,
+        closing_element: Option<ArenaBox<'a, JSXClosingElement<'a>>>,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
     {
         Self::JSXElement(JSXElement::boxed(
             span,
@@ -17906,15 +17276,12 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     /// * `expression`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: ArenaBox<'a, TSTypeParameterInstantiation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
-    {
+    ) -> Self {
         Self::TSInstantiationExpression(TSInstantiationExpression::boxed(
             span,
             expression,
@@ -18516,25 +17883,23 @@ impl<'a> JSXElement<'a> {
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
-        opening_element: T1,
-        children: T2,
-        closing_element: T3,
+        opening_element: ArenaBox<'a, JSXOpeningElement<'a>>,
+        children: T1,
+        closing_element: Option<ArenaBox<'a, JSXClosingElement<'a>>>,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
     {
         let builder = builder.builder();
         JSXElement {
             node_id: Cell::new(builder.node_id()),
             span,
-            opening_element: opening_element.into_in(builder.allocator()),
+            opening_element,
             children: children.into_in(builder.allocator()),
-            closing_element: closing_element.into_in(builder.allocator()),
+            closing_element,
         }
     }
 
@@ -18549,17 +17914,15 @@ impl<'a> JSXElement<'a> {
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
-        opening_element: T1,
-        children: T2,
-        closing_element: T3,
+        opening_element: ArenaBox<'a, JSXOpeningElement<'a>>,
+        children: T1,
+        closing_element: Option<ArenaBox<'a, JSXClosingElement<'a>>>,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
-        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -18581,23 +17944,22 @@ impl<'a> JSXOpeningElement<'a> {
     /// * `type_arguments`: Type parameters for generic JSX elements.
     /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         name: JSXElementName<'a>,
-        type_arguments: T1,
-        attributes: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        attributes: T1,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, JSXAttributeItem<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, JSXAttributeItem<'a>>>,
     {
         let builder = builder.builder();
         JSXOpeningElement {
             node_id: Cell::new(builder.node_id()),
             span,
             name,
-            type_arguments: type_arguments.into_in(builder.allocator()),
+            type_arguments,
             attributes: attributes.into_in(builder.allocator()),
         }
     }
@@ -18613,16 +17975,15 @@ impl<'a> JSXOpeningElement<'a> {
     /// * `type_arguments`: Type parameters for generic JSX elements.
     /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         name: JSXElementName<'a>,
-        type_arguments: T1,
-        attributes: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        attributes: T1,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, JSXAttributeItem<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, JSXAttributeItem<'a>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -19320,22 +18681,16 @@ impl<'a> JSXExpression<'a> {
     /// * `return_type`
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
-    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_arrow_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(ArrowFunctionExpression::boxed(
             span,
             expression,
@@ -19364,31 +18719,19 @@ impl<'a> JSXExpression<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-    >(
+    pub fn new_arrow_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         expression: bool,
         r#async: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
-        body: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: ArenaBox<'a, FunctionBody<'a>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
-    {
+    ) -> Self {
         Self::ArrowFunctionExpression(
             ArrowFunctionExpression::boxed_with_scope_id_and_pure_and_pife(
                 span,
@@ -19485,17 +18828,16 @@ impl<'a> JSXExpression<'a> {
     /// * `arguments`
     /// * `optional`
     #[inline]
-    pub fn new_call_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed(
             span,
@@ -19519,18 +18861,17 @@ impl<'a> JSXExpression<'a> {
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_call_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         optional: bool,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::CallExpression(CallExpression::boxed_with_pure(
             span,
@@ -19576,26 +18917,23 @@ impl<'a> JSXExpression<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
-    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed(
             span,
@@ -19631,16 +18969,16 @@ impl<'a> JSXExpression<'a> {
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
-    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_class_expression_with_scope_id<B: GetAstBuilder<'a>, T1, T2>(
         span: Span,
         r#type: ClassType,
         decorators: T1,
         id: Option<BindingIdentifier<'a>>,
-        type_parameters: T2,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         super_class: Option<Expression<'a>>,
-        super_type_arguments: T3,
-        implements: T4,
-        body: T5,
+        super_type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        implements: T2,
+        body: ArenaBox<'a, ClassBody<'a>>,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
@@ -19648,10 +18986,7 @@ impl<'a> JSXExpression<'a> {
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, Decorator<'a>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T4: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
-        T5: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
+        T2: IntoIn<'a, ArenaVec<'a, TSClassImplements<'a>>>,
     {
         Self::ClassExpression(Class::boxed_with_scope_id(
             span,
@@ -19713,27 +19048,20 @@ impl<'a> JSXExpression<'a> {
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
     #[inline]
-    pub fn new_function_expression<B: GetAstBuilder<'a>, T1, T2, T3, T4, T5>(
+    pub fn new_function_expression<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed(
             span,
             r#type,
@@ -19770,37 +19098,23 @@ impl<'a> JSXExpression<'a> {
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
-    pub fn new_function_expression_with_scope_id_and_pure_and_pife<
-        B: GetAstBuilder<'a>,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-    >(
+    pub fn new_function_expression_with_scope_id_and_pure_and_pife<B: GetAstBuilder<'a>>(
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
         generator: bool,
         r#async: bool,
         declare: bool,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
-        body: T5,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        body: Option<ArenaBox<'a, FunctionBody<'a>>>,
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
-    {
+    ) -> Self {
         Self::FunctionExpression(Function::boxed_with_scope_id_and_pure_and_pife(
             span,
             r#type,
@@ -19882,16 +19196,15 @@ impl<'a> JSXExpression<'a> {
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
-    pub fn new_new_expression<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed(
             span,
@@ -19913,17 +19226,16 @@ impl<'a> JSXExpression<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     /// * `pure`
     #[inline]
-    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_new_expression_with_pure<B: GetAstBuilder<'a>, T1>(
         span: Span,
         callee: Expression<'a>,
-        type_arguments: T1,
-        arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
+        arguments: T1,
         pure: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, Argument<'a>>>,
     {
         Self::NewExpression(NewExpression::boxed_with_pure(
             span,
@@ -20003,16 +19315,13 @@ impl<'a> JSXExpression<'a> {
     /// * `type_arguments`
     /// * `quasi`
     #[inline]
-    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_tagged_template_expression<B: GetAstBuilder<'a>>(
         span: Span,
         tag: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         quasi: TemplateLiteral<'a>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TaggedTemplateExpression(TaggedTemplateExpression::boxed(
             span,
             tag,
@@ -20145,17 +19454,15 @@ impl<'a> JSXExpression<'a> {
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
     #[inline]
-    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_jsx_element<B: GetAstBuilder<'a>, T1>(
         span: Span,
-        opening_element: T1,
-        children: T2,
-        closing_element: T3,
+        opening_element: ArenaBox<'a, JSXOpeningElement<'a>>,
+        children: T1,
+        closing_element: Option<ArenaBox<'a, JSXClosingElement<'a>>>,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
     {
         Self::JSXElement(JSXElement::boxed(
             span,
@@ -20289,15 +19596,12 @@ impl<'a> JSXExpression<'a> {
     /// * `expression`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_instantiation_expression<B: GetAstBuilder<'a>>(
         span: Span,
         expression: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: ArenaBox<'a, TSTypeParameterInstantiation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
-    {
+    ) -> Self {
         Self::TSInstantiationExpression(TSInstantiationExpression::boxed(
             span,
             expression,
@@ -20667,17 +19971,15 @@ impl<'a> JSXAttributeValue<'a> {
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
     #[inline]
-    pub fn new_element<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_element<B: GetAstBuilder<'a>, T1>(
         span: Span,
-        opening_element: T1,
-        children: T2,
-        closing_element: T3,
+        opening_element: ArenaBox<'a, JSXOpeningElement<'a>>,
+        children: T1,
+        closing_element: Option<ArenaBox<'a, JSXClosingElement<'a>>>,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
     {
         Self::Element(JSXElement::boxed(
             span,
@@ -20786,17 +20088,15 @@ impl<'a> JSXChild<'a> {
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
     #[inline]
-    pub fn new_element<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_element<B: GetAstBuilder<'a>, T1>(
         span: Span,
-        opening_element: T1,
-        children: T2,
-        closing_element: T3,
+        opening_element: ArenaBox<'a, JSXOpeningElement<'a>>,
+        children: T1,
+        closing_element: Option<ArenaBox<'a, JSXClosingElement<'a>>>,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaVec<'a, JSXChild<'a>>>,
     {
         Self::Element(JSXElement::boxed(
             span,
@@ -20966,22 +20266,14 @@ impl<'a> TSThisParameter<'a> {
     /// * `this_span`
     /// * `type_annotation`: Type type the `this` keyword will have in the function
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         this_span: Span,
-        type_annotation: T1,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
-        TSThisParameter {
-            node_id: Cell::new(builder.node_id()),
-            span,
-            this_span,
-            type_annotation: type_annotation.into_in(builder.allocator()),
-        }
+        TSThisParameter { node_id: Cell::new(builder.node_id()), span, this_span, type_annotation }
     }
 
     /// Build a [`TSThisParameter`], and store it in the memory arena.
@@ -20994,15 +20286,12 @@ impl<'a> TSThisParameter<'a> {
     /// * `this_span`
     /// * `type_annotation`: Type type the `this` keyword will have in the function
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         this_span: Span,
-        type_annotation: T1,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, this_span, type_annotation, builder), &builder.allocator())
     }
@@ -21721,19 +21010,14 @@ impl<'a> TSType<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn new_ts_constructor_type<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_ts_constructor_type<B: GetAstBuilder<'a>>(
         span: Span,
         r#abstract: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> Self {
         Self::TSConstructorType(TSConstructorType::boxed(
             span,
             r#abstract,
@@ -21756,20 +21040,15 @@ impl<'a> TSType<'a> {
     /// * `return_type`
     /// * `scope_id`
     #[inline]
-    pub fn new_ts_constructor_type_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_ts_constructor_type_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         r#abstract: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> Self {
         Self::TSConstructorType(TSConstructorType::boxed_with_scope_id(
             span,
             r#abstract,
@@ -21792,20 +21071,14 @@ impl<'a> TSType<'a> {
     /// * `params`: Function parameters. Akin to [`Function::params`].
     /// * `return_type`: Return type of the function.
     #[inline]
-    pub fn new_ts_function_type<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_ts_function_type<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> Self {
         Self::TSFunctionType(TSFunctionType::boxed(
             span,
             type_parameters,
@@ -21828,21 +21101,15 @@ impl<'a> TSType<'a> {
     /// * `return_type`: Return type of the function.
     /// * `scope_id`
     #[inline]
-    pub fn new_ts_function_type_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_ts_function_type_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> Self {
         Self::TSFunctionType(TSFunctionType::boxed_with_scope_id(
             span,
             type_parameters,
@@ -21865,18 +21132,14 @@ impl<'a> TSType<'a> {
     /// * `qualifier`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_import_type<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_ts_import_type<B: GetAstBuilder<'a>>(
         span: Span,
         source: StringLiteral<'a>,
-        options: T1,
+        options: Option<ArenaBox<'a, ObjectExpression<'a>>>,
         qualifier: Option<TSImportTypeQualifier<'a>>,
-        type_arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, ObjectExpression<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSImportType(TSImportType::boxed(
             span,
             source,
@@ -21918,14 +21181,11 @@ impl<'a> TSType<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_parameter`: The type bound when the
     #[inline]
-    pub fn new_ts_infer_type<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_infer_type<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameter: T1,
+        type_parameter: ArenaBox<'a, TSTypeParameter<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameter<'a>>>,
-    {
+    ) -> Self {
         Self::TSInferType(TSInferType::boxed(span, type_parameter, builder.builder()))
     }
 
@@ -22172,16 +21432,13 @@ impl<'a> TSType<'a> {
     /// * `asserts`: Does this predicate include an `asserts` modifier?
     /// * `type_annotation`
     #[inline]
-    pub fn new_ts_type_predicate<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_type_predicate<B: GetAstBuilder<'a>>(
         span: Span,
         parameter_name: TSTypePredicateName<'a>,
         asserts: bool,
-        type_annotation: T1,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSTypePredicate(TSTypePredicate::boxed(
             span,
             parameter_name,
@@ -22200,15 +21457,12 @@ impl<'a> TSType<'a> {
     /// * `expr_name`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_type_query<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_type_query<B: GetAstBuilder<'a>>(
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSTypeQuery(TSTypeQuery::boxed(span, expr_name, type_arguments, builder.builder()))
     }
 
@@ -22221,15 +21475,12 @@ impl<'a> TSType<'a> {
     /// * `type_name`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_type_reference<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_type_reference<B: GetAstBuilder<'a>>(
         span: Span,
         type_name: TSTypeName<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSTypeReference(TSTypeReference::boxed(
             span,
             type_name,
@@ -23126,19 +22377,14 @@ impl<'a> TSTupleElement<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn new_ts_constructor_type<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_ts_constructor_type<B: GetAstBuilder<'a>>(
         span: Span,
         r#abstract: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> Self {
         Self::TSConstructorType(TSConstructorType::boxed(
             span,
             r#abstract,
@@ -23161,20 +22407,15 @@ impl<'a> TSTupleElement<'a> {
     /// * `return_type`
     /// * `scope_id`
     #[inline]
-    pub fn new_ts_constructor_type_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_ts_constructor_type_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         r#abstract: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> Self {
         Self::TSConstructorType(TSConstructorType::boxed_with_scope_id(
             span,
             r#abstract,
@@ -23197,20 +22438,14 @@ impl<'a> TSTupleElement<'a> {
     /// * `params`: Function parameters. Akin to [`Function::params`].
     /// * `return_type`: Return type of the function.
     #[inline]
-    pub fn new_ts_function_type<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_ts_function_type<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> Self {
         Self::TSFunctionType(TSFunctionType::boxed(
             span,
             type_parameters,
@@ -23233,21 +22468,15 @@ impl<'a> TSTupleElement<'a> {
     /// * `return_type`: Return type of the function.
     /// * `scope_id`
     #[inline]
-    pub fn new_ts_function_type_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_ts_function_type_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> Self {
         Self::TSFunctionType(TSFunctionType::boxed_with_scope_id(
             span,
             type_parameters,
@@ -23270,18 +22499,14 @@ impl<'a> TSTupleElement<'a> {
     /// * `qualifier`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_import_type<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_ts_import_type<B: GetAstBuilder<'a>>(
         span: Span,
         source: StringLiteral<'a>,
-        options: T1,
+        options: Option<ArenaBox<'a, ObjectExpression<'a>>>,
         qualifier: Option<TSImportTypeQualifier<'a>>,
-        type_arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, ObjectExpression<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSImportType(TSImportType::boxed(
             span,
             source,
@@ -23323,14 +22548,11 @@ impl<'a> TSTupleElement<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_parameter`: The type bound when the
     #[inline]
-    pub fn new_ts_infer_type<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_infer_type<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameter: T1,
+        type_parameter: ArenaBox<'a, TSTypeParameter<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameter<'a>>>,
-    {
+    ) -> Self {
         Self::TSInferType(TSInferType::boxed(span, type_parameter, builder.builder()))
     }
 
@@ -23577,16 +22799,13 @@ impl<'a> TSTupleElement<'a> {
     /// * `asserts`: Does this predicate include an `asserts` modifier?
     /// * `type_annotation`
     #[inline]
-    pub fn new_ts_type_predicate<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_type_predicate<B: GetAstBuilder<'a>>(
         span: Span,
         parameter_name: TSTypePredicateName<'a>,
         asserts: bool,
-        type_annotation: T1,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSTypePredicate(TSTypePredicate::boxed(
             span,
             parameter_name,
@@ -23605,15 +22824,12 @@ impl<'a> TSTupleElement<'a> {
     /// * `expr_name`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_type_query<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_type_query<B: GetAstBuilder<'a>>(
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSTypeQuery(TSTypeQuery::boxed(span, expr_name, type_arguments, builder.builder()))
     }
 
@@ -23626,15 +22842,12 @@ impl<'a> TSTupleElement<'a> {
     /// * `type_name`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_type_reference<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_type_reference<B: GetAstBuilder<'a>>(
         span: Span,
         type_name: TSTypeName<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSTypeReference(TSTypeReference::boxed(
             span,
             type_name,
@@ -24139,22 +23352,14 @@ impl<'a> TSTypeReference<'a> {
     /// * `type_name`
     /// * `type_arguments`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         type_name: TSTypeName<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
-        TSTypeReference {
-            node_id: Cell::new(builder.node_id()),
-            span,
-            type_name,
-            type_arguments: type_arguments.into_in(builder.allocator()),
-        }
+        TSTypeReference { node_id: Cell::new(builder.node_id()), span, type_name, type_arguments }
     }
 
     /// Build a [`TSTypeReference`], and store it in the memory arena.
@@ -24167,15 +23372,12 @@ impl<'a> TSTypeReference<'a> {
     /// * `type_name`
     /// * `type_arguments`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         type_name: TSTypeName<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, type_name, type_arguments, builder), &builder.allocator())
     }
@@ -24470,23 +23672,20 @@ impl<'a> TSTypeAliasDeclaration<'a> {
     /// * `type_annotation`
     /// * `declare`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         type_annotation: TSType<'a>,
         declare: bool,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSTypeAliasDeclaration {
             node_id: Cell::new(builder.node_id()),
             span,
             id,
-            type_parameters: type_parameters.into_in(builder.allocator()),
+            type_parameters,
             type_annotation,
             declare,
             scope_id: Default::default(),
@@ -24505,17 +23704,14 @@ impl<'a> TSTypeAliasDeclaration<'a> {
     /// * `type_annotation`
     /// * `declare`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         type_annotation: TSType<'a>,
         declare: bool,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new(span, id, type_parameters, type_annotation, declare, builder),
@@ -24536,24 +23732,21 @@ impl<'a> TSTypeAliasDeclaration<'a> {
     /// * `declare`
     /// * `scope_id`
     #[inline]
-    pub fn new_with_scope_id<B: GetAstBuilder<'a>, T1>(
+    pub fn new_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         type_annotation: TSType<'a>,
         declare: bool,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSTypeAliasDeclaration {
             node_id: Cell::new(builder.node_id()),
             span,
             id,
-            type_parameters: type_parameters.into_in(builder.allocator()),
+            type_parameters,
             type_annotation,
             declare,
             scope_id: Cell::new(Some(scope_id)),
@@ -24573,18 +23766,15 @@ impl<'a> TSTypeAliasDeclaration<'a> {
     /// * `declare`
     /// * `scope_id`
     #[inline]
-    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
         type_annotation: TSType<'a>,
         declare: bool,
         scope_id: ScopeId,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new_with_scope_id(
@@ -24609,21 +23799,18 @@ impl<'a> TSClassImplements<'a> {
     /// * `expression`
     /// * `type_arguments`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         expression: TSTypeName<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSClassImplements {
             node_id: Cell::new(builder.node_id()),
             span,
             expression,
-            type_arguments: type_arguments.into_in(builder.allocator()),
+            type_arguments,
         }
     }
 }
@@ -24642,28 +23829,26 @@ impl<'a> TSInterfaceDeclaration<'a> {
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
-        extends: T2,
-        body: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        extends: T1,
+        body: ArenaBox<'a, TSInterfaceBody<'a>>,
         declare: bool,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
     {
         let builder = builder.builder();
         TSInterfaceDeclaration {
             node_id: Cell::new(builder.node_id()),
             span,
             id,
-            type_parameters: type_parameters.into_in(builder.allocator()),
+            type_parameters,
             extends: extends.into_in(builder.allocator()),
-            body: body.into_in(builder.allocator()),
+            body,
             declare,
             scope_id: Default::default(),
         }
@@ -24682,19 +23867,17 @@ impl<'a> TSInterfaceDeclaration<'a> {
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
-        extends: T2,
-        body: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        extends: T1,
+        body: ArenaBox<'a, TSInterfaceBody<'a>>,
         declare: bool,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -24717,29 +23900,27 @@ impl<'a> TSInterfaceDeclaration<'a> {
     /// * `declare`: `true` for `declare interface Foo {}`
     /// * `scope_id`
     #[inline]
-    pub fn new_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_with_scope_id<B: GetAstBuilder<'a>, T1>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
-        extends: T2,
-        body: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        extends: T1,
+        body: ArenaBox<'a, TSInterfaceBody<'a>>,
         declare: bool,
         scope_id: ScopeId,
         builder: &B,
     ) -> Self
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
     {
         let builder = builder.builder();
         TSInterfaceDeclaration {
             node_id: Cell::new(builder.node_id()),
             span,
             id,
-            type_parameters: type_parameters.into_in(builder.allocator()),
+            type_parameters,
             extends: extends.into_in(builder.allocator()),
-            body: body.into_in(builder.allocator()),
+            body,
             declare,
             scope_id: Cell::new(Some(scope_id)),
         }
@@ -24759,20 +23940,18 @@ impl<'a> TSInterfaceDeclaration<'a> {
     /// * `declare`: `true` for `declare interface Foo {}`
     /// * `scope_id`
     #[inline]
-    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>, T1>(
         span: Span,
         id: BindingIdentifier<'a>,
-        type_parameters: T1,
-        extends: T2,
-        body: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        extends: T1,
+        body: ArenaBox<'a, TSInterfaceBody<'a>>,
         declare: bool,
         scope_id: ScopeId,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -24845,18 +24024,15 @@ impl<'a> TSPropertySignature<'a> {
     /// * `key`
     /// * `type_annotation`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         computed: bool,
         optional: bool,
         readonly: bool,
         key: PropertyKey<'a>,
-        type_annotation: T1,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSPropertySignature {
             node_id: Cell::new(builder.node_id()),
@@ -24865,7 +24041,7 @@ impl<'a> TSPropertySignature<'a> {
             optional,
             readonly,
             key,
-            type_annotation: type_annotation.into_in(builder.allocator()),
+            type_annotation,
         }
     }
 
@@ -24882,18 +24058,15 @@ impl<'a> TSPropertySignature<'a> {
     /// * `key`
     /// * `type_annotation`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         computed: bool,
         optional: bool,
         readonly: bool,
         key: PropertyKey<'a>,
-        type_annotation: T1,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new(span, computed, optional, readonly, key, type_annotation, builder),
@@ -24914,17 +24087,16 @@ impl<'a> TSSignature<'a> {
     /// * `readonly`
     /// * `static`
     #[inline]
-    pub fn new_ts_index_signature<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_ts_index_signature<B: GetAstBuilder<'a>, T1>(
         span: Span,
         parameters: T1,
-        type_annotation: T2,
+        type_annotation: ArenaBox<'a, TSTypeAnnotation<'a>>,
         readonly: bool,
         r#static: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, TSIndexSignatureName<'a>>>,
-        T2: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         Self::TSIndexSignature(TSIndexSignature::boxed(
             span,
@@ -24948,18 +24120,15 @@ impl<'a> TSSignature<'a> {
     /// * `key`
     /// * `type_annotation`
     #[inline]
-    pub fn new_ts_property_signature<B: GetAstBuilder<'a>, T1>(
+    pub fn new_ts_property_signature<B: GetAstBuilder<'a>>(
         span: Span,
         computed: bool,
         optional: bool,
         readonly: bool,
         key: PropertyKey<'a>,
-        type_annotation: T1,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSPropertySignature(TSPropertySignature::boxed(
             span,
             computed,
@@ -24982,20 +24151,14 @@ impl<'a> TSSignature<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn new_ts_call_signature_declaration<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_ts_call_signature_declaration<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSCallSignatureDeclaration(TSCallSignatureDeclaration::boxed(
             span,
             type_parameters,
@@ -25018,21 +24181,15 @@ impl<'a> TSSignature<'a> {
     /// * `return_type`
     /// * `scope_id`
     #[inline]
-    pub fn new_ts_call_signature_declaration_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_ts_call_signature_declaration_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSCallSignatureDeclaration(TSCallSignatureDeclaration::boxed_with_scope_id(
             span,
             type_parameters,
@@ -25054,18 +24211,13 @@ impl<'a> TSSignature<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn new_ts_construct_signature_declaration<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_ts_construct_signature_declaration<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSConstructSignatureDeclaration(TSConstructSignatureDeclaration::boxed(
             span,
             type_parameters,
@@ -25086,19 +24238,14 @@ impl<'a> TSSignature<'a> {
     /// * `return_type`
     /// * `scope_id`
     #[inline]
-    pub fn new_ts_construct_signature_declaration_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_ts_construct_signature_declaration_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSConstructSignatureDeclaration(TSConstructSignatureDeclaration::boxed_with_scope_id(
             span,
             type_parameters,
@@ -25124,24 +24271,18 @@ impl<'a> TSSignature<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn new_ts_method_signature<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_ts_method_signature<B: GetAstBuilder<'a>>(
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
         optional: bool,
         kind: TSMethodSignatureKind,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSMethodSignature(TSMethodSignature::boxed(
             span,
             key,
@@ -25172,25 +24313,19 @@ impl<'a> TSSignature<'a> {
     /// * `return_type`
     /// * `scope_id`
     #[inline]
-    pub fn new_ts_method_signature_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_ts_method_signature_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
         optional: bool,
         kind: TSMethodSignatureKind,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSMethodSignature(TSMethodSignature::boxed_with_scope_id(
             span,
             key,
@@ -25220,24 +24355,23 @@ impl<'a> TSIndexSignature<'a> {
     /// * `readonly`
     /// * `static`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>, T1>(
         span: Span,
         parameters: T1,
-        type_annotation: T2,
+        type_annotation: ArenaBox<'a, TSTypeAnnotation<'a>>,
         readonly: bool,
         r#static: bool,
         builder: &B,
     ) -> Self
     where
         T1: IntoIn<'a, ArenaVec<'a, TSIndexSignatureName<'a>>>,
-        T2: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         let builder = builder.builder();
         TSIndexSignature {
             node_id: Cell::new(builder.node_id()),
             span,
             parameters: parameters.into_in(builder.allocator()),
-            type_annotation: type_annotation.into_in(builder.allocator()),
+            type_annotation,
             readonly,
             r#static,
         }
@@ -25255,17 +24389,16 @@ impl<'a> TSIndexSignature<'a> {
     /// * `readonly`
     /// * `static`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>, T1>(
         span: Span,
         parameters: T1,
-        type_annotation: T2,
+        type_annotation: ArenaBox<'a, TSTypeAnnotation<'a>>,
         readonly: bool,
         r#static: bool,
         builder: &B,
     ) -> ArenaBox<'a, Self>
     where
         T1: IntoIn<'a, ArenaVec<'a, TSIndexSignatureName<'a>>>,
-        T2: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         let builder = builder.builder();
         ArenaBox::new_in(
@@ -25288,28 +24421,22 @@ impl<'a> TSCallSignatureDeclaration<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSCallSignatureDeclaration {
             node_id: Cell::new(builder.node_id()),
             span,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            this_param: this_param.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
+            type_parameters,
+            this_param,
+            params,
+            return_type,
             scope_id: Default::default(),
         }
     }
@@ -25326,20 +24453,14 @@ impl<'a> TSCallSignatureDeclaration<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new(span, type_parameters, this_param, params, return_type, builder),
@@ -25360,29 +24481,23 @@ impl<'a> TSCallSignatureDeclaration<'a> {
     /// * `return_type`
     /// * `scope_id`
     #[inline]
-    pub fn new_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSCallSignatureDeclaration {
             node_id: Cell::new(builder.node_id()),
             span,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            this_param: this_param.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
+            type_parameters,
+            this_param,
+            params,
+            return_type,
             scope_id: Cell::new(Some(scope_id)),
         }
     }
@@ -25400,21 +24515,15 @@ impl<'a> TSCallSignatureDeclaration<'a> {
     /// * `return_type`
     /// * `scope_id`
     #[inline]
-    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new_with_scope_id(
@@ -25448,24 +24557,18 @@ impl<'a> TSMethodSignature<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
         optional: bool,
         kind: TSMethodSignatureKind,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSMethodSignature {
             node_id: Cell::new(builder.node_id()),
@@ -25474,10 +24577,10 @@ impl<'a> TSMethodSignature<'a> {
             computed,
             optional,
             kind,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            this_param: this_param.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
+            type_parameters,
+            this_param,
+            params,
+            return_type,
             scope_id: Default::default(),
         }
     }
@@ -25498,24 +24601,18 @@ impl<'a> TSMethodSignature<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
         optional: bool,
         kind: TSMethodSignatureKind,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new(
@@ -25551,25 +24648,19 @@ impl<'a> TSMethodSignature<'a> {
     /// * `return_type`
     /// * `scope_id`
     #[inline]
-    pub fn new_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
         optional: bool,
         kind: TSMethodSignatureKind,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSMethodSignature {
             node_id: Cell::new(builder.node_id()),
@@ -25578,10 +24669,10 @@ impl<'a> TSMethodSignature<'a> {
             computed,
             optional,
             kind,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            this_param: this_param.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
+            type_parameters,
+            this_param,
+            params,
+            return_type,
             scope_id: Cell::new(Some(scope_id)),
         }
     }
@@ -25603,25 +24694,19 @@ impl<'a> TSMethodSignature<'a> {
     /// * `return_type`
     /// * `scope_id`
     #[inline]
-    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
         optional: bool,
         kind: TSMethodSignatureKind,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new_with_scope_id(
@@ -25654,25 +24739,20 @@ impl<'a> TSConstructSignatureDeclaration<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSConstructSignatureDeclaration {
             node_id: Cell::new(builder.node_id()),
             span,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
+            type_parameters,
+            params,
+            return_type,
             scope_id: Default::default(),
         }
     }
@@ -25688,18 +24768,13 @@ impl<'a> TSConstructSignatureDeclaration<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new(span, type_parameters, params, return_type, builder),
@@ -25719,26 +24794,21 @@ impl<'a> TSConstructSignatureDeclaration<'a> {
     /// * `return_type`
     /// * `scope_id`
     #[inline]
-    pub fn new_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSConstructSignatureDeclaration {
             node_id: Cell::new(builder.node_id()),
             span,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
+            type_parameters,
+            params,
+            return_type,
             scope_id: Cell::new(Some(scope_id)),
         }
     }
@@ -25755,19 +24825,14 @@ impl<'a> TSConstructSignatureDeclaration<'a> {
     /// * `return_type`
     /// * `scope_id`
     #[inline]
-    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new_with_scope_id(span, type_parameters, params, return_type, scope_id, builder),
@@ -25784,22 +24849,21 @@ impl<'a> TSIndexSignatureName<'a> {
     /// * `name`
     /// * `type_annotation`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, S1, T1>(
+    pub fn new<B: GetAstBuilder<'a>, S1>(
         span: Span,
         name: S1,
-        type_annotation: T1,
+        type_annotation: ArenaBox<'a, TSTypeAnnotation<'a>>,
         builder: &B,
     ) -> Self
     where
         S1: Into<Str<'a>>,
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         let builder = builder.builder();
         TSIndexSignatureName {
             node_id: Cell::new(builder.node_id()),
             span,
             name: name.into(),
-            type_annotation: type_annotation.into_in(builder.allocator()),
+            type_annotation,
         }
     }
 }
@@ -25812,21 +24876,18 @@ impl<'a> TSInterfaceHeritage<'a> {
     /// * `expression`
     /// * `type_arguments`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         expression: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSInterfaceHeritage {
             node_id: Cell::new(builder.node_id()),
             span,
             expression,
-            type_arguments: type_arguments.into_in(builder.allocator()),
+            type_arguments,
         }
     }
 }
@@ -25843,23 +24904,20 @@ impl<'a> TSTypePredicate<'a> {
     /// * `asserts`: Does this predicate include an `asserts` modifier?
     /// * `type_annotation`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         parameter_name: TSTypePredicateName<'a>,
         asserts: bool,
-        type_annotation: T1,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSTypePredicate {
             node_id: Cell::new(builder.node_id()),
             span,
             parameter_name,
             asserts,
-            type_annotation: type_annotation.into_in(builder.allocator()),
+            type_annotation,
         }
     }
 
@@ -25874,16 +24932,13 @@ impl<'a> TSTypePredicate<'a> {
     /// * `asserts`: Does this predicate include an `asserts` modifier?
     /// * `type_annotation`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         parameter_name: TSTypePredicateName<'a>,
         asserts: bool,
-        type_annotation: T1,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new(span, parameter_name, asserts, type_annotation, builder),
@@ -26431,16 +25486,13 @@ impl<'a> TSInferType<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_parameter`: The type bound when the
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(span: Span, type_parameter: T1, builder: &B) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameter<'a>>>,
-    {
+    pub fn new<B: GetAstBuilder<'a>>(
+        span: Span,
+        type_parameter: ArenaBox<'a, TSTypeParameter<'a>>,
+        builder: &B,
+    ) -> Self {
         let builder = builder.builder();
-        TSInferType {
-            node_id: Cell::new(builder.node_id()),
-            span,
-            type_parameter: type_parameter.into_in(builder.allocator()),
-        }
+        TSInferType { node_id: Cell::new(builder.node_id()), span, type_parameter }
     }
 
     /// Build a [`TSInferType`], and store it in the memory arena.
@@ -26452,14 +25504,11 @@ impl<'a> TSInferType<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_parameter`: The type bound when the
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameter: T1,
+        type_parameter: ArenaBox<'a, TSTypeParameter<'a>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameter<'a>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, type_parameter, builder), &builder.allocator())
     }
@@ -26476,22 +25525,14 @@ impl<'a> TSTypeQuery<'a> {
     /// * `expr_name`
     /// * `type_arguments`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
-        TSTypeQuery {
-            node_id: Cell::new(builder.node_id()),
-            span,
-            expr_name,
-            type_arguments: type_arguments.into_in(builder.allocator()),
-        }
+        TSTypeQuery { node_id: Cell::new(builder.node_id()), span, expr_name, type_arguments }
     }
 
     /// Build a [`TSTypeQuery`], and store it in the memory arena.
@@ -26504,15 +25545,12 @@ impl<'a> TSTypeQuery<'a> {
     /// * `expr_name`
     /// * `type_arguments`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
-        type_arguments: T1,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, expr_name, type_arguments, builder), &builder.allocator())
     }
@@ -26530,18 +25568,14 @@ impl<'a> TSTypeQueryExprName<'a> {
     /// * `qualifier`
     /// * `type_arguments`
     #[inline]
-    pub fn new_ts_import_type<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new_ts_import_type<B: GetAstBuilder<'a>>(
         span: Span,
         source: StringLiteral<'a>,
-        options: T1,
+        options: Option<ArenaBox<'a, ObjectExpression<'a>>>,
         qualifier: Option<TSImportTypeQualifier<'a>>,
-        type_arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, ObjectExpression<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         Self::TSImportType(TSImportType::boxed(
             span,
             source,
@@ -26640,26 +25674,22 @@ impl<'a> TSImportType<'a> {
     /// * `qualifier`
     /// * `type_arguments`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         source: StringLiteral<'a>,
-        options: T1,
+        options: Option<ArenaBox<'a, ObjectExpression<'a>>>,
         qualifier: Option<TSImportTypeQualifier<'a>>,
-        type_arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, ObjectExpression<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSImportType {
             node_id: Cell::new(builder.node_id()),
             span,
             source,
-            options: options.into_in(builder.allocator()),
+            options,
             qualifier,
-            type_arguments: type_arguments.into_in(builder.allocator()),
+            type_arguments,
         }
     }
 
@@ -26675,18 +25705,14 @@ impl<'a> TSImportType<'a> {
     /// * `qualifier`
     /// * `type_arguments`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         source: StringLiteral<'a>,
-        options: T1,
+        options: Option<ArenaBox<'a, ObjectExpression<'a>>>,
         qualifier: Option<TSImportTypeQualifier<'a>>,
-        type_arguments: T2,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, ObjectExpression<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new(span, source, options, qualifier, type_arguments, builder),
@@ -26785,28 +25811,22 @@ impl<'a> TSFunctionType<'a> {
     /// * `params`: Function parameters. Akin to [`Function::params`].
     /// * `return_type`: Return type of the function.
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSFunctionType {
             node_id: Cell::new(builder.node_id()),
             span,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            this_param: this_param.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
+            type_parameters,
+            this_param,
+            params,
+            return_type,
             scope_id: Default::default(),
         }
     }
@@ -26823,20 +25843,14 @@ impl<'a> TSFunctionType<'a> {
     /// * `params`: Function parameters. Akin to [`Function::params`].
     /// * `return_type`: Return type of the function.
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new(span, type_parameters, this_param, params, return_type, builder),
@@ -26857,29 +25871,23 @@ impl<'a> TSFunctionType<'a> {
     /// * `return_type`: Return type of the function.
     /// * `scope_id`
     #[inline]
-    pub fn new_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn new_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSFunctionType {
             node_id: Cell::new(builder.node_id()),
             span,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            this_param: this_param.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
+            type_parameters,
+            this_param,
+            params,
+            return_type,
             scope_id: Cell::new(Some(scope_id)),
         }
     }
@@ -26897,21 +25905,15 @@ impl<'a> TSFunctionType<'a> {
     /// * `return_type`: Return type of the function.
     /// * `scope_id`
     #[inline]
-    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3, T4>(
+    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
-        type_parameters: T1,
-        this_param: T2,
-        params: T3,
-        return_type: T4,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        this_param: Option<ArenaBox<'a, TSThisParameter<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new_with_scope_id(
@@ -26941,27 +25943,22 @@ impl<'a> TSConstructorType<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         r#abstract: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSConstructorType {
             node_id: Cell::new(builder.node_id()),
             span,
             r#abstract,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
+            type_parameters,
+            params,
+            return_type,
             scope_id: Default::default(),
         }
     }
@@ -26978,19 +25975,14 @@ impl<'a> TSConstructorType<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         r#abstract: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new(span, r#abstract, type_parameters, params, return_type, builder),
@@ -27011,28 +26003,23 @@ impl<'a> TSConstructorType<'a> {
     /// * `return_type`
     /// * `scope_id`
     #[inline]
-    pub fn new_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn new_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         r#abstract: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSConstructorType {
             node_id: Cell::new(builder.node_id()),
             span,
             r#abstract,
-            type_parameters: type_parameters.into_in(builder.allocator()),
-            params: params.into_in(builder.allocator()),
-            return_type: return_type.into_in(builder.allocator()),
+            type_parameters,
+            params,
+            return_type,
             scope_id: Cell::new(Some(scope_id)),
         }
     }
@@ -27050,20 +26037,15 @@ impl<'a> TSConstructorType<'a> {
     /// * `return_type`
     /// * `scope_id`
     #[inline]
-    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>, T1, T2, T3>(
+    pub fn boxed_with_scope_id<B: GetAstBuilder<'a>>(
         span: Span,
         r#abstract: bool,
-        type_parameters: T1,
-        params: T2,
-        return_type: T3,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: ArenaBox<'a, TSTypeAnnotation<'a>>,
         scope_id: ScopeId,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(
             Self::new_with_scope_id(
@@ -27737,21 +26719,18 @@ impl<'a> TSInstantiationExpression<'a> {
     /// * `expression`
     /// * `type_arguments`
     #[inline]
-    pub fn new<B: GetAstBuilder<'a>, T1>(
+    pub fn new<B: GetAstBuilder<'a>>(
         span: Span,
         expression: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: ArenaBox<'a, TSTypeParameterInstantiation<'a>>,
         builder: &B,
-    ) -> Self
-    where
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
-    {
+    ) -> Self {
         let builder = builder.builder();
         TSInstantiationExpression {
             node_id: Cell::new(builder.node_id()),
             span,
             expression,
-            type_arguments: type_arguments.into_in(builder.allocator()),
+            type_arguments,
         }
     }
 
@@ -27765,15 +26744,12 @@ impl<'a> TSInstantiationExpression<'a> {
     /// * `expression`
     /// * `type_arguments`
     #[inline]
-    pub fn boxed<B: GetAstBuilder<'a>, T1>(
+    pub fn boxed<B: GetAstBuilder<'a>>(
         span: Span,
         expression: Expression<'a>,
-        type_arguments: T1,
+        type_arguments: ArenaBox<'a, TSTypeParameterInstantiation<'a>>,
         builder: &B,
-    ) -> ArenaBox<'a, Self>
-    where
-        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
-    {
+    ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, expression, type_arguments, builder), &builder.allocator())
     }

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, CloneIn, GetAllocator};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_span::{ContentEq, GetSpan, SPAN};
 
 use crate::{
@@ -205,7 +205,7 @@ impl<'a> IsolatedDeclarations<'a> {
             function.this_param.clone_in(self.allocator()),
             params,
             return_type,
-            NONE,
+            None,
             self,
         );
 
@@ -239,7 +239,7 @@ impl<'a> IsolatedDeclarations<'a> {
             r#type,
             [],
             key,
-            NONE,
+            None,
             None,
             false,
             r#static,
@@ -304,7 +304,7 @@ impl<'a> IsolatedDeclarations<'a> {
             }
             MethodDefinitionKind::Get | MethodDefinitionKind::Constructor => {
                 let params =
-                    FormalParameters::boxed(SPAN, FormalParameterKind::Signature, [], NONE, self);
+                    FormalParameters::boxed(SPAN, FormalParameterKind::Signature, [], None, self);
                 self.transform_class_method_definition(method, params, None)
             }
             MethodDefinitionKind::Set => {
@@ -695,7 +695,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 r#type,
                 [],
                 ident,
-                NONE,
+                None,
                 None,
                 false,
                 false,
@@ -734,7 +734,7 @@ impl<'a> IsolatedDeclarations<'a> {
         kind: BindingPattern<'a>,
     ) -> ArenaBox<'a, FormalParameters<'a>> {
         let parameter =
-            FormalParameter::new(SPAN, [], kind, NONE, NONE, false, None, false, false, self);
-        FormalParameters::boxed(SPAN, FormalParameterKind::Signature, [parameter], NONE, self)
+            FormalParameter::new(SPAN, [], kind, None, None, false, None, false, false, self);
+        FormalParameters::boxed(SPAN, FormalParameterKind::Signature, [parameter], None, self)
     }
 }

--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{ArenaBox, ArenaVec, CloneIn, GetAllocator};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_span::{SPAN, Span};
 
 use crate::{
@@ -33,7 +33,7 @@ impl<'a> IsolatedDeclarations<'a> {
             func.this_param.clone_in(self.allocator()),
             params,
             return_type,
-            NONE,
+            None,
             self,
         )
     }
@@ -116,7 +116,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 // not used afterwards, so move it in directly instead of cloning again.
                 pattern,
                 type_annotation,
-                NONE,
+                None,
                 optional,
                 None,
                 false,
@@ -130,7 +130,7 @@ impl<'a> IsolatedDeclarations<'a> {
             [],
             pattern,
             param.type_annotation.clone_in(self.allocator()),
-            NONE,
+            None,
             param.optional,
             None,
             false,

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -12,7 +12,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use oxc_allocator::{Allocator, ArenaVec, CloneIn, GetAllocator};
 use oxc_ast::{
     ast::*,
-    builder::{AstBuilder, GetAstBuilder, NONE},
+    builder::{AstBuilder, GetAstBuilder},
 };
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
@@ -433,7 +433,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 [],
                 None,
                 kind,
-                NONE,
+                None,
                 self,
             ));
         } else if self.scope.is_ts_module_block() {

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{ArenaBox, ArenaVec, CloneIn, GetAllocator, ReplaceWith};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_span::{GetSpan, SPAN};
 use oxc_str::Str;
 
@@ -18,7 +18,7 @@ impl<'a> IsolatedDeclarations<'a> {
             [],
             None,
             ImportOrExportKind::Value,
-            NONE,
+            None,
             self,
         ))
     }

--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -1,12 +1,9 @@
 use oxc_allocator::{ArenaVec, CloneIn, GetAllocator};
-use oxc_ast::{
-    ast::{
-        ArrayExpression, ArrayExpressionElement, ArrowFunctionExpression, Expression, Function,
-        ObjectExpression, ObjectPropertyKind, PropertyKey, PropertyKind, TSLiteral,
-        TSMethodSignatureKind, TSSignature, TSTupleElement, TSType, TSTypeAnnotation,
-        TSTypeOperatorOperator,
-    },
-    builder::NONE,
+use oxc_ast::ast::{
+    ArrayExpression, ArrayExpressionElement, ArrowFunctionExpression, Expression, Function,
+    ObjectExpression, ObjectPropertyKind, PropertyKey, PropertyKind, TSLiteral,
+    TSMethodSignatureKind, TSSignature, TSTupleElement, TSType, TSTypeAnnotation,
+    TSTypeOperatorOperator,
 };
 use oxc_span::{ContentEq, GetSpan, SPAN, Span};
 use oxc_syntax::identifier::is_identifier_name;
@@ -61,7 +58,7 @@ impl<'a> IsolatedDeclarations<'a> {
             TSType::new_ts_function_type(
                 func.span,
                 func.type_parameters.clone_in(self.allocator()),
-                NONE,
+                None,
                 params,
                 return_type,
                 self,

--- a/crates/oxc_minifier/src/keep_var.rs
+++ b/crates/oxc_minifier/src/keep_var.rs
@@ -1,8 +1,5 @@
 use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator};
-use oxc_ast::{
-    ast::*,
-    builder::{GetAstBuilder, NONE},
-};
+use oxc_ast::{ast::*, builder::GetAstBuilder};
 use oxc_ast_visit::VisitJs;
 use oxc_ecmascript::BoundNames;
 use oxc_span::{SPAN, Span};
@@ -81,7 +78,7 @@ impl<'a> KeepVar<'a> {
                         )
                     },
                 );
-                VariableDeclarator::new(span, kind, id, NONE, None, false, ast)
+                VariableDeclarator::new(span, kind, id, None, None, false, ast)
             }),
             ast,
         );

--- a/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
@@ -1,6 +1,6 @@
 use crate::TraverseCtx;
 use oxc_allocator::{ArenaVec, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_compat::ESFeature;
 use oxc_ecmascript::{
     constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType},
@@ -284,7 +284,7 @@ impl<'a> PeepholeOptimizations {
                         ctx,
                     );
                     return Some(Expression::new_call_expression(
-                        expr.span, callee, NONE, args, false, ctx,
+                        expr.span, callee, None, args, false, ctx,
                     ));
                 }
                 // `a ? b(c) : b(e)` -> `b(a ? c : e)`
@@ -308,7 +308,7 @@ impl<'a> PeepholeOptimizations {
                     );
                     args[0] = Argument::from(cond_expr);
                     return Some(Expression::new_call_expression(
-                        expr.span, callee, NONE, args, false, ctx,
+                        expr.span, callee, None, args, false, ctx,
                     ));
                 }
             }

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use cow_utils::CowUtils;
 
 use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_compat::ESFeature;
 use oxc_ecmascript::{
     StringCharAt, StringCharAtResult, ToBigInt, ToIntegerIndex,
@@ -193,7 +193,7 @@ impl<'a> PeepholeOptimizations {
         let new_expr = Expression::new_call_expression(
             original_span,
             new_root_callee.take_in(ctx),
-            NONE,
+            None,
             ArenaVec::from_iter_in(
                 collected_arguments.into_iter().rev().flat_map(|arg| arg.take_in(ctx)),
                 ctx,
@@ -263,7 +263,7 @@ impl<'a> PeepholeOptimizations {
                     Some(Expression::new_call_expression(
                         span,
                         callee.take_in(ctx),
-                        NONE,
+                        None,
                         args.take_in(ctx),
                         false,
                         ctx,

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -2,7 +2,7 @@ use std::iter::repeat_with;
 
 use crate::generated::ancestor::Ancestor;
 use oxc_allocator::{ArenaVec, CloneIn, GetAllocator, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_compat::ESFeature;
 use oxc_ecmascript::{
     BoundNames, ToJsString, ToNumber,
@@ -992,7 +992,7 @@ impl<'a> PeepholeOptimizations {
                 Expression::new_call_expression(
                     SPAN,
                     callee,
-                    NONE,
+                    None,
                     [Argument::new_numeric_literal(SPAN, offset, None, NumberBase::Decimal, ctx)],
                     false,
                     ctx,
@@ -1002,7 +1002,7 @@ impl<'a> PeepholeOptimizations {
             };
 
             let new_decl =
-                VariableDeclarator::new(SPAN, var_init.kind, r_id_pat, NONE, Some(arr), false, ctx);
+                VariableDeclarator::new(SPAN, var_init.kind, r_id_pat, None, Some(arr), false, ctx);
             // The old declarators (`e`, `a`, and `r`'s original init) are
             // replaced wholesale — walk them so refs inside (e.g. `e` in
             // `Array(e > 1 ? e - 1 : 0)`) reach `PassChanges`. The moved-out
@@ -1251,7 +1251,7 @@ impl<'a> PeepholeOptimizations {
                             let callee = callee.take_in(ctx);
                             let args = args.take_in(ctx);
                             let new_value = Expression::new_call_expression(
-                                *span, callee, NONE, args, false, ctx,
+                                *span, callee, None, args, false, ctx,
                             );
                             ctx.replace_expression(expr, new_value);
                         }
@@ -1270,7 +1270,7 @@ impl<'a> PeepholeOptimizations {
                         let callee = callee.take_in(ctx);
                         let args = args.take_in(ctx);
                         let new_value =
-                            Expression::new_call_expression(*span, callee, NONE, args, false, ctx);
+                            Expression::new_call_expression(*span, callee, None, args, false, ctx);
                         ctx.replace_expression(expr, new_value);
                     }
                 } else {
@@ -1344,7 +1344,7 @@ impl<'a> PeepholeOptimizations {
             let new_value = Expression::new_call_expression_with_pure(
                 e.span,
                 e.callee.take_in(ctx),
-                NONE,
+                None,
                 e.arguments.take_in(ctx),
                 false,
                 e.pure,
@@ -1770,7 +1770,7 @@ impl<'a> PeepholeOptimizations {
                 false,
                 ctx,
             ),
-            NONE,
+            None,
             [Argument::new_string_literal(
                 expr.span(),
                 Str::from_str_in(delimiter, ctx),

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::ArenaBox;
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_span::FileExtension;
 use oxc_syntax::precedence::Precedence;
 
@@ -238,7 +238,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             ident.span,
             FormalParameterKind::ArrowFormalParameters,
             [formal_parameter],
-            NONE,
+            None,
             self,
         );
 

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 use rustc_hash::FxHashMap;
 
@@ -466,7 +466,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         [],
                         None,
                         ImportOrExportKind::Value,
-                        NONE,
+                        None,
                         self,
                     );
                     if self.ctx.has_top_level() {
@@ -496,7 +496,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     [],
                     None,
                     ImportOrExportKind::Value,
-                    NONE,
+                    None,
                     self,
                 );
                 if self.ctx.has_top_level() {
@@ -665,7 +665,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             [],
             None,
             export_kind,
-            NONE,
+            None,
             self,
         );
         if self.ctx.has_top_level() {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{ArenaBox, ArenaVec};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 use oxc_syntax::operator::UnaryOperator;
 
@@ -1472,7 +1472,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             computed,
             /* optional */ false,
             kind,
-            NONE,
+            None,
             this_param,
             params,
             return_type,

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -15,7 +15,7 @@
 use cow_utils::CowUtils;
 use oxc_ast::AstKind;
 use oxc_ast::ast::*;
-use oxc_ast::builder::{AstBuilder, NONE};
+use oxc_ast::builder::AstBuilder;
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_span::{GetSpan, SPAN, Span};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -2118,10 +2118,10 @@ fn ox_build_function<'a>(
         codegen.generator,
         codegen.is_async,
         false,
-        NONE,
-        NONE,
+        None,
+        None,
         codegen.params.clone_in_with_semantic_ids(ast.allocator()),
-        NONE,
+        None,
         Some(codegen.body.clone_in_with_semantic_ids(ast.allocator())),
         ast,
     )
@@ -2139,9 +2139,9 @@ fn ox_build_compiled_expression<'a>(
             SPAN,
             false,
             codegen.is_async,
-            NONE,
+            None,
             codegen.params.clone_in_with_semantic_ids(ast.allocator()),
-            NONE,
+            None,
             codegen.body.clone_in_with_semantic_ids(ast.allocator()),
             ast,
         ),
@@ -2214,7 +2214,7 @@ fn ox_build_gated_const_decl<'a>(
         SPAN,
         VariableDeclarationKind::Const,
         BindingPattern::new_binding_identifier(SPAN, ox_atom(ast, name), ast),
-        NONE,
+        None,
         Some(gating_expression.clone_in_with_semantic_ids(ast.allocator())),
         false,
         ast,
@@ -2316,7 +2316,7 @@ impl<'a> OxcVisitor<'a, '_> {
                     [],
                     None,
                     ImportOrExportKind::Value,
-                    NONE,
+                    None,
                     ast,
                 );
             } else {
@@ -2378,10 +2378,10 @@ impl<'a> oxc_ast_visit::VisitMut<'a> for OxcVisitor<'a, '_> {
                         func.generator,
                         func.r#async,
                         false,
-                        NONE,
-                        NONE,
+                        None,
+                        None,
                         func.params.clone_in_with_semantic_ids(ast.allocator()),
-                        NONE,
+                        None,
                         func.body.clone_in_with_semantic_ids(ast.allocator()),
                         ast,
                     );
@@ -2499,7 +2499,7 @@ fn ox_gating_call<'a>(ast: &AstBuilder<'a>, callee_name: &str) -> Expression<'a>
     Expression::new_call_expression(
         SPAN,
         Expression::new_identifier(SPAN, ox_atom(ast, callee_name), ast),
-        NONE,
+        None,
         [],
         false,
         ast,
@@ -2741,7 +2741,7 @@ fn ox_add_imports_to_program<'a>(
                 Some(specifiers),
                 source,
                 None,
-                NONE,
+                None,
                 ImportOrExportKind::Value,
                 ast,
             );
@@ -2756,11 +2756,11 @@ fn ox_add_imports_to_program<'a>(
                     BindingPattern::new_binding_identifier(SPAN, ox_atom(ast, &spec.name), ast);
                 props.push(BindingProperty::new(SPAN, key, value, false, false, ast));
             }
-            let object_pattern = BindingPattern::new_object_pattern(SPAN, props, NONE, ast);
+            let object_pattern = BindingPattern::new_object_pattern(SPAN, props, None, ast);
             let require_call = Expression::new_call_expression(
                 SPAN,
                 Expression::new_identifier(SPAN, "require", ast),
-                NONE,
+                None,
                 [Argument::new_string_literal(SPAN, ox_atom(ast, module_name), None, ast)],
                 false,
                 ast,
@@ -2769,7 +2769,7 @@ fn ox_add_imports_to_program<'a>(
                 SPAN,
                 VariableDeclarationKind::Const,
                 object_pattern,
-                NONE,
+                None,
                 Some(require_call),
                 false,
                 ast,

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -120,7 +120,7 @@ pub fn codegen_function<'a>(
         let use_memo_cache = oxc_ast::ast::Expression::new_call_expression(
             SPAN,
             oxc_ast::ast::Expression::new_identifier(SPAN, memo_cache_name, ast),
-            NONE,
+            None,
             [oxc_ast::ast::Argument::from(ox_number(ast, cache_count as f64))],
             false,
             ast,
@@ -133,7 +133,7 @@ pub fn codegen_function<'a>(
                 ox_str(ast, &cache_name),
                 ast,
             ),
-            NONE,
+            None,
             Some(use_memo_cache),
             false,
             ast,
@@ -219,7 +219,6 @@ fn ox_codegen_outlined<'a>(
 use oxc_allocator::GetAllocator;
 use oxc_allocator::IntoIn;
 use oxc_ast::ast as oxc;
-use oxc_ast::builder::NONE;
 use oxc_span::SPAN;
 
 // Temp value tracking. Maps a temporary's declaration to its emitted oxc value
@@ -407,7 +406,7 @@ fn ox_symbol_for<'a>(ast: &oxc_ast::builder::AstBuilder<'a>, name: &str) -> oxc:
     oxc_ast::ast::Expression::new_call_expression(
         SPAN,
         callee,
-        NONE,
+        None,
         [oxc::Argument::from(oxc_ast::ast::Expression::new_string_literal(
             SPAN,
             ox_str(ast, name),
@@ -504,8 +503,8 @@ fn ox_convert_parameters<'a>(
                     SPAN,
                     [],
                     binding,
-                    NONE,
-                    NONE,
+                    None,
+                    None,
                     false,
                     None,
                     false,
@@ -520,7 +519,7 @@ fn ox_convert_parameters<'a>(
                     SPAN,
                     [],
                     rest_elem,
-                    NONE,
+                    None,
                     &cx.ast,
                 ));
             }
@@ -727,7 +726,7 @@ fn ox_codegen_reactive_scope<'a>(
                     ox_str(&cx.ast, &name),
                     &cx.ast,
                 ),
-                NONE,
+                None,
                 None,
                 false,
                 &cx.ast,
@@ -1033,7 +1032,7 @@ fn ox_codegen_terminal<'a>(
                     let ident = &cx.env.identifiers[binding.identifier];
                     cx.temp.insert(ident.declaration_id, None);
                     let pattern = ox_binding_for_identifier(cx, binding.identifier)?;
-                    Some(oxc_ast::ast::CatchParameter::new(SPAN, pattern, NONE, &cx.ast))
+                    Some(oxc_ast::ast::CatchParameter::new(SPAN, pattern, None, &cx.ast))
                 }
                 None => None,
             };
@@ -1045,7 +1044,7 @@ fn ox_codegen_terminal<'a>(
                 SPAN,
                 try_block,
                 Some(handler),
-                NONE,
+                None,
                 &cx.ast,
             )))
         }
@@ -1078,7 +1077,7 @@ fn ox_codegen_for_in<'a>(
         SPAN,
         var_decl_kind,
         lval,
-        NONE,
+        None,
         None,
         false,
         &cx.ast,
@@ -1130,7 +1129,7 @@ fn ox_codegen_for_of<'a>(
         SPAN,
         var_decl_kind,
         lval,
-        NONE,
+        None,
         None,
         false,
         &cx.ast,
@@ -1486,7 +1485,7 @@ fn ox_make_var_decl<'a>(
     init: Option<oxc::Expression<'a>>,
 ) -> oxc::Statement<'a> {
     let declarator =
-        oxc_ast::ast::VariableDeclarator::new(SPAN, kind, id, NONE, init, false, &cx.ast);
+        oxc_ast::ast::VariableDeclarator::new(SPAN, kind, id, None, init, false, &cx.ast);
     oxc::Statement::VariableDeclaration(oxc_ast::ast::VariableDeclaration::boxed(
         SPAN,
         kind,
@@ -1796,7 +1795,7 @@ fn ox_codegen_base_instruction_value<'a>(
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_new_expression(
                 SPAN,
                 callee_expr,
-                NONE,
+                None,
                 arguments,
                 &cx.ast,
             )))
@@ -1986,7 +1985,7 @@ fn ox_codegen_base_instruction_value<'a>(
             }
             let quasi = ox_template_literal(cx, quasis, exprs);
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_tagged_template_expression(
-                SPAN, tag_expr, NONE, quasi, &cx.ast,
+                SPAN, tag_expr, None, quasi, &cx.ast,
             )))
         }
         InstructionValue::TemplateLiteral { subexprs, quasis, .. } => {
@@ -2554,10 +2553,10 @@ fn ox_codegen_function_expression<'a>(
                 fn_result.generator,
                 fn_result.is_async,
                 false,
-                NONE,
-                NONE,
+                None,
+                None,
                 fn_result.params,
-                NONE,
+                None,
                 Some(fn_result.body),
                 &cx.ast,
             );
@@ -2611,7 +2610,7 @@ fn ox_build_arrow<'a>(
     expression: bool,
 ) -> oxc::Expression<'a> {
     oxc_ast::ast::Expression::new_arrow_function_expression(
-        SPAN, expression, is_async, NONE, params, NONE, body, &cx.ast,
+        SPAN, expression, is_async, None, params, None, body, &cx.ast,
     )
 }
 
@@ -2690,10 +2689,10 @@ fn ox_codegen_object_expression<'a>(
                             fn_result.generator,
                             fn_result.is_async,
                             false,
-                            NONE,
-                            NONE,
+                            None,
+                            None,
                             fn_result.params,
-                            NONE,
+                            None,
                             Some(fn_result.body),
                             &cx.ast,
                         );
@@ -2776,7 +2775,7 @@ fn ox_codegen_jsx_expression<'a>(
 
     let is_self_closing = children.is_none();
     let opening =
-        oxc_ast::ast::JSXOpeningElement::boxed(SPAN, opening_name, NONE, attributes, &cx.ast);
+        oxc_ast::ast::JSXOpeningElement::boxed(SPAN, opening_name, None, attributes, &cx.ast);
     let closing = if is_self_closing {
         None
     } else {
@@ -3040,7 +3039,7 @@ fn ox_dispatcher_guard_stmt<'a>(
     let call = oxc_ast::ast::Expression::new_call_expression(
         SPAN,
         oxc_ast::ast::Expression::new_identifier(SPAN, guard_name, ast),
-        NONE,
+        None,
         [oxc_ast::ast::Argument::from(ox_number(ast, kind as u8 as f64))],
         false,
         ast,
@@ -3068,7 +3067,7 @@ fn ox_create_hook_guard<'a>(
         [ox_dispatcher_guard_stmt(ast, guard_name, after)],
         ast,
     );
-    oxc_ast::ast::Statement::new_try_statement(SPAN, try_block, NONE, Some(finalizer), ast)
+    oxc_ast::ast::Statement::new_try_statement(SPAN, try_block, None, Some(finalizer), ast)
 }
 
 /// Build a call expression for `CallExpression`/`MethodCall`, matching TS
@@ -3083,7 +3082,7 @@ fn ox_create_call_expression<'a>(
 ) -> oxc::Expression<'a> {
     let ast = &cx.ast;
     let call_expr =
-        oxc_ast::ast::Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ast);
+        oxc_ast::ast::Expression::new_call_expression(SPAN, callee, None, arguments, false, ast);
     // The hook-kind lookup only runs with guards enabled, keeping the default
     // codegen path free of per-call shape probing.
     let Some(guard_name) = cx.env.hook_guard_name.as_deref() else {
@@ -3107,7 +3106,7 @@ fn ox_create_call_expression<'a>(
         SPAN,
         oxc_ast::ast::FormalParameterKind::FormalParameter,
         [],
-        NONE,
+        None,
         ast,
     );
     let iife = oxc_ast::ast::Function::new(
@@ -3117,17 +3116,17 @@ fn ox_create_call_expression<'a>(
         false,
         false,
         false,
-        NONE,
-        NONE,
+        None,
+        None,
         params,
-        NONE,
+        None,
         Some(body),
         ast,
     );
     oxc_ast::ast::Expression::new_call_expression(
         SPAN,
         oxc::Expression::FunctionExpression(oxc_allocator::ArenaBox::new_in(iife, ast)),
-        NONE,
+        None,
         [],
         false,
         ast,

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -92,7 +92,7 @@ use indexmap::IndexMap;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 
 use oxc_allocator::{ArenaBox, ArenaVec, ReplaceWith, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_ast_visit::{VisitJsMut, walk_js_mut::walk_expression};
 use oxc_data_structures::stack::{NonEmptyStack, SparseStack};
 use oxc_semantic::{ReferenceFlags, SymbolId};
@@ -665,7 +665,7 @@ impl<'a> ArrowFunctionConverter<'a> {
             arrow_function_expr.r#async,
             false,
             arrow_function_expr.type_parameters,
-            NONE,
+            None,
             arrow_function_expr.params,
             arrow_function_expr.return_type,
             Some(body),
@@ -797,7 +797,7 @@ impl<'a> ArrowFunctionConverter<'a> {
             arguments.push(Argument::from(assign_value.take_in(ctx)));
         }
         let call =
-            Expression::new_call_expression(expr.span(), callee, NONE, arguments, false, ctx);
+            Expression::new_call_expression(expr.span(), callee, None, arguments, false, ctx);
         Some(call)
     }
 
@@ -838,7 +838,7 @@ impl<'a> ArrowFunctionConverter<'a> {
         let callee =
             MemberExpression::new_static_member_expression(SPAN, object, property, false, ctx);
         let callee = Expression::from(callee);
-        Some(Expression::new_call_expression(call.span, callee, NONE, arguments, false, ctx))
+        Some(Expression::new_call_expression(call.span, callee, None, arguments, false, ctx))
     }
 
     /// Transform an `AssignmentExpression` whose assignment target is a `super` member expression.
@@ -924,8 +924,8 @@ impl<'a> ArrowFunctionConverter<'a> {
                 SPAN,
                 [],
                 param_binding.create_binding_pattern(ctx),
-                NONE,
-                NONE,
+                None,
+                None,
                 false,
                 None,
                 false,
@@ -954,8 +954,8 @@ impl<'a> ArrowFunctionConverter<'a> {
                 SPAN,
                 [],
                 param_binding.create_binding_pattern(ctx),
-                NONE,
-                NONE,
+                None,
+                None,
                 false,
                 None,
                 false,
@@ -981,19 +981,19 @@ impl<'a> ArrowFunctionConverter<'a> {
             SPAN,
             FormalParameterKind::ArrowFormalParameters,
             items,
-            NONE,
+            None,
             ctx,
         );
         let statement = Statement::new_expression_statement(SPAN, init, ctx);
         let body = FunctionBody::boxed(SPAN, [], [statement], ctx);
         let init = Expression::new_arrow_function_expression_with_scope_id_and_pure_and_pife(
-            SPAN, true, false, NONE, params, NONE, body, scope_id, false, false, ctx,
+            SPAN, true, false, None, params, None, body, scope_id, false, false, ctx,
         );
         VariableDeclarator::new(
             SPAN,
             VariableDeclarationKind::Var,
             binding.create_binding_pattern(ctx),
-            NONE,
+            None,
             Some(init),
             false,
             ctx,
@@ -1170,7 +1170,7 @@ impl<'a> ArrowFunctionConverter<'a> {
             SPAN,
             VariableDeclarationKind::Var,
             arguments_var.create_binding_pattern(ctx),
-            NONE,
+            None,
             Some(init),
             false,
             ctx,
@@ -1231,7 +1231,7 @@ impl<'a> ArrowFunctionConverter<'a> {
                 SPAN,
                 VariableDeclarationKind::Var,
                 this_var.create_binding_pattern(ctx),
-                NONE,
+                None,
                 init,
                 false,
                 ctx,

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -71,10 +71,7 @@ use rustc_hash::FxHashMap;
 use serde::Deserialize;
 
 use oxc_allocator::{ArenaBox, ArenaVec};
-use oxc_ast::{
-    ast::{Argument, CallExpression, Expression, IdentifierName},
-    builder::NONE,
-};
+use oxc_ast::ast::{Argument, CallExpression, Expression, IdentifierName};
 use oxc_semantic::{ReferenceFlags, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_str::{Str, static_ident};
@@ -276,7 +273,7 @@ pub fn helper_call<'a>(
 ) -> ArenaBox<'a, CallExpression<'a>> {
     let callee = helper_load(helper, ctx);
     let pure = helper.pure();
-    CallExpression::boxed_with_pure(SPAN, callee, NONE, arguments, false, pure, ctx)
+    CallExpression::boxed_with_pure(SPAN, callee, None, arguments, false, pure, ctx)
 }
 
 /// Same as [`helper_call`], but returns a `CallExpression` wrapped in an `Expression`.
@@ -289,7 +286,7 @@ pub fn helper_call_expr<'a>(
 ) -> Expression<'a> {
     let callee = helper_load(helper, ctx);
     let pure = helper.pure();
-    Expression::new_call_expression_with_pure(SPAN, callee, NONE, arguments, false, pure, ctx)
+    Expression::new_call_expression_with_pure(SPAN, callee, None, arguments, false, pure, ctx)
 }
 
 /// Load a helper function and return a callee expression.

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -33,7 +33,7 @@
 use indexmap::{IndexMap, map::Entry as IndexMapEntry};
 
 use oxc_allocator::ArenaVec;
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_semantic::ReferenceFlags;
 use oxc_span::SPAN;
 use oxc_str::{Str, static_ident};
@@ -164,7 +164,7 @@ impl<'a> ModuleImportsStore<'a> {
             Some(specifiers),
             StringLiteral::new(SPAN, source, None, ctx),
             None,
-            NONE,
+            None,
             ImportOrExportKind::Value,
             ctx,
         )
@@ -191,8 +191,8 @@ impl<'a> ModuleImportsStore<'a> {
         let id = local.create_binding_pattern(ctx);
         let var_kind = VariableDeclarationKind::Var;
         let decl = {
-            let init = Expression::new_call_expression(SPAN, callee, NONE, args, false, ctx);
-            let decl = VariableDeclarator::new(SPAN, var_kind, id, NONE, Some(init), false, ctx);
+            let init = Expression::new_call_expression(SPAN, callee, None, args, false, ctx);
+            let decl = VariableDeclarator::new(SPAN, var_kind, id, None, Some(init), false, ctx);
             [decl]
         };
         Statement::new_variable_declaration(SPAN, var_kind, decl, false, ctx)

--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -15,10 +15,7 @@
 //! ```
 
 use oxc_allocator::ArenaVec;
-use oxc_ast::{
-    ast::*,
-    builder::{AstBuilder, NONE},
-};
+use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_data_structures::stack::SparseStack;
 use oxc_span::SPAN;
 use oxc_traverse::{BoundIdentifier, ast_operations::GatherNodeParts};
@@ -153,7 +150,7 @@ impl<'a> VarDeclarationsStore<'a> {
             SPAN,
             VariableDeclarationKind::Var,
             ident,
-            NONE,
+            None,
             init,
             false,
             ast,
@@ -173,7 +170,7 @@ impl<'a> VarDeclarationsStore<'a> {
             SPAN,
             VariableDeclarationKind::Let,
             ident,
-            NONE,
+            None,
             init,
             false,
             ast,

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -52,7 +52,7 @@ use oxc_allocator::{
     Address, ArenaBox, ArenaVec, CloneIn, GetAddress, GetAllocator, ReplaceWith, TakeIn,
     UnstableAddress,
 };
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_ast_visit::{VisitJs, VisitMut};
 use oxc_data_structures::stack::NonEmptyStack;
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
@@ -413,7 +413,7 @@ impl<'a> LegacyDecorator<'a> {
                 PropertyDefinitionType::PropertyDefinition,
                 [],
                 PropertyKey::new_private_identifier(SPAN, storage_name, ctx),
-                NONE,
+                None,
                 accessor.value.take(),
                 false,
                 is_static,
@@ -499,7 +499,7 @@ impl<'a> LegacyDecorator<'a> {
 
         let (params, body_stmt) = if is_getter {
             let params =
-                FormalParameters::boxed(SPAN, FormalParameterKind::FormalParameter, [], NONE, ctx);
+                FormalParameters::boxed(SPAN, FormalParameterKind::FormalParameter, [], None, ctx);
             let field_expr = Expression::new_private_field_expression(
                 SPAN,
                 create_object(ctx),
@@ -519,8 +519,8 @@ impl<'a> LegacyDecorator<'a> {
                 SPAN,
                 [],
                 value_binding.create_binding_pattern(ctx),
-                NONE,
-                NONE,
+                None,
+                None,
                 false,
                 None,
                 false,
@@ -531,7 +531,7 @@ impl<'a> LegacyDecorator<'a> {
                 SPAN,
                 FormalParameterKind::FormalParameter,
                 [param],
-                NONE,
+                None,
                 ctx,
             );
             let assign = Expression::new_assignment_expression(
@@ -1017,7 +1017,7 @@ impl<'a> LegacyDecorator<'a> {
             SPAN,
             VariableDeclarationKind::Let,
             binding.create_spanned_binding_pattern(binding_span, ctx),
-            NONE,
+            None,
             Some(initializer),
             false,
             ctx,
@@ -1463,7 +1463,7 @@ impl<'a> LegacyDecorator<'a> {
         let exported = ModuleExportName::new_identifier_name(SPAN, class_binding.name, ctx);
         let specifiers = [ExportSpecifier::new(SPAN, local, exported, kind, ctx)];
         let export_class_reference = ModuleDeclaration::new_export_named_declaration(
-            SPAN, None, specifiers, None, kind, NONE, ctx,
+            SPAN, None, specifiers, None, kind, None, ctx,
         );
         Statement::from(export_class_reference)
     }

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -33,7 +33,7 @@
 //! * Exponentiation operator specification: <https://tc39.es/ecma262/#sec-exp-operator>
 
 use oxc_allocator::{ArenaVec, CloneIn, GetAllocator, ReplaceWith, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_semantic::ReferenceFlags;
 use oxc_span::{SPAN, Span};
 use oxc_str::static_ident;
@@ -550,7 +550,7 @@ impl<'a> ExponentiationOperator<'a> {
         let property = IdentifierName::new(SPAN, "pow", ctx);
         let callee = Expression::new_static_member_expression(span, object, property, false, ctx);
         let arguments = ArenaVec::from_array_in([Argument::from(left), Argument::from(right)], ctx);
-        Expression::new_call_expression(span, callee, NONE, arguments, false, ctx)
+        Expression::new_call_expression(span, callee, None, arguments, false, ctx)
     }
 
     /// Create a temporary variable.

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -54,7 +54,7 @@
 use std::{borrow::Cow, mem};
 
 use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, GetAllocator, ReplaceWith, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_ast_visit::VisitJs;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::{GetSpan, SPAN};
@@ -292,7 +292,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             (callee, ArenaVec::new_in(ctx))
         };
 
-        let expression = Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx);
+        let expression = Expression::new_call_expression(SPAN, callee, None, arguments, false, ctx);
         let statement = Statement::new_return_statement(SPAN, Some(expression), ctx);
 
         // Modify the wrapper function
@@ -411,7 +411,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
 
         // Construct the IIFE
         let callee = Expression::FunctionExpression(wrapper_function.take_in_box(ctx));
-        Expression::new_call_expression_with_pure(span, callee, NONE, [], false, true, ctx)
+        Expression::new_call_expression_with_pure(span, callee, None, [], false, true, ctx)
     }
 
     /// Transforms async function declarations into generator functions wrapped in the asyncToGenerator helper.
@@ -604,7 +604,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             );
             // Construct the IIFE
             let callee = Expression::FunctionExpression(wrapper_function);
-            Expression::new_call_expression(arrow_span, callee, NONE, [], false, ctx)
+            Expression::new_call_expression(arrow_span, callee, None, [], false, ctx)
         }
     }
 
@@ -703,10 +703,10 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             false,
             false,
             false,
-            NONE,
-            NONE,
+            None,
+            None,
             params,
-            NONE,
+            None,
             Some(body),
             scope_id,
             ctx,
@@ -753,7 +753,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             false,
             ctx,
         );
-        let argument = Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx);
+        let argument = Expression::new_call_expression(SPAN, callee, None, arguments, false, ctx);
         Statement::new_return_statement(SPAN, Some(argument), ctx)
     }
 
@@ -810,7 +810,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
                 SPAN,
                 VariableDeclarationKind::Var,
                 bound_ident.create_binding_pattern(ctx),
-                NONE,
+                None,
                 Some(init),
                 false,
                 ctx,
@@ -873,13 +873,13 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             ));
         }
 
-        FormalParameters::boxed(SPAN, FormalParameterKind::FormalParameter, parameters, NONE, ctx)
+        FormalParameters::boxed(SPAN, FormalParameterKind::FormalParameter, parameters, None, ctx)
     }
 
     /// Creates an empty [FormalParameters] with [FormalParameterKind::FormalParameter].
     #[inline]
     fn create_empty_params(ctx: &TraverseCtx<'a>) -> ArenaBox<'a, FormalParameters<'a>> {
-        FormalParameters::boxed(SPAN, FormalParameterKind::FormalParameter, [], NONE, ctx)
+        FormalParameters::boxed(SPAN, FormalParameterKind::FormalParameter, [], None, ctx)
     }
 
     /// Creates a [`BoundIdentifier`] for the id of the function.

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -1,7 +1,7 @@
 //! This module is responsible for transforming `for await` to `for` statement
 
 use oxc_allocator::{ArenaVec, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::{SPAN, Span};
 use oxc_str::static_ident;
@@ -230,7 +230,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                 SPAN,
                 VariableDeclarationKind::Var,
                 iterator_abrupt_completion.create_binding_pattern(ctx),
-                NONE,
+                None,
                 Some(Expression::new_boolean_literal(SPAN, false, ctx)),
                 false,
                 ctx,
@@ -245,7 +245,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                 SPAN,
                 VariableDeclarationKind::Var,
                 iterator_had_error_key.create_binding_pattern(ctx),
-                NONE,
+                None,
                 Some(Expression::new_boolean_literal(SPAN, false, ctx)),
                 false,
                 ctx,
@@ -260,7 +260,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                 SPAN,
                 VariableDeclarationKind::Var,
                 iterator_error_key.create_binding_pattern(ctx),
-                NONE,
+                None,
                 None,
                 false,
                 ctx,
@@ -286,7 +286,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                             SPAN,
                             VariableDeclarationKind::Var,
                             iterator_key.create_binding_pattern(ctx),
-                            NONE,
+                            None,
                             Some(iterator),
                             false,
                             ctx,
@@ -295,7 +295,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                             SPAN,
                             VariableDeclarationKind::Var,
                             step_key.create_binding_pattern(ctx),
-                            NONE,
+                            None,
                             None,
                             false,
                             ctx,
@@ -330,7 +330,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                                                 false,
                                                 ctx,
                                             ),
-                                            NONE,
+                                            None,
                                             [],
                                             false,
                                             ctx,
@@ -385,7 +385,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
             );
             Some(CatchClause::boxed_with_scope_id(
                 SPAN,
-                Some(CatchParameter::new(SPAN, err_ident.create_binding_pattern(ctx), NONE, ctx)),
+                Some(CatchParameter::new(SPAN, err_ident.create_binding_pattern(ctx), None, ctx)),
                 {
                     BlockStatement::boxed_with_scope_id(
                         SPAN,
@@ -466,7 +466,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                                             false,
                                             ctx,
                                         ),
-                                        NONE,
+                                        None,
                                         [],
                                         false,
                                         ctx,
@@ -513,7 +513,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                     };
                     BlockStatement::boxed_with_scope_id(SPAN, [if_statement], finally_scope_id, ctx)
                 };
-                Statement::new_try_statement(SPAN, block, NONE, Some(finally), ctx)
+                Statement::new_try_statement(SPAN, block, None, Some(finally), ctx)
             };
 
             let block_statement =

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -32,7 +32,7 @@ use std::{iter, mem};
 use serde::Deserialize;
 
 use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress, GetAllocator, ReplaceWith, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::{BoundNames, ToJsString, WithoutGlobalReferenceInformation};
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
@@ -215,7 +215,7 @@ impl<'a> ObjectRestSpread<'a> {
         let mut new_decls = vec![];
 
         if let Some(id) = reference_builder.binding.take() {
-            new_decls.push(VariableDeclarator::new(SPAN, state.kind, id, NONE, None, false, ctx));
+            new_decls.push(VariableDeclarator::new(SPAN, state.kind, id, None, None, false, ctx));
         }
 
         let data = Self::walk_assignment_target(&mut assign_expr.left, &mut new_decls, state, ctx);
@@ -457,7 +457,7 @@ impl<'a> ObjectRestSpread<'a> {
                 let bound_identifier = ctx.generate_uid_in_current_hoist_scope("ref");
                 let id = bound_identifier.create_binding_pattern(ctx);
                 let kind = VariableDeclarationKind::Var;
-                decls.push(VariableDeclarator::new(SPAN, kind, id, NONE, None, false, ctx));
+                decls.push(VariableDeclarator::new(SPAN, kind, id, None, None, false, ctx));
                 exprs.push(Expression::new_assignment_expression(
                     SPAN,
                     AssignmentOperator::Assign,
@@ -691,7 +691,7 @@ impl<'a> ObjectRestSpread<'a> {
         let id = bound_identifier.create_binding_pattern(ctx);
         let kind = VariableDeclarationKind::Var;
         let declarations = ArenaVec::from_value_in(
-            VariableDeclarator::new(SPAN, kind, id, NONE, None, false, ctx),
+            VariableDeclarator::new(SPAN, kind, id, None, None, false, ctx),
             ctx,
         );
         let decl = VariableDeclaration::boxed(SPAN, kind, declarations, false, ctx);
@@ -815,7 +815,7 @@ impl<'a> ObjectRestSpread<'a> {
         });
         let init = bound_identifier.create_read_expression(ctx);
         let declarations = ArenaVec::from_value_in(
-            VariableDeclarator::new(SPAN, kind, id, NONE, Some(init), false, ctx),
+            VariableDeclarator::new(SPAN, kind, id, None, Some(init), false, ctx),
             ctx,
         );
         VariableDeclaration::boxed(SPAN, kind, declarations, false, ctx)
@@ -881,7 +881,7 @@ impl<'a> ObjectRestSpread<'a> {
                 SPAN,
                 state.kind,
                 id,
-                NONE,
+                None,
                 Some(reference_builder.create_read_expression(ctx)),
                 false,
                 ctx,
@@ -939,7 +939,7 @@ impl<'a> ObjectRestSpread<'a> {
                         lhs.span(),
                         decl.kind,
                         lhs,
-                        NONE,
+                        None,
                         Some(rhs),
                         false,
                         ctx,
@@ -957,13 +957,13 @@ impl<'a> ObjectRestSpread<'a> {
 
         // Insert the original declarator by copying its data out.
         if !remove_empty_object_pattern {
-            let mut binding_pattern = BindingPattern::new_object_pattern(decl.span, [], NONE, ctx);
+            let mut binding_pattern = BindingPattern::new_object_pattern(decl.span, [], None, ctx);
             mem::swap(&mut binding_pattern, &mut decl.id);
             let decl = VariableDeclarator::new(
                 decl.span,
                 decl.kind,
                 binding_pattern,
-                NONE,
+                None,
                 Some(reference_builder.create_read_expression(ctx)),
                 false,
                 ctx,
@@ -1006,7 +1006,7 @@ impl<'a> ObjectRestSpread<'a> {
 
                     let init = bound_identifier.create_read_expression(ctx);
                     let mut decl =
-                        VariableDeclarator::new(SPAN, state.kind, id, NONE, Some(init), false, ctx);
+                        VariableDeclarator::new(SPAN, state.kind, id, None, Some(init), false, ctx);
                     let mut decls = self
                         .transform_variable_declarator(&mut decl, ctx)
                         .into_iter()
@@ -1078,7 +1078,7 @@ impl<'a> ObjectRestSpread<'a> {
                     SPAN,
                     state.kind,
                     p,
-                    NONE,
+                    None,
                     Some(lhs),
                     false,
                     ctx,
@@ -1181,7 +1181,7 @@ impl<'a> SpreadPair<'a> {
                     SPAN,
                     kind,
                     bound_identifier.create_binding_pattern(ctx),
-                    NONE,
+                    None,
                     Some(key_expression),
                     false,
                     ctx,
@@ -1203,7 +1203,7 @@ impl<'a> SpreadPair<'a> {
                     Argument::from(helper_load(Helper::ToPropertyKey, ctx)),
                     ctx,
                 );
-                Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx)
+                Expression::new_call_expression(SPAN, callee, None, arguments, false, ctx)
             } else {
                 key_expression
             };

--- a/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
+++ b/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
@@ -33,7 +33,7 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-optional-catch-binding>
 //! * Optional catch binding TC39 proposal: <https://github.com/tc39/proposal-optional-catch-binding>
 
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_semantic::SymbolFlags;
 use oxc_span::SPAN;
 use oxc_traverse::Traverse;
@@ -61,7 +61,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for OptionalCatchBinding {
             SymbolFlags::CatchVariable | SymbolFlags::FunctionScopedVariable,
         );
         let binding_pattern = binding.create_binding_pattern(ctx);
-        let param = CatchParameter::new(SPAN, binding_pattern, NONE, ctx);
+        let param = CatchParameter::new(SPAN, binding_pattern, None, ctx);
         clause.param = Some(param);
     }
 }

--- a/crates/oxc_transformer/src/es2020/export_namespace_from.rs
+++ b/crates/oxc_transformer/src/es2020/export_namespace_from.rs
@@ -26,7 +26,7 @@
 //! * "export ns from" TC39 proposal: <https://github.com/tc39/proposal-export-ns-from>
 
 use oxc_allocator::{ArenaVec, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_semantic::SymbolFlags;
 use oxc_span::SPAN;
 use oxc_traverse::Traverse;
@@ -83,7 +83,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExportNamespaceFrom {
                         Some(ArenaVec::from_value_in(import_specifier, ctx)),
                         source,
                         None,
-                        NONE,
+                        None,
                         export_kind,
                         ctx,
                     );
@@ -101,7 +101,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExportNamespaceFrom {
                         [export_specifier],
                         None,
                         export_kind,
-                        NONE,
+                        None,
                         ctx,
                     );
                     new_statements.push(Statement::ExportNamedDeclaration(export_named_decl));

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -29,7 +29,7 @@
 //! * Nullish coalescing TC39 proposal: <https://github.com/tc39-transfer/proposal-nullish-coalescing>
 
 use oxc_allocator::{ArenaBox, ReplaceWith};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_semantic::{ScopeFlags, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, LogicalOperator};
@@ -146,12 +146,12 @@ impl<'a> NullishCoalescingOperator {
             // so the temporary variable can be injected in correct scope
             let id = binding.create_binding_pattern(ctx);
             let param =
-                FormalParameter::new(SPAN, [], id, NONE, NONE, false, None, false, false, ctx);
+                FormalParameter::new(SPAN, [], id, None, None, false, None, false, false, ctx);
             let params = FormalParameters::boxed(
                 SPAN,
                 FormalParameterKind::ArrowFormalParameters,
                 [param],
-                NONE,
+                None,
                 ctx,
             );
             let body = FunctionBody::boxed(
@@ -165,9 +165,9 @@ impl<'a> NullishCoalescingOperator {
                     SPAN,
                     true,
                     false,
-                    NONE,
+                    None,
                     params,
-                    NONE,
+                    None,
                     body,
                     current_scope_id,
                     false,
@@ -175,7 +175,7 @@ impl<'a> NullishCoalescingOperator {
                     ctx,
                 );
             // `(x) => x;` -> `((x) => x)();`
-            new_expr = Expression::new_call_expression(SPAN, arrow_function, NONE, [], false, ctx);
+            new_expr = Expression::new_call_expression(SPAN, arrow_function, None, [], false, ctx);
         } else {
             ctx.state.var_declarations.insert_var(&binding, &ctx.ast);
         }

--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -50,7 +50,7 @@
 use std::mem;
 
 use oxc_allocator::{CloneIn, GetAllocator, ReplaceWith, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_span::{GetSpan, SPAN, Span};
 use oxc_traverse::{Ancestor, BoundIdentifier, MaybeBoundIdentifier, Traverse};
 
@@ -403,7 +403,7 @@ impl<'a> OptionalChaining<'a> {
         let callee =
             MemberExpression::new_static_member_expression(SPAN, expr, property, false, ctx);
         let callee = Expression::from(callee);
-        Expression::new_call_expression(SPAN, callee, NONE, [context], false, ctx)
+        Expression::new_call_expression(SPAN, callee, None, [context], false, ctx)
     }
 
     /// Recursively transform chain expression elements

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -2,7 +2,7 @@
 //! Transform of class itself.
 
 use oxc_allocator::{Address, ArenaVec, GetAddress, TakeIn, UnstableAddress};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_span::SPAN;
 use oxc_str::{Ident, static_ident};
 use oxc_syntax::{
@@ -901,7 +901,7 @@ fn create_new_weakmap<'a>(
     let symbol_id = *symbol_id
         .get_or_insert_with(|| ctx.scoping().find_binding(ctx.current_scope_id(), weak_map));
     let ident = ctx.create_ident_expr(SPAN, weak_map, symbol_id, ReferenceFlags::Read);
-    Expression::new_new_expression_with_pure(SPAN, ident, NONE, [], true, ctx)
+    Expression::new_new_expression_with_pure(SPAN, ident, None, [], true, ctx)
 }
 
 /// Create `new WeakSet()` expression.
@@ -909,5 +909,5 @@ fn create_new_weakset<'a>(ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
     let weak_set = static_ident!("WeakSet");
     let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), weak_set);
     let ident = ctx.create_ident_expr(SPAN, weak_set, symbol_id, ReferenceFlags::Read);
-    Expression::new_new_expression_with_pure(SPAN, ident, NONE, [], true, ctx)
+    Expression::new_new_expression_with_pure(SPAN, ident, None, [], true, ctx)
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -104,7 +104,7 @@ use std::iter;
 use oxc_allocator::{ArenaVec, ReplaceWith};
 use rustc_hash::FxHashMap;
 
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_ast_visit::{VisitJsMut, VisitMut, walk_js_mut};
 use oxc_span::SPAN;
 use oxc_str::Ident;
@@ -237,7 +237,7 @@ impl<'a> ClassProperties<'a> {
                 ctx.generate_uid("args", constructor_scope_id, SymbolFlags::FunctionScopedVariable);
             let rest_element =
                 BindingRestElement::new(SPAN, args_binding.create_binding_pattern(ctx), ctx);
-            params_rest = Some(FormalParameterRest::boxed(SPAN, [], rest_element, NONE, ctx));
+            params_rest = Some(FormalParameterRest::boxed(SPAN, [], rest_element, None, ctx));
             stmts.push(Statement::new_expression_statement(
                 SPAN,
                 create_super_call(&args_binding, ctx),
@@ -320,11 +320,11 @@ impl<'a> ClassProperties<'a> {
             SPAN,
             true,
             false,
-            NONE,
+            None,
             {
                 let rest_element =
                     BindingRestElement::new(SPAN, args_binding.create_binding_pattern(ctx), ctx);
-                let rest = FormalParameterRest::boxed(SPAN, [], rest_element, NONE, ctx);
+                let rest = FormalParameterRest::boxed(SPAN, [], rest_element, None, ctx);
                 FormalParameters::boxed(
                     SPAN,
                     FormalParameterKind::ArrowFormalParameters,
@@ -333,7 +333,7 @@ impl<'a> ClassProperties<'a> {
                     ctx,
                 )
             },
-            NONE,
+            None,
             FunctionBody::boxed(SPAN, [], body, ctx),
             super_func_scope_id,
             false,
@@ -349,7 +349,7 @@ impl<'a> ClassProperties<'a> {
                 SPAN,
                 VariableDeclarationKind::Var,
                 super_binding.create_binding_pattern(ctx),
-                NONE,
+                None,
                 Some(super_func),
                 false,
                 ctx,
@@ -399,10 +399,10 @@ impl<'a> ClassProperties<'a> {
             false,
             false,
             false,
-            NONE,
-            NONE,
-            FormalParameters::boxed(SPAN, FormalParameterKind::FormalParameter, [], NONE, ctx),
-            NONE,
+            None,
+            None,
+            FormalParameters::boxed(SPAN, FormalParameterKind::FormalParameter, [], None, ctx),
+            None,
             Some(FunctionBody::boxed(SPAN, directives, body_stmts, ctx)),
             super_func_scope_id,
             false,
@@ -601,7 +601,7 @@ impl<'a> ConstructorParamsSuperReplacer<'a, '_> {
                     false,
                     ctx,
                 ),
-                NONE,
+                None,
                 [Argument::from(super_call)],
                 false,
                 ctx,

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -4,7 +4,7 @@
 use std::mem;
 
 use oxc_allocator::{ArenaBox, ArenaVec, ReplaceWith, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_span::SPAN;
 use oxc_str::static_ident;
 use oxc_syntax::{reference::ReferenceId, symbol::SymbolId};
@@ -1830,7 +1830,7 @@ impl<'a> ClassProperties<'a> {
             ctx,
         );
         let arguments = ArenaVec::from_value_in(Argument::from(context), ctx);
-        Expression::new_call_expression(field_expr.span, callee, NONE, arguments, false, ctx)
+        Expression::new_call_expression(field_expr.span, callee, None, arguments, false, ctx)
     }
 
     /// Transform private field in assignment pattern.
@@ -1929,7 +1929,7 @@ impl<'a> ClassProperties<'a> {
         };
         let callee = create_member_callee(callee, static_ident!("has"), span, ctx);
         let argument = Argument::from(self.create_check_in_rhs(right, ctx));
-        Expression::new_call_expression(span, callee, NONE, [argument], false, ctx)
+        Expression::new_call_expression(span, callee, None, [argument], false, ctx)
     }
 
     /// Duplicate object to be used in get/set pair.
@@ -2215,7 +2215,7 @@ impl<'a> ClassProperties<'a> {
                 ArenaVec::from_array_in([Argument::from(object), Argument::from(value)], ctx);
             let callee = create_member_callee(prop_ident, static_ident!("call"), span, ctx);
             // `_prop.call(_assertClassBrand(Class, object), value)`
-            Expression::new_call_expression(span, callee, NONE, arguments, false, ctx)
+            Expression::new_call_expression(span, callee, None, arguments, false, ctx)
         } else {
             // `_privateFieldSet(_prop, object, value)`
             self.create_private_field_set(prop_ident, object, value, ctx)

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -2,7 +2,7 @@
 //! Transform of class property declarations (instance or static properties).
 
 use oxc_allocator::{ArenaBox, ArenaVec};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_span::{SPAN, Span};
 use oxc_str::static_ident;
 use oxc_syntax::reference::ReferenceFlags;
@@ -404,6 +404,6 @@ impl<'a> ClassProperties<'a> {
             ],
             ctx,
         );
-        Expression::new_call_expression(span, callee, NONE, arguments, false, ctx)
+        Expression::new_call_expression(span, callee, None, arguments, false, ctx)
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -3,7 +3,7 @@
 
 use std::path::Path;
 
-use oxc_ast::{ast::*, builder::AstBuilder, builder::NONE};
+use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_span::SPAN;
 use oxc_traverse::BoundIdentifier;
 
@@ -20,7 +20,7 @@ pub(super) fn create_variable_declaration<'a>(
         SPAN,
         kind,
         binding.create_binding_pattern(ctx),
-        NONE,
+        None,
         Some(init),
         false,
         ctx,

--- a/crates/oxc_transformer/src/es2022/class_static_block.rs
+++ b/crates/oxc_transformer/src/es2022/class_static_block.rs
@@ -42,7 +42,7 @@
 use itoa::Buffer as ItoaBuffer;
 
 use oxc_allocator::TakeIn;
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_span::SPAN;
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
 use oxc_traverse::Traverse;
@@ -119,7 +119,7 @@ impl ClassStaticBlock {
             PropertyDefinitionType::PropertyDefinition,
             [],
             key,
-            NONE,
+            None,
             Some(expr),
             false,
             true,

--- a/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
@@ -38,7 +38,7 @@ use std::mem;
 use rustc_hash::FxHashMap;
 
 use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress, ReplaceWith, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{NodeId, ScopeFlags, ScopeId, SymbolFlags, SymbolId};
 use oxc_span::{SPAN, Span};
@@ -109,7 +109,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                 SPAN,
                 variable_decl_kind,
                 binding_pattern,
-                NONE,
+                None,
                 Some(temp_id.create_read_expression(ctx)),
                 false,
                 ctx,
@@ -434,7 +434,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                                     span,
                                     VariableDeclarationKind::Var,
                                     var_id.create_spanned_binding_pattern(span, ctx),
-                                    NONE,
+                                    None,
                                     Some(expr),
                                     false,
                                     ctx,
@@ -457,7 +457,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                                 )],
                                 None,
                                 ImportOrExportKind::Value,
-                                NONE,
+                                None,
                                 ctx,
                             ));
                         }
@@ -557,7 +557,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                                 export_specifiers,
                                 None,
                                 export_kind,
-                                NONE,
+                                None,
                                 ctx,
                             ));
                         }
@@ -725,7 +725,7 @@ impl<'a> ExplicitResourceManagement<'a> {
                                 false,
                                 ctx,
                             ),
-                            NONE,
+                            None,
                             [Argument::from(old_init)],
                             false,
                             ctx,
@@ -754,11 +754,11 @@ impl<'a> ExplicitResourceManagement<'a> {
                                 SPAN,
                                 VariableDeclarationKind::Var,
                                 using_ctx.create_binding_pattern(ctx),
-                                NONE,
+                                None,
                                 Some(Expression::new_call_expression(
                                     SPAN,
                                     callee,
-                                    NONE,
+                                    None,
                                     [],
                                     false,
                                     ctx,
@@ -867,7 +867,7 @@ impl<'a> ExplicitResourceManagement<'a> {
                             false,
                             ctx,
                         ),
-                        NONE,
+                        None,
                         [Argument::from(old_init)],
                         false,
                         ctx,
@@ -889,8 +889,8 @@ impl<'a> ExplicitResourceManagement<'a> {
                 SPAN,
                 VariableDeclarationKind::Var,
                 using_ctx.create_binding_pattern(ctx),
-                NONE,
-                Some(Expression::new_call_expression(SPAN, callee, NONE, [], false, ctx)),
+                None,
+                Some(Expression::new_call_expression(SPAN, callee, None, [], false, ctx)),
                 false,
                 ctx,
             )],
@@ -936,7 +936,7 @@ impl<'a> ExplicitResourceManagement<'a> {
         );
 
         let catch_parameter =
-            CatchParameter::new(SPAN, ident.create_binding_pattern(ctx), NONE, ctx);
+            CatchParameter::new(SPAN, ident.create_binding_pattern(ctx), None, ctx);
 
         // `_usingCtx.e = _;`
         let stmt = Statement::new_expression_statement(
@@ -986,7 +986,7 @@ impl<'a> ExplicitResourceManagement<'a> {
                 false,
                 ctx,
             ),
-            NONE,
+            None,
             [],
             false,
             ctx,
@@ -1020,7 +1020,7 @@ impl<'a> ExplicitResourceManagement<'a> {
                 SPAN,
                 VariableDeclarationKind::Var,
                 binding.create_spanned_binding_pattern(original_span, ctx),
-                NONE,
+                None,
                 Some(class_expr),
                 false,
                 ctx,

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -89,10 +89,7 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-helper-builder-react-jsx>
 
 use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, GetAllocator, ReplaceWith};
-use oxc_ast::{
-    ast::*,
-    builder::{AstBuilder, NONE},
-};
+use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_ecmascript::PropName;
 use oxc_span::{SPAN, Span};
 use oxc_str::{Ident, Str};
@@ -808,7 +805,7 @@ impl<'a> JsxImpl<'a> {
 
         let callee = self.get_create_element(has_key_after_props_spread, need_jsxs, ctx);
         Expression::new_call_expression_with_pure(
-            span, callee, NONE, arguments, false, self.pure, ctx,
+            span, callee, None, arguments, false, self.pure, ctx,
         )
     }
 

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -33,7 +33,7 @@
 //!
 //! * Babel plugin implementation: <https://github.com/babel/babel/blob/v7.26.2/packages/babel-plugin-transform-react-jsx-source/src/index.ts>
 
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_data_structures::rope::{Rope, get_line_column};
 use oxc_span::SPAN;
 use oxc_syntax::{number::NumberBase, symbol::SymbolFlags};
@@ -199,7 +199,7 @@ impl<'a> JsxSource<'a> {
             SPAN,
             VariableDeclarationKind::Var,
             id,
-            NONE,
+            None,
             Some(init),
             false,
             ctx,

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -11,11 +11,7 @@ use oxc_allocator::{
     ArenaStringBuilder, ArenaVec, CloneIn, GetAddress, GetAllocator, ReplaceWith, TakeIn,
     UnstableAddress,
 };
-use oxc_ast::{
-    ast::*,
-    builder::{AstBuilder, NONE},
-    match_expression,
-};
+use oxc_ast::{ast::*, builder::AstBuilder, match_expression};
 use oxc_ast_visit::{
     VisitJs,
     walk_js::{walk_call_expression, walk_declaration},
@@ -182,7 +178,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
                 SPAN,
                 VariableDeclarationKind::Var,
                 binding.create_binding_pattern(ctx),
-                NONE,
+                None,
                 None,
                 false,
                 ctx,
@@ -195,7 +191,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
             ];
             Statement::new_expression_statement(
                 SPAN,
-                Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx),
+                Expression::new_call_expression(SPAN, callee, None, arguments, false, ctx),
                 ctx,
             )
         });
@@ -243,7 +239,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
 
         let binding = BoundIdentifier::from_binding_ident(&binding_identifier);
         let callee = binding.create_read_expression(ctx);
-        let expr = Expression::new_call_expression(func.span, callee, NONE, arguments, false, ctx);
+        let expr = Expression::new_call_expression(func.span, callee, None, arguments, false, ctx);
         let statement = Statement::new_expression_statement(func.span, expr, ctx);
 
         // Get the address of the statement containing this `FunctionDeclaration`
@@ -459,7 +455,7 @@ impl<'a> ReactRefresh<'a> {
             Expression::new_call_expression(
                 span,
                 binding.create_read_expression(ctx),
-                NONE,
+                None,
                 arguments,
                 false,
                 ctx,
@@ -653,7 +649,7 @@ impl<'a> ReactRefresh<'a> {
         if !custom_hooks_in_scope.is_empty() {
             // function () { return custom_hooks_in_scope }
             let formal_parameters =
-                FormalParameters::boxed(SPAN, FormalParameterKind::FormalParameter, [], NONE, ctx);
+                FormalParameters::boxed(SPAN, FormalParameterKind::FormalParameter, [], None, ctx);
             let function_body = FunctionBody::boxed(
                 SPAN,
                 [],
@@ -672,10 +668,10 @@ impl<'a> ReactRefresh<'a> {
                 false,
                 false,
                 false,
-                NONE,
-                NONE,
+                None,
+                None,
                 formal_parameters,
-                NONE,
+                None,
                 Some(function_body),
                 scope_id,
                 false,
@@ -689,7 +685,7 @@ impl<'a> ReactRefresh<'a> {
         let init = Expression::new_call_expression(
             SPAN,
             self.refresh_sig.to_expression(ctx),
-            NONE,
+            None,
             [],
             false,
             ctx,
@@ -702,7 +698,7 @@ impl<'a> ReactRefresh<'a> {
             Expression::new_call_expression(
                 SPAN,
                 binding.create_read_expression(ctx),
-                NONE,
+                None,
                 [],
                 false,
                 ctx,
@@ -896,7 +892,7 @@ impl<'a> ReactRefresh<'a> {
             Expression::new_call_expression(
                 SPAN,
                 binding.create_read_expression(ctx),
-                NONE,
+                None,
                 arguments,
                 false,
                 ctx,

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -64,10 +64,7 @@ use rustc_hash::FxHasher;
 use serde::Deserialize;
 
 use oxc_allocator::{ArenaVec, ReplaceWith, TakeIn};
-use oxc_ast::{
-    ast::*,
-    builder::{AstBuilder, NONE},
-};
+use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_data_structures::{inline_string::InlineString, slice_iter::SliceIter};
 use oxc_semantic::SymbolId;
 use oxc_span::SPAN;
@@ -464,7 +461,7 @@ impl<'a> StyledComponents<'a> {
                 let property = IdentifierName::new(SPAN, "withConfig", ctx);
                 let callee =
                     Expression::new_static_member_expression(SPAN, object, property, false, ctx);
-                Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx)
+                Expression::new_call_expression(SPAN, callee, None, arguments, false, ctx)
             });
         } else {
             return false;

--- a/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
+++ b/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
@@ -41,7 +41,7 @@
 use std::iter;
 
 use oxc_allocator::{ArenaVec, ReplaceWith};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_semantic::SymbolFlags;
 use oxc_span::SPAN;
 use oxc_traverse::{BoundIdentifier, Traverse};
@@ -233,7 +233,7 @@ impl<'a> TaggedTemplateTransform {
             SPAN,
             VariableDeclarationKind::Var,
             binding.create_binding_pattern(ctx),
-            NONE,
+            None,
             None,
             false,
             ctx,

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -45,7 +45,7 @@
 //! (actually these would be improvements on ESBuild, not Babel)
 
 use oxc_allocator::GetAllocator;
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_regular_expression::{
     RegexUnsupportedPatterns, has_unsupported_regular_expression_pattern,
 };
@@ -176,6 +176,6 @@ impl<'a> RegExp {
             ),
         ];
 
-        *expr = Expression::new_new_expression(regexp.span, callee, NONE, arguments, ctx);
+        *expr = Expression::new_new_expression(regexp.span, callee, None, arguments, ctx);
     }
 }

--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashSet;
 
 use oxc_allocator::{ArenaVec, ReplaceWith, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_semantic::{ScopeFlags, ScopeId};
 use oxc_span::SPAN;
 use oxc_str::Ident;
@@ -352,7 +352,7 @@ impl<'a> TypeScript<'a> {
             PropertyDefinitionType::PropertyDefinition,
             [],
             key,
-            NONE,
+            None,
             None,
             false,
             false,

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -1,7 +1,7 @@
 use std::cell::Cell;
 
 use oxc_allocator::{ArenaVec, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_ast_visit::{VisitJsMut, walk_js_mut};
 use oxc_data_structures::stack::NonEmptyStack;
 use oxc_semantic::{ScopeFlags, ScopeId};
@@ -187,12 +187,12 @@ impl<'a> TypeScriptEnum {
         let id = param_binding.create_binding_pattern(ctx);
 
         // ((Foo) => {
-        let param = FormalParameter::new(SPAN, [], id, NONE, NONE, false, None, false, false, ctx);
+        let param = FormalParameter::new(SPAN, [], id, None, None, false, None, false, false, ctx);
         let params = FormalParameters::boxed(
             SPAN,
             FormalParameterKind::ArrowFormalParameters,
             [param],
-            NONE,
+            None,
             ctx,
         );
 
@@ -218,10 +218,10 @@ impl<'a> TypeScriptEnum {
             false,
             false,
             false,
-            NONE,
-            NONE,
+            None,
+            None,
             params,
-            NONE,
+            None,
             Some(body),
             func_scope_id,
             false,
@@ -257,7 +257,7 @@ impl<'a> TypeScriptEnum {
         let call_expression = Expression::new_call_expression_with_pure(
             span,
             callee,
-            NONE,
+            None,
             arguments,
             false,
             !has_potential_side_effect,
@@ -299,7 +299,7 @@ impl<'a> TypeScriptEnum {
                 span,
                 kind,
                 binding,
-                NONE,
+                None,
                 Some(call_expression),
                 false,
                 ctx,

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{ArenaBox, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_semantic::{Reference, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_str::static_ident;
@@ -173,11 +173,11 @@ impl<'a> TypeScriptModule {
                 let argument = Argument::StringLiteral(str_lit);
                 (
                     VariableDeclarationKind::Const,
-                    Expression::new_call_expression(SPAN, callee, NONE, [argument], false, ctx),
+                    Expression::new_call_expression(SPAN, callee, None, [argument], false, ctx),
                 )
             }
         };
-        let decl = VariableDeclarator::new(SPAN, kind, binding, NONE, Some(init), false, ctx);
+        let decl = VariableDeclarator::new(SPAN, kind, binding, None, Some(init), false, ctx);
 
         Some(Declaration::new_variable_declaration(SPAN, kind, [decl], false, ctx))
     }

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{ArenaBox, ArenaVec, ReplaceWith, TakeIn};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_ecmascript::BoundNames;
 use oxc_span::{SPAN, Span};
 use oxc_syntax::{
@@ -328,7 +328,7 @@ impl<'a> TypeScriptNamespace {
         let kind = VariableDeclarationKind::Let;
         let decl = {
             let pattern = binding.create_spanned_binding_pattern(binding_span, ctx);
-            VariableDeclarator::new(span, kind, pattern, NONE, None, false, ctx)
+            VariableDeclarator::new(span, kind, pattern, None, None, false, ctx)
         };
         Declaration::new_variable_declaration(span, kind, [decl], false, ctx)
     }
@@ -353,7 +353,7 @@ impl<'a> TypeScriptNamespace {
                     SPAN,
                     FormalParameterKind::FormalParameter,
                     [item],
-                    NONE,
+                    None,
                     ctx,
                 )
             };
@@ -440,7 +440,7 @@ impl<'a> TypeScriptNamespace {
             )
         };
 
-        let expr = Expression::new_call_expression(span, callee, NONE, [argument], false, ctx);
+        let expr = Expression::new_call_expression(span, callee, None, [argument], false, ctx);
         Statement::new_expression_statement(span, expr, ctx)
     }
 

--- a/crates/oxc_transformer/src/utils/ast_builder.rs
+++ b/crates/oxc_transformer/src/utils/ast_builder.rs
@@ -1,7 +1,7 @@
 use std::iter;
 
 use oxc_allocator::{ArenaBox, ArenaVec};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::{GetSpan, SPAN};
 use oxc_str::{Ident, static_ident};
@@ -29,7 +29,7 @@ pub fn create_bind_call<'a>(
 ) -> Expression<'a> {
     let callee = create_member_callee(callee, static_ident!("bind"), span, ctx);
     let this = Argument::from(this);
-    Expression::new_call_expression(span, callee, NONE, [this], false, ctx)
+    Expression::new_call_expression(span, callee, None, [this], false, ctx)
 }
 
 /// `object` -> `object.call(...arguments)`.
@@ -41,7 +41,7 @@ pub fn create_call_call<'a>(
 ) -> Expression<'a> {
     let callee = create_member_callee(callee, static_ident!("call"), span, ctx);
     let this = Argument::from(this);
-    Expression::new_call_expression(span, callee, NONE, [this], false, ctx)
+    Expression::new_call_expression(span, callee, None, [this], false, ctx)
 }
 
 /// Wrap an `Expression` in an arrow function IIFE (immediately invoked function expression)
@@ -70,12 +70,12 @@ pub fn wrap_statements_in_arrow_function_iife<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let kind = FormalParameterKind::ArrowFormalParameters;
-    let params = FormalParameters::boxed(SPAN, kind, [], NONE, ctx);
+    let params = FormalParameters::boxed(SPAN, kind, [], None, ctx);
     let body = FunctionBody::boxed(SPAN, [], stmts, ctx);
     let arrow = Expression::new_arrow_function_expression_with_scope_id_and_pure_and_pife(
-        SPAN, false, false, NONE, params, NONE, body, scope_id, false, false, ctx,
+        SPAN, false, false, None, params, None, body, scope_id, false, false, ctx,
     );
-    Expression::new_call_expression(span, arrow, NONE, [], false, ctx)
+    Expression::new_call_expression(span, arrow, None, [], false, ctx)
 }
 
 /// `object` -> `object.prototype`.
@@ -147,7 +147,7 @@ pub fn create_super_call<'a>(
     Expression::new_call_expression(
         SPAN,
         Expression::new_super(SPAN, ctx),
-        NONE,
+        None,
         [Argument::new_spread_element(SPAN, args_binding.create_read_expression(ctx), ctx)],
         false,
         ctx,
@@ -172,7 +172,7 @@ pub fn create_class_constructor<'a, 'c>(
         let args_binding = ctx.generate_uid("args", scope_id, SymbolFlags::FunctionScopedVariable);
         let rest_element =
             BindingRestElement::new(SPAN, args_binding.create_binding_pattern(ctx), ctx);
-        params_rest = Some(FormalParameterRest::boxed(SPAN, [], rest_element, NONE, ctx));
+        params_rest = Some(FormalParameterRest::boxed(SPAN, [], rest_element, None, ctx));
         ArenaVec::from_iter_in(
             iter::once(Statement::new_expression_statement(
                 SPAN,
@@ -238,8 +238,8 @@ pub fn create_class_method<'a>(
             false,
             false,
             false,
-            NONE,
-            NONE,
+            None,
+            None,
             params,
             return_type,
             Some(FunctionBody::boxed(SPAN, [], stmts, ctx)),

--- a/crates/oxc_transformer_plugins/src/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/src/inject_global_variables.rs
@@ -5,7 +5,7 @@ use cow_utils::CowUtils;
 use oxc_allocator::{Allocator, ArenaVec, GetAllocator};
 use oxc_ast::{
     ast::*,
-    builder::{AstBuilder, GetAstBuilder, NONE},
+    builder::{AstBuilder, GetAstBuilder},
 };
 use oxc_semantic::Scoping;
 use oxc_span::SPAN;
@@ -221,7 +221,7 @@ impl<'a> InjectGlobalVariables<'a> {
                 StringLiteral::new(SPAN, Str::from_str_in(&inject.source, self), None, self);
             let kind = ImportOrExportKind::Value;
             let import_decl = ModuleDeclaration::new_import_declaration(
-                SPAN, specifiers, source, None, NONE, kind, self,
+                SPAN, specifiers, source, None, None, kind, self,
             );
             Statement::from(import_decl)
         });

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -51,7 +51,7 @@ use itoa::Buffer as ItoaBuffer;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator, ReplaceWith};
-use oxc_ast::{ast::*, builder::NONE};
+use oxc_ast::ast::*;
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, Scoping, SymbolFlags, SymbolId};
 use oxc_span::SPAN;
@@ -264,7 +264,7 @@ impl<'a> ModuleRunnerTransform<'a> {
             let arguments = options.into_iter().map(Argument::from);
             let arguments =
                 ArenaVec::from_iter_in(iter::once(Argument::from(source)).chain(arguments), ctx);
-            Expression::new_call_expression(span, callee, NONE, arguments, false, ctx)
+            Expression::new_call_expression(span, callee, None, arguments, false, ctx)
         });
     }
 
@@ -522,7 +522,7 @@ impl<'a> ModuleRunnerTransform<'a> {
                 Expression::new_identifier(SPAN, static_ident!("__vite_ssr_exportAll__"), ctx);
             let ident = Argument::from(ident);
             // `export * from 'vue'` -> `__vite_ssr_exportAll__(__vite_ssr_import_0__);`
-            let call = Expression::new_call_expression(SPAN, callee, NONE, [ident], false, ctx);
+            let call = Expression::new_call_expression(SPAN, callee, None, [ident], false, ctx);
             let export = Statement::new_expression_statement(span, call, ctx);
             // names from `export *` cannot be known, so add it right after the import.
             hoist_imports.extend([import, export]);
@@ -725,11 +725,11 @@ impl<'a> ModuleRunnerTransform<'a> {
             static_ident!("__vite_ssr_import__"),
             ReferenceFlags::Read,
         );
-        let call = Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx);
+        let call = Expression::new_call_expression(SPAN, callee, None, arguments, false, ctx);
         let init = Expression::new_await_expression(SPAN, call, ctx);
 
         let kind = VariableDeclarationKind::Const;
-        let declarator = VariableDeclarator::new(SPAN, kind, pattern, NONE, Some(init), false, ctx);
+        let declarator = VariableDeclarator::new(SPAN, kind, pattern, None, Some(init), false, ctx);
         let declaration =
             Declaration::new_variable_declaration(span, kind, [declarator], false, ctx);
         Statement::from(declaration)
@@ -743,7 +743,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         let object =
             ctx.create_unbound_ident_expr(SPAN, static_ident!("Object"), ReferenceFlags::Read);
         let member = create_member_callee(object, static_ident!("defineProperty"), ctx);
-        Expression::new_call_expression(SPAN, member, NONE, arguments, false, ctx)
+        Expression::new_call_expression(SPAN, member, None, arguments, false, ctx)
     }
 
     // `key: value` or `key() {}`
@@ -771,7 +771,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let kind = FormalParameterKind::FormalParameter;
-        let params = FormalParameters::boxed(SPAN, kind, [], NONE, ctx);
+        let params = FormalParameters::boxed(SPAN, kind, [], None, ctx);
         let statement = Statement::new_return_statement(SPAN, Some(expr), ctx);
         let body = FunctionBody::boxed(SPAN, [], [statement], ctx);
         let r#type = FunctionType::FunctionExpression;
@@ -783,10 +783,10 @@ impl<'a> ModuleRunnerTransform<'a> {
             false,
             false,
             false,
-            NONE,
-            NONE,
+            None,
+            None,
             params,
-            NONE,
+            None,
             Some(body),
             scope_id,
             false,
@@ -855,7 +855,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         let pattern = binding.create_binding_pattern(ctx);
         let kind = VariableDeclarationKind::Const;
         let declarator =
-            VariableDeclarator::new(SPAN, kind, pattern, NONE, Some(right), false, ctx);
+            VariableDeclarator::new(SPAN, kind, pattern, None, Some(right), false, ctx);
         let declaration =
             Declaration::new_variable_declaration(span, kind, [declarator], false, ctx);
         Statement::from(declaration)

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -124,7 +124,7 @@ struct Param<'d> {
     /// * `Some(GenericType::Into)` if is generic and uses `Into`
     ///   e.g. `name: S1 where S1: Into<Str<'a>>`.
     /// * `Some(GenericType::IntoIn)` if is generic and uses `IntoIn`
-    ///   e.g. `type_annotation: T1 where T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>`.
+    ///   e.g. `params: T1 where T1: IntoIn<'a, ArenaVec<'a, TSTypeParameter<'a>>>`.
     generic_type: Option<GenericType>,
 }
 
@@ -313,8 +313,8 @@ fn generate_builder_methods_for_struct_impl(
 ///
 /// ```
 /// //        ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓ generic params
-/// pub fn new<B: GetAstBuilder<'a>, T1>(span: Span, function: T1, builder: &B) -> Self
-///     where T1: IntoIn<'a, Box<'a, Function<'a>>>
+/// pub fn new<B: GetAstBuilder<'a>, T1>(span: Span, params: T1, builder: &B) -> Self
+///     where T1: IntoIn<'a, ArenaVec<'a, TSTypeParameter<'a>>>
 /// //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ where clause
 /// ```
 fn get_struct_params<'s>(
@@ -328,7 +328,7 @@ fn get_struct_params<'s>(
     TokenStream,    // `where` clause
     bool,           // Has default fields
 ) {
-    let mut generic_count = 0u32;
+    let mut vec_generic_count = 0u32;
     let mut str_generic_count = 0u32;
     let mut has_default_fields = false;
 
@@ -362,13 +362,9 @@ fn get_struct_params<'s>(
                     str_generic_count += 1;
                     Some((format_ident!("S{str_generic_count}"), GenericType::Into))
                 }
-                TypeDef::Box(_) | TypeDef::Vec(_) => {
-                    generic_count += 1;
-                    Some((format_ident!("T{generic_count}"), GenericType::IntoIn))
-                }
-                TypeDef::Option(option_def) if option_def.inner_type(schema).is_box() => {
-                    generic_count += 1;
-                    Some((format_ident!("T{generic_count}"), GenericType::IntoIn))
+                TypeDef::Vec(_) => {
+                    vec_generic_count += 1;
+                    Some((format_ident!("T{vec_generic_count}"), GenericType::IntoIn))
                 }
                 _ => None,
             };


### PR DESCRIPTION
AST builder methods accepted an `IntoIn<ArenaBox<T>>` for all params where an `ArenaBox<T>` is required. You could pass a plain `T`, and the builder method would automatically allocate space for it, and copy it into the arena.

This was originally intended as a convenience, but in fact it's a footgun - it encourages allocating late, holding types on the stack during other work, which results in register pressure, and churn of copying to/from the stack.

Remove the automatic conversion. All places where we were using auto-allocation are already fixed in previous PRs #25034, #25035, #25036, #25037.

Additional benefits of this change:

1. AST builder methods become less polymorphic which should help with compile times.
2. We can get rid of the `NONE` type, which was a hacky workaround, necessary for passing as params where an `IntoIn<Option<ArenaBox<T>>>` is required. Now these all become plain `None`.

Most of the diff in this PR is just replacing `NONE` with `None` all over the place.

Note: AST builder methods still define params which are `ArenaVec`s as `IntoIn<ArenaVec<T>>`, as this does add genuine value - it allows passing `[]` instead of the much more verbose `ArenaVec::new_in(self)`.