### PR TITLE
feat(minifier): remove dead object spreads of non-escaping literal bindings

### DIFF
--- a/crates/oxc_minifier/src/compression_pass.rs
+++ b/crates/oxc_minifier/src/compression_pass.rs
@@ -309,23 +309,43 @@ pub fn run_peephole_pass<'a>(
     // spread marks, its symbol values, its liveness data and the just-flushed
     // `Scoping` describe one and the same program.
     //
-    // Dropping the previous boundary's candidates here is also the terminal
-    // condition: a pass that consumed candidates and still changed nothing
-    // removed nothing, so re-publishing the same census would spin the loop.
-    // Every other route back to this point followed real progress.
-    //
-    // Defence in depth. `settle_candidates` only publishes a symbol with at
-    // least one copy in discarded position, so a published candidate always has
-    // something for the cleanup pass to remove and no constructible program
-    // reaches the suppression — which is also why no test can exercise it. Kept
-    // because the publish filter and the census are separate rules that can
-    // drift apart: relax the filter and this is what still terminates the loop.
-    let was_cleanup_pass = ctx.state.spread_cleanup.take_candidates();
-    if !needs_another_pass && !was_cleanup_pass && spread_cleanup::settle_candidates(program, ctx) {
-        needs_another_pass = true;
+    // The census's removals happen here and now, in a restricted walk, rather
+    // than by handing candidates to another peephole pass. Consuming them a
+    // pass at a time cost a global iteration per layer of spread dependency,
+    // because each layer's copies only reach discarded position once the layer
+    // above is gone — a four-layer chain exhausted the iteration budget. Batched
+    // locally, a chain of any depth costs one extra pass.
+    if !needs_another_pass && spread_cleanup::settle_candidates(program, ctx) {
+        while spread_cleanup::remove_dead_copies(program, ctx) {
+            needs_another_pass = true;
+            // Give the next round current reference counts: its declarator
+            // removals test bindings this round just orphaned.
+            prune_removed_references(program, ctx);
+        }
+        // The batch's own mutations are reported through `needs_another_pass`.
+        let _ = ctx.state.take_revisit_requested();
+        debug_assert_pass_changes_clean(ctx);
     }
 
     PassOutcome { needs_another_pass }
+}
+
+/// Prune the references a removal-batch round marked, so the next round sees
+/// current counts. The reference half of [`flush_pass_changes`], without the
+/// direct-eval and liveness work a restricted walk cannot invalidate.
+fn prune_removed_references(
+    #[cfg_attr(not(debug_assertions), expect(unused_variables))] program: &Program<'_>,
+    ctx: &mut TraverseCtx<'_>,
+) {
+    if ctx.state.pass_changes.removed_references.is_empty() {
+        return;
+    }
+    #[cfg(debug_assertions)]
+    debug_assert_no_over_prune(program, &ctx.state.pass_changes.removed_references);
+    ctx.scoping
+        .scoping_mut()
+        .retain_resolved_references_excluding(&ctx.state.pass_changes.removed_references);
+    ctx.state.pass_changes.removed_references.clear();
 }
 
 #[inline]

--- a/crates/oxc_minifier/src/compression_pass.rs
+++ b/crates/oxc_minifier/src/compression_pass.rs
@@ -294,45 +294,66 @@ pub fn run_peephole_pass<'a>(
     ctx.state_mut().spread_cleanup.begin_pass();
     traverse_mut_with_ctx(&mut PeepholeOptimizations, program, ctx);
 
-    let ctx = ctx.get_mut();
-    let revisit_requested = ctx.state.take_revisit_requested();
-    let newly_dead = finish_pass(program, ctx, /* force_liveness_analysis */ false);
-    debug_assert!(
-        !newly_dead || revisit_requested,
-        "ordinary liveness progress must follow a recorded pass change"
-    );
-    debug_assert_pass_changes_clean(ctx);
-    let mut needs_another_pass = revisit_requested || newly_dead;
+    let mut needs_another_pass = {
+        let ctx = ctx.get_mut();
+        let revisit_requested = ctx.state.take_revisit_requested();
+        let newly_dead = finish_pass(program, ctx, /* force_liveness_analysis */ false);
+        debug_assert!(
+            !newly_dead || revisit_requested,
+            "ordinary liveness progress must follow a recorded pass change"
+        );
+        debug_assert_pass_changes_clean(ctx);
+        revisit_requested || newly_dead
+    };
 
     // The quiet-pass boundary of [`crate::spread_cleanup`], reached only when
     // the traversal changed nothing — which is exactly what makes this pass's
     // spread marks, its symbol values, its liveness data and the just-flushed
     // `Scoping` describe one and the same program.
     //
-    // The census's removals happen here and now, in a restricted walk, rather
-    // than by handing candidates to another peephole pass. Consuming them a
-    // pass at a time cost a global iteration per layer of spread dependency,
-    // because each layer's copies only reach discarded position once the layer
-    // above is gone — a four-layer chain exhausted the iteration budget. Batched
-    // locally, a chain of any depth costs one extra pass.
-    if !needs_another_pass && spread_cleanup::settle_candidates(program, ctx) {
+    // The census's removals happen here and now, in a scope-aware cleanup
+    // traversal, rather than by handing candidates to another peephole pass.
+    // Consuming them a pass at a time cost a global iteration per layer of
+    // spread dependency, because each layer's copies only reach discarded
+    // position once the layer above is gone — a four-layer chain exhausted the
+    // iteration budget. Batched locally, a chain of any depth costs one extra
+    // ordinary pass.
+    let has_candidates =
+        !needs_another_pass && spread_cleanup::settle_candidates(program, ctx.get_mut());
+    if has_candidates {
+        let mut removed_any = false;
         while spread_cleanup::remove_dead_copies(program, ctx) {
-            needs_another_pass = true;
+            removed_any = true;
+            let pass_ctx = ctx.get_mut();
+            let revisit_requested = pass_ctx.state.take_revisit_requested();
+            debug_assert!(
+                revisit_requested,
+                "a successful spread cleanup round must record its AST changes"
+            );
             // Give the next round current reference counts: its declarator
             // removals test bindings this round just orphaned.
-            prune_removed_references(program, ctx);
+            prune_removed_references(program, pass_ctx);
         }
-        // The batch's own mutations are reported through `needs_another_pass`.
-        let _ = ctx.state.take_revisit_requested();
-        debug_assert_pass_changes_clean(ctx);
+        if removed_any {
+            needs_another_pass = true;
+            let pass_ctx = ctx.get_mut();
+            // The batch can orphan an entire recursive function component or
+            // drop a direct eval inside a dead method. Finish it through the
+            // normal semantic boundary instead of leaving cleanup-specific
+            // bookkeeping for the next compressor invocation.
+            needs_another_pass |=
+                finish_pass(program, pass_ctx, /* force_liveness_analysis */ true);
+            debug_assert_pass_changes_clean(pass_ctx);
+        }
     }
 
     PassOutcome { needs_another_pass }
 }
 
 /// Prune the references a removal-batch round marked, so the next round sees
-/// current counts. The reference half of [`flush_pass_changes`], without the
-/// direct-eval and liveness work a restricted walk cannot invalidate.
+/// current counts. This is only an intermediate batch boundary: direct-eval
+/// refresh and forced liveness analysis run through [`finish_pass`] after the
+/// batch reaches its local fixed point.
 fn prune_removed_references(
     #[cfg_attr(not(debug_assertions), expect(unused_variables))] program: &Program<'_>,
     ctx: &mut TraverseCtx<'_>,

--- a/crates/oxc_minifier/src/compression_pass.rs
+++ b/crates/oxc_minifier/src/compression_pass.rs
@@ -18,7 +18,8 @@ use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
 use crate::{
     ReusableTraverseCtx, TraverseCtx, minifier_traverse::traverse_mut_with_ctx,
-    peephole::PeepholeOptimizations, symbol_liveness, traverse_context::as_direct_eval_call,
+    peephole::PeepholeOptimizations, spread_cleanup, symbol_liveness,
+    traverse_context::as_direct_eval_call,
 };
 
 /// The fixed-point decision produced by one completed peephole pass.
@@ -290,6 +291,7 @@ pub fn run_peephole_pass<'a>(
 ) -> PassOutcome {
     debug_assert_pass_changes_clean(ctx.get_mut());
     ctx.state_mut().symbols.reset_values();
+    ctx.state_mut().spread_cleanup.begin_pass();
     traverse_mut_with_ctx(&mut PeepholeOptimizations, program, ctx);
 
     let ctx = ctx.get_mut();
@@ -300,8 +302,30 @@ pub fn run_peephole_pass<'a>(
         "ordinary liveness progress must follow a recorded pass change"
     );
     debug_assert_pass_changes_clean(ctx);
+    let mut needs_another_pass = revisit_requested || newly_dead;
 
-    PassOutcome { needs_another_pass: revisit_requested || newly_dead }
+    // The quiet-pass boundary of [`crate::spread_cleanup`], reached only when
+    // the traversal changed nothing — which is exactly what makes this pass's
+    // spread marks, its symbol values, its liveness data and the just-flushed
+    // `Scoping` describe one and the same program.
+    //
+    // Dropping the previous boundary's candidates here is also the terminal
+    // condition: a pass that consumed candidates and still changed nothing
+    // removed nothing, so re-publishing the same census would spin the loop.
+    // Every other route back to this point followed real progress.
+    //
+    // Defence in depth. `settle_candidates` only publishes a symbol with at
+    // least one copy in discarded position, so a published candidate always has
+    // something for the cleanup pass to remove and no constructible program
+    // reaches the suppression — which is also why no test can exercise it. Kept
+    // because the publish filter and the census are separate rules that can
+    // drift apart: relax the filter and this is what still terminates the loop.
+    let was_cleanup_pass = ctx.state.spread_cleanup.take_candidates();
+    if !needs_another_pass && !was_cleanup_pass && spread_cleanup::settle_candidates(program, ctx) {
+        needs_another_pass = true;
+    }
+
+    PassOutcome { needs_another_pass }
 }
 
 #[inline]

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -52,6 +52,7 @@ mod keep_var;
 mod minifier_traverse;
 mod options;
 mod peephole;
+mod spread_cleanup;
 mod state;
 mod symbol_liveness;
 mod symbol_metadata;

--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -53,7 +53,14 @@ impl<'a> PeepholeOptimizations {
         } else {
             FreshValueKind::None
         };
-        ctx.init_value(symbol_id, value, kind, falsy_init, decl.init.is_none());
+        ctx.init_value(
+            symbol_id,
+            value,
+            kind,
+            falsy_init,
+            decl.init.is_none(),
+            declaration_in_body_statement_list,
+        );
     }
 
     /// A `ConstantValue` that coerces to `false` (`false`, `0`/`-0`/`NaN`, `""`,
@@ -247,7 +254,7 @@ impl<'a> PeepholeOptimizations {
     ) {
         let Some(id) = id else { return };
         let Some(symbol_id) = id.symbol_id.get() else { return };
-        ctx.init_value(symbol_id, None, FreshValueKind::Function, false, false);
+        ctx.init_value(symbol_id, None, FreshValueKind::Function, false, false, true);
     }
 
     /// Initialize symbol value for class declarations.
@@ -261,7 +268,7 @@ impl<'a> PeepholeOptimizations {
         } else {
             FreshValueKind::Class
         };
-        ctx.init_value(symbol_id, None, kind, false, false);
+        ctx.init_value(symbol_id, None, kind, false, false, true);
     }
 
     fn is_for_statement_init(ctx: &TraverseCtx<'a>) -> bool {

--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -49,7 +49,14 @@ impl<'a> PeepholeOptimizations {
         } else {
             FreshValueKind::None
         };
-        ctx.init_value(symbol_id, value, kind, falsy_init, decl.init.is_none());
+        ctx.init_value(
+            symbol_id,
+            value,
+            kind,
+            falsy_init,
+            decl.init.is_none(),
+            declaration_in_body_statement_list,
+        );
     }
 
     /// A `ConstantValue` that coerces to `false` (`false`, `0`/`-0`/`NaN`, `""`,
@@ -243,7 +250,7 @@ impl<'a> PeepholeOptimizations {
     ) {
         let Some(id) = id else { return };
         let Some(symbol_id) = id.symbol_id.get() else { return };
-        ctx.init_value(symbol_id, None, FreshValueKind::Function, false, false);
+        ctx.init_value(symbol_id, None, FreshValueKind::Function, false, false, true);
     }
 
     /// Initialize symbol value for class declarations.
@@ -257,7 +264,7 @@ impl<'a> PeepholeOptimizations {
         } else {
             FreshValueKind::Class
         };
-        ctx.init_value(symbol_id, None, kind, false, false);
+        ctx.init_value(symbol_id, None, kind, false, false, true);
     }
 
     fn is_for_statement_init(ctx: &TraverseCtx<'a>) -> bool {

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -23,7 +23,9 @@ use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_ecmascript::constant_evaluation::IsLiteralValue;
 
-use crate::{Traverse, TraverseCtx, generated::ancestor::Ancestor, state::BodyFrame};
+use crate::{
+    Traverse, TraverseCtx, generated::ancestor::Ancestor, spread_cleanup, state::BodyFrame,
+};
 
 pub use self::normalize::{Normalize, NormalizeOptions};
 
@@ -396,7 +398,22 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         stmts: &mut ArenaVec<'a, Statement<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) {
+        // See `MinifierState::reprocessing_statements`: entries recorded for
+        // declarators later in this list break the traversal-order proof while
+        // the list is re-processed.
+        ctx.state.reprocessing_statements = true;
         Self::minimize_statements(stmts, ctx);
+        ctx.state.reprocessing_statements = false;
+    }
+
+    fn exit_spread_element(&mut self, spread: &mut SpreadElement<'a>, ctx: &mut TraverseCtx<'a>) {
+        // Record a direct `...Identifier` object copy for the census a
+        // quiet-pass boundary may run (see `crate::spread_cleanup`). Runs
+        // before the `exit_expression` transforms that may rewrite the
+        // enclosing literal, so a mark can name a reference that is then
+        // removed — harmless, since the census only ever consults marks of a
+        // pass that changed nothing.
+        spread_cleanup::mark_object_copy_spread(spread, ctx);
     }
 
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -546,6 +546,9 @@ impl<'a> PeepholeOptimizations {
             let reference_id = ident.reference_id();
             if let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id()
                 && ctx.state.symbols.function_summary(symbol_id).returns_undefined()
+                // Same binding-vs-value asymmetry as the other consumer; see
+                // `PeepholeOptimizations::summary_order_proven`.
+                && Self::summary_order_proven(symbol_id, ctx)
             {
                 let mut exprs = Self::fold_arguments_into_needed_expressions(&mut e.arguments, ctx);
                 if exprs.is_empty() {

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -543,6 +543,9 @@ impl<'a> PeepholeOptimizations {
             let reference_id = ident.reference_id();
             if let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id()
                 && ctx.state.symbols.function_summary(symbol_id).returns_undefined()
+                // Same binding-vs-value asymmetry as the other consumer; see
+                // `PeepholeOptimizations::summary_order_proven`.
+                && Self::summary_order_proven(symbol_id, ctx)
             {
                 let mut exprs = Self::fold_arguments_into_needed_expressions(&mut e.arguments, ctx);
                 if exprs.is_empty() {

--- a/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
@@ -5,7 +5,7 @@ use oxc_ecmascript::constant_evaluation::{DetermineValueType, ValueType};
 use oxc_syntax::symbol::SymbolId;
 
 impl<'a> PeepholeOptimizations {
-    pub(super) fn can_remove_unused_declarators(ctx: &TraverseCtx<'a>) -> bool {
+    pub(crate) fn can_remove_unused_declarators(ctx: &TraverseCtx<'a>) -> bool {
         ctx.options().unused != CompressOptionsUnused::Keep
             && !Self::is_script_root_scope(ctx)
             && !ctx.scoping().root_scope_flags().contains_direct_eval()

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -1,8 +1,7 @@
 use std::iter;
 
 use crate::{
-    CompressOptionsUnused, TraverseCtx, generated::ancestor::Ancestor, spread_cleanup,
-    symbol_value::FreshValueKind,
+    CompressOptionsUnused, TraverseCtx, generated::ancestor::Ancestor, symbol_value::FreshValueKind,
 };
 use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::ast::*;
@@ -448,10 +447,10 @@ impl<'a> PeepholeOptimizations {
         if object_expr.properties.iter().all(ObjectPropertyKind::is_spread) {
             // All-spread objects like `({...x})` can only be removed if
             // the spread arguments themselves have no side effects.
-            return !object_expr.properties.iter().any(|property| {
-                !spread_cleanup::is_dead_object_copy_spread(property, ctx)
-                    && property.may_have_side_effects(ctx)
-            });
+            return !object_expr
+                .properties
+                .iter()
+                .any(|property| property.may_have_side_effects(ctx));
         }
 
         let mut transformed_elements = ArenaVec::new_in(ctx);
@@ -459,17 +458,8 @@ impl<'a> PeepholeOptimizations {
 
         for prop in object_expr.properties.drain(..) {
             match prop {
-                ObjectPropertyKind::SpreadProperty(spread) => {
-                    // A copy the quiet-pass census proved dead contributes
-                    // nothing to the surviving groups. Dropping it here bypasses
-                    // the `replace_*` helpers, so walk its reference into
-                    // `pass_changes.removed_references` — same rationale as the
-                    // key and value branches below.
-                    if spread_cleanup::is_dead_object_copy_spread_argument(&spread.argument, ctx) {
-                        ctx.drop_expression(&spread.argument);
-                    } else {
-                        pending_spread_elements.push(ObjectPropertyKind::SpreadProperty(spread));
-                    }
+                ObjectPropertyKind::SpreadProperty(_) => {
+                    pending_spread_elements.push(prop);
                 }
                 ObjectPropertyKind::ObjectProperty(prop) => {
                     if !pending_spread_elements.is_empty() {
@@ -698,12 +688,18 @@ impl<'a> PeepholeOptimizations {
     ///    `reprocessing_statements` carve-out applies: re-processing a
     ///    statement list also surfaces entries for declarators positioned
     ///    later.
-    /// 2. The declarator is a direct body statement-list item
+    /// 2. The entry classifies the binding `FreshValueKind::Function`, i.e. the
+    ///    declarator visited THIS pass initializes it with a function literal.
+    ///    A summary is persistent state about a value; without this, one
+    ///    recorded before the declarator was folded away is still consumed
+    ///    against whatever `var f;` the hoist left behind
+    ///    (`while (0) { var f = () => {}; break; } x = f();`).
+    /// 3. The declarator is a direct body statement-list item
     ///    (`SymbolValue::declarator_in_body_statement_list`). Traversal order
     ///    is not execution order: `if (flag) var f = () => {}` is visited every
     ///    pass and assigns on none, so an entry alone says nothing about
     ///    whether the binding holds the function.
-    /// 3. The call is in the same function as the declarator. Traversal reaches
+    /// 4. The call is in the same function as the declarator. Traversal reaches
     ///    a declarator before a later function body, but that body can run
     ///    first — `g(); var f = () => {}; function g() { f(); }` calls `f`
     ///    while it is still `undefined`.
@@ -720,7 +716,7 @@ impl<'a> PeepholeOptimizations {
             return false;
         }
         let Some(value) = ctx.state.symbols.value(symbol_id) else { return false };
-        if !value.declarator_in_body_statement_list {
+        if value.kind != FreshValueKind::Function || !value.declarator_in_body_statement_list {
             return false;
         }
         // A `var`'s declaring scope IS its enclosing function body or the

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -12,7 +12,10 @@ use oxc_ecmascript::{
     side_effects::{MayHaveSideEffects, MayHaveSideEffectsContext},
 };
 use oxc_span::GetSpan;
-use oxc_syntax::{scope::ScopeId, symbol::SymbolId};
+use oxc_syntax::{
+    scope::ScopeId,
+    symbol::{SymbolFlags, SymbolId},
+};
 
 use super::PeepholeOptimizations;
 use super::fold_constants::is_cjs_module_exports_hint;
@@ -674,6 +677,39 @@ impl<'a> PeepholeOptimizations {
         false
     }
 
+    /// Whether a function summary may be consumed at the call site currently
+    /// being visited.
+    ///
+    /// A summary is a property of the function VALUE, but both consumers key it
+    /// by the BINDING. For a hoisted `function f() {}` those coincide: the
+    /// binding holds that function for the whole scope, so a side-effect-free
+    /// body licenses erasing any call. For `var f = <fn>` they do not — the
+    /// binding holds `undefined` until the assignment runs, and a call reached
+    /// first throws `TypeError`, which erasing the call would silently drop.
+    ///
+    /// So a `var` binding additionally needs proof that its declarator already
+    /// ran. Reuse the traversal-order proof: `SymbolState::values` is per-pass
+    /// scratch, reset at pass start and written by `exit_variable_declarator`,
+    /// so an entry existing when this call site is visited proves the
+    /// declarator precedes it in this pass's traversal — with a carve-out for
+    /// statement-list re-processing, where the list also holds entries for
+    /// declarators positioned later.
+    ///
+    /// `let` / `const` need no proof: a call before their declarator is a TDZ
+    /// `ReferenceError`, inside the minifier's documented `No TDZ Violation`
+    /// assumption.
+    ///
+    /// Conservative case: a call inside a function body traversed before the
+    /// declarator loses the optimization even when the body only runs later
+    /// (`function g() { f(); } var f = () => {}; g();`). Proving that needs
+    /// reachability, not traversal order.
+    pub(super) fn summary_order_proven(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
+        if !ctx.scoping().symbol_flags(symbol_id).contains(SymbolFlags::FunctionScopedVariable) {
+            return true;
+        }
+        !ctx.state.reprocessing_statements && ctx.state.symbols.value(symbol_id).is_some()
+    }
+
     fn remove_unused_call_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         let Expression::CallExpression(call_expr) = e else { return false };
 
@@ -685,6 +721,7 @@ impl<'a> PeepholeOptimizations {
                         ctx.scoping().get_reference(id.reference_id()).symbol_id()
                 {
                     ctx.state.symbols.function_summary(symbol_id).is_side_effect_free()
+                        && Self::summary_order_proven(symbol_id, ctx)
                 } else {
                     false
                 })

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -687,27 +687,61 @@ impl<'a> PeepholeOptimizations {
     /// binding holds `undefined` until the assignment runs, and a call reached
     /// first throws `TypeError`, which erasing the call would silently drop.
     ///
-    /// So a `var` binding additionally needs proof that its declarator already
-    /// ran. Reuse the traversal-order proof: `SymbolState::values` is per-pass
-    /// scratch, reset at pass start and written by `exit_variable_declarator`,
-    /// so an entry existing when this call site is visited proves the
-    /// declarator precedes it in this pass's traversal — with a carve-out for
-    /// statement-list re-processing, where the list also holds entries for
-    /// declarators positioned later.
-    ///
     /// `let` / `const` need no proof: a call before their declarator is a TDZ
     /// `ReferenceError`, inside the minifier's documented `No TDZ Violation`
-    /// assumption.
+    /// assumption. A `var` binding needs all three of the following, because
+    /// each closes a different way the assignment can fail to have run.
     ///
-    /// Conservative case: a call inside a function body traversed before the
-    /// declarator loses the optimization even when the body only runs later
-    /// (`function g() { f(); } var f = () => {}; g();`). Proving that needs
-    /// reachability, not traversal order.
+    /// 1. A value entry exists. `SymbolState::values` is per-pass scratch
+    ///    written by `exit_variable_declarator`, so an entry proves the
+    ///    declarator precedes this call in the pass's traversal. The
+    ///    `reprocessing_statements` carve-out applies: re-processing a
+    ///    statement list also surfaces entries for declarators positioned
+    ///    later.
+    /// 2. The declarator is a direct body statement-list item
+    ///    (`SymbolValue::declarator_in_body_statement_list`). Traversal order
+    ///    is not execution order: `if (flag) var f = () => {}` is visited every
+    ///    pass and assigns on none, so an entry alone says nothing about
+    ///    whether the binding holds the function.
+    /// 3. The call is in the same function as the declarator. Traversal reaches
+    ///    a declarator before a later function body, but that body can run
+    ///    first — `g(); var f = () => {}; function g() { f(); }` calls `f`
+    ///    while it is still `undefined`.
+    ///
+    /// Conservative cases: a call in a nested function loses the optimization
+    /// even when it only runs later, and a conditionally-initialized `var`
+    /// loses it outright. Proving either needs reachability, not traversal
+    /// order.
     pub(super) fn summary_order_proven(symbol_id: SymbolId, ctx: &TraverseCtx<'a>) -> bool {
         if !ctx.scoping().symbol_flags(symbol_id).contains(SymbolFlags::FunctionScopedVariable) {
             return true;
         }
-        !ctx.state.reprocessing_statements && ctx.state.symbols.value(symbol_id).is_some()
+        if ctx.state.reprocessing_statements {
+            return false;
+        }
+        let Some(value) = ctx.state.symbols.value(symbol_id) else { return false };
+        if !value.declarator_in_body_statement_list {
+            return false;
+        }
+        // A `var`'s declaring scope IS its enclosing function body or the
+        // Program, so comparing against the call site's own nearest such scope
+        // answers "same function".
+        let scoping = ctx.scoping();
+        Self::nearest_function_or_program_scope(ctx.current_scope_id(), ctx)
+            == scoping.symbol_scope_id(symbol_id)
+    }
+
+    /// The nearest enclosing function body or Program scope, starting from
+    /// `scope_id` itself. Class static blocks and other non-function var scopes
+    /// are deliberately walked past: the comparison then fails and the caller
+    /// bails, which is the conservative direction.
+    fn nearest_function_or_program_scope(scope_id: ScopeId, ctx: &TraverseCtx<'a>) -> ScopeId {
+        let scoping = ctx.scoping();
+        let root_scope_id = scoping.root_scope_id();
+        scoping
+            .scope_ancestors(scope_id)
+            .find(|&id| id == root_scope_id || scoping.scope_flags(id).is_function())
+            .unwrap_or(root_scope_id)
     }
 
     fn remove_unused_call_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -1,7 +1,8 @@
 use std::iter;
 
 use crate::{
-    CompressOptionsUnused, TraverseCtx, generated::ancestor::Ancestor, symbol_value::FreshValueKind,
+    CompressOptionsUnused, TraverseCtx, generated::ancestor::Ancestor, spread_cleanup,
+    symbol_value::FreshValueKind,
 };
 use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::ast::*;
@@ -444,10 +445,10 @@ impl<'a> PeepholeOptimizations {
         if object_expr.properties.iter().all(ObjectPropertyKind::is_spread) {
             // All-spread objects like `({...x})` can only be removed if
             // the spread arguments themselves have no side effects.
-            return !object_expr
-                .properties
-                .iter()
-                .any(|property| property.may_have_side_effects(ctx));
+            return !object_expr.properties.iter().any(|property| {
+                !spread_cleanup::is_dead_object_copy_spread(property, ctx)
+                    && property.may_have_side_effects(ctx)
+            });
         }
 
         let mut transformed_elements = ArenaVec::new_in(ctx);
@@ -455,8 +456,17 @@ impl<'a> PeepholeOptimizations {
 
         for prop in object_expr.properties.drain(..) {
             match prop {
-                ObjectPropertyKind::SpreadProperty(_) => {
-                    pending_spread_elements.push(prop);
+                ObjectPropertyKind::SpreadProperty(spread) => {
+                    // A copy the quiet-pass census proved dead contributes
+                    // nothing to the surviving groups. Dropping it here bypasses
+                    // the `replace_*` helpers, so walk its reference into
+                    // `pass_changes.removed_references` — same rationale as the
+                    // key and value branches below.
+                    if spread_cleanup::is_dead_object_copy_spread_argument(&spread.argument, ctx) {
+                        ctx.drop_expression(&spread.argument);
+                    } else {
+                        pending_spread_elements.push(ObjectPropertyKind::SpreadProperty(spread));
+                    }
                 }
                 ObjectPropertyKind::ObjectProperty(prop) => {
                     if !pending_spread_elements.is_empty() {

--- a/crates/oxc_minifier/src/spread_cleanup.rs
+++ b/crates/oxc_minifier/src/spread_cleanup.rs
@@ -1,0 +1,369 @@
+//! Removal-only cleanup for dead object-copy spreads of getter-free literals.
+//!
+//! `({ ...Proto })` in discarded position is kept whenever the spread argument
+//! is an identifier, because copying a binding's own enumerable properties runs
+//! that object's getters. When the binding provably still holds a getter-free
+//! object literal, there are no getters to run and the copy is dead code — the
+//! pattern from rolldown/rolldown#8582, which keeps whole modules alive.
+//!
+//! Proving it needs a whole-symbol fact ("nothing else can have installed an
+//! accessor"), but the minifier's symbol data is per-pass scratch that is only
+//! coherent at a pass boundary. So the fact is never computed mid-traversal:
+//!
+//! ```text
+//! ordinary peephole pass
+//!   ├─ changed → discard this pass's marks and continue
+//!   └─ quiet   → census against the settled references
+//!                  ↓
+//!               publish candidates, run one cleanup pass
+//!                  ↓
+//!               removals reopen ordinary DCE
+//! ```
+//!
+//! During traversal each object literal records the `ReferenceId` of every
+//! direct `...Identifier` argument it copies — at the spread node, so the cost
+//! is one bit per spread site rather than work per identifier. A pass that
+//! changed anything throws its marks away; only a QUIET pass gets to consume
+//! them, and a quiet pass by definition ended with the AST it started with, so
+//! its marks, its `SymbolValue` entries, its liveness data and the post-flush
+//! `Scoping` all describe the same program.
+//!
+//! The candidate test is then a positive census — *every* live reference of the
+//! symbol is one of those marks — rather than a list of read positions deemed
+//! harmless. Anything that is not literally an object-copy spread disqualifies
+//! the symbol: a call argument, a member write, an array spread, a reference
+//! this pass never saw. That is what keeps the fact honest as the AST changes
+//! underneath it, and it needs no sanction list to maintain.
+
+use oxc_allocator::{Allocator, BitSet, Vec as ArenaVec};
+#[cfg(debug_assertions)]
+use oxc_ast_visit::Visit;
+
+use oxc_ast::ast::*;
+use oxc_semantic::Scoping;
+use oxc_syntax::{reference::ReferenceId, scope::ScopeFlags, symbol::SymbolId};
+
+use crate::{TraverseCtx, generated::ancestor::Ancestor, symbol_value::FreshValueKind};
+
+/// Per-run state for the quiet-pass object-spread cleanup.
+pub struct SpreadCleanup<'a> {
+    /// References the current pass saw as the direct `...Identifier` argument
+    /// of an object literal, and that passed the mark-time proof.
+    ///
+    /// Reset at the start of every pass. Marks from a pass that changed the AST
+    /// are never consumed: consumption only follows a quiet pass, whose own
+    /// marks are complete and current.
+    ///
+    /// Sized once from the initial `references_len()`. A reference minted
+    /// during the loop is past capacity and so cannot be marked, which makes
+    /// the census treat it as an unknown use and reject its symbol — the
+    /// conservative direction, and the same capacity guard
+    /// `PassChanges::removed_references` relies on.
+    ///
+    /// FORWARD OBLIGATION. Every soundness argument here reduces to one
+    /// invariant: a transform that moves a marked identifier into an escaping
+    /// position necessarily records a pass change, so the pass is not quiet and
+    /// these marks are discarded unread. Any transform that changes which node
+    /// a `ReferenceId` occupies must therefore record a change. That is a
+    /// convention, not a mechanism — the one audited exception is
+    /// `dead_drop_mutates_ast` (`minimize_statements.rs`), which suppresses the
+    /// flag for identity drops of initializer-free `var` declarations to keep
+    /// the fixed-point loop from oscillating. Those declarations have no
+    /// initializer and so cannot relocate a spread.
+    marks: BitSet<'a>,
+
+    /// The subset of [`Self::marks`] whose enclosing object literal is itself
+    /// discarded, so removing the copy is something the following cleanup pass
+    /// can actually do.
+    ///
+    /// Purely an economy: a candidate whose copies all sit in live positions
+    /// (`const Q = { ...P };` with `Q` used) is real but useless, and
+    /// publishing it costs a full extra traversal that removes nothing. Only
+    /// [`Self::marks`] takes part in the census, so narrowing this set can lose
+    /// an optimization but never make one unsound.
+    removable_marks: BitSet<'a>,
+
+    /// Symbols the last quiet-pass boundary proved to hold a getter-free object
+    /// literal whose every live reference is a dead object-copy spread.
+    ///
+    /// Published by [`settle_candidates`], read by the single pass that follows
+    /// it, then dropped. Never carried across a boundary: the fact is about one
+    /// settled AST, and re-deriving it is what makes the construction
+    /// idempotent.
+    candidates: BitSet<'a>,
+
+    /// Whether [`Self::candidates`] holds anything, so the per-spread test on
+    /// the removal path is a branch rather than a scan.
+    has_candidates: bool,
+}
+
+impl<'a> SpreadCleanup<'a> {
+    pub fn new(scoping: &Scoping, allocator: &'a Allocator) -> Self {
+        Self {
+            marks: BitSet::new_in(scoping.references_len(), allocator),
+            removable_marks: BitSet::new_in(scoping.references_len(), allocator),
+            candidates: BitSet::new_in(scoping.symbols_len(), allocator),
+            has_candidates: false,
+        }
+    }
+
+    /// Discard the previous pass's marks. Called at the start of every pass.
+    pub fn begin_pass(&mut self) {
+        self.marks.clear();
+        self.removable_marks.clear();
+    }
+
+    /// Drop the published candidates and report whether there were any, i.e.
+    /// whether the pass that just finished was a cleanup pass.
+    pub fn take_candidates(&mut self) -> bool {
+        if !self.has_candidates {
+            return false;
+        }
+        self.candidates.clear();
+        self.has_candidates = false;
+        true
+    }
+}
+
+/// Record one `...Identifier` object-copy use.
+///
+/// Called from `PeepholeOptimizations::exit_spread_element`, so the cost is
+/// bounded by the number of spread sites rather than by the properties of every
+/// object literal. Array and call spreads reach the same hook, hence the parent
+/// test: only an object literal's own `properties` list is a copy.
+///
+/// The generated walk fires this exactly once per node per pass, in traversal
+/// order — `minimize_statements` and its helpers re-process already-walked
+/// statements with plain functions and never re-enter the traversal dispatch.
+///
+/// A spread that fails the mark-time proof is simply left unmarked, which makes
+/// the census reject its symbol.
+pub fn mark_object_copy_spread<'a>(spread: &SpreadElement<'a>, ctx: &mut TraverseCtx<'a>) {
+    // The mark-time order proof and `PeepholeOptimizations::summary_order_proven`
+    // read the same signal — "a `SymbolValue` entry exists right now" — as
+    // evidence that the declarator was traversed earlier this pass. That
+    // consumer needs the flag because it runs from positions reached during
+    // statement-list re-processing; marking is a traversal hook and cannot be,
+    // which is exactly what this asserts. Move marking to `exit_expression` and
+    // the assertion is what tells you the proof no longer holds.
+    debug_assert!(
+        !ctx.state.reprocessing_statements,
+        "spread marks require traversal-order recording; statement-list \
+         re-processing invalidates the declarator-precedes-use proof",
+    );
+    if !matches!(ctx.parent(), Ancestor::ObjectExpressionProperties(_)) {
+        return;
+    }
+    let Expression::Identifier(ident) = &spread.argument else { return };
+    let Some(reference_id) = ident.reference_id.get() else { return };
+    let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id() else { return };
+    if !mark_time_proof_holds(symbol_id, ctx) {
+        return;
+    }
+    let index = reference_id.index();
+    if index < ctx.state.spread_cleanup.marks.capacity() {
+        ctx.state.spread_cleanup.marks.set_bit(index);
+        if enclosing_literal_is_discarded(ctx) {
+            ctx.state.spread_cleanup.removable_marks.set_bit(index);
+        }
+    }
+}
+
+/// Whether the object literal holding the spread being exited is itself in a
+/// discarded position, i.e. one `remove_unused_expression` reaches.
+///
+/// The ancestor above `ObjectExpressionProperties` is the literal's own parent.
+/// An expression statement discards it outright; a sequence element discards
+/// every operand but the last, and treating the last one as discarded too is
+/// harmless here — this only decides whether publishing a candidate is worth a
+/// pass, never whether removing it is legal.
+fn enclosing_literal_is_discarded(ctx: &TraverseCtx<'_>) -> bool {
+    matches!(
+        ctx.ancestors().nth(1),
+        Some(
+            Ancestor::ExpressionStatementExpression(_) | Ancestor::SequenceExpressionExpressions(_)
+        )
+    )
+}
+
+/// Whether this spread may stand as evidence about the symbol's value.
+///
+/// Both halves are checked here rather than at the boundary because here the
+/// traversal cursor IS the spread's own position — at the boundary there is no
+/// cursor to ask.
+///
+/// - Declaration before use: `SymbolState::values` is per-pass scratch written
+///   by `exit_variable_declarator`, so an entry existing at this spread proves
+///   the declarator precedes it in this pass's traversal.
+/// - Same function: an entry orders the traversal, not execution. A nested
+///   function can run before a hoisted `var`'s initializer, when the binding
+///   holds `undefined` rather than the classified literal.
+///
+/// Both are stricter than the object case alone needs — spreading `undefined`
+/// is a no-op, and a `const` read before its declarator is a TDZ
+/// `ReferenceError` inside the documented `No TDZ Violation` assumption — but
+/// they are what lets the census be a plain membership test, with no reasoning
+/// about which reads observe which value.
+fn mark_time_proof_holds(symbol_id: SymbolId, ctx: &TraverseCtx<'_>) -> bool {
+    if ctx.state.symbols.value(symbol_id).is_none() {
+        return false;
+    }
+    let scoping = ctx.scoping();
+    let symbol_scope_id = scoping.symbol_scope_id(symbol_id);
+    !scoping
+        .scope_ancestors(ctx.current_scope_id())
+        .take_while(|&scope_id| scope_id != symbol_scope_id)
+        .any(|scope_id| scoping.scope_flags(scope_id).is_function())
+}
+
+/// Publish the symbols whose dead object-copy spreads the next pass may remove,
+/// and report whether there are any.
+///
+/// Called only at a quiet-pass boundary, after `finish_pass` has flushed the
+/// pass's changes, so `Scoping` lists exactly the references the settled AST
+/// contains.
+///
+/// A symbol qualifies when all of the following hold:
+///
+/// - its per-pass value entry classifies it `FreshValueKind::Object`, which
+///   `fresh_value_kind` grants only to a literal with no getter, no setter and
+///   no `__proto__:` key, and which `init_value` withholds entirely from a
+///   symbol with more than one value declaration;
+/// - it has no resolved write, so nothing replaces the classified value;
+/// - its declaring scope contains no direct `eval`, which could reach the
+///   binding without a resolved reference;
+/// - liveness data exists and does not mark it implicitly observable (a module
+///   export, a script global, an Annex B alias, a `using` resource). Absent
+///   liveness means observability is unknown, which is not a candidate;
+/// - the census: every live resolved reference is one of this pass's marks. An
+///   ordinary read, a call argument, a member write, an array spread, or a
+///   reference minted after the last flush is not a mark, and any one of them
+///   disqualifies the symbol.
+pub fn settle_candidates(
+    #[cfg_attr(not(debug_assertions), expect(unused_variables))] program: &Program<'_>,
+    ctx: &mut TraverseCtx<'_>,
+) -> bool {
+    // Arena-allocated so a boundary costs no system allocation; the marked
+    // symbols must be read out before `candidates` can be written to.
+    let mut marked_symbols = ArenaVec::new_in(&*ctx);
+    for index in ctx.state.spread_cleanup.marks.ones() {
+        if let Some(symbol_id) =
+            ctx.scoping().get_reference(ReferenceId::from_usize(index)).symbol_id()
+        {
+            marked_symbols.push(symbol_id);
+        }
+    }
+    let mut found_candidates = false;
+    for symbol_id in marked_symbols {
+        if !ctx.state.spread_cleanup.candidates.contains(symbol_id.index())
+            && is_candidate(symbol_id, ctx)
+        {
+            ctx.state.spread_cleanup.candidates.set_bit(symbol_id.index());
+            found_candidates = true;
+        }
+    }
+    ctx.state.spread_cleanup.has_candidates = found_candidates;
+    #[cfg(debug_assertions)]
+    if found_candidates {
+        debug_assert_census_complete(program, ctx);
+    }
+    found_candidates
+}
+
+/// Debug-only guard on the census's core premise: `Scoping` lists EVERY live
+/// reference of a candidate symbol.
+///
+/// The dangerous direction is a live reference to a candidate that the census
+/// never saw — an escape channel hidden behind an id the resolved-reference
+/// list omits, or a node whose `ReferenceId` is aliased by another. Either
+/// would let a copy be removed whose value was mutated behind the census's
+/// back. This is the same shape as `debug_assert_no_over_prune`, and costs
+/// nothing in release.
+///
+/// Two mechanisms could produce it, and both hold today: the minifier's only
+/// `clone_in` (`substitute_alternate_syntax.rs`) resets `reference_id` and
+/// mints fresh ones, and `remove_unused_object_expr`'s literal rebuilding always
+/// exits through `ctx.replace_expression`, which records a change and so cannot
+/// happen on a quiet pass. Neither is enforced by anything but this walk.
+#[cfg(debug_assertions)]
+fn debug_assert_census_complete(program: &Program<'_>, ctx: &TraverseCtx<'_>) {
+    struct CensusCheck<'b, 'c> {
+        ctx: &'b TraverseCtx<'c>,
+    }
+    impl<'a> Visit<'a> for CensusCheck<'_, '_> {
+        fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
+            let Some(reference_id) = it.reference_id.get() else { return };
+            let Some(symbol_id) = self.ctx.scoping().get_reference(reference_id).symbol_id() else {
+                return;
+            };
+            if !self.ctx.state.spread_cleanup.candidates.contains(symbol_id.index()) {
+                return;
+            }
+            assert!(
+                self.ctx.state.spread_cleanup.marks.contains(reference_id.index()),
+                "spread census incompleteness: reference {} of candidate symbol {} is live in \
+                 the program but was never marked as an object copy — `Scoping` did not list \
+                 it, or two nodes share the id",
+                reference_id.index(),
+                symbol_id.index(),
+            );
+        }
+    }
+    CensusCheck { ctx }.visit_program(program);
+}
+
+fn is_candidate(symbol_id: SymbolId, ctx: &TraverseCtx<'_>) -> bool {
+    let Some(value) = ctx.state.symbols.value(symbol_id) else { return false };
+    if value.kind != FreshValueKind::Object || value.references.has_writes() {
+        return false;
+    }
+    let scoping = ctx.scoping();
+    if scoping.scope_flags(scoping.symbol_scope_id(symbol_id)).contains(ScopeFlags::DirectEval) {
+        return false;
+    }
+    let Some(liveness) = ctx.state.symbols.liveness() else { return false };
+    if liveness.is_implicitly_observable(symbol_id) {
+        return false;
+    }
+    let reference_ids = scoping.get_resolved_reference_ids(symbol_id);
+    reference_ids
+        .iter()
+        .all(|reference_id| ctx.state.spread_cleanup.marks.contains(reference_id.index()))
+        && reference_ids.iter().any(|reference_id| {
+            ctx.state.spread_cleanup.removable_marks.contains(reference_id.index())
+        })
+}
+
+/// Whether this object property is a spread the last quiet-pass boundary proved
+/// dead, and may therefore be dropped from a discarded object literal.
+///
+/// Candidacy survives everything the cleanup pass does to the AST. A transform
+/// can delete references, which only shrinks the census; it can move a spread
+/// wholesale, which leaves it a spread; and none converts a spread use into a
+/// use of another shape. A transform that ever does — one that rewrites
+/// `({ ...P })` into something reading `P` in another position — must clear the
+/// candidate set, or this fact stops being true mid-pass.
+pub fn is_dead_object_copy_spread<'a>(
+    property: &ObjectPropertyKind<'a>,
+    ctx: &TraverseCtx<'a>,
+) -> bool {
+    let ObjectPropertyKind::SpreadProperty(spread) = property else { return false };
+    is_dead_object_copy_spread_argument(&spread.argument, ctx)
+}
+
+/// [`is_dead_object_copy_spread`] against a spread argument already
+/// destructured out of its property.
+pub fn is_dead_object_copy_spread_argument<'a>(
+    argument: &Expression<'a>,
+    ctx: &TraverseCtx<'a>,
+) -> bool {
+    if !ctx.state.spread_cleanup.has_candidates {
+        return false;
+    }
+    let Expression::Identifier(ident) = argument else { return false };
+    let Some(reference_id) = ident.reference_id.get() else { return false };
+    ctx.scoping()
+        .get_reference(reference_id)
+        .symbol_id()
+        .is_some_and(|symbol_id| ctx.state.spread_cleanup.candidates.contains(symbol_id.index()))
+}

--- a/crates/oxc_minifier/src/spread_cleanup.rs
+++ b/crates/oxc_minifier/src/spread_cleanup.rs
@@ -38,12 +38,18 @@
 use oxc_allocator::{Allocator, BitSet, Vec as ArenaVec};
 #[cfg(debug_assertions)]
 use oxc_ast_visit::Visit;
+use oxc_ast_visit::{VisitJsMut, walk_js_mut};
 
 use oxc_ast::ast::*;
 use oxc_semantic::Scoping;
 use oxc_syntax::{reference::ReferenceId, scope::ScopeFlags, symbol::SymbolId};
 
-use crate::{TraverseCtx, generated::ancestor::Ancestor, symbol_value::FreshValueKind};
+use oxc_ecmascript::side_effects::MayHaveSideEffects;
+
+use crate::{
+    TraverseCtx, generated::ancestor::Ancestor, peephole::PeepholeOptimizations,
+    symbol_value::FreshValueKind,
+};
 
 /// Per-run state for the quiet-pass object-spread cleanup.
 pub struct SpreadCleanup<'a> {
@@ -60,68 +66,30 @@ pub struct SpreadCleanup<'a> {
     /// conservative direction, and the same capacity guard
     /// `PassChanges::removed_references` relies on.
     ///
-    /// FORWARD OBLIGATION. Every soundness argument here reduces to one
-    /// invariant: a transform that moves a marked identifier into an escaping
-    /// position necessarily records a pass change, so the pass is not quiet and
-    /// these marks are discarded unread. Any transform that changes which node
-    /// a `ReferenceId` occupies must therefore record a change. That is a
-    /// convention, not a mechanism — the one audited exception is
-    /// `dead_drop_mutates_ast` (`minimize_statements.rs`), which suppresses the
-    /// flag for identity drops of initializer-free `var` declarations to keep
-    /// the fixed-point loop from oscillating. Those declarations have no
-    /// initializer and so cannot relocate a spread.
     marks: BitSet<'a>,
 
-    /// The subset of [`Self::marks`] whose enclosing object literal is itself
-    /// discarded, so removing the copy is something the following cleanup pass
-    /// can actually do.
+    /// Symbols this boundary's census proved to hold a getter-free object
+    /// literal whose every live reference is a dead object-copy copy.
     ///
-    /// Purely an economy: a candidate whose copies all sit in live positions
-    /// (`const Q = { ...P };` with `Q` used) is real but useless, and
-    /// publishing it costs a full extra traversal that removes nothing. Only
-    /// [`Self::marks`] takes part in the census, so narrowing this set can lose
-    /// an optimization but never make one unsound.
-    removable_marks: BitSet<'a>,
-
-    /// Symbols the last quiet-pass boundary proved to hold a getter-free object
-    /// literal whose every live reference is a dead object-copy spread.
-    ///
-    /// Published by [`settle_candidates`], read by the single pass that follows
-    /// it, then dropped. Never carried across a boundary: the fact is about one
-    /// settled AST, and re-deriving it is what makes the construction
+    /// Written by [`settle_candidates`] and read only by the removal batch that
+    /// immediately follows it, within the same boundary. Nothing carries it
+    /// into an ordinary pass, so no transform can invalidate it while it is
+    /// live, and re-deriving it at each boundary is what makes the construction
     /// idempotent.
     candidates: BitSet<'a>,
-
-    /// Whether [`Self::candidates`] holds anything, so the per-spread test on
-    /// the removal path is a branch rather than a scan.
-    has_candidates: bool,
 }
 
 impl<'a> SpreadCleanup<'a> {
     pub fn new(scoping: &Scoping, allocator: &'a Allocator) -> Self {
         Self {
             marks: BitSet::new_in(scoping.references_len(), allocator),
-            removable_marks: BitSet::new_in(scoping.references_len(), allocator),
             candidates: BitSet::new_in(scoping.symbols_len(), allocator),
-            has_candidates: false,
         }
     }
 
     /// Discard the previous pass's marks. Called at the start of every pass.
     pub fn begin_pass(&mut self) {
         self.marks.clear();
-        self.removable_marks.clear();
-    }
-
-    /// Drop the published candidates and report whether there were any, i.e.
-    /// whether the pass that just finished was a cleanup pass.
-    pub fn take_candidates(&mut self) -> bool {
-        if !self.has_candidates {
-            return false;
-        }
-        self.candidates.clear();
-        self.has_candidates = false;
-        true
     }
 }
 
@@ -163,27 +131,7 @@ pub fn mark_object_copy_spread<'a>(spread: &SpreadElement<'a>, ctx: &mut Travers
     let index = reference_id.index();
     if index < ctx.state.spread_cleanup.marks.capacity() {
         ctx.state.spread_cleanup.marks.set_bit(index);
-        if enclosing_literal_is_discarded(ctx) {
-            ctx.state.spread_cleanup.removable_marks.set_bit(index);
-        }
     }
-}
-
-/// Whether the object literal holding the spread being exited is itself in a
-/// discarded position, i.e. one `remove_unused_expression` reaches.
-///
-/// The ancestor above `ObjectExpressionProperties` is the literal's own parent.
-/// An expression statement discards it outright; a sequence element discards
-/// every operand but the last, and treating the last one as discarded too is
-/// harmless here — this only decides whether publishing a candidate is worth a
-/// pass, never whether removing it is legal.
-fn enclosing_literal_is_discarded(ctx: &TraverseCtx<'_>) -> bool {
-    matches!(
-        ctx.ancestors().nth(1),
-        Some(
-            Ancestor::ExpressionStatementExpression(_) | Ancestor::SequenceExpressionExpressions(_)
-        )
-    )
 }
 
 /// Whether this spread may stand as evidence about the symbol's value.
@@ -262,7 +210,6 @@ pub fn settle_candidates(
             found_candidates = true;
         }
     }
-    ctx.state.spread_cleanup.has_candidates = found_candidates;
     #[cfg(debug_assertions)]
     if found_candidates {
         debug_assert_census_complete(program, ctx);
@@ -325,45 +272,169 @@ fn is_candidate(symbol_id: SymbolId, ctx: &TraverseCtx<'_>) -> bool {
     if liveness.is_implicitly_observable(symbol_id) {
         return false;
     }
-    let reference_ids = scoping.get_resolved_reference_ids(symbol_id);
-    reference_ids
+    scoping
+        .get_resolved_reference_ids(symbol_id)
         .iter()
         .all(|reference_id| ctx.state.spread_cleanup.marks.contains(reference_id.index()))
-        && reference_ids.iter().any(|reference_id| {
-            ctx.state.spread_cleanup.removable_marks.contains(reference_id.index())
-        })
 }
 
-/// Whether this object property is a spread the last quiet-pass boundary proved
-/// dead, and may therefore be dropped from a discarded object literal.
+/// One round of the boundary's removal batch: delete the dead object copies the
+/// census just proved, and report whether anything went.
 ///
-/// Candidacy survives everything the cleanup pass does to the AST. A transform
-/// can delete references, which only shrinks the census; it can move a spread
-/// wholesale, which leaves it a spread; and none converts a spread use into a
-/// use of another shape. A transform that ever does — one that rewrites
-/// `({ ...P })` into something reading `P` in another position — must clear the
-/// candidate set, or this fact stops being true mid-pass.
-pub fn is_dead_object_copy_spread<'a>(
-    property: &ObjectPropertyKind<'a>,
-    ctx: &TraverseCtx<'a>,
-) -> bool {
-    let ObjectPropertyKind::SpreadProperty(spread) = property else { return false };
-    is_dead_object_copy_spread_argument(&spread.argument, ctx)
+/// This is a restricted walk, not a peephole pass. Nothing else transforms
+/// while it runs, so the candidate set cannot be invalidated underneath it, and
+/// the two shapes it removes are the only ones it knows:
+///
+/// - an expression statement whose value is discarded and whose every effect is
+///   a candidate copy or an effect-free property;
+/// - a variable declarator with no live reference left whose initializer is the
+///   same.
+///
+/// The second is what makes a chain collapse. `const P1 = { ...P0 }` keeps `P0`
+/// alive only through `P1`'s declarator, so each layer becomes removable one
+/// round after the layer above it. The caller loops rounds — pruning references
+/// between them so the next round sees current counts — until a round removes
+/// nothing. References only ever shrink, so it terminates, and a census member
+/// stays a member: every remaining reference was already a mark.
+pub fn remove_dead_copies<'a>(program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
+    let mut batch = RemovalBatch { ctx, removed: false };
+    batch.visit_program(program);
+    batch.removed
 }
 
-/// [`is_dead_object_copy_spread`] against a spread argument already
-/// destructured out of its property.
-pub fn is_dead_object_copy_spread_argument<'a>(
-    argument: &Expression<'a>,
-    ctx: &TraverseCtx<'a>,
-) -> bool {
-    if !ctx.state.spread_cleanup.has_candidates {
-        return false;
+struct RemovalBatch<'a, 'b> {
+    ctx: &'b mut TraverseCtx<'a>,
+    removed: bool,
+}
+
+impl<'a> VisitJsMut<'a> for RemovalBatch<'a, '_> {
+    fn visit_statements(&mut self, statements: &mut ArenaVec<'a, Statement<'a>>) {
+        walk_js_mut::walk_statements(self, statements);
+        statements.retain_mut(|statement| !self.statement_is_dead(statement));
     }
-    let Expression::Identifier(ident) = argument else { return false };
-    let Some(reference_id) = ident.reference_id.get() else { return false };
-    ctx.scoping()
-        .get_reference(reference_id)
-        .symbol_id()
-        .is_some_and(|symbol_id| ctx.state.spread_cleanup.candidates.contains(symbol_id.index()))
+}
+
+impl<'a> RemovalBatch<'a, '_> {
+    fn statement_is_dead(&mut self, statement: &mut Statement<'a>) -> bool {
+        match statement {
+            Statement::ExpressionStatement(statement) => {
+                if !self.strip_discarded_expression(&mut statement.expression) {
+                    return false;
+                }
+                self.ctx.drop_expression(&statement.expression);
+                self.removed = true;
+                true
+            }
+            Statement::VariableDeclaration(declaration) => self.strip_dead_declarators(declaration),
+            _ => false,
+        }
+    }
+
+    /// Take the census-proven copies out of an expression whose value is
+    /// discarded, and report whether nothing effectful is left.
+    ///
+    /// Deliberately narrow: only the shapes this batch can rewrite. Anything
+    /// else is left to ordinary DCE, which sees it on the next pass.
+    ///
+    /// Every operand of a discarded sequence is itself discarded, the last one
+    /// included — true only because the statement's own value is unused, which
+    /// is why the position test lives here rather than at the mark site, where
+    /// a sequence in value position is indistinguishable. Full minify fuses
+    /// statements into sequences, so a copy routinely ends up beside operands
+    /// that must stay; stripping per operand rather than testing the whole
+    /// statement is what keeps those removals.
+    fn strip_discarded_expression(&mut self, expression: &mut Expression<'a>) -> bool {
+        match expression {
+            Expression::ObjectExpression(object) => {
+                if object.properties.iter().all(|property| self.property_is_dead(property)) {
+                    // The caller drops the literal whole, references included.
+                    return true;
+                }
+                // Something in the literal must stay, so take out only the
+                // copies themselves. Their argument is a bare identifier, so
+                // one `drop_expression` prunes exactly the reference that goes.
+                object.properties.retain(|property| {
+                    let ObjectPropertyKind::SpreadProperty(spread) = property else { return true };
+                    if !self.is_candidate_copy(&spread.argument) {
+                        return true;
+                    }
+                    self.ctx.drop_expression(&spread.argument);
+                    self.removed = true;
+                    false
+                });
+                false
+            }
+            Expression::SequenceExpression(sequence) => {
+                let mut retained = ArenaVec::new_in(&*self.ctx);
+                for mut operand in sequence.expressions.drain(..) {
+                    if self.strip_discarded_expression(&mut operand) {
+                        self.ctx.drop_expression(&operand);
+                        self.removed = true;
+                    } else {
+                        retained.push(operand);
+                    }
+                }
+                sequence.expressions = retained;
+                sequence.expressions.is_empty()
+            }
+            _ => false,
+        }
+    }
+
+    /// The non-mutating form, for an initializer that is about to be dropped
+    /// whole rather than rewritten in place.
+    fn discarded_expression_is_dead(&self, expression: &Expression<'a>) -> bool {
+        match expression {
+            Expression::ObjectExpression(object) => {
+                object.properties.iter().all(|property| self.property_is_dead(property))
+            }
+            Expression::SequenceExpression(sequence) => sequence
+                .expressions
+                .iter()
+                .all(|expression| self.discarded_expression_is_dead(expression)),
+            _ => false,
+        }
+    }
+
+    fn property_is_dead(&self, property: &ObjectPropertyKind<'a>) -> bool {
+        if let ObjectPropertyKind::SpreadProperty(spread) = property
+            && self.is_candidate_copy(&spread.argument)
+        {
+            return true;
+        }
+        !property.may_have_side_effects(self.ctx)
+    }
+
+    fn is_candidate_copy(&self, argument: &Expression<'a>) -> bool {
+        let Expression::Identifier(ident) = argument else { return false };
+        let Some(reference_id) = ident.reference_id.get() else { return false };
+        self.ctx.scoping().get_reference(reference_id).symbol_id().is_some_and(|symbol_id| {
+            self.ctx.state.spread_cleanup.candidates.contains(symbol_id.index())
+        })
+    }
+
+    /// Drop declarators whose binding has no live reference left and whose
+    /// initializer is dead, and report whether the declaration is now empty.
+    ///
+    /// `should_remove_unused_declarator` supplies the unusedness rule (and its
+    /// `using` and configuration guards); requiring the initializer to be dead
+    /// on top is what keeps this from discarding effects ordinary DCE would
+    /// have preserved by rewriting the declarator into an expression statement.
+    fn strip_dead_declarators(&mut self, declaration: &mut VariableDeclaration<'a>) -> bool {
+        if !PeepholeOptimizations::can_remove_unused_declarators(self.ctx) {
+            return false;
+        }
+        declaration.declarations.retain_mut(|declarator| {
+            let Some(init) = &declarator.init else { return true };
+            if !PeepholeOptimizations::should_remove_unused_declarator(declarator, self.ctx)
+                || !self.discarded_expression_is_dead(init)
+            {
+                return true;
+            }
+            self.ctx.drop_expression(init);
+            self.removed = true;
+            false
+        });
+        declaration.declarations.is_empty()
+    }
 }

--- a/crates/oxc_minifier/src/spread_cleanup.rs
+++ b/crates/oxc_minifier/src/spread_cleanup.rs
@@ -15,7 +15,7 @@
 //!   ├─ changed → discard this pass's marks and continue
 //!   └─ quiet   → census against the settled references
 //!                  ↓
-//!               publish candidates, run one cleanup pass
+//!               publish candidates, run the cleanup batch
 //!                  ↓
 //!               removals reopen ordinary DCE
 //! ```
@@ -38,16 +38,16 @@
 use oxc_allocator::{Allocator, BitSet, Vec as ArenaVec};
 #[cfg(debug_assertions)]
 use oxc_ast_visit::Visit;
-use oxc_ast_visit::{VisitJsMut, walk_js_mut};
 
 use oxc_ast::ast::*;
 use oxc_semantic::Scoping;
-use oxc_syntax::{reference::ReferenceId, scope::ScopeFlags, symbol::SymbolId};
+use oxc_syntax::{scope::ScopeFlags, symbol::SymbolId};
 
 use oxc_ecmascript::side_effects::MayHaveSideEffects;
 
 use crate::{
-    TraverseCtx, generated::ancestor::Ancestor, peephole::PeepholeOptimizations,
+    ReusableTraverseCtx, Traverse, TraverseCtx, generated::ancestor::Ancestor,
+    minifier_traverse::traverse_mut_with_ctx, peephole::PeepholeOptimizations,
     symbol_value::FreshValueKind,
 };
 
@@ -87,9 +87,14 @@ impl<'a> SpreadCleanup<'a> {
         }
     }
 
-    /// Discard the previous pass's marks. Called at the start of every pass.
+    /// Discard all facts from the previous ordinary-pass boundary.
+    ///
+    /// Candidates remain live across the removal rounds that immediately
+    /// follow one quiet pass, but must never survive into the next ordinary
+    /// pass: that pass can expose new uses which invalidate the old census.
     pub fn begin_pass(&mut self) {
         self.marks.clear();
+        self.candidates.clear();
     }
 }
 
@@ -164,8 +169,8 @@ fn mark_time_proof_holds(symbol_id: SymbolId, ctx: &TraverseCtx<'_>) -> bool {
         .any(|scope_id| scoping.scope_flags(scope_id).is_function())
 }
 
-/// Publish the symbols whose dead object-copy spreads the next pass may remove,
-/// and report whether there are any.
+/// Publish the symbols whose dead object-copy spreads the immediate cleanup
+/// batch may remove, and report whether there are any.
 ///
 /// Called only at a quiet-pass boundary, after `finish_pass` has flushed the
 /// pass's changes, so `Scoping` lists exactly the references the settled AST
@@ -191,18 +196,15 @@ pub fn settle_candidates(
     #[cfg_attr(not(debug_assertions), expect(unused_variables))] program: &Program<'_>,
     ctx: &mut TraverseCtx<'_>,
 ) -> bool {
-    // Arena-allocated so a boundary costs no system allocation; the marked
-    // symbols must be read out before `candidates` can be written to.
-    let mut marked_symbols = ArenaVec::new_in(&*ctx);
-    for index in ctx.state.spread_cleanup.marks.ones() {
-        if let Some(symbol_id) =
-            ctx.scoping().get_reference(ReferenceId::from_usize(index)).symbol_id()
-        {
-            marked_symbols.push(symbol_id);
-        }
+    if ctx.state.spread_cleanup.marks.is_empty() {
+        return false;
     }
     let mut found_candidates = false;
-    for symbol_id in marked_symbols {
+    // Scanning dense symbol IDs avoids allocating a temporary symbol list and
+    // is no broader than scanning the reference-sized mark bitset. The census
+    // itself rejects symbols without at least one marked live reference.
+    for index in 0..ctx.scoping().symbols_len() {
+        let symbol_id = SymbolId::from_usize(index);
         if !ctx.state.spread_cleanup.candidates.contains(symbol_id.index())
             && is_candidate(symbol_id, ctx)
         {
@@ -272,18 +274,20 @@ fn is_candidate(symbol_id: SymbolId, ctx: &TraverseCtx<'_>) -> bool {
     if liveness.is_implicitly_observable(symbol_id) {
         return false;
     }
-    scoping
-        .get_resolved_reference_ids(symbol_id)
-        .iter()
-        .all(|reference_id| ctx.state.spread_cleanup.marks.contains(reference_id.index()))
+    let mut reference_ids = scoping.get_resolved_reference_ids(symbol_id).iter();
+    reference_ids.next().is_some_and(|reference_id| {
+        ctx.state.spread_cleanup.marks.contains(reference_id.index())
+            && reference_ids
+                .all(|reference_id| ctx.state.spread_cleanup.marks.contains(reference_id.index()))
+    })
 }
 
 /// One round of the boundary's removal batch: delete the dead object copies the
 /// census just proved, and report whether anything went.
 ///
-/// This is a restricted walk, not a peephole pass. Nothing else transforms
-/// while it runs, so the candidate set cannot be invalidated underneath it, and
-/// the two shapes it removes are the only ones it knows:
+/// This is a restricted scope-aware traversal, not a peephole pass. Nothing
+/// else transforms while it runs, so the candidate set cannot be invalidated
+/// underneath it, and the two shapes it removes are the only ones it knows:
 ///
 /// - an expression statement whose value is discarded and whose every effect is
 ///   a candidate copy or an effect-free property;
@@ -296,36 +300,47 @@ fn is_candidate(symbol_id: SymbolId, ctx: &TraverseCtx<'_>) -> bool {
 /// between them so the next round sees current counts — until a round removes
 /// nothing. References only ever shrink, so it terminates, and a census member
 /// stays a member: every remaining reference was already a mark.
-pub fn remove_dead_copies<'a>(program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
-    let mut batch = RemovalBatch { ctx, removed: false };
-    batch.visit_program(program);
+pub fn remove_dead_copies<'a>(
+    program: &mut Program<'a>,
+    ctx: &mut ReusableTraverseCtx<'a>,
+) -> bool {
+    let mut batch = RemovalBatch { removed: false };
+    traverse_mut_with_ctx(&mut batch, program, ctx);
     batch.removed
 }
 
-struct RemovalBatch<'a, 'b> {
-    ctx: &'b mut TraverseCtx<'a>,
+struct RemovalBatch {
     removed: bool,
 }
 
-impl<'a> VisitJsMut<'a> for RemovalBatch<'a, '_> {
-    fn visit_statements(&mut self, statements: &mut ArenaVec<'a, Statement<'a>>) {
-        walk_js_mut::walk_statements(self, statements);
-        statements.retain_mut(|statement| !self.statement_is_dead(statement));
+impl<'a> Traverse<'a> for RemovalBatch {
+    fn exit_statements(
+        &mut self,
+        statements: &mut ArenaVec<'a, Statement<'a>>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        statements.retain_mut(|statement| !self.statement_is_dead(statement, ctx));
     }
 }
 
-impl<'a> RemovalBatch<'a, '_> {
-    fn statement_is_dead(&mut self, statement: &mut Statement<'a>) -> bool {
+impl RemovalBatch {
+    fn statement_is_dead<'a>(
+        &mut self,
+        statement: &mut Statement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> bool {
         match statement {
             Statement::ExpressionStatement(statement) => {
-                if !self.strip_discarded_expression(&mut statement.expression) {
+                if !self.strip_discarded_expression(&mut statement.expression, ctx) {
                     return false;
                 }
-                self.ctx.drop_expression(&statement.expression);
+                ctx.drop_expression(&statement.expression);
                 self.removed = true;
                 true
             }
-            Statement::VariableDeclaration(declaration) => self.strip_dead_declarators(declaration),
+            Statement::VariableDeclaration(declaration) => {
+                self.strip_dead_declarators(declaration, ctx)
+            }
             _ => false,
         }
     }
@@ -343,10 +358,14 @@ impl<'a> RemovalBatch<'a, '_> {
     /// statements into sequences, so a copy routinely ends up beside operands
     /// that must stay; stripping per operand rather than testing the whole
     /// statement is what keeps those removals.
-    fn strip_discarded_expression(&mut self, expression: &mut Expression<'a>) -> bool {
+    fn strip_discarded_expression<'a>(
+        &mut self,
+        expression: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> bool {
         match expression {
             Expression::ObjectExpression(object) => {
-                if object.properties.iter().all(|property| self.property_is_dead(property)) {
+                if object.properties.iter().all(|property| Self::property_is_dead(property, ctx)) {
                     // The caller drops the literal whole, references included.
                     return true;
                 }
@@ -355,26 +374,25 @@ impl<'a> RemovalBatch<'a, '_> {
                 // one `drop_expression` prunes exactly the reference that goes.
                 object.properties.retain(|property| {
                     let ObjectPropertyKind::SpreadProperty(spread) = property else { return true };
-                    if !self.is_candidate_copy(&spread.argument) {
+                    if !Self::is_candidate_copy(&spread.argument, ctx) {
                         return true;
                     }
-                    self.ctx.drop_expression(&spread.argument);
+                    ctx.drop_expression(&spread.argument);
                     self.removed = true;
                     false
                 });
                 false
             }
             Expression::SequenceExpression(sequence) => {
-                let mut retained = ArenaVec::new_in(&*self.ctx);
-                for mut operand in sequence.expressions.drain(..) {
-                    if self.strip_discarded_expression(&mut operand) {
-                        self.ctx.drop_expression(&operand);
+                sequence.expressions.retain_mut(|operand| {
+                    if self.strip_discarded_expression(operand, ctx) {
+                        ctx.drop_expression(operand);
                         self.removed = true;
+                        false
                     } else {
-                        retained.push(operand);
+                        true
                     }
-                }
-                sequence.expressions = retained;
+                });
                 sequence.expressions.is_empty()
             }
             _ => false,
@@ -383,33 +401,36 @@ impl<'a> RemovalBatch<'a, '_> {
 
     /// The non-mutating form, for an initializer that is about to be dropped
     /// whole rather than rewritten in place.
-    fn discarded_expression_is_dead(&self, expression: &Expression<'a>) -> bool {
+    fn discarded_expression_is_dead<'a>(
+        expression: &Expression<'a>,
+        ctx: &TraverseCtx<'a>,
+    ) -> bool {
         match expression {
             Expression::ObjectExpression(object) => {
-                object.properties.iter().all(|property| self.property_is_dead(property))
+                object.properties.iter().all(|property| Self::property_is_dead(property, ctx))
             }
             Expression::SequenceExpression(sequence) => sequence
                 .expressions
                 .iter()
-                .all(|expression| self.discarded_expression_is_dead(expression)),
+                .all(|expression| Self::discarded_expression_is_dead(expression, ctx)),
             _ => false,
         }
     }
 
-    fn property_is_dead(&self, property: &ObjectPropertyKind<'a>) -> bool {
+    fn property_is_dead<'a>(property: &ObjectPropertyKind<'a>, ctx: &TraverseCtx<'a>) -> bool {
         if let ObjectPropertyKind::SpreadProperty(spread) = property
-            && self.is_candidate_copy(&spread.argument)
+            && Self::is_candidate_copy(&spread.argument, ctx)
         {
             return true;
         }
-        !property.may_have_side_effects(self.ctx)
+        !property.may_have_side_effects(ctx)
     }
 
-    fn is_candidate_copy(&self, argument: &Expression<'a>) -> bool {
+    fn is_candidate_copy<'a>(argument: &Expression<'a>, ctx: &TraverseCtx<'a>) -> bool {
         let Expression::Identifier(ident) = argument else { return false };
         let Some(reference_id) = ident.reference_id.get() else { return false };
-        self.ctx.scoping().get_reference(reference_id).symbol_id().is_some_and(|symbol_id| {
-            self.ctx.state.spread_cleanup.candidates.contains(symbol_id.index())
+        ctx.scoping().get_reference(reference_id).symbol_id().is_some_and(|symbol_id| {
+            ctx.state.spread_cleanup.candidates.contains(symbol_id.index())
         })
     }
 
@@ -420,18 +441,25 @@ impl<'a> RemovalBatch<'a, '_> {
     /// `using` and configuration guards); requiring the initializer to be dead
     /// on top is what keeps this from discarding effects ordinary DCE would
     /// have preserved by rewriting the declarator into an expression statement.
-    fn strip_dead_declarators(&mut self, declaration: &mut VariableDeclaration<'a>) -> bool {
-        if !PeepholeOptimizations::can_remove_unused_declarators(self.ctx) {
+    fn strip_dead_declarators<'a>(
+        &mut self,
+        declaration: &mut VariableDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> bool {
+        if !PeepholeOptimizations::can_remove_unused_declarators(ctx) {
             return false;
         }
+        let kind = declaration.kind;
         declaration.declarations.retain_mut(|declarator| {
-            let Some(init) = &declarator.init else { return true };
-            if !PeepholeOptimizations::should_remove_unused_declarator(declarator, self.ctx)
-                || !self.discarded_expression_is_dead(init)
+            if !PeepholeOptimizations::should_remove_unused_declarator(declarator, kind, ctx)
+                || !declarator
+                    .init
+                    .as_ref()
+                    .is_some_and(|init| Self::discarded_expression_is_dead(init, ctx))
             {
                 return true;
             }
-            self.ctx.drop_expression(init);
+            ctx.drop_variable_declarator(declarator);
             self.removed = true;
             false
         });

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -7,7 +7,7 @@ use oxc_span::SourceType;
 use oxc_str::Str;
 use oxc_syntax::scope::ScopeId;
 
-use crate::{CompressOptions, symbol_state::SymbolState};
+use crate::{CompressOptions, spread_cleanup::SpreadCleanup, symbol_state::SymbolState};
 
 /// Compression pipeline selected for this run.
 #[derive(Clone, Copy)]
@@ -111,6 +111,16 @@ pub struct MinifierState<'a> {
     /// consumed by `compression_pass` after Normalize and every peephole pass.
     pub(crate) pass_changes: PassChanges<'a>,
 
+    /// Marks and settled candidates for the quiet-pass object-spread cleanup.
+    pub(crate) spread_cleanup: SpreadCleanup<'a>,
+
+    /// Whether `exit_statements` is re-processing an already-traversed
+    /// statement list. Entry existence in `SymbolState::values` is a
+    /// traversal-order proof everywhere else, but not here: the list also
+    /// carries entries for declarators positioned LATER than the node being
+    /// visited.
+    pub(crate) reprocessing_statements: bool,
+
     /// Scratch buffer reused by `try_fold_concat` to build template literal
     /// quasis without allocating a fresh `String` per call.
     pub concat_scratch: String,
@@ -135,6 +145,8 @@ impl<'a> MinifierState<'a> {
                 this_initialized_at: None,
             }),
             pass_changes: PassChanges::new(scoping.references_len(), allocator),
+            spread_cleanup: SpreadCleanup::new(scoping, allocator),
+            reprocessing_statements: false,
             concat_scratch: String::new(),
         }
     }

--- a/crates/oxc_minifier/src/symbol_value.rs
+++ b/crates/oxc_minifier/src/symbol_value.rs
@@ -102,6 +102,18 @@ pub struct SymbolValue<'a> {
     /// object/array/function/class literals. See `FreshValueKind`.
     pub kind: FreshValueKind,
 
+    /// Whether a `var` declarator is a direct item of a function body's or the
+    /// Program's statement list, rather than nested in a conditional, a loop,
+    /// or another statement position.
+    ///
+    /// Only meaningful for `var`: a value entry proves the declarator was
+    /// *visited*, never that its initializer *ran*, and `if (flag) var f = …`
+    /// is visited on every traversal while assigning on none. Recorded here
+    /// because the consumer (`PeepholeOptimizations::summary_order_proven`)
+    /// sees a `SymbolId`, not the declarator. Other producers pass `true`; they
+    /// classify bindings the `var` arm never reaches.
+    pub declarator_in_body_statement_list: bool,
+
     /// The symbol is provably falsy in **boolean context** but not necessarily
     /// foldable in value context. Set for a write-once binding with a falsy
     /// constant initializer whose `initialized_constant` was withheld (a hoisted

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -313,6 +313,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         kind: FreshValueKind,
         falsy_init: bool,
         init_absent: bool,
+        declarator_in_body_statement_list: bool,
     ) {
         let mut references = ReferenceCounts::default();
         for reference in self.scoping().get_resolved_references(symbol_id) {
@@ -367,6 +368,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
             implicit_undefined,
             references,
             kind: if has_multiple_value_declarations { FreshValueKind::None } else { kind },
+            declarator_in_body_statement_list,
             boolean_falsy,
         };
         self.state.symbols.init_value(symbol_id, symbol_value);

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -1132,6 +1132,24 @@ fn remove_dead_object_spread_of_local_literal() {
     test("const P = { [\"__proto__\"]: base, a: 1 }; ({ ...P }); ({ ...P });", "base;");
 }
 
+// Each layer of a spread chain only reaches discarded position once the layer
+// above it is gone, so consuming candidates a pass at a time cost a global
+// iteration per layer and a four-layer chain exhausted the iteration budget.
+// The boundary batches its removals instead, and doubling each layer's copies
+// keeps single-use inlining from dissolving the chain first.
+#[test]
+fn remove_layered_object_spread_chain() {
+    test(
+        "const P0 = {}; const P1 = { ...P0, ...P0 }; const P2 = { ...P1, ...P1 }; const P3 = { ...P2, ...P2 }; ({ ...P3 }); ({ ...P3 });",
+        "",
+    );
+    // Depth five, same shape.
+    test(
+        "const P0 = {}; const P1 = { ...P0, ...P0 }; const P2 = { ...P1, ...P1 }; const P3 = { ...P2, ...P2 }; const P4 = { ...P3, ...P3 }; ({ ...P4 }); ({ ...P4 });",
+        "",
+    );
+}
+
 // A symbol whose every copy sits in a USED initializer passes the census but
 // has nothing removable, so it is never published. Were it published, the
 // cleanup pass would remove nothing, be quiet, and re-derive the identical

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -1056,3 +1056,75 @@ fn dce_keeps_implicitly_observable_bindings() {
         options,
     );
 }
+
+// A dead object-copy spread of a binding that provably still holds a
+// getter-free object literal runs no user code, so it is removable. Proven at a
+// quiet-pass boundary by a census over the symbol's live references — see
+// `crate::spread_cleanup`.
+// https://github.com/oxc-project/oxc/issues/20661
+// https://github.com/rolldown/rolldown/issues/8582
+#[test]
+fn remove_dead_object_spread_of_local_literal() {
+    // The effect / rolldown#8582 shape: computed keys and methods install no
+    // accessors, so both copies are dead. The computed key's own reads stay.
+    test(
+        "const Proto = { [TypeId]: TypeId, m() {} }; ({ ...Proto }); ({ ...Proto });",
+        "TypeId, TypeId;",
+    );
+    // Transitive, one cleanup round per quiet boundary: removing `P2`'s copies
+    // kills its declarator, which makes `P1`'s copy inside it dead in turn.
+    test("const P1 = { a: 1 }; const P2 = { ...P1, b: 2 }; ({ ...P2 }); ({ ...P2 });", "");
+    // The copies sit in dead declarator initializers, mixed with data keys.
+    test("const P = { a: 1 }; const X = { ...P, t: 1 }; const Y = { ...P, u: 2 };", "");
+    // A computed `["__proto__"]` key creates an own data property rather than
+    // setting the prototype, so the literal is still classified and the copies
+    // still go. The `base` read is an ordinary global read and stays.
+    test("const P = { [\"__proto__\"]: base, a: 1 }; ({ ...P }); ({ ...P });", "base;");
+}
+
+// A symbol whose every copy sits in a USED initializer passes the census but
+// has nothing removable, so it is never published. Were it published, the
+// cleanup pass would remove nothing, be quiet, and re-derive the identical
+// census — retrying until the iteration guard. Two guards stop that: the
+// publish filter here, and the terminal rule that a cleanup pass which changed
+// nothing ends the loop. `Q` is read twice so single-use inlining does not
+// dissolve the shape first.
+#[test]
+fn keep_object_spread_in_used_initializer() {
+    test(
+        "const P = { a: 1 }; const Q = { ...P }; console.log(Q, Q);",
+        "const Q = { a: 1 }; console.log(Q, Q);",
+    );
+}
+
+// Every keep below is the classifier or the census failing. This cleanup has no
+// sanctioned read positions: any live use that is not an object-copy spread
+// disqualifies the symbol, so the hazards do not need enumerating.
+#[test]
+fn keep_object_spread_disqualified_by_census() {
+    // A getter runs on copy, so the literal is never classified `Object`.
+    test_same("const P = { get a() { return 1 } }; ({ ...P }); ({ ...P });");
+    // An ordinary call argument: `foo` can install a getter.
+    test_same("const P = { a: 1 }; foo(P); ({ ...P });");
+    // `console.log` is no exception — Node invokes a `util.inspect.custom`
+    // method on the argument with the argument as the receiver.
+    test_same("const P = { a: 1 }; console.log(P); ({ ...P });");
+    // An array spread runs the value's own `@@iterator`. Deliberately out of
+    // scope for this object-only cleanup; the census keeps it sound anyway.
+    test_same(
+        "const P = { a: 1, [Symbol.iterator]() { return [][Symbol.iterator]() } }; [...P]; ({ ...P });",
+    );
+    // A member write is not a copy. Allowing static ones would be sound but is
+    // deliberately outside this scope.
+    test_same("const P = { a: 1 }; P.b = 2; ({ ...P }); ({ ...P });");
+    // Reassigned: the copied value is not the classified one.
+    test_same("let P = { a: 1 }; P = unknownGlobal; ({ ...P }); ({ ...P });");
+    // The copy precedes the declarator, so the mark-time order proof fails.
+    test_same("({ ...P }); const P = { a: 1 };");
+    // An exported binding fails twice over: `is_implicitly_observable` marks it,
+    // and the `export { P }` specifier is itself a live unmarked reference.
+    test_same("const P = { a: 1 }; ({ ...P }); export { P };");
+    // `f` runs while the hoisted `var` still holds `undefined`, so the copy
+    // inside it fails the mark-time same-function proof and goes unmarked.
+    test_same("function f() { ({ ...P }); } f(); var P = { a: 1 }; ({ ...P });");
+}

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -737,6 +737,38 @@ fn remove_pure_function_calls() {
 }
 
 #[test]
+fn keep_calls_before_var_function_assignment() {
+    // A `var` binding holds `undefined` until its assignment runs, so a call
+    // reached first throws `TypeError`. The function summary describes the
+    // VALUE; consuming it at a call site keyed only by the BINDING erases that
+    // throw. The trailing `var unused = 1` only supplies the extra pass that
+    // makes the summary available.
+    test("f(); var f = () => {}; var unused = 1;", "f(); var f = () => {};");
+
+    // Reached through a body that ordinary DCE empties. The trailing `f()` IS
+    // order-proven and still goes, so the fixed point keeps only the
+    // conditional call and the emptied declarator.
+    test(
+        "if (unknownGlobal) { f(); } var f = () => { var a = [1]; [...a]; }; f(); var unused = 1;",
+        "if (unknownGlobal) f(); var f = () => {};",
+    );
+
+    // A spread of an object literal is pure on its own, so the body empties.
+    test("f(); var f = () => { ({ ...{ a: 1 } }); }; var unused = 1;", "f(); var f = () => {};");
+
+    // The route the object-spread cleanup opens: its copies are removable, the
+    // body empties, and the summary reaches this same consumer.
+    test(
+        "f(); var f = () => { const P = { a: 1 }; ({ ...P }); ({ ...P }); }; var unused = 1;",
+        "f(); var f = () => {};",
+    );
+
+    // Order-proven calls keep optimizing: the declarator precedes them.
+    test("var f = () => {}; f(); f();", "");
+    test("const g = () => {}; g();", "");
+}
+
+#[test]
 fn preserve_iife_in_dce_mode() {
     // https://github.com/oxc-project/oxc/issues/17480
     // https://github.com/rolldown/rolldown/issues/9437

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -1189,6 +1189,24 @@ fn remove_dead_object_spread_of_local_literal() {
     test("const P = { [\"__proto__\"]: base, a: 1 }; ({ ...P }); ({ ...P });", "base;");
 }
 
+// Each layer of a spread chain only reaches discarded position once the layer
+// above it is gone, so consuming candidates a pass at a time cost a global
+// iteration per layer and a four-layer chain exhausted the iteration budget.
+// The boundary batches its removals instead, and doubling each layer's copies
+// keeps single-use inlining from dissolving the chain first.
+#[test]
+fn remove_layered_object_spread_chain() {
+    test(
+        "const P0 = {}; const P1 = { ...P0, ...P0 }; const P2 = { ...P1, ...P1 }; const P3 = { ...P2, ...P2 }; ({ ...P3 }); ({ ...P3 });",
+        "",
+    );
+    // Depth five, same shape.
+    test(
+        "const P0 = {}; const P1 = { ...P0, ...P0 }; const P2 = { ...P1, ...P1 }; const P3 = { ...P2, ...P2 }; const P4 = { ...P3, ...P3 }; ({ ...P4 }); ({ ...P4 });",
+        "",
+    );
+}
+
 // A symbol whose every copy sits in a USED initializer passes the census but
 // has nothing removable, so it is never published. Were it published, the
 // cleanup pass would remove nothing, be quiet, and re-derive the identical

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -1113,3 +1113,75 @@ fn dce_inline_template_literal_does_not_create_octal_escape() {
     // Expressions with side effects must still remain interpolation expressions.
     test_same(r"export function makeKey(messageId) { return `${messageId}\0${sideEffect()}`; }");
 }
+
+// A dead object-copy spread of a binding that provably still holds a
+// getter-free object literal runs no user code, so it is removable. Proven at a
+// quiet-pass boundary by a census over the symbol's live references — see
+// `crate::spread_cleanup`.
+// https://github.com/oxc-project/oxc/issues/20661
+// https://github.com/rolldown/rolldown/issues/8582
+#[test]
+fn remove_dead_object_spread_of_local_literal() {
+    // The effect / rolldown#8582 shape: computed keys and methods install no
+    // accessors, so both copies are dead. The computed key's own reads stay.
+    test(
+        "const Proto = { [TypeId]: TypeId, m() {} }; ({ ...Proto }); ({ ...Proto });",
+        "TypeId, TypeId;",
+    );
+    // Transitive, one cleanup round per quiet boundary: removing `P2`'s copies
+    // kills its declarator, which makes `P1`'s copy inside it dead in turn.
+    test("const P1 = { a: 1 }; const P2 = { ...P1, b: 2 }; ({ ...P2 }); ({ ...P2 });", "");
+    // The copies sit in dead declarator initializers, mixed with data keys.
+    test("const P = { a: 1 }; const X = { ...P, t: 1 }; const Y = { ...P, u: 2 };", "");
+    // A computed `["__proto__"]` key creates an own data property rather than
+    // setting the prototype, so the literal is still classified and the copies
+    // still go. The `base` read is an ordinary global read and stays.
+    test("const P = { [\"__proto__\"]: base, a: 1 }; ({ ...P }); ({ ...P });", "base;");
+}
+
+// A symbol whose every copy sits in a USED initializer passes the census but
+// has nothing removable, so it is never published. Were it published, the
+// cleanup pass would remove nothing, be quiet, and re-derive the identical
+// census — retrying until the iteration guard. Two guards stop that: the
+// publish filter here, and the terminal rule that a cleanup pass which changed
+// nothing ends the loop. `Q` is read twice so single-use inlining does not
+// dissolve the shape first.
+#[test]
+fn keep_object_spread_in_used_initializer() {
+    test(
+        "const P = { a: 1 }; const Q = { ...P }; console.log(Q, Q);",
+        "const Q = { a: 1 }; console.log(Q, Q);",
+    );
+}
+
+// Every keep below is the classifier or the census failing. This cleanup has no
+// sanctioned read positions: any live use that is not an object-copy spread
+// disqualifies the symbol, so the hazards do not need enumerating.
+#[test]
+fn keep_object_spread_disqualified_by_census() {
+    // A getter runs on copy, so the literal is never classified `Object`.
+    test_same("const P = { get a() { return 1 } }; ({ ...P }); ({ ...P });");
+    // An ordinary call argument: `foo` can install a getter.
+    test_same("const P = { a: 1 }; foo(P); ({ ...P });");
+    // `console.log` is no exception — Node invokes a `util.inspect.custom`
+    // method on the argument with the argument as the receiver.
+    test_same("const P = { a: 1 }; console.log(P); ({ ...P });");
+    // An array spread runs the value's own `@@iterator`. Deliberately out of
+    // scope for this object-only cleanup; the census keeps it sound anyway.
+    test_same(
+        "const P = { a: 1, [Symbol.iterator]() { return [][Symbol.iterator]() } }; [...P]; ({ ...P });",
+    );
+    // A member write is not a copy. Allowing static ones would be sound but is
+    // deliberately outside this scope.
+    test_same("const P = { a: 1 }; P.b = 2; ({ ...P }); ({ ...P });");
+    // Reassigned: the copied value is not the classified one.
+    test_same("let P = { a: 1 }; P = unknownGlobal; ({ ...P }); ({ ...P });");
+    // The copy precedes the declarator, so the mark-time order proof fails.
+    test_same("({ ...P }); const P = { a: 1 };");
+    // An exported binding fails twice over: `is_implicitly_observable` marks it,
+    // and the `export { P }` specifier is itself a live unmarked reference.
+    test_same("const P = { a: 1 }; ({ ...P }); export { P };");
+    // `f` runs while the hoisted `var` still holds `undefined`, so the copy
+    // inside it fails the mark-time same-function proof and goes unmarked.
+    test_same("function f() { ({ ...P }); } f(); var P = { a: 1 }; ({ ...P });");
+}

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -1178,8 +1178,8 @@ fn remove_dead_object_spread_of_local_literal() {
         "const Proto = { [TypeId]: TypeId, m() {} }; ({ ...Proto }); ({ ...Proto });",
         "TypeId, TypeId;",
     );
-    // Transitive, one cleanup round per quiet boundary: removing `P2`'s copies
-    // kills its declarator, which makes `P1`'s copy inside it dead in turn.
+    // Transitive: removing `P2`'s copies kills its declarator, which makes
+    // `P1`'s copy inside it dead in the next local cleanup round.
     test("const P1 = { a: 1 }; const P2 = { ...P1, b: 2 }; ({ ...P2 }); ({ ...P2 });", "");
     // The copies sit in dead declarator initializers, mixed with data keys.
     test("const P = { a: 1 }; const X = { ...P, t: 1 }; const Y = { ...P, u: 2 };", "");
@@ -1207,13 +1207,57 @@ fn remove_layered_object_spread_chain() {
     );
 }
 
-// A symbol whose every copy sits in a USED initializer passes the census but
-// has nothing removable, so it is never published. Were it published, the
-// cleanup pass would remove nothing, be quiet, and re-derive the identical
-// census — retrying until the iteration guard. Two guards stop that: the
-// publish filter here, and the terminal rule that a cleanup pass which changed
-// nothing ends the loop. `Q` is read twice so single-use inlining does not
-// dissolve the shape first.
+#[test]
+fn object_spread_cleanup_discards_stale_candidates() {
+    // Candidates describe one quiet-pass boundary. `P` qualifies before `A`
+    // is removed, but its copies only become discarded after ordinary DCE
+    // removes `f` and `Q`; the following boundary must re-census `P`.
+    test_source_type(
+        "const P = { a: 1 }; const Q = { ...P, ...P }; const f = () => console.log(Q); const A = { m() { f(); } }; ({ ...A }); ({ ...A });",
+        "",
+        SourceType::mjs(),
+    );
+}
+
+#[test]
+fn object_spread_cleanup_refreshes_liveness() {
+    // Removing `P` also removes the only external edge into this recursive
+    // function component. The cleanup boundary must refresh liveness so both
+    // functions disappear in the same compressor run.
+    test_source_type(
+        "function a() { b(); } function b() { a(); } const P = { m() { a(); } }; ({ ...P }); ({ ...P });",
+        "",
+        SourceType::mjs(),
+    );
+}
+
+#[test]
+fn object_spread_cleanup_tracks_nested_scope() {
+    // The cleanup walk must carry the function scope instead of consulting the
+    // Program scope while removing nested declarations in script mode.
+    test_source_type(
+        "function run() { const P0 = {}; const P1 = { ...P0, ...P0 }; const P2 = { ...P1, ...P1 }; const P3 = { ...P2, ...P2 }; const P4 = { ...P3, ...P3 }; const P5 = { ...P4, ...P4 }; const P6 = { ...P5, ...P5 }; const P7 = { ...P6, ...P6 }; ({ ...P7 }); ({ ...P7 }); } run();",
+        "function run() {} run();",
+        SourceType::script(),
+    );
+}
+
+#[test]
+fn object_spread_cleanup_drops_declarator_references() {
+    // Dropping the whole declarator must also prune references in its TypeScript
+    // annotation, not only references in its initializer.
+    test_source_type(
+        "export function run() { const X = Symbol('x'); const P: { [X]: number } = { [X]: 1 }; ({ ...P }); ({ ...P }); }",
+        "export function run() {}",
+        SourceType::ts(),
+    );
+}
+
+// A symbol whose every copy sits in a USED initializer passes the census, but
+// the cleanup traversal has nothing removable. A no-change round is terminal,
+// so publishing this harmless candidate cannot retry until the iteration
+// guard. `Q` is read twice so single-use inlining does not dissolve the shape
+// first.
 #[test]
 fn keep_object_spread_in_used_initializer() {
     test(

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -758,9 +758,27 @@ fn keep_calls_before_var_function_assignment() {
         "f(); var f = () => {};",
     );
 
-    // Order-proven calls keep optimizing: the declarator precedes them.
+    // A conditionally-initialized `var` is VISITED on every traversal and
+    // assigns on none, so a value entry proves nothing about the binding. Here
+    // `test(unknownGlobal)` with a falsy argument calls `f` while it is still
+    // `undefined`.
+    test(
+        "function test(flag) { if (flag) var f = () => { const P = {}; ({ ...P }); ({ ...P }); }; f(); } test(unknownGlobal);",
+        "function test(flag) { if (flag) var f = () => {}; f(); } test(unknownGlobal);",
+    );
+
+    // Traversal reaches the declarator before `g`'s body, but `g` runs first.
+    // The call must be in the same function as the declarator.
+    test(
+        "g(); var f = () => {}; function g() { f(); } var unused = 1;",
+        "g(); var f = () => {}; function g() { f(); }",
+    );
+
+    // Order-proven calls keep optimizing: the declarator precedes them, in the
+    // same function, unconditionally.
     test("var f = () => {}; f(); f();", "");
     test("const g = () => {}; g();", "");
+    test("function h() { var f = () => {}; f(); } h();", "");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -732,6 +732,38 @@ fn remove_pure_function_calls() {
 }
 
 #[test]
+fn keep_calls_before_var_function_assignment() {
+    // A `var` binding holds `undefined` until its assignment runs, so a call
+    // reached first throws `TypeError`. The function summary describes the
+    // VALUE; consuming it at a call site keyed only by the BINDING erases that
+    // throw. The trailing `var unused = 1` only supplies the extra pass that
+    // makes the summary available.
+    test("f(); var f = () => {}; var unused = 1;", "f(); var f = () => {};");
+
+    // Reached through a body that ordinary DCE empties. The trailing `f()` IS
+    // order-proven and still goes, so the fixed point keeps only the
+    // conditional call and the emptied declarator.
+    test(
+        "if (unknownGlobal) { f(); } var f = () => { var a = [1]; [...a]; }; f(); var unused = 1;",
+        "if (unknownGlobal) f(); var f = () => {};",
+    );
+
+    // A spread of an object literal is pure on its own, so the body empties.
+    test("f(); var f = () => { ({ ...{ a: 1 } }); }; var unused = 1;", "f(); var f = () => {};");
+
+    // The route the object-spread cleanup opens: its copies are removable, the
+    // body empties, and the summary reaches this same consumer.
+    test(
+        "f(); var f = () => { const P = { a: 1 }; ({ ...P }); ({ ...P }); }; var unused = 1;",
+        "f(); var f = () => {};",
+    );
+
+    // Order-proven calls keep optimizing: the declarator precedes them.
+    test("var f = () => {}; f(); f();", "");
+    test("const g = () => {}; g();", "");
+}
+
+#[test]
 fn preserve_iife_in_dce_mode() {
     // https://github.com/oxc-project/oxc/issues/17480
     // https://github.com/rolldown/rolldown/issues/9437

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -763,9 +763,27 @@ fn keep_calls_before_var_function_assignment() {
         "f(); var f = () => {};",
     );
 
-    // Order-proven calls keep optimizing: the declarator precedes them.
+    // A conditionally-initialized `var` is VISITED on every traversal and
+    // assigns on none, so a value entry proves nothing about the binding. Here
+    // `test(unknownGlobal)` with a falsy argument calls `f` while it is still
+    // `undefined`.
+    test(
+        "function test(flag) { if (flag) var f = () => { const P = {}; ({ ...P }); ({ ...P }); }; f(); } test(unknownGlobal);",
+        "function test(flag) { if (flag) var f = () => {}; f(); } test(unknownGlobal);",
+    );
+
+    // Traversal reaches the declarator before `g`'s body, but `g` runs first.
+    // The call must be in the same function as the declarator.
+    test(
+        "g(); var f = () => {}; function g() { f(); } var unused = 1;",
+        "g(); var f = () => {}; function g() { f(); }",
+    );
+
+    // Order-proven calls keep optimizing: the declarator precedes them, in the
+    // same function, unconditionally.
     test("var f = () => {}; f(); f();", "");
     test("const g = () => {}; g();", "");
+    test("function h() { var f = () => {}; f(); } h();", "");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
@@ -278,6 +278,14 @@ fn remove_empty_function() {
     test_options("var foo = () => {}; x = foo(a(), b())", "x = (a(), b(), void 0)", &options);
     test_options("var foo = function () {}; foo()", "", &options);
 
+    // The `void 0` rewrite is the other summary consumer, and it must respect
+    // the same ordering: `x = foo()` before the assignment throws.
+    test_options(
+        "x = foo(); var foo = () => {}; var unused = 1;",
+        "x = foo(); var foo = () => {};",
+        &options,
+    );
+
     test_options("var foo = (a = 0) => {}; foo()", "", &options);
     test_options(
         "var foo = (a = side_effect()) => {}; foo()",

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -1204,6 +1204,16 @@ fn test_remove_dead_object_spread_of_local_literal() {
     test("const P = { a: 1 }; ({ ...P, t: 1 }); ({ ...P, u: 2 });", "const P = { a: 1 };");
 }
 
+/// See `remove_layered_object_spread_chain` in the dce suite. `unused: Keep`
+/// retains the declarations, so this pins the copy removal alone.
+#[test]
+fn test_remove_layered_object_spread_chain() {
+    test(
+        "const P0 = {}; const P1 = { ...P0, ...P0 }; const P2 = { ...P1, ...P1 }; const P3 = { ...P2, ...P2 }; ({ ...P3 }); ({ ...P3 });",
+        "const P0 = {}, P1 = { ...P0, ...P0 }, P2 = { ...P1, ...P1 }, P3 = { ...P2, ...P2 };",
+    );
+}
+
 /// See `keep_object_spread_in_used_initializer` in the dce suite.
 #[test]
 fn test_keep_object_spread_in_used_initializer() {

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -452,6 +452,12 @@ fn test_fold_call_expression() {
     test("false || /* @__PURE__ */ noEffect()", "");
 
     test("var foo = () => 1; foo(), foo()", "var foo = () => 1");
+
+    // A call reached while the hoisted `var` still holds `undefined` throws, so
+    // the summary of the value assigned later must not erase it. The trailing
+    // `var unused = 1` supplies the extra pass that publishes the summary;
+    // without it the call site is visited before one exists.
+    test("foo(); var foo = () => 1; var unused = 1;", "foo(); var foo = () => 1, unused = 1;");
     test_same("var foo = () => { bar() }; foo(), foo()");
     test_same("const a = (x) => x, b = () => a(1);");
 }

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -1176,3 +1176,44 @@ fn test_update_expression_respects_property_read_side_effects() {
         &options,
     );
 }
+
+// Full-minify flavor of the quiet-pass object-spread cleanup (see
+// `crate::spread_cleanup`). `unused: Keep` retains the declarations, so these
+// pin the spread removal itself rather than the cascade behind it.
+// https://github.com/oxc-project/oxc/issues/20661
+// https://github.com/rolldown/rolldown/issues/8582
+#[test]
+fn test_remove_dead_object_spread_of_local_literal() {
+    test(
+        "const Proto = { [TypeId]: TypeId, m() {} }; ({ ...Proto }); ({ ...Proto });",
+        "const Proto = { [TypeId]: TypeId, m() {} };",
+    );
+    // `P1` is single-use once the copies go, so it inlines and folds into `P2`.
+    test(
+        "const P1 = { a: 1 }; const P2 = { ...P1, b: 2 }; ({ ...P2 }); ({ ...P2 });",
+        "const P2 = { a: 1, b: 2 };",
+    );
+    // Mixed properties: the copy is dropped from the group, the data keys are
+    // dropped by the ordinary unused-property path.
+    test("const P = { a: 1 }; ({ ...P, t: 1 }); ({ ...P, u: 2 });", "const P = { a: 1 };");
+}
+
+/// See `keep_object_spread_in_used_initializer` in the dce suite.
+#[test]
+fn test_keep_object_spread_in_used_initializer() {
+    test(
+        "const P = { a: 1 }; const Q = { ...P }; console.log(Q, Q);",
+        "const Q = { a: 1 }; console.log(Q, Q);",
+    );
+}
+
+#[test]
+fn test_keep_object_spread_disqualified_by_census() {
+    test_same("const P = { get a() { return 1 } }; ({ ...P }), { ...P };");
+    test_same("const P = { a: 1 }; foo(P), { ...P };");
+    test_same("const P = { a: 1 }; console.log(P), { ...P };");
+    test_same("const P = { a: 1 }; P.b = 2, { ...P }, { ...P };");
+    test_same("let P = { a: 1 }; P = unknownGlobal, { ...P }, { ...P };");
+    test_same("({ ...P }); const P = { a: 1 };");
+    test_same("const P = { a: 1 }; ({ ...P }); export { P };");
+}

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -27,7 +27,7 @@ RadixUIAdoptionSection.jsx:
   sys deallocs: 21
   sys alloc bytes: 17400 # 17.40 kB
   sys peak growth: 11628 # 11.63 kB
-  arena allocs: 33
+  arena allocs: 32
   arena reallocs: 6
   arena size: 35632 # 35.63 kB
 

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 152
   sys alloc bytes: 14996600 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 148428
+  arena allocs: 148430
   arena reallocs: 28468
-  arena size: 19204712 # 19.20 MB
+  arena size: 19215008 # 19.22 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,9 +16,9 @@ App.tsx:
   sys deallocs: 63
   sys alloc bytes: 2128555 # 2.13 MB
   sys peak growth: 1612427 # 1.61 MB
-  arena allocs: 16046
+  arena allocs: 16048
   arena reallocs: 2721
-  arena size: 2887488 # 2.89 MB
+  arena size: 2888488 # 2.89 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 2467
   sys alloc bytes: 5334247 # 5.33 MB
   sys peak growth: 3693355 # 3.69 MB
-  arena allocs: 45881
+  arena allocs: 45883
   arena reallocs: 7718
-  arena size: 6326224 # 6.33 MB
+  arena size: 6328496 # 6.33 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 1038
   sys alloc bytes: 29976031 # 29.98 MB
   sys peak growth: 19934725 # 19.93 MB
-  arena allocs: 371736
+  arena allocs: 371738
   arena reallocs: 76289
-  arena size: 49111064 # 49.11 MB
+  arena size: 49127944 # 49.13 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,7 +60,7 @@ binder.ts:
   sys deallocs: 33
   sys alloc bytes: 963008 # 963.01 kB
   sys peak growth: 657404 # 657.40 kB
-  arena allocs: 7032
+  arena allocs: 7034
   arena reallocs: 842
   arena size: 1167360 # 1.17 MB
 
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 1858
   sys alloc bytes: 5307512 # 5.31 MB
   sys peak growth: 3707425 # 3.71 MB
-  arena allocs: 66771
+  arena allocs: 66773
   arena reallocs: 12252
-  arena size: 9424360 # 9.42 MB
+  arena size: 9426312 # 9.43 MB

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 152
   sys alloc bytes: 14996600 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 148205
+  arena allocs: 148204
   arena reallocs: 28469
-  arena size: 19221592 # 19.22 MB
+  arena size: 19213112 # 19.21 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,9 +16,9 @@ App.tsx:
   sys deallocs: 63
   sys alloc bytes: 2128555 # 2.13 MB
   sys peak growth: 1612427 # 1.61 MB
-  arena allocs: 16031
-  arena reallocs: 2726
-  arena size: 2890112 # 2.89 MB
+  arena allocs: 16180
+  arena reallocs: 2957
+  arena size: 2898464 # 2.90 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -27,7 +27,7 @@ RadixUIAdoptionSection.jsx:
   sys deallocs: 21
   sys alloc bytes: 17400 # 17.40 kB
   sys peak growth: 11628 # 11.63 kB
-  arena allocs: 33
+  arena allocs: 32
   arena reallocs: 6
   arena size: 35712 # 35.71 kB
 
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 2467
   sys alloc bytes: 5334247 # 5.33 MB
   sys peak growth: 3693355 # 3.69 MB
-  arena allocs: 45876
+  arena allocs: 45875
   arena reallocs: 7718
-  arena size: 6330144 # 6.33 MB
+  arena size: 6328440 # 6.33 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 1038
   sys alloc bytes: 29976031 # 29.98 MB
   sys peak growth: 19934725 # 19.93 MB
-  arena allocs: 371612
+  arena allocs: 371611
   arena reallocs: 76289
-  arena size: 49137304 # 49.14 MB
+  arena size: 49125888 # 49.13 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,7 +60,7 @@ binder.ts:
   sys deallocs: 33
   sys alloc bytes: 963008 # 963.01 kB
   sys peak growth: 657404 # 657.40 kB
-  arena allocs: 7030
+  arena allocs: 7029
   arena reallocs: 842
   arena size: 1169104 # 1.17 MB
 
@@ -71,7 +71,7 @@ kitchen-sink.tsx:
   sys deallocs: 1858
   sys alloc bytes: 5307512 # 5.31 MB
   sys peak growth: 3707425 # 3.71 MB
-  arena allocs: 66765
-  arena reallocs: 12256
-  arena size: 9429840 # 9.43 MB
+  arena allocs: 67032
+  arena reallocs: 12664
+  arena size: 9442008 # 9.44 MB
 

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -27,7 +27,7 @@ RadixUIAdoptionSection.jsx:
   sys deallocs: 21
   sys alloc bytes: 17400 # 17.40 kB
   sys peak growth: 11628 # 11.63 kB
-  arena allocs: 30
+  arena allocs: 33
   arena reallocs: 6
   arena size: 35632 # 35.63 kB
 

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 152
   sys alloc bytes: 14996600 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 148201
-  arena reallocs: 28468
-  arena size: 19202816 # 19.20 MB
+  arena allocs: 148205
+  arena reallocs: 28469
+  arena size: 19221592 # 19.22 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,9 +16,9 @@ App.tsx:
   sys deallocs: 63
   sys alloc bytes: 2128555 # 2.13 MB
   sys peak growth: 1612427 # 1.61 MB
-  arena allocs: 16027
-  arena reallocs: 2721
-  arena size: 2888280 # 2.89 MB
+  arena allocs: 16031
+  arena reallocs: 2726
+  arena size: 2890112 # 2.89 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -27,7 +27,7 @@ RadixUIAdoptionSection.jsx:
   sys deallocs: 21
   sys alloc bytes: 17400 # 17.40 kB
   sys peak growth: 11628 # 11.63 kB
-  arena allocs: 30
+  arena allocs: 33
   arena reallocs: 6
   arena size: 35712 # 35.71 kB
 
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 2467
   sys alloc bytes: 5334247 # 5.33 MB
   sys peak growth: 3693355 # 3.69 MB
-  arena allocs: 45873
+  arena allocs: 45876
   arena reallocs: 7718
-  arena size: 6326168 # 6.33 MB
+  arena size: 6330144 # 6.33 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 1038
   sys alloc bytes: 29976031 # 29.98 MB
   sys peak growth: 19934725 # 19.93 MB
-  arena allocs: 371609
+  arena allocs: 371612
   arena reallocs: 76289
-  arena size: 49109008 # 49.11 MB
+  arena size: 49137304 # 49.14 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,9 +60,9 @@ binder.ts:
   sys deallocs: 33
   sys alloc bytes: 963008 # 963.01 kB
   sys peak growth: 657404 # 657.40 kB
-  arena allocs: 7026
+  arena allocs: 7030
   arena reallocs: 842
-  arena size: 1167904 # 1.17 MB
+  arena size: 1169104 # 1.17 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -71,7 +71,7 @@ kitchen-sink.tsx:
   sys deallocs: 1858
   sys alloc bytes: 5307512 # 5.31 MB
   sys peak growth: 3707425 # 3.71 MB
-  arena allocs: 66761
-  arena reallocs: 12252
-  arena size: 9425560 # 9.43 MB
+  arena allocs: 66765
+  arena reallocs: 12256
+  arena size: 9429840 # 9.43 MB
 


### PR DESCRIPTION
Spreading an identifier — `({ ...Proto })` — is always treated as side-effectful: a spread of an unknown value can invoke getters, and the side-effect analysis cannot know what a reference resolves to. #20299 covered inline literals, and single-reference bindings work via single-use inlining, but the multi-reference shape — a shared prototype object spread into several derived objects, which is what effect v4 compiles to — is never removed, and rolldown chunks keep the spreads and everything they transitively retain ([rolldown#8582](https://github.com/rolldown/rolldown/issues/8582)).

This replaces the earlier escape-tracking approach in this PR (see the review discussion) with the reviewed design: a quiet-pass, removal-only cleanup scoped to getter-free object literals whose surviving uses are dead object-copy spreads. During each ordinary peephole pass, direct `...Identifier` object-copy uses are recorded in a sparse mark set — at spread nodes only, with a mark-time declaration-order and same-function proof. The marks are consumed only after a quiet pass, when `SymbolValue`, liveness, and post-flush `Scoping` all describe the same settled AST. A binding qualifies when its initializer classifies as a getter-free literal (no accessors, no `__proto__:` key), it has no writes, no direct eval in scope, no exports or other implicit observation — and, the load-bearing test, **every live reference is one of the marked spread uses**. Anything else — a call argument, a member access, an array spread, a reference minted by a later transform — disqualifies by census rather than by classification, so there is no sanctions list to get wrong. Qualifying candidates are consumed immediately at the boundary by a restricted, removal-only walk, batched until dry: copies in discarded positions are stripped (with per-sequence-operand precision — the value-producing final operand is never touched), and declarators left with no live references and no remaining effects are removed under `main`'s own unusedness rule, which unlocks transitive `P1 → P2 → …` chains inside the same boundary at a cost of one extra global pass regardless of depth. A boundary that removes nothing is an ordinary quiet pass and terminates the loop.

Everything lives in one `oxc_minifier` module (`spread_cleanup.rs`, plus a debug-only census-completeness assert in the style of the existing prune checks); `oxc_ecmascript` is untouched. Array spreads are deliberately out of scope for this PR — iteration has different initialization and `@@iterator` hazards — and a `console.log(P)` keep-alive now disqualifies the binding, which is the correct call: Node's documented `util.inspect.custom` hook is invoked by an unmodified console with the argument as receiver and can install accessors.

The second commit fixes a pre-existing hole this work made more reachable (review finding 4): a call made while a hoisted `var f` still holds `undefined` could be erased whenever `f`'s eventual function value summarized as side-effect-free — `f(); var f = () => {};` collapses on `main` alone, deleting a `TypeError`. Var-assigned function summaries are now consumed only when the initializer provably executed before the call: the declarator must be an unconditional direct-body statement whose entry precedes the call site in the same function, and the recorded value must still be the function that was classified — conditional initializers, hoisted callers, and loop-folded declarators all bail. Hoisted function declarations and TDZ-protected `const`/`let` are exempt.

## Example

Input (the rolldown#8582 residue shape):
```js
const TypeId = "~effect/time/DateTime";
const Proto = {
	[TypeId]: TypeId,
	pipe() {
		return pipeArguments(this, arguments);
	},
};
({ ...Proto });
({ ...Proto });
console.log("app");
```

Before (`--example dce`):
```js
const TypeId = "~effect/time/DateTime";
const Proto = {
	[TypeId]: TypeId,
	pipe() {
		return pipeArguments(this, arguments);
	}
};
({ ...Proto });
({ ...Proto });
console.log("app");
```

After:
```js
console.log("app");
```

On the 350 kB effect-v4 chunk from the rolldown issue, the removed region is exactly the retained `effect/dist/internal/dateTime.js` block (`Proto`, `ProtoTimeZone`, both `TypeId` strings, `toDateUtc`) plus a `({ ...PipeInspectableProto })` leftover: 235,164 → 234,450 bytes (dce) and 154,896 → 154,301 (full minify). Fixed-point iterations on that chunk go from 13 to 17, which interacts with the pre-existing `iteration > 10` debug bound (the bound already trips on this input on `main`; worth revisiting separately).

Verified with `cargo test -p oxc_minifier` (650 passing, including census-disqualification pins for getters, escapes, array spreads, reassignment, TDZ order, exports, and console keep-alives), differential execution of the adversarial corpus and fuzz suites against node (positive-controlled against the earlier design's parent, where the known `@@iterator` divergences reproduce; zero on this branch), `--twice` idempotency in both debug and release builds including the effect chunk and a four-layer spread-dependency chain, clippy with warnings denied, formatting, `just minsize` (byte-identical) and `just allocs` (sys allocations identical to `main`; +3–4 arena allocations per file for the mark bitsets). Criterion on the minifier fixtures is flat to improved (react +0.65% n.s., App.tsx +1.86%, binder −0.46% n.s., kitchen-sink −2.39%).

closes #20661

Implemented with AI assistance (Claude). The contributor remains responsible for reviewing, understanding, and submitting these changes under the repository AI usage policy.
