### PR TITLE
refactor(formatter): clean up after `ArrowFunctionBody` migration

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/node.rs
+++ b/crates/oxc_formatter/src/ast_nodes/node.rs
@@ -151,18 +151,6 @@ impl<'a> AstNode<'a, ArrowFunctionBody<'a>> {
             }))
             .as_ref()
     }
-
-    /// Returns the block body as an [`AstNode`].
-    pub fn as_function_body(&self) -> Option<&AstNode<'a, FunctionBody<'a>>> {
-        self.allocator
-            .alloc(self.inner.as_function_body().map(|inner| AstNode {
-                inner,
-                parent: self.parent,
-                allocator: self.allocator,
-                following_span_start: self.following_span_start,
-            }))
-            .as_ref()
-    }
 }
 
 impl<'a> AstNode<'a, ImportExpression<'a>> {

--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -608,8 +608,6 @@ impl NeedsParentheses<'_> for AstNode<'_, AssignmentExpression<'_>> {
             // Expression statements, only object destructuring needs parens:
             // - `a = b` = no parens
             // - `{ x } = obj` -> `({ x } = obj)` = needed to prevent parsing as block statement
-            // - `() => { x } = obj` -> `() => ({ x } = obj)` = needed in arrow function body
-            // - `() => a = b` -> `() => (a = b)` = also parens needed
             AstNodes::ExpressionStatement(_) => {
                 matches!(self.left, AssignmentTarget::ObjectAssignmentTarget(_))
                     && is_first_in_statement(
@@ -618,6 +616,13 @@ impl NeedsParentheses<'_> for AstNode<'_, AssignmentExpression<'_>> {
                         FirstInStatementMode::ExpressionStatementOrArrow,
                     )
             }
+            // Concise arrow bodies always need parens,
+            // otherwise the `{` of an object pattern would parse as a block body
+            // and a bare `=` reads as the arrow's own body:
+            // - `() => { x } = obj` -> `() => ({ x } = obj)`
+            // - `() => a = b` -> `() => (a = b)`
+            #[expect(clippy::match_same_arms)]
+            AstNodes::ArrowFunctionExpression(_) => true,
             // Sequence expressions, need to traverse up to find if we're in a for statement context:
             // - `a = 1, b = 2` in for loops don't need parens
             // - `(a = 1, b = 2)` elsewhere usually need parens
@@ -682,7 +687,7 @@ impl NeedsParentheses<'_> for AstNode<'_, SequenceExpression<'_>> {
         match self.parent() {
             AstNodes::ReturnStatement(_)
             | AstNodes::ThrowStatement(_)
-            |AstNodes::ArrowFunctionExpression(_)
+            | AstNodes::ArrowFunctionExpression(_)
             // There's a precedence for writing `x++, y++`
             | AstNodes::ForStatement(_) => false,
             _ => true,

--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -119,7 +119,7 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                 });
 
                 let format_body =
-                    FormatMaybeCachedArrowFunctionBody { body, mode: self.options.cache_mode };
+                    FormatContentWithCacheMode::new(body.span(), body, self.options.cache_mode);
 
                 // With arrays, arrow self and objects, they have a natural line breaking strategy:
                 // Arrays and objects become blocks:
@@ -629,10 +629,11 @@ impl<'a> Format<'a, JsFormatContext<'a>> for ArrowChain<'a, '_> {
         });
 
         let format_tail_body_inner = format_with(|f| {
-            let format_tail_body = FormatMaybeCachedArrowFunctionBody {
-                body: tail_body,
-                mode: self.options.cache_mode,
-            };
+            let format_tail_body = FormatContentWithCacheMode::new(
+                tail_body.span(),
+                tail_body,
+                self.options.cache_mode,
+            );
 
             // Ensure that the parens of sequence expressions end up on their own line if the
             // body breaks
@@ -825,38 +826,6 @@ fn format_signature<'a, 'b>(
         let content = FormatTrailingComments::Comments(comments_before_fat_arrow);
         write!(f, [FormatContentWithCacheMode::new(arrow.span, content, cache_mode)]);
     })
-}
-
-/// Formats an arrow function body with additional caching depending on [`mode`](Self::mode).
-pub struct FormatMaybeCachedArrowFunctionBody<'a, 'b> {
-    /// The body to format.
-    pub body: &'b AstNode<'a, ArrowFunctionBody<'a>>,
-
-    /// If the body should be cached or if the formatter should try to retrieve it from the cache.
-    pub mode: FunctionCacheMode,
-}
-
-impl<'a> Format<'a, JsFormatContext<'a>> for FormatMaybeCachedArrowFunctionBody<'a, '_> {
-    fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let content = format_with(|f| self.body.fmt(f));
-        FormatContentWithCacheMode::new(self.body.span(), content, self.mode).fmt(f);
-    }
-}
-
-/// Formats a function block body with additional caching depending on [`mode`](Self::mode).
-pub struct FormatMaybeCachedFunctionBody<'a, 'b> {
-    /// The body to format.
-    pub body: &'b AstNode<'a, FunctionBody<'a>>,
-
-    /// If the body should be cached or if the formatter should try to retrieve it from the cache.
-    pub mode: FunctionCacheMode,
-}
-
-impl<'a> Format<'a, JsFormatContext<'a>> for FormatMaybeCachedFunctionBody<'a, '_> {
-    fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let content = format_with(|f| self.body.fmt(f));
-        FormatContentWithCacheMode::new(self.body.span, content, self.mode).fmt(f);
-    }
 }
 
 /// Format a sequence expression in an arrow function body that has a leading comment.

--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -1053,11 +1053,13 @@ fn is_commonjs_or_amd_call(
             }
         }
         "define" => {
-            let in_statement_like_position = matches!(
-                call.parent(),
-                AstNodes::ArrowFunctionExpression(_) | AstNodes::ExpressionStatement(_)
-            );
-            if in_statement_like_position {
+            // The AMD layout only applies in statement position, matching Prettier's
+            // `parent.type === "ExpressionStatement"` check. A concise arrow body is not statement
+            // position: its parent is the `ArrowFunctionExpression`, so `() => define(...)` formats
+            // as a normal call. (oxc used to accept it, because concise bodies were wrapped in a
+            // synthetic `ExpressionStatement` before `ArrowFunctionBody` existed.)
+            let in_statement = matches!(call.parent(), AstNodes::ExpressionStatement(_));
+            if in_statement {
                 match arguments.len() {
                     1 => true,
                     2 => matches!(arguments.first(), Some(Argument::ArrayExpression(_))),

--- a/crates/oxc_formatter/src/print/function.rs
+++ b/crates/oxc_formatter/src/print/function.rs
@@ -11,9 +11,7 @@ use crate::{
     ast_nodes::AstNode,
     format_args,
     formatter::{Buffer, prelude::*, trivia::FormatLeadingComments},
-    print::{
-        arrow_function_expression::FormatMaybeCachedFunctionBody, semicolon::OptionalSemicolon,
-    },
+    print::semicolon::OptionalSemicolon,
     write,
 };
 
@@ -125,7 +123,10 @@ impl<'a, 'b> FormatFunction<'a, 'b> {
         if let Some(body) = self.body() {
             write!(
                 f,
-                [space(), FormatMaybeCachedFunctionBody { body, mode: self.options.cache_mode }]
+                [
+                    space(),
+                    FormatContentWithCacheMode::new(body.span, body, self.options.cache_mode)
+                ]
             );
         }
 

--- a/crates/oxc_formatter/src/print/jsx/element.rs
+++ b/crates/oxc_formatter/src/print/jsx/element.rs
@@ -114,8 +114,9 @@ impl<'a> AnyJsxTagWithChildren<'a, '_> {
                     WrapState::WrapOnBreak
                 }
             }
-            // `() => <div></div>`
-            //        ^^^^^^^^^^^
+            // Concise arrow body: `() => <div></div>`
+            #[expect(clippy::match_same_arms)]
+            AstNodes::ArrowFunctionExpression(_) => WrapState::WrapOnBreak,
             _ => WrapState::WrapOnBreak,
         }
     }
@@ -245,12 +246,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AnyJsxTagWithChildren<'a, '_> {
 /// // As JSX attribute:
 /// <Tooltip title={[].map(name => (<Foo>{name}</Foo>))} />;
 /// ```
-pub fn should_expand(mut parent: &AstNodes<'_>) -> bool {
-    if let AstNodes::ExpressionStatement(stmt) = parent {
-        // If the parent is a JSXExpressionContainer, we need to check its parent
-        // to determine if it should expand.
-        parent = stmt.grand_parent();
-    }
+pub fn should_expand(parent: &AstNodes<'_>) -> bool {
     let maybe_jsx_expression_container = match parent {
         AstNodes::ArrowFunctionExpression(arrow) if arrow.is_expression() => match arrow.parent() {
             AstNodes::CallExpression(call) => call.parent(),

--- a/crates/oxc_formatter/src/print/semicolon.rs
+++ b/crates/oxc_formatter/src/print/semicolon.rs
@@ -71,7 +71,7 @@ pub fn keeps_trailing_comment_inside_parens(expr: &Expression<'_>, gated: bool) 
                     right => keeps_trailing_comment_inside_parens(right, false),
                 }
         }
-        Expression::ArrowFunctionExpression(arrow) if arrow.is_expression() => arrow
+        Expression::ArrowFunctionExpression(arrow) => arrow
             .get_expression()
             .is_some_and(|body| keeps_trailing_comment_inside_parens(body, true)),
         _ => false,

--- a/crates/oxc_formatter/tests/fixtures/js/arrow-function/parent-context.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/arrow-function/parent-context.js.snap
@@ -31,12 +31,13 @@ const assignmentChain = () =>
     thirdVeryLongIdentifier);
 
 const amd = () =>
-  define("a-very-long-module-name", [
-    "first-long-dependency",
-    "second-long-dependency",
-  ], () => {
-    return value;
-  });
+  define(
+    "a-very-long-module-name",
+    ["first-long-dependency", "second-long-dependency"],
+    () => {
+      return value;
+    },
+  );
 
 -------------------
 { printWidth: 100 }

--- a/crates/oxc_formatter/tests/fixtures/js/calls/amd-define-statement-position.js
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/amd-define-statement-position.js
@@ -1,0 +1,18 @@
+// The AMD `define` layout (arguments hugged on one line, never broken) applies only in
+// statement position, matching Prettier. A concise arrow body is not statement position.
+
+// Statement position: AMD layout.
+define(["aaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"], () => {});
+
+define("name", ["aaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"], () => {});
+
+// Concise arrow body: NOT statement position, so the arguments break normally.
+const d = () => define(["aaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"], () => {});
+
+// Block body: the call is a statement again, so AMD layout applies.
+const e = () => {
+  define(["aaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"], () => {});
+};
+
+// `require` is not gated on statement position, so a concise body keeps its layout.
+const r = () => require("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

--- a/crates/oxc_formatter/tests/fixtures/js/calls/amd-define-statement-position.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/calls/amd-define-statement-position.js.snap
@@ -1,0 +1,83 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// The AMD `define` layout (arguments hugged on one line, never broken) applies only in
+// statement position, matching Prettier. A concise arrow body is not statement position.
+
+// Statement position: AMD layout.
+define(["aaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"], () => {});
+
+define("name", ["aaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"], () => {});
+
+// Concise arrow body: NOT statement position, so the arguments break normally.
+const d = () => define(["aaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"], () => {});
+
+// Block body: the call is a statement again, so AMD layout applies.
+const e = () => {
+  define(["aaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"], () => {});
+};
+
+// `require` is not gated on statement position, so a concise body keeps its layout.
+const r = () => require("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// The AMD `define` layout (arguments hugged on one line, never broken) applies only in
+// statement position, matching Prettier. A concise arrow body is not statement position.
+
+// Statement position: AMD layout.
+define([
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "bbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+], () => {});
+
+define("name", [
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "bbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+], () => {});
+
+// Concise arrow body: NOT statement position, so the arguments break normally.
+const d = () =>
+  define(
+    ["aaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+    () => {},
+  );
+
+// Block body: the call is a statement again, so AMD layout applies.
+const e = () => {
+  define([
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  ], () => {});
+};
+
+// `require` is not gated on statement position, so a concise body keeps its layout.
+const r = () =>
+  require("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// The AMD `define` layout (arguments hugged on one line, never broken) applies only in
+// statement position, matching Prettier. A concise arrow body is not statement position.
+
+// Statement position: AMD layout.
+define(["aaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"], () => {});
+
+define("name", ["aaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"], () => {});
+
+// Concise arrow body: NOT statement position, so the arguments break normally.
+const d = () => define(["aaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"], () => {});
+
+// Block body: the call is a statement again, so AMD layout applies.
+const e = () => {
+  define(["aaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"], () => {});
+};
+
+// `require` is not gated on statement position, so a concise body keeps its layout.
+const r = () => require("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/arrow-body-comment-inside-parens.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/arrow-body-comment-inside-parens.js
@@ -1,0 +1,48 @@
+// Own-line comment *inside* the source parentheses of a concise arrow body.
+// The parens are not part of the AST, so the body's span starts at the expression:
+// the comment is a leading comment of the body, and the body moves to its own line.
+// (Distinct from `arrow-body-leading-comment-in-call.js`, where the comment sits
+// *before* the opening paren.)
+
+const array = () => (
+  // c
+  [1, 2, 3]
+);
+
+const object = () => (
+  // c
+  ({ a: 1 })
+);
+
+const arrow = () => (
+  // c
+  () => 1
+);
+
+const template = () => (
+  // c
+  `tpl ${x}
+  more`
+);
+
+// Block comment on the same line as the expression stays hugged.
+const inlineBlock = () => (
+  /* c */ [1, 2, 3]
+);
+
+// Chain tail body.
+const chainTail = (a) => (b) => (
+  // c
+  [1, 2]
+);
+
+// As a call argument: the body breaks and the call gets a trailing comma.
+foo(() => (
+  // c
+  [1, 2, 3]
+));
+
+foo((a) => (b) => (
+  // c
+  [1, 2]
+));

--- a/crates/oxc_formatter/tests/fixtures/js/comments/arrow-body-comment-inside-parens.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/arrow-body-comment-inside-parens.js.snap
@@ -1,0 +1,149 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Own-line comment *inside* the source parentheses of a concise arrow body.
+// The parens are not part of the AST, so the body's span starts at the expression:
+// the comment is a leading comment of the body, and the body moves to its own line.
+// (Distinct from `arrow-body-leading-comment-in-call.js`, where the comment sits
+// *before* the opening paren.)
+
+const array = () => (
+  // c
+  [1, 2, 3]
+);
+
+const object = () => (
+  // c
+  ({ a: 1 })
+);
+
+const arrow = () => (
+  // c
+  () => 1
+);
+
+const template = () => (
+  // c
+  `tpl ${x}
+  more`
+);
+
+// Block comment on the same line as the expression stays hugged.
+const inlineBlock = () => (
+  /* c */ [1, 2, 3]
+);
+
+// Chain tail body.
+const chainTail = (a) => (b) => (
+  // c
+  [1, 2]
+);
+
+// As a call argument: the body breaks and the call gets a trailing comma.
+foo(() => (
+  // c
+  [1, 2, 3]
+));
+
+foo((a) => (b) => (
+  // c
+  [1, 2]
+));
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Own-line comment *inside* the source parentheses of a concise arrow body.
+// The parens are not part of the AST, so the body's span starts at the expression:
+// the comment is a leading comment of the body, and the body moves to its own line.
+// (Distinct from `arrow-body-leading-comment-in-call.js`, where the comment sits
+// *before* the opening paren.)
+
+const array = () =>
+  // c
+  [1, 2, 3];
+
+const object = () =>
+  // c
+  ({ a: 1 });
+
+const arrow =
+  () =>
+  // c
+  () =>
+    1;
+
+const template = () =>
+  // c
+  `tpl ${x}
+  more`;
+
+// Block comment on the same line as the expression stays hugged.
+const inlineBlock = () => /* c */ [1, 2, 3];
+
+// Chain tail body.
+const chainTail = (a) => (b) =>
+  // c
+  [1, 2];
+
+// As a call argument: the body breaks and the call gets a trailing comma.
+foo(() =>
+  // c
+  [1, 2, 3],
+);
+
+foo((a) => (b) =>
+  // c
+  [1, 2],
+);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Own-line comment *inside* the source parentheses of a concise arrow body.
+// The parens are not part of the AST, so the body's span starts at the expression:
+// the comment is a leading comment of the body, and the body moves to its own line.
+// (Distinct from `arrow-body-leading-comment-in-call.js`, where the comment sits
+// *before* the opening paren.)
+
+const array = () =>
+  // c
+  [1, 2, 3];
+
+const object = () =>
+  // c
+  ({ a: 1 });
+
+const arrow =
+  () =>
+  // c
+  () =>
+    1;
+
+const template = () =>
+  // c
+  `tpl ${x}
+  more`;
+
+// Block comment on the same line as the expression stays hugged.
+const inlineBlock = () => /* c */ [1, 2, 3];
+
+// Chain tail body.
+const chainTail = (a) => (b) =>
+  // c
+  [1, 2];
+
+// As a call argument: the body breaks and the call gets a trailing comma.
+foo(() =>
+  // c
+  [1, 2, 3],
+);
+
+foo((a) => (b) =>
+  // c
+  [1, 2],
+);
+
+===================== End =====================


### PR DESCRIPTION
Follow up #24987 for `oxc_formatter`.