### PR TITLE
fix(transformer/typescript): insert class field assignments after nested super() in sequence expression

### DIFF
--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -479,17 +479,37 @@ impl<'a> TypeScript<'a> {
         Self::create_assignment(target, value, ctx)
     }
 
-    /// Find the position of the `super()` call in the constructor body, otherwise return 0.
-    ///
-    /// Don't need to handle nested `super()` call because `TypeScript` doesn't allow it.
+    /// Find the position of the statement that contains the `super()` call in the constructor body, otherwise return 0.
     pub fn get_super_call_position(statements: &[Statement<'a>]) -> usize {
-        // Find the position of the `super()` call in the constructor body.
-        // Don't need to handle nested `super()` call because `TypeScript` doesn't allow it.
+        use oxc_ast_visit::Visit;
+
+        struct FindSuperCall {
+            found: bool,
+        }
+
+        impl<'a> Visit<'a> for FindSuperCall {
+            fn visit_call_expression(&mut self, expr: &CallExpression<'a>) {
+                if expr.is_super_call_expression() {
+                    self.found = true;
+                }
+                if !self.found {
+                    oxc_ast_visit::walk_call_expression(self, expr);
+                }
+            }
+
+            // Don't traverse into nested function/class scopes - a `super()` there
+            // belongs to the inner class, not the outer constructor.
+            fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
+            fn visit_class(&mut self, _class: &Class<'a>) {}
+            fn visit_arrow_function_expression(&mut self, _expr: &ArrowFunctionExpression<'a>) {}
+        }
+
         statements
             .iter()
             .position(|stmt| {
-                matches!(stmt, Statement::ExpressionStatement(stmt)
-                        if stmt.expression.is_super_call_expression())
+                let mut visitor = FindSuperCall { found: false };
+                visitor.visit_statement(stmt);
+                visitor.found
             })
             .map_or(0, |pos| pos + 1)
     }

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/use-define-class-fields-nested-super/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/use-define-class-fields-nested-super/input.ts
@@ -1,0 +1,14 @@
+class Foo {}
+
+class Bar extends Foo {
+	test = "initial";
+	constructor() {
+		super(), console.log();
+	}
+}
+
+class Baz extends Foo {
+	constructor(public code: string) {
+		super(), console.log(this);
+	}
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/use-define-class-fields-nested-super/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/use-define-class-fields-nested-super/options.json
@@ -1,0 +1,13 @@
+{
+  "assumptions": {
+    "setPublicClassFields": true
+  },
+  "plugins": [
+    [
+      "transform-typescript",
+      {
+        "removeClassFieldsWithoutInitializer": true
+      }
+    ]
+  ]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/use-define-class-fields-nested-super/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/use-define-class-fields-nested-super/output.js
@@ -1,0 +1,13 @@
+class Foo {}
+class Bar extends Foo {
+  constructor() {
+    super(), console.log();
+    this.test = 'initial';
+  }
+}
+class Baz extends Foo {
+  constructor(code) {
+    super(), console.log(this);
+    this.code = code;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #25051
Related: #20527

When `useDefineForClassFields` is disabled and the target is ES2022+, the TypeScript transformer injects class field initializers into the constructor. The previous `get_super_call_position()` only detected a bare top-level `super()` `ExpressionStatement`, so when `super()` was nested inside a `SequenceExpression` (e.g. `super(), console.log()`), it went undetected and field initializers were inserted at position 0 — **before** the `super()` call — producing a runtime `ReferenceError`.

**Buggy output (before fix):**
```js
class Bar extends Foo {
  constructor() {
    this.test = "initial"; // ❌ `this` accessed before super()
    super(), console.log();
  }
}
