### PR TITLE
feat(tasks): add React Compiler comparison task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ target/
 /tasks/codegen_conformance/node_modules/
 /tasks/transform_conformance/node_modules/
 /tasks/compat_data/node_modules/
+/tasks/react_compiler/node_modules/
+/tasks/prettier_conformance/jsdoc/scripts/node_modules/
 /tasks/compat_data/compat-table/
 /tasks/e2e/node_modules/
 /plugins/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ target/
 /tasks/benchmark/codspeed/node_modules/
 /tasks/transform_conformance/node_modules/
 /tasks/compat_data/node_modules/
+/tasks/react_compiler/node_modules/
 /tasks/prettier_conformance/jsdoc/scripts/node_modules/
 /tasks/compat_data/compat-table/
 /tasks/e2e/node_modules/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "3"
 members = ["apps/*", "crates/*", "napi/*", "tasks/*"]
-exclude = ["apps/shared", "tasks/lint_rules", "tasks/e2e"]
+exclude = ["apps/shared", "tasks/lint_rules", "tasks/e2e", "tasks/react_compiler"]
 
 [workspace.package]
 authors = ["Boshen <boshenc@gmail.com>", "Oxc contributors"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,27 @@ importers:
         specifier: ^1.6.1
         version: 1.7.1
 
+  tasks/react_compiler:
+    devDependencies:
+      '@babel/core':
+        specifier: ^7.29.7
+        version: 7.29.7
+      '@babel/plugin-transform-react-jsx':
+        specifier: ^7.29.7
+        version: 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript':
+        specifier: ^7.29.7
+        version: 7.29.7(@babel/core@7.29.7)
+      babel-plugin-react-compiler:
+        specifier: 0.0.0-experimental-a1856f3-20260507
+        version: 0.0.0-experimental-a1856f3-20260507
+      oxc-transform:
+        specifier: link:../../napi/transform
+        version: link:../../napi/transform
+      oxc-transform-react:
+        specifier: link:../../napi/transform-react
+        version: link:../../napi/transform-react
+
   tasks/transform_conformance:
     devDependencies:
       '@babel/core':
@@ -692,25 +713,51 @@ packages:
     resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@8.0.0':
     resolution: {integrity: sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/core@8.0.1':
     resolution: {integrity: sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@8.0.0':
     resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@8.0.0':
     resolution: {integrity: sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-compilation-targets@8.0.0':
     resolution: {integrity: sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-create-class-features-plugin@7.29.7':
+    resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   '@babel/helper-create-class-features-plugin@8.0.1':
     resolution: {integrity: sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==}
@@ -718,21 +765,47 @@ packages:
     peerDependencies:
       '@babel/core': ^8.0.0
 
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-globals@8.0.0':
     resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-member-expression-to-functions@8.0.0':
     resolution: {integrity: sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-imports@8.0.0':
     resolution: {integrity: sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-optimise-call-expression@8.0.0':
     resolution: {integrity: sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-plugin-utils@8.0.1':
     resolution: {integrity: sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==}
@@ -746,11 +819,21 @@ packages:
     peerDependencies:
       '@babel/core': ^8.0.0
 
+  '@babel/helper-replace-supers@7.29.7':
+    resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-replace-supers@8.0.1':
     resolution: {integrity: sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==}
     engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
       '@babel/core': ^8.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
     resolution: {integrity: sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==}
@@ -772,6 +855,10 @@ packages:
     resolution: {integrity: sha512-kXxQVZHNOctSJJsqzmcbPSCEkM6oHNnDIkua7g9RCO9xRHj2eCiKvRx2KPdfWR9QxcGWnK/oArrtunmie3rL9g==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@8.0.0':
     resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -779,6 +866,10 @@ packages:
   '@babel/helper-wrap-function@8.0.0':
     resolution: {integrity: sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helpers@8.0.0':
     resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
@@ -811,6 +902,18 @@ packages:
     engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
       '@babel/core': ^8.0.0
+
+  '@babel/plugin-syntax-jsx@7.29.7':
+    resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.29.7':
+    resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-syntax-typescript@8.0.1':
     resolution: {integrity: sha512-YBpIeuOZSUZx7RGH/U+dIAsHDHyojBVDRHNBUgOiUDS5IIcgBm1uyu9xs/2kM27B/bmDfOxzJ9k8cU2QuOwGIA==}
@@ -884,6 +987,18 @@ packages:
     peerDependencies:
       '@babel/core': ^8.0.0
 
+  '@babel/plugin-transform-react-jsx@7.29.7':
+    resolution: {integrity: sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@7.29.7':
+    resolution: {integrity: sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-typescript@8.0.1':
     resolution: {integrity: sha512-0Svqp3413Eg0GElldykF/T7SNsxQO5YVGD70fZyAdZTnX8WRgcopmbiU7GTa5xY5ZnJcEpNbfns8/GjX+/1yeA==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -894,9 +1009,17 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@8.0.0':
     resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/traverse@8.0.0':
     resolution: {integrity: sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw==}
@@ -3854,6 +3977,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  babel-plugin-react-compiler@0.0.0-experimental-a1856f3-20260507:
+    resolution: {integrity: sha512-NH/o9ojGrQ5xQhkLry8KulKssfWuM68myEGVUpIJhExt1/WVWBOTBPSPGiSRoJtfB9yP8Kj4UXZpLXKFCXineg==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -4768,6 +4894,9 @@ packages:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
@@ -5264,6 +5393,10 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -5752,6 +5885,9 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -5863,7 +5999,29 @@ snapshots:
       '@babel/helper-validator-identifier': 8.0.0
       js-tokens: 10.0.0
 
+  '@babel/compat-data@7.29.7': {}
+
   '@babel/compat-data@8.0.0': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/core@8.0.1':
     dependencies:
@@ -5884,6 +6042,14 @@ snapshots:
       obug: 2.1.4
       semver: 7.8.5
 
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/generator@8.0.0':
     dependencies:
       '@babel/parser': 8.0.0
@@ -5893,9 +6059,21 @@ snapshots:
       '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
+  '@babel/helper-annotate-as-pure@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/helper-annotate-as-pure@8.0.0':
     dependencies:
       '@babel/types': 8.0.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
 
   '@babel/helper-compilation-targets@8.0.0':
     dependencies:
@@ -5904,6 +6082,19 @@ snapshots:
       browserslist: 4.28.2
       lru-cache: 11.5.2
       semver: 7.8.5
+
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-create-class-features-plugin@8.0.1(@babel/core@8.0.1)':
     dependencies:
@@ -5916,21 +6107,52 @@ snapshots:
       '@babel/traverse': 8.0.0
       semver: 7.8.5
 
+  '@babel/helper-globals@7.29.7': {}
+
   '@babel/helper-globals@8.0.0': {}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-member-expression-to-functions@8.0.0':
     dependencies:
       '@babel/traverse': 8.0.0
       '@babel/types': 8.0.0
 
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-imports@8.0.0':
     dependencies:
       '@babel/traverse': 8.0.0
       '@babel/types': 8.0.0
 
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/helper-optimise-call-expression@8.0.0':
     dependencies:
       '@babel/types': 8.0.0
+
+  '@babel/helper-plugin-utils@7.29.7': {}
 
   '@babel/helper-plugin-utils@8.0.1(@babel/core@8.0.1)':
     dependencies:
@@ -5943,12 +6165,28 @@ snapshots:
       '@babel/helper-wrap-function': 8.0.0
       '@babel/traverse': 8.0.0
 
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-replace-supers@8.0.1(@babel/core@8.0.1)':
     dependencies:
       '@babel/core': 8.0.1
       '@babel/helper-member-expression-to-functions': 8.0.0
       '@babel/helper-optimise-call-expression': 8.0.0
       '@babel/traverse': 8.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
     dependencies:
@@ -5963,6 +6201,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@8.0.0': {}
 
+  '@babel/helper-validator-option@7.29.7': {}
+
   '@babel/helper-validator-option@8.0.0': {}
 
   '@babel/helper-wrap-function@8.0.0':
@@ -5970,6 +6210,11 @@ snapshots:
       '@babel/template': 8.0.0
       '@babel/traverse': 8.0.0
       '@babel/types': 8.0.0
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/helpers@8.0.0':
     dependencies:
@@ -6000,6 +6245,16 @@ snapshots:
     dependencies:
       '@babel/core': 8.0.1
       '@babel/helper-plugin-utils': 8.0.1(@babel/core@8.0.1)
+
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-typescript@8.0.1(@babel/core@8.0.1)':
     dependencies:
@@ -6070,6 +6325,28 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 8.0.1(@babel/core@8.0.1)
       '@babel/helper-plugin-utils': 8.0.1(@babel/core@8.0.1)
 
+  '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-typescript@8.0.1(@babel/core@8.0.1)':
     dependencies:
       '@babel/core': 8.0.1
@@ -6081,11 +6358,29 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
   '@babel/template@8.0.0':
     dependencies:
       '@babel/code-frame': 8.0.0
       '@babel/parser': 8.0.0
       '@babel/types': 8.0.0
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/traverse@8.0.0':
     dependencies:
@@ -8768,6 +9063,10 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  babel-plugin-react-compiler@0.0.0-experimental-a1856f3-20260507:
+    dependencies:
+      '@babel/types': 7.29.7
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -9680,6 +9979,10 @@ snapshots:
 
   lru-cache@11.5.2: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   luxon@3.7.2: {}
 
   lz-string@1.5.0: {}
@@ -10339,6 +10642,8 @@ snapshots:
   scroll-into-view-if-needed@3.1.0:
     dependencies:
       compute-scroll-into-view: 3.1.1
+
+  semver@6.3.1: {}
 
   semver@7.8.5: {}
 
@@ -11056,6 +11361,8 @@ snapshots:
   ws@8.20.0: {}
 
   xtend@4.0.2: {}
+
+  yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,6 +531,27 @@ importers:
         specifier: ^1.6.1
         version: 1.7.1
 
+  tasks/react_compiler:
+    devDependencies:
+      '@babel/core':
+        specifier: ^7.29.7
+        version: 7.29.7
+      '@babel/plugin-transform-react-jsx':
+        specifier: ^7.29.7
+        version: 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript':
+        specifier: ^7.29.7
+        version: 7.29.7(@babel/core@7.29.7)
+      babel-plugin-react-compiler:
+        specifier: 0.0.0-experimental-a1856f3-20260507
+        version: 0.0.0-experimental-a1856f3-20260507
+      oxc-transform:
+        specifier: link:../../napi/transform
+        version: link:../../napi/transform
+      oxc-transform-react:
+        specifier: link:../../napi/transform-react
+        version: link:../../napi/transform-react
+
   tasks/transform_conformance:
     devDependencies:
       '@babel/core':
@@ -641,25 +662,51 @@ packages:
     resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@8.0.0':
     resolution: {integrity: sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/core@8.0.1':
     resolution: {integrity: sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@8.0.0':
     resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@8.0.0':
     resolution: {integrity: sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-compilation-targets@8.0.0':
     resolution: {integrity: sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-create-class-features-plugin@7.29.7':
+    resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   '@babel/helper-create-class-features-plugin@8.0.1':
     resolution: {integrity: sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==}
@@ -667,21 +714,47 @@ packages:
     peerDependencies:
       '@babel/core': ^8.0.0
 
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-globals@8.0.0':
     resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-member-expression-to-functions@8.0.0':
     resolution: {integrity: sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-imports@8.0.0':
     resolution: {integrity: sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-optimise-call-expression@8.0.0':
     resolution: {integrity: sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-plugin-utils@8.0.1':
     resolution: {integrity: sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==}
@@ -695,11 +768,21 @@ packages:
     peerDependencies:
       '@babel/core': ^8.0.0
 
+  '@babel/helper-replace-supers@7.29.7':
+    resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-replace-supers@8.0.1':
     resolution: {integrity: sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==}
     engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
       '@babel/core': ^8.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
     resolution: {integrity: sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==}
@@ -721,6 +804,10 @@ packages:
     resolution: {integrity: sha512-kXxQVZHNOctSJJsqzmcbPSCEkM6oHNnDIkua7g9RCO9xRHj2eCiKvRx2KPdfWR9QxcGWnK/oArrtunmie3rL9g==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@8.0.0':
     resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -728,6 +815,10 @@ packages:
   '@babel/helper-wrap-function@8.0.0':
     resolution: {integrity: sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helpers@8.0.0':
     resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
@@ -760,6 +851,18 @@ packages:
     engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
       '@babel/core': ^8.0.0
+
+  '@babel/plugin-syntax-jsx@7.29.7':
+    resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.29.7':
+    resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-syntax-typescript@8.0.1':
     resolution: {integrity: sha512-YBpIeuOZSUZx7RGH/U+dIAsHDHyojBVDRHNBUgOiUDS5IIcgBm1uyu9xs/2kM27B/bmDfOxzJ9k8cU2QuOwGIA==}
@@ -833,6 +936,18 @@ packages:
     peerDependencies:
       '@babel/core': ^8.0.0
 
+  '@babel/plugin-transform-react-jsx@7.29.7':
+    resolution: {integrity: sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@7.29.7':
+    resolution: {integrity: sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-typescript@8.0.1':
     resolution: {integrity: sha512-0Svqp3413Eg0GElldykF/T7SNsxQO5YVGD70fZyAdZTnX8WRgcopmbiU7GTa5xY5ZnJcEpNbfns8/GjX+/1yeA==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -843,9 +958,17 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@8.0.0':
     resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/traverse@8.0.0':
     resolution: {integrity: sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw==}
@@ -3812,6 +3935,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  babel-plugin-react-compiler@0.0.0-experimental-a1856f3-20260507:
+    resolution: {integrity: sha512-NH/o9ojGrQ5xQhkLry8KulKssfWuM68myEGVUpIJhExt1/WVWBOTBPSPGiSRoJtfB9yP8Kj4UXZpLXKFCXineg==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -4726,6 +4852,9 @@ packages:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
@@ -5222,6 +5351,10 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -5705,6 +5838,9 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -5816,7 +5952,29 @@ snapshots:
       '@babel/helper-validator-identifier': 8.0.0
       js-tokens: 10.0.0
 
+  '@babel/compat-data@7.29.7': {}
+
   '@babel/compat-data@8.0.0': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/core@8.0.1':
     dependencies:
@@ -5837,6 +5995,14 @@ snapshots:
       obug: 2.1.4
       semver: 7.8.5
 
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/generator@8.0.0':
     dependencies:
       '@babel/parser': 8.0.0
@@ -5846,9 +6012,21 @@ snapshots:
       '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
+  '@babel/helper-annotate-as-pure@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/helper-annotate-as-pure@8.0.0':
     dependencies:
       '@babel/types': 8.0.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
 
   '@babel/helper-compilation-targets@8.0.0':
     dependencies:
@@ -5857,6 +6035,19 @@ snapshots:
       browserslist: 4.28.2
       lru-cache: 11.5.2
       semver: 7.8.5
+
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-create-class-features-plugin@8.0.1(@babel/core@8.0.1)':
     dependencies:
@@ -5869,21 +6060,52 @@ snapshots:
       '@babel/traverse': 8.0.0
       semver: 7.8.5
 
+  '@babel/helper-globals@7.29.7': {}
+
   '@babel/helper-globals@8.0.0': {}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-member-expression-to-functions@8.0.0':
     dependencies:
       '@babel/traverse': 8.0.0
       '@babel/types': 8.0.0
 
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-imports@8.0.0':
     dependencies:
       '@babel/traverse': 8.0.0
       '@babel/types': 8.0.0
 
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/helper-optimise-call-expression@8.0.0':
     dependencies:
       '@babel/types': 8.0.0
+
+  '@babel/helper-plugin-utils@7.29.7': {}
 
   '@babel/helper-plugin-utils@8.0.1(@babel/core@8.0.1)':
     dependencies:
@@ -5896,12 +6118,28 @@ snapshots:
       '@babel/helper-wrap-function': 8.0.0
       '@babel/traverse': 8.0.0
 
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-replace-supers@8.0.1(@babel/core@8.0.1)':
     dependencies:
       '@babel/core': 8.0.1
       '@babel/helper-member-expression-to-functions': 8.0.0
       '@babel/helper-optimise-call-expression': 8.0.0
       '@babel/traverse': 8.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
     dependencies:
@@ -5916,6 +6154,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@8.0.0': {}
 
+  '@babel/helper-validator-option@7.29.7': {}
+
   '@babel/helper-validator-option@8.0.0': {}
 
   '@babel/helper-wrap-function@8.0.0':
@@ -5923,6 +6163,11 @@ snapshots:
       '@babel/template': 8.0.0
       '@babel/traverse': 8.0.0
       '@babel/types': 8.0.0
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/helpers@8.0.0':
     dependencies:
@@ -5953,6 +6198,16 @@ snapshots:
     dependencies:
       '@babel/core': 8.0.1
       '@babel/helper-plugin-utils': 8.0.1(@babel/core@8.0.1)
+
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-typescript@8.0.1(@babel/core@8.0.1)':
     dependencies:
@@ -6023,6 +6278,28 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 8.0.1(@babel/core@8.0.1)
       '@babel/helper-plugin-utils': 8.0.1(@babel/core@8.0.1)
 
+  '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-typescript@8.0.1(@babel/core@8.0.1)':
     dependencies:
       '@babel/core': 8.0.1
@@ -6034,11 +6311,29 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
   '@babel/template@8.0.0':
     dependencies:
       '@babel/code-frame': 8.0.0
       '@babel/parser': 8.0.0
       '@babel/types': 8.0.0
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/traverse@8.0.0':
     dependencies:
@@ -8832,6 +9127,10 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  babel-plugin-react-compiler@0.0.0-experimental-a1856f3-20260507:
+    dependencies:
+      '@babel/types': 7.29.7
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -9742,6 +10041,10 @@ snapshots:
 
   lru-cache@11.5.2: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   luxon@3.7.2: {}
 
   lz-string@1.5.0: {}
@@ -10337,6 +10640,8 @@ snapshots:
   scroll-into-view-if-needed@3.1.0:
     dependencies:
       compute-scroll-into-view: 3.1.1
+
+  semver@6.3.1: {}
 
   semver@7.8.5: {}
 
@@ -10962,6 +11267,8 @@ snapshots:
   ws@8.20.0: {}
 
   xtend@4.0.2: {}
+
+  yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
   - npm/*
   - tasks/codegen_conformance
   - tasks/e2e
+  - tasks/react_compiler
   - tasks/transform_conformance
   - tasks/compat_data
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - wasm/*
   - npm/*
   - tasks/e2e
+  - tasks/react_compiler
   - tasks/transform_conformance
   - tasks/compat_data
 

--- a/tasks/react_compiler/README.md
+++ b/tasks/react_compiler/README.md
@@ -9,7 +9,9 @@ Both React Compiler implementations receive the same explicit options. The
 comparison uses the v1 defaults for ESLint suppression rules and disables
 exhaustive manual-memo dependency validation, which was not enabled by default
 in v1. The scanned directory is passed as `sources` so dependency directories
-are handled consistently by both implementations.
+are handled consistently by both implementations. Babel's TypeScript transform
+also enables `allowDeclareFields` so uninitialized class fields use the same
+emit behavior as Oxc.
 
 Before comparing, the Babel output is parsed and printed by `oxc-transform`
 with no transforms enabled. This ensures both outputs use Oxc code generation

--- a/tasks/react_compiler/README.md
+++ b/tasks/react_compiler/README.md
@@ -5,6 +5,12 @@ the local `oxc-transform-react` NAPI package for every `.jsx` and `.tsx` file in
 a directory. Both pipelines run React Compiler first, remove TypeScript syntax,
 and lower JSX with the automatic runtime.
 
+Both React Compiler implementations receive the same explicit options. The
+comparison uses the v1 defaults for ESLint suppression rules and disables
+exhaustive manual-memo dependency validation, which was not enabled by default
+in v1. The scanned directory is passed as `sources` so dependency directories
+are handled consistently by both implementations.
+
 Before comparing, the Babel output is parsed and printed by `oxc-transform`
 with no transforms enabled. This ensures both outputs use Oxc code generation
 and removes printer-only differences.

--- a/tasks/react_compiler/README.md
+++ b/tasks/react_compiler/README.md
@@ -1,0 +1,22 @@
+# React Compiler comparison
+
+Recursively compares the published `babel-plugin-react-compiler` pipeline with
+the local `oxc-transform-react` NAPI package for every `.jsx` and `.tsx` file in
+a directory. Both pipelines run React Compiler first, remove TypeScript syntax,
+and lower JSX with the automatic runtime.
+
+Before comparing, the Babel output is parsed and printed by `oxc-transform`
+with no transforms enabled. This ensures both outputs use Oxc code generation
+and removes printer-only differences.
+
+Build the native bindings and pass a directory to scan:
+
+```sh
+pnpm --dir napi/transform build-test
+pnpm --dir napi/transform-react build-test
+pnpm --filter react_compiler compare ./path/to/source
+```
+
+The command prints each differing path relative to the scanned directory, one
+per line. Transform diagnostics and the final summary are written to stderr.
+It exits with status 1 when outputs differ or either transform fails.

--- a/tasks/react_compiler/README.md
+++ b/tasks/react_compiler/README.md
@@ -20,7 +20,7 @@ Before comparing, the Babel output is parsed and printed by `oxc-transform`
 with no transforms enabled. This ensures both outputs use Oxc code generation
 and removes printer-only differences.
 
-Build the native bindings and pass a directory to scan:
+Build the native bindings and pass a file or directory to scan:
 
 ```sh
 pnpm --dir napi/transform build-test
@@ -31,3 +31,48 @@ pnpm --filter react_compiler compare ./path/to/source
 The command prints each differing path relative to the scanned directory, one
 per line. Transform diagnostics and the final summary are written to stderr.
 It exits with status 1 when outputs differ or either transform fails.
+
+## Options
+
+- `--jobs=<count>` — how many worker threads compare files in parallel.
+  Defaults to two fewer than the available parallelism. Workers are recycled
+  periodically, and a file that takes longer than two minutes is reported as a
+  failure rather than stalling the scan.
+- `--report=<file>` — write one JSON object per non-matching file, holding its
+  status, category, and diff hunks.
+- `--dump=<directory>` — write both pipelines' full output for every
+  non-matching file, as `<path>.babel.js` and `<path>.oxc.js`, for diffing by
+  hand.
+
+A report file can then be summarized, which prints how the mismatches break
+down, which repositories each category comes from, and a representative diff
+for each:
+
+```sh
+pnpm --filter react_compiler compare ./path/to/source --report=report.jsonl
+pnpm --filter react_compiler report report.jsonl
+```
+
+## Categories
+
+Babel's JSX transform writes `/*#__PURE__*/` where Oxc's writes
+`/* @__PURE__ */`. Neither spelling comes from React Compiler, so files that
+differ only in it are reported separately as `pure-annotation` and the spelling
+is canonicalized before anything else is compared.
+
+Remaining mismatches are categorized by `categorize.mjs`, which applies known
+cosmetic normalizations — dropped comments, elided unused imports, import
+layout, whitespace, generated temporary numbering, binding renames, object
+shorthand, redundant parentheses — and reports the smallest set of them that
+makes the two outputs equal. Reporting the set rather than a single label keeps
+a file whose mismatch has several independent causes from being filed under
+whichever one happened to be checked first.
+
+A file no combination reconciles is `structural`: the two pipelines emitted
+genuinely different code. Two structural cases get their own labels first —
+`memoization-scope` when the sides memoized a different number of functions,
+and `statement-order` when they emitted the same lines in a different order.
+
+The normalizations are text-level heuristics for triage, not proofs of
+equivalence. Every report entry also carries diff hunks, so a category can be
+checked against the actual difference.

--- a/tasks/react_compiler/README.md
+++ b/tasks/react_compiler/README.md
@@ -5,13 +5,16 @@ the local `oxc-transform-react` NAPI package for every `.jsx` and `.tsx` file in
 a directory. Both pipelines run React Compiler first, remove TypeScript syntax,
 and lower JSX with the automatic runtime.
 
-Both React Compiler implementations receive the same explicit options. The
-comparison uses the v1 defaults for ESLint suppression rules and disables
-exhaustive manual-memo dependency validation, which was not enabled by default
-in v1. The scanned directory is passed as `sources` so dependency directories
-are handled consistently by both implementations. Babel's TypeScript transform
-also enables `allowDeclareFields` so uninitialized class fields use the same
-emit behavior as Oxc.
+Every React Compiler option shared by both implementations is set explicitly to
+the same value. The comparison uses the v1 defaults, including its ESLint
+suppression rules and disabled exhaustive manual-memo and void-`useMemo`
+validations. Per-binding adapters account for the two environment option names
+that Babel and Oxc spell differently. Babel-only callback, instrumentation, and
+test options are fixed at the neutral values used internally by Oxc. The scanned
+directory is passed as `sources` so dependency directories are handled
+consistently by both implementations. Babel's TypeScript transform also enables
+`allowDeclareFields` so uninitialized class fields use the same emit behavior as
+Oxc.
 
 Before comparing, the Babel output is parsed and printed by `oxc-transform`
 with no transforms enabled. This ensures both outputs use Oxc code generation

--- a/tasks/react_compiler/categorize.mjs
+++ b/tasks/react_compiler/categorize.mjs
@@ -1,0 +1,362 @@
+/**
+ * Explains why two outputs differ, by finding which known-cosmetic
+ * normalizations have to be applied before they compare equal.
+ *
+ * Each normalization stands for one class of difference. A file is described by
+ * the smallest set of them that reconciles the two outputs, so a mismatch caused
+ * by both dropped comments and renamed bindings is reported as both rather than
+ * as whichever happened to be checked first. A file that no combination
+ * reconciles is structural: the two pipelines emitted genuinely different code.
+ */
+
+/** React Compiler's generated temporaries, which the two may number apart. */
+const GENERATED_TEMPORARY = /\b(_temp|t)\d+\b/g;
+// `$` is not a word character, so these delimit identifiers with lookarounds
+// rather than `\b`, which would not fire on names like `$_0`.
+/** The `_1`, `_2`, … suffix React Compiler adds when it renames a binding. */
+const RENAME_SUFFIX = /(?<![\w$])([A-Za-z_$][\w$]*)_\d+(?![\w$])/g;
+/** An object property whose key and value are the same name, as in `a: a`. */
+const REDUNDANT_PROPERTY_KEY = /(?<![\w$])([A-Za-z_$][\w$]*)\s*:\s*\1(?![\w$])/g;
+/** Every `_c(n)` call, one per function React Compiler chose to memoize. */
+const MEMO_CACHE_CALL = /\b_c\((\d+)\)/g;
+/** Keywords after which a `/` opens a regular expression, never a division. */
+const REGEXP_PRECEDING_KEYWORD =
+  /\b(return|typeof|instanceof|in|of|new|delete|void|do|else|yield|await|case)$/;
+
+/** A generated top-level import, split into its clause and its module. */
+const IMPORT_STATEMENT = /^import\s+(.+?)\s+from\s+("[^"]*");$/;
+
+const NORMALIZATIONS = [
+  ["comments", (code) => dropBlankLines(stripComments(code))],
+  ["empty-statements", (code) => dropLines(code, (line) => line.trim() === ";")],
+  ["unused-imports", elideUnusedImports],
+  ["import-layout", canonicalizeImports],
+  // Collapses runs of whitespace and drops it next to punctuation, so removing
+  // a comment from inside a call no longer counts as a difference in its own
+  // right just because the remaining arguments fit on one line.
+  [
+    "whitespace",
+    (code) =>
+      code
+        .replace(/\s+/g, " ")
+        .replace(/ *([^\w$ ]) */g, "$1")
+        .trim(),
+  ],
+  ["temporaries", (code) => code.replace(GENERATED_TEMPORARY, "$1")],
+  ["renames", (code) => code.replace(RENAME_SUFFIX, "$1")],
+  // Renaming a binding forces a shorthand property to be written out in full,
+  // so collapse `a: a` back to `a` once the suffixes are gone.
+  ["shorthand", (code) => code.replace(REDUNDANT_PROPERTY_KEY, "$1")],
+  // Parentheses the two disagree about are always redundant ones: anything
+  // load-bearing would have changed the surrounding text as well. This runs
+  // last because dropping them fuses tokens, and the identifier rules above
+  // match on token boundaries.
+  ["parentheses", (code) => code.replace(/[()]/g, "")],
+];
+
+/**
+ * Describes a mismatch as a category plus the evidence behind it.
+ *
+ * `causes` is the minimal set of normalizations that reconciles the outputs;
+ * `memoizedFunctions` counts how many functions each side compiled, which
+ * separates a formatting difference from one side bailing out of compilation.
+ */
+export function categorizeDifference(babelOutput, oxcOutput) {
+  const causes = explainDifference(babelOutput, oxcOutput);
+  const babelCaches = memoCaches(babelOutput);
+  const oxcCaches = memoCaches(oxcOutput);
+  const memoizedFunctions = { babel: babelCaches.length, oxc: oxcCaches.length };
+  const memoizedSlots = { babel: sum(babelCaches), oxc: sum(oxcCaches) };
+
+  let category;
+  if (causes.length > 0) {
+    category = causes.join("+");
+  } else if (memoizedFunctions.babel !== memoizedFunctions.oxc) {
+    // One side declined to compile a function the other compiled.
+    category = "memoization-scope";
+  } else if (memoizedSlots.babel !== memoizedSlots.oxc) {
+    // The same functions were compiled, but into caches of different sizes.
+    category = "memoization-slots";
+  } else if (isReordered(babelOutput, oxcOutput)) {
+    category = "statement-order";
+  } else {
+    category = "structural";
+  }
+
+  return { category, causes, memoizedFunctions, memoizedSlots };
+}
+
+/** The slot count of every `_c(n)` cache the output allocates. */
+function memoCaches(code) {
+  return [...code.matchAll(MEMO_CACHE_CALL)].map(([, slots]) => Number.parseInt(slots, 10));
+}
+
+function sum(values) {
+  return values.reduce((total, value) => total + value, 0);
+}
+
+/**
+ * Returns the minimal set of normalization names explaining the difference, or
+ * an empty array when none of them do.
+ */
+function explainDifference(babelOutput, oxcOutput) {
+  if (!matchesUnder(NORMALIZATIONS, babelOutput, oxcOutput)) {
+    return [];
+  }
+
+  // Every normalization together reconciles the two, so drop the ones that are
+  // not pulling their weight and keep those whose removal breaks the match.
+  let required = NORMALIZATIONS;
+  for (const normalization of NORMALIZATIONS) {
+    const without = required.filter((candidate) => candidate !== normalization);
+    if (matchesUnder(without, babelOutput, oxcOutput)) {
+      required = without;
+    }
+  }
+  return required.map(([name]) => name);
+}
+
+/** Reports whether the two outputs hold the same lines in a different order. */
+function isReordered(babelOutput, oxcOutput) {
+  const key = (code) => dropBlankLines(stripComments(code)).split("\n").sort().join("\n");
+  return key(babelOutput) === key(oxcOutput);
+}
+
+function matchesUnder(normalizations, babelOutput, oxcOutput) {
+  const apply = (code) =>
+    normalizations.reduce((current, [, normalize]) => normalize(current), code);
+  return apply(babelOutput) === apply(oxcOutput);
+}
+
+function dropBlankLines(code) {
+  return dropLines(
+    code
+      .split("\n")
+      .map((line) => line.trim())
+      .join("\n"),
+    (line) => line === "",
+  );
+}
+
+function dropLines(code, shouldDrop) {
+  return code
+    .split("\n")
+    .filter((line) => !shouldDrop(line))
+    .join("\n");
+}
+
+/**
+ * Drops imported bindings that nothing else references, so a side that elides
+ * an import React Compiler made redundant lines up with a side that keeps it.
+ */
+function elideUnusedImports(code) {
+  const lines = code.split("\n");
+  const body = lines.filter((line) => !IMPORT_STATEMENT.test(line)).join("\n");
+  const isUsed = (localName) => new RegExp(`\\b${escapeRegExp(localName)}\\b`).test(body);
+
+  return lines
+    .map((line) => {
+      const statement = line.match(IMPORT_STATEMENT);
+      if (statement === null) {
+        return line;
+      }
+      const [, clause, module] = statement;
+      const kept = splitImportClause(clause).filter(({ localName }) => isUsed(localName));
+      if (kept.length === 0) {
+        return null;
+      }
+      const named = kept.filter(({ isNamed }) => isNamed).map(({ text }) => text);
+      const bare = kept.filter(({ isNamed }) => !isNamed).map(({ text }) => text);
+      const parts = named.length === 0 ? bare : [...bare, `{ ${named.join(", ")} }`];
+      return `import ${parts.join(", ")} from ${module};`;
+    })
+    .filter((line) => line !== null)
+    .join("\n");
+}
+
+/**
+ * Rewrites every top-level import to one sorted statement per module at the top
+ * of the file, so where an import was placed, how its modules were split, and
+ * what order its specifiers came in stop counting as differences.
+ */
+function canonicalizeImports(code) {
+  const others = [];
+  const bindingsByModule = new Map();
+
+  for (const line of code.split("\n")) {
+    const statement = line.match(IMPORT_STATEMENT);
+    if (statement === null) {
+      others.push(line);
+      continue;
+    }
+    const [, clause, module] = statement;
+    const bindings = bindingsByModule.get(module) ?? [];
+    // `default` keeps a default import from sorting in among the named ones.
+    bindings.push(
+      ...splitImportClause(clause).map(({ text, isNamed }) => (isNamed ? text : `default ${text}`)),
+    );
+    bindingsByModule.set(module, bindings);
+  }
+
+  const imports = [...bindingsByModule]
+    .sort(([left], [right]) => (left < right ? -1 : 1))
+    .map(
+      ([module, bindings]) => `import ${[...new Set(bindings)].sort().join(", ")} from ${module};`,
+    );
+  return [...imports, ...others].join("\n");
+}
+
+/** Splits `React, { a, b as c }` into its individual bindings. */
+function splitImportClause(clause) {
+  const named = clause.match(/\{([^}]*)\}/);
+  const bindings = [];
+
+  for (const text of clause.replace(/\{[^}]*\}/, "").split(",")) {
+    if (text.trim() !== "") {
+      bindings.push({ text: text.trim(), localName: localNameOf(text), isNamed: false });
+    }
+  }
+  for (const text of named?.[1].split(",") ?? []) {
+    if (text.trim() !== "") {
+      bindings.push({ text: text.trim(), localName: localNameOf(text), isNamed: true });
+    }
+  }
+
+  return bindings;
+}
+
+function localNameOf(specifier) {
+  return specifier
+    .trim()
+    .split(/\s+as\s+/)
+    .at(-1)
+    .trim();
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Removes comments from generated JavaScript. Scans literals rather than
+ * pattern-matching them, so comment markers inside strings, templates, and
+ * regular expressions are left alone.
+ */
+function stripComments(code) {
+  let output = "";
+  let index = 0;
+  // The brace depth each open template literal sits at, so a `}` can be told
+  // apart from the end of a `${…}` substitution.
+  const templateDepths = [];
+  let braceDepth = 0;
+  const emit = (text) => {
+    output += text;
+  };
+
+  while (index < code.length) {
+    const character = code[index];
+
+    if (templateDepths.length > 0 && braceDepth === templateDepths.at(-1)) {
+      // Inside template text, where nothing but `\`, a backtick, and `${` is
+      // special — comment markers there are literal characters.
+      if (character === "\\") {
+        emit(code.slice(index, index + 2));
+        index += 2;
+      } else if (character === "`") {
+        templateDepths.pop();
+        emit(character);
+        index++;
+      } else if (character === "$" && code[index + 1] === "{") {
+        braceDepth++;
+        emit("${");
+        index += 2;
+      } else {
+        emit(character);
+        index++;
+      }
+      continue;
+    }
+
+    if (character === "/" && code[index + 1] === "/") {
+      index = skipComment(code, index, "\n", false);
+    } else if (character === "/" && code[index + 1] === "*") {
+      index = skipComment(code, index + 2, "*/", true);
+    } else if (character === '"' || character === "'") {
+      index = copyQuoted(code, index, emit);
+    } else if (character === "/" && startsRegExp(output)) {
+      index = copyRegExp(code, index, emit);
+    } else {
+      if (character === "`") {
+        templateDepths.push(braceDepth);
+      } else if (character === "{") {
+        braceDepth++;
+      } else if (character === "}") {
+        braceDepth--;
+      }
+      emit(character);
+      index++;
+    }
+  }
+
+  return output;
+}
+
+/** Advances past a comment, keeping the newline that ended a line comment. */
+function skipComment(code, index, terminator, consumeTerminator) {
+  const end = code.indexOf(terminator, index);
+  if (end === -1) {
+    return code.length;
+  }
+  return consumeTerminator ? end + terminator.length : end;
+}
+
+function copyQuoted(code, index, emit) {
+  const quote = code[index];
+  let cursor = index + 1;
+  while (cursor < code.length && code[cursor] !== quote) {
+    cursor += code[cursor] === "\\" ? 2 : 1;
+  }
+  emit(code.slice(index, cursor + 1));
+  return cursor + 1;
+}
+
+function copyRegExp(code, index, emit) {
+  let cursor = index + 1;
+  let inCharacterClass = false;
+
+  while (cursor < code.length) {
+    const character = code[cursor];
+    if (character === "\\") {
+      cursor += 2;
+      continue;
+    }
+    if (character === "\n") {
+      // Not a regular expression after all, so treat the slash as an operator.
+      emit("/");
+      return index + 1;
+    }
+    if (character === "[") {
+      inCharacterClass = true;
+    } else if (character === "]") {
+      inCharacterClass = false;
+    } else if (character === "/" && !inCharacterClass) {
+      break;
+    }
+    cursor++;
+  }
+
+  emit(code.slice(index, cursor + 1));
+  return cursor + 1;
+}
+
+/**
+ * Decides whether a `/` opens a regular expression rather than a division, from
+ * what was emitted before it.
+ */
+function startsRegExp(output) {
+  const before = output.trimEnd();
+  if (before === "") {
+    return true;
+  }
+  return !/[\w$)\]]$/.test(before) || REGEXP_PRECEDING_KEYWORD.test(before);
+}

--- a/tasks/react_compiler/compare.mjs
+++ b/tasks/react_compiler/compare.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
-import { readdir, readFile, stat } from "node:fs/promises";
-import { extname, relative, resolve } from "node:path";
+import { createWriteStream } from "node:fs";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { availableParallelism } from "node:os";
+import { dirname, extname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isMainThread, parentPort, Worker, workerData } from "node:worker_threads";
 
 import { transformSync as babelTransformSync } from "@babel/core";
 import transformReactJsx from "@babel/plugin-transform-react-jsx";
@@ -8,6 +12,8 @@ import transformTypescript from "@babel/plugin-transform-typescript";
 import reactCompiler from "babel-plugin-react-compiler";
 import { transformSync as oxcCodegenSync } from "oxc-transform";
 import { transformSync as oxcReactCompilerSync } from "oxc-transform-react";
+
+import { categorizeDifference } from "./categorize.mjs";
 
 const SOURCE_EXTENSIONS = new Set([".jsx", ".tsx"]);
 const DEFAULT_ESLINT_SUPPRESSION_RULES_V1 = [
@@ -70,82 +76,121 @@ const BABEL_TYPESCRIPT_OPTIONS = {
   allowDeclareFields: true,
 };
 
-const args = process.argv.slice(2);
-if (args.length !== 1) {
-  throw new Error("Usage: pnpm --filter react_compiler compare <directory>");
+// A worker is replaced once it reaches this many files, so Babel's per-run
+// allocations cannot accumulate across a large scan.
+const FILES_PER_WORKER_LIFETIME = 500;
+// A file that outruns this budget is reported as a failure and its worker is
+// replaced, so one pathological input cannot stall the whole scan.
+const FILE_TIMEOUT_MS = 120_000;
+// Babel's JSX transform writes `/*#__PURE__*/` where Oxc's writes
+// `/* @__PURE__ */`. Both are equivalent, and neither comes from React
+// Compiler, so files differing only in this spelling get their own status and
+// the rest are diffed with the spelling canonicalized.
+const PURE_ANNOTATION = /\/\*\s*[#@]__PURE__\s*\*\//g;
+// Diff hunks kept per file, and the longest hunk body kept per side.
+const DIFF_MAX_HUNKS = 10;
+const DIFF_MAX_HUNK_LINES = 20;
+// Files needing more edits than this are reported as a single whole-file hunk
+// instead, which keeps the diff of a wildly diverging output cheap.
+const DIFF_MAX_EDITS = 400;
+
+if (isMainThread) {
+  await main();
+} else {
+  runWorker(workerData);
 }
 
-const invocationDirectory = process.env.INIT_CWD ?? process.cwd();
-const directory = resolve(invocationDirectory, args[0]);
-if (!(await stat(directory)).isDirectory()) {
-  throw new Error(`Not a directory: ${directory}`);
-}
-const {
-  validateNoDerivedComputationsInEffectsExperimental,
-  validateNoJsxInTryStatements,
-  ...sharedEnvironmentOptions
-} = REACT_COMPILER_ENVIRONMENT_OPTIONS_V1;
-const babelReactCompilerOptions = {
-  ...REACT_COMPILER_OPTIONS_V1,
-  logger: null,
-  enableReanimatedCheck: true,
-  sources: [directory],
-  environment: {
-    ...sharedEnvironmentOptions,
-    // These two Babel spellings differ from the Oxc NAPI property names.
-    validateNoDerivedComputationsInEffects_exp: validateNoDerivedComputationsInEffectsExperimental,
-    validateNoJSXInTryStatements: validateNoJsxInTryStatements,
-    // Oxc has the same neutral defaults internally, but does not expose these
-    // callback/test-only options across the NAPI boundary.
-    customHooks: new Map(),
-    moduleTypeProvider: null,
-    flowTypeProvider: null,
-    enableEmitHookGuards: null,
-    enableEmitInstrumentForget: null,
-    throwUnknownException__testonly: false,
-  },
-};
-const oxcReactCompilerOptions = {
-  // napi-rs represents optional object/list fields by omission and does not
-  // accept the explicit `null` values used by Babel's resolved configuration.
-  ...omitNullOptionsForNapi(REACT_COMPILER_OPTIONS_V1),
-  sources: [directory],
-  environment: {
-    ...omitNullOptionsForNapi(sharedEnvironmentOptions),
-    validateNoDerivedComputationsInEffectsExp: validateNoDerivedComputationsInEffectsExperimental,
-    validateNoJsxInTryStatements,
-  },
-};
+async function main() {
+  const { directory, filenames, jobs, reportPath, dumpDirectory } = await parseArguments(
+    process.argv.slice(2),
+  );
+  const report = reportPath === null ? null : createWriteStream(reportPath, { flags: "w" });
+  const counts = { same: 0, "pure-annotation": 0, different: 0, failed: 0 };
 
-const filenames = await findSourceFiles(directory);
-let differenceCount = 0;
-let failureCount = 0;
-
-for (const filename of filenames) {
-  const sourceText = await readFile(filename, "utf8");
-  const displayPath = relative(directory, filename);
-
-  try {
-    const babelOutput = transformWithBabel(filename, sourceText);
-    const oxcOutput = transformWithOxc(filename, sourceText);
-    if (babelOutput !== oxcOutput) {
-      console.log(displayPath);
-      differenceCount++;
+  await runPool({ directory, filenames, jobs, dumpDirectory }, (result) => {
+    counts[result.status]++;
+    if (result.status === "same") {
+      return;
     }
-  } catch (error) {
-    console.log(displayPath);
-    console.error(`${displayPath}: ${error instanceof Error ? error.message : String(error)}`);
-    differenceCount++;
-    failureCount++;
+    console.log(result.path);
+    if (result.status === "failed") {
+      console.error(`${result.path}: ${result.message}`);
+    }
+    report?.write(`${JSON.stringify(result)}\n`);
+  });
+
+  // A trailing summary record keeps the report self-describing, so a reader
+  // knows what share of the scan the listed mismatches represent.
+  report?.write(`${JSON.stringify({ status: "summary", compared: filenames.length, counts })}\n`);
+  if (report !== null) {
+    await new Promise((done) => report.end(done));
+  }
+
+  const differenceCount = counts["pure-annotation"] + counts.different + counts.failed;
+  console.error(
+    `Compared ${filenames.length} files: ${differenceCount} different ` +
+      `(${counts["pure-annotation"]} only in __PURE__ annotation spelling), ` +
+      `${counts.failed} failed to transform.`,
+  );
+
+  if (differenceCount > 0) {
+    process.exitCode = 1;
   }
 }
 
-console.error(
-  `Compared ${filenames.length} files: ${differenceCount} different, ${failureCount} failed to transform.`,
-);
+async function parseArguments(args) {
+  let targetArgument = null;
+  let jobs = Math.max(1, availableParallelism() - 2);
+  let reportPath = null;
+  let dumpDirectory = null;
 
-if (differenceCount > 0) {
-  process.exitCode = 1;
+  for (const arg of args) {
+    const [name, value] = splitOption(arg);
+    switch (name) {
+      case "--jobs":
+        jobs = Number.parseInt(value, 10);
+        assert(Number.isInteger(jobs) && jobs > 0, `Invalid --jobs value: ${value}`);
+        break;
+      case "--report":
+        assert(value !== "", "--report requires a file path");
+        reportPath = resolve(invocationDirectory(), value);
+        break;
+      case "--dump":
+        assert(value !== "", "--dump requires a directory path");
+        dumpDirectory = resolve(invocationDirectory(), value);
+        break;
+      default:
+        assert(!name.startsWith("--"), `Unknown option: ${name}`);
+        assert(targetArgument === null, "Pass exactly one file or directory");
+        targetArgument = arg;
+    }
+  }
+
+  assert(
+    targetArgument !== null,
+    "Usage: pnpm --filter react_compiler compare <file|directory> " +
+      "[--jobs=<count>] [--report=<file>] [--dump=<directory>]",
+  );
+  const target = resolve(invocationDirectory(), targetArgument);
+  const isDirectory = (await stat(target)).isDirectory();
+  return {
+    // Reported paths and the React Compiler `sources` option are both anchored
+    // at the scanned directory, which for a single file is the one holding it.
+    directory: isDirectory ? target : dirname(target),
+    filenames: isDirectory ? await findSourceFiles(target) : [target],
+    jobs,
+    reportPath,
+    dumpDirectory,
+  };
+}
+
+function splitOption(arg) {
+  const separator = arg.indexOf("=");
+  return separator === -1 ? [arg, ""] : [arg.slice(0, separator), arg.slice(separator + 1)];
+}
+
+function invocationDirectory() {
+  return process.env.INIT_CWD ?? process.cwd();
 }
 
 async function findSourceFiles(root) {
@@ -164,8 +209,184 @@ async function findSourceFiles(root) {
   return files.sort();
 }
 
-function transformWithBabel(filename, sourceText) {
-  const plugins = [[reactCompiler, babelReactCompilerOptions]];
+/**
+ * Compares every file across a pool of workers. Each worker is replaced when it
+ * reaches its file budget, times out, or dies. `onResult` sees the files in
+ * input order, so results can be streamed out without buffering the whole scan.
+ */
+async function runPool({ directory, filenames, jobs, dumpDirectory }, onResult) {
+  const finished = new Map();
+  let nextIndex = 0;
+  let flushIndex = 0;
+
+  function complete(index, result) {
+    finished.set(index, result);
+    while (finished.has(flushIndex)) {
+      onResult(finished.get(flushIndex));
+      finished.delete(flushIndex);
+      flushIndex++;
+      reportProgress(flushIndex, filenames.length);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(jobs, filenames.length) }, async () => {
+      let worker = null;
+      let filesOnWorker = 0;
+
+      try {
+        while (nextIndex < filenames.length) {
+          const index = nextIndex++;
+          if (worker === null || filesOnWorker >= FILES_PER_WORKER_LIFETIME) {
+            await worker?.terminate();
+            worker = startWorker({ directory, dumpDirectory });
+            filesOnWorker = 0;
+          }
+
+          const { result, workerIsUsable } = await compareOnWorker(worker, filenames[index]);
+          filesOnWorker++;
+          if (!workerIsUsable) {
+            await worker.terminate();
+            worker = null;
+          }
+          complete(index, { path: relative(directory, filenames[index]), ...result });
+        }
+      } finally {
+        await worker?.terminate();
+      }
+    }),
+  );
+}
+
+function startWorker(options) {
+  const worker = new Worker(fileURLToPath(import.meta.url), { workerData: options });
+  // Failures are surfaced per file by `compareOnWorker`. Without a permanent
+  // listener an error raised between files would take down the whole scan.
+  worker.on("error", () => {});
+  return worker;
+}
+
+/**
+ * Sends one file to a worker. A timed-out or crashed worker is reported as a
+ * failure for that file and flagged for replacement.
+ */
+function compareOnWorker(worker, filename) {
+  return new Promise((done) => {
+    const timeout = setTimeout(
+      () => finish({ status: "failed", message: `Timed out after ${FILE_TIMEOUT_MS}ms` }, false),
+      FILE_TIMEOUT_MS,
+    );
+
+    function finish(result, workerIsUsable) {
+      clearTimeout(timeout);
+      worker.off("message", onMessage);
+      worker.off("error", onError);
+      worker.off("exit", onExit);
+      done({ result, workerIsUsable });
+    }
+
+    function onMessage(result) {
+      finish(result, true);
+    }
+    function onError(error) {
+      finish({ status: "failed", message: `Worker error: ${error?.message ?? error}` }, false);
+    }
+    function onExit(code) {
+      finish({ status: "failed", message: `Worker exited with code ${code}` }, false);
+    }
+
+    worker.on("message", onMessage);
+    worker.on("error", onError);
+    worker.on("exit", onExit);
+    worker.postMessage(filename);
+  });
+}
+
+function reportProgress(completedCount, total) {
+  if (completedCount % 1000 === 0 || completedCount === total) {
+    console.error(`  ${completedCount}/${total} compared`);
+  }
+}
+
+function runWorker({ directory, dumpDirectory }) {
+  const { babelOptions, oxcOptions } = buildOptions(directory);
+
+  parentPort.on("message", async (filename) => {
+    let result;
+    try {
+      const sourceText = await readFile(filename, "utf8");
+      const babelOutput = transformWithBabel(filename, sourceText, babelOptions);
+      const oxcOutput = transformWithOxc(filename, sourceText, oxcOptions);
+      result = compareOutputs(babelOutput, oxcOutput);
+      if (dumpDirectory !== null && result.status !== "same") {
+        await dumpOutputs(dumpDirectory, relative(directory, filename), babelOutput, oxcOutput);
+      }
+    } catch (error) {
+      result = {
+        status: "failed",
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+    parentPort.postMessage(result);
+  });
+}
+
+/** Writes both pipelines' output for one file, for diffing by hand. */
+async function dumpOutputs(dumpDirectory, displayPath, babelOutput, oxcOutput) {
+  const target = resolve(dumpDirectory, displayPath);
+  await mkdir(dirname(target), { recursive: true });
+  await Promise.all([
+    writeFile(`${target}.babel.js`, babelOutput),
+    writeFile(`${target}.oxc.js`, oxcOutput),
+  ]);
+}
+
+function buildOptions(directory) {
+  const {
+    validateNoDerivedComputationsInEffectsExperimental,
+    validateNoJsxInTryStatements,
+    ...sharedEnvironmentOptions
+  } = REACT_COMPILER_ENVIRONMENT_OPTIONS_V1;
+
+  return {
+    babelOptions: {
+      ...REACT_COMPILER_OPTIONS_V1,
+      logger: null,
+      enableReanimatedCheck: true,
+      sources: [directory],
+      environment: {
+        ...sharedEnvironmentOptions,
+        // These two Babel spellings differ from the Oxc NAPI property names.
+        validateNoDerivedComputationsInEffects_exp:
+          validateNoDerivedComputationsInEffectsExperimental,
+        validateNoJSXInTryStatements: validateNoJsxInTryStatements,
+        // Oxc has the same neutral defaults internally, but does not expose these
+        // callback/test-only options across the NAPI boundary.
+        customHooks: new Map(),
+        moduleTypeProvider: null,
+        flowTypeProvider: null,
+        enableEmitHookGuards: null,
+        enableEmitInstrumentForget: null,
+        throwUnknownException__testonly: false,
+      },
+    },
+    oxcOptions: {
+      // napi-rs represents optional object/list fields by omission and does not
+      // accept the explicit `null` values used by Babel's resolved configuration.
+      ...omitNullOptionsForNapi(REACT_COMPILER_OPTIONS_V1),
+      sources: [directory],
+      environment: {
+        ...omitNullOptionsForNapi(sharedEnvironmentOptions),
+        validateNoDerivedComputationsInEffectsExp:
+          validateNoDerivedComputationsInEffectsExperimental,
+        validateNoJsxInTryStatements,
+      },
+    },
+  };
+}
+
+function transformWithBabel(filename, sourceText, babelOptions) {
+  const plugins = [[reactCompiler, babelOptions]];
   if (extname(filename).toLowerCase() === ".tsx") {
     plugins.push([transformTypescript, BABEL_TYPESCRIPT_OPTIONS]);
   }
@@ -192,13 +413,175 @@ function transformWithBabel(filename, sourceText) {
   return normalizedResult.code;
 }
 
-function transformWithOxc(filename, sourceText) {
-  const result = oxcReactCompilerSync(filename, sourceText, {
-    reactCompiler: oxcReactCompilerOptions,
-  });
+function transformWithOxc(filename, sourceText, oxcOptions) {
+  const result = oxcReactCompilerSync(filename, sourceText, { reactCompiler: oxcOptions });
   assertNoErrors(result, "oxc-transform-react failed");
   assert(result.code, "oxc-transform-react did not produce code");
   return result.code;
+}
+
+function compareOutputs(babelOutput, oxcOutput) {
+  if (babelOutput === oxcOutput) {
+    return { status: "same" };
+  }
+
+  const babelNormalized = babelOutput.replace(PURE_ANNOTATION, "/*@__PURE__*/");
+  const oxcNormalized = oxcOutput.replace(PURE_ANNOTATION, "/*@__PURE__*/");
+  if (babelNormalized === oxcNormalized) {
+    return { status: "pure-annotation" };
+  }
+  return {
+    status: "different",
+    ...categorizeDifference(babelNormalized, oxcNormalized),
+    ...computeDiff(babelNormalized, oxcNormalized),
+  };
+}
+
+/**
+ * Reports every place the two outputs diverge, rather than one span covering
+ * all of them. A file typically mixes unrelated differences, so a single span
+ * would let the first one hide all the rest.
+ */
+function computeDiff(babelOutput, oxcOutput) {
+  const babelLines = babelOutput.split("\n");
+  const oxcLines = oxcOutput.split("\n");
+
+  let prefix = 0;
+  while (
+    prefix < babelLines.length &&
+    prefix < oxcLines.length &&
+    babelLines[prefix] === oxcLines[prefix]
+  ) {
+    prefix++;
+  }
+  let babelEnd = babelLines.length;
+  let oxcEnd = oxcLines.length;
+  while (
+    babelEnd > prefix &&
+    oxcEnd > prefix &&
+    babelLines[babelEnd - 1] === oxcLines[oxcEnd - 1]
+  ) {
+    babelEnd--;
+    oxcEnd--;
+  }
+
+  const babelBody = babelLines.slice(prefix, babelEnd);
+  const oxcBody = oxcLines.slice(prefix, oxcEnd);
+  const hunks = diffHunks(babelBody, oxcBody, prefix) ?? [
+    { line: prefix + 1, babel: babelBody, oxc: oxcBody },
+  ];
+
+  return {
+    hunkCount: hunks.length,
+    hunks: hunks.slice(0, DIFF_MAX_HUNKS).map((hunk) => ({
+      line: hunk.line,
+      babel: truncateHunkSide(hunk.babel),
+      oxc: truncateHunkSide(hunk.oxc),
+    })),
+  };
+}
+
+/**
+ * Myers diff, capped at `DIFF_MAX_EDITS` edits. Returns `null` when the two
+ * sides are too far apart to be worth aligning line by line.
+ */
+function diffHunks(babelLines, oxcLines, lineOffset) {
+  const maxEdits = Math.min(DIFF_MAX_EDITS, babelLines.length + oxcLines.length);
+  const origin = maxEdits + 1;
+  const furthest = new Int32Array(2 * maxEdits + 3);
+  const trace = [];
+
+  for (let edits = 0; edits <= maxEdits; edits++) {
+    trace.push(furthest.slice());
+    for (let diagonal = -edits; diagonal <= edits; diagonal += 2) {
+      let babelIndex = takesDeletion(furthest, origin, diagonal, edits)
+        ? furthest[origin + diagonal - 1] + 1
+        : furthest[origin + diagonal + 1];
+      let oxcIndex = babelIndex - diagonal;
+      while (
+        babelIndex < babelLines.length &&
+        oxcIndex < oxcLines.length &&
+        babelLines[babelIndex] === oxcLines[oxcIndex]
+      ) {
+        babelIndex++;
+        oxcIndex++;
+      }
+      furthest[origin + diagonal] = babelIndex;
+      if (babelIndex >= babelLines.length && oxcIndex >= oxcLines.length) {
+        return collectHunks(trace, babelLines, oxcLines, edits, origin, lineOffset);
+      }
+    }
+  }
+
+  return null;
+}
+
+function takesDeletion(furthest, origin, diagonal, edits) {
+  if (diagonal === -edits) {
+    return false;
+  }
+  return diagonal === edits || furthest[origin + diagonal - 1] >= furthest[origin + diagonal + 1];
+}
+
+/** Walks the Myers trace backwards, grouping adjacent edits into hunks. */
+function collectHunks(trace, babelLines, oxcLines, edits, origin, lineOffset) {
+  const hunks = [];
+  let babelIndex = babelLines.length;
+  let oxcIndex = oxcLines.length;
+  let hunk = null;
+
+  function openHunk() {
+    if (hunk === null) {
+      hunk = { babel: [], oxc: [] };
+      hunks.push(hunk);
+    }
+    return hunk;
+  }
+
+  function closeHunk(babelStart) {
+    if (hunk !== null) {
+      hunk.line = lineOffset + babelStart + 1;
+      hunk.babel.reverse();
+      hunk.oxc.reverse();
+      hunk = null;
+    }
+  }
+
+  for (let edit = edits; edit > 0; edit--) {
+    const furthest = trace[edit];
+    const diagonal = babelIndex - oxcIndex;
+    const previousDiagonal = takesDeletion(furthest, origin, diagonal, edit)
+      ? diagonal - 1
+      : diagonal + 1;
+    const previousBabelIndex = furthest[origin + previousDiagonal];
+    const previousOxcIndex = previousBabelIndex - previousDiagonal;
+
+    if (babelIndex > previousBabelIndex && oxcIndex > previousOxcIndex) {
+      // Matching lines separate this edit from the ones already collected.
+      closeHunk(babelIndex);
+      do {
+        babelIndex--;
+        oxcIndex--;
+      } while (babelIndex > previousBabelIndex && oxcIndex > previousOxcIndex);
+    }
+    if (babelIndex > previousBabelIndex) {
+      openHunk().babel.push(babelLines[--babelIndex]);
+    } else if (oxcIndex > previousOxcIndex) {
+      openHunk().oxc.push(oxcLines[--oxcIndex]);
+    }
+  }
+  closeHunk(babelIndex);
+
+  return hunks.reverse();
+}
+
+function truncateHunkSide(lines) {
+  return lines.length <= DIFF_MAX_HUNK_LINES
+    ? lines
+    : [
+        ...lines.slice(0, DIFF_MAX_HUNK_LINES),
+        `… ${lines.length - DIFF_MAX_HUNK_LINES} more lines`,
+      ];
 }
 
 function assertNoErrors(result, message) {

--- a/tasks/react_compiler/compare.mjs
+++ b/tasks/react_compiler/compare.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { extname, relative, resolve } from "node:path";
+
+import { transformSync as babelTransformSync } from "@babel/core";
+import transformReactJsx from "@babel/plugin-transform-react-jsx";
+import transformTypescript from "@babel/plugin-transform-typescript";
+import reactCompiler from "babel-plugin-react-compiler";
+import { transformSync as oxcCodegenSync } from "oxc-transform";
+import { transformSync as oxcReactCompilerSync } from "oxc-transform-react";
+
+const SOURCE_EXTENSIONS = new Set([".jsx", ".tsx"]);
+
+const args = process.argv.slice(2);
+if (args.length !== 1) {
+  throw new Error("Usage: pnpm --filter react_compiler compare <directory>");
+}
+
+const invocationDirectory = process.env.INIT_CWD ?? process.cwd();
+const directory = resolve(invocationDirectory, args[0]);
+if (!(await stat(directory)).isDirectory()) {
+  throw new Error(`Not a directory: ${directory}`);
+}
+
+const filenames = await findSourceFiles(directory);
+let differenceCount = 0;
+let failureCount = 0;
+
+for (const filename of filenames) {
+  const sourceText = await readFile(filename, "utf8");
+  const displayPath = relative(directory, filename);
+
+  try {
+    const babelOutput = transformWithBabel(filename, sourceText);
+    const oxcOutput = transformWithOxc(filename, sourceText);
+    if (babelOutput !== oxcOutput) {
+      console.log(displayPath);
+      differenceCount++;
+    }
+  } catch (error) {
+    console.log(displayPath);
+    console.error(`${displayPath}: ${error instanceof Error ? error.message : String(error)}`);
+    differenceCount++;
+    failureCount++;
+  }
+}
+
+console.error(
+  `Compared ${filenames.length} files: ${differenceCount} different, ${failureCount} failed to transform.`,
+);
+
+if (differenceCount > 0) {
+  process.exitCode = 1;
+}
+
+async function findSourceFiles(root) {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const path = resolve(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await findSourceFiles(path)));
+    } else if (entry.isFile() && SOURCE_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
+      files.push(path);
+    }
+  }
+
+  return files.sort();
+}
+
+function transformWithBabel(filename, sourceText) {
+  const plugins = [[reactCompiler, {}]];
+  if (extname(filename).toLowerCase() === ".tsx") {
+    plugins.push([
+      transformTypescript,
+      {
+        allExtensions: true,
+        isTSX: true,
+      },
+    ]);
+  }
+  plugins.push([transformReactJsx, { runtime: "automatic" }]);
+
+  const result = babelTransformSync(sourceText, {
+    babelrc: false,
+    comments: true,
+    configFile: false,
+    filename,
+    plugins,
+    sourceMaps: false,
+    sourceType: "unambiguous",
+  });
+
+  assert(result?.code, "Babel did not produce code");
+
+  const normalizedResult = oxcCodegenSync(filename, result.code, {
+    lang: "js",
+    sourceType: "unambiguous",
+  });
+  assertNoErrors(normalizedResult, "Oxc failed to codegen Babel output");
+  assert(normalizedResult.code, "Oxc did not codegen Babel output");
+  return normalizedResult.code;
+}
+
+function transformWithOxc(filename, sourceText) {
+  const result = oxcReactCompilerSync(filename, sourceText);
+  assertNoErrors(result, "oxc-transform-react failed");
+  assert(result.code, "oxc-transform-react did not produce code");
+  return result.code;
+}
+
+function assertNoErrors(result, message) {
+  const errors = result.errors.filter(({ severity }) => severity === "Error");
+  assert.equal(errors.length, 0, `${message}\n${errors.map(({ message }) => message).join("\n")}`);
+}

--- a/tasks/react_compiler/compare.mjs
+++ b/tasks/react_compiler/compare.mjs
@@ -14,6 +14,55 @@ const DEFAULT_ESLINT_SUPPRESSION_RULES_V1 = [
   "react-hooks/exhaustive-deps",
   "react-hooks/rules-of-hooks",
 ];
+const REACT_COMPILER_ENVIRONMENT_OPTIONS_V1 = {
+  customMacros: null,
+  enableResetCacheOnSourceFileChanges: null,
+  enablePreserveExistingMemoizationGuarantees: true,
+  validatePreserveExistingMemoizationGuarantees: true,
+  validateExhaustiveMemoizationDependencies: false,
+  validateExhaustiveEffectDependencies: "off",
+  enableOptionalDependencies: true,
+  enableNameAnonymousFunctions: false,
+  validateHooksUsage: true,
+  validateRefAccessDuringRender: true,
+  validateNoSetStateInRender: true,
+  enableUseKeyedState: false,
+  validateNoSetStateInEffects: false,
+  validateNoDerivedComputationsInEffects: false,
+  validateNoDerivedComputationsInEffectsExperimental: false,
+  validateNoJsxInTryStatements: false,
+  validateStaticComponents: false,
+  validateNoCapitalizedCalls: null,
+  validateBlocklistedImports: null,
+  validateSourceLocations: false,
+  validateNoImpureFunctionsInRender: false,
+  validateNoFreezingKnownMutableFunctions: false,
+  enableAssumeHooksFollowRulesOfReact: true,
+  enableTransitivelyFreezeFunctionExpressions: true,
+  enableFunctionOutlining: true,
+  enableJsxOutlining: false,
+  assertValidMutableRanges: false,
+  enableCustomTypeDefinitionForReanimated: false,
+  enableTreatRefLikeIdentifiersAsRefs: true,
+  enableTreatSetIdentifiersAsStateSetters: false,
+  validateNoVoidUseMemo: false,
+  enableAllowSetStateFromRefsInEffects: true,
+  enableVerboseNoSetStateInEffect: false,
+  enableForest: false,
+};
+const REACT_COMPILER_OPTIONS_V1 = {
+  compilationMode: "infer",
+  panicThreshold: "none",
+  target: "19",
+  gating: null,
+  dynamicGating: null,
+  noEmit: false,
+  outputMode: null,
+  eslintSuppressionRules: DEFAULT_ESLINT_SUPPRESSION_RULES_V1,
+  flowSuppressions: true,
+  ignoreUseNoForget: false,
+  customOptOutDirectives: null,
+};
 const BABEL_TYPESCRIPT_OPTIONS = {
   allExtensions: true,
   isTSX: true,
@@ -31,17 +80,40 @@ const directory = resolve(invocationDirectory, args[0]);
 if (!(await stat(directory)).isDirectory()) {
   throw new Error(`Not a directory: ${directory}`);
 }
-const reactCompilerOptions = {
-  compilationMode: "infer",
-  panicThreshold: "none",
-  target: "19",
-  eslintSuppressionRules: DEFAULT_ESLINT_SUPPRESSION_RULES_V1,
-  flowSuppressions: true,
-  ignoreUseNoForget: false,
+const {
+  validateNoDerivedComputationsInEffectsExperimental,
+  validateNoJsxInTryStatements,
+  ...sharedEnvironmentOptions
+} = REACT_COMPILER_ENVIRONMENT_OPTIONS_V1;
+const babelReactCompilerOptions = {
+  ...REACT_COMPILER_OPTIONS_V1,
+  logger: null,
+  enableReanimatedCheck: true,
   sources: [directory],
   environment: {
-    validateExhaustiveMemoizationDependencies: false,
-    validateHooksUsage: true,
+    ...sharedEnvironmentOptions,
+    // These two Babel spellings differ from the Oxc NAPI property names.
+    validateNoDerivedComputationsInEffects_exp: validateNoDerivedComputationsInEffectsExperimental,
+    validateNoJSXInTryStatements: validateNoJsxInTryStatements,
+    // Oxc has the same neutral defaults internally, but does not expose these
+    // callback/test-only options across the NAPI boundary.
+    customHooks: new Map(),
+    moduleTypeProvider: null,
+    flowTypeProvider: null,
+    enableEmitHookGuards: null,
+    enableEmitInstrumentForget: null,
+    throwUnknownException__testonly: false,
+  },
+};
+const oxcReactCompilerOptions = {
+  // napi-rs represents optional object/list fields by omission and does not
+  // accept the explicit `null` values used by Babel's resolved configuration.
+  ...omitNullOptionsForNapi(REACT_COMPILER_OPTIONS_V1),
+  sources: [directory],
+  environment: {
+    ...omitNullOptionsForNapi(sharedEnvironmentOptions),
+    validateNoDerivedComputationsInEffectsExp: validateNoDerivedComputationsInEffectsExperimental,
+    validateNoJsxInTryStatements,
   },
 };
 
@@ -93,7 +165,7 @@ async function findSourceFiles(root) {
 }
 
 function transformWithBabel(filename, sourceText) {
-  const plugins = [[reactCompiler, reactCompilerOptions]];
+  const plugins = [[reactCompiler, babelReactCompilerOptions]];
   if (extname(filename).toLowerCase() === ".tsx") {
     plugins.push([transformTypescript, BABEL_TYPESCRIPT_OPTIONS]);
   }
@@ -122,7 +194,7 @@ function transformWithBabel(filename, sourceText) {
 
 function transformWithOxc(filename, sourceText) {
   const result = oxcReactCompilerSync(filename, sourceText, {
-    reactCompiler: reactCompilerOptions,
+    reactCompiler: oxcReactCompilerOptions,
   });
   assertNoErrors(result, "oxc-transform-react failed");
   assert(result.code, "oxc-transform-react did not produce code");
@@ -132,4 +204,8 @@ function transformWithOxc(filename, sourceText) {
 function assertNoErrors(result, message) {
   const errors = result.errors.filter(({ severity }) => severity === "Error");
   assert.equal(errors.length, 0, `${message}\n${errors.map(({ message }) => message).join("\n")}`);
+}
+
+function omitNullOptionsForNapi(options) {
+  return Object.fromEntries(Object.entries(options).filter(([, value]) => value !== null));
 }

--- a/tasks/react_compiler/compare.mjs
+++ b/tasks/react_compiler/compare.mjs
@@ -10,6 +10,10 @@ import { transformSync as oxcCodegenSync } from "oxc-transform";
 import { transformSync as oxcReactCompilerSync } from "oxc-transform-react";
 
 const SOURCE_EXTENSIONS = new Set([".jsx", ".tsx"]);
+const DEFAULT_ESLINT_SUPPRESSION_RULES_V1 = [
+  "react-hooks/exhaustive-deps",
+  "react-hooks/rules-of-hooks",
+];
 
 const args = process.argv.slice(2);
 if (args.length !== 1) {
@@ -21,6 +25,19 @@ const directory = resolve(invocationDirectory, args[0]);
 if (!(await stat(directory)).isDirectory()) {
   throw new Error(`Not a directory: ${directory}`);
 }
+const reactCompilerOptions = {
+  compilationMode: "infer",
+  panicThreshold: "none",
+  target: "19",
+  eslintSuppressionRules: DEFAULT_ESLINT_SUPPRESSION_RULES_V1,
+  flowSuppressions: true,
+  ignoreUseNoForget: false,
+  sources: [directory],
+  environment: {
+    validateExhaustiveMemoizationDependencies: false,
+    validateHooksUsage: true,
+  },
+};
 
 const filenames = await findSourceFiles(directory);
 let differenceCount = 0;
@@ -70,7 +87,7 @@ async function findSourceFiles(root) {
 }
 
 function transformWithBabel(filename, sourceText) {
-  const plugins = [[reactCompiler, {}]];
+  const plugins = [[reactCompiler, reactCompilerOptions]];
   if (extname(filename).toLowerCase() === ".tsx") {
     plugins.push([
       transformTypescript,
@@ -104,7 +121,9 @@ function transformWithBabel(filename, sourceText) {
 }
 
 function transformWithOxc(filename, sourceText) {
-  const result = oxcReactCompilerSync(filename, sourceText);
+  const result = oxcReactCompilerSync(filename, sourceText, {
+    reactCompiler: reactCompilerOptions,
+  });
   assertNoErrors(result, "oxc-transform-react failed");
   assert(result.code, "oxc-transform-react did not produce code");
   return result.code;

--- a/tasks/react_compiler/compare.mjs
+++ b/tasks/react_compiler/compare.mjs
@@ -14,6 +14,12 @@ const DEFAULT_ESLINT_SUPPRESSION_RULES_V1 = [
   "react-hooks/exhaustive-deps",
   "react-hooks/rules-of-hooks",
 ];
+const BABEL_TYPESCRIPT_OPTIONS = {
+  allExtensions: true,
+  isTSX: true,
+  // Match Oxc's default TypeScript emit for uninitialized class fields.
+  allowDeclareFields: true,
+};
 
 const args = process.argv.slice(2);
 if (args.length !== 1) {
@@ -89,13 +95,7 @@ async function findSourceFiles(root) {
 function transformWithBabel(filename, sourceText) {
   const plugins = [[reactCompiler, reactCompilerOptions]];
   if (extname(filename).toLowerCase() === ".tsx") {
-    plugins.push([
-      transformTypescript,
-      {
-        allExtensions: true,
-        isTSX: true,
-      },
-    ]);
+    plugins.push([transformTypescript, BABEL_TYPESCRIPT_OPTIONS]);
   }
   plugins.push([transformReactJsx, { runtime: "automatic" }]);
 

--- a/tasks/react_compiler/fixture.tsx
+++ b/tasks/react_compiler/fixture.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+
+interface Product {
+  id: number;
+  name: string;
+  price: number;
+}
+
+interface ProductListProps {
+  products: Product[];
+  query: string;
+}
+
+export function ProductList({ products, query }: ProductListProps) {
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const visibleProducts = products
+    .filter((product) => product.name.toLowerCase().includes(query.toLowerCase()))
+    .toSorted((left, right) => left.price - right.price);
+
+  return (
+    <ul>
+      {visibleProducts.map((product) => (
+        <li key={product.id}>
+          <button
+            aria-pressed={selectedId === product.id}
+            onClick={() => setSelectedId(product.id)}
+          >
+            {product.name}: ${product.price}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/tasks/react_compiler/package.json
+++ b/tasks/react_compiler/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "compare": "node compare.mjs"
+    "compare": "node compare.mjs",
+    "report": "node report.mjs"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/tasks/react_compiler/package.json
+++ b/tasks/react_compiler/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "react_compiler",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "compare": "node compare.mjs"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.29.7",
+    "@babel/plugin-transform-react-jsx": "^7.29.7",
+    "@babel/plugin-transform-typescript": "^7.29.7",
+    "babel-plugin-react-compiler": "0.0.0-experimental-a1856f3-20260507",
+    "oxc-transform": "link:../../napi/transform",
+    "oxc-transform-react": "link:../../napi/transform-react"
+  }
+}

--- a/tasks/react_compiler/report.mjs
+++ b/tasks/react_compiler/report.mjs
@@ -1,0 +1,282 @@
+/**
+ * Turns a `compare.mjs --report` file into a readable summary: how the
+ * mismatches break down by category, which repositories each category comes
+ * from, and a representative diff for each one.
+ *
+ *   node report.mjs <report.jsonl> [--examples=<count>]
+ */
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const DEFAULT_EXAMPLES = 2;
+/** Repositories named per category before the rest are counted as "other". */
+const TOP_REPOSITORIES = 6;
+/** Exact-combination rows listed before the tail is summarized in one row. */
+const CATEGORY_TABLE_ROWS = 20;
+/** Distinct failure messages listed per side before the tail is summarized. */
+const FAILURE_MESSAGE_ROWS = 12;
+/** Categories that stand on their own rather than being a set of causes. */
+const STANDALONE_CATEGORIES = [
+  "failed",
+  "structural",
+  "memoization-scope",
+  "memoization-slots",
+  "statement-order",
+  "pure-annotation",
+];
+
+const { reportPath, exampleCount } = parseArguments(process.argv.slice(2));
+const entries = (await readFile(reportPath, "utf8"))
+  .split("\n")
+  .filter((line) => line !== "")
+  .map((line) => JSON.parse(line));
+
+const summary = entries.find(({ status }) => status === "summary") ?? null;
+const mismatches = entries.filter(({ status }) => status !== "summary");
+console.log(renderReport(summary, mismatches));
+
+function parseArguments(args) {
+  let reportPath = null;
+  let exampleCount = DEFAULT_EXAMPLES;
+
+  for (const arg of args) {
+    const match = arg.match(/^--examples=(\d+)$/);
+    if (match !== null) {
+      exampleCount = Number.parseInt(match[1], 10);
+    } else {
+      assert(!arg.startsWith("--"), `Unknown option: ${arg}`);
+      assert(reportPath === null, "Pass exactly one report file");
+      reportPath = resolve(process.env.INIT_CWD ?? process.cwd(), arg);
+    }
+  }
+
+  assert(reportPath !== null, "Usage: node report.mjs <report.jsonl> [--examples=<count>]");
+  return { reportPath, exampleCount };
+}
+
+function renderReport(summary, mismatches) {
+  const groups = groupByCategory(mismatches);
+  const sections = [
+    renderSummary(summary, mismatches),
+    renderCauseTable(mismatches),
+    renderCategoryTable(groups, mismatches),
+  ];
+
+  // A file with several causes belongs in each of their sections, so the
+  // sections are keyed by cause rather than by the exact combination.
+  for (const category of STANDALONE_CATEGORIES) {
+    const files = groups.get(category);
+    if (files === undefined || category === "pure-annotation") {
+      continue;
+    }
+    sections.push(category === "failed" ? renderFailures(files) : renderCategory(category, files));
+  }
+  for (const cause of causeCounts(mismatches).keys()) {
+    sections.push(
+      renderCategory(
+        cause,
+        mismatches.filter(({ causes }) => causes?.includes(cause)),
+      ),
+    );
+  }
+
+  return sections.join("\n\n");
+}
+
+/** Counts how many files each individual cause contributes to. */
+function causeCounts(mismatches) {
+  const counts = new Map();
+  for (const { causes = [] } of mismatches) {
+    for (const cause of causes) {
+      counts.set(cause, (counts.get(cause) ?? 0) + 1);
+    }
+  }
+  return new Map([...counts].sort(([, left], [, right]) => right - left));
+}
+
+function renderCauseTable(mismatches) {
+  const standalone = groupByCategory(mismatches);
+  const rows = [
+    ...STANDALONE_CATEGORIES.filter((category) => standalone.has(category)).map((category) => [
+      category,
+      standalone.get(category).length,
+    ]),
+    ...causeCounts(mismatches),
+  ].sort(([, left], [, right]) => right - left);
+
+  return [
+    "## Causes",
+    "",
+    "One file can have several causes, so these overlap.",
+    "",
+    "| Cause | Files | Share of mismatches |",
+    "| --- | ---: | ---: |",
+    ...rows.map(
+      ([cause, total]) =>
+        `| \`${cause}\` | ${total.toLocaleString()} | ${percentage(total, mismatches.length)} |`,
+    ),
+  ].join("\n");
+}
+
+function groupByCategory(mismatches) {
+  const groups = new Map();
+  for (const mismatch of mismatches) {
+    const category = mismatch.status === "different" ? mismatch.category : mismatch.status;
+    groups.set(category, [...(groups.get(category) ?? []), mismatch]);
+  }
+  return new Map([...groups].sort(([, left], [, right]) => right.length - left.length));
+}
+
+function renderSummary(summary, mismatches) {
+  const lines = ["# React Compiler comparison report", ""];
+  if (summary === null) {
+    lines.push(`${count(mismatches.length, "mismatching file")}.`);
+    return lines.join("\n");
+  }
+
+  const matching = summary.counts.same;
+  lines.push(
+    `Compared ${summary.compared.toLocaleString()} files. ` +
+      `${matching.toLocaleString()} matched exactly ` +
+      `(${percentage(matching, summary.compared)}), ` +
+      `${mismatches.length.toLocaleString()} did not.`,
+  );
+  return lines.join("\n");
+}
+
+function renderCategoryTable(groups, mismatches) {
+  const shown = [...groups].slice(0, CATEGORY_TABLE_ROWS);
+  const remaining = [...groups].slice(CATEGORY_TABLE_ROWS);
+  const rows = shown.map(
+    ([category, files]) =>
+      `| \`${category}\` | ${files.length.toLocaleString()} | ${percentage(files.length, mismatches.length)} |`,
+  );
+  if (remaining.length > 0) {
+    const total = remaining.reduce((sum, [, files]) => sum + files.length, 0);
+    rows.push(
+      `| *${remaining.length} rarer combinations* | ${total.toLocaleString()} | ${percentage(total, mismatches.length)} |`,
+    );
+  }
+
+  return [
+    "## Exact categories",
+    "",
+    "| Category | Files | Share of mismatches |",
+    "| --- | ---: | ---: |",
+    ...rows,
+  ].join("\n");
+}
+
+function renderFailures(failures) {
+  const lines = [`## \`failed\` — ${count(failures.length, "file")}`, ""];
+
+  // Which pipeline refused the file matters more than the message: only the
+  // Oxc side points at Oxc, while the Babel side is a limit of this harness.
+  for (const side of ["oxc", "babel"]) {
+    const onThisSide = failures.filter((failure) => failingSide(failure.message) === side);
+    if (onThisSide.length === 0) {
+      continue;
+    }
+    lines.push(`### ${side} — ${count(onThisSide.length, "file")}`, "");
+
+    const byMessage = new Map();
+    for (const failure of onThisSide) {
+      const message = generalizeMessage(failure.message);
+      byMessage.set(message, [...(byMessage.get(message) ?? []), failure]);
+    }
+    const sorted = [...byMessage].sort(([, left], [, right]) => right.length - left.length);
+    for (const [message, files] of sorted.slice(0, FAILURE_MESSAGE_ROWS)) {
+      lines.push(`- **${files.length.toLocaleString()}×** ${message}`);
+      lines.push(`  - e.g. \`${files[0].path}\``);
+    }
+    const tail = sorted.slice(FAILURE_MESSAGE_ROWS);
+    if (tail.length > 0) {
+      const total = tail.reduce((sum, [, files]) => sum + files.length, 0);
+      lines.push(`- *${count(total, "file")} across ${count(tail.length, "rarer message")}*`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function failingSide(message) {
+  return message.startsWith("oxc-transform-react failed") ? "oxc" : "babel";
+}
+
+/** The harness prefixes its own assertions, so the detail is on the next line. */
+function meaningfulLines(message) {
+  const lines = message.split("\n").filter((line) => line.trim() !== "");
+  return /failed|Oxc did not|Babel did not/.test(lines[0]) ? lines.slice(0, 2) : lines.slice(0, 1);
+}
+
+function renderCategory(category, files) {
+  const lines = [
+    `## \`${category}\` — ${count(files.length, "file")}`,
+    "",
+    renderRepositories(files),
+  ];
+
+  for (const file of pickExamples(files)) {
+    lines.push("", `\`${file.path}\`${file.hunkCount > 1 ? ` (${file.hunkCount} hunks)` : ""}`, "");
+    lines.push("```diff");
+    for (const hunk of file.hunks.slice(0, 2)) {
+      lines.push(`@@ line ${hunk.line} @@`);
+      lines.push(...hunk.babel.map((line) => `-${line}`));
+      lines.push(...hunk.oxc.map((line) => `+${line}`));
+    }
+    lines.push("```");
+  }
+
+  return lines.join("\n");
+}
+
+function renderRepositories(files) {
+  const counts = new Map();
+  for (const { path } of files) {
+    const repository = path.split("/")[0];
+    counts.set(repository, (counts.get(repository) ?? 0) + 1);
+  }
+
+  const sorted = [...counts].sort(([, left], [, right]) => right - left);
+  const named = sorted.slice(0, TOP_REPOSITORIES).map(([name, total]) => `${name} (${total})`);
+  const remaining = sorted.length - named.length;
+  return `Repositories: ${named.join(", ")}${remaining > 0 ? `, and ${remaining} more` : ""}.`;
+}
+
+/** Prefers small diffs as examples, since they show the category most plainly. */
+function pickExamples(files) {
+  return files
+    .filter(({ hunks }) => hunks !== undefined && hunks.length > 0)
+    .sort((left, right) => hunkSize(left) - hunkSize(right))
+    .slice(0, exampleCount);
+}
+
+function hunkSize(file) {
+  return file.hunks.reduce((total, hunk) => total + hunk.babel.length + hunk.oxc.length, 0);
+}
+
+/** Collapses the varying parts of an error so like failures group together. */
+function generalizeMessage(message) {
+  return (
+    meaningfulLines(message)
+      .join(" — ")
+      .replace(/[^\s:]*[/\\][^\s:]*/g, "<path>")
+      .replace(/\(\d+[:,]\d+\)/g, "(<loc>)")
+      // The identifier a message names varies per file while the defect does not.
+      .replace(/\bimport\s+[A-Za-z_$][\w$]*\s*=\s*require/g, "import <name> = require")
+      .replace(/(['"`])[A-Za-z_$][\w$]*\1/g, "$1<name>$1")
+      .replace(/\b\d+\b/g, "<n>")
+      .slice(0, 200)
+  );
+}
+
+function percentage(part, total) {
+  return total === 0 ? "0%" : `${((part / total) * 100).toFixed(1)}%`;
+}
+
+function count(total, noun) {
+  return `${total.toLocaleString()} ${noun}${total === 1 ? "" : "s"}`;
+}


### PR DESCRIPTION
Adds a task that recursively compares Babel and Oxc React Compiler output.

AI-assisted.