### PR TITLE
test(oxfmt): fix windows ci

### DIFF
--- a/apps/oxfmt/test/cli/vite_plus/0.snap.md
+++ b/apps/oxfmt/test/cli/vite_plus/0.snap.md
@@ -2,7 +2,7 @@
 
 ## Command
 ```
-VP_VERSION=1 oxfmt --check test.ts
+VP_VERSION=1 NO_COLOR=1 oxfmt --check test.ts
 ```
 
 ## File tree

--- a/apps/oxfmt/test/cli/vite_plus/1.snap.md
+++ b/apps/oxfmt/test/cli/vite_plus/1.snap.md
@@ -2,7 +2,7 @@
 
 ## Command
 ```
-VP_VERSION=1 oxfmt --check --config vite.config.ts test.ts
+VP_VERSION=1 NO_COLOR=1 oxfmt --check --config vite.config.ts test.ts
 ```
 
 ## File tree

--- a/apps/oxfmt/test/cli/vite_plus/2.snap.md
+++ b/apps/oxfmt/test/cli/vite_plus/2.snap.md
@@ -2,7 +2,7 @@
 
 ## Command
 ```
-VP_VERSION=1 oxfmt --check --config vite.config.ts test.ts
+VP_VERSION=1 NO_COLOR=1 oxfmt --check --config vite.config.ts test.ts
 ```
 
 ## File tree

--- a/apps/oxfmt/test/cli/vite_plus/3.snap.md
+++ b/apps/oxfmt/test/cli/vite_plus/3.snap.md
@@ -2,7 +2,7 @@
 
 ## Command
 ```
-VP_VERSION=1 oxfmt --check test.ts
+VP_VERSION=1 NO_COLOR=1 oxfmt --check test.ts
 ```
 
 ## File tree

--- a/apps/oxfmt/test/cli/vite_plus/4.snap.md
+++ b/apps/oxfmt/test/cli/vite_plus/4.snap.md
@@ -2,7 +2,7 @@
 
 ## Command
 ```
-VP_VERSION=1 oxfmt --check test.ts
+VP_VERSION=1 NO_COLOR=1 oxfmt --check test.ts
 ```
 
 ## File tree

--- a/apps/oxfmt/test/cli/vite_plus/5.snap.md
+++ b/apps/oxfmt/test/cli/vite_plus/5.snap.md
@@ -2,7 +2,7 @@
 
 ## Command
 ```
-VP_VERSION=1 oxfmt --check test.ts
+VP_VERSION=1 NO_COLOR=1 oxfmt --check test.ts
 ```
 
 ## File tree

--- a/apps/oxfmt/test/cli/vite_plus/6.snap.md
+++ b/apps/oxfmt/test/cli/vite_plus/6.snap.md
@@ -2,7 +2,7 @@
 
 ## Command
 ```
-VP_VERSION=1 oxfmt --check test.ts
+VP_VERSION=1 NO_COLOR=1 oxfmt --check test.ts
 ```
 
 ## File tree

--- a/apps/oxfmt/test/cli/vite_plus/7.snap.md
+++ b/apps/oxfmt/test/cli/vite_plus/7.snap.md
@@ -2,7 +2,7 @@
 
 ## Command
 ```
-VP_VERSION=1 oxfmt --check test.ts
+VP_VERSION=1 NO_COLOR=1 oxfmt --check test.ts
 ```
 
 ## File tree

--- a/apps/oxfmt/test/cli/vite_plus/options.json
+++ b/apps/oxfmt/test/cli/vite_plus/options.json
@@ -1,26 +1,42 @@
 [
-  { "cwd": "basic", "args": ["--check", "test.ts"], "env": { "VP_VERSION": "1" } },
+  {
+    "cwd": "basic",
+    "args": ["--check", "test.ts"],
+    "env": { "VP_VERSION": "1", "NO_COLOR": "1" }
+  },
   {
     "cwd": "no_fmt_field",
     "args": ["--check", "--config", "vite.config.ts", "test.ts"],
-    "env": { "VP_VERSION": "1" }
+    "env": { "VP_VERSION": "1", "NO_COLOR": "1" }
   },
   {
     "cwd": "error_load_failure/child",
     "args": ["--check", "--config", "vite.config.ts", "test.ts"],
-    "env": { "VP_VERSION": "1" }
+    "env": { "VP_VERSION": "1", "NO_COLOR": "1" }
   },
   {
     "cwd": "error_load_failure/child",
     "args": ["--check", "test.ts"],
-    "env": { "VP_VERSION": "1" }
+    "env": { "VP_VERSION": "1", "NO_COLOR": "1" }
   },
-  { "cwd": "no_fmt_field", "args": ["--check", "test.ts"], "env": { "VP_VERSION": "1" } },
+  {
+    "cwd": "no_fmt_field",
+    "args": ["--check", "test.ts"],
+    "env": { "VP_VERSION": "1", "NO_COLOR": "1" }
+  },
   {
     "cwd": "skip_finds_parent/child",
     "args": ["--check", "test.ts"],
-    "env": { "VP_VERSION": "1" }
+    "env": { "VP_VERSION": "1", "NO_COLOR": "1" }
   },
-  { "cwd": "fn_export", "args": ["--check", "test.ts"], "env": { "VP_VERSION": "1" } },
-  { "cwd": "priority", "args": ["--check", "test.ts"], "env": { "VP_VERSION": "1" } }
+  {
+    "cwd": "fn_export",
+    "args": ["--check", "test.ts"],
+    "env": { "VP_VERSION": "1", "NO_COLOR": "1" }
+  },
+  {
+    "cwd": "priority",
+    "args": ["--check", "test.ts"],
+    "env": { "VP_VERSION": "1", "NO_COLOR": "1" }
+  }
 ]


### PR DESCRIPTION
It seems that picocolors, which Vite uses, always outputs color.