### PR TITLE
fix(linter/eslint/no-control-regex): allow null escape

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -20,10 +20,6 @@ fn no_control_regex_diagnostic(control_chars: &[Character]) -> OxcDiagnostic {
                         "'{ch}' is a control character. It looks like a backreference, but there is no corresponding capture group."
                     )
                 }
-                CharacterKind::Null => {
-                    "'\\0' matches the null character (U+0000), which is a control character."
-                        .to_string()
-                }
                 _ => {
                     // Show the code point since the character itself is not printable
                     let ch = format!("U+{:04X}", ch.value);
@@ -81,6 +77,7 @@ declare_oxc_lint!(
     /// var pattern6 = new RegExp("\x20");
     /// var pattern7 = new RegExp("\\t");
     /// var pattern8 = new RegExp("\\n");
+    /// var pattern9 = /\0/;
     /// ```
     NoControlRegex,
     eslint,
@@ -138,7 +135,7 @@ impl<'a> Visit<'a> for ControlCharacterFinder<'a> {
 
     fn visit_character(&mut self, ch: &Character) {
         // Control characters are in the range 0x00 to 0x1F
-        if ch.value <= 0x1F {
+        if ch.value <= 0x1F && ch.kind != CharacterKind::Null {
             let text: &str = ch.span.source_text(self.source_text);
             let is_code_point_match = text
                 .trim_start_matches('\\')
@@ -237,14 +234,11 @@ mod tests {
             r#"const filename = /filename[^;=\n]=((['"]).?\2|[^;\n]*)/;"#,
             r"const r = /([a-z])\1/;",
             r"const r = /\1([a-z])/;",
-        ];
-
-        let fail = vec![
             r"const r = /\0/;",
-            r"const r = /[a-z]\1/;",
-            r"const r = /([a-z])\2/;",
             r"const r = /([a-z])\0/;",
         ];
+
+        let fail = vec![r"const r = /[a-z]\1/;", r"const r = /([a-z])\2/;"];
 
         Tester::new(NoControlRegex::NAME, NoControlRegex::PLUGIN, pass, fail)
             .with_snapshot_suffix("capture-group-indexing")
@@ -281,6 +275,9 @@ mod tests {
             r"/^expected `string`\.\n {2}in Foo \(at (.*)[/\\]debug[/\\]test[/\\]browser[/\\]debug\.test\.js:[0-9]+\)$/",
             r"/\f/",
             r"/\v/",
+            // https://github.com/oxc-project/oxc/issues/25024
+            r"/\0\t\n\r/;",
+            r"new RegExp('\\0')", // the pattern contains a `\0` escape
         ];
 
         let fail = vec![
@@ -291,6 +288,7 @@ mod tests {
             "var regex = new RegExp('\\x1f\\x1e')",
             "var regex = new RegExp('\\x1fFOO\\x00')",
             "var regex = new RegExp('FOO\\x1fFOO\\x1f')",
+            "new RegExp('\\0')", // the pattern contains a literal U+0000 character
             "var regex = RegExp('\\x1f')",
             "var regex = /(?<a>\\x1f)/",
             r"var regex = /(?<\u{1d49c}>.)\x1f/",

--- a/crates/oxc_linter/src/snapshots/eslint_no_control_regex.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_control_regex.snap
@@ -62,6 +62,14 @@ source: crates/oxc_linter/src/tester.rs
   help: Avoid matching control characters in regular expressions. If intentional, consider using a Unicode escape instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
+   ╭─[no_control_regex.tsx:1:13]
+ 1 │ new RegExp('\0')
+   ·             ─┬
+   ·              ╰── 'U+0000' is a control character.
+   ╰────
+  help: Avoid matching control characters in regular expressions. If intentional, consider using a Unicode escape instead.
+
+  ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:21]
  1 │ var regex = RegExp('\x1f')
    ·                     ──┬─
@@ -190,12 +198,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Avoid matching control characters in regular expressions. If intentional, consider using a Unicode escape instead.
 
   ⚠ eslint(no-control-regex): Unexpected control characters
-   ╭─[no_control_regex.tsx:1:2]
+   ╭─[no_control_regex.tsx:1:4]
  1 │ /\0\1\2/
-   ·  ─┬─┬─┬
-   ·   │ │ ╰── '\2' is a control character. It looks like a backreference, but there is no corresponding capture group.
-   ·   │ ╰── '\1' is a control character. It looks like a backreference, but there is no corresponding capture group.
-   ·   ╰── '\0' matches the null character (U+0000), which is a control character.
+   ·    ─┬─┬
+   ·     │ ╰── '\2' is a control character. It looks like a backreference, but there is no corresponding capture group.
+   ·     ╰── '\1' is a control character. It looks like a backreference, but there is no corresponding capture group.
    ╰────
   help: Avoid matching control characters in regular expressions. If intentional, consider using a Unicode escape instead.
 
@@ -208,11 +215,10 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Avoid matching control characters in regular expressions. If intentional, consider using a Unicode escape instead.
 
-  ⚠ eslint(no-control-regex): Unexpected control characters
+  ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:2]
  1 │ /\x1f\0/
-   ·  ──┬──┬
-   ·    │  ╰── '\0' matches the null character (U+0000), which is a control character.
+   ·  ──┬─
    ·    ╰── 'U+001F' is a control character.
    ╰────
   help: Avoid matching control characters in regular expressions. If intentional, consider using a Unicode escape instead.
@@ -220,9 +226,8 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint(no-control-regex): Unexpected control characters
    ╭─[no_control_regex.tsx:1:2]
  1 │ /\x1f\0\2/
-   ·  ──┬──┬─┬
-   ·    │  │ ╰── '\2' is a control character. It looks like a backreference, but there is no corresponding capture group.
-   ·    │  ╰── '\0' matches the null character (U+0000), which is a control character.
+   ·  ──┬─  ─┬
+   ·    │    ╰── '\2' is a control character. It looks like a backreference, but there is no corresponding capture group.
    ·    ╰── 'U+001F' is a control character.
    ╰────
   help: Avoid matching control characters in regular expressions. If intentional, consider using a Unicode escape instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_control_regex@capture-group-indexing.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_control_regex@capture-group-indexing.snap
@@ -3,14 +3,6 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint(no-control-regex): Unexpected control character
-   ╭─[no_control_regex.tsx:1:12]
- 1 │ const r = /\0/;
-   ·            ─┬
-   ·             ╰── '\0' matches the null character (U+0000), which is a control character.
-   ╰────
-  help: Avoid matching control characters in regular expressions. If intentional, consider using a Unicode escape instead.
-
-  ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:17]
  1 │ const r = /[a-z]\1/;
    ·                 ─┬
@@ -23,13 +15,5 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const r = /([a-z])\2/;
    ·                   ─┬
    ·                    ╰── '\2' is a control character. It looks like a backreference, but there is no corresponding capture group.
-   ╰────
-  help: Avoid matching control characters in regular expressions. If intentional, consider using a Unicode escape instead.
-
-  ⚠ eslint(no-control-regex): Unexpected control character
-   ╭─[no_control_regex.tsx:1:19]
- 1 │ const r = /([a-z])\0/;
-   ·                   ─┬
-   ·                    ╰── '\0' matches the null character (U+0000), which is a control character.
    ╰────
   help: Avoid matching control characters in regular expressions. If intentional, consider using a Unicode escape instead.


### PR DESCRIPTION
## Summary

- allow the standard null escape in eslint/no-control-regex, matching ESLint
- continue reporting literal U+0000 characters, hexadecimal and Unicode escapes, and invalid legacy octal escapes
- add regression coverage for regex literals and RegExp constructor strings

Closes #25024

