### PR TITLE
refactor(ecmascript): impl `MayHaveSideEffects` for `SequenceExpression`

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -47,9 +47,7 @@ impl<'a> MayHaveSideEffects<'a> for Expression<'a> {
                 }
                 e.consequent.may_have_side_effects(ctx) || e.alternate.may_have_side_effects(ctx)
             }
-            Expression::SequenceExpression(e) => {
-                e.expressions.iter().any(|e| e.may_have_side_effects(ctx))
-            }
+            Expression::SequenceExpression(e) => e.may_have_side_effects(ctx),
             Expression::BinaryExpression(e) => e.may_have_side_effects(ctx),
             Expression::ObjectExpression(object_expr) => {
                 object_expr.properties.iter().any(|property| property.may_have_side_effects(ctx))
@@ -1111,5 +1109,11 @@ impl<'a> MayHaveSideEffects<'a> for UpdateExpression<'a> {
         // Terser, esbuild, Rollup, and SWC all treat updates as unconditionally
         // side-effectful; match that.
         true
+    }
+}
+
+impl<'a> MayHaveSideEffects<'a> for SequenceExpression<'a> {
+    fn may_have_side_effects(&self, ctx: &impl MayHaveSideEffectsContext<'a>) -> bool {
+        self.expressions.iter().any(|e| e.may_have_side_effects(ctx))
     }
 }


### PR DESCRIPTION
simple refactor to extract out `SequenceExpression` side effects such that it now implements `MayHaveSideEffects` to allow us to call `SequenceExpression::may_have_side_effects`