### PR TITLE
fix(docs): incorrect quotations in `role_supports_aria_props.rs`

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -37,7 +37,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
-    /// <ul role="radiogroup" "aria-labelledby"="foo">
+    /// <ul role="radiogroup" aria-labelledby="foo">
     ///     <li aria-required tabIndex="-1" role="radio" aria-checked="false">Rainbow Trout</li>
     ///     <li aria-required tabIndex="-1" role="radio" aria-checked="false">Brook Trout</li>
     ///     <li aria-required tabIndex="0" role="radio" aria-checked="true">Lake Trout</li>
@@ -46,7 +46,7 @@ declare_oxc_lint!(
     ///
     /// Examples of **correct** code for this rule:
     /// ```jsx
-    /// <ul role="radiogroup" aria-required "aria-labelledby"="foo">
+    /// <ul role="radiogroup" aria-required aria-labelledby="foo">
     ///     <li tabIndex="-1" role="radio" aria-checked="false">Rainbow Trout</li>
     ///     <li tabIndex="-1" role="radio" aria-checked="false">Brook Trout</li>
     ///     <li tabIndex="0" role="radio" aria-checked="true">Lake Trout</li>


### PR DESCRIPTION
To my understanding, those attribute keys shouldn't be included in quotationmarks.