### PR TITLE
test(semantic): cover JSDoc re-exports

### DIFF
--- a/crates/oxc_semantic/src/jsdoc.rs
+++ b/crates/oxc_semantic/src/jsdoc.rs
@@ -200,6 +200,7 @@ mod test {
             ("let v2a = 1, /** for v2b */ v2b = 2", "v2b = 2"),
             ("/** for v3a */ const v3a = 1, v3b = 2;", "const v3a = 1, v3b = 2;"),
             ("/** test */ export const e1 = 1;", "export const e1 = 1;"),
+            ("/** test */ export { x } from \"m\";", "export { x } from \"m\";"),
             ("/** test */ export default {};", "export default {};"),
             ("/** test */ import 'i1'", "import 'i1'"),
             ("/** test */ import I from 'i2'", "import I from 'i2'"),


### PR DESCRIPTION
## Summary
- add semantic JSDoc coverage for export { x } from "m"
