### PR TITLE
test(transformer): cover re-export extension rewriting

### DIFF
--- a/tasks/transform_conformance/tests/babel-preset-typescript/test/fixtures/rewriteImportExtensions/input.ts
+++ b/tasks/transform_conformance/tests/babel-preset-typescript/test/fixtures/rewriteImportExtensions/input.ts
@@ -2,6 +2,7 @@ import "./a.ts";
 import "./a.mts";
 import "./a.cts";
 import "./react.tsx";
+export { x } from "./a.mts";
 // .mtsx and .ctsx are not valid and should not be transformed.
 import "./react.mtsx";
 import "./react.ctsx";

--- a/tasks/transform_conformance/tests/babel-preset-typescript/test/fixtures/rewriteImportExtensions/output.js
+++ b/tasks/transform_conformance/tests/babel-preset-typescript/test/fixtures/rewriteImportExtensions/output.js
@@ -2,6 +2,7 @@ import "./a.js";
 import "./a.mjs";
 import "./a.cjs";
 import "./react.js";
+export { x } from "./a.mjs";
 // .mtsx and .ctsx are not valid and should not be transformed.
 import "./react.mtsx";
 import "./react.ctsx";


### PR DESCRIPTION
## Summary

- add transformer conformance coverage for named re-exports from `.mts` modules
- verify `export { x } from "./a.mts"` rewrites to the `.mjs` extension

