### PR TITLE
test(isolated-declarations): cover re-export syntax

### DIFF
--- a/crates/oxc_isolated_declarations/tests/fixtures/re-exports.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/re-exports.ts
@@ -1,0 +1,12 @@
+// Statement-level type-only re-export
+export type { Foo } from "./foo";
+
+// Mixed specifier-level type export
+export { type Foo, Bar } from "./foo";
+
+// String-named exports
+export { "default" as Foo } from "./foo";
+export { Foo as "non-identifier" } from "./foo";
+
+// Re-export with import attributes
+export { data } from "./data.json" with { type: "json" };

--- a/crates/oxc_isolated_declarations/tests/snapshots/re-exports.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/re-exports.snap
@@ -1,0 +1,12 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/re-exports.ts
+---
+```
+==================== .D.TS ====================
+
+export type { Foo } from "./foo";
+export { type Foo, Bar } from "./foo";
+export { "default" as Foo } from "./foo";
+export { Foo as "non-identifier" } from "./foo";
+export { data } from "./data.json" with { type: "json" };


### PR DESCRIPTION
## Summary

- cover statement-level and specifier-level type-only re-exports
- cover string-named export specifiers
- cover re-exports using import attributes
