### PR TITLE
test(formatter): cover export declaration shapes

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/ts/comments/export-declarations.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/export-declarations.ts
@@ -1,0 +1,24 @@
+const Foo = 1;
+type FooType = string;
+
+// Declaration-bearing exports
+export /* before declaration */ const declarationValue={foo:1};
+export type /* before type name */ DeclarationType={foo:string};
+
+// prettier-ignore
+export const ignoredDeclaration={foo:1,bar:2};
+
+// Local named exports
+export /* before local specifiers */ {Foo};
+export type /* before local type specifiers */ {FooType};
+
+// prettier-ignore
+export   {Foo as LocalFoo,FooType};
+
+// Source re-exports
+export {Foo} from /* before source */ "./mod";
+export type /* before source type specifiers */ {FooType} from "./mod";
+export {Foo as JsonFoo} from "./data.json" /* before attributes */ with {type:"json"};
+
+// prettier-ignore
+export   {Foo as RemoteFoo,FooType}   from   "./mod";

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/export-declarations.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/export-declarations.ts.snap
@@ -1,0 +1,87 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+const Foo = 1;
+type FooType = string;
+
+// Declaration-bearing exports
+export /* before declaration */ const declarationValue={foo:1};
+export type /* before type name */ DeclarationType={foo:string};
+
+// prettier-ignore
+export const ignoredDeclaration={foo:1,bar:2};
+
+// Local named exports
+export /* before local specifiers */ {Foo};
+export type /* before local type specifiers */ {FooType};
+
+// prettier-ignore
+export   {Foo as LocalFoo,FooType};
+
+// Source re-exports
+export {Foo} from /* before source */ "./mod";
+export type /* before source type specifiers */ {FooType} from "./mod";
+export {Foo as JsonFoo} from "./data.json" /* before attributes */ with {type:"json"};
+
+// prettier-ignore
+export   {Foo as RemoteFoo,FooType}   from   "./mod";
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+const Foo = 1;
+type FooType = string;
+
+// Declaration-bearing exports
+export /* before declaration */ const declarationValue = { foo: 1 };
+export type /* before type name */ DeclarationType = { foo: string };
+
+// prettier-ignore
+export const ignoredDeclaration={foo:1,bar:2};
+
+// Local named exports
+export { /* before local specifiers */ Foo };
+export type { /* before local type specifiers */ FooType };
+
+// prettier-ignore
+export   {Foo as LocalFoo,FooType};
+
+// Source re-exports
+export { Foo } from /* before source */ "./mod";
+export type { /* before source type specifiers */ FooType } from "./mod";
+export { Foo as JsonFoo } from "./data.json" /* before attributes */ with { type: "json" };
+
+// prettier-ignore
+export   {Foo as RemoteFoo,FooType}   from   "./mod";
+
+-------------------
+{ printWidth: 100 }
+-------------------
+const Foo = 1;
+type FooType = string;
+
+// Declaration-bearing exports
+export /* before declaration */ const declarationValue = { foo: 1 };
+export type /* before type name */ DeclarationType = { foo: string };
+
+// prettier-ignore
+export const ignoredDeclaration={foo:1,bar:2};
+
+// Local named exports
+export { /* before local specifiers */ Foo };
+export type { /* before local type specifiers */ FooType };
+
+// prettier-ignore
+export   {Foo as LocalFoo,FooType};
+
+// Source re-exports
+export { Foo } from /* before source */ "./mod";
+export type { /* before source type specifiers */ FooType } from "./mod";
+export { Foo as JsonFoo } from "./data.json" /* before attributes */ with { type: "json" };
+
+// prettier-ignore
+export   {Foo as RemoteFoo,FooType}   from   "./mod";
+
+===================== End =====================


### PR DESCRIPTION
## Summary

- add focused formatter coverage for declaration-bearing exports, local named exports, and source re-exports
- cover comment attachment and prettier-ignore behavior for each export shape
- include TypeScript type exports and re-export attributes
- covers edge cases to prep for #25095