### PR TITLE
fix(parser): parse async after relational expression

### DIFF
--- a/crates/oxc_parser/src/js/mod.rs
+++ b/crates/oxc_parser/src/js/mod.rs
@@ -10,7 +10,7 @@ mod expression;
 mod function;
 mod module;
 mod object;
-mod operator;
+pub mod operator;
 mod statement;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -272,16 +272,6 @@ impl Kind {
         self.is_identifier_name() && !self.is_reserved_keyword()
     }
 
-    /// TypeScript Identifier
-    ///
-    /// <https://github.com/microsoft/TypeScript/blob/15392346d05045742e653eab5c87538ff2a3c863/src/compiler/parser.ts#L2316-L2335>
-    #[inline]
-    pub const fn is_ts_identifier(self, is_yield_context: bool, is_await_context: bool) -> bool {
-        self.is_identifier_reference(is_yield_context, is_await_context)
-            && !self.is_strict_mode_contextual_keyword()
-            && !self.is_contextual_keyword()
-    }
-
     /// `IdentifierName`
     /// All identifier names are either `Ident` or keywords (Await..=Null in the enum).
     #[inline]

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -9,7 +9,10 @@ use crate::{
     modifiers::{ModifierKind, ModifierKinds, Modifiers},
 };
 
-use super::{super::js::FunctionKind, statement::CallOrConstructorSignature};
+use super::{
+    super::js::{FunctionKind, operator::kind_to_precedence},
+    statement::CallOrConstructorSignature,
+};
 
 impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_ts_type(&mut self) -> TSType<'a> {
@@ -1639,7 +1642,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.ctx.has_in() && self.at(Kind::In) {
             return false;
         }
-        self.cur_kind().is_binary_operator()
+        kind_to_precedence(self.cur_kind()).is_some()
     }
 
     fn is_start_of_expression(&mut self) -> bool {
@@ -1649,11 +1652,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         match self.cur_kind() {
             kind if kind.is_unary_operator() => true,
             kind if kind.is_update_operator() => true,
-            Kind::LAngle | Kind::Await | Kind::Yield | Kind::Private | Kind::At | Kind::Async => {
-                true
-            }
-            kind if kind.is_binary_operator() => true,
-            kind => kind.is_ts_identifier(self.ctx.has_yield(), self.ctx.has_await()),
+            Kind::LAngle | Kind::Await | Kind::Yield | Kind::Private | Kind::At => true,
+            _ if self.is_binary_operator() => true,
+            kind => kind.is_identifier_reference(self.ctx.has_yield(), self.ctx.has_await()),
         }
     }
 
@@ -1674,7 +1675,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Kind::Import => {
                 matches!(self.lexer.peek_token().kind(), Kind::LParen | Kind::LAngle | Kind::Dot)
             }
-            _ => false,
+            kind => kind.is_identifier_reference(self.ctx.has_yield(), self.ctx.has_await()),
         }
     }
 }

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1649,7 +1649,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         match self.cur_kind() {
             kind if kind.is_unary_operator() => true,
             kind if kind.is_update_operator() => true,
-            Kind::LAngle | Kind::Await | Kind::Yield | Kind::Private | Kind::At => true,
+            Kind::LAngle | Kind::Await | Kind::Yield | Kind::Private | Kind::At | Kind::Async => {
+                true
+            }
             kind if kind.is_binary_operator() => true,
             kind => kind.is_ts_identifier(self.ctx.has_yield(), self.ctx.has_await()),
         }

--- a/tasks/coverage/misc/pass/async-after-relational-type-arguments.ts
+++ b/tasks/coverage/misc/pass/async-after-relational-type-arguments.ts
@@ -1,0 +1,3 @@
+"0" < value > async;
+"0" < value > async function () {};
+"0" < value > async function* () {};

--- a/tasks/coverage/misc/pass/contextual-keyword-after-relational-type-arguments.ts
+++ b/tasks/coverage/misc/pass/contextual-keyword-after-relational-type-arguments.ts
@@ -1,3 +1,6 @@
 "0" < value > async;
 "0" < value > async function () {};
 "0" < value > async function* () {};
+"0" < value > from;
+"0" < value > get;
+"0" < value > type;

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 74/74 (100.00%)
-Positive Passed: 74/74 (100.00%)
+AST Parsed     : 75/75 (100.00%)
+Positive Passed: 75/75 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 74/74 (100.00%)
-Positive Passed: 74/74 (100.00%)
+AST Parsed     : 75/75 (100.00%)
+Positive Passed: 75/75 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 74/74 (100.00%)
-Positive Passed: 74/74 (100.00%)
+AST Parsed     : 75/75 (100.00%)
+Positive Passed: 75/75 (100.00%)
 Negative Passed: 155/155 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 74/74 (100.00%)
-Positive Passed: 70/74 (94.59%)
+AST Parsed     : 75/75 (100.00%)
+Positive Passed: 71/75 (94.67%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 74/74 (100.00%)
-Positive Passed: 74/74 (100.00%)
+AST Parsed     : 75/75 (100.00%)
+Positive Passed: 75/75 (100.00%)


### PR DESCRIPTION
## Summary

- recognize async as an expression start when disambiguating TypeScript type arguments
- add one consolidated regression fixture covering async identifiers, functions, and generators after relational operators
- update misc coverage snapshots
