### PR TITLE
feat(minifier): fold if statements before identical break/continue

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -317,6 +317,41 @@ impl<'a> PeepholeOptimizations {
                         _ => break 'throw_loop,
                     }
                 }
+            } else if matches!(
+                stmts.last(),
+                Some(Statement::BreakStatement(_) | Statement::ContinueStatement(_))
+            ) {
+                'jump_loop: while stmts.len() >= 2 {
+                    let prev_index = stmts.len() - 2;
+                    let prev_stmt = &stmts[prev_index];
+
+                    let Statement::IfStatement(if_stmt) = prev_stmt else {
+                        break 'jump_loop;
+                    };
+                    if let Some(alternate) = &if_stmt.alternate {
+                        if Self::jump_stmts_look_the_same(stmts.last().unwrap(), &alternate) {
+                            let Statement::IfStatement(prev_if) = &mut stmts[prev_index] else {
+                                unreachable!()
+                            };
+                            ctx.drop_statement(&prev_if.alternate.take().unwrap());
+                            continue 'jump_loop;
+                        }
+                    } else if Self::jump_stmts_look_the_same(
+                        stmts.last().unwrap(),
+                        &if_stmt.consequent,
+                    ) {
+                        let test = if let Statement::IfStatement(prev_if) = &mut stmts[prev_index] {
+                            prev_if.test.take_in(ctx)
+                        } else {
+                            unreachable!()
+                        };
+
+                        let new_expr = Statement::new_expression_statement(test.span(), test, ctx);
+                        ctx.replace_statement(&mut stmts[prev_index], new_expr);
+                        continue 'jump_loop;
+                    }
+                    break 'jump_loop;
+                }
             }
         }
     }

--- a/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
@@ -16,15 +16,23 @@ fn test_break_optimization() {
     test("f:{for(x in a())break}", "f:for(x in a())break;");
 
     test("f:try{break f;}catch(e){break f;}", "f:try{break f}catch{break f}"); // ;
-    test(
-        "f:try{if(a()){break f;}else{break f;} break f;}catch(e){}",
-        "f:try{if(a())break f;break f}catch{}",
-    ); // f:try{a()}catch{}
+    test("f:try{if(a()){break f;}else{break f;} break f;}catch(e){}", "f:try{a();break f}catch{}"); // f:try{a()}catch{}
 
     test_same("f:g:break f"); // ;
-    test("f:g:{if(a()){break f;}else{break f;} break f;}", "f:g:{if(a())break f;break f}"); // f:g:a();
+    test("f:g:{if(a()){break f;}else{break f;} break f;}", "f:g:{a();break f}"); // f:g:a();
     test("function f() { a: break a; }", "function f() {}");
     test("function f() { a: { break a; } }", "function f() {}");
+
+    test("f:{if(a)break f;break f;}", "f:{a;break f}"); // f:a;
+    test("f:{if(a){c();}else{break f;}break f;}", "f:{a&&c();break f}"); // f:a&&c();
+    test_same("f:{if(a)break g;break f;}"); // f:if(a)break g;
+    test("f:{if(a){break f;}else{c();}break f;}", "f:{if(a)break f;c();break f}"); // f:if(!a)c();
+    test("f:{if(a)break f;if(b)break f;break f;}", "f:{a||b;break f}"); // f:a||b;
+    test("f:{if(a&&b){break f;}else{break f;}break f;}", "f:{a&&b;break f}"); // f:a&&b;
+    test("f:{if(a){break f;}else if(b){break f;}break f;}", "f:{if(a)break f;b;break f}"); // f:if(a)break f
+    test_same("f:{if(a){b();break f;}break f;}"); // f:{if(a){b();break f;}break f}
+    test("f:{if(a){break f;}else{b();break f;}break f;}", "f:{if(a)break f;b();break f}");
+    test_same("f:{if(a){b();break g;}break f;}"); // f:{if(a){b();break g;}break f}
 }
 
 #[test]
@@ -125,6 +133,11 @@ fn test_while_continue_optimization() {
 
     test("while(true)while(a())continue;", "for(;;)for(;a();)continue;"); // for(;;)for(;a(););
     test("while(true)for(x in a())continue", "for(;;)for(x in a())continue;"); // for(;;)for(x in a());
+    test(
+        "while(true){try{if(a)c();else continue;continue}catch{}}",
+        "for(;;)try{a&&c();continue}catch{}",
+    ); // for(;;)try{a&&c();}catch{}
+    test("for(;;)x:{if(c)continue x;continue x}", "for(;;)x:{c;continue x}"); // for(;;)x:c
 
     test("while(true)while(a())break;", "for(;;)for(;a();)break");
     test("while(true)for(x in a())break", "for(;;)for(x in a())break");
@@ -132,15 +145,21 @@ fn test_while_continue_optimization() {
     test("while(true){try{continue;}catch(e){continue;}}", "for(;;)try{continue}catch{continue}"); // for(;;);
     test(
         "while(true){try{if(a()){continue;}else{continue;} continue;}catch(e){}}",
-        "for(;;)try{if(a())continue;continue}catch{}",
+        "for(;;)try{a();continue}catch{}",
     ); // for(;;)try{a()}catch{}
 
     test("while(true){g:continue}", "for(;;);");
     test("while(true){g:{continue}}", "for(;;);");
-    // This case could be improved.
+
     test("while(true){g:if(a()){continue;}else{continue;} continue;}", "for (;;)g:a();");
     test("while(true){g:{if(a()){continue;}else{continue;} continue;}}", "for(;;)g:a();");
     test("while(true){g:{a();if(b()){continue;}else{continue;} continue;}}", "for(;;)g:a(),b();");
+
+    test(
+        "x:while(true){if(a){continue x;}else{continue x;}continue x;}",
+        "x:for(;;){a;continue x}",
+    ); // x:for(;;){a;}
+    test("f:while(true){if(a){break f;}else{break f;}break f;}", "f:for(;;){a;break f}");
 }
 
 #[test]
@@ -173,11 +192,10 @@ fn test_do_continue_optimization() {
     ); // do;while(!0)
     test(
         "do{try{if(a()){continue;}else{continue;} continue;}catch(e){}}while(true)",
-        "do try{if(a())continue;continue}catch{}while(!0);",
+        "do try{a();continue;}catch{}while(!0);",
     ); // do try{a()}catch{}while(!0);
 
     test("do{g:continue}while(true)", "do;while(!0);");
-    // This case could be improved.
     test("do{g:if(a()){continue;}else{continue;} continue;}while(true)", "do g:a();while(!0);");
 
     test("do { foo(); continue; } while(false)", "do foo();while(!1)");
@@ -185,6 +203,7 @@ fn test_do_continue_optimization() {
 
     test("do{break}while(fn());", "do break; while(fn());");
     test("do{break}while(true);", "do break; while(!0);"); // do while(!1);
+    test("do{if(a){break;}else{break;}break;}while(true)", "do{a;break}while(!0);"); // do a; while(!1);
     test("do{break}while(!new Date());", "do;while(!1);");
 
     test(
@@ -256,7 +275,7 @@ fn test_for_continue_optimization() {
     ); // for(x=0;x<y;x++);
     test(
         "for(x=0;x<y;x++){try{if(a()){continue;}else{continue;} continue;}catch(e){}}",
-        "for(x=0;x<y;x++)try{if(a())continue;continue}catch{}",
+        "for(x=0;x<y;x++)try{a();continue}catch{}",
     ); // for(x=0;x<y;x++)try{a()}catch{}
 
     test("for(x=0;x<y;x++){g:continue}", "for(x=0;x<y;x++);");
@@ -272,6 +291,16 @@ fn test_for_continue_optimization() {
     test(
         "for(x=0;x<y;x++){g:{a();if(b()){continue;}else{continue;} continue;}}",
         "for(x=0;x<y;x++)g:a(),b();",
+    );
+
+    test("for(x=0;x<y;x++){if(a){b();continue;}continue;}", "for(x=0;x<y;x++)if(a){b();continue}"); // for(x=0;x<y;x++)a&&b();
+    test(
+        "for(x=0;x<y;x++){if(a){continue;}else{b();continue;}continue;}",
+        "for(x=0;x<y;x++)a||b();",
+    );
+    test(
+        "for(x=0;x<y;x++){if(a){b();continue x;}continue;}",
+        "for(x=0;x<y;x++)if(a){b();continue x}",
     );
 }
 


### PR DESCRIPTION
fold if statements whose `consequent` or `alternate` is an identical `break`/`continue` as the following statement.

```js
// source:
if (a) { break f; } else { break f; } break f;
// main:
if (a) break f; break f;
// new:
a; break f;
```