### PR TITLE
fix(oxfmt): rework tsx-in-vue support

### DIFF
--- a/apps/oxfmt/conformance/run.ts
+++ b/apps/oxfmt/conformance/run.ts
@@ -53,7 +53,7 @@ const categories: Category[] = [
     ],
     notes: {
       "externals/vue-vben-admin/effects/common-ui/src/components/api-component/api-component.vue":
-        "`<T = any,>() => {}` comma in generic param is removed even in .ts(x) file",
+        "`<T = any,>() => {}` comma removed in ts-in-vue as like plain `.ts`, intentional divergence: Prettier keeps in ts-in-xxx, but not in ts-in-md and also plain `.ts`. It is only required for `.tsx` and `.mts|cts`",
     },
   },
   {

--- a/apps/oxfmt/conformance/snapshots/conformance.snap.md
+++ b/apps/oxfmt/conformance/snapshots/conformance.snap.md
@@ -9,7 +9,7 @@
 | File | Note |
 | :--- | :--- |
 | [externals/vue-vben-admin/@core/ui-kit/shadcn-ui/src/components/render-content/render-content.vue](diffs/js-in-vue/externals__vue-vben-admin__@core__ui-kit__shadcn-ui__src__components__render-content__render-content.vue.md) |  |
-| [externals/vue-vben-admin/effects/common-ui/src/components/api-component/api-component.vue](diffs/js-in-vue/externals__vue-vben-admin__effects__common-ui__src__components__api-component__api-component.vue.md) | `<T = any,>() => {}` comma in generic param is removed even in .ts(x) file |
+| [externals/vue-vben-admin/effects/common-ui/src/components/api-component/api-component.vue](diffs/js-in-vue/externals__vue-vben-admin__effects__common-ui__src__components__api-component__api-component.vue.md) | `<T = any,>() => {}` comma removed in ts-in-vue as like plain `.ts`, intentional divergence: Prettier keeps in ts-in-xxx, but not in ts-in-md and also plain `.ts`. It is only required for `.tsx` and `.mts|cts` |
 
 ### Option 2: 424/425 (99.76%)
 
@@ -19,7 +19,7 @@
 
 | File | Note |
 | :--- | :--- |
-| [externals/vue-vben-admin/effects/common-ui/src/components/api-component/api-component.vue](diffs/js-in-vue/externals__vue-vben-admin__effects__common-ui__src__components__api-component__api-component.vue.md) | `<T = any,>() => {}` comma in generic param is removed even in .ts(x) file |
+| [externals/vue-vben-admin/effects/common-ui/src/components/api-component/api-component.vue](diffs/js-in-vue/externals__vue-vben-admin__effects__common-ui__src__components__api-component__api-component.vue.md) | `<T = any,>() => {}` comma removed in ts-in-vue as like plain `.ts`, intentional divergence: Prettier keeps in ts-in-xxx, but not in ts-in-md and also plain `.ts`. It is only required for `.tsx` and `.mts|cts` |
 
 ## gql-in-js
 

--- a/apps/oxfmt/conformance/snapshots/diffs/js-in-vue/externals__vue-vben-admin__effects__common-ui__src__components__api-component__api-component.vue.md
+++ b/apps/oxfmt/conformance/snapshots/diffs/js-in-vue/externals__vue-vben-admin__effects__common-ui__src__components__api-component__api-component.vue.md
@@ -1,6 +1,6 @@
 # externals/vue-vben-admin/effects/common-ui/src/components/api-component/api-component.vue
 
-> `<T = any,>() => {}` comma in generic param is removed even in .ts(x) file
+> `<T = any,>() => {}` comma removed in ts-in-vue as like plain `.ts`, intentional divergence: Prettier keeps in ts-in-xxx, but not in ts-in-md and also plain `.ts`. It is only required for `.tsx` and `.mts|cts`
 
 ## Option 1
 

--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -92,7 +92,37 @@ export async function formatFile({ code, options }: FormatFileParam): Promise<st
   // This plugin overrides `babel(-ts)` and `typescript` parsers to use `oxc_formatter` instead of built-in parsers
   if ("_oxfmtPluginOptionsJson" in options) await setupOxfmtPlugin(options);
 
+  // This is needed to detect tsx-in-vue properly, see `prettier-plugin-oxfmt` for details.
+  // All `<script>` blocks in one SFC must share the same `lang` (Vue compiler restriction),
+  // so a single per-file flag is enough.
+  if (options.parser === "vue" && hasTsxScriptBlock(code)) {
+    options._oxfmtVueScriptLang = "tsx";
+  }
+
   return prettier.format(code, options);
+}
+
+// `<script` + a tag boundary (so `<scripts` does not match) + attributes + the tag-closing `>`.
+// Quoted attribute values may contain `>` (e.g. `generic="T extends Record<string, string>"`),
+// so they are consumed as whole quoted chunks before `>` can terminate the tag.
+const SCRIPT_OPEN_TAG_RE = /<script(?=[\s>])((?:"[^"]*"|'[^']*'|[^"'>])*)>/gv;
+// Standalone `lang` attribute (not e.g. `data-lang`) whose whole value is "tsx", quoted or unquoted
+const LANG_TSX_ATTR_RE = /(?:^|\s)lang\s*=\s*(?:"tsx"|'tsx'|tsx(?=[\s\/]|$))/v;
+
+/**
+ * Whether any `<script ...>` open tag in `sourceText` carries `lang="tsx"`.
+ *
+ * A plain-text scan may have a false positive.
+ * (e.g. the literal tag inside a template string or comment),
+ * the block parses as `tsx`, worst case the lone generic comma is kept or,
+ * if the block uses ts-only syntax, it is left unformatted.
+ * Never destructive, so leniency is acceptable trade-off here.
+ */
+function hasTsxScriptBlock(sourceText: string): boolean {
+  for (const [, attrs] of sourceText.matchAll(SCRIPT_OPEN_TAG_RE)) {
+    if (LANG_TSX_ATTR_RE.test(attrs)) return true;
+  }
+  return false;
 }
 
 // ---

--- a/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/index.ts
+++ b/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/index.ts
@@ -12,12 +12,21 @@
 import { textToDoc } from "./text-to-doc";
 import type { Parser, Printer, Doc, SupportOptions } from "prettier";
 
+// NOTE: Custom options must be declared here,
+// or Prettier's normalization drops them before they reach `textToDoc()`.
 export const options: SupportOptions = {
   _oxfmtPluginOptionsJson: {
     category: "JavaScript",
     type: "string",
     default: "{}",
     description: "Bundled JSON string for oxfmt-plugin options",
+  },
+  _oxfmtVueScriptLang: {
+    category: "JavaScript",
+    type: "string",
+    default: "",
+    description:
+      'Effective `lang` of Vue SFC `<script>` blocks when it needs disambiguation (currently only "tsx"), scanned by the host',
   },
 };
 

--- a/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/text-to-doc.ts
+++ b/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/text-to-doc.ts
@@ -2,24 +2,27 @@ import { jsTextToDoc } from "../../index";
 import type { Parser, Doc } from "prettier";
 
 export const textToDoc: Parser<Doc>["parse"] = async (embeddedSourceText, textToDocOptions) => {
-  // `_oxfmtPluginOptionsJson` is a JSON string bundled by Rust (`oxfmtrc::inject_oxfmt_plugin_payload`),
+  // `_oxfmtPluginOptionsJson` is a JSON string bundled by Rust (`to_prettier::inject_oxfmt_plugin_payload`),
   // carrying the typed `FormatConfig` + parent filepath for the Rust-side `oxc_formatter`.
-  const { parser, parentParser, filepath, _oxfmtPluginOptionsJson } = textToDocOptions;
-
-  // For (j|t)s-in-xxx, default `parser` is either `babel`(JS), `babel-ts` or `typescript`
-  // We need to infer `SourceType::from_extension(ext)` for `oxc_formatter`.
-  // - JS: always enable JSX for js-in-xxx, it's syntactically valid
-  // - TS: `typescript` (ts-in-vue|markdown|mdx) or `babel-ts` (ts-in-vue(script generic="..."))
-  //   - In case of ts-in-md, `filepath` is overridden as `dummy.tx(x)` to distinguish TSX or TS
-  //   - For tsx-in-vue (`<script lang="tsx">`), there is no signal from Prettier to detect it
-  //     - `filepath` is the parent `.vue` file, so this resolves to "ts"
-  //     - The Rust side (`text_to_doc_api::run()`) retries the failed "ts" parse as "tsx"
-  //       - avoiding Prettier's `maybeJSXRe.test(sourceText)` sniff cost on every ts-in-vue
-  const isTS = parser === "typescript" || parser === "babel-ts";
-  const embeddedSourceExt = isTS ? (filepath?.endsWith(".tsx") ? "tsx" : "ts") : "jsx";
+  const { parser, parentParser, filepath, _oxfmtPluginOptionsJson, _oxfmtVueScriptLang } =
+    textToDocOptions;
 
   // Detect context from Prettier's internal flags
   const parentContext = detectParentContext(parentParser!, textToDocOptions);
+
+  // For (j|t)s-in-xxx, default `parser` is either `babel`(JS), `babel-ts` or `typescript`.
+  // We need to infer the parse grammar (`source_ext`) for `oxc_formatter`.
+  // - JS: always enable JSX for js-in-xxx, it's syntactically valid
+  // - TS: `typescript` (ts-in-vue|markdown|mdx) or `babel-ts` (ts-in-vue(script generic="..."))
+  //   - In case of ts-in-md, `filepath` is overridden as `dummy.ts(x)` to distinguish TSX or TS
+  //   - For tsx-in-vue (`<script lang="tsx">`), there is no signal from Prettier itself:
+  //     - both `lang="ts"` and `lang="tsx"` resolve to the `typescript` parser and `filepath` is the parent `.vue` file
+  //     - Nor from parsing: a JSX-free tsx block parses fine as plain ts
+  //     - So, our host pre-scans the SFC and passes `_oxfmtVueScriptLang: "tsx"` instead
+  const isTS = parser === "typescript" || parser === "babel-ts";
+  const isTSX =
+    filepath.endsWith(".tsx") || (parentContext === "vue-script" && _oxfmtVueScriptLang === "tsx");
+  const embeddedSourceExt = isTS ? (isTSX ? "tsx" : "ts") : "jsx";
 
   const docJSON = await jsTextToDoc(
     embeddedSourceExt,

--- a/apps/oxfmt/src/api/text_to_doc_api.rs
+++ b/apps/oxfmt/src/api/text_to_doc_api.rs
@@ -57,32 +57,37 @@ pub fn run(
     format_embedded_doc_cb: JsFormatEmbeddedDocCb,
     sort_tailwind_classes_cb: JsSortTailwindClassesCb,
 ) -> Option<String> {
-    let source_type = SourceType::from_extension(source_ext)
-        .expect("text-to-doc.ts should pass `source_ext` as one of 'jsx', 'ts', or 'tsx'");
+    // Embedded text belongs to the host file (`.vue`, `.md`, ...),
+    // so the `SourceType` carries no file extension of its own.
+    // `source_ext` selects the parse grammar only,
+    // and extension-keyed formatter rules (e.g. the `.mts`/`.cts` trailing comma reservation) must not fire from it.
+    //
+    // The JS side owns the grammar resolution (including the `lang="tsx"` scan for Vue, see `hasTsxScriptBlock` in `apis.ts`),
+    // so there is no parse retry here: a block
+    // that fails to parse under its declared grammar is left unformatted
+    // (`textToDoc()` error → Prettier keeps the original text).
+    let source_type = match source_ext {
+        "jsx" => SourceType::unambiguous().with_jsx(true),
+        "ts" => SourceType::ts(),
+        "tsx" => SourceType::tsx(),
+        _ => {
+            unreachable!("text-to-doc.ts should pass `source_ext` as one of 'jsx', 'ts', or 'tsx'")
+        }
+    };
 
-    let (fragment_kind, is_vue_script) = match parent_context {
-        "vue-for-binding-left" => (Some(FragmentKind::VueForBindingLeft), false),
-        "vue-bindings" => (Some(FragmentKind::VueBindings), false),
-        "vue-script-generic" => (Some(FragmentKind::VueScriptGeneric), false),
-        "vue-script" => (None, true),
-        // "svelte-script"
-        _ => (None, false),
+    let fragment_kind = match parent_context {
+        "vue-for-binding-left" => Some(FragmentKind::VueForBindingLeft),
+        "vue-bindings" => Some(FragmentKind::VueBindings),
+        "vue-script-generic" => Some(FragmentKind::VueScriptGeneric),
+        // "vue-script" | "svelte-script"
+        _ => None,
     };
 
     let doc_json = if let Some(kind) = fragment_kind {
         run_fragment(source_type, source_text, oxfmt_plugin_options_json, kind)?
     } else {
-        // NOTE: `<script lang="tsx">` in Vue has no signal to detect, the JS side resolves it to "ts".
-        // Retry a failed "ts" parse as "tsx": no source is valid under both grammars,
-        // so this order only affects cost (common ts path stays single-parse), not output.
-        // Markdown has the `dummy.ts(x)` extension signal and Svelte has no JSX, so neither needs this.
-        let fallback_source_type =
-            (is_vue_script && source_type.is_typescript() && !source_type.is_jsx())
-                .then(|| source_type.with_jsx(true));
-
         run_full(
             source_type,
-            fallback_source_type,
             source_text,
             oxfmt_plugin_options_json,
             format_file_cb,
@@ -111,7 +116,6 @@ pub fn run(
 #[instrument(level = "debug", name = "oxfmt::text_to_doc::full", skip_all, fields(?source_type))]
 fn run_full(
     source_type: SourceType,
-    fallback_source_type: Option<SourceType>,
     source_text: &str,
     oxfmt_plugin_options_json: &str,
     format_file_cb: JsFormatFileCb,
@@ -156,28 +160,22 @@ fn run_full(
         css_options,
     );
 
-    // A failed attempt is parse-failure only (no embed callbacks have run yet),
-    // so retrying with the fallback source type on the same allocator is safe.
     let allocator = Allocator::default();
-    let Some(formatted) =
-        std::iter::once(source_type).chain(fallback_source_type).find_map(|source_type| {
-            tokio::task::block_in_place(|| {
-                oxc_formatter::format(
-                    &allocator,
-                    source_text,
-                    source_type,
-                    resolved.format_options.as_ref().clone(),
-                    Some(external_callbacks.clone()),
-                )
-            })
-            .inspect_err(|err| {
-                debug!("`oxc_formatter::format()` failed for {source_type:?}: {err:?}");
-            })
-            .ok()
-        })
-    else {
-        external_formatter.cleanup();
-        return None;
+    let formatted = match tokio::task::block_in_place(|| {
+        oxc_formatter::format(
+            &allocator,
+            source_text,
+            source_type,
+            *resolved.format_options,
+            Some(external_callbacks),
+        )
+    }) {
+        Ok(formatted) => formatted,
+        Err(err) => {
+            debug!("`oxc_formatter::format()` failed for {source_type:?}: {err:?}");
+            external_formatter.cleanup();
+            return None;
+        }
     };
 
     let (elements, sorted_tailwind_classes) =

--- a/apps/oxfmt/test/api/js-in-vue.test.ts
+++ b/apps/oxfmt/test/api/js-in-vue.test.ts
@@ -135,7 +135,6 @@ const q = graphql\`
     expect(result2.errors).toStrictEqual([]);
   });
 
-  // tsx-in-vue: no parser-name signal from Prettier, handled by ts→tsx retry on the Rust side
   it('should format <script lang="tsx"> blocks', async () => {
     const input = `
 <script lang="tsx">
@@ -150,7 +149,6 @@ export default {
     expect(result.errors).toStrictEqual([]);
   });
 
-  // The ts-only grammar must keep winning on the first (ts) attempt
   it('should format generic arrows in <script lang="ts"> blocks', async () => {
     const input = `
 <script lang="ts">
@@ -160,6 +158,62 @@ export const identity=<T>(x:T):T=>x;
     const result = await format("a.vue", input);
 
     expect(result.code).toContain("export const identity = <T>(x: T): T => x;");
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  // NOTE: Trailing comma of a lone generic arrow param is grammar-keyed, not path-keyed:
+  // plain-TS blocks behave like plain .ts files (comma removable).
+  // Unlike Prettier, which keeps the comma for any non-.ts `opts.filepath`. (ts-in-vue)
+  it('should drop the lone generic param comma in <script lang="ts"> blocks', async () => {
+    const input = `
+<script setup lang="ts">
+const getOptions = <T = any,>(list: T[]) => list;
+const identity = <T,>(x: T) => x;
+</script>
+`;
+    const result = await format("a.vue", input);
+
+    expect(result.code).toContain("const getOptions = <T = any>(list: T[]) => list;");
+    expect(result.code).toContain("const identity = <T>(x: T) => x;");
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it('should keep the lone generic param comma in <script lang="tsx"> blocks', async () => {
+    const input = `
+<script lang="tsx">
+const identity = <T,>(x: T) => x;
+const el = <div>hi</div>;
+</script>
+`;
+    const result = await format("a.vue", input);
+
+    expect(result.code).toContain("const identity = <T,>(x: T) => x;");
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it('should keep the comma in a JSX-free lang="tsx" block', async () => {
+    const input = `
+<script setup lang="tsx">
+const getOptions = <T = any,>(list: T[]) => list;
+const identity = <T,>(x: T) => x;
+</script>
+`;
+    const result = await format("a.vue", input);
+
+    expect(result.code).toContain("const getOptions = <T = any,>(list: T[]) => list;");
+    expect(result.code).toContain("const identity = <T,>(x: T) => x;");
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it('should detect lang="tsx" after a generic attribute containing `>`', async () => {
+    const input = `
+<script setup generic="T extends Record<string, string>" lang="tsx">
+const pick = <U = T,>(x: U) => x;
+</script>
+`;
+    const result = await format("a.vue", input);
+
+    expect(result.code).toContain("const pick = <U = T,>(x: U) => x;");
     expect(result.errors).toStrictEqual([]);
   });
 });

--- a/crates/oxc_formatter/src/print/type_parameters.rs
+++ b/crates/oxc_formatter/src/print/type_parameters.rs
@@ -68,11 +68,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameter<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, TSTypeParameter<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        // Type parameter lists of arrow function expressions have to include at least one comma
-        // to avoid any ambiguity with JSX elements, and in `.mts`/`.cts` sources.
-        // Thus, we have to add a trailing comma when there is a single type parameter.
-        // The comma can be omitted in the case where the single parameter has a constraint,
-        // i.i. an `extends` clause.
+        // A lone type parameter on an arrow function may need a mandatory trailing comma;
         let trailing_separator = if should_force_trailing_comma_for_arrow_function(self, f) {
             TrailingSeparator::Mandatory
         } else {
@@ -87,9 +83,16 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, TSTypePara
     }
 }
 
-/// Matches Prettier's `shouldForceTrailingComma` behavior for arrow functions.
+/// The trailing comma of a lone, constraint-less type parameter
+/// on an arrow function is load-bearing in exactly two grammars,
+/// so it is forced there and removable everywhere else:
+/// - JSX sources parse a bare `<T>` as a JSX element opener
+/// - `.mts`/`.cts` reserve the constraint-less form at the grammar level (TS7060)
 ///
-/// <https://github.com/prettier/prettier/blob/070c89bba46235f4948560ed612a11e89ccd2da9/src/language-js/print/type-parameters.js#L33-L42>
+/// Prettier's `shouldForceTrailingComma` instead sniffs the file path
+/// and keeps the comma in every non-`.ts` host, including plain-TS embedded scripts (e.g. ts-in-vue).
+/// This is a deliberate divergence: removal is keyed on the grammar the source is consumed as,
+/// not on the host file's path, so plain-TS sources behave identically wherever they live.
 fn should_force_trailing_comma_for_arrow_function(
     params: &AstNode<'_, ArenaVec<'_, TSTypeParameter<'_>>>,
     f: &JsFormatter<'_, '_>,
@@ -103,16 +106,15 @@ fn should_force_trailing_comma_for_arrow_function(
     }
 
     // Ignore type parameters with a constraint (extends clause).
-    // A default type alone does not disambiguate from JSX, so the comma is still required.
+    // A default type alone does not disambiguate (neither from JSX nor for TS7060),
+    // so the comma is still required.
     if params.first().is_some_and(|t| t.constraint().is_some()) {
         return false;
     }
 
     let source_type = f.context().source_type();
-    let is_ts_extension = matches!(source_type.extension(), Some(FileExtension::Ts));
-
-    // Force trailing comma for non-.ts sources (e.g. .tsx, .mts, .cts) or when extension is unknown.
-    !is_ts_extension
+    source_type.is_jsx()
+        || matches!(source_type.extension(), Some(FileExtension::Mts | FileExtension::Cts))
 }
 
 #[derive(Default)]


### PR DESCRIPTION
Follow-up to #25063.

tsx-in-vue was supported in #25063 with a parse-retry (ts fails → retry as tsx), chosen to keep the common ts path single-parse.

However, this leaves a hole: a `lang="tsx"` block without JSX parses fine as plain ts, so the retry never fires and the lone generic comma is removed:

```vue
<script setup lang="tsx">
const identity = <T,>(x: T) => x; // → <T>(x: T) => x, breaks as TS17008
</script>
```

Since parse failure fundamentally cannot detect this, the only fix is to scan the `lang` declaration itself.

The JS host now scans the SFC once per file and passes `_oxfmtVueScriptLang: "tsx"` down to `textToDoc()`. This makes the retry obsolete, so it is removed.

This PR also settles the comma policy: keep it only where it is load-bearing.

- JSX grammar (`<T>` would be a JSX opener)
- and `.mts/.cts` (TS7060, #18928)

and remove it everywhere else, keyed on the grammar, regardless of context.

Deliberate divergence: Prettier keys on filepath and keeps the comma in ts-in-vue/svelte (while its own ts-in-md embed uses `dummy.ts` as `filepath` and removes it). Plain-TS sources now behave identically wherever they live.
