### PR TITLE
docs(linter/typescript/no-unnecessary-condition): clarify options

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -5759,12 +5759,30 @@ export interface NoUnnecessaryBooleanLiteralCompareConfig {
 }
 export interface NoUnnecessaryConditionConfig {
   /**
-   * Whether to allow constant loop conditions.
-   * `true` is treated as `"always"`, `false` as `"never"`.
+   * Controls which constant conditions are allowed in `while`, `do...while`, and `for` loops.
+   *
+   * - `"never"` (or `false`) reports all constant loop conditions.
+   * - `"always"` (or `true`) allows conditions whose type is the literal type `true`, such as
+   * `while (true)` or `while (variable)` when `variable` has type `true`.
+   * - `"only-allowed-literals"` allows only the literal expressions `true`, `false`, `0`, and
+   * `1`. Variables whose types are those literal types are still reported.
    */
   allowConstantLoopConditions?: AllowConstantLoopConditions;
   /**
-   * Whether to check type predicate functions.
+   * Whether to check arguments passed to type predicate and assertion functions.
+   *
+   * When enabled, the rule reports a call if the argument already satisfies the predicate or
+   * if an assertion function receives an argument that is always truthy or always falsy.
+   *
+   * For example, `narrow(value)` is unnecessary because `value` already has type `true`:
+   *
+   * ```ts
+   * declare const narrow: (value: unknown) => value is true;
+   * const value = true;
+   * if (narrow(value)) {
+   * // ...
+   * }
+   * ```
    */
   checkTypePredicates?: boolean;
 }

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_condition.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_condition.rs
@@ -35,10 +35,28 @@ pub enum AllowConstantLoopConditionsMode {
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoUnnecessaryConditionConfig {
-    /// Whether to allow constant loop conditions.
-    /// `true` is treated as `"always"`, `false` as `"never"`.
+    /// Controls which constant conditions are allowed in `while`, `do...while`, and `for` loops.
+    ///
+    /// - `"never"` (or `false`) reports all constant loop conditions.
+    /// - `"always"` (or `true`) allows conditions whose type is the literal type `true`, such as
+    ///   `while (true)` or `while (variable)` when `variable` has type `true`.
+    /// - `"only-allowed-literals"` allows only the literal expressions `true`, `false`, `0`, and
+    ///   `1`. Variables whose types are those literal types are still reported.
     pub allow_constant_loop_conditions: AllowConstantLoopConditions,
-    /// Whether to check type predicate functions.
+    /// Whether to check arguments passed to type predicate and assertion functions.
+    ///
+    /// When enabled, the rule reports a call if the argument already satisfies the predicate or
+    /// if an assertion function receives an argument that is always truthy or always falsy.
+    ///
+    /// For example, `narrow(value)` is unnecessary because `value` already has type `true`:
+    ///
+    /// ```ts
+    /// declare const narrow: (value: unknown) => value is true;
+    /// const value = true;
+    /// if (narrow(value)) {
+    ///   // ...
+    /// }
+    /// ```
     pub check_type_predicates: bool,
 }
 

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -15763,20 +15763,20 @@
       "type": "object",
       "properties": {
         "allowConstantLoopConditions": {
-          "description": "Whether to allow constant loop conditions.\n`true` is treated as `\"always\"`, `false` as `\"never\"`.",
+          "description": "Controls which constant conditions are allowed in `while`, `do...while`, and `for` loops.\n\n- `\"never\"` (or `false`) reports all constant loop conditions.\n- `\"always\"` (or `true`) allows conditions whose type is the literal type `true`, such as\n`while (true)` or `while (variable)` when `variable` has type `true`.\n- `\"only-allowed-literals\"` allows only the literal expressions `true`, `false`, `0`, and\n`1`. Variables whose types are those literal types are still reported.",
           "default": "never",
           "allOf": [
             {
               "$ref": "#/definitions/AllowConstantLoopConditions"
             }
           ],
-          "markdownDescription": "Whether to allow constant loop conditions.\n`true` is treated as `\"always\"`, `false` as `\"never\"`."
+          "markdownDescription": "Controls which constant conditions are allowed in `while`, `do...while`, and `for` loops.\n\n- `\"never\"` (or `false`) reports all constant loop conditions.\n- `\"always\"` (or `true`) allows conditions whose type is the literal type `true`, such as\n`while (true)` or `while (variable)` when `variable` has type `true`.\n- `\"only-allowed-literals\"` allows only the literal expressions `true`, `false`, `0`, and\n`1`. Variables whose types are those literal types are still reported."
         },
         "checkTypePredicates": {
-          "description": "Whether to check type predicate functions.",
+          "description": "Whether to check arguments passed to type predicate and assertion functions.\n\nWhen enabled, the rule reports a call if the argument already satisfies the predicate or\nif an assertion function receives an argument that is always truthy or always falsy.\n\nFor example, `narrow(value)` is unnecessary because `value` already has type `true`:\n\n```ts\ndeclare const narrow: (value: unknown) => value is true;\nconst value = true;\nif (narrow(value)) {\n// ...\n}\n```",
           "default": false,
           "type": "boolean",
-          "markdownDescription": "Whether to check type predicate functions."
+          "markdownDescription": "Whether to check arguments passed to type predicate and assertion functions.\n\nWhen enabled, the rule reports a call if the argument already satisfies the predicate or\nif an assertion function receives an argument that is always truthy or always falsy.\n\nFor example, `narrow(value)` is unnecessary because `value` already has type `true`:\n\n```ts\ndeclare const narrow: (value: unknown) => value is true;\nconst value = true;\nif (narrow(value)) {\n// ...\n}\n```"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

- document the exact allowConstantLoopConditions behavior, including the four directly allowed literals
- explain how always differs from only-allowed-literals
- add a checkTypePredicates example and regenerate the published configuration schema

Closes #25098