### PR TITLE
fix(codegen): preserve satisfies parentheses before bitwise operators

### DIFF
--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -214,6 +214,13 @@ impl<'a> BinaryExpressionVisitor<'a> {
                     self.left_precedence = Precedence::Call;
                 }
             }
+            BinaryishOperator::Binary(BinaryOperator::BitwiseOR | BinaryOperator::BitwiseAnd) => {
+                // Without parentheses, `|` or `&` becomes part of the type in
+                // `(value satisfies Type) | other` or `(value satisfies Type) & other`.
+                if matches!(e.left(), Expression::TSSatisfiesExpression(_)) {
+                    self.left_precedence = Precedence::Compare;
+                }
+            }
 
             _ => {}
         }

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -405,6 +405,8 @@ fn ts_instantiation_expression() {
 
 #[test]
 fn ts_satisfies_expression() {
+    test_same("(foo satisfies null) | ~\"\";\n");
+    test_same("(foo satisfies null) & ~\"\";\n");
     test_idempotency("d = x satisfies y");
     test_idempotency("const Foo = (() => {})() satisfies X");
     test_idempotency("const Bar = (x as Y) satisfies Z");


### PR DESCRIPTION
## Summary

- preserve parentheses around a satisfies expression used as the left operand of bitwise OR or AND
- prevent the operator from being consumed as part of the satisfies type
- add regression coverage for both operators

Part of #25111.
Closes #25112.
