### PR TITLE
fix(codegen): preserve comparison parentheses before regexp

### DIFF
--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -4,13 +4,57 @@
 
 use std::ops::Not;
 
-use oxc_ast::ast::{BinaryExpression, Expression, LogicalExpression};
+use oxc_ast::ast::{BinaryExpression, ChainElement, Expression, LogicalExpression};
 use oxc_syntax::{
     operator::{BinaryOperator, LogicalOperator},
     precedence::{GetPrecedence, Precedence},
 };
 
 use crate::{Codegen, Context, Operator, cjs_module_lexer, r#gen::GenExpr};
+
+fn expression_starts_with_regexp(expression: &Expression) -> bool {
+    match expression.without_parentheses() {
+        Expression::RegExpLiteral(_) => true,
+        Expression::BinaryExpression(expression) => expression_starts_with_regexp(&expression.left),
+        Expression::StaticMemberExpression(expression) => {
+            expression_starts_with_regexp(&expression.object)
+        }
+        Expression::ComputedMemberExpression(expression) => {
+            expression_starts_with_regexp(&expression.object)
+        }
+        Expression::PrivateFieldExpression(expression) => {
+            expression_starts_with_regexp(&expression.object)
+        }
+        Expression::CallExpression(expression) => expression_starts_with_regexp(&expression.callee),
+        Expression::TaggedTemplateExpression(expression) => {
+            expression_starts_with_regexp(&expression.tag)
+        }
+        Expression::TSNonNullExpression(expression) => {
+            expression_starts_with_regexp(&expression.expression)
+        }
+        Expression::TSInstantiationExpression(expression) => {
+            expression_starts_with_regexp(&expression.expression)
+        }
+        Expression::ChainExpression(expression) => match &expression.expression {
+            ChainElement::CallExpression(expression) => {
+                expression_starts_with_regexp(&expression.callee)
+            }
+            ChainElement::TSNonNullExpression(expression) => {
+                expression_starts_with_regexp(&expression.expression)
+            }
+            ChainElement::StaticMemberExpression(expression) => {
+                expression_starts_with_regexp(&expression.object)
+            }
+            ChainElement::ComputedMemberExpression(expression) => {
+                expression_starts_with_regexp(&expression.object)
+            }
+            ChainElement::PrivateFieldExpression(expression) => {
+                expression_starts_with_regexp(&expression.object)
+            }
+        },
+        _ => false,
+    }
+}
 
 #[derive(Clone, Copy)]
 pub enum Binaryish<'a> {
@@ -213,6 +257,16 @@ impl<'a> BinaryExpressionVisitor<'a> {
                 ) {
                     self.left_precedence = Precedence::Call;
                 }
+            }
+            BinaryishOperator::Binary(operator)
+                if operator.is_compare()
+                    && p.is_typescript
+                    && matches!(e.left(), Expression::BinaryExpression(left) if left.operator.is_compare())
+                    && expression_starts_with_regexp(e.right()) =>
+            {
+                // TypeScript parses `a < b > / x` as an instantiation expression followed by
+                // division. Preserve `(a < b) > /x/` so `/x/` remains a regexp literal.
+                self.left_precedence = Precedence::Compare;
             }
 
             _ => {}

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -45,6 +45,7 @@ pub trait GenExpr: GetSpan {
 impl Gen for Program<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.is_jsx = self.source_type.is_jsx();
+        p.is_typescript = self.source_type.is_typescript();
 
         // Allow for inserting comments to the top of the file.
         p.print_comments_at(0);

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -109,6 +109,8 @@ pub struct Codegen<'a> {
     /// Indicates the output is JSX type, it is set in [`Program::gen`] and the result
     /// is obtained by [`oxc_span::SourceType::is_jsx`]
     is_jsx: bool,
+    /// Whether the output is TypeScript, set in [`Program::gen`].
+    is_typescript: bool,
 
     /// For avoiding `;` if the previous statement ends with `}`.
     needs_semicolon: bool,
@@ -192,6 +194,7 @@ impl<'a> Codegen<'a> {
             start_of_arrow_expr: 0,
             start_of_default_export: 0,
             is_jsx: false,
+            is_typescript: false,
             indent: 0,
             quote: Quote::Double,
             comments: CommentsMap::default(),
@@ -222,6 +225,7 @@ impl<'a> Codegen<'a> {
     #[must_use]
     pub fn with_source_type(mut self, source_type: SourceType) -> Self {
         self.is_jsx = source_type.is_jsx();
+        self.is_typescript = source_type.is_typescript();
         self
     }
 

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -460,6 +460,11 @@ fn bitwise_and() {
 
 #[test]
 fn equality() {
+    test_unambiguous("(null < 356) > /a/;", "null < 356 > /a/;\n");
+    test_unambiguous(
+        "for (value of (this < \"hello\") > (/a/ / value?.value));",
+        "for (value of this < \"hello\" > /a/ / value?.value);\n",
+    );
     test_minify("a == b != c === d !== e", "a==b!=c===d!==e;");
     test_minify("a == (b != (c === (d !== e)))", "a==(b!=(c===(d!==e)));");
     test_minify("(((a == b) != c) === d) !== e", "a==b!=c===d!==e;");

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -359,6 +359,14 @@ fn ts_as_expression_in_binary_expr() {
 }
 
 #[test]
+fn comparison_before_regexp() {
+    test_same("(null < 356) > /a/;\n");
+    test_idempotency("for (value of (this < \"hello\") > (/a/ / value?.value));");
+    test_idempotency("(a < b) > /x/.source");
+    test_idempotency("(a < b) > /x/.test('')");
+}
+
+#[test]
 fn ts_type_assertion() {
     // `<T>x` (TS angle-bracket assertion) is only valid in non-tsx source.
     let test_ts =


### PR DESCRIPTION
## Summary

- preserve a nested comparison before a regular expression when emitting TypeScript
- avoid the flattened expression being reparsed as a TypeScript instantiation followed by division
- continue removing the redundant parentheses when emitting JavaScript
- add regression coverage for both source modes

Part of #25111.
Closes #25116.