### PR TITLE
fix(codegen): preserve sequence comparison parentheses

### DIFF
--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -12,7 +12,7 @@ use oxc_syntax::{
 
 use crate::{Codegen, Context, Operator, cjs_module_lexer, r#gen::GenExpr};
 
-fn expression_starts_with_regexp(expression: &Expression) -> bool {
+pub fn expression_starts_with_regexp(expression: &Expression) -> bool {
     match expression.without_parentheses() {
         Expression::RegExpLiteral(_) => true,
         Expression::BinaryExpression(expression) => expression_starts_with_regexp(&expression.left),
@@ -262,10 +262,20 @@ impl<'a> BinaryExpressionVisitor<'a> {
                 if operator.is_compare()
                     && p.is_typescript
                     && matches!(e.left(), Expression::BinaryExpression(left) if left.operator.is_compare())
-                    && expression_starts_with_regexp(e.right()) =>
+                    && (expression_starts_with_regexp(e.right())
+                        || matches!(e.right(), Expression::TemplateLiteral(_))) =>
             {
                 // TypeScript parses `a < b > / x` as an instantiation expression followed by
                 // division. Preserve `(a < b) > /x/` so `/x/` remains a regexp literal.
+                self.left_precedence = Precedence::Compare;
+            }
+            BinaryishOperator::Binary(BinaryOperator::BitwiseOR | BinaryOperator::BitwiseAnd)
+                if p.is_typescript
+                    && matches!(e.left(), Expression::BinaryExpression(left) if left.operator == BinaryOperator::LessThan)
+                    && matches!(e.right(), Expression::BinaryExpression(right) if right.operator == BinaryOperator::GreaterThan && expression_starts_with_regexp(&right.right)) =>
+            {
+                // TypeScript treats `|` and `&` as type separators inside `a<T | U>` and
+                // `a<T & U>`. Keep the opening comparison grouped so it cannot become type args.
                 self.left_precedence = Precedence::Compare;
             }
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -11,7 +11,9 @@ use oxc_syntax::{
 
 use crate::{
     Codegen, Context, Operator, Quote,
-    binary_expr_visitor::{BinaryExpressionVisitor, Binaryish, BinaryishOperator},
+    binary_expr_visitor::{
+        BinaryExpressionVisitor, Binaryish, BinaryishOperator, expression_starts_with_regexp,
+    },
     cjs_module_lexer,
     comment::AnnotationKind,
 };
@@ -1584,9 +1586,12 @@ impl GenExpr for CallExpression<'_> {
 
 impl Gen for Argument<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
-        match self {
-            Self::SpreadElement(elem) => elem.print(p, ctx),
-            _ => self.to_expression().print_expr(p, Precedence::Comma, Context::empty()),
+        if let Self::SpreadElement(elem) = self {
+            elem.print(p, ctx);
+        } else {
+            let expression = self.to_expression();
+            let precedence = comma_list_expression_precedence(p, expression);
+            expression.print_expr(p, precedence, Context::empty());
         }
     }
 }
@@ -1596,8 +1601,39 @@ impl Gen for ArrayExpressionElement<'_> {
         match self {
             Self::SpreadElement(elem) => elem.print(p, ctx),
             Self::Elision(_span) => {}
-            _ => self.to_expression().print_expr(p, Precedence::Comma, Context::empty()),
+            _ => {
+                let expression = self.to_expression();
+                let precedence = comma_list_expression_precedence(p, expression);
+                expression.print_expr(p, precedence, Context::empty());
+            }
         }
+    }
+}
+
+fn comma_list_expression_precedence(p: &Codegen, expression: &Expression) -> Precedence {
+    if p.is_typescript && expression_starts_with_ts_type_argument_closer(expression) {
+        Precedence::Compare
+    } else {
+        Precedence::Comma
+    }
+}
+
+fn expression_starts_with_ts_type_argument_closer(expression: &Expression) -> bool {
+    match expression.without_parentheses() {
+        Expression::BinaryExpression(binary) => {
+            if binary.operator == BinaryOperator::GreaterThan {
+                expression_starts_with_regexp(&binary.right)
+                    || matches!(binary.right.without_parentheses(), Expression::TemplateLiteral(_))
+            } else if binary.operator.precedence() < Precedence::Compare {
+                expression_starts_with_ts_type_argument_closer(&binary.left)
+            } else {
+                false
+            }
+        }
+        Expression::LogicalExpression(logical) => {
+            expression_starts_with_ts_type_argument_closer(&logical.left)
+        }
+        _ => false,
     }
 }
 
@@ -1605,7 +1641,8 @@ impl Gen for SpreadElement<'_> {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_ellipsis();
-        self.argument.print_expr(p, Precedence::Comma, Context::empty());
+        let precedence = comma_list_expression_precedence(p, &self.argument);
+        self.argument.print_expr(p, precedence, Context::empty());
     }
 }
 
@@ -2236,7 +2273,28 @@ impl Gen for AssignmentTargetRest<'_> {
 impl GenExpr for SequenceExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.wrap(precedence >= self.precedence(), |p| {
-            p.print_expressions(&self.expressions, Precedence::Lowest, ctx.and_forbid_call(false));
+            // In TypeScript, flattening `x, (a < b), c > /x/` creates the instantiation
+            // expression `a<b, c>` followed by division. Keep preceding sequence items grouped
+            // so a nested `<` cannot pair with the closing comparison.
+            let last_closing_comparison = p
+                .is_typescript
+                .then(|| {
+                    self.expressions
+                        .iter()
+                        .rposition(expression_starts_with_ts_type_argument_closer)
+                })
+                .flatten();
+            p.print_expressions(
+                &self.expressions,
+                |index, _| {
+                    if last_closing_comparison.is_some_and(|closing| index < closing) {
+                        Precedence::Compare
+                    } else {
+                        Precedence::Lowest
+                    }
+                },
+                ctx.and_forbid_call(false),
+            );
         });
     }
 }

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -745,15 +745,18 @@ impl<'a> Codegen<'a> {
     }
 
     #[inline]
-    fn print_expressions<T: GenExpr>(&mut self, items: &[T], precedence: Precedence, ctx: Context) {
-        let Some((first, rest)) = items.split_first() else {
-            return;
-        };
-        first.print_expr(self, precedence, ctx);
-        for item in rest {
-            self.print_comma();
-            self.print_soft_space();
-            item.print_expr(self, precedence, ctx);
+    fn print_expressions<T: GenExpr, F: FnMut(usize, &T) -> Precedence>(
+        &mut self,
+        items: &[T],
+        mut precedence: F,
+        ctx: Context,
+    ) {
+        for (index, item) in items.iter().enumerate() {
+            if index > 0 {
+                self.print_comma();
+                self.print_soft_space();
+            }
+            item.print_expr(self, precedence(index, item), ctx);
         }
     }
 

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -465,6 +465,10 @@ fn equality() {
         "for (value of (this < \"hello\") > (/a/ / value?.value));",
         "for (value of this < \"hello\" > /a/ / value?.value);\n",
     );
+    test_unambiguous("(\"hello\" < false), null > /a/;", "\"hello\" < false, null > /a/;\n");
+    test_unambiguous("0, (\"hello\" < false), null > /a/;", "0, \"hello\" < false, null > /a/;\n");
+    test_unambiguous("x((true < 0n), c > /a/);", "x(true < 0n, c > /a/);\n");
+    test_unambiguous("(c < \"key\") & 618 > /a/;", "c < \"key\" & 618 > /a/;\n");
     test_minify("a == b != c === d !== e", "a==b!=c===d!==e;");
     test_minify("a == (b != (c === (d !== e)))", "a==(b!=(c===(d!==e)));");
     test_minify("(((a == b) != c) === d) !== e", "a==b!=c===d!==e;");

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -367,6 +367,50 @@ fn comparison_before_regexp() {
 }
 
 #[test]
+fn sequence_comparison_before_regexp() {
+    test_same("(\"hello\" < false), null > /a/;\n");
+    test_same("for (;;) for (; 0n;) (\"hello\" < false), null > /a/;\n");
+    test_same("0, (\"hello\" < false), null > /a/;\n");
+    test_same("(\"a\" < A), (\"b\" < B), C > /x/;\n");
+    test_same("(\"a\" < A), B > /x/, 0;\n");
+    test_same("(x = a < b), c > /x/;\n");
+    test_options_with_source_type(
+        "0, (\"hello\" < false), null;\n",
+        "0, \"hello\" < false, null;\n",
+        SourceType::ts(),
+        default_options(),
+    );
+}
+
+#[test]
+fn comma_list_comparison_before_regexp() {
+    test_idempotency("x((true < 0n), c > /a/)");
+    test_idempotency("x<string>(null, .../a/, c, !null, (true < 0n), c > /a/)");
+    test_idempotency("new item(...899, value == 0n, y(false!), (0n < value), null > /a/)");
+    test_idempotency("new y<boolean[bigint]>(...281, (true < result), 950 > /a/, ...\"\")");
+    test_idempotency(
+        "let x = item = new result<bigint>(.../a/, (null < \"a\"), 635, \"key\" > /a/, {})",
+    );
+    test_idempotency(
+        "let value = b = new y<symbol | bigint>((null < `value`), \"value\" > /a/, [], ...`a`)",
+    );
+    test_idempotency("[(true < 0n), c > /a/]");
+    test_idempotency("x(...((true < 0n), c > /a/))");
+}
+
+#[test]
+fn comparison_before_template() {
+    test_idempotency("item = ((result?.[a] < \"hello\"), false > `hello` && (x ? x : false))");
+    test_idempotency("for (; (\"\"?.[\"a\"] < (() => {})) > `0`; { .../a/ });");
+}
+
+#[test]
+fn bitwise_comparison_before_regexp() {
+    test_idempotency("(c < \"key\") & 618 > /a/");
+    test_idempotency("(c < \"key\") | 618 > /a/");
+}
+
+#[test]
 fn ts_type_assertion() {
     // `<T>x` (TS angle-bracket assertion) is only valid in non-tsx source.
     let test_ts =


### PR DESCRIPTION
## Summary

- keep TypeScript sequence items grouped when a later greater-than comparison with a regular expression could form a fake type-argument list
- choose expression precedence per sequence item without allocating
- preserve minimal JavaScript output
- cover leading items, multiple comparisons, nested assignments, the original loop case, and non-ambiguous sequences

Stacked on #25118.
Part of #25111.
Closes #25120.
