### PR TITLE
perf(linter/plugins): reuse deserialized settings object across files

### DIFF
--- a/apps/oxlint/src-js/plugins/settings.ts
+++ b/apps/oxlint/src-js/plugins/settings.ts
@@ -20,11 +20,13 @@ export type Settings = JsonObject;
 let settingsJSON: string | null = null;
 export let settings: Readonly<Settings> | null = null;
 
+// Settings deserialized for the last file which had any, and the JSON they came from.
+// Retained across files, so unchanged settings are deserialized only once.
+let lastSettingsJSON: string | null = null;
+let lastSettings: Readonly<Settings> | null = null;
+
 /**
  * Updates the settings for the file.
- *
- * TODO(perf): Settings are deserialized once per file to accommodate folder level settings,
- * even if the settings haven't changed.
  *
  * @param settingsJSONInput - Settings for the file as JSON
  */
@@ -34,12 +36,31 @@ export function setSettingsForFile(settingsJSONInput: string): undefined {
 
 /**
  * Deserialize settings from JSON.
+ *
+ * Settings are passed in as JSON per file, to accommodate folder level settings, but in practice
+ * they're usually identical for every file. So reuse the object deserialized for the previous file
+ * when the JSON is unchanged.
+ *
+ * As well as skipping the `JSON.parse` and deep freeze, this keeps `context.settings` referentially
+ * stable across files. Plugins commonly normalize settings once and memoize the result in a
+ * `WeakMap` keyed on the settings object, which a fresh object per file would defeat.
+ *
+ * Reuse is safe because the object is deeply frozen, so no plugin can have mutated it.
  */
 export function initSettings(): undefined {
   debugAssertIsNonNull(settingsJSON);
+
+  if (settingsJSON === lastSettingsJSON) {
+    settings = lastSettings;
+    return;
+  }
+
   settings = JSON.parse(settingsJSON);
   // Deep freeze the settings object, to prevent any mutation of the settings from plugins
   deepFreezeJsonValue(settings);
+
+  lastSettingsJSON = settingsJSON;
+  lastSettings = settings;
 }
 
 /**
@@ -48,4 +69,16 @@ export function initSettings(): undefined {
 export function resetSettings(): undefined {
   settings = null;
   settingsJSON = null;
+}
+
+/**
+ * Discard the settings object retained for reuse.
+ *
+ * Called when switching workspaces, so that a settings object is never shared between two
+ * workspaces. Workspaces can have identical settings but different CWDs, and a plugin may derive
+ * state from `context.cwd` and cache it keyed on the settings object.
+ */
+export function resetSettingsCache(): undefined {
+  lastSettingsJSON = null;
+  lastSettings = null;
 }

--- a/apps/oxlint/src-js/plugins/workspace.ts
+++ b/apps/oxlint/src-js/plugins/workspace.ts
@@ -1,6 +1,7 @@
 import { setCwd } from "./context.ts";
 import { setRegisteredRules } from "./load.ts";
 import { setAllOptions } from "./options.ts";
+import { resetSettingsCache } from "./settings.ts";
 import {
   workspaces,
   currentWorkspace,
@@ -27,6 +28,7 @@ export function switchWorkspace(workspaceUri: string): void {
   setCwd(workspace.cwd);
   setRegisteredRules(workspace.rules);
   setAllOptions(workspace.allOptions);
+  resetSettingsCache();
 
   // Set this workspace as the current one
   setCurrentWorkspace(workspace, workspaceUri);

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -3961,6 +3961,64 @@ describe("RuleTester", () => {
       });
       expect(runCases()).toEqual([null, null]);
     });
+
+    // `Context` objects are reused across files, and `context.settings` should be too.
+    // Plugins commonly derive expensive state from settings once and cache it in a
+    // `WeakMap` keyed on the settings object. Handing out a fresh object per file
+    // silently disables that cache, and the plugin redoes the work for every file.
+    it("is the same object across files when settings are unchanged", () => {
+      const seenSettings: Readonly<object>[] = [];
+      const settingsCollectorRule: Rule = {
+        create(context) {
+          return {
+            Program() {
+              seenSettings.push(context.settings);
+            },
+          };
+        },
+      };
+
+      const tester = new RuleTester();
+      tester.run("no-foo", settingsCollectorRule, {
+        valid: [
+          { code: "a", settings: { foo: 123, nested: { bar: true } } },
+          { code: "b", settings: { foo: 123, nested: { bar: true } } },
+        ],
+        invalid: [],
+      });
+      expect(runCases()).toEqual([null, null]);
+
+      expect(seenSettings).toHaveLength(2);
+      expect(seenSettings[1]).toBe(seenSettings[0]);
+    });
+
+    it("is a different object across files when settings change", () => {
+      const seenSettings: Readonly<object>[] = [];
+      const settingsCollectorRule: Rule = {
+        create(context) {
+          return {
+            Program() {
+              seenSettings.push(context.settings);
+            },
+          };
+        },
+      };
+
+      const tester = new RuleTester();
+      tester.run("no-foo", settingsCollectorRule, {
+        valid: [
+          { code: "a", settings: { foo: 123 } },
+          { code: "b", settings: { foo: 456 } },
+        ],
+        invalid: [],
+      });
+      expect(runCases()).toEqual([null, null]);
+
+      expect(seenSettings).toHaveLength(2);
+      expect(seenSettings[1]).not.toBe(seenSettings[0]);
+      expect(seenSettings[0]).toEqual({ foo: 123 });
+      expect(seenSettings[1]).toEqual({ foo: 456 });
+    });
   });
 
   describe("`cwd` option", () => {


### PR DESCRIPTION
The two commits are meant to be read in order. The first adds a test that
reproduces the problem and fails on its own, with no production change. The
second is the fix that turns it green.

## Problem

Settings are deserialized from JSON separately for every file, so each file gets
a newly allocated object. [`settings.ts` notes this][todo]:

> TODO(perf): Settings are deserialized once per file to accommodate folder level
> settings, even if the settings haven't changed.

Besides repeating the `JSON.parse` and deep freeze, this has a second effect.
[`context.ts` documents that context objects are deliberately reused][ctx]:

> The difference is that we don't create new file context and rule context
> objects for each file, but instead reuse the same objects over and over. [...]
> This reduces pressure on garbage collector

`settings` is the exception. That matters because plugins commonly normalize
settings once and memoize the result in a `WeakMap` keyed on the settings
object. `eslint-plugin-boundaries` does this, and the pattern appears wherever
normalization is expensive. Under ESLint the key is stable: [`settings` is taken
off the resolved config][eslint] and passed by reference into the file context,
so every file under one config shares it and the work happens once. Under oxlint
the key differs per file, so the cache never hits and such a plugin
re-normalizes its whole configuration for every file.

[todo]: https://github.com/oxc-project/oxc/blob/8a47ff37439975bf279831e95492b15d411aca45/apps/oxlint/src-js/plugins/settings.ts#L26-L27
[ctx]: https://github.com/oxc-project/oxc/blob/8a47ff37439975bf279831e95492b15d411aca45/apps/oxlint/src-js/plugins/context.ts#L11-L13
[eslint]: https://github.com/eslint/eslint/blob/v10.2.0/lib/linter/linter.js#L982

## Solution

Retain the object deserialized for the previous file along with the JSON it came
from, and reuse it when the JSON is unchanged, which is the common case across a
run. Different JSON still produces a new object, so folder level settings are
unaffected.

Reuse is safe because the object is already deeply frozen, so no plugin can have
mutated it. Deserialization stays lazy (#15395), so files whose rules never read
settings still never parse.

The retained object is discarded on workspace switch, so it is never shared
between workspaces. Two workspaces can have identical settings but different
CWDs, and a plugin may derive state from `context.cwd` and cache it under the
settings key.

This is a smaller step than the direction suggested in #15395 (sending all
settings objects to JS once after parsing configs), and is compatible with it.

## Testing

Two cases added to the existing `settings` block in `rule_tester.test.ts`, which
exercises the real `lintFileImpl` path:

- unchanged settings yield the same object across files (fails before this change)
- changed settings still yield a different object, covering folder level settings

Verified that lint output is unchanged on a ~1,100 file project: identical
diagnostics, differing only in emission order between parallel runs.

I have not quoted a wall-clock figure. On the project I tested, run-to-run
variance was far larger than any effect I could attribute to this change, so I
would rather report the mechanism than a number I can't stand behind. The gain
should scale with settings size and with what plugins do with settings.

## AI assistance

Disclosed per the contributing policy: I used Claude Code on this. It profiled
the JS plugin path, identified the cause, and drafted the patch and tests. I have
reviewed and tested the result.
