### PR TITLE
fix(linter): make `extends` rule merging deterministic so aliased rule entries resolve consistently

### DIFF
--- a/crates/oxc_linter/fixtures/extends_config/aliased_rule_config.json
+++ b/crates/oxc_linter/fixtures/extends_config/aliased_rule_config.json
@@ -1,0 +1,9 @@
+{
+  "plugins": ["eslint", "typescript"],
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      { "patterns": [{ "group": ["*/internal"], "message": "from-base" }] }
+    ]
+  }
+}

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -1393,6 +1393,65 @@ mod test {
     }
 
     #[test]
+    fn test_extends_aliased_rule_overridden_regardless_of_siblings() {
+        // `no-restricted-imports` and `typescript/no-restricted-imports` resolve to the same
+        // rule. When a config extends a base that configures the rule under one name and
+        // configures it itself under the other, the extending config's options must win —
+        // regardless of which other rules are configured alongside it. The winner used to be
+        // decided by hash-map iteration order in `Oxlintrc::merge`, so an unrelated sibling
+        // rule entry could silently flip it.
+        let siblings = [
+            "",
+            r#""no-use-before-define": "off","#,
+            r#""no-shadow": "off","#,
+            r#""no-unused-vars": "off","#,
+            r#""no-redeclare": "off","#,
+            r#""eqeqeq": "off","#,
+            r#""no-var": "off","#,
+            r#""prefer-const": "off","#,
+        ];
+        for sibling in siblings {
+            let config = config_store_from_str(&format!(
+                r#"
+                {{
+                    "extends": ["fixtures/extends_config/aliased_rule_config.json"],
+                    "plugins": ["eslint", "typescript"],
+                    "rules": {{
+                        {sibling}
+                        "typescript/no-restricted-imports": [
+                            "error",
+                            {{ "paths": [{{ "name": "react-native", "message": "from-child" }}] }}
+                        ]
+                    }}
+                }}
+                "#
+            ));
+
+            let configured: Vec<_> = config
+                .rules()
+                .iter()
+                .filter(|(r, _)| r.name() == "no-restricted-imports")
+                .collect();
+            assert_eq!(
+                configured.len(),
+                1,
+                "aliased entries should collapse into one rule (sibling {sibling:?})"
+            );
+            let (rule, severity) = configured[0];
+            assert_eq!(*severity, AllowWarnDeny::Deny, "sibling {sibling:?}");
+            let debug = format!("{rule:?}");
+            assert!(
+                debug.contains("react-native"),
+                "extending config's `paths` should win (sibling {sibling:?}): {debug}"
+            );
+            assert!(
+                !debug.contains("*/internal"),
+                "base config's `patterns` should be overridden (sibling {sibling:?}): {debug}"
+            );
+        }
+    }
+
+    #[test]
     fn test_extends_invalid() {
         let invalid_config = {
             let mut external_plugin_store = ExternalPluginStore::default();

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -408,20 +408,27 @@ impl Oxlintrc {
         let mut categories = other.categories;
         categories.extend(self.categories.iter());
 
-        let rules = self
+        // Keep `other`'s rules first and `self`'s rules last, preserving each config's own
+        // ordering. Several rules can be configured under aliased names (e.g.
+        // `no-restricted-imports` and `typescript/no-restricted-imports`); such entries survive
+        // this exact-name merge as separate entries, and when they are later resolved to the same
+        // rule, the last entry wins. Ordering `self` last therefore guarantees the extending
+        // config's entry takes priority, regardless of what else is configured.
+        let self_rule_names: FxHashSet<(&str, &str)> = self
             .rules
             .rules
             .iter()
-            .chain(&other.rules.rules)
-            .fold(FxHashMap::default(), |mut rules_set, rule| {
-                if rules_set.contains_key(&(&rule.plugin_name, &rule.rule_name)) {
-                    return rules_set;
-                }
-                rules_set.insert((&rule.plugin_name, &rule.rule_name), rule);
-                rules_set
+            .map(|rule| (rule.plugin_name.as_str(), rule.rule_name.as_str()))
+            .collect();
+        let rules = other
+            .rules
+            .rules
+            .iter()
+            .filter(|rule| {
+                !self_rule_names.contains(&(rule.plugin_name.as_str(), rule.rule_name.as_str()))
             })
-            .values()
-            .map(|rule| (**rule).clone())
+            .chain(&self.rules.rules)
+            .cloned()
             .collect::<Vec<_>>();
 
         let settings = self.settings.clone();
@@ -647,6 +654,55 @@ mod test {
         let config: Result<Oxlintrc, _> =
             serde_json::from_value(json!({ "respectEslintDisableDirectives": false }));
         assert!(config.is_err());
+    }
+
+    #[test]
+    fn test_oxlintrc_merge_rules_order() {
+        // Merged rules must be deterministically ordered: `other`'s entries first, then
+        // `self`'s, each in their original order, with exact-name duplicates resolved in favor
+        // of `self`. Entries configured under aliased names (e.g. `no-restricted-imports` vs
+        // `typescript/no-restricted-imports`) are distinct at this stage and are only collapsed
+        // when rules are resolved, where the last entry wins — so `self` coming last is what
+        // makes the extending config's entry take priority.
+        let child: Oxlintrc = serde_json::from_value(json!({
+            "rules": {
+                "no-shadow": "off",
+                "typescript/no-restricted-imports": ["error", { "paths": ["a"] }],
+                "no-console": "error"
+            }
+        }))
+        .unwrap();
+        let base: Oxlintrc = serde_json::from_value(json!({
+            "rules": {
+                "no-restricted-imports": ["error", { "patterns": ["b"] }],
+                "no-console": "warn",
+                "no-debugger": "error"
+            }
+        }))
+        .unwrap();
+
+        let merged = child.merge(base);
+        let names: Vec<String> = merged
+            .rules
+            .rules
+            .iter()
+            .map(|r| format!("{}/{}", r.plugin_name, r.rule_name))
+            .collect();
+        assert_eq!(
+            names,
+            [
+                // from base, minus the exact-name duplicate `no-console`
+                "eslint/no-restricted-imports",
+                "eslint/no-debugger",
+                // from child, in its own order
+                "eslint/no-shadow",
+                "typescript/no-restricted-imports",
+                "eslint/no-console",
+            ]
+        );
+        // `self`'s entry wins for exact-name duplicates
+        let no_console = merged.rules.rules.iter().find(|r| r.rule_name == "no-console").unwrap();
+        assert_eq!(no_console.severity, AllowWarnDeny::Deny);
     }
 
     #[test]


### PR DESCRIPTION
The below diagnosis and the proposed fix were generated by Claude, but I am a human 😃 and I have reviewed the text, the attached MBE, and the fix pretty thoroughly. The TL;DR of it is that we migrated our monorepo at [Nonsense](https://www.nonsense.com/en) to Oxlint and ran into some weird gotchas related to rules being turned on and off when unrelated rules were changed, which was quite strange.

Thank you for Oxlint! It is amazingly fast and has made linting practical for us again.

## Problem

`Oxlintrc::merge` emits merged rules in `FxHashMap` iteration order. When a rule is
configured under both of its names — e.g. `no-restricted-imports` in a base config and
`typescript/no-restricted-imports` in the config that `extends` it — both entries survive
the merge, and iteration order decides which one ends up applied. The loser's options are
discarded with no diagnostic.

Because the order depends on hash bucket placement across the whole rule set, adding or
removing an **unrelated** rule elsewhere in the config can silently flip which entry wins.

## Why it happens

Two things combine, and neither is a bug on its own:

1. `Oxlintrc::merge` (`crates/oxc_linter/src/config/oxlintrc.rs`) dedupes by the *literal
   configured* `(plugin_name, rule_name)`. `no-restricted-imports` parses as
   `("eslint", …)` and `typescript/no-restricted-imports` stays `("typescript", …)`, so the
   two are different keys and **both entries survive**. The merged list is then built from
   `FxHashMap::values()` — i.e. hash order.

2. Downstream, `OxlintRules::override_rules` (`config/rules.rs`) canonicalizes
   `typescript/<adapted>` → `eslint/<rule>` via `transform_rule_and_plugin_name` /
   `is_eslint_rule_adapted_to_typescript`. Both entries therefore configure the **same**
   `RuleEnum` (whose `Hash`/`Eq` are id-only), and the final remove-then-insert loop means
   **last entry wins**.

So step 2 collapses the two entries onto one rule, and step 1 decides — arbitrarily but deterministically per key-set — which of them is last. Adding an unrelated rule changes the bucket layout and can reverse the outcome.

## Reproduction

Attached is 
[oxlint-extends-alias-repro.zip](https://github.com/user-attachments/files/30568455/oxlint-extends-alias-repro.zip), containing:

```
.oxlintrc.json        base:   no-restricted-imports            patterns: */internal
pkg/.oxlintrc.json    extends base, plus
                      typescript/no-restricted-imports         paths: Text from react-native
pkg/index.ts          violates both
```

The two configs restrict imports in different ways, under the two different names for the same rule. `pkg/index.ts` violates both, so linting it should report both errors — or, if one entry is meant to replace the other, consistently the same one every time.

```
$ npx oxlint pkg/index.ts
pkg/index.ts:2:1: error eslint(no-restricted-imports): 'some-package/internal' import is restricted from being used by a pattern. help: ROOT-PATTERN
```

Now change **one line** in `pkg/.oxlintrc.json` — `"no-shadow": "off"` to `"eqeqeq": "off"`
— and run the identical command again:

```
$ npx oxlint pkg/index.ts
pkg/index.ts:1:10: error eslint(no-restricted-imports): 'Text' import from 'react-native' is restricted. help: NESTED-PATH
```

The edited line configures an unrelated rule, it is `"off"` either way, and it restricts no imports at all — yet it decides which import restriction oxlint enforces. Only ever one of the two is reported; the other is discarded with no warning or error.

Same result on 1.75.0 (released) and on `main` @ `f9097f893d`. Substituting other rules on that line: `no-unused-vars`, `no-use-before-define` and `no-redeclare` behave like `no-shadow`; `no-var`, `prefer-const` and deleting the line behave like `eqeqeq`. That grouping isn't meaningful in itself — those names simply happen to hash into buckets that reverse the order, so any config edit can flip it.

## The fix

Order the merged rules deterministically — extended config's rules first, extending config's last, each config's own order preserved — instead of emitting `FxHashMap::values()`. The existing last-entry-wins collapse in `override_rules` then always resolves in favour of the extending config.

Exact-name overrides are unaffected (the child still wins, as before), and inheriting a rule the child does not configure is unchanged.

## Semantics chosen

oxlint models `typescript/<adapted>` rules as one rule with one slot, so "apply both entries" isn't available the way it would be in ESLint (where the core and `@typescript-eslint` rules are distinct rules that both run). The existing convention for two aliases within a *single* config is silent last-one-wins — see `test_override_plugin_prefix_duplicates`. Making the extending config's entry win is the consistent extension of that convention to `extends`.

Worth noting the entry still *replaces* rather than merges: a child configuring
`no-restricted-imports` with `paths` drops the base's `patterns`. That is existing behavior and this PR does not change it — only which entry survives, and that it is now predictable.

## Alternative considered

The merge dedup key could be canonicalized (typescript → eslint for adapted rules) so the base's aliased entry is dropped during merge. I kept the merge purely name-based to avoid leaking rule-resolution knowledge into the serde-level `Oxlintrc` type — once ordering is deterministic, the existing downstream collapse already produces the right answer.

## Possible follow-up (not in this PR)

A diagnostic when both aliases of one rule are configured with conflicting options would have been helpful to us in this case. I did not add one because the obvious form of that check would fire on a pattern oxlint deliberately supports:

```json
{ "no-unused-vars": "off", "typescript/no-unused-vars": "error" }
```

typescript-eslint documents this as required usage — "you must disable the base rule as it can report incorrect errors"
([no-unused-vars docs](https://typescript-eslint.io/rules/no-unused-vars/)) — so it arrives in any config migrated from ESLint. oxlint supports it deliberately:
`test_override_plugin_prefix_duplicates` in `config/rules.rs` asserts that exact object, and its `@typescript-eslint/` spelling, resolves to a single `no-unused-vars` at `Deny`.

## Tests

- `test_extends_aliased_rule_overridden_regardless_of_siblings` (`config/config_builder.rs`), with fixture `crates/oxc_linter/fixtures/extends_config/aliased_rule_config.json` — loops
  all eight sibling variants above and asserts the extending config's `paths` wins every time.
- `test_oxlintrc_merge_rules_order` (`config/oxlintrc.rs`) — locks the merge ordering contract: other-first/self-last, each config's order preserved, exact-name duplicates resolved to `self`.

Both fail on `main` and pass with the fix. Reverting only `oxlintrc.rs` makes the first fail on exactly the reported `"no-use-before-define"` case.

`cargo test -p oxc_linter --lib` → 1217 passed / 0 failed.
`cargo test -p oxlint` → 359 passed / 0 failed.
`cargo clippy -p oxc_linter --all-targets --all-features` with warnings denied → clean.
