### PR TITLE
fix(oxlint,oxfmt): respect `.gitignore` for walk targets and explicit paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ handlebars = "6.4.2" # Template engine
 hashbrown = { version = "0.17.1", default-features = false } # Fast hash map
 hmac-sha1-compact = "1.1.7" # Self-contained, zero-dependency SHA-1
 humansize = "2.1.3" # Human-readable sizes
-ignore = "0.4.27" # Gitignore matching
+ignore = "0.4.30" # Gitignore matching
 insta = "1.48.0" # Snapshot testing
 itertools = "0.15.0" # Iterator utilities
 itoa = "1.0.18" # Integer to string

--- a/apps/oxfmt/src/cli/walk.rs
+++ b/apps/oxfmt/src/cli/walk.rs
@@ -9,7 +9,9 @@ use ignore::gitignore::Gitignore;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::instrument;
 
-use oxc_config::{all_paths_have_vcs_boundary, configure_walk_builder, validate_glob_pattern};
+use oxc_config::{
+    GitignoreChecker, all_paths_have_vcs_boundary, configure_walk_builder, validate_glob_pattern,
+};
 use oxc_diagnostics::{DiagnosticSender, DiagnosticService, OxcDiagnostic};
 
 use super::resolve::{build_global_ignore_matchers, is_ignored};
@@ -138,17 +140,22 @@ impl ScopedWalker {
 
             let mut dirs = vec![];
             let mut files = vec![];
+            let mut gitignore_checker = GitignoreChecker::new();
             for path in &initial_targets {
                 // Base paths passed to `WalkBuilder` are not filtered by `filter_entry()`,
                 // so we need to filter them here before passing to the walker.
                 // This is needed for cases like `husky`, may specify ignored paths as staged files.
-                // NOTE: Git ignored paths are not filtered here.
-                // But it's OK because in cases like `husky`, they are never staged.
                 let Ok(metadata) = path.metadata() else { continue };
                 let is_dir = metadata.is_dir();
                 if is_ignored(&ignore_file_matchers, path, is_dir, true) {
                     continue;
                 }
+                // Also, the walker never filters gitignored walk roots.
+                // (including roots inside a gitignored directory)
+                if gitignore_checker.is_gitignored(path, &self.cwd) {
+                    continue;
+                }
+
                 if is_dir {
                     dirs.push(path.clone());
                 } else if metadata.is_file() {

--- a/apps/oxfmt/test/cli/gitignore_walk_root/0.snap.md
+++ b/apps/oxfmt/test/cli/gitignore_walk_root/0.snap.md
@@ -1,0 +1,35 @@
+# Input
+
+## Command
+```
+oxfmt --check
+```
+
+## File tree
+```
+- fixtures/
+  - sub/
+    - .gitignore
+    - generated/
+      - pkg/ <CWD>
+        - index.ts
+```
+
+# Result
+
+## Exit code
+2
+
+## stdout
+```
+Checking formatting...
+
+```
+
+## stderr
+```
+Expected at least one target file. All matched files may have been excluded by ignore rules.
+```
+
+## File changes
+No changes

--- a/apps/oxfmt/test/cli/gitignore_walk_root/1.snap.md
+++ b/apps/oxfmt/test/cli/gitignore_walk_root/1.snap.md
@@ -1,0 +1,35 @@
+# Input
+
+## Command
+```
+oxfmt --check index.ts
+```
+
+## File tree
+```
+- fixtures/
+  - sub/
+    - .gitignore
+    - generated/
+      - pkg/ <CWD>
+        - index.ts
+```
+
+# Result
+
+## Exit code
+2
+
+## stdout
+```
+Checking formatting...
+
+```
+
+## stderr
+```
+Expected at least one target file. All matched files may have been excluded by ignore rules.
+```
+
+## File changes
+No changes

--- a/apps/oxfmt/test/cli/gitignore_walk_root/2.snap.md
+++ b/apps/oxfmt/test/cli/gitignore_walk_root/2.snap.md
@@ -1,0 +1,35 @@
+# Input
+
+## Command
+```
+oxfmt --check sub/generated/pkg
+```
+
+## File tree
+```
+- fixtures/ <CWD>
+  - sub/
+    - .gitignore
+    - generated/
+      - pkg/
+        - index.ts
+```
+
+# Result
+
+## Exit code
+2
+
+## stdout
+```
+Checking formatting...
+
+```
+
+## stderr
+```
+Expected at least one target file. All matched files may have been excluded by ignore rules.
+```
+
+## File changes
+No changes

--- a/apps/oxfmt/test/cli/gitignore_walk_root/fixtures/sub/generated/pkg/index.ts
+++ b/apps/oxfmt/test/cli/gitignore_walk_root/fixtures/sub/generated/pkg/index.ts
@@ -1,0 +1,1 @@
+const answer = 42

--- a/apps/oxfmt/test/cli/gitignore_walk_root/options.json
+++ b/apps/oxfmt/test/cli/gitignore_walk_root/options.json
@@ -1,0 +1,22 @@
+[
+  {
+    "args": ["--check"],
+    "cwd": "sub/generated/pkg",
+    "gitignore": {
+      "sub/.gitignore": "generated\n"
+    }
+  },
+  {
+    "args": ["--check", "index.ts"],
+    "cwd": "sub/generated/pkg",
+    "gitignore": {
+      "sub/.gitignore": "generated\n"
+    }
+  },
+  {
+    "args": ["--check", "sub/generated/pkg"],
+    "gitignore": {
+      "sub/.gitignore": "generated\n"
+    }
+  }
+]

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -11,6 +11,7 @@ use std::{
 use cow_utils::CowUtils;
 use ignore::{gitignore::Gitignore, overrides::OverrideBuilder};
 
+use oxc_config::GitignoreChecker;
 use oxc_diagnostics::{DiagnosticSender, DiagnosticService, GraphicalReportHandler, OxcDiagnostic};
 use oxc_linter::{
     AllowWarnDeny, ConfigBuilderError, ConfigStore, ConfigStoreBuilder, ExternalLinter,
@@ -182,28 +183,35 @@ impl CliRunner {
             });
         }
 
-        if paths.is_empty() {
-            // If explicit paths were provided, but all have been
-            // filtered, return early.
-            if provided_path_count > 0 {
-                if debug_files {
-                    return crate::mode::run_debug_files(
-                        std::iter::empty::<&Path>(),
-                        &self.cwd,
-                        stdout,
-                    );
-                }
+        if paths.is_empty() && provided_path_count == 0 {
+            paths.push(self.cwd.clone());
+        }
 
-                return Self::handle_no_files_found(
+        // The walker never filters gitignored walk roots (including roots inside a gitignored directory).
+        // NOTE: Applied regardless of `--no-ignore`.
+        // Currently it only disables Oxlint's own ignore sources (`.eslintignore`, `--ignore-path`, `--ignore-pattern`),
+        // not git's. (Aligns with during walk filtering behavior)
+        let mut gitignore_checker = GitignoreChecker::new();
+        paths.retain(|p| !gitignore_checker.is_gitignored(p, &self.cwd));
+
+        // If explicit paths were provided but all have been filtered,
+        // or the default cwd target is gitignored, return early.
+        if paths.is_empty() {
+            if debug_files {
+                return crate::mode::run_debug_files(
+                    std::iter::empty::<&Path>(),
+                    &self.cwd,
                     stdout,
-                    &output_formatter,
-                    now,
-                    None,
-                    misc_options.no_error_on_unmatched_pattern,
                 );
             }
 
-            paths.push(self.cwd.clone());
+            return Self::handle_no_files_found(
+                stdout,
+                &output_formatter,
+                now,
+                None,
+                misc_options.no_error_on_unmatched_pattern,
+            );
         }
 
         let walker = Walk::new(&paths, &self.cwd, &ignore_options, override_builder);
@@ -831,6 +839,55 @@ mod test {
             "fixtures/cli/linter/nan.js",
         ];
         Tester::new().test_and_snapshot(args);
+    }
+
+    #[test]
+    // https://github.com/oxc-project/oxc/issues/25107
+    fn gitignored_walk_root() {
+        use crate::cli::CliRunResult;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path().join("repo");
+        let pkg_path = repo_path.join("sub").join("generated").join("pkg");
+        fs::create_dir_all(&pkg_path).unwrap();
+        fs::create_dir(repo_path.join(".git")).unwrap();
+        fs::write(repo_path.join("sub").join(".gitignore"), "generated\n").unwrap();
+        fs::write(pkg_path.join("index.ts"), "debugger;\n").unwrap();
+
+        // Running from inside the ignored tree finds nothing.
+        let (_, result) = Tester::new().with_cwd(pkg_path.clone()).test_output(&[]);
+        assert!(matches!(result, CliRunResult::LintNoFilesFound), "{result:?}");
+
+        // Explicitly passed gitignored targets are skipped too;
+        // `--no-ignore` only disables Oxlint's own ignore sources, not git's.
+        let (_, result) = Tester::new().with_cwd(pkg_path.clone()).test_output(&["index.ts"]);
+        assert!(matches!(result, CliRunResult::LintNoFilesFound), "{result:?}");
+        let (_, result) =
+            Tester::new().with_cwd(pkg_path).test_output(&["--no-ignore", "index.ts"]);
+        assert!(matches!(result, CliRunResult::LintNoFilesFound), "{result:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn gitignore_directory_pattern_does_not_filter_explicit_symlink() {
+        use std::os::unix::fs::symlink;
+
+        use crate::cli::CliRunResult;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path().join("repo");
+        let target = repo_path.join("target");
+
+        fs::create_dir_all(repo_path.join(".git")).unwrap();
+        fs::create_dir(&target).unwrap();
+        fs::write(target.join("index.js"), "debugger;\n").unwrap();
+        fs::write(repo_path.join(".gitignore"), "link/\n").unwrap();
+        symlink("target", repo_path.join("link")).unwrap();
+
+        let (stdout, result) =
+            Tester::new().with_cwd(repo_path).test_output(&["-D", "no-debugger", "link"]);
+        assert!(matches!(result, CliRunResult::LintFoundErrors), "{result:?}\n{stdout}");
+        assert!(stdout.contains("on 1 file"), "{stdout}");
     }
 
     #[test]

--- a/crates/oxc_config/src/lib.rs
+++ b/crates/oxc_config/src/lib.rs
@@ -10,4 +10,4 @@ pub use discovery::{
 };
 pub use glob_set::{GlobSet, validate_glob_pattern};
 pub use ignore_patterns::validate_ignore_pattern;
-pub use walk::{all_paths_have_vcs_boundary, configure_walk_builder};
+pub use walk::{GitignoreChecker, all_paths_have_vcs_boundary, configure_walk_builder};

--- a/crates/oxc_config/src/walk.rs
+++ b/crates/oxc_config/src/walk.rs
@@ -1,6 +1,9 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::hash_map::Entry,
+    path::{Path, PathBuf},
+};
 
-use ignore::WalkBuilder;
+use ignore::{IncrementalIgnore, WalkBuilder};
 use rustc_hash::FxHashMap;
 
 /// Apply `ignore::WalkBuilder` settings shared between Oxlint and Oxfmt.
@@ -8,6 +11,8 @@ use rustc_hash::FxHashMap;
 ///
 /// `has_vcs_boundary` should be the result of [`all_paths_have_vcs_boundary`] for the walk targets.
 /// Callers that build multiple walkers from the same targets can compute it once and reuse it.
+///
+/// [`GitignoreChecker`] uses these same settings for walk-root checks.
 pub fn configure_walk_builder(
     builder: &mut WalkBuilder,
     has_vcs_boundary: bool,
@@ -23,10 +28,70 @@ pub fn configure_walk_builder(
         .git_ignore(true)
         // Also look up parent directories
         .parents(true)
-        // Respect `.git/info/exclude` as well
+        // Respect `$GIT_COMMON_DIR/info/exclude` as well
         .git_exclude(true)
         // Parent `.gitignore` lookup stops at the repository boundary when targets are inside a repo
         .require_git(has_vcs_boundary)
+}
+
+/// Check whether walk target paths are gitignored, matching `git check-ignore`.
+///
+/// The `ignore` crate walker applies gitignore's "everything under an ignored directory is ignored" rule
+/// only by pruning ignored directories during traversal, and never filters its walk roots.
+/// A walk target inside an ignored directory is therefore never filtered.
+/// And a bare directory pattern like `generated` matches the directory itself, not the files below it.
+/// Use an incremental matcher rooted at the VCS (or filesystem) boundary to check targets first.
+/// See also <https://github.com/BurntSushi/ripgrep/issues/2595>.
+///
+/// NOTE: Mirrors the [`configure_walk_builder`] settings:
+/// - nested `.gitignore` files,
+/// - `$GIT_COMMON_DIR/info/exclude`,
+/// - and parent lookup stopping at the VCS boundary when one exists
+#[derive(Debug, Default)]
+pub struct GitignoreChecker {
+    /// Incremental matcher per VCS boundary (or filesystem root when no boundary exists).
+    matchers: FxHashMap<PathBuf, IncrementalIgnore>,
+    /// Whether a directory contains a `.git` or `.jj` marker.
+    vcs_roots: FxHashMap<PathBuf, bool>,
+}
+
+impl GitignoreChecker {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return `true` when `path` (or an ancestor directory below the VCS boundary) is
+    /// matched as ignored by a `.gitignore` in one of its ancestor directories.
+    ///
+    /// Directory-only patterns use the path's symlink type, matching Git's behavior.
+    /// A symlink to a directory is therefore treated as a symlink, not as a directory.
+    /// Relative paths are resolved against `cwd`.
+    pub fn is_gitignored(&mut self, path: &Path, cwd: &Path) -> bool {
+        let path = resolve_against_cwd(path, cwd);
+        let is_dir = path.symlink_metadata().is_ok_and(|metadata| metadata.is_dir());
+
+        // Match from the VCS boundary so ignored ancestors between it and the target are checked.
+        // Without a boundary, start at the filesystem root
+        // because the walker reads parent `.gitignore` files all the way up in that case.
+        let vcs_root = find_vcs_boundary(&path, &mut self.vcs_roots);
+        let has_vcs_boundary = vcs_root.is_some();
+        let root = vcs_root
+            .unwrap_or_else(|| path.ancestors().last().unwrap_or(path.as_path()))
+            .to_path_buf();
+        let Ok(relative) = path.strip_prefix(&root) else { return false };
+
+        let matcher = match self.matchers.entry(root) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let mut builder = WalkBuilder::new(entry.key());
+                configure_walk_builder(&mut builder, has_vcs_boundary);
+                let Some(matcher) = builder.build_matchers().pop() else { return false };
+                entry.insert(matcher)
+            }
+        };
+        matcher.matched(relative, is_dir).is_ignore()
+    }
 }
 
 /// Return `true` when every path is inside a Git or Jujutsu repository.
@@ -43,16 +108,27 @@ pub fn all_paths_have_vcs_boundary(paths: &[PathBuf], cwd: &Path) -> bool {
 }
 
 fn has_vcs_boundary(path: &Path, cwd: &Path, cache: &mut FxHashMap<PathBuf, bool>) -> bool {
-    let path = if path.is_absolute() { path.to_path_buf() } else { cwd.join(path) };
-    let start = if path.is_file() { path.parent().unwrap_or(&path) } else { path.as_path() };
+    let path = resolve_against_cwd(path, cwd);
+    find_vcs_boundary(&path, cache).is_some()
+}
 
-    // Cache per-directory marker presence so sibling paths reuse stat results.
-    start.ancestors().any(|dir| {
-        if let Some(&has) = cache.get(dir) {
+/// Whether `dir` contains a `.git` or `.jj` marker (directory, or file for worktrees).
+fn has_vcs_marker(dir: &Path) -> bool {
+    dir.join(".git").exists() || dir.join(".jj").exists()
+}
+
+fn resolve_against_cwd(path: &Path, cwd: &Path) -> PathBuf {
+    if path.is_absolute() { path.to_path_buf() } else { cwd.join(path) }
+}
+
+fn find_vcs_boundary<'a>(path: &'a Path, cache: &mut FxHashMap<PathBuf, bool>) -> Option<&'a Path> {
+    let start = if path.is_file() { path.parent().unwrap_or(path) } else { path };
+    start.ancestors().find(|dir| {
+        if let Some(&has) = cache.get(*dir) {
             return has;
         }
-        let has = dir.join(".git").exists() || dir.join(".jj").exists();
-        cache.insert(dir.to_path_buf(), has);
+        let has = has_vcs_marker(dir);
+        cache.insert((*dir).to_path_buf(), has);
         has
     })
 }
@@ -63,7 +139,7 @@ mod test {
 
     use ignore::WalkBuilder;
 
-    use super::{all_paths_have_vcs_boundary, configure_walk_builder};
+    use super::{GitignoreChecker, all_paths_have_vcs_boundary, configure_walk_builder};
 
     fn collect_walked_js_files(root: &Path) -> Vec<String> {
         let mut builder = WalkBuilder::new(root);
@@ -171,6 +247,131 @@ mod test {
         fs::write(repo_path.join("included.js"), "").unwrap();
 
         assert_eq!(collect_walked_js_files(&repo_path), vec!["included.js"]);
+    }
+
+    #[test]
+    fn gitignored_respects_info_exclude_in_linked_worktree() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let common_git_dir = temp_dir.path().join("main").join(".git");
+        let worktree_git_dir = common_git_dir.join("worktrees").join("linked");
+        let worktree_path = temp_dir.path().join("linked");
+
+        fs::create_dir_all(common_git_dir.join("info")).unwrap();
+        fs::create_dir_all(&worktree_git_dir).unwrap();
+        fs::create_dir(&worktree_path).unwrap();
+        fs::write(worktree_path.join(".git"), format!("gitdir: {}\n", worktree_git_dir.display()))
+            .unwrap();
+        fs::write(worktree_git_dir.join("commondir"), "../..\n").unwrap();
+        fs::write(common_git_dir.join("info").join("exclude"), "ignored.js\nignored/\n").unwrap();
+
+        let ignored_dir = worktree_path.join("ignored");
+        fs::create_dir(&ignored_dir).unwrap();
+        fs::write(worktree_path.join("ignored.js"), "").unwrap();
+        fs::write(worktree_path.join("included.js"), "").unwrap();
+
+        let mut checker = GitignoreChecker::new();
+        assert!(checker.is_gitignored(&worktree_path.join("ignored.js"), &worktree_path));
+        assert!(checker.is_gitignored(&ignored_dir, &worktree_path));
+        assert!(!checker.is_gitignored(&worktree_path.join("included.js"), &worktree_path));
+    }
+
+    #[test]
+    fn gitignored_with_bare_directory_pattern() {
+        // A bare directory pattern in a nested `.gitignore` must ignore walk
+        // targets inside that directory, matching `git check-ignore`.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path().join("repo");
+        let target = repo_path.join("sub").join("generated").join("pkg");
+
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir(repo_path.join(".git")).unwrap();
+        fs::write(repo_path.join("sub").join(".gitignore"), "generated\n").unwrap();
+
+        let mut checker = GitignoreChecker::new();
+        assert!(checker.is_gitignored(&target, &repo_path));
+        // Files inside the ignored tree are also ignored
+        assert!(checker.is_gitignored(&target.join("index.ts"), &repo_path));
+        // The ignored directory itself is also inside the ignored tree
+        assert!(checker.is_gitignored(&repo_path.join("sub").join("generated"), &repo_path));
+        // Sibling of the ignored directory is not
+        assert!(!checker.is_gitignored(&repo_path.join("sub"), &repo_path));
+    }
+
+    #[test]
+    fn gitignored_file_matched_by_own_directory_chain() {
+        // File-level patterns must apply to the file itself: both a glob form
+        // in an ancestor `.gitignore` and a pattern in the file's own directory.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path().join("repo");
+        let pkg = repo_path.join("sub").join("generated").join("pkg");
+
+        fs::create_dir_all(&pkg).unwrap();
+        fs::create_dir(repo_path.join(".git")).unwrap();
+        fs::write(repo_path.join("sub").join(".gitignore"), "generated/**\n").unwrap();
+        fs::write(pkg.join(".gitignore"), "local.ts\n").unwrap();
+
+        let mut checker = GitignoreChecker::new();
+        assert!(checker.is_gitignored(&pkg.join("index.ts"), &repo_path));
+        assert!(checker.is_gitignored(&pkg.join("local.ts"), &repo_path));
+        // A directory-only pattern must not match a file.
+        // Matchers are cached per checker, so use a fresh one after changing ignore files on disk.
+        let dist_file = repo_path.join("dist");
+        let build_dir = repo_path.join("build");
+        fs::write(&dist_file, "").unwrap();
+        fs::create_dir(&build_dir).unwrap();
+        fs::write(repo_path.join(".gitignore"), "dist/\nbuild/\n").unwrap();
+        let mut checker = GitignoreChecker::new();
+        assert!(!checker.is_gitignored(&dist_file, &repo_path));
+        assert!(checker.is_gitignored(&build_dir, &repo_path));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn gitignored_directory_pattern_does_not_match_symlink_to_directory() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path().join("repo");
+        let target = repo_path.join("target");
+        let link = repo_path.join("link");
+
+        fs::create_dir_all(repo_path.join(".git")).unwrap();
+        fs::create_dir(&target).unwrap();
+        symlink("target", &link).unwrap();
+        fs::write(repo_path.join(".gitignore"), "link/\ntarget/\n").unwrap();
+
+        let mut checker = GitignoreChecker::new();
+        assert!(!checker.is_gitignored(Path::new("link"), &repo_path));
+        assert!(checker.is_gitignored(&target, &repo_path));
+    }
+
+    #[test]
+    fn gitignored_respects_deeper_whitelist() {
+        // A deeper `.gitignore` re-including the directory takes precedence
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path().join("repo");
+        let target = repo_path.join("sub").join("generated").join("pkg");
+
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir(repo_path.join(".git")).unwrap();
+        fs::write(repo_path.join(".gitignore"), "generated\n").unwrap();
+        fs::write(repo_path.join("sub").join(".gitignore"), "!generated\n").unwrap();
+
+        assert!(!GitignoreChecker::new().is_gitignored(&target, &repo_path));
+    }
+
+    #[test]
+    fn gitignored_stops_at_vcs_boundary() {
+        // A `.gitignore` above the repository root must not apply
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path().join("sub").join("repo");
+        let target = repo_path.join("src");
+
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir(repo_path.join(".git")).unwrap();
+        fs::write(temp_dir.path().join(".gitignore"), "repo\n").unwrap();
+
+        assert!(!GitignoreChecker::new().is_gitignored(&target, &repo_path));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #25107.

The `ignore` crate walker enforces gitignore's "everything under an ignored directory is ignored" rule only by pruning ignored directories during traversal.

And it never filters its walk roots.
So when a walk target (based on cwd or an explicit CLI target path) is already inside a gitignored tree, pruning never happens and a bare directory pattern like `generated` matches nothing file-level. (even though `git check-ignore` says they are ignored)

See also BurntSushi/ripgrep#2595

### Changes

- oxc_config: added `GitignoreChecker`
  - a pre-walk check that replays git's resolution order over the ancestor chain
  - Matchers and `.git`/`.jj` probes are cached per directory
- oxlint / oxfmt: filter all CLI targets through this check before walking

### Behavior changes

- Explicitly passed gitignored files are now skipped (previously always linted/formatted)
- `oxlint --no-ignore` no longer force-lints gitignored targets
  - The same behavior as `--no-ignore` does not disable during walk `.gitignore`

<details>
<summary>FYI: Current our ignore model overview</summary>

Two independent families, AND-ed (a path excluded by any layer is skipped):

| Layer                                        | Source                                                 | oxlint                                                                                         | oxfmt                                                |
| -------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| git-derived (always on, not user-disablable) | nested `.gitignore`, `.git/info/exclude` (during walk) | walker via shared `configure_walk_builder`                                                     | same (shared)                                        |
|                                              | walk roots / explicit CLI targets                      | `GitignoreChecker` (this PR)                                                                   | `GitignoreChecker` (this PR)                         |
| tool-owned                                   | ignore file                                            | `.eslintignore` / `--ignore-path`; disabled by `--no-ignore`                                   | `.prettierignore` / `--ignore-path`; no disable flag |
|                                              | CLI patterns                                           | `--ignore-pattern`; disabled by `--no-ignore`                                                  | `!pattern` path args                                 |
|                                              | config `ignorePatterns`                                | `LintIgnoreMatcher` (already containment-correct via `matched_path_or_any_parents`); always on | scope-local `is_path_ignored` (same); always on      |

NOTE: `ignorePatterns` never had this bug, only the walker-backed gitignore layer did; this PR brings it to the same level.
A `!` negation in `ignorePatterns` cannot re-include gitignored paths (unchanged; the layers are independent).

</details>
