### PR TITLE
refactor(formatter_css,formatter_graphql,formatter_yaml): move Gap utils to core

### DIFF
--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -112,7 +112,14 @@ Parameterizing language differences (sharpened gate 2), when a shared helper nee
 
 `SourceText` follows this line. Core owns mechanical, offset-keyed access only (slicing, raw-byte lookups).
 Lexical-semantic scanning whose answer is language-defined, what counts as a newline (U+2028/U+2029), a comment, or ASI/parens trivia lives in the consumer (`oxc_formatter`'s `SourceTextExt`), not here.
-Even raw newline detection proved to be consumer-owned (every consumer needs the LS/PS-aware variant in addition to `\r|\n`), so core keeps no newline helpers.
+
+Newline-adjacent helpers split along the same line:
+
+- `spec/gap.rs` is the shared gap classifier for the CR, LF and CRLF terminator family
+  - It takes a raw `&[u8]` slice, never offsets (`SourceText` addresses), `spec/` interprets, consumers compose the two at the call site
+- Precedent for gate 2: json/js measure gaps under ECMAScript lexis (LS/PS terminators, blanks before a separator comma ignored)
+  - So they keep their own helpers instead of a parameter here
+
 Quote-style options, comment rules, and the like are likewise consumer-owned.
 
 ## Cargo features

--- a/crates/oxc_formatter_core/src/spec/gap.rs
+++ b/crates/oxc_formatter_core/src/spec/gap.rs
@@ -1,0 +1,95 @@
+//! Vertical-spacing classification of an inter-token source gap.
+//!
+//! Shared by the formatter family whose line terminators are CR, LF, or CRLF (no LS/PS).
+//! Languages whose gap semantics differ do NOT parameterize this function.
+//! They own their helper instead. (js, json)
+//!
+//! Some consumers that normalize line endings to `\n` before parsing (css, yaml)
+//! simply never exercise the CR branches;
+//! the CR handling is kept correct here for consumers that classify raw source slices (graphql).
+
+/// Vertical spacing implied by an inter-token source gap.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Gap {
+    /// Same line (no line terminator).
+    None,
+    /// One or more line breaks, but no blank line.
+    Line,
+    /// At least one blank line.
+    Blank,
+}
+
+/// Classifies the gap `slice` between two source positions.
+///
+/// A blank line is a line strictly inside the gap consisting solely of
+/// whitespace. Tokens in the gap make their line non-blank, so newline
+/// counting alone would over-report blank lines (e.g. a yaml `-` indicator or
+/// a graphql insignificant comma sitting on its own line).
+/// Recognizes `\n`, lone `\r`, and `\r\n` line terminators.
+pub fn classify_gap(slice: &[u8]) -> Gap {
+    let mut newline_count = 0;
+    let mut line_has_content = false;
+    let mut blank = false;
+    let mut i = 0;
+    while i < slice.len() {
+        match slice[i] {
+            b'\r' | b'\n' => {
+                // A line strictly between two terminators with no content is blank.
+                if newline_count > 0 && !line_has_content {
+                    blank = true;
+                }
+                newline_count += 1;
+                line_has_content = false;
+                // Collapse `\r\n` into one break.
+                if slice[i] == b'\r' && slice.get(i + 1) == Some(&b'\n') {
+                    i += 1;
+                }
+            }
+            b' ' | b'\t' => {}
+            _ => line_has_content = true,
+        }
+        i += 1;
+    }
+    if blank {
+        Gap::Blank
+    } else if newline_count > 0 {
+        Gap::Line
+    } else {
+        Gap::None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Gap, classify_gap};
+
+    // CR / CRLF cases matter for consumers that classify raw source slices
+    // (`.gitattributes` keeps CR out of fixture files, so they are pinned here).
+    #[test]
+    fn classify_gap_counts_line_terminators() {
+        assert_eq!(classify_gap(b" \t "), Gap::None);
+        assert_eq!(classify_gap(b"a"), Gap::None);
+        assert_eq!(classify_gap(b"\n"), Gap::Line);
+        assert_eq!(classify_gap(b"\n  \n"), Gap::Blank);
+        // CRLF must collapse to one break, never two (otherwise blank lines are invented).
+        assert_eq!(classify_gap(b"\r\n"), Gap::Line);
+        assert_eq!(classify_gap(b"\r\n\r\n"), Gap::Blank);
+        // Lone CR is a line terminator.
+        assert_eq!(classify_gap(b"\r"), Gap::Line);
+        assert_eq!(classify_gap(b"\r\r"), Gap::Blank);
+        // Mixed endings.
+        assert_eq!(classify_gap(b"\n\r\n"), Gap::Blank);
+    }
+
+    #[test]
+    fn classify_gap_treats_tokens_as_content() {
+        // A token on its own line (a yaml `-` indicator, the graphql `&` between
+        // two `implements` comments, an insignificant comma) is not a blank line.
+        assert_eq!(classify_gap(b"\n-\n"), Gap::Line);
+        assert_eq!(classify_gap(b"\n,\n"), Gap::Line);
+        assert_eq!(classify_gap(b",\n\n"), Gap::Blank);
+        // Content on the tail of the first or last line is not "inside" the gap.
+        assert_eq!(classify_gap(b"-\n  "), Gap::Line);
+        assert_eq!(classify_gap(b",\n  "), Gap::Line);
+    }
+}

--- a/crates/oxc_formatter_core/src/spec/mod.rs
+++ b/crates/oxc_formatter_core/src/spec/mod.rs
@@ -13,10 +13,12 @@
 //! Import discipline: files here import only `std` + `cow_utils`,
 //! never `oxc_*` crates or engine IR types via `crate::`.
 
+mod gap;
 mod number;
 pub mod string;
 mod suppression;
 
+pub use gap::{Gap, classify_gap};
 pub use number::{format_trimmed_number, is_simple_number};
 pub use string::normalize_string;
 pub use suppression::is_suppression_marker;

--- a/crates/oxc_formatter_css/src/comments.rs
+++ b/crates/oxc_formatter_css/src/comments.rs
@@ -67,51 +67,7 @@ impl<'a> Comments<'a> {
     }
 }
 
-/// Vertical spacing implied by an inter-token source gap.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Gap {
-    /// Same line (no line terminator).
-    None,
-    /// One or more line breaks, but no blank line.
-    Line,
-    /// At least one blank line.
-    Blank,
-}
-
-/// Classifies the gap `slice` between two source positions.
-///
-/// A blank line is a line strictly inside the gap consisting solely of whitespace.
-/// Recognizes `\n`, lone `\r`, and `\r\n` line terminators.
-pub fn classify_gap(slice: &[u8]) -> Gap {
-    let mut newline_count = 0;
-    let mut line_has_content = false;
-    let mut blank = false;
-    let mut i = 0;
-    while i < slice.len() {
-        match slice[i] {
-            b'\r' | b'\n' => {
-                if newline_count > 0 && !line_has_content {
-                    blank = true;
-                }
-                newline_count += 1;
-                line_has_content = false;
-                if slice[i] == b'\r' && slice.get(i + 1) == Some(&b'\n') {
-                    i += 1;
-                }
-            }
-            b' ' | b'\t' => {}
-            _ => line_has_content = true,
-        }
-        i += 1;
-    }
-    if blank {
-        Gap::Blank
-    } else if newline_count > 0 {
-        Gap::Line
-    } else {
-        Gap::None
-    }
-}
+pub use oxc_formatter_core::spec::{Gap, classify_gap};
 
 /// Emit a single comment verbatim.
 /// Mirrors Prettier's `css-comment` case: the original text slice,
@@ -250,20 +206,4 @@ pub fn is_suppression_comment(source: SourceText<'_>, comment: CssComment) -> bo
 /// the next line instead of following on the same one.
 pub fn last_line_has_inline_comment(raw: &str) -> bool {
     raw.rsplit('\n').next().unwrap_or(raw).contains("//")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{Gap, classify_gap};
-
-    #[test]
-    fn classify_gap_counts_line_terminators() {
-        assert_eq!(classify_gap(b" \t "), Gap::None);
-        assert_eq!(classify_gap(b"\n"), Gap::Line);
-        assert_eq!(classify_gap(b"\n  \n"), Gap::Blank);
-        assert_eq!(classify_gap(b"\r\n"), Gap::Line);
-        assert_eq!(classify_gap(b"\r\n\r\n"), Gap::Blank);
-        assert_eq!(classify_gap(b"\r"), Gap::Line);
-        assert_eq!(classify_gap(b"\r\r"), Gap::Blank);
-    }
 }

--- a/crates/oxc_formatter_graphql/AGENTS.md
+++ b/crates/oxc_formatter_graphql/AGENTS.md
@@ -111,8 +111,8 @@ Run `clippy` and resolve all warnings.
 Snapshot tests driven by fixture files under `tests/fixtures/graphql/`,
 covering what the Prettier conformance suite does not (suppression, string re-encoding, comment positions, extensions, ... — see the file names).
 `build.rs` auto-generates a test case from every `.graphql` file using the core `test_support` harness.
-Unit tests in `tests/fixtures/mod.rs` cover parse-error `Err` semantics and BOM preservation;
-`src/comments.rs` has `classify_gap` tests (CR / CRLF endings, which `.gitattributes` keeps out of fixture files).
+
+Unit tests in `tests/fixtures/mod.rs` cover parse-error `Err` semantics and BOM preservation.
 
 ```sh
 cargo test -p oxc_formatter_graphql

--- a/crates/oxc_formatter_graphql/Cargo.toml
+++ b/crates/oxc_formatter_graphql/Cargo.toml
@@ -35,3 +35,4 @@ oxc_formatter_core = { workspace = true, features = ["test_harness"] }
 
 [lib]
 doctest = false
+test = false

--- a/crates/oxc_formatter_graphql/src/comments.rs
+++ b/crates/oxc_formatter_graphql/src/comments.rs
@@ -13,6 +13,11 @@ use oxc_span::Span;
 
 use crate::print::{GraphqlFormatter, format_with};
 
+/// Comma note (why token-sensitivity matters for GraphQL):
+/// Prettier's `isNextLineEmpty` skips commas only on the current line's tail,
+/// so an insignificant comma-only line still counts as content (`a\n,\nb` has no blank line).
+pub use oxc_formatter_core::spec::{Gap, classify_gap};
+
 /// Cursor over a sorted comment-span list that hands out unprinted slices in span order.
 ///
 /// GraphQL comments are always single-line (`# ...` to end of line).
@@ -57,58 +62,6 @@ impl<'a> Comments<'a> {
     pub fn iter_before(&self, upper_bound: u32) -> impl Iterator<Item = Span> {
         let start = self.cursor.get();
         self.inner[start..].iter().copied().take_while(move |c| c.end <= upper_bound)
-    }
-}
-
-/// Vertical spacing implied by an inter-token source gap.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Gap {
-    /// Same line (no line terminator).
-    None,
-    /// One or more line breaks, but no blank line.
-    Line,
-    /// At least one blank line.
-    Blank,
-}
-
-/// Classifies the gap `slice` between two source positions.
-///
-/// A blank line is a line strictly inside the gap consisting solely of whitespace.
-/// Tokens in the gap make their line non-blank, so newline counting alone would
-/// over-report blank lines. This includes insignificant commas: Prettier's
-/// `isNextLineEmpty` skips commas only on the current line's tail, so a comma-only
-/// line still counts as content (`a\n,\nb` has no blank line).
-/// Recognizes GraphQL line terminators: `\n`, lone `\r`, `\r\n`.
-pub fn classify_gap(slice: &[u8]) -> Gap {
-    let mut newline_count = 0;
-    let mut line_has_content = false;
-    let mut blank = false;
-    let mut i = 0;
-    while i < slice.len() {
-        match slice[i] {
-            b'\r' | b'\n' => {
-                // A line strictly between two terminators with no content is blank.
-                if newline_count > 0 && !line_has_content {
-                    blank = true;
-                }
-                newline_count += 1;
-                line_has_content = false;
-                // Collapse `\r\n` into one break.
-                if slice[i] == b'\r' && slice.get(i + 1) == Some(&b'\n') {
-                    i += 1;
-                }
-            }
-            b' ' | b'\t' => {}
-            _ => line_has_content = true,
-        }
-        i += 1;
-    }
-    if blank {
-        Gap::Blank
-    } else if newline_count > 0 {
-        Gap::Line
-    } else {
-        Gap::None
     }
 }
 
@@ -331,41 +284,4 @@ pub fn write_suppressed_node(span: Span, f: &mut GraphqlFormatter<'_, '_>) {
     // The verbatim text already includes inside-span comments;
     // advance the cursor so they aren't re-emitted later.
     let _ = f.context().comments().take_before(span.end);
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{Gap, classify_gap};
-
-    // Whitebox coverage of `classify_gap`'s line-terminator handling.
-    // End-to-end CRLF behavior of the suppress path is covered by the
-    // `tests/fixtures/graphql/crlf/` fixtures.
-    #[test]
-    fn classify_gap_counts_line_terminators() {
-        assert_eq!(classify_gap(b" \t "), Gap::None);
-        assert_eq!(classify_gap(b"a"), Gap::None);
-        assert_eq!(classify_gap(b"\n"), Gap::Line);
-        assert_eq!(classify_gap(b"\n  \n"), Gap::Blank);
-        // CRLF must collapse to one break, never two (otherwise blank lines are invented).
-        assert_eq!(classify_gap(b"\r\n"), Gap::Line);
-        assert_eq!(classify_gap(b"\r\n\r\n"), Gap::Blank);
-        // Lone CR is a GraphQL line terminator.
-        assert_eq!(classify_gap(b"\r"), Gap::Line);
-        assert_eq!(classify_gap(b"\r\r"), Gap::Blank);
-        // Mixed endings.
-        assert_eq!(classify_gap(b"\n\r\n"), Gap::Blank);
-    }
-
-    #[test]
-    fn classify_gap_treats_tokens_as_content() {
-        // A token on its own line (e.g. the `&` between two `implements` comments)
-        // is not a blank line.
-        assert_eq!(classify_gap(b"\n&\n"), Gap::Line);
-        // Comma-only lines count as content too (mirrors Prettier's `isNextLineEmpty`,
-        // which skips commas only on the current line's tail).
-        assert_eq!(classify_gap(b"\n,\n"), Gap::Line);
-        assert_eq!(classify_gap(b",\n\n"), Gap::Blank);
-        // Content on the tail of the first or last line is not "inside" the gap.
-        assert_eq!(classify_gap(b",\n  "), Gap::Line);
-    }
 }

--- a/crates/oxc_formatter_yaml/src/comments.rs
+++ b/crates/oxc_formatter_yaml/src/comments.rs
@@ -81,57 +81,7 @@ impl<'a> Comments<'a> {
     }
 }
 
-/// Vertical spacing implied by an inter-token source gap.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Gap {
-    /// Same line (no line terminator).
-    None,
-    /// One or more line breaks, but no blank line.
-    Line,
-    /// At least one blank line.
-    Blank,
-}
-
-/// Classifies the gap `slice` between two source positions.
-///
-/// A blank line is a line strictly inside the gap consisting solely of whitespace.
-/// Tokens in the gap make their line non-blank,
-/// so newline counting alone would over-report blank lines (e.g. an indicator such as `-` sitting on its own line).
-///
-/// The source is normalized to `\n` before parsing (see `format()`),
-/// but the CR-handling is kept so the helper stays correct on raw slices in tests.
-pub fn classify_gap(slice: &[u8]) -> Gap {
-    let mut newline_count = 0;
-    let mut line_has_content = false;
-    let mut blank = false;
-    let mut i = 0;
-    while i < slice.len() {
-        match slice[i] {
-            b'\r' | b'\n' => {
-                // A line strictly between two terminators with no content is blank.
-                if newline_count > 0 && !line_has_content {
-                    blank = true;
-                }
-                newline_count += 1;
-                line_has_content = false;
-                // Collapse `\r\n` into one break.
-                if slice[i] == b'\r' && slice.get(i + 1) == Some(&b'\n') {
-                    i += 1;
-                }
-            }
-            b' ' | b'\t' => {}
-            _ => line_has_content = true,
-        }
-        i += 1;
-    }
-    if blank {
-        Gap::Blank
-    } else if newline_count > 0 {
-        Gap::Line
-    } else {
-        Gap::None
-    }
-}
+pub use oxc_formatter_core::spec::{Gap, classify_gap};
 
 /// `true` when the source between `from` and `to` holds nothing but whitespace and comments
 /// (every line blank or `#`-only after indentation).
@@ -355,28 +305,5 @@ pub fn flush_container_end_comments(
         });
         write!(f, align(align_width, &inner));
         prev_end = span.end;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{Gap, classify_gap};
-
-    #[test]
-    fn classify_gap_counts_line_terminators() {
-        assert_eq!(classify_gap(b" \t "), Gap::None);
-        assert_eq!(classify_gap(b"a"), Gap::None);
-        assert_eq!(classify_gap(b"\n"), Gap::Line);
-        assert_eq!(classify_gap(b"\n  \n"), Gap::Blank);
-        assert_eq!(classify_gap(b"\r\n"), Gap::Line);
-        assert_eq!(classify_gap(b"\r\n\r\n"), Gap::Blank);
-    }
-
-    #[test]
-    fn classify_gap_treats_tokens_as_content() {
-        // An indicator on its own line (e.g. `-` of a sequence item) is not a blank line.
-        assert_eq!(classify_gap(b"\n-\n"), Gap::Line);
-        // Content on the tail of the first or last line is not "inside" the gap.
-        assert_eq!(classify_gap(b"-\n  "), Gap::Line);
     }
 }


### PR DESCRIPTION
CSS, GraphQL, YAML formatters had the same logic to inspect source blank lines.