### PR TITLE
refactor(formatter_core): add `CoreFormatOptions` and `FormatOptions::apply_core`

### DIFF
--- a/apps/oxfmt/src/core/options/to_core_options.rs
+++ b/apps/oxfmt/src/core/options/to_core_options.rs
@@ -1,18 +1,8 @@
-use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
+use oxc_formatter_core::{CoreFormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth};
 
 use super::super::oxfmtrc::{EndOfLineConfig, FormatConfig};
 
-/// Language-neutral core formatting options shared by every formatter.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct CoreOptions {
-    pub indent_style: IndentStyle,
-    pub indent_width: IndentWidth,
-    pub line_width: LineWidth,
-    pub line_ending: LineEnding,
-}
-
-/// Convert the language-neutral core options shared by every formatter into a
-/// validated [`CoreOptions`].
+/// Convert the language-neutral core options shared by every formatter into a validated [`CoreFormatOptions`].
 ///
 /// This is the single source of truth for core-option parsing, validation, and default fallbacks.
 /// Each downstream converter ([`super::to_oxc_formatter()`], [`super::to_oxc_toml()`], etc) layers
@@ -21,8 +11,8 @@ pub struct CoreOptions {
 ///
 /// # Errors
 /// Returns an error if `tabWidth` or `printWidth` is out of range.
-pub fn to_core_options(config: &FormatConfig) -> Result<CoreOptions, String> {
-    let mut options = CoreOptions::default();
+pub fn to_core_options(config: &FormatConfig) -> Result<CoreFormatOptions, String> {
+    let mut options = CoreFormatOptions::default();
 
     // [Prettier] useTabs: boolean
     if let Some(use_tabs) = config.use_tabs {

--- a/apps/oxfmt/src/core/options/to_oxc_formatter.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter.rs
@@ -1,5 +1,7 @@
 use rustc_hash::FxHashSet;
 
+use oxc_formatter_core::FormatOptions;
+
 use oxc_formatter::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, CommentLineStrategy,
     CustomGroupDefinition, EmbeddedLanguageFormatting, Expand, GroupEntry, ImportModifier,
@@ -25,13 +27,8 @@ use super::{
 pub fn to_oxc_formatter(config: &FormatConfig) -> Result<JsFormatOptions, String> {
     let core = to_core_options(config)?;
 
-    let mut format_options = JsFormatOptions {
-        indent_style: core.indent_style,
-        indent_width: core.indent_width,
-        line_width: core.line_width,
-        line_ending: core.line_ending,
-        ..JsFormatOptions::default()
-    };
+    let mut format_options = JsFormatOptions::default();
+    format_options.apply_core(core);
 
     // NOTE: Not yet supported options:
     // [Prettier] experimentalOperatorPosition: "start" | "end"

--- a/apps/oxfmt/src/core/options/to_oxc_formatter_css.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter_css.rs
@@ -1,3 +1,4 @@
+use oxc_formatter_core::FormatOptions;
 use oxc_formatter_css::{CssFormatOptions, CssVariant, SingleQuote, TrailingCommas};
 
 use super::{
@@ -18,14 +19,8 @@ pub fn to_oxc_formatter_css(
 ) -> Result<CssFormatOptions, String> {
     let core = to_core_options(config)?;
 
-    let mut options = CssFormatOptions {
-        indent_style: core.indent_style,
-        indent_width: core.indent_width,
-        line_width: core.line_width,
-        line_ending: core.line_ending,
-        variant,
-        ..CssFormatOptions::default()
-    };
+    let mut options = CssFormatOptions { variant, ..CssFormatOptions::default() };
+    options.apply_core(core);
 
     // [Prettier] singleQuote: boolean
     if let Some(single_quote) = config.single_quote {

--- a/apps/oxfmt/src/core/options/to_oxc_formatter_graphql.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter_graphql.rs
@@ -1,3 +1,4 @@
+use oxc_formatter_core::FormatOptions;
 use oxc_formatter_graphql::{BracketSpacing, GraphqlFormatOptions};
 
 use super::{super::oxfmtrc::FormatConfig, to_core_options::to_core_options};
@@ -11,13 +12,8 @@ use super::{super::oxfmtrc::FormatConfig, to_core_options::to_core_options};
 pub fn to_oxc_formatter_graphql(config: &FormatConfig) -> Result<GraphqlFormatOptions, String> {
     let core = to_core_options(config)?;
 
-    let mut options = GraphqlFormatOptions {
-        indent_style: core.indent_style,
-        indent_width: core.indent_width,
-        line_width: core.line_width,
-        line_ending: core.line_ending,
-        ..GraphqlFormatOptions::default()
-    };
+    let mut options = GraphqlFormatOptions::default();
+    options.apply_core(core);
 
     // [Prettier] bracketSpacing: boolean
     if let Some(spacing) = config.bracket_spacing {

--- a/apps/oxfmt/src/core/options/to_oxc_formatter_json.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter_json.rs
@@ -1,3 +1,4 @@
+use oxc_formatter_core::FormatOptions;
 use oxc_formatter_json::{
     BracketSpacing, Expand, JsonFormatOptions, JsonVariant, QuoteProps, TrailingCommas,
 };
@@ -22,14 +23,8 @@ pub fn to_oxc_formatter_json(
 ) -> Result<JsonFormatOptions, String> {
     let core = to_core_options(config)?;
 
-    let mut options = JsonFormatOptions {
-        variant,
-        indent_style: core.indent_style,
-        indent_width: core.indent_width,
-        line_width: core.line_width,
-        line_ending: core.line_ending,
-        ..JsonFormatOptions::default()
-    };
+    let mut options = JsonFormatOptions { variant, ..JsonFormatOptions::default() };
+    options.apply_core(core);
 
     // [Prettier] trailingComma: "all" | "es5" | "none"
     if let Some(commas) = config.trailing_comma {

--- a/apps/oxfmt/src/core/options/to_oxc_formatter_yaml.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter_yaml.rs
@@ -1,3 +1,4 @@
+use oxc_formatter_core::FormatOptions;
 use oxc_formatter_yaml::{
     BracketSpacing, ProseWrap, SingleQuote, TrailingCommas, YamlFormatOptions,
 };
@@ -17,13 +18,8 @@ use super::{
 pub fn to_oxc_formatter_yaml(config: &FormatConfig) -> Result<YamlFormatOptions, String> {
     let core = to_core_options(config)?;
 
-    let mut options = YamlFormatOptions {
-        indent_style: core.indent_style,
-        indent_width: core.indent_width,
-        line_width: core.line_width,
-        line_ending: core.line_ending,
-        ..YamlFormatOptions::default()
-    };
+    let mut options = YamlFormatOptions::default();
+    options.apply_core(core);
 
     // [Prettier] proseWrap: "preserve" | "always" | "never"
     if let Some(prose_wrap) = config.prose_wrap {

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -1,12 +1,11 @@
 use std::{fmt, str::FromStr};
 
-use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
+use oxc_formatter_core::{CoreFormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth};
 
 use crate::{
     formatter::{
         Buffer, Format, JsFormatContext, JsFormatter,
         prelude::{if_group_breaks, token},
-        printer::PrinterOptions,
     },
     ir_transform::options::SortImportsOptions,
     write,
@@ -199,34 +198,6 @@ pub struct SortTailwindcssOptions {
     pub preserve_whitespace: bool,
 }
 
-impl JsFormatOptions {
-    pub fn new() -> Self {
-        Self {
-            indent_style: IndentStyle::default(),
-            indent_width: IndentWidth::default(),
-            line_ending: LineEnding::default(),
-            line_width: LineWidth::default(),
-            quote_style: QuoteStyle::default(),
-            jsx_quote_style: QuoteStyle::default(),
-            quote_properties: QuoteProperties::default(),
-            trailing_commas: TrailingCommas::default(),
-            semicolons: Semicolons::default(),
-            arrow_parentheses: ArrowParentheses::default(),
-            bracket_spacing: BracketSpacing::default(),
-            bracket_same_line: BracketSameLine::default(),
-            attribute_position: AttributePosition::default(),
-            expand: Expand::default(),
-            experimental_operator_position: OperatorPosition::default(),
-            experimental_ternaries: false,
-            html_whitespace_sensitivity_ignore: false,
-            embedded_language_formatting: EmbeddedLanguageFormatting::default(),
-            sort_imports: None,
-            sort_tailwindcss: None,
-            jsdoc: None,
-        }
-    }
-}
-
 impl oxc_formatter_core::FormatOptions for JsFormatOptions {
     fn indent_style(&self) -> IndentStyle {
         self.indent_style
@@ -244,12 +215,11 @@ impl oxc_formatter_core::FormatOptions for JsFormatOptions {
         self.line_ending
     }
 
-    fn as_print_options(&self) -> PrinterOptions {
-        PrinterOptions::default()
-            .with_indent_style(self.indent_style)
-            .with_indent_width(self.indent_width)
-            .with_print_width(self.line_width.into())
-            .with_line_ending(self.line_ending)
+    fn apply_core(&mut self, core: CoreFormatOptions) {
+        self.indent_style = core.indent_style;
+        self.indent_width = core.indent_width;
+        self.line_width = core.line_width;
+        self.line_ending = core.line_ending;
     }
 }
 

--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -55,8 +55,11 @@ The core is parameterized over a consumer-supplied context so it stays language-
 - `FormatContext` trait: no lifetime parameter
   - (avoids `oxc_allocator`'s `'ast` propagating through struct bounds and blocking anonymous lifetimes)
   - The allocator lives on `FormatState`, not the context
-- `FormatOptions` trait: `indent_style()`, `indent_width()`, `line_width()`, `line_ending()`, `as_print_options() -> PrinterOptions`
+- `FormatOptions` trait: `indent_style()`, `indent_width()`, `line_width()`, `line_ending()`, `apply_core(CoreFormatOptions)`;
+  - `as_print_options() -> PrinterOptions` is provided from the getters
   - Core option types: `IndentStyle`, `IndentWidth`, `LineWidth`, `LineEnding` (exactly the `PrinterOptions` inputs; see the boundary section below)
+  - `CoreFormatOptions`: the four bundled, for handing them across a host boundary (config resolver → language options) in one piece;
+    - `apply_core` is the write half of the trait's read-only getters
 - `Format<'ast, C>` trait + `FormatState<'ast, C>`, `Formatted<'ast, C>`, `Formatter<'buf, 'ast, C>`, `Buffer<'ast, C>`
   - All generic over the context `C`, consumers add a `C` bound only on `impl` blocks
   - Not on struct definitions, and typically define a `type FooFormatter<…> = Formatter<…, FooContext<…>>` alias to keep lifetimes aligned

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -61,7 +61,7 @@ pub use formatted::Formatted;
 pub use formatter::{Formatter, arena_cow_str};
 pub use group_id::{GroupId, UniqueGroupIdBuilder};
 pub use options::{
-    IndentStyle, IndentWidth, IndentWidthFromIntError, LineEnding, LineWidth,
+    CoreFormatOptions, IndentStyle, IndentWidth, IndentWidthFromIntError, LineEnding, LineWidth,
     LineWidthFromIntError, ParseFormatNumberError,
 };
 pub use printer::{PrintResult, PrintWidth, Printed, Printer, PrinterOptions};

--- a/crates/oxc_formatter_core/src/options.rs
+++ b/crates/oxc_formatter_core/src/options.rs
@@ -295,3 +295,40 @@ impl From<LineWidth> for u16 {
         value.0
     }
 }
+
+/// The language-neutral core of every language's format options:
+/// the four fields shared by all formatters, i.e. exactly the getters of [`crate::FormatOptions`].
+///
+/// Lets a host hand the shared options across an options boundary in one piece
+/// (see [`crate::FormatOptions::apply_core`]) instead of fanning the four fields out by hand.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub struct CoreFormatOptions {
+    pub indent_style: IndentStyle,
+    pub indent_width: IndentWidth,
+    pub line_width: LineWidth,
+    pub line_ending: LineEnding,
+}
+
+/// The bundle is also the minimal `FormatOptions` on its own
+/// (used by `SimpleFormatContext` for tests and debug rendering).
+impl crate::FormatOptions for CoreFormatOptions {
+    fn indent_style(&self) -> IndentStyle {
+        self.indent_style
+    }
+
+    fn indent_width(&self) -> IndentWidth {
+        self.indent_width
+    }
+
+    fn line_width(&self) -> LineWidth {
+        self.line_width
+    }
+
+    fn line_ending(&self) -> LineEnding {
+        self.line_ending
+    }
+
+    fn apply_core(&mut self, core: CoreFormatOptions) {
+        *self = core;
+    }
+}

--- a/crates/oxc_formatter_core/src/simple_context.rs
+++ b/crates/oxc_formatter_core/src/simple_context.rs
@@ -1,11 +1,9 @@
-use crate::{
-    FormatContext, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions,
-};
+use crate::{CoreFormatOptions, FormatContext};
 
 /// Simple format context useful for testing.
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct SimpleFormatContext<'src> {
-    options: SimpleFormatOptions,
+    options: CoreFormatOptions,
     source_code: &'src str,
     tailwind_classes: Vec<String>,
 }
@@ -25,7 +23,7 @@ impl<'src> SimpleFormatContext<'src> {
 }
 
 impl FormatContext for SimpleFormatContext<'_> {
-    type Options = SimpleFormatOptions;
+    type Options = CoreFormatOptions;
 
     fn options(&self) -> &Self::Options {
         &self.options
@@ -37,39 +35,5 @@ impl FormatContext for SimpleFormatContext<'_> {
 
     fn get_tailwind_class(&self, idx: usize) -> Option<&str> {
         self.tailwind_classes.get(idx).map(String::as_str)
-    }
-}
-
-#[derive(Debug, Default, Eq, PartialEq, Clone)]
-pub struct SimpleFormatOptions {
-    pub indent_style: IndentStyle,
-    pub indent_width: IndentWidth,
-    pub line_width: LineWidth,
-    pub line_ending: LineEnding,
-}
-
-impl FormatOptions for SimpleFormatOptions {
-    fn indent_style(&self) -> IndentStyle {
-        self.indent_style
-    }
-
-    fn indent_width(&self) -> IndentWidth {
-        self.indent_width
-    }
-
-    fn line_width(&self) -> LineWidth {
-        self.line_width
-    }
-
-    fn line_ending(&self) -> LineEnding {
-        self.line_ending
-    }
-
-    fn as_print_options(&self) -> PrinterOptions {
-        PrinterOptions::default()
-            .with_indent_style(self.indent_style)
-            .with_indent_width(self.indent_width)
-            .with_line_ending(self.line_ending)
-            .with_print_width(self.line_width.into())
     }
 }

--- a/crates/oxc_formatter_core/src/traits.rs
+++ b/crates/oxc_formatter_core/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::{IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions};
+use crate::{CoreFormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions};
 
 /// Language-agnostic formatting context trait.
 ///
@@ -47,5 +47,15 @@ pub trait FormatOptions {
     fn line_ending(&self) -> LineEnding;
 
     /// Convert to printer options.
-    fn as_print_options(&self) -> PrinterOptions;
+    fn as_print_options(&self) -> PrinterOptions {
+        PrinterOptions::default()
+            .with_indent_style(self.indent_style())
+            .with_indent_width(self.indent_width())
+            .with_line_ending(self.line_ending())
+            .with_print_width(self.line_width().into())
+    }
+
+    /// Overwrite the four core options with `core`'s values,
+    /// leaving language-specific options untouched.
+    fn apply_core(&mut self, core: CoreFormatOptions);
 }

--- a/crates/oxc_formatter_css/src/options.rs
+++ b/crates/oxc_formatter_css/src/options.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use cow_utils::CowUtils;
 
 use oxc_formatter_core::{
-    FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions,
+    CoreFormatOptions, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth,
 };
 
 /// CSS dialect variant.
@@ -150,11 +150,10 @@ impl FormatOptions for CssFormatOptions {
         self.line_ending
     }
 
-    fn as_print_options(&self) -> PrinterOptions {
-        PrinterOptions::default()
-            .with_indent_style(self.indent_style)
-            .with_indent_width(self.indent_width)
-            .with_line_ending(self.line_ending)
-            .with_print_width(self.line_width.into())
+    fn apply_core(&mut self, core: CoreFormatOptions) {
+        self.indent_style = core.indent_style;
+        self.indent_width = core.indent_width;
+        self.line_width = core.line_width;
+        self.line_ending = core.line_ending;
     }
 }

--- a/crates/oxc_formatter_graphql/src/options.rs
+++ b/crates/oxc_formatter_graphql/src/options.rs
@@ -1,5 +1,5 @@
 use oxc_formatter_core::{
-    FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions,
+    CoreFormatOptions, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth,
 };
 
 /// Format options for GraphQL.
@@ -56,11 +56,10 @@ impl FormatOptions for GraphqlFormatOptions {
         self.line_ending
     }
 
-    fn as_print_options(&self) -> PrinterOptions {
-        PrinterOptions::default()
-            .with_indent_style(self.indent_style)
-            .with_indent_width(self.indent_width)
-            .with_line_ending(self.line_ending)
-            .with_print_width(self.line_width.into())
+    fn apply_core(&mut self, core: CoreFormatOptions) {
+        self.indent_style = core.indent_style;
+        self.indent_width = core.indent_width;
+        self.line_width = core.line_width;
+        self.line_ending = core.line_ending;
     }
 }

--- a/crates/oxc_formatter_json/src/options.rs
+++ b/crates/oxc_formatter_json/src/options.rs
@@ -1,5 +1,5 @@
 use oxc_formatter_core::{
-    FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions,
+    CoreFormatOptions, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth,
 };
 
 /// JSON parser variant.
@@ -204,11 +204,10 @@ impl FormatOptions for JsonFormatOptions {
         self.line_ending
     }
 
-    fn as_print_options(&self) -> PrinterOptions {
-        PrinterOptions::default()
-            .with_indent_style(self.indent_style)
-            .with_indent_width(self.indent_width)
-            .with_line_ending(self.line_ending)
-            .with_print_width(self.line_width.into())
+    fn apply_core(&mut self, core: CoreFormatOptions) {
+        self.indent_style = core.indent_style;
+        self.indent_width = core.indent_width;
+        self.line_width = core.line_width;
+        self.line_ending = core.line_ending;
     }
 }

--- a/crates/oxc_formatter_yaml/src/options.rs
+++ b/crates/oxc_formatter_yaml/src/options.rs
@@ -1,5 +1,5 @@
 use oxc_formatter_core::{
-    FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions,
+    CoreFormatOptions, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth,
 };
 
 /// Format options for YAML.
@@ -111,11 +111,10 @@ impl FormatOptions for YamlFormatOptions {
         self.line_ending
     }
 
-    fn as_print_options(&self) -> PrinterOptions {
-        PrinterOptions::default()
-            .with_indent_style(self.indent_style)
-            .with_indent_width(self.indent_width)
-            .with_line_ending(self.line_ending)
-            .with_print_width(self.line_width.into())
+    fn apply_core(&mut self, core: CoreFormatOptions) {
+        self.indent_style = core.indent_style;
+        self.indent_width = core.indent_width;
+        self.line_width = core.line_width;
+        self.line_ending = core.line_ending;
     }
 }

--- a/tasks/prettier_conformance/src/jsdoc.rs
+++ b/tasks/prettier_conformance/src/jsdoc.rs
@@ -292,8 +292,7 @@ impl JsdocTestRunner {
             return None;
         }
 
-        // Use printWidth=80 to match Prettier's default (oxfmt defaults to 100)
-        let width = line_width_override.unwrap_or(80);
+        let width = line_width_override.unwrap_or(crate::PRETTIER_DEFAULT_LINE_WIDTH);
         let options = JsFormatOptions {
             line_width: LineWidth::try_from(width).unwrap(),
             quote_style,

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -5,6 +5,10 @@ pub mod jsdoc;
 pub mod options;
 mod spec;
 
+/// Prettier's default `printWidth` (oxfmt defaults to 100);
+/// every runner in this crate formats at Prettier's default so outputs are comparable.
+pub(crate) const PRETTIER_DEFAULT_LINE_WIDTH: u16 = 80;
+
 use std::{
     fmt::Write,
     path::{Path, PathBuf},

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -10,7 +10,9 @@ use oxc_formatter::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, Expand, JsFormatOptions,
     OperatorPosition, QuoteProperties, QuoteStyle, Semicolons, TrailingCommas,
 };
-use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
+use oxc_formatter_core::{
+    CoreFormatOptions, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth,
+};
 use oxc_formatter_css::{CssFormatOptions, CssVariant};
 use oxc_formatter_graphql::GraphqlFormatOptions;
 use oxc_formatter_json::{JsonFormatOptions, JsonVariant, QuoteProps};
@@ -151,13 +153,14 @@ impl VisitMut<'_> for SpecParser {
             return;
         }
 
-        let mut js_options = JsFormatOptions {
-            // Use Prettier's default printWidth(80) instead of our default(100)
-            line_width: LineWidth::try_from(80).unwrap(),
+        // The four core options are collected once here and applied to the
+        // selected language's options via `apply_core` after parsing.
+        let mut core_options = CoreFormatOptions {
+            line_width: LineWidth::try_from(crate::PRETTIER_DEFAULT_LINE_WIDTH).unwrap(),
             ..Default::default()
         };
+        let mut js_options = JsFormatOptions::default();
         let mut json_options = JsonFormatOptions {
-            line_width: LineWidth::try_from(80).unwrap(),
             variant: match self.language {
                 TestLanguage::Jsonc => JsonVariant::Jsonc,
                 TestLanguage::Json5 => JsonVariant::Json5,
@@ -166,12 +169,8 @@ impl VisitMut<'_> for SpecParser {
             },
             ..Default::default()
         };
-        let mut graphql_options = GraphqlFormatOptions {
-            line_width: LineWidth::try_from(80).unwrap(),
-            ..Default::default()
-        };
+        let mut graphql_options = GraphqlFormatOptions::default();
         let mut css_options = CssFormatOptions {
-            line_width: LineWidth::try_from(80).unwrap(),
             variant: match self.language {
                 TestLanguage::Scss => CssVariant::Scss,
                 TestLanguage::Less => CssVariant::Less,
@@ -179,10 +178,7 @@ impl VisitMut<'_> for SpecParser {
             },
             ..Default::default()
         };
-        let mut yaml_options = YamlFormatOptions {
-            line_width: LineWidth::try_from(80).unwrap(),
-            ..Default::default()
-        };
+        let mut yaml_options = YamlFormatOptions::default();
 
         // Get options
         if let Some(Argument::ObjectExpression(obj_expr)) = expr.arguments.get(2) {
@@ -224,16 +220,11 @@ impl VisitMut<'_> for SpecParser {
                                     QuoteStyle::Double
                                 };
                             } else if name == "useTabs" {
-                                let style = if literal.value {
+                                core_options.indent_style = if literal.value {
                                     IndentStyle::Tab
                                 } else {
                                     IndentStyle::Space
                                 };
-                                js_options.indent_style = style;
-                                json_options.indent_style = style;
-                                graphql_options.indent_style = style;
-                                css_options.indent_style = style;
-                                yaml_options.indent_style = style;
                             } else if name == "experimentalTernaries" {
                                 js_options.experimental_ternaries = literal.value;
                             } else if name == "singleAttributePerLine" {
@@ -247,20 +238,12 @@ impl VisitMut<'_> for SpecParser {
                         #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
                         Expression::NumericLiteral(literal) => match name.as_ref() {
                             "printWidth" => {
-                                let width = LineWidth::try_from(literal.value as u16).unwrap();
-                                js_options.line_width = width;
-                                json_options.line_width = width;
-                                graphql_options.line_width = width;
-                                css_options.line_width = width;
-                                yaml_options.line_width = width;
+                                core_options.line_width =
+                                    LineWidth::try_from(literal.value as u16).unwrap();
                             }
                             "tabWidth" => {
-                                let w = IndentWidth::try_from(literal.value as u8).unwrap();
-                                js_options.indent_width = w;
-                                json_options.indent_width = w;
-                                graphql_options.indent_width = w;
-                                css_options.indent_width = w;
-                                yaml_options.indent_width = w;
+                                core_options.indent_width =
+                                    IndentWidth::try_from(literal.value as u8).unwrap();
                             }
                             _ => {}
                         },
@@ -288,12 +271,8 @@ impl VisitMut<'_> for SpecParser {
                                 }
                                 "endOfLine" => {
                                     // TODO: change `unwrap_or_default` to `unwrap`
-                                    let ending = LineEnding::from_str(s).unwrap_or_default();
-                                    js_options.line_ending = ending;
-                                    json_options.line_ending = ending;
-                                    graphql_options.line_ending = ending;
-                                    css_options.line_ending = ending;
-                                    yaml_options.line_ending = ending;
+                                    core_options.line_ending =
+                                        LineEnding::from_str(s).unwrap_or_default();
                                 }
                                 "proseWrap" => {
                                     yaml_options.prose_wrap = match s {
@@ -369,13 +348,26 @@ impl VisitMut<'_> for SpecParser {
             TestLanguage::Json
             | TestLanguage::Jsonc
             | TestLanguage::Json5
-            | TestLanguage::JsonStringify => SpecOptions::Json(json_options),
-            TestLanguage::Graphql => SpecOptions::Graphql(graphql_options),
+            | TestLanguage::JsonStringify => {
+                json_options.apply_core(core_options);
+                SpecOptions::Json(json_options)
+            }
+            TestLanguage::Graphql => {
+                graphql_options.apply_core(core_options);
+                SpecOptions::Graphql(graphql_options)
+            }
             TestLanguage::Css | TestLanguage::Scss | TestLanguage::Less => {
+                css_options.apply_core(core_options);
                 SpecOptions::Css(css_options)
             }
-            TestLanguage::Yaml => SpecOptions::Yaml(yaml_options),
-            TestLanguage::Js | TestLanguage::Ts => SpecOptions::Js(Box::new(js_options)),
+            TestLanguage::Yaml => {
+                yaml_options.apply_core(core_options);
+                SpecOptions::Yaml(yaml_options)
+            }
+            TestLanguage::Js | TestLanguage::Ts => {
+                js_options.apply_core(core_options);
+                SpecOptions::Js(Box::new(js_options))
+            }
         };
         self.calls.push((options, snapshot_options));
     }


### PR DESCRIPTION
These common, core format options:

- LineEnding
- LineWidth
- IndentWidth
- IndentStyle

should be defined in core, and to be shared.