### PR TITLE
refactor(formatter_core): export `apply_core_options` for tests

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter/tests/fixtures/mod.rs
@@ -5,9 +5,8 @@ use oxc_formatter::{
     ArrowParentheses, BracketSameLine, BracketSpacing, JsFormatOptions, JsdocOptions,
     QuoteProperties, QuoteStyle, Semicolons, TrailingCommas,
 };
-use oxc_formatter_core::{
-    IndentStyle, IndentWidth, LineEnding, LineWidth,
-    test_support::{FixtureFormatter, OptionSet, build_fixture_snapshot},
+use oxc_formatter_core::test_support::{
+    FixtureFormatter, OptionSet, apply_core_options, build_fixture_snapshot,
 };
 use oxc_span::SourceType;
 
@@ -23,6 +22,7 @@ impl FixtureFormatter for JsHarness {
 
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = JsFormatOptions::default();
+        apply_core_options(&mut options, json);
 
         for (key, value) in json {
             match key.as_str() {
@@ -63,26 +63,6 @@ impl FixtureFormatter for JsHarness {
                         };
                     }
                 }
-                "printWidth" => {
-                    if let Some(n) = value.as_u64()
-                        && let Ok(width) = LineWidth::try_from(u16::try_from(n).unwrap())
-                    {
-                        options.line_width = width;
-                    }
-                }
-                "tabWidth" => {
-                    if let Some(n) = value.as_u64()
-                        && let Ok(width) = IndentWidth::try_from(u8::try_from(n).unwrap())
-                    {
-                        options.indent_width = width;
-                    }
-                }
-                "useTabs" => {
-                    if let Some(b) = value.as_bool() {
-                        options.indent_style =
-                            if b { IndentStyle::Tab } else { IndentStyle::Space };
-                    }
-                }
                 "bracketSpacing" => {
                     if let Some(b) = value.as_bool() {
                         options.bracket_spacing = BracketSpacing::from(b);
@@ -91,16 +71,6 @@ impl FixtureFormatter for JsHarness {
                 "bracketSameLine" | "jsxBracketSameLine" => {
                     if let Some(b) = value.as_bool() {
                         options.bracket_same_line = BracketSameLine::from(b);
-                    }
-                }
-                "endOfLine" => {
-                    if let Some(s) = value.as_str() {
-                        options.line_ending = match s {
-                            "lf" => LineEnding::Lf,
-                            "crlf" => LineEnding::Crlf,
-                            "cr" => LineEnding::Cr,
-                            _ => LineEnding::default(),
-                        };
                     }
                 }
                 "quoteProps" => {

--- a/crates/oxc_formatter_core/src/test_support/harness.rs
+++ b/crates/oxc_formatter_core/src/test_support/harness.rs
@@ -17,10 +17,67 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::LineWidth;
+use crate::{CoreFormatOptions, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth};
 
 /// A single `options.json` entry: a JSON object of per-test format options.
 pub type OptionSet = serde_json::Map<String, serde_json::Value>;
+
+/// Applies the four core options from a fixture `OptionSet` onto `options`.
+///
+/// Covers `printWidth` / `tabWidth` / `useTabs` / `endOfLine`;
+/// language-specific keys are the caller's [`FixtureFormatter::parse_options`].
+/// Fixture files are hand-authored, so parsing is lenient: unknown or invalid
+/// values are ignored. Values already set on `options` survive when the
+/// `OptionSet` doesn't mention their key (the current values seed the bundle).
+pub fn apply_core_options<O: FormatOptions>(options: &mut O, json: &OptionSet) {
+    let mut core = CoreFormatOptions {
+        indent_style: options.indent_style(),
+        indent_width: options.indent_width(),
+        line_width: options.line_width(),
+        line_ending: options.line_ending(),
+    };
+
+    for (key, value) in json {
+        match key.as_str() {
+            "printWidth" => {
+                if let Some(width) = value
+                    .as_u64()
+                    .and_then(|n| u16::try_from(n).ok())
+                    .and_then(|n| LineWidth::try_from(n).ok())
+                {
+                    core.line_width = width;
+                }
+            }
+            "tabWidth" => {
+                if let Some(width) = value
+                    .as_u64()
+                    .and_then(|n| u8::try_from(n).ok())
+                    .and_then(|n| IndentWidth::try_from(n).ok())
+                {
+                    core.indent_width = width;
+                }
+            }
+            "useTabs" => {
+                if let Some(b) = value.as_bool() {
+                    core.indent_style = if b { IndentStyle::Tab } else { IndentStyle::Space };
+                }
+            }
+            "endOfLine" => {
+                if let Some(s) = value.as_str() {
+                    core.line_ending = match s {
+                        "lf" => LineEnding::Lf,
+                        "crlf" => LineEnding::Crlf,
+                        "cr" => LineEnding::Cr,
+                        _ => LineEnding::default(),
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
+
+    options.apply_core(core);
+}
 
 /// Per-language hook for the fixture harness.
 pub trait FixtureFormatter {

--- a/crates/oxc_formatter_core/src/test_support/mod.rs
+++ b/crates/oxc_formatter_core/src/test_support/mod.rs
@@ -10,6 +10,6 @@ mod harness;
 
 pub use codegen::{GenerateConfig, generate_tests};
 pub use harness::{
-    FixtureFormatter, FixtureSnapshot, OptionSet, build_fixture_snapshot, format_options_display,
-    resolve_options,
+    FixtureFormatter, FixtureSnapshot, OptionSet, apply_core_options, build_fixture_snapshot,
+    format_options_display, resolve_options,
 };

--- a/crates/oxc_formatter_css/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_css/tests/fixtures/mod.rs
@@ -6,9 +6,8 @@
 use std::path::Path;
 
 use oxc_allocator::{Allocator, ArenaVec};
-use oxc_formatter_core::{
-    IndentStyle, IndentWidth, LineEnding, LineWidth,
-    test_support::{FixtureFormatter, OptionSet, build_fixture_snapshot},
+use oxc_formatter_core::test_support::{
+    FixtureFormatter, OptionSet, apply_core_options, build_fixture_snapshot,
 };
 use oxc_formatter_css::{CssFormatOptions, CssVariant, format};
 
@@ -19,39 +18,10 @@ impl FixtureFormatter for CssHarness {
 
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = CssFormatOptions::default();
+        apply_core_options(&mut options, json);
 
         for (key, value) in json {
             match key.as_str() {
-                "printWidth" => {
-                    if let Some(n) = value.as_u64()
-                        && let Ok(width) = LineWidth::try_from(u16::try_from(n).unwrap())
-                    {
-                        options.line_width = width;
-                    }
-                }
-                "tabWidth" => {
-                    if let Some(n) = value.as_u64()
-                        && let Ok(width) = IndentWidth::try_from(u8::try_from(n).unwrap())
-                    {
-                        options.indent_width = width;
-                    }
-                }
-                "useTabs" => {
-                    if let Some(b) = value.as_bool() {
-                        options.indent_style =
-                            if b { IndentStyle::Tab } else { IndentStyle::Space };
-                    }
-                }
-                "endOfLine" => {
-                    if let Some(s) = value.as_str() {
-                        options.line_ending = match s {
-                            "lf" => LineEnding::Lf,
-                            "crlf" => LineEnding::Crlf,
-                            "cr" => LineEnding::Cr,
-                            _ => LineEnding::default(),
-                        };
-                    }
-                }
                 "singleQuote" => {
                     if let Some(b) = value.as_bool() {
                         options.single_quote = b.into();

--- a/crates/oxc_formatter_graphql/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_graphql/tests/fixtures/mod.rs
@@ -1,9 +1,8 @@
 use std::path::Path;
 
 use oxc_allocator::Allocator;
-use oxc_formatter_core::{
-    IndentStyle, IndentWidth, LineEnding, LineWidth,
-    test_support::{FixtureFormatter, OptionSet, build_fixture_snapshot},
+use oxc_formatter_core::test_support::{
+    FixtureFormatter, OptionSet, apply_core_options, build_fixture_snapshot,
 };
 use oxc_formatter_graphql::{GraphqlFormatOptions, format};
 
@@ -14,45 +13,13 @@ impl FixtureFormatter for GraphqlHarness {
 
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = GraphqlFormatOptions::default();
+        apply_core_options(&mut options, json);
 
         for (key, value) in json {
-            match key.as_str() {
-                "printWidth" => {
-                    if let Some(n) = value.as_u64()
-                        && let Ok(width) = LineWidth::try_from(u16::try_from(n).unwrap())
-                    {
-                        options.line_width = width;
-                    }
-                }
-                "tabWidth" => {
-                    if let Some(n) = value.as_u64()
-                        && let Ok(width) = IndentWidth::try_from(u8::try_from(n).unwrap())
-                    {
-                        options.indent_width = width;
-                    }
-                }
-                "useTabs" => {
-                    if let Some(b) = value.as_bool() {
-                        options.indent_style =
-                            if b { IndentStyle::Tab } else { IndentStyle::Space };
-                    }
-                }
-                "endOfLine" => {
-                    if let Some(s) = value.as_str() {
-                        options.line_ending = match s {
-                            "lf" => LineEnding::Lf,
-                            "crlf" => LineEnding::Crlf,
-                            "cr" => LineEnding::Cr,
-                            _ => LineEnding::default(),
-                        };
-                    }
-                }
-                "bracketSpacing" => {
-                    if let Some(b) = value.as_bool() {
-                        options.bracket_spacing = b.into();
-                    }
-                }
-                _ => {}
+            if key.as_str() == "bracketSpacing"
+                && let Some(b) = value.as_bool()
+            {
+                options.bracket_spacing = b.into();
             }
         }
 

--- a/crates/oxc_formatter_json/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_json/tests/fixtures/mod.rs
@@ -1,9 +1,8 @@
 use std::path::Path;
 
 use oxc_allocator::Allocator;
-use oxc_formatter_core::{
-    IndentStyle, IndentWidth, LineEnding, LineWidth,
-    test_support::{FixtureFormatter, OptionSet, build_fixture_snapshot},
+use oxc_formatter_core::test_support::{
+    FixtureFormatter, OptionSet, apply_core_options, build_fixture_snapshot,
 };
 use oxc_formatter_json::{
     BracketSpacing, Expand, JsonFormatOptions, JsonVariant, QuoteProps, TrailingCommas, format,
@@ -16,39 +15,10 @@ impl FixtureFormatter for JsonHarness {
 
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = JsonFormatOptions::default();
+        apply_core_options(&mut options, json);
 
         for (key, value) in json {
             match key.as_str() {
-                "printWidth" => {
-                    if let Some(n) = value.as_u64()
-                        && let Ok(width) = LineWidth::try_from(u16::try_from(n).unwrap())
-                    {
-                        options.line_width = width;
-                    }
-                }
-                "tabWidth" => {
-                    if let Some(n) = value.as_u64()
-                        && let Ok(width) = IndentWidth::try_from(u8::try_from(n).unwrap())
-                    {
-                        options.indent_width = width;
-                    }
-                }
-                "useTabs" => {
-                    if let Some(b) = value.as_bool() {
-                        options.indent_style =
-                            if b { IndentStyle::Tab } else { IndentStyle::Space };
-                    }
-                }
-                "endOfLine" => {
-                    if let Some(s) = value.as_str() {
-                        options.line_ending = match s {
-                            "lf" => LineEnding::Lf,
-                            "crlf" => LineEnding::Crlf,
-                            "cr" => LineEnding::Cr,
-                            _ => LineEnding::default(),
-                        };
-                    }
-                }
                 "variant" => {
                     if let Some(s) = value.as_str() {
                         options.variant = match s {

--- a/crates/oxc_formatter_yaml/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_yaml/tests/fixtures/mod.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 
 use oxc_allocator::Allocator;
 use oxc_formatter_core::{
-    IndentStyle, IndentWidth, LineEnding, LineWidth,
-    test_support::{FixtureFormatter, OptionSet, build_fixture_snapshot},
+    LineEnding,
+    test_support::{FixtureFormatter, OptionSet, apply_core_options, build_fixture_snapshot},
 };
 use oxc_formatter_yaml::{ProseWrap, YamlFormatOptions, format};
 
@@ -14,39 +14,10 @@ impl FixtureFormatter for YamlHarness {
 
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = YamlFormatOptions::default();
+        apply_core_options(&mut options, json);
 
         for (key, value) in json {
             match key.as_str() {
-                "printWidth" => {
-                    if let Some(n) = value.as_u64()
-                        && let Ok(width) = LineWidth::try_from(u16::try_from(n).unwrap())
-                    {
-                        options.line_width = width;
-                    }
-                }
-                "tabWidth" => {
-                    if let Some(n) = value.as_u64()
-                        && let Ok(width) = IndentWidth::try_from(u8::try_from(n).unwrap())
-                    {
-                        options.indent_width = width;
-                    }
-                }
-                "useTabs" => {
-                    if let Some(b) = value.as_bool() {
-                        options.indent_style =
-                            if b { IndentStyle::Tab } else { IndentStyle::Space };
-                    }
-                }
-                "endOfLine" => {
-                    if let Some(s) = value.as_str() {
-                        options.line_ending = match s {
-                            "lf" => LineEnding::Lf,
-                            "crlf" => LineEnding::Crlf,
-                            "cr" => LineEnding::Cr,
-                            _ => LineEnding::default(),
-                        };
-                    }
-                }
                 "proseWrap" => {
                     if let Some(s) = value.as_str() {
                         options.prose_wrap = match s {


### PR DESCRIPTION
The same as #25138, for fixture tests.