### PR TITLE
refactor(formatter): drop `oxc_formatter_core` re-export

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -5,13 +5,14 @@ use std::mem::transmute;
 
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
+use oxc_formatter_core::Format;
 use oxc_span::GetSpan;
 use oxc_str::Ident;
 use oxc_syntax::node::NodeId;
 
 use crate::ast_nodes::AstNode;
 use crate::formatter::{
-    Format, JsFormatter,
+    JsFormatter,
     trivia::{format_leading_comments, format_trailing_comments},
 };
 

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -3,12 +3,13 @@
 
 #![expect(clippy::match_same_arms)]
 use oxc_ast::ast::*;
+use oxc_formatter_core::Format;
 use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::AstNode,
     formatter::{
-        Format, JsFormatContext, JsFormatter, JsFormatterExt as _,
+        JsFormatContext, JsFormatter, JsFormatterExt as _,
         trivia::{format_leading_comments, format_trailing_comments},
     },
     parentheses::NeedsParentheses,

--- a/crates/oxc_formatter/src/external_formatter.rs
+++ b/crates/oxc_formatter/src/external_formatter.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
 use oxc_allocator::Allocator;
-use oxc_formatter_core::{DispatchResult, EmbeddedContext, FormatDispatcher};
-
-use super::formatter::UniqueGroupIdBuilder;
+use oxc_formatter_core::{DispatchResult, EmbeddedContext, FormatDispatcher, UniqueGroupIdBuilder};
 
 /// Callback function type for formatting embedded code.
 /// Takes (tag_name, code) and returns formatted code or an error.

--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -98,9 +98,8 @@
 //! - [Prettier handles special comments](https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/comments/handle-comments.js)
 //! - [Prettier pre-processes comments](https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/main/comments/attach.js)
 use oxc_ast::{Comment, CommentContent};
+use oxc_formatter_core::SourceText;
 use oxc_span::{GetSpan, Span};
-
-use crate::formatter::SourceText;
 
 /// Snapshot of the comment processing state for speculative formatting.
 ///

--- a/crates/oxc_formatter/src/formatter/context.rs
+++ b/crates/oxc_formatter/src/formatter/context.rs
@@ -1,14 +1,13 @@
 use std::mem;
 
 use oxc_ast::Comment;
+use oxc_formatter_core::{FormatElement, SourceText};
 use oxc_span::{GetSpan, SourceType, Span};
 use rustc_hash::FxHashMap;
 
-use crate::{
-    external_formatter::ExternalCallbacks, formatter::FormatElement, options::JsFormatOptions,
-};
+use crate::{external_formatter::ExternalCallbacks, options::JsFormatOptions};
 
-use super::{Comments, SourceText};
+use super::Comments;
 
 /// Entry in the Tailwind context stack, tracking whether we're inside a Tailwind class context.
 #[derive(Clone, Copy, Debug)]

--- a/crates/oxc_formatter/src/formatter/formatter_js.rs
+++ b/crates/oxc_formatter/src/formatter/formatter_js.rs
@@ -5,15 +5,16 @@
 //! the JS-specific operations are exposed via the [`JsFormatter`] type alias and an
 //! extension trait that is blanket-implemented for the alias.
 
+use oxc_formatter_core::{
+    Buffer, Format, FormatElements, Formatter, GroupId, SourceText, UniqueGroupIdBuilder,
+};
 use oxc_span::{GetSpan, Span};
 
 use crate::source_text::SourceTextExt as _;
 
 use crate::formatter::{
-    Buffer, Comments, Format, Formatter, GroupId, JsFormatContext, SourceText,
-    UniqueGroupIdBuilder,
+    Comments, JsFormatContext,
     builders::{JoinNodesBuilder, Line, Space},
-    format_element::FormatElements,
     prelude::{hard_line_break, soft_line_break_or_space, space, token},
 };
 

--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -27,37 +27,13 @@ pub mod separated;
 pub mod token;
 pub mod trivia;
 
-/// Re-export of the core printer module so it can still be reached
-/// via `crate::formatter::printer` from existing call-sites.
-pub mod printer {
-    pub use oxc_formatter_core::printer::*;
-}
-
-/// Re-export of the core format element module so it can still be reached
-/// via `crate::formatter::format_element` from existing call-sites.
-pub mod format_element {
-    pub use oxc_formatter_core::format_element::*;
-}
-
-/// Re-export of the core buffer module so it can still be reached
-/// via `crate::formatter::buffer` from existing call-sites.
-pub mod buffer {
-    pub use oxc_formatter_core::buffer::*;
-}
-
-pub use oxc_formatter_core::{
-    Argument, Arguments, Buffer, BufferExtensions, Format, FormatElement, FormatOptions,
-    FormatState, Formatted, Formatter, GroupId, MemoizeFormat, Memoized, ScratchBuffer, SourceText,
-    UniqueGroupIdBuilder, VecBuffer,
-};
-
 pub use self::builders::JoinBuilderJsExt;
 pub use self::comments::Comments;
 pub use self::{
     context::{JsFormatContext, TailwindContextEntry},
     formatter_js::{JsFormatter, JsFormatterExt},
 };
-use oxc_formatter_core::Document;
+use oxc_formatter_core::{Arguments, Buffer as _, Document, FormatState, Formatted, VecBuffer};
 
 /// The `format` function takes an [`Arguments`] struct and returns the resulting formatting IR.
 ///

--- a/crates/oxc_formatter/src/formatter/prelude.rs
+++ b/crates/oxc_formatter/src/formatter/prelude.rs
@@ -1,12 +1,14 @@
-pub use super::{Buffer as _, BufferExtensions, Format, Format as _, FormatOptions as _};
 pub use super::{
-    Formatter, JoinBuilderJsExt as _, JsFormatContext, JsFormatter, JsFormatterExt as _,
-    MemoizeFormat, Memoized,
+    JoinBuilderJsExt as _, JsFormatContext, JsFormatter, JsFormatterExt as _,
     builders::*,
+    trivia::{format_dangling_comments, format_leading_comments},
+};
+pub use crate::source_text::SourceTextExt as _;
+pub use oxc_formatter_core::{
+    Buffer as _, BufferExtensions, Format, Format as _, FormatOptions as _, Formatter,
+    MemoizeFormat, Memoized,
     format_element::{
         tag::{LabelId, Tag, TagKind},
         *,
     },
-    trivia::{format_dangling_comments, format_leading_comments},
 };
-pub use crate::source_text::SourceTextExt as _;

--- a/crates/oxc_formatter/src/formatter/separated.rs
+++ b/crates/oxc_formatter/src/formatter/separated.rs
@@ -1,16 +1,15 @@
 use std::ops::Deref;
 
+use oxc_formatter_core::{Format, GroupId};
 use oxc_span::{GetSpan, Span};
 
 use crate::{
     formatter::{
-        Format, JsFormatContext, JsFormatter,
+        JsFormatContext, JsFormatter,
         prelude::{group, if_group_breaks},
     },
     options::TrailingSeparator,
 };
-
-use super::GroupId;
 
 /// Formats a single element inside a separated list.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/oxc_formatter/src/formatter/token/number.rs
+++ b/crates/oxc_formatter/src/formatter/token/number.rs
@@ -1,7 +1,7 @@
 use oxc_formatter_core::arena_cow_str;
 pub use oxc_formatter_core::spec::{format_trimmed_number, is_simple_number};
 
-use crate::formatter::{Format, JsFormatter, prelude::*};
+use crate::formatter::{JsFormatter, prelude::*};
 
 pub fn format_number_token(
     text: &str,

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -7,16 +7,14 @@ mod sortable_imports;
 mod source_line;
 
 use oxc_allocator::{Allocator, ArenaVec};
+use oxc_formatter_core::format_element::{
+    FormatElement, LineMode,
+    tag::{LabelId, Tag},
+};
 
 use crate::{
     Buffer, JsLabels, SortImportsOptions,
-    formatter::{
-        JsFormatter,
-        format_element::{
-            FormatElement, LineMode,
-            tag::{LabelId, Tag},
-        },
-    },
+    formatter::JsFormatter,
     ir_transform::sort_imports::{
         group_matcher::GroupMatcher, partitioned_chunk::PartitionedChunk, source_line::SourceLine,
     },

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/partitioned_chunk.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/partitioned_chunk.rs
@@ -1,12 +1,11 @@
-use crate::{
-    formatter::format_element::LineMode,
-    ir_transform::sort_imports::{
-        compute_metadata::compute_import_metadata,
-        group_matcher::GroupMatcher,
-        options::SortImportsOptions,
-        sortable_imports::{SortSortableImports, SortableImport},
-        source_line::SourceLine,
-    },
+use oxc_formatter_core::format_element::LineMode;
+
+use crate::ir_transform::sort_imports::{
+    compute_metadata::compute_import_metadata,
+    group_matcher::GroupMatcher,
+    options::SortImportsOptions,
+    sortable_imports::{SortSortableImports, SortableImport},
+    source_line::SourceLine,
 };
 
 /// Orphan content (comments/empty lines separated by empty line from the next import).

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
@@ -1,14 +1,12 @@
 use std::ops::Range;
 
 use oxc_allocator::ArenaVec;
-
-use crate::{
-    JsLabels,
-    formatter::format_element::{
-        FormatElement, LineMode,
-        tag::{LabelId, Tag},
-    },
+use oxc_formatter_core::format_element::{
+    FormatElement, LineMode,
+    tag::{LabelId, Tag},
 };
+
+use crate::JsLabels;
 
 #[derive(Debug)]
 pub enum SourceLine<'a> {

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -17,6 +17,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::Comment;
 use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
+use oxc_formatter_core::Formatted;
 use oxc_parser::{ParseOptions, Parser, ParserReturn};
 use oxc_span::SourceType;
 
@@ -41,9 +42,8 @@ pub use detect_code_removal::detect_code_removal;
 pub(crate) use oxc_formatter_core::{best_fitting, format_args, write};
 // Internal-only re-exports so crate-local `use crate::{Buffer, Format};` continues to work
 // without leaking these IR primitives in the public API.
-pub(crate) use crate::formatter::{Buffer, Format};
+pub(crate) use oxc_formatter_core::{Buffer, Format};
 
-use self::formatter::Formatted;
 use self::formatter::prelude::tag::Label;
 use crate::print::{FormatFunctionParams, FormatTypeParameters};
 
@@ -256,7 +256,7 @@ fn format_node<'a, F: Format<'a, JsFormatContext<'a>>>(
     formatter::format(
         context,
         allocator,
-        formatter::Arguments::new(&[formatter::Argument::new(node)]),
+        oxc_formatter_core::Arguments::new(&[oxc_formatter_core::Argument::new(node)]),
     )
 }
 

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -1,10 +1,12 @@
 use std::{fmt, str::FromStr};
 
-use oxc_formatter_core::{CoreFormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth};
+use oxc_formatter_core::{
+    Buffer, CoreFormatOptions, Format, IndentStyle, IndentWidth, LineEnding, LineWidth,
+};
 
 use crate::{
     formatter::{
-        Buffer, Format, JsFormatContext, JsFormatter,
+        JsFormatContext, JsFormatter,
         prelude::{if_group_breaks, token},
     },
     ir_transform::options::SortImportsOptions,

--- a/crates/oxc_formatter/src/print/array_element_list.rs
+++ b/crates/oxc_formatter/src/print/array_element_list.rs
@@ -1,12 +1,13 @@
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
+use oxc_formatter_core::{Buffer, Format, GroupId};
 use oxc_span::GetSpan;
 
 use crate::{
     FormatTrailingCommas,
     ast_nodes::AstNode,
     formatter::{
-        Buffer, Format, GroupId, JsFormatContext, JsFormatter,
+        JsFormatContext, JsFormatter,
         prelude::*,
         separated::FormatSeparatedIter,
         trivia::{DanglingIndentMode, FormatDanglingComments},

--- a/crates/oxc_formatter/src/print/array_expression.rs
+++ b/crates/oxc_formatter/src/print/array_expression.rs
@@ -1,11 +1,8 @@
 use oxc_ast::ast::*;
+use oxc_formatter_core::Buffer;
 use oxc_span::GetSpan;
 
-use crate::{
-    ast_nodes::AstNode,
-    formatter::{Buffer, prelude::*},
-    write,
-};
+use crate::{ast_nodes::AstNode, formatter::prelude::*, write};
 
 use super::array_element_list::ArrayElementList;
 

--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -1,13 +1,11 @@
 use oxc_ast::ast::*;
+use oxc_formatter_core::{Buffer, Format, RemoveSoftLinesBuffer, SourceText};
 use oxc_span::{GetSpan, Span};
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
-    formatter::{
-        Buffer, Format, JsFormatContext, JsFormatter, SourceText, buffer::RemoveSoftLinesBuffer,
-        prelude::*, trivia::FormatTrailingComments,
-    },
+    formatter::{JsFormatContext, JsFormatter, prelude::*, trivia::FormatTrailingComments},
     options::FormatTrailingCommas,
     print::function::FormatContentWithCacheMode,
     utils::{

--- a/crates/oxc_formatter/src/print/assignment_pattern_property_list.rs
+++ b/crates/oxc_formatter/src/print/assignment_pattern_property_list.rs
@@ -1,10 +1,11 @@
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
+use oxc_formatter_core::Format;
 use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::{AstNode, AstNodeIterator},
-    formatter::{Format, JsFormatContext, JsFormatter, JsFormatterExt as _},
+    formatter::{JsFormatContext, JsFormatter, JsFormatterExt as _},
     options::{FormatTrailingCommas, TrailingSeparator},
 };
 

--- a/crates/oxc_formatter/src/print/binding_property_list.rs
+++ b/crates/oxc_formatter/src/print/binding_property_list.rs
@@ -1,10 +1,11 @@
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
+use oxc_formatter_core::Format;
 use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::{AstNode, AstNodeIterator},
-    formatter::{Format, JsFormatContext, JsFormatter, JsFormatterExt as _},
+    formatter::{JsFormatContext, JsFormatter, JsFormatterExt as _},
     options::{FormatTrailingCommas, TrailingSeparator},
 };
 

--- a/crates/oxc_formatter/src/print/block_statement.rs
+++ b/crates/oxc_formatter/src/print/block_statement.rs
@@ -1,11 +1,12 @@
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
+use oxc_formatter_core::Buffer;
 
 use super::FormatWrite;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
-    formatter::{Buffer, prelude::*},
+    formatter::prelude::*,
     write,
 };
 

--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -1,5 +1,6 @@
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
+use oxc_formatter_core::{FormatElement, RemoveSoftLinesBuffer, SourceText, format_element};
 use oxc_span::GetSpan;
 
 use crate::{
@@ -7,10 +8,7 @@ use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{
-        Comments, FormatElement, JoinBuilderJsExt as _, JsFormatContext, JsFormatter,
-        JsFormatterExt as _, SourceText,
-        buffer::RemoveSoftLinesBuffer,
-        format_element,
+        Comments, JoinBuilderJsExt as _, JsFormatContext, JsFormatter, JsFormatterExt as _,
         prelude::{
             FormatElements, best_fitting_variant, empty_line, expand_parent, format_once,
             format_with, group, soft_block_indent, soft_line_break_or_space, space,

--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -2,6 +2,7 @@ use std::ops::Deref;
 
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
+use oxc_formatter_core::Buffer;
 use oxc_span::GetSpan;
 
 use crate::{
@@ -9,7 +10,6 @@ use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{
-        Buffer,
         prelude::*,
         separated::FormatSeparatedIter,
         trivia::{FormatLeadingComments, FormatTrailingComments},

--- a/crates/oxc_formatter/src/print/fragment.rs
+++ b/crates/oxc_formatter/src/print/fragment.rs
@@ -1,9 +1,10 @@
 use oxc_ast::ast::*;
+use oxc_formatter_core::Format;
 
 use crate::{
     ast_nodes::AstNode,
     format_args,
-    formatter::{Format, JsFormatter, prelude::*, trivia::format_dangling_comments},
+    formatter::{JsFormatter, prelude::*, trivia::format_dangling_comments},
     options::TrailingSeparator,
     write,
 };

--- a/crates/oxc_formatter/src/print/function.rs
+++ b/crates/oxc_formatter/src/print/function.rs
@@ -1,6 +1,7 @@
 use std::ops::Deref;
 
 use oxc_ast::ast::*;
+use oxc_formatter_core::Buffer;
 
 use super::{
     FormatWrite,
@@ -10,7 +11,7 @@ use super::{
 use crate::{
     ast_nodes::AstNode,
     format_args,
-    formatter::{Buffer, prelude::*, trivia::FormatLeadingComments},
+    formatter::{prelude::*, trivia::FormatLeadingComments},
     print::semicolon::OptionalSemicolon,
     write,
 };

--- a/crates/oxc_formatter/src/print/jsx/child_list.rs
+++ b/crates/oxc_formatter/src/print/jsx/child_list.rs
@@ -1,12 +1,13 @@
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
+use oxc_formatter_core::{Buffer, FormatElement, ScratchBuffer};
 use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::AstNode,
     format_args,
     formatter::{
-        Buffer, Comments, FormatElement, JsFormatContext, ScratchBuffer,
+        Comments, JsFormatContext,
         prelude::{tag::GroupMode, *},
     },
     utils::{

--- a/crates/oxc_formatter/src/print/member_expression.rs
+++ b/crates/oxc_formatter/src/print/member_expression.rs
@@ -1,11 +1,12 @@
 use oxc_ast::ast::*;
+use oxc_formatter_core::{Buffer, Format};
 use oxc_span::GetSpan;
 
 use crate::{
     JsLabels,
     ast_nodes::{AstNode, AstNodes},
     format_args,
-    formatter::{Buffer, Format, JsFormatter, prelude::*, trivia::FormatLeadingComments},
+    formatter::{JsFormatter, prelude::*, trivia::FormatLeadingComments},
     utils::{
         expression::as_call_expression_without_chain_wrappers,
         member_chain::chain_member::FormatComputedMemberExpressionWithoutObject,

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -45,14 +45,14 @@ use cow_utils::CowUtils;
 
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
-use oxc_formatter_core::arena_cow_str;
+use oxc_formatter_core::{Format, arena_cow_str};
 use oxc_span::{GetSpan, Span};
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     best_fitting, format_args,
     formatter::{
-        Format, JsFormatter,
+        JsFormatter,
         prelude::*,
         separated::FormatSeparatedIter,
         token::number::{format_number_token, format_trimmed_number, is_simple_number},

--- a/crates/oxc_formatter/src/print/object_like.rs
+++ b/crates/oxc_formatter/src/print/object_like.rs
@@ -1,11 +1,12 @@
 use oxc_ast::ast::*;
+use oxc_formatter_core::{Buffer, Format};
 use oxc_span::GetSpan;
 
 use crate::source_text::SourceTextExt as _;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{
-        Buffer, Format, JsFormatContext, JsFormatter, JsFormatterExt as _,
+        JsFormatContext, JsFormatter, JsFormatterExt as _,
         prelude::{format_with, group, soft_block_indent_with_maybe_space},
         trivia::format_dangling_comments,
     },

--- a/crates/oxc_formatter/src/print/object_pattern_like.rs
+++ b/crates/oxc_formatter/src/print/object_pattern_like.rs
@@ -1,10 +1,11 @@
 use oxc_ast::ast::*;
+use oxc_formatter_core::{Buffer, Format};
 use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{
-        Buffer, Format, JsFormatContext, JsFormatter,
+        JsFormatContext, JsFormatter,
         prelude::{format_with, group, soft_block_indent_with_maybe_space},
         trivia::format_dangling_comments,
     },

--- a/crates/oxc_formatter/src/print/parameters.rs
+++ b/crates/oxc_formatter/src/print/parameters.rs
@@ -1,11 +1,12 @@
 use oxc_ast::ast::*;
+use oxc_formatter_core::Format;
 use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::{AstNode, AstNodeIterator, AstNodes},
     format_args,
     formatter::{
-        Format, JsFormatter,
+        JsFormatter,
         prelude::*,
         trivia::{FormatLeadingComments, FormatTrailingComments},
     },

--- a/crates/oxc_formatter/src/print/semicolon.rs
+++ b/crates/oxc_formatter/src/print/semicolon.rs
@@ -1,8 +1,9 @@
 use oxc_ast::ast::{Comment, Expression};
+use oxc_formatter_core::{Buffer, Format};
 
 use crate::{
     ast_nodes::AstNodes,
-    formatter::{Buffer, Format, JsFormatContext, JsFormatter, trivia::FormatTrailingComments},
+    formatter::{JsFormatContext, JsFormatter, trivia::FormatTrailingComments},
     options::Semicolons,
     utils::format_node_without_trailing_comments::format_content_without_comments_after,
     write,

--- a/crates/oxc_formatter/src/print/sequence_expression.rs
+++ b/crates/oxc_formatter/src/print/sequence_expression.rs
@@ -1,8 +1,9 @@
 use oxc_ast::ast::*;
+use oxc_formatter_core::Format;
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
-    formatter::{Format, JsFormatter, prelude::*},
+    formatter::{JsFormatter, prelude::*},
     print::semicolon::write_trailing_comments_inside_parens,
     write,
 };

--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -1,10 +1,10 @@
 use oxc_allocator::ArenaStringBuilder;
 use oxc_ast::ast::*;
-use oxc_formatter_core::IndentWidth;
+use oxc_formatter_core::{FormatElement, IndentWidth, format_element::TextWidth};
 
 use crate::{
     ast_nodes::AstNode,
-    formatter::{FormatElement, format_element::TextWidth, prelude::*},
+    formatter::prelude::*,
     print::template::{
         FormatTemplateExpression, FormatTemplateExpressionOptions, TemplateExpression,
     },

--- a/crates/oxc_formatter/src/print/template/embed/graphql.rs
+++ b/crates/oxc_formatter/src/print/template/embed/graphql.rs
@@ -1,14 +1,13 @@
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
-use oxc_formatter_core::IndentWidth;
+use oxc_formatter_core::{
+    FormatElement, IndentWidth,
+    format_element::{LineMode, TextWidth},
+};
 
 use crate::{
     ast_nodes::AstNode,
-    formatter::{
-        FormatElement,
-        format_element::{LineMode, TextWidth},
-        prelude::*,
-    },
+    formatter::prelude::*,
     print::template::{
         FormatTemplateExpression, FormatTemplateExpressionOptions, TemplateExpression,
     },

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -2,13 +2,14 @@ use cow_utils::CowUtils;
 
 use oxc_allocator::ArenaStringBuilder;
 use oxc_ast::ast::*;
+use oxc_formatter_core::FormatElement;
 use oxc_syntax::line_terminator::LineTerminatorSplitter;
 
 use crate::{
     ast_nodes::AstNode,
     external_formatter::HtmlEmbedMeta,
     format_args,
-    formatter::{FormatElement, prelude::*},
+    formatter::prelude::*,
     print::template::{
         FormatTemplateExpression, FormatTemplateExpressionOptions, TemplateExpression,
     },

--- a/crates/oxc_formatter/src/print/template/embed/mod.rs
+++ b/crates/oxc_formatter/src/print/template/embed/mod.rs
@@ -5,11 +5,11 @@ mod markdown;
 
 use oxc_allocator::{Allocator, ArenaStringBuilder};
 use oxc_ast::ast::*;
-use oxc_formatter_core::IndentWidth;
+use oxc_formatter_core::{FormatElement, IndentWidth, format_element::TextWidth};
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
-    formatter::{FormatElement, format_element::TextWidth, prelude::*},
+    formatter::prelude::*,
     write,
 };
 

--- a/crates/oxc_formatter/src/print/template/mod.rs
+++ b/crates/oxc_formatter/src/print/template/mod.rs
@@ -6,17 +6,17 @@ use std::cmp;
 
 use oxc_allocator::{ArenaStringBuilder, ArenaVec};
 use oxc_ast::ast::*;
-use oxc_formatter_core::IndentWidth;
+use oxc_formatter_core::{
+    Format, FormatElement, IndentWidth, RemoveSoftLinesBuffer, VecBuffer, printer::Printer,
+};
 use oxc_span::{GetSpan, Span};
 
 use crate::{
     ast_nodes::{AstNode, AstNodeIterator},
     format_args,
     formatter::{
-        Format, FormatElement, TailwindContextEntry, VecBuffer,
-        buffer::RemoveSoftLinesBuffer,
+        TailwindContextEntry,
         prelude::{document::Document, *},
-        printer::Printer,
         trivia::{FormatLeadingComments, FormatTrailingComments},
     },
     utils::{

--- a/crates/oxc_formatter/src/print/type_parameters.rs
+++ b/crates/oxc_formatter/src/print/type_parameters.rs
@@ -1,12 +1,13 @@
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
+use oxc_formatter_core::{Buffer, Format, GroupId};
 use oxc_span::FileExtension;
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{
-        Buffer, Format, GroupId, JsFormatContext, JsFormatter,
+        JsFormatContext, JsFormatter,
         prelude::*,
         trivia::{DanglingIndentMode, FormatDanglingComments},
     },

--- a/crates/oxc_formatter/src/print/variable_declaration.rs
+++ b/crates/oxc_formatter/src/print/variable_declaration.rs
@@ -1,5 +1,6 @@
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
+use oxc_formatter_core::{Buffer, Format};
 use oxc_span::GetSpan;
 
 use crate::print::semicolon::{FormatContentWithSemicolon, keeps_trailing_comment_inside_parens};
@@ -7,9 +8,7 @@ use crate::utils::assignment_like::AssignmentLike;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
-    formatter::{
-        Buffer, Format, JsFormatContext, JsFormatter, prelude::*, separated::FormatSeparatedIter,
-    },
+    formatter::{JsFormatContext, JsFormatter, prelude::*, separated::FormatSeparatedIter},
     options::TrailingSeparator,
     write,
 };

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -1,10 +1,11 @@
 use oxc_ast::ast::*;
+use oxc_formatter_core::{Buffer, BufferExtensions, Format, ScratchBuffer};
 use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{
-        Buffer, BufferExtensions, Format, JsFormatter, ScratchBuffer,
+        JsFormatter,
         prelude::{FormatElements, format_once, line_suffix_boundary, *},
         trivia::FormatTrailingComments,
     },

--- a/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/chain_member.rs
@@ -3,10 +3,11 @@ use std::ops::Deref;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
-    formatter::{Format, JsFormatter, prelude::*, trivia::FormatLeadingComments},
+    formatter::{JsFormatter, prelude::*, trivia::FormatLeadingComments},
     write,
 };
 use oxc_ast::ast::*;
+use oxc_formatter_core::Format;
 use oxc_span::GetSpan;
 
 #[derive(Copy, Clone, Debug)]

--- a/crates/oxc_formatter/src/utils/member_chain/groups.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/groups.rs
@@ -6,7 +6,7 @@ use oxc_ast::ast::Expression;
 use oxc_span::GetSpan;
 
 use super::chain_member::ChainMember;
-use crate::formatter::{Format, JsFormatter, prelude::*};
+use crate::formatter::{JsFormatter, prelude::*};
 
 /// Sized for the common cases: `a.b()` (3 members) and `a.b.c()` (4).
 /// Longer chains spill to the heap, same as `Vec` did before.

--- a/crates/oxc_formatter/src/utils/member_chain/mod.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     JsLabels,
     ast_nodes::{AstNode, AstNodes},
     best_fitting,
-    formatter::{Buffer, Comments, Format, JsFormatter, prelude::*},
+    formatter::{Comments, JsFormatter, prelude::*},
     parentheses::NeedsParentheses,
     utils::{
         is_long_curried_call,
@@ -21,6 +21,7 @@ use crate::{
     write,
 };
 use oxc_ast::ast::*;
+use oxc_formatter_core::{Buffer, Format};
 use oxc_span::GetSpan;
 
 use super::typecast::classify_type_cast;

--- a/crates/oxc_formatter/src/utils/statement_body.rs
+++ b/crates/oxc_formatter/src/utils/statement_body.rs
@@ -1,10 +1,11 @@
 use oxc_ast::ast::Statement;
+use oxc_formatter_core::{Buffer, Format};
 use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{
-        Buffer, Format, JsFormatContext, JsFormatter,
+        JsFormatContext, JsFormatter,
         prelude::{format_once, soft_line_indent_or_space, space},
         trivia::{FormatTrailingComments, format_leading_comments},
     },

--- a/crates/oxc_formatter/src/utils/string.rs
+++ b/crates/oxc_formatter/src/utils/string.rs
@@ -2,13 +2,13 @@ use std::{borrow::Cow, ops::Deref};
 
 use unicode_width::UnicodeWidthStr;
 
-use oxc_formatter_core::{arena_cow_str, spec::normalize_string};
+use oxc_formatter_core::{Format, arena_cow_str, spec::normalize_string};
 use oxc_span::SourceType;
 use oxc_syntax::identifier::is_identifier_name_patched;
 
 use crate::{
     QuoteProperties, QuoteStyle,
-    formatter::{Format, JsFormatter, prelude::*},
+    formatter::{JsFormatter, prelude::*},
 };
 
 #[derive(Eq, PartialEq, Debug, Clone, Copy)]

--- a/crates/oxc_formatter/src/utils/tailwindcss.rs
+++ b/crates/oxc_formatter/src/utils/tailwindcss.rs
@@ -8,12 +8,13 @@
 //! Based on [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).
 
 use oxc_ast::ast::*;
+use oxc_formatter_core::FormatElement;
 use oxc_span::GetSpan;
 
 use crate::{
     Buffer, SortTailwindcssOptions,
     ast_nodes::{AstNode, AstNodes},
-    formatter::{FormatElement, TailwindContextEntry, prelude::*},
+    formatter::{TailwindContextEntry, prelude::*},
     write,
 };
 

--- a/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
+++ b/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
@@ -106,13 +106,14 @@ impl Generator for FormatterAstNodesGenerator {
             ///@@line_break
             use oxc_allocator::ArenaVec;
             use oxc_ast::ast::*;
+            use oxc_formatter_core::Format;
             use oxc_span::GetSpan;
             use oxc_str::Ident;
             use oxc_syntax::node::NodeId;
             ///@@line_break
             use crate::ast_nodes::AstNode;
             use crate::formatter::{
-                Format, JsFormatter,
+                JsFormatter,
                 trivia::{format_leading_comments, format_trailing_comments},
             };
 

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -113,11 +113,12 @@ impl Generator for FormatterFormatGenerator {
         let output = quote! {
             #![expect(clippy::match_same_arms)]
             use oxc_ast::ast::*;
+            use oxc_formatter_core::Format;
             use oxc_span::GetSpan;
 
             ///@@line_break
             use crate::{
-                formatter::{Format, JsFormatContext, JsFormatter, JsFormatterExt as _, trivia::{format_leading_comments, format_trailing_comments}},
+                formatter::{JsFormatContext, JsFormatter, JsFormatterExt as _, trivia::{format_leading_comments, format_trailing_comments}},
                 parentheses::NeedsParentheses,
                 ast_nodes::AstNode,
                 utils::{suppressed::FormatSuppressedNode, typecast::{format_type_cast_comment_node, format_leading_comments_and_open_paren}},


### PR DESCRIPTION
Leftovers from when we extract the `oxc_formatter_core`.