### PR TITLE
feat(ast)!: change `TSIndexSignatureName::name` to `Ident`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -25,7 +25,7 @@ use oxc_allocator::{Box, CloneIn, Dummy, GetAddress, ReplaceWith, TakeIn, Unstab
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_span::{ContentEq, GetSpan, GetSpanMut, Span};
-use oxc_str::Str;
+use oxc_str::Ident;
 use oxc_syntax::{node::NodeId, scope::ScopeId};
 
 use super::{js::*, literal::*};
@@ -1147,8 +1147,7 @@ pub struct TSConstructSignatureDeclaration<'a> {
 pub struct TSIndexSignatureName<'a> {
     pub node_id: Cell<NodeId>,
     pub span: Span,
-    #[estree(json_safe)]
-    pub name: Str<'a>,
+    pub name: Ident<'a>,
     pub type_annotation: Box<'a, TSTypeAnnotation<'a>>,
 }
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -3384,12 +3384,12 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSConstructSignatureDeclaration, return_type) == 24);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSIndexSignatureName>() == 24);
+    assert!(size_of::<TSIndexSignatureName>() == 28);
     assert!(align_of::<TSIndexSignatureName>() == 4);
     assert!(offset_of!(TSIndexSignatureName, span) == 0);
     assert!(offset_of!(TSIndexSignatureName, node_id) == 8);
     assert!(offset_of!(TSIndexSignatureName, name) == 12);
-    assert!(offset_of!(TSIndexSignatureName, type_annotation) == 20);
+    assert!(offset_of!(TSIndexSignatureName, type_annotation) == 24);
 
     // Padding: 0 bytes
     assert!(size_of::<TSInterfaceHeritage>() == 24);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -26249,7 +26249,7 @@ impl<'a> TSIndexSignatureName<'a> {
         builder: &B,
     ) -> Self
     where
-        S1: Into<Str<'a>>,
+        S1: Into<Ident<'a>>,
     {
         let builder = builder.builder();
         TSIndexSignatureName {

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2958,7 +2958,7 @@ impl ESTree for TSIndexSignatureName<'_> {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("decorators", &crate::serialize::basic::EmptyArray(self));
-        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
+        state.serialize_field("name", &self.name);
         state.serialize_field("optional", &crate::serialize::basic::False(self));
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_span(self.span);

--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -9369,7 +9369,7 @@ impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
     }
 
     #[inline]
-    pub fn name(&self) -> Str<'a> {
+    pub fn name(&self) -> Ident<'a> {
         self.inner.name
     }
 

--- a/crates/oxc_minifier/src/generated/ancestor.rs
+++ b/crates/oxc_minifier/src/generated/ancestor.rs
@@ -16062,9 +16062,9 @@ impl<'a, 't> TSIndexSignatureNameWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn name(self) -> &'t Str<'a> {
+    pub fn name(self) -> &'t Ident<'a> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NAME) as *const Str<'a>)
+            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NAME) as *const Ident<'a>)
         }
     }
 }

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -16062,9 +16062,9 @@ impl<'a, 't> TSIndexSignatureNameWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn name(self) -> &'t Str<'a> {
+    pub fn name(self) -> &'t Ident<'a> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NAME) as *const Str<'a>)
+            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NAME) as *const Ident<'a>)
         }
     }
 }


### PR DESCRIPTION
## Summary

Use `Ident<'a>` for `TSIndexSignatureName::name` instead of `Str<'a>`.

## Breaking Change

The Rust AST changes from:

```rust
pub struct TSIndexSignatureName<'a> {
    pub node_id: Cell<NodeId>,
    pub span: Span,
    #[estree(json_safe)]
    pub name: Str<'a>,
    pub type_annotation: Box<'a, TSTypeAnnotation<'a>>,
}
```

to:

```rust
pub struct TSIndexSignatureName<'a> {
    pub node_id: Cell<NodeId>,
    pub span: Span,
    pub name: Ident<'a>,
    pub type_annotation: Box<'a, TSTypeAnnotation<'a>>,
}
```

## Why?

Index-signature parameter names are identifiers, and the parser already produces an `Ident`. Storing the name as `Str` discarded its identifier-specific representation and precomputed hash.

`Ident` is also always JSON-safe, so the explicit `#[estree(json_safe)]` annotation is unnecessary. ESTree output remains unchanged.

## How to migrate

Use `Ident` wherever constructing or consuming `TSIndexSignatureName::name`.

| Previous representation | New representation |
| --- | --- |
| `name: Str<'a>` | `name: Ident<'a>` |
| Constructor input implementing `Into<Str<'a>>` | Input implementing `Into<Ident<'a>>` |
| Formatter/traversal accessors returning `Str` | Accessors returning `Ident` |
| Explicit JSON-safe serialization | Serialization through `Ident` |
| Generic string access | `name.as_str()` |

Related to oxc-project/backlog#232.