### PR TITLE
perf(lsp): increase concurrency level by available threads

### DIFF
--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -79,6 +79,7 @@ async fn run_server_impl(
     let capped_threads = if current_threads >= 6 { current_threads - 2 } else { current_threads };
     // Ensure that the concurrency level is at least 4, defaulting to the old behavior if the system has fewer than 4 threads.
     // Server-Requests can trigger Client-Requests, which will fill up the thread pool quickly, so we want to ensure that we have enough threads to handle both.
+    // https://github.com/ebkalderon/tower-lsp/blob/49e1ce54549d5efc53b75510517c2f0b86f5c827/src/transport.rs#L78-L80
     let level = std::cmp::max(4, capped_threads);
 
     Server::new(stdin, stdout, socket).concurrency_level(level).serve(service).await;

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{num::NonZero, sync::Arc};
 
 use futures::future::BoxFuture;
 use rustc_hash::FxBuildHasher;
@@ -73,5 +73,13 @@ async fn run_server_impl(
     })
     .finish();
 
-    Server::new(stdin, stdout, socket).serve(service).await;
+    // If the system has more than 6 threads, we use 2 less than the available threads
+    // to avoid overwhelming the system. Otherwise, we use all available threads.
+    let current_threads = std::thread::available_parallelism().map_or(1, NonZero::get);
+    let max = if current_threads >= 6 { current_threads - 2 } else { current_threads };
+    // Ensure that the concurrency level is at least 4, defaulting to the old behavior if the system has fewer than 4 threads.
+    // Server-Requests can trigger Client-Requests, which will fill up the thread pool quickly, so we want to ensure that we have enough threads to handle both.
+    let level = std::cmp::max(4, max);
+
+    Server::new(stdin, stdout, socket).concurrency_level(level).serve(service).await;
 }

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -73,13 +73,13 @@ async fn run_server_impl(
     })
     .finish();
 
-    // If the system has more than 6 threads, we use 2 less than the available threads
-    // to avoid overwhelming the system. Otherwise, we use all available threads.
+    // Baseline concurrency level from `available_parallelism()`. On systems with 6+ threads, leave 2
+    // threads for other work to avoid overwhelming the host (the minimum is clamped below).
     let current_threads = std::thread::available_parallelism().map_or(1, NonZero::get);
-    let max = if current_threads >= 6 { current_threads - 2 } else { current_threads };
+    let capped_threads = if current_threads >= 6 { current_threads - 2 } else { current_threads };
     // Ensure that the concurrency level is at least 4, defaulting to the old behavior if the system has fewer than 4 threads.
     // Server-Requests can trigger Client-Requests, which will fill up the thread pool quickly, so we want to ensure that we have enough threads to handle both.
-    let level = std::cmp::max(4, max);
+    let level = std::cmp::max(4, capped_threads);
 
     Server::new(stdin, stdout, socket).concurrency_level(level).serve(service).await;
 }

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{num::NonZero, sync::Arc};
 
 use rustc_hash::FxBuildHasher;
 use tower_lsp_server::ls_types::Uri;
@@ -59,5 +59,10 @@ pub async fn run_server(
     })
     .finish();
 
-    Server::new(stdin, stdout, socket).serve(service).await;
+    // If the system has more than 6 threads, we use 2 less than the available threads
+    // to avoid overwhelming the system. Otherwise, we use all available threads.
+    let current_threads = std::thread::available_parallelism().map_or(1, NonZero::get);
+    let max = if current_threads > 6 { current_threads - 2 } else { current_threads };
+
+    Server::new(stdin, stdout, socket).concurrency_level(max).serve(service).await;
 }


### PR DESCRIPTION
> Adjusts the Oxc language server startup to scale Tower LSP request handling concurrency based on the machine’s available parallelism, aiming to improve throughput on higher-core systems without fully saturating the host.

The saturation is from personal feeling and did not get benchmarked.