### PR TITLE
feat(oxfmt, oxlint): toml configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,6 +2259,7 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "smallvec",
+ "toml",
  "unicode-segmentation",
  "url",
 ]
@@ -2869,6 +2870,7 @@ dependencies = [
  "sort-package-json",
  "tempfile",
  "tokio",
+ "toml",
  "tower-lsp-server",
  "tracing",
  "tracing-subscriber",
@@ -2908,6 +2910,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml",
  "tower-lsp-server",
  "tracing",
  "tracing-subscriber",

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -57,6 +57,7 @@ simdutf8 = { workspace = true }
 sort-package-json = { workspace = true }
 oxc-toml = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
 tower-lsp-server = { workspace = true, features = ["proposed"] }

--- a/apps/oxfmt/src/cli/command.rs
+++ b/apps/oxfmt/src/cli/command.rs
@@ -143,7 +143,7 @@ pub enum MigrateSource {
 /// Config Options
 #[derive(Debug, Clone, Bpaf)]
 pub struct ConfigOptions {
-    /// Path to the configuration file (.json, .jsonc, .ts, .mts, .cts, .js, .mjs, .cjs)
+    /// Path to the configuration file (.json, .jsonc, .toml, .ts, .mts, .cts, .js, .mjs, .cjs)
     #[bpaf(short, long, argument("PATH"))]
     pub config: Option<PathBuf>,
     /// Do not search for configuration files in subdirectories

--- a/apps/oxfmt/src/core/config/mod.rs
+++ b/apps/oxfmt/src/core/config/mod.rs
@@ -19,7 +19,9 @@ use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use serde_json::Value;
 use tracing::instrument;
 
-use oxc_config::{ConfigDiscovery, ConfigFileNames, DiscoveredConfigFile, is_js_config_path};
+use oxc_config::{
+    ConfigDiscovery, ConfigFileNames, DiscoveredConfigFile, is_js_config_path, is_toml_config_path,
+};
 #[cfg(feature = "napi")]
 use oxc_formatter::JsFormatOptions;
 
@@ -40,6 +42,7 @@ use super::{
 const OXFMT_CONFIG_FILE_NAMES: ConfigFileNames = ConfigFileNames {
     json: ".oxfmtrc.json",
     jsonc: ".oxfmtrc.jsonc",
+    toml: ".oxfmtrc.toml",
     js: &["oxfmt.config.ts", "oxfmt.config.mts"],
     vite: "vite.config.ts",
 };
@@ -69,9 +72,12 @@ pub fn build_resolver_from_discovered(
         DiscoveredConfigFile::Json(path) | DiscoveredConfigFile::Jsonc(path) => {
             ConfigResolver::from_json_config(Some(&path), editorconfig).map(Some)
         }
+        DiscoveredConfigFile::Toml(path) => {
+            ConfigResolver::from_toml_config(Some(&path), editorconfig).map(Some)
+        }
         #[cfg(not(feature = "napi"))]
         DiscoveredConfigFile::Js(path) | DiscoveredConfigFile::Vite(path) => Err(format!(
-            "JS/TS config file ({}) is not supported in pure Rust CLI.\nUse JSON/JSONC instead.",
+            "JS/TS config file ({}) is not supported in pure Rust CLI.\nUse JSON/JSONC/TOML instead.",
             path.display()
         )),
         #[cfg(feature = "napi")]
@@ -211,8 +217,9 @@ pub struct ConfigResolver {
 }
 
 impl ConfigResolver {
-    /// Shared internal constructor used by both:
+    /// Shared internal constructor used by:
     /// - `from_json_config()` (JSON/JSONC)
+    /// - `from_toml_config()` (TOML)
     /// - and `from_config()` (JS/TS config evaluated externally)
     fn new(
         raw_config: Value,
@@ -243,7 +250,7 @@ impl ConfigResolver {
         })
     }
 
-    /// Create a resolver, handling both JSON/JSONC and JS/TS config files.
+    /// Create a resolver, handling both JSON/JSONC/TOML and JS/TS config files.
     ///
     /// When `oxfmtrc_path` is `Some`, it is treated as an explicitly specified config file.
     /// When `oxfmtrc_path` is `None`, auto-discovery searches upwards from `cwd`.
@@ -271,7 +278,7 @@ impl ConfigResolver {
                 #[cfg(not(feature = "napi"))]
                 {
                     return Err(format!(
-                        "JS/TS config file ({}) is not supported in pure Rust CLI.\nUse JSON/JSONC instead.",
+                        "JS/TS config file ({}) is not supported in pure Rust CLI.\nUse JSON/JSONC/TOML instead.",
                         path.display()
                     ));
                 }
@@ -296,6 +303,10 @@ impl ConfigResolver {
                         editorconfig,
                     ));
                 }
+            }
+
+            if is_toml_config_path(&path) {
+                return Self::from_toml_config(Some(&path), editorconfig);
             }
 
             return Self::from_json_config(Some(&path), editorconfig);
@@ -369,6 +380,35 @@ impl ConfigResolver {
         // Store the config directory for override path resolution
         let config_dir = oxfmtrc_path.and_then(|p| p.parent().map(Path::to_path_buf));
 
+        Ok(Self::new(raw_config, config_dir, editorconfig))
+    }
+
+    /// Create a resolver by loading TOML config from a file path.
+    ///
+    /// Also used as the default (empty config) fallback when no config file is found.
+    #[instrument(level = "debug", name = "oxfmt::config::from_toml_config", skip_all)]
+    pub(crate) fn from_toml_config(
+        oxfmtrc_path: Option<&Path>,
+        editorconfig: Option<EditorConfig>,
+    ) -> Result<Self, String> {
+        // Read and parse config file, or use empty TOML if not found
+        let toml_string = match oxfmtrc_path {
+            Some(path) => {
+                utils::read_to_string(path)
+                    // Do not include OS error, it differs between platforms
+                    .map_err(|_| format!("Failed to read {}: File not found", path.display()))?
+            }
+            None => "".to_string(),
+        };
+
+        // Parse as raw TOML value
+        let raw_config_table: toml::Table =
+            toml::from_str(&toml_string).map_err(|err| err.to_string())?;
+        // Store the config directory for override path resolution
+        let config_dir = oxfmtrc_path.and_then(|p| p.parent().map(Path::to_path_buf));
+
+        // Convert from TOML types to JSON types
+        let raw_config = raw_config_table.try_into().map_err(|err| err.to_string())?;
         Ok(Self::new(raw_config, config_dir, editorconfig))
     }
 

--- a/apps/oxfmt/test/cli/config_file/fixtures/fmt.toml
+++ b/apps/oxfmt/test/cli/config_file/fixtures/fmt.toml
@@ -1,0 +1,1 @@
+semi = true

--- a/apps/oxfmt/test/cli/config_file/options.json
+++ b/apps/oxfmt/test/cli/config_file/options.json
@@ -17,6 +17,9 @@
     "args": ["--check", "!*.{json,jsonc,ts}", "--config", "./fmt.jsonc"]
   },
   {
+    "args": ["--check", "!*.{json,jsonc,ts}", "--config", "./fmt.toml"]
+  },
+  {
     "args": ["--check", "!*.{json,jsonc,ts}", "--config", "./fmt.config.ts"]
   },
   {

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -55,6 +55,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+toml = { workspace = true }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
 tower-lsp-server = { workspace = true, features = ["proposed"] }
 

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -142,12 +142,12 @@ impl LintCommand {
 #[derive(Debug, Clone, Bpaf)]
 pub struct BasicOptions {
     /// Oxlint configuration file
-    ///  * `.json` and `.jsonc` config files are supported in all runtimes
+    ///  * `.json`, `.jsonc`, and `.toml` config files are supported in all runtimes
     ///  * JavaScript/TypeScript config files are experimental and require running via Node.js
     ///  * you can use comments in configuration files.
     ///  * tries to be compatible with ESLint v8's format
     ///
-    /// If not provided, Oxlint will look for a `.oxlintrc.json`, `.oxlintrc.jsonc`, `oxlint.config.ts`, or `oxlint.config.mts` file in the current working directory.
+    /// If not provided, Oxlint will look for a `.oxlintrc.json`, `.oxlintrc.jsonc`, `.oxlintrc.toml`, `oxlint.config.ts`, or `oxlint.config.mts` file in the current working directory.
     #[bpaf(long, short, argument("./.oxlintrc.json"))]
     pub config: Option<PathBuf>,
 

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -8,6 +8,7 @@ use ignore::DirEntry;
 
 use oxc_config::{
     ConfigConflict, ConfigDiscovery, ConfigFileNames, DiscoveredConfigFile, is_js_config_path,
+    is_toml_config_path,
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_linter::{
@@ -18,7 +19,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use crate::utils::normalize_path;
 use crate::{
     DEFAULT_JSONC_OXLINTRC_NAME, DEFAULT_MTS_OXLINTRC_NAME, DEFAULT_OXLINTRC_NAME,
-    DEFAULT_TS_OXLINTRC_NAME,
+    DEFAULT_TOML_OXLINTRC_NAME, DEFAULT_TS_OXLINTRC_NAME,
 };
 use crate::{VITE_CONFIG_NAME, vp_version};
 
@@ -38,6 +39,7 @@ pub struct JsConfigResult {
 const OXLINT_CONFIG_FILE_NAMES: ConfigFileNames = ConfigFileNames {
     json: DEFAULT_OXLINTRC_NAME,
     jsonc: DEFAULT_JSONC_OXLINTRC_NAME,
+    toml: DEFAULT_TOML_OXLINTRC_NAME,
     js: &[DEFAULT_TS_OXLINTRC_NAME, DEFAULT_MTS_OXLINTRC_NAME],
     vite: VITE_CONFIG_NAME,
 };
@@ -318,6 +320,12 @@ impl<'a> ConfigLoader<'a> {
             .map_err(|error| ConfigLoadError::Parse { path: path.to_path_buf(), error })
     }
 
+    /// Load a single config from a file path
+    fn load_toml(path: &Path) -> Result<Oxlintrc, ConfigLoadError> {
+        Oxlintrc::from_toml_file(path)
+            .map_err(|error| ConfigLoadError::Parse { path: path.to_path_buf(), error })
+    }
+
     pub fn load_js_configs(
         &self,
         paths: &[PathBuf],
@@ -391,6 +399,10 @@ impl<'a> ConfigLoader<'a> {
                         Err(e) => errors.push(e),
                     }
                 }
+                Some(DiscoveredConfigFile::Toml(path)) => match Self::load_toml(path.as_path()) {
+                    Ok(config) => configs.push(config),
+                    Err(e) => errors.push(e),
+                },
                 Some(DiscoveredConfigFile::Js(path) | DiscoveredConfigFile::Vite(path)) => {
                     js_configs.push(path);
                 }
@@ -506,8 +518,8 @@ impl<'a> ConfigLoader<'a> {
     /// Try to load config from a specific directory.
     ///
     /// In Vite+ mode (`VP_VERSION` set): only checks for `vite.config.ts`.
-    /// Otherwise: checks for `.oxlintrc.json`, `.oxlintrc.jsonc`, `oxlint.config.ts`,
-    /// and `oxlint.config.mts`.
+    /// Otherwise: checks for `.oxlintrc.json`, `.oxlintrc.jsonc`, `.oxlintrc.toml`,
+    /// `oxlint.config.ts`, and `oxlint.config.mts`.
     ///
     /// Returns `Ok(Some(config))` if found, `Ok(None)` if not found, or `Err` on error.
     fn try_load_config_from_dir(
@@ -522,6 +534,7 @@ impl<'a> ConfigLoader<'a> {
             Some(DiscoveredConfigFile::Json(path) | DiscoveredConfigFile::Jsonc(path)) => {
                 Oxlintrc::from_file(&path).map(Some)
             }
+            Some(DiscoveredConfigFile::Toml(path)) => Oxlintrc::from_toml_file(&path).map(Some),
             Some(DiscoveredConfigFile::Js(path)) => {
                 let config = self.load_root_js_config(&path)?;
                 debug_assert!(
@@ -588,6 +601,9 @@ impl<'a> ConfigLoader<'a> {
                     full_path.display()
                 ))
             });
+        }
+        if is_toml_config_path(&full_path) {
+            return Oxlintrc::from_toml_file(&full_path);
         }
         Oxlintrc::from_file(&full_path)
     }
@@ -711,7 +727,7 @@ fn js_config_not_supported_diagnostic(path: &Path) -> OxcDiagnostic {
         "JavaScript/TypeScript config file ({}) found but JS runtime not available.",
         path.display()
     ))
-    .with_help("Run oxlint via the npm package, or use JSON config files (.oxlintrc.json or .oxlintrc.jsonc).")
+    .with_help("Run oxlint via the npm package, or use JSON/TOML config files (.oxlintrc.json, .oxlintrc.jsonc, or .oxlintrc.toml).")
 }
 
 fn nested_type_aware_not_supported(path: &Path) -> OxcDiagnostic {
@@ -1272,6 +1288,25 @@ mod test {
     }
 
     #[test]
+    fn test_toml_config_discovery() {
+        let root_dir = tempfile::tempdir().unwrap();
+        // Create only a .oxlintrc.toml file
+        std::fs::write(root_dir.path().join(".oxlintrc.toml"), r#"# Comment\n[rules]"#).unwrap();
+
+        let mut external_plugin_store = ExternalPluginStore::new(false);
+        let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
+
+        let result = loader.load_root_config(root_dir.path(), None);
+        assert!(result.is_ok(), "Expected .oxlintrc.toml to be discovered and loaded");
+        let config = result.unwrap();
+        assert!(
+            config.path.to_string_lossy().ends_with(".oxlintrc.toml"),
+            "Expected config path to end with .oxlintrc.toml, got: {}",
+            config.path.display()
+        );
+    }
+
+    #[test]
     fn test_json_and_jsonc_conflict() {
         let root_dir = tempfile::tempdir().unwrap();
         // Create both .oxlintrc.json and .oxlintrc.jsonc
@@ -1290,6 +1325,23 @@ mod test {
     }
 
     #[test]
+    fn test_json_and_toml_conflict() {
+        let root_dir = tempfile::tempdir().unwrap();
+        // Create both .oxlintrc.json and .oxlintrc.jsonc
+        std::fs::write(root_dir.path().join(".oxlintrc.json"), r#"{ "rules": {} }"#).unwrap();
+        std::fs::write(root_dir.path().join(".oxlintrc.toml"), r#"# Comment\n[rules]"#).unwrap();
+
+        let mut external_plugin_store = ExternalPluginStore::new(false);
+        let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
+
+        let result = loader.load_root_config(root_dir.path(), None);
+        assert!(
+            result.is_err(),
+            "Expected an error when both .oxlintrc.json and .oxlintrc.toml exist"
+        );
+    }
+
+    #[test]
     fn test_json_and_ts_conflict() {
         let root_dir = tempfile::tempdir().unwrap();
         std::fs::write(root_dir.path().join(".oxlintrc.json"), r#"{ "rules": {} }"#).unwrap();
@@ -1300,6 +1352,20 @@ mod test {
 
         let result = loader.load_root_config(root_dir.path(), None);
         assert!(result.is_err(), "Expected an error when both JSON and TS configs exist");
+    }
+
+    #[test]
+    fn test_jsonc_and_toml_conflict() {
+        let root_dir = tempfile::tempdir().unwrap();
+        std::fs::write(root_dir.path().join(".oxlintrc.jsonc"), r#"{ /* comment */ "rules": {} }"#)
+            .unwrap();
+        std::fs::write(root_dir.path().join(".oxlintrc.toml"), r#"# Comment\n[rules]"#).unwrap();
+
+        let mut external_plugin_store = ExternalPluginStore::new(false);
+        let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
+
+        let result = loader.load_root_config(root_dir.path(), None);
+        assert!(result.is_err(), "Expected an error when both JSONC and TOML configs exist");
     }
 
     #[test]
@@ -1314,6 +1380,19 @@ mod test {
 
         let result = loader.load_root_config(root_dir.path(), None);
         assert!(result.is_err(), "Expected an error when both JSONC and TS configs exist");
+    }
+
+    #[test]
+    fn test_toml_and_ts_conflict() {
+        let root_dir = tempfile::tempdir().unwrap();
+        std::fs::write(root_dir.path().join(".oxlintrc.toml"), r#"# Comment\n[rules]"#).unwrap();
+        std::fs::write(root_dir.path().join("oxlint.config.ts"), "export default {};").unwrap();
+
+        let mut external_plugin_store = ExternalPluginStore::new(false);
+        let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
+
+        let result = loader.load_root_config(root_dir.path(), None);
+        assert!(result.is_err(), "Expected an error when both TOML and TS configs exist");
     }
 
     #[test]

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -60,6 +60,7 @@ static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 
 const DEFAULT_OXLINTRC_NAME: &str = ".oxlintrc.json";
 const DEFAULT_JSONC_OXLINTRC_NAME: &str = ".oxlintrc.jsonc";
+const DEFAULT_TOML_OXLINTRC_NAME: &str = ".oxlintrc.toml";
 const DEFAULT_TS_OXLINTRC_NAME: &str = "oxlint.config.ts";
 const DEFAULT_MTS_OXLINTRC_NAME: &str = "oxlint.config.mts";
 /// Vite config file that may contain oxlint config under a `.lint` field.

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -290,7 +290,7 @@ impl CliRunner {
                                 ConfigLoadError::JsConfigFileFoundButJsRuntimeNotAvailable => {
                                     "Error: JavaScript/TypeScript config files found but JS runtime not available.\n\
                                      This is an experimental feature that requires running oxlint via Node.js.\n\
-                                     Please use JSON config files (.oxlintrc.json or .oxlintrc.jsonc) instead, or run oxlint via the npm package.\n".to_string()
+                                     Please use JSON/TOML config files (.oxlintrc.json, .oxlintrc.jsonc, or .oxlintrc.toml) instead, or run oxlint via the npm package.\n".to_string()
                                 }
                                 ConfigLoadError::Diagnostic(error) => {
                                     let report = render_report(&handler, error);
@@ -966,6 +966,14 @@ mod test {
         let args = &["debugger.js"];
         Tester::new()
             .with_cwd("fixtures/cli/auto_config_detection_jsonc".into())
+            .test_and_snapshot(args);
+    }
+
+    #[test]
+    fn oxlint_config_auto_detection_toml() {
+        let args = &["debugger.js"];
+        Tester::new()
+            .with_cwd("fixtures/cli/auto_config_detection_toml".into())
             .test_and_snapshot(args);
     }
 

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -964,11 +964,12 @@ mod test_watchers {
             let patterns =
                 Tester::new("fixtures/lsp/watchers/default", json!({})).get_watcher_patterns();
 
-            assert_eq!(patterns.len(), 4);
+            assert_eq!(patterns.len(), 5);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
             assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
-            assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
-            assert_eq!(patterns[3], "**/oxlint.config.mts".to_string());
+            assert_eq!(patterns[2], "**/.oxlintrc.toml".to_string());
+            assert_eq!(patterns[3], "**/oxlint.config.ts".to_string());
+            assert_eq!(patterns[4], "**/oxlint.config.mts".to_string());
         }
 
         #[test]
@@ -984,8 +985,9 @@ mod test_watchers {
             assert_eq!(patterns.len(), 4);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
             assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
-            assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
-            assert_eq!(patterns[3], "**/oxlint.config.mts".to_string());
+            assert_eq!(patterns[2], "**/.oxlintrc.toml".to_string());
+            assert_eq!(patterns[3], "**/oxlint.config.ts".to_string());
+            assert_eq!(patterns[4], "**/oxlint.config.mts".to_string());
         }
 
         #[test]
@@ -1008,13 +1010,14 @@ mod test_watchers {
                 .get_watcher_patterns();
 
             // The `.oxlintrc.json` extends `./lint.json` -> 5 watchers
-            // (json, jsonc, ts, mts, lint.json)
+            // (json, jsonc, toml, ts, mts, lint.json)
             assert_eq!(patterns.len(), 5);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
             assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
-            assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
-            assert_eq!(patterns[3], "**/oxlint.config.mts".to_string());
-            assert_eq!(patterns[4], "lint.json".to_string());
+            assert_eq!(patterns[2], "**/.oxlintrc.toml".to_string());
+            assert_eq!(patterns[3], "**/oxlint.config.ts".to_string());
+            assert_eq!(patterns[4], "**/oxlint.config.mts".to_string());
+            assert_eq!(patterns[5], "lint.json".to_string());
         }
 
         #[test]
@@ -1045,9 +1048,10 @@ mod test_watchers {
             assert_eq!(patterns.len(), 5);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
             assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
-            assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
-            assert_eq!(patterns[3], "**/oxlint.config.mts".to_string());
-            assert_eq!(patterns[4], "**/tsconfig*.json".to_string());
+            assert_eq!(patterns[2], "**/.oxlintrc.toml".to_string());
+            assert_eq!(patterns[3], "**/oxlint.config.ts".to_string());
+            assert_eq!(patterns[4], "**/oxlint.config.mts".to_string());
+            assert_eq!(patterns[5], "**/tsconfig*.json".to_string());
         }
     }
 
@@ -1101,9 +1105,10 @@ mod test_watchers {
             assert_eq!(watch_patterns.as_ref().unwrap().len(), 5);
             assert_eq!(watch_patterns.as_ref().unwrap()[0], "**/.oxlintrc.json".to_string());
             assert_eq!(watch_patterns.as_ref().unwrap()[1], "**/.oxlintrc.jsonc".to_string());
-            assert_eq!(watch_patterns.as_ref().unwrap()[2], "**/oxlint.config.ts".to_string());
-            assert_eq!(watch_patterns.as_ref().unwrap()[3], "**/oxlint.config.mts".to_string());
-            assert_eq!(watch_patterns.as_ref().unwrap()[4], "**/tsconfig*.json".to_string());
+            assert_eq!(watch_patterns.as_ref().unwrap()[2], "**/.oxlintrc.toml".to_string());
+            assert_eq!(watch_patterns.as_ref().unwrap()[3], "**/oxlint.config.ts".to_string());
+            assert_eq!(watch_patterns.as_ref().unwrap()[4], "**/oxlint.config.mts".to_string());
+            assert_eq!(watch_patterns.as_ref().unwrap()[5], "**/tsconfig*.json".to_string());
         }
     }
 }

--- a/apps/oxlint/test/fixtures/basic_toml/.oxlintrc.toml
+++ b/apps/oxlint/test/fixtures/basic_toml/.oxlintrc.toml
@@ -1,0 +1,4 @@
+jsPlugins = ["./plugin.ts"]
+
+[rules]
+"basic-custom-plugin/no-debugger" = "error"

--- a/apps/oxlint/test/fixtures/basic_toml/files/index.js
+++ b/apps/oxlint/test/fixtures/basic_toml/files/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/basic_toml/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_toml/output.snap.md
@@ -1,0 +1,25 @@
+# Exit code
+1
+
+# stdout
+```
+  x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+
+  ! eslint(no-debugger): `debugger` statement is not allowed
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 1 warning and 1 error.
+Finished in Xms on 1 file with 97 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/basic_toml/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic_toml/plugin.ts
@@ -1,0 +1,23 @@
+import type { Plugin } from "#oxlint/plugins";
+
+const plugin: Plugin = {
+  meta: {
+    name: "basic-custom-plugin",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/apps/oxlint/test/fixtures/overrides_toml/.oxlintrc.toml
+++ b/apps/oxlint/test/fixtures/overrides_toml/.oxlintrc.toml
@@ -1,0 +1,9 @@
+[categories]
+correctness = "off"
+
+[[overrides]]
+files = [".js"]
+jsPlugins = ["./plugin.ts"]
+
+[overrides.rules]
+"basic-custom-plugin/no-debugger" = "error"

--- a/apps/oxlint/test/fixtures/overrides_toml/files/index.js
+++ b/apps/oxlint/test/fixtures/overrides_toml/files/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/overrides_toml/output.snap.md
+++ b/apps/oxlint/test/fixtures/overrides_toml/output.snap.md
@@ -1,0 +1,18 @@
+# Exit code
+1
+
+# stdout
+```
+  x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+
+Found 0 warnings and 1 error.
+Finished in Xms on 1 file with 1 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/overrides_toml/plugin.ts
+++ b/apps/oxlint/test/fixtures/overrides_toml/plugin.ts
@@ -1,0 +1,23 @@
+import type { Plugin } from "#oxlint/plugins";
+
+const plugin: Plugin = {
+  meta: {
+    name: "basic-custom-plugin",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/apps/oxlint/test/lsp/init/init.test.ts
+++ b/apps/oxlint/test/lsp/init/init.test.ts
@@ -57,11 +57,23 @@ describe("LSP initialization", () => {
   it.each([
     [
       undefined,
-      ["**/.oxlintrc.json", "**/.oxlintrc.jsonc", "**/oxlint.config.ts", "**/oxlint.config.mts"],
+      [
+        "**/.oxlintrc.json",
+        "**/.oxlintrc.jsonc",
+        "**/.oxlintrc.toml",
+        "**/oxlint.config.ts",
+        "**/oxlint.config.mts",
+      ],
     ],
     [
       { configPath: "" },
-      ["**/.oxlintrc.json", "**/.oxlintrc.jsonc", "**/oxlint.config.ts", "**/oxlint.config.mts"],
+      [
+        "**/.oxlintrc.json",
+        "**/.oxlintrc.jsonc",
+        "**/.oxlintrc.toml",
+        "**/oxlint.config.ts",
+        "**/oxlint.config.mts",
+      ],
     ],
     [{ configPath: "./custom-config.json" }, ["custom-config.json"]],
   ])(

--- a/crates/oxc_config/src/discovery.rs
+++ b/crates/oxc_config/src/discovery.rs
@@ -13,6 +13,11 @@ pub fn is_js_config_path(path: &Path) -> bool {
     )
 }
 
+/// Return `true` when `path` uses a TOML config extension.
+pub fn is_toml_config_path(path: &Path) -> bool {
+    matches!(path.extension().and_then(OsStr::to_str), Some("toml"))
+}
+
 /// A supported configuration file discovered on disk.
 ///
 /// The variant identifies which config source matched, while the contained path
@@ -22,6 +27,7 @@ pub fn is_js_config_path(path: &Path) -> bool {
 pub enum DiscoveredConfigFile {
     Json(PathBuf),
     Jsonc(PathBuf),
+    Toml(PathBuf),
     Js(PathBuf),
     Vite(PathBuf),
 }
@@ -30,7 +36,11 @@ impl DiscoveredConfigFile {
     /// Return the filesystem path for the discovered config file.
     pub fn path(&self) -> &Path {
         match self {
-            Self::Json(path) | Self::Jsonc(path) | Self::Js(path) | Self::Vite(path) => path,
+            Self::Json(path)
+            | Self::Jsonc(path)
+            | Self::Toml(path)
+            | Self::Js(path)
+            | Self::Vite(path) => path,
         }
     }
 }
@@ -45,6 +55,8 @@ pub struct ConfigFileNames {
     pub json: &'static str,
     /// JSONC config file name, such as `.oxlintrc.jsonc`.
     pub jsonc: &'static str,
+    /// TOML config file name, such as `.oxlintrc.toml`.
+    pub toml: &'static str,
     /// JavaScript or TypeScript config file names, such as `oxlint.config.ts`
     /// and `oxlint.config.mts`.
     pub js: &'static [&'static str],
@@ -68,14 +80,18 @@ impl ConfigDiscovery {
     /// Return supported config file names in discovery order.
     ///
     /// In Vite+ mode, only the configured Vite file name is returned. In
-    /// regular mode, JSON, JSONC, and JavaScript/TypeScript config names are
+    /// regular mode, JSON, JSONC, TOML, and JavaScript/TypeScript config names are
     /// returned in that order.
     pub fn config_file_names(&self) -> Vec<&'static str> {
         if self.vite_plus_mode {
             return vec![self.config_file_names.vite];
         }
 
-        let mut names = vec![self.config_file_names.json, self.config_file_names.jsonc];
+        let mut names = vec![
+            self.config_file_names.json,
+            self.config_file_names.jsonc,
+            self.config_file_names.toml,
+        ];
         names.extend_from_slice(self.config_file_names.js);
         names
     }
@@ -111,7 +127,10 @@ impl ConfigDiscovery {
             let name_supported = if self.vite_plus_mode {
                 name == names.vite
             } else {
-                name == names.json || name == names.jsonc || names.js.iter().any(|js| name == *js)
+                name == names.json
+                    || name == names.jsonc
+                    || name == names.toml
+                    || names.js.iter().any(|js| name == *js)
             };
             if !name_supported {
                 continue;
@@ -160,6 +179,9 @@ impl ConfigDiscovery {
         }
         if file_name == self.config_file_names.jsonc {
             return Some(DiscoveredConfigFile::Jsonc(candidate.to_path_buf()));
+        }
+        if file_name == self.config_file_names.toml {
+            return Some(DiscoveredConfigFile::Toml(candidate.to_path_buf()));
         }
         if self.config_file_names.js.iter().any(|js| file_name == *js) {
             return Some(DiscoveredConfigFile::Js(candidate.to_path_buf()));
@@ -257,11 +279,15 @@ fn format_conflicting_config_names(config_names: &[String]) -> String {
 mod test {
     use std::{fs, path::Path};
 
-    use super::{ConfigDiscovery, ConfigFileNames, DiscoveredConfigFile, is_js_config_path};
+    use super::{
+        ConfigDiscovery, ConfigFileNames, DiscoveredConfigFile, is_js_config_path,
+        is_toml_config_path,
+    };
 
     const NAMES: ConfigFileNames = ConfigFileNames {
         json: ".oxlintrc.json",
         jsonc: ".oxlintrc.jsonc",
+        toml: ".oxlintrc.toml",
         js: &["oxlint.config.ts", "oxlint.config.mts"],
         vite: "vite.config.ts",
     };
@@ -283,6 +309,12 @@ mod test {
         assert!(is_js_config_path(Path::new("my-config.cts")));
         assert!(is_js_config_path(Path::new("my-config.mts")));
         assert!(!is_js_config_path(Path::new("oxlint.config.json")));
+    }
+
+    #[test]
+    fn test_is_toml_config_path() {
+        assert!(is_toml_config_path(Path::new("my-config.toml")));
+        assert!(!is_toml_config_path(Path::new("oxlint.config.json")));
     }
 
     #[test]

--- a/crates/oxc_config/src/lib.rs
+++ b/crates/oxc_config/src/lib.rs
@@ -7,6 +7,7 @@ mod walk;
 
 pub use discovery::{
     ConfigConflict, ConfigDiscovery, ConfigFileNames, DiscoveredConfigFile, is_js_config_path,
+    is_toml_config_path,
 };
 pub use glob_set::{GlobSet, validate_glob_pattern};
 pub use ignore_patterns::validate_ignore_pattern;

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -75,6 +75,9 @@ serde_json = { workspace = true, features = [
 ] } # preserve_order: print config with ordered keys.
 simdutf8 = { workspace = true }
 smallvec = { workspace = true }
+toml = { workspace = true, features = [
+  "preserve_order",
+] } # preserve_order: print config with ordered keys.
 unicode-segmentation = { workspace = true }
 url = { workspace = true }
 

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -368,14 +368,6 @@ impl Oxlintrc {
         Ok(config)
     }
 
-    /// Returns the directory containing this configuration file.
-    ///
-    /// Returns `None` when the configuration was not loaded from a file (`path` is empty),
-    /// e.g. when no configuration file was found.
-    pub fn dir(&self) -> Option<&Path> {
-        self.path.parent()
-    }
-
     /// # Errors
     ///
     /// * Parse Failure
@@ -392,6 +384,58 @@ impl Oxlintrc {
         Self::deserialize(&json).map_err(|err| {
             OxcDiagnostic::error(format!("Failed to parse config with error {err:?}"))
         })
+    }
+
+    /// # Errors
+    ///
+    /// * Parse Failure
+    pub fn from_toml_file(path: &Path) -> Result<Self, OxcDiagnostic> {
+        let string = read_to_string(path).map_err(|e| {
+            OxcDiagnostic::error(format!(
+                "Failed to parse config {} with error {e:?}",
+                path.display()
+            ))
+        })?;
+
+        let toml = toml::from_str::<toml::Table>(&string).map_err(|err| {
+            OxcDiagnostic::error(format!(
+                "Failed to parse oxlint config {}.\n{err}",
+                path.display()
+            ))
+        })?;
+
+        let mut config = Self::deserialize(toml).map_err(|err| {
+            OxcDiagnostic::error(format!("Failed to parse config with error {err:?}"))
+        })?;
+
+        config.path = path.to_path_buf();
+
+        #[expect(clippy::missing_panics_doc)]
+        let config_dir =
+            config.path.parent().expect("config path should have a parent directory").to_path_buf();
+        config.set_config_dir(&config_dir);
+
+        Ok(config)
+    }
+
+    /// # Errors
+    ///
+    /// * Parse Failure
+    pub fn from_toml_string(toml_string: &str) -> Result<Self, OxcDiagnostic> {
+        let toml =
+            toml::from_str::<toml::Table>(toml_string).unwrap_or_else(|_| toml::Table::new());
+
+        Self::deserialize(toml).map_err(|err| {
+            OxcDiagnostic::error(format!("Failed to parse config with error {err:?}"))
+        })
+    }
+
+    /// Returns the directory containing this configuration file.
+    ///
+    /// Returns `None` when the configuration was not loaded from a file (`path` is empty),
+    /// e.g. when no configuration file was found.
+    pub fn dir(&self) -> Option<&Path> {
+        self.path.parent()
     }
 
     /// Merges two [Oxlintrc] files together.
@@ -509,6 +553,7 @@ fn is_json_ext(ext: &str) -> bool {
 mod test {
     use rustc_hash::FxHashSet;
     use serde_json::json;
+    use toml::toml;
 
     use crate::config::{external_plugins::ExternalPluginEntry, plugins::LintPlugins};
 
@@ -517,6 +562,24 @@ mod test {
     #[test]
     fn test_oxlintrc_de_empty() {
         let config: Oxlintrc = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(config.plugins, None);
+        assert_eq!(config.rules, OxlintRules::default());
+        assert!(config.rules.is_empty());
+        assert_eq!(config.settings, OxlintSettings::default());
+        assert_eq!(config.env, OxlintEnv::default());
+        assert_eq!(config.path, PathBuf::default());
+        assert_eq!(config.extends, Vec::<PathBuf>::default());
+        assert_eq!(config.options.type_aware, None);
+        assert_eq!(config.options.type_check, None);
+        assert_eq!(config.options.deny_warnings, None);
+        assert_eq!(config.options.max_warnings, None);
+        assert_eq!(config.options.report_unused_disable_directives, None);
+        assert_eq!(config.options.respect_eslint_disable_directives, None);
+    }
+
+    #[test]
+    fn test_oxlintrc_de_empty_toml() {
+        let config: Oxlintrc = toml::from_str::<Oxlintrc>("").unwrap();
         assert_eq!(config.plugins, None);
         assert_eq!(config.rules, OxlintRules::default());
         assert!(config.rules.is_empty());
@@ -646,6 +709,140 @@ mod test {
 
         let config: Result<Oxlintrc, _> =
             serde_json::from_value(json!({ "respectEslintDisableDirectives": false }));
+        assert!(config.is_err());
+    }
+
+    #[test]
+    fn test_oxlintrc_options_deserialize_toml() {
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            typeAware = true
+        })
+        .unwrap();
+        assert_eq!(config.options.type_aware, Some(true));
+
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            typeAware = false
+        })
+        .unwrap();
+        assert_eq!(config.options.type_aware, Some(false));
+
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            typeCheck = true
+        })
+        .unwrap();
+        assert_eq!(config.options.type_check, Some(true));
+
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            typeCheck = false
+        })
+        .unwrap();
+        assert_eq!(config.options.type_check, Some(false));
+
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            denyWarnings = true
+        })
+        .unwrap();
+        assert_eq!(config.options.deny_warnings, Some(true));
+
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            denyWarnings = false
+        })
+        .unwrap();
+        assert_eq!(config.options.deny_warnings, Some(false));
+
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            maxWarnings = 10
+        })
+        .unwrap();
+        assert_eq!(config.options.max_warnings, Some(10));
+
+        let config: Result<Oxlintrc, _> = Oxlintrc::deserialize(toml! {
+            [options]
+            maxWarnings = -1
+        });
+        assert!(config.is_err());
+
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            reportUnusedDisableDirectives = "warn"
+        })
+        .unwrap();
+        assert_eq!(config.options.report_unused_disable_directives, Some(AllowWarnDeny::Warn));
+
+        // error and deny
+
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            reportUnusedDisableDirectives = "error"
+        })
+        .unwrap();
+        assert_eq!(config.options.report_unused_disable_directives, Some(AllowWarnDeny::Deny));
+
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            reportUnusedDisableDirectives = "deny"
+        })
+        .unwrap();
+        assert_eq!(config.options.report_unused_disable_directives, Some(AllowWarnDeny::Deny));
+
+        // off and allow
+
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            reportUnusedDisableDirectives = "off"
+        })
+        .unwrap();
+        assert_eq!(config.options.report_unused_disable_directives, Some(AllowWarnDeny::Allow));
+
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            reportUnusedDisableDirectives = "allow"
+        })
+        .unwrap();
+        assert_eq!(config.options.report_unused_disable_directives, Some(AllowWarnDeny::Allow));
+
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            respectEslintDisableDirectives = false
+        })
+        .unwrap();
+        assert_eq!(config.options.respect_eslint_disable_directives, Some(false));
+
+        let config: Oxlintrc = Oxlintrc::deserialize(toml! {
+            [options]
+            respectEslintDisableDirectives = true
+        })
+        .unwrap();
+        assert_eq!(config.options.respect_eslint_disable_directives, Some(true));
+    }
+
+    #[test]
+    fn test_oxlintrc_top_level_options_rejected_toml() {
+        let config: Result<Oxlintrc, _> = Oxlintrc::deserialize(toml! { typeAware = true });
+        assert!(config.is_err());
+
+        let config: Result<Oxlintrc, _> = Oxlintrc::deserialize(toml! { typeCheck = true });
+        assert!(config.is_err());
+
+        let config: Result<Oxlintrc, _> = Oxlintrc::deserialize(toml! { denyWarnings = true });
+        assert!(config.is_err());
+
+        let config: Result<Oxlintrc, _> = Oxlintrc::deserialize(toml! { maxWarnings = 1 });
+        assert!(config.is_err());
+
+        let config: Result<Oxlintrc, _> =
+            Oxlintrc::deserialize(toml! { reportUnusedDisableDirectives = "warn" });
+        assert!(config.is_err());
+
+        let config: Result<Oxlintrc, _> =
+            Oxlintrc::deserialize(toml! { respectEslintDisableDirectives = false });
         assert!(config.is_err());
     }
 


### PR DESCRIPTION
This PR introduces support for `.ox{fmt|lint}rc.toml`, as a more readable alternative to jsonc. As Oxc already embarks the `toml` crate, this change should have a minimal impact on the binary sizes.

I added relevant tests for this new config format; they passed locally but I had a hard time generating the new/updated snapshots. I also encountered a bunch of failures that are seemingly unrelated to my changes (looks like some weird newline mixups?). I'll try to generate them properly later, for now I'm submitting it as a first draft to gauge interest in this new feature and have early feedback.