### PR TITLE
feat(linter/unicorn): implement no-useless-continue

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1578,6 +1578,7 @@ export interface DummyRuleMap {
   "unicorn/no-unreadable-array-destructuring"?: RuleNoConfig;
   "unicorn/no-unreadable-iife"?: RuleNoConfig;
   "unicorn/no-useless-collection-argument"?: RuleNoConfig;
+  "unicorn/no-useless-continue"?: RuleNoConfig;
   "unicorn/no-useless-error-capture-stack-trace"?: RuleNoConfig;
   "unicorn/no-useless-fallback-in-spread"?: RuleNoConfig;
   "unicorn/no-useless-iterator-to-array"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3399,6 +3399,12 @@ impl RuleRunner
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::no_useless_continue::NoUselessContinue {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ContinueStatement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner
     for crate::rules::unicorn::no_useless_error_capture_stack_trace::NoUselessErrorCaptureStackTrace
 {

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -662,6 +662,7 @@ pub use crate::rules::unicorn::no_unnecessary_slice_end::NoUnnecessarySliceEnd a
 pub use crate::rules::unicorn::no_unreadable_array_destructuring::NoUnreadableArrayDestructuring as UnicornNoUnreadableArrayDestructuring;
 pub use crate::rules::unicorn::no_unreadable_iife::NoUnreadableIife as UnicornNoUnreadableIife;
 pub use crate::rules::unicorn::no_useless_collection_argument::NoUselessCollectionArgument as UnicornNoUselessCollectionArgument;
+pub use crate::rules::unicorn::no_useless_continue::NoUselessContinue as UnicornNoUselessContinue;
 pub use crate::rules::unicorn::no_useless_error_capture_stack_trace::NoUselessErrorCaptureStackTrace as UnicornNoUselessErrorCaptureStackTrace;
 pub use crate::rules::unicorn::no_useless_fallback_in_spread::NoUselessFallbackInSpread as UnicornNoUselessFallbackInSpread;
 pub use crate::rules::unicorn::no_useless_iterator_to_array::NoUselessIteratorToArray as UnicornNoUselessIteratorToArray;
@@ -1388,6 +1389,7 @@ pub enum RuleEnum {
     UnicornNoUnreadableArrayDestructuring(UnicornNoUnreadableArrayDestructuring),
     UnicornNoUnreadableIife(UnicornNoUnreadableIife),
     UnicornNoUselessCollectionArgument(UnicornNoUselessCollectionArgument),
+    UnicornNoUselessContinue(UnicornNoUselessContinue),
     UnicornNoUselessErrorCaptureStackTrace(UnicornNoUselessErrorCaptureStackTrace),
     UnicornNoUselessFallbackInSpread(UnicornNoUselessFallbackInSpread),
     UnicornNoUselessIteratorToArray(UnicornNoUselessIteratorToArray),
@@ -2307,8 +2309,9 @@ const UNICORN_NO_UNREADABLE_ARRAY_DESTRUCTURING_ID: usize =
     UNICORN_NO_UNNECESSARY_SLICE_END_ID + 1usize;
 const UNICORN_NO_UNREADABLE_IIFE_ID: usize = UNICORN_NO_UNREADABLE_ARRAY_DESTRUCTURING_ID + 1usize;
 const UNICORN_NO_USELESS_COLLECTION_ARGUMENT_ID: usize = UNICORN_NO_UNREADABLE_IIFE_ID + 1usize;
+const UNICORN_NO_USELESS_CONTINUE_ID: usize = UNICORN_NO_USELESS_COLLECTION_ARGUMENT_ID + 1usize;
 const UNICORN_NO_USELESS_ERROR_CAPTURE_STACK_TRACE_ID: usize =
-    UNICORN_NO_USELESS_COLLECTION_ARGUMENT_ID + 1usize;
+    UNICORN_NO_USELESS_CONTINUE_ID + 1usize;
 const UNICORN_NO_USELESS_FALLBACK_IN_SPREAD_ID: usize =
     UNICORN_NO_USELESS_ERROR_CAPTURE_STACK_TRACE_ID + 1usize;
 const UNICORN_NO_USELESS_ITERATOR_TO_ARRAY_ID: usize =
@@ -3295,6 +3298,7 @@ impl RuleEnum {
             Self::UnicornNoUselessCollectionArgument(_) => {
                 UNICORN_NO_USELESS_COLLECTION_ARGUMENT_ID
             }
+            Self::UnicornNoUselessContinue(_) => UNICORN_NO_USELESS_CONTINUE_ID,
             Self::UnicornNoUselessErrorCaptureStackTrace(_) => {
                 UNICORN_NO_USELESS_ERROR_CAPTURE_STACK_TRACE_ID
             }
@@ -4266,6 +4270,7 @@ impl RuleEnum {
             }
             Self::UnicornNoUnreadableIife(_) => UnicornNoUnreadableIife::NAME,
             Self::UnicornNoUselessCollectionArgument(_) => UnicornNoUselessCollectionArgument::NAME,
+            Self::UnicornNoUselessContinue(_) => UnicornNoUselessContinue::NAME,
             Self::UnicornNoUselessErrorCaptureStackTrace(_) => {
                 UnicornNoUselessErrorCaptureStackTrace::NAME
             }
@@ -5265,6 +5270,7 @@ impl RuleEnum {
             Self::UnicornNoUselessCollectionArgument(_) => {
                 UnicornNoUselessCollectionArgument::CATEGORY
             }
+            Self::UnicornNoUselessContinue(_) => UnicornNoUselessContinue::CATEGORY,
             Self::UnicornNoUselessErrorCaptureStackTrace(_) => {
                 UnicornNoUselessErrorCaptureStackTrace::CATEGORY
             }
@@ -6255,6 +6261,7 @@ impl RuleEnum {
             }
             Self::UnicornNoUnreadableIife(_) => UnicornNoUnreadableIife::FIX,
             Self::UnicornNoUselessCollectionArgument(_) => UnicornNoUselessCollectionArgument::FIX,
+            Self::UnicornNoUselessContinue(_) => UnicornNoUselessContinue::FIX,
             Self::UnicornNoUselessErrorCaptureStackTrace(_) => {
                 UnicornNoUselessErrorCaptureStackTrace::FIX
             }
@@ -7365,6 +7372,7 @@ impl RuleEnum {
             Self::UnicornNoUselessCollectionArgument(_) => {
                 UnicornNoUselessCollectionArgument::documentation()
             }
+            Self::UnicornNoUselessContinue(_) => UnicornNoUselessContinue::documentation(),
             Self::UnicornNoUselessErrorCaptureStackTrace(_) => {
                 UnicornNoUselessErrorCaptureStackTrace::documentation()
             }
@@ -9336,6 +9344,8 @@ impl RuleEnum {
                 UnicornNoUselessCollectionArgument::config_schema(generator)
                     .or_else(|| UnicornNoUselessCollectionArgument::schema(generator))
             }
+            Self::UnicornNoUselessContinue(_) => UnicornNoUselessContinue::config_schema(generator)
+                .or_else(|| UnicornNoUselessContinue::schema(generator)),
             Self::UnicornNoUselessErrorCaptureStackTrace(_) => {
                 UnicornNoUselessErrorCaptureStackTrace::config_schema(generator)
                     .or_else(|| UnicornNoUselessErrorCaptureStackTrace::schema(generator))
@@ -10809,6 +10819,7 @@ impl RuleEnum {
             Self::UnicornNoUnreadableArrayDestructuring(_) => "unicorn",
             Self::UnicornNoUnreadableIife(_) => "unicorn",
             Self::UnicornNoUselessCollectionArgument(_) => "unicorn",
+            Self::UnicornNoUselessContinue(_) => "unicorn",
             Self::UnicornNoUselessErrorCaptureStackTrace(_) => "unicorn",
             Self::UnicornNoUselessFallbackInSpread(_) => "unicorn",
             Self::UnicornNoUselessIteratorToArray(_) => "unicorn",
@@ -12823,6 +12834,9 @@ impl RuleEnum {
                     UnicornNoUselessCollectionArgument::from_configuration(value)?,
                 ))
             }
+            Self::UnicornNoUselessContinue(_) => Ok(Self::UnicornNoUselessContinue(
+                UnicornNoUselessContinue::from_configuration(value)?,
+            )),
             Self::UnicornNoUselessErrorCaptureStackTrace(_) => {
                 Ok(Self::UnicornNoUselessErrorCaptureStackTrace(
                     UnicornNoUselessErrorCaptureStackTrace::from_configuration(value)?,
@@ -14396,6 +14410,7 @@ impl RuleEnum {
             Self::UnicornNoUnreadableArrayDestructuring(rule) => rule.to_configuration(),
             Self::UnicornNoUnreadableIife(rule) => rule.to_configuration(),
             Self::UnicornNoUselessCollectionArgument(rule) => rule.to_configuration(),
+            Self::UnicornNoUselessContinue(rule) => rule.to_configuration(),
             Self::UnicornNoUselessErrorCaptureStackTrace(rule) => rule.to_configuration(),
             Self::UnicornNoUselessFallbackInSpread(rule) => rule.to_configuration(),
             Self::UnicornNoUselessIteratorToArray(rule) => rule.to_configuration(),
@@ -15250,6 +15265,7 @@ impl RuleEnum {
             Self::UnicornNoUnreadableArrayDestructuring(rule) => rule.run(node, ctx),
             Self::UnicornNoUnreadableIife(rule) => rule.run(node, ctx),
             Self::UnicornNoUselessCollectionArgument(rule) => rule.run(node, ctx),
+            Self::UnicornNoUselessContinue(rule) => rule.run(node, ctx),
             Self::UnicornNoUselessErrorCaptureStackTrace(rule) => rule.run(node, ctx),
             Self::UnicornNoUselessFallbackInSpread(rule) => rule.run(node, ctx),
             Self::UnicornNoUselessIteratorToArray(rule) => rule.run(node, ctx),
@@ -16114,6 +16130,7 @@ impl RuleEnum {
             Self::UnicornNoUnreadableArrayDestructuring(rule) => rule.run_once(ctx),
             Self::UnicornNoUnreadableIife(rule) => rule.run_once(ctx),
             Self::UnicornNoUselessCollectionArgument(rule) => rule.run_once(ctx),
+            Self::UnicornNoUselessContinue(rule) => rule.run_once(ctx),
             Self::UnicornNoUselessErrorCaptureStackTrace(rule) => rule.run_once(ctx),
             Self::UnicornNoUselessFallbackInSpread(rule) => rule.run_once(ctx),
             Self::UnicornNoUselessIteratorToArray(rule) => rule.run_once(ctx),
@@ -17065,6 +17082,7 @@ impl RuleEnum {
             }
             Self::UnicornNoUnreadableIife(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoUselessCollectionArgument(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoUselessContinue(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoUselessErrorCaptureStackTrace(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
             }
@@ -17960,6 +17978,7 @@ impl RuleEnum {
             Self::UnicornNoUnreadableArrayDestructuring(rule) => rule.should_run(ctx),
             Self::UnicornNoUnreadableIife(rule) => rule.should_run(ctx),
             Self::UnicornNoUselessCollectionArgument(rule) => rule.should_run(ctx),
+            Self::UnicornNoUselessContinue(rule) => rule.should_run(ctx),
             Self::UnicornNoUselessErrorCaptureStackTrace(rule) => rule.should_run(ctx),
             Self::UnicornNoUselessFallbackInSpread(rule) => rule.should_run(ctx),
             Self::UnicornNoUselessIteratorToArray(rule) => rule.should_run(ctx),
@@ -19039,6 +19058,7 @@ impl RuleEnum {
             Self::UnicornNoUselessCollectionArgument(_) => {
                 UnicornNoUselessCollectionArgument::IS_TSGOLINT_RULE
             }
+            Self::UnicornNoUselessContinue(_) => UnicornNoUselessContinue::IS_TSGOLINT_RULE,
             Self::UnicornNoUselessErrorCaptureStackTrace(_) => {
                 UnicornNoUselessErrorCaptureStackTrace::IS_TSGOLINT_RULE
             }
@@ -20164,6 +20184,7 @@ impl RuleEnum {
             Self::UnicornNoUselessCollectionArgument(_) => {
                 UnicornNoUselessCollectionArgument::VERSION
             }
+            Self::UnicornNoUselessContinue(_) => UnicornNoUselessContinue::VERSION,
             Self::UnicornNoUselessErrorCaptureStackTrace(_) => {
                 UnicornNoUselessErrorCaptureStackTrace::VERSION
             }
@@ -21212,6 +21233,7 @@ impl RuleEnum {
             Self::UnicornNoUselessCollectionArgument(_) => {
                 UnicornNoUselessCollectionArgument::HAS_CONFIG
             }
+            Self::UnicornNoUselessContinue(_) => UnicornNoUselessContinue::HAS_CONFIG,
             Self::UnicornNoUselessErrorCaptureStackTrace(_) => {
                 UnicornNoUselessErrorCaptureStackTrace::HAS_CONFIG
             }
@@ -22219,6 +22241,7 @@ impl RuleEnum {
             }
             Self::UnicornNoUnreadableIife(_) => UnicornNoUnreadableIife::INFO,
             Self::UnicornNoUselessCollectionArgument(_) => UnicornNoUselessCollectionArgument::INFO,
+            Self::UnicornNoUselessContinue(_) => UnicornNoUselessContinue::INFO,
             Self::UnicornNoUselessErrorCaptureStackTrace(_) => {
                 UnicornNoUselessErrorCaptureStackTrace::INFO
             }
@@ -23105,6 +23128,7 @@ impl RuleEnum {
             Self::UnicornNoUnreadableArrayDestructuring(rule) => rule.types_info(),
             Self::UnicornNoUnreadableIife(rule) => rule.types_info(),
             Self::UnicornNoUselessCollectionArgument(rule) => rule.types_info(),
+            Self::UnicornNoUselessContinue(rule) => rule.types_info(),
             Self::UnicornNoUselessErrorCaptureStackTrace(rule) => rule.types_info(),
             Self::UnicornNoUselessFallbackInSpread(rule) => rule.types_info(),
             Self::UnicornNoUselessIteratorToArray(rule) => rule.types_info(),
@@ -23956,6 +23980,7 @@ impl RuleEnum {
             Self::UnicornNoUnreadableArrayDestructuring(rule) => rule.run_info(),
             Self::UnicornNoUnreadableIife(rule) => rule.run_info(),
             Self::UnicornNoUselessCollectionArgument(rule) => rule.run_info(),
+            Self::UnicornNoUselessContinue(rule) => rule.run_info(),
             Self::UnicornNoUselessErrorCaptureStackTrace(rule) => rule.run_info(),
             Self::UnicornNoUselessFallbackInSpread(rule) => rule.run_info(),
             Self::UnicornNoUselessIteratorToArray(rule) => rule.run_info(),
@@ -24913,6 +24938,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         ),
         RuleEnum::UnicornNoUnreadableIife(UnicornNoUnreadableIife::default()),
         RuleEnum::UnicornNoUselessCollectionArgument(UnicornNoUselessCollectionArgument::default()),
+        RuleEnum::UnicornNoUselessContinue(UnicornNoUselessContinue::default()),
         RuleEnum::UnicornNoUselessErrorCaptureStackTrace(
             UnicornNoUselessErrorCaptureStackTrace::default(),
         ),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -548,6 +548,7 @@ pub(crate) mod unicorn {
     pub mod no_unreadable_array_destructuring;
     pub mod no_unreadable_iife;
     pub mod no_useless_collection_argument;
+    pub mod no_useless_continue;
     pub mod no_useless_error_capture_stack_trace;
     pub mod no_useless_fallback_in_spread;
     pub mod no_useless_iterator_to_array;

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_continue.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_continue.rs
@@ -1,0 +1,381 @@
+// Ported from eslint-plugin-unicorn v72.0.0:
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v72.0.0/rules/no-useless-continue.js
+// Copyright (c) Sindre Sorhus and contributors. Licensed under MIT; see THIRD-PARTY-LICENSE.
+
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_useless_continue_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unnecessary `continue` statement.")
+        .with_help("Remove this redundant `continue` statement.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoUselessContinue;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows `continue` statements that are reached as the final action of
+    /// the current loop iteration.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A trailing `continue` statement has no effect because the loop advances
+    /// to its next iteration immediately afterward. Removing it makes the
+    /// control flow easier to read without changing behavior.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// for (const item of items) {
+    ///     process(item);
+    ///     continue;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// for (const item of items) {
+    ///     if (shouldSkip(item)) {
+    ///         continue;
+    ///     }
+    ///     process(item);
+    /// }
+    /// ```
+    NoUselessContinue,
+    unicorn,
+    pedantic,
+    fix,
+    version = "next",
+    short_description = "Disallows useless `continue` statements.",
+);
+
+impl Rule for NoUselessContinue {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ContinueStatement(continue_statement) = node.kind() else {
+            return;
+        };
+
+        if continue_statement.label.is_some() || !is_useless_continue(node, ctx) {
+            return;
+        }
+
+        ctx.diagnostic_with_fix(no_useless_continue_diagnostic(continue_statement.span), |fixer| {
+            fixer.delete(continue_statement)
+        });
+    }
+}
+
+/// Returns whether removing this `continue` would leave the loop iteration's
+/// behavior unchanged.
+fn is_useless_continue(node: &AstNode, ctx: &LintContext) -> bool {
+    let nodes = ctx.nodes();
+
+    // Removing a bare loop body such as `while (condition) continue;` would
+    // leave invalid syntax. Upstream intentionally treats these as valid.
+    if !matches!(nodes.parent_kind(node.id()), AstKind::BlockStatement(_)) {
+        return false;
+    }
+
+    let mut current_id = node.id();
+    let mut current_span = node.kind().span();
+
+    loop {
+        let parent = nodes.parent_node(current_id);
+
+        match parent.kind() {
+            AstKind::BlockStatement(block) => {
+                if block.body.last().is_none_or(|statement| statement.span() != current_span) {
+                    return false;
+                }
+
+                current_id = parent.id();
+                current_span = block.span;
+            }
+            AstKind::IfStatement(if_statement) => {
+                let is_branch = if_statement.consequent.span() == current_span
+                    || if_statement
+                        .alternate
+                        .as_ref()
+                        .is_some_and(|alternate| alternate.span() == current_span);
+
+                if !is_branch {
+                    return false;
+                }
+
+                current_id = parent.id();
+                current_span = if_statement.span;
+            }
+            AstKind::ForStatement(statement) => return statement.body.span() == current_span,
+            AstKind::ForInStatement(statement) => return statement.body.span() == current_span,
+            AstKind::ForOfStatement(statement) => return statement.body.span() == current_span,
+            AstKind::WhileStatement(statement) => return statement.body.span() == current_span,
+            AstKind::DoWhileStatement(statement) => return statement.body.span() == current_span,
+            _ => return false,
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "for (const x of xs) {
+                if (skip(x)) {
+                    continue;
+                }
+                process(x);
+            }",
+        "for (const x of xs) {
+                if (a) {
+                    continue;
+                }
+                doMore();
+            }",
+        "for (const x of xs) {
+                if (a) {
+                    continue;
+                } else {
+                    doMore();
+                }
+                use(x);
+            }",
+        "while (cond) continue;",
+        "for (;;) continue;",
+        "for (const x of xs) continue;",
+        "outer: for (const x of xs) {
+                for (const y of ys) {
+                    continue outer;
+                }
+            }",
+        "loop: for (const x of xs) {
+                doX();
+                continue loop;
+            }",
+        "for (const x of xs) {
+                switch (x) {
+                    case 1:
+                        continue;
+                }
+            }",
+        "for (const x of xs) {
+                try {
+                    continue;
+                } finally {
+                    cleanup();
+                }
+            }",
+        "for (const x of xs) {
+                try {
+                    doX();
+                    continue;
+                } catch {}
+            }",
+        "for (const x of xs) {
+                try {
+                    doX();
+                } catch {
+                    continue;
+                }
+            }",
+        "for (const x of xs) {
+                try {
+                    doX();
+                } finally {
+                    continue;
+                }
+            }",
+        "for (const x of xs) {
+                for (const y of ys) {
+                    if (skip(y)) {
+                        continue;
+                    }
+                    process(y);
+                }
+            }",
+        "for (const x of xs) {
+                continue;
+                doX();
+            }",
+        "for (const x of xs) {
+                continue;
+                function f() {}
+            }",
+        "for (const x of xs) {
+                if (a) {
+                    continue;
+                }
+                ;
+            }",
+        "for (const x of xs) {
+                {
+                    continue;
+                }
+                doMore();
+            }",
+        "for (const x of xs) {
+                block: {
+                    continue;
+                }
+            }",
+        "for (const x of xs) {
+                if (a) {
+                    if (b) {
+                        continue;
+                    }
+                }
+                doMore();
+            }",
+    ];
+
+    let fail = vec![
+        "for (const x of xs) {
+                process(x);
+                continue;
+            }",
+        "for (const x of xs) {
+                continue;
+            }",
+        "while (cond) {
+                doX();
+                continue;
+            }",
+        "do {
+                doX();
+                continue;
+            } while (cond);",
+        "for (const x in object) {
+                doX();
+                continue;
+            }",
+        "for (let i = 0; i < n; i++) {
+                doX();
+                continue;
+            }",
+        "for (const x of xs) if (a) { continue; }",
+        "for (const x of xs) {
+                if (a) {
+                    continue;
+                }
+            }",
+        "for (const x of xs) {
+                if (a) {
+                    if (b) {
+                        continue;
+                    }
+                }
+            }",
+        "for (const x of xs) {
+                if (a) {
+                    doX();
+                    continue;
+                } else {
+                    doY();
+                }
+            }",
+        "for (const x of xs) {
+                if (a) {
+                    doX();
+                } else {
+                    doY();
+                    continue;
+                }
+            }",
+        "for (const x of xs) {
+                if (a) {
+                    doX();
+                } else if (b) {
+                    doY();
+                    continue;
+                }
+            }",
+        "async function run() {
+                for await (const x of xs) {
+                    process(x);
+                    continue;
+                }
+            }",
+        "for (const x of xs) {
+                {
+                    continue;
+                }
+            }",
+        "for (const x of xs) {
+                for (const y of ys) {
+                    process(y);
+                    continue;
+                }
+            }",
+        "for (const x of xs) {
+                for (const y of ys) {
+                    continue;
+                }
+                continue;
+            }",
+        "outer: for (const x of xs) {
+                doX();
+                continue;
+            }",
+        "for (const x of xs) {
+                continue;
+                continue;
+            }",
+        "for (const x of xs) {
+                if (a) {
+                    doX();
+                } else {
+                    if (b) {
+                        continue;
+                    }
+                }
+            }",
+        "do {
+                if (a) {
+                    continue;
+                }
+            } while (cond);",
+        "for (const x of xs) {
+                doX();
+                continue; // trailing comment
+            }",
+        "for (const x of xs) {
+                doX();
+                // leading comment
+                continue;
+            }",
+    ];
+
+    let fix = vec![
+        ("for (const x of xs) { process(x); continue; }", "for (const x of xs) { process(x);  }"),
+        ("for (const x of xs) { continue; }", "for (const x of xs) {  }"),
+        ("for (const x of xs) { if (a) { continue; } }", "for (const x of xs) { if (a) {  } }"),
+        (
+            "for (const x of xs) { if (a) { doX(); } else { continue; } }",
+            "for (const x of xs) { if (a) { doX(); } else {  } }",
+        ),
+        (
+            "for (const x of xs) { for (const y of ys) { continue; } continue; }",
+            "for (const x of xs) { for (const y of ys) {  }  }",
+        ),
+        (
+            "for (const x of xs) { doX(); continue; // trailing comment\n}",
+            "for (const x of xs) { doX();  // trailing comment\n}",
+        ),
+        (
+            "for (const x of xs) { doX(); // leading comment\ncontinue; }",
+            "for (const x of xs) { doX(); // leading comment\n }",
+        ),
+    ];
+
+    Tester::new(NoUselessContinue::NAME, NoUselessContinue::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_no_useless_continue.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_useless_continue.snap
@@ -1,0 +1,209 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:3:17]
+ 2 │                 process(x);
+ 3 │                 continue;
+   ·                 ─────────
+ 4 │             }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:2:17]
+ 1 │ for (const x of xs) {
+ 2 │                 continue;
+   ·                 ─────────
+ 3 │             }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:3:17]
+ 2 │                 doX();
+ 3 │                 continue;
+   ·                 ─────────
+ 4 │             }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:3:17]
+ 2 │                 doX();
+ 3 │                 continue;
+   ·                 ─────────
+ 4 │             } while (cond);
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:3:17]
+ 2 │                 doX();
+ 3 │                 continue;
+   ·                 ─────────
+ 4 │             }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:3:17]
+ 2 │                 doX();
+ 3 │                 continue;
+   ·                 ─────────
+ 4 │             }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:1:30]
+ 1 │ for (const x of xs) if (a) { continue; }
+   ·                              ─────────
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:3:21]
+ 2 │                 if (a) {
+ 3 │                     continue;
+   ·                     ─────────
+ 4 │                 }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:4:25]
+ 3 │                     if (b) {
+ 4 │                         continue;
+   ·                         ─────────
+ 5 │                     }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:4:21]
+ 3 │                     doX();
+ 4 │                     continue;
+   ·                     ─────────
+ 5 │                 } else {
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:6:21]
+ 5 │                     doY();
+ 6 │                     continue;
+   ·                     ─────────
+ 7 │                 }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:6:21]
+ 5 │                     doY();
+ 6 │                     continue;
+   ·                     ─────────
+ 7 │                 }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:4:21]
+ 3 │                     process(x);
+ 4 │                     continue;
+   ·                     ─────────
+ 5 │                 }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:3:21]
+ 2 │                 {
+ 3 │                     continue;
+   ·                     ─────────
+ 4 │                 }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:4:21]
+ 3 │                     process(y);
+ 4 │                     continue;
+   ·                     ─────────
+ 5 │                 }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:3:21]
+ 2 │                 for (const y of ys) {
+ 3 │                     continue;
+   ·                     ─────────
+ 4 │                 }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:5:17]
+ 4 │                 }
+ 5 │                 continue;
+   ·                 ─────────
+ 6 │             }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:3:17]
+ 2 │                 doX();
+ 3 │                 continue;
+   ·                 ─────────
+ 4 │             }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:3:17]
+ 2 │                 continue;
+ 3 │                 continue;
+   ·                 ─────────
+ 4 │             }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:6:25]
+ 5 │                     if (b) {
+ 6 │                         continue;
+   ·                         ─────────
+ 7 │                     }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:3:21]
+ 2 │                 if (a) {
+ 3 │                     continue;
+   ·                     ─────────
+ 4 │                 }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:3:17]
+ 2 │                 doX();
+ 3 │                 continue; // trailing comment
+   ·                 ─────────
+ 4 │             }
+   ╰────
+  help: Remove this redundant `continue` statement.
+
+  ⚠ unicorn(no-useless-continue): Unnecessary `continue` statement.
+   ╭─[no_useless_continue.tsx:4:17]
+ 3 │                 // leading comment
+ 4 │                 continue;
+   ·                 ─────────
+ 5 │             }
+   ╰────
+  help: Remove this redundant `continue` statement.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9115,6 +9115,9 @@
         "unicorn/no-useless-collection-argument": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/no-useless-continue": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "unicorn/no-useless-error-capture-stack-trace": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -585,6 +585,7 @@ unicorn/no-unnecessary-slice-end                           |  62606
 unicorn/no-unreadable-array-destructuring                  |    276
 unicorn/no-unreadable-iife                                 |  62606
 unicorn/no-useless-collection-argument                     |   1421
+unicorn/no-useless-continue                                |    205
 unicorn/no-useless-error-capture-stack-trace               |  62606
 unicorn/no-useless-fallback-in-spread                      |  12119
 unicorn/no-useless-iterator-to-array                       |  65257


### PR DESCRIPTION
## Summary

Implements `unicorn/no-useless-continue` for Oxlint.

The rule reports unlabeled `continue` statements reached as the final action of the current loop iteration. It follows trailing block and `if` ancestry while preserving meaningful cases such as labeled continues, bare loop bodies, switch cases, and try/catch/finally blocks.

The autofix removes only the `continue` statement span, preserving leading and trailing comments.

## Testing

- Ported the eslint-plugin-unicorn v72 matrix: 20 valid cases and 22 invalid programs producing 23 diagnostics
- Added fix controls for nested loops and leading/trailing comments
- `cargo test -p oxc_linter --all-features`
- `CARGO_BUILD_WARNINGS=deny cargo lint -p oxc_linter`
- `cargo ck -p oxc_linter`
- `cargo test -p website_linter`
- `pnpm run fmt`
- `git diff --check`
- Manual Oxlint CLI diagnostic, fix, and post-fix verification

The repository `just ready` workflow passed dependency installation, typo checks, code generation, dependency shear, and formatting. Its workspace-wide `cargo ck` step could not complete locally because the machine does not have the system `cmake` executable required to build `libmimalloc-sys2`; all affected linter and generated-schema checks passed independently.

## Attribution

Ported from `eslint-plugin-unicorn` v72.0.0. The source includes attribution and points to the existing MIT notice in `THIRD-PARTY-LICENSE`.

## AI assistance

AI tools assisted with repository navigation, implementation review, and test execution. I reviewed and validated the code and am responsible for the submission.

Part of #684
