### PR TITLE
feat(minifier): drop nested jump statements outside block-like parents

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -105,7 +105,7 @@ impl<'a> PeepholeOptimizations {
 
         // Drop a trailing unconditional jump statement if applicable
         if let Some(last_stmt) = stmts.last()
-            && Self::can_remove_termination_statement(last_stmt, ctx)
+            && Self::can_remove_termination_statement(last_stmt, true, ctx)
         {
             let dropped = stmts.pop().unwrap();
             ctx.drop_statement(&dropped);
@@ -610,7 +610,7 @@ impl<'a> PeepholeOptimizations {
                     ctx.drop_statement(&previous.consequent);
                 }
 
-                if Self::can_remove_termination_statement(&if_stmt.consequent, ctx) {
+                if Self::can_remove_termination_statement(&if_stmt.consequent, true, ctx) {
                     // Don't do this transformation if the branch condition could
                     // potentially access symbols declared later on on this scope below.
                     // If so, inverting the branch condition and nesting statements after
@@ -1935,10 +1935,16 @@ impl<'a> PeepholeOptimizations {
     /// - Bare `return` statements that terminate a function body
     /// - Unlabeled `break` statements that terminate a `do...while` body whose test is statically `false`
     ///
+    /// skip_first_transparent_body: is used to ignore the first block Statement if we checked it before
+    ///
     /// Limitations:
     /// A single wrapping block is also transparent (caller guarantees it is the last statement),
     /// but deeper nested block (statements) are not — we cannot verify they are last in their parent.
-    fn can_remove_termination_statement(stmt: &Statement<'a>, ctx: &TraverseCtx<'a>) -> bool {
+    pub fn can_remove_termination_statement(
+        stmt: &Statement<'a>,
+        skip_first_transparent_body: bool,
+        ctx: &TraverseCtx<'a>,
+    ) -> bool {
         match stmt {
             // unlabeled `continue;` that terminates a `for`, `for...in`, `for...of`, `while`, `do...while` body.
             Statement::ContinueStatement(stmt) if stmt.label.is_none() => {
@@ -1951,7 +1957,8 @@ impl<'a> PeepholeOptimizations {
                         | Ancestor::DoWhileStatementBody(_) => {
                             return true;
                         }
-                        Ancestor::BlockStatementBody(_) if index == 0 => {}
+                        Ancestor::BlockStatementBody(_)
+                            if skip_first_transparent_body && index == 0 => {}
                         Ancestor::IfStatementConsequent(_)
                         | Ancestor::IfStatementAlternate(_)
                         | Ancestor::LabeledStatementBody(_) => {}
@@ -1967,7 +1974,8 @@ impl<'a> PeepholeOptimizations {
                         Ancestor::DoWhileStatementBody(do_while) => {
                             return do_while.test().get_side_free_boolean_value(ctx) == Some(false);
                         }
-                        Ancestor::BlockStatementBody(_) if index == 0 => {}
+                        Ancestor::BlockStatementBody(_)
+                            if skip_first_transparent_body && index == 0 => {}
                         Ancestor::IfStatementConsequent(_)
                         | Ancestor::IfStatementAlternate(_)
                         | Ancestor::LabeledStatementBody(_) => {}

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1933,29 +1933,48 @@ impl<'a> PeepholeOptimizations {
     /// safely removed:
     /// - Unlabeled `continue` statements that terminate a loop body
     /// - Bare `return` statements that terminate a function body
+    /// - Unlabeled `break` statements that terminate a `do...while` body whose test is statically `false`
+    ///
+    /// Limitations:
+    /// A single wrapping block is also transparent (caller guarantees it is the last statement),
+    /// but deeper nested block (statements) are not — we cannot verify they are last in their parent.
     fn can_remove_termination_statement(stmt: &Statement<'a>, ctx: &TraverseCtx<'a>) -> bool {
         match stmt {
             // unlabeled `continue;` that terminates a `for`, `for...in`, `for...of`, `while`, `do...while` body.
             Statement::ContinueStatement(stmt) if stmt.label.is_none() => {
-                matches!(
-                    ctx.ancestors().nth(1),
-                    Some(
+                for (index, ancestor) in ctx.ancestors().enumerate() {
+                    match ancestor {
                         Ancestor::ForStatementBody(_)
-                            | Ancestor::ForInStatementBody(_)
-                            | Ancestor::ForOfStatementBody(_)
-                            | Ancestor::WhileStatementBody(_)
-                            | Ancestor::DoWhileStatementBody(_)
-                    )
-                )
+                        | Ancestor::ForInStatementBody(_)
+                        | Ancestor::ForOfStatementBody(_)
+                        | Ancestor::WhileStatementBody(_)
+                        | Ancestor::DoWhileStatementBody(_) => {
+                            return true;
+                        }
+                        Ancestor::BlockStatementBody(_) if index == 0 => {}
+                        Ancestor::IfStatementConsequent(_)
+                        | Ancestor::IfStatementAlternate(_)
+                        | Ancestor::LabeledStatementBody(_) => {}
+                        _ => return false,
+                    }
+                }
+                false
             }
             // unlabeled `break;` that terminates a `do...while` body if test is false.
             Statement::BreakStatement(stmt) if stmt.label.is_none() => {
-                match ctx.ancestors().nth(1) {
-                    Some(Ancestor::DoWhileStatementBody(do_while)) => {
-                        do_while.test().get_side_free_boolean_value(ctx) == Some(false)
+                for (index, ancestor) in ctx.ancestors().enumerate() {
+                    match ancestor {
+                        Ancestor::DoWhileStatementBody(do_while) => {
+                            return do_while.test().get_side_free_boolean_value(ctx) == Some(false);
+                        }
+                        Ancestor::BlockStatementBody(_) if index == 0 => {}
+                        Ancestor::IfStatementConsequent(_)
+                        | Ancestor::IfStatementAlternate(_)
+                        | Ancestor::LabeledStatementBody(_) => {}
+                        _ => return false,
                     }
-                    _ => false,
                 }
+                false
             }
             // bare `return;` in function-body scope.
             Statement::ReturnStatement(stmt) if stmt.argument.is_none() => {

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -428,6 +428,9 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
                 Statement::ImportDeclaration(_) => {
                     Self::remove_unused_import_specifiers(stmt, ctx);
                 }
+                Statement::BreakStatement(_) | Statement::ContinueStatement(_) => {
+                    Self::try_remove_jump_statement(stmt, ctx);
+                }
                 _ => {}
             }
         } else {
@@ -469,6 +472,9 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
                     Self::remove_unused_class_declaration(stmt, ctx);
                 }
                 Statement::ImportDeclaration(_) => Self::remove_unused_import_specifiers(stmt, ctx),
+                Statement::BreakStatement(_) | Statement::ContinueStatement(_) => {
+                    Self::try_remove_jump_statement(stmt, ctx);
+                }
                 _ => {}
             }
             Self::try_fold_expression_stmt(stmt, ctx);

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -468,6 +468,13 @@ impl<'a> PeepholeOptimizations {
         ctx.replace_expression(expr, new_expr);
     }
 
+    /// Attempt to replace jump statements with empty statements when the parent is not a block-like statement.
+    pub fn try_remove_jump_statement(stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+        if Self::can_remove_termination_statement(stmt, false, ctx) {
+            ctx.replace_statement(stmt, Statement::new_empty_statement(stmt.span(), ctx));
+        }
+    }
+
     pub fn remove_sequence_expression(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::SequenceExpression(e) = expr else { return };
         let should_keep_as_sequence_expr = e

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -211,7 +211,7 @@ fn js_parser_test() {
     test("while (x) { debugger; if (1) { if (1) continue; z() } }", "for (; x; ) debugger;");
     // test("while (x()) continue", "for (; x(); ) ;");
     test("while (x) { y(); continue }", "for (; x; ) y();");
-    test("while (x) { if (y) { z(); continue } }", "for (; x; ) if (y) { z(); continue; }");
+    test("while (x) { if (y) { z(); continue } }", "for (; x; ) y && z();");
     test(
         "label: while (x) while (y) { z(); continue label }",
         "label: for (; x; ) for (; y; ) { z(); continue label;}",

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -209,7 +209,7 @@ fn js_parser_test() {
         "for (; x; ) { debugger; break; }",
     );
     test("while (x) { debugger; if (1) { if (1) continue; z() } }", "for (; x; ) debugger;");
-    // test("while (x()) continue", "for (; x(); ) ;");
+    test("while (x()) continue", "for (; x(); ) ;");
     test("while (x) { y(); continue }", "for (; x; ) y();");
     test("while (x) { if (y) { z(); continue } }", "for (; x; ) y && z();");
     test(

--- a/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
@@ -59,10 +59,13 @@ fn test_function_return_optimization() {
     test("f=()=>{return}", "f=()=>{}");
     test("function f(){if(a()){b();if(c())return;}}", "function f(){a()&&(b(),c());}");
     test("f=()=>{if(a()){b();if(c())return;}}", "f=()=>{a()&&(b(),c());}");
+    test("function f(){if(x){return;} b();}", "function f(){x||b()}");
+    test("function f(){if(x){if(y){return;}} b();}", "function f(){x&&y||b()}");
     test("function f(){if(x)return; x=3; return; }", "function f(){ x||=3;}");
     test("function f(){if(true){a();return;}else;b();}", "function f(){a();}");
     test("function f(){if(false){a();return;}else;b();return;}", "function f(){b();}");
     test("function f(){if(a()){b();return;}else;c();}", "function f(){if(a()){b();return}c()}"); // function f(){a()?b():c()}
+    test("function f(){if(a()){b();return;}}", "function f(){if(a()){b();return}}"); // function f(){a()?b():c()}
     test(
         "function f(){if(a()){b()}else{c();return;}}",
         "function f(){if(a())b();else{c();return}}",
@@ -171,14 +174,14 @@ fn test_while_continue_optimization() {
     test("while(true){if(true){a();continue;}else;b();}", "for(;;)a();");
     test("while(true){if(false){a();continue;}else;b();continue;}", "for(;;)b();");
     test("while(true){if(a()){b();continue;}else;c();}", "for(;;){if(a()){b();continue}c()}"); // for(;;)a()?b():c();
-    test("while(true){if(a()){b();}else{c();continue;}}", "for(;;)if(a())b();else{c();continue}"); // for(;;)a()?b():c();
-    test("while(true){if(a()){b();continue;}else;}", "for (;;) if(a()){b();continue;}"); // for(;;)a()&&b();
+    test("while(true){if(a()){b();}else{c();continue;}}", "for(;;)a()?b():c();");
+    test("while(true){if(a()){b();continue;}else;}", "for(;;)a()&&b();");
     test("while(true){if(a()){continue;}else{continue;} continue;}", "for(;;)a();");
     test("while(true){if(a()){continue;}else{continue;} b();}", "for(;;)a();");
     test(
         "while(true){d();if(a()){continue;}else if(b()){c();continue;}else{continue;}}",
-        "for(;;)if(d(),!a()&&b()){c();continue}",
-    ); // for(;;)d(),!a()&&b()&&c();
+        "for(;;)d(),!a()&&b()&&c();",
+    );
 
     test("while(true)while(a())continue;", "for(;;)for(;a();)continue;"); // for(;;)for(;a(););
     test("while(true)for(x in a())continue", "for(;;)for(x in a())continue;"); // for(;;)for(x in a());
@@ -199,14 +202,8 @@ fn test_while_continue_optimization() {
         "while(true){g:if(a()){continue;}else{continue;} continue;}",
         "for(;;)g:if(a())continue;else continue;",
     ); // for (;;)g:a();
-    test(
-        "while(true){g:{if(a()){continue;}else{continue;} continue;}}",
-        "for(;;)g:{if(a())continue;continue}",
-    ); // for(;;)g:a();
-    test(
-        "while(true){g:{a();if(b()){continue;}else{continue;} continue;}}",
-        "for(;;)g:{if(a(),b())continue;continue}",
-    ); // for(;;)g:a(),b();
+    test("while(true){g:{if(a()){continue;}else{continue;} continue;}}", "for(;;)g:a();");
+    test("while(true){g:{a();if(b()){continue;}else{continue;} continue;}}", "for(;;)g:a(),b();");
 }
 
 #[test]
@@ -216,11 +213,8 @@ fn test_do_continue_optimization() {
     test("do{if(true){a();continue;}else;b();}while(true)", "do a();while(1)");
     test("do{if(false){a();continue;}else;b();continue;}while(true)", "do b();while(1)");
     test("do{if(a()){b();continue;}else;c();}while(true)", "do{if(a()){b();continue}c()}while(1);"); // do a()?b():c();while(1)
-    test(
-        "do{if(a()){b();}else{c();continue;}}while(true)",
-        "do if(a())b();else{c();continue}while(1);",
-    ); // do a()?b():c();while(1)
-    test("do{if(a()){b();continue;}else;}while(true)", "do if(a()){b();continue}while(1);"); // do a()&&b();while(1)
+    test("do{if(a()){b();}else{c();continue;}}while(true)", "do a()?b():c();while(1);");
+    test("do{if(a()){b();continue;}else;}while(true)", "do a()&&b();while(1);");
     test("do{if(a()){continue;}else{continue;} continue;}while(true)", "do a();while(1)");
     test("do{if(a()){continue;}else{continue;} b();}while(true)", "do a();while(1)");
 
@@ -252,6 +246,11 @@ fn test_do_continue_optimization() {
     test("do{break}while(fn());", "do break; while(fn());");
     test("do{break}while(true);", "do break; while(1);"); // do while(0);
     test("do{break}while(!new Date());", "do;while(0);");
+    test("do{if(a)break;}while(false)", "do a;while(0)");
+    test("do if(a)break;while(false)", "do if(a)break;while(0)"); // do a;while(0)
+    test("do{if(a)break;b();} while(false)", "do a||b();while(0)");
+    test("do if(a)break;while(true)", "do if(a)break;while(1)");
+    test("do if(a){if(b)break;} while(false)", "do a&&b;while (0);");
 
     test(
         "do { foo(); switch (x) { case 1: break; default: f()} } while(false)",
@@ -266,20 +265,14 @@ fn test_for_continue_optimization() {
     test("for(x in y){if(true){a();continue;}else;b();}", "for(x in y)a()");
     test("for(x in y){if(false){a();continue;}else;b();continue;}", "for(x in y)b()");
     test("for(x in y){if(a()){b();continue;}else;c();}", "for(x in y){if(a()){b();continue}c()}"); // for(x in y)a()?b():c()
-    test(
-        "for(x in y){if(a()){b();}else{c();continue;}}",
-        "for(x in y)if(a())b();else{c();continue}",
-    ); // for(x in y)a()?b():c()
+    test("for(x in y){if(a()){b();}else{c();continue;}}", "for(x in y)a()?b():c()");
 
     test("for(x of y){if(x)continue; x=3; continue; }", "for(x of y)x||=3");
     test("for(x of y){a();continue;b()}", "for(x of y)a()");
     test("for(x of y){if(true){a();continue;}else;b();}", "for(x of y)a()");
     test("for(x of y){if(false){a();continue;}else;b();continue;}", "for(x of y)b()");
     test("for(x of y){if(a()){b();continue;}else;c();}", "for(x of y){if(a()){b();continue}c()}"); // for(x of y)a()?b():c()
-    test(
-        "for(x of y){if(a()){b();}else{c();continue;}}",
-        "for(x of y)if(a())b();else{c();continue}",
-    ); // for(x of y)a()?b():c()
+    test("for(x of y){if(a()){b();}else{c();continue;}}", "for(x of y)a()?b():c()");
 
     test(
         "r=async () => { for await (x of y){if(x)continue; x=3; continue; }}",
@@ -303,10 +296,10 @@ fn test_for_continue_optimization() {
     ); // r=async () => { for await(x of y)a()?b():c()};
     test(
         "r=async () => { for await (x of y){if(a()){b();}else{c();continue;}}}",
-        "r=async() => { for await(x of y)if(a())b();else{c();continue}};",
-    ); // r=async () => { for await (x of y) a() ? b() : c() };
+        "r=async () => { for await (x of y)a()?b():c();};",
+    );
 
-    test("for(x=0;x<y;x++){if(a()){b();continue;}else;}", "for(x=0;x<y;x++)if(a()){b();continue}"); // for(x=0;x<y;x++)a()&&b()
+    test("for(x=0;x<y;x++){if(a()){b();continue;}else;}", "for(x=0;x<y;x++)a()&&b()");
     test("for(x=0;x<y;x++){if(a()){continue;}else{continue;} continue;}", "for(x=0;x<y;x++)a()");
     test("for(x=0;x<y;x++){if(a()){continue;}else{continue;} b();}", "for(x=0;x<y;x++)a();");
 
@@ -333,11 +326,11 @@ fn test_for_continue_optimization() {
     ); // for(x=0;x<y;x++)g:a();
     test(
         "for(x=0;x<y;x++){g:{if(a()){continue;}else{continue;} continue;}}",
-        "for(x=0;x<y;x++)g:{if(a())continue;continue;}",
-    ); // for(x=0;x<y;x++)g:a();
+        "for(x=0;x<y;x++)g:a();",
+    );
     test(
         "for(x=0;x<y;x++){g:{a();if(b()){continue;}else{continue;} continue;}}",
-        "for(x=0;x<y;x++)g:{if(a(),b())continue;continue}",
+        "for(x=0;x<y;x++)g:a(),b();",
     );
 }
 

--- a/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
@@ -183,8 +183,8 @@ fn test_while_continue_optimization() {
         "for(;;)d(),!a()&&b()&&c();",
     );
 
-    test("while(true)while(a())continue;", "for(;;)for(;a();)continue;"); // for(;;)for(;a(););
-    test("while(true)for(x in a())continue", "for(;;)for(x in a())continue;"); // for(;;)for(x in a());
+    test("while(true)while(a())continue;", "for(;;)for(;a(););");
+    test("while(true)for(x in a())continue", "for(;;)for(x in a());");
 
     test("while(true)while(a())break;", "for(;;)for(;a();)break");
     test("while(true)for(x in a())break", "for(;;)for(x in a())break");
@@ -195,13 +195,10 @@ fn test_while_continue_optimization() {
         "for(;;)try{if(a())continue;continue}catch{}",
     ); // for(;;)try{a()}catch{}
 
-    test("while(true){g:continue}", "for(;;) g:continue;"); // for(;;);
-    test("while(true){g:{continue}}", "for(;;) g:continue;"); // for(;;);
+    test("while(true){g:continue}", "for(;;);");
+    test("while(true){g:{continue}}", "for(;;);");
     // This case could be improved.
-    test(
-        "while(true){g:if(a()){continue;}else{continue;} continue;}",
-        "for(;;)g:if(a())continue;else continue;",
-    ); // for (;;)g:a();
+    test("while(true){g:if(a()){continue;}else{continue;} continue;}", "for(;;)g:a();");
     test("while(true){g:{if(a()){continue;}else{continue;} continue;}}", "for(;;)g:a();");
     test("while(true){g:{a();if(b()){continue;}else{continue;} continue;}}", "for(;;)g:a(),b();");
 }
@@ -218,8 +215,8 @@ fn test_do_continue_optimization() {
     test("do{if(a()){continue;}else{continue;} continue;}while(true)", "do a();while(1)");
     test("do{if(a()){continue;}else{continue;} b();}while(true)", "do a();while(1)");
 
-    test("do{while(a())continue;}while(true)", "do for(;a();)continue;while(1);"); // do for(;a(););while(1)
-    test("do{for(x in a())continue}while(true)", "do for(x in a())continue;while(1);"); // do for(x in a());while(1)
+    test("do{while(a())continue;}while(true)", "do for(;a(););while(1);");
+    test("do{for(x in a())continue}while(true)", "do for(x in a());while(1);");
 
     test("do{while(a())break;}while(true)", "do for(;a();)break;while(1)");
     test("do for(x in a())break;while(true)", "do for(x in a())break;while(1)");
@@ -233,12 +230,9 @@ fn test_do_continue_optimization() {
         "do try{if(a())continue;continue}catch{}while(1);",
     ); // do try{a()}catch{}while(1);
 
-    test("do{g:continue}while(true)", "do g:continue;while(1);"); // do;while(1);
+    test("do{g:continue}while(true)", "do;while(1);");
     // This case could be improved.
-    test(
-        "do{g:if(a()){continue;}else{continue;} continue;}while(true)",
-        "do g:if(a())continue;else continue;while(1);",
-    ); // do g:a();while(1);
+    test("do{g:if(a()){continue;}else{continue;} continue;}while(true)", "do g:a();while(1);");
 
     test("do { foo(); continue; } while(false)", "do foo();while(0)");
     test("do { foo(); break; } while(false)", "do foo();while(0)");
@@ -247,7 +241,7 @@ fn test_do_continue_optimization() {
     test("do{break}while(true);", "do break; while(1);"); // do while(0);
     test("do{break}while(!new Date());", "do;while(0);");
     test("do{if(a)break;}while(false)", "do a;while(0)");
-    test("do if(a)break;while(false)", "do if(a)break;while(0)"); // do a;while(0)
+    test("do if(a)break;while(false)", "do a;while(0)");
     test("do{if(a)break;b();} while(false)", "do a||b();while(0)");
     test("do if(a)break;while(true)", "do if(a)break;while(1)");
     test("do if(a){if(b)break;} while(false)", "do a&&b;while (0);");
@@ -303,8 +297,8 @@ fn test_for_continue_optimization() {
     test("for(x=0;x<y;x++){if(a()){continue;}else{continue;} continue;}", "for(x=0;x<y;x++)a()");
     test("for(x=0;x<y;x++){if(a()){continue;}else{continue;} b();}", "for(x=0;x<y;x++)a();");
 
-    test("for(x=0;x<y;x++)while(a())continue;", "for(x=0;x<y;x++)for(;a();)continue;"); // for(x=0;x<y;x++)for(;a(););
-    test("for(x=0;x<y;x++)for(x in a())continue", "for(x=0;x<y;x++)for(x in a())continue;"); // for(x=0;x<y;x++)for(x in a());
+    test("for(x=0;x<y;x++)while(a())continue;", "for(x=0;x<y;x++)for(;a(););");
+    test("for(x=0;x<y;x++)for(x in a())continue", "for(x=0;x<y;x++)for(x in a());");
 
     test("for(x=0;x<y;x++)while(a())break;", "for(x=0;x<y;x++)for(;a();)break");
     test_same("for(x=0;x<y;x++)for(x in a())break");
@@ -318,12 +312,12 @@ fn test_for_continue_optimization() {
         "for(x=0;x<y;x++)try{if(a())continue;continue}catch{}",
     ); // for(x=0;x<y;x++)try{a()}catch{}
 
-    test("for(x=0;x<y;x++){g:continue}", "for(x=0;x<y;x++)g:continue;"); // for(x=0;x<y;x++);
-    test("for(x=0;x<y;x++){g:{continue}}", "for(x=0;x<y;x++)g:continue;"); // for(x=0;x<y;x++);
+    test("for(x=0;x<y;x++){g:continue}", "for(x=0;x<y;x++);");
+    test("for(x=0;x<y;x++){g:{continue}}", "for(x=0;x<y;x++);");
     test(
         "for(x=0;x<y;x++){g:if(a()){continue;}else{continue;} continue;}",
-        "for(x=0;x<y;x++)g:if(a())continue;else continue;",
-    ); // for(x=0;x<y;x++)g:a();
+        "for(x=0;x<y;x++)g:a();",
+    );
     test(
         "for(x=0;x<y;x++){g:{if(a()){continue;}else{continue;} continue;}}",
         "for(x=0;x<y;x++)g:a();",

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,7 +5,7 @@ checker.ts:
   sys deallocs: 150
   sys alloc bytes: 14996600 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 143560
+  arena allocs: 143570
   arena reallocs: 28269
   arena size: 19100024 # 19.10 MB
 

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 1854
   sys alloc bytes: 5307512 # 5.31 MB
   sys peak growth: 3707425 # 3.71 MB
-  arena allocs: 64844
-  arena reallocs: 12187
-  arena size: 9385624 # 9.39 MB
+  arena allocs: 64841
+  arena reallocs: 12169
+  arena size: 9384568 # 9.38 MB


### PR DESCRIPTION
Adds support for removing nested break/continue jump statements when they are provably removable

```js
while(a) if (b) continue; // for (; a;) b;
//              ^~~~~~~~ replaced with ;
while(a) if (b) if (b) if (b) continue; // for (; a;) b && b && b;
//                            ^~~~~~~~ replaced with ;
```

ref #25170

#### changes in stack:
- #25567
- #25132 
- #25213 
- #25159 👈
- #25128 
- `main`