### PR TITLE
fix(linter): don't insert an ASI semicolon into an unbraced statement body

### DIFF
--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -1095,6 +1095,25 @@ pub fn could_be_asi_hazard(node: &AstNode, ctx: &LintContext) -> bool {
     for ancestor in ctx.nodes().ancestors(node.id()) {
         match ancestor.kind() {
             AstKind::ExpressionStatement(expr_stmt) => {
+                // An unbraced statement body cannot continue a preceding expression:
+                // the token before it is the `)` or keyword that closes the statement
+                // head, so a semicolon is never needed. Inserting one anyway would
+                // silently empty the body, turning `if (x) [a] !== b` into
+                // `if (x) ;[a] !== b`.
+                if matches!(
+                    ctx.nodes().parent_kind(ancestor.id()),
+                    AstKind::IfStatement(_)
+                        | AstKind::WhileStatement(_)
+                        | AstKind::DoWhileStatement(_)
+                        | AstKind::ForStatement(_)
+                        | AstKind::ForInStatement(_)
+                        | AstKind::ForOfStatement(_)
+                        | AstKind::WithStatement(_)
+                        | AstKind::LabeledStatement(_)
+                ) {
+                    return false;
+                }
+
                 expr_stmt_span = Some(expr_stmt.span);
                 break;
             }

--- a/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
@@ -233,6 +233,20 @@ fn test() {
                         ;[a, b].join('') !== c
                     ",
         ),
+        // An unbraced statement body is never an ASI hazard: the token before it
+        // closes the statement head, so a leading `;` would empty the body instead.
+        ("if (x) ![a, b].join('') === c", "if (x) [a, b].join('') !== c"),
+        ("if (x) y; else ![a, b].join('') === c", "if (x) y; else [a, b].join('') !== c"),
+        ("while (x) ![a, b].join('') === c", "while (x) [a, b].join('') !== c"),
+        ("do ![a, b].join('') === c; while (x)", "do [a, b].join('') !== c; while (x)"),
+        ("for (;;) ![a, b].join('') === c", "for (;;) [a, b].join('') !== c"),
+        ("for (k in o) ![a, b].join('') === c", "for (k in o) [a, b].join('') !== c"),
+        ("for (k of o) ![a, b].join('') === c", "for (k of o) [a, b].join('') !== c"),
+        ("with (x) ![a, b].join('') === c", "with (x) [a, b].join('') !== c"),
+        // Not a regression case: `:` is not in the hazard set, so this already
+        // returned `false`. Kept as a guard so labeled bodies stay correct if
+        // that set ever grows.
+        ("lbl: ![a, b].join('') === c", "lbl: [a, b].join('') !== c"),
     ];
 
     Tester::new(NoNegationInEqualityCheck::NAME, NoNegationInEqualityCheck::PLUGIN, pass, fail)


### PR DESCRIPTION
`could_be_asi_hazard` decides whether a fixer must prefix its replacement with `;`. It looks only at the last meaningful character before the enclosing `ExpressionStatement`. When that statement is the *unbraced body* of another statement, the preceding character is the `)` closing the head — or the `e` of `else` — and both are in the hazard set.

The inserted semicolon then becomes the entire body, and the real body is silently demoted to a following statement:

```js
// input
do ![a, b].join('') === c; while (x)

// before this PR — the loop body is now empty
do ;[a, b].join('') !== c; while (x)
```

An unbraced statement body can never continue a preceding expression: the token before it is always the `)` or keyword that closes the statement head, so no semicolon is ever needed there. This bails out for `if`/`else`, `while`, `do`, `for`/`for-in`/`for-of`, `with`, and labeled statements.

### Affected rules

The helper is shared by five rules, all of which could emit the broken fix:

- `unicorn/no-negated-condition`
- `unicorn/no-negation-in-equality-check`
- `unicorn/no-new-array`
- `unicorn/prefer-response-static-json`
- `unicorn/prefer-spread`

### Tests

Regression cases are added to `no-negation-in-equality-check`, whose fixer output starts with `[` and so exercises the hazard path.

Eight cases are true regressions — `if`, `else`, `while`, `do`, all three `for` forms, and `with`. Each was verified to fail without the `ast_util.rs` change and pass with it.

The labeled-statement case is **not** a regression and is labelled as such in the test: `:` is not in the hazard set, so `lbl: ![a, b].join('') === c` already fixed correctly on `main`. It is kept only as a guard, so labeled bodies stay correct if that set ever grows.

---

🤖 AI disclosure: this change was developed with the assistance of Claude Code. I have reviewed, tested, and understand the change.
