### PR TITLE
fix(minifier): use UTF-16 indices for string folding

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -187,8 +187,9 @@ fn try_fold_string_substring_or_slice<'a>(
         }
         None => None,
     };
-    if start_idx.is_some_and(|start| start > s.value.len() as f64 || start < 0.0)
-        || end_idx.is_some_and(|end| end > s.value.len() as f64 || end < 0.0)
+    let string_len = s.value.as_str().encode_utf16().count() as f64;
+    if start_idx.is_some_and(|start| start > string_len || start < 0.0)
+        || end_idx.is_some_and(|end| end > string_len || end < 0.0)
     {
         return None;
     }
@@ -198,7 +199,7 @@ fn try_fold_string_substring_or_slice<'a>(
         return None;
     }
 
-    Some(ConstantValue::String(Cow::Owned(s.value.as_str().substring(start_idx, end_idx))))
+    Some(ConstantValue::String(Cow::Owned(s.value.as_str().substring(start_idx, end_idx)?)))
 }
 
 fn try_fold_string_char_at<'a>(

--- a/crates/oxc_ecmascript/src/string_index_of.rs
+++ b/crates/oxc_ecmascript/src/string_index_of.rs
@@ -1,4 +1,4 @@
-use crate::ToInt32;
+use crate::to_integer_or_infinity::{ToIntegerOrInfinity, ToIntegerOrInfinityResult};
 
 pub trait StringIndexOf {
     /// `String.prototype.indexOf ( searchString [ , position ] )`
@@ -7,14 +7,26 @@ pub trait StringIndexOf {
 }
 
 impl StringIndexOf for &str {
-    #[expect(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
     fn index_of(&self, search_value: Option<&str>, from_index: Option<f64>) -> isize {
-        let from_index = from_index.map_or(0, |x| x.to_int_32().max(0)) as usize;
-        let Some(search_value) = search_value else {
-            return -1;
+        let string = self.encode_utf16().collect::<Vec<_>>();
+        let search_value = search_value.unwrap_or("undefined").encode_utf16().collect::<Vec<_>>();
+        let from_index = match from_index.unwrap_or(0.0).to_integer_or_infinity_as_i64() {
+            ToIntegerOrInfinityResult::Infinity => string.len(),
+            ToIntegerOrInfinityResult::NegativeInfinity => 0,
+            ToIntegerOrInfinityResult::Value(value) if value <= 0 => 0,
+            ToIntegerOrInfinityResult::Value(value) => {
+                usize::try_from(value).unwrap_or(string.len()).min(string.len())
+            }
         };
-        let result = self.chars().skip(from_index).collect::<String>().find(search_value);
-        result.map(|index| index + from_index).map_or(-1, |index| index as isize)
+        if search_value.is_empty() {
+            return isize::try_from(from_index).unwrap_or(-1);
+        }
+
+        string[from_index..]
+            .windows(search_value.len())
+            .position(|window| window == search_value)
+            .and_then(|index| isize::try_from(index + from_index).ok())
+            .unwrap_or(-1)
     }
 }
 
@@ -46,5 +58,9 @@ mod test {
         assert_eq!("test test test".index_of(Some("test"), Some(0.0)), 0);
         assert_eq!("test test test".index_of(Some("notpresent"), Some(0.0)), -1);
         assert_eq!("test test test".index_of(None, Some(0.0)), -1);
+        assert_eq!("undefined".index_of(None, Some(0.0)), 0);
+        assert_eq!("éa".index_of(Some("a"), None), 1);
+        assert_eq!("中a".index_of(Some("a"), None), 1);
+        assert_eq!("😀a".index_of(Some("a"), None), 2);
     }
 }

--- a/crates/oxc_ecmascript/src/string_last_index_of.rs
+++ b/crates/oxc_ecmascript/src/string_last_index_of.rs
@@ -1,4 +1,4 @@
-use crate::ToInt32;
+use crate::to_integer_or_infinity::{ToIntegerOrInfinity, ToIntegerOrInfinityResult};
 
 pub trait StringLastIndexOf {
     /// `String.prototype.lastIndexOf ( searchString [ , position ] )`
@@ -7,16 +7,34 @@ pub trait StringLastIndexOf {
 }
 
 impl StringLastIndexOf for &str {
-    #[expect(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
     fn last_index_of(&self, search_value: Option<&str>, from_index: Option<f64>) -> isize {
-        let Some(search_value) = search_value else { return -1 };
-        let from_index =
-            from_index.map_or(usize::MAX, |x| x.to_int_32().max(0) as usize + search_value.len());
-        self.chars()
-            .take(from_index)
-            .collect::<String>()
-            .rfind(search_value)
-            .map_or(-1, |index| index as isize)
+        let string = self.encode_utf16().collect::<Vec<_>>();
+        let search_value = search_value.unwrap_or("undefined").encode_utf16().collect::<Vec<_>>();
+        let from_index = match from_index {
+            None => string.len(),
+            Some(value) if value.is_nan() => string.len(),
+            Some(value) => match value.to_integer_or_infinity_as_i64() {
+                ToIntegerOrInfinityResult::Infinity => string.len(),
+                ToIntegerOrInfinityResult::NegativeInfinity => 0,
+                ToIntegerOrInfinityResult::Value(value) if value <= 0 => 0,
+                ToIntegerOrInfinityResult::Value(value) => {
+                    usize::try_from(value).unwrap_or(string.len()).min(string.len())
+                }
+            },
+        };
+        if search_value.is_empty() {
+            return isize::try_from(from_index).unwrap_or(-1);
+        }
+        if search_value.len() > string.len() {
+            return -1;
+        }
+
+        let from_index = from_index.min(string.len() - search_value.len());
+        string[..from_index + search_value.len()]
+            .windows(search_value.len())
+            .rposition(|window| window == search_value)
+            .and_then(|index| isize::try_from(index).ok())
+            .unwrap_or(-1)
     }
 }
 
@@ -36,5 +54,8 @@ mod test {
         assert_eq!("test test test".last_index_of(Some("notpresent"), Some(0.0)), -1);
         assert_eq!("test test test".last_index_of(None, Some(1.0)), -1);
         assert_eq!("abcdef".last_index_of(Some("b"), None), 1);
+        assert_eq!("undefined".last_index_of(None, None), 0);
+        assert_eq!("a😀a".last_index_of(Some("a"), None), 3);
+        assert_eq!("aba".last_index_of(Some("b"), Some(f64::NAN)), 1);
     }
 }

--- a/crates/oxc_ecmascript/src/string_substring.rs
+++ b/crates/oxc_ecmascript/src/string_substring.rs
@@ -1,22 +1,29 @@
-use crate::ToInt32;
+use crate::to_integer_or_infinity::{ToIntegerOrInfinity, ToIntegerOrInfinityResult};
 
 pub trait StringSubstring {
     /// `String.prototype.substring ( start , end ] )`
     /// <https://tc39.es/ecma262/#sec-string.prototype.substring>
-    fn substring(&self, start: Option<f64>, end: Option<f64>) -> String;
+    fn substring(&self, start: Option<f64>, end: Option<f64>) -> Option<String>;
 }
 
 impl StringSubstring for &str {
-    #[expect(clippy::cast_sign_loss)]
-    fn substring(&self, start: Option<f64>, end: Option<f64>) -> String {
-        let start = start.map_or(0, |x| x.to_int_32().max(0) as usize);
-        let end = end.map_or(usize::MAX, |x| x.to_int_32().max(0) as usize);
-        let start = start.min(self.len());
-        let end = end.min(self.len());
+    fn substring(&self, start: Option<f64>, end: Option<f64>) -> Option<String> {
+        let string = self.encode_utf16().collect::<Vec<_>>();
+        let to_index = |value: f64| match value.to_integer_or_infinity_as_i64() {
+            ToIntegerOrInfinityResult::Infinity => string.len(),
+            ToIntegerOrInfinityResult::NegativeInfinity => 0,
+            ToIntegerOrInfinityResult::Value(value) if value <= 0 => 0,
+            ToIntegerOrInfinityResult::Value(value) => {
+                usize::try_from(value).unwrap_or(string.len()).min(string.len())
+            }
+        };
+        let start = start.map_or(0, to_index);
+        let end = end.map_or(string.len(), to_index);
         if start > end {
-            return String::new();
+            return Some(String::new());
         }
-        self.chars().skip(start).take(end - start).collect()
+
+        String::from_utf16(&string[start..end]).ok()
     }
 }
 
@@ -25,13 +32,15 @@ mod test {
     #[test]
     fn test_prototype_last_index_of() {
         use super::StringSubstring;
-        assert_eq!("foo".substring(Some(1.0), None), "oo");
-        assert_eq!("foo".substring(Some(1.0), Some(2.0)), "o");
-        assert_eq!("foo".substring(Some(1.0), Some(1.0)), "");
-        assert_eq!("foo".substring(Some(1.0), Some(0.0)), "");
-        assert_eq!("foo".substring(Some(0.0), Some(0.0)), "");
-        assert_eq!("foo".substring(Some(0.0), Some(1.0)), "f");
-        assert_eq!("abc".substring(Some(0.0), Some(2.0)), "ab");
-        assert_eq!("abcde".substring(Some(0.0), Some(2.0)), "ab");
+        assert_eq!("foo".substring(Some(1.0), None).as_deref(), Some("oo"));
+        assert_eq!("foo".substring(Some(1.0), Some(2.0)).as_deref(), Some("o"));
+        assert_eq!("foo".substring(Some(1.0), Some(1.0)).as_deref(), Some(""));
+        assert_eq!("foo".substring(Some(1.0), Some(0.0)).as_deref(), Some(""));
+        assert_eq!("foo".substring(Some(0.0), Some(0.0)).as_deref(), Some(""));
+        assert_eq!("foo".substring(Some(0.0), Some(1.0)).as_deref(), Some("f"));
+        assert_eq!("abc".substring(Some(0.0), Some(2.0)).as_deref(), Some("ab"));
+        assert_eq!("abcde".substring(Some(0.0), Some(2.0)).as_deref(), Some("ab"));
+        assert_eq!("😀a".substring(Some(2.0), None).as_deref(), Some("a"));
+        assert_eq!("😀a".substring(Some(1.0), None), None);
     }
 }

--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -32,6 +32,18 @@ fn test_string_index_of() {
     test("x = 'abcundefineddef'.indexOf(undefined)", "x = 3");
     test("x = 'abcnulldef'.indexOf(null)", "x = 3");
     test("x = 'abctruedef'.indexOf(true)", "x = 3");
+    test("x = 'undefined'.indexOf()", "x = 0");
+    test("x = 'undefined'.lastIndexOf()", "x = 0");
+
+    // String indices are UTF-16 code unit offsets, not UTF-8 byte offsets.
+    test("x = 'éa'.indexOf('a')", "x = 1");
+    test("x = '中a'.indexOf('a')", "x = 1");
+    test("x = '😀a'.indexOf('a')", "x = 2");
+    test("x = 'a😀a'.lastIndexOf('a')", "x = 3");
+
+    // NaN and undefined positions default to positive infinity for lastIndexOf.
+    test("x = 'aba'.lastIndexOf('b', NaN)", "x = 1");
+    test("x = 'aba'.lastIndexOf('b', undefined)", "x = 1");
 
     test_same("x = 1 .indexOf('bcd');");
     test_same("x = NaN.indexOf('bcd')");
@@ -195,6 +207,8 @@ fn test_fold_string_substring() {
     test("x = 'abcde'.substring(0,2)", "x = 'ab'");
     test("x = 'abcde'.substring(1,2)", "x = 'b'");
     test("x = 'abcde'.substring(2)", "x = 'cde'");
+    test("x = '😀a'.substring(2)", "x = 'a'");
+    test_same("x = '😀a'.substring(1)");
     test_same("x = 'abcde'.substring(...a, 1)");
     test_same("x = 'abcde'.substring(1, ...a)");
     test_same("x = 'abcde'.substring(a, 1)");
@@ -217,6 +231,8 @@ fn test_fold_string_slice() {
     test("x = 'abcde'.slice(0,2)", "x = 'ab'");
     test("x = 'abcde'.slice(1,2)", "x = 'b'");
     test("x = 'abcde'.slice(2)", "x = 'cde'");
+    test("x = '😀a'.slice(2)", "x = 'a'");
+    test_same("x = '😀a'.slice(1)");
 
     // we should be leaving negative, out-of-bound, and inverted indices alone for now
     test_same("x = 'abcde'.slice(-1)");


### PR DESCRIPTION
 Fixes #25158.

  Use UTF-16 code unit offsets when folding `indexOf`, `lastIndexOf`, `substring`, and `slice`. This also applies the missing-search-string coercion and the special `lastIndexOf` handling for `NaN`/
  `undefined` positions.

  Folding is skipped when a substring boundary would produce an unpaired surrogate that cannot be represented by a Rust string. Regression coverage includes Latin-1, CJK, astral characters, omitted arguments,
  and non finite positions