### PR TITLE
fix(linter/unicorn/new-for-builtins): align Date() diagnostic message with upstream

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -14,6 +14,10 @@ fn disallow(span: Span, fn_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use `{fn_name}()` instead of `new {fn_name}()`")).with_label(span)
 }
 
+fn error_date(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("Use `String(new Date())` instead of `Date()`")).with_label(span)
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct NewForBuiltins;
 
@@ -80,6 +84,13 @@ impl Rule for NewForBuiltins {
                         {
                             return;
                         }
+                    }
+
+                    // `Date()` returns a string representation of the current date and time, exactly as `new Date().toString()` does.
+                    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#return_value
+                    if builtin_name == "Date" {
+                        ctx.diagnostic(error_date(call_expr.span));
+                        return;
                     }
 
                     ctx.diagnostic(enforce(call_expr.span, builtin_name));

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -15,7 +15,7 @@ fn disallow(span: Span, fn_name: &str) -> OxcDiagnostic {
 }
 
 fn error_date(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Use `String(new Date())` instead of `Date()`").with_label(span)
+    OxcDiagnostic::warn("Use `String(new Date())` instead of `Date()`").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -43,12 +43,14 @@ declare_oxc_lint!(
     /// ```javascript
     /// const foo = new String('hello world');
     /// const bar = Array(1, 2, 3);
+    /// const now = Date();
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// const foo = String('hello world');
     /// const bar = new Array(1, 2, 3);
+    /// const now = String(new Date());
     /// ```
     NewForBuiltins,
     unicorn,

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -15,7 +15,7 @@ fn disallow(span: Span, fn_name: &str) -> OxcDiagnostic {
 }
 
 fn error_date(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("Use `String(new Date())` instead of `Date()`")).with_label(span)
+    OxcDiagnostic::error("Use `String(new Date())` instead of `Date()`").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/snapshots/unicorn_new_for_builtins.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_new_for_builtins.snap
@@ -340,31 +340,31 @@ source: crates/oxc_linter/src/tester.rs
  19 │             }
     ╰────
 
-  ⚠ unicorn(new-for-builtins): Use `new Date()` instead of `Date()`
+  ⚠ unicorn(new-for-builtins): Use `String(new Date())` instead of `Date()`
    ╭─[new_for_builtins.tsx:1:13]
  1 │ const foo = Date();
    ·             ──────
    ╰────
 
-  ⚠ unicorn(new-for-builtins): Use `new Date()` instead of `Date()`
+  ⚠ unicorn(new-for-builtins): Use `String(new Date())` instead of `Date()`
    ╭─[new_for_builtins.tsx:1:13]
  1 │ const foo = globalThis.Date();
    ·             ─────────────────
    ╰────
 
-  ⚠ unicorn(new-for-builtins): Use `new Date()` instead of `Date()`
+  ⚠ unicorn(new-for-builtins): Use `String(new Date())` instead of `Date()`
    ╭─[new_for_builtins.tsx:1:13]
  1 │ const foo = Date(/*comment*/);
    ·             ─────────────────
    ╰────
 
-  ⚠ unicorn(new-for-builtins): Use `new Date()` instead of `Date()`
+  ⚠ unicorn(new-for-builtins): Use `String(new Date())` instead of `Date()`
    ╭─[new_for_builtins.tsx:1:13]
  1 │ const foo = globalThis/*comment*/.Date();
    ·             ────────────────────────────
    ╰────
 
-  ⚠ unicorn(new-for-builtins): Use `new Date()` instead of `Date()`
+  ⚠ unicorn(new-for-builtins): Use `String(new Date())` instead of `Date()`
    ╭─[new_for_builtins.tsx:1:13]
  1 │ const foo = Date(bar);
    ·             ─────────


### PR DESCRIPTION
## Summary

- Align `new-for-builtins`'s diagnostic message for `Date()` with upstream `eslint-plugin-unicorn`
- Add code example

Reference
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/new-for-builtins.js
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/new-for-builtins.md