### PR TITLE
refactor(minifier): use `impl GetAstBuilder` instead of generic params

### DIFF
--- a/crates/oxc_minifier/src/keep_var.rs
+++ b/crates/oxc_minifier/src/keep_var.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::{ast::*, builder::GetAstBuilder};
 use oxc_ast_visit::VisitJs;
 use oxc_ecmascript::BoundNames;
@@ -59,37 +59,39 @@ impl<'a> KeepVar<'a> {
         Self { vars: std::vec![], all_hoisted: true }
     }
 
-    pub fn get_variable_declaration<B: GetAstBuilder<'a> + GetAllocator<'a>>(
+    pub fn get_variable_declaration(
         self,
-        ast: &B,
+        builder: &impl GetAstBuilder<'a>,
     ) -> Option<ArenaBox<'a, VariableDeclaration<'a>>> {
         if self.vars.is_empty() {
             return None;
         }
 
+        let builder = builder.builder();
+
         let kind = VariableDeclarationKind::Var;
         let decls = ArenaVec::from_iter_in(
             self.vars.into_iter().map(|(name, span, symbol_id)| {
                 let id = symbol_id.map_or_else(
-                    || BindingPattern::new_binding_identifier(span, name, ast),
+                    || BindingPattern::new_binding_identifier(span, name, builder),
                     |symbol_id| {
                         BindingPattern::new_binding_identifier_with_symbol_id(
-                            span, name, symbol_id, ast,
+                            span, name, symbol_id, builder,
                         )
                     },
                 );
-                VariableDeclarator::new(span, kind, id, None, None, false, ast)
+                VariableDeclarator::new(span, kind, id, None, None, false, builder)
             }),
-            ast,
+            builder,
         );
 
-        Some(VariableDeclaration::boxed(SPAN, kind, decls, false, ast))
+        Some(VariableDeclaration::boxed(SPAN, kind, decls, false, builder))
     }
 
-    pub fn get_variable_declaration_statement<B: GetAstBuilder<'a> + GetAllocator<'a>>(
+    pub fn get_variable_declaration_statement(
         self,
-        ast: &B,
+        builder: &impl GetAstBuilder<'a>,
     ) -> Option<Statement<'a>> {
-        self.get_variable_declaration(ast).map(Statement::VariableDeclaration)
+        self.get_variable_declaration(builder).map(Statement::VariableDeclaration)
     }
 }


### PR DESCRIPTION
Pure refactor.

Simplify methods of `KeepVar` trait, removing generic params. Also convert the `&impl GetAstBuilder<'a>` to an `&impl AstBuild<'a>` before calling other methods, to reduce polymorphism (affects compilation time, not run time).