### PR TITLE
refactor(allocator, str): use `impl GetAllocator` instead of generic params

### DIFF
--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -71,7 +71,7 @@ impl<'alloc, T> Box<'alloc, T> {
     // We always want it to be inlined.
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    pub fn new_in<A: GetAllocator<'alloc>>(value: T, allocator: &A) -> Self {
+    pub fn new_in(value: T, allocator: &impl GetAllocator<'alloc>) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
         Self(NonNull::from(allocator.allocator().alloc(value)), PhantomData)

--- a/crates/oxc_allocator/src/take_in.rs
+++ b/crates/oxc_allocator/src/take_in.rs
@@ -13,7 +13,7 @@ pub trait TakeIn<'a>: Dummy<'a> {
     ///
     /// [`replace_with`]: crate::ReplaceWith::replace_with
     #[must_use]
-    fn take_in<A: GetAllocator<'a>>(&mut self, allocator_accessor: &A) -> Self {
+    fn take_in(&mut self, allocator_accessor: &impl GetAllocator<'a>) -> Self {
         let allocator = allocator_accessor.allocator();
         let dummy = Dummy::dummy(allocator);
         mem::replace(self, dummy)
@@ -29,7 +29,7 @@ pub trait TakeIn<'a>: Dummy<'a> {
     ///
     /// [`replace_with`]: crate::ReplaceWith::replace_with
     #[must_use]
-    fn take_in_box<A: GetAllocator<'a>>(&mut self, allocator_accessor: &A) -> Box<'a, Self> {
+    fn take_in_box(&mut self, allocator_accessor: &impl GetAllocator<'a>) -> Box<'a, Self> {
         let allocator = allocator_accessor.allocator();
         let dummy = Dummy::dummy(allocator);
         Box::new_in(mem::replace(self, dummy), &allocator)

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -76,7 +76,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// assert!(vec.is_empty());
     /// ```
     #[inline(always)]
-    pub fn new_in<A: GetAllocator<'alloc>>(allocator: &A) -> Self {
+    pub fn new_in(allocator: &impl GetAllocator<'alloc>) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
         Self(InnerVec::new_in(allocator.allocator().arena()))
@@ -130,7 +130,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// assert_eq!(vec_units.capacity(), usize::MAX);
     /// ```
     #[inline(always)]
-    pub fn with_capacity_in<A: GetAllocator<'alloc>>(capacity: usize, allocator: &A) -> Self {
+    pub fn with_capacity_in(capacity: usize, allocator: &impl GetAllocator<'alloc>) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
         Self(InnerVec::with_capacity_in(capacity, allocator.allocator().arena()))
@@ -141,9 +141,9 @@ impl<'alloc, T> Vec<'alloc, T> {
     ///
     /// This is behaviorially identical to [`FromIterator::from_iter`].
     #[inline]
-    pub fn from_iter_in<I: IntoIterator<Item = T>, A: GetAllocator<'alloc>>(
-        iter: I,
-        allocator: &A,
+    pub fn from_iter_in(
+        iter: impl IntoIterator<Item = T>,
+        allocator: &impl GetAllocator<'alloc>,
     ) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
@@ -169,7 +169,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// assert_eq!(vec, [123]);
     /// ```
     #[inline]
-    pub fn from_value_in<A: GetAllocator<'alloc>>(value: T, allocator: &A) -> Self {
+    pub fn from_value_in(value: T, allocator: &impl GetAllocator<'alloc>) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
         let boxed = Box::new_in(value, allocator);
@@ -197,9 +197,9 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// let vec = Vec::from_array_in(array, &allocator);
     /// ```
     #[inline]
-    pub fn from_array_in<const N: usize, A: GetAllocator<'alloc>>(
+    pub fn from_array_in<const N: usize>(
         array: [T; N],
-        allocator: &A,
+        allocator: &impl GetAllocator<'alloc>,
     ) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
@@ -270,11 +270,11 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// assert_eq!(rebuilt, [4, 5, 6]);
     /// ```
     #[inline(always)]
-    pub unsafe fn from_raw_parts_in<A: GetAllocator<'alloc>>(
+    pub unsafe fn from_raw_parts_in(
         ptr: NonNull<T>,
         length: usize,
         capacity: usize,
-        allocator: &A,
+        allocator: &impl GetAllocator<'alloc>,
     ) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 

--- a/crates/oxc_ast/src/builder/mod.rs
+++ b/crates/oxc_ast/src/builder/mod.rs
@@ -1,7 +1,7 @@
 //! AST builder.
 //!
 //! AST nodes are created by builder methods defined on the AST types themselves,
-//! which are passed an `&impl GetAstBuilder` or `&A where A: GetAllocator`:
+//! which are passed an `&impl GetAstBuilder` or an `&impl GetAllocator`:
 //!
 //! * `Statement::new_expression_statement(span, expr, &builder)`
 //! * `Vec::new_in(&builder)`, `Ident::from_str_in(str, &builder)`
@@ -100,7 +100,7 @@ mod custom;
 /// * [`GetAllocator`]
 ///
 /// These bounds mean that any type returned by [`GetAstBuilder::builder`] can be passed to
-/// any other method which accepts any `&impl GetAstBuilder<'a>` or `&A where A: GetAllocator<'a>`
+/// any other method which accepts any `&impl GetAstBuilder<'a>` or `&impl GetAllocator<'a>`
 /// (i.e. other AST builder methods).
 pub trait AstBuild<'a>: GetAstBuilder<'a, Builder = Self> + GetAllocator<'a> {
     /// Get [`NodeId`] to assign to an AST node.

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -154,7 +154,7 @@ pub const fn new_const_ident(s: &str) -> Ident<'_> {
 impl<'a> Ident<'a> {
     /// Allocate provided `&str` into arena, and return an [`Ident<'a>`].
     #[inline]
-    pub fn from_str_in<A: GetAllocator<'a>>(s: &str, allocator: &A) -> Self {
+    pub fn from_str_in(s: &str, allocator: &impl GetAllocator<'a>) -> Self {
         new_const_ident(allocator.allocator().alloc_str(s))
     }
 
@@ -258,9 +258,9 @@ impl<'a> Ident<'a> {
     // are statically known. See `Allocator::alloc_concat_strs_array`.
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    pub fn from_strs_array_in<const N: usize, A: GetAllocator<'a>>(
+    pub fn from_strs_array_in<const N: usize>(
         strings: [&str; N],
-        allocator: &A,
+        allocator: &impl GetAllocator<'a>,
     ) -> Ident<'a> {
         Self::from(allocator.allocator().alloc_concat_strs_array(strings))
     }
@@ -272,7 +272,7 @@ impl<'a> Ident<'a> {
     ///
     /// If the `Cow` is owned, allocates the string into arena to generate a new `Ident`.
     #[inline]
-    pub fn from_cow_in<A: GetAllocator<'a>>(value: &Cow<'a, str>, allocator: &A) -> Ident<'a> {
+    pub fn from_cow_in(value: &Cow<'a, str>, allocator: &impl GetAllocator<'a>) -> Ident<'a> {
         match value {
             Cow::Borrowed(s) => Ident::from(*s),
             Cow::Owned(s) => Ident::from_str_in(s, allocator),

--- a/crates/oxc_str/src/str.rs
+++ b/crates/oxc_str/src/str.rs
@@ -40,7 +40,7 @@ impl Str<'static> {
 impl<'a> Str<'a> {
     /// Allocate provided `&str` into arena, and return a [`Str<'a>`].
     #[inline]
-    pub fn from_str_in<A: GetAllocator<'a>>(s: &str, allocator: &A) -> Self {
+    pub fn from_str_in(s: &str, allocator: &impl GetAllocator<'a>) -> Self {
         Self(allocator.allocator().alloc_str(s))
     }
 
@@ -93,9 +93,9 @@ impl<'a> Str<'a> {
     // are statically known. See `Allocator::alloc_concat_strs_array`.
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    pub fn from_strs_array_in<const N: usize, A: GetAllocator<'a>>(
+    pub fn from_strs_array_in<const N: usize>(
         strings: [&str; N],
-        allocator: &A,
+        allocator: &impl GetAllocator<'a>,
     ) -> Str<'a> {
         Self::from(allocator.allocator().alloc_concat_strs_array(strings))
     }
@@ -107,7 +107,7 @@ impl<'a> Str<'a> {
     ///
     /// If the `Cow` is owned, allocates the string into arena to generate a new `Str`.
     #[inline]
-    pub fn from_cow_in<A: GetAllocator<'a>>(value: &Cow<'a, str>, allocator: &A) -> Str<'a> {
+    pub fn from_cow_in(value: &Cow<'a, str>, allocator: &impl GetAllocator<'a>) -> Str<'a> {
         match value {
             Cow::Borrowed(s) => Str::from(*s),
             Cow::Owned(s) => Str::from_str_in(s, allocator),


### PR DESCRIPTION
Pure refactor. Along the same lines as #25174 and other PRs in this stack.

Replace generic params with `impl` for `GetAllocator` in methods of various types and traits across `oxc_allocator` and `oxc_str`, to make the code easier to read.