### PR TITLE
[experimental, do not merge] Native type-aware linting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,20 +1656,20 @@ name = "oxc"
 version = "0.142.0"
 dependencies = [
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_cfg",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
+ "oxc_cfg 0.142.0",
  "oxc_codegen",
- "oxc_diagnostics",
+ "oxc_diagnostics 0.142.0",
  "oxc_isolated_declarations",
  "oxc_mangler",
  "oxc_minifier",
- "oxc_parser",
- "oxc_regular_expression",
- "oxc_semantic",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_parser 0.142.0",
+ "oxc_regular_expression 0.142.0",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "oxc_transformer",
  "oxc_transformer_plugins",
 ]
@@ -1770,9 +1770,9 @@ dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
  "oxc_allocator",
- "oxc_ast_macros",
- "oxc_data_structures",
- "oxc_estree",
+ "oxc_ast_macros 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_estree 0.142.0",
  "quickcheck",
  "rand",
  "rustc-hash",
@@ -1787,19 +1787,49 @@ version = "0.142.0"
 dependencies = [
  "bitflags",
  "oxc_allocator",
- "oxc_ast_macros",
- "oxc_data_structures",
- "oxc_diagnostics",
- "oxc_estree",
- "oxc_regular_expression",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_ast_macros 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_diagnostics 0.142.0",
+ "oxc_estree 0.142.0",
+ "oxc_regular_expression 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
+]
+
+[[package]]
+name = "oxc_ast"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0d567d1a93714e4b6b14eabe76c45581a25f418f47c297911a43fe4ee99615"
+dependencies = [
+ "bitflags",
+ "oxc_allocator",
+ "oxc_ast_macros 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_data_structures 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_diagnostics 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_estree 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_regular_expression 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_span 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_str 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_syntax 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "oxc_ast_macros"
 version = "0.142.0"
+dependencies = [
+ "phf",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "oxc_ast_macros"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3fff81fa6fffffcf13826a6bc352e402a9197ac88ca286e2b09a0c538904708"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1820,15 +1850,15 @@ dependencies = [
  "javascript-globals",
  "lazy-regex",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
  "oxc_codegen",
  "oxc_index",
  "oxc_minifier",
- "oxc_parser",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_parser 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "phf",
  "phf_codegen",
  "prettyplease",
@@ -1847,9 +1877,21 @@ name = "oxc_ast_visit"
 version = "0.142.0"
 dependencies = [
  "oxc_allocator",
- "oxc_ast",
- "oxc_span",
- "oxc_syntax",
+ "oxc_ast 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_syntax 0.142.0",
+]
+
+[[package]]
+name = "oxc_ast_visit"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13c8c77043e21d491840a6d52aa00f3ed1432662b096665b6ad702626f3ec5e"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_span 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_syntax 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1860,8 +1902,8 @@ dependencies = [
  "criterion2",
  "oxc",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
  "oxc_codegen",
  "oxc_estree_tokens",
  "oxc_formatter",
@@ -1869,10 +1911,10 @@ dependencies = [
  "oxc_linter",
  "oxc_mangler",
  "oxc_minifier",
- "oxc_parser",
+ "oxc_parser 0.142.0",
  "oxc_react_compiler",
- "oxc_semantic",
- "oxc_span",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
  "oxc_tasks_common",
  "oxc_transformer",
  "rustc-hash",
@@ -1887,9 +1929,46 @@ dependencies = [
  "bitflags",
  "itertools",
  "oxc_index",
- "oxc_syntax",
+ "oxc_syntax 0.142.0",
  "petgraph",
  "rustc-hash",
+]
+
+[[package]]
+name = "oxc_cfg"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14ff3df2d3a269e010d792d19a02022dc72a8ec2d8268371844d4e736eef8f12"
+dependencies = [
+ "bitflags",
+ "itertools",
+ "oxc_index",
+ "oxc_syntax 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph",
+ "rustc-hash",
+]
+
+[[package]]
+name = "oxc_checker"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "oxc_allocator",
+ "oxc_ast 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_ast_visit 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_cfg 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_data_structures 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_index",
+ "oxc_parser 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_resolver",
+ "oxc_semantic 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_span 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_str 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_syntax 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon",
+ "simdutf8",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1900,16 +1979,16 @@ dependencies = [
  "cow-utils",
  "insta",
  "oxc_allocator",
- "oxc_ast",
- "oxc_data_structures",
- "oxc_ecmascript",
+ "oxc_ast 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_ecmascript 0.142.0",
  "oxc_index",
- "oxc_parser",
- "oxc_semantic",
+ "oxc_parser 0.142.0",
+ "oxc_semantic 0.142.0",
  "oxc_sourcemap",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "pico-args",
  "rustc-hash",
 ]
@@ -1920,7 +1999,7 @@ version = "0.142.0"
 dependencies = [
  "cow-utils",
  "oxc-browserslist",
- "oxc_syntax",
+ "oxc_syntax 0.142.0",
  "rustc-hash",
  "serde",
 ]
@@ -1946,7 +2025,7 @@ dependencies = [
  "fast-glob",
  "ignore",
  "oxc-schemars",
- "oxc_diagnostics",
+ "oxc_diagnostics 0.142.0",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -1988,8 +2067,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_data_structures"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7793b9a760ff426782915100e1f91b4a653873a5b681576214a6eb495d498a"
+
+[[package]]
 name = "oxc_diagnostics"
 version = "0.142.0"
+dependencies = [
+ "cow-utils",
+ "oxc-miette",
+ "percent-encoding",
+]
+
+[[package]]
+name = "oxc_diagnostics"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a401193a5bc7f8acc2665763ea5876cad4a64e4e85c55133376620906e34b9e1"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -2006,13 +2102,29 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "oxc_allocator",
- "oxc_ast",
+ "oxc_ast 0.142.0",
  "oxc_compat",
- "oxc_data_structures",
- "oxc_regular_expression",
- "oxc_span",
- "oxc_syntax",
+ "oxc_data_structures 0.142.0",
+ "oxc_regular_expression 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_syntax 0.142.0",
  "smallvec",
+]
+
+[[package]]
+name = "oxc_ecmascript"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f099596aa0f5cb1aac154f7833abc02e0205aac19ce8b2bd21ee1e52973de61"
+dependencies = [
+ "dragonbox_ecma",
+ "itoa",
+ "num-bigint",
+ "num-traits",
+ "oxc_ast 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_data_structures 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_span 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_syntax 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2021,20 +2133,26 @@ version = "0.142.0"
 dependencies = [
  "dragonbox_ecma",
  "itoa",
- "oxc_data_structures",
+ "oxc_data_structures 0.142.0",
 ]
+
+[[package]]
+name = "oxc_estree"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2284782be0ac819aa56b815e6448e140e9f4f2c917917ac4ffa8bd7ccc35a3b"
 
 [[package]]
 name = "oxc_estree_tokens"
 version = "0.142.0"
 dependencies = [
  "itoa",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_data_structures",
- "oxc_estree",
- "oxc_parser",
- "oxc_span",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_estree 0.142.0",
+ "oxc_parser 0.142.0",
+ "oxc_span 0.142.0",
 ]
 
 [[package]]
@@ -2049,15 +2167,15 @@ dependencies = [
  "natord",
  "nodejs-built-in-modules",
  "oxc_allocator",
- "oxc_ast",
- "oxc_diagnostics",
+ "oxc_ast 0.142.0",
+ "oxc_diagnostics 0.142.0",
  "oxc_formatter_core",
  "oxc_jsdoc",
- "oxc_parser",
- "oxc_semantic",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_parser 0.142.0",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "oxc_tasks_common",
  "phf",
  "pico-args",
@@ -2074,8 +2192,8 @@ version = "0.61.0"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
- "oxc_data_structures",
- "oxc_span",
+ "oxc_data_structures 0.142.0",
+ "oxc_span 0.142.0",
  "rustc-hash",
  "serde_json",
  "unicode-width",
@@ -2089,9 +2207,9 @@ dependencies = [
  "insta",
  "oxc-css-parser",
  "oxc_allocator",
- "oxc_diagnostics",
+ "oxc_diagnostics 0.142.0",
  "oxc_formatter_core",
- "oxc_span",
+ "oxc_span 0.142.0",
  "phf",
  "pico-args",
 ]
@@ -2104,9 +2222,9 @@ dependencies = [
  "insta",
  "oxc-graphql-parser",
  "oxc_allocator",
- "oxc_diagnostics",
+ "oxc_diagnostics 0.142.0",
  "oxc_formatter_core",
- "oxc_span",
+ "oxc_span 0.142.0",
  "oxc_tasks_common",
  "pico-args",
 ]
@@ -2118,12 +2236,12 @@ dependencies = [
  "dragonbox_ecma",
  "insta",
  "oxc_allocator",
- "oxc_ast",
- "oxc_diagnostics",
+ "oxc_ast 0.142.0",
+ "oxc_diagnostics 0.142.0",
  "oxc_formatter_core",
- "oxc_parser",
- "oxc_span",
- "oxc_syntax",
+ "oxc_parser 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_syntax 0.142.0",
  "oxc_tasks_common",
  "pico-args",
 ]
@@ -2136,9 +2254,9 @@ dependencies = [
  "insta",
  "oxc-yaml-parser",
  "oxc_allocator",
- "oxc_diagnostics",
+ "oxc_diagnostics 0.142.0",
  "oxc_formatter_core",
- "oxc_span",
+ "oxc_span 0.142.0",
  "oxc_tasks_common",
  "pico-args",
 ]
@@ -2160,15 +2278,15 @@ dependencies = [
  "bitflags",
  "insta",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
  "oxc_codegen",
- "oxc_diagnostics",
- "oxc_ecmascript",
- "oxc_parser",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_diagnostics 0.142.0",
+ "oxc_ecmascript 0.142.0",
+ "oxc_parser 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "rustc-hash",
 ]
 
@@ -2176,8 +2294,8 @@ dependencies = [
 name = "oxc_jsdoc"
 version = "0.142.0"
 dependencies = [
- "oxc_ast",
- "oxc_span",
+ "oxc_ast 0.142.0",
+ "oxc_span 0.142.0",
  "rustc-hash",
 ]
 
@@ -2201,10 +2319,10 @@ name = "oxc_lexer"
 version = "0.139.0"
 dependencies = [
  "memchr",
- "oxc_ast",
- "oxc_diagnostics",
- "oxc_span",
- "oxc_syntax",
+ "oxc_ast 0.142.0",
+ "oxc_diagnostics 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_syntax 0.142.0",
 ]
 
 [[package]]
@@ -2229,26 +2347,29 @@ dependencies = [
  "nodejs-built-in-modules",
  "oxc-schemars",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_macros",
- "oxc_ast_visit",
- "oxc_cfg",
+ "oxc_ast 0.142.0",
+ "oxc_ast 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_ast_macros 0.142.0",
+ "oxc_ast_visit 0.142.0",
+ "oxc_cfg 0.142.0",
+ "oxc_checker",
  "oxc_codegen",
  "oxc_config",
- "oxc_data_structures",
- "oxc_diagnostics",
- "oxc_ecmascript",
+ "oxc_data_structures 0.142.0",
+ "oxc_diagnostics 0.142.0",
+ "oxc_ecmascript 0.142.0",
  "oxc_estree_tokens",
  "oxc_index",
  "oxc_macros",
- "oxc_parser",
+ "oxc_parser 0.142.0",
  "oxc_react_compiler",
- "oxc_regular_expression",
+ "oxc_regular_expression 0.142.0",
  "oxc_resolver",
- "oxc_semantic",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_span 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "papaya",
  "phf",
  "rayon",
@@ -2292,15 +2413,15 @@ version = "0.142.0"
 dependencies = [
  "itertools",
  "oxc_allocator",
- "oxc_ast",
- "oxc_data_structures",
- "oxc_ecmascript",
+ "oxc_ast 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_ecmascript 0.142.0",
  "oxc_index",
- "oxc_parser",
- "oxc_semantic",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_parser 0.142.0",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "rustc-hash",
 ]
 
@@ -2313,20 +2434,20 @@ dependencies = [
  "itoa",
  "javascript-globals",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
  "oxc_codegen",
  "oxc_compat",
- "oxc_data_structures",
- "oxc_ecmascript",
+ "oxc_data_structures 0.142.0",
+ "oxc_ecmascript 0.142.0",
  "oxc_index",
  "oxc_mangler",
- "oxc_parser",
- "oxc_semantic",
+ "oxc_parser 0.142.0",
+ "oxc_semantic 0.142.0",
  "oxc_sourcemap",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "oxc_traverse",
  "pico-args",
  "rustc-hash",
@@ -2343,13 +2464,13 @@ dependencies = [
  "oxc_allocator",
  "oxc_codegen",
  "oxc_compat",
- "oxc_diagnostics",
+ "oxc_diagnostics 0.142.0",
  "oxc_minifier",
  "oxc_napi",
- "oxc_parser",
+ "oxc_parser 0.142.0",
  "oxc_sourcemap",
- "oxc_span",
- "oxc_str",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
 ]
 
 [[package]]
@@ -2362,9 +2483,9 @@ dependencies = [
  "oxc_allocator",
  "oxc_codegen",
  "oxc_minifier",
- "oxc_parser",
- "oxc_semantic",
- "oxc_span",
+ "oxc_parser 0.142.0",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
  "oxc_tasks_common",
  "oxc_transformer_plugins",
  "pico-args",
@@ -2379,11 +2500,11 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_diagnostics",
- "oxc_span",
- "oxc_syntax",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
+ "oxc_diagnostics 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_syntax 0.142.0",
 ]
 
 [[package]]
@@ -2396,16 +2517,40 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_data_structures",
- "oxc_diagnostics",
- "oxc_ecmascript",
- "oxc_regular_expression",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_diagnostics 0.142.0",
+ "oxc_ecmascript 0.142.0",
+ "oxc_regular_expression 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "pico-args",
+ "rustc-hash",
+ "seq-macro",
+]
+
+[[package]]
+name = "oxc_parser"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff65aedf1d4364457427d461b827cc43544c5275f2693144a4fdb5fe5c26fbd9"
+dependencies = [
+ "bitflags",
+ "cow-utils",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator",
+ "oxc_ast 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_data_structures 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_diagnostics 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_ecmascript 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_regular_expression 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_span 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_str 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_syntax 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash",
  "seq-macro",
 ]
@@ -2419,11 +2564,11 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "oxc",
- "oxc_ast_macros",
- "oxc_estree",
+ "oxc_ast_macros 0.142.0",
+ "oxc_estree 0.142.0",
  "oxc_estree_tokens",
  "oxc_napi",
- "oxc_str",
+ "oxc_str 0.142.0",
  "rustc-hash",
 ]
 
@@ -2452,16 +2597,16 @@ version = "0.0.0"
 dependencies = [
  "cow-utils",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
  "oxc_formatter",
  "oxc_formatter_core",
  "oxc_formatter_css",
  "oxc_formatter_graphql",
  "oxc_formatter_json",
  "oxc_formatter_yaml",
- "oxc_parser",
- "oxc_span",
+ "oxc_parser 0.142.0",
+ "oxc_span 0.142.0",
  "oxc_tasks_common",
  "pico-args",
  "rustc-hash",
@@ -2479,17 +2624,17 @@ dependencies = [
  "indexmap",
  "insta",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
  "oxc_codegen",
- "oxc_diagnostics",
- "oxc_ecmascript",
+ "oxc_diagnostics 0.142.0",
+ "oxc_ecmascript 0.142.0",
  "oxc_index",
- "oxc_parser",
- "oxc_semantic",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_parser 0.142.0",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "rustc-hash",
  "smallvec",
 ]
@@ -2501,10 +2646,27 @@ dependencies = [
  "bitflags",
  "insta",
  "oxc_allocator",
- "oxc_ast_macros",
- "oxc_diagnostics",
- "oxc_span",
- "oxc_str",
+ "oxc_ast_macros 0.142.0",
+ "oxc_diagnostics 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "phf",
+ "rustc-hash",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "oxc_regular_expression"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69bc0cfbcd78e42d9aaa72eccb77e62b4b85b671f5d08ff8430aeea9816a8273"
+dependencies = [
+ "bitflags",
+ "oxc_allocator",
+ "oxc_ast_macros 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_diagnostics 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_span 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_str 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf",
  "rustc-hash",
  "unicode-id-start",
@@ -2557,21 +2719,45 @@ dependencies = [
  "itertools",
  "memchr",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_cfg",
- "oxc_data_structures",
- "oxc_diagnostics",
- "oxc_ecmascript",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
+ "oxc_cfg 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_diagnostics 0.142.0",
+ "oxc_ecmascript 0.142.0",
  "oxc_index",
  "oxc_jsdoc",
- "oxc_parser",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_parser 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "rustc-hash",
  "self_cell",
  "serde_json",
+ "smallvec",
+]
+
+[[package]]
+name = "oxc_semantic"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0293d641451efb4d29bd17ab44e413f8d5daa10e9dc541c7b30ddcf136fd0a4d"
+dependencies = [
+ "itertools",
+ "memchr",
+ "oxc_allocator",
+ "oxc_ast 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_ast_visit 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_cfg 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_data_structures 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_diagnostics 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_ecmascript 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_index",
+ "oxc_span 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_str 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_syntax 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash",
+ "self_cell",
  "smallvec",
 ]
 
@@ -2599,10 +2785,24 @@ dependencies = [
  "oxc-miette",
  "oxc-schemars",
  "oxc_allocator",
- "oxc_ast_macros",
- "oxc_estree",
- "oxc_str",
+ "oxc_ast_macros 0.142.0",
+ "oxc_estree 0.142.0",
+ "oxc_str 0.142.0",
  "serde",
+]
+
+[[package]]
+name = "oxc_span"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "890589be8c87e7c0f7a1f0331a9b8d362ebcd3e543125815daa942fd550b0121"
+dependencies = [
+ "compact_str 0.10.0",
+ "oxc-miette",
+ "oxc_allocator",
+ "oxc_ast_macros 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_estree 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_str 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2613,9 +2813,21 @@ dependencies = [
  "hashbrown 0.17.1",
  "oxc-schemars",
  "oxc_allocator",
- "oxc_data_structures",
- "oxc_estree",
+ "oxc_data_structures 0.142.0",
+ "oxc_estree 0.142.0",
  "serde",
+]
+
+[[package]]
+name = "oxc_str"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f2b9a92f74a8231f21fccfb4eef937d266a7323d9597ccdcd74c7ad0f951b1"
+dependencies = [
+ "compact_str 0.10.0",
+ "hashbrown 0.17.1",
+ "oxc_allocator",
+ "oxc_estree 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2627,13 +2839,33 @@ dependencies = [
  "dragonbox_ecma",
  "nonmax",
  "oxc_allocator",
- "oxc_ast_macros",
- "oxc_estree",
+ "oxc_ast_macros 0.142.0",
+ "oxc_estree 0.142.0",
  "oxc_index",
- "oxc_span",
- "oxc_str",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
  "phf",
  "serde",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "oxc_syntax"
+version = "0.142.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54e5c73453878e194df8d77d5cdc9ef525fec8ad25c547cc87162318eda6adb"
+dependencies = [
+ "bitflags",
+ "cow-utils",
+ "dragonbox_ecma",
+ "nonmax",
+ "oxc_allocator",
+ "oxc_ast_macros 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_estree 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_index",
+ "oxc_span 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oxc_str 0.142.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf",
  "unicode-id-start",
 ]
 
@@ -2642,7 +2874,7 @@ name = "oxc_tasks_common"
 version = "0.0.0"
 dependencies = [
  "console",
- "oxc_span",
+ "oxc_span 0.142.0",
  "project-root",
  "similar 3.1.1",
  "ureq",
@@ -2654,12 +2886,12 @@ version = "0.0.0"
 dependencies = [
  "indexmap",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_diagnostics",
- "oxc_semantic",
- "oxc_str",
- "oxc_syntax",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
+ "oxc_diagnostics 0.142.0",
+ "oxc_semantic 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "rustc-hash",
 ]
 
@@ -2669,8 +2901,8 @@ version = "0.0.0"
 dependencies = [
  "oxc_allocator",
  "oxc_linter",
- "oxc_parser",
- "oxc_semantic",
+ "oxc_parser 0.142.0",
+ "oxc_semantic 0.142.0",
  "oxc_tasks_common",
  "rustc-hash",
 ]
@@ -2684,8 +2916,8 @@ dependencies = [
  "oxc_allocator",
  "oxc_formatter",
  "oxc_minifier",
- "oxc_parser",
- "oxc_semantic",
+ "oxc_parser 0.142.0",
+ "oxc_semantic 0.142.0",
  "oxc_tasks_common",
  "oxc_transformer",
  "saphyr",
@@ -2730,20 +2962,20 @@ dependencies = [
  "itoa",
  "memchr",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
  "oxc_codegen",
  "oxc_compat",
- "oxc_data_structures",
- "oxc_diagnostics",
- "oxc_ecmascript",
- "oxc_parser",
+ "oxc_data_structures 0.142.0",
+ "oxc_diagnostics 0.142.0",
+ "oxc_ecmascript 0.142.0",
+ "oxc_parser 0.142.0",
  "oxc_react_compiler",
- "oxc_regular_expression",
- "oxc_semantic",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_regular_expression 0.142.0",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "oxc_traverse",
  "pico-args",
  "rustc-hash",
@@ -2759,18 +2991,18 @@ dependencies = [
  "insta",
  "itoa",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
  "oxc_codegen",
- "oxc_diagnostics",
- "oxc_ecmascript",
+ "oxc_diagnostics 0.142.0",
+ "oxc_ecmascript 0.142.0",
  "oxc_minifier",
- "oxc_parser",
- "oxc_semantic",
+ "oxc_parser 0.142.0",
+ "oxc_semantic 0.142.0",
  "oxc_sourcemap",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "oxc_tasks_common",
  "oxc_transformer",
  "oxc_traverse",
@@ -2784,14 +3016,14 @@ version = "0.142.0"
 dependencies = [
  "itoa",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_data_structures",
- "oxc_ecmascript",
- "oxc_semantic",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
+ "oxc_data_structures 0.142.0",
+ "oxc_ecmascript 0.142.0",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "rustc-hash",
 ]
 
@@ -2803,16 +3035,16 @@ dependencies = [
  "bpaf",
  "indexmap",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_diagnostics",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
+ "oxc_diagnostics 0.142.0",
  "oxc_index",
- "oxc_parser",
+ "oxc_parser 0.142.0",
  "oxc_resolver",
- "oxc_semantic",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
+ "oxc_syntax 0.142.0",
  "rayon",
  "rustc-hash",
  "self_cell",
@@ -2837,7 +3069,7 @@ dependencies = [
  "oxc-toml",
  "oxc_allocator",
  "oxc_config",
- "oxc_diagnostics",
+ "oxc_diagnostics 0.142.0",
  "oxc_formatter",
  "oxc_formatter_core",
  "oxc_formatter_css",
@@ -2846,7 +3078,7 @@ dependencies = [
  "oxc_formatter_yaml",
  "oxc_language_server",
  "oxc_napi",
- "oxc_span",
+ "oxc_span 0.142.0",
  "phf",
  "rayon",
  "rustc-hash",
@@ -2877,18 +3109,18 @@ dependencies = [
  "oxc-miette",
  "oxc-schemars",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
  "oxc_config",
- "oxc_diagnostics",
+ "oxc_diagnostics 0.142.0",
  "oxc_estree_tokens",
  "oxc_language_server",
  "oxc_linter",
  "oxc_napi",
- "oxc_parser",
- "oxc_semantic",
- "oxc_span",
- "oxc_str",
+ "oxc_parser 0.142.0",
+ "oxc_semantic 0.142.0",
+ "oxc_span 0.142.0",
+ "oxc_str 0.142.0",
  "rayon",
  "rustc-hash",
  "serde",
@@ -3270,10 +3502,10 @@ dependencies = [
  "insta",
  "lazy-regex",
  "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_parser",
- "oxc_span",
+ "oxc_ast 0.142.0",
+ "oxc_ast_visit 0.142.0",
+ "oxc_parser 0.142.0",
+ "oxc_span 0.142.0",
  "oxc_tasks_common",
  "proc-macro2",
  "rustc-hash",
@@ -3728,6 +3960,16 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ oxc_language_server = { path = "crates/oxc_language_server", default-features = 
 oxc_lexer = { path = "crates/oxc_lexer" } # JS/TS lexer (incubating; x86_64 SIMD, stub elsewhere)
 oxc_linter = { path = "crates/oxc_linter" } # Linting engine
 oxc_macros = { path = "crates/oxc_macros" } # Proc macros
+oxc_checker = { path = "../oxc_checker" } # Experimental native type-aware linting
 oxc_tasks_common = { path = "tasks/common" } # Task utilities
 oxc_tasks_transform_checker = { path = "tasks/transform_checker" } # Transform validation
 website_common = { path = "tasks/website_common" } # Website utilities

--- a/apps/oxlint/fixtures/cli/native_type_aware/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cli/native_type_aware/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "typescript/no-unsafe-unary-minus": "error"
+  }
+}

--- a/apps/oxlint/fixtures/cli/native_type_aware/no-unsafe-unary-minus.ts
+++ b/apps/oxlint/fixtures/cli/native_type_aware/no-unsafe-unary-minus.ts
@@ -1,0 +1,24 @@
+import { importedResult, importedString } from "./values";
+import { parseSync } from "oxc-parser";
+
+declare const numberValue: number;
+declare const bigintValue: bigint;
+declare const anyValue: any;
+declare const stringValue: string;
+declare const unknownValue: unknown;
+declare const mixedValue: number | string;
+
+-numberValue;
+-bigintValue;
+-anyValue;
+-stringValue;
+// eslint-disable-next-line typescript/no-unsafe-unary-minus
+-unknownValue;
+-mixedValue;
+-importedString;
+-importedResult();
+-parseSync("example.ts", "const value = 1;");
+
+function negate<T extends number>(value: T) {
+  return -value;
+}

--- a/apps/oxlint/fixtures/cli/native_type_aware/values.ts
+++ b/apps/oxlint/fixtures/cli/native_type_aware/values.ts
@@ -1,0 +1,5 @@
+export const importedString = "value";
+
+export function importedResult(): string {
+	return importedString;
+}

--- a/apps/oxlint/src-js/plugins/tokens_methods.ts
+++ b/apps/oxlint/src-js/plugins/tokens_methods.ts
@@ -1288,7 +1288,7 @@ export function getTokenByRangeStart<Options extends RangeOptions | null | undef
   //
   // Note: Source text is limited to 1 GiB max, so offsets cannot exceed 2^30.
   // This makes it safe to use `>> 1` for division by 2 (which is faster than `>>> 1`).
-  for (let lo = 0, hi = len; lo < hi;) {
+  for (let lo = 0, hi = len; lo < hi; ) {
     const mid = (lo + hi) >> 1;
     const tokenStart = int32[mid << 2];
     if (tokenStart < offset) {
@@ -1546,7 +1546,7 @@ export function firstTokenAtOrAfter(
   startIndex: number,
   length: number,
 ): number {
-  for (let endIndex = length; startIndex < endIndex;) {
+  for (let endIndex = length; startIndex < endIndex; ) {
     const mid = (startIndex + endIndex) >> 1;
     if (int32[mid << 2] < offset) {
       startIndex = mid + 1;

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1607,6 +1607,12 @@ mod test {
             .test_and_snapshot(args);
     }
 
+    #[test]
+    fn test_native_type_aware_no_unsafe_unary_minus() {
+        let args = &["--type-aware", "no-unsafe-unary-minus.ts"];
+        Tester::new().with_cwd("fixtures/cli/native_type_aware".into()).test_and_snapshot(args);
+    }
+
     // ToDo: `tsgolint` does not support `big-endian`?
     #[test]
     #[cfg(not(target_endian = "big"))]

--- a/apps/oxlint/src/snapshots/fixtures__cli__native_type_aware_--type-aware no-unsafe-unary-minus.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__native_type_aware_--type-aware no-unsafe-unary-minus.ts@oxlint.snap
@@ -1,0 +1,144 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --type-aware no-unsafe-unary-minus.ts
+working directory: fixtures/cli/native_type_aware
+----------
+
+  ! eslint(no-unused-expressions): Expected expression to be used
+    ,-[no-unsafe-unary-minus.ts:11:1]
+ 10 | 
+ 11 | -numberValue;
+    : ^^^^^^^^^^^^^
+ 12 | -bigintValue;
+    `----
+  help: Consider using this expression or removing it
+
+  ! eslint(no-unused-expressions): Expected expression to be used
+    ,-[no-unsafe-unary-minus.ts:12:1]
+ 11 | -numberValue;
+ 12 | -bigintValue;
+    : ^^^^^^^^^^^^^
+ 13 | -anyValue;
+    `----
+  help: Consider using this expression or removing it
+
+  ! eslint(no-unused-expressions): Expected expression to be used
+    ,-[no-unsafe-unary-minus.ts:13:1]
+ 12 | -bigintValue;
+ 13 | -anyValue;
+    : ^^^^^^^^^^
+ 14 | -stringValue;
+    `----
+  help: Consider using this expression or removing it
+
+  x typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is string instead.
+    ,-[no-unsafe-unary-minus.ts:14:1]
+ 13 | -anyValue;
+ 14 | -stringValue;
+    : ^^^^^^^^^^^^
+ 15 | // eslint-disable-next-line typescript/no-unsafe-unary-minus
+    `----
+
+  ! eslint(no-unused-expressions): Expected expression to be used
+    ,-[no-unsafe-unary-minus.ts:14:1]
+ 13 | -anyValue;
+ 14 | -stringValue;
+    : ^^^^^^^^^^^^^
+ 15 | // eslint-disable-next-line typescript/no-unsafe-unary-minus
+    `----
+  help: Consider using this expression or removing it
+
+  ! eslint(no-unused-expressions): Expected expression to be used
+    ,-[no-unsafe-unary-minus.ts:16:1]
+ 15 | // eslint-disable-next-line typescript/no-unsafe-unary-minus
+ 16 | -unknownValue;
+    : ^^^^^^^^^^^^^^
+ 17 | -mixedValue;
+    `----
+  help: Consider using this expression or removing it
+
+  x typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is string instead.
+    ,-[no-unsafe-unary-minus.ts:17:1]
+ 16 | -unknownValue;
+ 17 | -mixedValue;
+    : ^^^^^^^^^^^
+ 18 | -importedString;
+    `----
+
+  ! eslint(no-unused-expressions): Expected expression to be used
+    ,-[no-unsafe-unary-minus.ts:17:1]
+ 16 | -unknownValue;
+ 17 | -mixedValue;
+    : ^^^^^^^^^^^^
+ 18 | -importedString;
+    `----
+  help: Consider using this expression or removing it
+
+  x typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is string instead.
+    ,-[no-unsafe-unary-minus.ts:18:1]
+ 17 | -mixedValue;
+ 18 | -importedString;
+    : ^^^^^^^^^^^^^^^
+ 19 | -importedResult();
+    `----
+
+  ! eslint(no-unused-expressions): Expected expression to be used
+    ,-[no-unsafe-unary-minus.ts:18:1]
+ 17 | -mixedValue;
+ 18 | -importedString;
+    : ^^^^^^^^^^^^^^^^
+ 19 | -importedResult();
+    `----
+  help: Consider using this expression or removing it
+
+  x typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is string instead.
+    ,-[no-unsafe-unary-minus.ts:19:1]
+ 18 | -importedString;
+ 19 | -importedResult();
+    : ^^^^^^^^^^^^^^^^^
+ 20 | -parseSync("example.ts", "const value = 1;");
+    `----
+
+  ! eslint(no-unused-expressions): Expected expression to be used
+    ,-[no-unsafe-unary-minus.ts:19:1]
+ 18 | -importedString;
+ 19 | -importedResult();
+    : ^^^^^^^^^^^^^^^^^^
+ 20 | -parseSync("example.ts", "const value = 1;");
+    `----
+  help: Consider using this expression or removing it
+
+  x typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is ParseResult instead.
+    ,-[no-unsafe-unary-minus.ts:20:1]
+ 19 | -importedResult();
+ 20 | -parseSync("example.ts", "const value = 1;");
+    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 21 | 
+    `----
+
+  ! eslint(no-unused-expressions): Expected expression to be used
+    ,-[no-unsafe-unary-minus.ts:20:1]
+ 19 | -importedResult();
+ 20 | -parseSync("example.ts", "const value = 1;");
+    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 21 | 
+    `----
+  help: Consider using this expression or removing it
+
+  ! eslint(no-unused-vars): Function 'negate' is declared but never used.
+    ,-[no-unsafe-unary-minus.ts:22:10]
+ 21 | 
+ 22 | function negate<T extends number>(value: T) {
+    :          ^^^|^^
+    :             `-- 'negate' is declared here
+ 23 |   return -value;
+    `----
+  help: Consider removing this declaration.
+
+Found 10 warnings and 5 errors.
+Finished in <variable>ms on 1 file with 111 rules using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -30,6 +30,7 @@ oxc_ast = { workspace = true }
 oxc_ast_macros = { workspace = true }
 oxc_ast_visit = { workspace = true, features = ["serialize"] }
 oxc_cfg = { workspace = true }
+oxc_checker = { workspace = true }
 oxc_codegen = { workspace = true, default-features = false }
 oxc_config = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["box_macros"] }
@@ -46,6 +47,8 @@ oxc_semantic = { workspace = true, features = ["cfg", "linter"] }
 oxc_span = { workspace = true, features = ["schemars", "serialize"] }
 oxc_str = { workspace = true, features = ["serialize"] }
 oxc_syntax = { workspace = true, features = ["serialize"] }
+oxc_ast_checker = { package = "oxc_ast", version = "0.142.0" }
+oxc_span_checker = { package = "oxc_span", version = "0.142.0" }
 
 #
 bitflags = { workspace = true }

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -8,6 +8,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::{
     AllowWarnDeny,
     external_plugin_store::{ExternalOptionsId, ExternalPluginStore, ExternalRuleId},
+    native_type_aware::is_type_aware_rule,
     rules::{RULES, RuleEnum},
 };
 
@@ -307,6 +308,22 @@ impl ConfigStore {
         }
     }
 
+    pub(crate) fn has_tsgolint_rules(&self) -> bool {
+        fn config_has_tsgolint_rules(config: &Config) -> bool {
+            config.base.rules.iter().any(|(rule, _)| rule.is_tsgolint_rule())
+                || config.overrides.iter().any(|override_config| {
+                    override_config
+                        .rules
+                        .builtin_rules
+                        .iter()
+                        .any(|(rule, severity)| severity.is_warn_deny() && rule.is_tsgolint_rule())
+                })
+        }
+
+        config_has_tsgolint_rules(&self.base)
+            || self.nested_configs.values().any(config_has_tsgolint_rules)
+    }
+
     /// Returns the total number of rules, inclusive of JS Plugin rules and overrides, optionally filtering out tsgolint rules if type_aware_enabled is false.
     pub fn number_of_rules(&self, type_aware_enabled: bool) -> Option<usize> {
         // If there are nested configs the number of rules may vary per-file, so return `None`.
@@ -321,7 +338,7 @@ impl ConfigStore {
                 .base
                 .rules
                 .iter()
-                .filter(|(rule, _)| !rule.is_tsgolint_rule())
+                .filter(|(rule, _)| !is_type_aware_rule(rule))
                 .map(|(rule, _)| rule.clone())
                 .collect::<FxHashSet<_>>()
         };
@@ -339,7 +356,7 @@ impl ConfigStore {
                 if !severity.is_warn_deny() {
                     continue;
                 }
-                if !type_aware_enabled && rule.is_tsgolint_rule() {
+                if !type_aware_enabled && is_type_aware_rule(rule) {
                     continue;
                 }
                 builtin_rules.insert(rule.clone());

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -20,6 +20,7 @@ use crate::{
     fixer::{Fix, FixKind, Message, PossibleFixes},
     frameworks::FrameworkOptions,
     module_record::ModuleRecord,
+    native_type_aware::TypedApiContext,
     options::LintOptions,
     rules::RuleEnum,
 };
@@ -169,6 +170,8 @@ pub struct ContextHost<'a> {
     pub(super) config: Arc<LintConfig>,
     /// Front-end frameworks that might be in use in the target file.
     pub(super) frameworks: FrameworkFlags,
+    /// Type information populated for native type-aware linting.
+    type_aware: Option<TypedApiContext<'a>>,
 }
 
 impl std::fmt::Debug for ContextHost<'_> {
@@ -207,8 +210,18 @@ impl<'a> ContextHost<'a> {
             file_extension,
             config,
             frameworks: options.framework_hints,
+            type_aware: None,
         }
         .sniff_for_frameworks()
+    }
+
+    pub(crate) fn with_type_aware(mut self, type_aware: TypedApiContext<'a>) -> Self {
+        self.type_aware = Some(type_aware);
+        self
+    }
+
+    pub fn type_aware(&self) -> Option<&TypedApiContext<'a>> {
+        self.type_aware.as_ref()
     }
 
     /// The current [`ContextSubHost`]

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     disable_directives::DisableDirectives,
     fixer::{Fix, FixKind, Message, MessageRule, PossibleFixes, RuleFix, RuleFixer},
     frameworks::FrameworkOptions,
+    native_type_aware::TypedApiContext,
 };
 
 mod host;
@@ -78,6 +79,12 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn semantic(&self) -> &Semantic<'a> {
         self.parent.semantic()
+    }
+
+    /// Type information for rules running in the native type-aware pass.
+    #[inline]
+    pub fn type_aware(&self) -> Option<&TypedApiContext<'a>> {
+        self.parent.type_aware()
     }
 
     /// Allocator that owns the parsed AST and semantic data.

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1974,8 +1974,9 @@ impl RuleRunner for crate::rules::typescript::no_unsafe_type_assertion::NoUnsafe
 }
 
 impl RuleRunner for crate::rules::typescript::no_unsafe_unary_minus::NoUnsafeUnaryMinus {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::UnaryExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -40,6 +40,7 @@ mod frameworks;
 mod globals;
 mod module_graph_visitor;
 mod module_record;
+mod native_type_aware;
 mod options;
 mod rule;
 mod service;
@@ -382,7 +383,7 @@ impl Linter {
             let rules = rules
                 .iter()
                 .filter(|(rule, _)| {
-                    if rule.is_tsgolint_rule() {
+                    if native_type_aware::is_type_aware_rule(rule) {
                         return false;
                     }
 

--- a/crates/oxc_linter/src/lint_runner.rs
+++ b/crates/oxc_linter/src/lint_runner.rs
@@ -225,9 +225,14 @@ impl LintRunnerBuilder {
         };
 
         let cwd = self.lint_service_options.cwd().to_path_buf();
-        let native_type_aware_linter = self
-            .type_aware_enabled
-            .then(|| NativeTypeAwareRunner::new(cwd.clone(), self.regular_linter.config.clone()));
+        let lint_options = *self.regular_linter.options();
+        let native_type_aware_linter = self.type_aware_enabled.then(|| {
+            NativeTypeAwareRunner::new(
+                cwd.clone(),
+                self.regular_linter.config.clone(),
+                lint_options,
+            )
+        });
         let mut lint_service = LintService::new(self.regular_linter, self.lint_service_options);
         lint_service.set_disable_directives_map(directives_coordinator.map());
 

--- a/crates/oxc_linter/src/lint_runner.rs
+++ b/crates/oxc_linter/src/lint_runner.rs
@@ -11,7 +11,8 @@ use oxc_span::Span;
 
 use crate::{
     AllowWarnDeny, DisableDirectives, FixKind, LintService, LintServiceOptions, Linter, Message,
-    OsFileSystem, RuleTimingStore, TsGoLintState, suppression::DiffManager,
+    OsFileSystem, RuleTimingStore, TsGoLintState, native_type_aware::NativeTypeAwareRunner,
+    suppression::DiffManager,
 };
 
 /// Unified runner that orchestrates both regular (oxc) and type-aware (tsgolint) linting
@@ -21,6 +22,8 @@ pub struct LintRunner {
     lint_service: LintService,
     /// Type-aware tsgolint
     type_aware_linter: Option<TsGoLintState>,
+    /// Native checker-backed type-aware rules
+    native_type_aware_linter: Option<NativeTypeAwareRunner>,
     /// Shared disable directives coordinator
     directives_store: DirectivesStore,
     /// Current working directory
@@ -202,7 +205,8 @@ impl LintRunnerBuilder {
     pub fn build(self) -> Result<LintRunner, String> {
         let directives_coordinator = DirectivesStore::new();
 
-        let type_aware_linter = if self.type_aware_enabled {
+        let needs_tsgolint = self.type_check || self.regular_linter.config.has_tsgolint_rules();
+        let type_aware_linter = if self.type_aware_enabled && needs_tsgolint {
             match TsGoLintState::try_new(
                 self.lint_service_options.cwd(),
                 self.regular_linter.config.clone(),
@@ -221,12 +225,16 @@ impl LintRunnerBuilder {
         };
 
         let cwd = self.lint_service_options.cwd().to_path_buf();
+        let native_type_aware_linter = self
+            .type_aware_enabled
+            .then(|| NativeTypeAwareRunner::new(cwd.clone(), self.regular_linter.config.clone()));
         let mut lint_service = LintService::new(self.regular_linter, self.lint_service_options);
         lint_service.set_disable_directives_map(directives_coordinator.map());
 
         Ok(LintRunner {
             lint_service,
             type_aware_linter,
+            native_type_aware_linter,
             directives_store: directives_coordinator,
             cwd,
             type_check_only: self.type_check_only,
@@ -264,6 +272,10 @@ impl LintRunner {
             );
         }
 
+        if let Some(native_type_aware_linter) = &self.native_type_aware_linter {
+            native_type_aware_linter.lint(files, &self.directives_store, &tx_error)?;
+        }
+
         if let Some(type_aware_linter) = self.type_aware_linter.take() {
             type_aware_linter.lint(
                 files,
@@ -289,6 +301,10 @@ impl LintRunner {
         file_system: &(dyn crate::RuntimeFileSystem + Sync + Send),
     ) -> Result<Vec<Message>, String> {
         let mut messages = self.lint_service.run_source(file_system, files.to_owned());
+
+        if let Some(native_type_aware_linter) = &self.native_type_aware_linter {
+            messages.extend(native_type_aware_linter.lint_source(files, file_system)?);
+        }
 
         if let Some(type_aware_linter) = &self.type_aware_linter {
             let tsgo_messages =
@@ -317,6 +333,6 @@ impl LintRunner {
 
     /// Check if type-aware linting is enabled
     pub fn has_type_aware(&self) -> bool {
-        self.type_aware_linter.is_some()
+        self.type_aware_linter.is_some() || self.native_type_aware_linter.is_some()
     }
 }

--- a/crates/oxc_linter/src/native_type_aware.rs
+++ b/crates/oxc_linter/src/native_type_aware.rs
@@ -1,0 +1,276 @@
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    rc::Rc,
+    sync::Arc,
+};
+
+use oxc_allocator::Allocator;
+use oxc_checker::{
+    checker::{Checker, CheckerBuilder, CheckerReturn, NodeRef},
+    program::{
+        FsProgramHost, HostModuleResolution, ProgramEntry, ProgramHost, ProgramStoreBuilder,
+        ProgramStoreError,
+    },
+    types::{CheckerArena, Ty, TypeData, TypeId},
+};
+use oxc_diagnostics::{DiagnosticSender, DiagnosticService};
+use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
+use oxc_span::{SourceType, Span};
+use oxc_span_checker::GetSpan;
+use rustc_hash::FxHashMap;
+
+use crate::{
+    AllowWarnDeny, ConfigStore, ContextHost, ContextSubHost, ContextSubHostOptions, LintOptions,
+    Message, ModuleRecord, RuleEnum, RuntimeFileSystem,
+};
+
+pub fn is_native_type_aware_rule(rule: &RuleEnum) -> bool {
+    // TODO: This would actually be part of the generated code, but this is just a proof of concept
+    rule.name() == "no-unsafe-unary-minus"
+}
+
+pub fn is_type_aware_rule(rule: &RuleEnum) -> bool {
+    rule.is_tsgolint_rule() || is_native_type_aware_rule(rule)
+}
+
+pub struct TypedApiContext<'a> {
+    arena: CheckerArena<'a>,
+    types_by_span: FxHashMap<Span, Ty<'a>>,
+    type_names: FxHashMap<(Span, TypeId), String>,
+}
+
+impl<'a> TypedApiContext<'a> {
+    fn new(checker: &CheckerReturn<'a, '_>, entry: &ProgramEntry<'a>) -> Self {
+        let arena = checker.arena();
+        let mut types_by_span = FxHashMap::default();
+        let mut type_names = FxHashMap::default();
+        for (node_id, node) in entry.semantic().nodes().iter_enumerated() {
+            let span = node.kind().span();
+            let node = NodeRef::new(entry.id(), node_id);
+            let ty = checker.get_constrained_type_at_location(node);
+            let span = Span::new(span.start, span.end);
+            types_by_span.insert(span, ty);
+            cache_type_names(checker, arena, ty, node, span, &mut type_names);
+        }
+        Self { arena, types_by_span, type_names }
+    }
+
+    #[inline]
+    pub fn type_at_span(&self, span: Span) -> Option<Ty<'a>> {
+        self.types_by_span.get(&span).copied()
+    }
+
+    #[inline]
+    pub fn type_data(&self, ty: Ty<'a>) -> TypeData<'a> {
+        self.arena.type_data(ty)
+    }
+
+    #[inline]
+    pub fn type_name(&self, span: Span, ty: Ty<'a>) -> Option<&str> {
+        self.type_names.get(&(span, ty.id())).map(String::as_str)
+    }
+}
+
+fn cache_type_names<'a>(
+    checker: &CheckerReturn<'a, '_>,
+    arena: CheckerArena<'a>,
+    ty: Ty<'a>,
+    node: NodeRef,
+    span: Span,
+    type_names: &mut FxHashMap<(Span, TypeId), String>,
+) {
+    if type_names.insert((span, ty.id()), checker.type_to_string(ty, node)).is_some() {
+        return;
+    }
+    match arena.type_data(ty) {
+        TypeData::Union(union) => {
+            for ty in &union.types {
+                cache_type_names(checker, arena, *ty, node, span, type_names);
+            }
+        }
+        TypeData::Intersection(intersection) => {
+            for ty in &intersection.types {
+                cache_type_names(checker, arena, *ty, node, span, type_names);
+            }
+        }
+        _ => {}
+    }
+}
+
+pub struct NativeTypeAwareRunner {
+    cwd: PathBuf,
+    config_store: ConfigStore,
+}
+
+struct RuntimeProgramHost<'a> {
+    file_system: &'a (dyn RuntimeFileSystem + Sync + Send),
+    resolver: FsProgramHost,
+}
+
+impl<'a> RuntimeProgramHost<'a> {
+    fn new(file_system: &'a (dyn RuntimeFileSystem + Sync + Send)) -> Self {
+        Self { file_system, resolver: FsProgramHost::new() }
+    }
+}
+
+impl ProgramHost for RuntimeProgramHost<'_> {
+    fn read_source(&self, path: &Path) -> Result<String, ProgramStoreError> {
+        let allocator = Allocator::default();
+        self.file_system.read_to_arena_str(path, &allocator).map(str::to_owned).map_err(|error| {
+            ProgramStoreError::ReadSource { path: path.to_path_buf(), message: error.to_string() }
+        })
+    }
+
+    fn canonicalize_path(&self, path: &Path) -> PathBuf {
+        self.resolver.canonicalize_path(path)
+    }
+
+    fn resolve_module(&self, containing_file: &Path, specifier: &str) -> HostModuleResolution {
+        self.resolver.resolve_module(containing_file, specifier)
+    }
+}
+
+impl NativeTypeAwareRunner {
+    pub fn new(cwd: PathBuf, config_store: ConfigStore) -> Self {
+        Self { cwd, config_store }
+    }
+
+    pub fn lint(
+        &self,
+        files: &[Arc<OsStr>],
+        _directives_store: &crate::DirectivesStore,
+        tx_error: &DiagnosticSender,
+    ) -> Result<(), String> {
+        for result in self.lint_with_host(files, FsProgramHost::new())? {
+            if result.messages.is_empty() {
+                continue;
+            }
+            let diagnostics = result.messages.into_iter().map(Into::into).collect::<Vec<_>>();
+            let wrapped = DiagnosticService::wrap_diagnostics(
+                &self.cwd,
+                result.path,
+                &result.source_text,
+                diagnostics,
+            );
+            tx_error.send(wrapped).map_err(|error| error.to_string())?;
+        }
+        Ok(())
+    }
+
+    pub fn lint_source(
+        &self,
+        files: &[Arc<OsStr>],
+        file_system: &(dyn RuntimeFileSystem + Sync + Send),
+    ) -> Result<Vec<Message>, String> {
+        Ok(self
+            .lint_with_host(files, RuntimeProgramHost::new(file_system))?
+            .into_iter()
+            .flat_map(|result| result.messages)
+            .collect())
+    }
+
+    fn lint_with_host<H: ProgramHost>(
+        &self,
+        files: &[Arc<OsStr>],
+        host: H,
+    ) -> Result<Vec<NativeLintResult>, String> {
+        let selected_files = files
+            .iter()
+            .map(PathBuf::from)
+            .filter(|path| SourceType::from_path(path).is_ok_and(SourceType::is_typescript))
+            .collect::<Vec<_>>();
+
+        if !selected_files.iter().any(|path| !self.rules(path).is_empty()) {
+            return Ok(Vec::new());
+        }
+
+        let allocator = Allocator::default();
+        let mut builder = ProgramStoreBuilder::new(&allocator, host);
+        for path in &selected_files {
+            builder = builder.add_root_file(path);
+        }
+        let store = builder.build().map_err(|error| error.to_string())?;
+        let checker = CheckerBuilder::new().build(&store);
+
+        let mut results = Vec::new();
+        for entry in store.entries().iter().filter(|entry| !entry.is_lib()) {
+            let Some(selected_path) =
+                selected_files.iter().find(|path| same_file(path, entry.path()))
+            else {
+                continue;
+            };
+            let resolved = self.config_store.resolve(selected_path);
+            let rules = resolved
+                .rules
+                .iter()
+                .filter(|(rule, severity)| {
+                    is_native_type_aware_rule(rule) && severity.is_warn_deny()
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if rules.is_empty() {
+                continue;
+            }
+
+            let source_type = SourceType::from_path(selected_path).map_err(|e| e.to_string())?;
+            let parsed = Parser::new(&allocator, entry.source_text(), source_type).parse();
+            if !parsed.diagnostics.is_empty() {
+                continue;
+            }
+            let semantic =
+                SemanticBuilder::new_linter().build(allocator.alloc(parsed.program)).semantic;
+            let module_record =
+                Arc::new(ModuleRecord::new(selected_path, &parsed.module_record, &semantic));
+            let sub_host =
+                ContextSubHost::new(semantic, module_record, 0, ContextSubHostOptions::default());
+            let typed_api = TypedApiContext::new(&checker, entry);
+            let ctx_host = Rc::new(
+                ContextHost::new(
+                    selected_path,
+                    vec![sub_host],
+                    &allocator,
+                    LintOptions::default(),
+                    Arc::clone(&resolved.config),
+                )
+                .with_type_aware(typed_api),
+            );
+
+            for (rule, severity) in &rules {
+                let ctx = Rc::clone(&ctx_host).spawn(rule, *severity);
+                for node in ctx.semantic().nodes().iter() {
+                    rule.run::<false>(node, &ctx, None);
+                }
+            }
+
+            results.push(NativeLintResult {
+                path: selected_path.clone(),
+                source_text: entry.source_text().to_string(),
+                messages: ctx_host.take_diagnostics(),
+            });
+        }
+
+        Ok(results)
+    }
+
+    fn rules(&self, path: &Path) -> Vec<(RuleEnum, AllowWarnDeny)> {
+        self.config_store
+            .resolve(path)
+            .rules
+            .iter()
+            .filter(|(rule, severity)| is_native_type_aware_rule(rule) && severity.is_warn_deny())
+            .cloned()
+            .collect()
+    }
+}
+
+struct NativeLintResult {
+    path: PathBuf,
+    source_text: String,
+    messages: Vec<Message>,
+}
+
+fn same_file(left: &Path, right: &Path) -> bool {
+    std::fs::canonicalize(left).unwrap_or_else(|_| left.to_path_buf()) == right
+}

--- a/crates/oxc_linter/src/native_type_aware.rs
+++ b/crates/oxc_linter/src/native_type_aware.rs
@@ -12,7 +12,7 @@ use oxc_checker::{
         FsProgramHost, HostModuleResolution, ProgramEntry, ProgramHost, ProgramStoreBuilder,
         ProgramStoreError,
     },
-    types::{CheckerArena, Ty, TypeData, TypeId},
+    types::{CheckerArena, SignatureKind, Ty, TypeData, TypeId},
 };
 use oxc_diagnostics::{DiagnosticSender, DiagnosticService};
 use oxc_parser::Parser;
@@ -28,7 +28,7 @@ use crate::{
 
 pub fn is_native_type_aware_rule(rule: &RuleEnum) -> bool {
     // TODO: This would actually be part of the generated code, but this is just a proof of concept
-    rule.name() == "no-unsafe-unary-minus"
+    matches!(rule.name(), "no-floating-promises" | "no-unsafe-unary-minus")
 }
 
 pub fn is_type_aware_rule(rule: &RuleEnum) -> bool {
@@ -39,6 +39,9 @@ pub struct TypedApiContext<'a> {
     arena: CheckerArena<'a>,
     types_by_span: FxHashMap<Span, Ty<'a>>,
     type_names: FxHashMap<(Span, TypeId), String>,
+    callable_by_span: FxHashMap<Span, bool>,
+    promise_like_by_span: FxHashMap<Span, [bool; 2]>,
+    promise_array_by_span: FxHashMap<Span, [bool; 2]>,
 }
 
 impl<'a> TypedApiContext<'a> {
@@ -46,6 +49,9 @@ impl<'a> TypedApiContext<'a> {
         let arena = checker.arena();
         let mut types_by_span = FxHashMap::default();
         let mut type_names = FxHashMap::default();
+        let mut callable_by_span = FxHashMap::default();
+        let mut promise_like_by_span = FxHashMap::default();
+        let mut promise_array_by_span = FxHashMap::default();
         for (node_id, node) in entry.semantic().nodes().iter_enumerated() {
             let span = node.kind().span();
             let node = NodeRef::new(entry.id(), node_id);
@@ -54,7 +60,33 @@ impl<'a> TypedApiContext<'a> {
             types_by_span.insert(span, ty);
             cache_type_names(checker, arena, ty, node, span, &mut type_names);
         }
-        Self { arena, types_by_span, type_names }
+        let builtin_promises =
+            arena.types().filter(|ty| is_builtin_promise(checker, arena, *ty)).collect::<Vec<_>>();
+        for (span, ty) in &types_by_span {
+            callable_by_span.insert(*span, is_callable(checker, arena, *ty));
+            promise_like_by_span.insert(
+                *span,
+                [
+                    is_promise_like(checker, arena, *ty, false, &builtin_promises),
+                    is_promise_like(checker, arena, *ty, true, &builtin_promises),
+                ],
+            );
+            promise_array_by_span.insert(
+                *span,
+                [
+                    is_promise_array(checker, arena, *ty, false, &builtin_promises),
+                    is_promise_array(checker, arena, *ty, true, &builtin_promises),
+                ],
+            );
+        }
+        Self {
+            arena,
+            types_by_span,
+            type_names,
+            callable_by_span,
+            promise_like_by_span,
+            promise_array_by_span,
+        }
     }
 
     #[inline]
@@ -70,6 +102,135 @@ impl<'a> TypedApiContext<'a> {
     #[inline]
     pub fn type_name(&self, span: Span, ty: Ty<'a>) -> Option<&str> {
         self.type_names.get(&(span, ty.id())).map(String::as_str)
+    }
+
+    #[inline]
+    pub fn is_callable(&self, span: Span) -> bool {
+        self.callable_by_span.get(&span).copied().unwrap_or(false)
+    }
+
+    #[inline]
+    pub fn is_promise_like(&self, span: Span, check_thenables: bool) -> bool {
+        self.promise_like_by_span
+            .get(&span)
+            .is_some_and(|result| result[usize::from(check_thenables)])
+    }
+
+    #[inline]
+    pub fn is_promise_array(&self, span: Span, check_thenables: bool) -> bool {
+        self.promise_array_by_span
+            .get(&span)
+            .is_some_and(|result| result[usize::from(check_thenables)])
+    }
+}
+
+fn is_builtin_promise<'a>(
+    checker: &CheckerReturn<'a, '_>,
+    arena: CheckerArena<'a>,
+    ty: Ty<'a>,
+) -> bool {
+    let TypeData::TypeReference(reference) = arena.type_data(ty) else {
+        return false;
+    };
+    if !matches!(reference.name, "Promise" | "PromiseLike") {
+        return false;
+    }
+    reference.target.is_none_or(|target| {
+        checker.store.entry(target.program_id).is_some_and(ProgramEntry::is_lib)
+    })
+}
+
+fn is_callable<'a>(checker: &CheckerReturn<'a, '_>, arena: CheckerArena<'a>, ty: Ty<'a>) -> bool {
+    match arena.type_data(ty) {
+        TypeData::Function(_) => true,
+        TypeData::Object(object) => {
+            object.signatures.iter().any(|signature| signature.kind == SignatureKind::Call)
+        }
+        TypeData::Union(union) => union.types.iter().any(|ty| is_callable(checker, arena, *ty)),
+        TypeData::Intersection(intersection) => {
+            intersection.types.iter().any(|ty| is_callable(checker, arena, *ty))
+        }
+        _ => !checker.get_signatures_of_type(ty, SignatureKind::Call).is_empty(),
+    }
+}
+
+fn is_promise_like<'a>(
+    checker: &CheckerReturn<'a, '_>,
+    arena: CheckerArena<'a>,
+    ty: Ty<'a>,
+    check_thenables: bool,
+    builtin_promises: &[Ty<'a>],
+) -> bool {
+    match arena.type_data(ty) {
+        TypeData::Union(union) => {
+            return union
+                .types
+                .iter()
+                .any(|ty| is_promise_like(checker, arena, *ty, check_thenables, builtin_promises));
+        }
+        TypeData::Intersection(intersection)
+            if intersection.types.iter().any(|ty| {
+                is_promise_like(checker, arena, *ty, check_thenables, builtin_promises)
+            }) =>
+        {
+            return true;
+        }
+        _ => {}
+    }
+    if is_builtin_promise(checker, arena, ty)
+        || builtin_promises.iter().any(|promise| checker.is_assignable_to(ty, *promise))
+    {
+        return true;
+    }
+    check_thenables && is_rejectable_thenable(checker, arena, ty)
+}
+
+fn is_rejectable_thenable<'a>(
+    checker: &CheckerReturn<'a, '_>,
+    arena: CheckerArena<'a>,
+    ty: Ty<'a>,
+) -> bool {
+    match arena.type_data(ty) {
+        TypeData::Object(object) => object.properties.iter().any(|property| {
+            property.name == "then"
+                && checker.get_signatures_of_type(property.ty, SignatureKind::Call).iter().any(
+                    |signature| {
+                        let parameters = &signature.function(arena).parameters;
+                        parameters.len() >= 2
+                            && is_callable(checker, arena, parameters[0].ty)
+                            && is_callable(checker, arena, parameters[1].ty)
+                    },
+                )
+        }),
+        TypeData::Union(union) => {
+            union.types.iter().any(|ty| is_rejectable_thenable(checker, arena, *ty))
+        }
+        TypeData::Intersection(intersection) => {
+            intersection.types.iter().any(|ty| is_rejectable_thenable(checker, arena, *ty))
+        }
+        _ => false,
+    }
+}
+
+fn is_promise_array<'a>(
+    checker: &CheckerReturn<'a, '_>,
+    arena: CheckerArena<'a>,
+    ty: Ty<'a>,
+    check_thenables: bool,
+    builtin_promises: &[Ty<'a>],
+) -> bool {
+    match arena.type_data(ty) {
+        TypeData::Union(union) => union
+            .types
+            .iter()
+            .any(|ty| is_promise_array(checker, arena, *ty, check_thenables, builtin_promises)),
+        TypeData::Array(array) => {
+            is_promise_like(checker, arena, array.element_type, check_thenables, builtin_promises)
+        }
+        TypeData::Tuple(tuple) => tuple.elements.iter().any(|element| {
+            is_promise_like(checker, arena, element.ty(), check_thenables, builtin_promises)
+        }),
+        _ => false,
     }
 }
 
@@ -102,6 +263,7 @@ fn cache_type_names<'a>(
 pub struct NativeTypeAwareRunner {
     cwd: PathBuf,
     config_store: ConfigStore,
+    lint_options: LintOptions,
 }
 
 struct RuntimeProgramHost<'a> {
@@ -133,8 +295,8 @@ impl ProgramHost for RuntimeProgramHost<'_> {
 }
 
 impl NativeTypeAwareRunner {
-    pub fn new(cwd: PathBuf, config_store: ConfigStore) -> Self {
-        Self { cwd, config_store }
+    pub fn new(cwd: PathBuf, config_store: ConfigStore, lint_options: LintOptions) -> Self {
+        Self { cwd, config_store, lint_options }
     }
 
     pub fn lint(
@@ -231,7 +393,7 @@ impl NativeTypeAwareRunner {
                     selected_path,
                     vec![sub_host],
                     &allocator,
-                    LintOptions::default(),
+                    self.lint_options,
                     Arc::clone(&resolved.config),
                 )
                 .with_type_aware(typed_api),

--- a/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
@@ -1,10 +1,22 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, CallExpression, ChainElement, Expression},
+};
+use oxc_checker::types::Ty;
+use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::operator::UnaryOperator;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    AstNode,
+    context::LintContext,
+    fixer::RuleFixer,
+    native_type_aware::TypedApiContext,
     rule::{DefaultRuleConfig, Rule},
-    utils::TypeOrValueSpecifier,
+    utils::{NameSpecifier, TypeOrValueSpecifier},
 };
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -103,7 +115,7 @@ declare_oxc_lint!(
     ///
     /// await Promise.all([1, 2, 3].map(async x => x + 1));
     /// ```
-    NoFloatingPromises(tsgolint),
+    NoFloatingPromises,
     typescript,
     correctness,
     suggestion,
@@ -120,12 +132,372 @@ impl Rule for NoFloatingPromises {
     fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {
         Some(serde_json::to_value(&*self.0))
     }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ExpressionStatement(statement) = node.kind() else {
+            return;
+        };
+        let Some(api) = ctx.type_aware() else { return };
+
+        if self.0.ignore_iife && is_iife(&statement.expression) {
+            return;
+        }
+        if is_known_safe_call(&statement.expression, api, &self.0.allow_for_known_safe_calls) {
+            return;
+        }
+
+        let Some(unhandled) = find_unhandled(
+            &statement.expression,
+            api,
+            self.0.check_thenables,
+            self.0.ignore_void,
+            &self.0.allow_for_known_safe_promises,
+        ) else {
+            return;
+        };
+
+        let type_name = api.type_name(unhandled.type_span, unhandled.ty).unwrap_or("unknown");
+        let (message, help) = if unhandled.promise_array {
+            (
+                "An array of Promises may be unintentional.",
+                if self.0.ignore_void {
+                    "Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator."
+                } else {
+                    "Consider handling the promises' fulfillment or rejection with Promise.all or similar."
+                },
+            )
+        } else if self.0.ignore_void {
+            (
+                "Promises must be awaited, add void operator to ignore.",
+                "The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.",
+            )
+        } else {
+            (
+                "Promises must be awaited, add await operator.",
+                "The promise must end with a call to .catch, or end with a call to .then with a rejection handler.",
+            )
+        };
+        let help = if let Some(handler_span) = unhandled.non_function_handler {
+            let handler_name = api
+                .type_at_span(handler_span)
+                .and_then(|ty| api.type_name(handler_span, ty))
+                .unwrap_or("unknown");
+            format!(
+                "{help} The rejection handler has type `{handler_name}`, which is not callable."
+            )
+        } else {
+            help.to_string()
+        };
+        let type_description = if unhandled.promise_array {
+            "This array contains Promises and"
+        } else {
+            "This unhandled promise-like value"
+        };
+        let diagnostic = OxcDiagnostic::warn(message).with_help(help).with_label(
+            unhandled.span.label(format!("{type_description} has type `{type_name}`.")),
+        );
+        if unhandled.promise_array {
+            ctx.diagnostic(diagnostic);
+            return;
+        }
+
+        let fixer = RuleFixer::new(crate::fixer::FixKind::Suggestion, ctx);
+        let expression = &statement.expression;
+        let await_replacement = suggestion_text("await", expression, ctx.source_text());
+        let await_fix =
+            fixer.replace(expression.span(), await_replacement).with_message("Add await operator.");
+        if self.0.ignore_void {
+            let void_fix = fixer
+                .replace(expression.span(), suggestion_text("void", expression, ctx.source_text()))
+                .with_message("Add void operator to ignore.");
+            ctx.diagnostic_with_suggestions(diagnostic, [void_fix, await_fix]);
+        } else {
+            ctx.diagnostic_with_suggestions(diagnostic, [await_fix]);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct UnhandledPromise<'a> {
+    span: Span,
+    type_span: Span,
+    ty: Ty<'a>,
+    promise_array: bool,
+    non_function_handler: Option<Span>,
+}
+
+fn find_unhandled<'a>(
+    expression: &'a Expression<'a>,
+    api: &TypedApiContext<'a>,
+    check_thenables: bool,
+    ignore_void: bool,
+    safe_promises: &[TypeOrValueSpecifier],
+) -> Option<UnhandledPromise<'a>> {
+    let expression = expression.get_inner_expression();
+
+    match expression {
+        Expression::AssignmentExpression(_) => return None,
+        Expression::SequenceExpression(sequence) => {
+            return sequence.expressions.iter().find_map(|expression| {
+                find_unhandled(expression, api, check_thenables, ignore_void, safe_promises)
+            });
+        }
+        Expression::UnaryExpression(unary)
+            if unary.operator == UnaryOperator::Void && !ignore_void =>
+        {
+            return find_unhandled(
+                &unary.argument,
+                api,
+                check_thenables,
+                ignore_void,
+                safe_promises,
+            );
+        }
+        Expression::ChainExpression(chain) => {
+            if let ChainElement::CallExpression(call) = &chain.expression {
+                return find_unhandled_call(
+                    call,
+                    chain.span,
+                    api,
+                    check_thenables,
+                    ignore_void,
+                    safe_promises,
+                );
+            }
+        }
+        _ => {}
+    }
+
+    let span = expression.span();
+    let ty = api.type_at_span(span)?;
+    if api.is_promise_array(span, check_thenables) {
+        return Some(UnhandledPromise {
+            span,
+            type_span: span,
+            ty,
+            promise_array: true,
+            non_function_handler: None,
+        });
+    }
+    if matches!(expression, Expression::AwaitExpression(_)) {
+        return None;
+    }
+    if !api.is_promise_like(span, check_thenables)
+        || type_matches_specifier(api.type_name(span, ty), safe_promises)
+    {
+        return None;
+    }
+
+    match expression {
+        Expression::CallExpression(call) => {
+            find_unhandled_call(call, span, api, check_thenables, ignore_void, safe_promises)
+        }
+        Expression::ConditionalExpression(conditional) => {
+            find_unhandled(&conditional.alternate, api, check_thenables, ignore_void, safe_promises)
+                .or_else(|| {
+                    find_unhandled(
+                        &conditional.consequent,
+                        api,
+                        check_thenables,
+                        ignore_void,
+                        safe_promises,
+                    )
+                })
+        }
+        Expression::LogicalExpression(logical) => {
+            find_unhandled(&logical.left, api, check_thenables, ignore_void, safe_promises).or_else(
+                || find_unhandled(&logical.right, api, check_thenables, ignore_void, safe_promises),
+            )
+        }
+        _ => Some(UnhandledPromise {
+            span,
+            type_span: span,
+            ty,
+            promise_array: false,
+            non_function_handler: None,
+        }),
+    }
+}
+
+fn find_unhandled_call<'a>(
+    call: &'a CallExpression<'a>,
+    span: Span,
+    api: &TypedApiContext<'a>,
+    check_thenables: bool,
+    ignore_void: bool,
+    safe_promises: &[TypeOrValueSpecifier],
+) -> Option<UnhandledPromise<'a>> {
+    let ty = api.type_at_span(span)?;
+    if !api.is_promise_like(span, check_thenables)
+        || type_matches_specifier(api.type_name(span, ty), safe_promises)
+    {
+        return None;
+    }
+    let Some(member) = call.callee.get_member_expr() else {
+        return Some(unhandled_call(span, ty));
+    };
+    match member.static_property_name() {
+        Some("catch") if !call.arguments.is_empty() => {
+            rejection_handler_result(call, 0, span, ty, api)
+        }
+        Some("then") if call.arguments.len() >= 2 => {
+            rejection_handler_result(call, 1, span, ty, api)
+        }
+        Some("finally") => {
+            let mut result =
+                find_unhandled(member.object(), api, check_thenables, ignore_void, safe_promises)?;
+            result.span = span;
+            result.type_span = span;
+            result.ty = ty;
+            Some(result)
+        }
+        _ => Some(unhandled_call(span, ty)),
+    }
+}
+
+fn rejection_handler_result<'a>(
+    call: &'a CallExpression<'a>,
+    index: usize,
+    span: Span,
+    ty: Ty<'a>,
+    api: &TypedApiContext<'a>,
+) -> Option<UnhandledPromise<'a>> {
+    if call.arguments[..=index]
+        .iter()
+        .any(|argument| matches!(argument, Argument::SpreadElement(_)))
+    {
+        return Some(unhandled_call(span, ty));
+    }
+    let handler = call.arguments[index].as_expression()?;
+    if api.is_callable(handler.span()) {
+        None
+    } else {
+        Some(UnhandledPromise {
+            non_function_handler: Some(handler.span()),
+            ..unhandled_call(span, ty)
+        })
+    }
+}
+
+fn unhandled_call(span: Span, ty: Ty<'_>) -> UnhandledPromise<'_> {
+    UnhandledPromise { span, type_span: span, ty, promise_array: false, non_function_handler: None }
+}
+
+fn is_iife(expression: &Expression<'_>) -> bool {
+    let Expression::CallExpression(call) = expression.get_inner_expression() else {
+        return false;
+    };
+    matches!(
+        call.callee.get_inner_expression(),
+        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_)
+    )
+}
+
+fn suggestion_text(operator: &str, expression: &Expression<'_>, source_text: &str) -> String {
+    if operator == "await"
+        && let Expression::UnaryExpression(unary) = expression.get_inner_expression()
+        && unary.operator == UnaryOperator::Void
+    {
+        return format!("await {}", unary.argument.span().source_text(source_text));
+    }
+    let source = expression.span().source_text(source_text);
+    if has_unary_operand_precedence(expression.get_inner_expression()) {
+        format!("{operator} {source}")
+    } else {
+        format!("{operator} ({source})")
+    }
+}
+
+fn has_unary_operand_precedence(expression: &Expression<'_>) -> bool {
+    !matches!(
+        expression,
+        Expression::AssignmentExpression(_)
+            | Expression::ConditionalExpression(_)
+            | Expression::LogicalExpression(_)
+            | Expression::SequenceExpression(_)
+            | Expression::YieldExpression(_)
+    )
+}
+
+fn is_known_safe_call(
+    expression: &Expression<'_>,
+    api: &TypedApiContext<'_>,
+    specifiers: &[TypeOrValueSpecifier],
+) -> bool {
+    let Expression::CallExpression(call) = expression.get_inner_expression() else {
+        return false;
+    };
+    let callee = call.callee.get_inner_expression();
+    let value_name = match callee {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        _ => {
+            callee.get_member_expr().and_then(oxc_ast::ast::MemberExpression::static_property_name)
+        }
+    };
+    value_name
+        .is_some_and(|name| specifiers.iter().any(|specifier| specifier_has_name(specifier, name)))
+        || api
+            .type_at_span(callee.span())
+            .is_some_and(|ty| type_matches_specifier(api.type_name(callee.span(), ty), specifiers))
+}
+
+fn type_matches_specifier(type_name: Option<&str>, specifiers: &[TypeOrValueSpecifier]) -> bool {
+    let Some(type_name) = type_name else { return false };
+    specifiers.iter().any(|specifier| {
+        specifier_names(specifier).any(|name| {
+            type_name == name
+                || type_name.strip_prefix(name).is_some_and(|rest| rest.starts_with('<'))
+        })
+    })
+}
+
+fn specifier_has_name(specifier: &TypeOrValueSpecifier, expected: &str) -> bool {
+    specifier_names(specifier).any(|name| name == expected)
+}
+
+fn specifier_names(specifier: &TypeOrValueSpecifier) -> impl Iterator<Item = &str> {
+    let names = match specifier {
+        TypeOrValueSpecifier::String(name) => {
+            return std::slice::from_ref(name).iter().map(String::as_str);
+        }
+        TypeOrValueSpecifier::File(specifier) => &specifier.name,
+        TypeOrValueSpecifier::Lib(specifier) => &specifier.name,
+        TypeOrValueSpecifier::Package(specifier) => &specifier.name,
+    };
+    match names {
+        NameSpecifier::Single(name) => std::slice::from_ref(name).iter().map(String::as_str),
+        NameSpecifier::Multiple(names) => names.iter().map(String::as_str),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tester::Tester;
     use serde_json::json;
+
+    #[test]
+    fn test_rule() {
+        let pass = vec![
+            "await Promise.resolve();",
+            "void Promise.resolve();",
+            "Promise.resolve().catch(() => {});",
+            "Promise.resolve().then(() => {}, () => {});",
+            "const promise = Promise.resolve();",
+        ];
+        let fail = vec![
+            "Promise.resolve();",
+            "Promise.resolve().then(() => {});",
+            "Promise.resolve().catch();",
+            "Promise.resolve().catch(undefined);",
+            "Promise.resolve().finally(() => {});",
+            "[Promise.resolve()];",
+        ];
+
+        Tester::new(NoFloatingPromises::NAME, NoFloatingPromises::PLUGIN, pass, fail)
+            .expect_fix(vec![("Promise.resolve();", "void Promise.resolve();")])
+            .test_and_snapshot();
+    }
 
     #[test]
     fn test_default_config() {

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_unary_minus.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_unary_minus.rs
@@ -1,6 +1,10 @@
+use oxc_ast::{AstKind, ast::UnaryOperator};
+use oxc_checker::types::{Ty, TypeData};
+use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
+use oxc_span::GetSpan;
 
-use crate::rule::Rule;
+use crate::{AstNode, context::LintContext, native_type_aware::TypedApiContext, rule::Rule};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoUnsafeUnaryMinus;
@@ -18,11 +22,8 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```ts
-    /// declare const value: any;
-    /// const result1 = -value; // unsafe on any
-    ///
     /// declare const str: string;
-    /// const result2 = -str; // unsafe on string
+    /// const result1 = -str; // unsafe on string
     ///
     /// declare const bool: boolean;
     /// const result3 = -bool; // unsafe on boolean
@@ -49,15 +50,106 @@ declare_oxc_lint!(
     /// declare const union: number | bigint;
     /// const result3 = -union; // safe
     ///
+    /// declare const anyValue: any;
+    /// const result4 = -anyValue; // allowed by the upstream rule
+    ///
+    /// declare const neverValue: never;
+    /// const result5 = -neverValue; // safe
+    ///
     /// // Convert to number first if needed
     /// declare const str: string;
-    /// const result4 = -Number(str); // safe conversion
+    /// const result6 = -Number(str); // safe conversion
     /// ```
-    NoUnsafeUnaryMinus(tsgolint),
+    NoUnsafeUnaryMinus,
     typescript,
     correctness,
     version = "1.12.0",
     short_description = "This rule disallows using the unary minus operator on a value which is not of type 'number' | 'bigint'.",
 );
 
-impl Rule for NoUnsafeUnaryMinus {}
+impl Rule for NoUnsafeUnaryMinus {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::UnaryExpression(unary) = node.kind() else {
+            return;
+        };
+        if unary.operator != UnaryOperator::UnaryNegation {
+            return;
+        }
+
+        let span = unary.argument.span();
+        let Some(api) = ctx.type_aware() else {
+            return;
+        };
+        let Some(ty) = api.type_at_span(span) else {
+            return;
+        };
+        let Some(unsafe_ty) = first_unsafe_type(api, ty) else {
+            return;
+        };
+        let type_name = api.type_name(span, unsafe_ty).unwrap_or("unknown");
+
+        ctx.diagnostic(
+            OxcDiagnostic::warn(format!(
+                "Argument of unary negation should be assignable to number | bigint but is {type_name} instead."
+            ))
+            .with_label(unary.span),
+        );
+    }
+}
+
+fn first_unsafe_type<'a>(api: &TypedApiContext<'a>, ty: Ty<'a>) -> Option<Ty<'a>> {
+    match api.type_data(ty) {
+        TypeData::Any
+        | TypeData::Never
+        | TypeData::Number
+        | TypeData::NumberLiteral(_)
+        | TypeData::Bigint
+        | TypeData::BigIntLiteral(_) => None,
+        TypeData::Union(union) => union.types.iter().find_map(|ty| first_unsafe_type(api, *ty)),
+        TypeData::Intersection(intersection) => {
+            if intersection.types.iter().any(|ty| first_unsafe_type(api, *ty).is_none()) {
+                None
+            } else {
+                Some(ty)
+            }
+        }
+        _ => Some(ty),
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "+42;",
+        "-42;",
+        "-42n;",
+        "(a: number) => -a;",
+        "(a: bigint) => -a;",
+        "(a: number | bigint) => -a;",
+        "(a: any) => -a;",
+        "(a: 1 | 2) => -a;",
+        "(a: string) => +a;",
+        "(a: number[]) => -a[0];",
+        "<T,>(t: T & number) => -t;",
+        "(a: { x: number }) => -a.x;",
+        "(a: never) => -a;",
+        "<T extends number>(t: T) => -t;",
+    ];
+
+    let fail = vec![
+        "(a: string) => -a;",
+        "(a: {}) => -a;",
+        "(a: number[]) => -a;",
+        "-'hello';",
+        "-`hello`;",
+        "(a: { x: number }) => -a;",
+        "(a: unknown) => -a;",
+        "(a: void) => -a;",
+        "<T,>(t: T) => -t;",
+    ];
+
+    Tester::new(NoUnsafeUnaryMinus::NAME, NoUnsafeUnaryMinus::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/typescript_no_floating_promises.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_floating_promises.snap
@@ -1,0 +1,51 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ typescript(no-floating-promises): Promises must be awaited, add void operator to ignore.
+   ╭─[no_floating_promises.tsx:1:1]
+ 1 │ Promise.resolve();
+   · ────────┬────────
+   ·         ╰── This unhandled promise-like value has type `Promise<void>`.
+   ╰────
+  help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
+
+  ⚠ typescript(no-floating-promises): Promises must be awaited, add void operator to ignore.
+   ╭─[no_floating_promises.tsx:1:1]
+ 1 │ Promise.resolve().then(() => {});
+   · ────────────────┬───────────────
+   ·                 ╰── This unhandled promise-like value has type `Promise<void>`.
+   ╰────
+  help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
+
+  ⚠ typescript(no-floating-promises): Promises must be awaited, add void operator to ignore.
+   ╭─[no_floating_promises.tsx:1:1]
+ 1 │ Promise.resolve().catch();
+   · ────────────┬────────────
+   ·             ╰── This unhandled promise-like value has type `Promise<void>`.
+   ╰────
+  help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
+
+  ⚠ typescript(no-floating-promises): Promises must be awaited, add void operator to ignore.
+   ╭─[no_floating_promises.tsx:1:1]
+ 1 │ Promise.resolve().catch(undefined);
+   · ─────────────────┬────────────────
+   ·                  ╰── This unhandled promise-like value has type `Promise<void>`.
+   ╰────
+  help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator. The rejection handler has type `undefined`, which is not callable.
+
+  ⚠ typescript(no-floating-promises): Promises must be awaited, add void operator to ignore.
+   ╭─[no_floating_promises.tsx:1:1]
+ 1 │ Promise.resolve().finally(() => {});
+   · ─────────────────┬─────────────────
+   ·                  ╰── This unhandled promise-like value has type `Promise<void>`.
+   ╰────
+  help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
+
+  ⚠ typescript(no-floating-promises): An array of Promises may be unintentional.
+   ╭─[no_floating_promises.tsx:1:1]
+ 1 │ [Promise.resolve()];
+   · ─────────┬─────────
+   ·          ╰── This array contains Promises and has type `Promise<void>[]`.
+   ╰────
+  help: Consider handling the promises' fulfillment or rejection with Promise.all or similar, or explicitly marking the expression as ignored with the `void` operator.

--- a/crates/oxc_linter/src/snapshots/typescript_no_unsafe_unary_minus.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_unsafe_unary_minus.snap
@@ -1,0 +1,57 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is string instead.
+   ╭─[no_unsafe_unary_minus.tsx:1:16]
+ 1 │ (a: string) => -a;
+   ·                ──
+   ╰────
+
+  ⚠ typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is {} instead.
+   ╭─[no_unsafe_unary_minus.tsx:1:12]
+ 1 │ (a: {}) => -a;
+   ·            ──
+   ╰────
+
+  ⚠ typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is number[] instead.
+   ╭─[no_unsafe_unary_minus.tsx:1:18]
+ 1 │ (a: number[]) => -a;
+   ·                  ──
+   ╰────
+
+  ⚠ typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is "hello" instead.
+   ╭─[no_unsafe_unary_minus.tsx:1:1]
+ 1 │ -'hello';
+   · ────────
+   ╰────
+
+  ⚠ typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is "hello" instead.
+   ╭─[no_unsafe_unary_minus.tsx:1:1]
+ 1 │ -`hello`;
+   · ────────
+   ╰────
+
+  ⚠ typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is { x: number; } instead.
+   ╭─[no_unsafe_unary_minus.tsx:1:23]
+ 1 │ (a: { x: number }) => -a;
+   ·                       ──
+   ╰────
+
+  ⚠ typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is unknown instead.
+   ╭─[no_unsafe_unary_minus.tsx:1:17]
+ 1 │ (a: unknown) => -a;
+   ·                 ──
+   ╰────
+
+  ⚠ typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is void instead.
+   ╭─[no_unsafe_unary_minus.tsx:1:14]
+ 1 │ (a: void) => -a;
+   ·              ──
+   ╰────
+
+  ⚠ typescript(no-unsafe-unary-minus): Argument of unary negation should be assignable to number | bigint but is T instead.
+   ╭─[no_unsafe_unary_minus.tsx:1:15]
+ 1 │ <T,>(t: T) => -t;
+   ·               ──
+   ╰────

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -17,10 +17,11 @@ use oxc_allocator::Allocator;
 use oxc_diagnostics::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 
 use crate::{
-    AllowWarnDeny, ConfigStore, ConfigStoreBuilder, LintPlugins, LintService, LintServiceOptions,
-    Linter, Oxlintrc, RuleEnum,
+    AllowWarnDeny, ConfigStore, ConfigStoreBuilder, LintPlugins, LintRunner, LintService,
+    LintServiceOptions, Linter, Oxlintrc, RuleEnum,
     external_plugin_store::ExternalPluginStore,
     fixer::{FixKind, Fixer},
+    native_type_aware::is_native_type_aware_rule,
     options::LintOptions,
     rules::RULES,
     service::RuntimeFileSystem,
@@ -633,6 +634,7 @@ impl Tester {
             );
         }
         let rule = self.find_rule().from_configuration(rule_config.unwrap_or_default()).unwrap();
+        let is_native_type_aware = is_native_type_aware_rule(&rule);
         let mut external_plugin_store = ExternalPluginStore::default();
         let linter = Linter::new(
             self.lint_options,
@@ -679,11 +681,19 @@ impl Tester {
         let cwd = self.current_working_directory.clone();
         let paths = vec![Arc::<OsStr>::from(path_to_lint.as_os_str())];
         let options = LintServiceOptions::new(cwd).with_cross_module(self.plugins.has_import());
-        let lint_service = LintService::new(linter, options);
         let file_system = TesterFileSystem::new(path_to_lint.clone(), source_text.to_string());
-
-        let (sender, _receiver) = mpsc::channel();
-        let result = lint_service.run_test_source(&file_system, paths, false, &sender);
+        let result = if is_native_type_aware {
+            LintRunner::builder(options, linter)
+                .with_type_aware(true)
+                .build()
+                .unwrap()
+                .run_source(&paths, &file_system)
+                .unwrap()
+        } else {
+            let lint_service = LintService::new(linter, options);
+            let (sender, _receiver) = mpsc::channel();
+            lint_service.run_test_source(&file_system, paths, false, &sender)
+        };
 
         if result.is_empty() {
             return TestResult::Passed;


### PR DESCRIPTION
This is an experimental proof-of-concept PR, not anything that we will actually merge. This is turbo AI slop.

The main goal of this PR is to answer the question: can we add native type-aware linting without depending on `typescript-go`? I think the short answer is: **yes**. The long answer is: yes, but it will definitely require more architectural work to incorporate into the linter as well as much more work done on the type checker.

This PR demonstrates:
- Basic implementation of `no-unsafe-unary-minus`
- Less basic implementation of `no-floating-promises`, albeit lacking quite a few test cases in order to keep this PR smallish.
- Generic typed APIs implemented via [`oxc_checker`](https://github.com/camchenry/oxc_checker) that can be used to add TypeScript support to any existing lint rules (e.g., differentiating `.sort()` call from global `Array.sort()`)
- Compatibility with linter codegen: Existing static code analysis of AST node types used in the rule works like any other rule. This enables greater efficiency of linting compared to `tsgolint`, because many type check calls can be skipped if there are no nodes that can trigger a lint rule.

Things this PR does not do:
- Implement a great architectural pattern for linting multiple files. Technically it does do that, but we ought to handwrite something here that also works with the import plugin rules too and ensures that files are read and cached once, not multiple times across threads/rules.
- Show how to provide these APIs to custom lint rules via NAPI. I don't see why this shouldn't be possible though, `oxc_checker` uses `oxc_allocator` for arena allocations already, so it seems viable.
- Implemented support for reading `tsconfig` files and using that to update the type-checking. In fact, `oxc_checker` doesn't even support any non-strict-mode configuration or multiple projects yet.

### Performance

Few performance optimizations have been made to `oxc_checker`, especially when it comes to memory. However, the performance is not so terrible it couldn't be improved with effort. Keep in mind: the diagnostics reported were not the same (`oxc_checker` had more false positives due to some of the naive implementation or lack of type checking in some cases), so they are not 1:1 comparisons.

- Running on a subset of `vscode` (`src/vs/editor/common`) (223 files):
  - Production `oxlint` + `oxlint-tsgolint`: 1.73 seconds
  - `oxc_checker`: 4.08 seconds
- Running on a single file is noticeably faster though:
  - Production `oxlint` + `oxlint-tsgolint`: ~1.2 seconds
  - `oxc_checker`: ~100ms
  
I think this demonstrates that if we put some effort into optimizing `oxc_checker`, we could achieve some impressive results. Since `oxc_checker` is not running in a separate process, we get much better cache/memory locality, and all of the code paths can be inlined to where they are actually used. In addition, since we don't require a separate binary, the total download size should be improved.
