### PR TITLE
fix(linter/typescript/consistent-type-imports): make token lookups comment-aware

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -507,7 +507,7 @@ fn fix_to_type_import_declaration(options: &FixOptions<'_, '_>) -> FixerResult<R
         // import Foo, * as Type from 'foo'
         // import DefType, * as Type from 'foo'
         // import DefType, * as Type from 'foo'
-        let comma = try_find_char(ctx.source_range(import_decl.span), ',')?;
+        let comma = try_find_token(ctx, import_decl.span, ",")?;
 
         // import Def, * as Ns from 'foo'
         //           ^^^^^^^^^ remove
@@ -539,8 +539,7 @@ fn fix_to_type_import_declaration(options: &FixOptions<'_, '_>) -> FixerResult<R
         } else {
             let import_text = ctx.source_range(import_decl.span);
             // import Type, { Foo } from 'foo'
-            //let import_text = ctx.source_range(import_decl.span);
-            let comma = try_find_char(import_text, ',')?;
+            let comma = try_find_token(ctx, import_decl.span, ",")?;
             // import Type , { ... } from 'foo'
             //        ^^^^^ pick
             let default_text = ctx.source_range(Span::new(
@@ -579,14 +578,24 @@ fn fix_insert_named_specifiers_in_named_specifier_list(
     insert_text: &str,
 ) -> FixerResult<RuleFix> {
     let FixOptions { fixer, import_decl, ctx, .. } = options;
-    let import_text = ctx.source_range(import_decl.span);
-    let close_brace = try_find_char(import_text, '}')?;
+    let close_brace = import_decl.span().start + try_find_token(ctx, import_decl.span, "}")?;
 
-    let first_non_whitespace_before_close_brace =
-        import_text[..close_brace as usize].chars().rev().find(|c| !c.is_whitespace());
+    // Anchor on the last named specifier so a separator between earlier specifiers isn't
+    // mistaken for a trailing comma.
+    let last_named_specifier_end = import_decl.specifiers.as_ref().and_then(|specifiers| {
+        specifiers
+            .iter()
+            .filter_map(|specifier| match specifier {
+                ImportDeclarationSpecifier::ImportSpecifier(specifier) => Some(specifier.span.end),
+                _ => None,
+            })
+            .next_back()
+    });
 
-    let span = Span::empty(import_decl.span().start + close_brace);
-    if first_non_whitespace_before_close_brace.is_some_and(|ch| !matches!(ch, ',' | '{')) {
+    let span = Span::empty(close_brace);
+    if last_named_specifier_end
+        .is_some_and(|end| ctx.find_next_token_within(end, close_brace, ",").is_none())
+    {
         Ok(fixer.insert_text_before(&span, format!(",{insert_text}")))
     } else {
         Ok(fixer.insert_text_before(&span, insert_text.to_string()))
@@ -646,22 +655,25 @@ fn get_fixes_named_specifiers<'a>(
         // import Foo, {Type1, Type2} from 'foo'
         // import DefType, {Type1, Type2} from 'foo'
         let import_text = ctx.source_range(import_decl.span);
-        let open_brace_token = try_find_char(import_text, '{')? as usize;
-        let Some(comma_token) = import_text[..open_brace_token].rfind(',') else {
+        let open_brace_token = try_find_token(ctx, import_decl.span, "{")?;
+        let Some(comma_token) = ctx.find_prev_token_within(
+            import_decl.span.start,
+            import_decl.span.start + open_brace_token,
+            ",",
+        ) else {
             return Err(format!("Missing comma token in import declaration: {import_text}").into());
         };
-        let close_brace_token = try_find_char(import_text, '}')? as usize;
-        let open_brace_token_end = open_brace_token + 1;
-        let close_brace_token_end = close_brace_token + 1;
+        let close_brace_token = try_find_token(ctx, import_decl.span, "}")?;
 
         // import DefType, {...} from 'foo'
         //                ^^^^^^ remove
         remove_type_named_specifiers.push(fixer.delete(&Span::new(
-            import_decl.span.start + u32::try_from(comma_token).unwrap_or_default(),
-            import_decl.span.start + u32::try_from(close_brace_token_end).unwrap_or_default(),
+            import_decl.span.start + comma_token,
+            import_decl.span.start + close_brace_token + 1,
         )));
 
-        type_named_specifiers_text.push(&import_text[open_brace_token_end..close_brace_token]);
+        type_named_specifiers_text
+            .push(&import_text[open_brace_token as usize + 1..close_brace_token as usize]);
     } else {
         let mut named_specifier_groups = vec![];
         let mut group = vec![];
@@ -714,17 +726,12 @@ fn get_named_specifier_ranges(
     let mut text_range = Span::new(first.span().start, last.span().end);
 
     let import_text = ctx.source_range(import_decl.span);
-    let open_brace_token_start = try_find_char(import_text, '{')?;
-    let open_brace_token_start = open_brace_token_start as usize;
-    if let Some(comma) = import_text
-        [open_brace_token_start..(first.span().start - import_decl.span().start) as usize]
-        .rfind(',')
-    {
+    let open_brace_start = import_decl.span().start + try_find_token(ctx, import_decl.span, "{")?;
+    if let Some(comma) = ctx.find_prev_token_within(open_brace_start, first.span().start, ",") {
         // It's not the first specifier.
         // import { Foo, Bar, Baz } from 'foo'
         //             ^ start
-        remove_range.start = import_decl.span().start
-            + u32::try_from(comma + open_brace_token_start).unwrap_or_default();
+        remove_range.start = open_brace_start + comma;
 
         // Skip the comma
         text_range.start = remove_range.start + 1;
@@ -732,8 +739,7 @@ fn get_named_specifier_ranges(
         // It's the first specifier.
         // import { Foo, Bar, Baz } from 'foo'
         //         ^ start
-        remove_range.start = import_decl.span().start
-            + u32::try_from(open_brace_token_start + 1).unwrap_or_default();
+        remove_range.start = open_brace_start + 1;
         // skip `{`
         text_range.start = remove_range.start;
     }
@@ -775,16 +781,17 @@ fn find_first_non_white_space(text: &str) -> Option<(usize, char)> {
     None
 }
 
-// Find the index of the first occurrence of a character in a string.
-// When call this method, **make sure the `c` is in the text.**
+// Find the offset from `span.start` of the first occurrence of a token within `span`, skipping
+// tokens inside comments.
+// When call this method, **make sure the `token` is in the span.**
 // e.g. I know "{" is in the text when call this in ImportDeclaration which contains named
 // specifiers.
-fn try_find_char(text: &str, c: char) -> Result<u32, Box<dyn Error>> {
-    let index = text.find(c);
+fn try_find_token(ctx: &LintContext, span: Span, token: &str) -> Result<u32, Box<dyn Error>> {
+    let index = ctx.find_next_token_within(span.start, span.end, token);
     if let Some(index) = index {
-        Ok(u32::try_from(index).unwrap_or_default())
+        Ok(index)
     } else {
-        Err(format!("Missing character '{c}' in text: {text}").into())
+        Err(format!("Missing token '{token}' in text: {}", ctx.source_range(span)).into())
     }
 }
 
@@ -825,11 +832,13 @@ fn fix_insert_type_specifier_for_import_declaration(
     //                                             ^^^^ add
     rule_fixes.push(fixer.replace(Span::sized(import_decl.span.start, 6), "import type"));
 
-    if is_default_import && let Ok(_opening_brace_token) = try_find_char(import_source, '{') {
+    if is_default_import
+        && let Ok(_opening_brace_token) = try_find_token(ctx, import_specifiers_span, "{")
+    {
         // `import foo, {} from 'foo'`
         // `import foo, { bar } from 'foo'`
-        let comma_token = try_find_char(import_source, ',')?;
-        let closing_brace_token = try_find_char(import_source, '}')?;
+        let comma_token = try_find_token(ctx, import_specifiers_span, ",")?;
+        let closing_brace_token = try_find_token(ctx, import_specifiers_span, "}")?;
         let base = import_decl.span.start;
         // import foo, {} from 'foo'
         //           ^^^^ delete
@@ -2277,6 +2286,35 @@ export class Foo extends Bar {}
     ];
 
     let fix = vec![
+        // the `{` inside the comment is not the start of the named specifiers
+        (
+            "import /* { */ Foo, { Type1 } from 'foo';\nlet a: Type1;\nnew Foo();",
+            "import type { Type1 } from 'foo';\nimport /* { */ Foo from 'foo';\nlet a: Type1;\nnew Foo();",
+            None,
+        ),
+        // the `}` inside the comment is not the end of the named specifiers
+        (
+            "import Foo, { Type1 /* } */ } from 'foo';\nlet a: Type1;\nnew Foo();",
+            "import type { Type1 /* } */ } from 'foo';\nimport Foo from 'foo';\nlet a: Type1;\nnew Foo();",
+            None,
+        ),
+        // the `,` inside the comment is not the separator after the default specifier
+        (
+            "import Foo, /* , */ { Type1 } from 'foo';\nlet a: Type1;\nnew Foo();",
+            "import type { Type1 } from 'foo';\nimport Foo from 'foo';\nlet a: Type1;\nnew Foo();",
+            None,
+        ),
+        // specifiers merged into an existing type-only import whose braces contain comments
+        (
+            "import type { /* } */ A } from 'foo';\nimport { B, Type1 } from 'foo';\nlet a: A;\nlet t: Type1;\nnew B();",
+            "import type { /* } */ A , Type1 } from 'foo';\nimport { B } from 'foo';\nlet a: A;\nlet t: Type1;\nnew B();",
+            None,
+        ),
+        (
+            "import type { A, /* x */ } from 'foo';\nimport { B, Type1 } from 'foo';\nlet a: A;\nlet t: Type1;\nnew B();",
+            "import type { A, /* x */  Type1 } from 'foo';\nimport { B } from 'foo';\nlet a: A;\nlet t: Type1;\nnew B();",
+            None,
+        ),
         (
             "
             import Foo from 'foo';


### PR DESCRIPTION
Generated with Claude Code, Opus 5. Reviewed and tested by me.

----

The `typescript/consistent-type-imports` fixer located its `{`, `}` and `,` tokens with plain `str::find`/`rfind` over the import declaration's source text. Any of those characters appearing inside a comment was picked up as if it were a real token, so the fixer computed spans that landed in the middle of a comment.

Depending on which token was hit, the result was a bail-out, syntactically invalid output, or — worst case — output that parses fine but silently drops an import.

## Before / after

| Input | Before | After |
| --- | --- | --- |
| `import /* { */ Foo, { Type1 } from 'foo';` | fixer bails (`Missing comma token`) — `debug_assert` panic in debug builds, no fix in release | fixed correctly |
| `import Foo, { Type1 /* } */ } from 'foo';` | `import type { Type1 /* } from 'foo';`<br>`import Foo */ } from 'foo';` | fixed correctly |
| `import Foo, /* , */ { Type1 } from 'foo';` | invalid syntax | fixed correctly |
| `import type { /* } */ A } from 'foo';`<br>`import { B, Type1 } from 'foo';` | `import type { /* , Type1 } */ A } from 'foo';` — **`Type1` silently swallowed into the comment** | fixed correctly |
| `import type { A, /* x */ } from 'foo';`<br>`import { B, Type1 } from 'foo';` | `import type { A, /* x */,Type1 }` — duplicate comma, invalid syntax | fixed correctly |

## Changes

**1. Comment-aware token lookups.** Replaced the private `try_find_char(text, char)` helper with `try_find_token(ctx, span, token)`, backed by `LintContext::find_next_token_within` / `find_prev_token_within`, which skip matches inside comments. Every raw `find`/`rfind` token search in the fixer moved over to it.

This also removes the `u32::try_from(..).unwrap_or_default()` conversions that silently clamped to `0` on failure, since the context helpers already return `u32` offsets.

**2. Comment-aware trailing-comma check.** `fix_insert_named_specifiers_in_named_specifier_list` decided whether to prepend a comma by scanning backwards from `}` for the first non-whitespace character. With a comment before the brace it saw `/` and emitted a duplicate comma (last row above).

It now anchors on the last named specifier's span end and asks `find_next_token_within` whether a real trailing comma follows. Anchoring on the specifier rather than the open brace matters — a plain "is there a comma inside the braces" check would read the separator in `{ A, B }` as a trailing comma. When there are no named specifiers it falls back to no comma, preserving the previous `{`-means-empty-list behaviour for `import type {} from 'foo'`.

## Tests

Five fix cases added, one per row of the table above. Each was verified to produce wrong or broken output on `main` before the fix.

`cargo test -p oxc_linter` passes (1215 tests, no snapshot drift); `cargo clippy -p oxc_linter --all-features` and `cargo fmt --check` are clean.

## Verification against a real codebase

Built release `oxlint` at the merge base (`ec7018ef`) and at this branch, then ran `typescript/consistent-type-imports` over the [vscode](https://github.com/microsoft/vscode) tree (12,289 files): **31,320 diagnostics**, identical between the two runs once normalized to sorted `(file, span, code, severity, message)` tuples.

Diagnostics alone don't exercise a fixer bug, so I also copied the corpus and ran `--fix --fix-suggestions --fix-dangerously` with each binary. This rule accounts for the bulk of the 5,560 files that were rewritten, and the two output trees are byte-identical — including the silent-import-drop case from the table above, which would have surfaced here as a real content difference rather than a span difference.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

