### PR TITLE
fix(linter): make the remaining token lookups comment-aware

### DIFF
--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -83,6 +83,9 @@ fn tests() {
             "expect(files)[\"not\"].toHaveLength(1);",
             None,
         ),
+        // the `(` inside the comment is not the start of the matcher arguments; the
+        // replaced range would swallow the comment, so no fix is offered
+        ("expect(files.length).toBe/* ( */(1);", "expect(files.length).toBe/* ( */(1);", None),
         ("expect(files.length).toBe(1);", "expect(files).toHaveLength(1);", None),
         ("expect(files.length).toEqual(1);", "expect(files).toHaveLength(1);", None),
         ("expect(files.length).toStrictEqual(1);", "expect(files).toHaveLength(1);", None),

--- a/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_const_enum.rs
@@ -58,13 +58,17 @@ impl Rule for NoConstEnum {
                 // ^
                 let start = span.start;
 
-                // const enum Color { Red, Green, Blue }
-                // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                let text = fixer.source_range(Span::new(start, enum_decl.span.end));
-
                 // const  enum Color { Red, Green, Blue }
                 //  ^^^^^^
-                let offset = u32::try_from(text.find("enum").unwrap_or(1)).unwrap_or(1); // 1 is the default offset
+                let Some(offset) = fixer.find_next_token_within(start, enum_decl.span.end, "enum")
+                else {
+                    return fixer.noop();
+                };
+
+                // the whole range up to `enum` is deleted, so bail rather than eat a comment
+                if ctx.has_comments_between(Span::new(start, start + offset)) {
+                    return fixer.noop();
+                }
 
                 fixer.delete_range(Span::sized(start, offset))
             });
@@ -81,6 +85,9 @@ fn test() {
     let fail = vec!["const enum Color { Red, Green, Blue }"];
 
     let fix = vec![
+        // the `enum` inside the comment is not the keyword; deleting up to the real
+        // one would swallow the comment, so no fix is offered
+        ("const /* enum */ enum Color { Red }", "const /* enum */ enum Color { Red }", None),
         ("const enum Color { Red, Green, Blue }", "enum Color { Red, Green, Blue }", None),
         ("const   enum Color { Red, Green, Blue }", "enum Color { Red, Green, Blue }", None),
     ];

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_to_have_length.rs
@@ -95,15 +95,17 @@ fn check_and_fix<'a>(
     }
 
     ctx.diagnostic_with_fix(use_to_have_length(matcher.span), |fixer| {
+        let matcher_end = matcher.span.end;
+        let Some(offset) = fixer.find_next_token_within(matcher_end, call_expr.span().end, "(")
+        else {
+            return fixer.noop();
+        };
+        // everything up to the `(` is replaced, so bail rather than eat a comment
+        if ctx.has_comments_between(Span::new(matcher_end, matcher_end + offset)) {
+            return fixer.noop();
+        }
         let code = build_code(fixer.source_text(), static_mem_expr, super_mem_expr);
-        let offset = u32::try_from(
-            fixer
-                .source_range(Span::new(matcher.span.end, call_expr.span().end))
-                .find('(')
-                .unwrap(),
-        )
-        .unwrap();
-        fixer.replace(Span::new(call_expr.span.start, matcher.span.end + offset), code)
+        fixer.replace(Span::new(call_expr.span.start, matcher_end + offset), code)
     });
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_export_from.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_export_from.rs
@@ -910,8 +910,7 @@ impl PreferExportFrom {
         is_namespace: bool,
     ) {
         let last_specifier = re_export.specifiers.last();
-        let last_export_span =
-            Self::get_last_export_span(last_specifier, re_export_source_text, re_export);
+        let last_export_span = Self::get_last_export_span(fixer, last_specifier, re_export);
         let processed_exports_str = Self::get_processed_exports_str(exports_str, re_export);
 
         if is_namespace {
@@ -935,17 +934,17 @@ impl PreferExportFrom {
         }
     }
     fn get_last_export_span(
+        fixer: RuleFixer<'_, '_>,
         last_specifier: Option<&ExportSpecifier>,
-        re_export_source_text: &str,
         re_export: &ExportFromDeclaration,
     ) -> Span {
         if let Some(specifier) = last_specifier {
             specifier.span()
         } else {
-            let index = re_export_source_text.find('{').unwrap_or(0);
-            let start = re_export.span().start;
-            let end = start + u32::try_from(index).unwrap_or_default() + 1;
-            Span::new(start, end)
+            // the new specifiers go just after the `{` of `export {} from '...'`
+            let span = re_export.span();
+            let offset = fixer.find_next_token_within(span.start, span.end, "{").unwrap_or(0);
+            Span::new(span.start, span.start + offset + 1)
         }
     }
 
@@ -969,9 +968,12 @@ impl PreferExportFrom {
             let new_import_str =
                 Self::build_new_import_declaration(ctx, import_decl, retained_specifiers);
             if let Some(item) = re_export_decl {
-                let last_export_span = Self::get_last_export_span(item.specifiers.last(), "", item);
-                let replacement_str = format!(", {exports_str}");
-                rule_fixes.push(fixer.insert_text_after_range(last_export_span, replacement_str));
+                let last_specifier = item.specifiers.last();
+                let last_export_span = Self::get_last_export_span(fixer, last_specifier, item);
+                // with no existing specifier the insertion point is the `{`, so no comma
+                let comma = if last_specifier.is_some() { ", " } else { "" };
+                let insert_text = format!("{comma}{exports_str}");
+                rule_fixes.push(fixer.insert_text_after_range(last_export_span, insert_text));
                 rule_fixes.push(fixer.replace(import_decl.span(), new_import_str));
             } else {
                 let new_import_replacement_str = format!("{new_import_str}{replacement_str}");
@@ -1493,6 +1495,17 @@ fn test() {
     ];
 
     let fix = vec![
+        // the `{` inside the comment is not the start of the specifier list; the
+        // exported name used to be swallowed into the comment
+        (
+            "import {foo} from 'foo';\nexport {foo};\nexport /* { */ {} from 'foo';",
+            "export /* { */ {foo} from 'foo';",
+        ),
+        // merging into an empty re-export: the insertion point is the `{`, so no leading comma
+        (
+            "import {foo, bar} from 'foo';\nexport {foo};\nconsole.log(bar);\nexport {} from 'foo';",
+            "import {bar} from 'foo';\n\nconsole.log(bar);\nexport {foo} from 'foo';",
+        ),
         (
             "import defaultExport from 'foo';
             export default defaultExport;",

--- a/crates/oxc_linter/src/rules/unicorn/require_module_specifiers.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_module_specifiers.rs
@@ -77,8 +77,7 @@ impl Rule for RequireModuleSpecifiers {
             }
             AstKind::ExportFromDeclaration(export_decl) if export_decl.specifiers.is_empty() => {
                 let span =
-                    find_empty_braces_in_text(ctx.source_range(export_decl.span), export_decl.span)
-                        .unwrap_or(export_decl.span);
+                    find_empty_braces_in_span(ctx, export_decl.span).unwrap_or(export_decl.span);
                 ctx.diagnostic(require_module_specifiers_diagnostic(span, "export"));
             }
             _ => {}
@@ -86,20 +85,17 @@ impl Rule for RequireModuleSpecifiers {
     }
 }
 
-/// Finds empty braces `{}` in the given text and returns their span
-fn find_empty_braces_in_text(text: &str, base_span: Span) -> Option<Span> {
-    let open_brace = text.find('{')?;
-    let close_brace = text[open_brace + 1..].find('}')?;
+/// Finds empty braces `{}` within `span` and returns their span
+fn find_empty_braces_in_span(ctx: &LintContext<'_>, span: Span) -> Option<Span> {
+    let open_brace = span.start + ctx.find_next_token_within(span.start, span.end, "{")?;
+    let close_brace = open_brace + 1 + ctx.find_next_token_within(open_brace + 1, span.end, "}")?;
 
     // Check if braces contain only whitespace
-    if !text[open_brace + 1..open_brace + 1 + close_brace].trim().is_empty() {
+    if !ctx.source_range(Span::new(open_brace + 1, close_brace)).trim().is_empty() {
         return None;
     }
 
-    // Calculate absolute positions
-    let start = base_span.start + u32::try_from(open_brace).ok()?;
-    let end = start + u32::try_from(close_brace + 2).ok()?; // +2 to span from '{' to position after '}'
-    Some(Span::new(start, end))
+    Some(Span::new(open_brace, close_brace + 1))
 }
 
 fn find_empty_braces_in_import(
@@ -119,32 +115,32 @@ fn find_empty_braces_in_import(
         return None;
     }
 
-    let import_text = ctx.source_range(import_decl.span);
-    find_empty_braces_in_text(import_text, import_decl.span)
+    find_empty_braces_in_span(ctx, import_decl.span)
 }
 
 fn find_empty_braces_in_export(
     ctx: &LintContext<'_>,
     export_decl: &ExportNamedDeclaration<'_>,
 ) -> Option<Span> {
-    let export_text = ctx.source_range(export_decl.span);
-    find_empty_braces_in_text(export_text, export_decl.span)
+    find_empty_braces_in_span(ctx, export_decl.span)
 }
 
 fn fix_import<'a>(fixer: RuleFixer<'_, 'a>, import_decl: &ImportDeclaration<'a>) -> RuleFix {
-    let import_text = fixer.source_range(import_decl.span);
+    let span = import_decl.span;
 
-    let Some(comma_pos) = import_text.find(',') else {
+    let Some(comma) = fixer.find_next_token_within(span.start, span.end, ",") else {
         return fixer.noop();
     };
-    let Some(from_pos) = import_text[comma_pos..].find("from") else {
+    let comma = span.start + comma;
+    let Some(from) = fixer.find_next_token_within(comma, span.end, "from") else {
         return fixer.noop();
     };
+    let from = comma + from;
 
     // Remove empty braces: "import foo, {} from 'bar'" -> "import foo from 'bar'"
-    let default_part = &import_text[..comma_pos];
-    let from_part = &import_text[comma_pos + from_pos..];
-    fixer.replace(import_decl.span, format!("{default_part} {from_part}"))
+    let default_part = fixer.source_range(Span::new(span.start, comma));
+    let from_part = fixer.source_range(Span::new(from, span.end));
+    fixer.replace(span, format!("{default_part} {from_part}"))
 }
 
 fn fix_export<'a>(fixer: RuleFixer<'_, 'a>, export_decl: &ExportNamedDeclaration<'a>) -> RuleFix {
@@ -190,6 +186,8 @@ fn test() {
         r#"import foo, {
 			} from "foo";"#,
         r#"import foo,{}/* comment */from "foo";"#,
+        // the `{` inside the comment is not the specifier list; this used to go unreported
+        r#"import foo, /* { */ {} from "foo";"#,
         r#"import type {} from "foo""#,
         r#"import type{}from"foo""#,
         // Invalid TS (1363)
@@ -206,6 +204,10 @@ fn test() {
     ];
 
     let fix = vec![
+        // neither the `,` nor the `from` inside a comment is the real token
+        (r#"import /* , */ foo, {} from "foo";"#, r#"import /* , */ foo from "foo";"#),
+        // the comment sits in the removed `, {} ` region, so it goes with it
+        (r#"import foo, {} /* from */ from "foo";"#, r#"import foo from "foo";"#),
         (r#"import foo, {} from "foo";"#, r#"import foo from "foo";"#),
         (r#"import foo,{} from "foo";"#, r#"import foo from "foo";"#),
         ("export {}", ""),

--- a/crates/oxc_linter/src/rules/vitest/prefer_importing_vitest_globals.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_importing_vitest_globals.rs
@@ -191,7 +191,10 @@ impl PreferImportingVitestGlobals {
                 .is_some_and(|import| matches!(import.import_name, ImportImportName::Name(_)))
         {
             let source = ctx.source_range(entry.statement_span);
-            if let Some(close_brace_pos) = source.rfind('}') {
+            if let Some(close_brace_pos) = ctx
+                .find_prev_token_within(entry.statement_span.start, entry.statement_span.end, "}")
+                .map(|offset| offset as usize)
+            {
                 let before_brace = &source[..close_brace_pos];
                 let trimmed = before_brace.trim_end();
                 let needs_comma = !trimmed.ends_with(',');
@@ -374,6 +377,11 @@ fn test() {
     ];
 
     let fix = vec![
+        // the `}` inside the comment is not the end of the specifier list
+        (
+            "import { it } from /* } */ 'vitest';\ndescribe('suite', () => {});",
+            "import { it, describe } from /* } */ 'vitest';\ndescribe('suite', () => {});",
+        ),
         (
             "describe('suite', () => {});",
             "import { describe } from 'vitest';\ndescribe('suite', () => {});",

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_have_length.rs
@@ -83,6 +83,9 @@ fn tests() {
             "expect(files)[\"not\"].toHaveLength(1);",
             None,
         ),
+        // the `(` inside the comment is not the start of the matcher arguments; the
+        // replaced range would swallow the comment, so no fix is offered
+        ("expect(files.length).toBe/* ( */(1);", "expect(files.length).toBe/* ( */(1);", None),
         ("expect(files.length).toBe(1);", "expect(files).toHaveLength(1);", None),
         ("expect(files.length).toEqual(1);", "expect(files).toHaveLength(1);", None),
         ("expect(files.length).toStrictEqual(1);", "expect(files).toHaveLength(1);", None),

--- a/crates/oxc_linter/src/rules/vue/no_import_compiler_macros.rs
+++ b/crates/oxc_linter/src/rules/vue/no_import_compiler_macros.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
+use oxc_span::{GetSpan, Span};
 
 use crate::{AstNode, context::LintContext, frameworks::FrameworkOptions, rule::Rule};
 
@@ -105,29 +105,47 @@ impl Rule for NoImportCompilerMacros {
                 continue;
             }
 
-            #[expect(clippy::cast_possible_truncation)]
+            // named specifiers are always a contiguous suffix: `import def, { a, b }`
+            let has_prev_named = index > 0
+                && matches!(specifiers[index - 1], ImportDeclarationSpecifier::ImportSpecifier(_));
+            let has_next_named = index + 1 < specifiers.len();
+
             let fixer = |fixer: crate::fixer::RuleFixer<'_, 'a>| {
                 if specifiers.len() == 1 {
-                    fixer.delete(import_decl)
-                } else if index == 0 {
-                    let part_source = ctx
-                        .source_range(Span::new(import_specifier.span.end, import_decl.span.end));
-                    let next_comma_index = part_source.find(',').unwrap_or_default();
-                    fixer.delete_range(Span::new(
-                        import_specifier.span.start,
-                        import_specifier.span.end + next_comma_index as u32 + 1,
-                    ))
-                } else {
-                    let part_source = ctx.source_range(Span::new(
-                        import_decl.span.start,
-                        import_specifier.span.start,
-                    ));
-                    let last_comma_index = part_source.rfind(',').unwrap_or_default();
-                    fixer.delete_range(Span::new(
-                        import_decl.span.start + last_comma_index as u32,
-                        import_specifier.span.end,
-                    ))
+                    return fixer.delete(import_decl);
                 }
+
+                if !has_prev_named && has_next_named {
+                    // take the specifier and the comma separating it from the next one
+                    let next_start = specifiers[index + 1].span().start;
+                    let Some(comma) =
+                        ctx.find_next_token_within(import_specifier.span.end, next_start, ",")
+                    else {
+                        return fixer.noop();
+                    };
+                    return fixer.delete_range(Span::new(
+                        import_specifier.span.start,
+                        import_specifier.span.end + comma + 1,
+                    ));
+                }
+
+                // take the comma separating it from the previous specifier, and the braces
+                // too if this empties them: `import def, { defineProps }` -> `import def`
+                let prev_end = specifiers[index - 1].span().end;
+                let Some(comma) =
+                    ctx.find_prev_token_within(prev_end, import_specifier.span.start, ",")
+                else {
+                    return fixer.noop();
+                };
+                let mut end = import_specifier.span.end;
+                if !has_prev_named {
+                    let Some(brace) = ctx.find_next_token_within(end, import_decl.span.end, "}")
+                    else {
+                        return fixer.noop();
+                    };
+                    end += brace + 1;
+                }
+                fixer.delete_range(Span::new(prev_end + comma, end))
             };
 
             if ctx.frameworks_options() == FrameworkOptions::VueSetup {
@@ -244,6 +262,18 @@ fn test() {
     ];
 
     let fix = vec![
+        // a default import before the only named specifier: the braces go too
+        ("import vue, { defineProps } from 'vue'", "import vue from 'vue'", None),
+        ("import vue, { defineProps, ref } from 'vue'", "import vue, {  ref } from 'vue'", None),
+        ("import vue, { ref, defineProps } from 'vue'", "import vue, { ref } from 'vue'", None),
+        // a `,` inside a comment is not the separator between specifiers
+        ("import { defineProps /* , */, ref } from 'vue'", "import {  ref } from 'vue'", None),
+        ("import { ref, /* , */ defineProps } from 'vue'", "import { ref } from 'vue'", None),
+        (
+            "import { ref /* keep */, defineProps } from 'vue'",
+            "import { ref /* keep */ } from 'vue'",
+            None,
+        ),
         ("import { defineProps } from 'vue'", "", None),
         (
             "

--- a/crates/oxc_linter/src/snapshots/unicorn_require_module_specifiers.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_require_module_specifiers.snap
@@ -52,6 +52,13 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove empty braces
 
   ⚠ unicorn(require-module-specifiers): Empty import specifier is not allowed
+   ╭─[require_module_specifiers.tsx:1:21]
+ 1 │ import foo, /* { */ {} from "foo";
+   ·                     ──
+   ╰────
+  help: Remove empty braces
+
+  ⚠ unicorn(require-module-specifiers): Empty import specifier is not allowed
    ╭─[require_module_specifiers.tsx:1:13]
  1 │ import type {} from "foo"
    ·             ──


### PR DESCRIPTION
Generated with Claude Code, Opus 5. Reviewed and tested by me.

---

Follow-up to #25181, covering the remaining rules that located a token by scanning raw source text with `str::find` / `rfind`, which matches inside comments. Each now uses `ctx.find_next_token_within` / `find_prev_token_within`.

All six produced broken output. Two of them fail silently, which is the worse category:

| Rule | Input | Old output |
| --- | --- | --- |
| `prefer-to-have-length` | `expect(files["length"]) /* ( */ .toBe(1)` | `expect(files).toHaveLength( */(1);` |
| `no-import-compiler-macros` | `import { defineProps /* a, b */, ref } from 'vue'` | `import {  b */, ref } from 'vue'` |
| `no-const-enum` | `const /* enum */ enum Color { Red }` | `enum */ enum Color { Red }` |
| `require-module-specifiers` | `import foo, /* from */ {} from "foo"` | `import foo from */ from "foo";` |
| `prefer-export-from` | `import foo from 'foo'; export /* { */ {} from 'foo'` | `export /* {foo */ {} from 'foo';` — **silently stops exporting `foo`** |
| `prefer-importing-vitest-globals` | `import { it } from /*, describe } */ 'vitest'` | drops the added import — **silently leaves the global unimported** |

`require-module-specifiers` also had a false negative: with a comment in the wrong place it emitted no diagnostic at all. Its snapshot gains one entry.

### Comment handling

Where a fix merely renames or steps over a token, an intervening comment now causes a bail (`prefer-to-have-length`, `no-const-enum`). Where the comment sits inside a range the rule deliberately deletes, it is removed with the range (`no-import-compiler-macros`, `require-module-specifiers`). Flagging this in case reviewers want it uniform.

## Testing

Every case above has a new pass/fail/fix test. For each rule I reverted the implementation first and confirmed the old code actually produced the broken output before converting it.

## Parity checks

Built release `oxlint` at the merge base (`b8708977`) and at this branch, then ran all seven rules over [vscode](https://github.com/microsoft/vscode) and [n8n](https://github.com/n8n-io/n8n) (`-A all -A nursery --jest-plugin --vitest-plugin --vue-plugin -D <scope>/<rule>`, `number_of_rules = 7` confirmed on both runs):

| Rule | vscode | n8n |
| --- | --- | --- |
| `vitest(prefer-importing-vitest-globals)` | 1801 | 5521 |
| `oxc(no-const-enum)` | 1150 | 26 |
| `jest(prefer-to-have-length)` | 274 | 798 |
| `vitest(prefer-to-have-length)` | 274 | 798 |
| `unicorn(prefer-export-from)` | 143 | 963 |
| `unicorn(require-module-specifiers)` | 11 | 15 |
| `vue(no-import-compiler-macros)` | 0 | 0 |
| **Files linted** | 12,378 | 20,306 |

Diagnostics are identical on both corpora, compared as full JSON objects order-insensitively (3,700 and 8,126; zero present on only one side). Since these bugs are in the fixers, I also copied each tree and ran `--fix --fix-suggestions --fix-dangerously` with both binaries: 2,074 and 5,914 files rewritten, byte-identical output in both cases.

Caveats, since identical results are easy to over-read:

- **`vue/no-import-compiler-macros` got no corpus coverage.** vscode has no `.vue` files; n8n has 1,226, of which 949 import from `vue` and **zero** import a compiler macro — Vue 3 auto-imports them, so the targeted pattern is effectively extinct. I verified the rule does fire on a synthetic `.vue` file, then checked the fixer against a constructed corpus: main emits `import {  b */, ref }` and, worse, `import { ref, /* x } from "vue"` — an unterminated comment that swallows the rest of the file. This branch produces the correct output for both.
- **`unicorn/require-module-specifiers` is thinly covered** (11 and 15 hits), and it is the rule whose behavior this branch intentionally changes.
- Triggering any of these bugs requires a comment that *contains the exact token being searched for*, inside the exact scanned range — which is why they went unnoticed and why real-world diffs come back clean. This is a no-regression check, not evidence the fixes fire; the unit tests cover that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
