### PR TITLE
perf(linter/unicorn/prefer-export-from): skip non-violating imports early

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_export_from.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_export_from.rs
@@ -149,6 +149,10 @@ impl PreferExportFrom {
         let (locally_used_specifiers, violations) =
             self.analyze_import_usage(ctx, symbol_to_specifier, import_decl);
 
+        if violations.is_empty() {
+            return;
+        }
+
         let source = import_decl.source.value.as_str();
         let with_clause = import_decl.with_clause.as_ref().map(|with_clause| {
             let keyword = match with_clause.keyword {


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, Opus 5.

If there are no violations we can bail early, so bail early and avoid doing extra work for no good reason.

### Parity

vscode `src/`, 8,006 files, with `unicorn/prefer-export-from` as the only enabled rule:

- 84 diagnostics before and after, identical once sorted (oxlint's parallel file order isn't stable run to run).
- `--fix-suggestions` output byte-identical across the 34 affected files, 26 of which are actually rewritten.

### Perf

`--debug=timings --threads=1`, 30 interleaved paired rounds with the binary order alternating. Dispatch count is 89,955 on both, so the early return isn't skipping any work it shouldn't.

| | rule time |
| --- | --- |
| before | 16.945 ms ± 0.205 |
| after | 15.125 ms ± 0.525 |

−1.82 ms (−10.7%), faster in 30/30 pairs, 95% CI −2.02 .. −1.63 ms.

Realistically this won't have any impact on runtime when multithreaded as it's an extremely minimal difference, but it's a simple enough optimization. It should also reduce memory allocs a tiny bit, though I didn't measure that.