### PR TITLE
chore(parser): Fix a typo in the Namespace keyword string.

### DIFF
--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -708,7 +708,7 @@ impl Kind {
             Is => "is",
             KeyOf => "keyof",
             Module => "module",
-            Namespace => "namaespace",
+            Namespace => "namespace",
             Never => "never",
             Out => "out",
             Require => "require",


### PR DESCRIPTION
I don't think this matters as I'm unclear where this is even used (no snapshots are updated by this change), but we may as well fix it.