### PR TITLE
fix(minifier): correct issue with try finally termination

### DIFF
--- a/crates/oxc_minifier/src/is_terminated.rs
+++ b/crates/oxc_minifier/src/is_terminated.rs
@@ -32,7 +32,7 @@ impl IsTerminated for TryStatement<'_> {
         // present (an exception thrown before the try block's jump lands there).
         self.finalizer.as_ref().is_some_and(|f| f.is_terminated())
             || (self.block.is_terminated()
-                && self.handler.as_ref().is_none_or(|h| h.body.is_terminated()))
+                && self.handler.as_ref().is_some_and(|h| h.body.is_terminated()))
     }
 }
 

--- a/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
@@ -297,6 +297,32 @@ fn test_dont_remove_break_in_try_finally() {
     test_same("function f() {b:try{throw 9} finally {break b} return 1;}");
 }
 
+#[test]
+fn test_try_catch_termination() {
+    test_same("function f(){if(a)try{b}catch{c}else throw i()}");
+    test_same("function f(){if(a)try{return g()}catch{c}else throw i()}");
+    test_same("function f(){if(a)try{b}catch{return g()}else throw i()}");
+    test(
+        "function f(){if(a)try{return g()}catch{return g()}else throw i()}",
+        "function f(){if(a)try{return g()}catch{return g()}throw i()}",
+    );
+
+    test_same("function f(){if(a)try{b}finally{d}else throw i()}");
+    test_same("function f(){if(a)try{return g()}finally{d}else throw i()}");
+    test(
+        "function f(){if(a)try{b}finally{return g()}else throw i()}",
+        "function f(){if(a)try{b}finally{return g()}throw i()}",
+    );
+
+    test_same("function f(){if(a)try{b}catch{c}finally{d}else throw i()}");
+    test_same("function f(){if(a)try{return g()}catch{d}finally{d}else throw i()}");
+    test_same("function f(){if(a)try{b}catch{return g()}finally{d}else throw i()}");
+    test(
+        "function f(){if(a)try{b}catch{c}finally{return g(d)}else throw i()}",
+        "function f(){if(a)try{b}catch{c}finally{return g(d)}throw i()}",
+    );
+}
+
 /**
  * The 'break' prevents the 'b=false' from being evaluated. If we test the do-while to
  * 'do;while(b=false)' the code will be incorrect.

--- a/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
@@ -197,7 +197,6 @@ fn remove_unreachable() {
         "function f() { try { return g(); } catch { return h(); } i(); }",
         "function f() { try { return g(); } catch { return h(); } }",
     );
-    test_same("function f() { if (a) try { return g(); } finally {} else i(); }");
     // Negative: the block can complete normally, so the tail stays.
     test_same("function f(c) { { let a = g(); if (c) return a; } return foo(); }");
     // Hoisting survivors trailing the jump inside the block — a kept

--- a/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
@@ -197,6 +197,7 @@ fn remove_unreachable() {
         "function f() { try { return g(); } catch { return h(); } i(); }",
         "function f() { try { return g(); } catch { return h(); } }",
     );
+    test_same("function f() { if (a) try { return g(); } finally {} else i(); }");
     // Negative: the block can complete normally, so the tail stays.
     test_same("function f(c) { { let a = g(); if (c) return a; } return foo(); }");
     // Hoisting survivors trailing the jump inside the block — a kept


### PR DESCRIPTION
fix bug with termination detection for `try finally`, 

when try has termination stmt and finally is missing it and we do not have catch stmt current code passes it and allows stmt to fold

```js
// base
function f() {
	if (a) try { return g(); } finally {}
	else i();
}
// main
function f() {
	if (a) try { return g(); } finally {}
	i();
}
// this branch
function f() {
	if (a) try { return g(); } finally {}
	else i();
}
```

this issue has been introduced by https://github.com/oxc-project/oxc/pull/24441 and copied over by https://github.com/oxc-project/oxc/pull/24950


fixes #25214