### PR TITLE
fix(linter/eslint/no-unexpected-multiline): use bounded token lookup

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unexpected_multiline.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unexpected_multiline.rs
@@ -1,4 +1,4 @@
-use memchr::{memchr, memrchr};
+use memchr::memchr;
 use oxc_ast::{AstKind, ast::BinaryOperator};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -126,7 +126,7 @@ impl Rule for NoUnexpectedMultiline {
                 };
 
                 let span = Span::new(start, call_expr.span.end);
-                if let Some(open_paren_pos) = has_newline_before(ctx, span, b'(') {
+                if let Some(open_paren_pos) = has_newline_before(ctx, span, "(") {
                     let paren_span = Span::sized(span.start + open_paren_pos, 1);
 
                     ctx.diagnostic_with_dangerous_fix(
@@ -143,7 +143,7 @@ impl Rule for NoUnexpectedMultiline {
                 }
 
                 let span = Span::new(member_expr.object.span().end, member_expr.span().end);
-                if let Some(open_bracket_pos) = has_newline_before(ctx, span, b'[') {
+                if let Some(open_bracket_pos) = has_newline_before(ctx, span, "[") {
                     let bracket_span = Span::sized(span.start + open_bracket_pos, 1);
 
                     ctx.diagnostic_with_dangerous_fix(
@@ -162,7 +162,7 @@ impl Rule for NoUnexpectedMultiline {
                 };
 
                 let span = Span::new(start, tagged_template_expr.span.end);
-                if let Some(backtick_pos) = has_newline_before(ctx, span, b'`') {
+                if let Some(backtick_pos) = has_newline_before(ctx, span, "`") {
                     let backtick_span = Span::sized(span.start + backtick_pos, 1);
 
                     ctx.diagnostic_with_dangerous_fix(
@@ -191,10 +191,12 @@ impl Rule for NoUnexpectedMultiline {
                 let Some(newline) = memchr(b'\n', src.as_bytes()) else {
                     return;
                 };
-                let Some(first_slash) = memchr(b'/', src.as_bytes()) else {
+                let Some(first_slash) = ctx.find_next_token_within(span.start, span.end, "/")
+                else {
                     return;
                 };
-                let Some(second_slash) = memrchr(b'/', src.as_bytes()) else {
+                let Some(second_slash) = ctx.find_prev_token_within(span.start, span.end, "/")
+                else {
                     return;
                 };
                 if first_slash == second_slash {
@@ -204,8 +206,9 @@ impl Rule for NoUnexpectedMultiline {
                 // the "identifier" will be the characters immediately following the second slash
                 // until we reach a non-identifier character
                 let ident_name = src
+                    .get(second_slash as usize + 1..)
+                    .unwrap_or_default()
                     .chars()
-                    .skip(second_slash + 1)
                     // This is a rough approximation of "looks like an identifier"
                     .take_while(|c| {
                         !(c.is_whitespace() || c.is_ascii_punctuation()) || c == &'_' || c == &'$'
@@ -216,10 +219,9 @@ impl Rule for NoUnexpectedMultiline {
 					// The identifier name should look like it was an attempt to use a regex
 					&& is_regex_flag(ident_name.as_str())
 					// if it was a regex attempt, the second slash should be before the identifier
-                    && second_slash + (span.start as usize) + 1 == parent_binary_expr.right.span().start as usize
+                    && second_slash + span.start + 1 == parent_binary_expr.right.span().start
                 {
-                    let slash_span =
-                        Span::sized(span.start + u32::try_from(first_slash).unwrap(), 1);
+                    let slash_span = Span::sized(span.start + first_slash, 1);
 
                     ctx.diagnostic_with_dangerous_fix(
                         no_unexpected_multiline_diagnostic(&DiagnosticKind::Division {
@@ -245,17 +247,16 @@ fn is_regex_flag(str: &str) -> bool {
     true
 }
 
-/// Check if there is a newline proceeding a target character within a snippet of source text.
-/// Returns `None` if the character is not found at all or has no proceeding newline. Otherwise,
-/// returns the byte offset of the target character with respect to the start of the span.
+/// Check if there is a newline preceding a target token within a source span. Returns `None` if
+/// the token is not found or has no preceding newline. Otherwise, returns the byte offset of the
+/// token with respect to the start of the span.
 ///
 /// Newlines do not have to be directly before the target character, but can be anywhere before it.
-fn has_newline_before(ctx: &LintContext, span: Span, c: u8) -> Option<u32> {
-    let src = ctx.source_range(span).as_bytes();
-    let target = memchr(c, src)?;
-    let newline = memchr(b'\n', src)?;
+fn has_newline_before(ctx: &LintContext, span: Span, token: &str) -> Option<u32> {
+    let target = ctx.find_next_token_within(span.start, span.end, token)?;
+    let before_target = Span::new(span.start, span.start + target);
 
-    (newline < target).then(|| u32::try_from(target).unwrap())
+    ctx.source_range(before_target).contains('\n').then_some(target)
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Replace raw source scanning for syntax tokens in `no-unexpected-multiline` with bounded, comment-aware token lookups.

## Details
- Use `find_next_token_within` and `find_prev_token_within` for delimiters and division slashes.
- Keep token offsets relative to the rule's source span when constructing diagnostics and fixes.