### PR TITLE
fix(linter/eslint/no-unused-vars): bound token lookups

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_imports.rs
@@ -54,7 +54,7 @@ impl NoUnusedVars {
             }
             ImportDeclarationSpecifier::ImportSpecifier(_) => {
                 if named_import_count == 1 {
-                    return Self::remove_named_imports_block(fixer, specifiers);
+                    return Self::remove_named_imports_block(fixer, import, specifiers);
                 }
 
                 Self::remove_specifier_from_list(fixer, specifiers, position, specifier)
@@ -112,6 +112,7 @@ impl NoUnusedVars {
     /// Transforms: `import Default, { Unused } from 'module'` -> `import Default from 'module'`
     fn remove_named_imports_block<'a>(
         fixer: RuleFixer<'_, 'a>,
+        import: &ImportDeclaration<'a>,
         specifiers: &[ImportDeclarationSpecifier<'a>],
     ) -> RuleFix {
         let default_specifier = specifiers
@@ -133,11 +134,14 @@ impl NoUnusedVars {
             return fixer.noop();
         };
 
-        let comma_offset = fixer.find_next_token_from(default_spec.span().end, ",").unwrap_or(0);
+        let comma_offset = fixer
+            .find_next_token_within(default_spec.span().end, last_named.span().start, ",")
+            .unwrap_or(0);
         let delete_start = default_spec.span().end + comma_offset;
 
-        let brace_offset =
-            fixer.find_next_token_from(last_named.span().end, "}").map_or(0, |i| i + 1);
+        let brace_offset = fixer
+            .find_next_token_within(last_named.span().end, import.span.end, "}")
+            .map_or(0, |i| i + 1);
         let delete_end = last_named.span().end + brace_offset;
 
         let span = Span::new(delete_start, delete_end);

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -466,9 +466,12 @@ fn remove_unused_catch_parameter<'a>(
 ) -> crate::fixer::RuleFix {
     let Span { start, end, .. } = catch.span();
 
-    let (Some(paren_start), Some(paren_end_offset)) =
-        (ctx.find_prev_token_from(start, "("), ctx.find_next_token_from(end, ")"))
-    else {
+    #[expect(clippy::cast_possible_truncation)]
+    let source_end = ctx.source_text().len() as u32;
+    let (Some(paren_start), Some(paren_end_offset)) = (
+        ctx.find_prev_token_within(0, start, "("),
+        ctx.find_next_token_within(end, source_end, ")"),
+    ) else {
         return fixer.noop();
     };
 


### PR DESCRIPTION
## Summary
Replace unbounded token searches in `no-unused-vars` fixers with bounded, comment-aware lookups.

## Details
- Bound comma and closing-brace searches to the import declaration when removing named imports.
- Bound catch-parameter parenthesis searches to the source range used by the fixer.