### PR TITLE
fix(linter/eslint/prefer-template): bound token lookup

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/prefer_template.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_template.rs
@@ -95,7 +95,8 @@ fn build_template_for_binary(
     let right = &binary.right;
 
     // Find the + operator between left and right
-    let plus_offset = fixer.find_next_token_from(left.span().end, "+").unwrap_or(0);
+    let plus_offset =
+        fixer.find_next_token_within(left.span().end, right.span().start, "+").unwrap_or(0);
     let plus_pos = left.span().end + plus_offset;
     let text_before_plus = &source_text[left.span().end as usize..plus_pos as usize];
     let text_after_plus = &source_text[plus_pos as usize + 1..right.span().start as usize];


### PR DESCRIPTION
## Summary
Replace the unbounded lookup for the `+` operator in `prefer-template` with a bounded, comment-aware token lookup.

## Details
- Search from the left operand end through the right operand start with `find_next_token_within`.
- Keep the replacement offsets anchored to the actual `+` operator.