### PR TITLE
perf(minifier): short-circuit IfStatement termination on alternate

### DIFF
--- a/crates/oxc_minifier/src/is_terminated.rs
+++ b/crates/oxc_minifier/src/is_terminated.rs
@@ -21,7 +21,7 @@ impl IsTerminated for Statement<'_> {
 
 impl IsTerminated for IfStatement<'_> {
     fn is_terminated(&self) -> bool {
-        self.consequent.is_terminated() && self.alternate.is_terminated()
+        self.alternate.is_terminated() && self.consequent.is_terminated()
     }
 }
 


### PR DESCRIPTION
Check alternate before consequent in `IfStatement::is_terminated()` so the common if-without-else case short-circuits immediately through `Option::is_some_and(...)`.
consequent is always present, while alternate is often absent, and `try_minimize_if` already rotates `if (...) {} else { ... }` shapes to help keep that common case favorable. 

This is a micro-optimization.