### PR TITLE
fix(linter/eslint/prefer-promise-reject-errors): move category to `pedantic`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
@@ -77,7 +77,7 @@ declare_oxc_lint!(
     /// ```
     PreferPromiseRejectErrors,
     eslint,
-    style,
+    pedantic,
     none,
     config = PreferPromiseRejectErrors,
     version = "0.15.7",


### PR DESCRIPTION
`eslint/prefer-promise-reject-errors` enforces the same defensive error-handling practice as its type-aware TypeScript extension, so classify both rules as `pedantic` instead of leaving the core rule under `style`.

The TypeScript variant was already `pedantic`; this updates the ESLint variant to match. 

Fixes #25168