### PR TITLE
fix(parser): reject exports in script source type

### DIFF
--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -450,7 +450,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // Module goal so the declaration parses under `Await` on the first pass and
         // isn't reparsed. e.g. `@foo export default class C { x = await + 1 }`
         if self.ctx.has_top_level() {
-            if !self.source_type.is_module() {
+            if self.source_type.is_script() || self.source_type.is_unambiguous() {
                 self.error_on_script(diagnostics::unexpected_export(export_span));
             }
             if self.source_type.is_unambiguous() {

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -444,12 +444,18 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         span: u32,
         mut decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> Statement<'a> {
+        let export_span = self.cur_token().span();
         self.bump_any(); // bump `export`
         // `export` is unambiguously module syntax (ECMA-262 §16.2.3): commit to the
         // Module goal so the declaration parses under `Await` on the first pass and
         // isn't reparsed. e.g. `@foo export default class C { x = await + 1 }`
-        if self.source_type.is_unambiguous() && self.ctx.has_top_level() {
-            self.ctx = self.ctx.and_await(true);
+        if self.ctx.has_top_level() {
+            if !self.source_type.is_module() {
+                self.error_on_script(diagnostics::unexpected_export(export_span));
+            }
+            if self.source_type.is_unambiguous() {
+                self.ctx = self.ctx.and_await(true);
+            }
         }
         let decl = match self.cur_kind() {
             // `export import A = B`

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -1105,6 +1105,18 @@ mod test {
     }
 
     #[test]
+    fn source_type_script_rejects_export_declarations() {
+        let allocator = Allocator::default();
+
+        let script_ret = Parser::new(&allocator, "export {};", SourceType::script()).parse();
+        assert_eq!(script_ret.diagnostics.len(), 1);
+        assert_eq!(script_ret.diagnostics[0].to_string(), "Unexpected export.");
+
+        let module_ret = Parser::new(&allocator, "export {};", SourceType::mjs()).parse();
+        assert!(module_ret.diagnostics.is_empty());
+    }
+
+    #[test]
     fn binary_file() {
         let allocator = Allocator::default();
         let source_type = SourceType::default();

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -1114,6 +1114,14 @@ mod test {
 
         let module_ret = Parser::new(&allocator, "export {};", SourceType::mjs()).parse();
         assert!(module_ret.diagnostics.is_empty());
+
+        let commonjs_ret = Parser::new(
+            &allocator,
+            "export function foo(): void; export function foo() {}",
+            SourceType::cjs().with_typescript(true),
+        )
+        .parse();
+        assert!(commonjs_ret.diagnostics.is_empty());
     }
 
     #[test]

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: c86e9e4b
 parser_babel Summary:
 AST Parsed     : 2235/2235 (100.00%)
 Positive Passed: 2221/2235 (99.37%)
-Negative Passed: 1728/1743 (99.14%)
+Negative Passed: 1729/1743 (99.20%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-assert-and-assign/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-type-assertion-and-assign/input.ts
@@ -15,8 +15,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/conditional/arrow-param/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/decorators/type-arguments-invalid/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/equals-in-script/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/invalid-as-namespace-duplicate-identifier/input.ts
 
@@ -5412,6 +5410,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·                     ──────────
    ╰────
 
+  × Unexpected export.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/invalid-escape-export-async-function/input.js:1:1]
+ 1 │ export \u0061sync function y() { await x }
+   · ──────
+   ╰────
+
   × Keywords cannot contain escape characters
    ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/invalid-escape-export-async-function/input.js:1:8]
  1 │ export \u0061sync function y() { await x }
@@ -9815,6 +9819,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·      ───────────
    ╰────
 
+  × Unexpected export.
+   ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-identifier/invalid_expression_await/input.js:1:1]
+ 1 │ export var answer = await + 1;
+   · ──────
+   ╰────
+
   × Cannot use export statement outside a module
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-identifier/invalid_expression_await/input.js:1:1]
  1 │ export var answer = await + 1;
@@ -9839,6 +9849,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·       ▲
    ╰────
   help: Try inserting a semicolon here
+
+  × Unexpected export.
+   ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-identifier/invalid_var_await/input.js:1:1]
+ 1 │ export var await;
+   · ──────
+   ╰────
 
   × Cannot use export statement outside a module
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-identifier/invalid_var_await/input.js:1:1]
@@ -13976,6 +13992,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·                ───────
    ╰────
   help: Remove the duplicate modifier.
+
+  × Unexpected export.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/export/equals-in-script/input.ts:1:1]
+ 1 │ export = f;
+   · ──────
+   ╰────
 
   × TS(1098): Type parameter list cannot be empty.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/empty-type-parameters/input.ts:1:13]

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -634,6 +634,12 @@ Negative Passed: 155/155 (100.00%)
  1 │ export import
    ╰────
 
+  × Unexpected export.
+   ╭─[misc/fail/oxc-11453.js:1:1]
+ 1 │ export import
+   · ──────
+   ╰────
+
   × Decorators may not appear after 'export' or 'export default' if they also appear before 'export'.
    ╭─[misc/fail/oxc-11472.js:1:14]
  1 │ @dec1 export @dec2 class C {}

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -21408,6 +21408,13 @@ Negative Passed: 4651/4651 (100.00%)
     ╰────
   note: This identifier is reserved in strict mode code
 
+  × Unexpected export.
+    ╭─[test262/test/language/global-code/export.js:22:1]
+ 21 │ 
+ 22 │ export default null;
+    · ──────
+    ╰────
+
   × Cannot use export statement outside a module
     ╭─[test262/test/language/global-code/export.js:22:1]
  21 │ 
@@ -22432,6 +22439,13 @@ Negative Passed: 4651/4651 (100.00%)
     ╭─[test262/test/language/import/import-defer/syntax/invalid-defer-named.js:34:1]
  33 │ 
  34 │ import defer { default as x } from "./dep_FIXTURE.js";
+    · ──────
+    ╰────
+
+  × Unexpected export.
+    ╭─[test262/test/language/import/import-defer/syntax/invalid-export-defer-namespace.js:33:1]
+ 32 │ 
+ 33 │ export defer * as ns from "./dep_FIXTURE.js";
     · ──────
     ╰────
 

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -6812,9 +6812,23 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╰────
 
   × Unexpected export.
+   ╭─[typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport1WithExport.ts:1:1]
+ 1 │ export import defaultBinding1, { } from "./server";
+   · ──────
+ 2 │ export var x1: number = defaultBinding1;
+   ╰────
+
+  × Unexpected export.
    ╭─[typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportWithExport.ts:1:8]
  1 │ export import defaultBinding1, { } from "./server";
    ·        ────────────────────────────────────────────
+ 2 │ export import defaultBinding2, { a } from "./server";
+   ╰────
+
+  × Unexpected export.
+   ╭─[typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportWithExport.ts:1:1]
+ 1 │ export import defaultBinding1, { } from "./server";
+   · ──────
  2 │ export import defaultBinding2, { a } from "./server";
    ╰────
 
@@ -6826,9 +6840,23 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╰────
 
   × Unexpected export.
+   ╭─[typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1WithExport.ts:1:1]
+ 1 │ export import defaultBinding, * as nameSpaceBinding  from "./server";
+   · ──────
+ 2 │ export var x: number = defaultBinding;
+   ╰────
+
+  × Unexpected export.
    ╭─[typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingWithExport.ts:1:8]
  1 │ export import defaultBinding, * as nameSpaceBinding  from "./server";
    ·        ──────────────────────────────────────────────────────────────
+ 2 │ export var x: number = nameSpaceBinding.a;
+   ╰────
+
+  × Unexpected export.
+   ╭─[typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingWithExport.ts:1:1]
+ 1 │ export import defaultBinding, * as nameSpaceBinding  from "./server";
+   · ──────
  2 │ export var x: number = nameSpaceBinding.a;
    ╰────
 
@@ -6850,6 +6878,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  2 │ export var x = defaultBinding;
    ╰────
 
+  × Unexpected export.
+   ╭─[typescript/tests/cases/compiler/es6ImportDefaultBindingWithExport.ts:1:1]
+ 1 │ export import defaultBinding from "./server";
+   · ──────
+ 2 │ export var x = defaultBinding;
+   ╰────
+
   × Identifier `nameSpaceBinding1` has already been declared
    ╭─[typescript/tests/cases/compiler/es6ImportNameSpaceImportMergeErrors.ts:4:13]
  3 │ 
@@ -6866,6 +6901,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╭─[typescript/tests/cases/compiler/es6ImportNameSpaceImportWithExport.ts:1:8]
  1 │ export import * as nameSpaceBinding from "server";
    ·        ───────────────────────────────────────────
+ 2 │ export var x = nameSpaceBinding.a;
+   ╰────
+
+  × Unexpected export.
+   ╭─[typescript/tests/cases/compiler/es6ImportNameSpaceImportWithExport.ts:1:1]
+ 1 │ export import * as nameSpaceBinding from "server";
+   · ──────
  2 │ export var x = nameSpaceBinding.a;
    ╰────
 
@@ -6987,6 +7029,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  2 │ export import { a } from "./server";
    ╰────
 
+  × Unexpected export.
+   ╭─[typescript/tests/cases/compiler/es6ImportNamedImportWithExport.ts:1:1]
+ 1 │ export import { } from "./server";
+   · ──────
+ 2 │ export import { a } from "./server";
+   ╰────
+
   × Expected `from` but found `decimal`
    ╭─[typescript/tests/cases/compiler/es6ImportParseErrors.ts:1:8]
  1 │ import 10;
@@ -6998,6 +7047,12 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╭─[typescript/tests/cases/compiler/es6ImportWithoutFromClauseWithExport.ts:1:8]
  1 │ export import "server";
    ·        ────────────────
+   ╰────
+
+  × Unexpected export.
+   ╭─[typescript/tests/cases/compiler/es6ImportWithoutFromClauseWithExport.ts:1:1]
+ 1 │ export import "server";
+   · ──────
    ╰────
 
   × TS(1030): 'export' modifier already seen.

--- a/tasks/track_memory_allocations/allocs_parser.yaml
+++ b/tasks/track_memory_allocations/allocs_parser.yaml
@@ -1,8 +1,8 @@
 checker.ts:
   file size: 2922154 # 2.92 MB
-  sys allocs: 23
-  sys reallocs: 10
-  sys deallocs: 23
+  sys allocs: 24
+  sys reallocs: 12
+  sys deallocs: 24
   sys alloc bytes: 4820 # 4.82 kB
   sys peak growth: 2432 # 2.43 kB
   arena allocs: 262590
@@ -11,9 +11,9 @@ checker.ts:
 
 App.tsx:
   file size: 415342 # 415.34 kB
-  sys allocs: 23
-  sys reallocs: 13
-  sys deallocs: 23
+  sys allocs: 24
+  sys reallocs: 15
+  sys deallocs: 24
   sys alloc bytes: 38116 # 38.12 kB
   sys peak growth: 26404 # 26.40 kB
   arena allocs: 44037
@@ -22,9 +22,9 @@ App.tsx:
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
-  sys allocs: 1
+  sys allocs: 2
   sys reallocs: 0
-  sys deallocs: 1
+  sys deallocs: 2
   sys alloc bytes: 108 # 108 B
   sys peak growth: 108 # 108 B
   arena allocs: 367
@@ -55,9 +55,9 @@ antd.js:
 
 binder.ts:
   file size: 193077 # 193.08 kB
-  sys allocs: 1
-  sys reallocs: 0
-  sys deallocs: 1
+  sys allocs: 2
+  sys reallocs: 1
+  sys deallocs: 2
   sys alloc bytes: 3016 # 3.02 kB
   sys peak growth: 251 # 251 B
   arena allocs: 16587
@@ -67,7 +67,7 @@ binder.ts:
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
   sys allocs: 190
-  sys reallocs: 160
+  sys reallocs: 163
   sys deallocs: 190
   sys alloc bytes: 51381 # 51.38 kB
   sys peak growth: 14644 # 14.64 kB

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,16 +1,14 @@
 commit: c86e9e4b
 
-Passed: 771/1164
+Passed: 734/1164
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
-* babel-plugin-transform-export-namespace-from
 * babel-plugin-transform-optional-chaining
 * babel-plugin-transform-optional-catch-binding
-* babel-plugin-transform-react-display-name
 
 
-# babel-preset-env (38/85)
+# babel-preset-env (35/85)
 * dynamic-import/auto-esm-unsupported-import-unsupported/input.mjs
 x Output mismatch
 
@@ -27,10 +25,49 @@ env: Systemjs module is not implemented.
 env: Umd module is not implemented.
 
 * export-namespace-from/auto-esm-not-supported/input.mjs
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-preset-env/test/fixtures/export-namespace-from/auto-esm-not-supported/input.mjs:1:1]
+ 1 | export * as foo from "./foo.mjs";
+   : ^^^^^^
+   `----
+
 
 * export-namespace-from/auto-export-namespace-not-supported/input.mjs
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-preset-env/test/fixtures/export-namespace-from/auto-export-namespace-not-supported/input.mjs:1:1]
+ 1 | export * as foo from "./foo.mjs";
+   : ^^^^^^
+   `----
+
+
+* export-namespace-from/false-export-namespace-not-supported/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-preset-env/test/fixtures/export-namespace-from/false-export-namespace-not-supported/input.mjs:1:1]
+ 1 | export * as foo from "./foo.mjs";
+   : ^^^^^^
+   `----
+
+
+* export-namespace-from/false-export-namespace-not-supported-caller-supported/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-preset-env/test/fixtures/export-namespace-from/false-export-namespace-not-supported-caller-supported/input.mjs:1:1]
+ 1 | export * as foo from "./foo.mjs";
+   : ^^^^^^
+   `----
+
+
+* export-namespace-from/false-export-namespace-supported/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-preset-env/test/fixtures/export-namespace-from/false-export-namespace-supported/input.mjs:1:1]
+ 1 | export * as foo from "./foo.mjs";
+   : ^^^^^^
+   `----
+
 
 * modules/auto-cjs/input.mjs
 x Output mismatch
@@ -75,13 +112,26 @@ x Output mismatch
 x Output mismatch
 
 * plugins-integration/issue-16155/input.mjs
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-preset-env/test/fixtures/plugins-integration/issue-16155/input.mjs:1:1]
+ 1 | export * as Extra from "./extra.js"
+   : ^^^^^^
+   `----
+
 
 * plugins-integration/issue-7527/input.mjs
 x Output mismatch
 
 * plugins-integration/regression-2892/input.mjs
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-preset-env/test/fixtures/plugins-integration/regression-2892/input.mjs:1:1]
+ 1 | export default class Foo {
+   : ^^^^^^
+ 2 |   async bar() {
+   `----
+
 
 * plugins-integration/regression-4855/input.js
 x Output mismatch
@@ -153,12 +203,128 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-explicit-resource-management (25/28)
+# babel-plugin-transform-explicit-resource-management (18/28)
 * integration/commonjs-transform/input.js
 x Output mismatch
 
 * transform-sync/named-evaluation/input.js
 x Output mismatch
+
+* transform-top-level/await-or-not-preserved/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-top-level/await-or-not-preserved/input.mjs:4:1]
+ 3 | 
+ 4 | export { x, y };
+   : ^^^^^^
+   `----
+
+
+* transform-top-level/hoisting/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-top-level/hoisting/input.mjs:2:1]
+ 1 | import { doSomething } from "somewhere";
+ 2 | export * from "somewhere else";
+   : ^^^^^^
+ 3 | export * as ns from "somewhere else";
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-top-level/hoisting/input.mjs:3:1]
+ 2 | export * from "somewhere else";
+ 3 | export * as ns from "somewhere else";
+   : ^^^^^^
+ 4 | 
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-top-level/hoisting/input.mjs:7:1]
+ 6 | function h() { b; A; }
+ 7 | export function g() { c; }
+   : ^^^^^^
+ 8 | 
+   `----
+
+
+  x Unexpected export.
+    ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-top-level/hoisting/input.mjs:11:1]
+ 10 | 
+ 11 | export { f };
+    : ^^^^^^
+ 12 | export let { b } = {};
+    `----
+
+
+  x Unexpected export.
+    ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-top-level/hoisting/input.mjs:12:1]
+ 11 | export { f };
+ 12 | export let { b } = {};
+    : ^^^^^^
+ 13 | 
+    `----
+
+
+  x Unexpected export.
+    ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-top-level/hoisting/input.mjs:16:1]
+ 15 | class A {}
+ 16 | export class B {}
+    : ^^^^^^
+ 17 | 
+    `----
+
+
+* transform-top-level/hoisting-default-clas-anon/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-top-level/hoisting-default-clas-anon/input.mjs:2:1]
+ 1 | using x = null;
+ 2 | export default class {}
+   : ^^^^^^
+   `----
+
+
+* transform-top-level/hoisting-default-class/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-top-level/hoisting-default-class/input.mjs:2:1]
+ 1 | using x = null;
+ 2 | export default class C {}
+   : ^^^^^^
+   `----
+
+
+* transform-top-level/hoisting-default-expr/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-top-level/hoisting-default-expr/input.mjs:2:1]
+ 1 | using x = null;
+ 2 | export default doSomething();
+   : ^^^^^^
+   `----
+
+
+* transform-top-level/hoisting-default-fn/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-top-level/hoisting-default-fn/input.mjs:2:1]
+ 1 | using x = null;
+ 2 | export default function fn() {}
+   : ^^^^^^
+   `----
+
+
+* transform-top-level/hoisting-default-fn-anon/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-explicit-resource-management/test/fixtures/transform-top-level/hoisting-default-fn-anon/input.mjs:2:1]
+ 1 | using x = null;
+ 2 | export default function fn() {}
+   : ^^^^^^
+   `----
+
 
 * transform-top-level/hoisting-mutate-outer-class-binding/input.js
 x Output mismatch
@@ -178,7 +344,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (214/269)
+# babel-plugin-transform-class-properties (193/269)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -196,6 +362,57 @@ x Output mismatch
 
 * assumption-setPublicClassFields/computed/input.js
 x Output mismatch
+
+* assumption-setPublicClassFields/non-block-arrow-func/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/non-block-arrow-func/input.mjs:1:1]
+ 1 | export default param =>
+   : ^^^^^^
+ 2 |   class App {
+   `----
+
+
+* assumption-setPublicClassFields/regression-T2983/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T2983/input.mjs:5:1]
+ 4 | 
+ 5 | export default class {
+   : ^^^^^^
+ 6 |   static test = true
+   `----
+
+
+* assumption-setPublicClassFields/regression-T7364/input.mjs
+
+  x Unexpected export.
+    ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/regression-T7364/input.mjs:13:1]
+ 12 | 
+ 13 | export default class MyClass3 {
+    : ^^^^^^
+ 14 |   myAsyncMethod = async () => {
+    `----
+
+
+* assumption-setPublicClassFields/static-export/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/static-export/input.mjs:1:1]
+ 1 | export class MyClass {
+   : ^^^^^^
+ 2 |   static property = value;
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/assumption-setPublicClassFields/static-export/input.mjs:5:1]
+ 4 | 
+ 5 | export default class MyClass2 {
+   : ^^^^^^
+ 6 |   static property = value;
+   `----
+
 
 * assumption-setPublicClassFields/static-infer-name/input.js
 x Output mismatch
@@ -228,7 +445,24 @@ x Output mismatch
 x Output mismatch
 
 * private/class-shadow-builtins/input.mjs
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/private/class-shadow-builtins/input.mjs:1:1]
+ 1 | export class TypeError {
+   : ^^^^^^
+ 2 |   #message
+   `----
+
+
+* private/non-block-arrow-func/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/private/non-block-arrow-func/input.mjs:1:1]
+ 1 | export default param =>
+   : ^^^^^^
+ 2 |   class App {
+   `----
+
 
 * private/optional-chain-cast-to-boolean/input.js
 x Output mismatch
@@ -251,6 +485,47 @@ x Output mismatch
 * private/parenthesized-optional-member-call-with-transform/input.js
 x Output mismatch
 
+* private/regression-T2983/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/private/regression-T2983/input.mjs:5:1]
+ 4 | 
+ 5 | export default class {
+   : ^^^^^^
+ 6 |   static #test = true
+   `----
+
+
+* private/regression-T7364/input.mjs
+
+  x Unexpected export.
+    ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/private/regression-T7364/input.mjs:13:1]
+ 12 | 
+ 13 | export default class MyClass3 {
+    : ^^^^^^
+ 14 |   #myAsyncMethod = async () => {
+    `----
+
+
+* private/static-export/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/private/static-export/input.mjs:1:1]
+ 1 | export class MyClass {
+   : ^^^^^^
+ 2 |   static #property = value;
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/private/static-export/input.mjs:5:1]
+ 4 | 
+ 5 | export default class MyClass2 {
+   : ^^^^^^
+ 6 |   static #property = value;
+   `----
+
+
 * private/static-infer-name/input.js
 x Output mismatch
 
@@ -261,7 +536,24 @@ x Output mismatch
 x Output mismatch
 
 * private-loose/class-shadow-builtins/input.mjs
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/class-shadow-builtins/input.mjs:1:1]
+ 1 | export class TypeError {
+   : ^^^^^^
+ 2 |   #message
+   `----
+
+
+* private-loose/non-block-arrow-func/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/non-block-arrow-func/input.mjs:1:1]
+ 1 | export default param =>
+   : ^^^^^^
+ 2 |   class App {
+   `----
+
 
 * private-loose/optional-chain-before-member-call/input.js
 x Output mismatch
@@ -308,11 +600,37 @@ x Output mismatch
 * private-loose/parenthesized-optional-member-call-with-transform/input.js
 x Output mismatch
 
+* private-loose/static-export/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/static-export/input.mjs:1:1]
+ 1 | export class MyClass {
+   : ^^^^^^
+ 2 |   static #property = value;
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/private-loose/static-export/input.mjs:5:1]
+ 4 | 
+ 5 | export default class MyClass2 {
+   : ^^^^^^
+ 6 |   static #property = value;
+   `----
+
+
 * private-loose/static-infer-name/input.js
 x Output mismatch
 
 * public/class-shadow-builtins/input.mjs
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/public/class-shadow-builtins/input.mjs:1:1]
+ 1 | export class TypeError {
+   : ^^^^^^
+ 2 |   message
+   `----
+
 
 * public/computed/input.js
 x Output mismatch
@@ -320,14 +638,123 @@ x Output mismatch
 * public/delete-super-property/input.js
 x Output mismatch
 
+* public/non-block-arrow-func/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/public/non-block-arrow-func/input.mjs:1:1]
+ 1 | export default param =>
+   : ^^^^^^
+ 2 |   class App {
+   `----
+
+
+* public/regression-T2983/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/public/regression-T2983/input.mjs:5:1]
+ 4 | 
+ 5 | export default class {
+   : ^^^^^^
+ 6 |   static test = true
+   `----
+
+
+* public/regression-T7364/input.mjs
+
+  x Unexpected export.
+    ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/public/regression-T7364/input.mjs:13:1]
+ 12 | 
+ 13 | export default class MyClass3 {
+    : ^^^^^^
+ 14 |   myAsyncMethod = async () => {
+    `----
+
+
+* public/static-export/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/public/static-export/input.mjs:1:1]
+ 1 | export class MyClass {
+   : ^^^^^^
+ 2 |   static property = value;
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/public/static-export/input.mjs:5:1]
+ 4 | 
+ 5 | export default class MyClass2 {
+   : ^^^^^^
+ 6 |   static property = value;
+   `----
+
+
 * public/static-infer-name/input.js
 x Output mismatch
 
 * public-loose/class-shadow-builtins/input.mjs
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/class-shadow-builtins/input.mjs:1:1]
+ 1 | export class TypeError {
+   : ^^^^^^
+ 2 |   message
+   `----
+
 
 * public-loose/computed/input.js
 x Output mismatch
+
+* public-loose/non-block-arrow-func/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/non-block-arrow-func/input.mjs:1:1]
+ 1 | export default param =>
+   : ^^^^^^
+ 2 |   class App {
+   `----
+
+
+* public-loose/regression-T2983/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/regression-T2983/input.mjs:5:1]
+ 4 | 
+ 5 | export default class {
+   : ^^^^^^
+ 6 |   static test = true
+   `----
+
+
+* public-loose/regression-T7364/input.mjs
+
+  x Unexpected export.
+    ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/regression-T7364/input.mjs:13:1]
+ 12 | 
+ 13 | export default class MyClass3 {
+    : ^^^^^^
+ 14 |   myAsyncMethod = async () => {
+    `----
+
+
+* public-loose/static-export/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/static-export/input.mjs:1:1]
+ 1 | export class MyClass {
+   : ^^^^^^
+ 2 |   static property = value;
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/public-loose/static-export/input.mjs:5:1]
+ 4 | 
+ 5 | export default class MyClass2 {
+   : ^^^^^^
+ 6 |   static property = value;
+   `----
+
 
 * public-loose/static-infer-name/input.js
 x Output mismatch
@@ -337,6 +764,38 @@ x Output mismatch
 
 * regression/6153/input.js
 x Output mismatch
+
+* regression/7951/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/regression/7951/input.mjs:1:1]
+ 1 | export class Foo extends Bar {
+   : ^^^^^^
+ 2 |   static foo = {};
+   `----
+
+
+* regression/T2983/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T2983/input.mjs:5:1]
+ 4 | 
+ 5 | export default class {
+   : ^^^^^^
+ 6 |   static test = true
+   `----
+
+
+* regression/T7364/input.mjs
+
+  x Unexpected export.
+    ,-[tasks/coverage/babel/packages/babel-plugin-transform-class-properties/test/fixtures/regression/T7364/input.mjs:13:1]
+ 12 | 
+ 13 | export default class MyClass3 {
+    : ^^^^^^
+ 14 |   myAsyncMethod = async () => {
+    `----
+
 
 * source-maps/private-get/input.js
 x Output mismatch
@@ -827,6 +1286,44 @@ x Output mismatch
 x Output mismatch
 
 
+# babel-plugin-transform-export-namespace-from (0/4)
+* export-namespace/namespace-default/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-export-namespace-from/test/fixtures/export-namespace/namespace-default/input.mjs:1:1]
+ 1 | export * as default from "foo";
+   : ^^^^^^
+   `----
+
+
+* export-namespace/namespace-es6/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-export-namespace-from/test/fixtures/export-namespace/namespace-es6/input.mjs:1:1]
+ 1 | export * as foo from "bar";
+   : ^^^^^^
+   `----
+
+
+* export-namespace/namespace-string/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-export-namespace-from/test/fixtures/export-namespace/namespace-string/input.mjs:1:1]
+ 1 | export * as "some exports" from "foo";
+   : ^^^^^^
+   `----
+
+
+* export-namespace/namespace-typescript/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-export-namespace-from/test/fixtures/export-namespace/namespace-typescript/input.mjs:1:1]
+ 1 | export * as foo from "bar";
+   : ^^^^^^
+   `----
+
+
+
 # babel-plugin-transform-nullish-coalescing-operator (9/24)
 * assumption-noDocumentAll/transform/input.js
 x Output mismatch
@@ -879,7 +1376,35 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-object-rest-spread (29/39)
+# babel-plugin-transform-object-rest-spread (28/39)
+* object-rest/export/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/export/input.mjs:2:1]
+ 1 | // ExportNamedDeclaration
+ 2 | export var { b, ...c } = asdf2;
+   : ^^^^^^
+ 3 | // Skip
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/export/input.mjs:4:1]
+ 3 | // Skip
+ 4 | export var { bb, cc } = ads;
+   : ^^^^^^
+ 5 | export var [ dd, ee, ...ff ] = ads;
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/export/input.mjs:5:1]
+ 4 | export var { bb, cc } = ads;
+ 5 | export var [ dd, ee, ...ff ] = ads;
+   : ^^^^^^
+   `----
+
+
 * object-rest/for-x/input.js
 x Output mismatch
 
@@ -927,11 +1452,27 @@ x Output mismatch
 # babel-plugin-transform-async-to-generator (9/31)
 * assumption-ignoreFunctionLength-true/basic/input.mjs
 
+  x Unexpected export.
+    ,-[tasks/coverage/babel/packages/babel-plugin-transform-async-to-generator/test/fixtures/assumption-ignoreFunctionLength-true/basic/input.mjs:15:1]
+ 14 | 
+ 15 | export default async ([...x]) => {};
+    : ^^^^^^
+ 16 | 
+    `----
+
+
   x Compiler assumption `ignoreFunctionLength` is not implemented for object-
   | rest-spread.
 
 
 * assumption-ignoreFunctionLength-true/export-default-function/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-async-to-generator/test/fixtures/assumption-ignoreFunctionLength-true/export-default-function/input.mjs:1:1]
+ 1 | export default async function (x) {}
+   : ^^^^^^
+   `----
+
 
   x Compiler assumption `ignoreFunctionLength` is not implemented for object-
   | rest-spread.
@@ -974,16 +1515,41 @@ x Output mismatch
 x Output mismatch
 
 * export-async/default-arrow-export/input.mjs
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-arrow-export/input.mjs:1:1]
+ 1 | export default async () => { return await foo(); }
+   : ^^^^^^
+   `----
+
 
 * export-async/default-export/input.mjs
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/default-export/input.mjs:1:1]
+ 1 | export default async function myFunc() {}
+   : ^^^^^^
+   `----
+
 
 * export-async/import-and-export/input.mjs
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/import-and-export/input.mjs:3:1]
+ 2 | 
+ 3 | export async function foo () { }
+   : ^^^^^^
+   `----
+
 
 * export-async/lone-export/input.mjs
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-async-to-generator/test/fixtures/export-async/lone-export/input.mjs:1:1]
+ 1 | export async function foo () { }
+   : ^^^^^^
+   `----
+
 
 * regression/15978/input.js
 x Output mismatch
@@ -1128,9 +1694,15 @@ after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
 
 * declarations/nested-namespace/input.mjs
-Bindings mismatch:
-after transform: ScopeId(0): ["P"]
-rebuilt        : ScopeId(0): []
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/declarations/nested-namespace/input.mjs:2:1]
+ 1 | ; // Otherwise-empty file
+ 2 | export declare namespace P {
+   : ^^^^^^
+ 3 |   export namespace C {}
+   `----
+
 
 * enum/enum-merging-inner-references/input.ts
 Symbol redeclarations mismatch for "Animals":
@@ -1448,6 +2020,18 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
 
 
   x Option `useBuiltIns` is not implemented for object-rest-spread.
+
+
+
+# babel-plugin-transform-react-display-name (15/16)
+* with-jsx-plugin/export-default/input.mjs
+
+  x Unexpected export.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-react-display-name/test/fixtures/with-jsx-plugin/export-default/input.mjs:1:1]
+ 1 | export default React.createClass({
+   : ^^^^^^
+ 2 |   render: function render() {
+   `----
 
 
 

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,17 +1,14 @@
 commit: c86e9e4b
 
-Passed: 270/398
+Passed: 240/398
 
 # All Passed:
-* babel-plugin-transform-class-static-block
 * babel-plugin-transform-private-methods
 * babel-plugin-transform-logical-assignment-operators
 * babel-plugin-transform-nullish-coalescing-operator
 * babel-plugin-transform-optional-chaining
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-async-generator-functions
-* babel-plugin-transform-object-rest-spread
-* babel-plugin-transform-async-to-generator
 * babel-plugin-transform-exponentiation-operator
 * babel-plugin-transform-arrow-functions
 * babel-preset-typescript
@@ -21,20 +18,30 @@ Passed: 270/398
 * plugin-tagged-template-transform
 
 
-# babel-plugin-transform-explicit-resource-management (3/4)
+# babel-plugin-transform-explicit-resource-management (2/4)
 * export-class-name/input.js
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(7)]
-rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(5), ReferenceId(6)]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(3): [ReferenceId(4)]
-Reference symbol mismatch for "C":
-after transform: SymbolId(1) "C"
-rebuilt        : SymbolId(3) "C"
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-explicit-resource-management/test/fixtures/export-class-name/input.js:3:1]
+ 2 | 
+ 3 | export class C {
+   : ^^^^^^
+ 4 |   static getSelf() { return C; }
+   `----
 
 
-# babel-plugin-transform-class-properties (29/33)
+* try-catch/input.js
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-explicit-resource-management/test/fixtures/try-catch/input.js:1:1]
+ 1 | export class WorkspaceResolver {
+   : ^^^^^^
+ 2 |     async invite() {
+   `----
+
+
+
+# babel-plugin-transform-class-properties (28/33)
 * private-field-resolve-to-method/input.js
 x Output mismatch
 
@@ -47,12 +54,108 @@ x Output mismatch
 * static-super-tagged-template/input.js
 x Output mismatch
 
+* typescript/class-fields-with-computed-key/input.ts
 
-# babel-plugin-transform-typescript (41/60)
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-class-properties/test/fixtures/typescript/class-fields-with-computed-key/input.ts:3:1]
+ 2 | 
+ 3 | export class Obj {
+   : ^^^^^^
+ 4 |   public readonly [Collection.identifier] = true;
+   `----
+
+
+
+# babel-plugin-transform-class-static-block (4/5)
+* properties-and-methods/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-class-static-block/test/fixtures/properties-and-methods/input.ts:3:1]
+ 2 | 
+ 3 | export class C {
+   : ^^^^^^
+ 4 |   // Private properties and methods use up prop names for static block
+   `----
+
+
+
+# babel-plugin-transform-object-rest-spread (7/8)
+* object-rest/export/input.js
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/export/input.js:1:1]
+ 1 | export let { ...a0 } = foo;
+   : ^^^^^^
+ 2 | export let [{...b0}] = z
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/export/input.js:2:1]
+ 1 | export let { ...a0 } = foo;
+ 2 | export let [{...b0}] = z
+   : ^^^^^^
+   `----
+
+
+
+# babel-plugin-transform-async-to-generator (25/28)
+* function/export/default-with-name/input.js
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/function/export/default-with-name/input.js:1:1]
+ 1 | export default async function D(a, b = 0) {
+   : ^^^^^^
+ 2 |   await Promise.resolve();
+   `----
+
+
+* function/export/default-without-name/input.js
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/function/export/default-without-name/input.js:1:1]
+ 1 | export default async function (a, b = 0) {
+   : ^^^^^^
+ 2 |   await Promise.resolve();
+   `----
+
+
+* function/export/named/input.js
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/function/export/named/input.js:1:1]
+ 1 | export async function named(...args) {
+   : ^^^^^^
+ 2 |   await Promise.resolve();
+   `----
+
+
+
+# babel-plugin-transform-typescript (29/60)
 * allow-declare-fields-false/input.ts
 Unresolved references mismatch:
 after transform: ["dce"]
 rebuilt        : []
+
+* class-constructor-arguments-with-declared-fields/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-declared-fields/input.ts:6:1]
+ 5 | // purely defensive.)
+ 6 | export class WithStaticSameName {
+   : ^^^^^^
+ 7 |   static x = 0;
+   `----
+
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-with-declared-fields/input.ts:11:1]
+ 10 | 
+ 11 | export class WithPrivateSameName {
+    : ^^^^^^
+ 12 |   #x = 0;
+    `----
+
 
 * computed-constant-value/input.ts
 Unresolved references mismatch:
@@ -61,6 +164,26 @@ rebuilt        : ["Infinity"]
 Unresolved reference IDs mismatch for "Infinity":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(18)]
 rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(12)]
+
+* computed-static-property-with-constructor/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/computed-static-property-with-constructor/input.ts:1:1]
+ 1 | export class SampleClass {
+   : ^^^^^^
+ 2 |     static [Symbol.toPrimitive] = "test";
+   `----
+
+
+* const-enum-value-ref-kept/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/const-enum-value-ref-kept/input.ts:9:1]
+ 8 | 
+ 9 | export default Phase;
+   : ^^^^^^
+   `----
+
 
 * declare-and-definite-with-initializer/input.ts
 
@@ -85,9 +208,50 @@ rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(12
 
 
 * elimination-declare/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "ReactiveMarker", "ReactiveMarkerSymbol"]
-rebuilt        : ScopeId(0): []
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/elimination-declare/input.ts:3:1]
+ 2 | 
+ 3 | export declare class ReactiveMarker {
+   : ^^^^^^
+ 4 |   private [ReactiveMarkerSymbol]?: void
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/elimination-declare/input.ts:7:1]
+ 6 | 
+ 7 | export declare const A = 1
+   : ^^^^^^
+   `----
+
+
+* elimination-empty-export-named/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/elimination-empty-export-named/input.ts:1:1]
+ 1 | export {} from 'mod';
+   : ^^^^^^
+ 2 | export {} from './app.ts';
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/elimination-empty-export-named/input.ts:2:1]
+ 1 | export {} from 'mod';
+ 2 | export {} from './app.ts';
+   : ^^^^^^
+ 3 | export {}
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/elimination-empty-export-named/input.ts:3:1]
+ 2 | export {} from './app.ts';
+ 3 | export {}
+   : ^^^^^^
+   `----
+
 
 * enum-member-reference/input.ts
 Missing ReferenceId: "Foo"
@@ -133,18 +297,43 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), R
 rebuilt        : SymbolId(0): [ReferenceId(5)]
 
 * export-elimination/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Bar", "Foo", "Func", "Im", "Name", "Ok"]
-rebuilt        : ScopeId(0): ["Bar", "Foo", "Func", "Im", "Name", "Ok", "T"]
-Symbol flags mismatch for "T":
-after transform: SymbolId(9): SymbolFlags(Function | TypeAlias)
-rebuilt        : SymbolId(8): SymbolFlags(Function)
-Symbol span mismatch for "T":
-after transform: SymbolId(9): Span { start: 205, end: 206 }
-rebuilt        : SymbolId(8): Span { start: 226, end: 227 }
-Symbol redeclarations mismatch for "T":
-after transform: SymbolId(9): [Span { start: 205, end: 206 }, Span { start: 226, end: 227 }]
-rebuilt        : SymbolId(8): []
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/export-elimination/input.ts:11:1]
+ 10 | 
+ 11 | export { Im, Ok, Foo, Bar, Func, Baz, Baq, Name };
+    : ^^^^^^
+ 12 | 
+    `----
+
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/export-elimination/input.ts:17:1]
+ 16 | }
+ 17 | export { T }
+    : ^^^^^^
+    `----
+
+
+* exports/type-and-non-type/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/exports/type-and-non-type/input.ts:4:1]
+ 3 | 
+ 4 | export { type ToastProps, ToastViewport };
+   : ^^^^^^
+   `----
+
+
+* jsx/issue-10956/input.tsx
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/jsx/issue-10956/input.tsx:3:1]
+ 2 | /** @jsxRuntime classic */
+ 3 | export const foo = <div></div>
+   : ^^^^^^
+   `----
+
 
 * namespace/import-=/input.ts
 Symbol reference IDs mismatch for "A":
@@ -159,27 +348,125 @@ Symbol redeclarations mismatch for "y":
 after transform: SymbolId(2): [Span { start: 59, end: 60 }, Span { start: 83, end: 84 }]
 rebuilt        : SymbolId(3): []
 
+* namespace/redeclaration-with-interface/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-interface/input.ts:1:1]
+ 1 | export interface Foo {}
+   : ^^^^^^
+ 2 | export namespace Foo {
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-interface/input.ts:2:1]
+ 1 | export interface Foo {}
+ 2 | export namespace Foo {
+   : ^^^^^^
+ 3 |   export const Bar = 1;
+   `----
+
+
+* namespace/redeclaration-with-type-alias/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-type-alias/input.ts:1:1]
+ 1 | export type Foo = {};
+   : ^^^^^^
+ 2 | export namespace Foo {
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-type-alias/input.ts:2:1]
+ 1 | export type Foo = {};
+ 2 | export namespace Foo {
+   : ^^^^^^
+ 3 |     export const Bar = 0;
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-type-alias/input.ts:5:1]
+ 4 | }
+ 5 | export namespace Foo {
+   : ^^^^^^
+ 6 |     export const Zoo = 1;
+   `----
+
+
+* namespace/redeclaration-with-type-only-namespace/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-type-only-namespace/input.ts:1:1]
+ 1 | export namespace Foo {
+   : ^^^^^^
+ 2 |     export type T = 0;
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-type-only-namespace/input.ts:4:1]
+ 3 | }
+ 4 | export namespace Foo {
+   : ^^^^^^
+ 5 |     export const Bar = 1;
+   `----
+
+
+* optimize-enums/exported-not-removed/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/optimize-enums/exported-not-removed/input.ts:1:1]
+ 1 | export enum Direction {
+   : ^^^^^^
+ 2 |   Up,
+   `----
+
+
 * optimize-enums/merged-enum/input.ts
 Unresolved references mismatch:
 after transform: ["A"]
 rebuilt        : []
 
+* optimize-enums/re-exported-not-removed/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/optimize-enums/re-exported-not-removed/input.ts:5:1]
+ 4 | enum B { Y = "hello" }
+ 5 | export { A, B }
+   : ^^^^^^
+ 6 | 
+   `----
+
+
 * redeclarations/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): ["A", "B", "T"]
-Symbol flags mismatch for "T":
-after transform: SymbolId(1): SymbolFlags(Import | TypeAlias)
-rebuilt        : SymbolId(1): SymbolFlags(Import)
-Symbol redeclarations mismatch for "T":
-after transform: SymbolId(1): [Span { start: 149, end: 150 }, Span { start: 170, end: 171 }]
-rebuilt        : SymbolId(1): []
-Symbol flags mismatch for "B":
-after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
-Symbol redeclarations mismatch for "B":
-after transform: SymbolId(2): [Span { start: 289, end: 290 }, Span { start: 304, end: 305 }]
-rebuilt        : SymbolId(2): []
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/redeclarations/input.ts:4:1]
+ 3 | const A: A = 0;
+ 4 | export {A};
+   : ^^^^^^
+ 5 | 
+   `----
+
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/redeclarations/input.ts:9:1]
+  8 | type T = number;
+  9 | export { T }
+    : ^^^^^^
+ 10 | 
+    `----
+
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/redeclarations/input.ts:15:1]
+ 14 | type B = number;
+ 15 | export { B }
+    : ^^^^^^
+    `----
+
 
 * remove-class-properties-without-initializer/input.ts
 Unresolved references mismatch:
@@ -187,15 +474,61 @@ after transform: ["dce"]
 rebuilt        : []
 
 * remove-unused-import-equals/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["D", "a", "b", "bar", "c"]
-rebuilt        : ScopeId(0): ["a", "b", "bar", "c"]
-Unresolved reference IDs mismatch for "foo":
-after transform: [ReferenceId(0), ReferenceId(6)]
-rebuilt        : [ReferenceId(0)]
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/remove-unused-import-equals/input.ts:17:1]
+ 16 | 
+ 17 | export let bar = c
+    : ^^^^^^
+    `----
+
 
 * ts-declaration-empty-output/input.d.ts
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/ts-declaration-empty-output/input.d.ts:1:1]
+ 1 | export interface Things<P, T> {
+   : ^^^^^^
+ 2 |     p: P;
+   `----
+
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/ts-declaration-empty-output/input.d.ts:6:1]
+ 5 | 
+ 6 | export interface Props {
+   : ^^^^^^
+ 7 | }
+   `----
+
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/ts-declaration-empty-output/input.d.ts:9:1]
+  8 | 
+  9 | export default class MyComponent {
+    : ^^^^^^
+ 10 |     props: Props;
+    `----
+
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/ts-declaration-empty-output/input.d.ts:12:1]
+ 11 | }
+ 12 | export namespace Something {
+    : ^^^^^^
+ 13 |     export const foo = 123;
+    `----
+
+
+* ts-private-field-with-remove-class-fields-without-initializer/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/ts-private-field-with-remove-class-fields-without-initializer/input.ts:1:1]
+ 1 | export class ArrayBufferViewTransferable implements Transferable {
+   : ^^^^^^
+ 2 |   #view: ArrayBufferView;
+   `----
+
 
 * use-define-for-class-fields/input.ts
 Unresolved references mismatch:
@@ -208,7 +541,7 @@ after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(9)
 rebuilt        : [ReferenceId(5)]
 
 
-# babel-plugin-transform-react-jsx (51/54)
+# babel-plugin-transform-react-jsx (50/54)
 * refresh/import-after-component/input.js
 Missing ScopeId
 Missing ReferenceId: "useFoo"
@@ -222,30 +555,31 @@ x Output mismatch
 * refresh/react-refresh/supports-typescript-namespace-syntax/input.tsx
 x Output mismatch
 
+* spread-props-classic/input.jsx
 
-# legacy-decorators (20/106)
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-react-jsx/test/fixtures/spread-props-classic/input.jsx:1:1]
+ 1 | export function Foo(props) {
+   : ^^^^^^
+ 2 |   return (
+   `----
+
+
+
+# legacy-decorators (13/106)
 * oxc/accessor/input.ts
 x Output mismatch
 
 * oxc/accessor-name-collision/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "_prop", "_prop2", "_prop3", "prop", "property"]
-rebuilt        : ScopeId(0): ["Foo", "_prop", "_prop2", "_prop3", "prop"]
-Reference symbol mismatch for "property":
-after transform: SymbolId(0) "property"
-rebuilt        : <None>
-Reference symbol mismatch for "property":
-after transform: SymbolId(0) "property"
-rebuilt        : <None>
-Reference symbol mismatch for "property":
-after transform: SymbolId(0) "property"
-rebuilt        : <None>
-Reference symbol mismatch for "property":
-after transform: SymbolId(0) "property"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: ["babelHelpers"]
-rebuilt        : ["babelHelpers", "property"]
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/accessor-name-collision/input.ts:6:1]
+ 5 | 
+ 6 | export class Foo {
+   : ^^^^^^
+ 7 |   @property()
+   `----
+
 
 * oxc/accessor-with-class-properties/input.ts
 Bindings mismatch:
@@ -273,10 +607,59 @@ Unresolved references mismatch:
 after transform: ["WeakMap", "babelHelpers"]
 rebuilt        : ["WeakMap", "a", "babelHelpers", "dec"]
 
+* oxc/class-without-name-with-decorated-static-element/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated-static-element/input.ts:3:1]
+ 2 | 
+ 3 | export default class {
+   : ^^^^^^
+ 4 |   @dec
+   `----
+
+
 * oxc/class-without-name-with-decorated_class/input.ts
-Symbol flags mismatch for "_default":
-after transform: SymbolId(1): SymbolFlags(Class)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_class/input.ts:4:1]
+ 3 | @dec
+ 4 | export default class {
+   : ^^^^^^
+ 5 |   @dec
+   `----
+
+
+* oxc/class-without-name-with-decorated_element/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/class-without-name-with-decorated_element/input.ts:3:1]
+ 2 | 
+ 3 | export default class {
+   : ^^^^^^
+ 4 |   @dec
+   `----
+
+
+* oxc/export-class-method-decorated/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/export-class-method-decorated/input.ts:1:1]
+ 1 | export class T {
+   : ^^^^^^
+ 2 |   @first() method(@first() test) {
+   `----
+
+
+* oxc/metadata/abstract-class/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/abstract-class/input.ts:4:1]
+ 3 | @dce()
+ 4 | export abstract class AbstractClass {
+   : ^^^^^^
+ 5 |     constructor(public dependency: Dependency) {}
+   `----
+
 
 * oxc/metadata/ambient-declared-class/input.ts
 Bindings mismatch:
@@ -294,6 +677,17 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Object", "babelHelpers"]
 rebuilt        : ["Ambient", "Object", "babelHelpers", "dec"]
+
+* oxc/metadata/class-and-method-decorators/input.ts
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/class-and-method-decorators/input.ts:5:1]
+ 4 | @singleton()
+ 5 | export class Problem extends C {
+   : ^^^^^^
+ 6 |   @deco()
+   `----
+
 
 * oxc/metadata/class-expression-via-const/input.ts
 Bindings mismatch:
@@ -342,6 +736,17 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Object", "babelHelpers"]
 rebuilt        : ["Object", "babelHelpers", "dec"]
+
+* oxc/metadata/enum-types/input.ts
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/enum-types/input.ts:48:1]
+ 47 | 
+ 48 | export class Foo {
+    : ^^^^^^
+ 49 |   @decorate
+    `----
+
 
 * oxc/metadata/erased-import-no-type-keyword/input.ts
 Bindings mismatch:
@@ -443,80 +848,35 @@ after transform: [ReferenceId(9), ReferenceId(21)]
 rebuilt        : [ReferenceId(8)]
 
 * oxc/metadata/params/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Foo", "methodDecorator", "paramDecorator"]
-rebuilt        : ScopeId(0): ["Foo"]
-Reference symbol mismatch for "methodDecorator":
-after transform: SymbolId(0) "methodDecorator"
-rebuilt        : <None>
-Reference symbol mismatch for "methodDecorator":
-after transform: SymbolId(0) "methodDecorator"
-rebuilt        : <None>
-Reference symbol mismatch for "paramDecorator":
-after transform: SymbolId(2) "paramDecorator"
-rebuilt        : <None>
-Reference symbol mismatch for "methodDecorator":
-after transform: SymbolId(0) "methodDecorator"
-rebuilt        : <None>
-Reference symbol mismatch for "methodDecorator":
-after transform: SymbolId(0) "methodDecorator"
-rebuilt        : <None>
-Reference symbol mismatch for "paramDecorator":
-after transform: SymbolId(2) "paramDecorator"
-rebuilt        : <None>
-Reference symbol mismatch for "paramDecorator":
-after transform: SymbolId(2) "paramDecorator"
-rebuilt        : <None>
-Reference symbol mismatch for "paramDecorator":
-after transform: SymbolId(2) "paramDecorator"
-rebuilt        : <None>
-Reference symbol mismatch for "paramDecorator":
-after transform: SymbolId(2) "paramDecorator"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: ["Boolean", "Function", "Number", "String", "babelHelpers"]
-rebuilt        : ["Boolean", "Function", "Number", "String", "babelHelpers", "methodDecorator", "paramDecorator"]
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/params/input.ts:4:1]
+ 3 | 
+ 4 | export class Foo {
+   : ^^^^^^
+ 5 |   @methodDecorator(1)
+   `----
+
 
 * oxc/metadata/private-in-expression-in-decorator/input.ts
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-Bindings mismatch:
-after transform: ScopeId(1): ["Cls"]
-rebuilt        : ScopeId(1): []
-Bindings mismatch:
-after transform: ScopeId(3): ["Cls2"]
-rebuilt        : ScopeId(4): []
-Symbol reference IDs mismatch for "dec":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(0), ReferenceId(1), ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(10)]
-Symbol scope ID mismatch for "Cls":
-after transform: SymbolId(4): ScopeId(1)
-rebuilt        : SymbolId(1): ScopeId(0)
-Symbol reference IDs mismatch for "Cls":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(7)]
-Symbol scope ID mismatch for "Cls2":
-after transform: SymbolId(5): ScopeId(3)
-rebuilt        : SymbolId(2): ScopeId(0)
-Symbol reference IDs mismatch for "Cls2":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(2): [ReferenceId(11), ReferenceId(17)]
-Reference symbol mismatch for "Cls":
-after transform: SymbolId(1) "Cls"
-rebuilt        : SymbolId(1) "Cls"
-Reference symbol mismatch for "Cls":
-after transform: SymbolId(1) "Cls"
-rebuilt        : SymbolId(1) "Cls"
-Reference symbol mismatch for "Cls2":
-after transform: SymbolId(2) "Cls2"
-rebuilt        : SymbolId(2) "Cls2"
-Reference symbol mismatch for "Cls2":
-after transform: SymbolId(2) "Cls2"
-rebuilt        : SymbolId(2) "Cls2"
-Unresolved reference IDs mismatch for "babelHelpers":
-after transform: [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(22), ReferenceId(24)]
-rebuilt        : [ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(12), ReferenceId(14), ReferenceId(16)]
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/private-in-expression-in-decorator/input.ts:4:1]
+ 3 | @dec
+ 4 | export class Cls {
+   : ^^^^^^
+ 5 |   #zoo = 0;
+   `----
+
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/private-in-expression-in-decorator/input.ts:11:1]
+ 10 | @dec
+ 11 | export class Cls2 {
+    : ^^^^^^
+ 12 |   #zoo = 0;
+    `----
+
 
 * oxc/metadata/readonly-array/input.ts
 Bindings mismatch:
@@ -544,15 +904,15 @@ after transform: ["Object", "babelHelpers"]
 rebuilt        : ["Object", "babelHelpers", "dec"]
 
 * oxc/metadata/static-anonymous-class-expression/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["A", "Foo", "dec"]
-rebuilt        : ScopeId(0): ["A", "Foo"]
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: ["Error", "Object", "babelHelpers"]
-rebuilt        : ["Error", "Object", "babelHelpers", "dec"]
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/static-anonymous-class-expression/input.ts:5:1]
+ 4 | @dec()
+ 5 | export class Foo {
+   : ^^^^^^
+ 6 |   static Error1 = class extends Error {};
+   `----
+
 
 * oxc/metadata/typescript-syntax/input.ts
 
@@ -591,10 +951,45 @@ Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10)]
 rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(6), ReferenceId(10)]
 
+* oxc/with-class-private-properties/input.ts
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/input.ts:10:1]
+  9 | @dec
+ 10 | export class D {
+    : ^^^^^^
+ 11 |   prop = 0;
+    `----
+
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/input.ts:18:1]
+ 17 | @dec
+ 18 | export default class E {
+    : ^^^^^^
+ 19 |   prop = 0;
+    `----
+
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/input.ts:30:1]
+ 29 | 
+ 30 | export class G {
+    : ^^^^^^
+ 31 |   @dec
+    `----
+
+
 * oxc/with-class-private-properties-unnamed-default-export/input.ts
-Symbol flags mismatch for "_default":
-after transform: SymbolId(0): SymbolFlags(Class)
-rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties-unnamed-default-export/input.ts:2:1]
+ 1 | @dec
+ 2 | export default class {
+   : ^^^^^^
+ 3 |   prop = 0;
+   `----
+
 
 * typescript/accessor/decoratorOnClassAccessor1/input.ts
 Bindings mismatch:
@@ -727,32 +1122,46 @@ x Output mismatch
 x Output mismatch
 
 * typescript/decoratedClassExportsCommonJS1/input.ts
-x Output mismatch
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsCommonJS1/input.ts:10:1]
+  9 | @Something({ v: () => Testing123 })
+ 10 | export class Testing123 {
+    : ^^^^^^
+ 11 |     static prop0: string;
+    `----
+
 
 * typescript/decoratedClassExportsCommonJS2/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Something", "Testing123", "forwardRef"]
-rebuilt        : ScopeId(0): ["Testing123"]
-Reference symbol mismatch for "Something":
-after transform: SymbolId(2) "Something"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: ["babelHelpers"]
-rebuilt        : ["Something", "babelHelpers"]
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsCommonJS2/input.ts:10:1]
+  9 | @Something({ v: () => Testing123 })
+ 10 | export class Testing123 { }
+    : ^^^^^^
+    `----
+
 
 * typescript/decoratedClassExportsSystem1/input.ts
-x Output mismatch
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsSystem1/input.ts:10:1]
+  9 | @Something({ v: () => Testing123 })
+ 10 | export class Testing123 {
+    : ^^^^^^
+ 11 |     static prop0: string;
+    `----
+
 
 * typescript/decoratedClassExportsSystem2/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["Something", "Testing123", "forwardRef"]
-rebuilt        : ScopeId(0): ["Testing123"]
-Reference symbol mismatch for "Something":
-after transform: SymbolId(2) "Something"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: ["babelHelpers"]
-rebuilt        : ["Something", "babelHelpers"]
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsSystem2/input.ts:10:1]
+  9 | @Something({ v: () => Testing123 })
+ 10 | export class Testing123 { }
+    : ^^^^^^
+    `----
+
 
 * typescript/decoratorChecksFunctionBodies/input.ts
 Scope flags mismatch:
@@ -774,26 +1183,26 @@ after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 * typescript/decoratorOnClass2/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["C", "dec"]
-rebuilt        : ScopeId(0): ["C"]
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: ["babelHelpers"]
-rebuilt        : ["babelHelpers", "dec"]
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass2/input.ts:7:1]
+ 6 | @dec
+ 7 | export class C {
+   : ^^^^^^
+ 8 | }
+   `----
+
 
 * typescript/decoratorOnClass3/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["C", "dec"]
-rebuilt        : ScopeId(0): ["C"]
-Reference symbol mismatch for "dec":
-after transform: SymbolId(0) "dec"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: ["babelHelpers"]
-rebuilt        : ["babelHelpers", "dec"]
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass3/input.ts:6:1]
+ 5 | 
+ 6 | export
+   : ^^^^^^
+ 7 | @dec
+   `----
+
 
 * typescript/decoratorOnClass4/input.ts
 Bindings mismatch:
@@ -1196,7 +1605,7 @@ after transform: ["babelHelpers"]
 rebuilt        : ["babelHelpers", "dec"]
 
 
-# plugin-styled-components (25/40)
+# plugin-styled-components (22/40)
 * minify-comments/input.js
 Unresolved references mismatch:
 after transform: ["x", "y", "z"]
@@ -1218,7 +1627,15 @@ x Output mismatch
 x Output mismatch
 
 * styled-components/css-declared-after-component/input.jsx
-x Output mismatch
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/css-declared-after-component/input.jsx:4:1]
+ 3 | 
+ 4 | export default function Example() {
+   : ^^^^^^
+ 5 |   return <div css={someCss}>oops</div>
+   `----
+
 
 * styled-components/does-not-replace-native-with-no-tags/input.js
 x Output mismatch
@@ -1233,15 +1650,59 @@ x Output mismatch
 x Output mismatch
 
 * styled-components/transpile-css-prop-add-import/input.jsx
-x Output mismatch
+
+  x Flow is not supported
+   ,-[tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/transpile-css-prop-add-import/input.jsx:1:1]
+ 1 | // @flow
+   : ^^^^^^^^
+ 2 | import React from 'react'
+   `----
+
 
 * styled-components/transpile-css-prop-add-require/input.jsx
-x Output mismatch
+
+  x Flow is not supported
+   ,-[tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/transpile-css-prop-add-require/input.jsx:1:1]
+ 1 | // @flow
+   : ^^^^^^^^
+ 2 | import React from 'react'
+   `----
+
 
 * styled-components/transpile-css-prop-all-options-on/input.jsx
 x Output mismatch
 
 * styled-components/transpile-require-default/input.js
 x Output mismatch
+
+* styled-components/use-directory-name/input.js
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/use-directory-name/input.js:6:1]
+ 5 | styled.div``;
+ 6 | export default styled.button``;
+   : ^^^^^^
+   `----
+
+
+* styled-components/use-file-name/input.js
+
+  x Unexpected export.
+   ,-[tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/use-file-name/input.js:6:1]
+ 5 | styled.div``;
+ 6 | export default styled.button``;
+   : ^^^^^^
+   `----
+
+
+* styled-components/use-namespace/input.js
+
+  x Unexpected export.
+    ,-[tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/use-namespace/input.js:23:1]
+ 22 | 
+ 23 | export default styled.default.button``
+    : ^^^^^^
+    `----
+
 
 


### PR DESCRIPTION
### AI usage disclosure

I used an AI assistant to help trace the parser behavior and draft this fix. I reviewed the resulting diff and verified it with the tests below.

### Summary

Fixes #25187.

When parsing with an explicit script source type, top-level `export` declarations now produce the existing `Unexpected export.` diagnostic instead of being accepted silently. Unambiguous mode still defers the diagnostic and discards it when module syntax resolves the file as an ES module.

### Tests

- `cargo fmt --check`
- `cargo test -p oxc_parser`
