### PR TITLE
feat(linter/jsdoc): implement `no-blank-blocks` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1028,6 +1028,7 @@ export interface DummyRuleMap {
   "jsdoc/check-tag-names"?: RuleNoConfig | [AllowWarnDeny, CheckTagNamesConfig];
   "jsdoc/empty-tags"?: RuleNoConfig | [AllowWarnDeny, EmptyTagsConfig];
   "jsdoc/implements-on-classes"?: RuleNoConfig;
+  "jsdoc/no-blank-blocks"?: RuleNoConfig | [AllowWarnDeny, NoBlankBlocks];
   "jsdoc/no-defaults"?: RuleNoConfig | [AllowWarnDeny, NoDefaultsConfig];
   "jsdoc/require-param"?: RuleNoConfig | [AllowWarnDeny, RequireParamConfig];
   "jsdoc/require-param-description"?: RuleNoConfig | [AllowWarnDeny, RequireParamDescriptionConfig];
@@ -2566,6 +2567,12 @@ export interface EmptyTagsConfig {
    * Additional tags to check for their descriptions.
    */
   tags?: string[];
+}
+export interface NoBlankBlocks {
+  /**
+   * Whether to automatically remove blank JSDoc blocks.
+   */
+  enableFixer?: boolean;
 }
 export interface NoDefaultsConfig {
   /**

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4458,6 +4458,11 @@ impl RuleRunner for crate::rules::jsdoc::implements_on_classes::ImplementsOnClas
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::jsdoc::no_blank_blocks::NoBlankBlocks {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::jsdoc::no_defaults::NoDefaults {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -294,6 +294,7 @@ pub use crate::rules::jsdoc::check_property_names::CheckPropertyNames as JsdocCh
 pub use crate::rules::jsdoc::check_tag_names::CheckTagNames as JsdocCheckTagNames;
 pub use crate::rules::jsdoc::empty_tags::EmptyTags as JsdocEmptyTags;
 pub use crate::rules::jsdoc::implements_on_classes::ImplementsOnClasses as JsdocImplementsOnClasses;
+pub use crate::rules::jsdoc::no_blank_blocks::NoBlankBlocks as JsdocNoBlankBlocks;
 pub use crate::rules::jsdoc::no_defaults::NoDefaults as JsdocNoDefaults;
 pub use crate::rules::jsdoc::require_param::RequireParam as JsdocRequireParam;
 pub use crate::rules::jsdoc::require_param_description::RequireParamDescription as JsdocRequireParamDescription;
@@ -1557,6 +1558,7 @@ pub enum RuleEnum {
     JsdocCheckTagNames(JsdocCheckTagNames),
     JsdocEmptyTags(JsdocEmptyTags),
     JsdocImplementsOnClasses(JsdocImplementsOnClasses),
+    JsdocNoBlankBlocks(JsdocNoBlankBlocks),
     JsdocNoDefaults(JsdocNoDefaults),
     JsdocRequireParam(JsdocRequireParam),
     JsdocRequireParamDescription(JsdocRequireParamDescription),
@@ -2500,7 +2502,8 @@ const JSDOC_CHECK_PROPERTY_NAMES_ID: usize = JSDOC_CHECK_ACCESS_ID + 1usize;
 const JSDOC_CHECK_TAG_NAMES_ID: usize = JSDOC_CHECK_PROPERTY_NAMES_ID + 1usize;
 const JSDOC_EMPTY_TAGS_ID: usize = JSDOC_CHECK_TAG_NAMES_ID + 1usize;
 const JSDOC_IMPLEMENTS_ON_CLASSES_ID: usize = JSDOC_EMPTY_TAGS_ID + 1usize;
-const JSDOC_NO_DEFAULTS_ID: usize = JSDOC_IMPLEMENTS_ON_CLASSES_ID + 1usize;
+const JSDOC_NO_BLANK_BLOCKS_ID: usize = JSDOC_IMPLEMENTS_ON_CLASSES_ID + 1usize;
+const JSDOC_NO_DEFAULTS_ID: usize = JSDOC_NO_BLANK_BLOCKS_ID + 1usize;
 const JSDOC_REQUIRE_PARAM_ID: usize = JSDOC_NO_DEFAULTS_ID + 1usize;
 const JSDOC_REQUIRE_PARAM_DESCRIPTION_ID: usize = JSDOC_REQUIRE_PARAM_ID + 1usize;
 const JSDOC_REQUIRE_PARAM_NAME_ID: usize = JSDOC_REQUIRE_PARAM_DESCRIPTION_ID + 1usize;
@@ -3484,6 +3487,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JSDOC_CHECK_TAG_NAMES_ID,
             Self::JsdocEmptyTags(_) => JSDOC_EMPTY_TAGS_ID,
             Self::JsdocImplementsOnClasses(_) => JSDOC_IMPLEMENTS_ON_CLASSES_ID,
+            Self::JsdocNoBlankBlocks(_) => JSDOC_NO_BLANK_BLOCKS_ID,
             Self::JsdocNoDefaults(_) => JSDOC_NO_DEFAULTS_ID,
             Self::JsdocRequireParam(_) => JSDOC_REQUIRE_PARAM_ID,
             Self::JsdocRequireParamDescription(_) => JSDOC_REQUIRE_PARAM_DESCRIPTION_ID,
@@ -4453,6 +4457,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::NAME,
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::NAME,
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::NAME,
+            Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::NAME,
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::NAME,
             Self::JsdocRequireParam(_) => JsdocRequireParam::NAME,
             Self::JsdocRequireParamDescription(_) => JsdocRequireParamDescription::NAME,
@@ -5462,6 +5467,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::CATEGORY,
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::CATEGORY,
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::CATEGORY,
+            Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::CATEGORY,
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::CATEGORY,
             Self::JsdocRequireParam(_) => JsdocRequireParam::CATEGORY,
             Self::JsdocRequireParamDescription(_) => JsdocRequireParamDescription::CATEGORY,
@@ -6442,6 +6448,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::FIX,
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::FIX,
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::FIX,
+            Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::FIX,
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::FIX,
             Self::JsdocRequireParam(_) => JsdocRequireParam::FIX,
             Self::JsdocRequireParamDescription(_) => JsdocRequireParamDescription::FIX,
@@ -7620,6 +7627,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::documentation(),
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::documentation(),
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::documentation(),
+            Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::documentation(),
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::documentation(),
             Self::JsdocRequireParam(_) => JsdocRequireParam::documentation(),
             Self::JsdocRequireParamDescription(_) => JsdocRequireParamDescription::documentation(),
@@ -9832,6 +9840,8 @@ impl RuleEnum {
                 .or_else(|| JsdocEmptyTags::schema(generator)),
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::config_schema(generator)
                 .or_else(|| JsdocImplementsOnClasses::schema(generator)),
+            Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::config_schema(generator)
+                .or_else(|| JsdocNoBlankBlocks::schema(generator)),
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::config_schema(generator)
                 .or_else(|| JsdocNoDefaults::schema(generator)),
             Self::JsdocRequireParam(_) => JsdocRequireParam::config_schema(generator)
@@ -10974,6 +10984,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => "jsdoc",
             Self::JsdocEmptyTags(_) => "jsdoc",
             Self::JsdocImplementsOnClasses(_) => "jsdoc",
+            Self::JsdocNoBlankBlocks(_) => "jsdoc",
             Self::JsdocNoDefaults(_) => "jsdoc",
             Self::JsdocRequireParam(_) => "jsdoc",
             Self::JsdocRequireParamDescription(_) => "jsdoc",
@@ -13356,6 +13367,9 @@ impl RuleEnum {
             Self::JsdocImplementsOnClasses(_) => Ok(Self::JsdocImplementsOnClasses(
                 JsdocImplementsOnClasses::from_configuration(value)?,
             )),
+            Self::JsdocNoBlankBlocks(_) => {
+                Ok(Self::JsdocNoBlankBlocks(JsdocNoBlankBlocks::from_configuration(value)?))
+            }
             Self::JsdocNoDefaults(_) => {
                 Ok(Self::JsdocNoDefaults(JsdocNoDefaults::from_configuration(value)?))
             }
@@ -14561,6 +14575,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(rule) => rule.to_configuration(),
             Self::JsdocEmptyTags(rule) => rule.to_configuration(),
             Self::JsdocImplementsOnClasses(rule) => rule.to_configuration(),
+            Self::JsdocNoBlankBlocks(rule) => rule.to_configuration(),
             Self::JsdocNoDefaults(rule) => rule.to_configuration(),
             Self::JsdocRequireParam(rule) => rule.to_configuration(),
             Self::JsdocRequireParamDescription(rule) => rule.to_configuration(),
@@ -15415,6 +15430,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(rule) => rule.run(node, ctx),
             Self::JsdocEmptyTags(rule) => rule.run(node, ctx),
             Self::JsdocImplementsOnClasses(rule) => rule.run(node, ctx),
+            Self::JsdocNoBlankBlocks(rule) => rule.run(node, ctx),
             Self::JsdocNoDefaults(rule) => rule.run(node, ctx),
             Self::JsdocRequireParam(rule) => rule.run(node, ctx),
             Self::JsdocRequireParamDescription(rule) => rule.run(node, ctx),
@@ -16279,6 +16295,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(rule) => rule.run_once(ctx),
             Self::JsdocEmptyTags(rule) => rule.run_once(ctx),
             Self::JsdocImplementsOnClasses(rule) => rule.run_once(ctx),
+            Self::JsdocNoBlankBlocks(rule) => rule.run_once(ctx),
             Self::JsdocNoDefaults(rule) => rule.run_once(ctx),
             Self::JsdocRequireParam(rule) => rule.run_once(ctx),
             Self::JsdocRequireParamDescription(rule) => rule.run_once(ctx),
@@ -17252,6 +17269,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsdocEmptyTags(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsdocImplementsOnClasses(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::JsdocNoBlankBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsdocNoDefaults(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsdocRequireParam(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsdocRequireParamDescription(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18125,6 +18143,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(rule) => rule.should_run(ctx),
             Self::JsdocEmptyTags(rule) => rule.should_run(ctx),
             Self::JsdocImplementsOnClasses(rule) => rule.should_run(ctx),
+            Self::JsdocNoBlankBlocks(rule) => rule.should_run(ctx),
             Self::JsdocNoDefaults(rule) => rule.should_run(ctx),
             Self::JsdocRequireParam(rule) => rule.should_run(ctx),
             Self::JsdocRequireParamDescription(rule) => rule.should_run(ctx),
@@ -19294,6 +19313,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::IS_TSGOLINT_RULE,
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::IS_TSGOLINT_RULE,
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::IS_TSGOLINT_RULE,
+            Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::IS_TSGOLINT_RULE,
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::IS_TSGOLINT_RULE,
             Self::JsdocRequireParam(_) => JsdocRequireParam::IS_TSGOLINT_RULE,
             Self::JsdocRequireParamDescription(_) => JsdocRequireParamDescription::IS_TSGOLINT_RULE,
@@ -20361,6 +20381,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::VERSION,
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::VERSION,
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::VERSION,
+            Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::VERSION,
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::VERSION,
             Self::JsdocRequireParam(_) => JsdocRequireParam::VERSION,
             Self::JsdocRequireParamDescription(_) => JsdocRequireParamDescription::VERSION,
@@ -21417,6 +21438,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::HAS_CONFIG,
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::HAS_CONFIG,
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::HAS_CONFIG,
+            Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::HAS_CONFIG,
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::HAS_CONFIG,
             Self::JsdocRequireParam(_) => JsdocRequireParam::HAS_CONFIG,
             Self::JsdocRequireParamDescription(_) => JsdocRequireParamDescription::HAS_CONFIG,
@@ -22406,6 +22428,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::INFO,
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::INFO,
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::INFO,
+            Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::INFO,
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::INFO,
             Self::JsdocRequireParam(_) => JsdocRequireParam::INFO,
             Self::JsdocRequireParamDescription(_) => JsdocRequireParamDescription::INFO,
@@ -23270,6 +23293,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(rule) => rule.types_info(),
             Self::JsdocEmptyTags(rule) => rule.types_info(),
             Self::JsdocImplementsOnClasses(rule) => rule.types_info(),
+            Self::JsdocNoBlankBlocks(rule) => rule.types_info(),
             Self::JsdocNoDefaults(rule) => rule.types_info(),
             Self::JsdocRequireParam(rule) => rule.types_info(),
             Self::JsdocRequireParamDescription(rule) => rule.types_info(),
@@ -24121,6 +24145,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(rule) => rule.run_info(),
             Self::JsdocEmptyTags(rule) => rule.run_info(),
             Self::JsdocImplementsOnClasses(rule) => rule.run_info(),
+            Self::JsdocNoBlankBlocks(rule) => rule.run_info(),
             Self::JsdocNoDefaults(rule) => rule.run_info(),
             Self::JsdocRequireParam(rule) => rule.run_info(),
             Self::JsdocRequireParamDescription(rule) => rule.run_info(),
@@ -25100,6 +25125,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JsdocCheckTagNames(JsdocCheckTagNames::default()),
         RuleEnum::JsdocEmptyTags(JsdocEmptyTags::default()),
         RuleEnum::JsdocImplementsOnClasses(JsdocImplementsOnClasses::default()),
+        RuleEnum::JsdocNoBlankBlocks(JsdocNoBlankBlocks::default()),
         RuleEnum::JsdocNoDefaults(JsdocNoDefaults::default()),
         RuleEnum::JsdocRequireParam(JsdocRequireParam::default()),
         RuleEnum::JsdocRequireParamDescription(JsdocRequireParamDescription::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -728,6 +728,7 @@ pub(crate) mod jsdoc {
     pub mod check_tag_names;
     pub mod empty_tags;
     pub mod implements_on_classes;
+    pub mod no_blank_blocks;
     pub mod no_defaults;
     pub mod require_param;
     pub mod require_param_description;

--- a/crates/oxc_linter/src/rules/jsdoc/no_blank_blocks.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_blank_blocks.rs
@@ -100,11 +100,18 @@ fn is_blank_jsdoc(content: &str) -> bool {
 fn fix_span(jsdoc_span: Span, source_text: &str) -> Span {
     let mut span = Span::new(jsdoc_span.start - 3, jsdoc_span.end + 2);
     let prefix = &source_text[..span.start as usize];
+    let line_start = prefix.rfind('\n').map_or(0, |index| index + 1);
 
-    if let Some(line_break) = prefix.rfind('\n')
-        && prefix[line_break + 1..].bytes().all(|byte| matches!(byte, b' ' | b'\t'))
-    {
-        span.start = u32::try_from(line_break).unwrap_or(span.start);
+    if prefix[line_start..].bytes().all(|byte| matches!(byte, b' ' | b'\t')) {
+        span.start = u32::try_from(line_start).unwrap_or(span.start);
+
+        let suffix = &source_text[span.end as usize..];
+        span.end += if suffix.starts_with("\r\n") {
+            2
+        } else {
+            u32::from(suffix.starts_with('\r') || suffix.starts_with('\n'))
+        };
+
         return span;
     }
 
@@ -195,6 +202,7 @@ fn test() {
                   ",
             None,
         ),
+        ("foo();\r\n/** */\r\nbar();", Some(serde_json::json!([ { "enableFixer": true, }, ]))),
     ];
 
     let fix = vec![
@@ -234,6 +242,11 @@ fn test() {
                   ",
             "
                   ",
+            Some(serde_json::json!([ { "enableFixer": true, }, ])),
+        ),
+        (
+            "foo();\r\n/** */\r\nbar();",
+            "foo();\r\nbar();",
             Some(serde_json::json!([ { "enableFixer": true, }, ])),
         ),
     ];

--- a/crates/oxc_linter/src/rules/jsdoc/no_blank_blocks.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_blank_blocks.rs
@@ -76,11 +76,10 @@ impl Rule for NoBlankBlocks {
             }
 
             let diagnostic = no_blank_blocks_diagnostic(jsdoc.span);
-            if self.enable_fixer {
-                ctx.diagnostic_with_fix(diagnostic, |fixer| {
-                    let span = fix_span(jsdoc.span, source_text);
-                    fixer.delete_range(span)
-                });
+            if self.enable_fixer
+                && let Some(span) = fix_span(jsdoc.span, source_text)
+            {
+                ctx.diagnostic_with_fix(diagnostic, |fixer| fixer.delete_range(span));
             } else {
                 ctx.diagnostic(diagnostic);
             }
@@ -96,32 +95,32 @@ fn is_blank_jsdoc(content: &str) -> bool {
     })
 }
 
-/// Expands JSDoc span to include `/**` and `*/`
-fn fix_span(jsdoc_span: Span, source_text: &str) -> Span {
-    let mut span = Span::new(jsdoc_span.start - 3, jsdoc_span.end + 2);
-    let prefix = &source_text[..span.start as usize];
+/// Expands a standalone JSDoc block to include its indentation and following line ending.
+fn fix_span(jsdoc_span: Span, source_text: &str) -> Option<Span> {
+    let comment_span = Span::new(jsdoc_span.start - 3, jsdoc_span.end + 2);
+    let prefix = &source_text[..comment_span.start as usize];
     let line_start = prefix.rfind('\n').map_or(0, |index| index + 1);
 
-    if prefix[line_start..].bytes().all(|byte| matches!(byte, b' ' | b'\t')) {
-        span.start = u32::try_from(line_start).unwrap_or(span.start);
-
-        let suffix = &source_text[span.end as usize..];
-        span.end += if suffix.starts_with("\r\n") {
-            2
-        } else {
-            u32::from(suffix.starts_with('\r') || suffix.starts_with('\n'))
-        };
-
-        return span;
+    if !prefix[line_start..].bytes().all(|byte| matches!(byte, b' ' | b'\t')) {
+        return None;
     }
 
-    if let Some(next) = source_text[span.end as usize..].chars().next()
-        && next.is_whitespace()
-    {
-        span.end += u32::try_from(next.len_utf8()).unwrap_or_default();
+    let suffix = &source_text[comment_span.end as usize..];
+    let line_end = suffix.find(['\r', '\n']).unwrap_or(suffix.len());
+    if !suffix[..line_end].bytes().all(|byte| matches!(byte, b' ' | b'\t')) {
+        return None;
     }
 
-    span
+    let line_ending_len = if suffix[line_end..].starts_with("\r\n") {
+        2
+    } else {
+        usize::from(line_end < suffix.len())
+    };
+
+    Some(Span::new(
+        u32::try_from(line_start).unwrap_or(comment_span.start),
+        comment_span.end + u32::try_from(line_end + line_ending_len).unwrap_or_default(),
+    ))
 }
 
 #[test]
@@ -247,6 +246,11 @@ fn test() {
         (
             "foo();\r\n/** */\r\nbar();",
             "foo();\r\nbar();",
+            Some(serde_json::json!([ { "enableFixer": true, }, ])),
+        ),
+        (
+            "const result = typeof/** */value;",
+            "const result = typeof/** */value;",
             Some(serde_json::json!([ { "enableFixer": true, }, ])),
         ),
     ];

--- a/crates/oxc_linter/src/rules/jsdoc/no_blank_blocks.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_blank_blocks.rs
@@ -1,0 +1,244 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn no_blank_blocks_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("No empty blocks").with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct NoBlankBlocks {
+    /// Whether to automatically remove blank JSDoc blocks.
+    enable_fixer: bool,
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Reports and optionally removes blocks with whitespace only.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Blank JSDoc blocks add noise without providing any documentation.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// /** */
+    ///
+    /// /**
+    ///  *
+    ///  */
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// /** @tag */
+    ///
+    /// /**
+    ///  * Text
+    ///  */
+    ///
+    /// /**
+    ///  * @tag
+    ///  */
+    /// ```
+    NoBlankBlocks,
+    jsdoc,
+    style,
+    conditional_fix,
+    config = NoBlankBlocks,
+    version = "next",
+    short_description = "Reports and optionally removes blocks with whitespace only.",
+);
+
+impl Rule for NoBlankBlocks {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run_once(&self, ctx: &LintContext) {
+        let source_text = ctx.source_text();
+
+        for jsdoc in ctx.jsdoc().iter_all() {
+            let content = &source_text[jsdoc.span.start as usize..jsdoc.span.end as usize];
+            if !is_blank_jsdoc(content) {
+                continue;
+            }
+
+            let diagnostic = no_blank_blocks_diagnostic(jsdoc.span);
+            if self.enable_fixer {
+                ctx.diagnostic_with_fix(diagnostic, |fixer| {
+                    let span = fix_span(jsdoc.span, source_text);
+                    fixer.delete_range(span)
+                });
+            } else {
+                ctx.diagnostic(diagnostic);
+            }
+        }
+    }
+}
+
+/// Returns whether the contents between `/**` and `*/` contain only whitespace and JSDoc line delimiters
+fn is_blank_jsdoc(content: &str) -> bool {
+    content.split('\n').enumerate().all(|(index, line)| {
+        let line = line.trim();
+        line.is_empty() || (index > 0 && line == "*")
+    })
+}
+
+/// Expands JSDoc span to include `/**` and `*/`
+fn fix_span(jsdoc_span: Span, source_text: &str) -> Span {
+    let mut span = Span::new(jsdoc_span.start - 3, jsdoc_span.end + 2);
+    let prefix = &source_text[..span.start as usize];
+
+    if let Some(line_break) = prefix.rfind('\n')
+        && prefix[line_break + 1..].bytes().all(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        span.start = u32::try_from(line_break).unwrap_or(span.start);
+        return span;
+    }
+
+    if let Some(next) = source_text[span.end as usize..].chars().next()
+        && next.is_whitespace()
+    {
+        span.end += u32::try_from(next.len_utf8()).unwrap_or_default();
+    }
+
+    span
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+                    /** @tag */
+                  ",
+            None,
+        ),
+        (
+            "
+                    /**
+                     * Text
+                     */
+                  ",
+            None,
+        ),
+        (
+            "
+                    /**
+                     * @tag
+                     */
+                  ",
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "
+                    /** */
+                  ",
+            Some(serde_json::json!([ { "enableFixer": true, }, ])),
+        ),
+        (
+            "
+                    /**
+                     */
+                  ",
+            Some(serde_json::json!([ { "enableFixer": true, }, ])),
+        ),
+        (
+            "
+                    /**
+                     *
+                     */
+                  ",
+            Some(serde_json::json!([ { "enableFixer": true, }, ])),
+        ),
+        (
+            "
+                    /**
+                     *
+                     *
+                     */
+                  ",
+            Some(serde_json::json!([ { "enableFixer": true, }, ])),
+        ),
+        (
+            "
+                    /**
+                     *
+                     *
+                     */
+                  ",
+            Some(serde_json::json!([ { "enableFixer": false, }, ])),
+        ),
+        (
+            "
+                    /**
+                     *
+                     *
+                     */
+                  ",
+            None,
+        ),
+    ];
+
+    let fix = vec![
+        (
+            "
+                    /** */
+                  ",
+            "
+                  ",
+            Some(serde_json::json!([ { "enableFixer": true, }, ])),
+        ),
+        (
+            "
+                    /**
+                     */
+                  ",
+            "
+                  ",
+            Some(serde_json::json!([ { "enableFixer": true, }, ])),
+        ),
+        (
+            "
+                    /**
+                     *
+                     */
+                  ",
+            "
+                  ",
+            Some(serde_json::json!([ { "enableFixer": true, }, ])),
+        ),
+        (
+            "
+                    /**
+                     *
+                     *
+                     */
+                  ",
+            "
+                  ",
+            Some(serde_json::json!([ { "enableFixer": true, }, ])),
+        ),
+    ];
+
+    Tester::new(NoBlankBlocks::NAME, NoBlankBlocks::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/jsdoc_no_blank_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_no_blank_blocks.snap
@@ -1,0 +1,62 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ jsdoc(no-blank-blocks): No empty blocks
+   ╭─[no_blank_blocks.tsx:2:24]
+ 1 │ 
+ 2 │                     /** */
+   ·                        ─
+ 3 │                   
+   ╰────
+  help: Delete this code.
+
+  ⚠ jsdoc(no-blank-blocks): No empty blocks
+   ╭─[no_blank_blocks.tsx:2:24]
+ 1 │     
+ 2 │ ╭─▶                     /**
+ 3 │ ╰─▶                      */
+ 4 │                       
+   ╰────
+  help: Delete this code.
+
+  ⚠ jsdoc(no-blank-blocks): No empty blocks
+   ╭─[no_blank_blocks.tsx:2:24]
+ 1 │     
+ 2 │ ╭─▶                     /**
+ 3 │ │                        *
+ 4 │ ╰─▶                      */
+ 5 │                       
+   ╰────
+  help: Delete this code.
+
+  ⚠ jsdoc(no-blank-blocks): No empty blocks
+   ╭─[no_blank_blocks.tsx:2:24]
+ 1 │     
+ 2 │ ╭─▶                     /**
+ 3 │ │                        *
+ 4 │ │                        *
+ 5 │ ╰─▶                      */
+ 6 │                       
+   ╰────
+  help: Delete this code.
+
+  ⚠ jsdoc(no-blank-blocks): No empty blocks
+   ╭─[no_blank_blocks.tsx:2:24]
+ 1 │     
+ 2 │ ╭─▶                     /**
+ 3 │ │                        *
+ 4 │ │                        *
+ 5 │ ╰─▶                      */
+ 6 │                       
+   ╰────
+
+  ⚠ jsdoc(no-blank-blocks): No empty blocks
+   ╭─[no_blank_blocks.tsx:2:24]
+ 1 │     
+ 2 │ ╭─▶                     /**
+ 3 │ │                        *
+ 4 │ │                        *
+ 5 │ ╰─▶                      */
+ 6 │                       
+   ╰────

--- a/crates/oxc_linter/src/snapshots/jsdoc_no_blank_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_no_blank_blocks.snap
@@ -60,3 +60,12 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶                      */
  6 │                       
    ╰────
+
+  ⚠ jsdoc(no-blank-blocks): No empty blocks
+   ╭─[no_blank_blocks.tsx:2:4]
+ 1 │ foo();
+ 2 │ /** */
+   ·    ─
+ 3 │ bar();
+   ╰────
+  help: Delete this code.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -3563,6 +3563,26 @@
         "jsdoc/implements-on-classes": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "jsdoc/no-blank-blocks": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/NoBlankBlocks"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "jsdoc/no-defaults": {
           "anyOf": [
             {
@@ -13711,6 +13731,18 @@
           "default": false,
           "type": "boolean",
           "markdownDescription": "When set to `true` the `int32Hint` option allows the use of bitwise OR in |0\npattern for type casting.\n\nFor example with `{ \"int32Hint\": true }` the following is permitted:\n\n```javascript\nconst b = a|0;\n```"
+        }
+      },
+      "additionalProperties": false
+    },
+    "NoBlankBlocks": {
+      "type": "object",
+      "properties": {
+        "enableFixer": {
+          "description": "Whether to automatically remove blank JSDoc blocks.",
+          "default": false,
+          "type": "boolean",
+          "markdownDescription": "Whether to automatically remove blank JSDoc blocks."
         }
       },
       "additionalProperties": false

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -281,6 +281,7 @@ jsdoc/check-property-names                                 |      7
 jsdoc/check-tag-names                                      |      7
 jsdoc/empty-tags                                           |      7
 jsdoc/implements-on-classes                                |  16812
+jsdoc/no-blank-blocks                                      |      7
 jsdoc/no-defaults                                          |  16812
 jsdoc/require-param                                        |  16812
 jsdoc/require-param-description                            |  16812


### PR DESCRIPTION
this PR implements `jsdoc/no-blank-blocks` rule, issue #1170