### PR TITLE
perf(linter): avoid duplicate import resolution in `is_import_symbol`

### DIFF
--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -2,11 +2,11 @@ use oxc_ast::{
     AstKind,
     ast::{
         BindingPattern, CallExpression, Expression, FormalParameters, FunctionBody,
-        IdentifierReference, ImportDeclarationSpecifier, LogicalExpression, MemberExpression,
-        Statement, match_member_expression,
+        IdentifierReference, ImportDeclaration, ImportDeclarationSpecifier, LogicalExpression,
+        MemberExpression, Statement, match_member_expression,
     },
 };
-use oxc_semantic::AstNode;
+use oxc_semantic::{AstNode, SymbolId};
 use oxc_span::{ContentEq, Span};
 use oxc_syntax::{
     operator::LogicalOperator,
@@ -32,6 +32,28 @@ pub const BUILT_IN_ERRORS: [&str; 9] = [
     "AggregateError",
 ];
 
+/// Resolves `ident` to the [`ImportDeclaration`] that binds it, along with its [`SymbolId`].
+///
+/// Returns `None` when the reference is unresolved, the symbol is not an import binding,
+/// or its declaration is not directly enclosed by an `ImportDeclaration`.
+fn resolve_import_declaration<'a>(
+    ident: &IdentifierReference,
+    ctx: &LintContext<'a>,
+) -> Option<(SymbolId, &'a ImportDeclaration<'a>)> {
+    let symbol_id = ctx.scoping().get_reference(ident.reference_id()).symbol_id()?;
+
+    if !ctx.scoping().symbol_flags(symbol_id).is_import() {
+        return None;
+    }
+
+    let declaration_id = ctx.scoping().symbol_declaration(symbol_id);
+    let AstKind::ImportDeclaration(import_decl) = ctx.nodes().parent_kind(declaration_id) else {
+        return None;
+    };
+
+    Some((symbol_id, import_decl))
+}
+
 /// Returns `true` when `ident` resolves to any import binding from `module_name`.
 ///
 /// This checks semantic resolution first (`reference_id` -> `symbol_id`) and then validates:
@@ -44,21 +66,8 @@ pub fn is_import_from_module(
     module_name: &str,
     ctx: &LintContext,
 ) -> bool {
-    let reference = ctx.scoping().get_reference(ident.reference_id());
-    let Some(symbol_id) = reference.symbol_id() else {
-        return false;
-    };
-
-    if !ctx.scoping().symbol_flags(symbol_id).is_import() {
-        return false;
-    }
-
-    let declaration_id = ctx.scoping().symbol_declaration(symbol_id);
-    let AstKind::ImportDeclaration(import_decl) = ctx.nodes().parent_kind(declaration_id) else {
-        return false;
-    };
-
-    import_decl.source.value.as_str() == module_name
+    resolve_import_declaration(ident, ctx)
+        .is_some_and(|(_, import_decl)| import_decl.source.value.as_str() == module_name)
 }
 
 /// Returns `true` when `ident` resolves to a named import with the given source module and
@@ -77,18 +86,13 @@ pub fn is_import_symbol(
     imported_name: &str,
     ctx: &LintContext,
 ) -> bool {
-    if !is_import_from_module(ident, module_name, ctx) {
+    let Some((symbol_id, import_decl)) = resolve_import_declaration(ident, ctx) else {
+        return false;
+    };
+
+    if import_decl.source.value.as_str() != module_name {
         return false;
     }
-
-    let reference = ctx.scoping().get_reference(ident.reference_id());
-    let Some(symbol_id) = reference.symbol_id() else {
-        return false;
-    };
-    let declaration_id = ctx.scoping().symbol_declaration(symbol_id);
-    let AstKind::ImportDeclaration(import_decl) = ctx.nodes().parent_kind(declaration_id) else {
-        return false;
-    };
 
     import_decl.specifiers.iter().flatten().any(|specifier| match specifier {
         ImportDeclarationSpecifier::ImportSpecifier(import_specifier) => {


### PR DESCRIPTION
Generated with Claude Code, Opus 5. Reviewed and tested by me. This is ultimately a micro-optimization, and can be closed as not worth the trouble or renamed as being just a refactor instead if preferred.

## What

`is_import_symbol` (`crates/oxc_linter/src/utils/unicorn.rs`) called `is_import_from_module`, which resolves `reference_id → symbol_id → symbol_declaration → parent_kind`, and then immediately repeated all four lookups to recover the `SymbolId` and `ImportDeclaration` it needed for the specifier scan.

The repeated `reference.symbol_id()` unwrap was also a dead branch — it could never fail, because the identical call had just succeeded inside `is_import_from_module`.

This extracts a private `resolve_import_declaration` that does the resolution once and returns both values, then builds `is_import_from_module` and `is_import_symbol` on top of it.

- Check order is unchanged: resolve → compare module → scan specifiers.
- Both public signatures are untouched, including elided lifetimes.
- No new allocations. `SymbolId` is a `NonMaxU32` newtype and the declaration is an arena reference, so the returned `Option<(SymbolId, &ImportDeclaration)>` is 16 bytes with a niche, passed in registers. The helper is private with two call sites and should inline away entirely.

## Correctness

Diagnostics are byte-identical between baseline and patched binaries on:

- a 12-case canary covering aliased, default, namespace, wrong-module, wrong-imported-name, shadowed, and unresolved imports, plus the `is_import_from_module` callers (`react/no-clone-element`, `unicorn/prefer-event-target`);
- a 60,000-diagnostic corpus.

`cargo test -p oxc_linter` passes (1218 tests). `just fmt` and `cargo clippy -p oxc_linter --all-features` are clean.

## Performance

The duplicated resolution only ran when the identifier genuinely resolved to an import from the requested module. All three `is_import_symbol` call sites hardcode `"effect"`, so the fixture is 80k call sites whose leftmost identifier resolves to an `effect` import. Two unaffected rules were measured **in the same process** as a control, so binary-layout and thermal effects cancel.

| group | base | opt | Δ | t | wins |
| --- | --- | --- | --- | --- | --- |
| treated (`no-array-for-each` + `no-array-sort`) | 2.428 ms | 2.335 ms | **+3.8%** | +19.95 | 59/60 |
| control (`prefer-date-now` + `prefer-array-flat-map`) | 2.289 ms | 2.296 ms | −0.3% | −1.66 | 25/60 |
| control-corrected net | | | **+0.100 ms** | +27.45 | 60/60 |

Two caveats, stated plainly:

- **Process wall clock is unchanged** (t = −0.41 / +0.90; the parse-only drift control swung ±5.8%). 0.1 ms against a ~9.5 ms process is below the noise floor. This is a rule-level improvement, not a user-visible one.
- **The win only applies to code importing from `effect`.** Everywhere else the old code early-returned before duplicating, so there was nothing to save — and the non-`effect` fixture shows no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
