### PR TITLE
fix(linter): report `jsPlugins` a build cannot run

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -340,6 +340,24 @@ impl CliRunner {
         }
         .with_filters(&filters);
 
+        // A build that cannot run JS plugins must say so. Without this the pure-Rust
+        // binary accepts a config naming `jsPlugins`, drops every rule they provide,
+        // and — when the violations come only from those rules — prints nothing and
+        // exits 0, where the npm distribution exits 1. A CI switched to the standalone
+        // binary goes green on code that breaks its own lint rules.
+        let skipped_plugins = external_plugin_store.skipped_plugin_specifiers();
+        if !skipped_plugins.is_empty() {
+            print_and_flush_stdout(
+                stdout,
+                &format!(
+                    "Warning: this build cannot run JS plugins, so rules from the following \
+                     `jsPlugins` entries are skipped:\n  {}\nUse the npm `oxlint` package \
+                     (requires Node.js) to run them.\n\n",
+                    skipped_plugins.join("\n  "),
+                ),
+            );
+        }
+
         if misc_options.print_config {
             return crate::mode::run_print_config(&config_builder, root_config, stdout);
         }

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -247,6 +247,17 @@ impl ConfigStoreBuilder {
         // i.e., when the external JS linter is available/initialized. If the store is
         // disabled, configs that reference external plugins are accepted but the plugins
         // themselves are not loaded, to avoid failing config parsing.
+        //
+        // Accepting the config is deliberate; doing it without a trace is not. Record
+        // the specifiers so a consumer can report the skip — the store itself stays
+        // silent, so the language server (which wants exactly this silence) is
+        // unaffected.
+        if !external_plugins.is_empty() && !external_plugin_store.is_enabled() {
+            for entry in &external_plugins {
+                external_plugin_store.note_skipped_plugin(&entry.specifier);
+            }
+        }
+
         if !external_plugins.is_empty() && external_plugin_store.is_enabled() {
             let Some(external_linter) = external_linter else {
                 #[expect(clippy::missing_panics_doc, reason = "infallible")]

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -46,6 +46,11 @@ pub struct ExternalPluginStore {
     options: IndexVec<ExternalOptionsId, (ExternalRuleId, SmallVec<[serde_json::Value; 1]>)>,
 
     is_enabled: bool,
+
+    /// Specifiers named by `jsPlugins` in a config that were NOT loaded because
+    /// this store is disabled. Recorded so a consumer can *choose* to report the
+    /// skip; nothing here reports anything on its own.
+    skipped_plugin_specifiers: Vec<String>,
 }
 
 impl Default for ExternalPluginStore {
@@ -65,12 +70,35 @@ impl ExternalPluginStore {
             rules: IndexVec::default(),
             options,
             is_enabled,
+            skipped_plugin_specifiers: Vec::new(),
         }
     }
 
     /// Returns `true` if external plugins are enabled.
     pub fn is_enabled(&self) -> bool {
         self.is_enabled
+    }
+
+    /// Record that a config named `specifier` in `jsPlugins` while this store was
+    /// disabled, so the plugin was never loaded and its rules will not run.
+    ///
+    /// De-duplicated and insertion-ordered: nested configs routinely name the same
+    /// plugin, and a consumer rendering this list wants a stable message.
+    pub fn note_skipped_plugin(&mut self, specifier: &str) {
+        if !self.skipped_plugin_specifiers.iter().any(|s| s == specifier) {
+            self.skipped_plugin_specifiers.push(specifier.to_string());
+        }
+    }
+
+    /// Specifiers from `jsPlugins` that were accepted by config parsing but never
+    /// loaded, because this store is disabled.
+    ///
+    /// Empty unless [`Self::is_enabled`] is `false` and some config named a plugin.
+    /// Reporting is the caller's decision — the language server deliberately stays
+    /// silent here (see `fix(language_server): ignore JS plugins`), while a CLI
+    /// that cannot run the plugins should say so.
+    pub fn skipped_plugin_specifiers(&self) -> &[String] {
+        &self.skipped_plugin_specifiers
     }
 
     /// Returns `true` if no external plugins have been loaded.


### PR DESCRIPTION
Closes #25203

## The problem

A build without an external linter accepts a config naming `jsPlugins`, never loads them, and says nothing. When a project's violations come only from JS-plugin rules, the standalone binary prints **no diagnostics and exits 0** where the npm distribution exits 1. A CI switched to the standalone binary goes green on code that breaks the project's own lint rules.

Accepting the config is clearly deliberate — `config_builder.rs`'s comment says so, and failing config parsing would be worse. Doing it *invisibly* is what this changes.

## The change

Three small pieces:

1. `ExternalPluginStore` records the specifiers it skipped while disabled (`note_skipped_plugin` / `skipped_plugin_specifiers`), de-duplicated and insertion-ordered so nested configs naming the same plugin produce one stable message.
2. `ConfigStoreBuilder::from_oxlintrc` records them in the `!is_enabled()` case. The existing branch is untouched.
3. The oxlint CLI prints one warning after config loading.

**Reporting stays the consumer's decision.** The language server wants exactly this silence (6e8d2f6318, *"fix(language_server): ignore JS plugins"*) and is unaffected — it simply never reads the accessor. That is why the warning lives in the app rather than in `oxc_linter`, which has no `eprintln!`/`tracing` precedent anywhere.

## Behaviour

With `jsPlugins` configured, on a build that cannot run them:

```
$ oxlint only.js
Warning: this build cannot run JS plugins, so rules from the following `jsPlugins` entries are skipped:
  ./plug/index.js
Use the npm `oxlint` package (requires Node.js) to run them.

Found 0 warnings and 0 errors.
Finished in 25ms on 1 file with 96 rules using 20 threads.
EXIT=0
```

Without `jsPlugins`, byte-identical to before:

```
$ oxlint a.js
  x eslint(no-debugger): `debugger` statement is not allowed
   ,-[a.js:1:1]
 1 | debugger;
   : ^^^^^^^^^
 2 | const x = 1;
   `----
  help: Remove the debugger statement

Found 0 warnings and 1 error.
EXIT=1
```

Backwards compatible by construction: a config without `jsPlugins` records nothing, so the condition is false and nothing is printed. **The exit code is unchanged even when the warning fires.** Making the skip a hard error (reusing `NoExternalLinterConfigured`, reworded to cover standalone builds alongside 32-bit/big-endian) would be more correct but changes exit codes for current users — that call is yours, and I'll switch if you prefer it.

## What I have and have not verified

- `cargo check -p oxlint` clean, and `cargo build -p oxlint` — both outputs above are from that binary on `x86_64-unknown-linux-gnu`.
- **No tests added yet.** I did not want to write snapshots against a design you may want changed. I expect no existing snapshot to move: the only Rust-side fixture with `jsPlugins` is `apps/oxlint/fixtures/lsp/js_plugins/`, and the LSP path never reads the new accessor; the other `jsPlugins` fixtures live under `apps/oxlint/test/fixtures/` and run through the napi build with the linter enabled. I have **not** run the full suite locally to confirm that — please tell me if you would like it, and whether a CLI snapshot test or a unit test on `ExternalPluginStore` is the shape you want.
- A `--no-js-plugins` flag to silence the warning (for people deliberately running the Rust CLI against a shared config) is easy to add; left out to keep this reviewable.

## How I ran into it

Running `oxlint` on a host with no Node.js at all (postmarketOS/aarch64), where the standalone binary is the only option. The silent drop is what made it hard to spot — the run looked successful.

## AI disclosure

Per the AI Usage Policy in CONTRIBUTING.md: this patch was written with AI assistance (Claude). The AI did the source analysis, wrote the code, and ran the builds and the reproductions above. Every claim here — the two command outputs, the crate-level reasoning about the LSP path, the fixture survey — was produced by actually running or reading the thing, not inferred. I reviewed the diff and the framing before submitting, and I am responsible for it. Happy to rework any part.