### PR TITLE
perf(linter/vue/no-side-effects-in-computed-properties): borrow property names in the mutation walk

### DIFF
--- a/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
+++ b/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
@@ -176,17 +176,17 @@ const MUTATING_METHODS: &[&str] =
 /// so the start node's own property counts as a chain step and a first-level
 /// mutating call like `foo.reverse()` is detected; `false` starts at the member
 /// expression itself (Options API), so `this.reverse()` is not a mutation.
-fn find_mutation_span(
-    start_node: &AstNode<'_>,
-    ctx: &LintContext<'_>,
+fn find_mutation_span<'a>(
+    start_node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
     seed_start: bool,
 ) -> Option<Span> {
     let nodes = ctx.nodes();
     let mut current = start_node;
-    let mut last_static_name: Option<String> = if seed_start {
+    let mut last_static_name: Option<&str> = if seed_start {
         match start_node.kind() {
-            AstKind::StaticMemberExpression(m) => Some(m.property.name.to_string()),
-            AstKind::ComputedMemberExpression(m) => m.static_property_name().map(|s| s.to_string()),
+            AstKind::StaticMemberExpression(m) => Some(m.property.name.as_str()),
+            AstKind::ComputedMemberExpression(m) => m.static_property_name().map(|s| s.as_str()),
             _ => None,
         }
     } else {
@@ -197,7 +197,7 @@ fn find_mutation_span(
         let parent = nodes.parent_node(current.id());
         match parent.kind() {
             AstKind::StaticMemberExpression(mem) if mem.object.span() == current.span() => {
-                last_static_name = Some(mem.property.name.to_string());
+                last_static_name = Some(mem.property.name.as_str());
                 current = parent;
             }
 
@@ -205,7 +205,7 @@ fn find_mutation_span(
             // Resolve string-literal keys (e.g. `this.arr['push']`) so mutating methods are
             // detected; dynamic keys (variables) remain None and correctly produce no match.
             AstKind::ComputedMemberExpression(mem) if mem.object.span() == current.span() => {
-                last_static_name = mem.static_property_name().map(|s| s.to_string());
+                last_static_name = mem.static_property_name().map(|s| s.as_str());
                 current = parent;
             }
 
@@ -234,8 +234,7 @@ fn find_mutation_span(
 
             // Call expression — check if we are the callee
             AstKind::CallExpression(call) if call.callee.span() == current.span() => {
-                if last_static_name.as_deref().is_some_and(|name| MUTATING_METHODS.contains(&name))
-                {
+                if last_static_name.is_some_and(|name| MUTATING_METHODS.contains(&name)) {
                     return Some(call.span());
                 }
                 return None;


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, Opus 5. Reviewed, tested, and benchmarked before submission.

I noticed this rule took up more time than I would've expected in the Codspeed data, and so had Claude investigate and improve the rule perf. Claude initially did a bunch of nonsense to make this faster, but ~90% of the improvement was from this borrow change, and so this is the only one I'm submitting.

---

`no-side-effects-in-computed-properties` visits every static and computed member expression, and for each one whose object is `this` or an identifier it walks up the member chain looking for a mutation. That walk tracked the last seen property name as an owned `String`, so it heap-allocated once up front and once per chain step — for a value that is only ever compared against `MUTATING_METHODS` and then dropped.

The names are arena-allocated `Atom`/`Str` values, so they can be borrowed as `&str` instead.

## Parity

Diagnostics are byte-identical before and after on both corpora below, no snapshot changes.

## Perf

`--debug=timings --threads=1`, 15 interleaved paired rounds with the binary order alternating each round so thermal drift cancels. Dispatch counts are identical between the two binaries, confirming this is per-call work removed rather than fewer calls.

| corpus | dispatches | before | after | |
| --- | --- | --- | --- | --- |
| [n8n](https://github.com/n8n-io/n8n) `.vue` files (1226 files, 277K lines) | 50,985 | 2.034 ms ± 0.029 | 1.053 ms ± 0.013 | **−0.982 ms (1.93x)** |
| n8n `packages/frontend` (mixed `.vue` + `.ts`) | 214,181 | 6.985 ms ± 0.080 | 4.062 ms ± 0.033 | **−2.923 ms (1.72x)** |

Faster in 15/15 pairs on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
