### PR TITLE
fix(linter/import/consistent-type-specifier-style): bound token lookup

### DIFF
--- a/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
+++ b/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
@@ -207,7 +207,11 @@ impl Rule for ConsistentTypeSpecifierStyle {
                         rule_fixes.push(fixer.insert_text_before(item, "type "));
                     }
                     // find the 'type' keyword and remove it
-                    if let Some(pos) = ctx.find_next_token_from(import_decl.span.start, "type") {
+                    if let Some(pos) = ctx.find_next_token_within(
+                        import_decl.span.start,
+                        import_decl.span.end,
+                        "type",
+                    ) {
                         let type_token_span = Span::sized(import_decl.span.start + pos, 4);
                         let remove_fix = fixer.delete_range(type_token_span);
                         rule_fixes.push(remove_fix);


### PR DESCRIPTION
## Summary
Bound `consistent-type-specifier-style` token lookup to the current import declaration.

## Details
- Use `find_next_token_within` when locating the `type` keyword to remove.
- Keep the deletion span anchored to the matched token.