### PR TITLE
fix(linter/import/no-duplicates): bound token lookup

### DIFF
--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -461,7 +461,7 @@ fn merge_imports_fix<'a>(
     let mut fixes = fixer.new_fix_with_capacity(decls.len() + 1);
 
     if should_add_specifiers && should_inline_type_imports && first.import_kind.is_type() {
-        if let Some(offset) = ctx.find_next_token_from(first.span.start, "type") {
+        if let Some(offset) = ctx.find_next_token_within(first.span.start, first.span.end, "type") {
             let type_start = first.span.start + offset;
             let mut type_end = type_start + u32::try_from("type".len()).unwrap();
             if ctx.semantic().source_text().as_bytes().get(type_end as usize) == Some(&b' ') {


### PR DESCRIPTION
## Summary
Bound the `no-duplicates` autofix lookup for the `type` keyword to the current import declaration.

## Details
- Use `find_next_token_within(first.span.start, first.span.end, "type")`.
- Keep the existing type-import deletion fix anchored to the matched token.