### PR TITLE
fix(linter/oxc/no-async-await): bound token lookup

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_async_await.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_await.rs
@@ -92,7 +92,9 @@ const ASYNC_LEN: u32 = 5;
 
 fn report_on_async_span(async_span: Span, ctx: &LintContext<'_>) {
     // find the `async` keyword within the span and report on it
-    let Some(async_keyword_offset) = ctx.find_next_token_from(async_span.start, "async") else {
+    let Some(async_keyword_offset) =
+        ctx.find_next_token_within(async_span.start, async_span.end, "async")
+    else {
         return;
     };
     let async_keyword_span = Span::sized(async_span.start + async_keyword_offset, ASYNC_LEN);


### PR DESCRIPTION
## Summary
Bound the `no-async-await` lookup for the `async` keyword to the reported span.

## Details
- Use `find_next_token_within(async_span.start, async_span.end, "async")`.
- Preserve the existing no-op behavior when the keyword cannot be found.