### PR TITLE
test(minifier): enable ignored Math.pow and merge/move test groups

### DIFF
--- a/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/tests/peephole/replace_known_methods.rs
@@ -606,15 +606,54 @@ fn test_fold_math_functions_min() {
 }
 
 #[test]
-#[ignore = "TODO: Math.pow optimization not yet implemented"]
 fn test_fold_math_functions_pow() {
-    test("Math.pow(1, 2)", "1");
-    test("Math.pow(2, 0)", "1");
-    test("Math.pow(2, 2)", "4");
-    test("Math.pow(2, 32)", "4294967296");
-    test("Math.pow(Infinity, 0)", "1");
-    test("Math.pow(Infinity, 1)", "Infinity");
-    test("Math.pow('a', 33)", "NaN");
+    test_value("Math.pow(1, 2)", "1");
+    test_value("Math.pow(2, 0)", "1");
+    test_value("Math.pow(2, 2)", "4");
+    test_value("Math.pow(2, 32)", "2 ** 32");
+    test_value("Math.pow(Infinity, 0)", "1");
+    test_value("Math.pow(Infinity, 1)", "Infinity");
+    test_value("Math.pow('a', 33)", "NaN");
+    test_value("Math.pow(2, 3)", "8");
+    test_value("Math.pow(a, 3)", "a ** 3");
+    test_value("Math.pow(2, b)", "2 ** b");
+    test_value("Math.pow(a, b)", "a ** +b");
+    test_value("Math.pow(2n, 3n)", "2n ** +3n"); // errors both before and after
+    test_value("Math.pow(a + b, c)", "(a + b) ** +c");
+    test_same_value("Math.pow()");
+    test_same_value("Math.pow(1)");
+    test_same_value("Math.pow(...a, 1)");
+    test_same_value("Math.pow(1, ...a)");
+    test_same_value("Math.pow(1, 2, 3)");
+    test_target("v = Math.pow(2, 3)", "v = Math.pow(2, 3)", "chrome51");
+    test_same_value(" Unknown.pow(1, 2)");
+}
+
+#[test]
+fn test_fold_math_functions_sqrt() {
+    test_same_value("Math.sqrt()");
+    test_same_value("Math.sqrt(1, 2)");
+    test_same_value("Math.sqrt(...a)");
+    test_same_value("Math.sqrt(a)"); // a maybe -0
+    test_same_value("Math.sqrt(2n)");
+    test_value("Math.sqrt(Infinity)", "Infinity");
+    test_value("Math.sqrt(NaN)", "NaN");
+    test_value("Math.sqrt(0)", "0");
+    test_value("Math.sqrt(-0)", "-0");
+    test_value("Math.sqrt(-1)", "NaN");
+    test_value("Math.sqrt(-Infinity)", "NaN");
+    test_value("Math.sqrt(1)", "1");
+    test_value("Math.sqrt(4)", "2");
+    test_same_value("Math.sqrt(2)");
+    test_same_value("Unknown.sqrt(1)");
+}
+
+#[test]
+fn test_fold_math_functions_cbrt() {
+    test_value("Math.cbrt(1)", "1");
+    test_value("Math.cbrt(8)", "2");
+    test_same_value("Math.cbrt(2)");
+    test_same_value("Unknown.cbrt(1)");
 }
 
 #[test]
@@ -983,46 +1022,6 @@ fn test_to_string() {
     test("123 .toString(b)", "123 .toString(b)");
     test("1e99.toString(b)", "1e99.toString(b)");
     test("/./.toString(b)", "/./.toString(b)");
-}
-
-#[test]
-fn test_fold_pow() {
-    test("v = Math.pow(2, 3)", "v = 8");
-    test("v = Math.pow(a, 3)", "v = a ** 3");
-    test("v = Math.pow(2, b)", "v = 2 ** b");
-    test("v = Math.pow(a, b)", "v = a ** +b");
-    test("v = Math.pow(2n, 3n)", "v = 2n ** +3n"); // errors both before and after
-    test("v = Math.pow(a + b, c)", "v = (a + b) ** +c");
-    test_same("v = Math.pow()");
-    test_same("v = Math.pow(1)");
-    test_same("v = Math.pow(...a, 1)");
-    test_same("v = Math.pow(1, ...a)");
-    test_same("v = Math.pow(1, 2, 3)");
-    test_target("v = Math.pow(2, 3)", "v = Math.pow(2, 3)", "chrome51");
-    test_same("v = Unknown.pow(1, 2)");
-}
-
-#[test]
-fn test_fold_roots() {
-    test_same("v = Math.sqrt()");
-    test_same("v = Math.sqrt(1, 2)");
-    test_same("v = Math.sqrt(...a)");
-    test_same("v = Math.sqrt(a)"); // a maybe -0
-    test_same("v = Math.sqrt(2n)");
-    test("v = Math.sqrt(Infinity)", "v = Infinity");
-    test("v = Math.sqrt(NaN)", "v = NaN");
-    test("v = Math.sqrt(0)", "v = 0");
-    test("v = Math.sqrt(-0)", "v = -0");
-    test("v = Math.sqrt(-1)", "v = NaN");
-    test("v = Math.sqrt(-Infinity)", "v = NaN");
-    test("v = Math.sqrt(1)", "v = 1");
-    test("v = Math.sqrt(4)", "v = 2");
-    test_same("v = Math.sqrt(2)");
-    test("v = Math.cbrt(1)", "v = 1");
-    test("v = Math.cbrt(8)", "v = 2");
-    test_same("v = Math.cbrt(2)");
-    test_same("Unknown.sqrt(1)");
-    test_same("Unknown.cbrt(1)");
 }
 
 #[test]


### PR DESCRIPTION
merge newly added `test_fold_pow` with `test_fold_math_functions_pow` and enable those tests
splits `test_fold_roots` to `test_fold_math_functions_sqrt` and `test_fold_math_functions_cbrt` and moves them to same place where other math tests live