### PR TITLE
fix(formatter_css): preserve glued plugin words in grid values

### DIFF
--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -463,7 +463,8 @@ pub(super) struct ValueContext<'a> {
     pub tail_bound: Option<u32>,
     /// Inside `url(...)`: colons stay tight (`url(fbglyph:cross-outline)`).
     pub in_url: bool,
-    /// Inside function/include arguments (comment-slot rules differ).
+    /// Inside function/include arguments
+    /// (comment-slot rules differ, and the grid line-structure rule is top-level only, see `is_grid`).
     pub in_args: bool,
     /// A multi-line `raws.between` was printed before the value:
     /// Prettier's printer counts its full width, so the first trailing comment always wraps.
@@ -476,7 +477,10 @@ pub(super) struct ValueContext<'a> {
 
 impl ValueContext<'_> {
     fn is_grid(&self) -> bool {
-        self.decl_prop.is_some_and(|p| p == "grid" || p.starts_with("grid-template"))
+        // Only the declaration's TOP-LEVEL value gets the grid line-structure treatment;
+        // inside function arguments (`repeat()`, `minmax()`, `theme()`) the normal separator rules apply.
+        !self.in_args
+            && self.decl_prop.is_some_and(|p| p == "grid" || p.starts_with("grid-template"))
     }
 
     fn is_font_or_custom(&self) -> bool {
@@ -1018,18 +1022,33 @@ fn raw_token<'b, 'a>(value: &'b ComponentValue<'a>) -> Option<&'b Token<'a>> {
 }
 
 /// Decides the separator BEFORE `values[i]` (i >= 1).
-///
-/// In Prettier's loop terms:
-/// - `iNode` = `values[i - 1]`
-/// - `iNextNode` = `values[i]`
-/// - `iPrevNode` = `values[i - 2]`
-/// - `iNextNextNode` = `values[i + 1]`
 fn separator_between(
     values: &[ComponentValue<'_>],
     i: usize,
     ctx: ValueContext<'_>,
     source: SourceText<'_>,
 ) -> Separator {
+    let sep = base_separator(values, i, ctx);
+    // Grid: preserve source line structure:
+    // Prettier emits a hardline where the source breaks and a PLAIN SPACE otherwise
+    // (never re-wraps a single-line grid value, however long).
+    // Only LAYOUT outcomes are overridden:
+    // a glued pair (`Tight`/`Word`) is part of ONE postcss word (`sandstone.10`, `1fr/2fr`)
+    // and survives verbatim in grid values too, grid never splits what other properties keep glued.
+    if ctx.is_grid() && matches!(sep, Separator::Line | Separator::Space) {
+        let prev_end = to_span(values[i - 1].span()).end;
+        let curr_start = to_span(values[i].span()).start;
+        return if source.bytes_contain(prev_end, curr_start, b'\n') {
+            Separator::Hard
+        } else {
+            Separator::Space
+        };
+    }
+    sep
+}
+
+/// The separator rules WITHOUT the grid line-structure override (`separator_between` applies that on top).
+fn base_separator(values: &[ComponentValue<'_>], i: usize, ctx: ValueContext<'_>) -> Separator {
     let prev = &values[i - 1];
     let curr = &values[i];
     let prev_span = to_span(prev.span());
@@ -1038,17 +1057,6 @@ fn separator_between(
     let gap_empty = prev_span.end == curr_span.start;
     // `hasEmptyRawBefore(iNode)`
     let prev_gap_empty = i >= 2 && to_span(values[i - 2].span()).end == prev_span.start;
-
-    // Grid: preserve source line structure:
-    // Prettier emits a hardline where the source breaks and a PLAIN SPACE otherwise
-    // (never re-wraps a single-line grid value, however long).
-    if ctx.is_grid() {
-        let gap = source.bytes_range(prev_span.end, curr_span.start);
-        if gap.contains(&b'\n') || gap.contains(&b'\r') {
-            return Separator::Hard;
-        }
-        return Separator::Space;
-    }
 
     // Solidus (`/`) spacing rules
     if is_solidus(curr) || is_solidus(prev) {
@@ -1102,15 +1110,22 @@ fn separator_between(
         return Separator::Line;
     }
 
-    // Less lookups: `@var [@result]` loses the gap (`var [@lookup]` rule)
+    // Less lookups: `@var [@result]` loses the gap (`var [@lookup]` rule).
+    // A `[...]` continues a lookup chain only when the chain HEAD is a Less value (`@config[@key][@key2]`);
+    // bracket runs without one are NOT lookups (CSS grid line names: `[row1-end]` newline `[row2-start]` stays two values).
     if matches!(curr, ComponentValue::BracketBlock(_))
-        && matches!(
-            prev,
-            ComponentValue::LessVariable(_)
-                | ComponentValue::LessNamespaceValue(_)
-                | ComponentValue::BracketBlock(_)
-                | ComponentValue::LessMixinCall(_)
-        )
+        && values[..i]
+            .iter()
+            .rev()
+            .find(|v| !matches!(v, ComponentValue::BracketBlock(_)))
+            .is_some_and(|head| {
+                matches!(
+                    head,
+                    ComponentValue::LessVariable(_)
+                        | ComponentValue::LessNamespaceValue(_)
+                        | ComponentValue::LessMixinCall(_)
+                )
+            })
     {
         return Separator::Tight;
     }

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/grid-glued-words.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/grid-glued-words.css
@@ -1,0 +1,24 @@
+/* oxc-project/oxc#25223: Tailwind v4 theme() paths in grid track lists */
+.tracks {
+  grid-template-rows: theme(spacing.4) auto theme(spacing.5);
+  grid-template-columns: theme(colors.red.500) 1fr;
+}
+
+/* glued plugin words at the TOP level of a grid value stay one word */
+.top-level {
+  grid-template-rows: sandstone.10 auto;
+}
+
+/* glued solidus is one word; spaced solidus keeps its space */
+.template {
+  grid-template: 1fr/2fr;
+  grid-template: "a" 1fr / auto;
+}
+
+/* multi-line grid values still preserve source line structure */
+.lines {
+  grid-template-columns:
+    [full-start] minmax(1em, 1fr)
+    [main-end] theme(spacing.4)
+    [full-end];
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/grid-glued-words.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/grid-glued-words.css.snap
@@ -1,0 +1,87 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/* oxc-project/oxc#25223: Tailwind v4 theme() paths in grid track lists */
+.tracks {
+  grid-template-rows: theme(spacing.4) auto theme(spacing.5);
+  grid-template-columns: theme(colors.red.500) 1fr;
+}
+
+/* glued plugin words at the TOP level of a grid value stay one word */
+.top-level {
+  grid-template-rows: sandstone.10 auto;
+}
+
+/* glued solidus is one word; spaced solidus keeps its space */
+.template {
+  grid-template: 1fr/2fr;
+  grid-template: "a" 1fr / auto;
+}
+
+/* multi-line grid values still preserve source line structure */
+.lines {
+  grid-template-columns:
+    [full-start] minmax(1em, 1fr)
+    [main-end] theme(spacing.4)
+    [full-end];
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+/* oxc-project/oxc#25223: Tailwind v4 theme() paths in grid track lists */
+.tracks {
+  grid-template-rows: theme(spacing.4) auto theme(spacing.5);
+  grid-template-columns: theme(colors.red.500) 1fr;
+}
+
+/* glued plugin words at the TOP level of a grid value stay one word */
+.top-level {
+  grid-template-rows: sandstone.10 auto;
+}
+
+/* glued solidus is one word; spaced solidus keeps its space */
+.template {
+  grid-template: 1fr/2fr;
+  grid-template: "a" 1fr / auto;
+}
+
+/* multi-line grid values still preserve source line structure */
+.lines {
+  grid-template-columns:
+    [full-start] minmax(1em, 1fr)
+    [main-end] theme(spacing.4)
+    [full-end];
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+/* oxc-project/oxc#25223: Tailwind v4 theme() paths in grid track lists */
+.tracks {
+  grid-template-rows: theme(spacing.4) auto theme(spacing.5);
+  grid-template-columns: theme(colors.red.500) 1fr;
+}
+
+/* glued plugin words at the TOP level of a grid value stay one word */
+.top-level {
+  grid-template-rows: sandstone.10 auto;
+}
+
+/* glued solidus is one word; spaced solidus keeps its space */
+.template {
+  grid-template: 1fr/2fr;
+  grid-template: "a" 1fr / auto;
+}
+
+/* multi-line grid values still preserve source line structure */
+.lines {
+  grid-template-columns:
+    [full-start] minmax(1em, 1fr)
+    [main-end] theme(spacing.4)
+    [full-end];
+}
+
+===================== End =====================


### PR DESCRIPTION
Fixes #25223
