### PR TITLE
fix(formatter/css): don't apply grid value layout inside function arguments

### DIFF
--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -475,8 +475,15 @@ pub(super) struct ValueContext<'a> {
 }
 
 impl ValueContext<'_> {
+    /// Source-driven grid layout applies to the DECLARATION value only, never inside
+    /// function arguments (Prettier's `isGridValue` also requires the value node itself).
+    ///
+    /// Inside arguments the normal value rules must run: the grid rule turns EVERY gap-free
+    /// pair into a plain space, which would split a `theme(spacing.4)` path
+    /// (ONE postcss word, see `is_word_glued_number`) into `theme(spacing 0.4)`.
     fn is_grid(&self) -> bool {
-        self.decl_prop.is_some_and(|p| p == "grid" || p.starts_with("grid-template"))
+        !self.in_args
+            && self.decl_prop.is_some_and(|p| p == "grid" || p.starts_with("grid-template"))
     }
 
     fn is_font_or_custom(&self) -> bool {

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/grid-value-scope.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/grid-value-scope.css
@@ -1,0 +1,25 @@
+/* Source-driven grid layout (hardline per source break, never re-wrapped) is a
+   DECLARATION-value rule; inside function arguments the normal value rules run.
+   Otherwise every gap-free pair in the args gets a plain space, which splits a
+   Tailwind `theme()` path (ONE postcss word) into a decimal number:
+   `theme(spacing.4)` -> `theme(spacing 0.4)`. */
+.theme-paths {
+  --gutter: theme(spacing.5);
+  margin: theme(spacing.4);
+  grid-template-rows: theme(spacing.4) auto theme(spacing.5);
+  grid-template-columns: theme(colors.red.500);
+  grid: theme(spacing.4) / auto;
+}
+.nested-args {
+  grid-template-columns: minmax(theme(spacing.4), 1fr);
+}
+/* The value's own line structure is still preserved... */
+.track-list {
+  grid-template-areas: "a a"
+    "b c";
+}
+/* ...while argument lists re-wrap normally. */
+.args {
+  grid-template-columns: repeat(2, minmax(0, 1fr)
+    minmax(0, 2fr));
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/grid-value-scope.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/grid-value-scope.css.snap
@@ -1,0 +1,90 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/* Source-driven grid layout (hardline per source break, never re-wrapped) is a
+   DECLARATION-value rule; inside function arguments the normal value rules run.
+   Otherwise every gap-free pair in the args gets a plain space, which splits a
+   Tailwind `theme()` path (ONE postcss word) into a decimal number:
+   `theme(spacing.4)` -> `theme(spacing 0.4)`. */
+.theme-paths {
+  --gutter: theme(spacing.5);
+  margin: theme(spacing.4);
+  grid-template-rows: theme(spacing.4) auto theme(spacing.5);
+  grid-template-columns: theme(colors.red.500);
+  grid: theme(spacing.4) / auto;
+}
+.nested-args {
+  grid-template-columns: minmax(theme(spacing.4), 1fr);
+}
+/* The value's own line structure is still preserved... */
+.track-list {
+  grid-template-areas: "a a"
+    "b c";
+}
+/* ...while argument lists re-wrap normally. */
+.args {
+  grid-template-columns: repeat(2, minmax(0, 1fr)
+    minmax(0, 2fr));
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+/* Source-driven grid layout (hardline per source break, never re-wrapped) is a
+   DECLARATION-value rule; inside function arguments the normal value rules run.
+   Otherwise every gap-free pair in the args gets a plain space, which splits a
+   Tailwind `theme()` path (ONE postcss word) into a decimal number:
+   `theme(spacing.4)` -> `theme(spacing 0.4)`. */
+.theme-paths {
+  --gutter: theme(spacing.5);
+  margin: theme(spacing.4);
+  grid-template-rows: theme(spacing.4) auto theme(spacing.5);
+  grid-template-columns: theme(colors.red.500);
+  grid: theme(spacing.4) / auto;
+}
+.nested-args {
+  grid-template-columns: minmax(theme(spacing.4), 1fr);
+}
+/* The value's own line structure is still preserved... */
+.track-list {
+  grid-template-areas:
+    "a a"
+    "b c";
+}
+/* ...while argument lists re-wrap normally. */
+.args {
+  grid-template-columns: repeat(2, minmax(0, 1fr) minmax(0, 2fr));
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+/* Source-driven grid layout (hardline per source break, never re-wrapped) is a
+   DECLARATION-value rule; inside function arguments the normal value rules run.
+   Otherwise every gap-free pair in the args gets a plain space, which splits a
+   Tailwind `theme()` path (ONE postcss word) into a decimal number:
+   `theme(spacing.4)` -> `theme(spacing 0.4)`. */
+.theme-paths {
+  --gutter: theme(spacing.5);
+  margin: theme(spacing.4);
+  grid-template-rows: theme(spacing.4) auto theme(spacing.5);
+  grid-template-columns: theme(colors.red.500);
+  grid: theme(spacing.4) / auto;
+}
+.nested-args {
+  grid-template-columns: minmax(theme(spacing.4), 1fr);
+}
+/* The value's own line structure is still preserved... */
+.track-list {
+  grid-template-areas:
+    "a a"
+    "b c";
+}
+/* ...while argument lists re-wrap normally. */
+.args {
+  grid-template-columns: repeat(2, minmax(0, 1fr) minmax(0, 2fr));
+}
+
+===================== End =====================


### PR DESCRIPTION
Closes #25223

## Problem

`ValueContext::is_grid()` only checked the enclosing declaration's property, so the source-driven grid layout (a hardline per source break, never re-wrapped) leaked into function argument lists nested in `grid` / `grid-template-*` values.

Inside those args the rule turns **every** gap-free pair into a plain space, which splits a Tailwind `theme()` path — a single postcss word — into a decimal number:

```css
/* input */
.bug {
  grid-template-rows: theme(spacing.4) auto theme(spacing.5);
  grid-template-columns: theme(colors.red.500);
}

/* oxfmt 0.61.0 (invalid) */
.bug {
  grid-template-rows: theme(spacing 0.4) auto theme(spacing 0.5);
  grid-template-columns: theme(colors . red 0.5);
}
```

The same value is left alone as a custom property (`--x: theme(spacing.5)`) or under `margin` / `gap` / `grid-auto-rows`, which is what narrowed it down to `is_grid()`.

Per `crates/oxc_formatter_css/AGENTS.md`, silent token corruption is the unsafe failure mode ("don't corrupt → then accept → then pretty-print"), so this is the rung-3 separator-layer class of bug rather than anything `theme()`-specific.

## Fix

Prettier's `isGridValue` requires `parentNode.type === "value-value"`, i.e. the grid rule applies to the declaration value itself and never inside a paren group. Gate `is_grid()` on `!in_args` — the flag already exists on `ValueContext` and is already set for function arguments, so no new plumbing:

```rust
fn is_grid(&self) -> bool {
    !self.in_args
        && self.decl_prop.is_some_and(|p| p == "grid" || p.starts_with("grid-template"))
}
```

This also fixes a second, unreported divergence from the same leak — source line breaks inside a grid property's argument list were being preserved instead of re-wrapped:

```css
/* before */
grid-template-columns: repeat(
  2,
    minmax(0, 1fr)
    minmax(0, 2fr)
);
/* after (= Prettier) */
grid-template-columns: repeat(2, minmax(0, 1fr) minmax(0, 2fr));
```

## Verification

- New fixture `tests/fixtures/format/css/grid-value-scope.css`, output verified against `npx prettier@3.9.6 --parser css` at both `--print-width 80` and `100`. It also pins the behavior that must NOT change: a multi-line `grid-template-areas` still keeps its source line structure.
- `cargo test -p oxc_formatter_css`: 82 passed, 0 failed; no pre-existing snapshot changed.
- `cargo run -p oxc_prettier_conformance` before/after: css 146/151, scss 86/90, less 40/40 — identical, and the conformance snapshots are byte-for-byte unchanged (no file newly fails, no existing failure hunk shifts).
- Clippy clean, `cargo fmt --check` clean.

## AI usage disclosure

Per the repository's AI usage policy: this change was developed with AI assistance (Claude Code). The diagnosis, the fix and the fixture were reviewed and verified locally against Prettier 3.9.6 before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
