### PR TITLE
feat(allocator)!: remove `ArenaBox::dangling` method

### DIFF
--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -77,17 +77,6 @@ impl<'alloc, T> Box<'alloc, T> {
         Self(NonNull::from(allocator.allocator().alloc(value)), PhantomData)
     }
 
-    /// Create a fake [`Box`] with a dangling pointer.
-    ///
-    /// # SAFETY
-    /// Safe to create, but must never be dereferenced, as does not point to a valid `T`.
-    /// Only purpose is for mocking types without allocating for const assertions.
-    pub const unsafe fn dangling() -> Self {
-        // SAFETY: None of `from_non_null`'s invariants are satisfied, but caller promises
-        // never to dereference the `Box`
-        unsafe { Self::from_non_null(ptr::NonNull::dangling()) }
-    }
-
     /// Take ownership of the value stored in this [`Box`], consuming the box in
     /// the process.
     ///


### PR DESCRIPTION
Remove the `ArenaBox::dangling` method.

This was a hack only required for checking enum discriminants in code generated by `inherit_variants!` macro. That code was removed in #23960, so `ArenaBox::dangling` can now be removed too.

Any code which for some reason needs to create an invalid `ArenaBox` with a dangling pointer can do so with `ArenaBox::from_non_null(NonNull::dangling())`.