### PR TITLE
refactor(ast_tools): avoid `#[doc]` for plain doc comments

### DIFF
--- a/tasks/ast_tools/src/derives/dummy.rs
+++ b/tasks/ast_tools/src/derives/dummy.rs
@@ -259,7 +259,7 @@ fn generate_impl(
     quote! {
         impl<'a> Dummy<'a> for #ty {
             #[doc = #comment1]
-            #[doc = ""]
+            ///
             #[doc = #comment2]
             #inline
             fn dummy(allocator: &'a Allocator) -> Self {

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -246,8 +246,8 @@ fn generate_builder_methods_for_struct_impl(
     if let Some(boxed_fn_name) = &boxed_fn_name {
         let fn_doc2 = format!(" use [`{struct_name}::{boxed_fn_name}`] instead.");
         fn_docs.extend(quote! {
-            #[doc = ""]
-            #[doc = " If you want the built node to be allocated in the memory arena,"]
+            ///
+            /// If you want the built node to be allocated in the memory arena,
             #[doc = #fn_doc2]
         });
     }
@@ -280,8 +280,8 @@ fn generate_builder_methods_for_struct_impl(
 
         ///@@line_break
         #[doc = #boxed_doc1]
-        #[doc = ""]
-        #[doc = " Returns a [`Box`](ArenaBox) containing the newly-allocated node."]
+        ///
+        /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
         #[doc = #boxed_doc2]
         #params_docs
         #[inline]
@@ -543,7 +543,10 @@ fn generate_builder_method_for_enum_variant_impl(
         let fn_doc2 = format!(
             " This node contains {article_variant} [`{variant_type_name}`] that will be stored in the memory arena."
         );
-        fn_docs.extend(quote!( #[doc = ""] #[doc = #fn_doc2] ));
+        fn_docs.extend(quote! {
+            ///
+            #[doc = #fn_doc2]
+        });
     }
     let params_docs = generate_doc_comment_for_params(params);
 


### PR DESCRIPTION
Pure refactor. `ast_tools` generators use plain doc comments instead of the the more verbose `#[doc = "..."]` where the comment can be written statically.