### PR TITLE
fix(linter/eslint/prefer-promise-reject-errors): handle ambient error variables

### DIFF
--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -630,11 +630,11 @@ fn could_be_error_impl(
             let decl = ctx.nodes().get_node(ctx.scoping().symbol_declaration(symbol_id));
             match decl.kind() {
                 AstKind::VariableDeclarator(decl) => {
-                    if decl
-                        .init
-                        .as_ref()
-                        .is_some_and(|init| could_be_error_impl(ctx, init, visited))
-                    {
+                    let Some(init) = &decl.init else {
+                        return ctx.scoping().symbol_flags(symbol_id).is_ambient();
+                    };
+
+                    if could_be_error_impl(ctx, init, visited) {
                         return true;
                     }
 

--- a/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
@@ -214,6 +214,10 @@ fn test() {
         ("Promise.reject(new Error())", None),
         ("Promise.reject(new TypeError)", None),
         ("Promise.reject(new Error('foo'))", None),
+        (
+            "declare const error: Error | undefined; new Promise((_, reject) => { if (error) reject(error); });",
+            None,
+        ),
         ("Promise.reject(foo || 5)", None),
         ("Promise.reject(5 && foo)", None),
         ("new Foo((resolve, reject) => reject(5))", None),


### PR DESCRIPTION
## Summary

- treat ambient variable declarations as possible Error values
- add a regression test for narrowed ambient Error variables

Fixes #25232
