### PR TITLE
fix(linter): ignore unsigned shifts in prefer-math-trunc

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
@@ -93,7 +93,6 @@ impl Rule for PreferMathTrunc {
                     bin_expr.operator,
                     BinaryOperator::BitwiseOR
                         | BinaryOperator::ShiftRight
-                        | BinaryOperator::ShiftRightZeroFill
                         | BinaryOperator::ShiftLeft
                         | BinaryOperator::BitwiseXOR
                 ) {
@@ -115,7 +114,6 @@ impl Rule for PreferMathTrunc {
                     assignment_expr.operator,
                     AssignmentOperator::BitwiseOR
                         | AssignmentOperator::ShiftRight
-                        | AssignmentOperator::ShiftRightZeroFill
                         | AssignmentOperator::ShiftLeft
                         | AssignmentOperator::BitwiseXOR
                 ) {
@@ -199,9 +197,12 @@ fn test() {
         "const foo = 1.4 & 0",
         "const foo = ~3.9;",
         "const foo = 1.1 >> 1",
+        "const foo = 1.1 >>> 0",
         "const foo = 0 << 1",
         "let foo = 0;
             foo |= 1;",
+        "let foo = 1.1;
+            foo >>>= 0;",
         "let foo = 1.2; // comment 1
             foo |= 1; // comment 2 and 1.2 | 0",
     ];


### PR DESCRIPTION
## Summary

- stop `unicorn/prefer-math-trunc` from reporting `>>> 0` and `>>>= 0`
- match upstream eslint-plugin-unicorn, whose supported operator set excludes unsigned right shift
- add regression coverage for binary and assignment expressions

Fixes #25239
