### PR TITLE
fix(linter): reject duplicate JS plugin names

### DIFF
--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -13,7 +13,7 @@ import util from "node:util";
 import stableJsonStringify from "json-stable-stringify-without-jsonify";
 import { applyFixes } from "../bindings.js";
 import { ecmaFeaturesOverride, setEcmaVersion, ECMA_VERSION } from "../plugins/context.ts";
-import { registerPlugin, registeredRules } from "../plugins/load.ts";
+import { registerPlugin, registeredPluginNames, registeredRules } from "../plugins/load.ts";
 import { lintFileImpl, resetStateAfterError } from "../plugins/lint.ts";
 import { getLineColumnFromOffset, getNodeByRangeIndex } from "../plugins/location.ts";
 import { allOptions, setOptions, DEFAULT_OPTIONS_ID } from "../plugins/options.ts";
@@ -1308,6 +1308,7 @@ function lint(test: TestCase, plugin: Plugin): Diagnostic[] {
   } finally {
     // Reset state
     registeredRules.length = 0;
+    registeredPluginNames.clear();
     if (allOptions !== null) allOptions.length = 1;
 
     // Even if there hasn't been an error, do a full reset of state just to be sure.

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -84,12 +84,24 @@ interface CreateOnceRuleDetails extends RuleDetailsBase {
 // May be changed when switching workspaces.
 export let registeredRules: RuleDetails[] = [];
 
+// Names of loaded plugins.
+// May be changed when switching workspaces.
+export let registeredPluginNames = new Set<string>();
+
 /**
  * Set `registeredRules`. Used when switching workspaces.
  * @param rules - Array of `RuleDetails` objects
  */
 export function setRegisteredRules(rules: RuleDetails[]) {
   registeredRules = rules;
+}
+
+/**
+ * Set `registeredPluginNames`. Used when switching workspaces.
+ * @param pluginNames - Set of registered plugin names
+ */
+export function setRegisteredPluginNames(pluginNames: Set<string>) {
+  registeredPluginNames = pluginNames;
 }
 
 // `before` hook which makes rule never run.
@@ -140,6 +152,7 @@ export async function loadPlugin(
  * @param workspaceUri - Workspace URI (`null` in CLI, string in LSP)
  * @returns - Plugin details
  * @throws {Error} If `plugin.meta.name` is `null` / `undefined` and `packageName` not provided
+ * @throws {Error} If another plugin with the same name is already registered
  * @throws {TypeError} If one of plugin's rules is malformed, or its `createOnce` method returns invalid visitor
  * @throws {TypeError} If `plugin.meta.name` is not a string
  */
@@ -157,6 +170,12 @@ export function registerPlugin(
   // In CLI, `workspaceUri` is `null`, and there's only 1 workspace, so no need to switch.
   // In LSP, there can be multiple workspaces, so we need to switch if we're not already in the right one.
   if (workspaceUri !== null) switchWorkspace(workspaceUri);
+
+  if (registeredPluginNames.has(pluginName)) {
+    throw new Error(
+      `Plugin name '${pluginName}' is already registered. Use a different name or an alias in \`jsPlugins\`.`,
+    );
+  }
 
   const offset = registeredRules.length;
   const { rules } = plugin;
@@ -303,6 +322,8 @@ export function registerPlugin(
 
     registeredRules.push(ruleDetails);
   }
+
+  registeredPluginNames.add(pluginName);
 
   return { name: pluginName, offset, ruleNames };
 }

--- a/apps/oxlint/src-js/plugins/workspace.ts
+++ b/apps/oxlint/src-js/plugins/workspace.ts
@@ -1,5 +1,5 @@
 import { setCwd } from "./context.ts";
-import { setRegisteredRules } from "./load.ts";
+import { setRegisteredPluginNames, setRegisteredRules } from "./load.ts";
 import { setAllOptions } from "./options.ts";
 import {
   workspaces,
@@ -26,6 +26,7 @@ export function switchWorkspace(workspaceUri: string): void {
   // Change global state to that of the workspace
   setCwd(workspace.cwd);
   setRegisteredRules(workspace.rules);
+  setRegisteredPluginNames(workspace.pluginNames);
   setAllOptions(workspace.allOptions);
 
   // Set this workspace as the current one

--- a/apps/oxlint/src-js/workspace/index.ts
+++ b/apps/oxlint/src-js/workspace/index.ts
@@ -17,6 +17,7 @@ import type { RuleDetails } from "../plugins/load.ts";
 interface Workspace {
   cwd: string;
   rules: RuleDetails[];
+  pluginNames: Set<string>;
   allOptions: Readonly<Options>[];
 }
 
@@ -48,11 +49,12 @@ export function createWorkspace(workspaceUri: string): undefined {
     cwd: "",
     allOptions: [],
     rules: [],
+    pluginNames: new Set(),
   });
 
   // Set current workspace to `null` to force switching workspace in the next call to `loadPlugin`.
   // Otherwise, if the new workspace has same URI as a previous workspace (which it does when reloading a workspace),
-  // `cwd`, `registeredRules` and `allOptions` will still contain the state from the old version of the workspace.
+  // `cwd`, `registeredRules`, `registeredPluginNames` and `allOptions` will still contain the state from the old version of the workspace.
   // This means `registeredRules` does not get replaced with an empty array before loading plugins again.
   // Forcing a switch to the new workspace overwrites the stale state.
   currentWorkspace = null;

--- a/apps/oxlint/test/fixtures/plugin_name_duplicate/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/plugin_name_duplicate/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "jsPlugins": ["./plugin1.ts", "./plugin2.ts"],
+  "rules": {
+    "@my/rule": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/plugin_name_duplicate/files/test.js
+++ b/apps/oxlint/test/fixtures/plugin_name_duplicate/files/test.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/plugin_name_duplicate/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_duplicate/output.snap.md
@@ -1,0 +1,14 @@
+# Exit code
+1
+
+# stdout
+```
+Failed to parse oxlint configuration file.
+
+  x Failed to load JS plugin: ./plugin2.ts
+  |   Error: Plugin name '@my' is already registered. Use a different name or an alias in `jsPlugins`.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/plugin_name_duplicate/plugin1.ts
+++ b/apps/oxlint/test/fixtures/plugin_name_duplicate/plugin1.ts
@@ -1,0 +1,18 @@
+import type { Plugin } from "#oxlint/plugins";
+
+const plugin: Plugin = {
+  meta: { name: "@my" },
+  rules: {
+    rule: {
+      create(context) {
+        return {
+          DebuggerStatement(node) {
+            context.report({ message: "plugin 1", node });
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/apps/oxlint/test/fixtures/plugin_name_duplicate/plugin2.ts
+++ b/apps/oxlint/test/fixtures/plugin_name_duplicate/plugin2.ts
@@ -1,0 +1,18 @@
+import type { Plugin } from "#oxlint/plugins";
+
+const plugin: Plugin = {
+  meta: { name: "@my" },
+  rules: {
+    rule: {
+      create(context) {
+        return {
+          DebuggerStatement(node) {
+            context.report({ message: "plugin 2", node });
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -243,6 +243,14 @@ impl ConfigStoreBuilder {
             }
         }
 
+        let mut external_plugins = external_plugins.into_iter().collect_vec();
+        external_plugins.sort_unstable_by(|a, b| {
+            a.specifier
+                .cmp(&b.specifier)
+                .then_with(|| a.name.cmp(&b.name))
+                .then_with(|| a.config_dir.cmp(&b.config_dir))
+        });
+
         // Only attempt to load external JS plugins when external plugins are enabled,
         // i.e., when the external JS linter is available/initialized. If the store is
         // disabled, configs that reference external plugins are accepted but the plugins
@@ -250,7 +258,7 @@ impl ConfigStoreBuilder {
         if !external_plugins.is_empty() && external_plugin_store.is_enabled() {
             let Some(external_linter) = external_linter else {
                 #[expect(clippy::missing_panics_doc, reason = "infallible")]
-                let first_plugin = external_plugins.iter().next().unwrap();
+                let first_plugin = external_plugins.first().unwrap();
                 return Err(ConfigBuilderError::NoExternalLinterConfigured {
                     plugin_specifier: first_plugin.specifier.clone(),
                 });
@@ -261,7 +269,7 @@ impl ConfigStoreBuilder {
                 ..Default::default()
             });
 
-            for entry in &external_plugins {
+            for entry in external_plugins {
                 Self::load_external_plugin(
                     &entry.config_dir,
                     &entry.specifier,


### PR DESCRIPTION
## Summary
- reject JS plugins whose normalized names collide
- keep registered plugin names isolated per LSP workspace
- add a CLI regression fixture covering two plugins that expose the same rule name

Fixes #25164