### PR TITLE
fix(playground): include generated runtime files

### DIFF
--- a/napi/playground/package.json
+++ b/napi/playground/package.json
@@ -3,6 +3,17 @@
   "version": "0.0.0",
   "private": true,
   "license": "MIT",
+  "files": [
+    "browser.js",
+    "index.d.ts",
+    "index.js",
+    "playground.wasi-browser.js",
+    "playground.wasi.cjs",
+    "playground.wasm32-wasi.debug.wasm",
+    "playground.wasm32-wasi.wasm",
+    "wasi-worker-browser.mjs",
+    "wasi-worker.mjs"
+  ],
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
- add an explicit `files` allowlist for `oxc-playground`
- include generated JS/types, WASM binaries, and worker modules
- fix `publint` failures under pnpm 11.17.0 affecting oxc-project/playground#414

