### PR TITLE
fix(linter/unicorn/new-for-builtins): detect parenthesized member expression object

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -118,7 +118,7 @@ fn is_expr_global_builtin<'a, 'b>(
     } else {
         let member_expr = expr.as_member_expression()?;
 
-        let Expression::Identifier(ident) = member_expr.object() else {
+        let Expression::Identifier(ident) = member_expr.object().without_parentheses() else {
             return None;
         };
 
@@ -337,14 +337,14 @@ fn test() {
                 }
                 return Map()
             }",
-        // "function foo() {
-        //         return(globalThis).Map()
-        //     }",
+        "function foo() {
+                return(globalThis).Map()
+            }",
         "const foo = Date();",
         "const foo = globalThis.Date();",
-        // "function foo() {
-        //         return(globalThis).Date();
-        //     }",
+        "function foo() {
+                return(globalThis).Date();
+            }",
         "const foo = Date(/*comment*/);",
         "const foo = globalThis/*comment*/.Date();",
         "const foo = Date(bar);",

--- a/crates/oxc_linter/src/snapshots/unicorn_new_for_builtins.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_new_for_builtins.snap
@@ -340,6 +340,14 @@ source: crates/oxc_linter/src/tester.rs
  19 │             }
     ╰────
 
+  ⚠ unicorn(new-for-builtins): Use `new Map()` instead of `Map()`
+   ╭─[new_for_builtins.tsx:2:23]
+ 1 │ function foo() {
+ 2 │                 return(globalThis).Map()
+   ·                       ──────────────────
+ 3 │             }
+   ╰────
+
   ⚠ unicorn(new-for-builtins): Use `String(new Date())` instead of `Date()`
    ╭─[new_for_builtins.tsx:1:13]
  1 │ const foo = Date();
@@ -350,6 +358,14 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[new_for_builtins.tsx:1:13]
  1 │ const foo = globalThis.Date();
    ·             ─────────────────
+   ╰────
+
+  ⚠ unicorn(new-for-builtins): Use `String(new Date())` instead of `Date()`
+   ╭─[new_for_builtins.tsx:2:23]
+ 1 │ function foo() {
+ 2 │                 return(globalThis).Date();
+   ·                       ───────────────────
+ 3 │             }
    ╰────
 
   ⚠ unicorn(new-for-builtins): Use `String(new Date())` instead of `Date()`


### PR DESCRIPTION
## Summary
- Made `new-for-builtins` detect parenthesized member expressions like `(globalThis).Map()`
- Restored the previously disabled test cases for this

## References
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/test/snapshots/new-for-builtins.js.md#invalid120-function-foo--returnglobalthismap-
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/test/snapshots/new-for-builtins.js.md#invalid3-function-foo--returnglobalthisdate-