### PR TITLE
fix(ci): use WASM build script for NAPI releases

### DIFF
--- a/.github/workflows/reusable_release_napi.yml
+++ b/.github/workflows/reusable_release_napi.yml
@@ -78,7 +78,7 @@ jobs:
 
           - os: ubuntu-latest
             target: wasm32-wasip1-threads
-            build: pnpm build --target wasm32-wasip1-threads
+            build: pnpm build-wasm
 
           - os: ubuntu-latest
             target: s390x-unknown-linux-gnu


### PR DESCRIPTION
In https://github.com/oxc-project/oxc/pull/25019, napi started emitting dedicated declaration files for wasi builds. This PR updated the necessary `package.json` scripts, however, in our release flow, this build step does not go via the dedicated build-wasm script, but uses build `--target wasm32-wasip1-threads`.

this PR changes the workflow to use each napi packages dedicated `build-wasm` script fixing this issue.

Failed job: https://github.com/oxc-project/oxc/actions/runs/30808750626/job/91670237826

