### PR TITLE
fix(linter/typescript/consistent-generic-constructors): bound token lookup

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -393,8 +393,8 @@ impl ConsistentGenericConstructors {
                 if prop_def.computed {
                     // Find the closing bracket after the key
                     let key_end = prop_def.key.span().end;
-                    // find_next_token_from returns offset from key_end, add 1 for position after ']'
-                    ctx.find_next_token_from(key_end, "]").map(|offset| key_end + offset + 1)
+                    ctx.find_next_token_within(key_end, prop_def.span.end, "]")
+                        .map(|offset| key_end + offset + 1)
                 } else {
                     // Insert after the property key
                     Some(prop_def.key.span().end)
@@ -403,7 +403,8 @@ impl ConsistentGenericConstructors {
             AstKind::AccessorProperty(accessor) => {
                 if accessor.computed {
                     let key_end = accessor.key.span().end;
-                    ctx.find_next_token_from(key_end, "]").map(|offset| key_end + offset + 1)
+                    ctx.find_next_token_within(key_end, accessor.span.end, "]")
+                        .map(|offset| key_end + offset + 1)
                 } else {
                     Some(accessor.key.span().end)
                 }


### PR DESCRIPTION
## Summary
Bound computed-property token lookup to the property span.

## Details
- Use `find_next_token_within` to find the closing bracket only within the current property.
- Preserve the existing insertion-point calculation for the closing bracket.