### PR TITLE
refactor(parser): rename vars for span starts

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -21,11 +21,13 @@ pub struct ParserCheckpoint<'a> {
 }
 
 impl<'a, C: Config> ParserImpl<'a, C> {
+    /// Get current token's span start.
     #[inline]
     pub(crate) fn start_span(&self) -> u32 {
         self.token.start()
     }
 
+    /// Create a [`Span`] from provided `start` to end of previous token.
     #[inline]
     pub(crate) fn end_span(&self, start: u32) -> Span {
         Span::new(start, self.prev_token_end)

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -11,7 +11,7 @@ struct ArrowFunctionHead<'a> {
     params: ArenaBox<'a, FormalParameters<'a>>,
     return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
     r#async: bool,
-    span: u32,
+    start: u32,
 }
 
 impl<'a, C: Config> ParserImpl<'a, C> {
@@ -35,7 +35,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         allow_return_type_in_arrow_function: bool,
     ) -> Option<Expression<'a>> {
         if self.at(Kind::Async) && self.is_un_parenthesized_async_arrow_function_worker() {
-            let span = self.start_span();
+            let start = self.start_span();
             self.bump_any(); // bump `async`
             let expr = self.parse_binary_expression_or_higher(Precedence::Comma);
             let Expression::Identifier(ident) = &expr else {
@@ -46,7 +46,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::identifier_async("await", ident.span));
             }
             return Some(self.parse_simple_arrow_function_expression(
-                span,
+                start,
                 ident,
                 /* async */ true,
                 allow_return_type_in_arrow_function,
@@ -227,7 +227,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_simple_arrow_function_expression(
         &mut self,
-        span: u32,
+        start: u32,
         ident: &IdentifierReference<'a>,
         r#async: bool,
         allow_return_type_in_arrow_function: bool,
@@ -249,13 +249,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect(Kind::Arrow);
 
         self.parse_arrow_function_expression_body(
-            ArrowFunctionHead { type_parameters: None, params, return_type: None, r#async, span },
+            ArrowFunctionHead { type_parameters: None, params, return_type: None, r#async, start },
             allow_return_type_in_arrow_function,
         )
     }
 
     fn parse_parenthesized_arrow_function_head(&mut self) -> ArrowFunctionHead<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let r#async = self.eat(Kind::Async);
 
         let has_await = self.ctx.has_await();
@@ -293,7 +293,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         self.expect(Kind::Arrow);
 
-        ArrowFunctionHead { type_parameters, params, return_type, r#async, span }
+        ArrowFunctionHead { type_parameters, params, return_type, r#async, start }
     }
 
     /// [ConciseBody](https://tc39.es/ecma262/#prod-ConciseBody)
@@ -306,7 +306,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         arrow_function_head: ArrowFunctionHead<'a>,
         allow_return_type_in_arrow_function: bool,
     ) -> Expression<'a> {
-        let ArrowFunctionHead { type_parameters, params, return_type, r#async, span } =
+        let ArrowFunctionHead { type_parameters, params, return_type, r#async, start } =
             arrow_function_head;
         let has_await = self.ctx.has_await();
         let has_yield = self.ctx.has_yield();
@@ -325,7 +325,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.ctx = self.ctx.and_await(has_await).and_yield(has_yield);
 
         Expression::new_arrow_function_expression(
-            self.end_span(span),
+            self.end_span(start),
             r#async,
             type_parameters,
             params,

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -9,9 +9,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     `SingleNameBinding`
     ///     `BindingPattern`[?Yield, ?Await] `Initializer`[+In, ?Yield, ?Await]opt
     pub(super) fn parse_binding_pattern_with_initializer(&mut self) -> BindingPattern<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let pattern = self.parse_binding_pattern();
-        self.context_add(Context::In, |p| p.parse_initializer(span, pattern))
+        self.context_add(Context::In, |p| p.parse_initializer(start, pattern))
     }
 
     pub(super) fn parse_binding_pattern(&mut self) -> BindingPattern<'a> {
@@ -41,7 +41,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.3.3 Object Binding Pattern
     fn parse_object_binding_pattern(&mut self) -> BindingPattern<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
         let (list, rest) = self.parse_delimited_list_with_rest(
@@ -59,12 +59,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         self.expect(Kind::RCurly);
-        BindingPattern::new_object_pattern(self.end_span(span), list, rest, self)
+        BindingPattern::new_object_pattern(self.end_span(start), list, rest, self)
     }
 
     /// Section 14.3.3 Array Binding Pattern
     fn parse_array_binding_pattern(&mut self) -> BindingPattern<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LBrack);
         let (list, rest) = self.parse_delimited_list_with_rest(
@@ -75,7 +75,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             diagnostics::binding_rest_element_last,
         );
         self.expect(Kind::RBrack);
-        BindingPattern::new_array_pattern(self.end_span(span), list, rest, self)
+        BindingPattern::new_array_pattern(self.end_span(start), list, rest, self)
     }
 
     fn parse_array_binding_element(&mut self) -> Option<BindingPattern<'a>> {
@@ -88,7 +88,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.3.3 Binding Rest Property
     pub(crate) fn parse_rest_element(&mut self) -> ArenaBox<'a, BindingRestElement<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // advance `...`
         let init_span = self.start_span();
 
@@ -116,14 +116,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::a_rest_element_cannot_have_an_initializer(pat.span));
         }
 
-        BindingRestElement::boxed(self.end_span(span), argument, self)
+        BindingRestElement::boxed(self.end_span(start), argument, self)
     }
 
     /// Parse rest element for function parameters (type annotation NOT consumed)
     /// The type annotation will be parsed by the caller and stored on FormalParameterRest
     /// We don't consume it here so the caller can access it
     pub(crate) fn parse_rest_element_for_formal_parameter(&mut self) -> BindingRestElement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // advance `...`
         let init_span = self.start_span();
 
@@ -145,14 +145,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::a_rest_parameter_cannot_have_an_initializer(pat.span));
         }
 
-        BindingRestElement::new(self.end_span(span), argument, self)
+        BindingRestElement::new(self.end_span(start), argument, self)
     }
 
     /// `BindingProperty`[Yield, Await] :
     ///     `SingleNameBinding`[?Yield, ?Await]
     ///     `PropertyName`[?Yield, ?Await] : `BindingElement`[?Yield, ?Await]
     pub(super) fn parse_binding_property(&mut self) -> BindingProperty<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
 
         let mut shorthand = false;
         let is_binding_identifier = self.cur_kind().is_binding_identifier();
@@ -168,7 +168,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.check_identifier_with_span(key_cur_kind, self.ctx, ident.span);
                 let identifier =
                     BindingPattern::new_binding_identifier(ident.span, ident.name, self);
-                self.context_add(Context::In, |p| p.parse_initializer(span, identifier))
+                self.context_add(Context::In, |p| p.parse_initializer(start, identifier))
             } else {
                 return self.unexpected();
             }
@@ -179,15 +179,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.parse_binding_pattern_with_initializer()
         };
 
-        BindingProperty::new(self.end_span(span), key, value, shorthand, computed, self)
+        BindingProperty::new(self.end_span(start), key, value, shorthand, computed, self)
     }
 
     /// Initializer[In, Yield, Await] :
     ///   = `AssignmentExpression`[?In, ?Yield, ?Await]
-    fn parse_initializer(&mut self, span: u32, left: BindingPattern<'a>) -> BindingPattern<'a> {
+    fn parse_initializer(&mut self, start: u32, left: BindingPattern<'a>) -> BindingPattern<'a> {
         if self.eat(Kind::Eq) {
             let expr = self.parse_assignment_expression_or_higher();
-            BindingPattern::new_assignment_pattern(self.end_span(span), left, expr, self)
+            BindingPattern::new_assignment_pattern(self.end_span(start), left, expr, self)
         } else {
             left
         }

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -15,15 +15,15 @@ type ImplementsWithKeywordSpan<'a> = (Span, ArenaVec<'a, TSClassImplements<'a>>)
 
 /// Section 15.7 Class Definitions
 impl<'a, C: Config> ParserImpl<'a, C> {
-    // `start_span` points at the start of all decoractors and `class` keyword.
+    // `start` points at the start of all decorators and `class` keyword.
     pub(crate) fn parse_class_statement(
         &mut self,
-        start_span: u32,
+        start: u32,
         stmt_ctx: StatementContext,
         modifiers: &Modifiers,
         decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> Statement<'a> {
-        let decl = self.parse_class_declaration(start_span, modifiers, decorators);
+        let decl = self.parse_class_declaration(start, modifiers, decorators);
         if stmt_ctx.is_single_statement() {
             self.error(diagnostics::class_declaration(Span::new(
                 decl.span.start,
@@ -36,11 +36,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// Section 15.7 Class Definitions
     pub(crate) fn parse_class_declaration(
         &mut self,
-        start_span: u32,
+        start: u32,
         modifiers: &Modifiers,
         decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ArenaBox<'a, Class<'a>> {
-        self.parse_class(start_span, ClassType::ClassDeclaration, modifiers, decorators)
+        self.parse_class(start, ClassType::ClassDeclaration, modifiers, decorators)
     }
 
     /// Section [Class Definitions](https://tc39.es/ecma262/#prod-ClassExpression)
@@ -48,17 +48,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     class `BindingIdentifier`[?Yield, ?Await]opt `ClassTail`[?Yield, ?Await]
     pub(crate) fn parse_class_expression(
         &mut self,
-        span: u32,
+        start: u32,
         modifiers: &Modifiers,
         decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> Expression<'a> {
-        let class = self.parse_class(span, ClassType::ClassExpression, modifiers, decorators);
+        let class = self.parse_class(start, ClassType::ClassExpression, modifiers, decorators);
         Expression::ClassExpression(class)
     }
 
     fn parse_class(
         &mut self,
-        start_span: u32,
+        start: u32,
         r#type: ClassType,
         modifiers: &Modifiers,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -66,11 +66,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.bump_any(); // advance `class`
 
         // Move span start to decorator position if this is a class expression.
-        let mut start_span = start_span;
+        let mut start = start;
         if r#type == ClassType::ClassExpression
             && let Some(d) = decorators.first()
         {
-            start_span = d.span.start;
+            start = d.span.start;
         }
 
         let id = if self.cur_kind().is_binding_identifier()
@@ -118,7 +118,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         );
 
         Class::boxed(
-            self.end_span(start_span),
+            self.end_span(start),
             r#type,
             decorators,
             id,
@@ -216,7 +216,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_class_body(&mut self) -> ArenaBox<'a, ClassBody<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         let class_elements = self.parse_normal_list_breakable(Kind::LCurly, Kind::RCurly, |p| {
             // Skip empty class element `;`
             if p.eat(Kind::Semicolon) {
@@ -227,7 +227,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
             Some(Self::parse_class_element(p))
         });
-        ClassBody::boxed(self.end_span(span), class_elements, self)
+        ClassBody::boxed(self.end_span(start), class_elements, self)
     }
 
     fn parse_class_element(&mut self) -> ClassElement<'a> {
@@ -244,7 +244,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_class_element_impl(&mut self) -> ClassElement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
 
         let decorators = self.parse_decorators();
         let modifiers = self.parse_modifiers(
@@ -263,7 +263,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 false,
                 diagnostics::modifiers_cannot_appear_here,
             );
-            return self.parse_class_static_block(span);
+            return self.parse_class_static_block(start);
         }
 
         self.verify_modifiers(
@@ -283,7 +283,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         if self.parse_contextual_modifier(Kind::Get) {
             return self.parse_accessor_declaration(
-                span,
+                start,
                 r#type,
                 MethodDefinitionKind::Get,
                 &modifiers,
@@ -293,7 +293,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         if self.parse_contextual_modifier(Kind::Set) {
             return self.parse_accessor_declaration(
-                span,
+                start,
                 r#type,
                 MethodDefinitionKind::Set,
                 &modifiers,
@@ -305,7 +305,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             && !modifiers.contains(ModifierKind::Static)
             && let Some(name) = self.parse_constructor_name()
         {
-            return self.parse_constructor_declaration(span, r#type, name, &modifiers, decorators);
+            return self.parse_constructor_declaration(start, r#type, name, &modifiers, decorators);
         }
 
         if self.is_index_signature() {
@@ -322,7 +322,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             );
 
             return ClassElement::TSIndexSignature(
-                self.parse_index_signature_declaration(span, &modifiers),
+                self.parse_index_signature_declaration(start, &modifiers),
             );
         }
 
@@ -331,10 +331,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             let is_ambient = modifiers.contains(ModifierKind::Declare);
             return if is_ambient {
                 self.context_add(Context::Ambient, |p| {
-                    p.parse_property_or_method_declaration(span, r#type, &modifiers, decorators)
+                    p.parse_property_or_method_declaration(start, r#type, &modifiers, decorators)
                 })
             } else {
-                self.parse_property_or_method_declaration(span, r#type, &modifiers, decorators)
+                self.parse_property_or_method_declaration(start, r#type, &modifiers, decorators)
             };
         }
 
@@ -384,20 +384,20 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// `ClassStaticBlockStatementList` :
     ///    `StatementList`[~Yield, +Await, ~Return]
-    fn parse_class_static_block(&mut self, span: u32) -> ClassElement<'a> {
+    fn parse_class_static_block(&mut self, start: u32) -> ClassElement<'a> {
         self.bump_any(); // bump `static`
         let block = self.context(
             Context::Await | Context::NewTarget,
             Context::Yield | Context::Return,
             Self::parse_block,
         );
-        ClassElement::new_static_block(self.end_span(span), block.unbox().body, self)
+        ClassElement::new_static_block(self.end_span(start), block.unbox().body, self)
     }
 
     /// <https://github.com/tc39/proposal-decorators>
     fn parse_class_accessor_property(
         &mut self,
-        span: u32,
+        start: u32,
         key: PropertyKey<'a>,
         computed: bool,
         definite: Option<u32>,
@@ -445,7 +445,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
         ClassElement::new_accessor_property(
-            self.end_span(span),
+            self.end_span(start),
             r#type,
             decorators,
             key,
@@ -462,7 +462,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_accessor_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         r#type: MethodDefinitionType,
         kind: MethodDefinitionKind,
         modifiers: &Modifiers,
@@ -475,7 +475,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             FunctionKind::ClassMethod,
         );
         let method_definition = MethodDefinition::boxed(
-            self.end_span(span),
+            self.end_span(start),
             r#type,
             decorators,
             name,
@@ -500,7 +500,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_constructor_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         r#type: MethodDefinitionType,
         name: PropertyKey<'a>,
         modifiers: &Modifiers,
@@ -516,7 +516,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             FunctionKind::Constructor,
         );
         let method_definition = MethodDefinition::boxed(
-            self.end_span(span),
+            self.end_span(start),
             r#type,
             decorators,
             name,
@@ -550,7 +550,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_property_or_method_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         r#type: MethodDefinitionType,
         modifiers: &Modifiers,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -598,7 +598,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 },
             );
             return self.parse_method_declaration(
-                span, r#type, generator, name, computed, optional, modifiers, decorators,
+                start, r#type, generator, name, computed, optional, modifiers, decorators,
             );
         }
 
@@ -617,12 +617,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::constructor_accessor(name.span()));
             }
             return self.parse_class_accessor_property(
-                span, name, computed, definite, modifiers, decorators,
+                start, name, computed, definite, modifiers, decorators,
             );
         }
 
         self.parse_property_declaration(
-            span,
+            start,
             name,
             computed,
             optional_span,
@@ -634,7 +634,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_method_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         r#type: MethodDefinitionType,
         generator: Option<u32>,
         name: PropertyKey<'a>,
@@ -649,7 +649,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             FunctionKind::ClassMethod,
         );
         let method_definition = MethodDefinition::boxed(
-            self.end_span(span),
+            self.end_span(start),
             r#type,
             decorators,
             name,
@@ -668,7 +668,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_property_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         name: PropertyKey<'a>,
         computed: bool,
         optional_span: Option<Span>,
@@ -737,7 +737,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
         ClassElement::new_property_definition(
-            self.end_span(span),
+            self.end_span(start),
             r#type,
             decorators,
             name,

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -7,33 +7,33 @@ use crate::{ParserConfig as Config, ParserImpl, StatementContext, diagnostics, l
 
 impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_let(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
 
         let peeked = self.lexer.peek_token().kind();
 
         // Fast path: avoid rewind.
         if !stmt_ctx.is_single_statement() && peeked.is_after_let() {
             self.bump_any(); // bump `let`
-            return self.parse_variable_statement(span, VariableDeclarationKind::Let, stmt_ctx);
+            return self.parse_variable_statement(start, VariableDeclarationKind::Let, stmt_ctx);
         }
 
         // let = foo, let instanceof x, let + 1
         if peeked.is_assignment_operator() || peeked.is_binary_operator() {
             let expr = self.parse_assignment_expression_or_higher();
-            self.parse_expression_statement(span, expr)
+            self.parse_expression_statement(start, expr)
         // let.a = 1, let?.a = 1, let()[a] = 1
         } else if matches!(peeked, Kind::Dot | Kind::QuestionDot | Kind::LParen) {
             let expr = self.parse_expr();
-            self.parse_expression_statement(span, expr)
+            self.parse_expression_statement(start, expr)
         // single statement let declaration: while (0) let
         } else if (stmt_ctx.is_single_statement() && peeked != Kind::LBrack)
             || peeked == Kind::Semicolon
         {
             let expr = self.parse_identifier_expression();
-            self.parse_expression_statement(span, expr)
+            self.parse_expression_statement(start, expr)
         } else {
             self.bump_any();
-            self.parse_variable_statement(span, VariableDeclarationKind::Let, stmt_ctx)
+            self.parse_variable_statement(start, VariableDeclarationKind::Let, stmt_ctx)
         }
     }
 
@@ -78,7 +78,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_variable_declaration(
         &mut self,
-        start_span: u32,
+        start: u32,
         kind: VariableDeclarationKind,
         decl_parent: VariableDeclarationParent,
         declare: bool,
@@ -95,7 +95,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if matches!(decl_parent, VariableDeclarationParent::Statement) {
             self.asi();
         }
-        VariableDeclaration::boxed(self.end_span(start_span), kind, declarations, declare, self)
+        VariableDeclaration::boxed(self.end_span(start), kind, declarations, declare, self)
     }
 
     fn parse_variable_declarator(
@@ -103,20 +103,20 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         decl_parent: VariableDeclarationParent,
         kind: VariableDeclarationKind,
     ) -> VariableDeclarator<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
 
         let id = self.parse_binding_pattern();
 
-        let (type_annotation, definite) = if self.is_ts {
+        let (type_annotation, definite_start) = if self.is_ts {
             // const x!: number = 1
             //        ^ definite
-            let definite = if id.is_binding_identifier()
+            let definite_start = if id.is_binding_identifier()
                 && !self.cur_token().is_on_new_line()
                 && self.at(Kind::Bang)
             {
-                let span_start = self.cur_token().start();
+                let definite_start = self.cur_token().start();
                 self.bump_any();
-                Some(span_start)
+                Some(definite_start)
             } else {
                 None
             };
@@ -125,7 +125,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.bump_any();
             }
             let type_annotation = self.parse_ts_type_annotation();
-            (type_annotation, definite)
+            (type_annotation, definite_start)
         } else {
             (None, None)
         };
@@ -133,12 +133,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.lexer.trivia_builder.mark_current_pure_comment_not_applied();
         let init = self.eat(Kind::Eq).then(|| self.parse_assignment_expression_or_higher());
         let decl = VariableDeclarator::new(
-            self.end_span(span),
+            self.end_span(start),
             kind,
             id,
             type_annotation,
             init,
-            definite.is_some(),
+            definite_start.is_some(),
             self,
         );
         if self.ctx.has_ambient()
@@ -151,8 +151,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if decl_parent == VariableDeclarationParent::Statement {
             self.check_missing_initializer(&decl);
         }
-        if let Some(definite_token_start) = definite {
-            let span = Span::sized(definite_token_start, 1);
+        if let Some(definite_start) = definite_start {
+            let span = Span::sized(definite_start, 1);
             if decl.init.is_some() {
                 self.error(diagnostics::variable_declarator_definite(span));
             } else if decl.type_annotation.is_none() {
@@ -184,7 +184,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         statement_ctx: StatementContext,
     ) -> ArenaBox<'a, VariableDeclaration<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
 
         let is_await = self.eat(Kind::Await);
         let kind = if is_await {
@@ -225,6 +225,6 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
 
-        VariableDeclaration::boxed(self.end_span(span), kind, declarations, false, self)
+        VariableDeclaration::boxed(self.end_span(start), kind, declarations, false, self)
     }
 }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -52,7 +52,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section [Expression](https://tc39.es/ecma262/#sec-ecmascript-language-expressions)
     pub(crate) fn parse_expr(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
 
         let has_decorator = self.ctx.has_decorator();
         if has_decorator {
@@ -64,7 +64,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return lhs;
         }
 
-        let expr = self.parse_sequence_expression(span, lhs);
+        let expr = self.parse_sequence_expression(start, lhs);
 
         if has_decorator {
             self.ctx = self.ctx.and_decorator(true);
@@ -229,9 +229,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // FunctionExpression, GeneratorExpression
         // AsyncFunctionExpression, AsyncGeneratorExpression
         if self.at_function_with_async() {
-            let span = self.start_span();
+            let start = self.start_span();
             let r#async = self.eat(Kind::Async);
-            return self.parse_function_expression(span, r#async);
+            return self.parse_function_expression(start, r#async);
         }
 
         let kind = self.cur_kind();
@@ -269,7 +269,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_parenthesized_expression(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let opening_span = self.cur_token().span();
         // Capture annotation flags before bumping `(` since bump resets them
         let has_no_side_effects_comment =
@@ -295,7 +295,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         if expressions.is_empty() {
             self.expect(Kind::RParen);
-            let error = diagnostics::empty_parenthesized_expression(self.end_span(span));
+            let error = diagnostics::empty_parenthesized_expression(self.end_span(start));
             return self.fatal_error(error);
         }
 
@@ -326,7 +326,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         if self.options.preserve_parens {
-            Expression::new_parenthesized_expression(self.end_span(span), expression, self)
+            Expression::new_parenthesized_expression(self.end_span(start), expression, self)
         } else {
             expression
         }
@@ -334,9 +334,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 13.2.2 This Expression
     fn parse_this_expression(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any();
-        Expression::new_this_expression(self.end_span(span), self)
+        Expression::new_this_expression(self.end_span(start), self)
     }
 
     /// [Literal Expression](https://tc39.es/ecma262/#prod-Literal)
@@ -359,14 +359,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_literal_boolean(&mut self) -> ArenaBox<'a, BooleanLiteral> {
-        let span = self.start_span();
+        let start = self.start_span();
         let value = match self.cur_kind() {
             Kind::True => true,
             Kind::False => false,
             _ => return self.unexpected(),
         };
         self.bump_any();
-        BooleanLiteral::boxed(self.end_span(span), value, self)
+        BooleanLiteral::boxed(self.end_span(start), value, self)
     }
 
     pub(crate) fn parse_literal_null(&mut self) -> ArenaBox<'a, NullLiteral> {
@@ -511,7 +511,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     [ `ElementList`[?Yield, ?Await] ]
     ///     [ `ElementList`[?Yield, ?Await] , Elisionopt ]
     pub(crate) fn parse_array_expression(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LBrack);
         let (elements, comma_span) = self.context_add(Context::In, |p| {
@@ -523,10 +523,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             )
         });
         if let Some(comma_span) = comma_span {
-            self.state.trailing_commas.insert(span, self.end_span(comma_span));
+            self.state.trailing_commas.insert(start, self.end_span(comma_span));
         }
         self.expect(Kind::RBrack);
-        Expression::new_array_expression(self.end_span(span), elements, self)
+        Expression::new_array_expression(self.end_span(start), elements, self)
     }
 
     fn parse_array_expression_element(&mut self) -> ArrayExpressionElement<'a> {
@@ -549,7 +549,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     `NoSubstitutionTemplate`
     ///     `SubstitutionTemplate`[?Yield, ?Await, ?Tagged]
     pub(crate) fn parse_template_literal(&mut self, tagged: bool) -> TemplateLiteral<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
 
         let (quasis, expressions) = match self.cur_kind() {
             Kind::NoSubstitutionTemplate => {
@@ -590,7 +590,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             _ => unreachable!("parse_template_literal"),
         };
 
-        TemplateLiteral::new(self.end_span(span), quasis, expressions, self)
+        TemplateLiteral::new(self.end_span(start), quasis, expressions, self)
     }
 
     pub(crate) fn parse_template_literal_expression(&mut self, tagged: bool) -> Expression<'a> {
@@ -600,13 +600,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_tagged_template(
         &mut self,
-        span: u32,
+        start: u32,
         lhs: Expression<'a>,
         in_optional_chain: bool,
         type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
     ) -> Expression<'a> {
         let quasi = self.parse_template_literal(true);
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         // OptionalChain :
         //   ?. TemplateLiteral
         //   OptionalChain TemplateLiteral
@@ -619,7 +619,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_template_element(&mut self, tagged: bool) -> TemplateElement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let cur_kind = self.cur_kind();
         let end_offset: u32 = match cur_kind {
             Kind::TemplateHead | Kind::TemplateMiddle => 2,
@@ -651,7 +651,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         self.bump_any();
 
-        let mut span = self.end_span(span);
+        let mut span = self.end_span(start);
         span.start += 1;
         span.end -= end_offset;
 
@@ -672,7 +672,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 13.3 ImportCall or ImportMeta
     fn parse_import_meta_or_call(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `import`
         match self.cur_kind() {
             Kind::Dot => {
@@ -681,7 +681,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     // `import.meta`
                     Kind::Meta => {
                         self.bump_any(); // bump `meta`
-                        let span = self.end_span(span);
+                        let span = self.end_span(start);
                         self.module_record_builder.visit_import_meta(span);
                         // `import.meta` is only allowed in module code.
                         if !self.source_type.is_module() {
@@ -692,20 +692,20 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     // `import.source(expr)`
                     Kind::Source => {
                         self.bump_any();
-                        self.parse_import_expression(span, Some(ImportPhase::Source))
+                        self.parse_import_expression(start, Some(ImportPhase::Source))
                     }
                     // `import.defer(expr)`
                     Kind::Defer => {
                         self.bump_any();
-                        self.parse_import_expression(span, Some(ImportPhase::Defer))
+                        self.parse_import_expression(start, Some(ImportPhase::Defer))
                     }
                     _ => {
                         self.bump_any();
-                        self.fatal_error(diagnostics::invalid_import_property(self.end_span(span)))
+                        self.fatal_error(diagnostics::invalid_import_property(self.end_span(start)))
                     }
                 }
             }
-            Kind::LParen => self.parse_import_expression(span, None),
+            Kind::LParen => self.parse_import_expression(start, None),
             _ => self.unexpected(),
         }
     }
@@ -713,7 +713,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// V8 Runtime calls.
     /// See: [runtime.h](https://github.com/v8/v8/blob/5fe0aa3bc79c0a9d3ad546b79211f07105f09585/src/runtime/runtime.h#L43)
     pub(crate) fn parse_v8_intrinsic_expression(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.expect(Kind::Percent);
         let name = self.parse_identifier_name();
 
@@ -728,7 +728,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             )
         });
         self.expect(Kind::RParen);
-        Expression::new_v8_intrinsic_expression(self.end_span(span), name, arguments, self)
+        Expression::new_v8_intrinsic_expression(self.end_span(start), name, arguments, self)
     }
 
     fn parse_v8_intrinsic_argument(&mut self) -> Argument<'a> {
@@ -742,12 +742,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 13.3 Left-Hand-Side Expression
     pub(crate) fn parse_lhs_expression_or_higher(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let mut in_optional_chain = false;
         // `MemberExpression`
         let primary = self.parse_primary_expression();
         let member_expression = self.parse_member_expression_rest(
-            span,
+            start,
             primary,
             &mut in_optional_chain,
             /* allow_optional_chain */ true,
@@ -756,7 +756,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // `Arguments` (`(`) or an `OptionalChain` (`?.`); see <https://tc39.es/ecma262/#sec-left-hand-side-expressions>.
         // So skip `parse_call_expression_rest` (and its redundant member-rest re-scan) otherwise.
         let lhs = if matches!(self.cur_kind(), Kind::LParen | Kind::QuestionDot) {
-            self.parse_call_expression_rest(span, member_expression, &mut in_optional_chain)
+            self.parse_call_expression_rest(start, member_expression, &mut in_optional_chain)
         } else {
             member_expression
         };
@@ -771,7 +771,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             expr.expression.replace_with(|expr| self.map_to_chain_expression(expr.span(), expr));
             Expression::TSInstantiationExpression(expr)
         } else {
-            let span = self.end_span(span);
+            let span = self.end_span(start);
             self.map_to_chain_expression(span, lhs)
         }
     }
@@ -794,9 +794,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 13.3 Super Call
     fn parse_super(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `super`
-        let span = self.end_span(span);
+        let span = self.end_span(start);
 
         // The `super` keyword can appear at below:
         // SuperProperty:
@@ -986,20 +986,20 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// [NewExpression](https://tc39.es/ecma262/#sec-new-operator)
     fn parse_new_expression(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `new`
 
         if self.eat(Kind::Dot) {
             return if self.at(Kind::Target) {
                 self.bump_any(); // bump `target`
-                let span = self.end_span(span);
+                let span = self.end_span(start);
                 if !self.ctx.has_new_target() {
                     self.error(diagnostics::new_target_outside_function(span));
                 }
                 Expression::new_new_target(span, self)
             } else {
                 self.bump_any();
-                self.fatal_error(diagnostics::new_target(self.end_span(span)))
+                self.fatal_error(diagnostics::new_target(self.end_span(start)))
             };
         }
 
@@ -1056,7 +1056,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::new_super(self.end_span(rhs_span)));
         }
 
-        let span = self.end_span(span);
+        let span = self.end_span(start);
 
         if optional {
             self.error(diagnostics::new_optional_chain(span));
@@ -1201,7 +1201,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return self.parse_jsx_expression();
         }
 
-        let span = self.start_span();
+        let start = self.start_span();
         let lhs = self.parse_lhs_expression_or_higher();
         // ++ -- postfix update expressions
         let post_kind = self.cur_kind();
@@ -1210,7 +1210,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.bump_any();
             let lhs = SimpleAssignmentTarget::cover(lhs, self);
             return Expression::new_update_expression(
-                self.end_span(span),
+                self.end_span(start),
                 operator,
                 false,
                 lhs,
@@ -1271,7 +1271,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_unary_expression(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let operator = map_unary_operator(self.cur_kind());
         self.bump_any();
         let pure_comment_index = self.lexer.trivia_builder.previous_token_has_pure_comment();
@@ -1281,7 +1281,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         {
             self.lexer.trivia_builder.mark_pure_comment_not_applied(index);
         }
-        Expression::new_unary_expression(self.end_span(span), operator, argument, self)
+        Expression::new_unary_expression(self.end_span(start), operator, argument, self)
     }
 
     pub(crate) fn parse_binary_expression_or_higher(
@@ -1510,10 +1510,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return arrow_expr;
         }
 
-        let span = self.start_span();
+        let start = self.start_span();
         let lhs_parenthesized = self.at(Kind::LParen);
         let lhs = self.parse_binary_expression_or_higher(Precedence::Comma);
-        let lhs_parenthesized_span = lhs_parenthesized.then(|| self.end_span(span));
+        let lhs_parenthesized_span = lhs_parenthesized.then(|| self.end_span(start));
         let kind = self.cur_kind();
 
         // `x => {}`
@@ -1521,7 +1521,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             && let Expression::Identifier(ident) = &lhs
         {
             let mut arrow_expr = self.parse_simple_arrow_function_expression(
-                span,
+                start,
                 ident,
                 /* async */ false,
                 allow_return_type_in_arrow_function,
@@ -1536,7 +1536,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         if kind.is_assignment_operator() {
             return self.parse_assignment_expression_recursive(
-                span,
+                start,
                 lhs,
                 lhs_parenthesized_span,
                 allow_return_type_in_arrow_function,
@@ -1544,7 +1544,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         let mut expr =
-            self.parse_conditional_expression_rest(span, lhs, allow_return_type_in_arrow_function);
+            self.parse_conditional_expression_rest(start, lhs, allow_return_type_in_arrow_function);
 
         if let Some(index) = pure_comment_index
             && !Self::set_pure_on_call_or_new_expr(&mut expr)
@@ -1615,7 +1615,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_assignment_expression_recursive(
         &mut self,
-        span: u32,
+        start: u32,
         lhs: Expression<'a>,
         left_parenthesized_span: Option<Span>,
         allow_return_type_in_arrow_function: bool,
@@ -1643,13 +1643,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.bump_any();
         let right =
             self.parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function);
-        Expression::new_assignment_expression(self.end_span(span), operator, left, right, self)
+        Expression::new_assignment_expression(self.end_span(start), operator, left, right, self)
     }
 
     /// Section 13.16 Sequence Expression
     fn parse_sequence_expression(
         &mut self,
-        span: u32,
+        start: u32,
         first_expression: Expression<'a>,
     ) -> Expression<'a> {
         let mut expressions = ArenaVec::with_capacity_in(2, self);
@@ -1658,7 +1658,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             let expression = self.parse_assignment_expression_or_higher();
             expressions.push(expression);
         }
-        Expression::new_sequence_expression(self.end_span(span), expressions, self)
+        Expression::new_sequence_expression(self.end_span(start), expressions, self)
     }
 
     /// Check if the current `await` token is unambiguously an await expression.
@@ -1705,10 +1705,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // Case 1: In await context (async function, module top-level, unambiguous mode top-level)
         // Always parse as await expression
         if self.ctx.has_await() {
-            let span = self.start_span();
+            let start = self.start_span();
             self.bump_any(); // consume `await`
             let argument = self.parse_unary_expression_or_higher(self.start_span());
-            return Expression::new_await_expression(self.end_span(span), argument, self);
+            return Expression::new_await_expression(self.end_span(start), argument, self);
         }
 
         // Case 2: Not in await context, but unambiguously an await expression
@@ -1722,7 +1722,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // Inside a function: await is always invalid in non-async functions, even in ESM.
         // Report error immediately.
         if self.is_unambiguous_await() {
-            let span = self.start_span();
+            let start = self.start_span();
 
             if self.ctx.has_top_level() {
                 // At top level - upgrade to ESM immediately (like Babel's `sawUnambiguousESM`)
@@ -1739,7 +1739,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.ctx = self.ctx.and_await(true);
             let argument = self.parse_unary_expression_or_higher(self.start_span());
             self.ctx = self.ctx.and_await(false);
-            return Expression::new_await_expression(self.end_span(span), argument, self);
+            return Expression::new_await_expression(self.end_span(start), argument, self);
         }
 
         // Case 3: Ambiguous - parse `await` as identifier
@@ -1749,11 +1749,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_decorated_expression(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let decorators = self.parse_decorators();
         let modifiers = self.parse_modifiers(false, false);
         if self.at(Kind::Class) {
-            self.parse_class_expression(span, &modifiers, decorators)
+            self.parse_class_expression(start, &modifiers, decorators)
         } else {
             self.unexpected()
         }
@@ -1776,10 +1776,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   ( `Expression`[+In, ?Yield, ?Await] )
     ///   `DecoratorCallExpression`
     pub(crate) fn parse_decorator(&mut self) -> Decorator<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump @
         let expr = self.context_add(Context::Decorator, Self::parse_lhs_expression_or_higher);
-        Decorator::new(self.end_span(span), expr, self)
+        Decorator::new(self.end_span(start), expr, self)
     }
 
     fn is_yield_expression(&mut self) -> bool {

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -29,7 +29,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_function_body(&mut self) -> ArenaBox<'a, FunctionBody<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
 
@@ -39,7 +39,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         });
 
         self.expect_closing(Kind::RCurly, opening_span);
-        FunctionBody::boxed(self.end_span(span), directives, statements, self)
+        FunctionBody::boxed(self.end_span(start), directives, statements, self)
     }
 
     pub(crate) fn parse_formal_parameters(
@@ -47,7 +47,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         func_kind: FunctionKind,
         params_kind: FormalParameterKind,
     ) -> (Option<ArenaBox<'a, TSThisParameter<'a>>>, ArenaBox<'a, FormalParameters<'a>>) {
-        let span = self.start_span();
+        let start = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LParen);
         let this_param = if self.is_ts && self.at(Kind::This) {
@@ -61,7 +61,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect(Kind::RParen);
 
         let formal_parameters =
-            FormalParameters::boxed(self.end_span(span), params_kind, list, rest, self);
+            FormalParameters::boxed(self.end_span(start), params_kind, list, rest, self);
         (this_param, formal_parameters)
     }
 
@@ -131,7 +131,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 break;
             }
 
-            let span = self.start_span();
+            let start = self.start_span();
             let decorators = self.parse_decorators();
 
             if self.at(Kind::Dot3) {
@@ -149,7 +149,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
 
                 rest = Some(FormalParameterRest::boxed(
-                    self.end_span(span),
+                    self.end_span(start),
                     decorators,
                     rest_element,
                     type_annotation,
@@ -157,7 +157,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 ));
             } else {
                 let param =
-                    self.parse_formal_parameter_with_decorators(func_kind, span, decorators);
+                    self.parse_formal_parameter_with_decorators(func_kind, start, decorators);
                 if param.optional {
                     has_optional = true;
                 } else if has_optional && param.initializer.is_none() {
@@ -175,7 +175,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_formal_parameter_with_decorators(
         &mut self,
         func_kind: FunctionKind,
-        span: u32,
+        start: u32,
         decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> FormalParameter<'a> {
         let modifiers = self.parse_modifiers(false, false);
@@ -236,7 +236,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
             } else {
                 self.error(diagnostics::parameter_property_cannot_be_binding_pattern(Span::new(
-                    span,
+                    start,
                     self.prev_token_end,
                 )));
             }
@@ -251,7 +251,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
         FormalParameter::new(
-            self.end_span(span),
+            self.end_span(start),
             decorators,
             pattern,
             type_annotation,
@@ -266,7 +266,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_function(
         &mut self,
-        span: u32,
+        start: u32,
         id: Option<BindingIdentifier<'a>>,
         r#async: bool,
         generator: Option<u32>,
@@ -298,7 +298,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             .and_yield(ctx.has_yield())
             .and_new_target(ctx.has_new_target());
         if (!self.is_ts || matches!(func_kind, FunctionKind::ObjectMethod)) && body.is_none() {
-            return self.fatal_error(diagnostics::expect_function_body(self.end_span(span)));
+            return self.fatal_error(diagnostics::expect_function_body(self.end_span(start)));
         }
         let function_type = match func_kind {
             FunctionKind::Declaration | FunctionKind::DefaultExport => {
@@ -348,7 +348,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             if ctx.has_ambient() {
                 self.error(diagnostics::generator_in_ambient_context(self.end_span(generator)));
             } else if body.is_none() {
-                self.error(diagnostics::overload_signature_generator(self.end_span(span)));
+                self.error(diagnostics::overload_signature_generator(self.end_span(start)));
             }
         }
         self.verify_modifiers(
@@ -359,7 +359,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         );
 
         Function::boxed(
-            self.end_span(span),
+            self.end_span(start),
             function_type,
             id,
             generator.is_some(),
@@ -377,12 +377,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// [Function Declaration](https://tc39.es/ecma262/#prod-FunctionDeclaration)
     pub(crate) fn parse_function_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         r#async: bool,
         stmt_ctx: StatementContext,
     ) -> Statement<'a> {
         let func_kind = FunctionKind::Declaration;
-        let decl = self.parse_function_impl(span, r#async, func_kind);
+        let decl = self.parse_function_impl(start, r#async, func_kind);
         if stmt_ctx.is_single_statement() {
             if decl.r#async {
                 self.error(diagnostics::async_function_declaration(Span::new(
@@ -403,7 +403,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// at `function` or `async function`
     pub(crate) fn parse_function_impl(
         &mut self,
-        span: u32,
+        start: u32,
         r#async: bool,
         func_kind: FunctionKind,
     ) -> ArenaBox<'a, Function<'a>> {
@@ -411,7 +411,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let generator = self.eat(Kind::Star).then_some(self.prev_token_end - 1);
         let id = self.parse_function_id(func_kind, r#async, generator.is_some());
         self.parse_function(
-            span,
+            start,
             id,
             r#async,
             generator,
@@ -425,7 +425,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// at `function`
     pub(crate) fn parse_ts_function_impl(
         &mut self,
-        start_span: u32,
+        start: u32,
         func_kind: FunctionKind,
         modifiers: &Modifiers,
     ) -> ArenaBox<'a, Function<'a>> {
@@ -434,7 +434,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let generator = self.eat(Kind::Star).then_some(self.prev_token_end - 1);
         let id = self.parse_function_id(func_kind, r#async, generator.is_some());
         self.parse_function(
-            start_span,
+            start,
             id,
             r#async,
             generator,
@@ -445,14 +445,18 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     /// [Function Expression](https://tc39.es/ecma262/#prod-FunctionExpression)
-    pub(crate) fn parse_function_expression(&mut self, span: u32, r#async: bool) -> Expression<'a> {
+    pub(crate) fn parse_function_expression(
+        &mut self,
+        start: u32,
+        r#async: bool,
+    ) -> Expression<'a> {
         let func_kind = FunctionKind::Expression;
         self.expect(Kind::Function);
 
         let generator = self.eat(Kind::Star).then_some(self.prev_token_end - 1);
         let id = self.parse_function_id(func_kind, r#async, generator.is_some());
         let function = self.parse_function(
-            span,
+            start,
             id,
             r#async,
             generator,
@@ -477,9 +481,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         generator: Option<u32>,
         func_kind: FunctionKind,
     ) -> ArenaBox<'a, Function<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.parse_function(
-            span,
+            start,
             None,
             r#async,
             generator,
@@ -494,12 +498,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// yield [no `LineTerminator` here] `AssignmentExpression`
     /// yield [no `LineTerminator` here] * `AssignmentExpression`
     pub(crate) fn parse_yield_expression(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // advance `yield`
 
         let has_yield = self.ctx.has_yield();
         if !has_yield {
-            self.error(diagnostics::yield_expression(Span::sized(span, 5)));
+            self.error(diagnostics::yield_expression(Span::sized(start, 5)));
         }
 
         let mut delegate = false;
@@ -524,7 +528,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
 
-        Expression::new_yield_expression(self.end_span(span), delegate, argument, self)
+        Expression::new_yield_expression(self.end_span(start), delegate, argument, self)
     }
 
     // id: None - for AnonymousDefaultExportedFunctionDeclaration

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -31,12 +31,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// `ImportCall` : import ( `AssignmentExpression` )
     pub(crate) fn parse_import_expression(
         &mut self,
-        span: u32,
+        start: u32,
         phase: Option<ImportPhase>,
     ) -> Expression<'a> {
         self.expect(Kind::LParen);
         if self.eat(Kind::RParen) {
-            let error = diagnostics::import_requires_a_specifier(self.end_span(span));
+            let error = diagnostics::import_requires_a_specifier(self.end_span(start));
             return self.fatal_error(error);
         }
         let has_in = self.ctx.has_in();
@@ -50,11 +50,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // Allow trailing comma
         self.bump(Kind::Comma);
         if !self.eat(Kind::RParen) {
-            let error = diagnostics::import_arguments(self.end_span(span));
+            let error = diagnostics::import_arguments(self.end_span(start));
             return self.fatal_error(error);
         }
         self.ctx = self.ctx.and_in(has_in);
-        let expr = ImportExpression::boxed(self.end_span(span), expression, arguments, phase, self);
+        let expr =
+            ImportExpression::boxed(self.end_span(start), expression, arguments, phase, self);
         self.module_record_builder.visit_import_expression(&expr);
         Expression::ImportExpression(expr)
     }
@@ -71,7 +72,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// Section 16.2.2 Import Declaration
     pub(crate) fn parse_import_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         should_record_module_record: bool,
     ) -> Statement<'a> {
         let token_after_import = self.cur_token();
@@ -96,7 +97,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             let decl = self.parse_ts_import_equals_declaration(
                 ImportOrExportKind::Value,
                 identifier_after_import,
-                span,
+                start,
             );
             return Statement::from(decl);
         } else if self.is_ts && token_after_import.kind() == Kind::Type {
@@ -130,7 +131,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         let decl = self.parse_ts_import_equals_declaration(
                             ImportOrExportKind::Type,
                             identifier_after_import.unwrap(),
-                            span,
+                            start,
                         );
                         return Statement::from(decl);
                     } else if self.at(Kind::From) {
@@ -240,7 +241,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let source = self.parse_literal_string();
         let with_clause = self.parse_import_attributes();
         self.asi();
-        let span = self.end_span(span);
+        let span = self.end_span(start);
 
         let import_decl = ImportDeclaration::boxed(
             span,
@@ -332,11 +333,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     // import * as name from "module-name"
     fn parse_import_namespace_specifier(&mut self) -> ImportDeclarationSpecifier<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // advance `*`
         self.expect(Kind::As);
         let local = self.parse_binding_identifier();
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         ImportDeclarationSpecifier::new_import_namespace_specifier(span, local, self)
     }
 
@@ -370,7 +371,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         };
         self.advance(keyword_kind);
 
-        let span = self.start_span();
+        let start = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
         let (with_entries, _) = self.context_remove(self.ctx, |p| {
@@ -392,11 +393,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
 
-        Some(WithClause::boxed(self.end_span(span), keyword, with_entries, self))
+        Some(WithClause::boxed(self.end_span(start), keyword, with_entries, self))
     }
 
     fn parse_import_attribute(&mut self) -> ImportAttribute<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let key = match self.cur_kind() {
             Kind::Str => ImportAttributeKey::StringLiteral(self.parse_literal_string()),
             _ => ImportAttributeKey::Identifier(self.parse_identifier_name()),
@@ -408,12 +409,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             ));
         }
         let value = self.parse_literal_string();
-        ImportAttribute::new(self.end_span(span), key, value, self)
+        ImportAttribute::new(self.end_span(start), key, value, self)
     }
 
     pub(crate) fn parse_ts_export_assignment_declaration(
         &mut self,
-        start_span: u32,
+        start: u32,
     ) -> ArenaBox<'a, TSExportAssignment<'a>> {
         self.expect(Kind::Eq);
         let expression = self.parse_assignment_expression_or_higher();
@@ -421,12 +422,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.ctx.has_top_level() {
             self.module_record_builder.set_module_syntax();
         }
-        TSExportAssignment::boxed(self.end_span(start_span), expression, self)
+        TSExportAssignment::boxed(self.end_span(start), expression, self)
     }
 
     pub(crate) fn parse_ts_export_namespace(
         &mut self,
-        start_span: u32,
+        start: u32,
     ) -> ArenaBox<'a, TSNamespaceExportDeclaration<'a>> {
         self.expect(Kind::As);
         self.expect(Kind::Namespace);
@@ -435,13 +436,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.ctx.has_top_level() {
             self.module_record_builder.set_module_syntax();
         }
-        TSNamespaceExportDeclaration::boxed(self.end_span(start_span), id, self)
+        TSNamespaceExportDeclaration::boxed(self.end_span(start), id, self)
     }
 
     /// [Exports](https://tc39.es/ecma262/#sec-exports)
     pub(crate) fn parse_export_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         mut decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> Statement<'a> {
         self.bump_any(); // bump `export`
@@ -461,7 +462,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 let stmt = self.parse_import_declaration(import_span, false);
                 if stmt.is_declaration() {
                     let export_decl = ExportDeclaration::boxed(
-                        self.end_span(span),
+                        self.end_span(start),
                         stmt.into_declaration(),
                         self,
                     );
@@ -485,40 +486,40 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 let modifiers = self.parse_modifiers(false, false);
                 let class_decl = self.parse_class_declaration(class_span, &modifiers, decorators);
                 let decl = Declaration::ClassDeclaration(class_decl);
-                let export_decl = ExportDeclaration::boxed(self.end_span(span), decl, self);
+                let export_decl = ExportDeclaration::boxed(self.end_span(start), decl, self);
                 if self.ctx.has_top_level() {
                     self.module_record_builder.visit_export_declaration(&export_decl);
                 }
                 ModuleDeclaration::ExportDeclaration(export_decl)
             }
             Kind::Eq if self.is_ts => ModuleDeclaration::TSExportAssignment(
-                self.parse_ts_export_assignment_declaration(span),
+                self.parse_ts_export_assignment_declaration(start),
             ),
             Kind::As if self.is_ts && self.lexer.peek_token().kind() == Kind::Namespace => {
                 // `export as namespace ...`
                 ModuleDeclaration::TSNamespaceExportDeclaration(
-                    self.parse_ts_export_namespace(span),
+                    self.parse_ts_export_namespace(start),
                 )
             }
             Kind::Default => ModuleDeclaration::ExportDefaultDeclaration(
-                self.parse_export_default_declaration(span, decorators),
+                self.parse_export_default_declaration(start, decorators),
             ),
             Kind::Star => {
-                ModuleDeclaration::ExportAllDeclaration(self.parse_export_all_declaration(span))
+                ModuleDeclaration::ExportAllDeclaration(self.parse_export_all_declaration(start))
             }
-            Kind::LCurly => self.parse_export_named_specifiers(span),
+            Kind::LCurly => self.parse_export_named_specifiers(start),
             Kind::Type if self.is_ts => {
                 let next_kind = self.lexer.peek_token().kind();
 
                 match next_kind {
                     // `export type { ...`
-                    Kind::LCurly => self.parse_export_named_specifiers(span),
+                    Kind::LCurly => self.parse_export_named_specifiers(start),
                     // `export type * as ...`
                     Kind::Star => ModuleDeclaration::ExportAllDeclaration(
-                        self.parse_export_all_declaration(span),
+                        self.parse_export_all_declaration(start),
                     ),
                     _ => ModuleDeclaration::ExportDeclaration(
-                        self.parse_exported_declaration(span, decorators),
+                        self.parse_exported_declaration(start, decorators),
                     ),
                 }
             }
@@ -531,7 +532,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     self.bump_any();
                 }
                 ModuleDeclaration::ExportDeclaration(
-                    self.parse_exported_declaration(span, decorators),
+                    self.parse_exported_declaration(start, decorators),
                 )
             }
         };
@@ -549,7 +550,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     // ExportSpecifier :
     //   ModuleExportName
     //   ModuleExportName as ModuleExportName
-    fn parse_export_named_specifiers(&mut self, span: u32) -> ModuleDeclaration<'a> {
+    fn parse_export_named_specifiers(&mut self, start: u32) -> ModuleDeclaration<'a> {
         let export_kind = self.parse_import_or_export_kind();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
@@ -604,7 +605,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         self.asi();
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         if let Some(source) = source {
             let export_from_decl = ExportFromDeclaration::boxed(
                 span,
@@ -631,7 +632,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     // export Declaration
     fn parse_exported_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ArenaBox<'a, ExportDeclaration<'a>> {
         let decl_span = self.start_span();
@@ -642,7 +643,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let declaration = self.parse_declaration(decl_span, &modifiers, decorators);
         self.ctx = reserved_ctx;
-        let export_decl = ExportDeclaration::boxed(self.end_span(span), declaration, self);
+        let export_decl = ExportDeclaration::boxed(self.end_span(start), declaration, self);
         if self.ctx.has_top_level() {
             self.module_record_builder.visit_export_declaration(&export_decl);
         }
@@ -654,13 +655,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     // export default AssignmentExpression[+In, ~Yield, +Await] ;
     fn parse_export_default_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ArenaBox<'a, ExportDefaultDeclaration<'a>> {
         let default_keyword_span = self.cur_token().span();
         self.advance(Kind::Default);
         let declaration = self.parse_export_default_declaration_kind(decorators);
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         let export_default_decl = ExportDefaultDeclaration::boxed(span, declaration, self);
         if self.ctx.has_top_level() {
             self.module_record_builder
@@ -789,7 +790,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     //   NamedExports
     fn parse_export_all_declaration(
         &mut self,
-        span: u32,
+        start: u32,
     ) -> ArenaBox<'a, ExportAllDeclaration<'a>> {
         let export_kind = self.parse_import_or_export_kind();
         self.bump_any(); // bump `star`
@@ -798,7 +799,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let source = self.parse_literal_string();
         let with_clause = self.parse_import_attributes();
         self.asi();
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         let export_all_decl =
             ExportAllDeclaration::boxed(span, exported, source, with_clause, export_kind, self);
         if self.ctx.has_top_level() {

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -17,7 +17,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     { `PropertyDefinitionList`[?Yield, ?Await] }
     ///     { `PropertyDefinitionList`[?Yield, ?Await] , }
     pub(crate) fn parse_object_expression(&mut self) -> ArenaBox<'a, ObjectExpression<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
         let (object_expression_properties, comma_span) = self.context_add(Context::In, |p| {
@@ -29,10 +29,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             )
         });
         if let Some(comma_span) = comma_span {
-            self.state.trailing_commas.insert(span, self.end_span(comma_span));
+            self.state.trailing_commas.insert(start, self.end_span(comma_span));
         }
         self.expect(Kind::RCurly);
-        ObjectExpression::boxed(self.end_span(span), object_expression_properties, self)
+        ObjectExpression::boxed(self.end_span(start), object_expression_properties, self)
     }
 
     fn parse_object_expression_property(&mut self) -> ObjectPropertyKind<'a> {
@@ -44,7 +44,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// `PropertyDefinition`[Yield, Await]
     fn parse_object_literal_element(&mut self) -> ArenaBox<'a, ObjectProperty<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
 
         let modifiers = self.parse_modifiers(
             /* permit_const_as_modifier */ false,
@@ -52,11 +52,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         );
 
         if self.parse_contextual_modifier(Kind::Get) {
-            return self.parse_method_getter_setter(span, PropertyKind::Get, &modifiers);
+            return self.parse_method_getter_setter(start, PropertyKind::Get, &modifiers);
         }
 
         if self.parse_contextual_modifier(Kind::Set) {
-            return self.parse_method_getter_setter(span, PropertyKind::Set, &modifiers);
+            return self.parse_method_getter_setter(start, PropertyKind::Set, &modifiers);
         }
 
         let asterisk_token = self.eat(Kind::Star).then_some(self.prev_token_end - 1);
@@ -77,7 +77,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 FunctionKind::ObjectMethod,
             );
             return ObjectProperty::boxed(
-                self.end_span(span),
+                self.end_span(start),
                 PropertyKind::Init,
                 key,
                 Expression::FunctionExpression(method),
@@ -108,18 +108,18 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         self,
                     );
                     let expr = AssignmentExpression::new(
-                        self.end_span(span),
+                        self.end_span(start),
                         AssignmentOperator::Assign,
                         left,
                         right,
                         self,
                     );
-                    self.state.cover_initialized_name.insert(span, expr);
+                    self.state.cover_initialized_name.insert(start, expr);
                 }
                 let value =
                     Expression::new_identifier(identifier_name.span, identifier_name.name, self);
                 ObjectProperty::boxed(
-                    self.end_span(span),
+                    self.end_span(start),
                     PropertyKind::Init,
                     PropertyKey::StaticIdentifier(identifier_name),
                     value,
@@ -132,31 +132,31 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.unexpected()
             }
         } else {
-            self.parse_property_definition_assignment(span, key, computed)
+            self.parse_property_definition_assignment(start, key, computed)
         }
     }
 
     /// `PropertyDefinition`[Yield, Await] :
     ///   ... `AssignmentExpression`[+In, ?Yield, ?Await]
     pub(crate) fn parse_spread_element(&mut self) -> ArenaBox<'a, SpreadElement<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // advance `...`
         let argument = self.parse_assignment_expression_or_higher();
-        SpreadElement::boxed(self.end_span(span), argument, self)
+        SpreadElement::boxed(self.end_span(start), argument, self)
     }
 
     /// `PropertyDefinition`[Yield, Await] :
     ///   `PropertyName`[?Yield, ?Await] : `AssignmentExpression`[+In, ?Yield, ?Await]
     fn parse_property_definition_assignment(
         &mut self,
-        span: u32,
+        start: u32,
         key: PropertyKey<'a>,
         computed: bool,
     ) -> ArenaBox<'a, ObjectProperty<'a>> {
         self.expect(Kind::Colon);
         let value = self.parse_assignment_expression_or_higher();
         ObjectProperty::boxed(
-            self.end_span(span),
+            self.end_span(start),
             PropertyKind::Init,
             key,
             value,
@@ -211,7 +211,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   set `ClassElementName`[?Yield, ?Await] ( `PropertySetParameterList` ) { `FunctionBody`[~Yield, ~Await] }
     fn parse_method_getter_setter(
         &mut self,
-        span: u32,
+        start: u32,
         kind: PropertyKind,
         modifiers: &Modifiers,
     ) -> ArenaBox<'a, ObjectProperty<'a>> {
@@ -229,7 +229,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             diagnostics::modifier_cannot_be_used_here,
         );
         ObjectProperty::boxed(
-            self.end_span(span),
+            self.end_span(start),
             kind,
             key,
             Expression::FunctionExpression(function),

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -16,9 +16,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     // or Module.
     pub(crate) fn parse_hashbang(&mut self) -> Option<Hashbang<'a>> {
         if self.cur_kind() == Kind::HashbangComment {
-            let span = self.start_span();
+            let start = self.start_span();
             self.bump_any();
-            let span = self.end_span(span);
+            let span = self.end_span(start);
             let src = &self.source_text[span.start as usize + 2..span.end as usize];
             Some(Hashbang::new(span, Str::from(src), self))
         } else {
@@ -162,9 +162,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             // [+Return] ReturnStatement[?Yield, ?Await]
             Kind::Return => self.parse_return_statement(),
             Kind::Var => {
-                let span = self.start_span();
+                let start = self.start_span();
                 self.bump_any();
-                self.parse_variable_statement(span, VariableDeclarationKind::Var, stmt_ctx)
+                self.parse_variable_statement(start, VariableDeclarationKind::Var, stmt_ctx)
             }
             // Fast path
             Kind::Function => {
@@ -250,7 +250,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_expression_or_labeled_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let expr = self.parse_expr();
         if let Expression::Identifier(ident) = &expr {
             // Section 14.13 Labelled Statement
@@ -258,19 +258,19 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             if self.eat(Kind::Colon) {
                 let label = LabelIdentifier::new(ident.span, ident.name, self);
                 let body = self.parse_statement_list_item(StatementContext::Label);
-                return Statement::new_labeled_statement(self.end_span(span), label, body, self);
+                return Statement::new_labeled_statement(self.end_span(start), label, body, self);
             }
         }
-        self.parse_expression_statement(span, expr)
+        self.parse_expression_statement(start, expr)
     }
 
     /// Section 14.2 Block Statement
     pub(crate) fn parse_block(&mut self) -> ArenaBox<'a, BlockStatement<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         let body = self.parse_normal_list(Kind::LCurly, Kind::RCurly, |p| {
             p.parse_statement_list_item(StatementContext::StatementList)
         });
-        BlockStatement::boxed(self.end_span(span), body, self)
+        BlockStatement::boxed(self.end_span(start), body, self)
     }
 
     pub(crate) fn parse_block_statement(&mut self) -> Statement<'a> {
@@ -281,12 +281,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// Section 14.3.2 Variable Statement
     pub(crate) fn parse_variable_statement(
         &mut self,
-        start_span: u32,
+        start: u32,
         kind: VariableDeclarationKind,
         stmt_ctx: StatementContext,
     ) -> Statement<'a> {
         let decl = self.parse_variable_declaration(
-            start_span,
+            start,
             kind,
             VariableDeclarationParent::Statement,
             false,
@@ -301,55 +301,55 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.4 Empty Statement
     fn parse_empty_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `;`
-        Statement::new_empty_statement(self.end_span(span), self)
+        Statement::new_empty_statement(self.end_span(start), self)
     }
 
     /// Section 14.5 Expression Statement
     pub(crate) fn parse_expression_statement(
         &mut self,
-        span: u32,
+        start: u32,
         expression: Expression<'a>,
     ) -> Statement<'a> {
         self.asi();
-        Statement::new_expression_statement(self.end_span(span), expression, self)
+        Statement::new_expression_statement(self.end_span(start), expression, self)
     }
 
     /// Section 14.6 If Statement
     fn parse_if_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `if`
         let test = self.parse_paren_expression();
         let consequent = self.parse_statement_list_item(StatementContext::If);
         let alternate =
             self.eat(Kind::Else).then(|| self.parse_statement_list_item(StatementContext::If));
-        Statement::new_if_statement(self.end_span(span), test, consequent, alternate, self)
+        Statement::new_if_statement(self.end_span(start), test, consequent, alternate, self)
     }
 
     /// Section 14.7.2 Do-While Statement
     fn parse_do_while_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // advance `do`
         let body = self.parse_statement_list_item(StatementContext::Do);
         self.expect(Kind::While);
         let test = self.parse_paren_expression();
         self.bump(Kind::Semicolon);
-        Statement::new_do_while_statement(self.end_span(span), body, test, self)
+        Statement::new_do_while_statement(self.end_span(start), body, test, self)
     }
 
     /// Section 14.7.3 While Statement
     fn parse_while_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `while`
         let test = self.parse_paren_expression();
         let body = self.parse_statement_list_item(StatementContext::While);
-        Statement::new_while_statement(self.end_span(span), test, body, self)
+        Statement::new_while_statement(self.end_span(start), test, body, self)
     }
 
     /// Section 14.7.4 For Statement
     fn parse_for_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let for_start = self.start_span();
         self.bump_any(); // bump `for`
 
         // [+Await]
@@ -377,28 +377,28 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         // for (;..
         if self.at(Kind::Semicolon) {
-            return self.parse_for_loop(span, parenthesis_opening_span, None, r#await);
+            return self.parse_for_loop(for_start, parenthesis_opening_span, None, r#await);
         }
 
         // `for (const` | `for (var`
         match self.cur_kind() {
             Kind::Const => {
-                let start_span = self.start_span();
+                let decl_start = self.start_span();
                 self.bump_any();
                 return self.parse_variable_declaration_for_statement(
-                    span,
-                    start_span,
+                    for_start,
+                    decl_start,
                     parenthesis_opening_span,
                     VariableDeclarationKind::Const,
                     r#await,
                 );
             }
             Kind::Var => {
-                let start_span = self.start_span();
+                let decl_start = self.start_span();
                 self.bump_any();
                 return self.parse_variable_declaration_for_statement(
-                    span,
-                    start_span,
+                    for_start,
+                    decl_start,
                     parenthesis_opening_span,
                     VariableDeclarationKind::Var,
                     r#await,
@@ -406,13 +406,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
             Kind::Let => {
                 // `for (let`
-                let start_span = self.start_span();
+                let decl_start = self.start_span();
                 // disallow `for (let in ...`
                 if self.lexer.peek_token().kind().is_after_let() {
                     self.bump_any(); // bump `let`
                     return self.parse_variable_declaration_for_statement(
-                        span,
-                        start_span,
+                        for_start,
+                        decl_start,
                         parenthesis_opening_span,
                         VariableDeclarationKind::Let,
                         r#await,
@@ -435,7 +435,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             })
         {
             return self.parse_using_declaration_for_statement(
-                span,
+                for_start,
                 parenthesis_opening_span,
                 r#await,
             );
@@ -460,14 +460,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             })
         {
             return self.parse_using_declaration_for_statement(
-                span,
+                for_start,
                 parenthesis_opening_span,
                 r#await,
             );
         }
 
         if self.at(Kind::RParen) {
-            return self.parse_for_loop(span, parenthesis_opening_span, None, r#await);
+            return self.parse_for_loop(for_start, parenthesis_opening_span, None, r#await);
         }
 
         let is_let = self.at(Kind::Let);
@@ -481,7 +481,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Kind::In => {
                 let target = AssignmentTarget::cover(init_expression, self);
                 let for_stmt_left = ForStatementLeft::from(target);
-                self.parse_for_in_loop(span, parenthesis_opening_span, r#await, for_stmt_left)
+                self.parse_for_in_loop(for_start, parenthesis_opening_span, r#await, for_stmt_left)
             }
             Kind::Of => {
                 if !r#await && is_async && init_expression.is_identifier_reference() {
@@ -494,10 +494,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
                 let target = AssignmentTarget::cover(init_expression, self);
                 let for_stmt_left = ForStatementLeft::from(target);
-                self.parse_for_of_loop(span, parenthesis_opening_span, r#await, for_stmt_left)
+                self.parse_for_of_loop(for_start, parenthesis_opening_span, r#await, for_stmt_left)
             }
             _ => self.parse_for_loop(
-                span,
+                for_start,
                 parenthesis_opening_span,
                 Some(ForStatementInit::from(init_expression)),
                 r#await,
@@ -507,22 +507,22 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_variable_declaration_for_statement(
         &mut self,
-        span: u32,
-        start_span: u32,
+        for_start: u32,
+        decl_start: u32,
         parenthesis_opening_span: Span,
         decl_kind: VariableDeclarationKind,
         r#await: bool,
     ) -> Statement<'a> {
         let init_declaration = self.context_remove(Context::In, |p| {
             p.parse_variable_declaration(
-                start_span,
+                decl_start,
                 decl_kind,
                 VariableDeclarationParent::For,
                 false,
             )
         });
 
-        self.parse_any_for_loop(span, parenthesis_opening_span, init_declaration, r#await)
+        self.parse_any_for_loop(for_start, parenthesis_opening_span, init_declaration, r#await)
     }
 
     pub(crate) fn is_using_declaration(&mut self) -> bool {
@@ -533,7 +533,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_using_declaration_for_statement(
         &mut self,
-        span: u32,
+        start: u32,
         parenthesis_opening_span: Span,
         r#await: bool,
     ) -> Statement<'a> {
@@ -551,31 +551,31 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
 
-        self.parse_any_for_loop(span, parenthesis_opening_span, using_decl, r#await)
+        self.parse_any_for_loop(start, parenthesis_opening_span, using_decl, r#await)
     }
 
     fn parse_any_for_loop(
         &mut self,
-        span: u32,
+        start: u32,
         parenthesis_opening_span: Span,
         init_declaration: ArenaBox<'a, VariableDeclaration<'a>>,
         r#await: bool,
     ) -> Statement<'a> {
         match self.cur_kind() {
             Kind::In => self.parse_for_in_loop(
-                span,
+                start,
                 parenthesis_opening_span,
                 r#await,
                 ForStatementLeft::VariableDeclaration(init_declaration),
             ),
             Kind::Of => self.parse_for_of_loop(
-                span,
+                start,
                 parenthesis_opening_span,
                 r#await,
                 ForStatementLeft::VariableDeclaration(init_declaration),
             ),
             _ => self.parse_for_loop(
-                span,
+                start,
                 parenthesis_opening_span,
                 Some(ForStatementInit::VariableDeclaration(init_declaration)),
                 r#await,
@@ -585,7 +585,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_for_loop(
         &mut self,
-        span: u32,
+        start: u32,
         parenthesis_opening_span: Span,
         init: Option<ForStatementInit<'a>>,
         r#await: bool,
@@ -609,15 +609,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         };
         self.expect_closing(Kind::RParen, parenthesis_opening_span);
         if r#await {
-            self.error(diagnostics::for_await(self.end_span(span)));
+            self.error(diagnostics::for_await(self.end_span(start)));
         }
         let body = self.parse_statement_list_item(StatementContext::For);
-        Statement::new_for_statement(self.end_span(span), init, test, update, body, self)
+        Statement::new_for_statement(self.end_span(start), init, test, update, body, self)
     }
 
     fn parse_for_in_loop(
         &mut self,
-        span: u32,
+        start: u32,
         parenthesis_opening_span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
@@ -627,17 +627,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect_closing(Kind::RParen, parenthesis_opening_span);
 
         if r#await {
-            self.error(diagnostics::for_await(self.end_span(span)));
+            self.error(diagnostics::for_await(self.end_span(start)));
         }
 
         let body = self.parse_statement_list_item(StatementContext::For);
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         Statement::new_for_in_statement(span, left, right, body, self)
     }
 
     fn parse_for_of_loop(
         &mut self,
-        span: u32,
+        start: u32,
         parenthesis_opening_span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
@@ -647,28 +647,28 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect_closing(Kind::RParen, parenthesis_opening_span);
 
         let body = self.parse_statement_list_item(StatementContext::For);
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         Statement::new_for_of_statement(span, r#await, left, right, body, self)
     }
 
     /// Section 14.8 Continue Statement
     fn parse_continue_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `continue`
         let label =
             if self.can_insert_semicolon() { None } else { Some(self.parse_label_identifier()) };
         self.asi();
-        Statement::new_continue_statement(self.end_span(span), label, self)
+        Statement::new_continue_statement(self.end_span(start), label, self)
     }
 
     /// Section 14.9 Break Statement
     fn parse_break_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `break`
         let label =
             if self.can_insert_semicolon() { None } else { Some(self.parse_label_identifier()) };
         self.asi();
-        Statement::new_break_statement(self.end_span(span), label, self)
+        Statement::new_break_statement(self.end_span(start), label, self)
     }
 
     /// Section 14.10 Return Statement
@@ -676,7 +676,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   return ;
     ///   return [no `LineTerminator` here] Expression[+In, ?Yield, ?Await] ;
     fn parse_return_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // advance `return`
         let argument = if self.eat(Kind::Semicolon) || self.can_insert_semicolon() {
             None
@@ -686,7 +686,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Some(expr)
         };
         if !self.ctx.has_return() {
-            let span = Span::sized(span, 6);
+            let span = Span::sized(start, 6);
             // Class static blocks enable `NewTarget` but disable `Return`.
             // Other contexts that allow `new.target` cannot directly contain
             // a return statement without entering a function body first.
@@ -696,22 +696,22 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::return_statement_only_in_function_body(span));
             }
         }
-        Statement::new_return_statement(self.end_span(span), argument, self)
+        Statement::new_return_statement(self.end_span(start), argument, self)
     }
 
     /// Section 14.11 With Statement
     fn parse_with_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `with`
         let object = self.parse_paren_expression();
         let body = self.parse_statement_list_item(StatementContext::With);
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         Statement::new_with_statement(span, object, body, self)
     }
 
     /// Section 14.12 Switch Statement
     fn parse_switch_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // advance `switch`
         let discriminant = self.parse_paren_expression();
         // A `switch` may contain at most one `default` clause. Track the first one
@@ -732,11 +732,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
             case
         });
-        Statement::new_switch_statement(self.end_span(span), discriminant, cases, self)
+        Statement::new_switch_statement(self.end_span(start), discriminant, cases, self)
     }
 
     pub(crate) fn parse_switch_case(&mut self) -> SwitchCase<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let test = match self.cur_kind() {
             Kind::Default => {
                 self.bump_any();
@@ -779,28 +779,28 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
             consequent.push(stmt);
         }
-        SwitchCase::new(self.end_span(span), test, consequent, self)
+        SwitchCase::new(self.end_span(start), test, consequent, self)
     }
 
     /// Section 14.14 Throw Statement
     fn parse_throw_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // advance `throw`
         if self.cur_token().is_on_new_line() {
             self.error(diagnostics::illegal_newline(
                 "throw",
-                self.end_span(span),
+                self.end_span(start),
                 self.cur_token().span(),
             ));
         }
         let argument = self.parse_expr();
         self.asi();
-        Statement::new_throw_statement(self.end_span(span), argument, self)
+        Statement::new_throw_statement(self.end_span(start), argument, self)
     }
 
     /// Section 14.15 Try Statement
     fn parse_try_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `try`
 
         let block = self.parse_block();
@@ -814,11 +814,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::expect_catch_finally(range));
         }
 
-        Statement::new_try_statement(self.end_span(span), block, handler, finalizer, self)
+        Statement::new_try_statement(self.end_span(start), block, handler, finalizer, self)
     }
 
     fn parse_catch_clause(&mut self) -> ArenaBox<'a, CatchClause<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // advance `catch`
         let pattern = if self.eat(Kind::LParen) {
             let (pattern, type_annotation) = self.parse_binding_pattern_with_type_annotation();
@@ -839,57 +839,57 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self,
             )
         });
-        CatchClause::boxed(self.end_span(span), param, body, self)
+        CatchClause::boxed(self.end_span(start), param, body, self)
     }
 
     /// Section 14.16 Debugger Statement
     fn parse_debugger_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any();
         self.asi();
-        Statement::new_debugger_statement(self.end_span(span), self)
+        Statement::new_debugger_statement(self.end_span(start), self)
     }
 
     /// Parse const declaration or `const enum`.
     fn parse_const_statement(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any();
         if self.is_ts && self.at(Kind::Enum) {
-            let modifiers = Modifiers::new_single(ModifierKind::Const, span);
-            Statement::from(self.parse_ts_enum_declaration(span, &modifiers))
+            let modifiers = Modifiers::new_single(ModifierKind::Const, start);
+            Statement::from(self.parse_ts_enum_declaration(start, &modifiers))
         } else {
-            self.parse_variable_statement(span, VariableDeclarationKind::Const, stmt_ctx)
+            self.parse_variable_statement(start, VariableDeclarationKind::Const, stmt_ctx)
         }
     }
 
     /// Parse import statement or import expression.
     fn parse_import_statement(&mut self) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         if matches!(self.lexer.peek_token().kind(), Kind::Dot | Kind::LParen) {
             // Parse the whole expression `import.meta.url`.
             self.parse_expression_or_labeled_statement()
         } else {
             self.bump_any(); // bump `import`
-            self.parse_import_declaration(span, self.ctx.has_top_level())
+            self.parse_import_declaration(start, self.ctx.has_top_level())
         }
     }
 
     /// Parse statements that start with `sync`.
-    fn parse_async_statement(&mut self, span: u32, stmt_ctx: StatementContext) -> Statement<'a> {
+    fn parse_async_statement(&mut self, start: u32, stmt_ctx: StatementContext) -> Statement<'a> {
         let token = self.lexer.peek_token();
         if token.kind() == Kind::Function && !token.is_on_new_line() {
             self.bump_any(); // bump `async`
-            return self.parse_function_declaration(span, /* async */ true, stmt_ctx);
+            return self.parse_function_declaration(start, /* async */ true, stmt_ctx);
         }
         if self.is_ts && self.at_start_of_ts_declaration() {
-            return self.parse_ts_declaration_statement(span, stmt_ctx);
+            return self.parse_ts_declaration_statement(start, stmt_ctx);
         }
         self.parse_expression_or_labeled_statement()
     }
 
     /// Parse statements that start with `@`.
     fn parse_decorated_statement(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let decorators = self.parse_decorators();
         let kind = self.cur_kind();
         if kind == Kind::Export {
@@ -899,7 +899,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let modifiers = self.parse_modifiers(false, false);
         if self.at(Kind::Class) {
             // Class span.start starts before decorators.
-            return self.parse_class_statement(span, stmt_ctx, &modifiers, decorators);
+            return self.parse_class_statement(start, stmt_ctx, &modifiers, decorators);
         }
         self.unexpected()
     }

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -23,13 +23,13 @@ impl<'a> Dummy<'a> for JSXClosing<'a> {
 
 impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_jsx_expression(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `<`
         let kind = self.cur_kind();
         let expr = if kind == Kind::RAngle {
-            Expression::JSXFragment(self.parse_jsx_fragment(span, false))
+            Expression::JSXFragment(self.parse_jsx_fragment(start, false))
         } else if kind.is_identifier_or_keyword() {
-            Expression::JSXElement(self.parse_jsx_element(span, false))
+            Expression::JSXElement(self.parse_jsx_element(start, false))
         } else {
             return self.unexpected();
         };
@@ -48,11 +48,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   < > `JSXChildren_opt` < / >
     fn parse_jsx_fragment(
         &mut self,
-        span: u32,
+        start: u32,
         in_jsx_child: bool,
     ) -> ArenaBox<'a, JSXFragment<'a>> {
         self.expect_jsx_child(Kind::RAngle);
-        let opening_fragment = JSXOpeningFragment::new(self.end_span(span), self);
+        let opening_fragment = JSXOpeningFragment::new(self.end_span(start), self);
         let (children, closing) = self.parse_jsx_children_and_closing(in_jsx_child);
         let closing_fragment = match closing {
             JSXClosing::Fragment(f) => f,
@@ -65,7 +65,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 JSXClosingFragment::new(e.span, self)
             }
         };
-        JSXFragment::boxed(self.end_span(span), opening_fragment, children, closing_fragment, self)
+        JSXFragment::boxed(self.end_span(start), opening_fragment, children, closing_fragment, self)
     }
 
     /// `JSXElement` :
@@ -74,8 +74,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// `in_jsx_child`:
     ///     used for telling `JSXClosingElement` to parse the next jsx child or not
     ///     true when inside jsx element, false when at top level expression
-    fn parse_jsx_element(&mut self, span: u32, in_jsx_child: bool) -> ArenaBox<'a, JSXElement<'a>> {
-        let (opening_element, self_closing) = self.parse_jsx_opening_element(span, in_jsx_child);
+    fn parse_jsx_element(
+        &mut self,
+        start: u32,
+        in_jsx_child: bool,
+    ) -> ArenaBox<'a, JSXElement<'a>> {
+        let (opening_element, self_closing) = self.parse_jsx_opening_element(start, in_jsx_child);
         let (children, closing_element) = if self_closing {
             (ArenaVec::new_in(self), None)
         } else {
@@ -102,14 +106,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             };
             (children, Some(closing_element))
         };
-        JSXElement::boxed(self.end_span(span), opening_element, children, closing_element, self)
+        JSXElement::boxed(self.end_span(start), opening_element, children, closing_element, self)
     }
 
     /// `JSXOpeningElement` :
     /// < `JSXElementName` `JSXAttributes_opt` >
     fn parse_jsx_opening_element(
         &mut self,
-        span: u32,
+        start: u32,
         in_jsx_child: bool,
     ) -> (
         ArenaBox<'a, JSXOpeningElement<'a>>,
@@ -126,7 +130,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.expect(Kind::RAngle);
         }
         let elem =
-            JSXOpeningElement::boxed(self.end_span(span), name, type_arguments, attributes, self);
+            JSXOpeningElement::boxed(self.end_span(start), name, type_arguments, attributes, self);
         (elem, self_closing)
     }
 
@@ -135,14 +139,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   `JSXNamespacedName`
     ///   `JSXMemberExpression`
     fn parse_jsx_element_name(&mut self) -> JSXElementName<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let (identifier, contains_dash) = self.parse_jsx_identifier();
 
         // <namespace:property />
         if self.eat(Kind::Colon) {
             let (property, _) = self.parse_jsx_identifier();
             return JSXElementName::new_namespaced_name(
-                self.end_span(span),
+                self.end_span(start),
                 identifier,
                 property,
                 self,
@@ -152,7 +156,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // <member.foo.bar />
         if self.at(Kind::Dot) {
             return JSXElementName::MemberExpression(
-                self.parse_jsx_member_expression(span, &identifier),
+                self.parse_jsx_member_expression(start, &identifier),
             );
         }
 
@@ -195,7 +199,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// `JSXMemberExpression` . `JSXIdentifier`
     fn parse_jsx_member_expression(
         &mut self,
-        span: u32,
+        start: u32,
         object: &JSXIdentifier<'a>,
     ) -> ArenaBox<'a, JSXMemberExpression<'a>> {
         let mut object = if object.name == "this" {
@@ -208,7 +212,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             )
         };
 
-        let mut span = Span::new(span, 0);
+        let mut span = Span::new(start, 0);
         let mut property = None;
 
         while self.eat(Kind::Dot) && self.fatal_error.is_none() {
@@ -264,20 +268,20 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
             match self.cur_kind() {
                 Kind::LAngle => {
-                    let span = self.start_span();
+                    let start = self.start_span();
                     self.bump_any(); // bump `<`
                     let kind = self.cur_kind();
 
                     // <> open nested fragment
                     if kind == Kind::RAngle {
-                        let child = JSXChild::Fragment(self.parse_jsx_fragment(span, true));
+                        let child = JSXChild::Fragment(self.parse_jsx_fragment(start, true));
                         children.push(child);
                         continue;
                     }
 
                     // <ident open nested element
                     if kind == Kind::Ident || kind.is_any_keyword() {
-                        let child = JSXChild::Element(self.parse_jsx_element(span, true));
+                        let child = JSXChild::Element(self.parse_jsx_element(start, true));
                         children.push(child);
                         continue;
                     }
@@ -285,27 +289,26 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     // </ closing tag - parse it inline and return
                     if kind == Kind::Slash {
                         self.bump_any(); // bump `/`
-                        return self.parse_jsx_closing_inline(span, in_jsx_child);
+                        return self.parse_jsx_closing_inline(start, in_jsx_child);
                     }
 
                     // Unexpected token after `<`
                     return self.unexpected();
                 }
                 Kind::LCurly => {
-                    let span_start = self.start_span();
+                    let start = self.start_span();
                     self.bump_any(); // bump `{`
 
                     // {...expr}
                     if self.eat(Kind::Dot3) {
-                        let child = JSXChild::Spread(self.parse_jsx_spread_child(span_start));
+                        let child = JSXChild::Spread(self.parse_jsx_spread_child(start));
                         children.push(child);
                         continue;
                     }
                     // {expr}
-                    let child =
-                        JSXChild::ExpressionContainer(self.parse_jsx_expression_container(
-                            span_start, /* in_jsx_child */ true,
-                        ));
+                    let child = JSXChild::ExpressionContainer(
+                        self.parse_jsx_expression_container(start, /* in_jsx_child */ true),
+                    );
                     children.push(child);
                 }
                 // text
@@ -354,7 +357,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   { `JSXChildExpression_opt` }
     fn parse_jsx_expression_container(
         &mut self,
-        span_start: u32,
+        start: u32,
         in_jsx_child: bool,
     ) -> ArenaBox<'a, JSXExpressionContainer<'a>> {
         let expr = if self.at(Kind::RCurly) {
@@ -363,7 +366,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             } else {
                 self.expect(Kind::RCurly);
             }
-            let span = self.end_span(span_start);
+            let span = self.end_span(start);
 
             // Empty expression is not allowed in JSX attribute value
             // e.g. `<C attr={} />`
@@ -390,15 +393,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             expr
         };
 
-        JSXExpressionContainer::boxed(self.end_span(span_start), expr, self)
+        JSXExpressionContainer::boxed(self.end_span(start), expr, self)
     }
 
     /// `JSXChildExpression` :
     ///   { ... `AssignmentExpression` }
-    fn parse_jsx_spread_child(&mut self, span_start: u32) -> ArenaBox<'a, JSXSpreadChild<'a>> {
+    fn parse_jsx_spread_child(&mut self, start: u32) -> ArenaBox<'a, JSXSpreadChild<'a>> {
         let expr = self.parse_expr();
         self.expect_jsx_child(Kind::RCurly);
-        JSXSpreadChild::boxed(self.end_span(span_start), expr, self)
+        JSXSpreadChild::boxed(self.end_span(start), expr, self)
     }
 
     /// `JSXAttributes` :
@@ -427,7 +430,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// `JSXAttribute` :
     ///   `JSXAttributeName` `JSXAttributeInitializer_opt`
     fn parse_jsx_attribute(&mut self) -> ArenaBox<'a, JSXAttribute<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         let name = self.parse_jsx_attribute_name();
         let value = if self.at(Kind::Eq) {
             self.advance_for_jsx_attribute_value();
@@ -435,31 +438,31 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         } else {
             None
         };
-        JSXAttribute::boxed(self.end_span(span), name, value, self)
+        JSXAttribute::boxed(self.end_span(start), name, value, self)
     }
 
     /// `JSXSpreadAttribute` :
     ///   { ... `AssignmentExpression` }
     fn parse_jsx_spread_attribute(&mut self) -> ArenaBox<'a, JSXSpreadAttribute<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `{`
         self.expect(Kind::Dot3);
         let argument = self.parse_expr();
         self.expect(Kind::RCurly);
-        JSXSpreadAttribute::boxed(self.end_span(span), argument, self)
+        JSXSpreadAttribute::boxed(self.end_span(start), argument, self)
     }
 
     /// `JSXAttributeName` :
     ///   `JSXIdentifier`
     ///   `JSXNamespacedName`
     fn parse_jsx_attribute_name(&mut self) -> JSXAttributeName<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let (identifier, _) = self.parse_jsx_identifier();
 
         if self.eat(Kind::Colon) {
             let (property, _) = self.parse_jsx_identifier();
             return JSXAttributeName::new_namespaced_name(
-                self.end_span(span),
+                self.end_span(start),
                 identifier,
                 property,
                 self,
@@ -476,11 +479,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 JSXAttributeValue::StringLiteral(self.alloc(str_lit))
             }
             Kind::LCurly => {
-                let span_start = self.start_span();
+                let start = self.start_span();
                 self.bump_any(); // bump `{`
 
                 let expr =
-                    self.parse_jsx_expression_container(span_start, /* in_jsx_child */ false);
+                    self.parse_jsx_expression_container(start, /* in_jsx_child */ false);
                 JSXAttributeValue::ExpressionContainer(expr)
             }
             Kind::LAngle => match self.parse_jsx_expression() {
@@ -502,7 +505,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         JSXIdentifier<'a>, // JSX identifier
         bool,              // `true` if contains `-`
     ) {
-        let span = self.start_span();
+        let start = self.start_span();
         let kind = self.cur_kind();
         if kind != Kind::Ident && !kind.is_any_keyword() {
             return (self.unexpected(), false);
@@ -510,7 +513,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // Currently at a valid normal Ident or Keyword, keep on lexing for `-` in `<component-name />`
         let contains_dash = self.continue_lex_jsx_identifier();
         self.bump_any();
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         let name = span.source_text(self.source_text);
         let identifier = JSXIdentifier::new(span, name, self);
         (identifier, contains_dash)

--- a/crates/oxc_parser/src/lexer/template.rs
+++ b/crates/oxc_parser/src/lexer/template.rs
@@ -405,8 +405,8 @@ impl<'a, C: Config> Lexer<'a, C> {
         self.token.set_escaped(true);
     }
 
-    pub(crate) fn get_template_string(&self, span_start: u32) -> Option<&'a str> {
-        self.escaped_templates[&span_start]
+    pub(crate) fn get_template_string(&self, start: u32) -> Option<&'a str> {
+        self.escaped_templates[&start]
     }
 }
 

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -17,19 +17,19 @@ use crate::{
 
 #[derive(Debug, Clone, Copy)]
 pub struct Modifier {
-    pub span_start: u32,
+    pub start: u32,
     pub kind: ModifierKind,
 }
 
 impl Modifier {
     #[inline]
-    pub const fn new(span_start: u32, kind: ModifierKind) -> Self {
-        Self { span_start, kind }
+    pub const fn new(start: u32, kind: ModifierKind) -> Self {
+        Self { start, kind }
     }
 
     #[inline]
     pub const fn span(self) -> Span {
-        Span::sized(self.span_start, self.kind.len())
+        Span::sized(self.start, self.kind.len())
     }
 }
 
@@ -497,7 +497,7 @@ impl<C: Config> ParserImpl<'_, C> {
             let modifier = Modifier::new(self.start_span(), modifier_kind);
             self.bump_any();
             self.check_modifier(modifiers.kinds(), modifier);
-            modifiers.add(modifier.kind, modifier.span_start);
+            modifiers.add(modifier.kind, modifier.start);
         }
         modifiers
     }
@@ -523,12 +523,12 @@ impl<C: Config> ParserImpl<'_, C> {
         if is_modifier { Some(modifier_kind) } else { None }
     }
 
-    fn modifier(&mut self, kind: Kind, span_start: u32) -> Modifier {
+    fn modifier(&mut self, kind: Kind, start: u32) -> Modifier {
         let modifier_kind = ModifierKind::try_from(kind).unwrap_or_else(|()| {
             self.set_unexpected();
             ModifierKind::Abstract // Dummy value
         });
-        Modifier::new(span_start, modifier_kind)
+        Modifier::new(start, modifier_kind)
     }
 
     pub(crate) fn parse_modifiers(
@@ -544,7 +544,7 @@ impl<C: Config> ParserImpl<'_, C> {
             stop_on_start_of_class_static_block,
         ) {
             self.check_modifier(modifiers.kinds(), modifier);
-            modifiers.add(modifier.kind, modifier.span_start);
+            modifiers.add(modifier.kind, modifier.start);
         }
 
         modifiers
@@ -556,7 +556,7 @@ impl<C: Config> ParserImpl<'_, C> {
         permit_const_as_modifier: bool,
         stop_on_start_of_class_static_block: bool,
     ) -> Option<Modifier> {
-        let span_start = self.start_span();
+        let start = self.start_span();
         let kind = self.cur_kind();
 
         if kind == Kind::Const {
@@ -590,7 +590,7 @@ impl<C: Config> ParserImpl<'_, C> {
             // next token is not a modifier
             return None;
         }
-        Some(self.modifier(kind, span_start))
+        Some(self.modifier(kind, start))
     }
 
     pub(crate) fn parse_contextual_modifier(&mut self, kind: Kind) -> bool {
@@ -826,7 +826,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     .iter()
                     .filter(|modifier| !allowed.contains(modifier.kind))
                     .collect::<Vec<_>>();
-                disallowed_modifiers.sort_unstable_by_key(|modifier| modifier.span_start);
+                disallowed_modifiers.sort_unstable_by_key(|modifier| modifier.start);
                 disallowed_modifiers
             }
 

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -20,14 +20,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// `https://www.typescriptlang.org/docs/handbook/enums.html`
     pub(crate) fn parse_ts_enum_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         modifiers: &Modifiers,
     ) -> Declaration<'a> {
         self.bump_any(); // bump `enum`
         let id = self.parse_binding_identifier();
         self.check_reserved_type_name(&id, "Enum");
         let body = self.parse_ts_enum_body();
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         self.verify_modifiers(
             modifiers,
             ModifierKinds::new([ModifierKind::Declare, ModifierKind::Const]),
@@ -45,7 +45,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_ts_enum_body(&mut self) -> TSEnumBody<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
         let (members, _) = self.parse_delimited_list(
@@ -55,18 +55,18 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Self::parse_ts_enum_member,
         );
         self.expect(Kind::RCurly);
-        TSEnumBody::new(self.end_span(span), members, self)
+        TSEnumBody::new(self.end_span(start), members, self)
     }
 
     pub(crate) fn parse_ts_enum_member(&mut self) -> TSEnumMember<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let id = self.parse_ts_enum_member_name();
         let initializer = if self.eat(Kind::Eq) {
             Some(self.parse_assignment_expression_or_higher())
         } else {
             None
         };
-        TSEnumMember::new(self.end_span(span), id, initializer, self)
+        TSEnumMember::new(self.end_span(start), id, initializer, self)
     }
 
     fn parse_ts_enum_member_name(&mut self) -> TSEnumMemberName<'a> {
@@ -119,15 +119,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if !self.at(Kind::Colon) {
             return None;
         }
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump ':'
         let type_annotation = self.parse_ts_type();
-        Some(TSTypeAnnotation::boxed(self.end_span(span), type_annotation, self))
+        Some(TSTypeAnnotation::boxed(self.end_span(start), type_annotation, self))
     }
 
     pub(crate) fn parse_ts_type_alias_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         modifiers: &Modifiers,
     ) -> Declaration<'a> {
         self.expect(Kind::Type);
@@ -175,7 +175,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         };
 
         self.asi();
-        let span = self.end_span(span);
+        let span = self.end_span(start);
 
         self.verify_modifiers(
             modifiers,
@@ -223,7 +223,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_ts_interface_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         modifiers: &Modifiers,
     ) -> Declaration<'a> {
         let id = self.parse_binding_identifier();
@@ -258,7 +258,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
         Declaration::new_ts_interface_declaration(
-            self.end_span(span),
+            self.end_span(start),
             id,
             type_parameters,
             extends,
@@ -273,7 +273,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let mut extends = ArenaVec::with_capacity_in(1, self);
         loop {
-            let span = self.start_span();
+            let start = self.start_span();
             let mut extend = self.parse_lhs_expression_or_higher();
             if self.fatal_error.is_some() {
                 break;
@@ -288,7 +288,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
 
             let heritage =
-                TSInterfaceHeritage::new(self.end_span(span), extend, type_argument, self);
+                TSInterfaceHeritage::new(self.end_span(start), extend, type_argument, self);
             extends.push(heritage);
 
             if !self.eat(Kind::Comma) {
@@ -300,14 +300,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_ts_interface_body(&mut self) -> ArenaBox<'a, TSInterfaceBody<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         let body_list =
             self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_ts_type_signature);
-        TSInterfaceBody::boxed(self.end_span(span), body_list, self)
+        TSInterfaceBody::boxed(self.end_span(start), body_list, self)
     }
 
     pub(crate) fn parse_ts_type_signature(&mut self) -> TSSignature<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let kind = self.cur_kind();
 
         if matches!(kind, Kind::LParen | Kind::LAngle) {
@@ -333,7 +333,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 diagnostics::cannot_appear_on_an_index_signature,
             );
             return TSSignature::TSIndexSignature(
-                self.parse_index_signature_declaration(span, &modifiers),
+                self.parse_index_signature_declaration(start, &modifiers),
             );
         }
 
@@ -345,14 +345,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         );
 
         if self.parse_contextual_modifier(Kind::Get) {
-            return self.parse_getter_setter_signature_member(span, TSMethodSignatureKind::Get);
+            return self.parse_getter_setter_signature_member(start, TSMethodSignatureKind::Get);
         }
 
         if self.parse_contextual_modifier(Kind::Set) {
-            return self.parse_getter_setter_signature_member(span, TSMethodSignatureKind::Set);
+            return self.parse_getter_setter_signature_member(start, TSMethodSignatureKind::Set);
         }
 
-        self.parse_property_or_method_signature(span, &modifiers)
+        self.parse_property_or_method_signature(start, &modifiers)
     }
 
     pub(crate) fn is_index_signature(&mut self) -> bool {
@@ -388,7 +388,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_ts_module_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         modifiers: &Modifiers,
     ) -> ArenaBox<'a, TSModuleDeclaration<'a>> {
         let kind = if self.eat(Kind::Namespace) {
@@ -396,16 +396,16 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         } else {
             self.expect(Kind::Module);
             if self.at(Kind::Str) {
-                return self.parse_ambient_external_module_declaration(span, modifiers);
+                return self.parse_ambient_external_module_declaration(start, modifiers);
             }
             TSModuleDeclarationKind::Module
         };
-        self.parse_module_or_namespace_declaration(span, kind, modifiers)
+        self.parse_module_or_namespace_declaration(start, kind, modifiers)
     }
 
     fn parse_ambient_external_module_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         modifiers: &Modifiers,
     ) -> ArenaBox<'a, TSModuleDeclaration<'a>> {
         let id = TSModuleDeclarationName::StringLiteral(self.parse_literal_string());
@@ -424,7 +424,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             diagnostics::modifier_cannot_be_used_here,
         );
         TSModuleDeclaration::boxed(
-            self.end_span(span),
+            self.end_span(start),
             id,
             body,
             TSModuleDeclarationKind::Module,
@@ -488,26 +488,26 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         in_ts_namespace_body: bool,
     ) -> ArenaBox<'a, TSModuleBlock<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.expect(Kind::LCurly);
         // Remove TopLevel context for module block
         let (directives, statements) = self.context_remove(Context::TopLevel, |p| {
             p.parse_directives_and_statements(in_ts_namespace_body)
         });
         self.expect(Kind::RCurly);
-        TSModuleBlock::boxed(self.end_span(span), directives, statements, self)
+        TSModuleBlock::boxed(self.end_span(start), directives, statements, self)
     }
 
     fn parse_module_or_namespace_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         kind: TSModuleDeclarationKind,
         modifiers: &Modifiers,
     ) -> ArenaBox<'a, TSModuleDeclaration<'a>> {
         let id = TSModuleDeclarationName::Identifier(self.parse_binding_identifier());
         let body = if self.eat(Kind::Dot) {
-            let span = self.start_span();
-            let decl = self.parse_module_or_namespace_declaration(span, kind, &Modifiers::empty());
+            let start = self.start_span();
+            let decl = self.parse_module_or_namespace_declaration(start, kind, &Modifiers::empty());
             TSModuleDeclarationBody::TSModuleDeclaration(decl)
         } else {
             // Internal namespace body — validate each statement inline as it is parsed
@@ -522,7 +522,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             diagnostics::modifier_cannot_be_used_here,
         );
         TSModuleDeclaration::boxed(
-            self.end_span(span),
+            self.end_span(start),
             id,
             Some(body),
             kind,
@@ -533,12 +533,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_ts_global_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         modifiers: &Modifiers,
     ) -> ArenaBox<'a, TSGlobalDeclaration<'a>> {
-        let keyword_span_start = self.start_span();
+        let keyword_start = self.start_span();
         self.expect(Kind::Global);
-        let keyword_span = self.end_span(keyword_span_start);
+        let keyword_span = self.end_span(keyword_start);
 
         let body = self.parse_ts_module_block(/* in_ts_namespace_body */ false).unbox();
 
@@ -550,7 +550,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         );
 
         TSGlobalDeclaration::boxed(
-            self.end_span(span),
+            self.end_span(start),
             keyword_span,
             body,
             modifiers.contains_declare(),
@@ -562,7 +562,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_ts_declaration_statement(
         &mut self,
-        start_span: u32,
+        start: u32,
         stmt_ctx: StatementContext,
     ) -> Statement<'a> {
         let reserved_ctx = self.ctx;
@@ -577,7 +577,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             .ctx
             .union_ambient_if(modifiers.contains_declare())
             .and_await(modifiers.contains_async());
-        let decl = self.parse_declaration(start_span, &modifiers, ArenaVec::new_in(self));
+        let decl = self.parse_declaration(start, &modifiers, ArenaVec::new_in(self));
         self.ctx = reserved_ctx;
         // A TypeScript declaration (`interface`, `type`, `enum`, `namespace`, …) is a
         // `Declaration`, not a `Statement`, so it cannot stand alone as the body of
@@ -590,7 +590,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_declaration(
         &mut self,
-        start_span: u32,
+        start: u32,
         modifiers: &Modifiers,
         decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> Declaration<'a> {
@@ -611,7 +611,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     diagnostics::modifier_cannot_be_used_here,
                 );
                 let decl = self.parse_variable_declaration(
-                    start_span,
+                    start,
                     kind,
                     VariableDeclarationParent::Statement,
                     modifiers.contains_declare(),
@@ -623,7 +623,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 let identifier = self.parse_identifier_kind(self.cur_kind()).1.as_str();
                 self.fatal_error(diagnostics::using_declaration_cannot_be_exported(
                     identifier,
-                    self.end_span(start_span),
+                    self.end_span(start),
                 ))
             }
             Kind::Await if self.is_using_statement() => {
@@ -632,11 +632,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 let identifier = self.parse_identifier_kind(self.cur_kind()).1.as_str();
                 self.fatal_error(diagnostics::using_declaration_cannot_be_exported(
                     identifier,
-                    self.end_span(start_span),
+                    self.end_span(start),
                 ))
             }
             Kind::Class => {
-                let decl = self.parse_class_declaration(start_span, modifiers, decorators);
+                let decl = self.parse_class_declaration(start, modifiers, decorators);
                 Declaration::ClassDeclaration(decl)
             }
             Kind::Import => {
@@ -652,38 +652,35 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     identifier = self.parse_binding_identifier();
                     import_kind = ImportOrExportKind::Type;
                 }
-                self.parse_ts_import_equals_declaration(import_kind, identifier, start_span)
+                self.parse_ts_import_equals_declaration(import_kind, identifier, start)
             }
             Kind::Module | Kind::Namespace if self.is_ts => {
-                let decl = self.parse_ts_module_declaration(start_span, modifiers);
+                let decl = self.parse_ts_module_declaration(start, modifiers);
                 Declaration::TSModuleDeclaration(decl)
             }
             Kind::Global if self.is_ts => {
-                let decl = self.parse_ts_global_declaration(start_span, modifiers);
+                let decl = self.parse_ts_global_declaration(start, modifiers);
                 Declaration::TSGlobalDeclaration(decl)
             }
-            Kind::Type if self.is_ts => self.parse_ts_type_alias_declaration(start_span, modifiers),
-            Kind::Enum if self.is_ts => self.parse_ts_enum_declaration(start_span, modifiers),
+            Kind::Type if self.is_ts => self.parse_ts_type_alias_declaration(start, modifiers),
+            Kind::Enum if self.is_ts => self.parse_ts_enum_declaration(start, modifiers),
             Kind::Interface if self.is_ts => {
                 self.bump_any();
-                self.parse_ts_interface_declaration(start_span, modifiers)
+                self.parse_ts_interface_declaration(start, modifiers)
             }
             _ if self.at_function_with_async() => {
                 let declare = modifiers.contains(ModifierKind::Declare);
                 if declare {
-                    let decl = self.parse_ts_declare_function(start_span, modifiers);
+                    let decl = self.parse_ts_declare_function(start, modifiers);
                     Declaration::FunctionDeclaration(decl)
                 } else if self.is_ts {
-                    let decl = self.parse_ts_function_impl(
-                        start_span,
-                        FunctionKind::Declaration,
-                        modifiers,
-                    );
+                    let decl =
+                        self.parse_ts_function_impl(start, FunctionKind::Declaration, modifiers);
                     Declaration::FunctionDeclaration(decl)
                 } else {
-                    let span = self.start_span();
+                    let start = self.start_span();
                     let r#async = self.eat(Kind::Async);
-                    let decl = self.parse_function_impl(span, r#async, FunctionKind::Declaration);
+                    let decl = self.parse_function_impl(start, r#async, FunctionKind::Declaration);
                     Declaration::FunctionDeclaration(decl)
                 }
             }
@@ -693,7 +690,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_ts_declare_function(
         &mut self,
-        start_span: u32,
+        start: u32,
         modifiers: &Modifiers,
     ) -> ArenaBox<'a, Function<'a>> {
         let r#async = modifiers.contains(ModifierKind::Async);
@@ -702,7 +699,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let func_kind = FunctionKind::TSDeclaration;
         let id = self.parse_function_id(func_kind, r#async, generator.is_some());
         self.parse_function(
-            start_span,
+            start,
             id,
             r#async,
             generator,
@@ -713,13 +710,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_ts_type_assertion(&mut self) -> Expression<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.expect(Kind::LAngle);
         let type_annotation = self.parse_ts_type();
         self.expect(Kind::RAngle);
         let lhs_span = self.start_span();
         let expression = self.parse_simple_unary_expression(lhs_span);
-        let span = self.end_span(span);
+        let span = self.end_span(start);
 
         if matches!(self.source_type.extension(), Some(FileExtension::Mts | FileExtension::Cts)) {
             self.error(diagnostics::jsx_type_assertion_in_mts_cts(span));
@@ -732,7 +729,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         import_kind: ImportOrExportKind,
         identifier: BindingIdentifier<'a>,
-        span: u32,
+        start: u32,
     ) -> Declaration<'a> {
         self.expect(Kind::Eq);
 
@@ -752,7 +749,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         self.asi();
 
-        let span = self.end_span(span);
+        let span = self.end_span(start);
 
         if !self.is_ts {
             self.error(diagnostics::import_equals_can_only_be_used_in_typescript_files(span));
@@ -774,7 +771,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// Parse `TSModuleReference` for `import x = foo` or `import x = foo.bar`.
     ///
     /// Unlike `parse_ts_type_name`, this does not allow `this` as the identifier.
-    fn parse_ts_module_reference(&mut self, span: u32) -> TSModuleReference<'a> {
+    fn parse_ts_module_reference(&mut self, start: u32) -> TSModuleReference<'a> {
         // Check for invalid `this` keyword
         if self.at(Kind::This) {
             let this_span = self.cur_token().span();
@@ -792,7 +789,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         // Parse qualified name: foo.bar.baz
         let type_name =
-            if self.at(Kind::Dot) { self.parse_ts_qualified_type_name(span, left) } else { left };
+            if self.at(Kind::Dot) { self.parse_ts_qualified_type_name(start, left) } else { left };
 
         // Convert TSTypeName to TSModuleReference
         match type_name {
@@ -807,12 +804,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_ts_this_parameter(&mut self) -> ArenaBox<'a, TSThisParameter<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any();
-        let this_span = self.end_span(span);
+        let this_span = self.end_span(start);
 
         let type_annotation = self.parse_ts_type_annotation();
-        TSThisParameter::boxed(self.end_span(span), this_span, type_annotation, self)
+        TSThisParameter::boxed(self.end_span(start), this_span, type_annotation, self)
     }
 
     pub(crate) fn at_start_of_ts_declaration(&mut self) -> bool {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -16,7 +16,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.is_start_of_function_type_or_constructor_type() {
             return self.parse_function_or_constructor_type();
         }
-        let span = self.start_span();
+        let start = self.start_span();
         let ty = self.parse_union_type_or_higher();
         if !self.ctx.has_disallow_conditional_types()
             && !self.cur_token().is_on_new_line()
@@ -32,7 +32,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             let false_type =
                 self.context_remove(Context::DisallowConditionalTypes, Self::parse_ts_type);
             return TSType::new_ts_conditional_type(
-                self.end_span(span),
+                self.end_span(start),
                 ty,
                 extends_type,
                 true_type,
@@ -44,7 +44,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_function_or_constructor_type(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let r#abstract = self.eat(Kind::Abstract);
         let is_constructor_type = self.eat(Kind::New);
         let type_parameters = self.parse_ts_type_parameters();
@@ -57,7 +57,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             TSTypeAnnotation::boxed(self.end_span(return_type_span), return_type, self)
         };
 
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         if is_constructor_type {
             if let Some(this_param) = &this_param {
                 // type Foo = new (this: number) => any;
@@ -187,7 +187,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if !self.at(Kind::LAngle) {
             return (None, false);
         }
-        let span = self.start_span();
+        let start = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LAngle);
         let (params, trailing_comma) =
@@ -195,7 +195,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 p.parse_ts_type_parameter(allow_variance)
             });
         self.expect(Kind::RAngle);
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         if params.is_empty() {
             self.error(diagnostics::ts_empty_type_parameter_list(span));
         }
@@ -213,7 +213,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_ts_type_parameter(&mut self, allow_variance: bool) -> TSTypeParameter<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
 
         let modifiers = self.parse_modifiers(true, false);
         let allowed_modifiers = if allow_variance {
@@ -242,7 +242,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let default = self.parse_ts_default_type();
 
         TSTypeParameter::new(
-            self.end_span(span),
+            self.end_span(start),
             name,
             constraint,
             default,
@@ -272,7 +272,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     where
         F: Fn(&mut Self) -> TSType<'a>,
     {
-        let span = self.start_span();
+        let start = self.start_span();
         let has_leading_operator = self.eat(kind);
         /* hasLeadingOperator && parseFunctionOrConstructorTypeToError(isUnionType) ||*/
         let mut ty = parse_constituent_type(self);
@@ -284,7 +284,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     parse_constituent_type(self);
                 types.push(ty);
             }
-            let span = self.end_span(span);
+            let span = self.end_span(start);
             ty = match kind {
                 Kind::Pipe => TSType::new_ts_union_type(span, types, self),
                 Kind::Amp => TSType::new_ts_intersection_type(span, types, self),
@@ -308,9 +308,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_type_operator(&mut self, operator: TSTypeOperatorOperator) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump operator
-        let operator_span = self.end_span(span);
+        let operator_span = self.end_span(start);
         let ty = self.parse_type_operator_or_higher();
         if operator == TSTypeOperatorOperator::Readonly
             && !matches!(ty, TSType::TSArrayType(_))
@@ -318,22 +318,22 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         {
             self.error(diagnostics::readonly_in_array_or_tuple_type(operator_span));
         }
-        TSType::new_ts_type_operator_type(self.end_span(span), operator, ty, self)
+        TSType::new_ts_type_operator_type(self.end_span(start), operator, ty, self)
     }
 
     fn parse_infer_type(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `infer`
         let type_parameter = self.parse_type_parameter_of_infer_type();
-        TSType::new_ts_infer_type(self.end_span(span), type_parameter, self)
+        TSType::new_ts_infer_type(self.end_span(start), type_parameter, self)
     }
 
     fn parse_type_parameter_of_infer_type(&mut self) -> ArenaBox<'a, TSTypeParameter<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         let name = self.parse_binding_identifier();
         self.check_reserved_type_name(&name, "Type parameter");
         let constraint = self.parse_constraint_of_infer_type();
-        let span = self.end_span(span);
+        let span = self.end_span(start);
 
         TSTypeParameter::boxed(span, name, constraint, None, false, false, false, self)
     }
@@ -371,7 +371,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_postfix_type_or_higher(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let mut ty = self.parse_non_array_type();
 
         while !self.cur_token().is_on_new_line() {
@@ -379,7 +379,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 Kind::Bang => {
                     self.bump_any();
                     ty = TSType::new_js_doc_non_nullable_type(
-                        self.end_span(span),
+                        self.end_span(start),
                         ty,
                         /* postfix */ true,
                         self,
@@ -395,7 +395,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     }
                     self.bump_any();
                     ty = TSType::new_js_doc_nullable_type(
-                        self.end_span(span),
+                        self.end_span(start),
                         ty,
                         /* postfix */ true,
                         self,
@@ -407,14 +407,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         let index_type = self.parse_ts_type();
                         self.expect(Kind::RBrack);
                         ty = TSType::new_ts_indexed_access_type(
-                            self.end_span(span),
+                            self.end_span(start),
                             ty,
                             index_type,
                             self,
                         );
                     } else {
                         self.expect(Kind::RBrack);
-                        ty = TSType::new_ts_array_type(self.end_span(span), ty, self);
+                        ty = TSType::new_ts_array_type(self.end_span(start), ty, self);
                     }
                 }
                 _ => return ty,
@@ -462,31 +462,31 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Kind::Str | Kind::True | Kind::False => self.parse_literal_type(),
             kind if kind.is_number() => self.parse_literal_type(),
             Kind::NoSubstitutionTemplate => {
-                let span = self.start_span();
+                let start = self.start_span();
                 let literal = self.parse_template_literal(false);
-                let span = self.end_span(span);
+                let span = self.end_span(start);
                 TSType::new_ts_literal_type(span, TSLiteral::TemplateLiteral(self.alloc(literal)), self)
             }
             Kind::Minus => {
                 if self.lexer.peek_token().kind().is_number() {
-                    let minus_start_span = self.start_span();
+                    let minus_start = self.start_span();
                     self.bump_any(); // bump `-`
-                    self.parse_literal_type_negative(minus_start_span)
+                    self.parse_literal_type_negative(minus_start)
                 } else {
                     self.parse_type_reference()
                 }
             }
             Kind::Void => {
-                let span = self.start_span();
+                let start = self.start_span();
                 self.bump_any();
-                TSType::new_ts_void_keyword(self.end_span(span), self)
+                TSType::new_ts_void_keyword(self.end_span(start), self)
             }
             Kind::This => {
-                let span = self.start_span();
+                let start = self.start_span();
                 self.bump_any(); // bump `this`
-                let this_type = TSThisType::boxed(self.end_span(span), self);
+                let this_type = TSThisType::boxed(self.end_span(start), self);
                 if self.at(Kind::Is) && !self.cur_token().is_on_new_line() {
-                    self.parse_this_type_predicate(span, this_type)
+                    self.parse_this_type_predicate(start, this_type)
                 } else {
                     TSType::TSThisType(this_type)
                 }
@@ -508,9 +508,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 // Peek the token after `asserts` to check if this is an asserts type predicate.
                 let next = self.lexer.peek_token();
                 if next.kind().is_identifier_name() && !next.is_on_new_line() {
-                    let asserts_start_span = self.start_span();
+                    let asserts_start = self.start_span();
                     self.bump_any(); // bump `asserts`
-                    self.parse_asserts_type_predicate(asserts_start_span)
+                    self.parse_asserts_type_predicate(asserts_start)
                 } else {
                     self.parse_type_reference()
                 }
@@ -521,51 +521,51 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_keyword_type(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         match self.cur_kind() {
             Kind::Any => {
                 self.bump_any();
-                TSType::new_ts_any_keyword(self.end_span(span), self)
+                TSType::new_ts_any_keyword(self.end_span(start), self)
             }
             Kind::BigInt => {
                 self.bump_any();
-                TSType::new_ts_big_int_keyword(self.end_span(span), self)
+                TSType::new_ts_big_int_keyword(self.end_span(start), self)
             }
             Kind::Boolean => {
                 self.bump_any();
-                TSType::new_ts_boolean_keyword(self.end_span(span), self)
+                TSType::new_ts_boolean_keyword(self.end_span(start), self)
             }
             Kind::Never => {
                 self.bump_any();
-                TSType::new_ts_never_keyword(self.end_span(span), self)
+                TSType::new_ts_never_keyword(self.end_span(start), self)
             }
             Kind::Number => {
                 self.bump_any();
-                TSType::new_ts_number_keyword(self.end_span(span), self)
+                TSType::new_ts_number_keyword(self.end_span(start), self)
             }
             Kind::Object => {
                 self.bump_any();
-                TSType::new_ts_object_keyword(self.end_span(span), self)
+                TSType::new_ts_object_keyword(self.end_span(start), self)
             }
             Kind::String => {
                 self.bump_any();
-                TSType::new_ts_string_keyword(self.end_span(span), self)
+                TSType::new_ts_string_keyword(self.end_span(start), self)
             }
             Kind::Symbol => {
                 self.bump_any();
-                TSType::new_ts_symbol_keyword(self.end_span(span), self)
+                TSType::new_ts_symbol_keyword(self.end_span(start), self)
             }
             Kind::Undefined => {
                 self.bump_any();
-                TSType::new_ts_undefined_keyword(self.end_span(span), self)
+                TSType::new_ts_undefined_keyword(self.end_span(start), self)
             }
             Kind::Unknown => {
                 self.bump_any();
-                TSType::new_ts_unknown_keyword(self.end_span(span), self)
+                TSType::new_ts_unknown_keyword(self.end_span(start), self)
             }
             Kind::Null => {
                 self.bump_any();
-                TSType::new_ts_null_keyword(self.end_span(span), self)
+                TSType::new_ts_null_keyword(self.end_span(start), self)
             }
             _ => self.unexpected(),
         }
@@ -653,7 +653,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_mapped_type(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.expect(Kind::LCurly);
         let mut readonly = None;
         if self.eat(Kind::Readonly) {
@@ -698,7 +698,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect(Kind::RCurly);
 
         TSType::new_ts_mapped_type(
-            self.end_span(span),
+            self.end_span(start),
             key,
             constraint,
             name_type,
@@ -710,14 +710,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_type_literal(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let member_list =
             self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_ts_type_signature);
-        TSType::new_ts_type_literal(self.end_span(span), member_list, self)
+        TSType::new_ts_type_literal(self.end_span(start), member_list, self)
     }
 
     fn parse_type_query(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // `bump `typeof`
         let (entity_name, type_arguments) = if self.at(Kind::Import) {
             let entity_name = TSTypeQueryExprName::TSImportType(self.parse_ts_import_type());
@@ -732,19 +732,19 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             };
             (entity_name, type_arguments)
         };
-        TSType::new_ts_type_query(self.end_span(span), entity_name, type_arguments, self)
+        TSType::new_ts_type_query(self.end_span(start), entity_name, type_arguments, self)
     }
 
     fn parse_this_type_predicate(
         &mut self,
-        span: u32,
+        start: u32,
         this_ty: ArenaBox<'a, TSThisType>,
     ) -> TSType<'a> {
         self.bump_any(); // bump `is`
         let ty = self.parse_ts_type();
         let type_annotation = Some(TSTypeAnnotation::boxed(ty.span(), ty, self));
         TSType::new_ts_type_predicate(
-            self.end_span(span),
+            self.end_span(start),
             TSTypePredicateName::This(this_ty),
             false,
             type_annotation,
@@ -753,9 +753,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_this_type_node(&mut self) -> ArenaBox<'a, TSThisType> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `this`
-        TSThisType::boxed(self.end_span(span), self)
+        TSThisType::boxed(self.end_span(start), self)
     }
 
     fn parse_ts_type_constraint(&mut self) -> Option<TSType<'a>> {
@@ -775,7 +775,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_template_type(&mut self, tagged: bool) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let mut types = ArenaVec::new_in(self);
         let mut quasis = ArenaVec::new_in(self);
         match self.cur_kind() {
@@ -809,10 +809,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             _ => unreachable!("parse_template_literal"),
         }
 
-        TSType::new_ts_template_literal_type(self.end_span(span), quasis, types, self)
+        TSType::new_ts_template_literal_type(self.end_span(start), quasis, types, self)
     }
 
-    fn parse_asserts_type_predicate(&mut self, asserts_start_span: u32) -> TSType<'a> {
+    fn parse_asserts_type_predicate(&mut self, asserts_start: u32) -> TSType<'a> {
         let parameter_name = if self.at(Kind::This) {
             TSTypePredicateName::This(self.parse_this_type_node())
         } else {
@@ -826,7 +826,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             type_annotation = Some(TSTypeAnnotation::boxed(self.end_span(type_span), ty, self));
         }
         TSType::new_ts_type_predicate(
-            self.end_span(asserts_start_span),
+            self.end_span(asserts_start),
             parameter_name,
             /* asserts */ true,
             type_annotation,
@@ -835,39 +835,40 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_type_reference(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let type_name = self.parse_ts_type_name();
         let type_parameters = self.parse_type_arguments_of_type_reference();
-        TSType::new_ts_type_reference(self.end_span(span), type_name, type_parameters, self)
+        TSType::new_ts_type_reference(self.end_span(start), type_name, type_parameters, self)
     }
 
     fn parse_ts_implement_name(&mut self) -> TSClassImplements<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let type_name = self.parse_ts_type_name();
         let type_parameters = self.parse_type_arguments_of_type_reference();
-        TSClassImplements::new(self.end_span(span), type_name, type_parameters, self)
+        TSClassImplements::new(self.end_span(start), type_name, type_parameters, self)
     }
 
     pub(crate) fn parse_ts_type_name(&mut self) -> TSTypeName<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let left = if self.at(Kind::This) {
             self.bump_any();
-            TSTypeName::new_this_expression(self.end_span(span), self)
+            TSTypeName::new_this_expression(self.end_span(start), self)
         } else {
             let ident = self.parse_identifier_name();
             TSTypeName::new_identifier_reference(ident.span, ident.name, self)
         };
-        if self.at(Kind::Dot) { self.parse_ts_qualified_type_name(span, left) } else { left }
+        if self.at(Kind::Dot) { self.parse_ts_qualified_type_name(start, left) } else { left }
     }
 
     pub(crate) fn parse_ts_qualified_type_name(
         &mut self,
-        span: u32,
+        start: u32,
         mut left_name: TSTypeName<'a>,
     ) -> TSTypeName<'a> {
         while self.eat(Kind::Dot) {
             let right = self.parse_identifier_name();
-            left_name = TSTypeName::new_qualified_name(self.end_span(span), left_name, right, self);
+            left_name =
+                TSTypeName::new_qualified_name(self.end_span(start), left_name, right, self);
         }
         left_name
     }
@@ -876,7 +877,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
     ) -> Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         if self.re_lex_ts_l_angle() {
-            let span = self.start_span();
+            let start = self.start_span();
             let opening_span = self.cur_token().span();
             self.expect(Kind::LAngle);
             let (params, _) = self.parse_delimited_list(
@@ -886,7 +887,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 Self::parse_ts_type,
             );
             self.expect(Kind::RAngle);
-            let span = self.end_span(span);
+            let span = self.end_span(start);
             if params.is_empty() {
                 self.error(diagnostics::ts_empty_type_argument_list(span));
             }
@@ -902,7 +903,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
     ) -> Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         if !self.cur_token().is_on_new_line() && self.re_lex_ts_l_angle() {
-            let span = self.start_span();
+            let start = self.start_span();
             let opening_span = self.cur_token().span();
             self.expect(Kind::LAngle);
             let (params, _) = self.parse_delimited_list(
@@ -912,7 +913,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 Self::parse_ts_type,
             );
             self.expect(Kind::RAngle);
-            let span = self.end_span(span);
+            let span = self.end_span(start);
             if params.is_empty() {
                 self.error(diagnostics::ts_empty_type_argument_list(span));
             }
@@ -939,7 +940,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return None;
         }
         let checkpoint = self.checkpoint();
-        let span = self.start_span();
+        let start = self.start_span();
         if !self.re_lex_ts_l_angle() {
             self.rewind(checkpoint);
             return None;
@@ -959,7 +960,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.rewind(checkpoint);
             return None;
         }
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         if params.is_empty() {
             self.error(diagnostics::ts_empty_type_argument_list(span));
         }
@@ -979,7 +980,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_tuple_type(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LBrack);
 
@@ -1041,26 +1042,26 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 tuple
             });
         self.expect(Kind::RBrack);
-        TSType::new_ts_tuple_type(self.end_span(span), elements, self)
+        TSType::new_ts_tuple_type(self.end_span(start), elements, self)
     }
 
     pub(super) fn parse_tuple_element(&mut self) -> TSTupleElement<'a> {
-        let span_start = self.start_span();
+        let start = self.start_span();
         let is_rest_type = self.eat(Kind::Dot3);
 
         if self.cur_kind().is_identifier_name()
             && self.lookahead(Self::is_next_token_colon_or_question_colon)
         {
-            let member_span_start = self.start_span();
+            let member_start = self.start_span();
             let label = self.parse_identifier_name();
             let optional = self.eat(Kind::Question);
             self.expect(Kind::Colon);
-            let type_span_start = self.start_span();
+            let type_start = self.start_span();
             let rest_after_tuple_member_name = self.eat(Kind::Dot3);
             let ty = self.parse_ts_type();
             let optional_after_tuple_member_name = matches!(ty, TSType::JSDocNullableType(_));
             let tuple_element = self.convert_type_to_tuple_element(ty);
-            let member_span = self.end_span(member_span_start);
+            let member_span = self.end_span(member_start);
             let named_tuple_member = TSType::new_ts_named_tuple_member(
                 member_span,
                 label,
@@ -1069,17 +1070,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self,
             );
             if rest_after_tuple_member_name {
-                self.error(diagnostics::rest_after_tuple_member_name(
-                    self.end_span(type_span_start),
-                ));
+                self.error(diagnostics::rest_after_tuple_member_name(self.end_span(type_start)));
             }
             if optional_after_tuple_member_name {
                 self.error(diagnostics::optional_after_tuple_member_name(
-                    self.end_span(type_span_start),
+                    self.end_span(type_start),
                 ));
             }
             if is_rest_type {
-                let span = self.end_span(span_start);
+                let span = self.end_span(start);
                 if optional {
                     self.error(diagnostics::optional_and_rest_tuple_member(span));
                 }
@@ -1090,7 +1089,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         } else {
             let ty = self.parse_ts_type();
             if is_rest_type {
-                TSTupleElement::new_ts_rest_type(self.end_span(span_start), ty, self)
+                TSTupleElement::new_ts_rest_type(self.end_span(start), ty, self)
             } else {
                 self.convert_type_to_tuple_element(ty)
             }
@@ -1116,21 +1115,21 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_parenthesized_type(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `(`
         let ty = self.parse_ts_type();
         self.expect(Kind::RParen);
         if self.options.preserve_parens {
-            TSType::new_ts_parenthesized_type(self.end_span(span), ty, self)
+            TSType::new_ts_parenthesized_type(self.end_span(start), ty, self)
         } else {
             ty
         }
     }
 
     fn parse_literal_type(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let expression = self.parse_literal_expression();
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         let literal = match expression {
             Expression::BooleanLiteral(literal) => TSLiteral::BooleanLiteral(literal),
             Expression::NumericLiteral(literal) => TSLiteral::NumericLiteral(literal),
@@ -1141,16 +1140,16 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         TSType::new_ts_literal_type(span, literal, self)
     }
 
-    fn parse_literal_type_negative(&mut self, span: u32) -> TSType<'a> {
+    fn parse_literal_type_negative(&mut self, start: u32) -> TSType<'a> {
         let literal_expr = self.parse_literal_expression();
-        let span = self.end_span(span);
+        let span = self.end_span(start);
         let literal =
             TSLiteral::new_unary_expression(span, UnaryOperator::UnaryNegation, literal_expr, self);
         TSType::new_ts_literal_type(span, literal, self)
     }
 
     fn parse_ts_import_type(&mut self) -> ArenaBox<'a, TSImportType<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.expect(Kind::Import);
         self.expect(Kind::LParen);
 
@@ -1174,18 +1173,18 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let qualifier =
             if self.eat(Kind::Dot) { Some(self.parse_ts_import_type_qualifier()) } else { None };
         let type_arguments = self.parse_type_arguments_of_type_reference();
-        TSImportType::boxed(self.end_span(span), source, options, qualifier, type_arguments, self)
+        TSImportType::boxed(self.end_span(start), source, options, qualifier, type_arguments, self)
     }
 
     fn parse_ts_import_type_qualifier(&mut self) -> TSImportTypeQualifier<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let ident = self.parse_identifier_name();
         let mut left = TSImportTypeQualifier::new_identifier(ident.span, ident.name, self);
 
         while self.eat(Kind::Dot) {
             let right = self.parse_identifier_name();
             left =
-                TSImportTypeQualifier::new_qualified_name(self.end_span(span), left, right, self);
+                TSImportTypeQualifier::new_qualified_name(self.end_span(start), left, right, self);
         }
 
         left
@@ -1197,7 +1196,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// If the value is an object literal, it must have only static key-value pairs
     /// (no computed keys, no spread elements).
     fn parse_ts_import_type_options(&mut self) -> ArenaBox<'a, ObjectExpression<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.expect(Kind::LCurly);
 
         // Expect `with` or `assert` as identifier (not string, not escaped)
@@ -1240,13 +1239,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let _ = self.eat(Kind::Comma);
 
         self.expect(Kind::RCurly);
-        ObjectExpression::boxed(self.end_span(span), [with_property], self)
+        ObjectExpression::boxed(self.end_span(start), [with_property], self)
     }
 
     /// Parse TypeScript import type attributes object: `{ type: "json" }`
     /// Only allows static key-value pairs (no computed keys, no spread elements).
     fn parse_ts_import_type_attributes(&mut self) -> ArenaBox<'a, ObjectExpression<'a>> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.expect(Kind::LCurly);
 
         let mut properties = ArenaVec::new_in(self);
@@ -1324,7 +1323,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         self.expect(Kind::RCurly);
-        ObjectExpression::boxed(self.end_span(span), properties, self)
+        ObjectExpression::boxed(self.end_span(start), properties, self)
     }
 
     pub(crate) fn parse_ts_return_type_annotation(
@@ -1333,9 +1332,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if !self.at(Kind::Colon) {
             return None;
         }
-        let span = self.start_span();
+        let start = self.start_span();
         let return_type = self.parse_return_type();
-        Some(TSTypeAnnotation::boxed(self.end_span(span), return_type, self))
+        Some(TSTypeAnnotation::boxed(self.end_span(start), return_type, self))
     }
 
     fn parse_return_type(&mut self) -> TSType<'a> {
@@ -1344,14 +1343,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_type_or_type_predicate(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let type_predicate_variable = self.parse_type_predicate_prefix();
 
         let ty = self.parse_ts_type();
         if let Some(parameter_name) = type_predicate_variable {
             let type_annotation = Some(TSTypeAnnotation::boxed(ty.span(), ty, self));
             return TSType::new_ts_type_predicate(
-                self.end_span(span),
+                self.end_span(start),
                 parameter_name,
                 false,
                 type_annotation,
@@ -1386,7 +1385,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         kind: CallOrConstructorSignature,
     ) -> TSSignature<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         if kind == CallOrConstructorSignature::Constructor {
             self.expect(Kind::New);
         }
@@ -1403,7 +1402,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.parse_type_member_semicolon();
         match kind {
             CallOrConstructorSignature::Call => TSSignature::new_ts_call_signature_declaration(
-                self.end_span(span),
+                self.end_span(start),
                 type_parameters,
                 this_param,
                 params,
@@ -1412,7 +1411,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             ),
             CallOrConstructorSignature::Constructor => {
                 TSSignature::new_ts_construct_signature_declaration(
-                    self.end_span(span),
+                    self.end_span(start),
                     type_parameters,
                     params,
                     return_type,
@@ -1424,7 +1423,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_getter_setter_signature_member(
         &mut self,
-        span: u32,
+        start: u32,
         kind: TSMethodSignatureKind,
     ) -> TSSignature<'a> {
         let (key, computed) = self.parse_property_name();
@@ -1467,7 +1466,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         TSSignature::new_ts_method_signature(
-            self.end_span(span),
+            self.end_span(start),
             key,
             computed,
             /* optional */ false,
@@ -1482,7 +1481,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(super) fn parse_property_or_method_signature(
         &mut self,
-        span: u32,
+        start: u32,
         modifiers: &Modifiers,
     ) -> TSSignature<'a> {
         let (key, computed) = self.parse_property_name();
@@ -1503,7 +1502,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             let return_type = self.parse_ts_return_type_annotation();
             self.parse_type_member_semicolon();
             TSSignature::new_ts_method_signature(
-                self.end_span(span),
+                self.end_span(start),
                 key,
                 computed,
                 optional,
@@ -1518,7 +1517,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             let type_annotation = self.parse_ts_type_annotation();
             self.parse_type_member_semicolon();
             TSSignature::new_ts_property_signature(
-                self.end_span(span),
+                self.end_span(start),
                 computed,
                 optional,
                 modifiers.contains_readonly(),
@@ -1531,7 +1530,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_index_signature_declaration(
         &mut self,
-        span: u32,
+        start: u32,
         modifiers: &Modifiers,
     ) -> ArenaBox<'a, TSIndexSignature<'a>> {
         let opening_span = self.cur_token().span();
@@ -1586,15 +1585,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 _ => {}
             }
         } else {
-            self.error(diagnostics::index_signature_one_parameter(self.end_span(span)));
+            self.error(diagnostics::index_signature_one_parameter(self.end_span(start)));
         }
         let Some(type_annotation) = self.parse_ts_type_annotation() else {
             return self
-                .fatal_error(diagnostics::index_signature_type_annotation(self.end_span(span)));
+                .fatal_error(diagnostics::index_signature_type_annotation(self.end_span(start)));
         };
         self.parse_type_member_semicolon();
         TSIndexSignature::boxed(
-            self.end_span(span),
+            self.end_span(start),
             parameter,
             type_annotation,
             modifiers.contains(ModifierKind::Readonly),
@@ -1614,7 +1613,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_ts_index_signature_name(&mut self) -> TSIndexSignatureName<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         let name = self.parse_identifier_name().name;
         if self.at(Kind::Question) {
             self.error(diagnostics::index_signature_question_mark(self.cur_token().span()));
@@ -1622,24 +1621,24 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         let type_annotation = self.parse_ts_type_annotation();
         if let Some(type_annotation) = type_annotation {
-            TSIndexSignatureName::new(self.end_span(span), name, type_annotation, self)
+            TSIndexSignatureName::new(self.end_span(start), name, type_annotation, self)
         } else {
             self.unexpected()
         }
     }
 
     fn parse_js_doc_unknown_or_nullable_type(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `?`
         if matches!(
             self.cur_kind(),
             Kind::Comma | Kind::RCurly | Kind::RParen | Kind::RAngle | Kind::Eq | Kind::Pipe
         ) {
-            return TSType::new_js_doc_unknown_type(self.end_span(span), self);
+            return TSType::new_js_doc_unknown_type(self.end_span(start), self);
         }
         let type_annotation = self.parse_ts_type();
         TSType::new_js_doc_nullable_type(
-            self.end_span(span),
+            self.end_span(start),
             type_annotation,
             /* postfix */ false,
             self,
@@ -1647,11 +1646,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_js_doc_non_nullable_type(&mut self) -> TSType<'a> {
-        let span = self.start_span();
+        let start = self.start_span();
         self.bump_any(); // bump `!`
         let ty = self.parse_non_array_type();
         TSType::new_js_doc_non_nullable_type(
-            self.end_span(span),
+            self.end_span(start),
             ty,
             /* postfix */ false,
             self,


### PR DESCRIPTION
Pure refactor.

Rename vars which contain a `u32` for start of a span to `start`.

Previously there were vars named variously `span` or `start_span` - both of which imply the var contains a `Span`, not the `u32` representing the _start_ of a span. Other vars which _do_ contain a `Span` were also named `span` or `start_span`. It was confusing.

After this PR:

* All vars called `start` are a `u32` representing the start of a span.  
* All vars called `span` are an actual `Span`.