### PR TITLE
refactor(parser): rename `cur_start` method

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -23,7 +23,7 @@ pub struct ParserCheckpoint<'a> {
 impl<'a, C: Config> ParserImpl<'a, C> {
     /// Get current token's span start.
     #[inline]
-    pub(crate) fn start_span(&self) -> u32 {
+    pub(crate) fn cur_start(&self) -> u32 {
         self.token.start()
     }
 

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -35,7 +35,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         allow_return_type_in_arrow_function: bool,
     ) -> Option<Expression<'a>> {
         if self.at(Kind::Async) && self.is_un_parenthesized_async_arrow_function_worker() {
-            let start = self.start_span();
+            let start = self.cur_start();
             self.bump_any(); // bump `async`
             let expr = self.parse_binary_expression_or_higher(Precedence::Comma);
             let Expression::Identifier(ident) = &expr else {
@@ -255,7 +255,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_parenthesized_arrow_function_head(&mut self) -> ArrowFunctionHead<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let r#async = self.eat(Kind::Async);
 
         let has_await = self.ctx.has_await();

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -9,7 +9,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     `SingleNameBinding`
     ///     `BindingPattern`[?Yield, ?Await] `Initializer`[+In, ?Yield, ?Await]opt
     pub(super) fn parse_binding_pattern_with_initializer(&mut self) -> BindingPattern<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let pattern = self.parse_binding_pattern();
         self.context_add(Context::In, |p| p.parse_initializer(start, pattern))
     }
@@ -41,7 +41,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.3.3 Object Binding Pattern
     fn parse_object_binding_pattern(&mut self) -> BindingPattern<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
         let (list, rest) = self.parse_delimited_list_with_rest(
@@ -64,7 +64,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.3.3 Array Binding Pattern
     fn parse_array_binding_pattern(&mut self) -> BindingPattern<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LBrack);
         let (list, rest) = self.parse_delimited_list_with_rest(
@@ -88,9 +88,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.3.3 Binding Rest Property
     pub(crate) fn parse_rest_element(&mut self) -> ArenaBox<'a, BindingRestElement<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // advance `...`
-        let init_span = self.start_span();
+        let init_span = self.cur_start();
 
         let pattern = self.parse_binding_pattern_kind();
         // Rest element does not allow `?`, checked in checker/typescript.rs
@@ -123,9 +123,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// The type annotation will be parsed by the caller and stored on FormalParameterRest
     /// We don't consume it here so the caller can access it
     pub(crate) fn parse_rest_element_for_formal_parameter(&mut self) -> BindingRestElement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // advance `...`
-        let init_span = self.start_span();
+        let init_span = self.cur_start();
 
         let pattern = self.parse_binding_pattern_kind();
         // Rest element does not allow `?`, checked in checker/typescript.rs
@@ -152,7 +152,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     `SingleNameBinding`[?Yield, ?Await]
     ///     `PropertyName`[?Yield, ?Await] : `BindingElement`[?Yield, ?Await]
     pub(super) fn parse_binding_property(&mut self) -> BindingProperty<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
 
         let mut shorthand = false;
         let is_binding_identifier = self.cur_kind().is_binding_identifier();

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -216,7 +216,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_class_body(&mut self) -> ArenaBox<'a, ClassBody<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let class_elements = self.parse_normal_list_breakable(Kind::LCurly, Kind::RCurly, |p| {
             // Skip empty class element `;`
             if p.eat(Kind::Semicolon) {
@@ -244,7 +244,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_class_element_impl(&mut self) -> ClassElement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
 
         let decorators = self.parse_decorators();
         let modifiers = self.parse_modifiers(

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -7,7 +7,7 @@ use crate::{ParserConfig as Config, ParserImpl, StatementContext, diagnostics, l
 
 impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_let(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
 
         let peeked = self.lexer.peek_token().kind();
 
@@ -103,7 +103,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         decl_parent: VariableDeclarationParent,
         kind: VariableDeclarationKind,
     ) -> VariableDeclarator<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
 
         let id = self.parse_binding_pattern();
 
@@ -184,7 +184,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         statement_ctx: StatementContext,
     ) -> ArenaBox<'a, VariableDeclaration<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
 
         let is_await = self.eat(Kind::Await);
         let kind = if is_await {

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -52,7 +52,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section [Expression](https://tc39.es/ecma262/#sec-ecmascript-language-expressions)
     pub(crate) fn parse_expr(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
 
         let has_decorator = self.ctx.has_decorator();
         if has_decorator {
@@ -229,7 +229,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // FunctionExpression, GeneratorExpression
         // AsyncFunctionExpression, AsyncGeneratorExpression
         if self.at_function_with_async() {
-            let start = self.start_span();
+            let start = self.cur_start();
             let r#async = self.eat(Kind::Async);
             return self.parse_function_expression(start, r#async);
         }
@@ -243,7 +243,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Kind::LCurly => Expression::ObjectExpression(self.parse_object_expression()),
             // ClassExpression
             Kind::Class => self.parse_class_expression(
-                self.start_span(),
+                self.cur_start(),
                 &Modifiers::empty(),
                 ArenaVec::new_in(self),
             ),
@@ -269,13 +269,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_parenthesized_expression(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let opening_span = self.cur_token().span();
         // Capture annotation flags before bumping `(` since bump resets them
         let has_no_side_effects_comment =
             self.lexer.trivia_builder.previous_token_has_no_side_effects_comment();
         self.bump_any(); // `bump` `(`
-        let expr_span = self.start_span();
+        let expr_span = self.cur_start();
         let (mut expressions, comma_span) = self.context(Context::In, Context::Decorator, |p| {
             p.parse_delimited_list(
                 Kind::RParen,
@@ -334,7 +334,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 13.2.2 This Expression
     fn parse_this_expression(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any();
         Expression::new_this_expression(self.end_span(start), self)
     }
@@ -359,7 +359,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_literal_boolean(&mut self) -> ArenaBox<'a, BooleanLiteral> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let value = match self.cur_kind() {
             Kind::True => true,
             Kind::False => false,
@@ -511,7 +511,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     [ `ElementList`[?Yield, ?Await] ]
     ///     [ `ElementList`[?Yield, ?Await] , Elisionopt ]
     pub(crate) fn parse_array_expression(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LBrack);
         let (elements, comma_span) = self.context_add(Context::In, |p| {
@@ -549,7 +549,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     `NoSubstitutionTemplate`
     ///     `SubstitutionTemplate`[?Yield, ?Await, ?Tagged]
     pub(crate) fn parse_template_literal(&mut self, tagged: bool) -> TemplateLiteral<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
 
         let (quasis, expressions) = match self.cur_kind() {
             Kind::NoSubstitutionTemplate => {
@@ -619,7 +619,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_template_element(&mut self, tagged: bool) -> TemplateElement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let cur_kind = self.cur_kind();
         let end_offset: u32 = match cur_kind {
             Kind::TemplateHead | Kind::TemplateMiddle => 2,
@@ -672,7 +672,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 13.3 ImportCall or ImportMeta
     fn parse_import_meta_or_call(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `import`
         match self.cur_kind() {
             Kind::Dot => {
@@ -713,7 +713,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// V8 Runtime calls.
     /// See: [runtime.h](https://github.com/v8/v8/blob/5fe0aa3bc79c0a9d3ad546b79211f07105f09585/src/runtime/runtime.h#L43)
     pub(crate) fn parse_v8_intrinsic_expression(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.expect(Kind::Percent);
         let name = self.parse_identifier_name();
 
@@ -742,7 +742,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 13.3 Left-Hand-Side Expression
     pub(crate) fn parse_lhs_expression_or_higher(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let mut in_optional_chain = false;
         // `MemberExpression`
         let primary = self.parse_primary_expression();
@@ -794,7 +794,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 13.3 Super Call
     fn parse_super(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `super`
         let span = self.end_span(start);
 
@@ -986,7 +986,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// [NewExpression](https://tc39.es/ecma262/#sec-new-operator)
     fn parse_new_expression(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `new`
 
         if self.eat(Kind::Dot) {
@@ -1003,7 +1003,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             };
         }
 
-        let rhs_span = self.start_span();
+        let rhs_span = self.cur_start();
         let is_import = self.at(Kind::Import); // Syntax Error for `new import('mod')` but not `new (import('mod'))`.
         let mut optional = false;
         let mut callee = {
@@ -1201,7 +1201,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return self.parse_jsx_expression();
         }
 
-        let start = self.start_span();
+        let start = self.cur_start();
         let lhs = self.parse_lhs_expression_or_higher();
         // ++ -- postfix update expressions
         let post_kind = self.cur_kind();
@@ -1271,11 +1271,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_unary_expression(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let operator = map_unary_operator(self.cur_kind());
         self.bump_any();
         let pure_comment_index = self.lexer.trivia_builder.previous_token_has_pure_comment();
-        let mut argument = self.parse_simple_unary_expression(self.start_span());
+        let mut argument = self.parse_simple_unary_expression(self.cur_start());
         if let Some(index) = pure_comment_index
             && !Self::set_pure_on_call_or_new_expr(&mut argument)
         {
@@ -1288,7 +1288,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         lhs_precedence: Precedence,
     ) -> Expression<'a> {
-        let lhs_span = self.start_span();
+        let lhs_span = self.cur_start();
 
         let lhs_parenthesized = self.at(Kind::LParen);
         // [+In] PrivateIdentifier in ShiftExpression[?Yield, ?Await]
@@ -1510,7 +1510,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return arrow_expr;
         }
 
-        let start = self.start_span();
+        let start = self.cur_start();
         let lhs_parenthesized = self.at(Kind::LParen);
         let lhs = self.parse_binary_expression_or_higher(Precedence::Comma);
         let lhs_parenthesized_span = lhs_parenthesized.then(|| self.end_span(start));
@@ -1705,9 +1705,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // Case 1: In await context (async function, module top-level, unambiguous mode top-level)
         // Always parse as await expression
         if self.ctx.has_await() {
-            let start = self.start_span();
+            let start = self.cur_start();
             self.bump_any(); // consume `await`
-            let argument = self.parse_unary_expression_or_higher(self.start_span());
+            let argument = self.parse_unary_expression_or_higher(self.cur_start());
             return Expression::new_await_expression(self.end_span(start), argument, self);
         }
 
@@ -1722,7 +1722,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // Inside a function: await is always invalid in non-async functions, even in ESM.
         // Report error immediately.
         if self.is_unambiguous_await() {
-            let start = self.start_span();
+            let start = self.cur_start();
 
             if self.ctx.has_top_level() {
                 // At top level - upgrade to ESM immediately (like Babel's `sawUnambiguousESM`)
@@ -1737,7 +1737,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.bump_any(); // consume `await`
             // Parse argument with await context enabled for this expression
             self.ctx = self.ctx.and_await(true);
-            let argument = self.parse_unary_expression_or_higher(self.start_span());
+            let argument = self.parse_unary_expression_or_higher(self.cur_start());
             self.ctx = self.ctx.and_await(false);
             return Expression::new_await_expression(self.end_span(start), argument, self);
         }
@@ -1749,7 +1749,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_decorated_expression(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let decorators = self.parse_decorators();
         let modifiers = self.parse_modifiers(false, false);
         if self.at(Kind::Class) {
@@ -1776,7 +1776,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   ( `Expression`[+In, ?Yield, ?Await] )
     ///   `DecoratorCallExpression`
     pub(crate) fn parse_decorator(&mut self) -> Decorator<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump @
         let expr = self.context_add(Context::Decorator, Self::parse_lhs_expression_or_higher);
         Decorator::new(self.end_span(start), expr, self)

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -29,7 +29,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_function_body(&mut self) -> ArenaBox<'a, FunctionBody<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
 
@@ -47,7 +47,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         func_kind: FunctionKind,
         params_kind: FormalParameterKind,
     ) -> (Option<ArenaBox<'a, TSThisParameter<'a>>>, ArenaBox<'a, FormalParameters<'a>>) {
-        let start = self.start_span();
+        let start = self.cur_start();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LParen);
         let this_param = if self.is_ts && self.at(Kind::This) {
@@ -131,7 +131,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 break;
             }
 
-            let start = self.start_span();
+            let start = self.cur_start();
             let decorators = self.parse_decorators();
 
             if self.at(Kind::Dot3) {
@@ -481,7 +481,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         generator: Option<u32>,
         func_kind: FunctionKind,
     ) -> ArenaBox<'a, Function<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.parse_function(
             start,
             None,
@@ -498,7 +498,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// yield [no `LineTerminator` here] `AssignmentExpression`
     /// yield [no `LineTerminator` here] * `AssignmentExpression`
     pub(crate) fn parse_yield_expression(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // advance `yield`
 
         let has_yield = self.ctx.has_yield();

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -333,7 +333,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     // import * as name from "module-name"
     fn parse_import_namespace_specifier(&mut self) -> ImportDeclarationSpecifier<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // advance `*`
         self.expect(Kind::As);
         let local = self.parse_binding_identifier();
@@ -371,7 +371,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         };
         self.advance(keyword_kind);
 
-        let start = self.start_span();
+        let start = self.cur_start();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
         let (with_entries, _) = self.context_remove(self.ctx, |p| {
@@ -397,7 +397,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_import_attribute(&mut self) -> ImportAttribute<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let key = match self.cur_kind() {
             Kind::Str => ImportAttributeKey::StringLiteral(self.parse_literal_string()),
             _ => ImportAttributeKey::Identifier(self.parse_identifier_name()),
@@ -455,7 +455,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let decl = match self.cur_kind() {
             // `export import A = B`
             Kind::Import => {
-                let import_span = self.start_span();
+                let import_span = self.cur_start();
                 self.bump_any();
                 // Pass `should_record_module_record: false` to prevent an `import` module record
                 // being created. It's an export not an import.
@@ -475,7 +475,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
             }
             Kind::At => {
-                let class_span = self.start_span();
+                let class_span = self.cur_start();
                 let after_export_decorators = self.parse_decorators();
                 if !decorators.is_empty() {
                     for decorator in &after_export_decorators {
@@ -635,7 +635,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         start: u32,
         decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ArenaBox<'a, ExportDeclaration<'a>> {
-        let decl_span = self.start_span();
+        let decl_span = self.cur_start();
         let reserved_ctx = self.ctx;
         let modifiers =
             if self.is_ts { self.eat_modifiers_before_declaration() } else { Modifiers::empty() };
@@ -674,7 +674,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         mut decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ExportDefaultDeclarationKind<'a> {
-        let decl_span = self.start_span();
+        let decl_span = self.cur_start();
 
         // export default /* @__NO_SIDE_EFFECTS__ */ ...
         let has_no_side_effects_comment =
@@ -692,7 +692,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             decorators.extend(after_export_decorators);
         }
 
-        let function_span = self.start_span();
+        let function_span = self.cur_start();
 
         // ExportDeclaration :
         //   export default HoistableDeclaration
@@ -707,7 +707,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // a declaration. `[no LineTerminator here]` maps to `!next.is_on_new_line()`.
         let kind = self.cur_kind();
         if matches!(kind, Kind::Abstract | Kind::Async | Kind::Interface) {
-            let modifier_span = self.start_span();
+            let modifier_span = self.cur_start();
             let next = self.lexer.peek_token();
             if !next.is_on_new_line() {
                 // export default abstract class C {}
@@ -828,7 +828,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         specifier_type: ImportOrExport,
         parent_kind: ImportOrExportKind,
     ) -> ImportOrExportSpecifier<'a> {
-        let specifier_span = self.start_span();
+        let specifier_span = self.cur_start();
         let type_or_name_token = self.cur_token();
         let type_or_name_token_kind = type_or_name_token.kind();
         let mut check_identifier_token = self.cur_token();

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -17,7 +17,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     { `PropertyDefinitionList`[?Yield, ?Await] }
     ///     { `PropertyDefinitionList`[?Yield, ?Await] , }
     pub(crate) fn parse_object_expression(&mut self) -> ArenaBox<'a, ObjectExpression<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
         let (object_expression_properties, comma_span) = self.context_add(Context::In, |p| {
@@ -44,7 +44,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// `PropertyDefinition`[Yield, Await]
     fn parse_object_literal_element(&mut self) -> ArenaBox<'a, ObjectProperty<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
 
         let modifiers = self.parse_modifiers(
             /* permit_const_as_modifier */ false,
@@ -139,7 +139,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// `PropertyDefinition`[Yield, Await] :
     ///   ... `AssignmentExpression`[+In, ?Yield, ?Await]
     pub(crate) fn parse_spread_element(&mut self) -> ArenaBox<'a, SpreadElement<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // advance `...`
         let argument = self.parse_assignment_expression_or_higher();
         SpreadElement::boxed(self.end_span(start), argument, self)

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -16,7 +16,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     // or Module.
     pub(crate) fn parse_hashbang(&mut self) -> Option<Hashbang<'a>> {
         if self.cur_kind() == Kind::HashbangComment {
-            let start = self.start_span();
+            let start = self.cur_start();
             self.bump_any();
             let span = self.end_span(start);
             let src = &self.source_text[span.start as usize + 2..span.end as usize];
@@ -151,28 +151,26 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Kind::Try => self.parse_try_statement(),
             Kind::Debugger => self.parse_debugger_statement(),
             Kind::Class => self.parse_class_statement(
-                self.start_span(),
+                self.cur_start(),
                 stmt_ctx,
                 &Modifiers::empty(),
                 ArenaVec::new_in(self),
             ),
-            Kind::Export => {
-                self.parse_export_declaration(self.start_span(), ArenaVec::new_in(self))
-            }
+            Kind::Export => self.parse_export_declaration(self.cur_start(), ArenaVec::new_in(self)),
             // [+Return] ReturnStatement[?Yield, ?Await]
             Kind::Return => self.parse_return_statement(),
             Kind::Var => {
-                let start = self.start_span();
+                let start = self.cur_start();
                 self.bump_any();
                 self.parse_variable_statement(start, VariableDeclarationKind::Var, stmt_ctx)
             }
             // Fast path
             Kind::Function => {
-                self.parse_function_declaration(self.start_span(), /* async */ false, stmt_ctx)
+                self.parse_function_declaration(self.cur_start(), /* async */ false, stmt_ctx)
             }
             Kind::At => self.parse_decorated_statement(stmt_ctx),
             Kind::Let if !self.cur_token().escaped() => self.parse_let(stmt_ctx),
-            Kind::Async => self.parse_async_statement(self.start_span(), stmt_ctx),
+            Kind::Async => self.parse_async_statement(self.cur_start(), stmt_ctx),
             Kind::Import => self.parse_import_statement(),
             Kind::Const => self.parse_const_statement(stmt_ctx),
             Kind::Using if self.is_using_declaration() => self.parse_using_statement(stmt_ctx),
@@ -193,7 +191,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             | Kind::Global
                 if self.is_ts && self.at_start_of_ts_declaration() =>
             {
-                self.parse_ts_declaration_statement(self.start_span(), stmt_ctx)
+                self.parse_ts_declaration_statement(self.cur_start(), stmt_ctx)
             }
             _ => self.parse_expression_or_labeled_statement(),
         };
@@ -250,7 +248,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_expression_or_labeled_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let expr = self.parse_expr();
         if let Expression::Identifier(ident) = &expr {
             // Section 14.13 Labelled Statement
@@ -266,7 +264,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.2 Block Statement
     pub(crate) fn parse_block(&mut self) -> ArenaBox<'a, BlockStatement<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let body = self.parse_normal_list(Kind::LCurly, Kind::RCurly, |p| {
             p.parse_statement_list_item(StatementContext::StatementList)
         });
@@ -301,7 +299,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.4 Empty Statement
     fn parse_empty_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `;`
         Statement::new_empty_statement(self.end_span(start), self)
     }
@@ -318,7 +316,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.6 If Statement
     fn parse_if_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `if`
         let test = self.parse_paren_expression();
         let consequent = self.parse_statement_list_item(StatementContext::If);
@@ -329,7 +327,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.7.2 Do-While Statement
     fn parse_do_while_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // advance `do`
         let body = self.parse_statement_list_item(StatementContext::Do);
         self.expect(Kind::While);
@@ -340,7 +338,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.7.3 While Statement
     fn parse_while_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `while`
         let test = self.parse_paren_expression();
         let body = self.parse_statement_list_item(StatementContext::While);
@@ -349,7 +347,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.7.4 For Statement
     fn parse_for_statement(&mut self) -> Statement<'a> {
-        let for_start = self.start_span();
+        let for_start = self.cur_start();
         self.bump_any(); // bump `for`
 
         // [+Await]
@@ -383,7 +381,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // `for (const` | `for (var`
         match self.cur_kind() {
             Kind::Const => {
-                let decl_start = self.start_span();
+                let decl_start = self.cur_start();
                 self.bump_any();
                 return self.parse_variable_declaration_for_statement(
                     for_start,
@@ -394,7 +392,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 );
             }
             Kind::Var => {
-                let decl_start = self.start_span();
+                let decl_start = self.cur_start();
                 self.bump_any();
                 return self.parse_variable_declaration_for_statement(
                     for_start,
@@ -406,7 +404,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
             Kind::Let => {
                 // `for (let`
-                let decl_start = self.start_span();
+                let decl_start = self.cur_start();
                 // disallow `for (let in ...`
                 if self.lexer.peek_token().kind().is_after_let() {
                     self.bump_any(); // bump `let`
@@ -473,7 +471,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let is_let = self.at(Kind::Let);
         // `async` is allowed as `for (async of ...)` if `async` is escaped
         let is_async = self.at(Kind::Async) && !self.cur_token().escaped();
-        let expr_span = self.start_span();
+        let expr_span = self.cur_start();
 
         let init_expression = self.context_remove(Context::In, ParserImpl::parse_expr);
 
@@ -653,7 +651,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.8 Continue Statement
     fn parse_continue_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `continue`
         let label =
             if self.can_insert_semicolon() { None } else { Some(self.parse_label_identifier()) };
@@ -663,7 +661,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.9 Break Statement
     fn parse_break_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `break`
         let label =
             if self.can_insert_semicolon() { None } else { Some(self.parse_label_identifier()) };
@@ -676,7 +674,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   return ;
     ///   return [no `LineTerminator` here] Expression[+In, ?Yield, ?Await] ;
     fn parse_return_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // advance `return`
         let argument = if self.eat(Kind::Semicolon) || self.can_insert_semicolon() {
             None
@@ -701,7 +699,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.11 With Statement
     fn parse_with_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `with`
         let object = self.parse_paren_expression();
         let body = self.parse_statement_list_item(StatementContext::With);
@@ -711,7 +709,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.12 Switch Statement
     fn parse_switch_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // advance `switch`
         let discriminant = self.parse_paren_expression();
         // A `switch` may contain at most one `default` clause. Track the first one
@@ -736,7 +734,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_switch_case(&mut self) -> SwitchCase<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let test = match self.cur_kind() {
             Kind::Default => {
                 self.bump_any();
@@ -784,7 +782,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.14 Throw Statement
     fn parse_throw_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // advance `throw`
         if self.cur_token().is_on_new_line() {
             self.error(diagnostics::illegal_newline(
@@ -800,7 +798,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.15 Try Statement
     fn parse_try_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `try`
 
         let block = self.parse_block();
@@ -818,7 +816,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_catch_clause(&mut self) -> ArenaBox<'a, CatchClause<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // advance `catch`
         let pattern = if self.eat(Kind::LParen) {
             let (pattern, type_annotation) = self.parse_binding_pattern_with_type_annotation();
@@ -844,7 +842,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Section 14.16 Debugger Statement
     fn parse_debugger_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any();
         self.asi();
         Statement::new_debugger_statement(self.end_span(start), self)
@@ -852,7 +850,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Parse const declaration or `const enum`.
     fn parse_const_statement(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any();
         if self.is_ts && self.at(Kind::Enum) {
             let modifiers = Modifiers::new_single(ModifierKind::Const, start);
@@ -864,7 +862,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Parse import statement or import expression.
     fn parse_import_statement(&mut self) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         if matches!(self.lexer.peek_token().kind(), Kind::Dot | Kind::LParen) {
             // Parse the whole expression `import.meta.url`.
             self.parse_expression_or_labeled_statement()
@@ -889,12 +887,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Parse statements that start with `@`.
     fn parse_decorated_statement(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let decorators = self.parse_decorators();
         let kind = self.cur_kind();
         if kind == Kind::Export {
             // Export span.start starts after decorators.
-            return self.parse_export_declaration(self.start_span(), decorators);
+            return self.parse_export_declaration(self.cur_start(), decorators);
         }
         let modifiers = self.parse_modifiers(false, false);
         if self.at(Kind::Class) {

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -23,7 +23,7 @@ impl<'a> Dummy<'a> for JSXClosing<'a> {
 
 impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_jsx_expression(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `<`
         let kind = self.cur_kind();
         let expr = if kind == Kind::RAngle {
@@ -139,7 +139,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   `JSXNamespacedName`
     ///   `JSXMemberExpression`
     fn parse_jsx_element_name(&mut self) -> JSXElementName<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let (identifier, contains_dash) = self.parse_jsx_identifier();
 
         // <namespace:property />
@@ -268,7 +268,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
             match self.cur_kind() {
                 Kind::LAngle => {
-                    let start = self.start_span();
+                    let start = self.cur_start();
                     self.bump_any(); // bump `<`
                     let kind = self.cur_kind();
 
@@ -296,7 +296,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     return self.unexpected();
                 }
                 Kind::LCurly => {
-                    let start = self.start_span();
+                    let start = self.cur_start();
                     self.bump_any(); // bump `{`
 
                     // {...expr}
@@ -430,7 +430,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// `JSXAttribute` :
     ///   `JSXAttributeName` `JSXAttributeInitializer_opt`
     fn parse_jsx_attribute(&mut self) -> ArenaBox<'a, JSXAttribute<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let name = self.parse_jsx_attribute_name();
         let value = if self.at(Kind::Eq) {
             self.advance_for_jsx_attribute_value();
@@ -444,7 +444,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// `JSXSpreadAttribute` :
     ///   { ... `AssignmentExpression` }
     fn parse_jsx_spread_attribute(&mut self) -> ArenaBox<'a, JSXSpreadAttribute<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `{`
         self.expect(Kind::Dot3);
         let argument = self.parse_expr();
@@ -456,7 +456,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   `JSXIdentifier`
     ///   `JSXNamespacedName`
     fn parse_jsx_attribute_name(&mut self) -> JSXAttributeName<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let (identifier, _) = self.parse_jsx_identifier();
 
         if self.eat(Kind::Colon) {
@@ -479,7 +479,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 JSXAttributeValue::StringLiteral(self.alloc(str_lit))
             }
             Kind::LCurly => {
-                let start = self.start_span();
+                let start = self.cur_start();
                 self.bump_any(); // bump `{`
 
                 let expr =
@@ -505,7 +505,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         JSXIdentifier<'a>, // JSX identifier
         bool,              // `true` if contains `-`
     ) {
-        let start = self.start_span();
+        let start = self.cur_start();
         let kind = self.cur_kind();
         if kind != Kind::Ident && !kind.is_any_keyword() {
             return (self.unexpected(), false);

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -494,7 +494,7 @@ impl<C: Config> ParserImpl<'_, C> {
     pub(crate) fn eat_modifiers_before_declaration(&mut self) -> Modifiers {
         let mut modifiers = Modifiers::empty();
         while let Some(modifier_kind) = self.get_modifier() {
-            let modifier = Modifier::new(self.start_span(), modifier_kind);
+            let modifier = Modifier::new(self.cur_start(), modifier_kind);
             self.bump_any();
             self.check_modifier(modifiers.kinds(), modifier);
             modifiers.add(modifier.kind, modifier.start);
@@ -556,7 +556,7 @@ impl<C: Config> ParserImpl<'_, C> {
         permit_const_as_modifier: bool,
         stop_on_start_of_class_static_block: bool,
     ) -> Option<Modifier> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let kind = self.cur_kind();
 
         if kind == Kind::Const {

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -45,7 +45,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_ts_enum_body(&mut self) -> TSEnumBody<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
         let (members, _) = self.parse_delimited_list(
@@ -59,7 +59,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_ts_enum_member(&mut self) -> TSEnumMember<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let id = self.parse_ts_enum_member_name();
         let initializer = if self.eat(Kind::Eq) {
             Some(self.parse_assignment_expression_or_higher())
@@ -119,7 +119,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if !self.at(Kind::Colon) {
             return None;
         }
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump ':'
         let type_annotation = self.parse_ts_type();
         Some(TSTypeAnnotation::boxed(self.end_span(start), type_annotation, self))
@@ -273,7 +273,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let mut extends = ArenaVec::with_capacity_in(1, self);
         loop {
-            let start = self.start_span();
+            let start = self.cur_start();
             let mut extend = self.parse_lhs_expression_or_higher();
             if self.fatal_error.is_some() {
                 break;
@@ -300,14 +300,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_ts_interface_body(&mut self) -> ArenaBox<'a, TSInterfaceBody<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let body_list =
             self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_ts_type_signature);
         TSInterfaceBody::boxed(self.end_span(start), body_list, self)
     }
 
     pub(crate) fn parse_ts_type_signature(&mut self) -> TSSignature<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let kind = self.cur_kind();
 
         if matches!(kind, Kind::LParen | Kind::LAngle) {
@@ -488,7 +488,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         in_ts_namespace_body: bool,
     ) -> ArenaBox<'a, TSModuleBlock<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.expect(Kind::LCurly);
         // Remove TopLevel context for module block
         let (directives, statements) = self.context_remove(Context::TopLevel, |p| {
@@ -506,7 +506,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> ArenaBox<'a, TSModuleDeclaration<'a>> {
         let id = TSModuleDeclarationName::Identifier(self.parse_binding_identifier());
         let body = if self.eat(Kind::Dot) {
-            let start = self.start_span();
+            let start = self.cur_start();
             let decl = self.parse_module_or_namespace_declaration(start, kind, &Modifiers::empty());
             TSModuleDeclarationBody::TSModuleDeclaration(decl)
         } else {
@@ -536,7 +536,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         start: u32,
         modifiers: &Modifiers,
     ) -> ArenaBox<'a, TSGlobalDeclaration<'a>> {
-        let keyword_start = self.start_span();
+        let keyword_start = self.cur_start();
         self.expect(Kind::Global);
         let keyword_span = self.end_span(keyword_start);
 
@@ -678,7 +678,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         self.parse_ts_function_impl(start, FunctionKind::Declaration, modifiers);
                     Declaration::FunctionDeclaration(decl)
                 } else {
-                    let start = self.start_span();
+                    let start = self.cur_start();
                     let r#async = self.eat(Kind::Async);
                     let decl = self.parse_function_impl(start, r#async, FunctionKind::Declaration);
                     Declaration::FunctionDeclaration(decl)
@@ -710,11 +710,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_ts_type_assertion(&mut self) -> Expression<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.expect(Kind::LAngle);
         let type_annotation = self.parse_ts_type();
         self.expect(Kind::RAngle);
-        let lhs_span = self.start_span();
+        let lhs_span = self.cur_start();
         let expression = self.parse_simple_unary_expression(lhs_span);
         let span = self.end_span(start);
 
@@ -733,7 +733,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> Declaration<'a> {
         self.expect(Kind::Eq);
 
-        let reference_span = self.start_span();
+        let reference_span = self.cur_start();
         let module_reference = if self.eat(Kind::Require) {
             self.expect(Kind::LParen);
             let expression = self.parse_literal_string();
@@ -804,7 +804,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_ts_this_parameter(&mut self) -> ArenaBox<'a, TSThisParameter<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any();
         let this_span = self.end_span(start);
 

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -16,7 +16,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.is_start_of_function_type_or_constructor_type() {
             return self.parse_function_or_constructor_type();
         }
-        let start = self.start_span();
+        let start = self.cur_start();
         let ty = self.parse_union_type_or_higher();
         if !self.ctx.has_disallow_conditional_types()
             && !self.cur_token().is_on_new_line()
@@ -44,7 +44,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_function_or_constructor_type(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let r#abstract = self.eat(Kind::Abstract);
         let is_constructor_type = self.eat(Kind::New);
         let type_parameters = self.parse_ts_type_parameters();
@@ -52,7 +52,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             p.parse_formal_parameters(FunctionKind::Declaration, FormalParameterKind::Signature)
         });
         let return_type = {
-            let return_type_span = self.start_span();
+            let return_type_span = self.cur_start();
             let return_type = self.parse_return_type();
             TSTypeAnnotation::boxed(self.end_span(return_type_span), return_type, self)
         };
@@ -187,7 +187,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if !self.at(Kind::LAngle) {
             return (None, false);
         }
-        let start = self.start_span();
+        let start = self.cur_start();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LAngle);
         let (params, trailing_comma) =
@@ -213,7 +213,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_ts_type_parameter(&mut self, allow_variance: bool) -> TSTypeParameter<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
 
         let modifiers = self.parse_modifiers(true, false);
         let allowed_modifiers = if allow_variance {
@@ -272,7 +272,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     where
         F: Fn(&mut Self) -> TSType<'a>,
     {
-        let start = self.start_span();
+        let start = self.cur_start();
         let has_leading_operator = self.eat(kind);
         /* hasLeadingOperator && parseFunctionOrConstructorTypeToError(isUnionType) ||*/
         let mut ty = parse_constituent_type(self);
@@ -308,7 +308,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_type_operator(&mut self, operator: TSTypeOperatorOperator) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump operator
         let operator_span = self.end_span(start);
         let ty = self.parse_type_operator_or_higher();
@@ -322,14 +322,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_infer_type(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `infer`
         let type_parameter = self.parse_type_parameter_of_infer_type();
         TSType::new_ts_infer_type(self.end_span(start), type_parameter, self)
     }
 
     fn parse_type_parameter_of_infer_type(&mut self) -> ArenaBox<'a, TSTypeParameter<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let name = self.parse_binding_identifier();
         self.check_reserved_type_name(&name, "Type parameter");
         let constraint = self.parse_constraint_of_infer_type();
@@ -371,7 +371,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_postfix_type_or_higher(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let mut ty = self.parse_non_array_type();
 
         while !self.cur_token().is_on_new_line() {
@@ -462,14 +462,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Kind::Str | Kind::True | Kind::False => self.parse_literal_type(),
             kind if kind.is_number() => self.parse_literal_type(),
             Kind::NoSubstitutionTemplate => {
-                let start = self.start_span();
+                let start = self.cur_start();
                 let literal = self.parse_template_literal(false);
                 let span = self.end_span(start);
                 TSType::new_ts_literal_type(span, TSLiteral::TemplateLiteral(self.alloc(literal)), self)
             }
             Kind::Minus => {
                 if self.lexer.peek_token().kind().is_number() {
-                    let minus_start = self.start_span();
+                    let minus_start = self.cur_start();
                     self.bump_any(); // bump `-`
                     self.parse_literal_type_negative(minus_start)
                 } else {
@@ -477,12 +477,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
             }
             Kind::Void => {
-                let start = self.start_span();
+                let start = self.cur_start();
                 self.bump_any();
                 TSType::new_ts_void_keyword(self.end_span(start), self)
             }
             Kind::This => {
-                let start = self.start_span();
+                let start = self.cur_start();
                 self.bump_any(); // bump `this`
                 let this_type = TSThisType::boxed(self.end_span(start), self);
                 if self.at(Kind::Is) && !self.cur_token().is_on_new_line() {
@@ -508,7 +508,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 // Peek the token after `asserts` to check if this is an asserts type predicate.
                 let next = self.lexer.peek_token();
                 if next.kind().is_identifier_name() && !next.is_on_new_line() {
-                    let asserts_start = self.start_span();
+                    let asserts_start = self.cur_start();
                     self.bump_any(); // bump `asserts`
                     self.parse_asserts_type_predicate(asserts_start)
                 } else {
@@ -521,7 +521,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_keyword_type(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         match self.cur_kind() {
             Kind::Any => {
                 self.bump_any();
@@ -653,7 +653,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_mapped_type(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.expect(Kind::LCurly);
         let mut readonly = None;
         if self.eat(Kind::Readonly) {
@@ -710,14 +710,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_type_literal(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let member_list =
             self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_ts_type_signature);
         TSType::new_ts_type_literal(self.end_span(start), member_list, self)
     }
 
     fn parse_type_query(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // `bump `typeof`
         let (entity_name, type_arguments) = if self.at(Kind::Import) {
             let entity_name = TSTypeQueryExprName::TSImportType(self.parse_ts_import_type());
@@ -753,7 +753,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_this_type_node(&mut self) -> ArenaBox<'a, TSThisType> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `this`
         TSThisType::boxed(self.end_span(start), self)
     }
@@ -775,7 +775,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_template_type(&mut self, tagged: bool) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let mut types = ArenaVec::new_in(self);
         let mut quasis = ArenaVec::new_in(self);
         match self.cur_kind() {
@@ -821,7 +821,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         };
         let mut type_annotation = None;
         if self.eat(Kind::Is) {
-            let type_span = self.start_span();
+            let type_span = self.cur_start();
             let ty = self.parse_ts_type();
             type_annotation = Some(TSTypeAnnotation::boxed(self.end_span(type_span), ty, self));
         }
@@ -835,21 +835,21 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(crate) fn parse_type_reference(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let type_name = self.parse_ts_type_name();
         let type_parameters = self.parse_type_arguments_of_type_reference();
         TSType::new_ts_type_reference(self.end_span(start), type_name, type_parameters, self)
     }
 
     fn parse_ts_implement_name(&mut self) -> TSClassImplements<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let type_name = self.parse_ts_type_name();
         let type_parameters = self.parse_type_arguments_of_type_reference();
         TSClassImplements::new(self.end_span(start), type_name, type_parameters, self)
     }
 
     pub(crate) fn parse_ts_type_name(&mut self) -> TSTypeName<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let left = if self.at(Kind::This) {
             self.bump_any();
             TSTypeName::new_this_expression(self.end_span(start), self)
@@ -877,7 +877,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
     ) -> Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         if self.re_lex_ts_l_angle() {
-            let start = self.start_span();
+            let start = self.cur_start();
             let opening_span = self.cur_token().span();
             self.expect(Kind::LAngle);
             let (params, _) = self.parse_delimited_list(
@@ -903,7 +903,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
     ) -> Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         if !self.cur_token().is_on_new_line() && self.re_lex_ts_l_angle() {
-            let start = self.start_span();
+            let start = self.cur_start();
             let opening_span = self.cur_token().span();
             self.expect(Kind::LAngle);
             let (params, _) = self.parse_delimited_list(
@@ -940,7 +940,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return None;
         }
         let checkpoint = self.checkpoint();
-        let start = self.start_span();
+        let start = self.cur_start();
         if !self.re_lex_ts_l_angle() {
             self.rewind(checkpoint);
             return None;
@@ -980,7 +980,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_tuple_type(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LBrack);
 
@@ -1046,17 +1046,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     pub(super) fn parse_tuple_element(&mut self) -> TSTupleElement<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let is_rest_type = self.eat(Kind::Dot3);
 
         if self.cur_kind().is_identifier_name()
             && self.lookahead(Self::is_next_token_colon_or_question_colon)
         {
-            let member_start = self.start_span();
+            let member_start = self.cur_start();
             let label = self.parse_identifier_name();
             let optional = self.eat(Kind::Question);
             self.expect(Kind::Colon);
-            let type_start = self.start_span();
+            let type_start = self.cur_start();
             let rest_after_tuple_member_name = self.eat(Kind::Dot3);
             let ty = self.parse_ts_type();
             let optional_after_tuple_member_name = matches!(ty, TSType::JSDocNullableType(_));
@@ -1115,7 +1115,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_parenthesized_type(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `(`
         let ty = self.parse_ts_type();
         self.expect(Kind::RParen);
@@ -1127,7 +1127,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_literal_type(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let expression = self.parse_literal_expression();
         let span = self.end_span(start);
         let literal = match expression {
@@ -1149,7 +1149,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_ts_import_type(&mut self) -> ArenaBox<'a, TSImportType<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.expect(Kind::Import);
         self.expect(Kind::LParen);
 
@@ -1177,7 +1177,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_ts_import_type_qualifier(&mut self) -> TSImportTypeQualifier<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let ident = self.parse_identifier_name();
         let mut left = TSImportTypeQualifier::new_identifier(ident.span, ident.name, self);
 
@@ -1196,7 +1196,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// If the value is an object literal, it must have only static key-value pairs
     /// (no computed keys, no spread elements).
     fn parse_ts_import_type_options(&mut self) -> ArenaBox<'a, ObjectExpression<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.expect(Kind::LCurly);
 
         // Expect `with` or `assert` as identifier (not string, not escaped)
@@ -1209,7 +1209,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         // Use the actual string from the source (not a static string) to ensure it's in the arena
         let key_name = self.ident(self.cur_string());
-        let with_key_span = self.start_span();
+        let with_key_span = self.cur_start();
         self.bump_any();
         let with_key = IdentifierName::boxed(self.end_span(with_key_span), key_name, self);
 
@@ -1245,7 +1245,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// Parse TypeScript import type attributes object: `{ type: "json" }`
     /// Only allows static key-value pairs (no computed keys, no spread elements).
     fn parse_ts_import_type_attributes(&mut self) -> ArenaBox<'a, ObjectExpression<'a>> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.expect(Kind::LCurly);
 
         let mut properties = ArenaVec::new_in(self);
@@ -1270,7 +1270,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 continue;
             }
 
-            let prop_span = self.start_span();
+            let prop_span = self.cur_start();
 
             // Check for computed property
             if self.at(Kind::LBrack) {
@@ -1332,7 +1332,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if !self.at(Kind::Colon) {
             return None;
         }
-        let start = self.start_span();
+        let start = self.cur_start();
         let return_type = self.parse_return_type();
         Some(TSTypeAnnotation::boxed(self.end_span(start), return_type, self))
     }
@@ -1343,7 +1343,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_type_or_type_predicate(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let type_predicate_variable = self.parse_type_predicate_prefix();
 
         let ty = self.parse_ts_type();
@@ -1385,7 +1385,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         kind: CallOrConstructorSignature,
     ) -> TSSignature<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         if kind == CallOrConstructorSignature::Constructor {
             self.expect(Kind::New);
         }
@@ -1613,7 +1613,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_ts_index_signature_name(&mut self) -> TSIndexSignatureName<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         let name = self.parse_identifier_name().name;
         if self.at(Kind::Question) {
             self.error(diagnostics::index_signature_question_mark(self.cur_token().span()));
@@ -1628,7 +1628,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_js_doc_unknown_or_nullable_type(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `?`
         if matches!(
             self.cur_kind(),
@@ -1646,7 +1646,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn parse_js_doc_non_nullable_type(&mut self) -> TSType<'a> {
-        let start = self.start_span();
+        let start = self.cur_start();
         self.bump_any(); // bump `!`
         let ty = self.parse_non_array_type();
         TSType::new_js_doc_non_nullable_type(


### PR DESCRIPTION
Pure refactor. Continuation of #25262.

Rename `ParserImpl::start_span` method to `cur_start`.

This name matches `cur_token`, `cur_kind`, `cur_src` etc. It more clearly describes what it does - returns the current span start as a `u32`, rather than the old name which suggested that it returned a `Span`.