### PR TITLE
refactor(parser): rename more vars for span starts

### DIFF
--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -90,7 +90,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_rest_element(&mut self) -> ArenaBox<'a, BindingRestElement<'a>> {
         let start = self.cur_start();
         self.bump_any(); // advance `...`
-        let init_span = self.cur_start();
+        let init_start = self.cur_start();
 
         let pattern = self.parse_binding_pattern_kind();
         // Rest element does not allow `?`, checked in checker/typescript.rs
@@ -111,7 +111,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // Rest element does not allow `= initializer`
         // function foo([...x = []]) { }
         //                    ^^^^ A rest element cannot have an initializer
-        let argument = self.context_add(Context::In, |p| p.parse_initializer(init_span, pattern));
+        let argument = self.context_add(Context::In, |p| p.parse_initializer(init_start, pattern));
         if let BindingPattern::AssignmentPattern(pat) = &argument {
             self.error(diagnostics::a_rest_element_cannot_have_an_initializer(pat.span));
         }
@@ -125,7 +125,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_rest_element_for_formal_parameter(&mut self) -> BindingRestElement<'a> {
         let start = self.cur_start();
         self.bump_any(); // advance `...`
-        let init_span = self.cur_start();
+        let init_start = self.cur_start();
 
         let pattern = self.parse_binding_pattern_kind();
         // Rest element does not allow `?`, checked in checker/typescript.rs
@@ -140,7 +140,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // Rest parameter does not allow `= initializer`
         // function foo(...x = []) { }
         //                 ^^^^^^ A rest parameter cannot have an initializer
-        let argument = self.context_add(Context::In, |p| p.parse_initializer(init_span, pattern));
+        let argument = self.context_add(Context::In, |p| p.parse_initializer(init_start, pattern));
         if let BindingPattern::AssignmentPattern(pat) = &argument {
             self.error(diagnostics::a_rest_parameter_cannot_have_an_initializer(pat.span));
         }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -192,7 +192,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// [+In] PrivateIdentifier in ShiftExpression[?Yield, ?Await]
     fn parse_private_in_expression(
         &mut self,
-        lhs_span: u32,
+        lhs_start: u32,
         lhs_precedence: Precedence,
     ) -> Expression<'a> {
         let left = self.parse_private_identifier();
@@ -207,7 +207,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if let Expression::PrivateInExpression(private_in_expr) = right {
             return self.fatal_error(diagnostics::private_in_private(private_in_expr.span));
         }
-        Expression::new_private_in_expression(self.end_span(lhs_span), left, right, self)
+        Expression::new_private_in_expression(self.end_span(lhs_start), left, right, self)
     }
 
     /// Section [Primary Expression](https://tc39.es/ecma262/#sec-primary-expression)
@@ -275,8 +275,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let has_no_side_effects_comment =
             self.lexer.trivia_builder.previous_token_has_no_side_effects_comment();
         self.bump_any(); // `bump` `(`
-        let expr_span = self.cur_start();
-        let (mut expressions, comma_span) = self.context(Context::In, Context::Decorator, |p| {
+        let expr_start = self.cur_start();
+        let (mut expressions, comma_start) = self.context(Context::In, Context::Decorator, |p| {
             p.parse_delimited_list(
                 Kind::RParen,
                 Kind::Comma,
@@ -285,10 +285,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             )
         });
 
-        if let Some(comma_span) = comma_span {
+        if let Some(comma_start) = comma_start {
             let error = diagnostics::unexpected_trailing_comma(
                 "Parenthesized expressions",
-                self.end_span(comma_span),
+                self.end_span(comma_start),
             );
             return self.fatal_error(error);
         }
@@ -299,7 +299,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return self.fatal_error(error);
         }
 
-        let expr_span = self.end_span(expr_span);
+        let expr_span = self.end_span(expr_start);
         self.expect(Kind::RParen);
 
         // ParenthesizedExpression is from acorn --preserveParens
@@ -514,7 +514,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let start = self.cur_start();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LBrack);
-        let (elements, comma_span) = self.context_add(Context::In, |p| {
+        let (elements, comma_start) = self.context_add(Context::In, |p| {
             p.parse_delimited_list(
                 Kind::RBrack,
                 Kind::Comma,
@@ -522,8 +522,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 Self::parse_array_expression_element,
             )
         });
-        if let Some(comma_span) = comma_span {
-            self.state.trailing_commas.insert(start, self.end_span(comma_span));
+        if let Some(comma_start) = comma_start {
+            self.state.trailing_commas.insert(start, self.end_span(comma_start));
         }
         self.expect(Kind::RBrack);
         Expression::new_array_expression(self.end_span(start), elements, self)
@@ -822,12 +822,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn error_if_unparenthesized_instantiation_expression(
         &mut self,
         lhs: &Expression<'a>,
-        lhs_span: u32,
+        lhs_start: u32,
     ) {
-        if matches!(lhs, Expression::TSInstantiationExpression(e) if e.span.start == lhs_span) {
+        if matches!(lhs, Expression::TSInstantiationExpression(e) if e.span.start == lhs_start) {
             self.error(
                 diagnostics::ts_instantiation_expression_cannot_be_followed_by_property_access(
-                    self.end_span(lhs_span),
+                    self.end_span(lhs_start),
                 ),
             );
         }
@@ -836,7 +836,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// parse rhs of a member expression, starting from lhs
     fn parse_member_expression_rest(
         &mut self,
-        lhs_span: u32,
+        lhs_start: u32,
         lhs: Expression<'a>,
         in_optional_chain: &mut bool,
         allow_optional_chain: bool,
@@ -850,8 +850,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             match self.cur_kind() {
                 Kind::Dot => {
                     self.bump_any();
-                    self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_span);
-                    lhs = self.parse_static_member_expression(lhs_span, lhs, false);
+                    self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_start);
+                    lhs = self.parse_static_member_expression(lhs_start, lhs, false);
                 }
                 Kind::QuestionDot if allow_optional_chain => {
                     // Fast check to avoid checkpoint/rewind in common cases
@@ -865,16 +865,16 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         *in_optional_chain = true;
                         if self.cur_kind().is_identifier_or_keyword() {
                             // ?.something
-                            self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_span);
-                            lhs = self.parse_static_member_expression(lhs_span, lhs, true);
+                            self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_start);
+                            lhs = self.parse_static_member_expression(lhs_start, lhs, true);
                         } else if self.at(Kind::LBrack) {
                             // ?.[
-                            self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_span);
-                            lhs = self.parse_computed_member_expression(lhs_span, lhs, true);
+                            self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_start);
+                            lhs = self.parse_computed_member_expression(lhs_start, lhs, true);
                         } else {
                             // ?.template`...`
                             lhs =
-                                self.parse_tagged_template_rest(lhs_span, lhs, *in_optional_chain);
+                                self.parse_tagged_template_rest(lhs_start, lhs, *in_optional_chain);
                         }
                     } else {
                         // This is not a valid optional chain pattern, don't consume ?.
@@ -884,21 +884,21 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     }
                 }
                 Kind::LBrack if !self.ctx.has_decorator() => {
-                    self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_span);
-                    lhs = self.parse_computed_member_expression(lhs_span, lhs, false);
+                    self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_start);
+                    lhs = self.parse_computed_member_expression(lhs_start, lhs, false);
                 }
                 kind if kind.is_template_start_of_tagged_template() => {
-                    lhs = self.parse_tagged_template_rest(lhs_span, lhs, *in_optional_chain);
+                    lhs = self.parse_tagged_template_rest(lhs_start, lhs, *in_optional_chain);
                 }
                 Kind::Bang if self.is_ts && !self.cur_token().is_on_new_line() => {
                     self.bump_any();
                     lhs =
-                        Expression::new_ts_non_null_expression(self.end_span(lhs_span), lhs, self);
+                        Expression::new_ts_non_null_expression(self.end_span(lhs_start), lhs, self);
                 }
                 Kind::LAngle | Kind::ShiftLeft if self.is_ts => {
                     if let Some(arguments) = self.parse_type_arguments_in_expression() {
                         lhs = Expression::new_ts_instantiation_expression(
-                            self.end_span(lhs_span),
+                            self.end_span(lhs_start),
                             lhs,
                             arguments,
                             self,
@@ -921,7 +921,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// unwrapping a `TSInstantiationExpression` lhs (`` foo<T>`...` ``) into its type arguments.
     fn parse_tagged_template_rest(
         &mut self,
-        lhs_span: u32,
+        lhs_start: u32,
         lhs: Expression<'a>,
         in_optional_chain: bool,
     ) -> Expression<'a> {
@@ -932,20 +932,20 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             } else {
                 (lhs, None)
             };
-        self.parse_tagged_template(lhs_span, expr, in_optional_chain, type_arguments)
+        self.parse_tagged_template(lhs_start, expr, in_optional_chain, type_arguments)
     }
 
     /// Section 13.3 `MemberExpression`
     /// static member `a.b`
     fn parse_static_member_expression(
         &mut self,
-        lhs_span: u32,
+        lhs_start: u32,
         lhs: Expression<'a>,
         optional: bool,
     ) -> Expression<'a> {
         Expression::from(if self.cur_kind() == Kind::PrivateIdentifier {
             let private_ident = self.parse_private_identifier();
-            let span = self.end_span(lhs_span);
+            let span = self.end_span(lhs_start);
             // `super.#field` is not allowed.
             if lhs.is_super() {
                 self.error(diagnostics::super_private(span));
@@ -954,7 +954,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         } else {
             let ident = self.parse_identifier_name();
             MemberExpression::new_static_member_expression(
-                self.end_span(lhs_span),
+                self.end_span(lhs_start),
                 lhs,
                 ident,
                 optional,
@@ -968,7 +968,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   `MemberExpression`[?Yield, ?Await] [ Expression[+In, ?Yield, ?Await] ]
     fn parse_computed_member_expression(
         &mut self,
-        lhs_span: u32,
+        lhs_start: u32,
         lhs: Expression<'a>,
         optional: bool,
     ) -> Expression<'a> {
@@ -976,7 +976,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let property = self.context_add(Context::In, Self::parse_expr);
         self.expect(Kind::RBrack);
         Expression::new_computed_member_expression(
-            self.end_span(lhs_span),
+            self.end_span(lhs_start),
             lhs,
             property,
             optional,
@@ -1003,13 +1003,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             };
         }
 
-        let rhs_span = self.cur_start();
+        let rhs_start = self.cur_start();
         let is_import = self.at(Kind::Import); // Syntax Error for `new import('mod')` but not `new (import('mod'))`.
         let mut optional = false;
         let mut callee = {
             let lhs = self.parse_primary_expression();
             self.parse_member_expression_rest(
-                rhs_span,
+                rhs_start,
                 lhs,
                 &mut optional,
                 /* allow_optional_chain */ false,
@@ -1049,11 +1049,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         };
 
         if is_import && is_import_expression_or_member_access_on_import_expression(&callee) {
-            self.error(diagnostics::new_dynamic_import(self.end_span(rhs_span)));
+            self.error(diagnostics::new_dynamic_import(self.end_span(rhs_start)));
         }
 
         if matches!(callee, Expression::Super(_)) {
-            self.error(diagnostics::new_super(self.end_span(rhs_span)));
+            self.error(diagnostics::new_super(self.end_span(rhs_start)));
         }
 
         let span = self.end_span(start);
@@ -1068,7 +1068,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// Section 13.3 Call Expression
     fn parse_call_expression_rest(
         &mut self,
-        lhs_span: u32,
+        lhs_start: u32,
         lhs: Expression<'a>,
         in_optional_chain: &mut bool,
     ) -> Expression<'a> {
@@ -1085,7 +1085,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         while self.fatal_error.is_none() {
             if rescan_members {
                 lhs = self.parse_member_expression_rest(
-                    lhs_span,
+                    lhs_start,
                     lhs,
                     in_optional_chain,
                     /* allow_optional_chain */ true,
@@ -1113,7 +1113,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     }
                 }
                 if self.cur_kind().is_template_start_of_tagged_template() {
-                    lhs = self.parse_tagged_template(lhs_span, lhs, question_dot, type_arguments);
+                    lhs = self.parse_tagged_template(lhs_start, lhs, question_dot, type_arguments);
                     continue;
                 }
             }
@@ -1125,7 +1125,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     lhs = expr.expression;
                 }
 
-                lhs = self.parse_call_arguments(lhs_span, lhs, question_dot, type_arguments.take());
+                lhs =
+                    self.parse_call_arguments(lhs_start, lhs, question_dot, type_arguments.take());
                 continue;
             }
 
@@ -1143,7 +1144,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_call_arguments(
         &mut self,
-        lhs_span: u32,
+        lhs_start: u32,
         lhs: Expression<'a>,
         optional: bool,
         type_parameters: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
@@ -1162,7 +1163,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         });
         self.expect(Kind::RParen);
         Expression::new_call_expression(
-            self.end_span(lhs_span),
+            self.end_span(lhs_start),
             lhs,
             type_parameters,
             call_arguments,
@@ -1180,16 +1181,16 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     /// Section 13.4 Update Expression
-    fn parse_update_expression(&mut self, lhs_span: u32) -> Expression<'a> {
+    fn parse_update_expression(&mut self, lhs_start: u32) -> Expression<'a> {
         let kind = self.cur_kind();
         // ++ -- prefix update expressions
         if kind.is_update_operator() {
             let operator = map_update_operator(kind);
             self.bump_any();
-            let argument = self.parse_unary_expression_or_higher(lhs_span);
+            let argument = self.parse_unary_expression_or_higher(lhs_start);
             let argument = SimpleAssignmentTarget::cover(argument, self);
             return Expression::new_update_expression(
-                self.end_span(lhs_span),
+                self.end_span(lhs_start),
                 operator,
                 true,
                 argument,
@@ -1221,7 +1222,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     /// Section 13.5 Unary Expression
-    pub(crate) fn parse_unary_expression_or_higher(&mut self, lhs_span: u32) -> Expression<'a> {
+    pub(crate) fn parse_unary_expression_or_higher(&mut self, lhs_start: u32) -> Expression<'a> {
         match self.cur_kind() {
             // `UnaryExpression : (delete | void | typeof | + | - | ~ | !) UnaryExpression`
             // e.g. `!x`, `-1`, `typeof y`, `void 0`, `delete a.b`
@@ -1239,14 +1240,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
             // `UnaryExpression : [+Await] AwaitExpression`, with `AwaitExpression : await UnaryExpression`
             // e.g. `await foo`
-            Kind::Await => self.parse_await_expression(lhs_span),
+            Kind::Await => self.parse_await_expression(lhs_start),
             // `UnaryExpression : UpdateExpression` — a `LeftHandSideExpression` with an optional
             // prefix or postfix `++`/`--`. e.g. `a`, `f()`, `a++`, `++a`
-            _ => self.parse_update_expression(lhs_span),
+            _ => self.parse_update_expression(lhs_start),
         }
     }
 
-    pub(crate) fn parse_simple_unary_expression(&mut self, lhs_span: u32) -> Expression<'a> {
+    pub(crate) fn parse_simple_unary_expression(&mut self, lhs_start: u32) -> Expression<'a> {
         match self.cur_kind() {
             kind if kind.is_unary_operator() => self.parse_unary_expression(),
             Kind::LAngle => {
@@ -1258,8 +1259,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
                 self.parse_jsx_in_non_jsx_error()
             }
-            Kind::Await => self.parse_await_expression(lhs_span),
-            _ => self.parse_update_expression(lhs_span),
+            Kind::Await => self.parse_await_expression(lhs_start),
+            _ => self.parse_update_expression(lhs_start),
         }
     }
 
@@ -1288,29 +1289,29 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         lhs_precedence: Precedence,
     ) -> Expression<'a> {
-        let lhs_span = self.cur_start();
+        let lhs_start = self.cur_start();
 
         let lhs_parenthesized = self.at(Kind::LParen);
         // [+In] PrivateIdentifier in ShiftExpression[?Yield, ?Await]
         let lhs = if self.ctx.has_in() && self.at(Kind::PrivateIdentifier) {
-            self.parse_private_in_expression(lhs_span, lhs_precedence)
+            self.parse_private_in_expression(lhs_start, lhs_precedence)
         } else {
             let has_pure_comment =
                 self.lexer.trivia_builder.previous_token_has_pure_comment().is_some();
-            let mut expr = self.parse_unary_expression_or_higher(lhs_span);
+            let mut expr = self.parse_unary_expression_or_higher(lhs_start);
             if has_pure_comment {
                 Self::set_pure_on_call_or_new_expr(&mut expr);
             }
             expr
         };
 
-        self.parse_binary_expression_rest(lhs_span, lhs, lhs_parenthesized, lhs_precedence)
+        self.parse_binary_expression_rest(lhs_start, lhs, lhs_parenthesized, lhs_precedence)
     }
 
     /// Section 13.6 - 13.13 Binary Expression
     fn parse_binary_expression_rest(
         &mut self,
-        lhs_span: u32,
+        lhs_start: u32,
         lhs: Expression<'a>,
         lhs_parenthesized: bool,
         min_precedence: Precedence,
@@ -1353,7 +1354,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
                 self.bump_any();
                 let type_annotation = self.parse_ts_type();
-                let span = self.end_span(lhs_span);
+                let span = self.end_span(lhs_start);
                 lhs = if kind == Kind::As {
                     if !self.is_ts {
                         self.error(diagnostics::as_in_ts(span));
@@ -1384,7 +1385,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             let rhs = self.parse_binary_expression_or_higher(left_precedence);
 
             lhs = if kind.is_logical_operator() {
-                let span = self.end_span(lhs_span);
+                let span = self.end_span(lhs_start);
                 let op = map_logical_operator(kind);
                 // check mixed coalesce
                 if op == LogicalOperator::Coalesce {
@@ -1406,7 +1407,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
                 Expression::new_logical_expression(span, lhs, op, rhs, self)
             } else if kind.is_binary_operator() {
-                let span = self.end_span(lhs_span);
+                let span = self.end_span(lhs_start);
                 let op = map_binary_operator(kind);
                 if op == BinaryOperator::Exponential && !lhs_parenthesized {
                     let diagnostic = match &lhs {
@@ -1444,7 +1445,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     `ShortCircuitExpression`[?In, ?Yield, ?Await] ? `AssignmentExpression`[+In, ?Yield, ?Await] : `AssignmentExpression`[?In, ?Yield, ?Await]
     fn parse_conditional_expression_rest(
         &mut self,
-        lhs_span: u32,
+        lhs_start: u32,
         lhs: Expression<'a>,
         allow_return_type_in_arrow_function: bool,
     ) -> Expression<'a> {
@@ -1461,7 +1462,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let alternate =
             self.parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function);
         Expression::new_conditional_expression(
-            self.end_span(lhs_span),
+            self.end_span(lhs_start),
             lhs,
             consequent,
             alternate,
@@ -1701,7 +1702,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// ``AwaitExpression`[Yield]` :
     ///     await `UnaryExpression`[?Yield, +Await]
-    fn parse_await_expression(&mut self, lhs_span: u32) -> Expression<'a> {
+    fn parse_await_expression(&mut self, lhs_start: u32) -> Expression<'a> {
         // Case 1: In await context (async function, module top-level, unambiguous mode top-level)
         // Always parse as await expression
         if self.ctx.has_await() {
@@ -1745,7 +1746,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // Case 3: Ambiguous - parse `await` as identifier
         // This applies to scripts where `await` might be identifier or keyword
         // The statement-level checkpoint system handles reparsing if ESM detected
-        self.parse_update_expression(lhs_span)
+        self.parse_update_expression(lhs_start)
     }
 
     fn parse_decorated_expression(&mut self) -> Expression<'a> {

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -455,11 +455,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let decl = match self.cur_kind() {
             // `export import A = B`
             Kind::Import => {
-                let import_span = self.cur_start();
+                let import_start = self.cur_start();
                 self.bump_any();
                 // Pass `should_record_module_record: false` to prevent an `import` module record
                 // being created. It's an export not an import.
-                let stmt = self.parse_import_declaration(import_span, false);
+                let stmt = self.parse_import_declaration(import_start, false);
                 if stmt.is_declaration() {
                     let export_decl = ExportDeclaration::boxed(
                         self.end_span(start),
@@ -475,7 +475,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
             }
             Kind::At => {
-                let class_span = self.cur_start();
+                let class_start = self.cur_start();
                 let after_export_decorators = self.parse_decorators();
                 if !decorators.is_empty() {
                     for decorator in &after_export_decorators {
@@ -484,7 +484,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
                 decorators.extend(after_export_decorators);
                 let modifiers = self.parse_modifiers(false, false);
-                let class_decl = self.parse_class_declaration(class_span, &modifiers, decorators);
+                let class_decl = self.parse_class_declaration(class_start, &modifiers, decorators);
                 let decl = Declaration::ClassDeclaration(class_decl);
                 let export_decl = ExportDeclaration::boxed(self.end_span(start), decl, self);
                 if self.ctx.has_top_level() {
@@ -635,13 +635,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         start: u32,
         decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ArenaBox<'a, ExportDeclaration<'a>> {
-        let decl_span = self.cur_start();
+        let decl_start = self.cur_start();
         let reserved_ctx = self.ctx;
         let modifiers =
             if self.is_ts { self.eat_modifiers_before_declaration() } else { Modifiers::empty() };
         self.ctx = self.ctx.union_ambient_if(modifiers.contains_declare());
 
-        let declaration = self.parse_declaration(decl_span, &modifiers, decorators);
+        let declaration = self.parse_declaration(decl_start, &modifiers, decorators);
         self.ctx = reserved_ctx;
         let export_decl = ExportDeclaration::boxed(self.end_span(start), declaration, self);
         if self.ctx.has_top_level() {
@@ -674,7 +674,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         mut decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ExportDefaultDeclarationKind<'a> {
-        let decl_span = self.cur_start();
+        let decl_start = self.cur_start();
 
         // export default /* @__NO_SIDE_EFFECTS__ */ ...
         let has_no_side_effects_comment =
@@ -692,7 +692,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             decorators.extend(after_export_decorators);
         }
 
-        let function_span = self.cur_start();
+        let function_start = self.cur_start();
 
         // ExportDeclaration :
         //   export default HoistableDeclaration
@@ -707,15 +707,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // a declaration. `[no LineTerminator here]` maps to `!next.is_on_new_line()`.
         let kind = self.cur_kind();
         if matches!(kind, Kind::Abstract | Kind::Async | Kind::Interface) {
-            let modifier_span = self.cur_start();
+            let modifier_start = self.cur_start();
             let next = self.lexer.peek_token();
             if !next.is_on_new_line() {
                 // export default abstract class C {}
                 if kind == Kind::Abstract && next.kind() == Kind::Class {
                     self.bump_any();
-                    let modifiers = Modifiers::new_single(ModifierKind::Abstract, modifier_span);
+                    let modifiers = Modifiers::new_single(ModifierKind::Abstract, modifier_start);
                     return ExportDefaultDeclarationKind::ClassDeclaration(
-                        self.parse_class_declaration(decl_span, &modifiers, decorators),
+                        self.parse_class_declaration(decl_start, &modifiers, decorators),
                     );
                 }
                 // export default async function f() {}
@@ -725,7 +725,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         self.error(diagnostics::decorators_are_not_valid_here(decorator.span));
                     }
                     let mut func = self.parse_function_impl(
-                        function_span,
+                        function_start,
                         /* r#async */ true,
                         FunctionKind::DefaultExport,
                     );
@@ -741,7 +741,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         self.error(diagnostics::decorators_are_not_valid_here(decorator.span));
                     }
                     if let Declaration::TSInterfaceDeclaration(decl) =
-                        self.parse_ts_interface_declaration(modifier_span, &Modifiers::empty())
+                        self.parse_ts_interface_declaration(modifier_start, &Modifiers::empty())
                     {
                         return ExportDefaultDeclarationKind::TSInterfaceDeclaration(decl);
                     }
@@ -754,7 +754,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // export default class C {}
         if kind == Kind::Class {
             return ExportDefaultDeclarationKind::ClassDeclaration(self.parse_class_declaration(
-                decl_span,
+                decl_start,
                 &Modifiers::empty(),
                 decorators,
             ));
@@ -767,7 +767,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // export default function f() {}
         if kind == Kind::Function {
             let mut func = self.parse_function_impl(
-                function_span,
+                function_start,
                 /* r#async */ false,
                 FunctionKind::DefaultExport,
             );
@@ -828,7 +828,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         specifier_type: ImportOrExport,
         parent_kind: ImportOrExportKind,
     ) -> ImportOrExportSpecifier<'a> {
-        let specifier_span = self.cur_start();
+        let specifier_start = self.cur_start();
         let type_or_name_token = self.cur_token();
         let type_or_name_token_kind = type_or_name_token.kind();
         let mut check_identifier_token = self.cur_token();
@@ -932,7 +932,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     BindingIdentifier::new(name.span(), self.ident(name.name().as_str()), self);
                 let imported = property_name.unwrap_or(name);
                 ImportOrExportSpecifier::Import(ImportSpecifier::new(
-                    self.end_span(specifier_span),
+                    self.end_span(specifier_start),
                     imported,
                     local,
                     kind,
@@ -952,7 +952,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     None => self.duplicate_module_export_name(&name),
                 };
                 ImportOrExportSpecifier::Export(ExportSpecifier::new(
-                    self.end_span(specifier_span),
+                    self.end_span(specifier_start),
                     local,
                     name,
                     kind,

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -20,7 +20,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let start = self.cur_start();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
-        let (object_expression_properties, comma_span) = self.context_add(Context::In, |p| {
+        let (object_expression_properties, comma_start) = self.context_add(Context::In, |p| {
             p.parse_delimited_list(
                 Kind::RCurly,
                 Kind::Comma,
@@ -28,8 +28,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 Self::parse_object_expression_property,
             )
         });
-        if let Some(comma_span) = comma_span {
-            self.state.trailing_commas.insert(start, self.end_span(comma_span));
+        if let Some(comma_start) = comma_start {
+            self.state.trailing_commas.insert(start, self.end_span(comma_start));
         }
         self.expect(Kind::RCurly);
         ObjectExpression::boxed(self.end_span(start), object_expression_properties, self)

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -471,7 +471,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let is_let = self.at(Kind::Let);
         // `async` is allowed as `for (async of ...)` if `async` is escaped
         let is_async = self.at(Kind::Async) && !self.cur_token().escaped();
-        let expr_span = self.cur_start();
+        let expr_start = self.cur_start();
 
         let init_expression = self.context_remove(Context::In, ParserImpl::parse_expr);
 
@@ -484,11 +484,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Kind::Of => {
                 if !r#await && is_async && init_expression.is_identifier_reference() {
                     // `for (async of ...)` is not allowed
-                    self.error(diagnostics::for_loop_async_of(self.end_span(expr_span)));
+                    self.error(diagnostics::for_loop_async_of(self.end_span(expr_start)));
                 }
                 if is_let {
                     // `for (let of ...)`, `for (let.something of ...)` is not allowed
-                    self.error(diagnostics::for_loop_let_reserved_word(self.end_span(expr_span)));
+                    self.error(diagnostics::for_loop_let_reserved_word(self.end_span(expr_start)));
                 }
                 let target = AssignmentTarget::cover(init_expression, self);
                 let for_stmt_left = ForStatementLeft::from(target);

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -327,7 +327,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// Parses the closing element or fragment after `</` has been consumed.
     fn parse_jsx_closing_inline(
         &mut self,
-        open_angle_span: u32,
+        open_angle_start: u32,
         in_jsx_child: bool,
     ) -> JSXClosing<'a> {
         if self.at(Kind::RAngle) {
@@ -337,7 +337,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             } else {
                 self.expect(Kind::RAngle);
             }
-            JSXClosing::Fragment(JSXClosingFragment::new(self.end_span(open_angle_span), self))
+            JSXClosing::Fragment(JSXClosingFragment::new(self.end_span(open_angle_start), self))
         } else {
             // Closing element: </name>
             let name = self.parse_jsx_element_name();
@@ -347,7 +347,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.expect(Kind::RAngle);
             }
             JSXClosing::Element(JSXClosingElement::boxed(
-                self.end_span(open_angle_span),
+                self.end_span(open_angle_start),
                 name,
                 self,
             ))

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -714,8 +714,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect(Kind::LAngle);
         let type_annotation = self.parse_ts_type();
         self.expect(Kind::RAngle);
-        let lhs_span = self.cur_start();
-        let expression = self.parse_simple_unary_expression(lhs_span);
+        let lhs_start = self.cur_start();
+        let expression = self.parse_simple_unary_expression(lhs_start);
         let span = self.end_span(start);
 
         if matches!(self.source_type.extension(), Some(FileExtension::Mts | FileExtension::Cts)) {
@@ -733,18 +733,18 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> Declaration<'a> {
         self.expect(Kind::Eq);
 
-        let reference_span = self.cur_start();
+        let reference_start = self.cur_start();
         let module_reference = if self.eat(Kind::Require) {
             self.expect(Kind::LParen);
             let expression = self.parse_literal_string();
             self.expect(Kind::RParen);
             TSModuleReference::new_external_module_reference(
-                self.end_span(reference_span),
+                self.end_span(reference_start),
                 expression,
                 self,
             )
         } else {
-            self.parse_ts_module_reference(reference_span)
+            self.parse_ts_module_reference(reference_start)
         };
 
         self.asi();

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -52,9 +52,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             p.parse_formal_parameters(FunctionKind::Declaration, FormalParameterKind::Signature)
         });
         let return_type = {
-            let return_type_span = self.cur_start();
+            let return_type_start = self.cur_start();
             let return_type = self.parse_return_type();
-            TSTypeAnnotation::boxed(self.end_span(return_type_span), return_type, self)
+            TSTypeAnnotation::boxed(self.end_span(return_type_start), return_type, self)
         };
 
         let span = self.end_span(start);
@@ -821,9 +821,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         };
         let mut type_annotation = None;
         if self.eat(Kind::Is) {
-            let type_span = self.cur_start();
+            let type_start = self.cur_start();
             let ty = self.parse_ts_type();
-            type_annotation = Some(TSTypeAnnotation::boxed(self.end_span(type_span), ty, self));
+            type_annotation = Some(TSTypeAnnotation::boxed(self.end_span(type_start), ty, self));
         }
         TSType::new_ts_type_predicate(
             self.end_span(asserts_start),
@@ -1209,9 +1209,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         // Use the actual string from the source (not a static string) to ensure it's in the arena
         let key_name = self.ident(self.cur_string());
-        let with_key_span = self.cur_start();
+        let with_key_start = self.cur_start();
         self.bump_any();
-        let with_key = IdentifierName::boxed(self.end_span(with_key_span), key_name, self);
+        let with_key = IdentifierName::boxed(self.end_span(with_key_start), key_name, self);
 
         self.expect(Kind::Colon);
 
@@ -1225,7 +1225,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         // Create the outer `with: { ... }` property
         let with_property = ObjectPropertyKind::new_object_property(
-            self.end_span(with_key_span),
+            self.end_span(with_key_start),
             PropertyKind::Init,
             PropertyKey::StaticIdentifier(with_key),
             value,
@@ -1270,7 +1270,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 continue;
             }
 
-            let prop_span = self.cur_start();
+            let prop_start = self.cur_start();
 
             // Check for computed property
             if self.at(Kind::LBrack) {
@@ -1284,7 +1284,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 let value = self.parse_assignment_expression_or_higher();
                 let key = PropertyKey::new_string_literal(bracket_span, "", None, self);
                 let property = ObjectPropertyKind::new_object_property(
-                    self.end_span(prop_span),
+                    self.end_span(prop_start),
                     PropertyKind::Init,
                     key,
                     value,
@@ -1310,7 +1310,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             let value = self.parse_assignment_expression_or_higher();
 
             let property = ObjectPropertyKind::new_object_property(
-                self.end_span(prop_span),
+                self.end_span(prop_start),
                 PropertyKind::Init,
                 key,
                 value,
@@ -1536,7 +1536,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let opening_span = self.cur_token().span();
         self.expect(Kind::LBrack);
         let mut parameter_count = 0;
-        let mut comma_span = None;
+        let mut comma_start = None;
         let parameter = if self.at(Kind::RBrack) || self.has_fatal_error() {
             TSIndexSignatureName::dummy(self.allocator())
         } else {
@@ -1555,7 +1555,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
                 self.advance(Kind::Comma);
                 if self.at(Kind::RBrack) {
-                    comma_span = Some(self.prev_token_end - 1);
+                    comma_start = Some(self.prev_token_end - 1);
                     break;
                 }
                 parameter_count += 1;
@@ -1563,10 +1563,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
             parameter
         };
-        if let Some(comma_span) = comma_span {
+        if let Some(comma_start) = comma_start {
             self.error(diagnostics::unexpected_trailing_comma(
                 "Index signature declarations",
-                self.end_span(comma_span),
+                self.end_span(comma_start),
             ));
         }
         self.expect(Kind::RBrack);


### PR DESCRIPTION
Pure refactor. Continuation of #25262.

Rename vars in parser called `*_span` to `*_start` where the var is a `u32` representing the _start_ of a span, rather than a whole `Span`.