### PR TITLE
chore(tools): add VS Code config to speed up Rust Analyzer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,31 @@
   },
   "[rust]": {
     "editor.defaultFormatter": "rust-lang.rust-analyzer"
-  }
+  },
+  // Exclude huge gitignored submodules and `node_modules` from rust-analyzer's file scan -
+  // it does not respect `.gitignore`.
+  // Skipping these directories (500k+ files) speeds up server startup and reduces memory use.
+  // Paths are workspace-root relative. Globs are not supported, so each is listed explicitly.
+  "rust-analyzer.files.exclude": [
+    "apps/oxfmt/node_modules",
+    "apps/oxlint/conformance/submodules",
+    "apps/oxlint/node_modules",
+    "apps/shared/node_modules",
+    "napi/minify/node_modules",
+    "napi/parser/node_modules",
+    "napi/playground/node_modules",
+    "napi/transform/node_modules",
+    "napi/transform-react/node_modules",
+    "node_modules",
+    "npm/oxfmt/node_modules",
+    "npm/oxlint/node_modules",
+    "tasks/e2e/node_modules",
+    "tasks/compat_data/node_modules",
+    "tasks/coverage/test262",
+    "tasks/coverage/babel",
+    "tasks/coverage/typescript",
+    "tasks/coverage/estree-conformance",
+    "tasks/prettier_conformance/prettier",
+    "tasks/transform_conformance/node_modules"
+  ]
 }


### PR DESCRIPTION
Prevent Rust Analyzer indexing and tracking files in directories it doesn't need to (`node_modules`, submodules).

Rust Analyzer doesn't obey `.gitignore`, so the thousands of files in these directories all get indexed, unless explicitly excluded.

This makes Rust Analyzer's startup faster and makes it use less memory.

Working on my MacBook Air which has limited memory, I've found Rust Analyzer grinds the machine to a halt when have multiple worktrees going in different VS Code windows. This appears to help a bit.