### PR TITLE
feat(linter): add unicorn prefer-unary-minus rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1644,6 +1644,7 @@ export interface DummyRuleMap {
   "unicorn/prefer-ternary"?: RuleNoConfig | [AllowWarnDeny, PreferTernaryOption];
   "unicorn/prefer-top-level-await"?: RuleNoConfig;
   "unicorn/prefer-type-error"?: RuleNoConfig;
+  "unicorn/prefer-unary-minus"?: RuleNoConfig;
   "unicorn/relative-url-style"?: RuleNoConfig | [AllowWarnDeny, RelativeUrlStyleConfig];
   "unicorn/require-array-join-separator"?: RuleNoConfig;
   "unicorn/require-module-attributes"?: RuleNoConfig;

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1653,6 +1653,7 @@ export interface DummyRuleMap {
   "unicorn/prefer-ternary"?: RuleNoConfig | [AllowWarnDeny, PreferTernaryOption];
   "unicorn/prefer-top-level-await"?: RuleNoConfig;
   "unicorn/prefer-type-error"?: RuleNoConfig;
+  "unicorn/prefer-unary-minus"?: RuleNoConfig;
   "unicorn/relative-url-style"?: RuleNoConfig | [AllowWarnDeny, RelativeUrlStyleConfig];
   "unicorn/require-array-join-separator"?: RuleNoConfig;
   "unicorn/require-module-attributes"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3846,6 +3846,12 @@ impl RuleRunner for crate::rules::unicorn::prefer_type_error::PreferTypeError {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::prefer_unary_minus::PreferUnaryMinus {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::relative_url_style::RelativeUrlStyle {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3851,6 +3851,12 @@ impl RuleRunner for crate::rules::unicorn::prefer_type_error::PreferTypeError {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::prefer_unary_minus::PreferUnaryMinus {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::relative_url_style::RelativeUrlStyle {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::NewExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -730,6 +730,7 @@ pub use crate::rules::unicorn::prefer_structured_clone::PreferStructuredClone as
 pub use crate::rules::unicorn::prefer_ternary::PreferTernary as UnicornPreferTernary;
 pub use crate::rules::unicorn::prefer_top_level_await::PreferTopLevelAwait as UnicornPreferTopLevelAwait;
 pub use crate::rules::unicorn::prefer_type_error::PreferTypeError as UnicornPreferTypeError;
+pub use crate::rules::unicorn::prefer_unary_minus::PreferUnaryMinus as UnicornPreferUnaryMinus;
 pub use crate::rules::unicorn::relative_url_style::RelativeUrlStyle as UnicornRelativeUrlStyle;
 pub use crate::rules::unicorn::require_array_join_separator::RequireArrayJoinSeparator as UnicornRequireArrayJoinSeparator;
 pub use crate::rules::unicorn::require_module_attributes::RequireModuleAttributes as UnicornRequireModuleAttributes;
@@ -1457,6 +1458,7 @@ pub enum RuleEnum {
     UnicornPreferTernary(UnicornPreferTernary),
     UnicornPreferTopLevelAwait(UnicornPreferTopLevelAwait),
     UnicornPreferTypeError(UnicornPreferTypeError),
+    UnicornPreferUnaryMinus(UnicornPreferUnaryMinus),
     UnicornRelativeUrlStyle(UnicornRelativeUrlStyle),
     UnicornRequireArrayJoinSeparator(UnicornRequireArrayJoinSeparator),
     UnicornRequireModuleAttributes(UnicornRequireModuleAttributes),
@@ -2388,7 +2390,8 @@ const UNICORN_PREFER_STRUCTURED_CLONE_ID: usize = UNICORN_PREFER_STRING_TRIM_STA
 const UNICORN_PREFER_TERNARY_ID: usize = UNICORN_PREFER_STRUCTURED_CLONE_ID + 1usize;
 const UNICORN_PREFER_TOP_LEVEL_AWAIT_ID: usize = UNICORN_PREFER_TERNARY_ID + 1usize;
 const UNICORN_PREFER_TYPE_ERROR_ID: usize = UNICORN_PREFER_TOP_LEVEL_AWAIT_ID + 1usize;
-const UNICORN_RELATIVE_URL_STYLE_ID: usize = UNICORN_PREFER_TYPE_ERROR_ID + 1usize;
+const UNICORN_PREFER_UNARY_MINUS_ID: usize = UNICORN_PREFER_TYPE_ERROR_ID + 1usize;
+const UNICORN_RELATIVE_URL_STYLE_ID: usize = UNICORN_PREFER_UNARY_MINUS_ID + 1usize;
 const UNICORN_REQUIRE_ARRAY_JOIN_SEPARATOR_ID: usize = UNICORN_RELATIVE_URL_STYLE_ID + 1usize;
 const UNICORN_REQUIRE_MODULE_ATTRIBUTES_ID: usize =
     UNICORN_REQUIRE_ARRAY_JOIN_SEPARATOR_ID + 1usize;
@@ -2685,7 +2688,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 849usize] = [
+static RULE_NAMES: [&str; 850usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3272,6 +3275,7 @@ static RULE_NAMES: [&str; 849usize] = [
     UnicornPreferTernary::NAME,
     UnicornPreferTopLevelAwait::NAME,
     UnicornPreferTypeError::NAME,
+    UnicornPreferUnaryMinus::NAME,
     UnicornRelativeUrlStyle::NAME,
     UnicornRequireArrayJoinSeparator::NAME,
     UnicornRequireModuleAttributes::NAME,
@@ -4227,6 +4231,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UNICORN_PREFER_TERNARY_ID,
             Self::UnicornPreferTopLevelAwait(_) => UNICORN_PREFER_TOP_LEVEL_AWAIT_ID,
             Self::UnicornPreferTypeError(_) => UNICORN_PREFER_TYPE_ERROR_ID,
+            Self::UnicornPreferUnaryMinus(_) => UNICORN_PREFER_UNARY_MINUS_ID,
             Self::UnicornRelativeUrlStyle(_) => UNICORN_RELATIVE_URL_STYLE_ID,
             Self::UnicornRequireArrayJoinSeparator(_) => UNICORN_REQUIRE_ARRAY_JOIN_SEPARATOR_ID,
             Self::UnicornRequireModuleAttributes(_) => UNICORN_REQUIRE_MODULE_ATTRIBUTES_ID,
@@ -5243,6 +5248,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::CATEGORY,
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::CATEGORY,
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::CATEGORY,
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::CATEGORY,
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::CATEGORY,
             Self::UnicornRequireArrayJoinSeparator(_) => UnicornRequireArrayJoinSeparator::CATEGORY,
             Self::UnicornRequireModuleAttributes(_) => UnicornRequireModuleAttributes::CATEGORY,
@@ -6229,6 +6235,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::FIX,
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::FIX,
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::FIX,
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::FIX,
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::FIX,
             Self::UnicornRequireArrayJoinSeparator(_) => UnicornRequireArrayJoinSeparator::FIX,
             Self::UnicornRequireModuleAttributes(_) => UnicornRequireModuleAttributes::FIX,
@@ -7375,6 +7382,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::documentation(),
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::documentation(),
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::documentation(),
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::documentation(),
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::documentation(),
             Self::UnicornRequireArrayJoinSeparator(_) => {
                 UnicornRequireArrayJoinSeparator::documentation()
@@ -9454,6 +9462,8 @@ impl RuleEnum {
             }
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::config_schema(generator)
                 .or_else(|| UnicornPreferTypeError::schema(generator)),
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::config_schema(generator)
+                .or_else(|| UnicornPreferUnaryMinus::schema(generator)),
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::config_schema(generator)
                 .or_else(|| UnicornRelativeUrlStyle::schema(generator)),
             Self::UnicornRequireArrayJoinSeparator(_) => {
@@ -10784,6 +10794,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => "unicorn",
             Self::UnicornPreferTopLevelAwait(_) => "unicorn",
             Self::UnicornPreferTypeError(_) => "unicorn",
+            Self::UnicornPreferUnaryMinus(_) => "unicorn",
             Self::UnicornRelativeUrlStyle(_) => "unicorn",
             Self::UnicornRequireArrayJoinSeparator(_) => "unicorn",
             Self::UnicornRequireModuleAttributes(_) => "unicorn",
@@ -12734,6 +12745,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.to_configuration(),
             Self::UnicornPreferTopLevelAwait(rule) => rule.to_configuration(),
             Self::UnicornPreferTypeError(rule) => rule.to_configuration(),
+            Self::UnicornPreferUnaryMinus(rule) => rule.to_configuration(),
             Self::UnicornRelativeUrlStyle(rule) => rule.to_configuration(),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.to_configuration(),
             Self::UnicornRequireModuleAttributes(rule) => rule.to_configuration(),
@@ -13590,6 +13602,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.run(node, ctx),
             Self::UnicornPreferTopLevelAwait(rule) => rule.run(node, ctx),
             Self::UnicornPreferTypeError(rule) => rule.run(node, ctx),
+            Self::UnicornPreferUnaryMinus(rule) => rule.run(node, ctx),
             Self::UnicornRelativeUrlStyle(rule) => rule.run(node, ctx),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.run(node, ctx),
             Self::UnicornRequireModuleAttributes(rule) => rule.run(node, ctx),
@@ -14456,6 +14469,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.run_once(ctx),
             Self::UnicornPreferTopLevelAwait(rule) => rule.run_once(ctx),
             Self::UnicornPreferTypeError(rule) => rule.run_once(ctx),
+            Self::UnicornPreferUnaryMinus(rule) => rule.run_once(ctx),
             Self::UnicornRelativeUrlStyle(rule) => rule.run_once(ctx),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.run_once(ctx),
             Self::UnicornRequireModuleAttributes(rule) => rule.run_once(ctx),
@@ -15417,6 +15431,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornPreferTopLevelAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornPreferTypeError(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornPreferUnaryMinus(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornRelativeUrlStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornRequireModuleAttributes(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16306,6 +16321,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.should_run(ctx),
             Self::UnicornPreferTopLevelAwait(rule) => rule.should_run(ctx),
             Self::UnicornPreferTypeError(rule) => rule.should_run(ctx),
+            Self::UnicornPreferUnaryMinus(rule) => rule.should_run(ctx),
             Self::UnicornRelativeUrlStyle(rule) => rule.should_run(ctx),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.should_run(ctx),
             Self::UnicornRequireModuleAttributes(rule) => rule.should_run(ctx),
@@ -17429,6 +17445,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::IS_TSGOLINT_RULE,
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::IS_TSGOLINT_RULE,
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::IS_TSGOLINT_RULE,
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::IS_TSGOLINT_RULE,
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::IS_TSGOLINT_RULE,
             Self::UnicornRequireArrayJoinSeparator(_) => {
                 UnicornRequireArrayJoinSeparator::IS_TSGOLINT_RULE
@@ -18528,6 +18545,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::VERSION,
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::VERSION,
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::VERSION,
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::VERSION,
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::VERSION,
             Self::UnicornRequireArrayJoinSeparator(_) => UnicornRequireArrayJoinSeparator::VERSION,
             Self::UnicornRequireModuleAttributes(_) => UnicornRequireModuleAttributes::VERSION,
@@ -19580,6 +19598,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::HAS_CONFIG,
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::HAS_CONFIG,
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::HAS_CONFIG,
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::HAS_CONFIG,
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::HAS_CONFIG,
             Self::UnicornRequireArrayJoinSeparator(_) => {
                 UnicornRequireArrayJoinSeparator::HAS_CONFIG
@@ -20581,6 +20600,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::INFO,
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::INFO,
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::INFO,
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::INFO,
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::INFO,
             Self::UnicornRequireArrayJoinSeparator(_) => UnicornRequireArrayJoinSeparator::INFO,
             Self::UnicornRequireModuleAttributes(_) => UnicornRequireModuleAttributes::INFO,
@@ -21461,6 +21481,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.types_info(),
             Self::UnicornPreferTopLevelAwait(rule) => rule.types_info(),
             Self::UnicornPreferTypeError(rule) => rule.types_info(),
+            Self::UnicornPreferUnaryMinus(rule) => rule.types_info(),
             Self::UnicornRelativeUrlStyle(rule) => rule.types_info(),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.types_info(),
             Self::UnicornRequireModuleAttributes(rule) => rule.types_info(),
@@ -22314,6 +22335,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.run_info(),
             Self::UnicornPreferTopLevelAwait(rule) => rule.run_info(),
             Self::UnicornPreferTypeError(rule) => rule.run_info(),
+            Self::UnicornPreferUnaryMinus(rule) => rule.run_info(),
             Self::UnicornRelativeUrlStyle(rule) => rule.run_info(),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.run_info(),
             Self::UnicornRequireModuleAttributes(rule) => rule.run_info(),
@@ -23281,6 +23303,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornPreferTernary(UnicornPreferTernary::default()),
         RuleEnum::UnicornPreferTopLevelAwait(UnicornPreferTopLevelAwait::default()),
         RuleEnum::UnicornPreferTypeError(UnicornPreferTypeError::default()),
+        RuleEnum::UnicornPreferUnaryMinus(UnicornPreferUnaryMinus::default()),
         RuleEnum::UnicornRelativeUrlStyle(UnicornRelativeUrlStyle::default()),
         RuleEnum::UnicornRequireArrayJoinSeparator(UnicornRequireArrayJoinSeparator::default()),
         RuleEnum::UnicornRequireModuleAttributes(UnicornRequireModuleAttributes::default()),

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -728,6 +728,7 @@ pub use crate::rules::unicorn::prefer_structured_clone::PreferStructuredClone as
 pub use crate::rules::unicorn::prefer_ternary::PreferTernary as UnicornPreferTernary;
 pub use crate::rules::unicorn::prefer_top_level_await::PreferTopLevelAwait as UnicornPreferTopLevelAwait;
 pub use crate::rules::unicorn::prefer_type_error::PreferTypeError as UnicornPreferTypeError;
+pub use crate::rules::unicorn::prefer_unary_minus::PreferUnaryMinus as UnicornPreferUnaryMinus;
 pub use crate::rules::unicorn::relative_url_style::RelativeUrlStyle as UnicornRelativeUrlStyle;
 pub use crate::rules::unicorn::require_array_join_separator::RequireArrayJoinSeparator as UnicornRequireArrayJoinSeparator;
 pub use crate::rules::unicorn::require_module_attributes::RequireModuleAttributes as UnicornRequireModuleAttributes;
@@ -1454,6 +1455,7 @@ pub enum RuleEnum {
     UnicornPreferTernary(UnicornPreferTernary),
     UnicornPreferTopLevelAwait(UnicornPreferTopLevelAwait),
     UnicornPreferTypeError(UnicornPreferTypeError),
+    UnicornPreferUnaryMinus(UnicornPreferUnaryMinus),
     UnicornRelativeUrlStyle(UnicornRelativeUrlStyle),
     UnicornRequireArrayJoinSeparator(UnicornRequireArrayJoinSeparator),
     UnicornRequireModuleAttributes(UnicornRequireModuleAttributes),
@@ -2383,7 +2385,8 @@ const UNICORN_PREFER_STRUCTURED_CLONE_ID: usize = UNICORN_PREFER_STRING_TRIM_STA
 const UNICORN_PREFER_TERNARY_ID: usize = UNICORN_PREFER_STRUCTURED_CLONE_ID + 1usize;
 const UNICORN_PREFER_TOP_LEVEL_AWAIT_ID: usize = UNICORN_PREFER_TERNARY_ID + 1usize;
 const UNICORN_PREFER_TYPE_ERROR_ID: usize = UNICORN_PREFER_TOP_LEVEL_AWAIT_ID + 1usize;
-const UNICORN_RELATIVE_URL_STYLE_ID: usize = UNICORN_PREFER_TYPE_ERROR_ID + 1usize;
+const UNICORN_PREFER_UNARY_MINUS_ID: usize = UNICORN_PREFER_TYPE_ERROR_ID + 1usize;
+const UNICORN_RELATIVE_URL_STYLE_ID: usize = UNICORN_PREFER_UNARY_MINUS_ID + 1usize;
 const UNICORN_REQUIRE_ARRAY_JOIN_SEPARATOR_ID: usize = UNICORN_RELATIVE_URL_STYLE_ID + 1usize;
 const UNICORN_REQUIRE_MODULE_ATTRIBUTES_ID: usize =
     UNICORN_REQUIRE_ARRAY_JOIN_SEPARATOR_ID + 1usize;
@@ -3369,6 +3372,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UNICORN_PREFER_TERNARY_ID,
             Self::UnicornPreferTopLevelAwait(_) => UNICORN_PREFER_TOP_LEVEL_AWAIT_ID,
             Self::UnicornPreferTypeError(_) => UNICORN_PREFER_TYPE_ERROR_ID,
+            Self::UnicornPreferUnaryMinus(_) => UNICORN_PREFER_UNARY_MINUS_ID,
             Self::UnicornRelativeUrlStyle(_) => UNICORN_RELATIVE_URL_STYLE_ID,
             Self::UnicornRequireArrayJoinSeparator(_) => UNICORN_REQUIRE_ARRAY_JOIN_SEPARATOR_ID,
             Self::UnicornRequireModuleAttributes(_) => UNICORN_REQUIRE_MODULE_ATTRIBUTES_ID,
@@ -4340,6 +4344,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::NAME,
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::NAME,
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::NAME,
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::NAME,
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::NAME,
             Self::UnicornRequireArrayJoinSeparator(_) => UnicornRequireArrayJoinSeparator::NAME,
             Self::UnicornRequireModuleAttributes(_) => UnicornRequireModuleAttributes::NAME,
@@ -5345,6 +5350,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::CATEGORY,
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::CATEGORY,
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::CATEGORY,
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::CATEGORY,
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::CATEGORY,
             Self::UnicornRequireArrayJoinSeparator(_) => UnicornRequireArrayJoinSeparator::CATEGORY,
             Self::UnicornRequireModuleAttributes(_) => UnicornRequireModuleAttributes::CATEGORY,
@@ -6329,6 +6335,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::FIX,
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::FIX,
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::FIX,
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::FIX,
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::FIX,
             Self::UnicornRequireArrayJoinSeparator(_) => UnicornRequireArrayJoinSeparator::FIX,
             Self::UnicornRequireModuleAttributes(_) => UnicornRequireModuleAttributes::FIX,
@@ -7473,6 +7480,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::documentation(),
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::documentation(),
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::documentation(),
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::documentation(),
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::documentation(),
             Self::UnicornRequireArrayJoinSeparator(_) => {
                 UnicornRequireArrayJoinSeparator::documentation()
@@ -9548,6 +9556,8 @@ impl RuleEnum {
             }
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::config_schema(generator)
                 .or_else(|| UnicornPreferTypeError::schema(generator)),
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::config_schema(generator)
+                .or_else(|| UnicornPreferUnaryMinus::schema(generator)),
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::config_schema(generator)
                 .or_else(|| UnicornRelativeUrlStyle::schema(generator)),
             Self::UnicornRequireArrayJoinSeparator(_) => {
@@ -10875,6 +10885,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => "unicorn",
             Self::UnicornPreferTopLevelAwait(_) => "unicorn",
             Self::UnicornPreferTypeError(_) => "unicorn",
+            Self::UnicornPreferUnaryMinus(_) => "unicorn",
             Self::UnicornRelativeUrlStyle(_) => "unicorn",
             Self::UnicornRequireArrayJoinSeparator(_) => "unicorn",
             Self::UnicornRequireModuleAttributes(_) => "unicorn",
@@ -13037,6 +13048,9 @@ impl RuleEnum {
             Self::UnicornPreferTypeError(_) => {
                 Ok(Self::UnicornPreferTypeError(UnicornPreferTypeError::from_configuration(value)?))
             }
+            Self::UnicornPreferUnaryMinus(_) => Ok(Self::UnicornPreferUnaryMinus(
+                UnicornPreferUnaryMinus::from_configuration(value)?,
+            )),
             Self::UnicornRelativeUrlStyle(_) => Ok(Self::UnicornRelativeUrlStyle(
                 UnicornRelativeUrlStyle::from_configuration(value)?,
             )),
@@ -14462,6 +14476,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.to_configuration(),
             Self::UnicornPreferTopLevelAwait(rule) => rule.to_configuration(),
             Self::UnicornPreferTypeError(rule) => rule.to_configuration(),
+            Self::UnicornPreferUnaryMinus(rule) => rule.to_configuration(),
             Self::UnicornRelativeUrlStyle(rule) => rule.to_configuration(),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.to_configuration(),
             Self::UnicornRequireModuleAttributes(rule) => rule.to_configuration(),
@@ -15316,6 +15331,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.run(node, ctx),
             Self::UnicornPreferTopLevelAwait(rule) => rule.run(node, ctx),
             Self::UnicornPreferTypeError(rule) => rule.run(node, ctx),
+            Self::UnicornPreferUnaryMinus(rule) => rule.run(node, ctx),
             Self::UnicornRelativeUrlStyle(rule) => rule.run(node, ctx),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.run(node, ctx),
             Self::UnicornRequireModuleAttributes(rule) => rule.run(node, ctx),
@@ -16180,6 +16196,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.run_once(ctx),
             Self::UnicornPreferTopLevelAwait(rule) => rule.run_once(ctx),
             Self::UnicornPreferTypeError(rule) => rule.run_once(ctx),
+            Self::UnicornPreferUnaryMinus(rule) => rule.run_once(ctx),
             Self::UnicornRelativeUrlStyle(rule) => rule.run_once(ctx),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.run_once(ctx),
             Self::UnicornRequireModuleAttributes(rule) => rule.run_once(ctx),
@@ -17139,6 +17156,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornPreferTopLevelAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornPreferTypeError(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornPreferUnaryMinus(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornRelativeUrlStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornRequireModuleAttributes(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18026,6 +18044,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.should_run(ctx),
             Self::UnicornPreferTopLevelAwait(rule) => rule.should_run(ctx),
             Self::UnicornPreferTypeError(rule) => rule.should_run(ctx),
+            Self::UnicornPreferUnaryMinus(rule) => rule.should_run(ctx),
             Self::UnicornRelativeUrlStyle(rule) => rule.should_run(ctx),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.should_run(ctx),
             Self::UnicornRequireModuleAttributes(rule) => rule.should_run(ctx),
@@ -19147,6 +19166,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::IS_TSGOLINT_RULE,
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::IS_TSGOLINT_RULE,
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::IS_TSGOLINT_RULE,
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::IS_TSGOLINT_RULE,
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::IS_TSGOLINT_RULE,
             Self::UnicornRequireArrayJoinSeparator(_) => {
                 UnicornRequireArrayJoinSeparator::IS_TSGOLINT_RULE
@@ -20244,6 +20264,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::VERSION,
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::VERSION,
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::VERSION,
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::VERSION,
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::VERSION,
             Self::UnicornRequireArrayJoinSeparator(_) => UnicornRequireArrayJoinSeparator::VERSION,
             Self::UnicornRequireModuleAttributes(_) => UnicornRequireModuleAttributes::VERSION,
@@ -21294,6 +21315,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::HAS_CONFIG,
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::HAS_CONFIG,
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::HAS_CONFIG,
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::HAS_CONFIG,
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::HAS_CONFIG,
             Self::UnicornRequireArrayJoinSeparator(_) => {
                 UnicornRequireArrayJoinSeparator::HAS_CONFIG
@@ -22293,6 +22315,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(_) => UnicornPreferTernary::INFO,
             Self::UnicornPreferTopLevelAwait(_) => UnicornPreferTopLevelAwait::INFO,
             Self::UnicornPreferTypeError(_) => UnicornPreferTypeError::INFO,
+            Self::UnicornPreferUnaryMinus(_) => UnicornPreferUnaryMinus::INFO,
             Self::UnicornRelativeUrlStyle(_) => UnicornRelativeUrlStyle::INFO,
             Self::UnicornRequireArrayJoinSeparator(_) => UnicornRequireArrayJoinSeparator::INFO,
             Self::UnicornRequireModuleAttributes(_) => UnicornRequireModuleAttributes::INFO,
@@ -23171,6 +23194,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.types_info(),
             Self::UnicornPreferTopLevelAwait(rule) => rule.types_info(),
             Self::UnicornPreferTypeError(rule) => rule.types_info(),
+            Self::UnicornPreferUnaryMinus(rule) => rule.types_info(),
             Self::UnicornRelativeUrlStyle(rule) => rule.types_info(),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.types_info(),
             Self::UnicornRequireModuleAttributes(rule) => rule.types_info(),
@@ -24022,6 +24046,7 @@ impl RuleEnum {
             Self::UnicornPreferTernary(rule) => rule.run_info(),
             Self::UnicornPreferTopLevelAwait(rule) => rule.run_info(),
             Self::UnicornPreferTypeError(rule) => rule.run_info(),
+            Self::UnicornPreferUnaryMinus(rule) => rule.run_info(),
             Self::UnicornRelativeUrlStyle(rule) => rule.run_info(),
             Self::UnicornRequireArrayJoinSeparator(rule) => rule.run_info(),
             Self::UnicornRequireModuleAttributes(rule) => rule.run_info(),
@@ -24987,6 +25012,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornPreferTernary(UnicornPreferTernary::default()),
         RuleEnum::UnicornPreferTopLevelAwait(UnicornPreferTopLevelAwait::default()),
         RuleEnum::UnicornPreferTypeError(UnicornPreferTypeError::default()),
+        RuleEnum::UnicornPreferUnaryMinus(UnicornPreferUnaryMinus::default()),
         RuleEnum::UnicornRelativeUrlStyle(UnicornRelativeUrlStyle::default()),
         RuleEnum::UnicornRequireArrayJoinSeparator(UnicornRequireArrayJoinSeparator::default()),
         RuleEnum::UnicornRequireModuleAttributes(UnicornRequireModuleAttributes::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -614,6 +614,7 @@ pub(crate) mod unicorn {
     pub mod prefer_ternary;
     pub mod prefer_top_level_await;
     pub mod prefer_type_error;
+    pub mod prefer_unary_minus;
     pub mod relative_url_style;
     pub mod require_array_join_separator;
     pub mod require_module_attributes;

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -615,6 +615,7 @@ pub(crate) mod unicorn {
     pub mod prefer_ternary;
     pub mod prefer_top_level_await;
     pub mod prefer_type_error;
+    pub mod prefer_unary_minus;
     pub mod relative_url_style;
     pub mod require_array_join_separator;
     pub mod require_module_attributes;

--- a/crates/oxc_linter/src/rules/unicorn/prefer_unary_minus.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_unary_minus.rs
@@ -1,0 +1,201 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::{
+    operator::{BinaryOperator, UnaryOperator},
+    precedence::Precedence,
+};
+
+use crate::{AstNode, ast_util, context::LintContext, rule::Rule, utils::get_precedence};
+
+fn prefer_unary_minus_diagnostic(span: Span, operation: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer the unary minus operator over {operation} by `-1`."))
+        .with_help("Replace the binary expression with a unary minus expression.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferUnaryMinus;
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Prefers the unary minus operator over multiplying or dividing by `-1`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unary negation expresses the intent directly and avoids an unnecessary
+    /// arithmetic operation.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const negative = value * -1;
+    /// const alsoNegative = value / -1;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const negative = -value;
+    /// ```
+    PreferUnaryMinus,
+    unicorn,
+    style,
+    conditional_fix,
+    version = "next",
+    short_description = "Prefer unary negation over multiplying or dividing by `-1`.",
+);
+
+impl Rule for PreferUnaryMinus {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::BinaryExpression(binary) = node.kind() else { return };
+
+        let operand = match binary.operator {
+            BinaryOperator::Multiplication => {
+                let left_is_negative_one = is_negative_one(binary.left.without_parentheses());
+                let right_is_negative_one = is_negative_one(binary.right.without_parentheses());
+                match (left_is_negative_one, right_is_negative_one) {
+                    (true, false) => &binary.right,
+                    (false, true) => &binary.left,
+                    _ => return,
+                }
+            }
+            BinaryOperator::Division
+                if is_negative_one(binary.right.without_parentheses())
+                    && !is_negative_one(binary.left.without_parentheses()) =>
+            {
+                &binary.left
+            }
+            _ => return,
+        };
+
+        let operation = if binary.operator == BinaryOperator::Multiplication {
+            "multiplying"
+        } else {
+            "dividing"
+        };
+        let diagnostic = prefer_unary_minus_diagnostic(binary.span, operation);
+        if ctx.has_comments_between(binary.span) {
+            ctx.diagnostic(diagnostic);
+            return;
+        }
+
+        ctx.diagnostic_with_fix(diagnostic, |fixer| {
+            let operand = operand.without_parentheses();
+            let source = fixer.source_range(operand.span());
+            let needs_parentheses = get_precedence(operand)
+                .is_some_and(|precedence| precedence < Precedence::Prefix)
+                || matches!(
+                    operand,
+                    Expression::UpdateExpression(_)
+                        | Expression::TSNonNullExpression(_)
+                        | Expression::TSTypeAssertion(_)
+                )
+                || matches!(operand, Expression::UnaryExpression(unary) if unary.operator == UnaryOperator::UnaryNegation);
+            let mut replacement =
+                if needs_parentheses { format!("-({source})") } else { format!("-{source}") };
+
+            if ast_util::could_be_asi_hazard(node, ctx) {
+                replacement.insert(0, ';');
+            } else if binary.span.start > 0
+                && ctx.source_text().as_bytes()[binary.span.start as usize - 1] == b'-'
+            {
+                replacement.insert(0, ' ');
+            }
+
+            fixer.replace(binary.span, replacement)
+        });
+    }
+}
+
+fn is_negative_one(expression: &Expression) -> bool {
+    let Expression::UnaryExpression(unary) = expression else { return false };
+    unary.operator == UnaryOperator::UnaryNegation
+        && matches!(&unary.argument, Expression::NumericLiteral(literal) if literal.value.to_bits() == 1.0_f64.to_bits())
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "x * 2;",
+        "x / 2;",
+        "x * -2;",
+        "x / -2;",
+        "-1 * -1;",
+        "-1 / -1;",
+        "-1 / x;",
+        "-1 / (a + b);",
+        "x * -1n;",
+        "x / -1n;",
+        "-1n * x;",
+        "-1n / x;",
+        "x ** -1;",
+        "x - 1;",
+        "x + -1;",
+        "x % -1;",
+        "x & -1;",
+    ];
+
+    let fail = vec![
+        "x * -1;",
+        "-1 * x;",
+        "x / -1;",
+        "a.b * -1;",
+        "foo() * -1;",
+        "5 * -1;",
+        "-1 * 5;",
+        "foo?.bar * -1;",
+        "tag`str` * -1;",
+        "--x * -1;",
+        "x++ * -1;",
+        "-y * -1;",
+        "+x * -1;",
+        "(a + b) * -1;",
+        "-1 * (a + b);",
+        "(a ? b : c) * -1;",
+        "(a, b) * -1;",
+        "(a = b) * -1;",
+        "(a + b) / -1;",
+        "(x) * -1;",
+        "(x * -1) ** 2;",
+        "a-x*-1;",
+        "a - x * -1;",
+        "foo
+            x * -1;",
+        "function f() { return x * -1; }",
+        "x * -1 * -1;",
+        "a + b * -1;",
+        "x /* c */ * -1;",
+        "x * -1 /* c */;",
+        "(x as number) * -1;", // {"parser": parsers.typescript},
+        "-1 * (x as number);", // {"parser": parsers.typescript},
+        "x! * -1;",            // {"parser": parsers.typescript}
+    ];
+
+    let fix = vec![
+        ("x * -1;", "-x;"),
+        ("-1 * x;", "-x;"),
+        ("x / -1;", "-x;"),
+        ("--x * -1;", "-(--x);"),
+        ("x++ * -1;", "-(x++);"),
+        ("-y * -1;", "-(-y);"),
+        ("+x * -1;", "-+x;"),
+        ("(a + b) * -1;", "-(a + b);"),
+        ("-1 * (a ? b : c);", "-(a ? b : c);"),
+        ("(x) * -1;", "-x;"),
+        ("a-x*-1;", "a- -x;"),
+        ("foo\nx * -1;", "foo\n;-x;"),
+        ("x /* c */ * -1;", "x /* c */ * -1;"),
+        ("x * -1 /* c */;", "-x /* c */;"),
+        ("x! * -1;", "-(x!);"),
+    ];
+
+    Tester::new(PreferUnaryMinus::NAME, PreferUnaryMinus::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_unary_minus.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_unary_minus.snap
@@ -1,0 +1,236 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ x * -1;
+   · ──────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ -1 * x;
+   · ──────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over dividing by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ x / -1;
+   · ──────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ a.b * -1;
+   · ────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ foo() * -1;
+   · ──────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ 5 * -1;
+   · ──────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ -1 * 5;
+   · ──────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ foo?.bar * -1;
+   · ─────────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ tag`str` * -1;
+   · ─────────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ --x * -1;
+   · ────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ x++ * -1;
+   · ────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ -y * -1;
+   · ───────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ +x * -1;
+   · ───────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ (a + b) * -1;
+   · ────────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ -1 * (a + b);
+   · ────────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ (a ? b : c) * -1;
+   · ────────────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ (a, b) * -1;
+   · ───────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ (a = b) * -1;
+   · ────────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over dividing by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ (a + b) / -1;
+   · ────────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ (x) * -1;
+   · ────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:2]
+ 1 │ (x * -1) ** 2;
+   ·  ──────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:3]
+ 1 │ a-x*-1;
+   ·   ────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:5]
+ 1 │ a - x * -1;
+   ·     ──────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:2:13]
+ 1 │ foo
+ 2 │             x * -1;
+   ·             ──────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:23]
+ 1 │ function f() { return x * -1; }
+   ·                       ──────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ x * -1 * -1;
+   · ───────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ x * -1 * -1;
+   · ──────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:5]
+ 1 │ a + b * -1;
+   ·     ──────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ x /* c */ * -1;
+   · ──────────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ x * -1 /* c */;
+   · ──────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ (x as number) * -1;
+   · ──────────────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ -1 * (x as number);
+   · ──────────────────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.
+
+  ⚠ unicorn(prefer-unary-minus): Prefer the unary minus operator over multiplying by `-1`.
+   ╭─[prefer_unary_minus.tsx:1:1]
+ 1 │ x! * -1;
+   · ───────
+   ╰────
+  help: Replace the binary expression with a unary minus expression.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9558,6 +9558,9 @@
         "unicorn/prefer-type-error": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/prefer-unary-minus": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "unicorn/relative-url-style": {
           "anyOf": [
             {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9483,6 +9483,9 @@
         "unicorn/prefer-type-error": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/prefer-unary-minus": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "unicorn/relative-url-style": {
           "anyOf": [
             {

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -653,6 +653,7 @@ unicorn/prefer-structured-clone                            |  62606
 unicorn/prefer-ternary                                     |  13190
 unicorn/prefer-top-level-await                             |  62606
 unicorn/prefer-type-error                                  |    224
+unicorn/prefer-unary-minus                                 |  20604
 unicorn/relative-url-style                                 |   1421
 unicorn/require-array-join-separator                       |  62606
 unicorn/require-module-attributes                          |    126

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -651,6 +651,7 @@ unicorn/prefer-structured-clone                            |  62606
 unicorn/prefer-ternary                                     |  13190
 unicorn/prefer-top-level-await                             |  62606
 unicorn/prefer-type-error                                  |    224
+unicorn/prefer-unary-minus                                 |  20604
 unicorn/relative-url-style                                 |   1421
 unicorn/require-array-join-separator                       |  62606
 unicorn/require-module-attributes                          |    126


### PR DESCRIPTION
## Summary

- implement `unicorn/prefer-unary-minus` from the rule tracker in #684
- report multiplication/division by numeric `-1` while excluding non-equivalent cases
- provide conditional fixes that preserve precedence, comments, ASI, and token boundaries
- register the rule and update generated config/schema/timing artifacts

## Validation

- rebased onto current `main` (`c3e99d160d`) and regenerated linter registries
- `cargo lintgen` — passed
- `cargo lint-timings` — passed
- `just fmt` — passed
- `cargo test -p oxc_linter prefer_unary_minus` — passed
- `just ready` — passed (including clean-diff verification, dependency policy validation, `typos`, linter code generation, formatting, and `cargo shear`)

## Evidence and risk

The implementation and cases are ported from the current upstream `eslint-plugin-unicorn` rule and tests. Fixes are omitted when comments occur inside the replaced expression. The focused test matrix covers multiplication/division direction, `-1n`, precedence, TypeScript expressions, comment preservation, ASI, and adjacent-minus token merging.

Risk is limited to a new nursery/style rule that is not enabled by default; rollback is removal of the rule registration and generated entries.

AI assistance was used for repository research, implementation, and conflict resolution. I reviewed the generated and handwritten changes and ran the checks listed above.
