### PR TITLE
feat(minifier): invert if whose alternate is terminated

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
@@ -5,6 +5,7 @@ use oxc_semantic::ScopeFlags;
 use oxc_span::GetSpan;
 
 use crate::TraverseCtx;
+use crate::generated::ancestor::Ancestor;
 
 use super::PeepholeOptimizations;
 
@@ -49,27 +50,23 @@ impl<'a> PeepholeOptimizations {
         // Consequent is non-empty from here on.
 
         if let Some(alternate) = &mut if_stmt.alternate {
-            if let Statement::ExpressionStatement(expr_stmt) = &mut if_stmt.consequent {
-                if let Statement::ExpressionStatement(alternate_expr_stmt) = alternate {
-                    // `if (a) b(); else c();` => `a ? b() : c();`
-                    let test = if_stmt.test.take_in(ctx);
-                    let consequent = expr_stmt.expression.take_in(ctx);
-                    let alternate = alternate_expr_stmt.expression.take_in(ctx);
-                    let expr =
-                        Self::minimize_conditional(if_stmt.span, test, consequent, alternate, ctx);
-                    return Some(Statement::new_expression_statement(if_stmt.span, expr, ctx));
-                }
-            } else {
-                // Normalize: move the `!` out of the test by swapping branches.
-                // Avoid swapping when alternate is an `if` — that risks a worse chain.
-                // `if (!a) return b; else return c;` => `if (a) return c; else return b;`
-                if !matches!(alternate, Statement::IfStatement(_))
-                    && let Expression::UnaryExpression(unary_expr) = &mut if_stmt.test
-                    && unary_expr.operator.is_not()
-                {
-                    ctx.replace_expression_with(&mut if_stmt.test, Self::unwrap_unary);
-                    std::mem::swap(&mut if_stmt.consequent, alternate);
-                }
+            if let Statement::ExpressionStatement(expr_stmt) = &mut if_stmt.consequent
+                && let Statement::ExpressionStatement(alternate_expr_stmt) = alternate
+            {
+                // `if (a) b(); else c();` => `a ? b() : c();`
+                let test = if_stmt.test.take_in(ctx);
+                let consequent = expr_stmt.expression.take_in(ctx);
+                let alternate = alternate_expr_stmt.expression.take_in(ctx);
+                let expr =
+                    Self::minimize_conditional(if_stmt.span, test, consequent, alternate, ctx);
+                return Some(Statement::new_expression_statement(if_stmt.span, expr, ctx));
+            }
+
+            if Self::should_invert_if(&if_stmt.consequent, alternate, &if_stmt.test, ctx) {
+                ctx.replace_expression_with(&mut if_stmt.test, |old, ctx| {
+                    Self::minimize_not(old.span(), old, ctx, true)
+                });
+                std::mem::swap(&mut if_stmt.consequent, alternate);
             }
         } else if let Statement::ExpressionStatement(expr_stmt) = &mut if_stmt.consequent {
             let (op, a) = match &mut if_stmt.test {
@@ -96,6 +93,57 @@ impl<'a> PeepholeOptimizations {
 
         Self::wrap_to_avoid_ambiguous_else(if_stmt, ctx);
         None
+    }
+
+    /// Returns true when the current statement position accepts only a single
+    /// statement, so rewriting to multiple statements requires a block wrapper.
+    fn parent_requires_single_statement(ctx: &TraverseCtx<'a>) -> bool {
+        matches!(
+            ctx.parent(),
+            Ancestor::ForStatementBody(_)
+                | Ancestor::ForInStatementBody(_)
+                | Ancestor::ForOfStatementBody(_)
+                | Ancestor::WhileStatementBody(_)
+                | Ancestor::DoWhileStatementBody(_)
+                | Ancestor::IfStatementConsequent(_)
+                | Ancestor::IfStatementAlternate(_)
+                | Ancestor::LabeledStatementBody(_)
+        )
+    }
+
+    fn should_invert_if(
+        consequent: &Statement<'a>,
+        alternate: &Statement<'a>,
+        test: &Expression<'a>,
+        ctx: &TraverseCtx<'a>,
+    ) -> bool {
+        let is_alternate_terminated = alternate.is_jump_statement();
+        let is_consequent_terminated = consequent.is_jump_statement();
+
+        // When exactly one branch terminates (and parent is not `if`),
+        // place the terminating branch in the consequent.
+        // `if (a) c(); else return;` => `if (!a) return; else c();`
+        // `if (!a) c(); else return;` => `if (a) return; else c();`
+        if is_alternate_terminated != is_consequent_terminated
+            && !Self::parent_requires_single_statement(ctx)
+            && !Self::statement_cares_about_scope(consequent)
+            && !Self::statement_cares_about_scope(alternate)
+        {
+            return is_alternate_terminated;
+        }
+
+        // Normalize: move the `!` out of the test by swapping branches.
+        // `if (!a) b; else c;` => `if (a) c; else b;`
+        // `if (!a) return b; else return c;` => `if (a) return c; else return b;`
+        // Avoid swapping when alternate is an `if` — that risks a worse chain.
+        if !matches!(alternate, Statement::IfStatement(_))
+            && let Expression::UnaryExpression(unary_expr) = test
+            && unary_expr.operator.is_not()
+        {
+            return true;
+        }
+
+        false
     }
 
     /// Wrap to avoid ambiguous else.

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -795,31 +795,31 @@ fn js_parser_test() {
     test("if (0 == ~a) throw 0", "if (~a == 0) throw 0;");
     test(
         "function _() { if (a) { if (b) return c } else return d }",
-        "function _() { if (a) { if (b) return c;} else return d; }",
+        "function _() { if (!a) return d; if (b) return c; }",
     );
     test(
         "function _() { if (a) while (1) { if (b) return c } else return d }",
-        "function _() { if (a) { for (;;) if (b) return c;} else return d; }",
+        "function _() { if (!a) return d; for (;;) if (b) return c; }",
     );
     test(
         "function _() { if (a) for (;;) { if (b) return c } else return d }",
-        "function _() { if (a) { for (;;) if (b) return c;} else return d; }",
+        "function _() { if (!a) return d; for (;;) if (b) return c; }",
     );
     test(
         "function _() { if (a) for (x in y) { if (b) return c } else return d }",
-        "function _() { if (a) { for (x in y) if (b) return c;} else return d; }",
+        "function _() { if (!a) return d; for (x in y) if (b) return c; }",
     );
     test(
         "function _() { if (a) for (x of y) { if (b) return c } else return d }",
-        "function _() { if (a) { for (x of y) if (b) return c;} else return d; }",
+        "function _() { if (!a) return d; for (x of y) if (b) return c; }",
     );
     test(
         "function _() { if (a) with (x) { if (b) return c } else return d }",
-        "function _() { if (a) { with (x) if (b) return c;} else return d; }",
+        "function _() { if (!a) return d; with(x) if (b) return c; }",
     );
     test(
         "function _() { if (a) x: { if (b) break x } else return c }",
-        "function _() { if (a) { x: if (b) break x;} else return c; }",
+        "function _() { if (!a) return c; x: if (b) break x; }",
     );
     test(
         "function _() { let a = foo(); return a != null ? a.b : undefined }",
@@ -2285,7 +2285,7 @@ fn test_remove_dead_expr_other() {
     test("if (1) a(); else { let b }", "a();");
     test("if (1) a(); else { throw b }", "a();");
     test("if (1) a(); else { return b }", "a();");
-    test("b: { if (x) a(); else { break b } }", "b: if (x) a(); else break b;");
+    test("b: { if (x) a(); else { break b } }", "b: { if (!x) break b; a(); }");
     // test("b: { if (1) a(); else { break b } }", "a();");
     test("b: { if (0) a(); else { break b } }", "");
     test(

--- a/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
@@ -122,10 +122,10 @@ fn test_fold_returns() {
 #[test]
 fn test_combine_ifs1() {
     test("function f() {if (x) return 1; if (y) return 1}", "function f() {if (x || y) return 1;}");
-    // test(
-    //     "function f() {if (x) return 1; if (y) foo(); else return 1}",
-    //     "function f() {if ((!x)&&y) foo(); else return 1;}",
-    // );
+    test(
+        "function f() {if (x) return 1; if (y) foo(); else return 1}",
+        "function f() {if (x || !y) return 1; foo();}",
+    );
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
@@ -68,12 +68,12 @@ fn test_function_return_optimization() {
         "function f(){if(a())b();else{c();return}}",
     ); // function f(){a()?b():c()}
     test(
-        "function f(){ if(a()) { if (a) { return } throw a; } else return 2; }",
-        "function f(){ if(a()) { if (a) return; throw a } return 2 }",
+        "function f(){if(a()){if(a){return}throw a}else return 2}",
+        "function f(){if(!a())return 2;if(!a)throw a}",
     );
     test(
         "function f(){if(a()){if(b()){d();return;}else{return;}}else{return;} c();}",
-        "function f(){if(a()){if(b()){d();return}return}}",
+        "function f(){if(a()){if(!b())return;d()}}",
     ); // function f(){a()&&b()&&d()}
     test(
         "function f(a,b,c){if(a){}else if(b){x();return}else if(c){y();return}z()}",
@@ -303,7 +303,7 @@ fn test_for_continue_optimization() {
     ); // r=async () => { for await(x of y)a()?b():c()};
     test(
         "r=async () => { for await (x of y){if(a()){b();}else{c();continue;}}}",
-        "r=async() => { for await(x of y)if(a())b();else{c();continue}};",
+        "r=async () => { for await(x of y)if(a())b();else{c();continue}};",
     ); // r=async () => { for await (x of y) a() ? b() : c() };
 
     test("for(x=0;x<y;x++){if(a()){b();continue;}else;}", "for(x=0;x<y;x++)if(a()){b();continue}"); // for(x=0;x<y;x++)a()&&b()
@@ -356,27 +356,27 @@ fn test_dont_remove_break_in_try_finally() {
 
 #[test]
 fn test_try_catch_termination() {
-    test_same("function f(){if(a)try{b}catch{c}else throw i()}");
-    test_same("function f(){if(a)try{return g()}catch{c}else throw i()}");
-    test_same("function f(){if(a)try{b}catch{return g()}else throw i()}");
+    test_same("function f(){if(a)try{b}catch{c}else i()}");
+    test_same("function f(){if(a)try{return g()}catch{c}else i()}");
+    test_same("function f(){if(a)try{b}catch{return g()}else i()}");
     test(
-        "function f(){if(a)try{return g()}catch{return g()}else throw i()}",
-        "function f(){if(a)try{return g()}catch{return g()}throw i()}",
+        "function f(){if(a)try{return g()}catch{return g()}else i()}",
+        "function f(){if(a)try{return g()}catch{return g()}i()}",
     );
 
-    test_same("function f(){if(a)try{b}finally{d}else throw i()}");
-    test_same("function f(){if(a)try{return g()}finally{d}else throw i()}");
+    test_same("function f(){if(a)try{b}finally{d}else i()}");
+    test_same("function f(){if(a)try{return g()}finally{d}else i()}");
     test(
-        "function f(){if(a)try{b}finally{return g()}else throw i()}",
-        "function f(){if(a)try{b}finally{return g()}throw i()}",
+        "function f(){if(a)try{b}finally{return g()}else i()}",
+        "function f(){if(a)try{b}finally{return g()}i()}",
     );
 
-    test_same("function f(){if(a)try{b}catch{c}finally{d}else throw i()}");
-    test_same("function f(){if(a)try{return g()}catch{d}finally{d}else throw i()}");
-    test_same("function f(){if(a)try{b}catch{return g()}finally{d}else throw i()}");
+    test_same("function f(){if(a)try{b}catch{c}finally{d}else i()}");
+    test_same("function f(){if(a)try{return g()}catch{d}finally{d}else i()}");
+    test_same("function f(){if(a)try{b}catch{return g()}finally{d}else i()}");
     test(
-        "function f(){if(a)try{b}catch{c}finally{return g(d)}else throw i()}",
-        "function f(){if(a)try{b}catch{c}finally{return g(d)}throw i()}",
+        "function f(){if(a)try{b}catch{c}finally{return g(d)}else i()}",
+        "function f(){if(a)try{b}catch{c}finally{return g(d)}i()}",
     );
 }
 

--- a/crates/oxc_minifier/tests/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_if_statement.rs
@@ -85,8 +85,14 @@ fn test_minimize_if() {
     );
     test("function f(){if(a){}else return b;}", "function f(){if(!a)return b;}");
     test("function f(){if(!a){}else return b;}", "function f(){if(a)return b;}");
-    test("function f(){if(!a)b();else return c;}", "function f(){if(!a)b();else return c;}");
+    test("function f(){if(!a)b();else return c;}", "function f(){if(a)return c;b()}");
     test("function f(){if(a)return c;else b();}", "function f(){if(a)return c;b();}");
     test("function f(){if((a(),b)){}else c();}", "function f(){a(),b||c();}");
     test("function f(){if(a(),!(b||c)){}else d();}", "function f(){a(),!(b||c)||d();}");
+    test("function f(){if(a){let x=1;}else return c;}", "function f(){if(!a)return c;{let x=1;}}");
+    test(
+        "function f(){if(a)if(b){let x=1;}else return c;}",
+        "function f(){if(a){if(!b)return c;{let x=1;}}}",
+    );
+    test("function f(){if(!a)b();else if(c)d();}", "function f(){a?c&&d():b();}");
 }

--- a/crates/oxc_minifier/tests/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_statements.rs
@@ -265,7 +265,7 @@ fn test_handle_switch_statement() {
     test_same("switch (a) { case 1: if (b) break; c(); }");
     test(
         "switch (a) { case 3: { if(b) {c()} else {break;} }}",
-        "switch (a) { case 3: if (b) c(); else break; }",
+        "switch (a) { case 3: if (!b) break; c(); }",
     ); // a === 3 && b && c();
     test(
         "switch (a) { case 3: { if(b) {c(); break;} else { d(); break;} }}",

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -3,25 +3,25 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 -------------------------------------------------------------------------------------
 72.14 kB   | 22.48 kB   | 23.70 kB   | 8.19 kB    | 8.54 kB    |          2 | react.development.js
 
-173.90 kB  | 55.50 kB   | 59.82 kB   | 18.77 kB   | 19.33 kB   |          2 | moment.js
+173.90 kB  | 55.46 kB   | 59.82 kB   | 18.76 kB   | 19.33 kB   |          2 | moment.js
 
-287.63 kB  | 89.01 kB   | 90.07 kB   | 30.85 kB   | 31.95 kB   |          2 | jquery.js
+287.63 kB  | 88.99 kB   | 90.07 kB   | 30.84 kB   | 31.95 kB   |          2 | jquery.js
 
-342.15 kB  | 114.80 kB  | 118.14 kB  | 42.71 kB   | 44.37 kB   |          2 | vue.js
+342.15 kB  | 114.79 kB  | 118.14 kB  | 42.71 kB   | 44.37 kB   |          2 | vue.js
 
 544.10 kB  | 69.88 kB   | 72.48 kB   | 25.58 kB   | 26.20 kB   |          2 | lodash.js
 
-555.77 kB  | 262.75 kB  | 270.13 kB  | 87.66 kB   | 90.80 kB   |          2 | d3.js
+555.77 kB  | 262.74 kB  | 270.13 kB  | 87.66 kB   | 90.80 kB   |          2 | d3.js
 
-1.01 MB    | 435.99 kB  | 458.89 kB  | 121.78 kB  | 126.71 kB  |          2 | bundle.min.js
+1.01 MB    | 435.96 kB  | 458.89 kB  | 121.78 kB  | 126.71 kB  |          2 | bundle.min.js
 
-1.25 MB    | 634.39 kB  | 646.76 kB  | 158.43 kB  | 163.73 kB  |          2 | three.js
+1.25 MB    | 634.38 kB  | 646.76 kB  | 158.44 kB  | 163.73 kB  |          2 | three.js
 
-2.14 MB    | 707.63 kB  | 724.14 kB  | 160.08 kB  | 181.07 kB  |          2 | victory.js
+2.14 MB    | 707.59 kB  | 724.14 kB  | 160.06 kB  | 181.07 kB  |          2 | victory.js
 
-3.20 MB    | 958.89 kB  | 1.01 MB    | 317.07 kB  | 331.56 kB  |          2 | echarts.js
+3.20 MB    | 958.86 kB  | 1.01 MB    | 317.06 kB  | 331.56 kB  |          2 | echarts.js
 
-6.69 MB    | 2.12 MB    | 2.31 MB    | 453.42 kB  | 488.28 kB  |          5 | antd.js
+6.69 MB    | 2.12 MB    | 2.31 MB    | 453.40 kB  | 488.28 kB  |          5 | antd.js
 
-10.95 MB   | 3.31 MB    | 3.49 MB    | 849.97 kB  | 915.50 kB  |          4 | typescript.js
+10.95 MB   | 3.31 MB    | 3.49 MB    | 849.93 kB  | 915.50 kB  |          4 | typescript.js
 

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 122
   sys alloc bytes: 14996632 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 59908
-  arena reallocs: 21415
-  arena size: 16569784 # 16.57 MB
+  arena allocs: 59924
+  arena reallocs: 21449
+  arena size: 16571272 # 16.57 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 1038
   sys alloc bytes: 29976375 # 29.98 MB
   sys peak growth: 19934749 # 19.93 MB
-  arena allocs: 207313
-  arena reallocs: 75941
-  arena size: 45450136 # 45.45 MB
+  arena allocs: 207318
+  arena reallocs: 75962
+  arena size: 45451312 # 45.45 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,7 +60,7 @@ binder.ts:
   sys deallocs: 33
   sys alloc bytes: 963032 # 963.03 kB
   sys peak growth: 657404 # 657.40 kB
-  arena allocs: 3311
+  arena allocs: 3312
   arena reallocs: 834
   arena size: 1083312 # 1.08 MB
 
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 1854
   sys alloc bytes: 5304692 # 5.30 MB
   sys peak growth: 3707457 # 3.71 MB
-  arena allocs: 31993
-  arena reallocs: 12186
+  arena allocs: 31997
+  arena reallocs: 12194
   arena size: 8689832 # 8.69 MB


### PR DESCRIPTION
goal of this change is to normalize nested if/else chains for them to be unfolded to
```js
if (ts.isPrologueDirective(statement)) {
	if (isUseStrictPrologue(statement)) return statement;
} else break;
```
```js
if (!ts.isPrologueDirective(statement)) break;
if (isUseStrictPrologue(statement)) return statement;
```
with that if any of termination stmts can be removed we can reuse same logic for all if stmts

```js
for (;;) { if (a()) { if (b()) return statement; } else continue; }
//             ^~~ rotate stmt as else is terminated - this change
for (;;) { if (!a()) continue; else if (b()) return statement; }
//                             ^~~~ if cons is terminated onfold ✔️ - only work for block's
for (;;) { if (!a()) continue; if (b()) return statement; }
//                   ^~~~~~~~~ continue can be removed by inverting if - this is only partially supported
for (;;) { if (!!a()) if (b()) return statement; }
//             ^~~~~      ^~~ we can merge nested conditions ✔️
for (;;) { if (!!a() && b()) return statement; }
//       ^                                     ^ remove block stmts (dce) ✔️
for (;;) if (!!a() && b()) return statement;
//           ^~ minimize expressions in boolean context ✔️
for (;;) if (a() && b()) return statement;
```


----------------------

#### changes in stack:
- #26119
- #25267 👈
- #25178
- `main`