### PR TITLE
refactor(tasks/allocations): do not print redundunt traling blank line

### DIFF
--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -74,4 +74,3 @@ kitchen-sink.tsx:
   arena allocs: 555511
   arena reallocs: 1041
   arena size: 38314608 # 38.31 MB
-

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -74,4 +74,3 @@ kitchen-sink.tsx:
   arena allocs: 66806
   arena reallocs: 12252
   arena size: 9424640 # 9.42 MB
-

--- a/tasks/track_memory_allocations/allocs_parser.yaml
+++ b/tasks/track_memory_allocations/allocs_parser.yaml
@@ -74,4 +74,3 @@ kitchen-sink.tsx:
   arena allocs: 136453
   arena reallocs: 11898
   arena size: 6440384 # 6.44 MB
-

--- a/tasks/track_memory_allocations/allocs_semantic.yaml
+++ b/tasks/track_memory_allocations/allocs_semantic.yaml
@@ -74,4 +74,3 @@ kitchen-sink.tsx:
   arena allocs: 0
   arena reallocs: 0
   arena size: 6440384 # 6.44 MB
-

--- a/tasks/track_memory_allocations/allocs_transformer.yaml
+++ b/tasks/track_memory_allocations/allocs_transformer.yaml
@@ -74,4 +74,3 @@ kitchen-sink.tsx:
   arena allocs: 6132
   arena reallocs: 280
   arena size: 6774480 # 6.77 MB
-

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -564,7 +564,10 @@ fn write_snapshot(file_path: &str, entries: &[(&TestFile, StageStats)]) -> Resul
 
     let mut out = String::new();
     let committed_doc = committed_docs.first();
-    for (file, stats) in entries {
+    for (i, (file, stats)) in entries.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
         let committed_file = committed_doc.get(file.file_name.as_str());
         let metrics = stats.metrics(file.source_text.len());
         render_file_stats(&mut out, &file.file_name, &metrics, committed_file);
@@ -596,5 +599,4 @@ fn render_file_stats(
         }
         .unwrap();
     }
-    out.push('\n');
 }


### PR DESCRIPTION
Otherwise, our new YAML formatter trims it, then remains as diff.
