### PR TITLE
feat(linter): add unicorn no-async-promise-finally rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1543,6 +1543,7 @@ export interface DummyRuleMap {
   "unicorn/no-array-reduce"?: RuleNoConfig | [AllowWarnDeny, NoArrayReduce];
   "unicorn/no-array-reverse"?: RuleNoConfig | [AllowWarnDeny, NoArrayReverse];
   "unicorn/no-array-sort"?: RuleNoConfig | [AllowWarnDeny, NoArraySort];
+  "unicorn/no-async-promise-finally"?: RuleNoConfig;
   "unicorn/no-await-expression-member"?: RuleNoConfig;
   "unicorn/no-await-in-promise-methods"?: RuleNoConfig;
   "unicorn/no-confusing-array-with"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3158,6 +3158,12 @@ impl RuleRunner for crate::rules::unicorn::no_array_sort::NoArraySort {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::no_async_promise_finally::NoAsyncPromiseFinally {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::no_await_expression_member::NoAwaitExpressionMember {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::ComputedMemberExpression,

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -627,6 +627,7 @@ pub use crate::rules::unicorn::no_array_method_this_argument::NoArrayMethodThisA
 pub use crate::rules::unicorn::no_array_reduce::NoArrayReduce as UnicornNoArrayReduce;
 pub use crate::rules::unicorn::no_array_reverse::NoArrayReverse as UnicornNoArrayReverse;
 pub use crate::rules::unicorn::no_array_sort::NoArraySort as UnicornNoArraySort;
+pub use crate::rules::unicorn::no_async_promise_finally::NoAsyncPromiseFinally as UnicornNoAsyncPromiseFinally;
 pub use crate::rules::unicorn::no_await_expression_member::NoAwaitExpressionMember as UnicornNoAwaitExpressionMember;
 pub use crate::rules::unicorn::no_await_in_promise_methods::NoAwaitInPromiseMethods as UnicornNoAwaitInPromiseMethods;
 pub use crate::rules::unicorn::no_confusing_array_with::NoConfusingArrayWith as UnicornNoConfusingArrayWith;
@@ -1353,6 +1354,7 @@ pub enum RuleEnum {
     UnicornNoArrayReduce(UnicornNoArrayReduce),
     UnicornNoArrayReverse(UnicornNoArrayReverse),
     UnicornNoArraySort(UnicornNoArraySort),
+    UnicornNoAsyncPromiseFinally(UnicornNoAsyncPromiseFinally),
     UnicornNoAwaitExpressionMember(UnicornNoAwaitExpressionMember),
     UnicornNoAwaitInPromiseMethods(UnicornNoAwaitInPromiseMethods),
     UnicornNoConfusingArrayWith(UnicornNoConfusingArrayWith),
@@ -2265,7 +2267,8 @@ const UNICORN_NO_ARRAY_METHOD_THIS_ARGUMENT_ID: usize = UNICORN_NO_ARRAY_FOR_EAC
 const UNICORN_NO_ARRAY_REDUCE_ID: usize = UNICORN_NO_ARRAY_METHOD_THIS_ARGUMENT_ID + 1usize;
 const UNICORN_NO_ARRAY_REVERSE_ID: usize = UNICORN_NO_ARRAY_REDUCE_ID + 1usize;
 const UNICORN_NO_ARRAY_SORT_ID: usize = UNICORN_NO_ARRAY_REVERSE_ID + 1usize;
-const UNICORN_NO_AWAIT_EXPRESSION_MEMBER_ID: usize = UNICORN_NO_ARRAY_SORT_ID + 1usize;
+const UNICORN_NO_ASYNC_PROMISE_FINALLY_ID: usize = UNICORN_NO_ARRAY_SORT_ID + 1usize;
+const UNICORN_NO_AWAIT_EXPRESSION_MEMBER_ID: usize = UNICORN_NO_ASYNC_PROMISE_FINALLY_ID + 1usize;
 const UNICORN_NO_AWAIT_IN_PROMISE_METHODS_ID: usize =
     UNICORN_NO_AWAIT_EXPRESSION_MEMBER_ID + 1usize;
 const UNICORN_NO_CONFUSING_ARRAY_WITH_ID: usize = UNICORN_NO_AWAIT_IN_PROMISE_METHODS_ID + 1usize;
@@ -3248,6 +3251,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(_) => UNICORN_NO_ARRAY_REDUCE_ID,
             Self::UnicornNoArrayReverse(_) => UNICORN_NO_ARRAY_REVERSE_ID,
             Self::UnicornNoArraySort(_) => UNICORN_NO_ARRAY_SORT_ID,
+            Self::UnicornNoAsyncPromiseFinally(_) => UNICORN_NO_ASYNC_PROMISE_FINALLY_ID,
             Self::UnicornNoAwaitExpressionMember(_) => UNICORN_NO_AWAIT_EXPRESSION_MEMBER_ID,
             Self::UnicornNoAwaitInPromiseMethods(_) => UNICORN_NO_AWAIT_IN_PROMISE_METHODS_ID,
             Self::UnicornNoConfusingArrayWith(_) => UNICORN_NO_CONFUSING_ARRAY_WITH_ID,
@@ -4223,6 +4227,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(_) => UnicornNoArrayReduce::NAME,
             Self::UnicornNoArrayReverse(_) => UnicornNoArrayReverse::NAME,
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::NAME,
+            Self::UnicornNoAsyncPromiseFinally(_) => UnicornNoAsyncPromiseFinally::NAME,
             Self::UnicornNoAwaitExpressionMember(_) => UnicornNoAwaitExpressionMember::NAME,
             Self::UnicornNoAwaitInPromiseMethods(_) => UnicornNoAwaitInPromiseMethods::NAME,
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::NAME,
@@ -5216,6 +5221,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(_) => UnicornNoArrayReduce::CATEGORY,
             Self::UnicornNoArrayReverse(_) => UnicornNoArrayReverse::CATEGORY,
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::CATEGORY,
+            Self::UnicornNoAsyncPromiseFinally(_) => UnicornNoAsyncPromiseFinally::CATEGORY,
             Self::UnicornNoAwaitExpressionMember(_) => UnicornNoAwaitExpressionMember::CATEGORY,
             Self::UnicornNoAwaitInPromiseMethods(_) => UnicornNoAwaitInPromiseMethods::CATEGORY,
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::CATEGORY,
@@ -6212,6 +6218,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(_) => UnicornNoArrayReduce::FIX,
             Self::UnicornNoArrayReverse(_) => UnicornNoArrayReverse::FIX,
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::FIX,
+            Self::UnicornNoAsyncPromiseFinally(_) => UnicornNoAsyncPromiseFinally::FIX,
             Self::UnicornNoAwaitExpressionMember(_) => UnicornNoAwaitExpressionMember::FIX,
             Self::UnicornNoAwaitInPromiseMethods(_) => UnicornNoAwaitInPromiseMethods::FIX,
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::FIX,
@@ -7310,6 +7317,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(_) => UnicornNoArrayReduce::documentation(),
             Self::UnicornNoArrayReverse(_) => UnicornNoArrayReverse::documentation(),
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::documentation(),
+            Self::UnicornNoAsyncPromiseFinally(_) => UnicornNoAsyncPromiseFinally::documentation(),
             Self::UnicornNoAwaitExpressionMember(_) => {
                 UnicornNoAwaitExpressionMember::documentation()
             }
@@ -9227,6 +9235,10 @@ impl RuleEnum {
                 .or_else(|| UnicornNoArrayReverse::schema(generator)),
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::config_schema(generator)
                 .or_else(|| UnicornNoArraySort::schema(generator)),
+            Self::UnicornNoAsyncPromiseFinally(_) => {
+                UnicornNoAsyncPromiseFinally::config_schema(generator)
+                    .or_else(|| UnicornNoAsyncPromiseFinally::schema(generator))
+            }
             Self::UnicornNoAwaitExpressionMember(_) => {
                 UnicornNoAwaitExpressionMember::config_schema(generator)
                     .or_else(|| UnicornNoAwaitExpressionMember::schema(generator))
@@ -10774,6 +10786,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(_) => "unicorn",
             Self::UnicornNoArrayReverse(_) => "unicorn",
             Self::UnicornNoArraySort(_) => "unicorn",
+            Self::UnicornNoAsyncPromiseFinally(_) => "unicorn",
             Self::UnicornNoAwaitExpressionMember(_) => "unicorn",
             Self::UnicornNoAwaitInPromiseMethods(_) => "unicorn",
             Self::UnicornNoConfusingArrayWith(_) => "unicorn",
@@ -12702,6 +12715,9 @@ impl RuleEnum {
             Self::UnicornNoArraySort(_) => {
                 Ok(Self::UnicornNoArraySort(UnicornNoArraySort::from_configuration(value)?))
             }
+            Self::UnicornNoAsyncPromiseFinally(_) => Ok(Self::UnicornNoAsyncPromiseFinally(
+                UnicornNoAsyncPromiseFinally::from_configuration(value)?,
+            )),
             Self::UnicornNoAwaitExpressionMember(_) => Ok(Self::UnicornNoAwaitExpressionMember(
                 UnicornNoAwaitExpressionMember::from_configuration(value)?,
             )),
@@ -14361,6 +14377,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(rule) => rule.to_configuration(),
             Self::UnicornNoArrayReverse(rule) => rule.to_configuration(),
             Self::UnicornNoArraySort(rule) => rule.to_configuration(),
+            Self::UnicornNoAsyncPromiseFinally(rule) => rule.to_configuration(),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.to_configuration(),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.to_configuration(),
             Self::UnicornNoConfusingArrayWith(rule) => rule.to_configuration(),
@@ -15215,6 +15232,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(rule) => rule.run(node, ctx),
             Self::UnicornNoArrayReverse(rule) => rule.run(node, ctx),
             Self::UnicornNoArraySort(rule) => rule.run(node, ctx),
+            Self::UnicornNoAsyncPromiseFinally(rule) => rule.run(node, ctx),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.run(node, ctx),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.run(node, ctx),
             Self::UnicornNoConfusingArrayWith(rule) => rule.run(node, ctx),
@@ -16079,6 +16097,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(rule) => rule.run_once(ctx),
             Self::UnicornNoArrayReverse(rule) => rule.run_once(ctx),
             Self::UnicornNoArraySort(rule) => rule.run_once(ctx),
+            Self::UnicornNoAsyncPromiseFinally(rule) => rule.run_once(ctx),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.run_once(ctx),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.run_once(ctx),
             Self::UnicornNoConfusingArrayWith(rule) => rule.run_once(ctx),
@@ -17022,6 +17041,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoArrayReverse(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoArraySort(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoAsyncPromiseFinally(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoConfusingArrayWith(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17925,6 +17945,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(rule) => rule.should_run(ctx),
             Self::UnicornNoArrayReverse(rule) => rule.should_run(ctx),
             Self::UnicornNoArraySort(rule) => rule.should_run(ctx),
+            Self::UnicornNoAsyncPromiseFinally(rule) => rule.should_run(ctx),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.should_run(ctx),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.should_run(ctx),
             Self::UnicornNoConfusingArrayWith(rule) => rule.should_run(ctx),
@@ -18984,6 +19005,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(_) => UnicornNoArrayReduce::IS_TSGOLINT_RULE,
             Self::UnicornNoArrayReverse(_) => UnicornNoArrayReverse::IS_TSGOLINT_RULE,
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::IS_TSGOLINT_RULE,
+            Self::UnicornNoAsyncPromiseFinally(_) => UnicornNoAsyncPromiseFinally::IS_TSGOLINT_RULE,
             Self::UnicornNoAwaitExpressionMember(_) => {
                 UnicornNoAwaitExpressionMember::IS_TSGOLINT_RULE
             }
@@ -20115,6 +20137,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(_) => UnicornNoArrayReduce::VERSION,
             Self::UnicornNoArrayReverse(_) => UnicornNoArrayReverse::VERSION,
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::VERSION,
+            Self::UnicornNoAsyncPromiseFinally(_) => UnicornNoAsyncPromiseFinally::VERSION,
             Self::UnicornNoAwaitExpressionMember(_) => UnicornNoAwaitExpressionMember::VERSION,
             Self::UnicornNoAwaitInPromiseMethods(_) => UnicornNoAwaitInPromiseMethods::VERSION,
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::VERSION,
@@ -21161,6 +21184,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(_) => UnicornNoArrayReduce::HAS_CONFIG,
             Self::UnicornNoArrayReverse(_) => UnicornNoArrayReverse::HAS_CONFIG,
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::HAS_CONFIG,
+            Self::UnicornNoAsyncPromiseFinally(_) => UnicornNoAsyncPromiseFinally::HAS_CONFIG,
             Self::UnicornNoAwaitExpressionMember(_) => UnicornNoAwaitExpressionMember::HAS_CONFIG,
             Self::UnicornNoAwaitInPromiseMethods(_) => UnicornNoAwaitInPromiseMethods::HAS_CONFIG,
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::HAS_CONFIG,
@@ -22176,6 +22200,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(_) => UnicornNoArrayReduce::INFO,
             Self::UnicornNoArrayReverse(_) => UnicornNoArrayReverse::INFO,
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::INFO,
+            Self::UnicornNoAsyncPromiseFinally(_) => UnicornNoAsyncPromiseFinally::INFO,
             Self::UnicornNoAwaitExpressionMember(_) => UnicornNoAwaitExpressionMember::INFO,
             Self::UnicornNoAwaitInPromiseMethods(_) => UnicornNoAwaitInPromiseMethods::INFO,
             Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::INFO,
@@ -23070,6 +23095,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(rule) => rule.types_info(),
             Self::UnicornNoArrayReverse(rule) => rule.types_info(),
             Self::UnicornNoArraySort(rule) => rule.types_info(),
+            Self::UnicornNoAsyncPromiseFinally(rule) => rule.types_info(),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.types_info(),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.types_info(),
             Self::UnicornNoConfusingArrayWith(rule) => rule.types_info(),
@@ -23921,6 +23947,7 @@ impl RuleEnum {
             Self::UnicornNoArrayReduce(rule) => rule.run_info(),
             Self::UnicornNoArrayReverse(rule) => rule.run_info(),
             Self::UnicornNoArraySort(rule) => rule.run_info(),
+            Self::UnicornNoAsyncPromiseFinally(rule) => rule.run_info(),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.run_info(),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.run_info(),
             Self::UnicornNoConfusingArrayWith(rule) => rule.run_info(),
@@ -24870,6 +24897,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornNoArrayReduce(UnicornNoArrayReduce::default()),
         RuleEnum::UnicornNoArrayReverse(UnicornNoArrayReverse::default()),
         RuleEnum::UnicornNoArraySort(UnicornNoArraySort::default()),
+        RuleEnum::UnicornNoAsyncPromiseFinally(UnicornNoAsyncPromiseFinally::default()),
         RuleEnum::UnicornNoAwaitExpressionMember(UnicornNoAwaitExpressionMember::default()),
         RuleEnum::UnicornNoAwaitInPromiseMethods(UnicornNoAwaitInPromiseMethods::default()),
         RuleEnum::UnicornNoConfusingArrayWith(UnicornNoConfusingArrayWith::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -513,6 +513,7 @@ pub(crate) mod unicorn {
     pub mod no_array_reduce;
     pub mod no_array_reverse;
     pub mod no_array_sort;
+    pub mod no_async_promise_finally;
     pub mod no_await_expression_member;
     pub mod no_await_in_promise_methods;
     pub mod no_confusing_array_with;

--- a/crates/oxc_linter/src/rules/unicorn/no_async_promise_finally.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_async_promise_finally.rs
@@ -1,0 +1,165 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, MemberExpression, VariableDeclarationKind},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_async_promise_finally_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not pass an async function to `Promise#finally()`.")
+        .with_help(
+            "Use a synchronous callback so the promise is not delayed by unrelated async work.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoAsyncPromiseFinally;
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows async functions as `Promise#finally()` callbacks.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// An async `finally` callback delays settlement of the original promise and
+    /// can replace its result with a rejection from the callback. Cleanup that
+    /// must be awaited should usually be expressed explicitly.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// promise.finally(async () => cleanup());
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// promise.finally(() => cleanup());
+    /// ```
+    NoAsyncPromiseFinally,
+    unicorn,
+    suspicious,
+    none,
+    version = "next",
+    short_description = "Disallow async functions as `Promise#finally()` callbacks.",
+);
+
+impl Rule for NoAsyncPromiseFinally {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call) = node.kind() else { return };
+        let Some(member) = call.callee.get_member_expr() else { return };
+        if !is_finally_member(member, ctx) {
+            return;
+        }
+
+        let Some(callback) = call.arguments.first().and_then(|argument| argument.as_expression())
+        else {
+            return;
+        };
+        if is_async_non_generator_function(callback.get_inner_expression(), ctx) {
+            ctx.diagnostic(no_async_promise_finally_diagnostic(callback.span()));
+        }
+    }
+}
+
+fn is_finally_member(member: &MemberExpression<'_>, ctx: &LintContext<'_>) -> bool {
+    if member.static_property_name() == Some("finally") {
+        return true;
+    }
+
+    let MemberExpression::ComputedMemberExpression(computed) = member else { return false };
+    let Expression::Identifier(identifier) = computed.expression.get_inner_expression() else {
+        return false;
+    };
+    let Some(symbol_id) = ctx.scoping().get_reference(identifier.reference_id()).symbol_id() else {
+        return false;
+    };
+    let AstKind::VariableDeclarator(declarator) = ctx.symbol_declaration(symbol_id).kind() else {
+        return false;
+    };
+    declarator.kind == VariableDeclarationKind::Const
+        && declarator.init.as_ref().is_some_and(|init| {
+            matches!(init.get_inner_expression(), Expression::StringLiteral(literal) if literal.value == "finally")
+        })
+}
+
+fn is_async_non_generator_function(expression: &Expression<'_>, ctx: &LintContext<'_>) -> bool {
+    match expression {
+        Expression::ArrowFunctionExpression(function) => function.r#async,
+        Expression::FunctionExpression(function) => function.r#async && !function.generator,
+        Expression::Identifier(identifier) => {
+            let Some(symbol_id) =
+                ctx.scoping().get_reference(identifier.reference_id()).symbol_id()
+            else {
+                return false;
+            };
+            match ctx.symbol_declaration(symbol_id).kind() {
+                AstKind::Function(function) => function.r#async && !function.generator,
+                AstKind::VariableDeclarator(declarator)
+                    if declarator.kind == VariableDeclarationKind::Const =>
+                {
+                    declarator.init.as_ref().is_some_and(|initializer| {
+                        is_async_non_generator_function(initializer.get_inner_expression(), ctx)
+                    })
+                }
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "promise.finally(() => {})",
+        "promise.finally(() => cleanup())",
+        "promise.finally(function () {})",
+        "promise.finally(async function * () {})",
+        "promise.finally()",
+        "promise.finally(undefined)",
+        "promise.finally(cleanup)",
+        "promise.finally(object.cleanup)",
+        "promise.then(async () => {})",
+        "promise.catch(async () => {})",
+        "finalizer(async () => {})",
+        "promise.notFinally(async () => {})",
+        "promise[method](async () => {})",
+        "const cleanup = () => {}; promise.finally(cleanup);",
+        "let cleanup = async () => {}; promise.finally(cleanup);",
+        "async function * cleanup() {} promise.finally(cleanup);",
+        "const cleanup = async function * () {}; promise.finally(cleanup);",
+        "const cleanup = async () => {}; promise.finally(...[cleanup]);",
+        r#"import {cleanup} from "./cleanup.js"; promise.finally(cleanup);"#,
+    ];
+
+    let fail = vec![
+        "promise.finally(async () => {})",
+        "promise.finally(async () => cleanup())",
+        "promise.finally(async () => { await cleanup(); })",
+        "promise.finally(async function () { await cleanup(); })",
+        "Promise.resolve(value).finally(async () => cleanup())",
+        "new Promise(resolve => resolve()).finally(async () => cleanup())",
+        "promise?.finally(async () => {})",
+        "promise.finally?.(async () => {})",
+        r#"promise["finally"](async () => {})"#,
+        "promise[`finally`](async () => {})",
+        r#"const method = "finally"; promise[method](async () => {});"#,
+        "async function cleanup() {} promise.finally(cleanup);",
+        "const cleanup = async () => {}; promise.finally(cleanup);",
+        "const cleanup = async function () {}; promise.finally(cleanup);",
+        "type Callback = () => void; promise.finally((async () => {}) as Callback);", // {"parser": parsers.typescript},
+        "type Callback = () => void; const cleanup = (async () => {}) as Callback; promise.finally(cleanup);", // {"parser": parsers.typescript}
+    ];
+
+    Tester::new(NoAsyncPromiseFinally::NAME, NoAsyncPromiseFinally::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_no_async_promise_finally.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_async_promise_finally.snap
@@ -1,0 +1,116 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:17]
+ 1 │ promise.finally(async () => {})
+   ·                 ──────────────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:17]
+ 1 │ promise.finally(async () => cleanup())
+   ·                 ─────────────────────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:17]
+ 1 │ promise.finally(async () => { await cleanup(); })
+   ·                 ────────────────────────────────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:17]
+ 1 │ promise.finally(async function () { await cleanup(); })
+   ·                 ──────────────────────────────────────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:32]
+ 1 │ Promise.resolve(value).finally(async () => cleanup())
+   ·                                ─────────────────────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:43]
+ 1 │ new Promise(resolve => resolve()).finally(async () => cleanup())
+   ·                                           ─────────────────────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:18]
+ 1 │ promise?.finally(async () => {})
+   ·                  ──────────────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:19]
+ 1 │ promise.finally?.(async () => {})
+   ·                   ──────────────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:20]
+ 1 │ promise["finally"](async () => {})
+   ·                    ──────────────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:20]
+ 1 │ promise[`finally`](async () => {})
+   ·                    ──────────────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:43]
+ 1 │ const method = "finally"; promise[method](async () => {});
+   ·                                           ──────────────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:45]
+ 1 │ async function cleanup() {} promise.finally(cleanup);
+   ·                                             ───────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:49]
+ 1 │ const cleanup = async () => {}; promise.finally(cleanup);
+   ·                                                 ───────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:55]
+ 1 │ const cleanup = async function () {}; promise.finally(cleanup);
+   ·                                                       ───────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:45]
+ 1 │ type Callback = () => void; promise.finally((async () => {}) as Callback);
+   ·                                             ────────────────────────────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.
+
+  ⚠ unicorn(no-async-promise-finally): Do not pass an async function to `Promise#finally()`.
+   ╭─[no_async_promise_finally.tsx:1:91]
+ 1 │ type Callback = () => void; const cleanup = (async () => {}) as Callback; promise.finally(cleanup);
+   ·                                                                                           ───────
+   ╰────
+  help: Use a synchronous callback so the promise is not delayed by unrelated async work.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -8959,6 +8959,9 @@
             }
           ]
         },
+        "unicorn/no-async-promise-finally": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "unicorn/no-await-expression-member": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -550,6 +550,7 @@ unicorn/no-array-method-this-argument                      |  62606
 unicorn/no-array-reduce                                    |  62606
 unicorn/no-array-reverse                                   |  62606
 unicorn/no-array-sort                                      |  62606
+unicorn/no-async-promise-finally                           |  62606
 unicorn/no-await-expression-member                         |  95297
 unicorn/no-await-in-promise-methods                        |  62606
 unicorn/no-confusing-array-with                            |  62606


### PR DESCRIPTION
## Summary

- implement `unicorn/no-async-promise-finally` from the maintainer-managed tracker in #684
- detect direct async callbacks, async function declarations, and immutable async-function aliases
- support optional calls, static/computed `finally` properties, constant computed method names, and TypeScript expression wrappers
- register the rule and update generated config/schema/timing artifacts

## Why

An async `Promise#finally()` callback delays settlement of the original promise and can replace its outcome if cleanup rejects. The rule reports this potentially surprising control flow without offering an unsafe automatic rewrite.

## Validation

- `cargo test -p oxc_linter no_async_promise_finally -- --nocapture` — passed (21 pass cases, 17 violation cases)
- `cargo lintgen` — passed
- `cargo lint-timings` — passed
- `just fmt` — passed
- `just check` — passed
- `just lint` — passed with warnings denied
- `just doc` — passed with rustdoc warnings denied
- `just ast` — passed

The full workspace test command was not repeated because this checkout already reproduced an unrelated Node-version-sensitive `stacktrace_is_correct` snapshot mismatch; the focused rule tests and repository-wide compile/lint/doc checks above passed.

## Evidence, risk, and rollback

Behavior and cases are ported from the current upstream `eslint-plugin-unicorn` rule and test suite. The implementation intentionally has no autofix because removing `async` can change cleanup semantics. The rule is new and not enabled by default, so rollback is removal of its registration and generated entries.

AI assistance was used for repository research and implementation. I reviewed all handwritten/generated changes and ran the checks listed above.