### PR TITLE
feat(linter): add unicorn no-global-object-property-assignment rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1549,6 +1549,7 @@ export interface DummyRuleMap {
   "unicorn/no-console-spaces"?: RuleNoConfig;
   "unicorn/no-document-cookie"?: RuleNoConfig;
   "unicorn/no-empty-file"?: RuleNoConfig;
+  "unicorn/no-global-object-property-assignment"?: RuleNoConfig;
   "unicorn/no-hex-escape"?: RuleNoConfig;
   "unicorn/no-immediate-mutation"?: RuleNoConfig;
   "unicorn/no-instanceof-array"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3196,6 +3196,11 @@ impl RuleRunner for crate::rules::unicorn::no_empty_file::NoEmptyFile {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::unicorn::no_global_object_property_assignment::NoGlobalObjectPropertyAssignment {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[AstType::ComputedMemberExpression, AstType::PrivateFieldExpression, AstType::StaticMemberExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::no_hex_escape::NoHexEscape {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::RegExpLiteral,

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -633,6 +633,7 @@ pub use crate::rules::unicorn::no_confusing_array_with::NoConfusingArrayWith as 
 pub use crate::rules::unicorn::no_console_spaces::NoConsoleSpaces as UnicornNoConsoleSpaces;
 pub use crate::rules::unicorn::no_document_cookie::NoDocumentCookie as UnicornNoDocumentCookie;
 pub use crate::rules::unicorn::no_empty_file::NoEmptyFile as UnicornNoEmptyFile;
+pub use crate::rules::unicorn::no_global_object_property_assignment::NoGlobalObjectPropertyAssignment as UnicornNoGlobalObjectPropertyAssignment;
 pub use crate::rules::unicorn::no_hex_escape::NoHexEscape as UnicornNoHexEscape;
 pub use crate::rules::unicorn::no_immediate_mutation::NoImmediateMutation as UnicornNoImmediateMutation;
 pub use crate::rules::unicorn::no_instanceof_array::NoInstanceofArray as UnicornNoInstanceofArray;
@@ -1359,6 +1360,7 @@ pub enum RuleEnum {
     UnicornNoConsoleSpaces(UnicornNoConsoleSpaces),
     UnicornNoDocumentCookie(UnicornNoDocumentCookie),
     UnicornNoEmptyFile(UnicornNoEmptyFile),
+    UnicornNoGlobalObjectPropertyAssignment(UnicornNoGlobalObjectPropertyAssignment),
     UnicornNoHexEscape(UnicornNoHexEscape),
     UnicornNoImmediateMutation(UnicornNoImmediateMutation),
     UnicornNoInstanceofArray(UnicornNoInstanceofArray),
@@ -2272,7 +2274,8 @@ const UNICORN_NO_CONFUSING_ARRAY_WITH_ID: usize = UNICORN_NO_AWAIT_IN_PROMISE_ME
 const UNICORN_NO_CONSOLE_SPACES_ID: usize = UNICORN_NO_CONFUSING_ARRAY_WITH_ID + 1usize;
 const UNICORN_NO_DOCUMENT_COOKIE_ID: usize = UNICORN_NO_CONSOLE_SPACES_ID + 1usize;
 const UNICORN_NO_EMPTY_FILE_ID: usize = UNICORN_NO_DOCUMENT_COOKIE_ID + 1usize;
-const UNICORN_NO_HEX_ESCAPE_ID: usize = UNICORN_NO_EMPTY_FILE_ID + 1usize;
+const UNICORN_NO_GLOBAL_OBJECT_PROPERTY_ASSIGNMENT_ID: usize = UNICORN_NO_EMPTY_FILE_ID + 1usize;
+const UNICORN_NO_HEX_ESCAPE_ID: usize = UNICORN_NO_GLOBAL_OBJECT_PROPERTY_ASSIGNMENT_ID + 1usize;
 const UNICORN_NO_IMMEDIATE_MUTATION_ID: usize = UNICORN_NO_HEX_ESCAPE_ID + 1usize;
 const UNICORN_NO_INSTANCEOF_ARRAY_ID: usize = UNICORN_NO_IMMEDIATE_MUTATION_ID + 1usize;
 const UNICORN_NO_INSTANCEOF_BUILTINS_ID: usize = UNICORN_NO_INSTANCEOF_ARRAY_ID + 1usize;
@@ -3254,6 +3257,9 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UNICORN_NO_CONSOLE_SPACES_ID,
             Self::UnicornNoDocumentCookie(_) => UNICORN_NO_DOCUMENT_COOKIE_ID,
             Self::UnicornNoEmptyFile(_) => UNICORN_NO_EMPTY_FILE_ID,
+            Self::UnicornNoGlobalObjectPropertyAssignment(_) => {
+                UNICORN_NO_GLOBAL_OBJECT_PROPERTY_ASSIGNMENT_ID
+            }
             Self::UnicornNoHexEscape(_) => UNICORN_NO_HEX_ESCAPE_ID,
             Self::UnicornNoImmediateMutation(_) => UNICORN_NO_IMMEDIATE_MUTATION_ID,
             Self::UnicornNoInstanceofArray(_) => UNICORN_NO_INSTANCEOF_ARRAY_ID,
@@ -4229,6 +4235,9 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::NAME,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::NAME,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::NAME,
+            Self::UnicornNoGlobalObjectPropertyAssignment(_) => {
+                UnicornNoGlobalObjectPropertyAssignment::NAME
+            }
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::NAME,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::NAME,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::NAME,
@@ -5222,6 +5231,9 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::CATEGORY,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::CATEGORY,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::CATEGORY,
+            Self::UnicornNoGlobalObjectPropertyAssignment(_) => {
+                UnicornNoGlobalObjectPropertyAssignment::CATEGORY
+            }
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::CATEGORY,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::CATEGORY,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::CATEGORY,
@@ -6218,6 +6230,9 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::FIX,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::FIX,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::FIX,
+            Self::UnicornNoGlobalObjectPropertyAssignment(_) => {
+                UnicornNoGlobalObjectPropertyAssignment::FIX
+            }
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::FIX,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::FIX,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::FIX,
@@ -7320,6 +7335,9 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::documentation(),
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::documentation(),
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::documentation(),
+            Self::UnicornNoGlobalObjectPropertyAssignment(_) => {
+                UnicornNoGlobalObjectPropertyAssignment::documentation()
+            }
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::documentation(),
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::documentation(),
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::documentation(),
@@ -9245,6 +9263,10 @@ impl RuleEnum {
                 .or_else(|| UnicornNoDocumentCookie::schema(generator)),
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::config_schema(generator)
                 .or_else(|| UnicornNoEmptyFile::schema(generator)),
+            Self::UnicornNoGlobalObjectPropertyAssignment(_) => {
+                UnicornNoGlobalObjectPropertyAssignment::config_schema(generator)
+                    .or_else(|| UnicornNoGlobalObjectPropertyAssignment::schema(generator))
+            }
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::config_schema(generator)
                 .or_else(|| UnicornNoHexEscape::schema(generator)),
             Self::UnicornNoImmediateMutation(_) => {
@@ -10780,6 +10802,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => "unicorn",
             Self::UnicornNoDocumentCookie(_) => "unicorn",
             Self::UnicornNoEmptyFile(_) => "unicorn",
+            Self::UnicornNoGlobalObjectPropertyAssignment(_) => "unicorn",
             Self::UnicornNoHexEscape(_) => "unicorn",
             Self::UnicornNoImmediateMutation(_) => "unicorn",
             Self::UnicornNoInstanceofArray(_) => "unicorn",
@@ -12720,6 +12743,11 @@ impl RuleEnum {
             Self::UnicornNoEmptyFile(_) => {
                 Ok(Self::UnicornNoEmptyFile(UnicornNoEmptyFile::from_configuration(value)?))
             }
+            Self::UnicornNoGlobalObjectPropertyAssignment(_) => {
+                Ok(Self::UnicornNoGlobalObjectPropertyAssignment(
+                    UnicornNoGlobalObjectPropertyAssignment::from_configuration(value)?,
+                ))
+            }
             Self::UnicornNoHexEscape(_) => {
                 Ok(Self::UnicornNoHexEscape(UnicornNoHexEscape::from_configuration(value)?))
             }
@@ -14367,6 +14395,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.to_configuration(),
             Self::UnicornNoDocumentCookie(rule) => rule.to_configuration(),
             Self::UnicornNoEmptyFile(rule) => rule.to_configuration(),
+            Self::UnicornNoGlobalObjectPropertyAssignment(rule) => rule.to_configuration(),
             Self::UnicornNoHexEscape(rule) => rule.to_configuration(),
             Self::UnicornNoImmediateMutation(rule) => rule.to_configuration(),
             Self::UnicornNoInstanceofArray(rule) => rule.to_configuration(),
@@ -15221,6 +15250,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.run(node, ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run(node, ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run(node, ctx),
+            Self::UnicornNoGlobalObjectPropertyAssignment(rule) => rule.run(node, ctx),
             Self::UnicornNoHexEscape(rule) => rule.run(node, ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run(node, ctx),
             Self::UnicornNoInstanceofArray(rule) => rule.run(node, ctx),
@@ -16085,6 +16115,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.run_once(ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run_once(ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run_once(ctx),
+            Self::UnicornNoGlobalObjectPropertyAssignment(rule) => rule.run_once(ctx),
             Self::UnicornNoHexEscape(rule) => rule.run_once(ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run_once(ctx),
             Self::UnicornNoInstanceofArray(rule) => rule.run_once(ctx),
@@ -17028,6 +17059,9 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoGlobalObjectPropertyAssignment(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
             Self::UnicornNoHexEscape(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoInstanceofArray(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17931,6 +17965,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.should_run(ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.should_run(ctx),
             Self::UnicornNoEmptyFile(rule) => rule.should_run(ctx),
+            Self::UnicornNoGlobalObjectPropertyAssignment(rule) => rule.should_run(ctx),
             Self::UnicornNoHexEscape(rule) => rule.should_run(ctx),
             Self::UnicornNoImmediateMutation(rule) => rule.should_run(ctx),
             Self::UnicornNoInstanceofArray(rule) => rule.should_run(ctx),
@@ -18994,6 +19029,9 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::IS_TSGOLINT_RULE,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::IS_TSGOLINT_RULE,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::IS_TSGOLINT_RULE,
+            Self::UnicornNoGlobalObjectPropertyAssignment(_) => {
+                UnicornNoGlobalObjectPropertyAssignment::IS_TSGOLINT_RULE
+            }
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::IS_TSGOLINT_RULE,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::IS_TSGOLINT_RULE,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::IS_TSGOLINT_RULE,
@@ -20121,6 +20159,9 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::VERSION,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::VERSION,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::VERSION,
+            Self::UnicornNoGlobalObjectPropertyAssignment(_) => {
+                UnicornNoGlobalObjectPropertyAssignment::VERSION
+            }
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::VERSION,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::VERSION,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::VERSION,
@@ -21167,6 +21208,9 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::HAS_CONFIG,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::HAS_CONFIG,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::HAS_CONFIG,
+            Self::UnicornNoGlobalObjectPropertyAssignment(_) => {
+                UnicornNoGlobalObjectPropertyAssignment::HAS_CONFIG
+            }
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::HAS_CONFIG,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::HAS_CONFIG,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::HAS_CONFIG,
@@ -22182,6 +22226,9 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::INFO,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::INFO,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::INFO,
+            Self::UnicornNoGlobalObjectPropertyAssignment(_) => {
+                UnicornNoGlobalObjectPropertyAssignment::INFO
+            }
             Self::UnicornNoHexEscape(_) => UnicornNoHexEscape::INFO,
             Self::UnicornNoImmediateMutation(_) => UnicornNoImmediateMutation::INFO,
             Self::UnicornNoInstanceofArray(_) => UnicornNoInstanceofArray::INFO,
@@ -23076,6 +23123,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.types_info(),
             Self::UnicornNoDocumentCookie(rule) => rule.types_info(),
             Self::UnicornNoEmptyFile(rule) => rule.types_info(),
+            Self::UnicornNoGlobalObjectPropertyAssignment(rule) => rule.types_info(),
             Self::UnicornNoHexEscape(rule) => rule.types_info(),
             Self::UnicornNoImmediateMutation(rule) => rule.types_info(),
             Self::UnicornNoInstanceofArray(rule) => rule.types_info(),
@@ -23927,6 +23975,7 @@ impl RuleEnum {
             Self::UnicornNoConsoleSpaces(rule) => rule.run_info(),
             Self::UnicornNoDocumentCookie(rule) => rule.run_info(),
             Self::UnicornNoEmptyFile(rule) => rule.run_info(),
+            Self::UnicornNoGlobalObjectPropertyAssignment(rule) => rule.run_info(),
             Self::UnicornNoHexEscape(rule) => rule.run_info(),
             Self::UnicornNoImmediateMutation(rule) => rule.run_info(),
             Self::UnicornNoInstanceofArray(rule) => rule.run_info(),
@@ -24876,6 +24925,9 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornNoConsoleSpaces(UnicornNoConsoleSpaces::default()),
         RuleEnum::UnicornNoDocumentCookie(UnicornNoDocumentCookie::default()),
         RuleEnum::UnicornNoEmptyFile(UnicornNoEmptyFile::default()),
+        RuleEnum::UnicornNoGlobalObjectPropertyAssignment(
+            UnicornNoGlobalObjectPropertyAssignment::default(),
+        ),
         RuleEnum::UnicornNoHexEscape(UnicornNoHexEscape::default()),
         RuleEnum::UnicornNoImmediateMutation(UnicornNoImmediateMutation::default()),
         RuleEnum::UnicornNoInstanceofArray(UnicornNoInstanceofArray::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -519,6 +519,7 @@ pub(crate) mod unicorn {
     pub mod no_console_spaces;
     pub mod no_document_cookie;
     pub mod no_empty_file;
+    pub mod no_global_object_property_assignment;
     pub mod no_hex_escape;
     pub mod no_immediate_mutation;
     pub mod no_instanceof_array;

--- a/crates/oxc_linter/src/rules/unicorn/no_global_object_property_assignment.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_global_object_property_assignment.rs
@@ -1,0 +1,154 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::IsGlobalReference;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_global_object_property_assignment_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not assign properties on the global object.")
+        .with_help("Store application state in a module or another explicitly owned object.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoGlobalObjectPropertyAssignment;
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows assigning properties on the global object.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Mutating the global object creates implicit shared state and can overwrite
+    /// properties provided by the runtime or another library.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// globalThis.appState = state;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const app = { state };
+    /// ```
+    NoGlobalObjectPropertyAssignment,
+    unicorn,
+    suspicious,
+    none,
+    version = "next",
+    short_description = "Disallow assigning properties on the global object.",
+);
+
+impl Rule for NoGlobalObjectPropertyAssignment {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let Some(member) = node.kind().as_member_expression_kind() else { return };
+        if member.static_property_name().is_none() {
+            return;
+        }
+
+        let Expression::Identifier(object) = member.object().get_inner_expression() else {
+            return;
+        };
+        if !matches!(object.name.as_str(), "global" | "globalThis" | "self" | "window")
+            || !object.is_global_reference(ctx.scoping())
+            || !is_assignment_target(node, member, ctx)
+        {
+            return;
+        }
+
+        ctx.diagnostic(no_global_object_property_assignment_diagnostic(node.span()));
+    }
+}
+
+fn is_assignment_target<'a>(
+    node: &AstNode<'a>,
+    member: oxc_ast::MemberExpressionKind<'a>,
+    ctx: &LintContext<'a>,
+) -> bool {
+    let mut target = node;
+    let mut parent = ctx.nodes().parent_node(target.id());
+    while matches!(
+        parent.kind(),
+        AstKind::TSAsExpression(_)
+            | AstKind::TSSatisfiesExpression(_)
+            | AstKind::TSTypeAssertion(_)
+            | AstKind::TSNonNullExpression(_)
+    ) {
+        target = parent;
+        parent = ctx.nodes().parent_node(target.id());
+    }
+
+    if target.id() == node.id() {
+        return member.is_assigned_to_in_parent(&parent.kind());
+    }
+
+    match parent.kind() {
+        AstKind::AssignmentExpression(assignment) => assignment.left.span() == target.span(),
+        AstKind::UpdateExpression(update) => update.argument.span() == target.span(),
+        AstKind::ForInStatement(for_in) => for_in.left.span() == target.span(),
+        AstKind::ForOfStatement(for_of) => for_of.left.span() == target.span(),
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "globalThis.foo",
+        "window.foo()",
+        "globalThis = value",
+        "globalThis[property] = value",
+        "delete globalThis.foo",
+        "Object.assign(globalThis, {foo: value})",
+        r#"Reflect.set(globalThis, "foo", value)"#,
+        "function test(window) {
+                window.foo = 1;
+            }",
+        "const global = {};
+            global.foo = 1;",
+        "const globalThis = {};
+            globalThis.foo = 1;",
+        "const self = {};
+            self.foo++;",
+        "const root = globalThis;
+            root.foo = 1;",
+    ];
+
+    let fail = vec![
+        "globalThis.foo = 1",
+        "window.foo += 1",
+        "self.foo ||= value",
+        "global.foo++",
+        r#"globalThis["foo"] = 1"#,
+        "({
+                foo: globalThis.foo,
+            } = object);",
+        "[globalThis.foo] = array",
+        "({...globalThis.foo} = object)",
+        "[...globalThis.foo] = array",
+        "for (globalThis.foo of iterable) {}",
+        "for (globalThis.foo in object) {}",
+        "globalThis!.foo = 1",                // {"parser": parsers.typescript},
+        "(globalThis as any).foo = 1",        // {"parser": parsers.typescript},
+        "(<any>globalThis).foo = 1",          // {"parser": parsers.typescript},
+        "(globalThis satisfies any).foo = 1", // {"parser": parsers.typescript},
+        "globalThis.foo! = 1",                // {"parser": parsers.typescript}
+    ];
+
+    Tester::new(
+        NoGlobalObjectPropertyAssignment::NAME,
+        NoGlobalObjectPropertyAssignment::PLUGIN,
+        pass,
+        fail,
+    )
+    .change_rule_path_extension("ts")
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_no_global_object_property_assignment.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_global_object_property_assignment.snap
@@ -1,0 +1,118 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:1]
+ 1 │ globalThis.foo = 1
+   · ──────────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:1]
+ 1 │ window.foo += 1
+   · ──────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:1]
+ 1 │ self.foo ||= value
+   · ────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:1]
+ 1 │ global.foo++
+   · ──────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:1]
+ 1 │ globalThis["foo"] = 1
+   · ─────────────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:2:22]
+ 1 │ ({
+ 2 │                 foo: globalThis.foo,
+   ·                      ──────────────
+ 3 │             } = object);
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:2]
+ 1 │ [globalThis.foo] = array
+   ·  ──────────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:6]
+ 1 │ ({...globalThis.foo} = object)
+   ·      ──────────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:5]
+ 1 │ [...globalThis.foo] = array
+   ·     ──────────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:6]
+ 1 │ for (globalThis.foo of iterable) {}
+   ·      ──────────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:6]
+ 1 │ for (globalThis.foo in object) {}
+   ·      ──────────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:1]
+ 1 │ globalThis!.foo = 1
+   · ───────────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:1]
+ 1 │ (globalThis as any).foo = 1
+   · ───────────────────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:1]
+ 1 │ (<any>globalThis).foo = 1
+   · ─────────────────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:1]
+ 1 │ (globalThis satisfies any).foo = 1
+   · ──────────────────────────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.
+
+  ⚠ unicorn(no-global-object-property-assignment): Do not assign properties on the global object.
+   ╭─[no_global_object_property_assignment.ts:1:1]
+ 1 │ globalThis.foo! = 1
+   · ──────────────
+   ╰────
+  help: Store application state in a module or another explicitly owned object.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -8977,6 +8977,9 @@
         "unicorn/no-empty-file": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/no-global-object-property-assignment": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "unicorn/no-hex-escape": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -556,6 +556,7 @@ unicorn/no-confusing-array-with                            |  62606
 unicorn/no-console-spaces                                  |  62606
 unicorn/no-document-cookie                                 |  13005
 unicorn/no-empty-file                                      |      7
+unicorn/no-global-object-property-assignment               |  95297
 unicorn/no-hex-escape                                      |  63282
 unicorn/no-immediate-mutation                              |  24802
 unicorn/no-instanceof-array                                |  20604


### PR DESCRIPTION
## Summary

- implement `unicorn/no-global-object-property-assignment` from the maintainer-managed tracker in #684
- detect writes through `global`, `globalThis`, `self`, and `window` while respecting lexical shadowing
- cover assignment/update operators, destructuring and rest targets, `for…in/of`, computed properties, and TypeScript expression wrappers
- register the rule and update generated config/schema/timing artifacts

## Why

Writing properties directly onto the global object creates implicit shared state and can overwrite runtime- or library-owned properties. This rule reports those writes while allowing reads, deletes, dynamic property names, explicit reflective APIs, and locally shadowed identifiers.

## Validation

- `cargo test -p oxc_linter no_global_object_property_assignment -- --nocapture` — passed (12 pass cases, 16 violation cases)
- `cargo lintgen` — passed
- `cargo lint-timings` — passed
- `just fmt` — passed
- `just check` — passed
- `just lint` — passed with warnings denied
- `just doc` — passed with rustdoc warnings denied
- `just ast` — passed

The full workspace test command was not repeated because this checkout already reproduced an unrelated Node-version-sensitive `stacktrace_is_correct` snapshot mismatch; the focused matrix and repository-wide compile/lint/doc checks above passed.

## Evidence, risk, and rollback

Behavior and cases are ported from the current upstream `eslint-plugin-unicorn` rule and tests. No autofix is offered because selecting a safe state owner requires application context. The rule is new and not enabled by default; rollback is removal of its registration and generated entries.

AI assistance was used for repository research and implementation. I reviewed all handwritten/generated changes and ran the checks listed above.