### PR TITLE
fix(react_compiler): discover functions in parameter defaults

### DIFF
--- a/crates/oxc_react_compiler/fixtures/infer-functions-in-parameter-defaults.tsx
+++ b/crates/oxc_react_compiler/fixtures/infer-functions-in-parameter-defaults.tsx
@@ -1,0 +1,18 @@
+// @compilationMode:"infer"
+import { memo } from "react";
+
+function createWrapper(Wrapper = memo(({ value }) => <div>{value}</div>)) {
+  return Wrapper;
+}
+
+function createDestructuredWrapper({ Wrapper = memo(({ value }) => <span>{value}</span>) } = {}) {
+  return Wrapper;
+}
+
+const factory = {
+  create(Wrapper = memo(({ value }) => <p>{value}</p>)) {
+    return Wrapper;
+  },
+};
+
+export { createWrapper, createDestructuredWrapper, factory };

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -1348,6 +1348,53 @@ impl<'a, 'b, 'ast> DiscoveryWalker<'a, 'b, 'ast> {
         }
     }
 
+    fn walk_formal_parameters(&mut self, params: &'b FormalParameters<'ast>) {
+        for param in &params.items {
+            for decorator in &param.decorators {
+                self.walk_expression(&decorator.expression);
+            }
+            self.walk_binding_pattern(&param.pattern);
+            if let Some(initializer) = &param.initializer {
+                self.walk_expression(initializer);
+            }
+        }
+        if let Some(rest) = &params.rest {
+            for decorator in &rest.decorators {
+                self.walk_expression(&decorator.expression);
+            }
+            self.walk_binding_pattern(&rest.rest.argument);
+        }
+    }
+
+    fn walk_binding_pattern(&mut self, pattern: &'b BindingPattern<'ast>) {
+        match pattern {
+            BindingPattern::BindingIdentifier(_) => {}
+            BindingPattern::ObjectPattern(object) => {
+                for property in &object.properties {
+                    if property.computed {
+                        self.walk_property_key(&property.key);
+                    }
+                    self.walk_binding_pattern(&property.value);
+                }
+                if let Some(rest) = &object.rest {
+                    self.walk_binding_pattern(&rest.argument);
+                }
+            }
+            BindingPattern::ArrayPattern(array) => {
+                for element in array.elements.iter().flatten() {
+                    self.walk_binding_pattern(element);
+                }
+                if let Some(rest) = &array.rest {
+                    self.walk_binding_pattern(&rest.argument);
+                }
+            }
+            BindingPattern::AssignmentPattern(assignment) => {
+                self.walk_binding_pattern(&assignment.left);
+                self.walk_expression(&assignment.right);
+            }
+        }
+    }
+
     fn walk_statement(&mut self, stmt: &'b Statement<'ast>) {
         match stmt {
             Statement::BlockStatement(node) => self.walk_block(node),
@@ -1560,7 +1607,10 @@ impl<'a, 'b, 'ast> DiscoveryWalker<'a, 'b, 'ast> {
 
         if !skip_body {
             // Babel `fn.skip()` is only called for compiled functions; other
-            // functions are descended to find nested declarations.
+            // functions are descended to find nested declarations. Parameters
+            // are visited before the body because their defaults may contain a
+            // compilable function (for example, `Wrapper = memo(() => ...)`).
+            self.walk_formal_parameters(&func.params);
             if let Some(body) = &func.body {
                 self.walk_function_body_block(body);
             }
@@ -1598,6 +1648,7 @@ impl<'a, 'b, 'ast> DiscoveryWalker<'a, 'b, 'ast> {
         };
 
         if !skip_body {
+            self.walk_formal_parameters(&arrow.params);
             if let Some(expression) = arrow.get_expression() {
                 self.walk_expression(expression);
             } else {
@@ -1780,6 +1831,7 @@ impl<'a, 'b, 'ast> DiscoveryWalker<'a, 'b, 'ast> {
                 if is_method {
                     if let Expression::FunctionExpression(func) = &p.value {
                         let pushed = self.try_push_scope(func.scope_id.get());
+                        self.walk_formal_parameters(&func.params);
                         if let Some(body) = &func.body {
                             self.walk_function_body_block(body);
                         }

--- a/crates/oxc_react_compiler/tests/snapshots/infer-functions-in-parameter-defaults.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/infer-functions-in-parameter-defaults.snap
@@ -1,0 +1,53 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/infer-functions-in-parameter-defaults.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+// @compilationMode:"infer"
+import { memo } from "react";
+function createWrapper(Wrapper = memo((t0) => {
+	const $ = _c(2);
+	const { value } = t0;
+	let t1;
+	if ($[0] !== value) {
+		t1 = <div>{value}</div>;
+		$[0] = value;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	return t1;
+})) {
+	return Wrapper;
+}
+function createDestructuredWrapper({ Wrapper = memo((t0) => {
+	const $ = _c(2);
+	const { value } = t0;
+	let t1;
+	if ($[0] !== value) {
+		t1 = <span>{value}</span>;
+		$[0] = value;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	return t1;
+}) } = {}) {
+	return Wrapper;
+}
+const factory = { create(Wrapper = memo((t0) => {
+	const $ = _c(2);
+	const { value } = t0;
+	let t1;
+	if ($[0] !== value) {
+		t1 = <p>{value}</p>;
+		$[0] = value;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	return t1;
+})) {
+	return Wrapper;
+} };
+export { createWrapper, createDestructuredWrapper, factory };


### PR DESCRIPTION
Fix React Compiler discovery of `memo` and `forwardRef` callbacks in runtime parameter defaults when the enclosing function is skipped.

Validated against the React Compiler suite and the Kibana reproduction.

AI-assisted.
