### PR TITLE
fix(react_compiler): preserve parenthesized non-node returns

### DIFF
--- a/crates/oxc_react_compiler/fixtures/infer-no-component-parenthesized-obj-return.js
+++ b/crates/oxc_react_compiler/fixtures/infer-no-component-parenthesized-obj-return.js
@@ -1,0 +1,4 @@
+// @expectNothingCompiled @compilationMode:"infer"
+const ArrowComponent = () => ({ child: <div /> });
+
+export { ArrowComponent };

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -279,6 +279,9 @@ fn get_function_name_from_id<'ast>(id: Option<&BindingIdentifier<'ast>>) -> Opti
 /// Check if an expression is a "non-node" return value (indicating the function
 /// is not a React component). This matches the TS `isNonNode` function.
 fn is_non_node(expr: &Expression) -> bool {
+    if let Expression::ParenthesizedExpression(parenthesized) = expr {
+        return is_non_node(&parenthesized.expression);
+    }
     matches!(
         expr,
         Expression::ObjectExpression(_)

--- a/crates/oxc_react_compiler/tests/snapshots/infer-no-component-parenthesized-obj-return.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/infer-no-component-parenthesized-obj-return.snap
@@ -1,0 +1,7 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/infer-no-component-parenthesized-obj-return.js
+---
+// @expectNothingCompiled @compilationMode:"infer"
+const ArrowComponent = () => ({ child: <div /> });
+export { ArrowComponent };


### PR DESCRIPTION
Preserve Babel's non-node classification for parenthesized object returns so ordinary PascalCase factories are not compiled as React components.

Validated against the React Compiler suite and the Kibana reproduction.

AI-assisted.