### PR TITLE
fix(linter): check padding after Jest and Vitest blocks

### DIFF
--- a/crates/oxc_linter/src/rules/jest/padding_around_after_all_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_after_all_blocks.rs
@@ -35,6 +35,8 @@ fn test() {
 
     let pass = vec![
         "afterAll(() => {});",
+        "afterAll(() => {});\n\nconst thing = 123;",
+        "afterAll(() => {});\n\nafterAll(() => {});",
         "const thing = 123;\n\nafterAll(() => {});",
         "describe('foo', () => {\nafterAll(() => {});\n});",
         "const thing = 123;\n\n/* one */\n/* two */\nafterAll(() => {});",
@@ -42,11 +44,15 @@ fn test() {
 
     let fail = vec![
         "const thing = 123;\nafterAll(() => {});",
+        "afterAll(() => {});\nconst thing = 123;",
+        "afterAll(() => {});\nafterAll(() => {});",
         "const thing = 123;\n/* one */\n/* two */\nafterAll(() => {});",
     ];
 
     let fix = vec![
         ("const thing = 123;\nafterAll(() => {});", "const thing = 123;\n\nafterAll(() => {});"),
+        ("afterAll(() => {});\nconst thing = 123;", "afterAll(() => {});\n\nconst thing = 123;"),
+        ("afterAll(() => {});\nafterAll(() => {});", "afterAll(() => {});\n\nafterAll(() => {});"),
         (
             "const thing = 123;\n/* one */\n/* two */\nafterAll(() => {});",
             "const thing = 123;\n\n/* one */\n/* two */\nafterAll(() => {});",

--- a/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
@@ -37,6 +37,8 @@ fn test() {
 
     let pass = vec![
         "test('foo', () => {});",
+        "test('foo', () => {});\n\nconst thing = 123;",
+        "test('foo', () => {}); // trailing comment\n\nconst thing = 123;",
         "test('foo', () => {});\n\ntest('bar', () => {});",
         "const thing = 123;\n\ntest('foo', () => {});",
         "{ test('foo', () => {}); }",
@@ -45,8 +47,13 @@ fn test() {
     ];
 
     let fail = vec![
+        "test('foo', () => {});\nconst thing = 123;",
+        "test('foo', () => {});\n// comment\nconst thing = 123;",
+        "test('foo', () => {}); // trailing comment\nconst thing = 123;",
         "test('foo', () => {});test('bar', () => {});",
         "test('foo', () => {});\ntest('bar', () => {});",
+        "import { test as t } from '@jest/globals';\n\nt('a', () => {});\nt('b', () => {});",
+        "import { test as t } from '@jest/globals';\n\n// attached\nt('a', () => {});\ntest('local', () => {});\nfunction test() {}",
         "it('foo', () => {});\nfit('bar', () => {});\ntest('baz', () => {});",
         "const thing = 123;\n/* one */\n/* two */\ntest('foo', () => {});",
         r"
@@ -88,12 +95,32 @@ describe('other bar', function() {
 
     let fix = vec![
         (
+            "test('foo', () => {});\nconst thing = 123;",
+            "test('foo', () => {});\n\nconst thing = 123;",
+        ),
+        (
+            "test('foo', () => {});\n// comment\nconst thing = 123;",
+            "test('foo', () => {});\n\n// comment\nconst thing = 123;",
+        ),
+        (
+            "test('foo', () => {}); // trailing comment\nconst thing = 123;",
+            "test('foo', () => {}); // trailing comment\n\nconst thing = 123;",
+        ),
+        (
             "test('foo', () => {});test('bar', () => {});",
             "test('foo', () => {});\n\ntest('bar', () => {});",
         ),
         (
             "test('foo', () => {});\ntest('bar', () => {});",
             "test('foo', () => {});\n\ntest('bar', () => {});",
+        ),
+        (
+            "import { test as t } from '@jest/globals';\n\nt('a', () => {});\nt('b', () => {});",
+            "import { test as t } from '@jest/globals';\n\nt('a', () => {});\n\nt('b', () => {});",
+        ),
+        (
+            "import { test as t } from '@jest/globals';\n\n// attached\nt('a', () => {});\ntest('local', () => {});\nfunction test() {}",
+            "import { test as t } from '@jest/globals';\n\n// attached\nt('a', () => {});\n\ntest('local', () => {});\nfunction test() {}",
         ),
         (
             "it('foo', () => {});\nfit('bar', () => {});\ntest('baz', () => {});",

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_after_all_blocks.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_after_all_blocks.rs
@@ -3,10 +3,12 @@ use oxc_ast::AstKind;
 use crate::{
     context::LintContext,
     utils::{
-        JestGeneralFnKind, ParsedGeneralJestFnCall, PossibleJestNode, parse_general_jest_fn_call,
-        report_missing_padding_before_jest_block,
+        JestGeneralFnKind, JestPaddingConfig, JestPaddingTarget, ParsedGeneralJestFnCall,
+        PossibleJestNode, parse_general_jest_fn_call, report_missing_padding_around_jest_block,
     },
 };
+
+const PADDING_TARGETS: &[JestPaddingTarget] = &[JestPaddingTarget::Hook("afterAll")];
 
 pub const DOCUMENTATION: &str = r"### What it does
 
@@ -54,5 +56,10 @@ pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<
     if name != "afterAll" {
         return;
     }
-    report_missing_padding_before_jest_block(node, ctx, name);
+    report_missing_padding_around_jest_block(
+        node,
+        ctx,
+        name,
+        JestPaddingConfig::new(PADDING_TARGETS),
+    );
 }

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_test_blocks.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_test_blocks.rs
@@ -3,10 +3,12 @@ use oxc_ast::AstKind;
 use crate::{
     context::LintContext,
     utils::{
-        JestGeneralFnKind, ParsedGeneralJestFnCall, PossibleJestNode, parse_general_jest_fn_call,
-        report_missing_padding_before_jest_block,
+        JestGeneralFnKind, JestPaddingConfig, JestPaddingTarget, ParsedGeneralJestFnCall,
+        PossibleJestNode, parse_general_jest_fn_call, report_missing_padding_around_jest_block,
     },
 };
+
+const PADDING_TARGETS: &[JestPaddingTarget] = &[JestPaddingTarget::Test];
 
 pub const DOCUMENTATION: &str = r"### What it does
 
@@ -68,5 +70,10 @@ pub fn run<'a>(jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
     if kind != JestGeneralFnKind::Test {
         return;
     }
-    report_missing_padding_before_jest_block(node, ctx, name);
+    report_missing_padding_around_jest_block(
+        node,
+        ctx,
+        name,
+        JestPaddingConfig::new(PADDING_TARGETS),
+    );
 }

--- a/crates/oxc_linter/src/rules/vitest/padding_around_after_all_blocks.rs
+++ b/crates/oxc_linter/src/rules/vitest/padding_around_after_all_blocks.rs
@@ -35,6 +35,7 @@ fn test() {
 
     let pass = vec![
         "afterAll(() => {});",
+        "afterAll(() => {});\n\nconst thing = 123;",
         "const thing = 123;\n\nafterAll(() => {});",
         "describe('foo', () => {\nafterAll(() => {});\n});",
         "// This is a comment\nafterAll(() => {});",
@@ -51,6 +52,7 @@ fn test() {
 
     let fail = vec![
         "const thing = 123;\nafterAll(() => {});",
+        "afterAll(() => {});\nconst thing = 123;",
         "const thing = 123;\n//My comment\nafterAll(() => {});",
         "import { afterAll } from 'vitest';\nafterAll(() => {});",
         "import { afterAll } from 'vitest';\nimport { helper } from './helper';\nafterAll(() => {});",
@@ -63,6 +65,7 @@ fn test() {
 
     let fix = vec![
         ("const thing = 123;\nafterAll(() => {});", "const thing = 123;\n\nafterAll(() => {});"),
+        ("afterAll(() => {});\nconst thing = 123;", "afterAll(() => {});\n\nconst thing = 123;"),
         (
             "const thing = 123;\n// This is a comment\nafterAll(() => {});",
             "const thing = 123;\n\n// This is a comment\nafterAll(() => {});",

--- a/crates/oxc_linter/src/rules/vitest/padding_around_test_blocks.rs
+++ b/crates/oxc_linter/src/rules/vitest/padding_around_test_blocks.rs
@@ -37,6 +37,7 @@ fn test() {
 
     let pass = vec![
         "test('foo', () => {});",
+        "test('foo', () => {});\n\nconst thing = 123;",
         "test('foo', () => {});\n\ntest('bar', () => {});",
         "const thing = 123;\n\ntest('foo', () => {});",
         "{ test('foo', () => {}); }",
@@ -45,6 +46,7 @@ fn test() {
     ];
 
     let fail = vec![
+        "test('foo', () => {});\nconst thing = 123;",
         "test('foo', () => {});test('bar', () => {});",
         "test('foo', () => {});\ntest('bar', () => {});",
         "const thing = 123;\n/* one */\n/* two */\ntest('foo', () => {});",
@@ -82,6 +84,10 @@ describe('other bar', function() {
     ];
 
     let fix = vec![
+        (
+            "test('foo', () => {});\nconst thing = 123;",
+            "test('foo', () => {});\n\nconst thing = 123;",
+        ),
         (
             "test('foo', () => {});test('bar', () => {});",
             "test('foo', () => {});\n\ntest('bar', () => {});",

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_after_all_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_after_all_blocks.snap
@@ -10,6 +10,22 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Make sure there is an empty new line before the afterAll block
 
+  ⚠ jest(padding-around-after-all-blocks): Missing padding after afterAll block
+   ╭─[padding_around_after_all_blocks.tsx:1:19]
+ 1 │ afterAll(() => {});
+   ·                   ▲
+ 2 │ const thing = 123;
+   ╰────
+  help: Make sure there is an empty new line after the afterAll block
+
+  ⚠ jest(padding-around-after-all-blocks): Missing padding before afterAll block
+   ╭─[padding_around_after_all_blocks.tsx:2:1]
+ 1 │ afterAll(() => {});
+ 2 │ afterAll(() => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the afterAll block
+
   ⚠ jest(padding-around-after-all-blocks): Missing padding before afterAll block
    ╭─[padding_around_after_all_blocks.tsx:4:1]
  3 │ /* two */

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
@@ -2,6 +2,30 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
+  ⚠ jest(padding-around-test-blocks): Missing padding after test block
+   ╭─[padding_around_test_blocks.tsx:1:22]
+ 1 │ test('foo', () => {});
+   ·                      ▲
+ 2 │ const thing = 123;
+   ╰────
+  help: Make sure there is an empty new line after the test block
+
+  ⚠ jest(padding-around-test-blocks): Missing padding after test block
+   ╭─[padding_around_test_blocks.tsx:1:22]
+ 1 │ test('foo', () => {});
+   ·                      ▲
+ 2 │ // comment
+   ╰────
+  help: Make sure there is an empty new line after the test block
+
+  ⚠ jest(padding-around-test-blocks): Missing padding after test block
+   ╭─[padding_around_test_blocks.tsx:1:22]
+ 1 │ test('foo', () => {}); // trailing comment
+   ·                      ▲
+ 2 │ const thing = 123;
+   ╰────
+  help: Make sure there is an empty new line after the test block
+
   ⚠ jest(padding-around-test-blocks): Missing padding before test block
    ╭─[padding_around_test_blocks.tsx:1:23]
  1 │ test('foo', () => {});test('bar', () => {});
@@ -16,6 +40,23 @@ source: crates/oxc_linter/src/tester.rs
    · ▲
    ╰────
   help: Make sure there is an empty new line before the test block
+
+  ⚠ jest(padding-around-test-blocks): Missing padding before test block
+   ╭─[padding_around_test_blocks.tsx:4:1]
+ 3 │ t('a', () => {});
+ 4 │ t('b', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the test block
+
+  ⚠ jest(padding-around-test-blocks): Missing padding after test block
+   ╭─[padding_around_test_blocks.tsx:4:17]
+ 3 │ // attached
+ 4 │ t('a', () => {});
+   ·                 ▲
+ 5 │ test('local', () => {});
+   ╰────
+  help: Make sure there is an empty new line after the test block
 
   ⚠ jest(padding-around-test-blocks): Missing padding before test block
    ╭─[padding_around_test_blocks.tsx:3:1]

--- a/crates/oxc_linter/src/snapshots/vitest_padding_around_after_all_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_padding_around_after_all_blocks.snap
@@ -10,6 +10,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Make sure there is an empty new line before the afterAll block
 
+  ⚠ vitest(padding-around-after-all-blocks): Missing padding after afterAll block
+   ╭─[padding_around_after_all_blocks.tsx:1:19]
+ 1 │ afterAll(() => {});
+   ·                   ▲
+ 2 │ const thing = 123;
+   ╰────
+  help: Make sure there is an empty new line after the afterAll block
+
   ⚠ vitest(padding-around-after-all-blocks): Missing padding before afterAll block
    ╭─[padding_around_after_all_blocks.tsx:3:1]
  2 │ //My comment

--- a/crates/oxc_linter/src/snapshots/vitest_padding_around_test_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_padding_around_test_blocks.snap
@@ -2,6 +2,14 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
+  ⚠ vitest(padding-around-test-blocks): Missing padding after test block
+   ╭─[padding_around_test_blocks.tsx:1:22]
+ 1 │ test('foo', () => {});
+   ·                      ▲
+ 2 │ const thing = 123;
+   ╰────
+  help: Make sure there is an empty new line after the test block
+
   ⚠ vitest(padding-around-test-blocks): Missing padding before test block
    ╭─[padding_around_test_blocks.tsx:1:23]
  1 │ test('foo', () => {});test('bar', () => {});

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -19,7 +19,9 @@ pub use crate::utils::jest::parse_jest_fn::{
     MemberExpressionElement, ParsedExpectFnCall, ParsedGeneralJestFnCall,
     ParsedJestFnCall as ParsedJestFnCallNew, parse_jest_fn_call,
 };
-pub use padding_around_block::report_missing_padding_before_jest_block;
+pub use padding_around_block::{
+    JestPaddingConfig, JestPaddingTarget, report_missing_padding_around_jest_block,
+};
 
 mod padding_around_block;
 mod parse_jest_fn;

--- a/crates/oxc_linter/src/utils/jest/padding_around_block.rs
+++ b/crates/oxc_linter/src/utils/jest/padding_around_block.rs
@@ -1,44 +1,134 @@
-use oxc_ast::{AstKind, ast::Statement};
+use oxc_ast::{
+    AstKind,
+    ast::{CallExpression, Expression, IdentifierReference, Statement, match_member_expression},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::AstNode;
 use oxc_span::{GetSpan, Span};
 
-use crate::context::LintContext;
+use crate::{
+    context::LintContext,
+    utils::{
+        JestFnKind, JestGeneralFnKind, ParsedGeneralJestFnCall, PossibleJestNode,
+        parse_general_jest_fn_call,
+    },
+};
 
-fn padding_around_jest_block_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Missing padding before {name} block"))
-        .with_help(format!("Make sure there is an empty new line before the {name} block"))
+#[derive(Clone, Copy)]
+pub enum JestPaddingTarget {
+    Hook(&'static str),
+    Test,
+}
+
+#[derive(Clone, Copy)]
+pub struct JestPaddingConfig<'a> {
+    targets: &'a [JestPaddingTarget],
+}
+
+impl<'a> JestPaddingConfig<'a> {
+    pub const fn new(targets: &'a [JestPaddingTarget]) -> Self {
+        Self { targets }
+    }
+
+    fn matches(self, jest_fn_call: &ParsedGeneralJestFnCall) -> bool {
+        self.targets.iter().any(|target| target.matches(jest_fn_call))
+    }
+}
+
+impl JestPaddingTarget {
+    fn matches(self, jest_fn_call: &ParsedGeneralJestFnCall) -> bool {
+        match self {
+            Self::Hook(name) => {
+                jest_fn_call.kind == JestFnKind::General(JestGeneralFnKind::Hook)
+                    && jest_fn_call.name == name
+            }
+            Self::Test => jest_fn_call.kind == JestFnKind::General(JestGeneralFnKind::Test),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum PaddingDirection {
+    Before,
+    After,
+}
+
+struct StatementsAroundNode<'a> {
+    prev: Option<&'a Statement<'a>>,
+    current: &'a Statement<'a>,
+    next: Option<&'a Statement<'a>>,
+}
+
+impl<'a> StatementsAroundNode<'a> {
+    fn into_parts(
+        self,
+    ) -> (Option<&'a Statement<'a>>, &'a Statement<'a>, Option<&'a Statement<'a>>) {
+        (self.prev, self.current, self.next)
+    }
+}
+
+fn padding_around_jest_block_diagnostic(
+    span: Span,
+    name: &str,
+    direction: PaddingDirection,
+) -> OxcDiagnostic {
+    let direction = match direction {
+        PaddingDirection::Before => "before",
+        PaddingDirection::After => "after",
+    };
+    OxcDiagnostic::warn(format!("Missing padding {direction} {name} block"))
+        .with_help(format!("Make sure there is an empty new line {direction} the {name} block"))
         .with_label(span)
 }
 
-pub fn report_missing_padding_before_jest_block<'a>(
+pub fn report_missing_padding_around_jest_block<'a>(
     node: &AstNode<'a>,
     ctx: &LintContext<'a>,
     name: &str,
+    config: JestPaddingConfig<'_>,
 ) {
-    let scope_node = ctx.nodes().get_node(ctx.scoping().get_node_id(node.scope_id()));
-    let prev_statement_span = match scope_node.kind() {
-        AstKind::Program(program) => get_statement_span_before_node(node, program.body.as_slice()),
-        AstKind::ArrowFunctionExpression(arrow_func_expr) => {
-            let Some(body) = arrow_func_expr.get_function_body() else { return };
-            get_statement_span_before_node(node, body.statements.as_slice())
-        }
-        AstKind::Function(function) => {
-            let Some(body) = &function.body else {
-                return;
-            };
-            get_statement_span_before_node(node, body.statements.as_slice())
-        }
-        _ => None,
-    };
-    let Some(prev_statement_span) = prev_statement_span else {
+    let Some(statements) = get_statements_around_node(node, ctx) else {
         return;
     };
+    let (prev_statement, current_statement, next_statement) = statements.into_parts();
 
-    let comments_range = ctx.comments_range(prev_statement_span.end..node.span().start);
+    if let Some(prev_statement) = prev_statement {
+        report_missing_padding_between_statements(
+            prev_statement.span(),
+            node.span(),
+            Span::new(node.span().start, node.span().start),
+            ctx,
+            name,
+            PaddingDirection::Before,
+        );
+    }
+
+    if let Some(next_statement) = next_statement
+        && !is_padding_target_statement(next_statement, ctx, config)
+    {
+        report_missing_padding_between_statements(
+            current_statement.span(),
+            next_statement.span(),
+            Span::new(node.span().end, node.span().end),
+            ctx,
+            name,
+            PaddingDirection::After,
+        );
+    }
+}
+
+fn report_missing_padding_between_statements(
+    prev_statement_span: Span,
+    next_statement_span: Span,
+    report_span: Span,
+    ctx: &LintContext,
+    name: &str,
+    direction: PaddingDirection,
+) {
+    let comments_range = ctx.comments_range(prev_statement_span.end..next_statement_span.start);
     let mut span_between_start = prev_statement_span.end;
-    let mut span_between_end = node.span().start;
-    let mut next_attached_start = node.span().start;
+    let mut span_between_end = next_statement_span.start;
+    let mut next_attached_start = next_statement_span.start;
     for comment in comments_range.rev() {
         let comment_span = comment.span;
         let space_after = ctx.source_range(Span::new(comment_span.end, next_attached_start));
@@ -58,10 +148,7 @@ pub fn report_missing_padding_before_jest_block<'a>(
     let content = ctx.source_range(span_between);
     if content.matches('\n').count() < 2 {
         ctx.diagnostic_with_fix(
-            padding_around_jest_block_diagnostic(
-                Span::new(node.span().start, node.span().start),
-                name,
-            ),
+            padding_around_jest_block_diagnostic(report_span, name, direction),
             |fixer| {
                 let whitespace_after_last_line =
                     content.rfind('\n').map_or("", |index| content.split_at(index + 1).1);
@@ -71,11 +158,111 @@ pub fn report_missing_padding_before_jest_block<'a>(
     }
 }
 
-fn get_statement_span_before_node(node: &AstNode, statements: &[Statement]) -> Option<Span> {
-    statements
-        .iter()
-        .filter_map(|statement| {
-            if statement.span().end <= node.span().start { Some(statement.span()) } else { None }
-        })
-        .next_back()
+fn is_padding_target_statement<'a>(
+    statement: &Statement<'a>,
+    ctx: &LintContext<'a>,
+    config: JestPaddingConfig<'_>,
+) -> bool {
+    let Statement::ExpressionStatement(expr_stmt) = statement else {
+        return false;
+    };
+    let Expression::CallExpression(call_expr) = &expr_stmt.expression else {
+        return false;
+    };
+    let AstKind::CallExpression(call_expr) = ctx.nodes().get_node(call_expr.node_id()).kind()
+    else {
+        return false;
+    };
+    let Some(possible_jest_node) = get_possible_jest_node_for_call_expression(call_expr, ctx)
+    else {
+        return false;
+    };
+    let Some(jest_fn_call) = parse_general_jest_fn_call(call_expr, &possible_jest_node, ctx) else {
+        return false;
+    };
+
+    config.matches(&jest_fn_call)
+}
+
+fn get_possible_jest_node_for_call_expression<'a, 'c>(
+    call_expr: &'a CallExpression<'a>,
+    ctx: &'c LintContext<'a>,
+) -> Option<PossibleJestNode<'a, 'c>> {
+    let ident = resolve_first_ident(&call_expr.callee)?;
+    let reference_id = ident.reference_id.get()?;
+    let reference = ctx.scoping().get_reference(reference_id);
+    let original = if let Some(symbol_id) = reference.symbol_id() {
+        if !ctx.scoping().symbol_flags(symbol_id).is_import() {
+            return None;
+        }
+        let declaration_id = ctx.scoping().symbol_declaration(symbol_id);
+        let AstKind::ImportDeclaration(import_decl) = ctx.nodes().parent_kind(declaration_id)
+        else {
+            return None;
+        };
+        if !matches!(
+            import_decl.source.value.as_str(),
+            "@jest/globals" | "vitest" | "vite-plus/test" | "@effect/vitest"
+        ) {
+            return None;
+        }
+        let name = ctx.scoping().symbol_name(symbol_id);
+        super::find_original_name(import_decl, name)
+    } else {
+        if !super::JEST_METHOD_NAMES.contains(&ident.name.as_str()) {
+            return None;
+        }
+        None
+    };
+
+    Some(PossibleJestNode { node: ctx.nodes().get_node(call_expr.node_id()), original })
+}
+
+fn resolve_first_ident<'a>(expr: &'a Expression<'a>) -> Option<&'a IdentifierReference<'a>> {
+    match expr {
+        Expression::Identifier(ident) => Some(ident),
+        match_member_expression!(Expression) => {
+            resolve_first_ident(expr.to_member_expression().object())
+        }
+        Expression::CallExpression(call_expr) => resolve_first_ident(&call_expr.callee),
+        Expression::TaggedTemplateExpression(tagged_expr) => resolve_first_ident(&tagged_expr.tag),
+        _ => None,
+    }
+}
+
+fn get_statements_around_node<'a>(
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+) -> Option<StatementsAroundNode<'a>> {
+    let scope_node = ctx.nodes().get_node(ctx.scoping().get_node_id(node.scope_id()));
+    match scope_node.kind() {
+        AstKind::Program(program) => {
+            get_statements_around_node_from_statements(node, program.body.as_slice())
+        }
+        AstKind::ArrowFunctionExpression(arrow_func_expr) => {
+            let body = arrow_func_expr.get_function_body()?;
+            get_statements_around_node_from_statements(node, body.statements.as_slice())
+        }
+        AstKind::Function(function) => {
+            let body = function.body.as_ref()?;
+            get_statements_around_node_from_statements(node, body.statements.as_slice())
+        }
+        _ => None,
+    }
+}
+
+fn get_statements_around_node_from_statements<'a>(
+    node: &AstNode<'a>,
+    statements: &'a [Statement<'a>],
+) -> Option<StatementsAroundNode<'a>> {
+    let index = statements.iter().position(|statement| {
+        let statement_span = statement.span();
+        statement_span.start <= node.span().start && node.span().end <= statement_span.end
+    })?;
+
+    Some(StatementsAroundNode {
+        prev: index.checked_sub(1).map(|index| &statements[index]),
+        current: &statements[index],
+        next: statements.get(index + 1),
+    })
 }


### PR DESCRIPTION
 Fixes #25590

## Summary

  The existing Jest and Vitest implementations of
  `padding-around-after-all-blocks` and `padding-around-test-blocks` only
  enforced padding before matched statements, although their documentation
  requires padding both before and after.

  This change:

  - checks the gap after matched statements;
  - reports each gap once when matching statements are consecutive by letting
    the later statement's before check own the shared gap;
  - preserves comment-aware fixes, including trailing comments;
  - uses semantic Jest/Vitest call parsing for imported aliases and avoids
    treating locally shadowed functions as adjacent padding targets.

  No rule names, configuration, or default enablement are changed.

  Related to #492 and #4656.
  This overlaps with the padding helper work in #21994 and #23286.

  ## AI usage disclosure

  OpenAI Codex was used to investigate the existing Oxc and
  eslint-plugin-jest implementations, discuss the design and edge cases,
  edit the Rust implementation and tests, and draft this PR description.

  I manually reviewed and understand the final changes and test results,
  and I take full responsibility for this contribution.


 ## Changes

  ### Helper changes (`utils/jest/padding_around_block.rs`)

  Replaced `report_missing_padding_before_jest_block` with
  `report_missing_padding_around_jest_block`, which checks both the preceding and
  following statement gaps.

  Introduced `JestPaddingConfig` and `JestPaddingTarget` to describe which Jest or
  Vitest calls belong to the same padding rule.

  Added `StatementsAroundNode` and statement lookup helpers to locate the
  previous, current, and next statements in one pass. The current statement span
  is used for the after check so the padding is inserted after the complete
  statement, including its trailing semicolon.

  Added `report_missing_padding_between_statements` to share the comment-aware
  padding detection, diagnostic, and fixer logic between the before and after
  directions.

  When the next statement is also a target of the same padding rule, the current
  statement's after check is skipped. The next target's before check owns that
  gap, preventing duplicate diagnostics and overlapping fixes.

  Adjacent target detection uses the existing semantic Jest/Vitest call parser,
  supporting imported aliases while excluding locally shadowed functions.

  ### Existing rule updates

  `jest/padding-around-after-all-blocks` and
  `vitest/padding-around-after-all-blocks` now enforce blank lines both before and
  after `afterAll(...)` statements, matching their documented behavior.

  `jest/padding-around-test-blocks` and
  `vitest/padding-around-test-blocks` now enforce blank lines after test
  statements as well as before them.

  ### Tests

  Added coverage for:

  - missing and existing padding after matched statements;
  - consecutive targets producing one diagnostic per gap;
  - imported Jest aliases and locally shadowed functions;
  - comments attached to the following statement;
  - trailing comments remaining attached to the preceding target during fixes.

