### PR TITLE
feat(linter): implement unicorn/no-optional-chaining-on-undeclared-variable

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1565,6 +1565,7 @@ export interface DummyRuleMap {
   "unicorn/no-new-buffer"?: RuleNoConfig;
   "unicorn/no-null"?: RuleNoConfig | [AllowWarnDeny, NoNull];
   "unicorn/no-object-as-default-parameter"?: RuleNoConfig;
+  "unicorn/no-optional-chaining-on-undeclared-variable"?: RuleNoConfig;
   "unicorn/no-process-exit"?: RuleNoConfig;
   "unicorn/no-single-promise-in-promise-methods"?: RuleNoConfig;
   "unicorn/no-static-only-class"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3301,6 +3301,11 @@ impl RuleRunner
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::no_optional_chaining_on_undeclared_variable::NoOptionalChainingOnUndeclaredVariable {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::unicorn::no_process_exit::NoProcessExit {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -649,6 +649,7 @@ pub use crate::rules::unicorn::no_new_array::NoNewArray as UnicornNoNewArray;
 pub use crate::rules::unicorn::no_new_buffer::NoNewBuffer as UnicornNoNewBuffer;
 pub use crate::rules::unicorn::no_null::NoNull as UnicornNoNull;
 pub use crate::rules::unicorn::no_object_as_default_parameter::NoObjectAsDefaultParameter as UnicornNoObjectAsDefaultParameter;
+pub use crate::rules::unicorn::no_optional_chaining_on_undeclared_variable::NoOptionalChainingOnUndeclaredVariable as UnicornNoOptionalChainingOnUndeclaredVariable;
 pub use crate::rules::unicorn::no_process_exit::NoProcessExit as UnicornNoProcessExit;
 pub use crate::rules::unicorn::no_single_promise_in_promise_methods::NoSinglePromiseInPromiseMethods as UnicornNoSinglePromiseInPromiseMethods;
 pub use crate::rules::unicorn::no_static_only_class::NoStaticOnlyClass as UnicornNoStaticOnlyClass;
@@ -1375,6 +1376,7 @@ pub enum RuleEnum {
     UnicornNoNewBuffer(UnicornNoNewBuffer),
     UnicornNoNull(UnicornNoNull),
     UnicornNoObjectAsDefaultParameter(UnicornNoObjectAsDefaultParameter),
+    UnicornNoOptionalChainingOnUndeclaredVariable(UnicornNoOptionalChainingOnUndeclaredVariable),
     UnicornNoProcessExit(UnicornNoProcessExit),
     UnicornNoSinglePromiseInPromiseMethods(UnicornNoSinglePromiseInPromiseMethods),
     UnicornNoStaticOnlyClass(UnicornNoStaticOnlyClass),
@@ -2290,7 +2292,10 @@ const UNICORN_NO_NEW_ARRAY_ID: usize = UNICORN_NO_NESTED_TERNARY_ID + 1usize;
 const UNICORN_NO_NEW_BUFFER_ID: usize = UNICORN_NO_NEW_ARRAY_ID + 1usize;
 const UNICORN_NO_NULL_ID: usize = UNICORN_NO_NEW_BUFFER_ID + 1usize;
 const UNICORN_NO_OBJECT_AS_DEFAULT_PARAMETER_ID: usize = UNICORN_NO_NULL_ID + 1usize;
-const UNICORN_NO_PROCESS_EXIT_ID: usize = UNICORN_NO_OBJECT_AS_DEFAULT_PARAMETER_ID + 1usize;
+const UNICORN_NO_OPTIONAL_CHAINING_ON_UNDECLARED_VARIABLE_ID: usize =
+    UNICORN_NO_OBJECT_AS_DEFAULT_PARAMETER_ID + 1usize;
+const UNICORN_NO_PROCESS_EXIT_ID: usize =
+    UNICORN_NO_OPTIONAL_CHAINING_ON_UNDECLARED_VARIABLE_ID + 1usize;
 const UNICORN_NO_SINGLE_PROMISE_IN_PROMISE_METHODS_ID: usize = UNICORN_NO_PROCESS_EXIT_ID + 1usize;
 const UNICORN_NO_STATIC_ONLY_CLASS_ID: usize =
     UNICORN_NO_SINGLE_PROMISE_IN_PROMISE_METHODS_ID + 1usize;
@@ -3272,6 +3277,9 @@ impl RuleEnum {
             Self::UnicornNoNewBuffer(_) => UNICORN_NO_NEW_BUFFER_ID,
             Self::UnicornNoNull(_) => UNICORN_NO_NULL_ID,
             Self::UnicornNoObjectAsDefaultParameter(_) => UNICORN_NO_OBJECT_AS_DEFAULT_PARAMETER_ID,
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(_) => {
+                UNICORN_NO_OPTIONAL_CHAINING_ON_UNDECLARED_VARIABLE_ID
+            }
             Self::UnicornNoProcessExit(_) => UNICORN_NO_PROCESS_EXIT_ID,
             Self::UnicornNoSinglePromiseInPromiseMethods(_) => {
                 UNICORN_NO_SINGLE_PROMISE_IN_PROMISE_METHODS_ID
@@ -4247,6 +4255,9 @@ impl RuleEnum {
             Self::UnicornNoNewBuffer(_) => UnicornNoNewBuffer::NAME,
             Self::UnicornNoNull(_) => UnicornNoNull::NAME,
             Self::UnicornNoObjectAsDefaultParameter(_) => UnicornNoObjectAsDefaultParameter::NAME,
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(_) => {
+                UnicornNoOptionalChainingOnUndeclaredVariable::NAME
+            }
             Self::UnicornNoProcessExit(_) => UnicornNoProcessExit::NAME,
             Self::UnicornNoSinglePromiseInPromiseMethods(_) => {
                 UnicornNoSinglePromiseInPromiseMethods::NAME
@@ -5242,6 +5253,9 @@ impl RuleEnum {
             Self::UnicornNoObjectAsDefaultParameter(_) => {
                 UnicornNoObjectAsDefaultParameter::CATEGORY
             }
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(_) => {
+                UnicornNoOptionalChainingOnUndeclaredVariable::CATEGORY
+            }
             Self::UnicornNoProcessExit(_) => UnicornNoProcessExit::CATEGORY,
             Self::UnicornNoSinglePromiseInPromiseMethods(_) => {
                 UnicornNoSinglePromiseInPromiseMethods::CATEGORY
@@ -6236,6 +6250,9 @@ impl RuleEnum {
             Self::UnicornNoNewBuffer(_) => UnicornNoNewBuffer::FIX,
             Self::UnicornNoNull(_) => UnicornNoNull::FIX,
             Self::UnicornNoObjectAsDefaultParameter(_) => UnicornNoObjectAsDefaultParameter::FIX,
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(_) => {
+                UnicornNoOptionalChainingOnUndeclaredVariable::FIX
+            }
             Self::UnicornNoProcessExit(_) => UnicornNoProcessExit::FIX,
             Self::UnicornNoSinglePromiseInPromiseMethods(_) => {
                 UnicornNoSinglePromiseInPromiseMethods::FIX
@@ -7341,6 +7358,9 @@ impl RuleEnum {
             Self::UnicornNoNull(_) => UnicornNoNull::documentation(),
             Self::UnicornNoObjectAsDefaultParameter(_) => {
                 UnicornNoObjectAsDefaultParameter::documentation()
+            }
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(_) => {
+                UnicornNoOptionalChainingOnUndeclaredVariable::documentation()
             }
             Self::UnicornNoProcessExit(_) => UnicornNoProcessExit::documentation(),
             Self::UnicornNoSinglePromiseInPromiseMethods(_) => {
@@ -9296,6 +9316,10 @@ impl RuleEnum {
                 UnicornNoObjectAsDefaultParameter::config_schema(generator)
                     .or_else(|| UnicornNoObjectAsDefaultParameter::schema(generator))
             }
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(_) => {
+                UnicornNoOptionalChainingOnUndeclaredVariable::config_schema(generator)
+                    .or_else(|| UnicornNoOptionalChainingOnUndeclaredVariable::schema(generator))
+            }
             Self::UnicornNoProcessExit(_) => UnicornNoProcessExit::config_schema(generator)
                 .or_else(|| UnicornNoProcessExit::schema(generator)),
             Self::UnicornNoSinglePromiseInPromiseMethods(_) => {
@@ -10796,6 +10820,7 @@ impl RuleEnum {
             Self::UnicornNoNewBuffer(_) => "unicorn",
             Self::UnicornNoNull(_) => "unicorn",
             Self::UnicornNoObjectAsDefaultParameter(_) => "unicorn",
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(_) => "unicorn",
             Self::UnicornNoProcessExit(_) => "unicorn",
             Self::UnicornNoSinglePromiseInPromiseMethods(_) => "unicorn",
             Self::UnicornNoStaticOnlyClass(_) => "unicorn",
@@ -12774,6 +12799,11 @@ impl RuleEnum {
                     UnicornNoObjectAsDefaultParameter::from_configuration(value)?,
                 ))
             }
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(_) => {
+                Ok(Self::UnicornNoOptionalChainingOnUndeclaredVariable(
+                    UnicornNoOptionalChainingOnUndeclaredVariable::from_configuration(value)?,
+                ))
+            }
             Self::UnicornNoProcessExit(_) => {
                 Ok(Self::UnicornNoProcessExit(UnicornNoProcessExit::from_configuration(value)?))
             }
@@ -14383,6 +14413,7 @@ impl RuleEnum {
             Self::UnicornNoNewBuffer(rule) => rule.to_configuration(),
             Self::UnicornNoNull(rule) => rule.to_configuration(),
             Self::UnicornNoObjectAsDefaultParameter(rule) => rule.to_configuration(),
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(rule) => rule.to_configuration(),
             Self::UnicornNoProcessExit(rule) => rule.to_configuration(),
             Self::UnicornNoSinglePromiseInPromiseMethods(rule) => rule.to_configuration(),
             Self::UnicornNoStaticOnlyClass(rule) => rule.to_configuration(),
@@ -15237,6 +15268,7 @@ impl RuleEnum {
             Self::UnicornNoNewBuffer(rule) => rule.run(node, ctx),
             Self::UnicornNoNull(rule) => rule.run(node, ctx),
             Self::UnicornNoObjectAsDefaultParameter(rule) => rule.run(node, ctx),
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(rule) => rule.run(node, ctx),
             Self::UnicornNoProcessExit(rule) => rule.run(node, ctx),
             Self::UnicornNoSinglePromiseInPromiseMethods(rule) => rule.run(node, ctx),
             Self::UnicornNoStaticOnlyClass(rule) => rule.run(node, ctx),
@@ -16101,6 +16133,7 @@ impl RuleEnum {
             Self::UnicornNoNewBuffer(rule) => rule.run_once(ctx),
             Self::UnicornNoNull(rule) => rule.run_once(ctx),
             Self::UnicornNoObjectAsDefaultParameter(rule) => rule.run_once(ctx),
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(rule) => rule.run_once(ctx),
             Self::UnicornNoProcessExit(rule) => rule.run_once(ctx),
             Self::UnicornNoSinglePromiseInPromiseMethods(rule) => rule.run_once(ctx),
             Self::UnicornNoStaticOnlyClass(rule) => rule.run_once(ctx),
@@ -17046,6 +17079,9 @@ impl RuleEnum {
             Self::UnicornNoNewBuffer(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoNull(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoObjectAsDefaultParameter(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
             Self::UnicornNoProcessExit(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoSinglePromiseInPromiseMethods(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
@@ -17947,6 +17983,7 @@ impl RuleEnum {
             Self::UnicornNoNewBuffer(rule) => rule.should_run(ctx),
             Self::UnicornNoNull(rule) => rule.should_run(ctx),
             Self::UnicornNoObjectAsDefaultParameter(rule) => rule.should_run(ctx),
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(rule) => rule.should_run(ctx),
             Self::UnicornNoProcessExit(rule) => rule.should_run(ctx),
             Self::UnicornNoSinglePromiseInPromiseMethods(rule) => rule.should_run(ctx),
             Self::UnicornNoStaticOnlyClass(rule) => rule.should_run(ctx),
@@ -19015,6 +19052,9 @@ impl RuleEnum {
             Self::UnicornNoNull(_) => UnicornNoNull::IS_TSGOLINT_RULE,
             Self::UnicornNoObjectAsDefaultParameter(_) => {
                 UnicornNoObjectAsDefaultParameter::IS_TSGOLINT_RULE
+            }
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(_) => {
+                UnicornNoOptionalChainingOnUndeclaredVariable::IS_TSGOLINT_RULE
             }
             Self::UnicornNoProcessExit(_) => UnicornNoProcessExit::IS_TSGOLINT_RULE,
             Self::UnicornNoSinglePromiseInPromiseMethods(_) => {
@@ -20141,6 +20181,9 @@ impl RuleEnum {
             Self::UnicornNoObjectAsDefaultParameter(_) => {
                 UnicornNoObjectAsDefaultParameter::VERSION
             }
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(_) => {
+                UnicornNoOptionalChainingOnUndeclaredVariable::VERSION
+            }
             Self::UnicornNoProcessExit(_) => UnicornNoProcessExit::VERSION,
             Self::UnicornNoSinglePromiseInPromiseMethods(_) => {
                 UnicornNoSinglePromiseInPromiseMethods::VERSION
@@ -21189,6 +21232,9 @@ impl RuleEnum {
             Self::UnicornNoObjectAsDefaultParameter(_) => {
                 UnicornNoObjectAsDefaultParameter::HAS_CONFIG
             }
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(_) => {
+                UnicornNoOptionalChainingOnUndeclaredVariable::HAS_CONFIG
+            }
             Self::UnicornNoProcessExit(_) => UnicornNoProcessExit::HAS_CONFIG,
             Self::UnicornNoSinglePromiseInPromiseMethods(_) => {
                 UnicornNoSinglePromiseInPromiseMethods::HAS_CONFIG
@@ -22200,6 +22246,9 @@ impl RuleEnum {
             Self::UnicornNoNewBuffer(_) => UnicornNoNewBuffer::INFO,
             Self::UnicornNoNull(_) => UnicornNoNull::INFO,
             Self::UnicornNoObjectAsDefaultParameter(_) => UnicornNoObjectAsDefaultParameter::INFO,
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(_) => {
+                UnicornNoOptionalChainingOnUndeclaredVariable::INFO
+            }
             Self::UnicornNoProcessExit(_) => UnicornNoProcessExit::INFO,
             Self::UnicornNoSinglePromiseInPromiseMethods(_) => {
                 UnicornNoSinglePromiseInPromiseMethods::INFO
@@ -23092,6 +23141,7 @@ impl RuleEnum {
             Self::UnicornNoNewBuffer(rule) => rule.types_info(),
             Self::UnicornNoNull(rule) => rule.types_info(),
             Self::UnicornNoObjectAsDefaultParameter(rule) => rule.types_info(),
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(rule) => rule.types_info(),
             Self::UnicornNoProcessExit(rule) => rule.types_info(),
             Self::UnicornNoSinglePromiseInPromiseMethods(rule) => rule.types_info(),
             Self::UnicornNoStaticOnlyClass(rule) => rule.types_info(),
@@ -23943,6 +23993,7 @@ impl RuleEnum {
             Self::UnicornNoNewBuffer(rule) => rule.run_info(),
             Self::UnicornNoNull(rule) => rule.run_info(),
             Self::UnicornNoObjectAsDefaultParameter(rule) => rule.run_info(),
+            Self::UnicornNoOptionalChainingOnUndeclaredVariable(rule) => rule.run_info(),
             Self::UnicornNoProcessExit(rule) => rule.run_info(),
             Self::UnicornNoSinglePromiseInPromiseMethods(rule) => rule.run_info(),
             Self::UnicornNoStaticOnlyClass(rule) => rule.run_info(),
@@ -24894,6 +24945,9 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornNoNewBuffer(UnicornNoNewBuffer::default()),
         RuleEnum::UnicornNoNull(UnicornNoNull::default()),
         RuleEnum::UnicornNoObjectAsDefaultParameter(UnicornNoObjectAsDefaultParameter::default()),
+        RuleEnum::UnicornNoOptionalChainingOnUndeclaredVariable(
+            UnicornNoOptionalChainingOnUndeclaredVariable::default(),
+        ),
         RuleEnum::UnicornNoProcessExit(UnicornNoProcessExit::default()),
         RuleEnum::UnicornNoSinglePromiseInPromiseMethods(
             UnicornNoSinglePromiseInPromiseMethods::default(),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -535,6 +535,7 @@ pub(crate) mod unicorn {
     pub mod no_new_buffer;
     pub mod no_null;
     pub mod no_object_as_default_parameter;
+    pub mod no_optional_chaining_on_undeclared_variable;
     pub mod no_process_exit;
     pub mod no_single_promise_in_promise_methods;
     pub mod no_static_only_class;

--- a/crates/oxc_linter/src/rules/unicorn/no_optional_chaining_on_undeclared_variable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_optional_chaining_on_undeclared_variable.rs
@@ -1,0 +1,194 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::NodeId;
+use oxc_span::{GetSpan, Span};
+
+use crate::{context::LintContext, rule::Rule};
+
+fn no_optional_chaining_on_undeclared_variable_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Optional chaining on undeclared variable `{name}` throws a ReferenceError."
+    ))
+    .with_help(format!("Declare `{name}` before using optional chaining."))
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoOptionalChainingOnUndeclaredVariable;
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows optional chaining on undeclared variables.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Optional chaining only guards against `null` and `undefined` values. It does not guard
+    /// against an undeclared root variable, which throws a `ReferenceError` before the chain is
+    /// evaluated.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// undeclared?.property;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// let declared;
+    /// declared?.property;
+    /// ```
+    NoOptionalChainingOnUndeclaredVariable,
+    unicorn,
+    correctness,
+    none,
+    version = "next",
+    short_description = "Disallow optional chaining on undeclared variables.",
+);
+
+impl Rule for NoOptionalChainingOnUndeclaredVariable {
+    fn run_once(&self, ctx: &LintContext) {
+        for reference_ids in ctx.scoping().root_unresolved_references_ids() {
+            for reference_id in reference_ids {
+                let reference = ctx.scoping().get_reference(reference_id);
+                if reference.is_type() {
+                    continue;
+                }
+
+                let name = ctx.semantic().reference_name(reference);
+                if ctx.is_global_defined(name) {
+                    continue;
+                }
+
+                let node = ctx.nodes().get_node(reference.node_id());
+                if is_optional_chain_root(node.id(), ctx) {
+                    ctx.diagnostic(no_optional_chaining_on_undeclared_variable_diagnostic(
+                        name,
+                        node.kind().span(),
+                    ));
+                }
+            }
+        }
+    }
+}
+
+fn is_optional_chain_root(mut node_id: NodeId, ctx: &LintContext) -> bool {
+    let mut has_optional_operation = false;
+
+    loop {
+        let node = ctx.nodes().get_node(node_id);
+        let parent = ctx.nodes().parent_node(node_id);
+
+        match parent.kind() {
+            kind if kind.is_member_expression_kind() => {
+                let member = kind.as_member_expression_kind().unwrap();
+                if !member.object().span().contains_inclusive(node.kind().span()) {
+                    return false;
+                }
+                has_optional_operation |= member.optional();
+            }
+            AstKind::CallExpression(call) => {
+                if !call.callee.span().contains_inclusive(node.kind().span()) {
+                    return false;
+                }
+                // A non-optional call before the optional operation produces a value. The
+                // identifier used to call it is not the base guarded by optional chaining.
+                if !call.optional && !has_optional_operation {
+                    return false;
+                }
+                has_optional_operation |= call.optional;
+            }
+            AstKind::ParenthesizedExpression(_)
+            | AstKind::TSAsExpression(_)
+            | AstKind::TSSatisfiesExpression(_)
+            | AstKind::TSInstantiationExpression(_)
+            | AstKind::TSNonNullExpression(_) => {}
+            AstKind::ChainExpression(_) => return has_optional_operation,
+            _ => return false,
+        }
+
+        node_id = parent.id();
+    }
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::{TestCase, Tester};
+
+    let pass: Vec<TestCase> = vec![
+        "let foo; foo?.bar;".into(),
+        "function fn(foo) { foo?.(); }".into(),
+        ("foo?.bar;", None, Some(json!({ "globals": { "foo": "readonly" } }))).into(),
+        "globalThis.foo?.bar;".into(),
+        "globalThis.foo?.();".into(),
+        "getFoo()?.bar;".into(),
+        "(foo || bar)?.baz;".into(),
+        "this?.foo;".into(),
+        "foo().bar?.baz;".into(),
+        "let foo = {}; let bar; foo[bar]?.baz;".into(),
+        "let foo; let bar; foo?.[bar];".into(),
+        "let foo; let bar; foo?.(bar);".into(),
+        "class Foo extends Bar {
+                method() {
+                    super.foo?.();
+                }
+            }"
+        .into(),
+        "let foo;
+            function fn() {
+                foo?.bar;
+            }"
+        .into(),
+        "let foo; (foo?.bar as Foo)?.baz;".into(),
+        "let foo; (foo<string>)?.bar;".into(),
+        r#"import {foo} from "foo"; foo?.bar;"#.into(),
+        "type foo = {}; const foo = {}; foo?.bar;".into(),
+        ("type foo = {}; foo?.bar;", None, Some(json!({ "globals": { "foo": "readonly" } })))
+            .into(),
+    ];
+
+    let fail: Vec<TestCase> = vec![
+        "foo?.bar;",
+        "foo?.();",
+        "foo?.bar();",
+        "foo?.bar?.baz;",
+        "foo.bar?.();",
+        "foo.bar?.baz;",
+        "foo?.().bar?.baz;",
+        "foo?.bar().baz?.qux;",
+        "(foo?.bar)?.baz;",
+        "(foo?.bar)?.();",
+        "foo[bar]?.baz;",
+        "foo?.[bar];",
+        "function fn() {
+                foo?.bar;
+            }",
+        "(foo as Foo)?.bar;",         // {"parser": parsers.typescript},
+        "foo!.bar?.();",              // {"parser": parsers.typescript},
+        "(foo?.bar as Foo)?.baz;",    // {"parser": parsers.typescript},
+        "(foo<string>)?.bar;",        // {"parser": parsers.typescript},
+        "(foo<string>)?.();",         // {"parser": parsers.typescript},
+        "(foo<string>).bar?.baz;",    // {"parser": parsers.typescript},
+        "type foo = {}; foo?.bar;",   // {"parser": parsers.typescript},
+        "interface foo {} foo?.bar;", // {"parser": parsers.typescript},
+        r#"import type {foo} from "foo"; foo?.bar;"#, // {"parser": parsers.typescript},
+        r#"import {type foo} from "foo"; foo.bar?.baz;"#, // {"parser": parsers.typescript}
+    ]
+    .into_iter()
+    .map(Into::into)
+    .collect();
+
+    Tester::new(
+        NoOptionalChainingOnUndeclaredVariable::NAME,
+        NoOptionalChainingOnUndeclaredVariable::PLUGIN,
+        pass,
+        fail,
+    )
+    .change_rule_path_extension("ts")
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_no_optional_chaining_on_undeclared_variable.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_optional_chaining_on_undeclared_variable.snap
@@ -1,0 +1,166 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:1]
+ 1 │ foo?.bar;
+   · ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:1]
+ 1 │ foo?.();
+   · ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:1]
+ 1 │ foo?.bar();
+   · ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:1]
+ 1 │ foo?.bar?.baz;
+   · ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:1]
+ 1 │ foo.bar?.();
+   · ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:1]
+ 1 │ foo.bar?.baz;
+   · ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:1]
+ 1 │ foo?.().bar?.baz;
+   · ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:1]
+ 1 │ foo?.bar().baz?.qux;
+   · ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:2]
+ 1 │ (foo?.bar)?.baz;
+   ·  ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:2]
+ 1 │ (foo?.bar)?.();
+   ·  ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:1]
+ 1 │ foo[bar]?.baz;
+   · ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:1]
+ 1 │ foo?.[bar];
+   · ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:2:17]
+ 1 │ function fn() {
+ 2 │                 foo?.bar;
+   ·                 ───
+ 3 │             }
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:2]
+ 1 │ (foo as Foo)?.bar;
+   ·  ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:1]
+ 1 │ foo!.bar?.();
+   · ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:2]
+ 1 │ (foo?.bar as Foo)?.baz;
+   ·  ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:2]
+ 1 │ (foo<string>)?.bar;
+   ·  ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:2]
+ 1 │ (foo<string>)?.();
+   ·  ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:2]
+ 1 │ (foo<string>).bar?.baz;
+   ·  ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:16]
+ 1 │ type foo = {}; foo?.bar;
+   ·                ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:18]
+ 1 │ interface foo {} foo?.bar;
+   ·                  ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:31]
+ 1 │ import type {foo} from "foo"; foo?.bar;
+   ·                               ───
+   ╰────
+  help: Declare `foo` before using optional chaining.
+
+  ⚠ unicorn(no-optional-chaining-on-undeclared-variable): Optional chaining on undeclared variable `foo` throws a ReferenceError.
+   ╭─[no_optional_chaining_on_undeclared_variable.ts:1:31]
+ 1 │ import {type foo} from "foo"; foo.bar?.baz;
+   ·                               ───
+   ╰────
+  help: Declare `foo` before using optional chaining.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9059,6 +9059,9 @@
         "unicorn/no-object-as-default-parameter": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/no-optional-chaining-on-undeclared-variable": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "unicorn/no-process-exit": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -572,6 +572,7 @@ unicorn/no-new-array                                       |   1421
 unicorn/no-new-buffer                                      |   1421
 unicorn/no-null                                            |   2492
 unicorn/no-object-as-default-parameter                     |  24806
+unicorn/no-optional-chaining-on-undeclared-variable        |      7
 unicorn/no-process-exit                                    |  62606
 unicorn/no-single-promise-in-promise-methods               |  62606
 unicorn/no-static-only-class                               |    300


### PR DESCRIPTION
Closes #684

## Summary

Implements `unicorn/no-optional-chaining-on-undeclared-variable`, matching the current eslint-plugin-unicorn rule behavior. Optional chaining does not suppress the `ReferenceError` raised by an undeclared root binding, so the rule reports that root while respecting lexical bindings, configured/environment globals, type-only declarations, and call boundaries.

The implementation is a once-per-file semantic pass over unresolved runtime references. It has no fixer because declaring or otherwise replacing the missing binding requires program-specific intent.

## Validation

- `cargo test -p oxc_linter no_optional_chaining_on_undeclared_variable` — passed (19 pass cases, 23 fail cases)
- `PATH=/opt/homebrew/Cellar/node@24/24.13.1/bin:$PATH just fmt` — passed
- `cargo lintgen` — passed; generated rule registry/schema refreshed
- `cargo lint-timings` — passed; timing snapshot refreshed
- `cargo ck -p oxc_linter` — passed
- `CARGO_BUILD_WARNINGS=deny cargo lint -p oxc_linter` — passed
- `git diff --check` — passed

Tests are derived from the upstream rule suite and cover nested/member/call chains, computed properties, scoped and imported bindings, configured globals, built-in globals, TypeScript assertions/instantiations, and type-only declarations/imports.

## Risk and rollback

Risk is limited to a new opt-in rule and generated registration/config artifacts. Reverting commit `77d06c2ed9` fully removes it.

## AI disclosure

AI assistance was used to research the upstream rule, implement the initial patch, and run validation. I reviewed the resulting logic, tests, diagnostics, generated changes, and command outcomes before submission.