### PR TITLE
perf(oxfmt): spawn tinypool lazily

### DIFF
--- a/apps/oxfmt/src-js/cli/worker-proxy.ts
+++ b/apps/oxfmt/src-js/cli/worker-proxy.ts
@@ -10,21 +10,29 @@ import type {
 
 // Worker pool for parallel Prettier formatting
 let pool: Tinypool | null = null;
+let poolSize: number | null = null;
 
 export async function initExternalFormatter(numThreads: number): Promise<void> {
   // In LSP mode, this can be called repeatedly for the lifetime of the process.
   // e.g. on every workspace folder build, config-triggered rebuild, etc
-  // The pool is a process-wide singleton shared across workspace folders,
-  // so reuse it instead of creating a new one, which would leak the previous pool's `child_process`.
+  // The process-wide pool must never be recreated or destroyed on re-init:
+  // that leaks the previous `child_process` workers, and other workspace folders may have formats in-flight.
   // (https://github.com/oxc-project/oxc/issues/24147)
-  // Destroying here is not safe either: another workspace folder may have formats in-flight.
-  // NOTE: `numThreads` never changes within a single session, so the pool size is left as-is.
-  if (pool !== null) return;
+  // NOTE: `numThreads` never changes within a single session, so the first value wins.
+  poolSize ??= numThreads;
+}
 
-  pool = new Tinypool({
+// Create the pool lazily on first use,
+// so runs that never delegate to Prettier spawn no `child_process` workers at all.
+// (e.g. Rust-tier files only)
+async function getPool(): Promise<Tinypool> {
+  // Rust always calls `initExternalFormatter` before formatting, so this is defensive.
+  if (poolSize === null) throw new Error("External formatter is not initialized");
+
+  pool ??= new Tinypool({
     filename: new URL("./cli-worker.js", import.meta.url).href,
-    minThreads: numThreads,
-    maxThreads: numThreads,
+    minThreads: poolSize,
+    maxThreads: poolSize,
     // XXX: Use `child_process` instead of `worker_threads`.
     // Not sure why, but when using `worker_threads`,
     // calls from NAPI (CLI) -> worker threads -> NAPI (prettier-plugin-oxfmt) causes a hang...
@@ -33,11 +41,13 @@ export async function initExternalFormatter(numThreads: number): Promise<void> {
     // `process.env` is not inherited (likely a bug), so it needs to be explicitly specified.
     env: process.env as Record<string, string>,
   });
+  return pool;
 }
 
 export async function disposeExternalFormatter(): Promise<void> {
   await pool?.destroy();
   pool = null;
+  poolSize = null;
 }
 
 // ---
@@ -47,7 +57,9 @@ export function formatFile(
   code: string,
 ): Promise<FormatFileResult> {
   return toFormatFileResult(
-    pool!.run({ options, code } satisfies FormatFileParam, { name: "formatFile" }),
+    getPool().then((pool) =>
+      pool.run({ options, code } satisfies FormatFileParam, { name: "formatFile" }),
+    ),
   );
 }
 
@@ -58,7 +70,11 @@ export function formatEmbeddedCode(
   code: string,
 ): Promise<string | null> {
   return toNullable(
-    pool!.run({ options, code } satisfies FormatEmbeddedCodeParam, { name: "formatEmbeddedCode" }),
+    getPool().then((pool) =>
+      pool.run({ options, code } satisfies FormatEmbeddedCodeParam, {
+        name: "formatEmbeddedCode",
+      }),
+    ),
   );
 }
 
@@ -67,7 +83,11 @@ export function formatEmbeddedDoc(
   texts: string[],
 ): Promise<string[] | null> {
   return toNullable(
-    pool!.run({ options, texts } satisfies FormatEmbeddedDocParam, { name: "formatEmbeddedDoc" }),
+    getPool().then((pool) =>
+      pool.run({ options, texts } satisfies FormatEmbeddedDocParam, {
+        name: "formatEmbeddedDoc",
+      }),
+    ),
   );
 }
 
@@ -76,8 +96,10 @@ export function sortTailwindClasses(
   classes: string[],
 ): Promise<string[] | null> {
   return toNullable(
-    pool!.run({ classes, options } satisfies SortTailwindClassesArgs, {
-      name: "sortTailwindClasses",
-    }),
+    getPool().then((pool) =>
+      pool.run({ classes, options } satisfies SortTailwindClassesArgs, {
+        name: "sortTailwindClasses",
+      }),
+    ),
   );
 }


### PR DESCRIPTION
Partially fixes #25196

- Before: create `child_process` worker pool on startup
  - Spawned even when nothing needs JS side delegation (e.g. JS/TS-only projects)
  - For LSP, the idle workers stayed resident for the whole session
- After: create the pool on the first format that actually delegates to JS side
  - Runs that never reach JS side spawn zero workers
  - As more formatters are rewritten in Rust, the share of such runs keeps growing

Trade-off: the first JS-delegated format in an LSP session now pays the spawn cost.
But that is what every one-shot CLI run already pays, so it is far from slow, and subsequent formats are unchanged.
