### PR TITLE
perf(linter/typescript/ban-tslint-comment): replace regex with manual parser

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
@@ -1,4 +1,3 @@
-use lazy_regex::{Lazy, Regex, lazy_regex};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -42,15 +41,23 @@ declare_oxc_lint!(
     short_description = "This rule disallows `tslint:<rule-flag>` comments.",
 );
 
-static ENABLE_DISABLE_REGEX: Lazy<Regex> =
-    lazy_regex!(r"^\s*tslint:(enable|disable)(?:-(line|next-line))?(:|\s|$)");
+/// `^\s*tslint:(enable|disable)(?:-(line|next-line))?(:|\s|$)`
+fn is_tslint_enable_disable_comment(raw: &str) -> bool {
+    let Some(rest) = raw.trim_start().strip_prefix("tslint:") else { return false };
+    let Some(rest) = rest.strip_prefix("enable").or_else(|| rest.strip_prefix("disable")) else {
+        return false;
+    };
+    let rest =
+        rest.strip_prefix("-line").or_else(|| rest.strip_prefix("-next-line")).unwrap_or(rest);
+    rest.is_empty() || rest.starts_with(':') || rest.starts_with(char::is_whitespace)
+}
 
 impl Rule for BanTslintComment {
     fn run_once(&self, ctx: &LintContext) {
         let comments = ctx.comments();
         for comment in comments {
             let raw = ctx.source_range(comment.content_span());
-            if ENABLE_DISABLE_REGEX.is_match(raw) {
+            if is_tslint_enable_disable_comment(raw) {
                 let comment_span = get_full_comment(ctx, comment.span);
                 ctx.diagnostic_with_fix(
                     ban_tslint_comment_diagnostic(raw.trim(), comment_span),
@@ -86,6 +93,8 @@ fn test() {
         "// TODO: this is a comment that mentions tslint",
         "/* another comment that mentions tslint */",
         "someCode(); // This is a comment that just happens to mention tslint",
+        "// tslint:disabled",
+        "// TSLint:disable",
     ];
 
     let fail = vec![


### PR DESCRIPTION
replace regex with manual parser

TRPC had the biggest speedup, at 22.6x p50 and rolldown had lowest at 2.84x p50. Each codebase had parity with reported lint violations

The below measurements are from `--debug=timings` and ran 30 times


| corpus | speedup (p50) | baseline ms (n=30) | fixed ms (n=30) |
|---|---|---|---|
| cal.com | 5.99x | 3.662 +/- 0.798 | 0.611 +/- 0.153 |
| vue-vben-admin | 15.75x | 2.402 +/- 1.048 | 0.152 +/- 0.043 |
| actual | 11.86x | 4.851 +/- 1.214 | 0.409 +/- 0.061 |
| storybook | 6.86x | 6.859 +/- 1.416 | 1.000 +/- 0.726 |
| rolldown | 2.84x | 2.290 +/- 0.192 | 0.806 +/- 0.127 |
| nest | 7.20x | 1.138 +/- 0.420 | 0.158 +/- 0.270 |
| vite | 8.30x | 1.805 +/- 0.339 | 0.217 +/- 0.011 |
| trpc | 22.60x | 3.017 +/- 0.622 | 0.134 +/- 0.014 |




