### PR TITLE
perf(linter/typescript/ban-ts-comment): bail early with substring guard

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -302,15 +302,11 @@ impl BanTsComment {
 pub fn find_ts_comment_directive(raw: &str, single_line: bool) -> Option<(&str, &str)> {
     let prefix = "@ts-";
 
-    let mut last_line_start = None;
-    let mut char_indices = raw.char_indices().peekable();
-    while let Some((_, c)) = char_indices.next() {
-        if c == '\n' {
-            last_line_start = char_indices.peek().map(|(i, _)| *i);
-        }
+    if !raw.contains(prefix) {
+        return None;
     }
 
-    let multi_len = last_line_start.unwrap_or(0);
+    let multi_len = if single_line { 0 } else { raw.rfind('\n').map_or(0, |i| i + 1) };
     let line = &raw[multi_len..];
 
     // Check the content before the prefix


### PR DESCRIPTION
Most comments do not have an `@ts` prefix, so bail early after a quick byte scan. Additionally, single line comments don't need scanned for newlines, and multiline comments can be scanned from the back to avoid tracking last seen newlines. There is no need to track multibyte characters when we only care about newlines


vite had the biggest speedup, at 4.19x p50 and actual had lowest at 2.76x p50. Each codebase had parity with reported lint violations. speedup scales with comment density

The below measurements are from `--debug=timings` and ran 30 times

| corpus | speedup (p50) | baseline ms (n=30) | fixed ms (n=30) |
|---|---|---|---|
| cal.com | 3.06x | 3.657 +/- 0.478 | 1.195 +/- 0.131 |
| vue-vben-admin | 3.39x | 0.859 +/- 0.055 | 0.254 +/- 0.019 |
| actual | 2.76x | 1.601 +/- 0.266 | 0.580 +/- 0.049 |
| storybook | 3.73x | 5.633 +/- 1.003 | 1.510 +/- 0.108 |
| rolldown | 4.10x | 1.268 +/- 0.073 | 0.309 +/- 0.369 |
| nest | 2.93x | 0.784 +/- 0.052 | 0.268 +/- 0.041 |
| vite | 4.19x | 1.078 +/- 0.629 | 0.257 +/- 0.014 |
| trpc | 2.92x | 0.915 +/- 0.069 | 0.314 +/- 0.048 |

