### PR TITLE
fix(parser): report TS1035 for quoted module names

### DIFF
--- a/crates/oxc_codegen/tests/integration/snapshots/minify.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/minify.snap
@@ -112,9 +112,9 @@ enum A { a, 'b' }
 ----------
 enum A{a,"b"}
 ########## 26
-module 'a'
+module a {}
 ----------
-module "a";
+module a{}
 ########## 27
 declare module 'a'
 ----------

--- a/crates/oxc_codegen/tests/integration/snapshots/ts.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/ts.snap
@@ -173,9 +173,9 @@ enum A {
 }
 
 ########## 26
-module 'a'
+module a {}
 ----------
-module 'a';
+module a {}
 
 ########## 27
 declare module 'a'

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -101,7 +101,7 @@ fn ts() {
         "class A {private static readonly prop: string}",
         "interface A { a: string, 'b': number, 'c'(): void }",
         "enum A { a, 'b' }",
-        "module 'a'",
+        "module a {}",
         "declare module 'a'",
         "a = x!;",
         "b = (x as y);",

--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -328,6 +328,10 @@ parser_diagnostics! {
             .with_label(span)
     };
 
+    quoted_module_name_only_allowed_in_ambient_module(span: Span) => {
+        ts_error("1035", "Only ambient modules can use quoted names.").with_label(span)
+    };
+
     declaration_single_statement(span: Span) => {
         OxcDiagnostic::error("Declaration cannot appear in a single-statement context")
             .with_help("Wrap this declaration in a block statement")

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -409,6 +409,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         modifiers: &Modifiers,
     ) -> ArenaBox<'a, TSModuleDeclaration<'a>> {
         let id = TSModuleDeclarationName::StringLiteral(self.parse_literal_string());
+        if !self.ctx.has_ambient() {
+            self.error(diagnostics::quoted_module_name_only_allowed_in_ambient_module(id.span()));
+        }
         let body = if self.at(Kind::LCurly) {
             // External module body (`declare module "x" {}`); `import`/`export` are allowed here.
             let block = self.parse_ts_module_block(/* in_ts_namespace_body */ false);

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -2,7 +2,7 @@ commit: 06b6eae3
 
 parser_babel Summary:
 AST Parsed     : 2234/2234 (100.00%)
-Positive Passed: 2219/2234 (99.33%)
+Positive Passed: 2218/2234 (99.28%)
 Negative Passed: 1727/1742 (99.14%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-assert-and-assign/input.ts
 
@@ -246,6 +246,23 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/declare-pattern-parameters/input.ts:1:25]
  1 │ declare function f([]?, {})
    ·                         ──
+   ╰────
+
+Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/head/input.ts
+
+  × TS(1035): Only ambient modules can use quoted names.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/head/input.ts:3:8]
+ 2 │ namespace M.N.O {}
+ 3 │ module "m" {}
+   ·        ───
+ 4 │ module 'n' {}
+   ╰────
+
+  × TS(1035): Only ambient modules can use quoted names.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/module-namespace/head/input.ts:4:8]
+ 3 │ module "m" {}
+ 4 │ module 'n' {}
+   ·        ───
    ╰────
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-in-nested-module/input.ts

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: b465fdbf
 parser_typescript Summary:
 AST Parsed     : 9779/9779 (100.00%)
 Positive Passed: 9779/9779 (100.00%)
-Negative Passed: 1645/2640 (62.31%)
+Negative Passed: 1647/2640 (62.39%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -775,8 +775,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/pushTypeGetT
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/qualifiedModuleLocals.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/quotedModuleNameMustBeAmbient.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reboundIdentifierOnImportAlias.ts
 
@@ -1741,8 +1739,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration1.d.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration10.ts
 
@@ -11293,6 +11289,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ·         ┬
    ·         ╰── `;` expected
  4 │ 
+   ╰────
+
+  × TS(1035): Only ambient modules can use quoted names.
+   ╭─[typescript/tests/cases/compiler/quotedModuleNameMustBeAmbient.ts:1:8]
+ 1 │ module 'M' {}
+   ·        ───
+ 2 │ 
    ╰────
 
   × Expected `,` or `)` but found `!`
@@ -26812,6 +26815,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/MissingTokens/parserMissingToken2.ts:1:1]
  1 │ / b;
    · ────
+   ╰────
+
+  × TS(1035): Only ambient modules can use quoted names.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration1.ts:1:8]
+ 1 │ module "Foo" {
+   ·        ─────
+ 2 │ }
    ╰────
 
   × TS(1038): A 'declare' modifier cannot be used in an already ambient context.

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -286,6 +286,8 @@ after transform: ScopeId(0): ["A"]
 rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/head/input.ts
+Only ambient modules can use quoted names.
+Only ambient modules can use quoted names.
 Ambient modules cannot be nested in other modules or namespaces.
 Ambient modules cannot be nested in other modules or namespaces.
 Bindings mismatch:

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 624/659 (94.69%), 15 files skipped
+ts compatibility: 624/659 (94.69%), 16 files skipped
 
 # Failed
 
@@ -55,5 +55,6 @@ ts compatibility: 624/659 (94.69%), 15 files skipped
 - typescript/definite/definite.ts
 - typescript/definite/without-annotation.ts
 - typescript/interface2/module.ts
+- typescript/module/keyword.ts
 - typescript/namespace/invalid-await.ts
 - typescript/type-parameters-arguments/const.ts

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 06b6eae3
 
-Passed: 771/1164
+Passed: 769/1162
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -1055,7 +1055,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (115/157)
+# babel-plugin-transform-typescript (113/155)
 * class/accessor-allowDeclareFields-false/input.ts
 
   x TS(18010): An accessibility modifier cannot be used with a private


### PR DESCRIPTION
Quoted module names are only valid in ambient contexts in TypeScript, but we were accepting them in regular TypeScript files.

This reports TS1035 when a quoted module name appears outside a declaration file or ambient declaration. The conformance snapshots now cover both TypeScript cases, and the old invalid codegen fixture has been replaced with a valid internal module declaration.
