### PR TITLE
fix(transform_conformance): record missing expected errors

### DIFF
--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 1eac4481
 
-Passed: 769/1162
+Passed: 732/1162
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -10,7 +10,7 @@ Passed: 769/1162
 * babel-plugin-transform-react-display-name
 
 
-# babel-preset-env (38/85)
+# babel-preset-env (36/85)
 * dynamic-import/auto-esm-unsupported-import-unsupported/input.mjs
 x Output mismatch
 
@@ -116,6 +116,12 @@ x Output mismatch
 * preset-options/regexp-modifiers-chrome-121/input.js
 x Output mismatch
 
+* preset-options/removed-loose/input.js
+x Expected transform error, but transformation succeeded: @babel/preset-env: The 'loose' and 'spec' options have been removed, and you should configure granular compiler assumptions instead. See https://babeljs.io/assumptions for more information.
+
+* preset-options/removed-spec/input.js
+x Expected transform error, but transformation succeeded: @babel/preset-env: The 'loose' and 'spec' options have been removed, and you should configure granular compiler assumptions instead. See https://babeljs.io/assumptions for more information.
+
 * preset-options/reserved-keys-ie8/input.mjs
 x Output mismatch
 
@@ -178,7 +184,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-class-properties (214/269)
+# babel-plugin-transform-class-properties (208/269)
 * assumption-constantSuper/complex-super-class/input.js
 x Output mismatch
 
@@ -311,6 +317,9 @@ x Output mismatch
 * private-loose/static-infer-name/input.js
 x Output mismatch
 
+* public/arrow-this-without-transform/input.js
+x Expected transform error, but transformation succeeded: Unable to transform arrow inside class property
+
 * public/class-shadow-builtins/input.mjs
 x Output mismatch
 
@@ -322,6 +331,21 @@ x Output mismatch
 
 * public/static-infer-name/input.js
 x Output mismatch
+
+* public/super-destructuring-array-pattern/input.js
+x Expected transform error, but transformation succeeded: Destructuring to a super field is not supported yet.
+
+* public/super-destructuring-array-pattern-1/input.js
+x Expected transform error, but transformation succeeded: Destructuring to a super field is not supported yet.
+
+* public/super-destructuring-object-pattern/input.js
+x Expected transform error, but transformation succeeded: Destructuring to a super field is not supported yet.
+
+* public/super-destructuring-object-pattern-1/input.js
+x Expected transform error, but transformation succeeded: Destructuring to a super field is not supported yet.
+
+* public-loose/arrow-this-without-transform/input.js
+x Expected transform error, but transformation succeeded: Unable to transform arrow inside class property
 
 * public-loose/class-shadow-builtins/input.mjs
 x Output mismatch
@@ -386,7 +410,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-private-methods (48/148)
+# babel-plugin-transform-private-methods (41/148)
 * accessors-loose/basic/input.js
 x Output mismatch
 
@@ -446,6 +470,27 @@ x Output mismatch
 
 * assumption-constantSuper/private-method-super/input.js
 x Output mismatch
+
+* duplicated-names/get-get/input.js
+x Expected transform error, but transformation succeeded: Duplicate private name #getSet
+
+* duplicated-names/get-method/input.js
+x Expected transform error, but transformation succeeded: Duplicate private name #foo
+
+* duplicated-names/method-get/input.js
+x Expected transform error, but transformation succeeded: Duplicate private name #foo
+
+* duplicated-names/method-method/input.js
+x Expected transform error, but transformation succeeded: Duplicate private name #dank
+
+* duplicated-names/method-set/input.js
+x Expected transform error, but transformation succeeded: Duplicate private name #foo
+
+* duplicated-names/set-method/input.js
+x Expected transform error, but transformation succeeded: Duplicate private name #foo
+
+* duplicated-names/set-set/input.js
+x Expected transform error, but transformation succeeded: Duplicate private name #getSet
 
 * private-method/super/input.js
 x Output mismatch
@@ -1018,7 +1063,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-arrow-functions (3/11)
+# babel-plugin-transform-arrow-functions (1/11)
 * arrow-functions/implicit-var-arguments/input.js
 x Output mismatch
 
@@ -1027,6 +1072,14 @@ x Output mismatch
 
 * arrow-functions/spec/input.js
 x Output mismatch
+
+* arrow-functions/super-call/input.js
+x Expected transform error, but transformation succeeded: When using '@babel/plugin-transform-arrow-functions', it's not possible to compile `super()` in an arrow function without compiling classes.
+Please add '@babel/plugin-transform-classes' to your Babel configuration.
+
+* arrow-functions/super-prop/input.js
+x Expected transform error, but transformation succeeded: When using '@babel/plugin-transform-arrow-functions', it's not possible to compile `super.prop` in an arrow function without compiling classes.
+Please add '@babel/plugin-transform-classes' to your Babel configuration.
 
 * assumption-newableArrowFunctions-false/basic/input.js
 x Output mismatch
@@ -1044,9 +1097,15 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-preset-typescript (9/12)
+# babel-preset-typescript (7/12)
 * node-extensions/import-in-cts/input.cts
 x Output mismatch
+
+* node-extensions/with-in-mts/input.mts
+x Expected transform error, but transformation succeeded: 'with' in strict mode. (1:0)
+
+* opts/allowDeclareFields/input.ts
+x Expected transform error, but transformation succeeded: The .allowDeclareFields option has been removed and it's now always enabled. Please remove it from your config.
 
 * opts/rewriteImportExtensions/input.ts
 x Output mismatch
@@ -1055,7 +1114,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (113/155)
+# babel-plugin-transform-typescript (110/155)
 * class/accessor-allowDeclareFields-false/input.ts
 
   x TS(18010): An accessibility modifier cannot be used with a private
@@ -1111,6 +1170,13 @@ x Output mismatch
 
 * class/private-method-override-transform-private/input.ts
 x Output mismatch
+
+* class/transform-properties-declare-wrong-order/input.ts
+x Expected transform error, but transformation succeeded: TypeScript 'declare' fields must first be transformed by @babel/plugin-transform-typescript.
+If you have already enabled that plugin (or '@babel/preset-typescript'), make sure that it runs before any plugin related to additional class features:
+ - @babel/plugin-transform-class-properties
+ - @babel/plugin-transform-private-methods
+ - @babel/plugin-proposal-decorators
 
 * declarations/const-enum/input.ts
 Bindings mismatch:
@@ -1215,6 +1281,10 @@ Symbol redeclarations mismatch for "BB":
 after transform: SymbolId(10): [Span { start: 445, end: 447 }, Span { start: 461, end: 463 }]
 rebuilt        : SymbolId(1): []
 
+* exports/export=/input.ts
+x Expected transform error, but transformation succeeded: `export = <value>;` is only supported when compiling modules to CommonJS.
+Please consider using `export default <value>;`, or add @babel/plugin-transform-modules-commonjs to your Babel config.
+
 * exports/interface/input.ts
 x Output mismatch
 
@@ -1233,6 +1303,10 @@ rebuilt        : SymbolId(0): Span { start: 29, end: 30 }
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 29, end: 30 }]
 rebuilt        : SymbolId(0): []
+
+* imports/import=-module/input.ts
+x Expected transform error, but transformation succeeded: `import lib = require(...);` is only supported when compiling modules to CommonJS.
+Please consider using `import lib from '...';` alongside Typescript's --allowSyntheticDefaultImports option, or add @babel/plugin-transform-modules-commonjs to your Babel config.
 
 * imports/type-only-export-specifier-2/input.ts
 x Output mismatch
@@ -1358,7 +1432,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-react-jsx (137/149)
+# babel-plugin-transform-react-jsx (122/149)
 * autoImport/after-polyfills-compiled-to-cjs/input.mjs
 x Output mismatch
 
@@ -1367,6 +1441,27 @@ x Output mismatch
 
 * pure/false-default-pragma-classic-runtime/input.js
 x Output mismatch
+
+* pure/false-pragma-comment-automatic-runtime/input.js
+x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic
+
+* pure/false-pragma-option-automatic-runtime/input.js
+x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic.
+
+* pure/true-pragma-comment-automatic-runtime/input.js
+x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic
+
+* pure/true-pragma-option-automatic-runtime/input.js
+x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic.
+
+* pure/unset-pragma-comment-automatic-runtime/input.js
+x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic
+
+* pure/unset-pragma-option-automatic-runtime/input.js
+x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic.
+
+* react/should-disallow-spread-children/input.js
+x Expected transform error, but transformation succeeded: Spread children are not supported in React.
 
 * react/should-disallow-valueless-key/input.js
 
@@ -1401,8 +1496,17 @@ x Output mismatch
    `----
 
 
+* react/should-warn-when-importSource-is-set/input.js
+x Expected transform error, but transformation succeeded: importSource cannot be set when runtime is classic.
+
+* react/should-warn-when-importSource-pragma-is-set/input.js
+x Expected transform error, but transformation succeeded: importSource cannot be set when runtime is classic.
+
 * react-automatic/does-not-add-source-self-automatic/input.mjs
 transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `development`, `throwIfNamespace`, `pure`, `importSource`, `pragma`, `pragmaFrag`, `useBuiltIns`, `useSpread`, `refresh`
+
+* react-automatic/should-disallow-spread-children/input.js
+x Expected transform error, but transformation succeeded: Spread children are not supported in React.
 
 * react-automatic/should-disallow-valueless-key/input.js
 
@@ -1436,6 +1540,21 @@ transform-react-jsx: unknown field `autoImport`, expected one of `runtime`, `dev
    :  ^^^^^^^
    `----
 
+
+* react-automatic/should-warn-when-pragma-or-pragmaFrag-is-set/input.js
+x Expected transform error, but transformation succeeded: pragma and pragmaFrag cannot be set when runtime is automatic.
+
+* removed-options/invalid-use-builtins-false/input.js
+x Expected transform error, but transformation succeeded: @babel/plugin-transform-react-jsx: Since "useBuiltIns" is removed in Babel 8, you can remove it from the config.
+
+* removed-options/invalid-use-builtins-true/input.js
+x Expected transform error, but transformation succeeded: @babel/plugin-transform-react-jsx: Since "useBuiltIns" is removed in Babel 8, you can remove it from the config.
+
+* removed-options/invalid-use-spread-false/input.js
+x Expected transform error, but transformation succeeded: transform-react-jsx: Since Babel 8, an inline object with spread elements is always used, and the "useSpread" option is no longer available. Please remove it from your config.
+
+* removed-options/invalid-use-spread-true/input.js
+x Expected transform error, but transformation succeeded: transform-react-jsx: Since Babel 8, an inline object with spread elements is always used, and the "useSpread" option is no longer available. Please remove it from your config.
 
 * spread-transform/transform-to-babel-extend/input.js
 

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -408,8 +408,8 @@ impl TestCase {
                 .errors();
                 self.errors.extend(mismatch_errors);
             }
-        } else if let Some(actual_errors) = actual_errors {
-            self.errors.push(OxcDiagnostic::error(actual_errors));
+        } else {
+            record_conformance_failure(&mut self.errors, actual_errors, &output);
         }
     }
 
@@ -477,10 +477,39 @@ test("exec", () => {{
     }
 }
 
+fn record_conformance_failure(
+    errors: &mut Diagnostics,
+    actual_errors: Option<String>,
+    expected: &str,
+) {
+    let error = actual_errors.unwrap_or_else(|| {
+        format!("x Expected transform error, but transformation succeeded: {expected}")
+    });
+    errors.push(OxcDiagnostic::error(error));
+}
+
 fn get_babel_error(error: &str) -> String {
     match error {
         "transform-react-jsx: unknown variant `invalidOption`, expected `classic` or `automatic`" => "Runtime must be either \"classic\" or \"automatic\".",
         "Expected `>` but found `/`" => "Unexpected token, expected \",\"",
         _ => error
     }.to_string()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn records_missing_expected_transform_error() {
+        let mut errors = Diagnostics::new();
+
+        record_conformance_failure(&mut errors, None, "expected error");
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors[0].message,
+            "x Expected transform error, but transformation succeeded: expected error"
+        );
+    }
 }


### PR DESCRIPTION
Fix the transformer conformance runner incorrectly marking a fixture as passed that specified `throws` when Oxc produces no error.


Failed conformance cases now always record a diagnostic. This exposes previously hidden failures in the Babel snapshot, including the nested ambient-module fixtures.

