### PR TITLE
feat(linter): port eslint-plugin-no-unsanitized (property, method)

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1226,8 +1226,26 @@ export interface DummyRuleMap {
   "no-unsafe-finally"?: RuleNoConfig;
   "no-unsafe-negation"?: RuleNoConfig | [AllowWarnDeny, NoUnsafeNegation];
   "no-unsafe-optional-chaining"?: RuleNoConfig | [AllowWarnDeny, NoUnsafeOptionalChaining];
-  "no-unsanitized/method"?: RuleNoConfig | [AllowWarnDeny, MethodOptionsSchema];
-  "no-unsanitized/property"?: RuleNoConfig | [AllowWarnDeny, PropertyOptionsSchema];
+  "no-unsanitized/method"?:
+    | RuleNoConfig
+    | [AllowWarnDeny, MethodGlobalOptions]
+    | [
+        AllowWarnDeny,
+        MethodGlobalOptions,
+        {
+          [k: string]: MethodSinkOptions | undefined;
+        }
+      ];
+  "no-unsanitized/property"?:
+    | RuleNoConfig
+    | [AllowWarnDeny, PropertyGlobalOptions]
+    | [
+        AllowWarnDeny,
+        PropertyGlobalOptions,
+        {
+          [k: string]: PropertySinkOptions | undefined;
+        }
+      ];
   "no-unused-expressions"?: RuleNoConfig | [AllowWarnDeny, NoUnusedExpressionsConfig];
   "no-unused-labels"?: RuleNoConfig;
   "no-unused-private-class-members"?: RuleNoConfig;
@@ -3811,22 +3829,27 @@ export interface NoUnsafeOptionalChaining {
    */
   disallowArithmeticOperators?: boolean;
 }
-export interface MethodOptionsSchema {
+/**
+ * The first options object, applying to every sink.
+ */
+export interface MethodGlobalOptions {
   /**
    * Drops the built-in sink list, so only sinks given in the second options
-   * object are checked.
+   * object are checked. Built-in sinks named there keep their argument indices.
    */
   defaultDisable?: boolean;
   /**
-   * Escaping functions which mark a value as safe, for every sink.
+   * Escaping functions which mark a value as safe.
    */
   escape?: EscapeSchema;
   /**
-   * Regexes the object of a call must match, for every sink.
+   * Regexes the name of the object a method is called on must match.
+   *
+   * These are Rust regexes, which do not support backreferences or lookaround.
    */
   objectMatches?: string[];
   /**
-   * Argument indices which are parsed as HTML, for every sink.
+   * Argument indices which are parsed as HTML.
    */
   properties?: number[];
   /**
@@ -3850,21 +3873,48 @@ export interface EscapeSchema {
    */
   taggedTemplates?: string[];
 }
-export interface PropertyOptionsSchema {
+/**
+ * The options of a single sink in the second options object.
+ */
+export interface MethodSinkOptions {
+  /**
+   * Escaping functions accepted for this sink, replacing the ones from the
+   * first options object.
+   */
+  escape?: EscapeSchema;
+  /**
+   * Regexes the name of the object must match, replacing the ones from the
+   * first options object.
+   */
+  objectMatches?: string[];
+  /**
+   * Argument indices which are parsed as HTML.
+   */
+  properties?: number[];
+}
+/**
+ * The first options object, applying to every property.
+ */
+export interface PropertyGlobalOptions {
   /**
    * Escaping functions which mark a value as safe.
    */
   escape?: EscapeSchema;
   /**
-   * Property names treated as HTML sinks, replacing the defaults
-   * `["innerHTML", "outerHTML"]`.
-   */
-  properties?: string[];
-  /**
    * Whether values assigned from local `let`/`const` variables are traced back
    * to their initializers. Defaults to `true`.
    */
   variableTracing?: boolean;
+}
+/**
+ * The options of a single property in the second options object.
+ */
+export interface PropertySinkOptions {
+  /**
+   * Escaping functions accepted for this property, replacing the ones from the
+   * first options object.
+   */
+  escape?: EscapeSchema;
 }
 export interface NoUnusedExpressionsConfig {
   /**

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -56,7 +56,8 @@ export type LintPluginOptionsSchema =
   | "react-perf"
   | "promise"
   | "node"
-  | "vue";
+  | "vue"
+  | "no-unsanitized";
 export type LintPlugins = LintPluginOptionsSchema[];
 export type RuleNoConfig = AllowWarnDeny | [AllowWarnDeny];
 export type Mode2 = "as-needed" | "always" | "never";
@@ -1225,6 +1226,8 @@ export interface DummyRuleMap {
   "no-unsafe-finally"?: RuleNoConfig;
   "no-unsafe-negation"?: RuleNoConfig | [AllowWarnDeny, NoUnsafeNegation];
   "no-unsafe-optional-chaining"?: RuleNoConfig | [AllowWarnDeny, NoUnsafeOptionalChaining];
+  "no-unsanitized/method"?: RuleNoConfig | [AllowWarnDeny, MethodOptionsSchema];
+  "no-unsanitized/property"?: RuleNoConfig | [AllowWarnDeny, PropertyOptionsSchema];
   "no-unused-expressions"?: RuleNoConfig | [AllowWarnDeny, NoUnusedExpressionsConfig];
   "no-unused-labels"?: RuleNoConfig;
   "no-unused-private-class-members"?: RuleNoConfig;
@@ -3807,6 +3810,61 @@ export interface NoUnsafeOptionalChaining {
    * If this is true, this rule warns arithmetic operations on optional chaining expressions, which possibly result in NaN.
    */
   disallowArithmeticOperators?: boolean;
+}
+export interface MethodOptionsSchema {
+  /**
+   * Drops the built-in sink list, so only sinks given in the second options
+   * object are checked.
+   */
+  defaultDisable?: boolean;
+  /**
+   * Escaping functions which mark a value as safe, for every sink.
+   */
+  escape?: EscapeSchema;
+  /**
+   * Regexes the object of a call must match, for every sink.
+   */
+  objectMatches?: string[];
+  /**
+   * Argument indices which are parsed as HTML, for every sink.
+   */
+  properties?: number[];
+  /**
+   * Whether values coming from local `let`/`const` variables are traced back
+   * to their initializers. Defaults to `true`.
+   */
+  variableTracing?: boolean;
+}
+/**
+ * The `escape` option of both `no-unsanitized` rules.
+ */
+export interface EscapeSchema {
+  /**
+   * Methods which return safe HTML.
+   * Defaults to `["Sanitizer.unwrapSafeHTML", "unwrapSafeHTML"]`.
+   */
+  methods?: string[];
+  /**
+   * Tagged template functions which return safe HTML.
+   * Defaults to `["Sanitizer.escapeHTML", "escapeHTML"]`.
+   */
+  taggedTemplates?: string[];
+}
+export interface PropertyOptionsSchema {
+  /**
+   * Escaping functions which mark a value as safe.
+   */
+  escape?: EscapeSchema;
+  /**
+   * Property names treated as HTML sinks, replacing the defaults
+   * `["innerHTML", "outerHTML"]`.
+   */
+  properties?: string[];
+  /**
+   * Whether values assigned from local `let`/`const` variables are traced back
+   * to their initializers. Defaults to `true`.
+   */
+  variableTracing?: boolean;
 }
 export interface NoUnusedExpressionsConfig {
   /**

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -451,6 +451,10 @@ pub struct EnablePlugins {
     /// Enable the vue plugin and detect vue usage problems
     #[bpaf(flag(OverrideToggle::Enable, OverrideToggle::NotSet), hide_usage)]
     pub vue_plugin: OverrideToggle,
+
+    /// Enable the no-unsanitized plugin and detect unsanitized HTML sinks
+    #[bpaf(flag(OverrideToggle::Enable, OverrideToggle::NotSet), hide_usage)]
+    pub no_unsanitized_plugin: OverrideToggle,
 }
 
 /// Enables or disables a boolean option, or leaves it unset.
@@ -526,6 +530,7 @@ impl EnablePlugins {
         self.promise_plugin.inspect(|yes| plugins.set(LintPlugins::PROMISE, yes));
         self.node_plugin.inspect(|yes| plugins.set(LintPlugins::NODE, yes));
         self.vue_plugin.inspect(|yes| plugins.set(LintPlugins::VUE, yes));
+        self.no_unsanitized_plugin.inspect(|yes| plugins.set(LintPlugins::NO_UNSANITIZED, yes));
     }
 }
 

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -741,7 +741,7 @@ mod test {
             serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn"] }"#).unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::TYPESCRIPT | LintPlugins::UNICORN));
         let config: Oxlintrc =
-            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node", "vue"] }"#).unwrap();
+            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node", "vue", "no-unsanitized"] }"#).unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::all()));
 
         let config: Oxlintrc =

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -110,6 +110,8 @@ bitflags! {
         const NODE = 1 << 12;
         /// `eslint-plugin-vue`
         const VUE = 1 << 13;
+        /// `eslint-plugin-no-unsanitized`
+        const NO_UNSANITIZED = 1 << 14;
     }
 }
 
@@ -175,6 +177,7 @@ impl TryFrom<&str> for LintPlugins {
             "promise" => Ok(LintPlugins::PROMISE),
             "node" => Ok(LintPlugins::NODE),
             "vue" => Ok(LintPlugins::VUE),
+            "no-unsanitized" | "no_unsanitized" => Ok(LintPlugins::NO_UNSANITIZED),
             // "eslint" is not really a plugin, so it's 'empty'. This has the added benefit of
             // making it the default value.
             "eslint" => Ok(LintPlugins::ESLINT),
@@ -200,6 +203,7 @@ impl From<LintPlugins> for &'static str {
             LintPlugins::PROMISE => "promise",
             LintPlugins::NODE => "node",
             LintPlugins::VUE => "vue",
+            LintPlugins::NO_UNSANITIZED => "no-unsanitized",
             _ => "",
         }
     }
@@ -271,6 +275,7 @@ impl JsonSchema for LintPlugins {
             Promise,
             Node,
             Vue,
+            NoUnsanitized,
         }
 
         let enum_schema = r#gen.subschema_for::<LintPluginOptionsSchema>();

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5429,3 +5429,9 @@ impl RuleRunner for crate::rules::vue::valid_next_tick::ValidNextTick {
     ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
+
+impl RuleRunner for crate::rules::no_unsanitized::property::Property {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5430,6 +5430,15 @@ impl RuleRunner for crate::rules::vue::valid_next_tick::ValidNextTick {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::no_unsanitized::method::Method {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::CallExpression,
+        AstType::ImportExpression,
+        AstType::TaggedTemplateExpression,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::no_unsanitized::property::Property {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -368,6 +368,7 @@ pub use crate::rules::nextjs::no_sync_scripts::NoSyncScripts as NextjsNoSyncScri
 pub use crate::rules::nextjs::no_title_in_document_head::NoTitleInDocumentHead as NextjsNoTitleInDocumentHead;
 pub use crate::rules::nextjs::no_typos::NoTypos as NextjsNoTypos;
 pub use crate::rules::nextjs::no_unwanted_polyfillio::NoUnwantedPolyfillio as NextjsNoUnwantedPolyfillio;
+pub use crate::rules::no_unsanitized::method::Method as NoUnsanitizedMethod;
 pub use crate::rules::no_unsanitized::property::Property as NoUnsanitizedProperty;
 pub use crate::rules::node::callback_return::CallbackReturn as NodeCallbackReturn;
 pub use crate::rules::node::exports_style::ExportsStyle as NodeExportsStyle;
@@ -1723,6 +1724,7 @@ pub enum RuleEnum {
     VueValidDefineOptions(VueValidDefineOptions),
     VueValidDefineProps(VueValidDefineProps),
     VueValidNextTick(VueValidNextTick),
+    NoUnsanitizedMethod(NoUnsanitizedMethod),
     NoUnsanitizedProperty(NoUnsanitizedProperty),
 }
 const IMPORT_CONSISTENT_TYPE_SPECIFIER_STYLE_ID: usize = 0usize;
@@ -2681,7 +2683,8 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-const NO_UNSANITIZED_PROPERTY_ID: usize = VUE_VALID_NEXT_TICK_ID + 1usize;
+const NO_UNSANITIZED_METHOD_ID: usize = VUE_VALID_NEXT_TICK_ID + 1usize;
+const NO_UNSANITIZED_PROPERTY_ID: usize = NO_UNSANITIZED_METHOD_ID + 1usize;
 impl RuleEnum {
     pub fn id(&self) -> usize {
         match self {
@@ -3662,6 +3665,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VUE_VALID_DEFINE_OPTIONS_ID,
             Self::VueValidDefineProps(_) => VUE_VALID_DEFINE_PROPS_ID,
             Self::VueValidNextTick(_) => VUE_VALID_NEXT_TICK_ID,
+            Self::NoUnsanitizedMethod(_) => NO_UNSANITIZED_METHOD_ID,
             Self::NoUnsanitizedProperty(_) => NO_UNSANITIZED_PROPERTY_ID,
         }
     }
@@ -4628,6 +4632,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::NAME,
             Self::VueValidDefineProps(_) => VueValidDefineProps::NAME,
             Self::VueValidNextTick(_) => VueValidNextTick::NAME,
+            Self::NoUnsanitizedMethod(_) => NoUnsanitizedMethod::NAME,
             Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::NAME,
         }
     }
@@ -5652,6 +5657,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::CATEGORY,
             Self::VueValidDefineProps(_) => VueValidDefineProps::CATEGORY,
             Self::VueValidNextTick(_) => VueValidNextTick::CATEGORY,
+            Self::NoUnsanitizedMethod(_) => NoUnsanitizedMethod::CATEGORY,
             Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::CATEGORY,
         }
     }
@@ -6619,6 +6625,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::FIX,
             Self::VueValidDefineProps(_) => VueValidDefineProps::FIX,
             Self::VueValidNextTick(_) => VueValidNextTick::FIX,
+            Self::NoUnsanitizedMethod(_) => NoUnsanitizedMethod::FIX,
             Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::FIX,
         }
     }
@@ -7854,6 +7861,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::documentation(),
             Self::VueValidDefineProps(_) => VueValidDefineProps::documentation(),
             Self::VueValidNextTick(_) => VueValidNextTick::documentation(),
+            Self::NoUnsanitizedMethod(_) => NoUnsanitizedMethod::documentation(),
             Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::documentation(),
         }
     }
@@ -10294,6 +10302,8 @@ impl RuleEnum {
                 .or_else(|| VueValidDefineProps::schema(generator)),
             Self::VueValidNextTick(_) => VueValidNextTick::config_schema(generator)
                 .or_else(|| VueValidNextTick::schema(generator)),
+            Self::NoUnsanitizedMethod(_) => NoUnsanitizedMethod::config_schema(generator)
+                .or_else(|| NoUnsanitizedMethod::schema(generator)),
             Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::config_schema(generator)
                 .or_else(|| NoUnsanitizedProperty::schema(generator)),
         }
@@ -11147,6 +11157,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => "vue",
             Self::VueValidDefineProps(_) => "vue",
             Self::VueValidNextTick(_) => "vue",
+            Self::NoUnsanitizedMethod(_) => "no_unsanitized",
             Self::NoUnsanitizedProperty(_) => "no_unsanitized",
         }
     }
@@ -13882,6 +13893,9 @@ impl RuleEnum {
             Self::VueValidNextTick(_) => {
                 Ok(Self::VueValidNextTick(VueValidNextTick::from_configuration(value)?))
             }
+            Self::NoUnsanitizedMethod(_) => {
+                Ok(Self::NoUnsanitizedMethod(NoUnsanitizedMethod::from_configuration(value)?))
+            }
             Self::NoUnsanitizedProperty(_) => {
                 Ok(Self::NoUnsanitizedProperty(NoUnsanitizedProperty::from_configuration(value)?))
             }
@@ -14740,6 +14754,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.to_configuration(),
             Self::VueValidDefineProps(rule) => rule.to_configuration(),
             Self::VueValidNextTick(rule) => rule.to_configuration(),
+            Self::NoUnsanitizedMethod(rule) => rule.to_configuration(),
             Self::NoUnsanitizedProperty(rule) => rule.to_configuration(),
         }
     }
@@ -15593,6 +15608,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.run(node, ctx),
             Self::VueValidDefineProps(rule) => rule.run(node, ctx),
             Self::VueValidNextTick(rule) => rule.run(node, ctx),
+            Self::NoUnsanitizedMethod(rule) => rule.run(node, ctx),
             Self::NoUnsanitizedProperty(rule) => rule.run(node, ctx),
         }
     }
@@ -16458,6 +16474,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.run_once(ctx),
             Self::VueValidDefineProps(rule) => rule.run_once(ctx),
             Self::VueValidNextTick(rule) => rule.run_once(ctx),
+            Self::NoUnsanitizedMethod(rule) => rule.run_once(ctx),
             Self::NoUnsanitizedProperty(rule) => rule.run_once(ctx),
         }
     }
@@ -17440,6 +17457,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueValidDefineProps(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueValidNextTick(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::NoUnsanitizedMethod(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NoUnsanitizedProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
         }
     }
@@ -18306,6 +18324,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.should_run(ctx),
             Self::VueValidDefineProps(rule) => rule.should_run(ctx),
             Self::VueValidNextTick(rule) => rule.should_run(ctx),
+            Self::NoUnsanitizedMethod(rule) => rule.should_run(ctx),
             Self::NoUnsanitizedProperty(rule) => rule.should_run(ctx),
         }
     }
@@ -19540,6 +19559,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::IS_TSGOLINT_RULE,
             Self::VueValidDefineProps(_) => VueValidDefineProps::IS_TSGOLINT_RULE,
             Self::VueValidNextTick(_) => VueValidNextTick::IS_TSGOLINT_RULE,
+            Self::NoUnsanitizedMethod(_) => NoUnsanitizedMethod::IS_TSGOLINT_RULE,
             Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::IS_TSGOLINT_RULE,
         }
     }
@@ -20566,6 +20586,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::VERSION,
             Self::VueValidDefineProps(_) => VueValidDefineProps::VERSION,
             Self::VueValidNextTick(_) => VueValidNextTick::VERSION,
+            Self::NoUnsanitizedMethod(_) => NoUnsanitizedMethod::VERSION,
             Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::VERSION,
         }
     }
@@ -21631,6 +21652,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::HAS_CONFIG,
             Self::VueValidDefineProps(_) => VueValidDefineProps::HAS_CONFIG,
             Self::VueValidNextTick(_) => VueValidNextTick::HAS_CONFIG,
+            Self::NoUnsanitizedMethod(_) => NoUnsanitizedMethod::HAS_CONFIG,
             Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::HAS_CONFIG,
         }
     }
@@ -22599,6 +22621,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::INFO,
             Self::VueValidDefineProps(_) => VueValidDefineProps::INFO,
             Self::VueValidNextTick(_) => VueValidNextTick::INFO,
+            Self::NoUnsanitizedMethod(_) => NoUnsanitizedMethod::INFO,
             Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::INFO,
         }
     }
@@ -23456,6 +23479,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.types_info(),
             Self::VueValidDefineProps(rule) => rule.types_info(),
             Self::VueValidNextTick(rule) => rule.types_info(),
+            Self::NoUnsanitizedMethod(rule) => rule.types_info(),
             Self::NoUnsanitizedProperty(rule) => rule.types_info(),
         }
     }
@@ -24308,6 +24332,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.run_info(),
             Self::VueValidDefineProps(rule) => rule.run_info(),
             Self::VueValidNextTick(rule) => rule.run_info(),
+            Self::NoUnsanitizedMethod(rule) => rule.run_info(),
             Self::NoUnsanitizedProperty(rule) => rule.run_info(),
         }
     }
@@ -25296,6 +25321,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueValidDefineOptions(VueValidDefineOptions::default()),
         RuleEnum::VueValidDefineProps(VueValidDefineProps::default()),
         RuleEnum::VueValidNextTick(VueValidNextTick::default()),
+        RuleEnum::NoUnsanitizedMethod(NoUnsanitizedMethod::default()),
         RuleEnum::NoUnsanitizedProperty(NoUnsanitizedProperty::default()),
     ]
 });

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -368,6 +368,7 @@ pub use crate::rules::nextjs::no_sync_scripts::NoSyncScripts as NextjsNoSyncScri
 pub use crate::rules::nextjs::no_title_in_document_head::NoTitleInDocumentHead as NextjsNoTitleInDocumentHead;
 pub use crate::rules::nextjs::no_typos::NoTypos as NextjsNoTypos;
 pub use crate::rules::nextjs::no_unwanted_polyfillio::NoUnwantedPolyfillio as NextjsNoUnwantedPolyfillio;
+pub use crate::rules::no_unsanitized::property::Property as NoUnsanitizedProperty;
 pub use crate::rules::node::callback_return::CallbackReturn as NodeCallbackReturn;
 pub use crate::rules::node::exports_style::ExportsStyle as NodeExportsStyle;
 pub use crate::rules::node::global_require::GlobalRequire as NodeGlobalRequire;
@@ -1722,6 +1723,7 @@ pub enum RuleEnum {
     VueValidDefineOptions(VueValidDefineOptions),
     VueValidDefineProps(VueValidDefineProps),
     VueValidNextTick(VueValidNextTick),
+    NoUnsanitizedProperty(NoUnsanitizedProperty),
 }
 const IMPORT_CONSISTENT_TYPE_SPECIFIER_STYLE_ID: usize = 0usize;
 const IMPORT_DEFAULT_ID: usize = IMPORT_CONSISTENT_TYPE_SPECIFIER_STYLE_ID + 1usize;
@@ -2679,6 +2681,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
+const NO_UNSANITIZED_PROPERTY_ID: usize = VUE_VALID_NEXT_TICK_ID + 1usize;
 impl RuleEnum {
     pub fn id(&self) -> usize {
         match self {
@@ -3659,6 +3662,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VUE_VALID_DEFINE_OPTIONS_ID,
             Self::VueValidDefineProps(_) => VUE_VALID_DEFINE_PROPS_ID,
             Self::VueValidNextTick(_) => VUE_VALID_NEXT_TICK_ID,
+            Self::NoUnsanitizedProperty(_) => NO_UNSANITIZED_PROPERTY_ID,
         }
     }
     pub fn name(&self) -> &'static str {
@@ -4624,6 +4628,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::NAME,
             Self::VueValidDefineProps(_) => VueValidDefineProps::NAME,
             Self::VueValidNextTick(_) => VueValidNextTick::NAME,
+            Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::NAME,
         }
     }
     pub fn category(&self) -> RuleCategory {
@@ -5647,6 +5652,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::CATEGORY,
             Self::VueValidDefineProps(_) => VueValidDefineProps::CATEGORY,
             Self::VueValidNextTick(_) => VueValidNextTick::CATEGORY,
+            Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::CATEGORY,
         }
     }
     #[doc = r" This [`Rule`]'s auto-fix capabilities."]
@@ -6613,6 +6619,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::FIX,
             Self::VueValidDefineProps(_) => VueValidDefineProps::FIX,
             Self::VueValidNextTick(_) => VueValidNextTick::FIX,
+            Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::FIX,
         }
     }
     #[cfg(feature = "ruledocs")]
@@ -7847,6 +7854,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::documentation(),
             Self::VueValidDefineProps(_) => VueValidDefineProps::documentation(),
             Self::VueValidNextTick(_) => VueValidNextTick::documentation(),
+            Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::documentation(),
         }
     }
     #[cfg(feature = "ruledocs")]
@@ -10286,6 +10294,8 @@ impl RuleEnum {
                 .or_else(|| VueValidDefineProps::schema(generator)),
             Self::VueValidNextTick(_) => VueValidNextTick::config_schema(generator)
                 .or_else(|| VueValidNextTick::schema(generator)),
+            Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::config_schema(generator)
+                .or_else(|| NoUnsanitizedProperty::schema(generator)),
         }
     }
     pub fn plugin_name(&self) -> &'static str {
@@ -11137,6 +11147,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => "vue",
             Self::VueValidDefineProps(_) => "vue",
             Self::VueValidNextTick(_) => "vue",
+            Self::NoUnsanitizedProperty(_) => "no_unsanitized",
         }
     }
     pub fn from_configuration(
@@ -13871,6 +13882,9 @@ impl RuleEnum {
             Self::VueValidNextTick(_) => {
                 Ok(Self::VueValidNextTick(VueValidNextTick::from_configuration(value)?))
             }
+            Self::NoUnsanitizedProperty(_) => {
+                Ok(Self::NoUnsanitizedProperty(NoUnsanitizedProperty::from_configuration(value)?))
+            }
         }
     }
     pub fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {
@@ -14726,6 +14740,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.to_configuration(),
             Self::VueValidDefineProps(rule) => rule.to_configuration(),
             Self::VueValidNextTick(rule) => rule.to_configuration(),
+            Self::NoUnsanitizedProperty(rule) => rule.to_configuration(),
         }
     }
     #[inline(never)]
@@ -15578,6 +15593,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.run(node, ctx),
             Self::VueValidDefineProps(rule) => rule.run(node, ctx),
             Self::VueValidNextTick(rule) => rule.run(node, ctx),
+            Self::NoUnsanitizedProperty(rule) => rule.run(node, ctx),
         }
     }
     pub(crate) fn run<'a, const TIMINGS: bool>(
@@ -16442,6 +16458,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.run_once(ctx),
             Self::VueValidDefineProps(rule) => rule.run_once(ctx),
             Self::VueValidNextTick(rule) => rule.run_once(ctx),
+            Self::NoUnsanitizedProperty(rule) => rule.run_once(ctx),
         }
     }
     pub(crate) fn run_once<const TIMINGS: bool>(
@@ -17423,6 +17440,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueValidDefineProps(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueValidNextTick(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::NoUnsanitizedProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
         }
     }
     pub(crate) fn run_on_jest_node<'a, 'c, const TIMINGS: bool>(
@@ -18288,6 +18306,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.should_run(ctx),
             Self::VueValidDefineProps(rule) => rule.should_run(ctx),
             Self::VueValidNextTick(rule) => rule.should_run(ctx),
+            Self::NoUnsanitizedProperty(rule) => rule.should_run(ctx),
         }
     }
     pub fn is_tsgolint_rule(&self) -> bool {
@@ -19521,6 +19540,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::IS_TSGOLINT_RULE,
             Self::VueValidDefineProps(_) => VueValidDefineProps::IS_TSGOLINT_RULE,
             Self::VueValidNextTick(_) => VueValidNextTick::IS_TSGOLINT_RULE,
+            Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::IS_TSGOLINT_RULE,
         }
     }
     #[doc = r" The version of oxlint in which this rule was first available."]
@@ -20546,6 +20566,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::VERSION,
             Self::VueValidDefineProps(_) => VueValidDefineProps::VERSION,
             Self::VueValidNextTick(_) => VueValidNextTick::VERSION,
+            Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::VERSION,
         }
     }
     #[doc = r" Whether this rule declares a configuration type."]
@@ -21610,6 +21631,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::HAS_CONFIG,
             Self::VueValidDefineProps(_) => VueValidDefineProps::HAS_CONFIG,
             Self::VueValidNextTick(_) => VueValidNextTick::HAS_CONFIG,
+            Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::HAS_CONFIG,
         }
     }
     #[doc = r" Additional information about this rule."]
@@ -22577,6 +22599,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(_) => VueValidDefineOptions::INFO,
             Self::VueValidDefineProps(_) => VueValidDefineProps::INFO,
             Self::VueValidNextTick(_) => VueValidNextTick::INFO,
+            Self::NoUnsanitizedProperty(_) => NoUnsanitizedProperty::INFO,
         }
     }
     #[doc = r" A short, one-line summary of what this rule does."]
@@ -23433,6 +23456,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.types_info(),
             Self::VueValidDefineProps(rule) => rule.types_info(),
             Self::VueValidNextTick(rule) => rule.types_info(),
+            Self::NoUnsanitizedProperty(rule) => rule.types_info(),
         }
     }
     pub fn run_info(&self) -> RuleRunFunctionsImplemented {
@@ -24284,6 +24308,7 @@ impl RuleEnum {
             Self::VueValidDefineOptions(rule) => rule.run_info(),
             Self::VueValidDefineProps(rule) => rule.run_info(),
             Self::VueValidNextTick(rule) => rule.run_info(),
+            Self::NoUnsanitizedProperty(rule) => rule.run_info(),
         }
     }
 }
@@ -25271,5 +25296,6 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueValidDefineOptions(VueValidDefineOptions::default()),
         RuleEnum::VueValidDefineProps(VueValidDefineProps::default()),
         RuleEnum::VueValidNextTick(VueValidNextTick::default()),
+        RuleEnum::NoUnsanitizedProperty(NoUnsanitizedProperty::default()),
     ]
 });

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -911,6 +911,7 @@ pub(crate) mod vue {
 
 /// <https://github.com/mozilla/eslint-plugin-no-unsanitized>
 pub(crate) mod no_unsanitized {
+    pub mod method;
     pub mod property;
 }
 

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -909,6 +909,11 @@ pub(crate) mod vue {
     pub mod valid_next_tick;
 }
 
+/// <https://github.com/mozilla/eslint-plugin-no-unsanitized>
+pub(crate) mod no_unsanitized {
+    pub mod property;
+}
+
 pub(crate) mod shared;
 
 // Re-export RuleEnum, RULES, and all rule type aliases from generated code

--- a/crates/oxc_linter/src/rules/no_unsanitized/method.rs
+++ b/crates/oxc_linter/src/rules/no_unsanitized/method.rs
@@ -1,24 +1,26 @@
 use lazy_regex::Regex;
+use oxc_allocator::Vec as ArenaVec;
 use oxc_ast::{
     AstKind,
-    ast::{Argument, CallExpression, Expression, TaggedTemplateExpression},
+    ast::{Argument, AssignmentOperator, AssignmentTarget, Expression, TemplateLiteral},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_str::CompactStr;
 use rustc_hash::FxHashMap;
-use schemars::JsonSchema;
-use serde::Deserialize;
+use schemars::{
+    JsonSchema, SchemaGenerator,
+    schema::{ArrayValidation, InstanceType, Schema, SchemaObject, SingleOrVec},
+};
+use serde::{Deserialize, de::Error as _};
 use serde_json::Value;
 
 use crate::{
     AstNode,
     context::LintContext,
     rule::Rule,
-    utils::{
-        EscapeConfig, EscapeSchema, Sanitization, SinkValue, callee_code_name, object_code_name,
-    },
+    utils::{EscapeConfig, EscapeSchema, Sanitization, SinkValue, object_code_name},
 };
 
 fn unsafe_call_diagnostic(callee: &str, argument: usize, span: Span) -> OxcDiagnostic {
@@ -39,6 +41,23 @@ struct SinkCheck {
     escape: EscapeConfig,
 }
 
+/// A built-in sink, before user configuration is applied.
+struct DefaultSink {
+    name: &'static str,
+    properties: &'static [usize],
+    object_matches: Option<&'static [&'static str]>,
+}
+
+/// `document` is a regex upstream, so it also matches `documentish`, `window.document`, ...
+const DEFAULT_SINKS: [DefaultSink; 6] = [
+    DefaultSink { name: "insertAdjacentHTML", properties: &[1], object_matches: None },
+    DefaultSink { name: "import", properties: &[0], object_matches: None },
+    DefaultSink { name: "createContextualFragment", properties: &[0], object_matches: None },
+    DefaultSink { name: "write", properties: &[0], object_matches: Some(&["document"]) },
+    DefaultSink { name: "writeln", properties: &[0], object_matches: Some(&["document"]) },
+    DefaultSink { name: "setHTMLUnsafe", properties: &[0], object_matches: None },
+];
+
 #[derive(Debug, Clone)]
 pub struct MethodConfig {
     checks: FxHashMap<CompactStr, SinkCheck>,
@@ -52,50 +71,90 @@ impl Default for MethodConfig {
 }
 
 fn default_checks() -> FxHashMap<CompactStr, SinkCheck> {
-    let sink = |properties: Vec<usize>, object_matches: Option<Vec<Regex>>| SinkCheck {
-        properties,
-        object_matches,
-        escape: EscapeConfig::default(),
-    };
-    // `document` as a regex, as upstream: it matches `documentish`, `window.document`, ...
-    let document = || Some(vec![Regex::new("(?i)document").unwrap()]);
-    FxHashMap::from_iter([
-        (CompactStr::new("insertAdjacentHTML"), sink(vec![1], None)),
-        (CompactStr::new("import"), sink(vec![0], None)),
-        (CompactStr::new("createContextualFragment"), sink(vec![0], None)),
-        (CompactStr::new("write"), sink(vec![0], document())),
-        (CompactStr::new("writeln"), sink(vec![0], document())),
-        (CompactStr::new("setHTMLUnsafe"), sink(vec![0], None)),
-    ])
+    DEFAULT_SINKS
+        .iter()
+        .map(|sink| {
+            let object_matches = sink
+                .object_matches
+                .map(|patterns| patterns.iter().map(|p| compile_regex(p).unwrap()).collect());
+            (
+                CompactStr::new(sink.name),
+                SinkCheck {
+                    properties: sink.properties.to_vec(),
+                    object_matches,
+                    escape: EscapeConfig::default(),
+                },
+            )
+        })
+        .collect()
 }
 
 #[derive(Debug, Default, Clone)]
 pub struct Method(Box<MethodConfig>);
 
+/// The first options object, applying to every sink.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct MethodOptionsSchema {
-    /// Escaping functions which mark a value as safe, for every sink.
+pub struct MethodGlobalOptions {
+    /// Escaping functions which mark a value as safe.
     escape: Option<EscapeSchema>,
     /// Drops the built-in sink list, so only sinks given in the second options
-    /// object are checked.
+    /// object are checked. Built-in sinks named there keep their argument indices.
     default_disable: Option<bool>,
-    /// Regexes the object of a call must match, for every sink.
+    /// Regexes the name of the object a method is called on must match.
+    ///
+    /// These are Rust regexes, which do not support backreferences or lookaround.
     object_matches: Option<Vec<String>>,
-    /// Argument indices which are parsed as HTML, for every sink.
+    /// Argument indices which are parsed as HTML.
     properties: Option<Vec<usize>>,
     /// Whether values coming from local `let`/`const` variables are traced back
     /// to their initializers. Defaults to `true`.
     variable_tracing: Option<bool>,
 }
 
-/// The per-sink options of the second options object.
+/// The options of a single sink in the second options object.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct SinkSchema {
+struct MethodSinkOptions {
+    /// Escaping functions accepted for this sink, replacing the ones from the
+    /// first options object.
     escape: Option<EscapeSchema>,
+    /// Regexes the name of the object must match, replacing the ones from the
+    /// first options object.
     object_matches: Option<Vec<String>>,
+    /// Argument indices which are parsed as HTML.
     properties: Option<Vec<usize>>,
+}
+
+/// `[globalOptions, { methodName: sinkOptions }]`, as upstream.
+#[derive(Debug)]
+#[expect(unused)] // only for schemars
+pub struct MethodOptionsSchema(MethodGlobalOptions, FxHashMap<String, MethodSinkOptions>);
+
+impl JsonSchema for MethodOptionsSchema {
+    fn schema_name() -> String {
+        "MethodOptionsSchema".to_string()
+    }
+
+    fn is_referenceable() -> bool {
+        false
+    }
+
+    fn json_schema(r#gen: &mut SchemaGenerator) -> Schema {
+        let global = r#gen.subschema_for::<MethodGlobalOptions>();
+        let sinks = r#gen.subschema_for::<FxHashMap<String, MethodSinkOptions>>();
+
+        SchemaObject {
+            instance_type: Some(InstanceType::Array.into()),
+            array: Some(Box::new(ArrayValidation {
+                items: Some(SingleOrVec::Vec(vec![global, sinks])),
+                max_items: Some(2),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
+    }
 }
 
 declare_oxc_lint!(
@@ -152,6 +211,17 @@ declare_oxc_lint!(
     ///   ]
     /// }
     /// ```
+    ///
+    /// `objectMatches` patterns are matched case-insensitively as Rust regexes,
+    /// which unlike JavaScript regexes support no backreferences and no lookaround.
+    /// A pattern that fails to compile is reported as a configuration error rather
+    /// than silently disabling the sink.
+    ///
+    /// ### Known limitations
+    ///
+    /// Calls whose method name is only known at runtime (`node[whichMethod](evil)`)
+    /// and arguments hidden behind a spread (`node.insertAdjacentHTML(...args)`)
+    /// are not reported, as upstream.
     Method,
     no_unsanitized,
     restriction,
@@ -162,65 +232,102 @@ declare_oxc_lint!(
 
 impl Rule for Method {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        let parent = value.get(0).cloned().unwrap_or(Value::Null);
-        let parent: MethodOptionsSchema = if parent.is_null() {
-            MethodOptionsSchema::default()
-        } else {
-            serde_json::from_value(parent)?
+        let global = match value.get(0) {
+            Some(global) if !global.is_null() => {
+                serde_json::from_value::<MethodGlobalOptions>(global.clone())?
+            }
+            _ => MethodGlobalOptions::default(),
         };
-        let children: FxHashMap<String, SinkSchema> = match value.get(1) {
+        let sinks: FxHashMap<String, MethodSinkOptions> = match value.get(1) {
             Some(Value::Object(_)) => serde_json::from_value(value[1].clone())?,
             _ => FxHashMap::default(),
         };
 
-        let default_disable = parent.default_disable.unwrap_or(false);
-        let mut checks = if default_disable { FxHashMap::default() } else { default_checks() };
+        let global_escape = global.escape.as_ref().map(EscapeConfig::from);
+        let global_object_matches =
+            global.object_matches.as_ref().map(|patterns| compile_regexes(patterns)).transpose()?;
 
-        // The first options object applies to every sink, ...
-        for check in checks.values_mut() {
-            apply_parent(check, &parent);
-        }
-        // ... the second one adds or overrides individual sinks.
-        for (name, child) in &children {
-            let name = CompactStr::from(name.as_str());
-            let mut check = checks.remove(&name).unwrap_or_else(|| {
-                let escape = if default_disable {
-                    EscapeConfig { tagged_templates: Vec::new(), methods: Vec::new() }
-                } else {
-                    EscapeConfig::default()
-                };
-                let mut check = SinkCheck { properties: Vec::new(), object_matches: None, escape };
-                apply_parent(&mut check, &parent);
-                check
-            });
-            if let Some(escape) = &child.escape {
-                check.escape.apply(escape);
-            }
-            if let Some(properties) = &child.properties {
-                check.properties.clone_from(properties);
-            }
-            if let Some(object_matches) = &child.object_matches {
-                check.object_matches = Some(compile_regexes(object_matches));
-            }
-            checks.insert(name, check);
+        // Without `defaultDisable` every built-in sink is checked, with it only the
+        // ones named in the second options object -- but those keep the built-in
+        // argument indices.
+        let default_disable = global.default_disable.unwrap_or(false);
+        let names: Vec<&str> = if default_disable {
+            sinks.keys().map(String::as_str).collect()
+        } else {
+            DEFAULT_SINKS
+                .iter()
+                .map(|sink| sink.name)
+                .chain(
+                    sinks
+                        .keys()
+                        .map(String::as_str)
+                        .filter(|name| !DEFAULT_SINKS.iter().any(|sink| sink.name == *name)),
+                )
+                .collect()
+        };
+
+        let mut checks = FxHashMap::default();
+        for name in names {
+            let default = DEFAULT_SINKS.iter().find(|sink| sink.name == name);
+            let sink = sinks.get(name);
+
+            let properties = sink
+                .and_then(|sink| sink.properties.clone())
+                .or_else(|| global.properties.clone())
+                .or_else(|| default.map(|default| default.properties.to_vec()))
+                .unwrap_or_default();
+
+            let object_matches = match sink.and_then(|sink| sink.object_matches.as_ref()) {
+                Some(patterns) => Some(compile_regexes(patterns)?),
+                None => match &global_object_matches {
+                    Some(regexes) => Some(regexes.clone()),
+                    None => default
+                        .and_then(|default| default.object_matches)
+                        .map(|patterns| {
+                            patterns.iter().map(|pattern| compile_regex(pattern)).collect()
+                        })
+                        .transpose()?,
+                },
+            };
+
+            // An `escape` object replaces the one it overrides as a whole.
+            let escape = sink
+                .and_then(|sink| sink.escape.as_ref())
+                .map(EscapeConfig::from)
+                .or_else(|| global_escape.clone())
+                .unwrap_or_default();
+
+            checks.insert(CompactStr::from(name), SinkCheck { properties, object_matches, escape });
         }
 
         Ok(Self(Box::new(MethodConfig {
             checks,
-            variable_tracing: parent.variable_tracing.unwrap_or(true),
+            variable_tracing: global.variable_tracing.unwrap_or(true),
         })))
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
-            AstKind::CallExpression(call) => self.check_call(call, ctx),
-            AstKind::TaggedTemplateExpression(tagged) => self.check_tagged_template(tagged, ctx),
+            AstKind::CallExpression(call) => {
+                if call.arguments.is_empty() {
+                    return;
+                }
+                let Some(callee) = effective_callee(&call.callee) else {
+                    return;
+                };
+                self.check(callee, &SinkArguments::Call(&call.arguments), call.span, ctx);
+            }
+            AstKind::TaggedTemplateExpression(tagged) => {
+                let Some(callee) = effective_callee(&tagged.tag) else {
+                    return;
+                };
+                self.check(callee, &SinkArguments::Template(&tagged.quasi), tagged.span, ctx);
+            }
             AstKind::ImportExpression(import) => {
-                self.check(
+                self.check_sink(
                     "import",
                     None,
-                    &[SinkValue::Expression(&import.source)],
-                    "import",
+                    &SinkArguments::Single(&import.source),
                     import.span,
                     ctx,
                 );
@@ -231,73 +338,32 @@ impl Rule for Method {
 }
 
 impl Method {
-    fn check_call<'a>(&self, call: &CallExpression<'a>, ctx: &LintContext<'a>) {
-        if call.arguments.is_empty() {
-            return;
-        }
-        // Tagged templates are visited on their own.
-        let Some(callee) = effective_callee(&call.callee) else {
-            return;
-        };
-        let arguments: Vec<SinkValue> = call
-            .arguments
-            .iter()
-            .map(|argument| match argument {
-                Argument::SpreadElement(_) => SinkValue::Unsupported,
-                argument => {
-                    argument.as_expression().map_or(SinkValue::Unsupported, SinkValue::Expression)
-                }
-            })
-            .collect();
-        self.check_callee(callee, &arguments, call.span, ctx);
-    }
-
-    /// A tagged template behaves like a call with the quasis as first argument,
-    /// followed by the interpolated expressions.
-    fn check_tagged_template<'a>(
+    fn check<'a>(
         &self,
-        tagged: &TaggedTemplateExpression<'a>,
-        ctx: &LintContext<'a>,
-    ) {
-        let Some(callee) = effective_callee(&tagged.tag) else {
-            return;
-        };
-        let mut arguments = vec![SinkValue::Quasis];
-        arguments.extend(tagged.quasi.expressions.iter().map(SinkValue::Expression));
-        self.check_callee(callee, &arguments, tagged.span, ctx);
-    }
-
-    fn check_callee<'a>(
-        &self,
-        callee: &Expression<'a>,
-        arguments: &[SinkValue<'a, '_>],
+        callee: Callee<'a, '_>,
+        arguments: &SinkArguments<'a, '_>,
         span: Span,
         ctx: &LintContext<'a>,
     ) {
-        let (method_name, object) = match callee {
-            Expression::Identifier(identifier) => (identifier.name.as_str(), None),
-            Expression::StaticMemberExpression(member) => {
-                // `foo.import(bar)` is a plain method call, not a dynamic import.
-                if member.property.name == "import" {
-                    return;
-                }
-                (member.property.name.as_str(), Some(&member.object))
-            }
-            _ => return,
+        let Some((method_name, object)) = callee.parts() else {
+            return;
         };
-        let code_name = callee_code_name(callee, ctx).unwrap_or_else(|| method_name.to_string());
-        self.check(method_name, object, arguments, &code_name, span, ctx);
+        // `foo.import(bar)` is a plain method call, not a dynamic import.
+        if method_name == "import" && object.is_some() {
+            return;
+        }
+        self.check_sink(method_name, object, arguments, span, ctx);
     }
 
-    fn check<'a>(
+    fn check_sink<'a>(
         &self,
         method_name: &str,
         object: Option<&Expression<'a>>,
-        arguments: &[SinkValue<'a, '_>],
-        code_name: &str,
+        arguments: &SinkArguments<'a, '_>,
         span: Span,
         ctx: &LintContext<'a>,
     ) {
+        // Cheapest first: most calls are not sinks at all.
         let Some(check) = self.0.checks.get(method_name) else {
             return;
         };
@@ -319,43 +385,135 @@ impl Method {
             let Some(argument) = arguments.get(*index) else {
                 continue;
             };
-            if !sanitization.is_allowed(*argument, ctx) {
-                ctx.diagnostic(unsafe_call_diagnostic(code_name, *index, span));
+            if !sanitization.is_allowed(argument, ctx) {
+                let code_name = match object {
+                    Some(object) => format!("{}.{method_name}", object_code_name(object, ctx)),
+                    None => method_name.to_string(),
+                };
+                ctx.diagnostic(unsafe_call_diagnostic(&code_name, *index, span));
             }
         }
     }
 }
 
-fn apply_parent(check: &mut SinkCheck, parent: &MethodOptionsSchema) {
-    if let Some(escape) = &parent.escape {
-        check.escape.apply(escape);
-    }
-    if let Some(properties) = &parent.properties {
-        check.properties.clone_from(properties);
-    }
-    if let Some(object_matches) = &parent.object_matches {
-        check.object_matches = Some(compile_regexes(object_matches));
+/// The arguments of a sink, without collecting them into a new list.
+enum SinkArguments<'a, 'b> {
+    Call(&'b ArenaVec<'a, Argument<'a>>),
+    /// A tagged template behaves like a call with the quasis as first argument,
+    /// followed by the interpolated expressions.
+    Template(&'b TemplateLiteral<'a>),
+    /// The single argument of a dynamic `import()`.
+    Single(&'b Expression<'a>),
+}
+
+impl<'a, 'b> SinkArguments<'a, 'b> {
+    fn get(&self, index: usize) -> Option<SinkValue<'a, 'b>> {
+        match self {
+            Self::Call(arguments) => match arguments.get(index)? {
+                Argument::SpreadElement(_) => Some(SinkValue::Unsupported),
+                argument => Some(
+                    argument.as_expression().map_or(SinkValue::Unsupported, SinkValue::Expression),
+                ),
+            },
+            Self::Template(template) => match index.checked_sub(1) {
+                None => Some(SinkValue::Quasis),
+                Some(index) => template.expressions.get(index).map(SinkValue::Expression),
+            },
+            Self::Single(expression) => (index == 0).then_some(SinkValue::Expression(expression)),
+        }
     }
 }
 
-fn compile_regexes(patterns: &[String]) -> Vec<Regex> {
-    patterns.iter().filter_map(|pattern| Regex::new(&format!("(?i){pattern}")).ok()).collect()
+/// What a call expression actually calls.
+#[derive(Clone, Copy)]
+enum Callee<'a, 'b> {
+    Expression(&'b Expression<'a>),
+    /// The left-hand side of a logical assignment, whose value may well be the
+    /// sink that was already there: `(node.insertAdjacentHTML ||= fallback)(...)`.
+    AssignmentTarget(&'b AssignmentTarget<'a>),
+}
+
+impl<'a, 'b> Callee<'a, 'b> {
+    /// Method name and the object it is called on, if any.
+    fn parts(self) -> Option<(&'a str, Option<&'b Expression<'a>>)> {
+        let member = match self {
+            Self::Expression(Expression::Identifier(identifier)) => {
+                return Some((identifier.name.as_str(), None));
+            }
+            Self::Expression(expression) => expression.as_member_expression()?,
+            Self::AssignmentTarget(target) => {
+                let simple = target.as_simple_assignment_target()?;
+                match simple.get_expression() {
+                    Some(expression) => expression.get_inner_expression().get_member_expr()?,
+                    None => simple.as_member_expression()?,
+                }
+            }
+        };
+        Some((member.static_property_name()?, Some(member.object())))
+    }
+}
+
+fn compile_regexes(patterns: &[String]) -> Result<Vec<Regex>, serde_json::Error> {
+    patterns.iter().map(|pattern| compile_regex(pattern)).collect()
+}
+
+fn compile_regex(pattern: &str) -> Result<Regex, serde_json::Error> {
+    Regex::new(&format!("(?i){pattern}")).map_err(|err| {
+        serde_json::Error::custom(format!("invalid `objectMatches` regex `{pattern}`: {err}"))
+    })
 }
 
 /// Resolves what is actually being called, following the upstream
 /// `checkCallExpression` walk.
 ///
-/// Returns `None` for callees the rule intentionally does not reason about,
-/// such as calls, conditionals or function expressions.
-fn effective_callee<'a, 'b>(callee: &'b Expression<'a>) -> Option<&'b Expression<'a>> {
+/// Returns `None` for callees the rule intentionally does not reason about.
+// The ignored callee shapes are listed one by one on purpose, so that they are
+// documented rather than hidden behind the catch-all arm.
+#[expect(clippy::match_same_arms)]
+fn effective_callee<'a, 'b>(callee: &'b Expression<'a>) -> Option<Callee<'a, 'b>> {
     match callee {
-        Expression::Identifier(_) | Expression::StaticMemberExpression(_) => Some(callee),
+        Expression::Identifier(_)
+        | Expression::StaticMemberExpression(_)
+        | Expression::ComputedMemberExpression(_) => Some(Callee::Expression(callee)),
         Expression::ParenthesizedExpression(paren) => effective_callee(&paren.expression),
-        Expression::TSNonNullExpression(non_null) => effective_callee(&non_null.expression),
+        Expression::TSNonNullExpression(_)
+        | Expression::TSAsExpression(_)
+        | Expression::TSSatisfiesExpression(_)
+        | Expression::TSTypeAssertion(_)
+        | Expression::TSInstantiationExpression(_) => {
+            effective_callee(callee.get_inner_expression())
+        }
         // The value of a sequence is its last expression.
         Expression::SequenceExpression(sequence) => effective_callee(sequence.expressions.last()?),
-        // `(a.b = c.d)()` calls whatever was assigned.
-        Expression::AssignmentExpression(assignment) => effective_callee(&assignment.right),
+        Expression::AssignmentExpression(assignment) => match assignment.operator {
+            // `(a.b = c.d)()` calls whatever was assigned.
+            AssignmentOperator::Assign => effective_callee(&assignment.right),
+            // A logical assignment may evaluate to the previous value of the
+            // left-hand side, so that is what gets called.
+            AssignmentOperator::LogicalOr
+            | AssignmentOperator::LogicalAnd
+            | AssignmentOperator::LogicalNullish => {
+                Some(Callee::AssignmentTarget(&assignment.left))
+            }
+            // Arithmetic and bitwise compound assignments cannot produce a callable sink.
+            _ => None,
+        },
+        // Known callee shapes whose target the rule cannot resolve, listed
+        // explicitly so that new expression kinds are not silently ignored.
+        Expression::CallExpression(_)
+        | Expression::NewExpression(_)
+        | Expression::ConditionalExpression(_)
+        | Expression::LogicalExpression(_)
+        | Expression::ArrowFunctionExpression(_)
+        | Expression::FunctionExpression(_)
+        | Expression::AwaitExpression(_)
+        | Expression::ThisExpression(_)
+        | Expression::Super(_)
+        | Expression::ChainExpression(_)
+        | Expression::ImportExpression(_)
+        | Expression::TaggedTemplateExpression(_)
+        | Expression::YieldExpression(_)
+        | Expression::PrivateFieldExpression(_) => None,
         _ => None,
     }
 }
@@ -436,6 +594,31 @@ fn test() {
         ("let l = ['afterend', 'harmless']; foo.insertAdjacentHTML(...l);", None),
         ("foo.insertAdjacentHTML(wrongParamCount);", None),
         ("foo.setHTMLUnsafe('static string')", None),
+        // computed member access with a dynamic key: documented false negative
+        ("document[whichMethod](evil)", None),
+        // a spread argument shifts the checked index out of range, as upstream
+        ("foo.insertAdjacentHTML(...args);", None),
+        // a logical assignment callee is treated as a call to the existing sink
+        ("(node.insertAdjacentHTML ||= fallback)('beforebegin', '<b>static</b>')", None),
+        // an arithmetic compound assignment cannot produce a callable sink
+        ("(node.insertAdjacentHTML += fallback)('beforebegin', evil)", None),
+        // `defaultDisable` with a re-enabled built-in sink keeps its argument index,
+        // so the harmless first argument stays unchecked
+        (
+            "document.write('<b>static</b>')",
+            Some(json!([{"defaultDisable": true}, {"write": {"objectMatches": ["document"]}}])),
+        ),
+        // a per-sink `escape` replaces the global one as a whole, so `methods`
+        // falls back to the built-in escapers again
+        (
+            "n.insertAdjacentHTML('afterend', Sanitizer.unwrapSafeHTML(x));",
+            Some(json!([
+                {"escape": {"methods": ["DOMPurify.sanitize"]}},
+                {"insertAdjacentHTML": {"escape": {"taggedTemplates": ["safeHTML"]}}}
+            ])),
+        ),
+        // per-sink configuration of a method that is not a built-in sink
+        ("html('<b>static</b>')", Some(json!([{}, {"html": {"properties": [0]}}]))),
     ];
 
     let fail = vec![
@@ -510,6 +693,27 @@ fn test() {
         ),
         ("(info.current = n.insertAdjacentHTML)('beforebegin', c)", None),
         ("foo.setHTMLUnsafe(badness)", None),
+        // computed member access with a static key
+        ("document['write'](evil)", None),
+        // logical assignment callee: the call may hit the sink that was there before
+        ("(node.insertAdjacentHTML ||= fallback)('beforebegin', evil)", None),
+        ("(node.insertAdjacentHTML &&= fallback)('beforebegin', evil)", None),
+        ("(node.insertAdjacentHTML ??= fallback)('beforebegin', evil)", None),
+        // `defaultDisable` with a re-enabled built-in sink keeps its argument index
+        (
+            "document.write(evil)",
+            Some(json!([{"defaultDisable": true}, {"write": {"objectMatches": ["document"]}}])),
+        ),
+        // the per-sink `escape` object replaces the global one as a whole
+        (
+            "n.insertAdjacentHTML('afterend', DOMPurify.sanitize(evil));",
+            Some(json!([
+                {"escape": {"methods": ["DOMPurify.sanitize"]}},
+                {"insertAdjacentHTML": {"escape": {"taggedTemplates": ["safeHTML"]}}}
+            ])),
+        ),
+        // per-sink configuration of a method that is not a built-in sink
+        ("html(evil)", Some(json!([{}, {"html": {"properties": [0]}}]))),
     ];
 
     Tester::new(Method::NAME, Method::PLUGIN, pass, fail).test_and_snapshot();
@@ -521,6 +725,7 @@ fn test() {
     ];
 
     let ts_fail = vec![
+        ("(node.insertAdjacentHTML as InsertFn)('beforebegin', htmlString);", None),
         ("node!().insertAdjacentHTML('beforebegin', htmlString);", None),
         ("node!.insertAdjacentHTML('beforebegin', htmlString);", None),
         ("(x as HTMLElement).insertAdjacentHTML('beforebegin', htmlString)", None),
@@ -530,4 +735,16 @@ fn test() {
         .change_rule_path_extension("ts")
         .with_snapshot_suffix("typescript")
         .test_and_snapshot();
+}
+
+#[test]
+fn invalid_object_matches_regex_is_a_configuration_error() {
+    let error = Method::from_configuration(serde_json::json!([{"objectMatches": ["("]}]))
+        .expect_err("an invalid regex must be rejected instead of disabling the sink");
+    assert!(error.to_string().contains("invalid `objectMatches` regex"));
+
+    let error =
+        Method::from_configuration(serde_json::json!([{}, {"write": {"objectMatches": ["*"]}}]))
+            .expect_err("an invalid regex must be rejected instead of disabling the sink");
+    assert!(error.to_string().contains("invalid `objectMatches` regex"));
 }

--- a/crates/oxc_linter/src/rules/no_unsanitized/method.rs
+++ b/crates/oxc_linter/src/rules/no_unsanitized/method.rs
@@ -1,0 +1,533 @@
+use lazy_regex::Regex;
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, CallExpression, Expression, TaggedTemplateExpression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use oxc_str::CompactStr;
+use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        EscapeConfig, EscapeSchema, Sanitization, SinkValue, callee_code_name, object_code_name,
+    },
+};
+
+fn unsafe_call_diagnostic(callee: &str, argument: usize, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unsafe call to {callee} for argument {argument}"))
+        .with_help(
+            "Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.",
+        )
+        .with_label(span)
+}
+
+/// One HTML sink: which arguments are parsed as HTML, and on which objects.
+#[derive(Debug, Clone)]
+struct SinkCheck {
+    /// Indices of the arguments that end up being parsed as HTML.
+    properties: Vec<usize>,
+    /// Regexes the name of the object must match, `None` matches everything.
+    object_matches: Option<Vec<Regex>>,
+    escape: EscapeConfig,
+}
+
+#[derive(Debug, Clone)]
+pub struct MethodConfig {
+    checks: FxHashMap<CompactStr, SinkCheck>,
+    variable_tracing: bool,
+}
+
+impl Default for MethodConfig {
+    fn default() -> Self {
+        Self { checks: default_checks(), variable_tracing: true }
+    }
+}
+
+fn default_checks() -> FxHashMap<CompactStr, SinkCheck> {
+    let sink = |properties: Vec<usize>, object_matches: Option<Vec<Regex>>| SinkCheck {
+        properties,
+        object_matches,
+        escape: EscapeConfig::default(),
+    };
+    // `document` as a regex, as upstream: it matches `documentish`, `window.document`, ...
+    let document = || Some(vec![Regex::new("(?i)document").unwrap()]);
+    FxHashMap::from_iter([
+        (CompactStr::new("insertAdjacentHTML"), sink(vec![1], None)),
+        (CompactStr::new("import"), sink(vec![0], None)),
+        (CompactStr::new("createContextualFragment"), sink(vec![0], None)),
+        (CompactStr::new("write"), sink(vec![0], document())),
+        (CompactStr::new("writeln"), sink(vec![0], document())),
+        (CompactStr::new("setHTMLUnsafe"), sink(vec![0], None)),
+    ])
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Method(Box<MethodConfig>);
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MethodOptionsSchema {
+    /// Escaping functions which mark a value as safe, for every sink.
+    escape: Option<EscapeSchema>,
+    /// Drops the built-in sink list, so only sinks given in the second options
+    /// object are checked.
+    default_disable: Option<bool>,
+    /// Regexes the object of a call must match, for every sink.
+    object_matches: Option<Vec<String>>,
+    /// Argument indices which are parsed as HTML, for every sink.
+    properties: Option<Vec<usize>>,
+    /// Whether values coming from local `let`/`const` variables are traced back
+    /// to their initializers. Defaults to `true`.
+    variable_tracing: Option<bool>,
+}
+
+/// The per-sink options of the second options object.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SinkSchema {
+    escape: Option<EscapeSchema>,
+    object_matches: Option<Vec<String>>,
+    properties: Option<Vec<usize>>,
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows passing values that are not provably safe to DOM methods which
+    /// parse an argument as HTML, such as `insertAdjacentHTML`, `document.write`
+    /// or `Range.createContextualFragment`. Dynamic `import()` is checked as well,
+    /// since its argument is a code location.
+    ///
+    /// This is a port of the `method` rule of
+    /// [`eslint-plugin-no-unsanitized`](https://github.com/mozilla/eslint-plugin-no-unsanitized).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Passing a dynamic value to a method that parses HTML is a common source of
+    /// DOM based cross-site scripting. Only string literals, template literals whose
+    /// interpolations are themselves safe, and the output of a known escaping
+    /// function can be assumed not to introduce markup an attacker controls.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// node.insertAdjacentHTML("beforebegin", htmlString);
+    /// document.write("<span>" + userInput + "</span>");
+    /// range.createContextualFragment(userInput);
+    /// import(userInput);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// node.insertAdjacentHTML("beforebegin", "<b>static</b>");
+    /// node.insertAdjacentHTML("beforebegin", Sanitizer.escapeHTML`<b>${userInput}</b>`);
+    /// document.write("static");
+    /// import("lodash");
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// The first object configures all sinks, the second one adds or overrides
+    /// individual sinks:
+    ///
+    /// ```json
+    /// {
+    ///   "no-unsanitized/method": [
+    ///     "error",
+    ///     {
+    ///       "escape": { "methods": ["DOMPurify.sanitize"] }
+    ///     },
+    ///     {
+    ///       "setHTML": { "properties": [0] }
+    ///     }
+    ///   ]
+    /// }
+    /// ```
+    Method,
+    no_unsanitized,
+    restriction,
+    config = MethodOptionsSchema,
+    version = "1.78.0",
+    short_description = "Disallow unsanitized arguments to DOM methods that parse HTML.",
+);
+
+impl Rule for Method {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        let parent = value.get(0).cloned().unwrap_or(Value::Null);
+        let parent: MethodOptionsSchema = if parent.is_null() {
+            MethodOptionsSchema::default()
+        } else {
+            serde_json::from_value(parent)?
+        };
+        let children: FxHashMap<String, SinkSchema> = match value.get(1) {
+            Some(Value::Object(_)) => serde_json::from_value(value[1].clone())?,
+            _ => FxHashMap::default(),
+        };
+
+        let default_disable = parent.default_disable.unwrap_or(false);
+        let mut checks = if default_disable { FxHashMap::default() } else { default_checks() };
+
+        // The first options object applies to every sink, ...
+        for check in checks.values_mut() {
+            apply_parent(check, &parent);
+        }
+        // ... the second one adds or overrides individual sinks.
+        for (name, child) in &children {
+            let name = CompactStr::from(name.as_str());
+            let mut check = checks.remove(&name).unwrap_or_else(|| {
+                let escape = if default_disable {
+                    EscapeConfig { tagged_templates: Vec::new(), methods: Vec::new() }
+                } else {
+                    EscapeConfig::default()
+                };
+                let mut check = SinkCheck { properties: Vec::new(), object_matches: None, escape };
+                apply_parent(&mut check, &parent);
+                check
+            });
+            if let Some(escape) = &child.escape {
+                check.escape.apply(escape);
+            }
+            if let Some(properties) = &child.properties {
+                check.properties.clone_from(properties);
+            }
+            if let Some(object_matches) = &child.object_matches {
+                check.object_matches = Some(compile_regexes(object_matches));
+            }
+            checks.insert(name, check);
+        }
+
+        Ok(Self(Box::new(MethodConfig {
+            checks,
+            variable_tracing: parent.variable_tracing.unwrap_or(true),
+        })))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::CallExpression(call) => self.check_call(call, ctx),
+            AstKind::TaggedTemplateExpression(tagged) => self.check_tagged_template(tagged, ctx),
+            AstKind::ImportExpression(import) => {
+                self.check(
+                    "import",
+                    None,
+                    &[SinkValue::Expression(&import.source)],
+                    "import",
+                    import.span,
+                    ctx,
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Method {
+    fn check_call<'a>(&self, call: &CallExpression<'a>, ctx: &LintContext<'a>) {
+        if call.arguments.is_empty() {
+            return;
+        }
+        // Tagged templates are visited on their own.
+        let Some(callee) = effective_callee(&call.callee) else {
+            return;
+        };
+        let arguments: Vec<SinkValue> = call
+            .arguments
+            .iter()
+            .map(|argument| match argument {
+                Argument::SpreadElement(_) => SinkValue::Unsupported,
+                argument => {
+                    argument.as_expression().map_or(SinkValue::Unsupported, SinkValue::Expression)
+                }
+            })
+            .collect();
+        self.check_callee(callee, &arguments, call.span, ctx);
+    }
+
+    /// A tagged template behaves like a call with the quasis as first argument,
+    /// followed by the interpolated expressions.
+    fn check_tagged_template<'a>(
+        &self,
+        tagged: &TaggedTemplateExpression<'a>,
+        ctx: &LintContext<'a>,
+    ) {
+        let Some(callee) = effective_callee(&tagged.tag) else {
+            return;
+        };
+        let mut arguments = vec![SinkValue::Quasis];
+        arguments.extend(tagged.quasi.expressions.iter().map(SinkValue::Expression));
+        self.check_callee(callee, &arguments, tagged.span, ctx);
+    }
+
+    fn check_callee<'a>(
+        &self,
+        callee: &Expression<'a>,
+        arguments: &[SinkValue<'a, '_>],
+        span: Span,
+        ctx: &LintContext<'a>,
+    ) {
+        let (method_name, object) = match callee {
+            Expression::Identifier(identifier) => (identifier.name.as_str(), None),
+            Expression::StaticMemberExpression(member) => {
+                // `foo.import(bar)` is a plain method call, not a dynamic import.
+                if member.property.name == "import" {
+                    return;
+                }
+                (member.property.name.as_str(), Some(&member.object))
+            }
+            _ => return,
+        };
+        let code_name = callee_code_name(callee, ctx).unwrap_or_else(|| method_name.to_string());
+        self.check(method_name, object, arguments, &code_name, span, ctx);
+    }
+
+    fn check<'a>(
+        &self,
+        method_name: &str,
+        object: Option<&Expression<'a>>,
+        arguments: &[SinkValue<'a, '_>],
+        code_name: &str,
+        span: Span,
+        ctx: &LintContext<'a>,
+    ) {
+        let Some(check) = self.0.checks.get(method_name) else {
+            return;
+        };
+        if let Some(object_matches) = &check.object_matches {
+            let Some(object) = object else {
+                // A bare function call cannot match an object name.
+                return;
+            };
+            let object_name = object_code_name(object, ctx);
+            if !object_matches.iter().any(|regex| regex.is_match(&object_name)) {
+                return;
+            }
+        }
+
+        let sanitization =
+            Sanitization { escape: &check.escape, variable_tracing: self.0.variable_tracing };
+        for index in &check.properties {
+            // Fewer arguments than configured, e.g. because of a spread element.
+            let Some(argument) = arguments.get(*index) else {
+                continue;
+            };
+            if !sanitization.is_allowed(*argument, ctx) {
+                ctx.diagnostic(unsafe_call_diagnostic(code_name, *index, span));
+            }
+        }
+    }
+}
+
+fn apply_parent(check: &mut SinkCheck, parent: &MethodOptionsSchema) {
+    if let Some(escape) = &parent.escape {
+        check.escape.apply(escape);
+    }
+    if let Some(properties) = &parent.properties {
+        check.properties.clone_from(properties);
+    }
+    if let Some(object_matches) = &parent.object_matches {
+        check.object_matches = Some(compile_regexes(object_matches));
+    }
+}
+
+fn compile_regexes(patterns: &[String]) -> Vec<Regex> {
+    patterns.iter().filter_map(|pattern| Regex::new(&format!("(?i){pattern}")).ok()).collect()
+}
+
+/// Resolves what is actually being called, following the upstream
+/// `checkCallExpression` walk.
+///
+/// Returns `None` for callees the rule intentionally does not reason about,
+/// such as calls, conditionals or function expressions.
+fn effective_callee<'a, 'b>(callee: &'b Expression<'a>) -> Option<&'b Expression<'a>> {
+    match callee {
+        Expression::Identifier(_) | Expression::StaticMemberExpression(_) => Some(callee),
+        Expression::ParenthesizedExpression(paren) => effective_callee(&paren.expression),
+        Expression::TSNonNullExpression(non_null) => effective_callee(&non_null.expression),
+        // The value of a sequence is its last expression.
+        Expression::SequenceExpression(sequence) => effective_callee(sequence.expressions.last()?),
+        // `(a.b = c.d)()` calls whatever was assigned.
+        Expression::AssignmentExpression(assignment) => effective_callee(&assignment.right),
+        _ => None,
+    }
+}
+
+#[test]
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("n.insertAdjacentHTML('afterend', 'meh');", None),
+        ("n.insertAdjacentHTML('afterend', `<br>`);", None),
+        ("n.insertAdjacentHTML('afterend', Sanitizer.escapeHTML`${title}`);", None),
+        ("document.write('lulz');", None),
+        ("document.write();", None),
+        ("document.writeln(Sanitizer.escapeHTML`<em>${evil}</em>`);", None),
+        ("otherNodeWeDontCheckFor.writeln(evil);", None),
+        ("document.toString(evil);", None),
+        ("document.write(escaper(x))", Some(json!([{"escape": {"methods": ["escaper"]}}]))),
+        (
+            "document.write(evilest)",
+            Some(
+                json!([{"objectMatches": ["document", "documentFun"]}, {"write": {"objectMatches": ["thing"]}}]),
+            ),
+        ),
+        ("document.write(evil)", Some(json!([{"defaultDisable": true}]))),
+        ("  _tests.shift()();", None),
+        ("(Async.checkAppReady = function() { return true; })();", None),
+        ("let endTime = (mapEnd || (e => e.delta))(this._data[this._data.length - 1]);", None),
+        ("(text.endsWith('\\n') ? document.write : document.writeln)(text)", None),
+        ("function foo() { return this().bar(); };", None),
+        ("new Function()();", None),
+        ("range.createContextualFragment('<p class=\"greeting\">Hello!</p>');", None),
+        (
+            "range.createContextualFragment(Sanitizer.escapeHTML`<em>${evil}</em>`);",
+            Some(json!([{"escape": {"methods": ["escaper"]}}])),
+        ),
+        (
+            "range.createContextualFragment(escaper('<em>'+evil+'</em>'));",
+            Some(json!([{"escape": {"methods": ["escaper"]}}])),
+        ),
+        ("import('lodash')", None),
+        (
+            "range.createContextualFragment(templateEscaper`<em>${evil}</em>`);",
+            Some(json!([{"escape": {"taggedTemplates": ["templateEscaper"]}}])),
+        ),
+        (
+            "n.insertAdjacentHTML('afterend', DOMPurify.sanitize(evil));",
+            Some(json!([{"escape": {"methods": ["DOMPurify.sanitize"]}}])),
+        ),
+        (
+            "n.insertAdjacentHTML('afterend', DOMPurify.sanitize(evil, options));",
+            Some(json!([{"escape": {"methods": ["DOMPurify.sanitize"]}}])),
+        ),
+        (
+            "n.insertAdjacentHTML('afterend', DOMPurify.sanitize(evil, {ALLOWED_TAGS: ['b']}));",
+            Some(json!([{"escape": {"methods": ["DOMPurify.sanitize"]}}])),
+        ),
+        ("describe.each`table`(name, fn, timeout)", None),
+        ("document.write`text`", None),
+        ("document.write`text ${'static string'}`", None),
+        ("custom`text ${variable}`", Some(json!([{}, {"custom": {"properties": [0]}}]))),
+        ("custom`text ${'string'}`", Some(json!([{}, {"custom": {"properties": [1]}}]))),
+        ("document.write`text ${variable}`", None),
+        ("let a = (0,1,2,34);", None),
+        ("(async function()  { (await somePromise)(); })", None),
+        ("async () => (await TheRuleDoesntKnowWhatIsBeingReturnedHere())('afterend', blah);", None),
+        ("(e = this.n[n.i])(i, r)", None),
+        ("(e = node.insertAdjacentHTML('beforebegin', '<s>safe</s>'))()", None),
+        ("foo.import(bar)", None),
+        ("let c; n.insertAdjacentHTML('beforebegin', c)", None),
+        ("x.setHTML(evil)", None),
+        ("x.setHTML(evil, { sanitizer: s })", None),
+        ("x.setHTML(evil, { sanitizer: new Sanitizer()})", None),
+        ("(info.current = type)(child_ctx)", None),
+        ("(info.current = n.insertAdjacentHTML)('beforebegin', 'innocent')", None),
+        ("let l = ['afterend', 'harmless']; foo.insertAdjacentHTML(...l);", None),
+        ("foo.insertAdjacentHTML(wrongParamCount);", None),
+        ("foo.setHTMLUnsafe('static string')", None),
+    ];
+
+    let fail = vec![
+        ("node.insertAdjacentHTML('beforebegin', htmlString);", None),
+        ("node.insertAdjacentHTML('beforebegin', template.getHTML());", None),
+        ("document.write('<span>'+ htmlInput + '</span>');", None),
+        ("documentish.write('<span>'+ htmlInput + '</span>');", None),
+        ("documentIframe.write('<span>'+ htmlInput + '</span>');", None),
+        ("document.writeln(evil);", None),
+        ("window.document.writeln(bad);", None),
+        ("function foo() { return this().insertAdjacentHTML(foo, bar); };", None),
+        (
+            "document.write(evil); b.thing(x); b.other(me);",
+            Some(json!([{"defaultDisable": true}, {"other": {"properties": [0]}}])),
+        ),
+        ("getDocument(myID).write(evil)", None),
+        ("range.createContextualFragment(badness)", None),
+        ("import(foo)", None),
+        ("(0, node.insertAdjacentHTML)('beforebegin', evil);", None),
+        (
+            "n.insertAdjacentHTML('afterend', templateEscaper(evil, options));",
+            Some(json!([{"escape": {"taggedTemplates": ["templateEscaper"]}}])),
+        ),
+        (
+            "n.insertAdjacentHTML('afterend', sanitize`<em>${evil}</em>`);",
+            Some(json!([{"escape": {"methods": ["sanitize"]}}])),
+        ),
+        (
+            "document.writeln(Sanitizer.escapeHTML`<em>${evil}</em>`);",
+            Some(json!([
+                {"defaultDisable": true},
+                {"writeln": {"objectMatches": ["document"], "properties": [0], "escape": {"methods": [], "taggedTemplates": []}}}
+            ])),
+        ),
+        (
+            "describe.each`table${node.insertAdjacentHTML('beforebegin', htmlString)}`(name, fn, timeout)",
+            None,
+        ),
+        ("describe.each`table${document.writeln(evil)}`(name, fn, timeout)", None),
+        ("node.insertAdjacentHTML`text ${variable}`", None),
+        ("custom`text ${variable}`", Some(json!([{}, {"custom": {"properties": [1]}}]))),
+        (
+            "custom`text ${variable} ${variable2}`",
+            Some(json!([{}, {"custom": {"properties": [2]}}])),
+        ),
+        ("async () => await foo.insertAdjacentHTML('afterend', blah);", None),
+        ("async () => (await foo.insertAdjacentHTML('afterend', blah))();", None),
+        ("async () => (await foo)().insertAdjacentHTML('afterend', blah);", None),
+        ("(e = node.insertAdjacentHTML)('beforebegin', evil)", None),
+        ("(e = node.insertAdjacentHTML('beforebegin', evil))()", None),
+        ("var copies = '<b>safe</b>'; n.insertAdjacentHTML('beforebegin', copies);", None),
+        ("let copies = evil; n.insertAdjacentHTML('beforebegin', copies);", None),
+        (
+            "let copies = '<b>safe</b>'; copies = suddenlyUnsafe; n.insertAdjacentHTML('beforebegin', copies);",
+            None,
+        ),
+        (
+            "function test(evil) { let copies = '<b>safe</b>'; copies = evil; n.insertAdjacentHTML('beforebegin', copies); }",
+            None,
+        ),
+        (
+            "const fn = function (evil) { let copies = '<b>safe</b>'; copies = evil; n.insertAdjacentHTML('beforebegin', copies); }",
+            None,
+        ),
+        (
+            "const fn = (evil) => { let copies = '<b>safe</b>'; copies = evil; n.insertAdjacentHTML('beforebegin', copies); }",
+            None,
+        ),
+        (
+            "let c; if (cond) { c = '<b>safe</b>'; } else { c = evil; } n.insertAdjacentHTML('beforebegin', `${c}`);",
+            None,
+        ),
+        ("(info.current = n.insertAdjacentHTML)('beforebegin', c)", None),
+        ("foo.setHTMLUnsafe(badness)", None),
+    ];
+
+    Tester::new(Method::NAME, Method::PLUGIN, pass, fail).test_and_snapshot();
+
+    let ts_pass = vec![
+        ("node.insertAdjacentHTML('beforebegin', (5 as string));", None),
+        ("node!.insertAdjacentHTML('beforebegin', 'raw string');", None),
+        ("node!().insertAdjacentHTML('beforebegin', 'raw string');", None),
+    ];
+
+    let ts_fail = vec![
+        ("node!().insertAdjacentHTML('beforebegin', htmlString);", None),
+        ("node!.insertAdjacentHTML('beforebegin', htmlString);", None),
+        ("(x as HTMLElement).insertAdjacentHTML('beforebegin', htmlString)", None),
+    ];
+
+    Tester::new(Method::NAME, Method::PLUGIN, ts_pass, ts_fail)
+        .change_rule_path_extension("ts")
+        .with_snapshot_suffix("typescript")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/no_unsanitized/property.rs
+++ b/crates/oxc_linter/src/rules/no_unsanitized/property.rs
@@ -1,13 +1,18 @@
 use oxc_ast::{
     AstKind,
-    ast::{AssignmentOperator, AssignmentTarget, MemberExpression},
+    ast::{AssignmentOperator, AssignmentTarget},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_str::CompactStr;
-use schemars::JsonSchema;
+use rustc_hash::FxHashMap;
+use schemars::{
+    JsonSchema, SchemaGenerator,
+    schema::{ArrayValidation, InstanceType, Schema, SchemaObject, SingleOrVec},
+};
 use serde::Deserialize;
+use serde_json::Value;
 
 use crate::{
     AstNode,
@@ -26,36 +31,77 @@ fn unsafe_assignment_diagnostic(property: &str, span: Span) -> OxcDiagnostic {
 
 #[derive(Debug, Clone)]
 pub struct PropertyConfig {
-    /// Property names which are treated as HTML sinks.
-    properties: Vec<CompactStr>,
-    escape: EscapeConfig,
+    /// Property names treated as HTML sinks, with the escaping functions accepted
+    /// for each of them.
+    checks: FxHashMap<CompactStr, EscapeConfig>,
     variable_tracing: bool,
 }
 
 impl Default for PropertyConfig {
     fn default() -> Self {
-        Self {
-            properties: vec![CompactStr::new("innerHTML"), CompactStr::new("outerHTML")],
-            escape: EscapeConfig::default(),
-            variable_tracing: true,
-        }
+        Self { checks: default_checks(), variable_tracing: true }
     }
+}
+
+fn default_checks() -> FxHashMap<CompactStr, EscapeConfig> {
+    FxHashMap::from_iter([
+        (CompactStr::new("innerHTML"), EscapeConfig::default()),
+        (CompactStr::new("outerHTML"), EscapeConfig::default()),
+    ])
 }
 
 #[derive(Debug, Default, Clone)]
 pub struct Property(Box<PropertyConfig>);
 
+/// The first options object, applying to every property.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct PropertyOptionsSchema {
+pub struct PropertyGlobalOptions {
     /// Escaping functions which mark a value as safe.
     escape: Option<EscapeSchema>,
     /// Whether values assigned from local `let`/`const` variables are traced back
     /// to their initializers. Defaults to `true`.
     variable_tracing: Option<bool>,
-    /// Property names treated as HTML sinks, replacing the defaults
-    /// `["innerHTML", "outerHTML"]`.
-    properties: Option<Vec<String>>,
+}
+
+/// The options of a single property in the second options object.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PropertySinkOptions {
+    /// Escaping functions accepted for this property, replacing the ones from the
+    /// first options object.
+    escape: Option<EscapeSchema>,
+}
+
+/// `[globalOptions, { propertyName: sinkOptions }]`, as upstream.
+#[derive(Debug)]
+#[expect(unused)] // only for schemars
+pub struct PropertyOptionsSchema(PropertyGlobalOptions, FxHashMap<String, PropertySinkOptions>);
+
+impl JsonSchema for PropertyOptionsSchema {
+    fn schema_name() -> String {
+        "PropertyOptionsSchema".to_string()
+    }
+
+    fn is_referenceable() -> bool {
+        false
+    }
+
+    fn json_schema(r#gen: &mut SchemaGenerator) -> Schema {
+        let global = r#gen.subschema_for::<PropertyGlobalOptions>();
+        let sinks = r#gen.subschema_for::<FxHashMap<String, PropertySinkOptions>>();
+
+        SchemaObject {
+            instance_type: Some(InstanceType::Array.into()),
+            array: Some(Box::new(ArrayValidation {
+                items: Some(SingleOrVec::Vec(vec![global, sinks])),
+                max_items: Some(2),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
+    }
 }
 
 declare_oxc_lint!(
@@ -93,6 +139,9 @@ declare_oxc_lint!(
     ///
     /// ### Options
     ///
+    /// The first object configures every property, the second one adds properties
+    /// to the built-in `innerHTML` and `outerHTML` or overrides their escapers:
+    ///
     /// ```json
     /// {
     ///   "no-unsanitized/property": [
@@ -102,12 +151,19 @@ declare_oxc_lint!(
     ///         "taggedTemplates": ["safeHTML"],
     ///         "methods": ["DOMPurify.sanitize"]
     ///       },
-    ///       "properties": ["innerHTML", "outerHTML", "srcdoc"],
     ///       "variableTracing": true
+    ///     },
+    ///     {
+    ///       "srcdoc": {}
     ///     }
     ///   ]
     /// }
     /// ```
+    ///
+    /// ### Known limitations
+    ///
+    /// Assignments whose property name is only known at runtime
+    /// (`node[whichProperty] = evil`) are not reported, as upstream.
     Property,
     no_unsanitized,
     restriction,
@@ -118,25 +174,39 @@ declare_oxc_lint!(
 
 impl Rule for Property {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        let mut config = PropertyConfig::default();
+        let global = match value.get(0) {
+            Some(global) if !global.is_null() => {
+                serde_json::from_value::<PropertyGlobalOptions>(global.clone())?
+            }
+            _ => PropertyGlobalOptions::default(),
+        };
+        let sinks: FxHashMap<String, PropertySinkOptions> = match value.get(1) {
+            Some(Value::Object(_)) => serde_json::from_value(value[1].clone())?,
+            _ => FxHashMap::default(),
+        };
 
-        let options = value.get(0).cloned().unwrap_or(serde_json::Value::Null);
-        if options.is_null() {
-            return Ok(Self(Box::new(config)));
+        let global_escape = global.escape.as_ref().map(EscapeConfig::from);
+        let mut checks = default_checks();
+        if let Some(global_escape) = &global_escape {
+            for escape in checks.values_mut() {
+                *escape = global_escape.clone();
+            }
         }
-        let options: PropertyOptionsSchema = serde_json::from_value(options)?;
+        // The second object adds properties to the defaults, or overrides their escapers.
+        for (property, sink) in &sinks {
+            let escape = sink
+                .escape
+                .as_ref()
+                .map(EscapeConfig::from)
+                .or_else(|| global_escape.clone())
+                .unwrap_or_default();
+            checks.insert(CompactStr::from(property.as_str()), escape);
+        }
 
-        if let Some(escape) = &options.escape {
-            config.escape.apply(escape);
-        }
-        if let Some(variable_tracing) = options.variable_tracing {
-            config.variable_tracing = variable_tracing;
-        }
-        if let Some(properties) = options.properties {
-            config.properties = properties.iter().map(|s| CompactStr::from(s.as_str())).collect();
-        }
-
-        Ok(Self(Box::new(config)))
+        Ok(Self(Box::new(PropertyConfig {
+            checks,
+            variable_tracing: global.variable_tracing.unwrap_or(true),
+        })))
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -149,12 +219,11 @@ impl Rule for Property {
         let Some(property) = assigned_property_name(&assignment.left) else {
             return;
         };
-        if !self.0.properties.iter().any(|p| p == property) {
+        let Some(escape) = self.0.checks.get(property) else {
             return;
-        }
+        };
 
-        let sanitization =
-            Sanitization { escape: &self.0.escape, variable_tracing: self.0.variable_tracing };
+        let sanitization = Sanitization { escape, variable_tracing: self.0.variable_tracing };
         if !sanitization.is_allowed(SinkValue::Expression(&assignment.right), ctx) {
             ctx.diagnostic(unsafe_assignment_diagnostic(property, assignment.span));
         }
@@ -177,7 +246,10 @@ fn is_checked_operator(operator: AssignmentOperator) -> bool {
 }
 
 /// Name of the statically known property being assigned to, e.g. `innerHTML` for
-/// `node.innerHTML = x`. Computed accesses are not resolved, as upstream.
+/// `node.innerHTML = x` and for `node["innerHTML"] = x`.
+///
+/// A computed access with a dynamic key (`node[name] = x`) cannot be resolved and
+/// is not reported, as upstream.
 fn assigned_property_name<'a>(target: &AssignmentTarget<'a>) -> Option<&'a str> {
     let simple = target.as_simple_assignment_target()?;
     let member = match simple.get_expression() {
@@ -185,10 +257,7 @@ fn assigned_property_name<'a>(target: &AssignmentTarget<'a>) -> Option<&'a str> 
         Some(expression) => expression.get_inner_expression().get_member_expr(),
         None => simple.as_member_expression(),
     }?;
-    match member {
-        MemberExpression::StaticMemberExpression(member) => Some(member.property.name.as_str()),
-        _ => None,
-    }
+    member.static_property_name()
 }
 
 #[test]
@@ -224,6 +293,20 @@ fn test() {
         // not a sink
         ("document.toString = evil;", None),
         ("document.writeln(Sanitizer.escapeHTML`<em>${evil}</em>`);", None),
+        // computed member access with a static key
+        ("node['innerHTML'] = '<b>static</b>';", None),
+        // computed member with a dynamic key is a documented false negative
+        ("node[whichProperty] = evil;", None),
+        // per-property escaper, replacing the global one
+        (
+            "el.innerHTML = safeHTML`<b>${evil}</b>`;",
+            Some(json!([{}, {"innerHTML": {"escape": {"taggedTemplates": ["safeHTML"]}}}])),
+        ),
+        // a property added through the second object keeps the global escapers
+        (
+            "frame.srcdoc = DOMPurify.sanitize(evil);",
+            Some(json!([{"escape": {"methods": ["DOMPurify.sanitize"]}}, {"srcdoc": {}}])),
+        ),
         // configured escapers
         (
             "w.innerHTML = templateEscaper`<em>${evil}</em>`;",
@@ -261,6 +344,7 @@ fn test() {
         ("a.innerHTML += htmlString;", None),
         ("a.innerHTML += template.toHtml();", None),
         ("m.outerHTML = htmlString;", None),
+        ("node['innerHTML'] = htmlString;", None),
         ("t.innerHTML = `<span>${name}</span>`;", None),
         ("t.innerHTML = `<span>${'foobar'}</span>${evil}`;", None),
         ("node.innerHTML = '<span>'+ htmlInput;", None),
@@ -301,7 +385,22 @@ fn test() {
             Some(json!([{"variableTracing": false}])),
         ),
         // configurable sinks
-        ("frame.srcdoc = evil;", Some(json!([{"properties": ["srcdoc"]}]))),
+        // per-property configuration in the second options object
+        ("frame.srcdoc = evil;", Some(json!([{}, {"srcdoc": {}}]))),
+        (
+            "el.innerHTML = safeHTML`<b>${evil}</b>`;",
+            Some(
+                json!([{"escape": {"taggedTemplates": ["otherEscaper"]}}, {"innerHTML": {"escape": {"taggedTemplates": ["alsoNot"]}}}]),
+            ),
+        ),
+        // a per-property `escape` replaces the global one as a whole, so
+        // `methods` falls back to the built-in escapers again
+        (
+            "el.innerHTML = DOMPurify.sanitize(evil);",
+            Some(
+                json!([{"escape": {"methods": ["DOMPurify.sanitize"]}}, {"innerHTML": {"escape": {"taggedTemplates": ["safeHTML"]}}}]),
+            ),
+        ),
     ];
 
     Tester::new(Property::NAME, Property::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/no_unsanitized/property.rs
+++ b/crates/oxc_linter/src/rules/no_unsanitized/property.rs
@@ -1,0 +1,514 @@
+use oxc_ast::{
+    AstKind,
+    ast::{
+        AssignmentOperator, AssignmentTarget, Expression, IdentifierReference,
+        VariableDeclarationKind,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::SymbolId;
+use oxc_span::{GetSpan, Span};
+use oxc_str::CompactStr;
+use rustc_hash::FxHashSet;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn unsafe_assignment_diagnostic(property: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unsafe assignment to {property}"))
+        .with_help(
+            "Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.",
+        )
+        .with_label(span)
+}
+
+/// Escaping functions which mark a value as safe.
+#[derive(Debug, Clone)]
+struct Escape {
+    tagged_templates: Vec<CompactStr>,
+    methods: Vec<CompactStr>,
+}
+
+impl Default for Escape {
+    fn default() -> Self {
+        Self {
+            tagged_templates: vec![
+                CompactStr::new("Sanitizer.escapeHTML"),
+                CompactStr::new("escapeHTML"),
+            ],
+            methods: vec![
+                CompactStr::new("Sanitizer.unwrapSafeHTML"),
+                CompactStr::new("unwrapSafeHTML"),
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PropertyConfig {
+    /// Property names which are treated as HTML sinks.
+    properties: Vec<CompactStr>,
+    escape: Escape,
+    variable_tracing: bool,
+}
+
+impl Default for PropertyConfig {
+    fn default() -> Self {
+        Self {
+            properties: vec![CompactStr::new("innerHTML"), CompactStr::new("outerHTML")],
+            escape: Escape::default(),
+            variable_tracing: true,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Property(Box<PropertyConfig>);
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct EscapeSchema {
+    /// Tagged template functions which return safe HTML.
+    /// Defaults to `["Sanitizer.escapeHTML", "escapeHTML"]`.
+    tagged_templates: Option<Vec<String>>,
+    /// Methods which return safe HTML.
+    /// Defaults to `["Sanitizer.unwrapSafeHTML", "unwrapSafeHTML"]`.
+    methods: Option<Vec<String>>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PropertyOptionsSchema {
+    /// Escaping functions which mark a value as safe.
+    escape: Option<EscapeSchema>,
+    /// Whether values assigned from local `let`/`const` variables are traced back
+    /// to their initializers. Defaults to `true`.
+    variable_tracing: Option<bool>,
+    /// Property names treated as HTML sinks, replacing the defaults
+    /// `["innerHTML", "outerHTML"]`.
+    properties: Option<Vec<String>>,
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows assigning values that are not provably safe to DOM properties
+    /// which parse their input as HTML, such as `innerHTML` and `outerHTML`.
+    ///
+    /// This is a port of the `property` rule of
+    /// [`eslint-plugin-no-unsanitized`](https://github.com/mozilla/eslint-plugin-no-unsanitized).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Assigning a dynamic value to an HTML sink is the most common source of DOM
+    /// based cross-site scripting. Only string literals, template literals whose
+    /// interpolations are themselves safe, and the output of a known escaping
+    /// function can be assumed not to introduce markup an attacker controls.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// node.innerHTML = htmlString;
+    /// node.innerHTML = "<span>" + userInput + "</span>";
+    /// node.innerHTML = `<span>${userInput}</span>`;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// node.innerHTML = "<span>static</span>";
+    /// node.innerHTML = ``;
+    /// node.innerHTML = Sanitizer.escapeHTML`<span>${userInput}</span>`;
+    /// node.innerHTML = Sanitizer.unwrapSafeHTML(safeHtml);
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// ```json
+    /// {
+    ///   "no-unsanitized/property": [
+    ///     "error",
+    ///     {
+    ///       "escape": {
+    ///         "taggedTemplates": ["safeHTML"],
+    ///         "methods": ["DOMPurify.sanitize"]
+    ///       },
+    ///       "properties": ["innerHTML", "outerHTML", "srcdoc"],
+    ///       "variableTracing": true
+    ///     }
+    ///   ]
+    /// }
+    /// ```
+    Property,
+    no_unsanitized,
+    restriction,
+    config = PropertyOptionsSchema,
+    version = "1.78.0",
+    short_description = "Disallow unsanitized assignment to DOM properties that parse HTML.",
+);
+
+impl Rule for Property {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        let mut config = PropertyConfig::default();
+
+        let options = value.get(0).cloned().unwrap_or(serde_json::Value::Null);
+        if options.is_null() {
+            return Ok(Self(Box::new(config)));
+        }
+        let options: PropertyOptionsSchema = serde_json::from_value(options)?;
+
+        if let Some(escape) = options.escape {
+            if let Some(tagged_templates) = escape.tagged_templates {
+                config.escape.tagged_templates =
+                    tagged_templates.iter().map(|s| CompactStr::from(s.as_str())).collect();
+            }
+            if let Some(methods) = escape.methods {
+                config.escape.methods =
+                    methods.iter().map(|s| CompactStr::from(s.as_str())).collect();
+            }
+        }
+        if let Some(variable_tracing) = options.variable_tracing {
+            config.variable_tracing = variable_tracing;
+        }
+        if let Some(properties) = options.properties {
+            config.properties = properties.iter().map(|s| CompactStr::from(s.as_str())).collect();
+        }
+
+        Ok(Self(Box::new(config)))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::AssignmentExpression(assignment) = node.kind() else {
+            return;
+        };
+        if !is_checked_operator(assignment.operator) {
+            return;
+        }
+        let Some(property) = assigned_property_name(&assignment.left) else {
+            return;
+        };
+        if !self.0.properties.iter().any(|p| p == property) {
+            return;
+        }
+
+        let mut seen = FxHashSet::default();
+        if !self.is_allowed_expression(&assignment.right, ctx, &mut seen) {
+            ctx.diagnostic(unsafe_assignment_diagnostic(property, assignment.span));
+        }
+    }
+}
+
+impl Property {
+    fn is_allowed_expression<'a>(
+        &self,
+        expression: &Expression<'a>,
+        ctx: &LintContext<'a>,
+        seen: &mut FxHashSet<SymbolId>,
+    ) -> bool {
+        match expression {
+            // A literal cannot carry attacker controlled markup, only malice.
+            Expression::StringLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_)
+            | Expression::BigIntLiteral(_)
+            | Expression::RegExpLiteral(_) => true,
+            // Only the `${...}` parts need checking, a quasi is raw text.
+            // A template literal without interpolations is therefore always safe.
+            Expression::TemplateLiteral(template) => template
+                .expressions
+                .iter()
+                .all(|expression| self.is_allowed_expression(expression, ctx, seen)),
+            Expression::TaggedTemplateExpression(tagged) => {
+                is_allowed_callee(&tagged.tag, &self.0.escape.tagged_templates, ctx)
+            }
+            Expression::CallExpression(call) => {
+                is_allowed_callee(&call.callee, &self.0.escape.methods, ctx)
+            }
+            Expression::BinaryExpression(binary) => {
+                self.is_allowed_expression(&binary.left, ctx, seen)
+                    && self.is_allowed_expression(&binary.right, ctx, seen)
+            }
+            Expression::ParenthesizedExpression(paren) => {
+                self.is_allowed_expression(&paren.expression, ctx, seen)
+            }
+            Expression::TSAsExpression(_)
+            | Expression::TSSatisfiesExpression(_)
+            | Expression::TSNonNullExpression(_)
+            | Expression::TSTypeAssertion(_)
+            | Expression::TSInstantiationExpression(_) => {
+                self.is_allowed_expression(expression.get_inner_expression(), ctx, seen)
+            }
+            Expression::Identifier(identifier) => self.is_allowed_identifier(identifier, ctx, seen),
+            _ => false,
+        }
+    }
+
+    /// Traces an identifier back to its declaration.
+    ///
+    /// Only `let`/`const` bindings whose initializer and every write reference are
+    /// themselves allowed expressions are considered safe.
+    fn is_allowed_identifier<'a>(
+        &self,
+        identifier: &IdentifierReference<'a>,
+        ctx: &LintContext<'a>,
+        seen: &mut FxHashSet<SymbolId>,
+    ) -> bool {
+        if !self.0.variable_tracing {
+            return false;
+        }
+        let scoping = ctx.scoping();
+        // Unresolved references (globals, implicit assignments) cannot be traced.
+        let Some(symbol_id) = scoping.get_reference(identifier.reference_id()).symbol_id() else {
+            return false;
+        };
+        // Guard against cycles such as `let a = ''; a = `${a}<p>`;`.
+        if !seen.insert(symbol_id) {
+            return false;
+        }
+
+        let allowed = self.is_allowed_symbol(symbol_id, ctx, seen);
+        seen.remove(&symbol_id);
+        allowed
+    }
+
+    fn is_allowed_symbol(
+        &self,
+        symbol_id: SymbolId,
+        ctx: &LintContext<'_>,
+        seen: &mut FxHashSet<SymbolId>,
+    ) -> bool {
+        let scoping = ctx.scoping();
+        let declaration = ctx.nodes().get_node(scoping.symbol_declaration(symbol_id));
+        let AstKind::VariableDeclarator(declarator) = declaration.kind() else {
+            // Function parameters, imports, classes, ... are not traceable.
+            return false;
+        };
+        // `var` can be overwritten in ways that are not visible here.
+        if !matches!(declarator.kind, VariableDeclarationKind::Let | VariableDeclarationKind::Const)
+        {
+            return false;
+        }
+        if let Some(init) = &declarator.init
+            && !self.is_allowed_expression(init, ctx, seen)
+        {
+            return false;
+        }
+
+        scoping.get_resolved_references(symbol_id).filter(|reference| reference.is_write()).all(
+            |reference| {
+                write_expression(ctx, reference.node_id())
+                    .is_some_and(|expression| self.is_allowed_expression(expression, ctx, seen))
+            },
+        )
+    }
+}
+
+/// The right-hand side of the assignment a write reference belongs to.
+fn write_expression<'a, 'b>(
+    ctx: &'b LintContext<'a>,
+    node_id: oxc_semantic::NodeId,
+) -> Option<&'b Expression<'a>> {
+    match ctx.nodes().parent_kind(node_id) {
+        AstKind::AssignmentExpression(assignment) => Some(&assignment.right),
+        _ => None,
+    }
+}
+
+/// Operators which need checking.
+///
+/// Arithmetic and bitwise compound assignments such as `x.innerHTML *= 2` cannot
+/// introduce markup and are ignored, matching the upstream rule.
+fn is_checked_operator(operator: AssignmentOperator) -> bool {
+    matches!(
+        operator,
+        AssignmentOperator::Assign
+            | AssignmentOperator::Addition
+            | AssignmentOperator::LogicalOr
+            | AssignmentOperator::LogicalAnd
+            | AssignmentOperator::LogicalNullish
+    )
+}
+
+/// Name of the statically known property being assigned to, e.g. `innerHTML` for
+/// `node.innerHTML = x`. Computed accesses are not resolved, as upstream.
+fn assigned_property_name<'a>(target: &AssignmentTarget<'a>) -> Option<&'a str> {
+    let simple = target.as_simple_assignment_target()?;
+    let member = match simple.get_expression() {
+        // `(a.b as T) = c` and friends
+        Some(expression) => expression.get_inner_expression().get_member_expr(),
+        None => simple.as_member_expression(),
+    }?;
+    match member {
+        oxc_ast::ast::MemberExpression::StaticMemberExpression(member) => {
+            Some(member.property.name.as_str())
+        }
+        _ => None,
+    }
+}
+
+/// `foo` for `foo()`, `obj.foo` for `obj.foo()`, using source text for
+/// non-identifier objects, matching the upstream `getCodeName` helper.
+fn is_allowed_callee<'a>(
+    callee: &Expression<'a>,
+    allowed: &[CompactStr],
+    ctx: &LintContext<'a>,
+) -> bool {
+    let Some(name) = callee_code_name(callee, ctx) else {
+        return false;
+    };
+    allowed.iter().any(|candidate| candidate.as_str() == name)
+}
+
+fn callee_code_name<'a>(callee: &Expression<'a>, ctx: &LintContext<'a>) -> Option<String> {
+    match callee {
+        Expression::Identifier(identifier) => Some(identifier.name.to_string()),
+        Expression::StaticMemberExpression(member) => {
+            let object = match &member.object {
+                Expression::Identifier(identifier) => identifier.name.to_string(),
+                object => ctx.source_range(object.span()).to_string(),
+            };
+            Some(format!("{object}.{}", member.property.name))
+        }
+        _ => None,
+    }
+}
+
+#[test]
+#[expect(clippy::literal_string_with_formatting_args)] // test cases contain `${...}` in JS strings
+fn test() {
+    use serde_json::json;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // literals and template literals without interpolation
+        ("a.innerHTML = '';", None),
+        ("a.innerHTML *= 'test';", None),
+        ("c.innerHTML = ``;", None),
+        ("a.innerHTML += '';", None),
+        ("b.innerHTML += \"\";", None),
+        ("c.innerHTML += ``;", None),
+        ("x.innerHTML = `foo`+`bar`;", None),
+        ("y.innerHTML = '<span>' + 5 + '</span>';", None),
+        ("u.innerHTML = `<span>${'lulz'}</span>`;", None),
+        ("v.innerHTML = `<span>${'lulz'}</span>${55}`;", None),
+        ("w.innerHTML = `<span>${'lulz'+'meh'}</span>`;", None),
+        // escaping functions
+        ("g.innerHTML = Sanitizer.escapeHTML``;", None),
+        ("h.innerHTML = Sanitizer.escapeHTML`foo`;", None),
+        ("i.innerHTML = Sanitizer.escapeHTML`foo${bar}baz`;", None),
+        ("g.innerHTML += Sanitizer.escapeHTML``;", None),
+        ("h.innerHTML += Sanitizer.escapeHTML`foo`;", None),
+        ("i.innerHTML += Sanitizer.escapeHTML`foo${bar}baz`;", None),
+        ("i.innerHTML += Sanitizer.unwrapSafeHTML(htmlSnippet)", None),
+        ("i.outerHTML += Sanitizer.unwrapSafeHTML(htmlSnippet)", None),
+        ("this.imeList.innerHTML = Sanitizer.unwrapSafeHTML(...listHtml);", None),
+        // not a sink
+        ("document.toString = evil;", None),
+        ("document.writeln(Sanitizer.escapeHTML`<em>${evil}</em>`);", None),
+        // configured escapers
+        (
+            "w.innerHTML = templateEscaper`<em>${evil}</em>`;",
+            Some(json!([{"escape": {"taggedTemplates": ["templateEscaper"]}}])),
+        ),
+        (
+            "w.innerHTML = DOMPurify.sanitize('<em>${evil}</em>');",
+            Some(json!([{"escape": {"methods": ["DOMPurify.sanitize"]}}])),
+        ),
+        // variable tracing
+        ("let c; c = 123; a.innerHTML = `${c}`;", None),
+        ("let c; a.innerHTML = `${c}`;", None),
+        ("let literalFromElsewhere = '<b>safe</b>'; y.innerHTML = literalFromElsewhere;", None),
+        (
+            "const literalFromElsewhereWithInnerExpr = '<b>safe</b>'+'yo'; y.innerHTML = literalFromElsewhereWithInnerExpr;",
+            None,
+        ),
+        (
+            "let multiStepVarSearch = '<b>safe</b>'+'yo'; const copy = multiStepVarSearch; y.innerHTML = copy;",
+            None,
+        ),
+        ("let copies = '<b>safe</b>'; copies = 'stillOK'; y.innerHTML = copies;", None),
+        (
+            "let copies = '<b>safe</b>'; if (monday) { copies = 'stillOK'; }; y.innerHTML = copies;",
+            None,
+        ),
+        (
+            "let msg = '<b>safe</b>'; let altMsg = 'also cool';  if (monday) { msg = altMsg; }; y.innerHTML = msg;",
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        ("m.innerHTML = htmlString;", None),
+        ("a.innerHTML += htmlString;", None),
+        ("a.innerHTML += template.toHtml();", None),
+        ("m.outerHTML = htmlString;", None),
+        ("t.innerHTML = `<span>${name}</span>`;", None),
+        ("t.innerHTML = `<span>${'foobar'}</span>${evil}`;", None),
+        ("node.innerHTML = '<span>'+ htmlInput;", None),
+        ("node.innerHTML = '<span>'+ htmlInput + '</span>';", None),
+        ("title.innerHTML = _('WB_LT_TIPS_S_SEARCH', {value0:engine});", None),
+        ("x.innerHTML = Sanitizer.escapeHTML(evil)", None),
+        ("x.innerHTML = Sanitizer.escapeHTML(`evil`)", None),
+        ("y.innerHTML = ((arrow_function)=>null)`some HTML`", None),
+        ("this.imeList.innerHTML = Sanitizer.unrapSafeHTML(...listHtml);", None),
+        ("g.innerHTML = potentiallyUnsafe;", None),
+        ("function foo() { return this().innerHTML = evil; };", None),
+        ("describe.each`table${m.innerHTML = htmlString}`(name, fn, timeout)", None),
+        ("a.innerHTML = somefn()()", None),
+        ("a.innerHTML = (cond ? maybe_safe : or_evil)()", None),
+        ("yoink.innerHTML &&= bar;", None),
+        ("yoink.innerHTML ||= bar;", None),
+        ("yoink.innerHTML ??= bar;", None),
+        // variable tracing
+        ("copy = '<b>safe</b>'; copy = evil; y.innerHTML = copy;", None),
+        ("let copies = '<b>safe</b>'; copies = suddenlyUnsafe; y.innerHTML = copies;", None),
+        (
+            "let copies = '<b>safe</b>'; if (monday) { copies = badness }; y.innerHTML = copies;",
+            None,
+        ),
+        (
+            "let copies = '<b>safe</b>'; (() => { copies = badness; })(); y.innerHTML = copies;",
+            None,
+        ),
+        (
+            "let obj = { prop: '<b>safe</b>' }; doSomething(obj); let copies = obj.prop; y.innerHTML = copies;",
+            None,
+        ),
+        ("let c; if (cond) { c = '<b>safe</b>'; } else { c = evil; } a.innerHTML = `${c}`;", None),
+        ("let c; c = 'apparently-safe'; functionCall(c); n.innerHTML = c.property;", None),
+        ("let text = ''; text = `${text}<p>`; scratchDiv.innerHTML = text;", None),
+        (
+            "let msg = '<b>safe</b>'; let altMsg = 'also cool';  if (monday) { msg = altMsg; }; y.innerHTML = msg;",
+            Some(json!([{"variableTracing": false}])),
+        ),
+        // configurable sinks
+        ("frame.srcdoc = evil;", Some(json!([{"properties": ["srcdoc"]}]))),
+    ];
+
+    Tester::new(Property::NAME, Property::PLUGIN, pass, fail).test_and_snapshot();
+
+    let ts_pass = vec![
+        ("(options as HTMLElement).innerHTML = '<s>safe</s>';", None),
+        ("(<HTMLElement>items[i](args)).innerHTML = 'rawstring';", None),
+        ("lol.innerHTML = (5 as string);", None),
+        (
+            "node!.innerHTML = DOMPurify.sanitize(evil);",
+            Some(json!([{"escape": {"methods": ["DOMPurify.sanitize"]}}])),
+        ),
+    ];
+
+    let ts_fail = vec![
+        ("x!().innerHTML = htmlString", None),
+        ("(x as HTMLElement).innerHTML = htmlString", None),
+        ("lol.innerHTML = (foo as string);", None),
+    ];
+
+    Tester::new(Property::NAME, Property::PLUGIN, ts_pass, ts_fail)
+        .change_rule_path_extension("ts")
+        .with_snapshot_suffix("typescript")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/no_unsanitized/property.rs
+++ b/crates/oxc_linter/src/rules/no_unsanitized/property.rs
@@ -1,20 +1,20 @@
 use oxc_ast::{
     AstKind,
-    ast::{
-        AssignmentOperator, AssignmentTarget, Expression, IdentifierReference,
-        VariableDeclarationKind,
-    },
+    ast::{AssignmentOperator, AssignmentTarget, MemberExpression},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::SymbolId;
-use oxc_span::{GetSpan, Span};
+use oxc_span::Span;
 use oxc_str::CompactStr;
-use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{EscapeConfig, EscapeSchema, Sanitization, SinkValue},
+};
 
 fn unsafe_assignment_diagnostic(property: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Unsafe assignment to {property}"))
@@ -24,33 +24,11 @@ fn unsafe_assignment_diagnostic(property: &str, span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-/// Escaping functions which mark a value as safe.
-#[derive(Debug, Clone)]
-struct Escape {
-    tagged_templates: Vec<CompactStr>,
-    methods: Vec<CompactStr>,
-}
-
-impl Default for Escape {
-    fn default() -> Self {
-        Self {
-            tagged_templates: vec![
-                CompactStr::new("Sanitizer.escapeHTML"),
-                CompactStr::new("escapeHTML"),
-            ],
-            methods: vec![
-                CompactStr::new("Sanitizer.unwrapSafeHTML"),
-                CompactStr::new("unwrapSafeHTML"),
-            ],
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct PropertyConfig {
     /// Property names which are treated as HTML sinks.
     properties: Vec<CompactStr>,
-    escape: Escape,
+    escape: EscapeConfig,
     variable_tracing: bool,
 }
 
@@ -58,7 +36,7 @@ impl Default for PropertyConfig {
     fn default() -> Self {
         Self {
             properties: vec![CompactStr::new("innerHTML"), CompactStr::new("outerHTML")],
-            escape: Escape::default(),
+            escape: EscapeConfig::default(),
             variable_tracing: true,
         }
     }
@@ -66,17 +44,6 @@ impl Default for PropertyConfig {
 
 #[derive(Debug, Default, Clone)]
 pub struct Property(Box<PropertyConfig>);
-
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct EscapeSchema {
-    /// Tagged template functions which return safe HTML.
-    /// Defaults to `["Sanitizer.escapeHTML", "escapeHTML"]`.
-    tagged_templates: Option<Vec<String>>,
-    /// Methods which return safe HTML.
-    /// Defaults to `["Sanitizer.unwrapSafeHTML", "unwrapSafeHTML"]`.
-    methods: Option<Vec<String>>,
-}
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -159,15 +126,8 @@ impl Rule for Property {
         }
         let options: PropertyOptionsSchema = serde_json::from_value(options)?;
 
-        if let Some(escape) = options.escape {
-            if let Some(tagged_templates) = escape.tagged_templates {
-                config.escape.tagged_templates =
-                    tagged_templates.iter().map(|s| CompactStr::from(s.as_str())).collect();
-            }
-            if let Some(methods) = escape.methods {
-                config.escape.methods =
-                    methods.iter().map(|s| CompactStr::from(s.as_str())).collect();
-            }
+        if let Some(escape) = &options.escape {
+            config.escape.apply(escape);
         }
         if let Some(variable_tracing) = options.variable_tracing {
             config.variable_tracing = variable_tracing;
@@ -193,127 +153,11 @@ impl Rule for Property {
             return;
         }
 
-        let mut seen = FxHashSet::default();
-        if !self.is_allowed_expression(&assignment.right, ctx, &mut seen) {
+        let sanitization =
+            Sanitization { escape: &self.0.escape, variable_tracing: self.0.variable_tracing };
+        if !sanitization.is_allowed(SinkValue::Expression(&assignment.right), ctx) {
             ctx.diagnostic(unsafe_assignment_diagnostic(property, assignment.span));
         }
-    }
-}
-
-impl Property {
-    fn is_allowed_expression<'a>(
-        &self,
-        expression: &Expression<'a>,
-        ctx: &LintContext<'a>,
-        seen: &mut FxHashSet<SymbolId>,
-    ) -> bool {
-        match expression {
-            // A literal cannot carry attacker controlled markup, only malice.
-            Expression::StringLiteral(_)
-            | Expression::NumericLiteral(_)
-            | Expression::BooleanLiteral(_)
-            | Expression::NullLiteral(_)
-            | Expression::BigIntLiteral(_)
-            | Expression::RegExpLiteral(_) => true,
-            // Only the `${...}` parts need checking, a quasi is raw text.
-            // A template literal without interpolations is therefore always safe.
-            Expression::TemplateLiteral(template) => template
-                .expressions
-                .iter()
-                .all(|expression| self.is_allowed_expression(expression, ctx, seen)),
-            Expression::TaggedTemplateExpression(tagged) => {
-                is_allowed_callee(&tagged.tag, &self.0.escape.tagged_templates, ctx)
-            }
-            Expression::CallExpression(call) => {
-                is_allowed_callee(&call.callee, &self.0.escape.methods, ctx)
-            }
-            Expression::BinaryExpression(binary) => {
-                self.is_allowed_expression(&binary.left, ctx, seen)
-                    && self.is_allowed_expression(&binary.right, ctx, seen)
-            }
-            Expression::ParenthesizedExpression(paren) => {
-                self.is_allowed_expression(&paren.expression, ctx, seen)
-            }
-            Expression::TSAsExpression(_)
-            | Expression::TSSatisfiesExpression(_)
-            | Expression::TSNonNullExpression(_)
-            | Expression::TSTypeAssertion(_)
-            | Expression::TSInstantiationExpression(_) => {
-                self.is_allowed_expression(expression.get_inner_expression(), ctx, seen)
-            }
-            Expression::Identifier(identifier) => self.is_allowed_identifier(identifier, ctx, seen),
-            _ => false,
-        }
-    }
-
-    /// Traces an identifier back to its declaration.
-    ///
-    /// Only `let`/`const` bindings whose initializer and every write reference are
-    /// themselves allowed expressions are considered safe.
-    fn is_allowed_identifier<'a>(
-        &self,
-        identifier: &IdentifierReference<'a>,
-        ctx: &LintContext<'a>,
-        seen: &mut FxHashSet<SymbolId>,
-    ) -> bool {
-        if !self.0.variable_tracing {
-            return false;
-        }
-        let scoping = ctx.scoping();
-        // Unresolved references (globals, implicit assignments) cannot be traced.
-        let Some(symbol_id) = scoping.get_reference(identifier.reference_id()).symbol_id() else {
-            return false;
-        };
-        // Guard against cycles such as `let a = ''; a = `${a}<p>`;`.
-        if !seen.insert(symbol_id) {
-            return false;
-        }
-
-        let allowed = self.is_allowed_symbol(symbol_id, ctx, seen);
-        seen.remove(&symbol_id);
-        allowed
-    }
-
-    fn is_allowed_symbol(
-        &self,
-        symbol_id: SymbolId,
-        ctx: &LintContext<'_>,
-        seen: &mut FxHashSet<SymbolId>,
-    ) -> bool {
-        let scoping = ctx.scoping();
-        let declaration = ctx.nodes().get_node(scoping.symbol_declaration(symbol_id));
-        let AstKind::VariableDeclarator(declarator) = declaration.kind() else {
-            // Function parameters, imports, classes, ... are not traceable.
-            return false;
-        };
-        // `var` can be overwritten in ways that are not visible here.
-        if !matches!(declarator.kind, VariableDeclarationKind::Let | VariableDeclarationKind::Const)
-        {
-            return false;
-        }
-        if let Some(init) = &declarator.init
-            && !self.is_allowed_expression(init, ctx, seen)
-        {
-            return false;
-        }
-
-        scoping.get_resolved_references(symbol_id).filter(|reference| reference.is_write()).all(
-            |reference| {
-                write_expression(ctx, reference.node_id())
-                    .is_some_and(|expression| self.is_allowed_expression(expression, ctx, seen))
-            },
-        )
-    }
-}
-
-/// The right-hand side of the assignment a write reference belongs to.
-fn write_expression<'a, 'b>(
-    ctx: &'b LintContext<'a>,
-    node_id: oxc_semantic::NodeId,
-) -> Option<&'b Expression<'a>> {
-    match ctx.nodes().parent_kind(node_id) {
-        AstKind::AssignmentExpression(assignment) => Some(&assignment.right),
-        _ => None,
     }
 }
 
@@ -342,36 +186,7 @@ fn assigned_property_name<'a>(target: &AssignmentTarget<'a>) -> Option<&'a str> 
         None => simple.as_member_expression(),
     }?;
     match member {
-        oxc_ast::ast::MemberExpression::StaticMemberExpression(member) => {
-            Some(member.property.name.as_str())
-        }
-        _ => None,
-    }
-}
-
-/// `foo` for `foo()`, `obj.foo` for `obj.foo()`, using source text for
-/// non-identifier objects, matching the upstream `getCodeName` helper.
-fn is_allowed_callee<'a>(
-    callee: &Expression<'a>,
-    allowed: &[CompactStr],
-    ctx: &LintContext<'a>,
-) -> bool {
-    let Some(name) = callee_code_name(callee, ctx) else {
-        return false;
-    };
-    allowed.iter().any(|candidate| candidate.as_str() == name)
-}
-
-fn callee_code_name<'a>(callee: &Expression<'a>, ctx: &LintContext<'a>) -> Option<String> {
-    match callee {
-        Expression::Identifier(identifier) => Some(identifier.name.to_string()),
-        Expression::StaticMemberExpression(member) => {
-            let object = match &member.object {
-                Expression::Identifier(identifier) => identifier.name.to_string(),
-                object => ctx.source_range(object.span()).to_string(),
-            };
-            Some(format!("{object}.{}", member.property.name))
-        }
+        MemberExpression::StaticMemberExpression(member) => Some(member.property.name.as_str()),
         _ => None,
     }
 }

--- a/crates/oxc_linter/src/snapshots/no_unsanitized_method.snap
+++ b/crates/oxc_linter/src/snapshots/no_unsanitized_method.snap
@@ -1,0 +1,248 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ no_unsanitized(method): Unsafe call to node.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:1]
+ 1 │ node.insertAdjacentHTML('beforebegin', htmlString);
+   · ──────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to node.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:1]
+ 1 │ node.insertAdjacentHTML('beforebegin', template.getHTML());
+   · ──────────────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to document.write for argument 0
+   ╭─[method.tsx:1:1]
+ 1 │ document.write('<span>'+ htmlInput + '</span>');
+   · ───────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to documentish.write for argument 0
+   ╭─[method.tsx:1:1]
+ 1 │ documentish.write('<span>'+ htmlInput + '</span>');
+   · ──────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to documentIframe.write for argument 0
+   ╭─[method.tsx:1:1]
+ 1 │ documentIframe.write('<span>'+ htmlInput + '</span>');
+   · ─────────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to document.writeln for argument 0
+   ╭─[method.tsx:1:1]
+ 1 │ document.writeln(evil);
+   · ──────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to window.document.writeln for argument 0
+   ╭─[method.tsx:1:1]
+ 1 │ window.document.writeln(bad);
+   · ────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to this().insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:25]
+ 1 │ function foo() { return this().insertAdjacentHTML(foo, bar); };
+   ·                         ───────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to b.other for argument 0
+   ╭─[method.tsx:1:35]
+ 1 │ document.write(evil); b.thing(x); b.other(me);
+   ·                                   ───────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to getDocument(myID).write for argument 0
+   ╭─[method.tsx:1:1]
+ 1 │ getDocument(myID).write(evil)
+   · ─────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to range.createContextualFragment for argument 0
+   ╭─[method.tsx:1:1]
+ 1 │ range.createContextualFragment(badness)
+   · ───────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to import for argument 0
+   ╭─[method.tsx:1:1]
+ 1 │ import(foo)
+   · ───────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to node.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:1]
+ 1 │ (0, node.insertAdjacentHTML)('beforebegin', evil);
+   · ─────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to n.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:1]
+ 1 │ n.insertAdjacentHTML('afterend', templateEscaper(evil, options));
+   · ────────────────────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to n.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:1]
+ 1 │ n.insertAdjacentHTML('afterend', sanitize`<em>${evil}</em>`);
+   · ────────────────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to document.writeln for argument 0
+   ╭─[method.tsx:1:1]
+ 1 │ document.writeln(Sanitizer.escapeHTML`<em>${evil}</em>`);
+   · ────────────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to node.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:22]
+ 1 │ describe.each`table${node.insertAdjacentHTML('beforebegin', htmlString)}`(name, fn, timeout)
+   ·                      ──────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to document.writeln for argument 0
+   ╭─[method.tsx:1:22]
+ 1 │ describe.each`table${document.writeln(evil)}`(name, fn, timeout)
+   ·                      ──────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to node.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:1]
+ 1 │ node.insertAdjacentHTML`text ${variable}`
+   · ─────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to custom for argument 1
+   ╭─[method.tsx:1:1]
+ 1 │ custom`text ${variable}`
+   · ────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to custom for argument 2
+   ╭─[method.tsx:1:1]
+ 1 │ custom`text ${variable} ${variable2}`
+   · ─────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to foo.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:19]
+ 1 │ async () => await foo.insertAdjacentHTML('afterend', blah);
+   ·                   ────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to foo.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:20]
+ 1 │ async () => (await foo.insertAdjacentHTML('afterend', blah))();
+   ·                    ────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to (await foo)().insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:13]
+ 1 │ async () => (await foo)().insertAdjacentHTML('afterend', blah);
+   ·             ──────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to node.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:1]
+ 1 │ (e = node.insertAdjacentHTML)('beforebegin', evil)
+   · ──────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to node.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:6]
+ 1 │ (e = node.insertAdjacentHTML('beforebegin', evil))()
+   ·      ────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to n.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:29]
+ 1 │ var copies = '<b>safe</b>'; n.insertAdjacentHTML('beforebegin', copies);
+   ·                             ───────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to n.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:20]
+ 1 │ let copies = evil; n.insertAdjacentHTML('beforebegin', copies);
+   ·                    ───────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to n.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:54]
+ 1 │ let copies = '<b>safe</b>'; copies = suddenlyUnsafe; n.insertAdjacentHTML('beforebegin', copies);
+   ·                                                      ───────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to n.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:66]
+ 1 │ function test(evil) { let copies = '<b>safe</b>'; copies = evil; n.insertAdjacentHTML('beforebegin', copies); }
+   ·                                                                  ───────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to n.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:73]
+ 1 │ const fn = function (evil) { let copies = '<b>safe</b>'; copies = evil; n.insertAdjacentHTML('beforebegin', copies); }
+   ·                                                                         ───────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to n.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:67]
+ 1 │ const fn = (evil) => { let copies = '<b>safe</b>'; copies = evil; n.insertAdjacentHTML('beforebegin', copies); }
+   ·                                                                   ───────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to n.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:60]
+ 1 │ let c; if (cond) { c = '<b>safe</b>'; } else { c = evil; } n.insertAdjacentHTML('beforebegin', `${c}`);
+   ·                                                            ───────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to n.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:1]
+ 1 │ (info.current = n.insertAdjacentHTML)('beforebegin', c)
+   · ───────────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to foo.setHTMLUnsafe for argument 0
+   ╭─[method.tsx:1:1]
+ 1 │ foo.setHTMLUnsafe(badness)
+   · ──────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.

--- a/crates/oxc_linter/src/snapshots/no_unsanitized_method.snap
+++ b/crates/oxc_linter/src/snapshots/no_unsanitized_method.snap
@@ -246,3 +246,52 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────────────────
    ╰────
   help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to document.write for argument 0
+   ╭─[method.tsx:1:1]
+ 1 │ document['write'](evil)
+   · ───────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to node.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:1]
+ 1 │ (node.insertAdjacentHTML ||= fallback)('beforebegin', evil)
+   · ───────────────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to node.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:1]
+ 1 │ (node.insertAdjacentHTML &&= fallback)('beforebegin', evil)
+   · ───────────────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to node.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:1]
+ 1 │ (node.insertAdjacentHTML ??= fallback)('beforebegin', evil)
+   · ───────────────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to document.write for argument 0
+   ╭─[method.tsx:1:1]
+ 1 │ document.write(evil)
+   · ────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to n.insertAdjacentHTML for argument 1
+   ╭─[method.tsx:1:1]
+ 1 │ n.insertAdjacentHTML('afterend', DOMPurify.sanitize(evil));
+   · ──────────────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to html for argument 0
+   ╭─[method.tsx:1:1]
+ 1 │ html(evil)
+   · ──────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.

--- a/crates/oxc_linter/src/snapshots/no_unsanitized_method@typescript.snap
+++ b/crates/oxc_linter/src/snapshots/no_unsanitized_method@typescript.snap
@@ -2,6 +2,13 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
+  ⚠ no_unsanitized(method): Unsafe call to node.insertAdjacentHTML for argument 1
+   ╭─[method.ts:1:1]
+ 1 │ (node.insertAdjacentHTML as InsertFn)('beforebegin', htmlString);
+   · ────────────────────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
   ⚠ no_unsanitized(method): Unsafe call to node!().insertAdjacentHTML for argument 1
    ╭─[method.ts:1:1]
  1 │ node!().insertAdjacentHTML('beforebegin', htmlString);

--- a/crates/oxc_linter/src/snapshots/no_unsanitized_method@typescript.snap
+++ b/crates/oxc_linter/src/snapshots/no_unsanitized_method@typescript.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ no_unsanitized(method): Unsafe call to node!().insertAdjacentHTML for argument 1
+   ╭─[method.ts:1:1]
+ 1 │ node!().insertAdjacentHTML('beforebegin', htmlString);
+   · ─────────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to node!.insertAdjacentHTML for argument 1
+   ╭─[method.ts:1:1]
+ 1 │ node!.insertAdjacentHTML('beforebegin', htmlString);
+   · ───────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(method): Unsafe call to (x as HTMLElement).insertAdjacentHTML for argument 1
+   ╭─[method.ts:1:1]
+ 1 │ (x as HTMLElement).insertAdjacentHTML('beforebegin', htmlString)
+   · ────────────────────────────────────────────────────────────────
+   ╰────
+  help: Pass a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.

--- a/crates/oxc_linter/src/snapshots/no_unsanitized_property.snap
+++ b/crates/oxc_linter/src/snapshots/no_unsanitized_property.snap
@@ -32,6 +32,13 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
    ╭─[property.tsx:1:1]
+ 1 │ node['innerHTML'] = htmlString;
+   · ──────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
  1 │ t.innerHTML = `<span>${name}</span>`;
    · ────────────────────────────────────
    ╰────
@@ -216,5 +223,19 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[property.tsx:1:1]
  1 │ frame.srcdoc = evil;
    · ───────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ el.innerHTML = safeHTML`<b>${evil}</b>`;
+   · ───────────────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ el.innerHTML = DOMPurify.sanitize(evil);
+   · ───────────────────────────────────────
    ╰────
   help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.

--- a/crates/oxc_linter/src/snapshots/no_unsanitized_property.snap
+++ b/crates/oxc_linter/src/snapshots/no_unsanitized_property.snap
@@ -1,0 +1,220 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ m.innerHTML = htmlString;
+   · ────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ a.innerHTML += htmlString;
+   · ─────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ a.innerHTML += template.toHtml();
+   · ────────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to outerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ m.outerHTML = htmlString;
+   · ────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ t.innerHTML = `<span>${name}</span>`;
+   · ────────────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ t.innerHTML = `<span>${'foobar'}</span>${evil}`;
+   · ───────────────────────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ node.innerHTML = '<span>'+ htmlInput;
+   · ────────────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ node.innerHTML = '<span>'+ htmlInput + '</span>';
+   · ────────────────────────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ title.innerHTML = _('WB_LT_TIPS_S_SEARCH', {value0:engine});
+   · ───────────────────────────────────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ x.innerHTML = Sanitizer.escapeHTML(evil)
+   · ────────────────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ x.innerHTML = Sanitizer.escapeHTML(`evil`)
+   · ──────────────────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ y.innerHTML = ((arrow_function)=>null)`some HTML`
+   · ─────────────────────────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ this.imeList.innerHTML = Sanitizer.unrapSafeHTML(...listHtml);
+   · ─────────────────────────────────────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ g.innerHTML = potentiallyUnsafe;
+   · ───────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:25]
+ 1 │ function foo() { return this().innerHTML = evil; };
+   ·                         ───────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:22]
+ 1 │ describe.each`table${m.innerHTML = htmlString}`(name, fn, timeout)
+   ·                      ────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ a.innerHTML = somefn()()
+   · ────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ a.innerHTML = (cond ? maybe_safe : or_evil)()
+   · ─────────────────────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ yoink.innerHTML &&= bar;
+   · ───────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ yoink.innerHTML ||= bar;
+   · ───────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:1]
+ 1 │ yoink.innerHTML ??= bar;
+   · ───────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:36]
+ 1 │ copy = '<b>safe</b>'; copy = evil; y.innerHTML = copy;
+   ·                                    ──────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:54]
+ 1 │ let copies = '<b>safe</b>'; copies = suddenlyUnsafe; y.innerHTML = copies;
+   ·                                                      ────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:63]
+ 1 │ let copies = '<b>safe</b>'; if (monday) { copies = badness }; y.innerHTML = copies;
+   ·                                                               ────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:62]
+ 1 │ let copies = '<b>safe</b>'; (() => { copies = badness; })(); y.innerHTML = copies;
+   ·                                                              ────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:77]
+ 1 │ let obj = { prop: '<b>safe</b>' }; doSomething(obj); let copies = obj.prop; y.innerHTML = copies;
+   ·                                                                             ────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:60]
+ 1 │ let c; if (cond) { c = '<b>safe</b>'; } else { c = evil; } a.innerHTML = `${c}`;
+   ·                                                            ────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:48]
+ 1 │ let c; c = 'apparently-safe'; functionCall(c); n.innerHTML = c.property;
+   ·                                                ────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:37]
+ 1 │ let text = ''; text = `${text}<p>`; scratchDiv.innerHTML = text;
+   ·                                     ───────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.tsx:1:84]
+ 1 │ let msg = '<b>safe</b>'; let altMsg = 'also cool';  if (monday) { msg = altMsg; }; y.innerHTML = msg;
+   ·                                                                                    ─────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to srcdoc
+   ╭─[property.tsx:1:1]
+ 1 │ frame.srcdoc = evil;
+   · ───────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.

--- a/crates/oxc_linter/src/snapshots/no_unsanitized_property@typescript.snap
+++ b/crates/oxc_linter/src/snapshots/no_unsanitized_property@typescript.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.ts:1:1]
+ 1 │ x!().innerHTML = htmlString
+   · ───────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.ts:1:1]
+ 1 │ (x as HTMLElement).innerHTML = htmlString
+   · ─────────────────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.
+
+  ⚠ no_unsanitized(property): Unsafe assignment to innerHTML
+   ╭─[property.ts:1:1]
+ 1 │ lol.innerHTML = (foo as string);
+   · ───────────────────────────────
+   ╰────
+  help: Assign a string literal, or wrap the value in an escaping function such as `Sanitizer.escapeHTML`.

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -21,6 +21,7 @@ mod express;
 mod jest;
 mod jsdoc;
 mod nextjs;
+mod no_unsanitized;
 mod node;
 mod promise;
 mod react;
@@ -37,9 +38,9 @@ mod vue;
 pub mod vue_casing;
 
 pub use self::{
-    comment::*, config::*, control_flow::*, express::*, jest::*, jsdoc::*, nextjs::*, node::*,
-    promise::*, react::*, react_perf::*, regex::*, schemars::*, static_value::*,
-    this_expression::*, typescript::*, unicorn::*, url::*, vitest::*, vue::*,
+    comment::*, config::*, control_flow::*, express::*, jest::*, jsdoc::*, nextjs::*,
+    no_unsanitized::*, node::*, promise::*, react::*, react_perf::*, regex::*, schemars::*,
+    static_value::*, this_expression::*, typescript::*, unicorn::*, url::*, vitest::*, vue::*,
 };
 
 /// List of Eslint rules that have TypeScript equivalents.

--- a/crates/oxc_linter/src/utils/no_unsanitized.rs
+++ b/crates/oxc_linter/src/utils/no_unsanitized.rs
@@ -1,0 +1,239 @@
+//! Shared sanitization analysis for the `no-unsanitized` plugin.
+//!
+//! Ported from the `RuleHelper` of
+//! <https://github.com/mozilla/eslint-plugin-no-unsanitized>.
+
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, IdentifierReference, VariableDeclarationKind},
+};
+use oxc_semantic::SymbolId;
+use oxc_span::GetSpan;
+use oxc_str::CompactStr;
+use rustc_hash::FxHashSet;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::context::LintContext;
+
+/// Escaping functions whose output is considered safe HTML.
+#[derive(Debug, Clone)]
+pub struct EscapeConfig {
+    pub tagged_templates: Vec<CompactStr>,
+    pub methods: Vec<CompactStr>,
+}
+
+impl Default for EscapeConfig {
+    fn default() -> Self {
+        Self {
+            tagged_templates: vec![
+                CompactStr::new("Sanitizer.escapeHTML"),
+                CompactStr::new("escapeHTML"),
+            ],
+            methods: vec![
+                CompactStr::new("Sanitizer.unwrapSafeHTML"),
+                CompactStr::new("unwrapSafeHTML"),
+            ],
+        }
+    }
+}
+
+impl EscapeConfig {
+    /// Applies the `escape` part of a user configuration on top of `self`.
+    pub fn apply(&mut self, schema: &EscapeSchema) {
+        if let Some(tagged_templates) = &schema.tagged_templates {
+            self.tagged_templates =
+                tagged_templates.iter().map(|s| CompactStr::from(s.as_str())).collect();
+        }
+        if let Some(methods) = &schema.methods {
+            self.methods = methods.iter().map(|s| CompactStr::from(s.as_str())).collect();
+        }
+    }
+}
+
+/// The `escape` option of both `no-unsanitized` rules.
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct EscapeSchema {
+    /// Tagged template functions which return safe HTML.
+    /// Defaults to `["Sanitizer.escapeHTML", "escapeHTML"]`.
+    pub tagged_templates: Option<Vec<String>>,
+    /// Methods which return safe HTML.
+    /// Defaults to `["Sanitizer.unwrapSafeHTML", "unwrapSafeHTML"]`.
+    pub methods: Option<Vec<String>>,
+}
+
+/// A value flowing into an HTML sink.
+#[derive(Debug, Clone, Copy)]
+pub enum SinkValue<'a, 'b> {
+    Expression(&'b Expression<'a>),
+    /// The quasis of a tagged template, which are raw text and therefore always safe.
+    Quasis,
+    /// A value the rule cannot reason about, e.g. a spread element.
+    Unsupported,
+}
+
+/// Decides whether a value is provably safe to pass into an HTML sink.
+pub struct Sanitization<'e> {
+    pub escape: &'e EscapeConfig,
+    pub variable_tracing: bool,
+}
+
+impl Sanitization<'_> {
+    pub fn is_allowed<'a>(&self, value: SinkValue<'a, '_>, ctx: &LintContext<'a>) -> bool {
+        match value {
+            SinkValue::Quasis => true,
+            SinkValue::Unsupported => false,
+            SinkValue::Expression(expression) => {
+                let mut seen = FxHashSet::default();
+                self.is_allowed_expression(expression, ctx, &mut seen)
+            }
+        }
+    }
+
+    fn is_allowed_expression<'a>(
+        &self,
+        expression: &Expression<'a>,
+        ctx: &LintContext<'a>,
+        seen: &mut FxHashSet<SymbolId>,
+    ) -> bool {
+        match expression {
+            // A literal cannot carry attacker controlled markup, only malice.
+            Expression::StringLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_)
+            | Expression::BigIntLiteral(_)
+            | Expression::RegExpLiteral(_) => true,
+            // Only the `${...}` parts need checking, a quasi is raw text.
+            // A template literal without interpolations is therefore always safe.
+            Expression::TemplateLiteral(template) => template
+                .expressions
+                .iter()
+                .all(|expression| self.is_allowed_expression(expression, ctx, seen)),
+            Expression::TaggedTemplateExpression(tagged) => {
+                is_allowed_callee(&tagged.tag, &self.escape.tagged_templates, ctx)
+            }
+            Expression::CallExpression(call) => {
+                is_allowed_callee(&call.callee, &self.escape.methods, ctx)
+            }
+            Expression::BinaryExpression(binary) => {
+                self.is_allowed_expression(&binary.left, ctx, seen)
+                    && self.is_allowed_expression(&binary.right, ctx, seen)
+            }
+            Expression::ParenthesizedExpression(paren) => {
+                self.is_allowed_expression(&paren.expression, ctx, seen)
+            }
+            Expression::TSAsExpression(_)
+            | Expression::TSSatisfiesExpression(_)
+            | Expression::TSNonNullExpression(_)
+            | Expression::TSTypeAssertion(_)
+            | Expression::TSInstantiationExpression(_) => {
+                self.is_allowed_expression(expression.get_inner_expression(), ctx, seen)
+            }
+            Expression::Identifier(identifier) => self.is_allowed_identifier(identifier, ctx, seen),
+            _ => false,
+        }
+    }
+
+    /// Traces an identifier back to its declaration.
+    ///
+    /// Only `let`/`const` bindings whose initializer and every write reference are
+    /// themselves allowed expressions are considered safe.
+    fn is_allowed_identifier<'a>(
+        &self,
+        identifier: &IdentifierReference<'a>,
+        ctx: &LintContext<'a>,
+        seen: &mut FxHashSet<SymbolId>,
+    ) -> bool {
+        if !self.variable_tracing {
+            return false;
+        }
+        // Unresolved references (globals, implicit assignments) cannot be traced.
+        let Some(symbol_id) = ctx.scoping().get_reference(identifier.reference_id()).symbol_id()
+        else {
+            return false;
+        };
+        // Guard against cycles such as `let a = ''; a = `${a}<p>`;`.
+        if !seen.insert(symbol_id) {
+            return false;
+        }
+
+        let allowed = self.is_allowed_symbol(symbol_id, ctx, seen);
+        seen.remove(&symbol_id);
+        allowed
+    }
+
+    fn is_allowed_symbol(
+        &self,
+        symbol_id: SymbolId,
+        ctx: &LintContext<'_>,
+        seen: &mut FxHashSet<SymbolId>,
+    ) -> bool {
+        let scoping = ctx.scoping();
+        let declaration = ctx.nodes().get_node(scoping.symbol_declaration(symbol_id));
+        let AstKind::VariableDeclarator(declarator) = declaration.kind() else {
+            // Function parameters, imports, classes, ... are not traceable.
+            return false;
+        };
+        // `var` can be overwritten in ways that are not visible here.
+        if !matches!(declarator.kind, VariableDeclarationKind::Let | VariableDeclarationKind::Const)
+        {
+            return false;
+        }
+        if let Some(init) = &declarator.init
+            && !self.is_allowed_expression(init, ctx, seen)
+        {
+            return false;
+        }
+
+        scoping.get_resolved_references(symbol_id).filter(|reference| reference.is_write()).all(
+            |reference| {
+                write_expression(ctx, reference.node_id())
+                    .is_some_and(|expression| self.is_allowed_expression(expression, ctx, seen))
+            },
+        )
+    }
+}
+
+/// The right-hand side of the assignment a write reference belongs to.
+fn write_expression<'a, 'b>(
+    ctx: &'b LintContext<'a>,
+    node_id: oxc_semantic::NodeId,
+) -> Option<&'b Expression<'a>> {
+    match ctx.nodes().parent_kind(node_id) {
+        AstKind::AssignmentExpression(assignment) => Some(&assignment.right),
+        _ => None,
+    }
+}
+
+fn is_allowed_callee<'a>(
+    callee: &Expression<'a>,
+    allowed: &[CompactStr],
+    ctx: &LintContext<'a>,
+) -> bool {
+    let Some(name) = callee_code_name(callee, ctx) else {
+        return false;
+    };
+    allowed.iter().any(|candidate| candidate.as_str() == name)
+}
+
+/// `foo` for `foo()`, `obj.foo` for `obj.foo()`, using source text for
+/// non-identifier objects, matching the upstream `getCodeName` helper.
+pub fn callee_code_name<'a>(callee: &Expression<'a>, ctx: &LintContext<'a>) -> Option<String> {
+    match callee {
+        Expression::Identifier(identifier) => Some(identifier.name.to_string()),
+        Expression::StaticMemberExpression(member) => {
+            Some(format!("{}.{}", object_code_name(&member.object, ctx), member.property.name))
+        }
+        _ => None,
+    }
+}
+
+/// Name of the object a method is called on, as used for `objectMatches`.
+pub fn object_code_name<'a>(object: &Expression<'a>, ctx: &LintContext<'a>) -> String {
+    match object {
+        Expression::Identifier(identifier) => identifier.name.to_string(),
+        object => ctx.source_range(object.span()).to_string(),
+    }
+}

--- a/crates/oxc_linter/src/utils/no_unsanitized.rs
+++ b/crates/oxc_linter/src/utils/no_unsanitized.rs
@@ -16,37 +16,63 @@ use serde::Deserialize;
 
 use crate::context::LintContext;
 
+/// Escaping functions the upstream plugin knows without configuration.
+const DEFAULT_TAGGED_TEMPLATES: [&str; 2] = ["Sanitizer.escapeHTML", "escapeHTML"];
+const DEFAULT_METHODS: [&str; 2] = ["Sanitizer.unwrapSafeHTML", "unwrapSafeHTML"];
+
 /// Escaping functions whose output is considered safe HTML.
-#[derive(Debug, Clone)]
+///
+/// A field that was not configured falls back to the built-in list, an explicitly
+/// empty list disables it, mirroring `escapeObject.methods || VALID_UNWRAPPERS`
+/// upstream.
+#[derive(Debug, Default, Clone)]
 pub struct EscapeConfig {
-    pub tagged_templates: Vec<CompactStr>,
-    pub methods: Vec<CompactStr>,
+    tagged_templates: Option<Vec<CompactStr>>,
+    methods: Option<Vec<CompactStr>>,
 }
 
-impl Default for EscapeConfig {
-    fn default() -> Self {
-        Self {
-            tagged_templates: vec![
-                CompactStr::new("Sanitizer.escapeHTML"),
-                CompactStr::new("escapeHTML"),
-            ],
-            methods: vec![
-                CompactStr::new("Sanitizer.unwrapSafeHTML"),
-                CompactStr::new("unwrapSafeHTML"),
-            ],
+impl EscapeConfig {
+    fn tagged_templates(&self) -> Escapers<'_> {
+        match &self.tagged_templates {
+            Some(configured) => Escapers::Configured(configured),
+            None => Escapers::Default(&DEFAULT_TAGGED_TEMPLATES),
+        }
+    }
+
+    fn methods(&self) -> Escapers<'_> {
+        match &self.methods {
+            Some(configured) => Escapers::Configured(configured),
+            None => Escapers::Default(&DEFAULT_METHODS),
         }
     }
 }
 
-impl EscapeConfig {
-    /// Applies the `escape` part of a user configuration on top of `self`.
-    pub fn apply(&mut self, schema: &EscapeSchema) {
-        if let Some(tagged_templates) = &schema.tagged_templates {
-            self.tagged_templates =
-                tagged_templates.iter().map(|s| CompactStr::from(s.as_str())).collect();
+enum Escapers<'a> {
+    Configured(&'a [CompactStr]),
+    Default(&'a [&'static str]),
+}
+
+impl Escapers<'_> {
+    fn contains(&self, name: &str) -> bool {
+        match self {
+            Self::Configured(escapers) => escapers.iter().any(|escaper| escaper == name),
+            Self::Default(escapers) => escapers.contains(&name),
         }
-        if let Some(methods) = &schema.methods {
-            self.methods = methods.iter().map(|s| CompactStr::from(s.as_str())).collect();
+    }
+}
+
+impl From<&EscapeSchema> for EscapeConfig {
+    /// An `escape` object replaces a previous one as a whole, as upstream's
+    /// `Object.assign` does.
+    fn from(schema: &EscapeSchema) -> Self {
+        let convert = |names: &Option<Vec<String>>| -> Option<Vec<CompactStr>> {
+            names
+                .as_ref()
+                .map(|names| names.iter().map(|name| CompactStr::from(name.as_str())).collect())
+        };
+        Self {
+            tagged_templates: convert(&schema.tagged_templates),
+            methods: convert(&schema.methods),
         }
     }
 }
@@ -112,10 +138,10 @@ impl Sanitization<'_> {
                 .iter()
                 .all(|expression| self.is_allowed_expression(expression, ctx, seen)),
             Expression::TaggedTemplateExpression(tagged) => {
-                is_allowed_callee(&tagged.tag, &self.escape.tagged_templates, ctx)
+                is_allowed_callee(&tagged.tag, &self.escape.tagged_templates(), ctx)
             }
             Expression::CallExpression(call) => {
-                is_allowed_callee(&call.callee, &self.escape.methods, ctx)
+                is_allowed_callee(&call.callee, &self.escape.methods(), ctx)
             }
             Expression::BinaryExpression(binary) => {
                 self.is_allowed_expression(&binary.left, ctx, seen)
@@ -209,18 +235,15 @@ fn write_expression<'a, 'b>(
 
 fn is_allowed_callee<'a>(
     callee: &Expression<'a>,
-    allowed: &[CompactStr],
+    allowed: &Escapers<'_>,
     ctx: &LintContext<'a>,
 ) -> bool {
-    let Some(name) = callee_code_name(callee, ctx) else {
-        return false;
-    };
-    allowed.iter().any(|candidate| candidate.as_str() == name)
+    callee_code_name(callee, ctx).is_some_and(|name| allowed.contains(&name))
 }
 
 /// `foo` for `foo()`, `obj.foo` for `obj.foo()`, using source text for
 /// non-identifier objects, matching the upstream `getCodeName` helper.
-pub fn callee_code_name<'a>(callee: &Expression<'a>, ctx: &LintContext<'a>) -> Option<String> {
+fn callee_code_name<'a>(callee: &Expression<'a>, ctx: &LintContext<'a>) -> Option<String> {
     match callee {
         Expression::Identifier(identifier) => Some(identifier.name.to_string()),
         Expression::StaticMemberExpression(member) => {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -5479,6 +5479,26 @@
             }
           ]
         },
+        "no-unsanitized/property": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/PropertyOptionsSchema"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "no-unused-expressions": {
           "anyOf": [
             {
@@ -10730,6 +10750,28 @@
       },
       "additionalProperties": false
     },
+    "EscapeSchema": {
+      "type": "object",
+      "properties": {
+        "methods": {
+          "description": "Methods which return safe HTML.\nDefaults to `[\"Sanitizer.unwrapSafeHTML\", \"unwrapSafeHTML\"]`.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Methods which return safe HTML.\nDefaults to `[\"Sanitizer.unwrapSafeHTML\", \"unwrapSafeHTML\"]`."
+        },
+        "taggedTemplates": {
+          "description": "Tagged template functions which return safe HTML.\nDefaults to `[\"Sanitizer.escapeHTML\", \"escapeHTML\"]`.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Tagged template functions which return safe HTML.\nDefaults to `[\"Sanitizer.escapeHTML\", \"escapeHTML\"]`."
+        }
+      },
+      "additionalProperties": false
+    },
     "ExhaustiveDepsConfig": {
       "type": "object",
       "properties": {
@@ -12664,7 +12706,8 @@
         "react-perf",
         "promise",
         "node",
-        "vue"
+        "vue",
+        "no-unsanitized"
       ]
     },
     "LintPlugins": {
@@ -17969,6 +18012,34 @@
       "additionalItems": {
         "$ref": "#/definitions/PropertyDetails"
       }
+    },
+    "PropertyOptionsSchema": {
+      "type": "object",
+      "properties": {
+        "escape": {
+          "description": "Escaping functions which mark a value as safe.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EscapeSchema"
+            }
+          ],
+          "markdownDescription": "Escaping functions which mark a value as safe."
+        },
+        "properties": {
+          "description": "Property names treated as HTML sinks, replacing the defaults\n`[\"innerHTML\", \"outerHTML\"]`.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Property names treated as HTML sinks, replacing the defaults\n`[\"innerHTML\", \"outerHTML\"]`."
+        },
+        "variableTracing": {
+          "description": "Whether values assigned from local `let`/`const` variables are traced back\nto their initializers. Defaults to `true`.",
+          "type": "boolean",
+          "markdownDescription": "Whether values assigned from local `let`/`const` variables are traced back\nto their initializers. Defaults to `true`."
+        }
+      },
+      "additionalProperties": false
     },
     "RadixType": {
       "oneOf": [

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -5491,10 +5491,16 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "$ref": "#/definitions/MethodOptionsSchema"
+                  "$ref": "#/definitions/MethodGlobalOptions"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/definitions/MethodSinkOptions"
+                  }
                 }
               ],
-              "maxItems": 2,
+              "maxItems": 3,
               "minItems": 2
             }
           ]
@@ -5511,10 +5517,16 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "$ref": "#/definitions/PropertyOptionsSchema"
+                  "$ref": "#/definitions/PropertyGlobalOptions"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/definitions/PropertySinkOptions"
+                  }
                 }
               ],
-              "maxItems": 2,
+              "maxItems": 3,
               "minItems": 2
             }
           ]
@@ -13183,40 +13195,41 @@
         }
       ]
     },
-    "MethodOptionsSchema": {
+    "MethodGlobalOptions": {
+      "description": "The first options object, applying to every sink.",
       "type": "object",
       "properties": {
         "defaultDisable": {
-          "description": "Drops the built-in sink list, so only sinks given in the second options\nobject are checked.",
+          "description": "Drops the built-in sink list, so only sinks given in the second options\nobject are checked. Built-in sinks named there keep their argument indices.",
           "type": "boolean",
-          "markdownDescription": "Drops the built-in sink list, so only sinks given in the second options\nobject are checked."
+          "markdownDescription": "Drops the built-in sink list, so only sinks given in the second options\nobject are checked. Built-in sinks named there keep their argument indices."
         },
         "escape": {
-          "description": "Escaping functions which mark a value as safe, for every sink.",
+          "description": "Escaping functions which mark a value as safe.",
           "allOf": [
             {
               "$ref": "#/definitions/EscapeSchema"
             }
           ],
-          "markdownDescription": "Escaping functions which mark a value as safe, for every sink."
+          "markdownDescription": "Escaping functions which mark a value as safe."
         },
         "objectMatches": {
-          "description": "Regexes the object of a call must match, for every sink.",
+          "description": "Regexes the name of the object a method is called on must match.\n\nThese are Rust regexes, which do not support backreferences or lookaround.",
           "type": "array",
           "items": {
             "type": "string"
           },
-          "markdownDescription": "Regexes the object of a call must match, for every sink."
+          "markdownDescription": "Regexes the name of the object a method is called on must match.\n\nThese are Rust regexes, which do not support backreferences or lookaround."
         },
         "properties": {
-          "description": "Argument indices which are parsed as HTML, for every sink.",
+          "description": "Argument indices which are parsed as HTML.",
           "type": "array",
           "items": {
             "type": "integer",
             "format": "uint",
             "minimum": 0.0
           },
-          "markdownDescription": "Argument indices which are parsed as HTML, for every sink."
+          "markdownDescription": "Argument indices which are parsed as HTML."
         },
         "variableTracing": {
           "description": "Whether values coming from local `let`/`const` variables are traced back\nto their initializers. Defaults to `true`.",
@@ -13224,7 +13237,8 @@
           "markdownDescription": "Whether values coming from local `let`/`const` variables are traced back\nto their initializers. Defaults to `true`."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "markdownDescription": "The first options object, applying to every sink."
     },
     "MethodSignatureStyleConfig": {
       "oneOf": [
@@ -13245,6 +13259,41 @@
           "markdownDescription": "Enforce using method signature for functions. Use this if you aren't using TypeScript's strict mode and prefer this style."
         }
       ]
+    },
+    "MethodSinkOptions": {
+      "description": "The options of a single sink in the second options object.",
+      "type": "object",
+      "properties": {
+        "escape": {
+          "description": "Escaping functions accepted for this sink, replacing the ones from the\nfirst options object.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EscapeSchema"
+            }
+          ],
+          "markdownDescription": "Escaping functions accepted for this sink, replacing the ones from the\nfirst options object."
+        },
+        "objectMatches": {
+          "description": "Regexes the name of the object must match, replacing the ones from the\nfirst options object.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Regexes the name of the object must match, replacing the ones from the\nfirst options object."
+        },
+        "properties": {
+          "description": "Argument indices which are parsed as HTML.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          },
+          "markdownDescription": "Argument indices which are parsed as HTML."
+        }
+      },
+      "additionalProperties": false,
+      "markdownDescription": "The options of a single sink in the second options object."
     },
     "Mode": {
       "oneOf": [
@@ -18078,7 +18127,8 @@
         "$ref": "#/definitions/PropertyDetails"
       }
     },
-    "PropertyOptionsSchema": {
+    "PropertyGlobalOptions": {
+      "description": "The first options object, applying to every property.",
       "type": "object",
       "properties": {
         "escape": {
@@ -18090,21 +18140,31 @@
           ],
           "markdownDescription": "Escaping functions which mark a value as safe."
         },
-        "properties": {
-          "description": "Property names treated as HTML sinks, replacing the defaults\n`[\"innerHTML\", \"outerHTML\"]`.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "Property names treated as HTML sinks, replacing the defaults\n`[\"innerHTML\", \"outerHTML\"]`."
-        },
         "variableTracing": {
           "description": "Whether values assigned from local `let`/`const` variables are traced back\nto their initializers. Defaults to `true`.",
           "type": "boolean",
           "markdownDescription": "Whether values assigned from local `let`/`const` variables are traced back\nto their initializers. Defaults to `true`."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "markdownDescription": "The first options object, applying to every property."
+    },
+    "PropertySinkOptions": {
+      "description": "The options of a single property in the second options object.",
+      "type": "object",
+      "properties": {
+        "escape": {
+          "description": "Escaping functions accepted for this property, replacing the ones from the\nfirst options object.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EscapeSchema"
+            }
+          ],
+          "markdownDescription": "Escaping functions accepted for this property, replacing the ones from the\nfirst options object."
+        }
+      },
+      "additionalProperties": false,
+      "markdownDescription": "The options of a single property in the second options object."
     },
     "RadixType": {
       "oneOf": [

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -5479,6 +5479,26 @@
             }
           ]
         },
+        "no-unsanitized/method": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/MethodOptionsSchema"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "no-unsanitized/property": {
           "anyOf": [
             {
@@ -10751,6 +10771,7 @@
       "additionalProperties": false
     },
     "EscapeSchema": {
+      "description": "The `escape` option of both `no-unsanitized` rules.",
       "type": "object",
       "properties": {
         "methods": {
@@ -10770,7 +10791,8 @@
           "markdownDescription": "Tagged template functions which return safe HTML.\nDefaults to `[\"Sanitizer.escapeHTML\", \"escapeHTML\"]`."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "markdownDescription": "The `escape` option of both `no-unsanitized` rules."
     },
     "ExhaustiveDepsConfig": {
       "type": "object",
@@ -13160,6 +13182,49 @@
           "markdownDescription": "Prefer using `.each` to create parameterized tests."
         }
       ]
+    },
+    "MethodOptionsSchema": {
+      "type": "object",
+      "properties": {
+        "defaultDisable": {
+          "description": "Drops the built-in sink list, so only sinks given in the second options\nobject are checked.",
+          "type": "boolean",
+          "markdownDescription": "Drops the built-in sink list, so only sinks given in the second options\nobject are checked."
+        },
+        "escape": {
+          "description": "Escaping functions which mark a value as safe, for every sink.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EscapeSchema"
+            }
+          ],
+          "markdownDescription": "Escaping functions which mark a value as safe, for every sink."
+        },
+        "objectMatches": {
+          "description": "Regexes the object of a call must match, for every sink.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Regexes the object of a call must match, for every sink."
+        },
+        "properties": {
+          "description": "Argument indices which are parsed as HTML, for every sink.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          },
+          "markdownDescription": "Argument indices which are parsed as HTML, for every sink."
+        },
+        "variableTracing": {
+          "description": "Whether values coming from local `let`/`const` variables are traced back\nto their initializers. Defaults to `true`.",
+          "type": "boolean",
+          "markdownDescription": "Whether values coming from local `let`/`const` variables are traced back\nto their initializers. Defaults to `true`."
+        }
+      },
+      "additionalProperties": false
     },
     "MethodSignatureStyleConfig": {
       "oneOf": [

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -353,6 +353,8 @@ nextjs/no-styled-jsx-in-document                           |    452
 nextjs/no-sync-scripts                                     |    452
 nextjs/no-title-in-document-head                           |    103
 nextjs/no-unwanted-polyfillio                              |    452
+no_unsanitized/method                                      |  62626
+no_unsanitized/property                                    |  13005
 node/callback-return                                       |  62606
 node/exports-style                                         |      7
 node/global-require                                        |  62606

--- a/tasks/website_linter/src/rules/doc_page.rs
+++ b/tasks/website_linter/src/rules/doc_page.rs
@@ -355,6 +355,9 @@ fn upstream_docs_url(plugin: &str, name: &str) -> Option<String> {
             "https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/{name}.md"
         ),
         "vue" => format!("https://eslint.vuejs.org/rules/{name}.html"),
+        "no_unsanitized" => format!(
+            "https://github.com/mozilla/eslint-plugin-no-unsanitized/blob/main/docs/rules/{name}.md"
+        ),
         _ => return None,
     })
 }

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -83,6 +83,8 @@ Arguments:
   Enable the node plugin and detect node usage problems
 - **`    --vue-plugin`** &mdash; 
   Enable the vue plugin and detect vue usage problems
+- **`    --no-unsanitized-plugin`** &mdash; 
+  Enable the no-unsanitized plugin and detect unsanitized HTML sinks
 
 
 

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -50,6 +50,7 @@ Enable/Disable Plugins
         --promise-plugin      Enable the promise plugin and detect promise usage problems
         --node-plugin         Enable the node plugin and detect node usage problems
         --vue-plugin          Enable the vue plugin and detect vue usage problems
+        --no-unsanitized-plugin  Enable the no-unsanitized plugin and detect unsanitized HTML sinks
 
 Fix Problems
         --fix                 Fix as many issues as possible. Only unfixed issues are reported in

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -624,7 +624,7 @@ omitted, the base config's plugins are used.
 
 ##### overrides[n].plugins[n]
 
-type: `"eslint" | "react" | "unicorn" | "typescript" | "oxc" | "import" | "jsdoc" | "jest" | "vitest" | "jsx-a11y" | "nextjs" | "react-perf" | "promise" | "node" | "vue"`
+type: `"eslint" | "react" | "unicorn" | "typescript" | "oxc" | "import" | "jsdoc" | "jest" | "vitest" | "jsx-a11y" | "nextjs" | "react-perf" | "promise" | "node" | "vue" | "no-unsanitized"`
 
 
 
@@ -654,7 +654,7 @@ The `plugins` array should reflect all of the plugins you want to use.
 
 ### plugins[n]
 
-type: `"eslint" | "react" | "unicorn" | "typescript" | "oxc" | "import" | "jsdoc" | "jest" | "vitest" | "jsx-a11y" | "nextjs" | "react-perf" | "promise" | "node" | "vue"`
+type: `"eslint" | "react" | "unicorn" | "typescript" | "oxc" | "import" | "jsdoc" | "jest" | "vitest" | "jsx-a11y" | "nextjs" | "react-perf" | "promise" | "node" | "vue" | "no-unsanitized"`
 
 
 


### PR DESCRIPTION
Closes #25308

Ports Mozilla's [`eslint-plugin-no-unsanitized`](https://github.com/mozilla/eslint-plugin-no-unsanitized) (`property` + `method`) as built-in rules under a new opt-in `no-unsanitized` plugin (category `restriction`, enabled via `plugins` or `--no-unsanitized-plugin`). See the issue for the motivation; the open question from there (own plugin namespace vs. `oxc/`) is reflected here as its own namespace — easy to reshape if you'd rather have it under `oxc`.

What's in the port:

- `crates/oxc_linter/src/rules/no_unsanitized/{property,method}.rs`, with the shared safety analysis in `utils/no_unsanitized.rs`: literals, template literals (checking only the interpolations, like upstream), binary concatenations, tagged templates and calls against the `escape` allowlists, plus TS wrapper unwrapping (`as`, `!`, `<T>`).
- Upstream operator semantics: `=`, `+=`, `||=`, `&&=`, `??=` are checked, `*=` etc. are not. The callee walk handles sequence/assignment/non-null/tagged-template forms; for logical assignments in callee position only the right side that can actually reach the call is followed.
- Config parity with upstream's `[severity, globalOptions, perSinkMap]` shape, including per-sink `escape` replacing the global one wholesale (upstream does `Object.assign`), `defaultDisable`, and `objectMatches`. Patterns compile as Rust regexes; a pattern that doesn't compile is a configuration error, not a silently disabled sink.
- `variableTracing` via `Scoping`: declaration kind plus all write references, with a recursion guard.
- Computed members with literal keys (`node['innerHTML'] = ...`) are caught too.
- Upstream's `tests/rules/property.js` and `tests/rules/method.js` translated to the `Tester` (JS and TS variants, snapshots included). Skipped: Flow-only cases and the ones needing upstream's "fantasy operator" parser. `reportUnsupported` is not ported — upstream uses it to collect bug reports for unknown node types.
- Generated artifacts regenerated (`cargo lintgen`, configuration schema, `config.generated.ts`, docs URL).

`just ready` passes locally except two failures that are already present on the base commit (a typos-version mismatch and a V8-dependent sourcemap snapshot) — verified by running the same commands on a clean worktree of the base.

Disclosure per the contributing guide: an AI assistant helped with the port; I reviewed and ran the code and tests myself.
