### PR TITLE
perf(linter): compute diagnostic `Info` once per diagnostic in junit reporter

### DIFF
--- a/apps/oxlint/src/output_formatter/junit.rs
+++ b/apps/oxlint/src/output_formatter/junit.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write;
+
 use oxc_diagnostics::{
     Error, Severity,
     reporter::{DiagnosticReporter, DiagnosticResult, Info},
@@ -32,31 +34,33 @@ impl DiagnosticReporter for JUnitReporter {
 }
 
 fn format_junit(diagnostics: &[Error]) -> String {
-    let mut grouped: FxHashMap<String, Vec<&Error>> = FxHashMap::default();
+    // `Info::new` scans the source to resolve the span, so build it exactly once per
+    // diagnostic and group by index rather than re-deriving it inside the render loop.
+    let infos: Vec<Info> = diagnostics.iter().map(Info::new).collect();
 
-    for diagnostic in diagnostics {
-        let info = Info::new(diagnostic);
-        grouped.entry(info.filename).or_default().push(diagnostic);
+    let mut grouped: FxHashMap<&str, Vec<usize>> = FxHashMap::default();
+    for (index, info) in infos.iter().enumerate() {
+        grouped.entry(info.filename.as_str()).or_default().push(index);
     }
 
-    let mut filenames: Vec<_> = grouped.keys().cloned().collect();
-    filenames.sort();
+    let mut filenames: Vec<&str> = grouped.keys().copied().collect();
+    filenames.sort_unstable();
 
     let mut total_errors = 0;
     let mut total_warnings = 0;
-    let mut test_suites = Vec::new();
+    let mut test_suites = String::new();
 
-    for filename in filenames {
-        let diagnostics = grouped.get(&filename).expect("filename collected from map");
+    for (suite_index, filename) in filenames.iter().enumerate() {
+        let indices = grouped.get(filename).expect("filename collected from map");
         let mut test_cases = String::new();
         let mut error = 0;
         let mut warning = 0;
 
-        for diagnostic in diagnostics {
-            let rule = diagnostic.code().map_or_else(String::new, |code| code.to_string());
-            let Info { message, start, .. } = Info::new(diagnostic);
+        for &index in indices {
+            let Info { message, start, rule_id, .. } = &infos[index];
+            let rule = rule_id.as_deref().unwrap_or("");
 
-            let severity = if diagnostic.severity() == Some(Severity::Error) {
+            let severity = if diagnostics[index].severity() == Some(Severity::Error) {
                 total_errors += 1;
                 error += 1;
                 "error"
@@ -65,38 +69,29 @@ fn format_junit(diagnostics: &[Error]) -> String {
                 warning += 1;
                 "failure"
             };
-            let description =
-                format!("line {}, column {}, {}", start.line, start.column, xml_escape(&message));
+            let escaped_message = xml_escape(message);
 
-            let status = format!(
-                "            <{} message=\"{}\">{}</{}>",
-                severity,
-                xml_escape(&message),
-                description,
-                severity
+            let _ = write!(
+                test_cases,
+                "\n        <testcase name=\"{rule}\">\n            <{severity} message=\"{escaped_message}\">line {}, column {}, {escaped_message}</{severity}>\n        </testcase>",
+                start.line, start.column,
             );
-            let test_case =
-                format!("\n        <testcase name=\"{rule}\">\n{status}\n        </testcase>");
-            test_cases.push_str(&test_case);
         }
-        test_suites.push(format!(
-            "    <testsuite name=\"{}\" tests=\"{}\" disabled=\"0\" errors=\"{}\" failures=\"{}\">{}\n    </testsuite>",
-            filename,
-            diagnostics.len(),
-            error,
-            warning,
-            test_cases
-        ));
-    }
-    let test_suites = format!(
-        "<testsuites name=\"Oxlint\" tests=\"{}\" failures=\"{}\" errors=\"{}\">\n{}\n</testsuites>\n",
-        total_errors + total_warnings,
-        total_warnings,
-        total_errors,
-        test_suites.join("\n")
-    );
 
-    format!("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n{test_suites}")
+        if suite_index > 0 {
+            test_suites.push('\n');
+        }
+        let _ = write!(
+            test_suites,
+            "    <testsuite name=\"{filename}\" tests=\"{}\" disabled=\"0\" errors=\"{error}\" failures=\"{warning}\">{test_cases}\n    </testsuite>",
+            indices.len(),
+        );
+    }
+
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites name=\"Oxlint\" tests=\"{}\" failures=\"{total_warnings}\" errors=\"{total_errors}\">\n{test_suites}\n</testsuites>\n",
+        total_errors + total_warnings,
+    )
 }
 
 #[cfg(test)]

--- a/apps/oxlint/src/output_formatter/junit.rs
+++ b/apps/oxlint/src/output_formatter/junit.rs
@@ -131,6 +131,32 @@ mod test {
         assert_eq!(output, EXPECTED_REPORT);
     }
 
+    // The message is escaped once and interpolated into both the attribute and the element
+    // body, so assert both. Also the only coverage of a non-empty rule name.
+    #[test]
+    fn test_junit_reporter_escapes_message_and_reports_rule() {
+        const EXPECTED_REPORT: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Oxlint" tests="1" failures="0" errors="1">
+    <testsuite name="file.js" tests="1" disabled="0" errors="1" failures="0">
+        <testcase name="eslint(no-debugger)">
+            <error message="unexpected &apos;a &lt; b&apos; &amp; &quot;c&quot;">line 1, column 1, unexpected &apos;a &lt; b&apos; &amp; &quot;c&quot;</error>
+        </testcase>
+    </testsuite>
+</testsuites>
+"#;
+        let mut reporter = JUnitReporter::default();
+
+        reporter.render_error(
+            OxcDiagnostic::error("unexpected 'a < b' & \"c\"")
+                .with_error_code("eslint", "no-debugger")
+                .with_label(Span::new(0, 8))
+                .with_source_code(NamedSource::new("file.js", "debugger;")),
+        );
+
+        let output = reporter.finish(&DiagnosticResult::default()).unwrap();
+        assert_eq!(output, EXPECTED_REPORT);
+    }
+
     #[test]
     fn test_junit_reporter_multiple_files() {
         const EXPECTED_REPORT: &str = r#"<?xml version="1.0" encoding="UTF-8"?>

--- a/apps/oxlint/src/output_formatter/xml_utils.rs
+++ b/apps/oxlint/src/output_formatter/xml_utils.rs
@@ -50,3 +50,27 @@ fn xml_escape_impl<F: Fn(u8) -> bool>(raw: &str, escape_chars: F) -> Cow<'_, str
         Cow::Borrowed(raw)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::borrow::Cow;
+
+    use super::xml_escape;
+
+    #[test]
+    fn borrows_when_there_is_nothing_to_escape() {
+        assert!(matches!(xml_escape("nothing to escape here"), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn escapes_every_special_character() {
+        assert_eq!(xml_escape("<>&'\""), "&lt;&gt;&amp;&apos;&quot;");
+    }
+
+    // Only single-byte characters are matched, so multibyte sequences must survive the
+    // `from_utf8_unchecked` in one piece.
+    #[test]
+    fn keeps_surrounding_text_and_multibyte_characters() {
+        assert_eq!(xml_escape("café <b> & 🎉"), "café &lt;b&gt; &amp; 🎉");
+    }
+}


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, Opus 5. Tested and reviewed by me for correctness.

---

`format_junit` built an `Info` for every diagnostic twice: once to group diagnostics by filename, then again inside the render loop. `Info::new` reads the span out of the source, so this doubled the most expensive part of the reporter. Build it once and group by index instead.

Also drop two other duplicated pieces of work in the same loop: the message was `xml_escape`d twice (once for the attribute, once for the description), and the rule name was re-derived via `code().to_string()` even though `Info` already carries it as `rule_id`. And the nested `Vec<String>` + `join` is now a single output buffer.

Benchmarked with 3 runs x 2 format options (checkstyle as the control) x 3 repos, shows small reductions on junit in RSS thanks to this change, and 40-47% drops in runtime (`oxlint -D all --format=NAME`):

| repo | diagnostics | format | main | branch | delta | change | RSS main | RSS branch |
| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| vscode | 1,366,572 | checkstyle | 11832ms | 11645ms | -187ms | -1.6% | 3272 MB | 3273 MB |
| vscode | 1,366,572 | **junit** | 22022ms | 11611ms | -10410ms | **-47.3%** | 3325 MB | 3287 MB |
| gitlab | 363,895 | checkstyle | 1749ms | 1723ms | -26ms | -1.5% | 966 MB | 971 MB |
| gitlab | 363,895 | **junit** | 2895ms | 1718ms | -1177ms | **-40.7%** | 989 MB | 948 MB |
| canvas-lms | 350,637 | checkstyle | 2207ms | 2155ms | -52ms | -2.3% | 917 MB | 915 MB |
| canvas-lms | 350,637 | **junit** | 3944ms | 2139ms | -1805ms | **-45.8%** | 921 MB | 886 MB |

On a more reasonable number of diagnostics (running on canvas-lms with the default ruleset) the numbers are less pronounced but still show a 17% drop:

| repo | ruleset | diagnostics | format | main | branch | delta | change |
| --- | --- | ---: | --- | ---: | ---: | ---: | ---: |
| canvas-lms | default | 3,149 | checkstyle | 218ms | 219ms | +1ms | +0.5% |
| canvas-lms | default | 3,149 | junit | 265ms | 219ms | -46ms | -17.3% |

On a repo with 0 violations, the runtime difference for junit on main vs. this branch is entirely noise.

Realistically this won't have much of an impact in a user's actual run, as most of the time a lint run results in one of:

- 0 diagnostics
- a single digit number of diagnostics in a junit run due to new violations introduced by code changes
- or there are only a few hundred to a few thousand max (due to, for example, warnings which are considered safe and are only used for a "transition" period where a rule is soft-enabled until all existing violations of it are fixed).

But I think it's worthwhile regardless to help on smaller #s of diagnostics.