### PR TITLE
perf(linter): hoist `current_dir` out of the stylish reporter loop

### DIFF
--- a/apps/oxlint/src/output_formatter/stylish.rs
+++ b/apps/oxlint/src/output_formatter/stylish.rs
@@ -67,10 +67,12 @@ impl StylishReporter {
             grouped.entry(info.filename.clone()).or_default().push((info, diagnostic));
         }
 
+        let cwd = std::env::current_dir().ok();
+
         for diagnostics in grouped.values() {
             let filename = &diagnostics[0].0.filename;
             let filename = if let Some(path) =
-                std::env::current_dir().ok().and_then(|d| d.join(filename).canonicalize().ok())
+                cwd.as_ref().and_then(|d| d.join(filename).canonicalize().ok())
             {
                 path.display().to_string()
             } else {


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, reviewed and tested by me. Just a micro-optimization.

The stylish reporter calls `std::env::current_dir()` once per file group, in order to canonicalize each filename for display. That is a syscall, and the result is identical for every group, so this reads it once before the loop and borrows it.

Output is unchanged — `current_dir()` is not expected to vary mid-run, and the value is used the same way.