### PR TITLE
perf(linter): avoid redundant message work in the agent reporter

### DIFF
--- a/apps/oxlint/src/output_formatter/agent.rs
+++ b/apps/oxlint/src/output_formatter/agent.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use oxc_diagnostics::{
     Error, Severity,
     reporter::{DiagnosticReporter, DiagnosticResult, Info},
@@ -48,7 +50,8 @@ fn format_agent(diagnostic: &Error) -> String {
         _ => "error",
     };
     let rule = rule_id.map_or_else(String::new, |rule_id| format!(" {rule_id}"));
-    let message = compact_message(&diagnostic.to_string());
+    let rendered_message = diagnostic.to_string();
+    let message = compact_message(&rendered_message);
     let help = diagnostic
         .help()
         .map(|help| format!(" help: {}", compact_message(&help)))
@@ -59,23 +62,92 @@ fn format_agent(diagnostic: &Error) -> String {
     format!("{filename}{location}: {severity}{rule}: {message}{help}\n")
 }
 
-fn compact_message(message: &str) -> String {
-    let mut compact = String::new();
+/// Collapse whitespace runs to single spaces and trim. Borrows when already compact,
+/// which is the case for nearly every rule message.
+fn compact_message(message: &str) -> Cow<'_, str> {
+    if is_already_compact(message) {
+        return Cow::Borrowed(message);
+    }
+
+    let mut compact = String::with_capacity(message.len());
     for word in message.split_whitespace() {
         if !compact.is_empty() {
             compact.push(' ');
         }
         compact.push_str(word);
     }
-    compact
+    Cow::Owned(compact)
+}
+
+/// True when every whitespace run is already a single space and there is none at either end.
+fn is_already_compact(message: &str) -> bool {
+    let mut after_space = true;
+    for c in message.chars() {
+        if c.is_whitespace() {
+            if c != ' ' || after_space {
+                return false;
+            }
+            after_space = true;
+        } else {
+            after_space = false;
+        }
+    }
+    !after_space
 }
 
 #[cfg(test)]
 mod test {
+    use std::borrow::Cow;
+
     use oxc_diagnostics::{NamedSource, OxcDiagnostic, reporter::DiagnosticReporter};
     use oxc_span::Span;
 
-    use super::AgentReporter;
+    use super::{AgentReporter, compact_message};
+
+    // The borrowed fast path has to agree with the collapsing slow path on every input,
+    // or messages silently change shape depending on which branch is taken.
+    #[test]
+    fn compact_message_fast_path_matches_slow_path() {
+        fn collapse(message: &str) -> String {
+            let mut compact = String::new();
+            for word in message.split_whitespace() {
+                if !compact.is_empty() {
+                    compact.push(' ');
+                }
+                compact.push_str(word);
+            }
+            compact
+        }
+
+        for input in [
+            "",
+            " ",
+            "   ",
+            "a",
+            "already compact",
+            " leading",
+            "trailing ",
+            " both ",
+            "double  space",
+            "tab\tseparated",
+            "newline\nseparated",
+            "crlf\r\nseparated",
+            "mixed \t\n runs",
+            "non\u{a0}breaking",
+            "trailing newline\n",
+            "\nleading newline",
+            "unicode \u{2192} \u{2716} ok",
+        ] {
+            assert_eq!(compact_message(input), collapse(input), "mismatch for {input:?}");
+        }
+    }
+
+    #[test]
+    fn compact_message_borrows_only_when_already_compact() {
+        assert!(matches!(compact_message("already compact"), Cow::Borrowed(_)));
+        assert!(matches!(compact_message("double  space"), Cow::Owned(_)));
+        assert!(matches!(compact_message("trailing "), Cow::Owned(_)));
+    }
 
     #[test]
     fn reporter_error() {

--- a/apps/oxlint/src/output_formatter/agent.rs
+++ b/apps/oxlint/src/output_formatter/agent.rs
@@ -35,7 +35,7 @@ impl DiagnosticReporter for AgentReporter {
 }
 
 fn format_agent(diagnostic: &Error) -> String {
-    let Info { start, filename, message, rule_id, .. } = Info::new(diagnostic);
+    let Info { start, filename, message: info_message, rule_id, .. } = Info::new(diagnostic);
     let filename = if filename.is_empty() {
         diagnostic
             .source_code()
@@ -51,7 +51,8 @@ fn format_agent(diagnostic: &Error) -> String {
     };
     let rule = rule_id.map_or_else(String::new, |rule_id| format!(" {rule_id}"));
     // `Info` only fills in the message when the diagnostic has a resolvable label.
-    let rendered_message = if message.is_empty() { diagnostic.to_string() } else { message };
+    let rendered_message =
+        if info_message.is_empty() { diagnostic.to_string() } else { info_message };
     let message = compact_message(&rendered_message);
     let help = diagnostic
         .help()

--- a/apps/oxlint/src/output_formatter/agent.rs
+++ b/apps/oxlint/src/output_formatter/agent.rs
@@ -35,7 +35,7 @@ impl DiagnosticReporter for AgentReporter {
 }
 
 fn format_agent(diagnostic: &Error) -> String {
-    let Info { start, filename, rule_id, .. } = Info::new(diagnostic);
+    let Info { start, filename, message, rule_id, .. } = Info::new(diagnostic);
     let filename = if filename.is_empty() {
         diagnostic
             .source_code()
@@ -50,7 +50,8 @@ fn format_agent(diagnostic: &Error) -> String {
         _ => "error",
     };
     let rule = rule_id.map_or_else(String::new, |rule_id| format!(" {rule_id}"));
-    let rendered_message = diagnostic.to_string();
+    // `Info` only fills in the message when the diagnostic has a resolvable label.
+    let rendered_message = if message.is_empty() { diagnostic.to_string() } else { message };
     let message = compact_message(&rendered_message);
     let help = diagnostic
         .help()


### PR DESCRIPTION
Generated with Claude Code, Opus 5. Reviewed and tested by me. Mainly just avoiding extra, unneeded allocations per-diagnostic.

This shouldn't matter much at normal scales, but given that many people are using Claude Code, Codex, etc for setting up their linter config or to mass-resolve lint violations, I think the tradeoff in extra code here is probably worth it because there are definite cases where this will be getting triggered with large diagnostic counts. I will admit the `is_already_compact` method here is jank, though.

---

Two small changes to `format_agent`, both removing work that was already done.

**1. Borrow already-compact messages.** `compact_message` rebuilt every message into a fresh `String` by splitting on whitespace and rejoining, even though nearly every rule message is already compact and comes out byte-for-byte identical. It now checks first and borrows when there is nothing to collapse, falling back to the rebuild otherwise.

**2. Reuse the message `Info` already rendered.** `Info::new` calls `diagnostic.to_string()` internally; `format_agent` discarded that and rendered it a second time. It now takes the message from `Info`. `Info` only fills the message in when the diagnostic has a resolvable label, so the direct render is kept for the label-less case — which the existing `reporter_error_without_label` test covers.

## Allocations

Measured with a counting global allocator, `--threads=1` for deterministic counts, on a corpus of 20k small files producing exactly 2,400,000 diagnostics. `unix` is a control (untouched by this PR) and `--silent` is the no-formatter baseline.

| format | main allocs | branch allocs | diff | change |
| --- | ---: | ---: | ---: | ---: |
| silent (baseline) | 55,672,894 | 55,672,894 | 0 | 0.00% |
| unix (control) | 91,353,791 | 91,353,791 | 0 | 0.00% |
| agent | 124,894,389 | 104,194,389 | -20,700,000 | -16.57% |

Subtracting the baseline to isolate the formatter itself:

| | main | branch | change |
| --- | ---: | ---: | ---: |
| agent formatter allocations | 69,221,495 | 48,521,495 | **-29.9%** |
| per diagnostic | 28.84 | 20.22 | -8.62 |
| bytes requested | 8.39 GB | 7.66 GB | -729.7 MB |

Worth noting that the saving is much larger than the two `String`s the diff visibly removes. `diagnostic.to_string()` is not one allocation — rendering an `Error` goes through miette formatting, which allocates repeatedly — so removing the duplicate render is worth around 8 allocations per diagnostic, not one (we should maybe consider figuring out if we can fix that separately to reduce the allocations per diagnostic, but usually there aren't too many diagnostics so it's a minor improvement).

## Timing

Paired-difference measurement: samples interleaved one-for-one between the two binaries and differenced pairwise, so drift cancels. `unix` again as control.

| corpus | format | main | branch | diff | 95% CI | change |
| --- | --- | ---: | ---: | ---: | :---: | ---: |
| 20k small files (2.4M diagnostics) | agent | 3837ms | 3272ms | -564.4ms | [-590.7, -538.2]ms | -14.7% |
| 20k small files (2.4M diagnostics) | unix (control) | 2846ms | 2832ms | -14.2ms | [-39.4, +10.9]ms | -0.5% |
| vscode `-D all` (1.37M diagnostics) | agent | 13721ms | 13381ms | -339.8ms | [-511.6, -168.0]ms | -2.5% |
| vscode `-D all` (1.37M diagnostics) | unix (control) | 12794ms | 12781ms | -12.9ms | [-70.1, +44.4]ms | -0.1% |

## Equivalence

Confirmed byte-identical output from the formatter on main vs this branch over VS Code.