### PR TITLE
fix(oxlint): normalize customized rule names

### DIFF
--- a/apps/oxlint/src/lsp/options.rs
+++ b/apps/oxlint/src/lsp/options.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, de::Error};
 use serde_json::Value;
 
-use oxc_linter::FixKind;
+use oxc_linter::{FixKind, normalize_rule_name};
 use tracing::error;
 
 #[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, JsonSchema)]
@@ -130,7 +130,7 @@ impl<'de> Deserialize<'de> for RulesCustomization {
                 error!("failed to deserialize customization for rule {rule_name}, skipping.");
                 continue;
             };
-            rules.insert(rule_name.clone(), customization);
+            rules.insert(normalize_rule_name(rule_name), customization);
         }
 
         Ok(Self { rules })
@@ -300,6 +300,21 @@ mod test {
         let eqeqeq = &rules_customization.rules["eqeqeq"];
         assert_eq!(eqeqeq.severity, Some(RuleCustomizationSeverity::Warn));
         assert_eq!(eqeqeq.autofix, None);
+    }
+
+    #[test]
+    fn test_rule_customization_normalizes_rule_name() {
+        let options = LintOptions::try_from(json!({
+            "rulesCustomization": {
+                "eslint/no-unused-vars": {
+                    "severity": "error"
+                }
+            }
+        }))
+        .unwrap();
+
+        let rules_customization = options.rules_customization.unwrap();
+        assert!(rules_customization.rules.contains_key("no-unused-vars"));
     }
 
     #[test]

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -1535,12 +1535,45 @@ mod test {
     }
 
     #[test]
+    fn test_rules_customization_severity_with_eslint_prefix() {
+        let tester = Tester::new(
+            "fixtures/lsp/rules_customization/severity",
+            json!({
+                "rulesCustomization": {
+                    "eslint/no-debugger": {
+                        "severity": "warn"
+                    },
+                    "eslint/no-console": {
+                        "severity": "off"
+                    }
+                }
+            }),
+        );
+        tester.test_and_snapshot_single_file("test.ts");
+    }
+
+    #[test]
     fn test_rules_customization_autofix() {
         let tester = Tester::new(
             "fixtures/lsp/rules_customization/autofix",
             json!({
                 "rulesCustomization": {
                     "no-debugger": {
+                        "autofix": false
+                    }
+                }
+            }),
+        );
+        tester.test_and_snapshot_single_file("test.ts");
+    }
+
+    #[test]
+    fn test_rules_customization_autofix_with_eslint_prefix() {
+        let tester = Tester::new(
+            "fixtures/lsp/rules_customization/autofix",
+            json!({
+                "rulesCustomization": {
+                    "eslint/no-debugger": {
                         "autofix": false
                     }
                 }

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -20,7 +20,7 @@ pub use ignore_matcher::LintIgnoreMatcher;
 pub use overrides::OxlintOverrides;
 pub use oxlintrc::Oxlintrc;
 pub use plugins::LintPlugins;
-pub use rules::{ESLintRule, OxlintRules};
+pub use rules::{ESLintRule, OxlintRules, normalize_rule_name};
 pub use settings::{OxlintSettings, ReactVersion, jsdoc::JSDocPluginSettings};
 
 pub use oxc_config::GlobSet;

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -62,6 +62,17 @@ pub fn normalize_plugin_name(plugin_name: &str) -> Cow<'_, str> {
     Cow::Borrowed(plugin_name)
 }
 
+/// Gets the canonical display name for a plugin from its internal short name.
+#[inline]
+pub fn plugin_display_name(plugin_name: &str) -> &str {
+    match plugin_name {
+        "jsx_a11y" => "jsx-a11y",
+        "react_perf" => "react-perf",
+        "nextjs" => "next",
+        _ => plugin_name,
+    }
+}
+
 /// Checks if the given plugin name is valid.
 ///
 /// Returns `true` if the given plugin name is already in its normalized form.

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -659,28 +659,32 @@ fn parse_rule_key(name: &str) -> (String, String) {
     unalias_plugin_name(plugin_name, rule_name)
 }
 
-pub(super) fn unalias_plugin_name(plugin_name: &str, rule_name: &str) -> (String, String) {
-    // First normalize the plugin name by stripping eslint-plugin- prefix/suffix
-    let normalized = super::plugins::normalize_plugin_name(plugin_name);
-    let plugin_name = normalized.as_ref();
+/// Normalize a rule name to the canonical name used by diagnostics.
+///
+/// This removes the plugin prefix from ESLint rules and resolves plugin aliases such as
+/// `@typescript-eslint` to `typescript`.
+pub fn normalize_rule_name(name: &str) -> String {
+    let (plugin_name, rule_name) = parse_rule_key(name);
+    let plugin_name = super::plugins::plugin_display_name(&plugin_name);
+    if plugin_name == "eslint" { rule_name } else { format!("{plugin_name}/{rule_name}") }
+}
 
-    let (oxlint_plugin_name, rule_name) = match plugin_name {
-        "@typescript-eslint" => ("typescript", rule_name),
-        // import-x has the same rules but better performance
-        "import-x" => ("import", rule_name),
-        // jsx-a11y-x has the same rules but better maintained
-        "jsx-a11y" | "jsx-a11y-x" | "jsx_a11y-x" => ("jsx_a11y", rule_name),
-        "react-perf" => ("react_perf", rule_name),
+pub(super) fn unalias_plugin_name(plugin_name: &str, rule_name: &str) -> (String, String) {
+    let normalized = super::plugins::normalize_plugin_name(plugin_name);
+    let plugin_name = match normalized.as_ref() {
         // e.g. "@next/google-font-display", "@next/next/google-font-display"
-        "@next" | "@next/next" => ("nextjs", rule_name),
-        // For backwards compatibility, react hook rules reside in the react plugin.
-        "react-hooks" => ("react", rule_name),
-        // For backwards compatibility, deepscan rules reside in the oxc plugin.
-        "deepscan" => ("oxc", rule_name),
-        _ => (plugin_name, rule_name),
+        "@next" | "@next/next" => "nextjs".to_string(),
+        plugin_name => match LintPlugins::try_from(plugin_name) {
+            Ok(LintPlugins::ESLINT) => "eslint".to_string(),
+            Ok(plugin) => {
+                let plugin_name: &str = plugin.into();
+                plugin_name.cow_replace('-', "_").into_owned()
+            }
+            Err(()) => normalized.into_owned(),
+        },
     };
 
-    (oxlint_plugin_name.to_string(), rule_name.to_string())
+    (plugin_name, rule_name.to_string())
 }
 
 fn parse_rule_value(
@@ -1004,6 +1008,25 @@ mod test {
         assert_eq!(r3.rule_name, "no-cycle");
         assert_eq!(r3.plugin_name, "import");
         assert!(r3.severity.is_warn_deny());
+    }
+
+    #[test]
+    fn test_normalize_rule_name() {
+        assert_eq!(super::normalize_rule_name("eslint/curly"), "curly");
+        assert_eq!(
+            super::normalize_rule_name("@typescript-eslint/no-unused-vars"),
+            "typescript/no-unused-vars"
+        );
+        assert_eq!(
+            super::normalize_rule_name("eslint-plugin-react/jsx-uses-vars"),
+            "react/jsx-uses-vars"
+        );
+        assert_eq!(super::normalize_rule_name("jsx-a11y/alt-text"), "jsx-a11y/alt-text");
+        assert_eq!(
+            super::normalize_rule_name("react-perf/jsx-no-new-object-as-prop"),
+            "react-perf/jsx-no-new-object-as-prop"
+        );
+        assert_eq!(super::normalize_rule_name("@next/next/no-img-element"), "next/no-img-element");
     }
 
     #[test]

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -15,7 +15,10 @@ use oxc_span::{SourceType, Span};
 
 use crate::{
     AllowWarnDeny, FrameworkFlags,
-    config::{LintConfig, LintPlugins, OxlintEnv, OxlintGlobals, OxlintSettings},
+    config::{
+        LintConfig, LintPlugins, OxlintEnv, OxlintGlobals, OxlintSettings,
+        plugins::plugin_display_name,
+    },
     disable_directives::{DisableDirectives, DisableDirectivesBuilder, RuleCommentType},
     fixer::{Fix, FixKind, Message, PossibleFixes},
     frameworks::FrameworkOptions,
@@ -27,7 +30,7 @@ use crate::{
 #[cfg(not(test))]
 use crate::frameworks::{has_jest_imports, has_vitest_imports, is_jestlike_file};
 
-use super::{LintContext, plugin_display_name};
+use super::LintContext;
 
 /// Stores shared information about a script block being linted.
 pub struct ContextSubHost<'a> {

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -567,27 +567,3 @@ impl<'a> LintContext<'a> {
         self.parent.other_file_hosts()
     }
 }
-
-/// Gets the canonical display name for a plugin, given its internal short plugin name.
-///
-/// This is what is shown to users in diagnostic output (e.g. `unicorn(prefer-date-now)`).
-/// Most plugin names are returned unchanged; the exceptions are plugins whose internal
-/// name differs from the canonical name (`jsx_a11y` → `jsx-a11y`, `react_perf` →
-/// `react-perf`, `nextjs` → `next`).
-///
-/// Example:
-///
-/// ```ignore
-/// assert_eq!(plugin_display_name("react"), "react");
-/// assert_eq!(plugin_display_name("jsx_a11y"), "jsx-a11y");
-/// assert_eq!(plugin_display_name("nextjs"), "next");
-/// ```
-#[inline]
-fn plugin_display_name(plugin_name: &'static str) -> &'static str {
-    match plugin_name {
-        "jsx_a11y" => "jsx-a11y",
-        "react_perf" => "react-perf",
-        "nextjs" => "next",
-        _ => plugin_name,
-    }
-}

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -63,7 +63,7 @@ mod tester;
 
 mod lint_runner;
 
-pub use crate::config::plugins::normalize_plugin_name;
+pub use crate::config::{normalize_rule_name, plugins::normalize_plugin_name};
 pub use crate::disable_directives::{
     DirectivePrefix, DisableDirectives, DisableRuleComment, RuleCommentRule, RuleCommentType,
     create_unused_directives_diagnostics,


### PR DESCRIPTION
## Summary

- normalize LSP `rulesCustomization` keys using the linter config rule-name parser
- support `eslint/` prefixes and existing plugin aliases such as `@typescript-eslint`
- cover prefixed severity and autofix customization paths

Closes #25311
