### PR TITLE
perf(minifier): short-circuit scope check when alternate already determines result

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -855,17 +855,11 @@ impl<'a> PeepholeOptimizations {
                     //   if (a(() => b)) return; let b;
                     //   if (a(() => b)) { let b; }
                     //
-                    let mut can_move_branch_condition_outside_scope =
-                        !if_stmt.alternate.as_ref().is_some_and(Self::statement_cares_about_scope);
-
-                    if let Some(stmts) = stmts.get(i + 1..) {
-                        for stmt in stmts {
-                            if Self::statement_cares_about_scope(stmt) {
-                                can_move_branch_condition_outside_scope = false;
-                                break;
-                            }
-                        }
-                    }
+                    let can_move_branch_condition_outside_scope =
+                        !if_stmt.alternate.as_ref().is_some_and(Self::statement_cares_about_scope)
+                            && !stmts.get(i + 1..).is_some_and(|stmts| {
+                                stmts.iter().any(Self::statement_cares_about_scope)
+                            });
 
                     if can_move_branch_condition_outside_scope {
                         let drained_stmts = stmts.drain(i + 1..);


### PR DESCRIPTION
add a short-circuit to avoid iterating over remaining statements when the `alternate` branch already determines `can_move_branch_condition_outside_scope` is `false`.

llvm is not able to short circuit it: [godbolt](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DEArgoKkl9ZATwDKjdAGFUtEywYgATKUcAZPAZMADl3ACNMYm8AdlIAB1QFQjsGFzcPb3jE5IEAoNCWCKivWKtMGxShAiZiAjT3Tx8yioEqmoI8kPDImMtq2vqMpv6OwK7CnpKASktUE2Jkdg44kzCAakZ3NbaCTDZBNYBSaIAhQ40AQTXrtZPaVGQAax29xgtzq5uANRq8JjD6AARcoGYhMWwCCBhVCuGYfG5rADyBAQkVIH2OgIxlxW6yoDDW5nBr0EAH1RMRMApSf85gRSQo0HFMBBzCwCCAjl4AGwvfYEKZrAC0hwAzNg1tDXEdTvCbixwcgEISCOyZWdLgiEXy3iAQHcHs9qrt%2BUdRVjxWsqGIlOjNVrrjrBHqfsQ/gDMMDkKDwSkIHhqQA3GqCsUWiVgMAB0nBshyh2ks3htYEUyYO2fa6YjHRLGXDFeUWHACsJ0CtDGECCgciUxLeYuuKtBJIeGAgTEEDEu2IzF2nMRcQhDDFTkOPKdBDF2FIKvZCk54%2B5JZOk/rs4oazMeAAXphBSLLVLaOr42t6AQ1iwTJfKQoTLRL2G1pHu5E%2B5gAHTRhSoNg0hh0FZY0SXpCkqRpaEbwZJl9zFDVMzWPAqHPTBLyEP8WTvAUkznAgFE/YA0P9LkTjWLhP0/UNZXtB1%2BGIPCkIJbDT1oh0bmQlViX5ckagg2loMZVBmWA9lqIQ9jJLWO8Hyfc0rRtTB4LPKSbjCSkmEeZS2Mk7MdJuPTEMMhEZMfHNAQ4GZaE4YteE8DgtFIVBOAAJTMS9f3mRYuVFHhSA5BzLNICAkDQFg4joNEKAgMKIvoKJiC4ABOaIND4OgewXKFNF4MIO2IABPTg/Ly5hCsRMJtHKAK/LC/lEQYWgisC0gsDCExgCcMRaAXbheCwBUjHEFr8EpCoa16xzMFUcobyWPzAl2ayWordSagKlwsGK3hUzwFhttIGtiGhJRgUG4AKyMHKZioAxgAUL48EwAB3QdGAO/hBBEMR2CkGRBEUFR1Ba3QuH0QxjHc/Q8DCBdIBmYTh16oUnDWRGhXoGtaDDUVeFQI63SwOGoGYNgQEwfBh0OsQTCWLwNC8SRLJmZphwcQDBk8MH/DGAoij0BIkmHTmBeyYdOj5nowdZyoRhF6XMGsYc2lqCXuiiaW5dcBo9CJVXefViQWbmBZfqsmy7JypzOGk9zkHIz8Us/DQ1ggXBCBIHyuCmHbrpmR5vG5T9uR5UUNCSpLku5UViySjQAA59E4JnSH2rgNDS%2BzHOcjheAXNKAq0GY4FgUKMBwSmSHISgaHoUn5t4T7hFEcQ/qbwG1Ct3QfAMK7THMSxFeqlJ2ecbWhl8QC1YmYowcFnJUnHxosiFlJp/5rwFaV2X2hFpoh5aBgVdGfJDc3vpd6XzI9ZP8YN%2B92YvKWJtNhYbYQNNY4JJuA0nknDMESundECEENRfSQmPHCNiyJURxnzLmbEjZVjNi4iaN4vE7yQTpDBYSLI2Qci5LyD%2BbwDzTklDCE8X8zwKgIEqRiVD9KOmIc6fU9w/7MLksma0PV0wqRuJOF0vx/ggO9GA4c/ogwhiTGQyM0ZYwAPYomMMZDUy0wUVmBB8CGwFiLKWcslZqy1nrB8Js%2BIkLUl/P%2BQw6AYxCMEF2R875iQDiHCkUcS41zilnPghchCVxrmLICDcnJtx7lIUeChrFEKvkcb2Yk34LGYQAkBIkaCyTgWpAJekQlmR1kYX4nkL4wA%2BMIsRPApEHZUQSQyJJ1iIDHCcNhBpUTVLXGwt%2BHsEApifkMAVYC3F0EZKwYJWCeTEIIkxGMzEQVlq2VIFnPGrl3KEhNt5ccoovC%2B0CsXMu4VIpkGirFfZIBEopTSrXTKlAwhW1KutA6tzyqVWqgdOqbwGpNStm1DqXVaA9QOgNCGw1HKjWHhNK201Zr9j6uQQQisrarTBIVTaSxHK7X2tCo6J1PR7EBYEUA2y%2BB3Qek9V6zJ7J%2BSbt9Vu0h25KE7iDTIvdIYD1WsTBGriBDI1RujTGiscZ4wJngIm8AqysHYBTBe1M3B0wZkzKYLMD5swgI4eWk90DrylivBeqr57iwNjPXWiqd4DCvlvYerQRgao1hfE16QuY2tvpLDWxsn7eHNhwOZCzrYcFtuYe2FEnYuzdpXBi6yvA%2B38n7UgqImBYCiF00gAcvDFk/KKDZjNojRC8JHUU8c/rLRTmnDO8yrY5zziAAu11gowEQCAfAVAqDV2oLIKlv0aWyA7sDRytAEALjBj2hQ9aqAEAKsyCtpBiC9syJOwdyFh2jvYBod1nrS2cEBHOtYj0XqRDWG5cwKyn5e19bQh2gbhTcqHBjTAWMcZrEDAoXdyzPKmx8l4Y9/rHbRGduetGl7eXY3NLjSN2yZgxrjZQf2IBJDx2dpIKQkhCzFi4F4ZNSVuRJw4CnL1ZbLDjsLszDDmyS0tRw/h%2BVh1IhJHsJIIAA%3D)

alternatively we could just add `can_move_branch_condition_outside_scope` check before `if let Some(stmts) = stmts.get(i + 1..) {`, but that generates eq assembly