### PR TITLE
fix(linter/typescript/no-namespace): bound token lookup

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -142,7 +142,8 @@ impl Rule for NoNamespace {
 
         let keyword = declaration.kind.as_str();
         let mut span_start = declaration.span.start;
-        span_start += ctx.find_next_token_from(span_start, keyword).unwrap();
+        span_start +=
+            ctx.find_next_token_within(span_start, declaration.span.end, keyword).unwrap();
         #[expect(clippy::cast_possible_truncation)]
         let span = Span::sized(span_start, keyword.len() as u32);
         ctx.diagnostic(no_namespace_diagnostic(span));


### PR DESCRIPTION
## Summary
Bound the `no-namespace` keyword lookup to the declaration span.

## Details
- Use `find_next_token_within` when locating the reported namespace keyword.
- Preserve the existing diagnostic span calculation.