### PR TITLE
fix(linter/typescript/prefer-namespace-keyword): bound token lookup

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -79,7 +79,8 @@ impl Rule for PreferNamespaceKeyword {
 
         ctx.diagnostic_with_fix(prefer_namespace_keyword_diagnostic(module.span), |fixer| {
             let mut span_start = module.span.start;
-            span_start += ctx.find_next_token_from(span_start, "module").unwrap();
+            span_start +=
+                ctx.find_next_token_within(span_start, module.span.end, "module").unwrap();
             fixer.replace(Span::sized(span_start, 6), "namespace")
         });
     }


### PR DESCRIPTION
## Summary
Bound the `prefer-namespace-keyword` token lookup to the module span.

## Details
- Use `find_next_token_within` when locating the `module` keyword.
- Preserve the existing replacement span and fix behavior.