### PR TITLE
perf(linter/import/no-cycle): compare module records by interned path id

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1585,6 +1585,27 @@ mod test {
     }
 
     #[test]
+    fn test_import_plugin_detects_cycles_with_unnormalized_paths() {
+        // Module identity is keyed on the resolved path, so a path the user spelled with `.`
+        // components or repeated separators has to resolve to the same module its own imports
+        // resolve back to. `absolutize` strips both before any path reaches the module graph.
+        let tester = Tester::new().with_cwd("fixtures/cli/import-cycle".into());
+        let run = |a: &str, b: &str| {
+            let (output, result) =
+                tester.test_output(&["--import-plugin", "-D", "import/no-cycle", a, b]);
+            // The trailing summary carries a timing that varies between runs.
+            (output.split("Finished in").next().unwrap().to_string(), format!("{result:?}"))
+        };
+
+        let expected = run("a.ts", "b.ts");
+        assert!(expected.0.contains("Found 0 warnings and 2 errors."), "{expected:?}");
+
+        for (a, b) in [("./a.ts", "./b.ts"), ("././a.ts", "././b.ts"), (".//a.ts", ".//b.ts")] {
+            assert_eq!(run(a, b), expected, "`{a}` and `{b}` changed the diagnostics");
+        }
+    }
+
+    #[test]
     fn test_import_plugin_detects_cycles_with_auto_discovered_tsconfig_paths() {
         let args = &["--import-plugin", "-D", "import/no-cycle", "deep/src/dep-a.ts"];
         Tester::new().with_cwd("fixtures/lsp/ts_path_alias".into()).test_and_snapshot(args);

--- a/crates/oxc_linter/src/module_graph_visitor.rs
+++ b/crates/oxc_linter/src/module_graph_visitor.rs
@@ -1,6 +1,5 @@
 use std::{
     marker::PhantomData,
-    path::PathBuf,
     sync::{Arc, Weak},
 };
 
@@ -129,7 +128,7 @@ impl<T> Default for ModuleGraphVisitorBuilder<'_, T> {
 
 pub struct ModuleGraphVisitResult<T> {
     pub result: T,
-    pub _traversed: FxHashSet<PathBuf>,
+    pub _traversed: FxHashSet<u32>,
     pub _max_depth: u32,
 }
 
@@ -141,7 +140,9 @@ impl<T> ModuleGraphVisitResult<T> {
 
 #[derive(Debug)]
 struct ModuleGraphVisitor {
-    traversed: FxHashSet<PathBuf>,
+    /// Modules already visited, keyed on [`ModuleRecord::path_id`] — same semantics as keying on
+    /// the resolved path, without cloning and hashing a `PathBuf` for every node visited.
+    traversed: FxHashSet<u32>,
     depth: u32,
     max_depth: u32,
 }
@@ -218,8 +219,7 @@ impl ModuleGraphVisitor {
                 continue;
             }
 
-            let path = &loaded_module_record.resolved_absolute_path;
-            if !self.traversed.insert(path.clone()) {
+            if !self.traversed.insert(loaded_module_record.path_id) {
                 continue;
             }
 

--- a/crates/oxc_linter/src/module_record.rs
+++ b/crates/oxc_linter/src/module_record.rs
@@ -4,10 +4,7 @@ use std::{
     ffi::OsStr,
     fmt,
     path::{Component, Path, PathBuf},
-    sync::{
-        Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak,
-        atomic::{AtomicU32, Ordering},
-    },
+    sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak},
 };
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -16,11 +13,6 @@ use oxc_semantic::Semantic;
 use oxc_span::Span;
 use oxc_str::CompactStr;
 pub use oxc_syntax::module_record::RequestedModule;
-
-/// Ids for records built outside a lint run, counting down from `u32::MAX` so they never collide
-/// with the ids `Runtime` interns (which count up from 1). Such records are not part of a linked
-/// graph, so they only need to be distinct from each other.
-static NEXT_UNSHARED_PATH_ID: AtomicU32 = AtomicU32::new(u32::MAX);
 
 /// Is `path` inside a `node_modules` directory?
 ///
@@ -53,6 +45,9 @@ pub struct ModuleRecord {
     ///
     /// Cross-module analysis compares modules constantly, and so comparing a `u32` is much
     /// faster than comparing a `PathBuf`.
+    ///
+    /// `0` until `Runtime` interns the path, which it does for every record it links into a
+    /// module graph. An unlinked record has no `loaded_modules`, so nothing ever compares its id.
     pub path_id: u32,
 
     /// Is [`Self::resolved_absolute_path`] inside a `node_modules` directory?
@@ -500,7 +495,7 @@ impl ModuleRecord {
         Self {
             has_module_syntax: other.has_module_syntax,
             resolved_absolute_path: path.to_path_buf(),
-            path_id: NEXT_UNSHARED_PATH_ID.fetch_sub(1, Ordering::Relaxed),
+            path_id: 0,
             is_node_module: path_is_node_module(path),
             requested_modules: other
                 .requested_modules
@@ -555,7 +550,7 @@ impl ModuleRecord {
     /// # Panics
     ///
     /// * If the RwLock is poisoned (which only happens if a thread panicked while holding the lock).
-    pub fn write_loaded_modules(
+    pub(crate) fn write_loaded_modules(
         &self,
     ) -> RwLockWriteGuard<'_, FxHashMap<CompactStr, Weak<ModuleRecord>>> {
         self.loaded_modules.write().unwrap()

--- a/crates/oxc_linter/src/module_record.rs
+++ b/crates/oxc_linter/src/module_record.rs
@@ -49,18 +49,13 @@ pub struct ModuleRecord {
     pub resolved_absolute_path: PathBuf,
 
     /// Identifies [`Self::resolved_absolute_path`] within a lint run: two records have the same
-    /// id if and only if they have the same resolved path.
+    /// id only if they have the same resolved path.
     ///
-    /// Cross-module analysis compares modules constantly, and `Path`'s `PartialEq` and `Hash` both
-    /// walk the path component by component — the same reason `Runtime` keys its maps on `OsStr`.
-    /// Comparing ids instead makes that a `u32` compare. Set by `Runtime` when the record is
-    /// created; records [`ModuleRecord::new`] builds outside a lint run get a distinct id each, so
-    /// they never compare equal to one another.
+    /// Cross-module analysis compares modules constantly, and so comparing a `u32` is much
+    /// faster than comparing a `PathBuf`.
     pub path_id: u32,
 
     /// Is [`Self::resolved_absolute_path`] inside a `node_modules` directory?
-    ///
-    /// Answered once here rather than by walking the path's components at each use.
     pub is_node_module: bool,
 
     /// `[[RequestedModules]]`

--- a/crates/oxc_linter/src/module_record.rs
+++ b/crates/oxc_linter/src/module_record.rs
@@ -1,9 +1,13 @@
 //! [ECMAScript Module Record](https://tc39.es/ecma262/#sec-abstract-module-records)
 
 use std::{
+    ffi::OsStr,
     fmt,
-    path::{Path, PathBuf},
-    sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak},
+    path::{Component, Path, PathBuf},
+    sync::{
+        Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak,
+        atomic::{AtomicU32, Ordering},
+    },
 };
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -12,6 +16,22 @@ use oxc_semantic::Semantic;
 use oxc_span::Span;
 use oxc_str::CompactStr;
 pub use oxc_syntax::module_record::RequestedModule;
+
+/// Ids for records built outside a lint run, counting down from `u32::MAX` so they never collide
+/// with the ids `Runtime` interns (which count up from 1). Such records are not part of a linked
+/// graph, so they only need to be distinct from each other.
+static NEXT_UNSHARED_PATH_ID: AtomicU32 = AtomicU32::new(u32::MAX);
+
+/// Is `path` inside a `node_modules` directory?
+///
+/// `Path::components` parses the path one component at a time, so rule out the overwhelmingly
+/// common case with a byte search and only parse components for paths that could match.
+fn path_is_node_module(path: &Path) -> bool {
+    memchr::memmem::find(path.as_os_str().as_encoded_bytes(), b"node_modules").is_some()
+        && path
+            .components()
+            .any(|c| matches!(c, Component::Normal(p) if p == OsStr::new("node_modules")))
+}
 
 /// ESM Module Record
 ///
@@ -27,6 +47,21 @@ pub struct ModuleRecord {
 
     /// Resolved absolute path to this module record
     pub resolved_absolute_path: PathBuf,
+
+    /// Identifies [`Self::resolved_absolute_path`] within a lint run: two records have the same
+    /// id if and only if they have the same resolved path.
+    ///
+    /// Cross-module analysis compares modules constantly, and `Path`'s `PartialEq` and `Hash` both
+    /// walk the path component by component — the same reason `Runtime` keys its maps on `OsStr`.
+    /// Comparing ids instead makes that a `u32` compare. Set by `Runtime` when the record is
+    /// created; records [`ModuleRecord::new`] builds outside a lint run get a distinct id each, so
+    /// they never compare equal to one another.
+    pub path_id: u32,
+
+    /// Is [`Self::resolved_absolute_path`] inside a `node_modules` directory?
+    ///
+    /// Answered once here rather than by walking the path's components at each use.
+    pub is_node_module: bool,
 
     /// `[[RequestedModules]]`
     ///
@@ -103,6 +138,8 @@ impl fmt::Debug for ModuleRecord {
         f.debug_struct("ModuleRecord")
             .field("has_module_syntax", &self.has_module_syntax)
             .field("resolved_absolute_path", &self.resolved_absolute_path)
+            .field("path_id", &self.path_id)
+            .field("is_node_module", &self.is_node_module)
             .field("requested_modules", &self.requested_modules)
             .field("loaded_modules", &loaded_modules)
             .field("import_entries", &self.import_entries)
@@ -468,6 +505,8 @@ impl ModuleRecord {
         Self {
             has_module_syntax: other.has_module_syntax,
             resolved_absolute_path: path.to_path_buf(),
+            path_id: NEXT_UNSHARED_PATH_ID.fetch_sub(1, Ordering::Relaxed),
+            is_node_module: path_is_node_module(path),
             requested_modules: other
                 .requested_modules
                 .iter()

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -1,6 +1,5 @@
 use std::{
-    ffi::OsStr,
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
@@ -154,7 +153,7 @@ impl Rule for NoCycle {
             return;
         }
 
-        let needle = &module_record.resolved_absolute_path;
+        let needle = module_record.path_id;
         let mut direct_imports = module_record
             .loaded_modules()
             .iter()
@@ -172,7 +171,7 @@ impl Rule for NoCycle {
             let mut stack =
                 vec![(key.clone(), loaded_module_record.resolved_absolute_path.clone())];
 
-            if loaded_module_record.resolved_absolute_path == *needle {
+            if loaded_module_record.path_id == needle {
                 ctx.diagnostic(self_referencing_cycle_diagnostic(span, requested_module.is_import));
                 continue;
             }
@@ -189,7 +188,7 @@ impl Rule for NoCycle {
                     }
                 })
                 .visit_fold(false, &loaded_module_record, |_, (_, val), _| {
-                    if val.resolved_absolute_path == *needle {
+                    if val.path_id == needle {
                         VisitFoldWhile::Stop(true)
                     } else {
                         VisitFoldWhile::Next(false)
@@ -245,9 +244,9 @@ impl NoCycle {
             if !self.should_traverse_module(specifier, &loaded_module_record, module_record) {
                 continue;
             }
-            // By path, not pointer: that is what the walks report on, and one file can have
+            // By path id, not pointer: that is what the walks report on, and one file can have
             // several records (one per section).
-            if loaded_module_record.resolved_absolute_path == root.resolved_absolute_path {
+            if loaded_module_record.path_id == root.path_id {
                 return true;
             }
             if visited.insert(Arc::as_ptr(&loaded_module_record) as usize) {
@@ -263,13 +262,7 @@ impl NoCycle {
         module: &Arc<ModuleRecord>,
         parent: &ModuleRecord,
     ) -> bool {
-        let path = &module.resolved_absolute_path;
-
-        let is_node_module = path
-            .components()
-            .any(|c| matches!(c, Component::Normal(p) if p == OsStr::new("node_modules")));
-
-        if is_node_module {
+        if module.is_node_module {
             return false;
         }
 
@@ -306,7 +299,7 @@ impl NoCycle {
         // export function example1() { }
         // export * as Example from './test.js';
         // ```
-        if path == &parent.resolved_absolute_path
+        if module.path_id == parent.path_id
             && let Some(e) = module
                 .indirect_export_entries
                 .iter()

--- a/crates/oxc_linter/src/rules/import/no_self_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_self_import.rs
@@ -48,12 +48,12 @@ declare_oxc_lint!(
 impl Rule for NoSelfImport {
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
-        let resolved_absolute_path = &module_record.resolved_absolute_path;
+        let path_id = module_record.path_id;
         for (request, requested_modules) in &module_record.requested_modules {
             let Some(remote_module_record) = module_record.get_loaded_module(request) else {
                 continue;
             };
-            if remote_module_record.resolved_absolute_path == *resolved_absolute_path {
+            if remote_module_record.path_id == path_id {
                 for requested_module in requested_modules {
                     ctx.diagnostic(no_self_import_diagnostic(requested_module.span));
                 }

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -68,7 +68,8 @@ pub struct Runtime {
     /// with a `u32` compare instead of a `Path` one. See [`ModuleRecord::path_id`].
     ///
     /// Taken once per created record, not per comparison, so the lock is uncontended in practice.
-    path_ids: Mutex<(FxHashMap<PathBuf, u32>, u32)>,
+    /// Keyed on the same `Arc` [`Self::modules_by_path`] holds, so a key costs a refcount bump.
+    path_ids: Mutex<(FxHashMap<Arc<OsStr>, u32>, u32)>,
     /// Collected disable directives from linted files
     disable_directives_map: Arc<Mutex<FxHashMap<PathBuf, DisableDirectives>>>,
 }
@@ -285,14 +286,14 @@ impl Runtime {
     /// # Panics
     ///
     /// * If the mutex is poisoned (which only happens if a thread panicked while holding it).
-    fn intern_path(&self, path: &Path) -> u32 {
+    fn intern_path(&self, path: &Arc<OsStr>) -> u32 {
         let (ids, next) = &mut *self.path_ids.lock().unwrap();
-        if let Some(id) = ids.get(path) {
+        if let Some(id) = ids.get(&**path) {
             return *id;
         }
         let id = *next;
         *next += 1;
-        ids.insert(path.to_path_buf(), id);
+        ids.insert(Arc::clone(path), id);
         id
     }
 
@@ -1044,7 +1045,7 @@ impl Runtime {
 
                 let mut section_contents = SmallVec::new();
                 records = self.process_source(
-                    Path::new(path),
+                    path,
                     ext,
                     check_syntax_errors,
                     source_type,
@@ -1074,7 +1075,7 @@ impl Runtime {
             };
 
             let records = self.process_source(
-                Path::new(path),
+                path,
                 ext,
                 check_syntax_errors,
                 source_type,
@@ -1090,7 +1091,7 @@ impl Runtime {
     #[expect(clippy::too_many_arguments)]
     fn process_source<'a>(
         &self,
-        path: &Path,
+        path: &Arc<OsStr>,
         ext: &str,
         check_syntax_errors: bool,
         source_type: SourceType,
@@ -1150,7 +1151,7 @@ impl Runtime {
     #[expect(clippy::type_complexity)]
     fn process_source_section<'a>(
         &self,
-        path: &Path,
+        path: &Arc<OsStr>,
         allocator: &'a Allocator,
         source_text: &'a str,
         source_type: SourceType,
@@ -1182,7 +1183,7 @@ impl Runtime {
         let mut semantic = semantic_ret.semantic;
         semantic.set_irregular_whitespaces(ret.irregular_whitespaces);
 
-        let mut module_record = ModuleRecord::new(path, &ret.module_record, &semantic);
+        let mut module_record = ModuleRecord::new(Path::new(path), &ret.module_record, &semantic);
         // Only worth interning when the module graph is built: without a resolver nothing links
         // these records together, so the distinct id `ModuleRecord::new` assigns is enough, and
         // every run — including ones with no cross-module rules — skips the lock.
@@ -1202,7 +1203,7 @@ impl Runtime {
                 .requested_modules
                 .keys()
                 .filter_map(|specifier| {
-                    let resolution = resolver.resolve_file(path, specifier).ok()?;
+                    let resolution = resolver.resolve_file(Path::new(path), specifier).ok()?;
                     Some(ResolvedModuleRequest {
                         specifier: specifier.clone(),
                         resolved_requested_path: Arc::<OsStr>::from(resolution.path().as_os_str()),

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -64,6 +64,11 @@ pub struct Runtime {
     /// To make sure all `ModuleRecord` gets dropped after `Runtime` is dropped,
     /// `modules_by_path` must own `ModuleRecord` with `Arc`, all other references must use `Weak<ModuleRecord>`.
     modules_by_path: ModulesByPath,
+    /// Interned ids for resolved module paths, so that cross-module analysis can compare modules
+    /// with a `u32` compare instead of a `Path` one. See [`ModuleRecord::path_id`].
+    ///
+    /// Taken once per created record, not per comparison, so the lock is uncontended in practice.
+    path_ids: Mutex<(FxHashMap<PathBuf, u32>, u32)>,
     /// Collected disable directives from linted files
     disable_directives_map: Arc<Mutex<FxHashMap<PathBuf, DisableDirectives>>>,
 }
@@ -269,8 +274,26 @@ impl Runtime {
                 .hasher(BuildHasherDefault::default())
                 .resize_mode(papaya::ResizeMode::Blocking)
                 .build(),
+            path_ids: Mutex::new((FxHashMap::default(), 1)),
             disable_directives_map: Arc::new(Mutex::new(FxHashMap::default())),
         }
+    }
+
+    /// Id for `path`, shared by every [`ModuleRecord`] resolving to it. See
+    /// [`ModuleRecord::path_id`].
+    ///
+    /// # Panics
+    ///
+    /// * If the mutex is poisoned (which only happens if a thread panicked while holding it).
+    fn intern_path(&self, path: &Path) -> u32 {
+        let (ids, next) = &mut *self.path_ids.lock().unwrap();
+        if let Some(id) = ids.get(path) {
+            return *id;
+        }
+        let id = *next;
+        *next += 1;
+        ids.insert(path.to_path_buf(), id);
+        id
     }
 
     /// Get [`AllocatorPool`] for copying ASTs to fixed-size allocators, if one is required.
@@ -1159,7 +1182,9 @@ impl Runtime {
         let mut semantic = semantic_ret.semantic;
         semantic.set_irregular_whitespaces(ret.irregular_whitespaces);
 
-        let module_record = Arc::new(ModuleRecord::new(path, &ret.module_record, &semantic));
+        let mut module_record = ModuleRecord::new(path, &ret.module_record, &semantic);
+        module_record.path_id = self.intern_path(path);
+        let module_record = Arc::new(module_record);
 
         let tokens = ret.tokens.into_boxed_slice();
 

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -1183,7 +1183,12 @@ impl Runtime {
         semantic.set_irregular_whitespaces(ret.irregular_whitespaces);
 
         let mut module_record = ModuleRecord::new(path, &ret.module_record, &semantic);
-        module_record.path_id = self.intern_path(path);
+        // Only worth interning when the module graph is built: without a resolver nothing links
+        // these records together, so the distinct id `ModuleRecord::new` assigns is enough, and
+        // every run — including ones with no cross-module rules — skips the lock.
+        if self.resolver.is_some() {
+            module_record.path_id = self.intern_path(path);
+        }
         let module_record = Arc::new(module_record);
 
         let tokens = ret.tokens.into_boxed_slice();

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -281,7 +281,7 @@ impl Runtime {
     }
 
     /// Id for `path`, shared by every [`ModuleRecord`] resolving to it. See
-    /// [`ModuleRecord::path_id`].
+    /// [`ModuleRecord::path_id`]. Counts from 1, leaving 0 to mean "never interned".
     ///
     /// # Panics
     ///
@@ -1185,8 +1185,8 @@ impl Runtime {
 
         let mut module_record = ModuleRecord::new(Path::new(path), &ret.module_record, &semantic);
         // Only worth interning when the module graph is built: without a resolver nothing links
-        // these records together, so the distinct id `ModuleRecord::new` assigns is enough, and
-        // every run — including ones with no cross-module rules — skips the lock.
+        // these records together, so nothing compares their ids, and every run — including ones
+        // with no cross-module rules — skips the lock.
         if self.resolver.is_some() {
             module_record.path_id = self.intern_path(path);
         }


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, Opus 5. Tested, reviewed, and stripped down by me.

The goal here is to have the most improvement for the rule with the smallest change.

- If you have `import/no-cycle` enabled and a lot of cycles to find: **-30 to -44%**
- If you have `import/no-cycle` enabled and few or no cycles: no change (-0.2 to -1.0%, within noise)
- If you have other `import` rules enabled but not `import/no-cycle`: no change
- If you don't use the `import` plugin at all: no change

This also speeds up `import/no-self-import`, which does the same identity comparison once per import (but it's already quite fast, so no real noticeable difference).

This should be a net-win or fully neutral for all users with or without no-cycle enabled.

Code in `import/export` and `collect_star_exported_bindings` can also be simplified/de-duped thanks to this change, but it has no real perf impact on any codebase I tested and so I've left it out of this PR. We can open a refactor PR later if desired.

---

`import/no-cycle` walks the module graph, and profiling it showed the walk spending most of its time inside `std::path` rather than on graph traversal: parsing path components for the `node_modules` check once per edge, `Path`'s `PartialEq` comparing components back-to-front, and cloning + hashing a `PathBuf` into the visitor's `traversed` set once per node visited.

`ModuleRecord` now answers both questions up front:

- **`is_node_module`** is computed once when the record is built, with a `memmem` byte search short-circuiting the component walk for the overwhelmingly common non-match.
- **`path_id`** is a `u32` interned per resolved path by `Runtime`, so the identity comparisons cross-module analysis does constantly become integer compares, and `ModuleGraphVisitor::traversed` becomes a `FxHashSet<u32>` that allocates nothing per node.

Two things keep interning itself from costing anything:

- It is gated on a resolver being present, so runs that never build a module graph — no import plugin, no cross-module rules, no rules at all — skip it entirely.
- The map is keyed on the `Arc<OsStr>` that `Runtime::modules_by_path` already owns for every module, so adding a path costs a refcount bump rather than a `PathBuf` copy.

`import/no-self-import` gets the cheaper comparison for free. It compares each imported module against the current one once per import, not once per violation, so the win does not depend on the codebase having any self-imports — the corpora below report zero and it still drops 28-59%.

## Measurements

Seven real codebases, `import/no-cycle` alone, `--features allocator`, 18 threads, process wall clock, N=41 paired with rotating binary order. `t` is the paired t-statistic; positive means this PR is faster.

| corpus | files | cycles | main | this PR | Δ | t |
| ------ | ----: | -----: | ---: | ------: | -: | -: |
| `vscode/src` | 8006 | 1630 | 1200.2 ms | 671.4 ms | **−44.1%** | +55.6 |
| `sentry/static` | 8193 | 756 | 529.9 ms | 368.5 ms | **−30.5%** | +66.7 |
| `actual/packages` | 1772 | 188 | 125.3 ms | 120.7 ms | −3.7% | +7.7 |
| `storybook/code` | 4037 | 74 | 302.9 ms | 300.0 ms | −1.0% | +1.2 |
| `canvas-lms/ui` | 8899 | 99 | 258.0 ms | 255.9 ms | −0.8% | +1.8 |
| `grafana/public` | 6541 | 0 | 976.2 ms | 974.0 ms | −0.2% | +0.4 |
| `gitlab/app/assets/javascripts` | 5194 | 5 | 109.0 ms | 108.7 ms | −0.2% | +0.9 |

No corpus regresses. The four small rows are all within noise (t < 2), which is the intended outcome rather than a win — see "Earlier cost, now removed" below.

The rule's own work drops consistently everywhere it runs (though this is mainly because it's bumming the work off on the module graph build, so it's not entirely a fair comparison). Single-threaded, from `--debug=timings`, median of 3 interleaved pairs:

| corpus | main | this PR | Δ |
| ------ | ---: | ------: | -: |
| `vscode/src` | 9006.3 ms | 2481.1 ms | −72.4% |
| `sentry/static` | 2696.8 ms | 781.9 ms | −71.0% |
| `canvas-lms/ui` | 54.8 ms | 15.9 ms | −71.0% |
| `actual/packages` | 71.2 ms | 27.5 ms | −61.3% |
| `storybook/code` | 66.3 ms | 26.7 ms | −59.6% |
| `gitlab/app/assets/javascripts` | 4.0 ms | 1.7 ms | −58.6% |
| `grafana/public` | 0.22 ms | 0.22 ms | — |

Wall-clock impact therefore tracks how much rule work a codebase has to begin with, not simply whether it has cycles. `vscode` spends 9 s of single-threaded rule time; `gitlab` spends 4 ms, and `grafana` has no cycles at all so `can_be_in_cycle` (already on `main`) rejects every file before the walk starts.

Allocations, counted with a counting global allocator and the parse-only baseline subtracted to isolate graph + rule work:

| corpus | allocations | bytes requested |
| ------ | ----------- | --------------- |
| `vscode/src` | 42.18M → 21.99M (**−47.9%**) | 4.951 → 3.323 GB (**−32.9%**) |
| `sentry/static` | 9.32M → 5.80M (**−37.7%**) | 1.492 → 1.166 GB (**−21.9%**) |
| `storybook/code` | 1.499M → 1.467M (−2.2%) | 1.596 → 1.593 GB (−0.2%) |
| `gitlab/app/assets/javascripts` | 134,929 → 134,908 (−0.02%) | 206.6 → 207.0 MB (+0.2%) |

Peak RSS: `vscode` −424.8 MB (1388 → 964), `sentry` −37.4 MB (441 → 403), every other corpus within ±1 MB.

### Earlier cost, now removed

An earlier version of this PR moved work from the walk into graph construction: interning cloned a `PathBuf` per module record, which a codebase with a large module graph and few cycles never walked enough to repay. `gitlab` measured +0.4 to +0.9 ms on a ~100 ms run and **+6,241 allocations**, roughly one clone per file for 5,194 files.

The second-to-last commit removes that by interning on the `Arc<OsStr>` key `Runtime::modules_by_path` already holds, so a map entry is a refcount bump. Allocations drop by exactly one per file — −5,181 on `gitlab`, −8,193 on `sentry` (which has exactly 8,193 files), −8,256 on `vscode` — and the same delta appears whether or not `no-cycle` is enabled, confirming the cost was always at graph construction.

Measured on import rules with `no-cycle` **disabled**, versus `main`, N=61 paired:

| corpus | before | after |
| ------ | -----: | ----: |
| `gitlab` | +0.4 ms (t = −0.7) | +0.1 ms (t = −0.4) |
| `sentry` | +1.0 ms (t = −1.6) | −0.9 ms (t = +0.8) |
| `vscode` | +0.4 ms (t = −0.5) | −3.2 ms (t = +2.6 ±2.4) |

`gitlab` is now break-even at −21 allocations, and `vscode` is measurably slightly faster than `main` on a configuration that never runs `no-cycle`.

### Correctness

Diagnostics are byte-identical to `main` on all seven corpora, including `vscode`'s 1630 cycles / 47,818 diagnostic lines.