### PR TITLE
refactor(formatter_core): finalize documents once at print time

### DIFF
--- a/apps/oxfmt/src/api/text_to_doc_api.rs
+++ b/apps/oxfmt/src/api/text_to_doc_api.rs
@@ -179,7 +179,7 @@ fn run_full(
     };
 
     let (elements, sorted_tailwind_classes) =
-        formatted.into_document().into_elements_and_tailwind_classes();
+        formatted.into_final_document().into_elements_and_tailwind_classes();
 
     external_formatter.cleanup();
     Some(
@@ -236,7 +236,7 @@ fn run_fragment(
     };
 
     let (elements, sorted_tailwind_classes) =
-        formatted.into_document().into_elements_and_tailwind_classes();
+        formatted.into_final_document().into_elements_and_tailwind_classes();
     Some(
         to_prettier_doc::format_elements_to_prettier_doc(elements, &sorted_tailwind_classes)
             .expect("Formatter IR to Prettier Doc conversion should not fail"),

--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -60,9 +60,7 @@ pub fn format<'ast>(
     let sorted_tailwind_classes =
         context.external_callbacks().sort_tailwind_classes(tailwind_classes);
 
-    let document = Document::new(elements, sorted_tailwind_classes);
+    let ir = Document::new(elements, sorted_tailwind_classes);
 
-    document.propagate_expand();
-
-    Formatted::new(document, context)
+    Formatted::new(ir, context)
 }

--- a/crates/oxc_formatter_core/src/formatted.rs
+++ b/crates/oxc_formatter_core/src/formatted.rs
@@ -25,8 +25,14 @@ impl<'a, C> Formatted<'a, C> {
         &mut self.document
     }
 
-    /// Consumes `self` and returns the formatted document.
-    pub fn into_document(self) -> Document<'a> {
+    /// Consumes `self` and returns the finalized document:
+    /// group expansion is propagated across the whole IR, including any embedded IR merged into it.
+    ///
+    /// Finalization must run once on the final document, never on partial embedded IR;
+    /// [`Self::print`] / [`Self::print_with_indent`] finalize themselves,
+    /// so this is only for consumers that bypass them (e.g. IR to Prettier Doc conversion).
+    pub fn into_final_document(self) -> Document<'a> {
+        self.document.propagate_expand();
         self.document
     }
 }
@@ -34,11 +40,14 @@ impl<'a, C> Formatted<'a, C> {
 impl<C: FormatContext> Formatted<'_, C> {
     /// Prints the formatted document to a string.
     ///
+    /// Finalizes the document first (see [`Self::into_final_document`]).
+    ///
     /// # Errors
     /// Returns `PrintError` if the document contains invalid structure.
     pub fn print(self) -> PrintResult<Printed> {
         let print_options = self.context.options().as_print_options();
         let source_size_hint = self.context.source_code().len();
+        self.document.propagate_expand();
         let (elements, sorted_tailwind_classes) =
             self.document.into_elements_and_tailwind_classes();
         let printed =
@@ -49,11 +58,14 @@ impl<C: FormatContext> Formatted<'_, C> {
 
     /// Prints the formatted document to a string, starting at the given indentation level.
     ///
+    /// Finalizes the document first (see [`Self::into_final_document`]).
+    ///
     /// # Errors
     /// Returns `PrintError` if the document contains invalid structure.
     pub fn print_with_indent(self, indent: u16) -> PrintResult<Printed> {
         let print_options = self.context.options().as_print_options();
         let source_size_hint = self.context.source_code().len();
+        self.document.propagate_expand();
         let (elements, sorted_tailwind_classes) =
             self.document.into_elements_and_tailwind_classes();
         let printed =

--- a/crates/oxc_formatter_core/src/macros.rs
+++ b/crates/oxc_formatter_core/src/macros.rs
@@ -183,7 +183,7 @@ macro_rules! dbg_write {
 ///     ]
 /// )?;
 ///
-/// let document = formatted.into_document();
+/// let document = formatted.into_final_document();
 ///
 /// // Takes the first variant if everything fits on a single line
 /// assert_eq!(
@@ -263,7 +263,7 @@ macro_rules! dbg_write {
 ///     ]
 /// )?;
 ///
-/// let document = formatted.into_document();
+/// let document = formatted.into_final_document();
 ///
 /// assert_eq!(
 ///     "expect(a).toMatch([\n\t1,\n\t2,\n\t3\n])",

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -66,7 +66,6 @@ pub fn format<'a>(
     };
 
     let ir = Document::new(elements, sorted_tailwind_classes);
-    ir.propagate_expand();
 
     Ok(Formatted::new(ir, context))
 }
@@ -77,7 +76,6 @@ pub fn format<'a>(
 /// Unlike [`format()`], this:
 /// - allocates from the shared arena in `ctx`
 /// - emits neither a BOM nor the trailing newline
-/// - skips `propagate_expand()`, which the parent runs on the merged document
 ///
 /// The returned [`EmbeddedIr`] also carries the pre-sort `@apply` Tailwind
 /// classes the IR's `TailwindClass(index)` elements refer to (empty unless

--- a/crates/oxc_formatter_graphql/src/format.rs
+++ b/crates/oxc_formatter_graphql/src/format.rs
@@ -43,7 +43,6 @@ pub fn format<'a>(
     let context = state.into_context();
 
     let ir = Document::new(elements, Vec::new());
-    ir.propagate_expand();
 
     Ok(Formatted::new(ir, context))
 }
@@ -56,7 +55,6 @@ pub fn format<'a>(
 ///   so the IR lives as long as the parent's document
 /// - emits neither a BOM nor the trailing newline (the parent owns the layout
 ///   around the embedded part, matching Prettier's `textToDoc` + `stripTrailingHardline` behavior)
-/// - skips `propagate_expand()`, which the parent runs on the merged document
 ///
 /// # Errors
 /// Same as [`format()`]: any parse error bails out.

--- a/crates/oxc_formatter_json/src/format.rs
+++ b/crates/oxc_formatter_json/src/format.rs
@@ -53,7 +53,6 @@ pub fn format<'a>(
     }
 
     let document = Document::new(elements, Vec::new());
-    document.propagate_expand();
 
     Ok(Formatted::new(document, context))
 }

--- a/crates/oxc_formatter_yaml/src/format.rs
+++ b/crates/oxc_formatter_yaml/src/format.rs
@@ -42,7 +42,6 @@ pub fn format<'a>(
     let context = state.into_context();
 
     let ir = Document::new(elements, Vec::new());
-    ir.propagate_expand();
 
     Ok(Formatted::new(ir, context))
 }
@@ -53,7 +52,6 @@ pub fn format<'a>(
 /// Unlike [`format()`], this:
 /// - allocates from the shared arena in `ctx`, so the IR lives as long as the parent's document
 /// - emits neither a BOM nor the trailing newline
-/// - skips `propagate_expand()`, which the parent runs on the merged document
 ///
 /// # Errors
 /// Same as [`format()`]: any parse error bails out.


### PR DESCRIPTION
Call `propagate_expand()` inside `Formatted`, here is the only place to finalize IRs.