### PR TITLE
refactor(formatter_core): introduce `FormatSession` with shared `GroupId` space

### DIFF
--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -73,7 +73,7 @@ The core is parameterized over a consumer-supplied context so it stays language-
   - All generic over the context `C`, consumers add a `C` bound only on `impl` blocks
   - Not on struct definitions, and typically define a `type FooFormatter<…> = Formatter<…, FooContext<…>>` alias to keep lifetimes aligned
 
-### Embedded-language infrastructure (`embedded.rs`)
+### Embedded-language infrastructure (`embedded.rs`, `session.rs`)
 
 `EmbeddedContext` / `FormatDispatcher` / `DispatchResult` / `TailwindCollector` let one formatter's IR be built inside another's document (e.g. graphql-in-js):
 
@@ -85,6 +85,10 @@ The core is parameterized over a consumer-supplied context so it stays language-
   - Only truly language-pair specific data crosses as `dyn Any` (e.g. HTML's `has_multiple_root_elements`), core never learns concrete languages
 - Consumers access `DispatchResult.docs` directly (single-doc takes `docs.into_iter().next()`, multi-doc walks `docs`)
   - Call `DispatchResult::remap_tailwind_into` first when the child may carry classes, the printer's `debug_assert` catches a forgotten merge
+- `FormatSession` (`session.rs`) is the successor execution unit:
+  - One arena, one shared `GroupId` space (`Arc<UniqueGroupIdBuilder>`), the dispatcher, and the input's envelope semantics (`InputKind`), usable by standalone roots and dispatched children alike
+  - `FormatState` holds one (`new_with_session`; plain `new` wraps a dispatcher-less `PhysicalFile` session), and `Formatter::session()` exposes it during a write.
+  - `EmbeddedContext` remains as a migration adapter until every entry point is session-aware
 
 ## What belongs in core (the boundary)
 

--- a/crates/oxc_formatter_core/src/embedded.rs
+++ b/crates/oxc_formatter_core/src/embedded.rs
@@ -23,6 +23,9 @@ use crate::{FormatElement, group_id::UniqueGroupIdBuilder};
 /// The same context is threaded through recursive dispatcher calls so that
 /// nested embeddings (e.g. css-in-html-in-js) share one arena and one
 /// `GroupId` space.
+///
+/// TODO: Migration adapter: [`crate::FormatSession`] supersedes this type
+/// and will replace it once every entry point is session-aware.
 pub struct EmbeddedContext<'a, 'g> {
     /// Arena shared between parent and child formatters;
     /// strings allocated by the child live as long as the parent's IR.

--- a/crates/oxc_formatter_core/src/formatter.rs
+++ b/crates/oxc_formatter_core/src/formatter.rs
@@ -5,7 +5,8 @@ use std::borrow::Cow;
 use oxc_allocator::{Allocator, ArenaVec, GetAllocator};
 
 use crate::{
-    Argument, Arguments, Buffer, FormatContext, FormatElement, FormatState, ScratchBuffer,
+    Argument, Arguments, Buffer, FormatContext, FormatElement, FormatSession, FormatState,
+    ScratchBuffer,
     buffer::HeapVecBuffer,
     builders::{FillBuilder, JoinBuilder},
     format::{Format, write},
@@ -54,6 +55,11 @@ impl<'buf, 'ast, C> Formatter<'buf, 'ast, C> {
 
     pub fn allocator(&self) -> &'ast Allocator {
         self.state().allocator()
+    }
+
+    /// The [`FormatSession`] this format run executes under.
+    pub fn session(&self) -> &FormatSession<'ast> {
+        self.state().session()
     }
 
     /// Returns the Context specifying how to format the current CST

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -27,6 +27,7 @@ mod group_id;
 mod macros;
 mod options;
 pub mod printer;
+mod session;
 mod simple_context;
 mod source;
 pub mod spec;
@@ -64,6 +65,7 @@ pub use options::{
     LineWidthFromIntError, ParseFormatNumberError,
 };
 pub use printer::{PrintResult, PrintWidth, Printed, Printer, PrinterOptions};
+pub use session::{FormatSession, InputKind};
 pub(crate) use simple_context::SimpleFormatContext;
 pub use source::{SourceText, SpanCursor};
 pub use state::FormatState;

--- a/crates/oxc_formatter_core/src/session.rs
+++ b/crates/oxc_formatter_core/src/session.rs
@@ -1,0 +1,148 @@
+//! Per-run execution unit shared by a root formatter and its embedded children.
+
+use std::sync::Arc;
+
+use oxc_allocator::Allocator;
+
+use crate::{FormatDispatcher, UniqueGroupIdBuilder};
+
+/// Document-envelope semantics of the input being formatted.
+///
+/// This describes ONLY who owns file-level envelope concerns (front matter, BOM).
+/// It never selects parser dialects or tolerances: css-in-js and a JSDoc CSS fence are both [`InputKind::Fragment`],
+/// yet parse in different modes, that difference travels as pair-specific dispatch context, not here.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InputKind {
+    /// A root selected by filepath and config resolution.
+    /// The only input that may own a BOM and (for supporting hosts) front matter.
+    PhysicalFile,
+    /// A complete document a host formatter passes as embedded input
+    /// (e.g. a whole fenced stylesheet in Markdown).
+    VirtualDocument,
+    /// A grammar fragment such as css-in-js or a JSDoc fence.
+    /// Never acquires file semantics, even when its head looks like front matter.
+    Fragment,
+}
+
+/// Execution unit threaded through a formatting run: one arena, one `GroupId` space,
+/// one dispatcher, plus the input's envelope semantics.
+///
+/// The same type serves standalone roots and dispatched children,
+/// so any formatter (not just JS) can dispatch embedded languages.
+/// Cloning hands out another handle to the SAME session (shared `GroupId` space, same depth);
+/// the session for one embedded child comes from [`Self::derive_child`].
+///
+/// TODO: Supersedes [`crate::EmbeddedContext`],
+/// which remains as a migration adapter until every entry point is session-aware.
+#[derive(Clone)]
+pub struct FormatSession<'a> {
+    allocator: &'a Allocator,
+    group_id_builder: Arc<UniqueGroupIdBuilder>,
+    dispatcher: Option<FormatDispatcher>,
+    input_kind: InputKind,
+    dispatch_depth: u16,
+}
+
+impl<'a> FormatSession<'a> {
+    /// Creates a root session. Children must come from [`Self::derive_child`],
+    /// never be re-rooted, so the `GroupId` space stays shared.
+    pub fn new(
+        allocator: &'a Allocator,
+        input_kind: InputKind,
+        dispatcher: Option<FormatDispatcher>,
+    ) -> Self {
+        Self {
+            allocator,
+            group_id_builder: Arc::new(UniqueGroupIdBuilder::default()),
+            dispatcher,
+            input_kind,
+            dispatch_depth: 0,
+        }
+    }
+
+    /// Derives the session for one embedded child: same arena, `GroupId` space,
+    /// and dispatcher; the child's envelope semantics and one more dispatch level.
+    /// The recursion limit over `dispatch_depth` is enforced by the dispatch path, not here.
+    #[must_use]
+    pub fn derive_child(&self, input_kind: InputKind) -> Self {
+        Self {
+            allocator: self.allocator,
+            group_id_builder: Arc::clone(&self.group_id_builder),
+            dispatcher: self.dispatcher.clone(),
+            input_kind,
+            dispatch_depth: self.dispatch_depth + 1,
+        }
+    }
+
+    /// The arena shared between the root and every embedded child.
+    #[inline]
+    pub fn allocator(&self) -> &'a Allocator {
+        self.allocator
+    }
+
+    /// The `GroupId` space shared between the root and every embedded child.
+    #[inline]
+    pub fn group_id_builder(&self) -> &UniqueGroupIdBuilder {
+        &self.group_id_builder
+    }
+
+    /// Envelope semantics of the input this session formats.
+    pub fn input_kind(&self) -> InputKind {
+        self.input_kind
+    }
+
+    /// The dispatcher for formatting embedded languages,
+    /// `None` when recursion is unavailable (plain standalone formatting).
+    pub fn dispatcher(&self) -> Option<&FormatDispatcher> {
+        self.dispatcher.as_ref()
+    }
+
+    /// How many dispatch boundaries deep this session is (0 for a root).
+    pub fn dispatch_depth(&self) -> u16 {
+        self.dispatch_depth
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use oxc_allocator::Allocator;
+
+    use super::{FormatSession, InputKind};
+    use crate::FormatState;
+
+    #[test]
+    fn derived_child_shares_the_group_id_space() {
+        let allocator = Allocator::default();
+        let parent = FormatSession::new(&allocator, InputKind::PhysicalFile, None);
+        let child = parent.derive_child(InputKind::Fragment);
+
+        assert_eq!(child.input_kind(), InputKind::Fragment);
+        assert_eq!(child.dispatch_depth(), 1);
+        // Ids stay unique across the boundary; independent builders would
+        // both hand out the same first id.
+        assert_ne!(parent.group_id_builder().group_id("a"), child.group_id_builder().group_id("b"));
+    }
+
+    #[test]
+    fn states_built_from_one_session_share_the_group_id_space() {
+        let allocator = Allocator::default();
+        let session = FormatSession::new(&allocator, InputKind::PhysicalFile, None);
+
+        let parent_state = FormatState::new_with_session((), session.clone());
+        let child_state = FormatState::new_with_session((), session);
+
+        // Ids stay unique across the two states;
+        // independent builders would both hand out the same first id.
+        assert_ne!(parent_state.group_id("parent"), child_state.group_id("child"));
+    }
+
+    #[test]
+    fn compatibility_wrapper_keeps_independent_spaces() {
+        let allocator = Allocator::default();
+        let a = FormatState::new((), &allocator);
+        let b = FormatState::new((), &allocator);
+
+        // Pre-session behavior, pinned: two plain states are unrelated runs.
+        assert_eq!(a.group_id("a"), b.group_id("b"));
+    }
+}

--- a/crates/oxc_formatter_core/src/state.rs
+++ b/crates/oxc_formatter_core/src/state.rs
@@ -2,7 +2,10 @@ use rustc_hash::FxHashMap;
 
 use oxc_allocator::{Allocator, GetAllocator};
 
-use crate::{FormatElement, GroupId, UniqueGroupIdBuilder, format_element::Interned};
+use crate::{
+    FormatElement, FormatSession, GroupId, InputKind, UniqueGroupIdBuilder,
+    format_element::Interned,
+};
 
 /// This structure stores the state that is relevant for the formatting of the whole document.
 ///
@@ -11,8 +14,8 @@ use crate::{FormatElement, GroupId, UniqueGroupIdBuilder, format_element::Intern
 /// for the whole process of formatting a root with [crate::format!].
 pub struct FormatState<'ast, C> {
     context: C,
-    allocator: &'ast Allocator,
-    group_id_builder: UniqueGroupIdBuilder,
+    /// The shared execution unit of this format run; see [`FormatSession`].
+    session: FormatSession<'ast>,
     // For the document IR printing process
     /// The interned elements that have been printed to this point
     printed_interned_elements: FxHashMap<Interned<'ast>, usize>,
@@ -28,15 +31,35 @@ impl<C: std::fmt::Debug> std::fmt::Debug for FormatState<'_, C> {
 }
 
 impl<'ast, C> FormatState<'ast, C> {
-    /// Creates a new state with the given language specific context
+    /// Creates a new state with the given language specific context.
+    ///
+    /// Compatibility wrapper: builds a dispatcher-less [`InputKind::PhysicalFile`]
+    /// session with its own `GroupId` space.
+    /// Entry points that share a run with other formatters use [`Self::new_with_session`] instead.
+    ///
+    /// NOTE: embedded entries (`format_to_ir`) still run through this wrapper,
+    /// so their `input_kind` is mislabeled until they migrate to [`Self::new_with_session`];
+    /// nothing may consult `input_kind` for envelope decisions (front matter, BOM) before that migration.
     pub fn new(context: C, allocator: &'ast Allocator) -> Self {
+        Self::new_with_session(
+            context,
+            FormatSession::new(allocator, InputKind::PhysicalFile, None),
+        )
+    }
+
+    /// Creates a new state on an existing session, sharing its arena and `GroupId` space.
+    pub fn new_with_session(context: C, session: FormatSession<'ast>) -> Self {
         Self {
             context,
-            allocator,
-            group_id_builder: UniqueGroupIdBuilder::default(),
+            session,
             printed_interned_elements: FxHashMap::default(),
             scratch: Vec::new(),
         }
+    }
+
+    /// The session this state formats under.
+    pub fn session(&self) -> &FormatSession<'ast> {
+        &self.session
     }
 
     /// The heap staging vector shared by all [`crate::HeapVecBuffer`]s of this format run.
@@ -51,7 +74,7 @@ impl<'ast, C> FormatState<'ast, C> {
 
     /// Returns the allocator used for arena-allocating format elements.
     pub fn allocator(&self) -> &'ast Allocator {
-        self.allocator
+        self.session.allocator()
     }
 
     pub fn into_context(self) -> C {
@@ -72,12 +95,12 @@ impl<'ast, C> FormatState<'ast, C> {
     /// [std::fmt::Debug] of the document if this is a debug build.
     /// The name is unused for production builds and has no meaning on the equality of two group ids.
     pub fn group_id(&self, debug_name: &'static str) -> GroupId {
-        self.group_id_builder.group_id(debug_name)
+        self.session.group_id_builder().group_id(debug_name)
     }
 
     /// Returns a reference to the unique group id builder.
     pub fn group_id_builder(&self) -> &UniqueGroupIdBuilder {
-        &self.group_id_builder
+        self.session.group_id_builder()
     }
 
     #[expect(clippy::mutable_key_type)]
@@ -89,6 +112,6 @@ impl<'ast, C> FormatState<'ast, C> {
 impl<'ast, C> GetAllocator<'ast> for FormatState<'ast, C> {
     #[inline]
     fn allocator(&self) -> &'ast Allocator {
-        self.allocator
+        self.session.allocator()
     }
 }

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -1,8 +1,8 @@
 checker.ts:
   file size: 2922154 # 2.92 MB
-  sys allocs: 19382
+  sys allocs: 19383
   sys reallocs: 1166
-  sys deallocs: 19381
+  sys deallocs: 19382
   sys alloc bytes: 6767781 # 6.77 MB
   sys peak growth: 2973674 # 2.97 MB
   arena allocs: 1064047
@@ -11,9 +11,9 @@ checker.ts:
 
 App.tsx:
   file size: 415342 # 415.34 kB
-  sys allocs: 5191
+  sys allocs: 5192
   sys reallocs: 524
-  sys deallocs: 5190
+  sys deallocs: 5191
   sys alloc bytes: 1564670 # 1.56 MB
   sys peak growth: 435358 # 435.36 kB
   arena allocs: 208775
@@ -22,9 +22,9 @@ App.tsx:
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
-  sys allocs: 89
+  sys allocs: 90
   sys reallocs: 74
-  sys deallocs: 88
+  sys deallocs: 89
   sys alloc bytes: 36132 # 36.13 kB
   sys peak growth: 12192 # 12.19 kB
   arena allocs: 1128
@@ -33,9 +33,9 @@ RadixUIAdoptionSection.jsx:
 
 pdf.mjs:
   file size: 567296 # 567.30 kB
-  sys allocs: 9775
+  sys allocs: 9776
   sys reallocs: 1327
-  sys deallocs: 9774
+  sys deallocs: 9775
   sys alloc bytes: 3141552 # 3.14 MB
   sys peak growth: 1156432 # 1.16 MB
   arena allocs: 427539
@@ -44,9 +44,9 @@ pdf.mjs:
 
 antd.js:
   file size: 6686316 # 6.69 MB
-  sys allocs: 90042
+  sys allocs: 90043
   sys reallocs: 7663
-  sys deallocs: 90041
+  sys deallocs: 90042
   sys alloc bytes: 76472316 # 76.47 MB
   sys peak growth: 50737424 # 50.74 MB
   arena allocs: 2503924
@@ -55,9 +55,9 @@ antd.js:
 
 binder.ts:
   file size: 193077 # 193.08 kB
-  sys allocs: 972
+  sys allocs: 973
   sys reallocs: 97
-  sys deallocs: 971
+  sys deallocs: 972
   sys alloc bytes: 356005 # 356.00 kB
   sys peak growth: 195149 # 195.15 kB
   arena allocs: 63389
@@ -66,9 +66,9 @@ binder.ts:
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
-  sys allocs: 17087
+  sys allocs: 17088
   sys reallocs: 4956
-  sys deallocs: 17086
+  sys deallocs: 17087
   sys alloc bytes: 4436340 # 4.44 MB
   sys peak growth: 1491796 # 1.49 MB
   arena allocs: 555537


### PR DESCRIPTION
In theory, the group id needs to function across embedded boundaries.

To achieve this, a "session" mechanism that can be carried over those boundaries was required.