### PR TITLE
refactor(oxfmt,formatter_core): add `DispatchOutcome` with recursion limit

### DIFF
--- a/apps/oxfmt/src/core/embed/ir_channel.rs
+++ b/apps/oxfmt/src/core/embed/ir_channel.rs
@@ -14,7 +14,8 @@ use tracing::{debug, debug_span};
 use oxc_allocator::Allocator;
 use oxc_formatter::HtmlEmbedMeta;
 use oxc_formatter_core::{
-    DispatchResult, EmbeddedContext, EmbeddedIr, FormatDispatcher, UniqueGroupIdBuilder,
+    DispatchOutcome, DispatchRequest, DispatchResult, EmbeddedContext, EmbeddedIr,
+    FormatDispatcher, UniqueGroupIdBuilder,
 };
 use oxc_formatter_css::CssFormatOptions;
 use oxc_formatter_graphql::GraphqlFormatOptions;
@@ -37,35 +38,53 @@ pub fn build_dispatcher(
     css_options: CssFormatOptions,
 ) -> FormatDispatcher {
     let prettier_fallback = build_prettier_fallback(format_embedded_doc, options);
-    Arc::new(
-        move |ctx: &EmbeddedContext<'_, '_>, language: &str, texts: &[&str], _parent_context| {
-            // Rust implementations replace branches one by one;
-            match language {
-                // This is always `graphql` for now
-                "graphql" | "gql" => format_graphql_to_irs(ctx, texts, graphql_options)
-                    .inspect_err(|err| {
+    Arc::new(move |ctx: &EmbeddedContext<'_, '_>, request: DispatchRequest<'_>| {
+        // Rust implementations replace branches one by one;
+        match request.language {
+            // This is always `graphql` for now
+            "graphql" | "gql" => {
+                match format_graphql_to_irs(ctx, request.texts, graphql_options) {
+                    Ok(result) => Ok(DispatchOutcome::Formatted(result)),
+                    // A parse failure is a deliberate skip, not an operational error.
+                    Err(err) => {
                         debug!(
                             "`format_graphql_to_irs` failed, gql-in-xxx part stays as-is: {err}"
                         );
-                    }),
-                // This is always `css` with `CssVariant:Scss` for now
-                "css" | "scss" | "less" => {
-                    format_css_to_irs(ctx, texts, css_options).inspect_err(|err| {
-                        debug!("`format_css_to_irs` failed, css-in-xxx part stays as-is: {err}");
-                    })
+                        Ok(DispatchOutcome::PreserveOriginal)
+                    }
                 }
-                // Everything else: Prettier fallback (Doc→IR path)
-                _ => prettier_fallback(ctx, language, texts),
             }
-        },
-    )
+            // This is always `css` with `CssVariant:Scss` for now
+            "css" | "scss" | "less" => {
+                // A wrong text count is a host-contract violation, not a parse failure:
+                // unlike GraphQL's one-IR-per-quasi, the CSS embed joins quasis with
+                // placeholders into a single text before dispatching.
+                let [text] = request.texts else {
+                    return Err(format!(
+                        "CSS dispatch expects exactly one text, got {}",
+                        request.texts.len()
+                    ));
+                };
+                match format_css_to_ir(ctx, text, css_options) {
+                    Ok(result) => Ok(DispatchOutcome::Formatted(result)),
+                    // A parse failure is a deliberate skip, not an operational error.
+                    Err(err) => {
+                        debug!("`format_css_to_ir` failed, css-in-xxx part stays as-is: {err}");
+                        Ok(DispatchOutcome::PreserveOriginal)
+                    }
+                }
+            }
+            // Everything else: Prettier fallback (Doc→IR path)
+            _ => prettier_fallback(ctx, request.language, request.texts),
+        }
+    })
 }
 
 /// Format each text as a standalone GraphQL document via `oxc_formatter_graphql`,
 /// returning one IR per text (the IR-channel contract for GraphQL).
 ///
 /// Any parse error fails the whole batch (an embedded template is all-or-nothing):
-/// `Err` makes the parent print the template as-is.
+/// the caller maps `Err` to `PreserveOriginal`, so the parent prints the template as-is.
 fn format_graphql_to_irs<'a>(
     ctx: &EmbeddedContext<'a, '_>,
     texts: &[&str],
@@ -86,16 +105,11 @@ fn format_graphql_to_irs<'a>(
 
 /// Format the single joined CSS text (placeholders included) via `oxc_formatter_css`,
 /// returning one IR per call (the IR-channel contract for CSS).
-fn format_css_to_irs<'a>(
+fn format_css_to_ir<'a>(
     ctx: &EmbeddedContext<'a, '_>,
-    texts: &[&str],
+    text: &str,
     options: CssFormatOptions,
 ) -> Result<DispatchResult<'a>, String> {
-    // Unlike GraphQL's one-IR-per-quasi,
-    // the CSS embed joins quasis with placeholders into a single text before dispatching.
-    let [text] = texts else {
-        return Err(format!("CSS dispatch expects exactly one text, got {}", texts.len()));
-    };
     debug_span!("oxfmt::external::format_css_to_ir").in_scope(|| {
         let EmbeddedIr { ir, tailwind_classes } =
             oxc_formatter_css::format_to_ir(ctx, text, options).map_err(|err| err.to_string())?;
@@ -104,13 +118,15 @@ fn format_css_to_irs<'a>(
 }
 
 /// Type of the Prettier Doc→IR fallback used inside [`build_dispatcher`].
-/// Same shape as `FormatDispatcher` minus the `parent_context` passthrough.
+/// Same shape as `FormatDispatcher` minus the request envelope
+/// (the Doc path consumes neither `input_kind` nor `parent_context` today;
+/// re-examine if it ever serves envelope-bearing inputs).
 type PrettierDocFallback = Arc<
     dyn for<'a, 'g> Fn(
             &EmbeddedContext<'a, 'g>,
             &str,
             &[&str],
-        ) -> Result<DispatchResult<'a>, String>
+        ) -> Result<DispatchOutcome<'a>, String>
         + Send
         + Sync,
 >;
@@ -123,7 +139,9 @@ fn build_prettier_fallback(
 ) -> PrettierDocFallback {
     Arc::new(move |ctx: &EmbeddedContext<'_, '_>, language: &str, texts: &[&str]| {
         let Some(parser_name) = language_to_prettier_parser(language) else {
-            return Err(format!("Unsupported language: {language}"));
+            // An unsupported language is a deliberate skip, not an operational error.
+            debug!("No Prettier parser for language '{language}', part stays as-is");
+            return Ok(DispatchOutcome::PreserveOriginal);
         };
         debug_span!("oxfmt::external::format_embedded_doc", parser = parser_name)
             .in_scope(|| {
@@ -154,6 +172,7 @@ fn build_prettier_fallback(
                     ctx.allocator,
                     ctx.group_id_builder,
                 )
+                .map(DispatchOutcome::Formatted)
             })
             .inspect_err(|err| {
                 debug!("Failed to format embedded doc for parser '{parser_name}': {err}");

--- a/crates/oxc_formatter/src/external_formatter.rs
+++ b/crates/oxc_formatter/src/external_formatter.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use oxc_allocator::Allocator;
-use oxc_formatter_core::{DispatchResult, EmbeddedContext, FormatDispatcher, UniqueGroupIdBuilder};
+use oxc_formatter_core::{
+    DispatchOutcome, DispatchRequest, EmbeddedContext, FormatDispatcher, InputKind,
+    UniqueGroupIdBuilder,
+};
 
 /// Callback function type for formatting embedded code.
 /// Takes (tag_name, code) and returns formatted code or an error.
@@ -97,23 +100,38 @@ impl ExternalCallbacks {
     /// * `texts` - The code texts to format (multiple quasis for GraphQL, single joined text for CSS/HTML)
     ///
     /// # Returns
-    /// * `Some(Ok(DispatchResult))` - The formatted IR(s) plus optional child→parent metadata
-    /// * `Some(Err(String))` - An error message if formatting failed
-    /// * `None` - No dispatcher is set
+    /// See [`DispatchOutcome`] for the outcome-vs-error contract;
+    /// "no dispatcher set" counts as the deliberate `PreserveOriginal`.
+    ///
+    /// # Errors
+    /// Operational failures only (transport / internal errors).
+    /// NOTE: unlike `FormatSession::dispatch`, this legacy adapter does NOT enforce the recursion limit;
+    /// the guard arrives when embed sites become session-aware.
     pub fn dispatch_embedded<'a>(
         &self,
         allocator: &'a Allocator,
         group_id_builder: &UniqueGroupIdBuilder,
         language: &str,
         texts: &[&str],
-    ) -> Option<Result<DispatchResult<'a>, String>> {
-        let dispatcher = self.dispatcher.as_ref()?;
+    ) -> Result<DispatchOutcome<'a>, String> {
+        let Some(dispatcher) = self.dispatcher.as_ref() else {
+            return Ok(DispatchOutcome::PreserveOriginal);
+        };
+
         let ctx = EmbeddedContext {
             allocator,
             group_id_builder,
             dispatcher: Some(Arc::clone(dispatcher)),
         };
-        Some(dispatcher(&ctx, language, texts, None))
+        // Every JS template embed is a grammar fragment; parser modes
+        // (e.g. css-in-js placeholder tolerance) travel separately.
+        let request = DispatchRequest {
+            language,
+            texts,
+            input_kind: InputKind::Fragment,
+            parent_context: None,
+        };
+        dispatcher(&ctx, request)
     }
 
     /// Sort Tailwind CSS classes.

--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -1,6 +1,6 @@
 use oxc_allocator::ArenaStringBuilder;
 use oxc_ast::ast::*;
-use oxc_formatter_core::{FormatElement, IndentWidth, format_element::TextWidth};
+use oxc_formatter_core::{DispatchOutcome, FormatElement, IndentWidth, format_element::TextWidth};
 
 use crate::{
     ast_nodes::AstNode,
@@ -53,12 +53,11 @@ pub(super) fn format_css_doc<'a>(
 
         let allocator = f.allocator();
         let group_id_builder = f.group_id_builder();
-        let Some(Ok(mut result)) = f.context().external_callbacks().dispatch_embedded(
-            allocator,
-            group_id_builder,
-            "css",
-            &[raw],
-        ) else {
+        let Ok(DispatchOutcome::Formatted(mut result)) = f
+            .context()
+            .external_callbacks()
+            .dispatch_embedded(allocator, group_id_builder, "css", &[raw])
+        else {
             return false;
         };
         result.remap_tailwind_into(f.context_mut());
@@ -90,12 +89,11 @@ pub(super) fn format_css_doc<'a>(
     // Phase 2: Format via the dispatcher (IR path)
     let allocator = f.allocator();
     let group_id_builder = f.group_id_builder();
-    let Some(Ok(mut result)) = f.context().external_callbacks().dispatch_embedded(
-        allocator,
-        group_id_builder,
-        "css",
-        &[joined],
-    ) else {
+    let Ok(DispatchOutcome::Formatted(mut result)) = f
+        .context()
+        .external_callbacks()
+        .dispatch_embedded(allocator, group_id_builder, "css", &[joined])
+    else {
         return false;
     };
     result.remap_tailwind_into(f.context_mut());

--- a/crates/oxc_formatter/src/print/template/embed/graphql.rs
+++ b/crates/oxc_formatter/src/print/template/embed/graphql.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_formatter_core::{
-    FormatElement, IndentWidth,
+    DispatchOutcome, FormatElement, IndentWidth,
     format_element::{LineMode, TextWidth},
 };
 
@@ -89,12 +89,11 @@ pub(super) fn format_graphql_doc<'a>(
     } else {
         let allocator = f.allocator();
         let group_id_builder = f.group_id_builder();
-        let Some(Ok(result)) = f.context().external_callbacks().dispatch_embedded(
-            allocator,
-            group_id_builder,
-            "graphql",
-            &texts_to_format,
-        ) else {
+        let Ok(DispatchOutcome::Formatted(result)) = f
+            .context()
+            .external_callbacks()
+            .dispatch_embedded(allocator, group_id_builder, "graphql", &texts_to_format)
+        else {
             return false;
         };
         // One IR per sent text is the dispatcher contract for GraphQL.

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -2,7 +2,7 @@ use cow_utils::CowUtils;
 
 use oxc_allocator::ArenaStringBuilder;
 use oxc_ast::ast::*;
-use oxc_formatter_core::FormatElement;
+use oxc_formatter_core::{DispatchOutcome, FormatElement};
 use oxc_syntax::line_terminator::LineTerminatorSplitter;
 
 use crate::{
@@ -55,12 +55,11 @@ pub(super) fn format_html_doc<'a>(
 
         let allocator = f.allocator();
         let group_id_builder = f.group_id_builder();
-        let Some(Ok(mut result)) = f.context().external_callbacks().dispatch_embedded(
-            allocator,
-            group_id_builder,
-            embedded_language,
-            &[cooked],
-        ) else {
+        let Ok(DispatchOutcome::Formatted(mut result)) = f
+            .context()
+            .external_callbacks()
+            .dispatch_embedded(allocator, group_id_builder, embedded_language, &[cooked])
+        else {
             return false;
         };
         let Some(html_has_multiple_root_elements) = result
@@ -123,12 +122,11 @@ pub(super) fn format_html_doc<'a>(
     // Phase 2: Format via the dispatcher (IR path)
     let allocator = f.allocator();
     let group_id_builder = f.group_id_builder();
-    let Some(Ok(mut result)) = f.context().external_callbacks().dispatch_embedded(
-        allocator,
-        group_id_builder,
-        embedded_language,
-        &[joined],
-    ) else {
+    let Ok(DispatchOutcome::Formatted(mut result)) = f
+        .context()
+        .external_callbacks()
+        .dispatch_embedded(allocator, group_id_builder, embedded_language, &[joined])
+    else {
         // NOTE: If this html-in-js part contains `<script>` (= js-in-html-in-js),
         // returned Prettier's `Doc` output may contain `conditionalGroup`.
         // But currently, `oxfmt/prettier_compat/from_prettier_doc.rs` does not support this.
@@ -140,6 +138,10 @@ pub(super) fn format_html_doc<'a>(
         // Of course, there will be formatting differences.
         // Support `conditionalGroup` and convert to our `BestFitting` may be possible,
         // but it also requires placeholder replacement, which is non-trivial.
+        //
+        // NOTE: `Ok(PreserveOriginal)` lands here too and gets the same recovery attempt;
+        // splitting the match (PreserveOriginal -> plain template path)
+        // is deferred until this site is session-aware.
         return format_js_in_html_as_fallback(joined, &expressions, f);
     };
 

--- a/crates/oxc_formatter/src/print/template/embed/markdown.rs
+++ b/crates/oxc_formatter/src/print/template/embed/markdown.rs
@@ -1,6 +1,8 @@
 use oxc_allocator::{Allocator, ArenaStringBuilder};
 use oxc_ast::ast::*;
 
+use oxc_formatter_core::DispatchOutcome;
+
 use crate::{ast_nodes::AstNode, format_args, formatter::prelude::*, write};
 
 /// Format a Markdown-in-JS tagged template literal via the Doc→IR path.
@@ -32,12 +34,11 @@ pub(super) fn try_embed_markdown<'a>(
     // Phase 3: Get the IR from the dispatcher
     let allocator = f.allocator();
     let group_id_builder = f.group_id_builder();
-    let Some(Ok(result)) = f.context().external_callbacks().dispatch_embedded(
-        allocator,
-        group_id_builder,
-        "markdown",
-        &[text],
-    ) else {
+    let Ok(DispatchOutcome::Formatted(result)) = f
+        .context()
+        .external_callbacks()
+        .dispatch_embedded(allocator, group_id_builder, "markdown", &[text])
+    else {
         return false;
     };
     let Some(mut ir) = result.docs.into_iter().next() else {

--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -89,6 +89,11 @@ The core is parameterized over a consumer-supplied context so it stays language-
   - One arena, one shared `GroupId` space (`Arc<UniqueGroupIdBuilder>`), the dispatcher, and the input's envelope semantics (`InputKind`), usable by standalone roots and dispatched children alike
   - `FormatState` holds one (`new_with_session`; plain `new` wraps a dispatcher-less `PhysicalFile` session), and `Formatter::session()` exposes it during a write.
   - `EmbeddedContext` remains as a migration adapter until every entry point is session-aware
+- A dispatch states its request as `DispatchRequest` (language, texts, `InputKind`, pair-specific context) and yields `Result<DispatchOutcome, String>`:
+  - `DispatchOutcome::PreserveOriginal` is the DELIBERATE "keep the source as-is" answer (unsupported language, child parse failure, no dispatcher installed); `Err` is reserved for operational failures (transport / internal, recursion limit)
+  - Optional-embed callers degrade the same way for both, but never conflate them at the source
+  - `FormatSession::dispatch` owns the no-dispatcher case and the recursion limit (`MAX_DISPATCH_DEPTH`), and runs the callback on a `derive_child`ed session
+    (the JS host's legacy `dispatch_embedded` adapter bypasses the guard until it migrates to sessions)
 
 ## What belongs in core (the boundary)
 

--- a/crates/oxc_formatter_core/src/embedded.rs
+++ b/crates/oxc_formatter_core/src/embedded.rs
@@ -16,7 +16,7 @@ use std::{any::Any, sync::Arc};
 
 use oxc_allocator::{Allocator, ArenaVec};
 
-use crate::{FormatElement, group_id::UniqueGroupIdBuilder};
+use crate::{FormatElement, InputKind, group_id::UniqueGroupIdBuilder};
 
 /// Shared IR-infrastructure context for formatting embedded code.
 ///
@@ -37,24 +37,49 @@ pub struct EmbeddedContext<'a, 'g> {
     pub dispatcher: Option<FormatDispatcher>,
 }
 
+/// One embedded-language formatting request, as the host formatter states it.
+pub struct DispatchRequest<'r> {
+    /// Generic language identifier (e.g. `"css"`, `"graphql"`);
+    /// the dispatcher implementation maps it to its own parser/language names.
+    pub language: &'r str,
+    /// Code to format. Usually a single text;
+    /// GraphQL sends N quasis and receives N IRs back (the batch is atomic: all format or none do).
+    pub texts: &'r [&'r str],
+    /// Envelope semantics of the child input, as declared by the host.
+    pub input_kind: InputKind,
+    /// Parent→child language-pair specific data,
+    /// downcast by the implementation (`None` for most pairs).
+    pub parent_context: Option<&'r dyn Any>,
+}
+
+/// What a dispatch produced.
+///
+/// [`Self::PreserveOriginal`] is the DELIBERATE "do not format" answer
+/// (unsupported language, child parse failure, an envelope the child refuses,
+/// embedded formatting turned off): the caller keeps the original source as-is.
+/// `Result::Err` around this enum is reserved for operational failures (transport / internal errors);
+/// optional-embed callers degrade the same way for both,
+/// but the two must never be conflated at the source.
+pub enum DispatchOutcome<'a> {
+    /// The child formatted the request; consume [`DispatchResult`].
+    Formatted(DispatchResult<'a>),
+    /// Deliberately not formatted; keep the original source untouched.
+    PreserveOriginal,
+}
+
 /// Dispatcher resolving a language name to a formatter implementation.
 ///
 /// Assembled by the orchestrator (oxfmt), which knows all languages;
-/// formatter crates only invoke it. Arguments are
-/// `(context, language, texts, parent_context)`:
-///
-/// - `language`: generic language identifier (e.g. `"css"`, `"graphql"`)
-/// - `texts`: code to format. Usually a single text; GraphQL sends N quasis
-///   and receives N IRs back
-/// - `parent_context`: parent→child language-pair specific data, downcast by
-///   the implementation (`None` for most pairs)
+/// formatter crates only invoke it.
+/// The intended entry is [`crate::FormatSession::dispatch`]
+/// (which owns the recursion limit and the no-dispatcher case),
+/// but until every entry point is session-aware,
+/// the JS host's `dispatch_embedded` adapter still invokes it directly WITHOUT the depth guard.
 pub type FormatDispatcher = Arc<
-    dyn for<'a, 'g> Fn(
+    dyn for<'a, 'g, 'r> Fn(
             &EmbeddedContext<'a, 'g>,
-            &str,
-            &[&str],
-            Option<&dyn Any>,
-        ) -> Result<DispatchResult<'a>, String>
+            DispatchRequest<'r>,
+        ) -> Result<DispatchOutcome<'a>, String>
         + Send
         + Sync,
 >;

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -44,7 +44,8 @@ pub use buffer::{
 };
 pub use diagnostics::{ActualStart, FormatError, InvalidDocumentError, PrintError};
 pub use embedded::{
-    DispatchResult, EmbeddedContext, EmbeddedIr, FormatDispatcher, TailwindCollector,
+    DispatchOutcome, DispatchRequest, DispatchResult, EmbeddedContext, EmbeddedIr,
+    FormatDispatcher, TailwindCollector,
 };
 pub use format::{Format, write};
 pub use format_element::debug::DisplayDocument;

--- a/crates/oxc_formatter_core/src/session.rs
+++ b/crates/oxc_formatter_core/src/session.rs
@@ -4,7 +4,13 @@ use std::sync::Arc;
 
 use oxc_allocator::Allocator;
 
-use crate::{FormatDispatcher, UniqueGroupIdBuilder};
+use crate::{
+    DispatchOutcome, DispatchRequest, EmbeddedContext, FormatDispatcher, UniqueGroupIdBuilder,
+};
+
+/// Upper bound on nested embedded dispatches;
+/// exceeding it is an operational error, catching accidental A-in-B-in-A infinite recursion.
+pub const MAX_DISPATCH_DEPTH: u16 = 32;
 
 /// Document-envelope semantics of the input being formatted.
 ///
@@ -74,6 +80,39 @@ impl<'a> FormatSession<'a> {
         }
     }
 
+    /// Formats one embedded-language request on a child session derived from this one.
+    ///
+    /// See [`DispatchOutcome`] for the outcome-vs-`Err` contract; this method adds two rules:
+    /// no dispatcher installed (plain standalone run) counts as the deliberate
+    /// `Ok(DispatchOutcome::PreserveOriginal)`, and reaching `MAX_DISPATCH_DEPTH` is an `Err`.
+    ///
+    /// TODO: The callback should receive the derived child session itself
+    /// (and must then not create another `GroupId` space or bump the depth again).
+    /// Until the dispatcher signature is session-aware, it receives an
+    /// [`EmbeddedContext`] adapter sourced from the child,
+    /// so the child's bumped depth is not yet visible to nested dispatches.
+    ///
+    /// # Errors
+    /// Operational failures only (recursion limit, transport/internal errors).
+    pub fn dispatch(&self, request: DispatchRequest<'_>) -> Result<DispatchOutcome<'a>, String> {
+        let Some(dispatcher) = &self.dispatcher else {
+            return Ok(DispatchOutcome::PreserveOriginal);
+        };
+        if self.dispatch_depth >= MAX_DISPATCH_DEPTH {
+            return Err(format!(
+                "embedded dispatch exceeded the recursion limit ({MAX_DISPATCH_DEPTH})"
+            ));
+        }
+        let FormatSession { allocator, group_id_builder, dispatcher: child_dispatcher, .. } =
+            self.derive_child(request.input_kind);
+        let ctx = EmbeddedContext {
+            allocator,
+            group_id_builder: &group_id_builder,
+            dispatcher: child_dispatcher,
+        };
+        dispatcher(&ctx, request)
+    }
+
     /// The arena shared between the root and every embedded child.
     #[inline]
     pub fn allocator(&self) -> &'a Allocator {
@@ -105,10 +144,57 @@ impl<'a> FormatSession<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use oxc_allocator::Allocator;
 
-    use super::{FormatSession, InputKind};
-    use crate::FormatState;
+    use super::{FormatSession, InputKind, MAX_DISPATCH_DEPTH};
+    use crate::{DispatchOutcome, DispatchRequest, DispatchResult, FormatDispatcher, FormatState};
+
+    fn request<'r>() -> DispatchRequest<'r> {
+        DispatchRequest {
+            language: "yaml",
+            texts: &[],
+            input_kind: InputKind::Fragment,
+            parent_context: None,
+        }
+    }
+
+    #[test]
+    fn dispatch_without_dispatcher_preserves_original() {
+        let allocator = Allocator::default();
+        let session = FormatSession::new(&allocator, InputKind::PhysicalFile, None);
+
+        assert!(matches!(session.dispatch(request()), Ok(DispatchOutcome::PreserveOriginal)));
+    }
+
+    #[test]
+    fn dispatch_stops_at_the_depth_limit() {
+        let allocator = Allocator::default();
+        let dispatcher: FormatDispatcher = Arc::new(|_ctx, _request| {
+            Ok(DispatchOutcome::Formatted(DispatchResult {
+                docs: Vec::new(),
+                tailwind_classes: Vec::new(),
+                meta: None,
+            }))
+        });
+        let mut session = FormatSession::new(&allocator, InputKind::PhysicalFile, Some(dispatcher));
+
+        assert!(matches!(session.dispatch(request()), Ok(DispatchOutcome::Formatted(_))));
+        for _ in 0..MAX_DISPATCH_DEPTH {
+            session = session.derive_child(InputKind::Fragment);
+        }
+        assert!(session.dispatch(request()).is_err());
+    }
+
+    #[test]
+    fn dispatch_propagates_operational_errors() {
+        let allocator = Allocator::default();
+        let dispatcher: FormatDispatcher = Arc::new(|_ctx, _request| Err("boom".to_string()));
+        let session = FormatSession::new(&allocator, InputKind::PhysicalFile, Some(dispatcher));
+
+        assert_eq!(session.dispatch(request()).err().as_deref(), Some("boom"));
+    }
 
     #[test]
     fn derived_child_shares_the_group_id_space() {


### PR DESCRIPTION
In the embedding format, issuing a `DispatchRequest` returns a `DispatchOutcome`.

Additionally, by managing the nesting depth, made it possible to limit the number of recursion.