### PR TITLE
refactor(formatter): migrate embedded entries to `FormatSession`

### DIFF
--- a/apps/oxfmt/src/api/text_to_doc_api.rs
+++ b/apps/oxfmt/src/api/text_to_doc_api.rs
@@ -6,6 +6,7 @@ use tracing::{debug, instrument};
 
 use oxc_allocator::Allocator;
 use oxc_formatter::FragmentContext;
+use oxc_formatter_core::{FormatSession, InputKind};
 use oxc_span::SourceType;
 
 use crate::{
@@ -137,13 +138,20 @@ fn run_full(
     let dispatch_config =
         Arc::new(ResolvedDispatchConfig::new(config, core).with_path(parent_filepath));
 
-    let external_callbacks =
+    let (external_callbacks, dispatcher) =
         external_formatter.to_external_callbacks(&format_options, &dispatch_config);
 
     let allocator = Allocator::default();
+    let session = FormatSession::new(
+        &allocator,
+        // A Vue/Svelte `<script>` block is a complete document the host passes as embedded input,
+        // never the owner of file envelopes (BOM / front matter).
+        InputKind::VirtualDocument,
+        dispatcher,
+    );
     let formatted = match tokio::task::block_in_place(|| {
-        oxc_formatter::format(
-            &allocator,
+        oxc_formatter::format_with_session(
+            &session,
             source_text,
             source_type,
             *format_options,

--- a/apps/oxfmt/src/core/embed/dispatcher.rs
+++ b/apps/oxfmt/src/core/embed/dispatcher.rs
@@ -8,9 +8,10 @@ use std::sync::{Arc, OnceLock};
 
 use tracing::{debug, debug_span};
 
+use oxc_formatter::CssInJsTemplate;
 use oxc_formatter_core::{
-    CoreFormatOptions, DispatchOutcome, DispatchRequest, DispatchResult, EmbeddedContext,
-    EmbeddedIr, FormatDispatcher,
+    CoreFormatOptions, DispatchOutcome, DispatchRequest, DispatchResult, EmbeddedIr,
+    FormatDispatcher, FormatSession,
 };
 use oxc_formatter_css::{CssFormatOptions, CssVariant};
 use oxc_formatter_graphql::GraphqlFormatOptions;
@@ -106,11 +107,7 @@ impl ResolvedDispatchConfig {
 /// Assembled only in napi builds ([`super::prettier_fallback`]);
 /// the pure Rust build passes `None` and unsupported languages are deliberately preserved as-is.
 pub type PrettierDocFallback = Arc<
-    dyn for<'a, 'g> Fn(
-            &EmbeddedContext<'a, 'g>,
-            &str,
-            &[&str],
-        ) -> Result<DispatchOutcome<'a>, String>
+    dyn for<'a> Fn(&FormatSession<'a>, &str, &[&str]) -> Result<DispatchOutcome<'a>, String>
         + Send
         + Sync,
 >;
@@ -122,11 +119,11 @@ pub fn build_dispatcher(
     dispatch_config: Arc<ResolvedDispatchConfig>,
     fallback: Option<PrettierDocFallback>,
 ) -> FormatDispatcher {
-    Arc::new(move |ctx: &EmbeddedContext<'_, '_>, request: DispatchRequest<'_>| {
+    Arc::new(move |session: &FormatSession<'_>, request: DispatchRequest<'_>| {
         // Rust implementations replace branches one by one;
         match request.language {
             "graphql" | "gql" => Ok(formatted_or_preserved(
-                format_graphql_to_irs(ctx, request.texts, dispatch_config.graphql_options()),
+                format_graphql_to_irs(session, request.texts, dispatch_config.graphql_options()),
                 "format_graphql_to_irs",
             )),
             "css" | "scss" | "less" => {
@@ -139,21 +136,36 @@ pub fn build_dispatcher(
                         request.texts.len()
                     ));
                 };
-                // CSS-in-JS is always parsed as SCSS (Prettier's embed uses the
-                // `scss` parser for all of css/scss/less template tags).
+                // css-in-js (typed `CssInJsTemplate` context) is always parsed as SCSS
+                // with `${}` placeholder markers.
+                // Any other caller gets the strict standalone grammar with the variant
+                // taken from the fence/request language.
+                let (variant, template_placeholders) = if request
+                    .parent_context
+                    .is_some_and(|c| c.downcast_ref::<CssInJsTemplate>().is_some())
+                {
+                    (CssVariant::Scss, true)
+                } else {
+                    (css_variant_for(request.language), false)
+                };
                 Ok(formatted_or_preserved(
-                    format_css_to_ir(ctx, text, dispatch_config.css_options(CssVariant::Scss)),
+                    format_css_to_ir(
+                        session,
+                        text,
+                        dispatch_config.css_options(variant),
+                        template_placeholders,
+                    ),
                     "format_css_to_ir",
                 ))
             }
             "yaml" | "yml" => Ok(formatted_or_preserved(
-                format_yaml_to_irs(ctx, request.texts, dispatch_config.yaml_options()),
+                format_yaml_to_irs(session, request.texts, dispatch_config.yaml_options()),
                 "format_yaml_to_irs",
             )),
             // Everything else: Prettier fallback (Doc→IR path) when available
             _ => {
                 if let Some(fallback) = &fallback {
-                    fallback(ctx, request.language, request.texts)
+                    fallback(session, request.language, request.texts)
                 } else {
                     // A language without a formatter is a deliberate skip.
                     debug!("No formatter for language '{}', part stays as-is", request.language);
@@ -162,6 +174,16 @@ pub fn build_dispatcher(
             }
         }
     })
+}
+
+/// Map a fence/request language to its standalone [`CssVariant`]
+/// (css-in-js is Scss regardless of the tag; see the dispatcher's css arm).
+pub fn css_variant_for(language: &str) -> CssVariant {
+    match language {
+        "scss" => CssVariant::Scss,
+        "less" => CssVariant::Less,
+        _ => CssVariant::Css,
+    }
 }
 
 /// Maps a native branch result: a parse failure is a deliberate skip
@@ -184,7 +206,7 @@ fn formatted_or_preserved<'a>(
 ///
 /// Any parse error fails the whole batch (an embedded template is all-or-nothing).
 fn format_graphql_to_irs<'a>(
-    ctx: &EmbeddedContext<'a, '_>,
+    session: &FormatSession<'a>,
     texts: &[&str],
     options: GraphqlFormatOptions,
 ) -> Result<DispatchResult<'a>, String> {
@@ -192,7 +214,7 @@ fn format_graphql_to_irs<'a>(
         .iter()
         .map(|text| {
             debug_span!("oxfmt::external::format_graphql_to_ir").in_scope(|| {
-                let embedded = oxc_formatter_graphql::format_to_ir(ctx, text, options)
+                let embedded = oxc_formatter_graphql::format_to_ir(session, text, options)
                     .map_err(|err| err.to_string())?;
                 Ok(embedded.ir)
             })
@@ -204,13 +226,15 @@ fn format_graphql_to_irs<'a>(
 /// Format the single joined CSS text (placeholders included) via `oxc_formatter_css`,
 /// returning one IR per call (the IR-channel contract for CSS).
 fn format_css_to_ir<'a>(
-    ctx: &EmbeddedContext<'a, '_>,
+    session: &FormatSession<'a>,
     text: &str,
     options: CssFormatOptions,
+    template_placeholders: bool,
 ) -> Result<DispatchResult<'a>, String> {
     debug_span!("oxfmt::external::format_css_to_ir").in_scope(|| {
         let EmbeddedIr { ir, tailwind_classes } =
-            oxc_formatter_css::format_to_ir(ctx, text, options).map_err(|err| err.to_string())?;
+            oxc_formatter_css::format_to_ir(session, text, options, template_placeholders)
+                .map_err(|err| err.to_string())?;
         Ok(DispatchResult { docs: vec![ir], tailwind_classes, meta: None })
     })
 }
@@ -220,7 +244,7 @@ fn format_css_to_ir<'a>(
 ///
 /// Any parse error fails the whole batch (an embedded template is all-or-nothing).
 fn format_yaml_to_irs<'a>(
-    ctx: &EmbeddedContext<'a, '_>,
+    session: &FormatSession<'a>,
     texts: &[&str],
     options: YamlFormatOptions,
 ) -> Result<DispatchResult<'a>, String> {
@@ -228,7 +252,7 @@ fn format_yaml_to_irs<'a>(
         .iter()
         .map(|text| {
             debug_span!("oxfmt::external::format_yaml_to_ir").in_scope(|| {
-                let embedded = oxc_formatter_yaml::format_to_ir(ctx, text, options)
+                let embedded = oxc_formatter_yaml::format_to_ir(session, text, options)
                     .map_err(|err| err.to_string())?;
                 Ok(embedded.ir)
             })
@@ -243,8 +267,7 @@ mod tests {
 
     use oxc_allocator::Allocator;
     use oxc_formatter_core::{
-        CoreFormatOptions, DispatchOutcome, DispatchRequest, EmbeddedContext, InputKind,
-        UniqueGroupIdBuilder,
+        CoreFormatOptions, DispatchOutcome, DispatchRequest, FormatSession, InputKind,
     };
 
     use super::{ResolvedDispatchConfig, build_dispatcher};
@@ -260,24 +283,19 @@ mod tests {
     /// Pure-build criterion: the native registry dispatches YAML with no fallback installed.
     #[test]
     fn native_yaml_dispatch_works_without_fallback() {
-        let dispatcher = build_dispatcher(dispatch_config(), None);
         let allocator = Allocator::default();
-        let group_id_builder = UniqueGroupIdBuilder::default();
-        let ctx = EmbeddedContext {
-            allocator: &allocator,
-            group_id_builder: &group_id_builder,
-            dispatcher: None,
-        };
-
-        let outcome = dispatcher(
-            &ctx,
-            DispatchRequest {
-                language: "yaml",
-                texts: &["a:   1"],
-                input_kind: InputKind::Fragment,
-                parent_context: None,
-            },
+        let session = FormatSession::new(
+            &allocator,
+            InputKind::PhysicalFile,
+            Some(build_dispatcher(dispatch_config(), None)),
         );
+
+        let outcome = session.dispatch(DispatchRequest {
+            language: "yaml",
+            texts: &["a:   1"],
+            input_kind: InputKind::Fragment,
+            parent_context: None,
+        });
         assert!(
             matches!(outcome, Ok(DispatchOutcome::Formatted(ref result)) if result.docs.len() == 1)
         );
@@ -285,24 +303,19 @@ mod tests {
 
     #[test]
     fn unsupported_language_without_fallback_preserves_original() {
-        let dispatcher = build_dispatcher(dispatch_config(), None);
         let allocator = Allocator::default();
-        let group_id_builder = UniqueGroupIdBuilder::default();
-        let ctx = EmbeddedContext {
-            allocator: &allocator,
-            group_id_builder: &group_id_builder,
-            dispatcher: None,
-        };
-
-        let outcome = dispatcher(
-            &ctx,
-            DispatchRequest {
-                language: "html",
-                texts: &["<div></div>"],
-                input_kind: InputKind::Fragment,
-                parent_context: None,
-            },
+        let session = FormatSession::new(
+            &allocator,
+            InputKind::PhysicalFile,
+            Some(build_dispatcher(dispatch_config(), None)),
         );
+
+        let outcome = session.dispatch(DispatchRequest {
+            language: "html",
+            texts: &["<div></div>"],
+            input_kind: InputKind::Fragment,
+            parent_context: None,
+        });
         assert!(matches!(outcome, Ok(DispatchOutcome::PreserveOriginal)));
     }
 }

--- a/apps/oxfmt/src/core/embed/mod.rs
+++ b/apps/oxfmt/src/core/embed/mod.rs
@@ -1,7 +1,7 @@
 //! Embedded-language formatting orchestration.
 //!
-//! `oxc_formatter_core::embedded` holds the abstract contract
-//! (`EmbeddedContext`, `FormatDispatcher`, `DispatchResult`, `TailwindCollector`);
+//! `oxc_formatter_core` holds the abstract contract
+//! (`FormatSession`, `FormatDispatcher`, `DispatchRequest`/`DispatchOutcome`, `TailwindCollector`);
 //! this module is its concrete counterpart owned by the orchestrator (Oxfmt).
 //!
 //! - [`dispatcher`] (every build): the native registry — `ResolvedDispatchConfig`

--- a/apps/oxfmt/src/core/embed/prettier_fallback.rs
+++ b/apps/oxfmt/src/core/embed/prettier_fallback.rs
@@ -12,7 +12,7 @@ use tracing::{debug, debug_span};
 
 use oxc_allocator::Allocator;
 use oxc_formatter::HtmlEmbedMeta;
-use oxc_formatter_core::{DispatchOutcome, DispatchResult, EmbeddedContext, UniqueGroupIdBuilder};
+use oxc_formatter_core::{DispatchOutcome, DispatchResult, FormatSession, UniqueGroupIdBuilder};
 
 use crate::{
     core::{
@@ -31,7 +31,7 @@ pub fn build_prettier_fallback(
     dispatch_config: Arc<ResolvedDispatchConfig>,
     format_embedded_doc: FormatEmbeddedDocWithConfigCallback,
 ) -> PrettierDocFallback {
-    Arc::new(move |ctx: &EmbeddedContext<'_, '_>, language: &str, texts: &[&str]| {
+    Arc::new(move |session: &FormatSession<'_>, language: &str, texts: &[&str]| {
         let Some(parser_name) = language_to_prettier_parser(language) else {
             // An unsupported language is a deliberate skip, not an operational error.
             debug!("No Prettier parser for language '{language}', part stays as-is");
@@ -62,8 +62,8 @@ pub fn build_prettier_fallback(
                 to_format_elements_for_template(
                     language,
                     doc_jsons,
-                    ctx.allocator,
-                    ctx.group_id_builder,
+                    session.allocator(),
+                    session.group_id_builder(),
                 )
                 .map(DispatchOutcome::Formatted)
             })

--- a/apps/oxfmt/src/core/embed/string_channel.rs
+++ b/apps/oxfmt/src/core/embed/string_channel.rs
@@ -16,13 +16,14 @@ use tracing::{debug, debug_span};
 use oxc_allocator::Allocator;
 use oxc_formatter::EmbeddedFormatterCallback;
 use oxc_formatter_core::{FormatContext, Formatted};
-use oxc_formatter_css::{CssFormatOptions, CssVariant};
+use oxc_formatter_css::CssFormatOptions;
 use oxc_formatter_graphql::GraphqlFormatOptions;
 
 use crate::core::{
     embed::{
         FormatEmbeddedWithConfigCallback, TailwindWithConfigCallback,
-        dispatcher::ResolvedDispatchConfig, language_to_prettier_parser,
+        dispatcher::{ResolvedDispatchConfig, css_variant_for},
+        language_to_prettier_parser,
     },
     options::inject_parser,
 };
@@ -48,11 +49,7 @@ pub fn build_embedded_callback(
                 return format_graphql_embedded(code, dispatch_config.graphql_options());
             }
             "css" | "scss" | "less" => {
-                let css_options = dispatch_config.css_options(match language {
-                    "scss" => CssVariant::Scss,
-                    "less" => CssVariant::Less,
-                    _ => CssVariant::Css,
-                });
+                let css_options = dispatch_config.css_options(css_variant_for(language));
                 return match &sort_tailwind {
                     Some(sort) => {
                         let sorter = |classes: Vec<String>| {

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -256,18 +256,22 @@ impl ExternalFormatter {
     ///    so the sort must run inside that call, not via `DispatchResult` remapping.
     ///    The `string_channel::build_embedded_callback` factory receives the sorter for this case.
     ///
-    /// All four paths use the SAME `sort_tailwindcss_classes` napi callback;
-    /// only the wiring differs.
+    /// All four paths use the SAME `sort_tailwindcss_classes` napi callback; only the wiring differs.
     /// Moving sorting to the wrong layer (e.g. sorting inside embedded CSS instead of remapping)
     /// would double-sort or drop classes.
     /// `DispatchResult::remap_tailwind_into`'s printer `debug_assert` catches dropped remaps.
+    ///
+    /// Also returns the `FormatDispatcher` for the root's `FormatSession`,
+    /// gated by the SAME `embeddedLanguageFormatting` predicate as the string channel
+    /// (off => `None` => embeds deliberately stay as-is): the two channels must never diverge on the off-semantics.
     pub fn to_external_callbacks(
         &self,
         format_options: &JsFormatOptions,
         dispatch_config: &Arc<embed::dispatcher::ResolvedDispatchConfig>,
-    ) -> ExternalCallbacks {
+    ) -> (ExternalCallbacks, Option<oxc_formatter_core::FormatDispatcher>) {
         let needs_embedded = !format_options.embedded_language_formatting.is_off();
         let tailwind_enabled = format_options.sort_tailwindcss.is_some();
+        let dispatcher = needs_embedded.then(|| self.build_dispatcher(dispatch_config));
 
         let embedded_callback = needs_embedded.then(|| {
             embed::string_channel::build_embedded_callback(
@@ -275,14 +279,6 @@ impl ExternalFormatter {
                 tailwind_enabled.then(|| Arc::clone(&self.sort_tailwindcss_classes)),
                 Arc::clone(dispatch_config),
             )
-        });
-
-        let dispatcher = needs_embedded.then(|| {
-            let fallback = embed::prettier_fallback::build_prettier_fallback(
-                Arc::clone(dispatch_config),
-                Arc::clone(&self.format_embedded_doc),
-            );
-            embed::dispatcher::build_dispatcher(Arc::clone(dispatch_config), Some(fallback))
         });
 
         let tailwind_callback: Option<TailwindCallback> = tailwind_enabled.then(|| {
@@ -294,10 +290,25 @@ impl ExternalFormatter {
             }) as TailwindCallback
         });
 
-        ExternalCallbacks::new()
-            .with_embedded_formatter(embedded_callback)
-            .with_dispatcher(dispatcher)
-            .with_tailwind(tailwind_callback)
+        (
+            ExternalCallbacks::new()
+                .with_embedded_formatter(embedded_callback)
+                .with_tailwind(tailwind_callback),
+            dispatcher,
+        )
+    }
+
+    /// Build the `FormatDispatcher` for the JS root's `FormatSession`:
+    /// the native registry plus this formatter's Prettier Doc→IR fallback.
+    fn build_dispatcher(
+        &self,
+        dispatch_config: &Arc<embed::dispatcher::ResolvedDispatchConfig>,
+    ) -> oxc_formatter_core::FormatDispatcher {
+        let fallback = embed::prettier_fallback::build_prettier_fallback(
+            Arc::clone(dispatch_config),
+            Arc::clone(&self.format_embedded_doc),
+        );
+        embed::dispatcher::build_dispatcher(Arc::clone(dispatch_config), Some(fallback))
     }
 
     #[cfg(test)]

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -7,6 +7,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter::JsFormatOptions;
 #[cfg(feature = "napi")]
 use oxc_formatter_core::CoreFormatOptions;
+use oxc_formatter_core::{FormatSession, InputKind};
 use oxc_formatter_css::CssFormatOptions;
 use oxc_formatter_graphql::GraphqlFormatOptions;
 use oxc_formatter_json::{JsonFormatOptions, JsonVariant};
@@ -401,16 +402,20 @@ impl SourceFormatter {
         let allocator = self.allocator_pool.get();
 
         #[cfg(feature = "napi")]
-        let external_callbacks =
-            Some(self.build_external_callbacks(&format_options, config, core, path));
+        let (external_callbacks, dispatcher) = {
+            let (callbacks, dispatcher) =
+                self.build_external_callbacks(&format_options, config, core, path);
+            (Some(callbacks), dispatcher)
+        };
         #[cfg(not(feature = "napi"))]
-        let external_callbacks = {
+        let (external_callbacks, dispatcher) = {
             let _ = path;
-            None
+            (None, None)
         };
 
-        let formatted = oxc_formatter::format(
-            &allocator,
+        let session = FormatSession::new(&allocator, InputKind::PhysicalFile, dispatcher);
+        let formatted = oxc_formatter::format_with_session(
+            &session,
             source_text,
             source_type,
             format_options,
@@ -621,20 +626,22 @@ impl SourceFormatter {
     ///
     /// Tailwind is always considered "capable" here because `oxc_formatter` embeds the sorter internally;
     /// the inject helper itself decides whether to fire based on user config.
+    /// Also returns the `FormatDispatcher` for the JS root's `FormatSession`
+    /// (`None` when `embeddedLanguageFormatting: off`; the gate is owned by `ExternalFormatter::to_external_callbacks`).
     fn build_external_callbacks(
         &self,
         format_options: &JsFormatOptions,
         config: &Arc<FormatConfig>,
         core: CoreFormatOptions,
         path: &Path,
-    ) -> oxc_formatter::ExternalCallbacks {
+    ) -> (oxc_formatter::ExternalCallbacks, Option<oxc_formatter_core::FormatDispatcher>) {
         let external_formatter = self
             .external_formatter
             .as_ref()
             .expect("`external_formatter` must exist when `napi` feature is enabled");
 
-        // Per-language options are mapped lazily at dispatch time; `core` is the
-        // validated bundle carried on the strategy since resolution.
+        // Per-language options are mapped lazily at dispatch time;
+        // `core` is the validated bundle carried on the strategy since resolution.
         let dispatch_config = Arc::new(
             ResolvedDispatchConfig::new(Arc::clone(config), core).with_path(path.to_path_buf()),
         );

--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -23,9 +23,12 @@ The AST-wrapping IR primitives (`AstNode`, `Format`, `Buffer`, …) are `pub(cra
   - Drives context-dependent decisions like forced parentheses / quote style
   - The formatter knows nothing about Prettier/Vue vocabulary, callers pass wrapped source
 - `format_program`: Special-purpose AST-in entry point
-- `ExternalCallbacks` (in `external_formatter.rs`): The host-supplied `FormatDispatcher`
-  (embedded-language formatting, see `oxc_formatter_core`'s `embedded` module)
-  plus string-based / Tailwind callbacks delegated back to the host
+- `format_with_session`: session-aware entry whose `FormatSession` carries the
+  host-supplied `FormatDispatcher` for embedded languages
+  (plain `format` / `format_program` wrap a dispatcher-less `PhysicalFile` session)
+- `ExternalCallbacks` (in `external_formatter.rs`): the string-based (JSDoc fences + html-in-js recovery)
+  and Tailwind callbacks delegated back to the host;
+  IR-channel dispatch is NOT here, it travels on the session
 
 ### Generated code
 

--- a/crates/oxc_formatter/src/external_formatter.rs
+++ b/crates/oxc_formatter/src/external_formatter.rs
@@ -1,15 +1,20 @@
 use std::sync::Arc;
 
-use oxc_allocator::Allocator;
-use oxc_formatter_core::{
-    DispatchOutcome, DispatchRequest, EmbeddedContext, FormatDispatcher, InputKind,
-    UniqueGroupIdBuilder,
-};
-
 /// Callback function type for formatting embedded code.
 /// Takes (tag_name, code) and returns formatted code or an error.
 pub type EmbeddedFormatterCallback =
     Arc<dyn Fn(&str, &str) -> Result<String, String> + Send + Sync>;
+
+/// Parent→child parse-mode context for CSS dispatched from a JS template literal (css-in-js).
+///
+/// Requests SCSS grammar + `${}` placeholder markers + top-level declarations.
+/// Travels as `DispatchRequest::parent_context`;
+/// its ABSENCE means the child parses as a plain standalone stylesheet
+/// (e.g. a JSDoc fence routed through the dispatcher).
+///
+/// Defined here for the same reason as [`HtmlEmbedMeta`]:
+/// it is JS↔CSS pair-specific, and `oxc_formatter` must never depend on language crates.
+pub struct CssInJsTemplate;
 
 /// Child→parent metadata for HTML/Angular formatted as an embedded child.
 ///
@@ -31,34 +36,28 @@ pub type TailwindCallback = Arc<dyn Fn(Vec<String>) -> Vec<String> + Send + Sync
 
 /// External callbacks for JS-side functionality.
 ///
-/// This struct holds all callbacks that delegate to external implementations:
-/// - Embedded language formatting (CSS, GraphQL, HTML in template literals)
-///   via the orchestrator-assembled [`FormatDispatcher`]
+/// This struct holds the callbacks that delegate to the host's JS side:
+/// - String-based embedded formatting (JSDoc fenced blocks + the html-in-js recovery)
 /// - Tailwind CSS class sorting
+///
+/// IR-channel embedded dispatch is NOT here: it travels on the
+/// `FormatSession` this formatter runs under (see `oxc_formatter_core`).
 #[derive(Default, Clone)]
 pub struct ExternalCallbacks {
     embedded_formatter: Option<EmbeddedFormatterCallback>,
-    dispatcher: Option<FormatDispatcher>,
     tailwind: Option<TailwindCallback>,
 }
 
 impl ExternalCallbacks {
     /// Create a new `ExternalCallbacks` with no callbacks set.
     pub fn new() -> Self {
-        Self { embedded_formatter: None, dispatcher: None, tailwind: None }
+        Self { embedded_formatter: None, tailwind: None }
     }
 
     /// Set the embedded formatter callback.
     #[must_use]
     pub fn with_embedded_formatter(mut self, callback: Option<EmbeddedFormatterCallback>) -> Self {
         self.embedded_formatter = callback;
-        self
-    }
-
-    /// Set the embedded-language dispatcher (IR path).
-    #[must_use]
-    pub fn with_dispatcher(mut self, dispatcher: Option<FormatDispatcher>) -> Self {
-        self.dispatcher = dispatcher;
         self
     }
 
@@ -83,55 +82,6 @@ impl ExternalCallbacks {
     /// * `None` - No embedded formatter callback is set
     pub fn format_embedded(&self, language: &str, code: &str) -> Option<Result<String, String>> {
         self.embedded_formatter.as_ref().map(|cb| cb(language, code))
-    }
-
-    /// Format embedded code through the dispatcher (IR path).
-    ///
-    /// Builds an [`EmbeddedContext`] from the current formatting state and
-    /// invokes the dispatcher with it, so the child formatter shares this
-    /// formatter's arena and `GroupId` space (and can recurse further).
-    ///
-    /// # Arguments
-    /// * `allocator` - The arena allocator for allocating strings in `FormatElement::Text`
-    /// * `group_id_builder` - Builder for creating unique `GroupId`s
-    /// * `language` - A generic language identifier (e.g., "css", "graphql", "html", "angular").
-    ///   These are NOT specific to any external formatter.
-    ///   The dispatcher implementation is responsible for mapping them to its own parser/language names.
-    /// * `texts` - The code texts to format (multiple quasis for GraphQL, single joined text for CSS/HTML)
-    ///
-    /// # Returns
-    /// See [`DispatchOutcome`] for the outcome-vs-error contract;
-    /// "no dispatcher set" counts as the deliberate `PreserveOriginal`.
-    ///
-    /// # Errors
-    /// Operational failures only (transport / internal errors).
-    /// NOTE: unlike `FormatSession::dispatch`, this legacy adapter does NOT enforce the recursion limit;
-    /// the guard arrives when embed sites become session-aware.
-    pub fn dispatch_embedded<'a>(
-        &self,
-        allocator: &'a Allocator,
-        group_id_builder: &UniqueGroupIdBuilder,
-        language: &str,
-        texts: &[&str],
-    ) -> Result<DispatchOutcome<'a>, String> {
-        let Some(dispatcher) = self.dispatcher.as_ref() else {
-            return Ok(DispatchOutcome::PreserveOriginal);
-        };
-
-        let ctx = EmbeddedContext {
-            allocator,
-            group_id_builder,
-            dispatcher: Some(Arc::clone(dispatcher)),
-        };
-        // Every JS template embed is a grammar fragment; parser modes
-        // (e.g. css-in-js placeholder tolerance) travel separately.
-        let request = DispatchRequest {
-            language,
-            texts,
-            input_kind: InputKind::Fragment,
-            parent_context: None,
-        };
-        dispatcher(&ctx, request)
     }
 
     /// Sort Tailwind CSS classes.

--- a/crates/oxc_formatter/src/formatter/formatter_js.rs
+++ b/crates/oxc_formatter/src/formatter/formatter_js.rs
@@ -5,9 +5,7 @@
 //! the JS-specific operations are exposed via the [`JsFormatter`] type alias and an
 //! extension trait that is blanket-implemented for the alias.
 
-use oxc_formatter_core::{
-    Buffer, Format, FormatElements, Formatter, GroupId, SourceText, UniqueGroupIdBuilder,
-};
+use oxc_formatter_core::{Buffer, Format, FormatElements, Formatter, GroupId, SourceText};
 use oxc_span::{GetSpan, Span};
 
 use crate::source_text::SourceTextExt as _;
@@ -31,7 +29,6 @@ pub trait JsFormatterExt<'buf, 'ast> {
     fn comments(&self) -> &Comments<'_>;
     fn lines_before(&self, span: Span) -> usize;
     fn group_id(&self, debug_name: &'static str) -> GroupId;
-    fn group_id_builder(&self) -> &UniqueGroupIdBuilder;
     fn join_nodes_with_soft_line<'fmt>(&'fmt mut self) -> JoinNodesBuilder<'fmt, 'buf, 'ast, Line>;
     fn join_nodes_with_hardline<'fmt>(&'fmt mut self) -> JoinNodesBuilder<'fmt, 'buf, 'ast, Line>;
     fn join_nodes_with_space<'fmt>(&'fmt mut self) -> JoinNodesBuilder<'fmt, 'buf, 'ast, Space>;
@@ -65,12 +62,6 @@ impl<'buf, 'ast> JsFormatterExt<'buf, 'ast> for Formatter<'buf, 'ast, JsFormatCo
     #[inline]
     fn group_id(&self, debug_name: &'static str) -> GroupId {
         self.state().group_id(debug_name)
-    }
-
-    /// Returns a reference to the unique group id builder for this document.
-    #[inline]
-    fn group_id_builder(&self) -> &UniqueGroupIdBuilder {
-        self.state().group_id_builder()
     }
 
     fn join_nodes_with_soft_line<'fmt>(&'fmt mut self) -> JoinNodesBuilder<'fmt, 'buf, 'ast, Line> {

--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -33,14 +33,16 @@ pub use self::{
     context::{JsFormatContext, TailwindContextEntry},
     formatter_js::{JsFormatter, JsFormatterExt},
 };
-use oxc_formatter_core::{Arguments, Buffer as _, Document, FormatState, Formatted, VecBuffer};
+use oxc_formatter_core::{
+    Arguments, Buffer as _, Document, FormatSession, FormatState, Formatted, VecBuffer,
+};
 
 /// The `format` function takes an [`Arguments`] struct and returns the resulting formatting IR.
 ///
 /// The [`Arguments`] instance can be created with the [`format_args!`].
 pub fn format<'ast>(
     context: JsFormatContext<'ast>,
-    allocator: &'ast oxc_allocator::Allocator,
+    session: &FormatSession<'ast>,
     arguments: Arguments<'_, 'ast, JsFormatContext<'ast>>,
 ) -> Formatted<'ast, JsFormatContext<'ast>> {
     // Pre-allocate buffer at 40% of source length (source_len * 2 / 5).
@@ -48,7 +50,7 @@ pub fn format<'ast>(
     // with 95th percentile at 30-38% across all file sizes. This 0.4x multiplier avoids reallocation for 95%+ of files.
     let capacity = (context.source_text().len() * 2) / 5;
 
-    let mut state = FormatState::new(context, allocator);
+    let mut state = FormatState::new_with_session(context, session.clone());
     let mut buffer = VecBuffer::with_capacity(capacity, &mut state);
 
     buffer.write_fmt(arguments);

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -17,7 +17,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::Comment;
 use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_formatter_core::Formatted;
+use oxc_formatter_core::{FormatSession, Formatted, InputKind};
 use oxc_parser::{ParseOptions, Parser, ParserReturn};
 use oxc_span::SourceType;
 
@@ -26,7 +26,7 @@ use oxc_span::SourceType;
 // or the special-purpose AST-in `format_program`.
 pub(crate) use crate::ast_nodes::{AstNode, AstNodes};
 pub use crate::external_formatter::{
-    EmbeddedFormatterCallback, ExternalCallbacks, HtmlEmbedMeta, TailwindCallback,
+    CssInJsTemplate, EmbeddedFormatterCallback, ExternalCallbacks, HtmlEmbedMeta, TailwindCallback,
 };
 // `JsFormatContext` is public solely as the type parameter of the `Formatted`
 // returned by `format` / `format_fragment`.
@@ -84,8 +84,33 @@ pub fn format<'a>(
     options: JsFormatOptions,
     external_callbacks: Option<ExternalCallbacks>,
 ) -> Result<Formatted<'a, JsFormatContext<'a>>, OxcDiagnostic> {
-    let program = parse(allocator, source_text, source_type)?;
-    Ok(format_program(allocator, program, options, external_callbacks))
+    // Compatibility wrapper: a dispatcher-less `PhysicalFile` session,
+    // so embedded languages stay as-is.
+    // Hosts that dispatch (oxfmt) use [`format_with_session`].
+    format_with_session(
+        &FormatSession::new(allocator, InputKind::PhysicalFile, None),
+        source_text,
+        source_type,
+        options,
+        external_callbacks,
+    )
+}
+
+/// Like [`format()`], but on a caller-supplied [`FormatSession`]:
+/// the root whose session carries the dispatcher for embedded languages
+/// (css-in-js, graphql-in-js, ...).
+///
+/// # Errors
+/// Same as [`format()`].
+pub fn format_with_session<'a>(
+    session: &FormatSession<'a>,
+    source_text: &'a str,
+    source_type: SourceType,
+    options: JsFormatOptions,
+    external_callbacks: Option<ExternalCallbacks>,
+) -> Result<Formatted<'a, JsFormatContext<'a>>, OxcDiagnostic> {
+    let program = parse(session.allocator(), source_text, source_type)?;
+    Ok(format_program_with_session(session, program, options, external_callbacks))
 }
 
 /// Format a pre-wrapped JS/TS-in-xxx fragment from source text.
@@ -114,6 +139,10 @@ pub fn format_fragment<'a>(
     // But it seems fine for almost all cases, so leave it for now.
     let options = JsFormatOptions { quote_style: QuoteStyle::Single, ..options };
 
+    // A js-in-xxx fragment never owns file envelopes (BOM / front matter)
+    // and never dispatches embedded languages of its own.
+    let session = FormatSession::new(allocator, InputKind::Fragment, None);
+
     let formatted = match context {
         FragmentContext::FunctionParamsAsBindingLhs | FragmentContext::FunctionParamsAsBinding => {
             let Some(Statement::FunctionDeclaration(func)) = program.body.first() else {
@@ -128,7 +157,7 @@ pub fn format_fragment<'a>(
             let node = AstNode::new(params, AstNodes::Dummy(), allocator);
             let content = FormatFunctionParams::new(&node, with_parens);
             format_node(
-                allocator,
+                &session,
                 options,
                 &content,
                 program.source_text,
@@ -149,7 +178,7 @@ pub fn format_fragment<'a>(
             let node = AstNode::new(type_params, AstNodes::Dummy(), allocator);
             let content = FormatTypeParameters::new(&node);
             format_node(
-                allocator,
+                &session,
                 options,
                 &content,
                 program.source_text,
@@ -178,9 +207,24 @@ pub fn format_program<'a>(
     options: JsFormatOptions,
     external_callbacks: Option<ExternalCallbacks>,
 ) -> Formatted<'a, JsFormatContext<'a>> {
-    let node = AstNode::new(program, AstNodes::Dummy(), allocator);
+    format_program_with_session(
+        &FormatSession::new(allocator, InputKind::PhysicalFile, None),
+        program,
+        options,
+        external_callbacks,
+    )
+}
+
+/// Shared AST-in funnel for [`format_with_session`] / [`format_program`].
+fn format_program_with_session<'a>(
+    session: &FormatSession<'a>,
+    program: &'a Program<'a>,
+    options: JsFormatOptions,
+    external_callbacks: Option<ExternalCallbacks>,
+) -> Formatted<'a, JsFormatContext<'a>> {
+    let node = AstNode::new(program, AstNodes::Dummy(), session.allocator());
     format_node(
-        allocator,
+        session,
         options,
         &node,
         program.source_text,
@@ -243,7 +287,7 @@ fn parse<'a>(
 /// Callers ([`format_program`] / [`format_fragment`]) construct the node (a whole-`Program` wrapper or a fragment),
 /// and pass the surrounding `source_text` / `comments`.
 fn format_node<'a, F: Format<'a, JsFormatContext<'a>>>(
-    allocator: &'a Allocator,
+    session: &FormatSession<'a>,
     options: JsFormatOptions,
     node: &F,
     source_text: &'a str,
@@ -255,7 +299,7 @@ fn format_node<'a, F: Format<'a, JsFormatContext<'a>>>(
         JsFormatContext::new(source_text, source_type, comments, options, external_callbacks);
     formatter::format(
         context,
-        allocator,
+        session,
         oxc_formatter_core::Arguments::new(&[oxc_formatter_core::Argument::new(node)]),
     )
 }

--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -1,9 +1,13 @@
 use oxc_allocator::ArenaStringBuilder;
 use oxc_ast::ast::*;
-use oxc_formatter_core::{DispatchOutcome, FormatElement, IndentWidth, format_element::TextWidth};
+use oxc_formatter_core::{
+    DispatchOutcome, DispatchRequest, FormatElement, IndentWidth, InputKind,
+    format_element::TextWidth,
+};
 
 use crate::{
     ast_nodes::AstNode,
+    external_formatter::CssInJsTemplate,
     formatter::prelude::*,
     print::template::{
         FormatTemplateExpression, FormatTemplateExpressionOptions, TemplateExpression,
@@ -51,13 +55,12 @@ pub(super) fn format_css_doc<'a>(
             return true;
         }
 
-        let allocator = f.allocator();
-        let group_id_builder = f.group_id_builder();
-        let Ok(DispatchOutcome::Formatted(mut result)) = f
-            .context()
-            .external_callbacks()
-            .dispatch_embedded(allocator, group_id_builder, "css", &[raw])
-        else {
+        let Ok(DispatchOutcome::Formatted(mut result)) = f.session().dispatch(DispatchRequest {
+            language: "css",
+            texts: &[raw],
+            input_kind: InputKind::Fragment,
+            parent_context: Some(&CssInJsTemplate),
+        }) else {
             return false;
         };
         result.remap_tailwind_into(f.context_mut());
@@ -87,13 +90,12 @@ pub(super) fn format_css_doc<'a>(
     };
 
     // Phase 2: Format via the dispatcher (IR path)
-    let allocator = f.allocator();
-    let group_id_builder = f.group_id_builder();
-    let Ok(DispatchOutcome::Formatted(mut result)) = f
-        .context()
-        .external_callbacks()
-        .dispatch_embedded(allocator, group_id_builder, "css", &[joined])
-    else {
+    let Ok(DispatchOutcome::Formatted(mut result)) = f.session().dispatch(DispatchRequest {
+        language: "css",
+        texts: &[joined],
+        input_kind: InputKind::Fragment,
+        parent_context: Some(&CssInJsTemplate),
+    }) else {
         return false;
     };
     result.remap_tailwind_into(f.context_mut());

--- a/crates/oxc_formatter/src/print/template/embed/graphql.rs
+++ b/crates/oxc_formatter/src/print/template/embed/graphql.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_formatter_core::{
-    DispatchOutcome, FormatElement, IndentWidth,
+    DispatchOutcome, DispatchRequest, FormatElement, IndentWidth, InputKind,
     format_element::{LineMode, TextWidth},
 };
 
@@ -87,13 +87,12 @@ pub(super) fn format_graphql_doc<'a>(
     let all_irs = if texts_to_format.is_empty() {
         vec![]
     } else {
-        let allocator = f.allocator();
-        let group_id_builder = f.group_id_builder();
-        let Ok(DispatchOutcome::Formatted(result)) = f
-            .context()
-            .external_callbacks()
-            .dispatch_embedded(allocator, group_id_builder, "graphql", &texts_to_format)
-        else {
+        let Ok(DispatchOutcome::Formatted(result)) = f.session().dispatch(DispatchRequest {
+            language: "graphql",
+            texts: &texts_to_format,
+            input_kind: InputKind::Fragment,
+            parent_context: None,
+        }) else {
             return false;
         };
         // One IR per sent text is the dispatcher contract for GraphQL.

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -2,7 +2,7 @@ use cow_utils::CowUtils;
 
 use oxc_allocator::ArenaStringBuilder;
 use oxc_ast::ast::*;
-use oxc_formatter_core::{DispatchOutcome, FormatElement};
+use oxc_formatter_core::{DispatchOutcome, DispatchRequest, FormatElement, InputKind};
 use oxc_syntax::line_terminator::LineTerminatorSplitter;
 
 use crate::{
@@ -53,13 +53,12 @@ pub(super) fn format_html_doc<'a>(
         let has_leading_ws = cooked.starts_with(|c: char| c.is_ascii_whitespace());
         let has_trailing_ws = cooked.ends_with(|c: char| c.is_ascii_whitespace());
 
-        let allocator = f.allocator();
-        let group_id_builder = f.group_id_builder();
-        let Ok(DispatchOutcome::Formatted(mut result)) = f
-            .context()
-            .external_callbacks()
-            .dispatch_embedded(allocator, group_id_builder, embedded_language, &[cooked])
-        else {
+        let Ok(DispatchOutcome::Formatted(mut result)) = f.session().dispatch(DispatchRequest {
+            language: embedded_language,
+            texts: &[cooked],
+            input_kind: InputKind::Fragment,
+            parent_context: None,
+        }) else {
             return false;
         };
         let Some(html_has_multiple_root_elements) = result
@@ -80,6 +79,7 @@ pub(super) fn format_html_doc<'a>(
 
         // Re-escape template chars in `Text` runs:
         // the IR is reinserted into a JS template literal built from `.cooked` values.
+        let allocator = f.allocator();
         super::escape_template_chars_in_ir(&mut ir, allocator, f.options().indent_width);
 
         let content = format_once(|f| f.write_elements(ir));
@@ -120,17 +120,16 @@ pub(super) fn format_html_doc<'a>(
     let has_trailing_ws = joined.ends_with(|c: char| c.is_ascii_whitespace());
 
     // Phase 2: Format via the dispatcher (IR path)
-    let allocator = f.allocator();
-    let group_id_builder = f.group_id_builder();
-    let Ok(DispatchOutcome::Formatted(mut result)) = f
-        .context()
-        .external_callbacks()
-        .dispatch_embedded(allocator, group_id_builder, embedded_language, &[joined])
-    else {
+    let Ok(DispatchOutcome::Formatted(mut result)) = f.session().dispatch(DispatchRequest {
+        language: embedded_language,
+        texts: &[joined],
+        input_kind: InputKind::Fragment,
+        parent_context: None,
+    }) else {
         // NOTE: If this html-in-js part contains `<script>` (= js-in-html-in-js),
         // returned Prettier's `Doc` output may contain `conditionalGroup`.
         // But currently, `oxfmt/prettier_compat/from_prettier_doc.rs` does not support this.
-        // So `dispatch_embedded()` will return `Err`.
+        // So the dispatch will return `Err`.
         //
         // In Prettier, `conditionalGroup` is only used by JS and YAML formatting.
         // And we want to format JS by `oxc_formatter` via oxfmt-plugin,
@@ -139,9 +138,12 @@ pub(super) fn format_html_doc<'a>(
         // Support `conditionalGroup` and convert to our `BestFitting` may be possible,
         // but it also requires placeholder replacement, which is non-trivial.
         //
-        // NOTE: `Ok(PreserveOriginal)` lands here too and gets the same recovery attempt;
-        // splitting the match (PreserveOriginal -> plain template path)
-        // is deferred until this site is session-aware.
+        // NOTE: `Ok(PreserveOriginal)` lands here too and gets the same recovery attempt
+        // (today it only arises when the dispatcher is absent,
+        // in which case the string callback is absent under the same gate
+        // and recovery degrades to the plain template path anyway).
+        // Splitting the match is string-channel-migration work,
+        // out of scope while html stays on the Prettier string path.
         return format_js_in_html_as_fallback(joined, &expressions, f);
     };
 

--- a/crates/oxc_formatter/src/print/template/embed/markdown.rs
+++ b/crates/oxc_formatter/src/print/template/embed/markdown.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Allocator, ArenaStringBuilder};
 use oxc_ast::ast::*;
 
-use oxc_formatter_core::DispatchOutcome;
+use oxc_formatter_core::{DispatchOutcome, DispatchRequest, InputKind};
 
 use crate::{ast_nodes::AstNode, format_args, formatter::prelude::*, write};
 
@@ -32,13 +32,12 @@ pub(super) fn try_embed_markdown<'a>(
     let text = if has_indent { strip_indentation(text, indentation, allocator) } else { text };
 
     // Phase 3: Get the IR from the dispatcher
-    let allocator = f.allocator();
-    let group_id_builder = f.group_id_builder();
-    let Ok(DispatchOutcome::Formatted(result)) = f
-        .context()
-        .external_callbacks()
-        .dispatch_embedded(allocator, group_id_builder, "markdown", &[text])
-    else {
+    let Ok(DispatchOutcome::Formatted(result)) = f.session().dispatch(DispatchRequest {
+        language: "markdown",
+        texts: &[text],
+        input_kind: InputKind::Fragment,
+        parent_context: None,
+    }) else {
         return false;
     };
     let Some(mut ir) = result.docs.into_iter().next() else {

--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -75,25 +75,23 @@ The core is parameterized over a consumer-supplied context so it stays language-
 
 ### Embedded-language infrastructure (`embedded.rs`, `session.rs`)
 
-`EmbeddedContext` / `FormatDispatcher` / `DispatchResult` / `TailwindCollector` let one formatter's IR be built inside another's document (e.g. graphql-in-js):
+`FormatSession` / `FormatDispatcher` / `DispatchRequest` / `DispatchResult` / `TailwindCollector` let one formatter's IR be built inside another's document (e.g. graphql-in-js):
 
 - The orchestrator (oxfmt) assembles the dispatcher, mapping language names to formatter implementations (or a Prettier fallback)
-  - Formatter crates only invoke it
-- Parent and child share one arena and one `GroupId` space through `EmbeddedContext`
+  - Formatter crates only invoke it via `FormatSession::dispatch`
+- Parent and child share one arena and one `GroupId` space through the session
 - A language crate's `format_to_ir` entry returns `EmbeddedIr` (IR + pre-sort Tailwind classes), one shape for every child language, no per-crate tuples
 - Cross-language contract data is first-class on `DispatchResult` (`tailwind_classes`)
   - Only truly language-pair specific data crosses as `dyn Any` (e.g. HTML's `has_multiple_root_elements`), core never learns concrete languages
 - Consumers access `DispatchResult.docs` directly (single-doc takes `docs.into_iter().next()`, multi-doc walks `docs`)
   - Call `DispatchResult::remap_tailwind_into` first when the child may carry classes, the printer's `debug_assert` catches a forgotten merge
-- `FormatSession` (`session.rs`) is the successor execution unit:
+- `FormatSession` (`session.rs`) is the execution unit:
   - One arena, one shared `GroupId` space (`Arc<UniqueGroupIdBuilder>`), the dispatcher, and the input's envelope semantics (`InputKind`), usable by standalone roots and dispatched children alike
-  - `FormatState` holds one (`new_with_session`; plain `new` wraps a dispatcher-less `PhysicalFile` session), and `Formatter::session()` exposes it during a write.
-  - `EmbeddedContext` remains as a migration adapter until every entry point is session-aware
+  - `FormatState` holds one (`new_with_session`; plain `new` wraps a dispatcher-less `PhysicalFile` session), and `Formatter::session()` exposes it during a write
 - A dispatch states its request as `DispatchRequest` (language, texts, `InputKind`, pair-specific context) and yields `Result<DispatchOutcome, String>`:
   - `DispatchOutcome::PreserveOriginal` is the DELIBERATE "keep the source as-is" answer (unsupported language, child parse failure, no dispatcher installed); `Err` is reserved for operational failures (transport / internal, recursion limit)
   - Optional-embed callers degrade the same way for both, but never conflate them at the source
   - `FormatSession::dispatch` owns the no-dispatcher case and the recursion limit (`MAX_DISPATCH_DEPTH`), and runs the callback on a `derive_child`ed session
-    (the JS host's legacy `dispatch_embedded` adapter bypasses the guard until it migrates to sessions)
 
 ## What belongs in core (the boundary)
 

--- a/crates/oxc_formatter_core/src/embedded.rs
+++ b/crates/oxc_formatter_core/src/embedded.rs
@@ -14,28 +14,9 @@
 
 use std::{any::Any, sync::Arc};
 
-use oxc_allocator::{Allocator, ArenaVec};
+use oxc_allocator::ArenaVec;
 
-use crate::{FormatElement, InputKind, group_id::UniqueGroupIdBuilder};
-
-/// Shared IR-infrastructure context for formatting embedded code.
-///
-/// The same context is threaded through recursive dispatcher calls so that
-/// nested embeddings (e.g. css-in-html-in-js) share one arena and one
-/// `GroupId` space.
-///
-/// TODO: Migration adapter: [`crate::FormatSession`] supersedes this type
-/// and will replace it once every entry point is session-aware.
-pub struct EmbeddedContext<'a, 'g> {
-    /// Arena shared between parent and child formatters;
-    /// strings allocated by the child live as long as the parent's IR.
-    pub allocator: &'a Allocator,
-    /// `GroupId` builder shared to avoid id collisions across formatters.
-    pub group_id_builder: &'g UniqueGroupIdBuilder,
-    /// Dispatcher for the child formatter to format its own embedded languages.
-    /// `None` when recursion is not available (e.g. plain standalone formatting).
-    pub dispatcher: Option<FormatDispatcher>,
-}
+use crate::{FormatElement, FormatSession, InputKind};
 
 /// One embedded-language formatting request, as the host formatter states it.
 pub struct DispatchRequest<'r> {
@@ -70,14 +51,13 @@ pub enum DispatchOutcome<'a> {
 /// Dispatcher resolving a language name to a formatter implementation.
 ///
 /// Assembled by the orchestrator (oxfmt), which knows all languages;
-/// formatter crates only invoke it.
-/// The intended entry is [`crate::FormatSession::dispatch`]
-/// (which owns the recursion limit and the no-dispatcher case),
-/// but until every entry point is session-aware,
-/// the JS host's `dispatch_embedded` adapter still invokes it directly WITHOUT the depth guard.
+/// formatter crates only invoke it via [`FormatSession::dispatch`],
+/// which owns the recursion limit and the no-dispatcher case.
+/// The callback receives the CHILD session, already derived from the caller's
+/// (same arena / `GroupId` space / dispatcher, the request's `InputKind`, depth + 1).
 pub type FormatDispatcher = Arc<
-    dyn for<'a, 'g, 'r> Fn(
-            &EmbeddedContext<'a, 'g>,
+    dyn for<'a, 'r> Fn(
+            &FormatSession<'a>,
             DispatchRequest<'r>,
         ) -> Result<DispatchOutcome<'a>, String>
         + Send
@@ -144,19 +124,16 @@ impl DispatchResult<'_> {
 
 /// Index-space provider for batched Tailwind class sorting.
 ///
-/// `FormatElement::TailwindClass(usize)` holds pre-sort class strings by
-/// index; sorting happens in one host-supplied batch when the entry
-/// formatter's document is finalized. A child formatter collects classes
-/// locally (0-based) and returns them in [`DispatchResult::tailwind_classes`];
-/// the receiving parent implements this trait on its format context and
-/// calls [`DispatchResult::remap_tailwind_into`] before consuming `docs`.
+/// `FormatElement::TailwindClass(usize)` holds pre-sort class strings by index;
+/// sorting happens in one host-supplied batch when the entry formatter's document is finalized.
+/// A child formatter collects classes locally (0-based) and returns them in [`DispatchResult::tailwind_classes`];
+/// the receiving parent implements this trait on its format context
+/// and calls [`DispatchResult::remap_tailwind_into`] before consuming `docs`.
 ///
-/// NOTE: an alternative design — threading one shared collector through
-/// [`EmbeddedContext`] so children allocate parent indices directly — was
-/// considered and deferred: it needs interior mutability plumbing through
-/// every format context for no current gain. Revisit if deep embedding nests
-/// (e.g. css-in-html-in-js at plan Step 8/9) make per-boundary remapping
-/// burdensome.
+/// NOTE: an alternative design (threading one shared collector through [`FormatSession`]
+/// so children allocate parent indices directly) was considered and deferred:
+/// it needs interior mutability plumbing through every format context for no current gain.
+/// Revisit if deep embedding nests (e.g. css-in-html-in-js at plan Step 8/9) make per-boundary remapping burdensome.
 pub trait TailwindCollector {
     /// Register a class string, returning its index in the collector's space.
     fn add_class(&mut self, class: String) -> usize;

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -44,8 +44,8 @@ pub use buffer::{
 };
 pub use diagnostics::{ActualStart, FormatError, InvalidDocumentError, PrintError};
 pub use embedded::{
-    DispatchOutcome, DispatchRequest, DispatchResult, EmbeddedContext, EmbeddedIr,
-    FormatDispatcher, TailwindCollector,
+    DispatchOutcome, DispatchRequest, DispatchResult, EmbeddedIr, FormatDispatcher,
+    TailwindCollector,
 };
 pub use format::{Format, write};
 pub use format_element::debug::DisplayDocument;

--- a/crates/oxc_formatter_core/src/session.rs
+++ b/crates/oxc_formatter_core/src/session.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 
 use oxc_allocator::Allocator;
 
-use crate::{
-    DispatchOutcome, DispatchRequest, EmbeddedContext, FormatDispatcher, UniqueGroupIdBuilder,
-};
+use crate::{DispatchOutcome, DispatchRequest, FormatDispatcher, UniqueGroupIdBuilder};
 
 /// Upper bound on nested embedded dispatches;
 /// exceeding it is an operational error, catching accidental A-in-B-in-A infinite recursion.
@@ -37,9 +35,6 @@ pub enum InputKind {
 /// so any formatter (not just JS) can dispatch embedded languages.
 /// Cloning hands out another handle to the SAME session (shared `GroupId` space, same depth);
 /// the session for one embedded child comes from [`Self::derive_child`].
-///
-/// TODO: Supersedes [`crate::EmbeddedContext`],
-/// which remains as a migration adapter until every entry point is session-aware.
 #[derive(Clone)]
 pub struct FormatSession<'a> {
     allocator: &'a Allocator,
@@ -86,11 +81,8 @@ impl<'a> FormatSession<'a> {
     /// no dispatcher installed (plain standalone run) counts as the deliberate
     /// `Ok(DispatchOutcome::PreserveOriginal)`, and reaching `MAX_DISPATCH_DEPTH` is an `Err`.
     ///
-    /// TODO: The callback should receive the derived child session itself
-    /// (and must then not create another `GroupId` space or bump the depth again).
-    /// Until the dispatcher signature is session-aware, it receives an
-    /// [`EmbeddedContext`] adapter sourced from the child,
-    /// so the child's bumped depth is not yet visible to nested dispatches.
+    /// The callback receives the derived child session;
+    /// it must not create another `GroupId` space or bump the depth again.
     ///
     /// # Errors
     /// Operational failures only (recursion limit, transport/internal errors).
@@ -103,14 +95,8 @@ impl<'a> FormatSession<'a> {
                 "embedded dispatch exceeded the recursion limit ({MAX_DISPATCH_DEPTH})"
             ));
         }
-        let FormatSession { allocator, group_id_builder, dispatcher: child_dispatcher, .. } =
-            self.derive_child(request.input_kind);
-        let ctx = EmbeddedContext {
-            allocator,
-            group_id_builder: &group_id_builder,
-            dispatcher: child_dispatcher,
-        };
-        dispatcher(&ctx, request)
+        let child = self.derive_child(request.input_kind);
+        dispatcher(&child, request)
     }
 
     /// The arena shared between the root and every embedded child.
@@ -128,12 +114,6 @@ impl<'a> FormatSession<'a> {
     /// Envelope semantics of the input this session formats.
     pub fn input_kind(&self) -> InputKind {
         self.input_kind
-    }
-
-    /// The dispatcher for formatting embedded languages,
-    /// `None` when recursion is unavailable (plain standalone formatting).
-    pub fn dispatcher(&self) -> Option<&FormatDispatcher> {
-        self.dispatcher.as_ref()
     }
 
     /// How many dispatch boundaries deep this session is (0 for a root).

--- a/crates/oxc_formatter_core/src/state.rs
+++ b/crates/oxc_formatter_core/src/state.rs
@@ -2,10 +2,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_allocator::{Allocator, GetAllocator};
 
-use crate::{
-    FormatElement, FormatSession, GroupId, InputKind, UniqueGroupIdBuilder,
-    format_element::Interned,
-};
+use crate::{FormatElement, FormatSession, GroupId, InputKind, format_element::Interned};
 
 /// This structure stores the state that is relevant for the formatting of the whole document.
 ///
@@ -37,9 +34,11 @@ impl<'ast, C> FormatState<'ast, C> {
     /// session with its own `GroupId` space.
     /// Entry points that share a run with other formatters use [`Self::new_with_session`] instead.
     ///
-    /// NOTE: embedded entries (`format_to_ir`) still run through this wrapper,
-    /// so their `input_kind` is mislabeled until they migrate to [`Self::new_with_session`];
-    /// nothing may consult `input_kind` for envelope decisions (front matter, BOM) before that migration.
+    /// NOTE: standalone `format()` compatibility wrappers reach this
+    /// (directly or via their own dispatcher-less session),
+    /// including the string channel's JSDoc-fence formatting, which is semantically a fragment;
+    /// nothing may consult `input_kind` for envelope decisions on those paths
+    /// until that channel routes through the dispatcher.
     pub fn new(context: C, allocator: &'ast Allocator) -> Self {
         Self::new_with_session(
             context,
@@ -96,11 +95,6 @@ impl<'ast, C> FormatState<'ast, C> {
     /// The name is unused for production builds and has no meaning on the equality of two group ids.
     pub fn group_id(&self, debug_name: &'static str) -> GroupId {
         self.session.group_id_builder().group_id(debug_name)
-    }
-
-    /// Returns a reference to the unique group id builder.
-    pub fn group_id_builder(&self) -> &UniqueGroupIdBuilder {
-        self.session.group_id_builder()
     }
 
     #[expect(clippy::mutable_key_type)]

--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -8,9 +8,10 @@ Prettier compatible CSS/SCSS/Less formatter (`oxfmt`'s Tier 1 backend), using th
 
 - Built on `oxc_formatter_core` for the language-agnostic IR + Printer + builders + macros
   - See `crates/oxc_formatter_core/AGENTS.md` for the IR/pipeline details
-- Two entry points:
-  - `format()`: standalone files (returns a printable `Formatted`)
-  - `format_to_ir()`: embedded use via the dispatcher (e.g. css-in-js); tolerates `${}` placeholders and `TopLevelDeclaration`
+- Entry points:
+  - `format()`: standalone files (returns a printable `Formatted`); wraps a dispatcher-less session
+  - `format_with_session()`: standalone on a caller-supplied `FormatSession` (the root that will dispatch front-matter YAML once wired)
+  - `format_to_ir()`: embedded use via the dispatcher; the `template_placeholders` mode enables `${}` placeholders and `TopLevelDeclaration` (css-in-js), `false` is the strict whole-stylesheet grammar
 
 ### Forked parser
 
@@ -22,7 +23,7 @@ The fork adds:
   - Backtick-delimited marker `` `<prefix><digits>` `` with a parameterized inner affix (`TemplatePlaceholder { prefix }`);
   - Backtick is invalid CSS/SCSS/Sass (only Less's inline-JS delimiter), so the marker is
     unmistakably out-of-band, not a real `@var`/`$var` or at-rule
-  - Only `format_to_ir` enables it (with the option unset a backtick is a syntax error)
+  - Only `format_to_ir` with `template_placeholders: true` enables it (with the option unset a backtick is a syntax error)
   - MUST be used with `Syntax::Scss`; css-in-js is `CssVariant::Scss`-hardcoded
   - Tokenized as one typed `Token::Placeholder { index, suffix }` accepted in value / selector / statement / declaration-name positions
     - Per-position layout and coverage: see "css-in-js specifics" below

--- a/crates/oxc_formatter_css/examples/embedded_debug.rs
+++ b/crates/oxc_formatter_css/examples/embedded_debug.rs
@@ -12,7 +12,7 @@
 use std::path::Path;
 
 use oxc_allocator::Allocator;
-use oxc_formatter_core::{Document, EmbeddedContext, FormatOptions, Printer, UniqueGroupIdBuilder};
+use oxc_formatter_core::{Document, FormatOptions, FormatSession, InputKind, Printer};
 use oxc_formatter_css::{CssFormatOptions, CssVariant, format_to_ir};
 
 fn main() {
@@ -30,14 +30,9 @@ fn main() {
         CssFormatOptions { variant: CssVariant::Scss, line_width, ..CssFormatOptions::default() };
 
     let allocator = Allocator::new();
-    let group_id_builder = UniqueGroupIdBuilder::default();
-    let ctx = EmbeddedContext {
-        allocator: &allocator,
-        group_id_builder: &group_id_builder,
-        dispatcher: None,
-    };
+    let session = FormatSession::new(&allocator, InputKind::Fragment, None);
 
-    match format_to_ir(&ctx, &source_text, options) {
+    match format_to_ir(&session, &source_text, options, /* template_placeholders */ true) {
         Ok(embedded) => {
             let document = Document::new(embedded.ir, Vec::new());
             document.propagate_expand();

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -3,7 +3,8 @@ use oxc_css_parser::{ParserBuilder, ParserOptions, TemplatePlaceholder, ast::Sty
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter_core::{
-    Buffer, Document, EmbeddedContext, EmbeddedIr, Format, FormatState, Formatted, VecBuffer,
+    Buffer, Document, EmbeddedIr, Format, FormatSession, FormatState, Formatted, InputKind,
+    VecBuffer,
     builders::{empty_line, hard_line_break, text},
     write,
 };
@@ -40,6 +41,32 @@ pub fn format<'a>(
     options: CssFormatOptions,
     sort_tailwind_classes: Option<TailwindSorter<'_>>,
 ) -> Result<Formatted<'a, CssFormatContext<'a>>, OxcDiagnostic> {
+    // NOTE: this wrapper labels the run `PhysicalFile`.
+    // JSDoc CSS fences still reach it through the string channel,
+    // so front-matter support on this entry MUST NOT land
+    // before those fences route through the dispatcher as `Fragment`s.
+    // Otherwise fence content starting with `---` would wrongly acquire file envelope semantics.
+    format_with_session(
+        &FormatSession::new(allocator, InputKind::PhysicalFile, None),
+        source_text,
+        options,
+        sort_tailwind_classes,
+    )
+}
+
+/// Like [`format()`], but on a caller-supplied [`FormatSession`]:
+/// the root that lets this formatter dispatch its own embedded languages
+/// (front matter YAML, once wired) through the session's dispatcher.
+///
+/// # Errors
+/// Same as [`format()`].
+pub fn format_with_session<'a>(
+    session: &FormatSession<'a>,
+    source_text: &str,
+    options: CssFormatOptions,
+    sort_tailwind_classes: Option<TailwindSorter<'_>>,
+) -> Result<Formatted<'a, CssFormatContext<'a>>, OxcDiagnostic> {
+    let allocator = session.allocator();
     let has_bom = source_text.starts_with('\u{feff}');
 
     let (stylesheet, source, comments) =
@@ -48,7 +75,7 @@ pub fn format<'a>(
 
     let context =
         CssFormatContext::new(options, source, comments, /* template_placeholders */ false);
-    let mut state = FormatState::new(context, allocator);
+    let mut state = FormatState::new_with_session(context, session.clone());
     // Pre-allocate: measured on 616 real-world files (bootstrap, vscode, saleor; css/scss/less),
     // 0.5x source bytes plus a 1024-element floor for tiny-file spikes avoids reallocation for 98% of the corpus.
     let capacity = (source.len() / 2).max(1024);
@@ -74,8 +101,11 @@ pub fn format<'a>(
 /// formatter's document (dispatcher path, e.g. css-in-js).
 ///
 /// Unlike [`format()`], this:
-/// - allocates from the shared arena in `ctx`
+/// - allocates from the session's shared arena and `GroupId` space
 /// - emits neither a BOM nor the trailing newline
+/// - `template_placeholders` enables the css-in-js parse mode
+///   (`` `PLACEHOLDER-N` `` markers + top-level declarations);
+///   JSDoc-style whole-stylesheet fragments pass `false`
 ///
 /// The returned [`EmbeddedIr`] also carries the pre-sort `@apply` Tailwind
 /// classes the IR's `TailwindClass(index)` elements refer to (empty unless
@@ -87,28 +117,21 @@ pub fn format<'a>(
 /// # Errors
 /// Same as [`format()`].
 pub fn format_to_ir<'a>(
-    ctx: &EmbeddedContext<'a, '_>,
+    session: &FormatSession<'a>,
     source_text: &str,
     options: CssFormatOptions,
+    template_placeholders: bool,
 ) -> Result<EmbeddedIr<'a>, OxcDiagnostic> {
-    let allocator = ctx.allocator;
-    // css-in-js: The dispatcher input substitutes `${}` interpolations
-    // with `` `PLACEHOLDER-N` `` markers, which may sit in value or selector position.
-    let allow_placeholders = true;
+    let allocator = session.allocator();
     let (stylesheet, source, comments) = parse_stylesheet(
         allocator,
         source_text,
         options,
-        /* tolerate_placeholders */ allow_placeholders,
+        /* tolerate_placeholders */ template_placeholders,
     )?;
 
-    let context = CssFormatContext::new(
-        options,
-        source,
-        comments,
-        /* template_placeholders */ allow_placeholders,
-    );
-    let mut state = FormatState::new(context, allocator);
+    let context = CssFormatContext::new(options, source, comments, template_placeholders);
+    let mut state = FormatState::new_with_session(context, session.clone());
     let mut buffer = VecBuffer::new(&mut state);
 
     write!(&mut buffer, FormatCssEmbedded { stylesheet: &stylesheet });

--- a/crates/oxc_formatter_css/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_css/tests/fixtures/mod.rs
@@ -70,19 +70,18 @@ impl FixtureFormatter for CssHarness {
 /// Format through `format_to_ir` and print the raw IR, mirroring what the
 /// oxfmt dispatcher + parent template printing do (minus `${}` substitution).
 fn format_embedded(source: &str, options: CssFormatOptions) -> String {
-    use oxc_formatter_core::{
-        Document, EmbeddedContext, FormatElement, FormatOptions, Printer, TextWidth,
-    };
+    use oxc_formatter_core::{Document, FormatElement, FormatOptions, Printer, TextWidth};
 
     let allocator = Allocator::default();
-    let group_id_builder = oxc_formatter_core::UniqueGroupIdBuilder::default();
-    let ctx = EmbeddedContext {
-        allocator: &allocator,
-        group_id_builder: &group_id_builder,
-        dispatcher: None,
-    };
-    let embedded =
-        oxc_formatter_css::format_to_ir(&ctx, source, options).expect("format should succeed");
+    let session = oxc_formatter_core::FormatSession::new(
+        &allocator,
+        oxc_formatter_core::InputKind::Fragment,
+        None,
+    );
+    let embedded = oxc_formatter_css::format_to_ir(
+        &session, source, options, /* template_placeholders */ true,
+    )
+    .expect("format should succeed");
     let document = Document::new(embedded.ir, Vec::new());
     document.propagate_expand();
     let (elements, tailwind_classes) = document.into_elements_and_tailwind_classes();
@@ -100,7 +99,7 @@ fn format_embedded(source: &str, options: CssFormatOptions) -> String {
             }
             other => other.clone(),
         }),
-        &ctx.allocator,
+        &session.allocator(),
     )
     .into_arena_slice();
     let mut code =

--- a/crates/oxc_formatter_graphql/src/format.rs
+++ b/crates/oxc_formatter_graphql/src/format.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter_core::{
-    Buffer, Document, EmbeddedContext, EmbeddedIr, Format, FormatState, Formatted, VecBuffer,
+    Buffer, Document, EmbeddedIr, Format, FormatSession, FormatState, Formatted, VecBuffer,
     builders::{hard_line_break, text},
     write,
 };
@@ -51,7 +51,7 @@ pub fn format<'a>(
 /// formatter's document (dispatcher path, e.g. graphql-in-js).
 ///
 /// Unlike [`format()`], this:
-/// - allocates from the shared arena in `ctx`,
+/// - allocates from the session's shared arena and `GroupId` space,
 ///   so the IR lives as long as the parent's document
 /// - emits neither a BOM nor the trailing newline (the parent owns the layout
 ///   around the embedded part, matching Prettier's `textToDoc` + `stripTrailingHardline` behavior)
@@ -59,15 +59,15 @@ pub fn format<'a>(
 /// # Errors
 /// Same as [`format()`]: any parse error bails out.
 pub fn format_to_ir<'a>(
-    ctx: &EmbeddedContext<'a, '_>,
+    session: &FormatSession<'a>,
     source_text: &str,
     options: GraphqlFormatOptions,
 ) -> Result<EmbeddedIr<'a>, OxcDiagnostic> {
-    let allocator = ctx.allocator;
+    let allocator = session.allocator();
     let (document, source, comments) = parse_document(allocator, source_text)?;
 
     let context = GraphqlFormatContext::new(options, source, comments);
-    let mut state = FormatState::new(context, allocator);
+    let mut state = FormatState::new_with_session(context, session.clone());
     let mut buffer = VecBuffer::new(&mut state);
 
     write!(&mut buffer, FormatGraphqlEmbedded { document });

--- a/crates/oxc_formatter_yaml/src/format.rs
+++ b/crates/oxc_formatter_yaml/src/format.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter_core::{
-    Buffer, Document, EmbeddedContext, EmbeddedIr, Format, FormatState, Formatted, VecBuffer,
+    Buffer, Document, EmbeddedIr, Format, FormatSession, FormatState, Formatted, VecBuffer,
     builders::{hard_line_break, text},
     write,
 };
@@ -50,22 +50,22 @@ pub fn format<'a>(
 /// formatter's document (dispatcher path, e.g. a fenced block in markdown).
 ///
 /// Unlike [`format()`], this:
-/// - allocates from the shared arena in `ctx`, so the IR lives as long as the parent's document
+/// - allocates from the session's shared arena and `GroupId` space, so the IR lives as long as the parent's document
 /// - emits neither a BOM nor the trailing newline
 ///
 /// # Errors
 /// Same as [`format()`]: any parse error bails out.
 pub fn format_to_ir<'a>(
-    ctx: &EmbeddedContext<'a, '_>,
+    session: &FormatSession<'a>,
     source_text: &str,
     options: YamlFormatOptions,
 ) -> Result<EmbeddedIr<'a>, OxcDiagnostic> {
-    let allocator = ctx.allocator;
+    let allocator = session.allocator();
     let (root, source, comments) = parse_root(allocator, source_text)?;
 
     let context =
         YamlFormatContext::new(options, source, comments, print::last_descendant_end(root));
-    let mut state = FormatState::new(context, allocator);
+    let mut state = FormatState::new_with_session(context, session.clone());
     let mut buffer = VecBuffer::new(&mut state);
 
     write!(&mut buffer, FormatYamlEmbedded { root });

--- a/tasks/prettier_conformance/src/jsdoc.rs
+++ b/tasks/prettier_conformance/src/jsdoc.rs
@@ -284,9 +284,11 @@ impl JsdocTestRunner {
         let allocator = Allocator::default();
         let source_type = SourceType::from_path(path).unwrap_or_default();
 
-        // Parse here (not via `oxc_formatter::format`) so recoverable parse errors are tolerated:
-        // some jsdoc fixtures (e.g. duplicate declarations) still format correctly. Only a hard
-        // parser panic aborts. `format_program` is the AST-in entry point for exactly this.
+        // NOTE: Parse here (not via `oxc_formatter::format`) so recoverable parse errors are tolerated,
+        // some jsdoc fixtures (e.g. duplicate declarations) still format correctly.
+        // Only a hard parser panic aborts.
+        // This deliberately DIVERGES from production oxfmt,
+        // whose fail-loud `format()` would report a diagnostic for these fixtures instead of formatting.
         let ret = parse_for_format(&allocator, source_text, source_type);
         if ret.panicked {
             return None;


### PR DESCRIPTION
Apply `FormatSession` everywhere introduced in #25329.