### PR TITLE
refactor(formatter_core): share `split_bom` helper

### DIFF
--- a/apps/oxfmt/test/api/bom.test.ts
+++ b/apps/oxfmt/test/api/bom.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { format } from "../../dist/index.js";
+
+// Pins the physical-file BOM contract (`oxc_formatter_core::spec::split_bom`):
+// each Rust formatter strips the BOM before parsing and re-emits it exactly once at byte 0 of the output.
+describe("BOM handling", () => {
+  it("preserves a leading BOM across Tier 1 languages", async () => {
+    const cases: [string, string, string][] = [
+      ["a.js", "\uFEFFlet a = 1", "\uFEFFlet a = 1;\n"],
+      ["a.css", "\uFEFFa { color: red }", "\uFEFFa {\n  color: red;\n}\n"],
+      ["a.yaml", "\uFEFFkey:   value", "\uFEFFkey: value\n"],
+      ["a.graphql", "\uFEFF{ a }", "\uFEFF{\n  a\n}\n"],
+      ["a.json", '\uFEFF{"a":1}', '\uFEFF{ "a": 1 }\n'],
+    ];
+    for (const [filename, source, expected] of cases) {
+      // oxlint-disable-next-line no-await-in-loop
+      const result = await format(filename, source);
+      expect(result.errors).toStrictEqual([]);
+      expect(result.code).toBe(expected);
+    }
+  });
+
+  it("keeps a BOM-only file as-is", async () => {
+    const result = await format("a.js", "\uFEFF");
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toBe("\uFEFF");
+  });
+
+  it("pins the doubled-BOM behavior (only the first is the BOM; the second reaches the parser)", async () => {
+    // Both parsers treat the second U+FEFF as ordinary whitespace,
+    // so it is swallowed and a single BOM comes back out.
+    const js = await format("a.js", "\uFEFF\uFEFFlet a = 1");
+    expect(js.errors).toStrictEqual([]);
+    expect(js.code).toBe("\uFEFFlet a = 1;\n");
+
+    const yaml = await format("a.yaml", "\uFEFF\uFEFFkey: value");
+    expect(yaml.errors).toStrictEqual([]);
+    expect(yaml.code).toBe("\uFEFFkey: value\n");
+  });
+});

--- a/crates/oxc_formatter/src/print/program.rs
+++ b/crates/oxc_formatter/src/print/program.rs
@@ -3,7 +3,6 @@ use std::ops::Deref;
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
-use oxc_syntax::identifier::ZWNBSP;
 
 use crate::{
     Buffer, Format,
@@ -26,15 +25,15 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Program<'a>> {
             );
         });
 
+        // BOM: JS is the exception to the entries-own-the-strip rule — `format_program`
+        // is AST-in (the formatter never owns pre-parse text) and oxc_parser lexes
+        // U+FEFF as whitespace itself. Detect at print time, re-emit once at byte 0.
+        let has_bom = oxc_formatter_core::spec::split_bom(f.source_text().as_str()).0;
+
         write!(
             f,
             [
-                // BOM
-                f.source_text()
-                    .chars()
-                    .next()
-                    .is_some_and(|c| c == ZWNBSP)
-                    .then_some(text("\u{feff}")),
+                has_bom.then_some(text("\u{feff}")),
                 self.hashbang(),
                 self.directives(),
                 FormatStatementsWithImports(self.body()),

--- a/crates/oxc_formatter/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter/tests/fixtures/mod.rs
@@ -118,5 +118,24 @@ fn test_file(path: &Path) {
     });
 }
 
+/// A leading BOM is preserved (Prettier does the same);
+/// `oxc_parser` keeps it in the source and the root re-emits it at byte 0.
+#[test]
+fn bom_is_preserved() {
+    let allocator = Allocator::default();
+    let formatted = oxc_formatter::format(
+        &allocator,
+        "\u{feff}let a = 1",
+        SourceType::mjs(),
+        JsFormatOptions::default(),
+        None,
+    )
+    .expect("BOM input should parse")
+    .print()
+    .expect("print should succeed")
+    .into_code();
+    assert_eq!(formatted, "\u{feff}let a = 1;\n");
+}
+
 // Include auto-generated test functions from build.rs
 include!(concat!(env!("OUT_DIR"), "/generated_tests.rs"));

--- a/crates/oxc_formatter_core/src/spec/bom.rs
+++ b/crates/oxc_formatter_core/src/spec/bom.rs
@@ -1,0 +1,46 @@
+//! Byte-order-mark handling shared by every formatter's file entries.
+
+/// Splits one leading U+FEFF off `source`, returning whether it was present and the remainder.
+///
+/// The contract every formatter follows: ENTRIES own the strip, parse layers
+/// assume BOM-free input (spans and gap scans never see it).
+/// A physical root entry keeps the flag and re-emits the BOM exactly once at byte 0 of its IR;
+/// an embedded entry (`format_to_ir`) strips as input hygiene and never re-emits.
+/// The one exception is JS: its AST-in entry (`format_program`) means the formatter
+/// never owns pre-parse text — oxc_parser lexes U+FEFF as whitespace itself,
+/// so the root printer detects at print time instead.
+///
+/// Exactly ONE BOM is split: a doubled BOM keeps its second copy in the remainder
+/// and reaches the parser as ordinary input. (matching Prettier, which strips only `charAt(0)`)
+pub fn split_bom(source: &str) -> (bool, &str) {
+    match source.strip_prefix('\u{feff}') {
+        Some(rest) => (true, rest),
+        None => (false, source),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_bom;
+
+    #[test]
+    fn no_bom_passes_through() {
+        assert_eq!(split_bom("a: 1"), (false, "a: 1"));
+        assert_eq!(split_bom(""), (false, ""));
+    }
+
+    #[test]
+    fn one_bom_is_split() {
+        assert_eq!(split_bom("\u{feff}a"), (true, "a"));
+    }
+
+    #[test]
+    fn bom_only_leaves_an_empty_remainder() {
+        assert_eq!(split_bom("\u{feff}"), (true, ""));
+    }
+
+    #[test]
+    fn doubled_bom_keeps_the_second_copy() {
+        assert_eq!(split_bom("\u{feff}\u{feff}a"), (true, "\u{feff}a"));
+    }
+}

--- a/crates/oxc_formatter_core/src/spec/mod.rs
+++ b/crates/oxc_formatter_core/src/spec/mod.rs
@@ -13,11 +13,13 @@
 //! Import discipline: files here import only `std` + `cow_utils`,
 //! never `oxc_*` crates or engine IR types via `crate::`.
 
+mod bom;
 mod gap;
 mod number;
 pub mod string;
 mod suppression;
 
+pub use bom::split_bom;
 pub use gap::{Gap, classify_gap};
 pub use number::{format_trimmed_number, is_simple_number};
 pub use string::normalize_string;

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -67,7 +67,7 @@ pub fn format_with_session<'a>(
     sort_tailwind_classes: Option<TailwindSorter<'_>>,
 ) -> Result<Formatted<'a, CssFormatContext<'a>>, OxcDiagnostic> {
     let allocator = session.allocator();
-    let has_bom = source_text.starts_with('\u{feff}');
+    let (has_bom, source_text) = oxc_formatter_core::spec::split_bom(source_text);
 
     let (stylesheet, source, comments) =
         parse_stylesheet(allocator, source_text, options, /* tolerate_placeholders */ false)?;
@@ -123,6 +123,8 @@ pub fn format_to_ir<'a>(
     template_placeholders: bool,
 ) -> Result<EmbeddedIr<'a>, OxcDiagnostic> {
     let allocator = session.allocator();
+    // Input hygiene: embedded sources may carry a BOM; strip it, never re-emit.
+    let (_, source_text) = oxc_formatter_core::spec::split_bom(source_text);
     let (stylesheet, source, comments) = parse_stylesheet(
         allocator,
         source_text,
@@ -144,15 +146,15 @@ pub fn format_to_ir<'a>(
 
 /// Parse the source into an AST and collect comments, bailing out on any error.
 ///
-/// Copies the source into the arena (minus any BOM, which `oxc-css-parser` would skip anyway)
-/// so every slice taken from it carries `'a`.
+/// Copies the source into the arena so every slice taken from it carries `'a`.
+/// Entries own the BOM strip; a leading `\u{feff}` still reaching this point is content
+/// (e.g. a doubled BOM's second copy) and is the parser's to judge.
 fn parse_stylesheet<'a>(
     allocator: &'a Allocator,
     source_text: &str,
     options: CssFormatOptions,
     tolerate_placeholders: bool,
 ) -> Result<(Stylesheet<'a>, &'a str, &'a [CssComment]), OxcDiagnostic> {
-    let source_text = source_text.strip_prefix('\u{feff}').unwrap_or(source_text);
     // NOTE: Normalize line endings BEFORE parsing like Prettier, unlike other `oxc_formatter_xxx`.
     // For CSS formatter, the printer slices verbatim text from the source in many places.
     // (comments, progid, custom properties, ...etc)

--- a/crates/oxc_formatter_css/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_css/tests/fixtures/mod.rs
@@ -132,6 +132,19 @@ include!(concat!(env!("OUT_DIR"), "/generated_tests.rs"));
 
 // ---
 
+/// A leading BOM is preserved (Prettier does the same).
+#[test]
+fn bom_is_preserved() {
+    let allocator = Allocator::default();
+    let formatted =
+        format(&allocator, "\u{feff}a {\n  color: red;\n}\n", CssFormatOptions::default(), None)
+            .expect("BOM input should parse")
+            .print()
+            .expect("print should succeed")
+            .into_code();
+    assert_eq!(formatted, "\u{feff}a {\n  color: red;\n}\n");
+}
+
 /// Any parse error must surface as `Err` from the standalone `format()` entry,
 /// including oxc-css-parser's recoverable ones (top-level declarations are invalid here
 /// too — only the embedded `format_to_ir` entry tolerates them, see

--- a/crates/oxc_formatter_graphql/src/format.rs
+++ b/crates/oxc_formatter_graphql/src/format.rs
@@ -25,9 +25,7 @@ pub fn format<'a>(
     source_text: &str,
     options: GraphqlFormatOptions,
 ) -> Result<Formatted<'a, GraphqlFormatContext<'a>>, OxcDiagnostic> {
-    // Checked against the original input: `parse_document` strips the BOM
-    // before copying into the arena, so spans and gap scans never see it.
-    let has_bom = source_text.starts_with('\u{feff}');
+    let (has_bom, source_text) = oxc_formatter_core::spec::split_bom(source_text);
     let (document, source, comments) = parse_document(allocator, source_text)?;
 
     let context = GraphqlFormatContext::new(options, source, comments);
@@ -64,6 +62,8 @@ pub fn format_to_ir<'a>(
     options: GraphqlFormatOptions,
 ) -> Result<EmbeddedIr<'a>, OxcDiagnostic> {
     let allocator = session.allocator();
+    // Input hygiene: embedded sources may carry a BOM; strip it, never re-emit.
+    let (_, source_text) = oxc_formatter_core::spec::split_bom(source_text);
     let (document, source, comments) = parse_document(allocator, source_text)?;
 
     let context = GraphqlFormatContext::new(options, source, comments);
@@ -79,15 +79,14 @@ pub fn format_to_ir<'a>(
 /// Parse the source into a direct AST and collect comment trivia,
 /// bailing out on any parse error.
 ///
-/// Copies the source into the arena so every slice taken from it carries `'a`,
-/// stripping any BOM first so offset-based scans never see it
-/// (the caller re-emits it from `has_bom`).
+/// Copies the source into the arena so every slice taken from it carries `'a`.
+/// Entries own the BOM strip; a leading `\u{feff}` still reaching this point is content
+/// (e.g. a doubled BOM's second copy) and is the parser's to judge.
 fn parse_document<'a>(
     allocator: &'a Allocator,
     source_text: &str,
 ) -> Result<(&'a GraphQLDocument<'a>, &'a str, &'a [Span]), OxcDiagnostic> {
-    let source: &'a str =
-        allocator.alloc_str(source_text.strip_prefix('\u{feff}').unwrap_or(source_text));
+    let source: &'a str = allocator.alloc_str(source_text);
 
     // Opt-in graphql-js 17 syntax
     let ast = Parser::new(allocator, source).experimental_fragment_arguments(true).parse();

--- a/crates/oxc_formatter_json/src/format.rs
+++ b/crates/oxc_formatter_json/src/format.rs
@@ -7,7 +7,6 @@ use oxc_formatter_core::{
     write,
 };
 use oxc_span::GetSpan;
-use oxc_syntax::identifier::ZWNBSP;
 
 use crate::{
     comments::write_trailing_inside_comments,
@@ -26,6 +25,7 @@ pub fn format<'a>(
     source_text: &str,
     options: JsonFormatOptions,
 ) -> Result<Formatted<'a, JsonFormatContext<'a>>, OxcDiagnostic> {
+    let (has_bom, source_text) = oxc_formatter_core::spec::split_bom(source_text);
     let parsed = parse_json(allocator, source_text, options.variant)?;
 
     let context = JsonFormatContext::new(
@@ -41,8 +41,6 @@ pub fn format<'a>(
     let capacity = (source_text.len() * 3 / 10).max(1024);
     let mut buffer = VecBuffer::with_capacity(capacity, &mut state);
 
-    // BOM detection runs on the original `source_text`; `wrapped_source` may prepend `(`.
-    let has_bom = source_text.starts_with(ZWNBSP);
     write!(&mut buffer, FormatJsonRoot { expression: parsed.expression, has_bom });
 
     let elements = buffer.into_vec();

--- a/crates/oxc_formatter_yaml/src/format.rs
+++ b/crates/oxc_formatter_yaml/src/format.rs
@@ -24,8 +24,7 @@ pub fn format<'a>(
     source_text: &str,
     options: YamlFormatOptions,
 ) -> Result<Formatted<'a, YamlFormatContext<'a>>, OxcDiagnostic> {
-    // Checked against the original input: `parse_root` strips the BOM
-    let has_bom = source_text.starts_with('\u{feff}');
+    let (has_bom, source_text) = oxc_formatter_core::spec::split_bom(source_text);
     let (root, source, comments) = parse_root(allocator, source_text)?;
 
     let context =
@@ -61,6 +60,8 @@ pub fn format_to_ir<'a>(
     options: YamlFormatOptions,
 ) -> Result<EmbeddedIr<'a>, OxcDiagnostic> {
     let allocator = session.allocator();
+    // Input hygiene: embedded sources may carry a BOM; strip it, never re-emit.
+    let (_, source_text) = oxc_formatter_core::spec::split_bom(source_text);
     let (root, source, comments) = parse_root(allocator, source_text)?;
 
     let context =
@@ -78,11 +79,12 @@ pub fn format_to_ir<'a>(
 /// bailing out on any parse error.
 ///
 /// Copies the source into the arena so every slice taken from it carries `'a`.
+/// Entries own the BOM strip; a leading `\u{feff}` still reaching this point is content
+/// (e.g. a doubled BOM's second copy) and is the parser's to judge.
 fn parse_root<'a>(
     allocator: &'a Allocator,
     source_text: &str,
 ) -> Result<(&'a Root<'a>, &'a str, &'a [SourceComment]), OxcDiagnostic> {
-    let source_text = source_text.strip_prefix('\u{feff}').unwrap_or(source_text);
     // NOTE: Normalize line endings BEFORE parsing, unlike other `oxc_formatter_xxx`.
     // For YAML formatter, the printer slices verbatim text from the source in many places.
     // YAML is also unusual in that line breaks and whitespace have meaning.


### PR DESCRIPTION
In order to standardise the handling of front matter, it was also necessary to standardise the handling of the BOM, which may appear before the FM.