### PR TITLE
refactor(oxfmt): route JSDoc fence through the dispatcher

### DIFF
--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -45,13 +45,17 @@ Oxfmt utilizes different implementations depending on the file extension and fil
 NOTE: Rust written formatters never fall back to Prettier, since they exist to reduce the dependency on Prettier.
 
 Embedded languages (e.g. css-in-js) go through the `FormatDispatcher` (defined in `oxc_formatter_core`) assembled by `src/core/embed/dispatcher.rs`.
-Rust formatter branches (graphql / css / yaml) in every build, plus the Prettier Doc→IR fallback (`embed/prettier_fallback.rs`, napi only) for the rest, the pure Rust build deliberately preserves those as-is. Per-language options are NOT built up front: `ResolvedDispatchConfig` maps them lazily at dispatch time (`OnceLock`-memoized) from the host file's resolved config, including the Prettier options JSON for the JS-side consumers. `src/core/external_formatter.rs` bridges the napi callbacks into these factories.
+Rust formatter branches (the `NativeLanguage` registry in that file) in every build, plus the Prettier Doc→IR fallback (`embed/prettier_fallback.rs`, napi only) for the rest, the pure Rust build deliberately preserves those as-is. Per-language options are NOT built up front: `ResolvedDispatchConfig` maps them lazily at dispatch time (`OnceLock`-memoized) from the host file's resolved config, including the Prettier options JSON for the JS-side consumers. `src/core/external_formatter.rs` bridges the napi callbacks into these factories.
 
-A separate string-out channel (the `embedded_callback` in the same file, NOT the dispatcher) carries the cases that don't fit IR integration.
-Two consumers today:
+A separate string-out channel (the `embedded_callback` in the same file, NOT the dispatcher) carries the string-in/string-out consumers:
 
-- JSDoc fenced code blocks
+- JSDoc fenced code blocks: routing follows ONE rule
+  - a fence language in the `NativeLanguage` registry formats through the dispatcher via a thin string adapter (`string_channel.rs::format_native_fence`)
+  - md/html/angular fences stay on the Prettier string path (their Doc→IR conversion has unrepresentable cases);
+  - everything else stays verbatim
 - html-in-js fallback (`format_js_in_html_as_fallback` in `oxc_formatter/src/print/template/embed/html.rs`)
+
+NOTE: These string-out channel is temporary workaround, should be replaced by native implementations and Prettier usage should be eliminated in the future.
 
 Tailwind class sorting (`sortTailwindcss`) splits responsibilities:
 

--- a/apps/oxfmt/src/core/config/mod.rs
+++ b/apps/oxfmt/src/core/config/mod.rs
@@ -10,6 +10,7 @@ pub use js_config::{JsConfigLoaderCb, JsLoadJsConfigCb, create_js_config_loader}
 pub use nested::NestedConfigCtx;
 
 use std::{
+    borrow::Cow,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -30,10 +31,10 @@ use self::{
     overrides::OxfmtrcOverrides,
 };
 #[cfg(feature = "napi")]
-use super::options::{to_core_options, to_oxc_formatter};
+use super::options::to_oxc_formatter;
 use super::{
     FormatStrategy,
-    options::validate,
+    options::{ValidatedOptions, validate},
     oxfmtrc::{FormatConfig, Oxfmtrc},
     support::FileKind,
     utils,
@@ -142,14 +143,14 @@ pub fn resolve_for_api(
     let mut format_config: FormatConfig =
         serde_json::from_value(raw_config).map_err(|err| err.to_string())?;
     format_config.resolve_tailwind_paths(cwd);
-    // Validate eagerly, as the single gate for every option (core bundle + sortImports):
-    // downstream mapping (`from_format_config`, `ResolvedDispatchConfig`) relies on values having been rejected here,
+    // Validate eagerly, as the single gate for every option (core + js/sortImports):
+    // downstream mapping consumes the derived artifacts and cannot re-fail,
     // and `ExternalFormatter*` kinds have no later chance before values reach Prettier.
-    validate(&format_config)?;
+    let validated = validate(&format_config)?;
     if let Some(plugin) = kind.requires_plugin(&format_config) {
         return Ok(ResolveOutcome::MissingPlugin(plugin));
     }
-    FormatStrategy::from_format_config(format_config, kind).map(ResolveOutcome::Format)
+    Ok(ResolveOutcome::Format(FormatStrategy::from_format_config(format_config, &validated, kind)))
 }
 
 /// Resolved options ready for the embedded callback to drive `oxc_formatter`.
@@ -183,8 +184,8 @@ pub fn resolve_for_embedded_js(
     config: FormatConfig,
     parent_filepath: PathBuf,
 ) -> Result<EmbeddedCallbackResolved, String> {
-    let core = to_core_options(&config)?;
-    let format_options = Box::new(to_oxc_formatter(&config)?);
+    let ValidatedOptions { core, sort_imports } = validate(&config)?;
+    let format_options = Box::new(to_oxc_formatter(&config, core, sort_imports));
     Ok(EmbeddedCallbackResolved { format_options, config: Arc::new(config), core, parent_filepath })
 }
 
@@ -207,9 +208,11 @@ pub struct ConfigResolver {
     raw_config: Value,
     /// Directory containing the config file (for relative path resolution in overrides).
     config_dir: Option<PathBuf>,
-    /// Cached typed `FormatConfig` after `.oxfmtrc` base + `.editorconfig` `[*]` section is folded in.
-    /// Used as the fast-path snapshot when no per-file overrides apply.
-    base_config: Option<FormatConfig>,
+    /// Fast-path snapshot for files without per-file overrides:
+    /// the typed `FormatConfig` (`.oxfmtrc` base + `.editorconfig` `[*]` folded in)
+    /// together with its validation-gate artifacts,
+    /// so the pair can never go stale against each other and the fast path re-derives nothing.
+    base: Option<(FormatConfig, ValidatedOptions)>,
     /// Resolved overrides from `.oxfmtrc` for file-specific matching.
     oxfmtrc_overrides: Option<OxfmtrcOverrides>,
     /// Ignore glob built from this config's `ignorePatterns`.
@@ -230,7 +233,7 @@ impl ConfigResolver {
         Self {
             raw_config,
             config_dir,
-            base_config: None,
+            base: None,
             oxfmtrc_overrides: None,
             ignore_glob: None,
             editorconfig,
@@ -383,12 +386,12 @@ impl ConfigResolver {
     /// Validate config and build the ignore glob from `ignorePatterns` for file walking.
     ///
     /// Side effects:
-    /// - `self.base_config` is set to the validated `FormatConfig` snapshot
-    ///   (with `.editorconfig` `[*]` already folded in)
+    /// - `self.base` is set to the validated `FormatConfig` snapshot
+    ///   (with `.editorconfig` `[*]` already folded in) paired with its gate artifacts
     /// - `self.oxfmtrc_overrides` is set if `overrides` exists
     /// - `self.ignore_glob` is built from `ignorePatterns`
     ///
-    /// Validation runs eagerly via `validate(&base_config)`,
+    /// Validation runs eagerly via `validate()`,
     /// so invalid values are surfaced at config load time, rather than format time.
     ///
     /// # Errors
@@ -419,9 +422,9 @@ impl ConfigResolver {
         }
 
         // Eagerly validate; see method doc for the rationale.
-        validate(&format_config)?;
-        // Save cached snapshot for fast path: no per-file overrides
-        self.base_config = Some(format_config);
+        // The snapshot and its gate artifacts are cached as one pair for the fast path.
+        let validated = validate(&format_config)?;
+        self.base = Some((format_config, validated));
 
         // Build ignore glob from `ignorePatterns` config field
         let ignore_patterns = oxfmtrc.ignore_patterns.unwrap_or_default();
@@ -435,12 +438,16 @@ impl ConfigResolver {
     /// Returns `Err` only when the merged config (after override application) fails validation.
     #[instrument(level = "debug", name = "oxfmt::config::resolve", skip_all, fields(path = %kind.path().display()))]
     pub fn resolve(&self, kind: FileKind) -> Result<ResolveOutcome, String> {
-        let format_config = self.resolve_options(kind.path())?;
+        let (format_config, validated) = self.resolve_options(kind.path())?;
         #[cfg(feature = "napi")]
         if let Some(plugin) = kind.requires_plugin(&format_config) {
             return Ok(ResolveOutcome::MissingPlugin(plugin));
         }
-        FormatStrategy::from_format_config(format_config, kind).map(ResolveOutcome::Format)
+        Ok(ResolveOutcome::Format(FormatStrategy::from_format_config(
+            format_config,
+            &validated,
+            kind,
+        )))
     }
 
     /// Resolve `FormatConfig` for a specific file path.
@@ -450,16 +457,19 @@ impl ConfigResolver {
     /// - `.oxfmtrc` base
     /// - `.oxfmtrc` overrides matching the file path
     ///
-    /// Fast path: Skips validation within this method because `base_config` is pre-validated in [`Self::build_and_validate`].
-    /// Slow path: Always validates the merged config here.
-    /// - For `OxcFormatter` / `OxfmtToml` kinds, [`FormatStrategy::from_format_config`] also re-validates via typed conversion (redundant but harmless).
-    /// - For `ExternalFormatter*` kinds, this is the only safety net before values reach Prettier.
+    /// Fast path: reuses the snapshot + gate artifacts cached by [`Self::build_and_validate`].
+    /// Slow path: always validates the merged config here
+    ///   the single gate for every kind (downstream carving is infallible;
+    ///   for `ExternalFormatter*` kinds this is also the only safety net before values reach Prettier).
     ///
     /// # Errors
     /// Returns `Err` when overrides introduce invalid values, including:
     /// - range-out values (e.g., `printWidth: 1000`)
     /// - broken compound-option combinations (e.g., `sortImports.groups` + `partitionByNewline`)
-    fn resolve_options(&self, path: &Path) -> Result<FormatConfig, String> {
+    fn resolve_options(
+        &self,
+        path: &Path,
+    ) -> Result<(FormatConfig, Cow<'_, ValidatedOptions>), String> {
         let has_editorconfig_overrides =
             self.editorconfig.as_ref().is_some_and(|ec| has_editorconfig_overrides(ec, path));
         let has_oxfmtrc_overrides =
@@ -468,13 +478,12 @@ impl ConfigResolver {
         // Fast path: no per-file overrides → reuse the cached (already-validated) snapshot.
         // `.editorconfig` `[*]` is already folded in during `build_and_validate()`.
         if !has_editorconfig_overrides && !has_oxfmtrc_overrides {
-            return Ok(self
-                .base_config
-                .clone()
-                .expect("`build_and_validate()` must be called first"));
+            let (config, validated) =
+                self.base.as_ref().expect("`build_and_validate()` must be called first");
+            return Ok((config.clone(), Cow::Borrowed(validated)));
         }
 
-        // Slow path: must rebuild from `raw_config`, NOT from `base_config`.
+        // Slow path: must rebuild from `raw_config`, NOT from the cached snapshot.
         // See `raw_config` field doc for why cloning the typed snapshot is insufficient.
         let mut format_config: FormatConfig = serde_json::from_value(self.raw_config.clone())
             .expect("`build_and_validate()` should catch this before");
@@ -497,11 +506,11 @@ impl ConfigResolver {
             format_config.resolve_tailwind_paths(config_dir);
         }
 
-        // Validate the merged config; see method doc for what kinds of errors are caught
-        // and why this is the only safety net for `ExternalFormatter*` kinds.
-        validate(&format_config)?;
+        // Validate the merged config;
+        // see method doc for what kinds of errors are caught and why this is the single gate.
+        let validated = validate(&format_config)?;
 
-        Ok(format_config)
+        Ok((format_config, Cow::Owned(validated)))
     }
 }
 
@@ -596,10 +605,8 @@ mod tests_slow_path_validation {
     }
 
     /// PR #21919 follow-up: invalid override values must be caught at resolve time
-    /// even for `ExternalFormatter*` kinds (which don't re-validate inside
-    /// `from_format_config`). Without slow-path validation in `resolve_options`,
-    /// `printWidth: 1000` (above LineWidth::MAX = 320) would silently leak into
-    /// the Prettier options.
+    /// (`from_format_config` is infallible, so `resolve_options`'s slow-path validation is the only gate).
+    /// Without it, `printWidth: 1000` (above LineWidth::MAX = 320) would silently leak into the Prettier options.
     #[test]
     #[cfg(feature = "napi")]
     fn override_only_invalid_value_is_rejected_for_external_formatter() {
@@ -639,13 +646,8 @@ mod tests_slow_path_validation {
         assert!(err.contains("tabWidth"), "expected tabWidth validation error, got: {err}");
     }
 
-    /// Smoke test: when no overrides match, `resolve()` returns successfully.
-    ///
-    /// `resolve_options` itself skips re-validation on the fast path
-    /// (just clones the pre-validated `base_config`),
-    /// but `FormatStrategy::from_format_config` still runs the typed conversion
-    /// (`to_oxc_formatter` / `to_oxc_toml`) for `OxcFormatter`/`OxfmtToml`,
-    /// so this test cannot directly assert "no re-validation". Only that the overall call succeeds.
+    /// Smoke test: when no overrides match, `resolve()` returns successfully from the fast path
+    /// (cloned pre-validated snapshot + gate artifacts, no re-validation anywhere downstream).
     #[test]
     fn fast_path_resolve_succeeds() {
         let resolver = resolver_from_json(serde_json::json!({ "printWidth": 80 }));

--- a/apps/oxfmt/src/core/embed/dispatcher.rs
+++ b/apps/oxfmt/src/core/embed/dispatcher.rs
@@ -11,16 +11,53 @@ use tracing::{debug, debug_span};
 use oxc_formatter::CssInJsTemplate;
 use oxc_formatter_core::{
     CoreFormatOptions, DispatchOutcome, DispatchRequest, DispatchResult, EmbeddedIr,
-    FormatDispatcher, FormatSession,
+    FormatDispatcher, FormatOptions, FormatSession, PrinterOptions,
 };
 use oxc_formatter_css::{CssFormatOptions, CssVariant};
 use oxc_formatter_graphql::GraphqlFormatOptions;
+use oxc_formatter_json::{JsonFormatOptions, JsonVariant};
 use oxc_formatter_yaml::YamlFormatOptions;
 
 use crate::core::{
-    options::{to_oxc_formatter_css, to_oxc_formatter_graphql, to_oxc_formatter_yaml},
+    options::{
+        to_oxc_formatter_css, to_oxc_formatter_graphql, to_oxc_formatter_json,
+        to_oxc_formatter_yaml,
+    },
     oxfmtrc::FormatConfig,
 };
+
+/// The native formatter registry:
+/// a request/fence language parses to its Rust formatter branch here, or it has none.
+///
+/// [`build_dispatcher`] and the JSDoc string adapter ([`is_native_language`])
+/// both consult this single mapping, so their notions of "native" can never drift.
+enum NativeLanguage {
+    Graphql,
+    /// The fence-derived variant;
+    /// the css-in-js typed context overrides it to Scss + placeholders at dispatch time (see the css branch).
+    Css(CssVariant),
+    Yaml,
+    Json(JsonVariant),
+}
+
+fn native_language(language: &str) -> Option<NativeLanguage> {
+    Some(match language {
+        "graphql" | "gql" => NativeLanguage::Graphql,
+        "css" => NativeLanguage::Css(CssVariant::Css),
+        "scss" => NativeLanguage::Css(CssVariant::Scss),
+        "less" => NativeLanguage::Css(CssVariant::Less),
+        "yaml" | "yml" => NativeLanguage::Yaml,
+        "json" => NativeLanguage::Json(JsonVariant::Json),
+        "jsonc" => NativeLanguage::Json(JsonVariant::Jsonc),
+        "json5" => NativeLanguage::Json(JsonVariant::Json5),
+        _ => return None,
+    })
+}
+
+/// Whether `language` has a native (Rust formatter) branch in the registry.
+pub fn is_native_language(language: &str) -> bool {
+    native_language(language).is_some()
+}
 
 /// Per-run dispatch configuration: the resolved config plus lazily-mapped per-language options.
 ///
@@ -39,6 +76,8 @@ pub struct ResolvedDispatchConfig {
     /// One cell per [`CssVariant`]: JSDoc fences dispatch css/scss/less as-is, while css-in-js always uses Scss.
     css: [OnceLock<CssFormatOptions>; 3],
     yaml: OnceLock<YamlFormatOptions>,
+    /// One cell per fence-reachable [`JsonVariant`] (json / jsonc / json5; `JsonStringify` is `package.json`-only).
+    json: [OnceLock<JsonFormatOptions>; 3],
     /// Host file path, for `filepath` injection into the Prettier options JSON.
     #[cfg(feature = "napi")]
     path: std::path::PathBuf,
@@ -57,6 +96,7 @@ impl ResolvedDispatchConfig {
             graphql: OnceLock::new(),
             css: [OnceLock::new(), OnceLock::new(), OnceLock::new()],
             yaml: OnceLock::new(),
+            json: [OnceLock::new(), OnceLock::new(), OnceLock::new()],
             #[cfg(feature = "napi")]
             path: std::path::PathBuf::new(),
             #[cfg(feature = "napi")]
@@ -90,6 +130,26 @@ impl ResolvedDispatchConfig {
         *self.yaml.get_or_init(|| to_oxc_formatter_yaml(&self.config, self.core))
     }
 
+    pub fn json_options(&self, variant: JsonVariant) -> JsonFormatOptions {
+        let cell = match variant {
+            JsonVariant::Json => &self.json[0],
+            JsonVariant::Jsonc => &self.json[1],
+            JsonVariant::Json5 => &self.json[2],
+            JsonVariant::JsonStringify => {
+                unreachable!(
+                    "JsonStringify is the package.json pipeline's variant, never dispatched"
+                )
+            }
+        };
+        *cell.get_or_init(|| to_oxc_formatter_json(&self.config, self.core, variant))
+    }
+
+    /// Printer options from the shared resolved core bundle;
+    /// the string adapter prints dispatched child IR standalone with these.
+    pub fn print_options(&self) -> PrinterOptions {
+        self.core.as_print_options()
+    }
+
     /// The Prettier options JSON shared by the JS-side consumers
     /// (see [`crate::core::options::build_external_options`]).
     #[cfg(feature = "napi")]
@@ -112,41 +172,38 @@ pub type PrettierDocFallback = Arc<
         + Sync,
 >;
 
-/// Build the `FormatDispatcher` carried by `ExternalCallbacks` (and, once hosts are session-aware, by `FormatSession`):
-/// Rust formatters for graphql / css / yaml (no Prettier fallback for them),
+/// Build the `FormatDispatcher` carried by the root's `FormatSession`:
+/// Rust formatters for the [`NativeLanguage`] registry (no Prettier fallback for them),
 /// `fallback` for everything else.
 pub fn build_dispatcher(
     dispatch_config: Arc<ResolvedDispatchConfig>,
     fallback: Option<PrettierDocFallback>,
 ) -> FormatDispatcher {
     Arc::new(move |session: &FormatSession<'_>, request: DispatchRequest<'_>| {
-        // Rust implementations replace branches one by one;
-        match request.language {
-            "graphql" | "gql" => Ok(formatted_or_preserved(
+        match native_language(request.language) {
+            Some(NativeLanguage::Graphql) => Ok(formatted_or_preserved(
                 format_graphql_to_irs(session, request.texts, dispatch_config.graphql_options()),
                 "format_graphql_to_irs",
             )),
-            "css" | "scss" | "less" => {
+            Some(NativeLanguage::Css(variant)) => {
                 // A wrong text count is a host-contract violation, not a parse failure:
-                // unlike GraphQL's one-IR-per-quasi, the CSS embed joins quasis with
-                // placeholders into a single text before dispatching.
+                // unlike GraphQL's one-IR-per-quasi,
+                // the CSS embed joins quasis with placeholders into a single text before dispatching.
                 let [text] = request.texts else {
                     return Err(format!(
                         "CSS dispatch expects exactly one text, got {}",
                         request.texts.len()
                     ));
                 };
-                // css-in-js (typed `CssInJsTemplate` context) is always parsed as SCSS
-                // with `${}` placeholder markers.
-                // Any other caller gets the strict standalone grammar with the variant
-                // taken from the fence/request language.
+                // css-in-js (typed `CssInJsTemplate` context) is always parsed as SCSS with `${}` placeholder markers.
+                // Any other caller gets the strict standalone grammar with the fence/request language's variant.
                 let (variant, template_placeholders) = if request
                     .parent_context
                     .is_some_and(|c| c.downcast_ref::<CssInJsTemplate>().is_some())
                 {
                     (CssVariant::Scss, true)
                 } else {
-                    (css_variant_for(request.language), false)
+                    (variant, false)
                 };
                 Ok(formatted_or_preserved(
                     format_css_to_ir(
@@ -158,12 +215,16 @@ pub fn build_dispatcher(
                     "format_css_to_ir",
                 ))
             }
-            "yaml" | "yml" => Ok(formatted_or_preserved(
+            Some(NativeLanguage::Yaml) => Ok(formatted_or_preserved(
                 format_yaml_to_irs(session, request.texts, dispatch_config.yaml_options()),
                 "format_yaml_to_irs",
             )),
+            Some(NativeLanguage::Json(variant)) => Ok(formatted_or_preserved(
+                format_json_to_irs(session, request.texts, dispatch_config.json_options(variant)),
+                "format_json_to_irs",
+            )),
             // Everything else: Prettier fallback (Doc→IR path) when available
-            _ => {
+            None => {
                 if let Some(fallback) = &fallback {
                     fallback(session, request.language, request.texts)
                 } else {
@@ -174,16 +235,6 @@ pub fn build_dispatcher(
             }
         }
     })
-}
-
-/// Map a fence/request language to its standalone [`CssVariant`]
-/// (css-in-js is Scss regardless of the tag; see the dispatcher's css arm).
-pub fn css_variant_for(language: &str) -> CssVariant {
-    match language {
-        "scss" => CssVariant::Scss,
-        "less" => CssVariant::Less,
-        _ => CssVariant::Css,
-    }
 }
 
 /// Maps a native branch result: a parse failure is a deliberate skip
@@ -201,26 +252,37 @@ fn formatted_or_preserved<'a>(
     }
 }
 
-/// Format each text as a standalone GraphQL document via `oxc_formatter_graphql`,
-/// returning one IR per text (the IR-channel contract for GraphQL).
+/// Format each text as a standalone document via `format_one`,
+/// returning one IR per text (the IR-channel contract for the per-quasi languages:
+/// graphql templates, yaml front matter bodies, and fenced blocks).
 ///
 /// Any parse error fails the whole batch (an embedded template is all-or-nothing).
-fn format_graphql_to_irs<'a>(
+fn format_texts_to_irs<'a, E: std::fmt::Display>(
     session: &FormatSession<'a>,
     texts: &[&str],
-    options: GraphqlFormatOptions,
+    language: &'static str,
+    format_one: impl Fn(&FormatSession<'a>, &str) -> Result<EmbeddedIr<'a>, E>,
 ) -> Result<DispatchResult<'a>, String> {
     let docs = texts
         .iter()
         .map(|text| {
-            debug_span!("oxfmt::external::format_graphql_to_ir").in_scope(|| {
-                let embedded = oxc_formatter_graphql::format_to_ir(session, text, options)
-                    .map_err(|err| err.to_string())?;
+            debug_span!("oxfmt::external::format_to_ir", language).in_scope(|| {
+                let embedded = format_one(session, text).map_err(|err| err.to_string())?;
                 Ok(embedded.ir)
             })
         })
         .collect::<Result<Vec<_>, String>>()?;
     Ok(DispatchResult { docs, tailwind_classes: Vec::new(), meta: None })
+}
+
+fn format_graphql_to_irs<'a>(
+    session: &FormatSession<'a>,
+    texts: &[&str],
+    options: GraphqlFormatOptions,
+) -> Result<DispatchResult<'a>, String> {
+    format_texts_to_irs(session, texts, "graphql", |session, text| {
+        oxc_formatter_graphql::format_to_ir(session, text, options)
+    })
 }
 
 /// Format the single joined CSS text (placeholders included) via `oxc_formatter_css`,
@@ -239,26 +301,24 @@ fn format_css_to_ir<'a>(
     })
 }
 
-/// Format each text as a standalone YAML document via `oxc_formatter_yaml`,
-/// returning one IR per text (front matter bodies and future fenced blocks).
-///
-/// Any parse error fails the whole batch (an embedded template is all-or-nothing).
+fn format_json_to_irs<'a>(
+    session: &FormatSession<'a>,
+    texts: &[&str],
+    options: JsonFormatOptions,
+) -> Result<DispatchResult<'a>, String> {
+    format_texts_to_irs(session, texts, "json", |session, text| {
+        oxc_formatter_json::format_to_ir(session, text, options)
+    })
+}
+
 fn format_yaml_to_irs<'a>(
     session: &FormatSession<'a>,
     texts: &[&str],
     options: YamlFormatOptions,
 ) -> Result<DispatchResult<'a>, String> {
-    let docs = texts
-        .iter()
-        .map(|text| {
-            debug_span!("oxfmt::external::format_yaml_to_ir").in_scope(|| {
-                let embedded = oxc_formatter_yaml::format_to_ir(session, text, options)
-                    .map_err(|err| err.to_string())?;
-                Ok(embedded.ir)
-            })
-        })
-        .collect::<Result<Vec<_>, String>>()?;
-    Ok(DispatchResult { docs, tailwind_classes: Vec::new(), meta: None })
+    format_texts_to_irs(session, texts, "yaml", |session, text| {
+        oxc_formatter_yaml::format_to_ir(session, text, options)
+    })
 }
 
 #[cfg(test)]
@@ -278,6 +338,41 @@ mod tests {
             Arc::new(FormatConfig::default()),
             CoreFormatOptions::default(),
         ))
+    }
+
+    /// Every fence language the registry claims as native must format
+    /// WITHOUT a fallback installed
+    /// (an accidentally dropped `native_language` entry would fall through to `PreserveOriginal` and fail here).
+    #[test]
+    fn every_native_language_dispatches() {
+        let allocator = Allocator::default();
+        let session = FormatSession::new(
+            &allocator,
+            InputKind::PhysicalFile,
+            Some(build_dispatcher(dispatch_config(), None)),
+        );
+
+        for language in
+            ["graphql", "gql", "css", "scss", "less", "yaml", "yml", "json", "jsonc", "json5"]
+        {
+            let text = match language {
+                "graphql" | "gql" => "{ a }",
+                "css" | "scss" | "less" => "a { color: red }",
+                "yaml" | "yml" => "a: 1",
+                "json" | "jsonc" | "json5" => "{ \"a\": 1 }",
+                other => panic!("no sample input for native language '{other}'"),
+            };
+            let outcome = session.dispatch(DispatchRequest {
+                language,
+                texts: &[text],
+                input_kind: InputKind::Fragment,
+                parent_context: None,
+            });
+            assert!(
+                matches!(outcome, Ok(DispatchOutcome::Formatted(ref result)) if result.docs.len() == 1),
+                "language '{language}' did not dispatch natively"
+            );
+        }
     }
 
     /// Pure-build criterion: the native registry dispatches YAML with no fallback installed.

--- a/apps/oxfmt/src/core/embed/mod.rs
+++ b/apps/oxfmt/src/core/embed/mod.rs
@@ -5,8 +5,8 @@
 //! this module is its concrete counterpart owned by the orchestrator (Oxfmt).
 //!
 //! - [`dispatcher`] (every build): the native registry — `ResolvedDispatchConfig`
-//!   (lazy per-language options) + `build_dispatcher` with Rust branches for
-//!   graphql / css / yaml; IR integrates into the parent's arena / `GroupId` space
+//!   (lazy per-language options) + `build_dispatcher` with a Rust branch per `NativeLanguage`;
+//!   IR integrates into the parent's arena / `GroupId` space
 //! - [`prettier_fallback`] (napi only): Prettier Doc→IR path for the rest
 //! - [`string_channel`] (napi only): string-in/string-out channel
 //!   - JSDoc fenced blocks + html-in-js fallback

--- a/apps/oxfmt/src/core/embed/string_channel.rs
+++ b/apps/oxfmt/src/core/embed/string_channel.rs
@@ -1,13 +1,19 @@
 //! String-in/string-out embedded channel.
 //!
 //! Two consumers reach this channel through the same `EmbeddedFormatterCallback` contract on `ExternalCallbacks`:
-//! - JSDoc fenced code blocks (` ```css `, ` ```graphql `, …)
+//! - JSDoc fenced code blocks (` ```css `, ` ```yaml `, …)
 //! - html-in-js fallback (`format_js_in_html_as_fallback`):
 //!   the IR channel's HTML route returned Prettier Doc that the IR converter can't represent,
 //!   so the parent re-requests the same HTML via this string channel and substitutes placeholders back to `${expr}`.
 //!
+//! Fence routing follows ONE rule: a language in the native registry ([`dispatcher::is_native_language`]) formats
+//! through the dispatcher via [`format_native_fence`];
+//! md/html/angular stay on the Prettier string path
+//! (their Doc→IR conversion has unrepresentable cases,
+//! so forcing them through the dispatcher would regress to verbatim; the wall falls with the HTML Rust port).
+//!
 //! Unlike the [`super::dispatcher`], errors here keep the input verbatim
-//! (no Prettier fallback, no diagnostics for JSDoc since it's inside a comment).
+//! (no Prettier fallback for native languages, no diagnostics for JSDoc since it's inside a comment).
 
 use std::sync::Arc;
 
@@ -15,14 +21,14 @@ use tracing::{debug, debug_span};
 
 use oxc_allocator::Allocator;
 use oxc_formatter::EmbeddedFormatterCallback;
-use oxc_formatter_core::{FormatContext, Formatted};
-use oxc_formatter_css::CssFormatOptions;
-use oxc_formatter_graphql::GraphqlFormatOptions;
+use oxc_formatter_core::{
+    DispatchOutcome, DispatchRequest, DispatchResult, Document, FormatDispatcher, FormatSession,
+    InputKind,
+};
 
 use crate::core::{
     embed::{
-        FormatEmbeddedWithConfigCallback, TailwindWithConfigCallback,
-        dispatcher::{ResolvedDispatchConfig, css_variant_for},
+        FormatEmbeddedWithConfigCallback, TailwindWithConfigCallback, dispatcher,
         language_to_prettier_parser,
     },
     options::inject_parser,
@@ -30,37 +36,31 @@ use crate::core::{
 
 /// Build the `embedded_formatter` callback installed on `ExternalCallbacks`.
 ///
-/// Dispatches by language identifier: a Rust formatter when available (graphql/gql, css/scss/less),
+/// Dispatches by language identifier: the native registry when available,
 /// otherwise Prettier via `format_embedded`.
 /// The JSDoc fenced consumer reaches every language;
 /// the html-in-js fallback only ever passes `"html"` and therefore always lands on the Prettier branch.
 ///
 /// `dispatch_config.external_options()` already carries the Tailwind plugin payload,
-/// so the JS-side sorter can resolve class order when the CSS branch passes its collected `@apply` classes.
+/// so the JS-side sorter can resolve class order when a CSS fence collects `@apply` classes.
 pub fn build_embedded_callback(
     format_embedded: FormatEmbeddedWithConfigCallback,
     sort_tailwind: Option<TailwindWithConfigCallback>,
-    dispatch_config: Arc<ResolvedDispatchConfig>,
+    dispatch_config: Arc<dispatcher::ResolvedDispatchConfig>,
 ) -> EmbeddedFormatterCallback {
+    let fence_dispatcher = dispatcher::build_dispatcher(Arc::clone(&dispatch_config), None);
     Arc::new(move |language: &str, code: &str| {
-        // Rust implementations first (JSDoc fenced code blocks).
-        match language {
-            "graphql" | "gql" => {
-                return format_graphql_embedded(code, dispatch_config.graphql_options());
-            }
-            "css" | "scss" | "less" => {
-                let css_options = dispatch_config.css_options(css_variant_for(language));
-                return match &sort_tailwind {
-                    Some(sort) => {
-                        let sorter = |classes: Vec<String>| {
-                            sort(dispatch_config.external_options(), classes)
-                        };
-                        format_css_embedded(code, css_options, Some(&sorter))
-                    }
-                    None => format_css_embedded(code, css_options, None),
-                };
-            }
-            _ => {}
+        // Native registry first (JSDoc fenced code blocks).
+        if dispatcher::is_native_language(language) {
+            // Native fences never fall back to Prettier,
+            // so the dispatcher is invariant across the callback's lifetime: build it once, not per fence.
+            return format_native_fence(
+                language,
+                code,
+                &fence_dispatcher,
+                &dispatch_config,
+                sort_tailwind.as_ref(),
+            );
         }
         let Some(parser_name) = language_to_prettier_parser(language) else {
             // NOTE: Do not return `Ok(original)` here.
@@ -87,39 +87,59 @@ pub fn build_embedded_callback(
     })
 }
 
-/// Format a JSDoc fenced code block as a standalone GraphQL document
-/// (string-in/string-out, unlike the [`super::dispatcher`] contract).
-fn format_graphql_embedded(code: &str, options: GraphqlFormatOptions) -> Result<String, String> {
-    debug_span!("oxfmt::external::format_graphql_embedded").in_scope(|| {
-        let allocator = Allocator::default();
-        let formatted = oxc_formatter_graphql::format(&allocator, code, options)
-            .map_err(|err| err.to_string())?;
-        print_embedded_block(formatted)
-    })
-}
-
-/// Format a JSDoc fenced code block as a standalone stylesheet
-/// (string-in/string-out, unlike the [`super::dispatcher`] contract).
-/// The `options` already carry the fence language's variant.
-fn format_css_embedded(
+/// Format a JSDoc fenced code block through the native dispatch registry:
+/// a string-in/string-out adapter over the IR contract.
+///
+/// Load-bearing notes:
+/// - The fence has no parent index space, so its Tailwind classes are sorted here
+///   (element-wise: the sorter reorders classes WITHIN each collected string, never the vector,
+///   keeping `TailwindClass(index)` references valid).
+/// - `Err` keeps the fence verbatim, covering both `PreserveOriginal`
+///   (parse failure — never a Prettier fallback for native languages) and operational errors.
+/// - The session-less `EmbeddedFormatterCallback` contract forces a fresh root session per fence,
+///   so `dispatch_depth` resets at this string boundary (inert today: no native fence language re-dispatches).
+///   Threading the parent session through the callback is the eventual fix.
+fn format_native_fence(
+    language: &str,
     code: &str,
-    options: CssFormatOptions,
-    sorter: Option<oxc_formatter_css::TailwindSorter<'_>>,
+    fence_dispatcher: &FormatDispatcher,
+    dispatch_config: &Arc<dispatcher::ResolvedDispatchConfig>,
+    sort_tailwind: Option<&TailwindWithConfigCallback>,
 ) -> Result<String, String> {
-    debug_span!("oxfmt::external::format_css_embedded").in_scope(|| {
+    debug_span!("oxfmt::external::format_native_fence", language = language).in_scope(|| {
         let allocator = Allocator::default();
-        let formatted = oxc_formatter_css::format(&allocator, code, options, sorter)
-            .map_err(|err| err.to_string())?;
-        print_embedded_block(formatted)
-    })
-}
+        let session =
+            FormatSession::new(&allocator, InputKind::Fragment, Some(Arc::clone(fence_dispatcher)));
+        let outcome = session.dispatch(DispatchRequest {
+            language,
+            texts: &[code],
+            input_kind: InputKind::Fragment,
+            parent_context: None,
+        })?;
 
-/// Print a formatted JSDoc fenced code block to a string.
-/// The trailing newline is trimmed because the block is re-embedded
-/// line-by-line into the comment.
-fn print_embedded_block<C: FormatContext>(formatted: Formatted<'_, C>) -> Result<String, String> {
-    let printed = formatted.print().map_err(|err| err.to_string())?;
-    let mut code = printed.into_code();
-    code.truncate(code.trim_end().len());
-    Ok(code)
+        let DispatchOutcome::Formatted(result) = outcome else {
+            return Err(format!("Native formatter for '{language}' kept the input as-is"));
+        };
+        let DispatchResult { mut docs, tailwind_classes, .. } = result;
+        if docs.len() != 1 {
+            return Err(format!("Expected exactly one IR, got {}", docs.len()));
+        }
+        let ir = docs.pop().unwrap();
+
+        let tailwind_classes = match sort_tailwind {
+            Some(sort) if !tailwind_classes.is_empty() => {
+                sort(dispatch_config.external_options(), tailwind_classes)
+            }
+            _ => tailwind_classes,
+        };
+
+        let mut code = Document::new(ir, tailwind_classes)
+            .print(code.len(), dispatch_config.print_options())
+            .map_err(|err| err.to_string())?
+            .into_code();
+        // The block is re-embedded line-by-line into the comment; no trailing newline
+        code.truncate(code.trim_end().len());
+
+        Ok(code)
+    })
 }

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -251,9 +251,10 @@ impl ExternalFormatter {
     ///    so they ride the SAME parent batch as path 1.
     ///    The standalone CSS sort closure is NOT invoked here.
     /// 4. JSDoc fenced CSS (Markdown code fence in JSDoc descriptions):
-    ///    Goes through the string channel,
-    ///    `format_embedded()` returns a formatted string (not parent-integrated IR),
-    ///    so the sort must run inside that call, not via `DispatchResult` remapping.
+    ///    Goes through the string channel's dispatcher adapter,
+    ///    which returns a formatted string (not parent-integrated IR),
+    ///    so there is no parent index space to remap into:
+    ///    the adapter sorts the returned `DispatchResult::tailwind_classes` itself before printing.
     ///    The `string_channel::build_embedded_callback` factory receives the sorter for this case.
     ///
     /// All four paths use the SAME `sort_tailwindcss_classes` napi callback; only the wiring differs.

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -24,7 +24,7 @@ use super::options::{
 };
 use super::{
     options::{
-        to_core_options, to_oxc_formatter, to_oxc_formatter_css, to_oxc_formatter_graphql,
+        ValidatedOptions, to_oxc_formatter, to_oxc_formatter_css, to_oxc_formatter_graphql,
         to_oxc_formatter_json, to_oxc_formatter_yaml, to_oxc_toml, to_sort_package_json,
     },
     oxfmtrc::FormatConfig,
@@ -137,32 +137,38 @@ impl FormatStrategy {
         }
     }
 
-    /// Build a `FormatStrategy` from a typed [`FormatConfig`] and a [`FileKind`].
+    /// Build a `FormatStrategy` from a typed [`FormatConfig`], the validation gate's artifacts, and a [`FileKind`].
     ///
-    /// `to_oxc_formatter` / `to_oxc_toml` run eagerly: their validating
-    /// typed conversion belongs at carving so the format step stays infallible.
-    /// The Prettier `Value` for `ExternalFormatter*` is deferred:
+    /// Infallible by construction:
+    /// every fallible conversion already ran at the gate (`options::validate`),
+    /// whose derived values arrive as `validated`; the option mappers below are pure field translation.
+    ///
+    /// The Prettier `Value` for `ExternalFormatter*` is deferred to the format step:
     /// `FormatConfig` is the single SoT, no validation needed,
     /// and `Box<FormatConfig>` is materially smaller per file than a fully-built `Value`.
-    ///
-    /// # Errors
-    /// Returns `Err` if the kind needs `JsFormatOptions`/`TomlFormatterOptions`
-    /// and the config fails validation.
     // `config` is moved into the napi-only `ExternalFormatter*` variants;
     // when the `napi` feature is off, those branches are cfg-gated out and the
     // value is only borrowed, but we keep the by-value signature for symmetry.
     #[cfg_attr(not(feature = "napi"), expect(clippy::needless_pass_by_value))]
-    pub(crate) fn from_format_config(config: FormatConfig, kind: FileKind) -> Result<Self, String> {
+    pub(crate) fn from_format_config(
+        config: FormatConfig,
+        validated: &ValidatedOptions,
+        kind: FileKind,
+    ) -> Self {
         let insert_final_newline = config.insert_final_newline.unwrap_or(true);
-        // Single validation point for the core options shared by every mapper below;
-        // graphql/css/yaml mappers take the validated bundle and cannot fail.
-        let core = to_core_options(&config)?;
+        // Borrowed so the resolver's fast path can hand out its cached artifacts per file;
+        // `sort_imports` (the only non-`Copy` member) is cloned in the one arm that needs it.
+        let core = validated.core;
 
-        Ok(match kind {
+        match kind {
             FileKind::OxcFormatter { path, source_type } => Self::OxcFormatter {
                 path,
                 source_type,
-                format_options: Box::new(to_oxc_formatter(&config)?),
+                format_options: Box::new(to_oxc_formatter(
+                    &config,
+                    core,
+                    validated.sort_imports.clone(),
+                )),
                 #[cfg(feature = "napi")]
                 config: Arc::new(config),
                 #[cfg(feature = "napi")]
@@ -171,15 +177,16 @@ impl FormatStrategy {
             },
             FileKind::OxcFormatterJson { path, variant } => Self::OxcFormatterJson {
                 path,
-                format_options: Box::new(to_oxc_formatter_json(&config, variant)?),
+                format_options: Box::new(to_oxc_formatter_json(&config, core, variant)),
                 insert_final_newline,
             },
             FileKind::OxcFormatterJsonPackageJson { path } => Self::OxcFormatterJsonPackageJson {
                 path,
                 format_options: Box::new(to_oxc_formatter_json(
                     &config,
+                    core,
                     JsonVariant::JsonStringify,
-                )?),
+                )),
                 sort_package_json: to_sort_package_json(&config),
                 insert_final_newline,
             },
@@ -203,12 +210,18 @@ impl FormatStrategy {
             FileKind::OxcFormatterYamlRc { path } => Self::OxcFormatterYamlRc {
                 path,
                 yaml_format_options: Box::new(to_oxc_formatter_yaml(&config, core)),
-                json_format_options: Box::new(to_oxc_formatter_json(&config, JsonVariant::Json)?),
+                json_format_options: Box::new(to_oxc_formatter_json(
+                    &config,
+                    core,
+                    JsonVariant::Json,
+                )),
                 insert_final_newline,
             },
-            FileKind::OxfmtToml { path } => {
-                Self::OxfmtToml { path, toml_options: to_oxc_toml(&config)?, insert_final_newline }
-            }
+            FileKind::OxfmtToml { path } => Self::OxfmtToml {
+                path,
+                toml_options: to_oxc_toml(&config, core),
+                insert_final_newline,
+            },
             #[cfg(feature = "napi")]
             FileKind::ExternalFormatter {
                 path,
@@ -225,7 +238,7 @@ impl FormatStrategy {
                 supports_svelte,
                 insert_final_newline,
             },
-        })
+        }
     }
 }
 

--- a/apps/oxfmt/src/core/options/mod.rs
+++ b/apps/oxfmt/src/core/options/mod.rs
@@ -10,7 +10,9 @@
 //! - [`to_oxc_toml()`]: `oxc_toml::Options` for TOML formatting
 //! - `to_prettier`(NAPI-only): Prettier-compatible JSON, plus `inject_*` helpers for
 //!   layering in `parser` / `filepath` / plugin payloads at the format step
-//! - [`validate()`]: validate a config without building any formatter's options
+//! - [`validate()`]: the validation gate runs every fallible conversion once
+//!   and returns the derived artifacts ([`ValidatedOptions`]) the mappers above consume,
+//!   which is what keeps them infallible
 
 mod to_core_options;
 mod to_oxc_formatter;
@@ -23,7 +25,6 @@ mod to_oxc_toml;
 mod to_prettier;
 mod validate;
 
-pub use to_core_options::to_core_options;
 pub use to_oxc_formatter::to_oxc_formatter;
 pub use to_oxc_formatter_css::to_oxc_formatter_css;
 pub use to_oxc_formatter_graphql::to_oxc_formatter_graphql;
@@ -35,4 +36,4 @@ pub use to_prettier::{
     build_external_options, inject_filepath, inject_oxfmt_plugin_payload, inject_parser,
     inject_svelte_plugin_payload, inject_tailwind_plugin_payload, to_prettier,
 };
-pub use validate::validate;
+pub use validate::{ValidatedOptions, validate};

--- a/apps/oxfmt/src/core/options/to_core_options.rs
+++ b/apps/oxfmt/src/core/options/to_core_options.rs
@@ -5,13 +5,13 @@ use super::super::oxfmtrc::{EndOfLineConfig, FormatConfig};
 /// Convert the language-neutral core options shared by every formatter into a validated [`CoreFormatOptions`].
 ///
 /// This is the single source of truth for core-option parsing, validation, and default fallbacks.
-/// Each downstream converter ([`super::to_oxc_formatter()`], [`super::to_oxc_toml()`], etc) layers
-/// its language-specific options on top of the result,
-/// so none of them depends on another formatter crate just to resolve these shared fields.
+/// Only the gate ([`super::validate::validate()`]) calls it;
+/// downstream converters receive the resulting bundle as a parameter and never re-derive it
+/// (`pub(super)` enforces that).
 ///
 /// # Errors
 /// Returns an error if `tabWidth` or `printWidth` is out of range.
-pub fn to_core_options(config: &FormatConfig) -> Result<CoreFormatOptions, String> {
+pub(super) fn to_core_options(config: &FormatConfig) -> Result<CoreFormatOptions, String> {
     let mut options = CoreFormatOptions::default();
 
     // [Prettier] useTabs: boolean

--- a/apps/oxfmt/src/core/options/to_oxc_formatter.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter.rs
@@ -1,34 +1,32 @@
 use rustc_hash::FxHashSet;
 
-use oxc_formatter_core::FormatOptions;
-
 use oxc_formatter::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, CommentLineStrategy,
     CustomGroupDefinition, EmbeddedLanguageFormatting, Expand, GroupEntry, ImportModifier,
     ImportSelector, JsFormatOptions, JsdocOptions, LineWrappingStyle, QuoteProperties, QuoteStyle,
     Semicolons, SortImportsOptions, SortOrder, SortTailwindcssOptions, TrailingCommas,
 };
+use oxc_formatter_core::{CoreFormatOptions, FormatOptions};
 
-use super::{
-    super::oxfmtrc::{
-        ArrowParensConfig, CommentLineStrategyConfig, CustomGroupItemConfig,
-        EmbeddedLanguageFormattingConfig, FormatConfig, HtmlWhitespaceSensitivityConfig,
-        JsdocUserConfig, LineWrappingStyleConfig, ObjectWrapConfig, QuotePropsConfig,
-        SortGroupItemConfig, SortImportsUserConfig, SortOrderConfig, SortTailwindcssUserConfig,
-        TrailingCommaConfig,
-    },
-    to_core_options::to_core_options,
+use super::super::oxfmtrc::{
+    ArrowParensConfig, CommentLineStrategyConfig, CustomGroupItemConfig,
+    EmbeddedLanguageFormattingConfig, FormatConfig, HtmlWhitespaceSensitivityConfig,
+    JsdocUserConfig, LineWrappingStyleConfig, ObjectWrapConfig, QuotePropsConfig,
+    SortGroupItemConfig, SortImportsUserConfig, SortOrderConfig, SortTailwindcssUserConfig,
+    TrailingCommaConfig,
 };
 
-/// Convert `FormatConfig` into validated `JsFormatOptions` for `oxc_formatter`.
+/// Convert `FormatConfig` into `JsFormatOptions` for `oxc_formatter`.
 ///
-/// # Errors
-/// Returns error if any option value is invalid.
-pub fn to_oxc_formatter(config: &FormatConfig) -> Result<JsFormatOptions, String> {
-    let core = to_core_options(config)?;
-
+/// NOTE: Pure field translation:
+/// `core` and `sort_imports` are the validation gate's artifacts ([`super::validate::validate()`]), so this cannot fail.
+pub fn to_oxc_formatter(
+    config: &FormatConfig,
+    core_options: CoreFormatOptions,
+    sort_imports: Option<SortImportsOptions>,
+) -> JsFormatOptions {
     let mut format_options = JsFormatOptions::default();
-    format_options.apply_core(core);
+    format_options.apply_core(core_options);
 
     // NOTE: Not yet supported options:
     // [Prettier] experimentalOperatorPosition: "start" | "end"
@@ -121,7 +119,7 @@ pub fn to_oxc_formatter(config: &FormatConfig) -> Result<JsFormatOptions, String
 
     // Below are our own extensions
 
-    format_options.sort_imports = to_sort_imports(config)?;
+    format_options.sort_imports = sort_imports;
     format_options.jsdoc = to_jsdoc(config);
     if let Some(tw_config) =
         config.sort_tailwindcss.clone().and_then(SortTailwindcssUserConfig::into_config)
@@ -136,13 +134,15 @@ pub fn to_oxc_formatter(config: &FormatConfig) -> Result<JsFormatOptions, String
         });
     }
 
-    Ok(format_options)
+    format_options
 }
 
 /// Parse and validate `sortImports` into [`SortImportsOptions`].
 ///
-/// Parsing is the validation here, so this is shared by
-/// both [`to_oxc_formatter()`] (build) and [`super::validate::validate()`] (gate).
+/// If possible, all validations should happen when deserializing `Oxfmtrc`.
+/// However, these options become problematic depending on their combinations.
+/// Also, since it cannot be known until `overrides` are resolved, the validation is done here.
+/// the gate ([`super::validate::validate()`]) runs it once and hands the artifact to [`to_oxc_formatter()`].
 ///
 /// # Errors
 /// Returns an error if the `sortImports` configuration is invalid.
@@ -328,6 +328,12 @@ mod tests {
     use super::super::validate::validate;
     use super::*;
 
+    /// Production shape: the gate validates/derives, then the infallible mapper builds.
+    fn build(config: &FormatConfig) -> Result<JsFormatOptions, String> {
+        let validated = validate(config)?;
+        Ok(to_oxc_formatter(config, validated.core, validated.sort_imports))
+    }
+
     #[test]
     fn test_config_parsing() {
         let json = r#"{
@@ -345,7 +351,7 @@ mod tests {
         }"#;
 
         let config: FormatConfig = serde_json::from_str(json).unwrap();
-        let format_options = to_oxc_formatter(&config).unwrap();
+        let format_options = build(&config).unwrap();
 
         assert!(format_options.indent_style.is_tab());
         assert_eq!(format_options.indent_width.value(), 4);
@@ -369,7 +375,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let format_options = to_oxc_formatter(&config).unwrap();
+        let format_options = build(&config).unwrap();
 
         // Should use defaults
         assert!(format_options.indent_style.is_space());
@@ -381,7 +387,7 @@ mod tests {
     #[test]
     fn test_empty_config() {
         let config: FormatConfig = serde_json::from_str("{}").unwrap();
-        let format_options = to_oxc_formatter(&config).unwrap();
+        let format_options = build(&config).unwrap();
 
         // Should use defaults
         assert!(format_options.indent_style.is_space());
@@ -394,12 +400,12 @@ mod tests {
     fn test_arrow_parens_normalization() {
         // Test "avoid" -> "as-needed" normalization
         let config: FormatConfig = serde_json::from_str(r#"{"arrowParens": "avoid"}"#).unwrap();
-        let format_options = to_oxc_formatter(&config).unwrap();
+        let format_options = build(&config).unwrap();
         assert!(format_options.arrow_parentheses.is_as_needed());
 
         // Test "always" remains unchanged
         let config: FormatConfig = serde_json::from_str(r#"{"arrowParens": "always"}"#).unwrap();
-        let format_options = to_oxc_formatter(&config).unwrap();
+        let format_options = build(&config).unwrap();
         assert!(format_options.arrow_parentheses.is_always());
     }
 
@@ -407,12 +413,12 @@ mod tests {
     fn test_object_wrap_normalization() {
         // Test "preserve" -> "auto" normalization
         let config: FormatConfig = serde_json::from_str(r#"{"objectWrap": "preserve"}"#).unwrap();
-        let format_options = to_oxc_formatter(&config).unwrap();
+        let format_options = build(&config).unwrap();
         assert_eq!(format_options.expand, Expand::Auto);
 
         // Test "collapse" -> "never" normalization
         let config: FormatConfig = serde_json::from_str(r#"{"objectWrap": "collapse"}"#).unwrap();
-        let format_options = to_oxc_formatter(&config).unwrap();
+        let format_options = build(&config).unwrap();
         assert_eq!(format_options.expand, Expand::Never);
     }
 
@@ -424,7 +430,7 @@ mod tests {
         }"#,
         )
         .unwrap();
-        let format_options = to_oxc_formatter(&config).unwrap();
+        let format_options = build(&config).unwrap();
         let sort_imports = format_options.sort_imports.unwrap();
         assert!(sort_imports.newlines_between);
         assert!(!sort_imports.partition_by_newline);
@@ -438,7 +444,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let format_options = to_oxc_formatter(&config).unwrap();
+        let format_options = build(&config).unwrap();
         let sort_imports = format_options.sort_imports.unwrap();
         assert!(!sort_imports.newlines_between);
         assert!(!sort_imports.partition_by_newline);
@@ -452,7 +458,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let format_options = to_oxc_formatter(&config).unwrap();
+        let format_options = build(&config).unwrap();
         let sort_imports = format_options.sort_imports.unwrap();
         assert!(sort_imports.newlines_between);
         assert!(!sort_imports.partition_by_newline);
@@ -466,7 +472,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert!(to_oxc_formatter(&config).is_ok());
+        assert!(build(&config).is_ok());
         let config: FormatConfig = serde_json::from_str(
             r#"{
                 "experimentalSortImports": {
@@ -476,7 +482,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert!(to_oxc_formatter(&config).is_err_and(|e| e.contains("newlinesBetween")));
+        assert!(build(&config).is_err_and(|e| e.contains("newlinesBetween")));
 
         let config: FormatConfig = serde_json::from_str(
             r#"{
@@ -492,7 +498,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let format_options = to_oxc_formatter(&config).unwrap();
+        let format_options = build(&config).unwrap();
         let sort_imports = format_options.sort_imports.unwrap();
         assert_eq!(sort_imports.groups.len(), 5);
         assert_eq!(
@@ -525,7 +531,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let format_options = to_oxc_formatter(&config).unwrap();
+        let format_options = build(&config).unwrap();
         let sort_imports = format_options.sort_imports.unwrap();
         assert_eq!(sort_imports.groups.len(), 3);
         assert_eq!(
@@ -557,7 +563,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert!(to_oxc_formatter(&config).is_err_and(|e| e.contains("start")));
+        assert!(build(&config).is_err_and(|e| e.contains("start")));
 
         // Test error: newlinesBetween at end of groups
         let config: FormatConfig = serde_json::from_str(
@@ -572,7 +578,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert!(to_oxc_formatter(&config).is_err_and(|e| e.contains("end")));
+        assert!(build(&config).is_err_and(|e| e.contains("end")));
 
         // Test error: consecutive newlinesBetween markers
         let config: FormatConfig = serde_json::from_str(
@@ -588,7 +594,7 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert!(to_oxc_formatter(&config).is_err_and(|e| e.contains("consecutive")));
+        assert!(build(&config).is_err_and(|e| e.contains("consecutive")));
 
         // Test error: partitionByNewline with per-group newlinesBetween markers
         let config: FormatConfig = serde_json::from_str(
@@ -604,28 +610,28 @@ mod tests {
             }"#,
         )
         .unwrap();
-        assert!(to_oxc_formatter(&config).is_err_and(|e| e.contains("partitionByNewline")));
+        assert!(build(&config).is_err_and(|e| e.contains("partitionByNewline")));
     }
 
     #[test]
     fn test_bool_for_object_options() {
         let config: FormatConfig = serde_json::from_str(r#"{"sortImports": true}"#).unwrap();
-        assert!(to_oxc_formatter(&config).unwrap().sort_imports.is_some());
+        assert!(build(&config).unwrap().sort_imports.is_some());
 
         let config: FormatConfig = serde_json::from_str(r#"{"sortImports": false}"#).unwrap();
-        assert!(to_oxc_formatter(&config).unwrap().sort_imports.is_none());
+        assert!(build(&config).unwrap().sort_imports.is_none());
 
         let config: FormatConfig = serde_json::from_str(r#"{"sortTailwindcss": true}"#).unwrap();
-        assert!(to_oxc_formatter(&config).unwrap().sort_tailwindcss.is_some());
+        assert!(build(&config).unwrap().sort_tailwindcss.is_some());
 
         let config: FormatConfig = serde_json::from_str(r#"{"sortTailwindcss": false}"#).unwrap();
-        assert!(to_oxc_formatter(&config).unwrap().sort_tailwindcss.is_none());
+        assert!(build(&config).unwrap().sort_tailwindcss.is_none());
 
         let config: FormatConfig = serde_json::from_str(r#"{"jsdoc": true}"#).unwrap();
-        assert!(to_oxc_formatter(&config).unwrap().jsdoc.is_some());
+        assert!(build(&config).unwrap().jsdoc.is_some());
 
         let config: FormatConfig = serde_json::from_str(r#"{"jsdoc": false}"#).unwrap();
-        assert!(to_oxc_formatter(&config).unwrap().jsdoc.is_none());
+        assert!(build(&config).unwrap().jsdoc.is_none());
     }
 
     #[test]
@@ -634,12 +640,12 @@ mod tests {
         let config: FormatConfig =
             serde_json::from_str(r#"{ "printWidth": 80, "sortImports": true }"#).unwrap();
         assert!(validate(&config).is_ok());
-        assert!(to_oxc_formatter(&config).is_ok());
+        assert!(build(&config).is_ok());
 
         // Core range error (valid u16, but outside `LineWidth` bounds).
         let config: FormatConfig = serde_json::from_str(r#"{ "printWidth": 1000 }"#).unwrap();
         assert!(validate(&config).is_err());
-        assert!(to_oxc_formatter(&config).is_err());
+        assert!(build(&config).is_err());
 
         // JS-specific error (sortImports) must be caught by `validate` too,
         // not just by building `JsFormatOptions`.
@@ -648,7 +654,7 @@ mod tests {
         )
         .unwrap();
         assert!(validate(&config).is_err_and(|e| e.contains("start")));
-        assert!(to_oxc_formatter(&config).is_err_and(|e| e.contains("start")));
+        assert!(build(&config).is_err_and(|e| e.contains("start")));
 
         // JS-specific error (jsdoc enum) is rejected at deserialize time,
         // so neither `validate` nor `to_oxc_formatter` can ever see it.

--- a/apps/oxfmt/src/core/options/to_oxc_formatter_json.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter_json.rs
@@ -1,30 +1,26 @@
-use oxc_formatter_core::FormatOptions;
+use oxc_formatter_core::{CoreFormatOptions, FormatOptions};
 use oxc_formatter_json::{
     BracketSpacing, Expand, JsonFormatOptions, JsonVariant, QuoteProps, TrailingCommas,
 };
 
-use super::{
-    super::oxfmtrc::{
-        FormatConfig, ObjectWrapConfig, QuotePropsConfig, SortPackageJsonConfig,
-        SortPackageJsonUserConfig, TrailingCommaConfig,
-    },
-    to_core_options::to_core_options,
+use super::super::oxfmtrc::{
+    FormatConfig, ObjectWrapConfig, QuotePropsConfig, SortPackageJsonConfig,
+    SortPackageJsonUserConfig, TrailingCommaConfig,
 };
 
-/// Convert `FormatConfig` into validated `JsonFormatOptions` for `oxc_formatter_json`.
+/// Convert `FormatConfig` into `JsonFormatOptions` for `oxc_formatter_json`.
 ///
 /// Most JSON-specific output options are fixed by [`oxc_formatter_json::JsonVariant`].
 ///
-/// # Errors
-/// Returns error if any option value is invalid.
+/// NOTE: Pure field translation:
+/// `core` comes pre-validated from the config-resolution gate (`validate()`), so this cannot fail.
 pub fn to_oxc_formatter_json(
     config: &FormatConfig,
+    core_options: CoreFormatOptions,
     variant: JsonVariant,
-) -> Result<JsonFormatOptions, String> {
-    let core = to_core_options(config)?;
-
+) -> JsonFormatOptions {
     let mut options = JsonFormatOptions { variant, ..JsonFormatOptions::default() };
-    options.apply_core(core);
+    options.apply_core(core_options);
 
     // [Prettier] trailingComma: "all" | "es5" | "none"
     if let Some(commas) = config.trailing_comma {
@@ -58,7 +54,7 @@ pub fn to_oxc_formatter_json(
         };
     }
 
-    Ok(options)
+    options
 }
 
 /// Convert `FormatConfig` into `sort_package_json::SortOptions`,

--- a/apps/oxfmt/src/core/options/to_oxc_toml.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_toml.rs
@@ -1,33 +1,29 @@
+use oxc_formatter_core::CoreFormatOptions;
 use oxc_toml::Options as TomlFormatterOptions;
 
-use super::{
-    super::oxfmtrc::{FormatConfig, TrailingCommaConfig},
-    to_core_options::to_core_options,
-};
+use super::super::oxfmtrc::{FormatConfig, TrailingCommaConfig};
 
-/// Convert `FormatConfig` into validated `TomlFormatterOptions` for `oxc_toml`.
+/// Convert `FormatConfig` into `TomlFormatterOptions` for `oxc_toml`.
 ///
 /// Currently, `oxfmtrc` does not have dedicated TOML-specific options.
 /// So it mirrors Prettier's `prettier-plugin-toml` conventions.
 /// <https://github.com/un-ts/prettier/blob/7a4346d5dbf6b63987c0f81228fc46bb12f8692f/packages/toml/src/index.ts#L27-L31>
 ///
-/// # Errors
-/// Returns error if any core option value is invalid (delegates to `to_core_options`).
-pub fn to_oxc_toml(config: &FormatConfig) -> Result<TomlFormatterOptions, String> {
-    let core = to_core_options(config)?;
-
-    Ok(TomlFormatterOptions {
-        column_width: core.line_width.value() as usize,
-        indent_string: if core.indent_style.is_tab() {
+/// NOTE: Pure field translation:
+/// `core` comes pre-validated from the config-resolution gate (`validate()`), so this cannot fail.
+pub fn to_oxc_toml(config: &FormatConfig, core_options: CoreFormatOptions) -> TomlFormatterOptions {
+    TomlFormatterOptions {
+        column_width: core_options.line_width.value() as usize,
+        indent_string: if core_options.indent_style.is_tab() {
             "\t".to_string()
         } else {
-            " ".repeat(core.indent_width.value() as usize)
+            " ".repeat(core_options.indent_width.value() as usize)
         },
-        crlf: core.line_ending.is_carriage_return_line_feed(),
+        crlf: core_options.line_ending.is_carriage_return_line_feed(),
         // [Prettier] trailingComma: "all" | "es5" | "none"
         array_trailing_comma: !matches!(config.trailing_comma, Some(TrailingCommaConfig::None)),
         // NOTE: This is needed to `oxfmtrc.insertFinalNewline` work
         trailing_newline: true,
         ..Default::default()
-    })
+    }
 }

--- a/apps/oxfmt/src/core/options/validate.rs
+++ b/apps/oxfmt/src/core/options/validate.rs
@@ -1,18 +1,31 @@
+use oxc_formatter::SortImportsOptions;
+use oxc_formatter_core::CoreFormatOptions;
+
 use super::{
     super::oxfmtrc::FormatConfig, to_core_options::to_core_options,
     to_oxc_formatter::to_sort_imports,
 };
 
-/// This is the eager validation gate during config resolution.
+/// The artifacts of the validation gate:
+/// every value whose derivation can fail, derived exactly once.
+///
+/// Downstream mapping (`FormatStrategy::from_format_config` and the option mappers) consumes these
+/// instead of re-deriving, so it stays infallible.
+#[derive(Debug, Clone)]
+pub struct ValidatedOptions {
+    pub core: CoreFormatOptions,
+    pub sort_imports: Option<SortImportsOptions>,
+}
+
+/// The eager validation gate during config resolution.
 /// For `ExternalFormatter*` kinds, it is the only safety net before values reach Prettier.
 ///
-/// This lists every fallible conversion rather than building any formatter's options.
-/// (Enumerated options are already rejected at deserialize time.)
+/// This runs every fallible conversion and returns the derived artifacts
+/// (enumerated options are already rejected at deserialize time,
+/// everything else is pure field translation).
 ///
 /// # Errors
 /// Returns an error if any option value is invalid.
-pub fn validate(config: &FormatConfig) -> Result<(), String> {
-    to_core_options(config)?;
-    to_sort_imports(config)?;
-    Ok(())
+pub fn validate(config: &FormatConfig) -> Result<ValidatedOptions, String> {
+    Ok(ValidatedOptions { core: to_core_options(config)?, sort_imports: to_sort_imports(config)? })
 }

--- a/apps/oxfmt/test/api/jsdoc.test.ts
+++ b/apps/oxfmt/test/api/jsdoc.test.ts
@@ -54,11 +54,7 @@ describe("JSDoc", () => {
     );
   });
 
-  it("should format fenced scss, less and graphql through the Rust standalone path", async () => {
-    // Since plan Step 5-1, these languages format via `oxc_formatter_css` /
-    // `oxc_formatter_graphql` (string-in/string-out) instead of Prettier.
-    // scss/less use their own variant (the old Prettier path parsed all of
-    // css/scss/less as scss).
+  it("should format fenced scss, less and graphql through the native dispatch registry", async () => {
     const source = `
 /**
  * \`\`\`scss
@@ -107,8 +103,67 @@ describe("JSDoc", () => {
     );
   });
 
+  it("should format fenced json, json5 and yaml via the native registry", async () => {
+    const source = `
+/**
+ * \`\`\`json
+ * {"a":1,   "b":[2,3]}
+ * \`\`\`
+ *
+ * \`\`\`json5
+ * {a:1,}
+ * \`\`\`
+ *
+ * \`\`\`yaml
+ * key:   value
+ * list:
+ *   -   1
+ * \`\`\`
+ */
+`.trim();
+
+    const result = await format("a.js", source, { jsdoc: {} });
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toBe(
+      `
+/**
+ * \`\`\`json
+ * { "a": 1, "b": [2, 3] }
+ * \`\`\`
+ *
+ * \`\`\`json5
+ * { a: 1 }
+ * \`\`\`
+ *
+ * \`\`\`yaml
+ * key: value
+ * list:
+ *   - 1
+ * \`\`\`
+ */
+`.trimStart(),
+    );
+  });
+
+  it("should keep fenced code verbatim for languages outside the registry", async () => {
+    const source = `
+/**
+ * \`\`\`ruby
+ * var =   1
+ * \`\`\`
+ *
+ * \`\`\`python
+ * x   =   1
+ * \`\`\`
+ */
+`.trim();
+
+    const result = await format("a.ts", source, { jsdoc: {} });
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toBe(`${source}\n`);
+  });
+
   it("should keep fenced code verbatim when the Rust formatter cannot parse it", async () => {
-    // Parse errors inside comments are NOT diagnostics and stays as-is.
     const source = `
 /**
  * \`\`\`css

--- a/crates/oxc_formatter_core/src/format_element/document.rs
+++ b/crates/oxc_formatter_core/src/format_element/document.rs
@@ -4,6 +4,8 @@ use std::ops::Deref;
 use oxc_allocator::ArenaVec;
 use rustc_hash::FxHashMap;
 
+use crate::{PrintResult, Printed, Printer, PrinterOptions};
+
 use super::{
     FormatElement, FormatElements, Interned,
     tag::{self, LabelId, Tag, TagKind},
@@ -48,6 +50,37 @@ impl<'a> Document<'a> {
     /// use this method to set the new elements.
     pub fn replace_elements(&mut self, elements: ArenaVec<'a, FormatElement<'a>>) {
         self.elements = elements.into_arena_slice();
+    }
+
+    /// Finalizes and prints the document: propagates group expansion once
+    /// ([`Self::propagate_expand`]) and hands the elements to the [`Printer`].
+    ///
+    /// The single home of the finalize-once-then-print sequence:
+    /// [`crate::Formatted::print`] and standalone raw-IR consumers
+    /// (e.g. dispatched embedded IR wrapped into a temporary root) delegate here.
+    ///
+    /// # Errors
+    /// Returns `PrintError` if the document contains invalid structure.
+    pub fn print(self, source_size_hint: usize, options: PrinterOptions) -> PrintResult<Printed> {
+        self.propagate_expand();
+        let (elements, sorted_tailwind_classes) = self.into_elements_and_tailwind_classes();
+        Printer::with_capacity(source_size_hint, options, &sorted_tailwind_classes).print(elements)
+    }
+
+    /// Like [`Self::print`], but starts at the given indentation level.
+    ///
+    /// # Errors
+    /// Returns `PrintError` if the document contains invalid structure.
+    pub fn print_with_indent(
+        self,
+        source_size_hint: usize,
+        options: PrinterOptions,
+        indent: u16,
+    ) -> PrintResult<Printed> {
+        self.propagate_expand();
+        let (elements, sorted_tailwind_classes) = self.into_elements_and_tailwind_classes();
+        Printer::with_capacity(source_size_hint, options, &sorted_tailwind_classes)
+            .print_with_indent(elements, indent)
     }
 }
 

--- a/crates/oxc_formatter_core/src/formatted.rs
+++ b/crates/oxc_formatter_core/src/formatted.rs
@@ -1,4 +1,4 @@
-use crate::{Document, FormatContext, FormatOptions, PrintResult, Printed, Printer};
+use crate::{Document, FormatContext, FormatOptions, PrintResult, Printed};
 
 #[derive(Debug)]
 pub struct Formatted<'a, C> {
@@ -47,13 +47,7 @@ impl<C: FormatContext> Formatted<'_, C> {
     pub fn print(self) -> PrintResult<Printed> {
         let print_options = self.context.options().as_print_options();
         let source_size_hint = self.context.source_code().len();
-        self.document.propagate_expand();
-        let (elements, sorted_tailwind_classes) =
-            self.document.into_elements_and_tailwind_classes();
-        let printed =
-            Printer::with_capacity(source_size_hint, print_options, &sorted_tailwind_classes)
-                .print(elements)?;
-        Ok(printed)
+        self.document.print(source_size_hint, print_options)
     }
 
     /// Prints the formatted document to a string, starting at the given indentation level.
@@ -65,12 +59,6 @@ impl<C: FormatContext> Formatted<'_, C> {
     pub fn print_with_indent(self, indent: u16) -> PrintResult<Printed> {
         let print_options = self.context.options().as_print_options();
         let source_size_hint = self.context.source_code().len();
-        self.document.propagate_expand();
-        let (elements, sorted_tailwind_classes) =
-            self.document.into_elements_and_tailwind_classes();
-        let printed =
-            Printer::with_capacity(source_size_hint, print_options, &sorted_tailwind_classes)
-                .print_with_indent(elements, indent)?;
-        Ok(printed)
+        self.document.print_with_indent(source_size_hint, print_options, indent)
     }
 }

--- a/crates/oxc_formatter_css/examples/embedded_debug.rs
+++ b/crates/oxc_formatter_css/examples/embedded_debug.rs
@@ -12,7 +12,7 @@
 use std::path::Path;
 
 use oxc_allocator::Allocator;
-use oxc_formatter_core::{Document, FormatOptions, FormatSession, InputKind, Printer};
+use oxc_formatter_core::{Document, FormatOptions, FormatSession, InputKind};
 use oxc_formatter_css::{CssFormatOptions, CssVariant, format_to_ir};
 
 fn main() {
@@ -35,20 +35,14 @@ fn main() {
     match format_to_ir(&session, &source_text, options, /* template_placeholders */ true) {
         Ok(embedded) => {
             let document = Document::new(embedded.ir, Vec::new());
-            document.propagate_expand();
             if std::env::var("DUMP_IR").is_ok() {
+                // Show the finalized IR (`Document::print` would re-propagate; it's idempotent).
+                document.propagate_expand();
                 for el in document.elements() {
                     eprintln!("{el:?}");
                 }
             }
-            let (elements, tailwind_classes) = document.into_elements_and_tailwind_classes();
-            match Printer::with_capacity(
-                source_text.len(),
-                options.as_print_options(),
-                &tailwind_classes,
-            )
-            .print(elements)
-            {
+            match document.print(source_text.len(), options.as_print_options()) {
                 Ok(printed) => println!("{}", printed.into_code()),
                 Err(err) => eprintln!("Print error: {err:?}"),
             }

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -41,11 +41,9 @@ pub fn format<'a>(
     options: CssFormatOptions,
     sort_tailwind_classes: Option<TailwindSorter<'_>>,
 ) -> Result<Formatted<'a, CssFormatContext<'a>>, OxcDiagnostic> {
-    // NOTE: this wrapper labels the run `PhysicalFile`.
-    // JSDoc CSS fences still reach it through the string channel,
-    // so front-matter support on this entry MUST NOT land
-    // before those fences route through the dispatcher as `Fragment`s.
-    // Otherwise fence content starting with `---` would wrongly acquire file envelope semantics.
+    // NOTE: this wrapper labels the run `PhysicalFile`, so front-matter support may land on this entry.
+    // Every embedded caller (css-in-js, JSDoc fences) reaches the crate through `format_to_ir` as a `Fragment` instead,
+    // and fence content starting with `---` never acquires file envelope semantics.
     format_with_session(
         &FormatSession::new(allocator, InputKind::PhysicalFile, None),
         source_text,

--- a/crates/oxc_formatter_json/AGENTS.md
+++ b/crates/oxc_formatter_json/AGENTS.md
@@ -8,6 +8,9 @@ Prettier compatible JSON/JSONC/JSON5/JSON.stringify formatter (`oxfmt`'s Tier 1 
 
 - Built on `oxc_formatter_core` for the language-agnostic IR + Printer + builders + macros
   - See `crates/oxc_formatter_core/AGENTS.md` for the IR/pipeline details
+- Two entry points:
+  - `format()`: standalone files (returns a printable `Formatted`)
+  - `format_to_ir()`: embedded use via the dispatcher (e.g. a fenced block in JSDoc)
 - This crate holds only the JSON-specific layer
 - Parses with `oxc_parser`, not `serde_json`
   - For Prettier, JSON is not spec compliant JSON

--- a/crates/oxc_formatter_json/src/format.rs
+++ b/crates/oxc_formatter_json/src/format.rs
@@ -2,7 +2,8 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::Expression;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter_core::{
-    Buffer, Document, Format, FormatContext, FormatState, Formatted, VecBuffer,
+    Buffer, Document, EmbeddedIr, Format, FormatContext, FormatSession, FormatState, Formatted,
+    VecBuffer,
     builders::{hard_line_break, text},
     write,
 };
@@ -55,6 +56,48 @@ pub fn format<'a>(
     Ok(Formatted::new(document, context))
 }
 
+/// Parse `source_text` and build the formatter IR for embedding into another
+/// formatter's document (dispatcher path, e.g. a fenced block in JSDoc/markdown).
+///
+/// Unlike [`format()`], this:
+/// - allocates from the session's shared arena and `GroupId` space,
+///   so the IR lives as long as the parent's document
+/// - emits neither a BOM nor the trailing newline (the parent owns the surrounding layout)
+///
+/// # Errors
+/// Same as [`format()`]: any parse error bails out.
+pub fn format_to_ir<'a>(
+    session: &FormatSession<'a>,
+    source_text: &str,
+    options: JsonFormatOptions,
+) -> Result<EmbeddedIr<'a>, OxcDiagnostic> {
+    let allocator = session.allocator();
+    // Input hygiene: embedded sources may carry a BOM; strip it, never re-emit.
+    let (_, source_text) = oxc_formatter_core::spec::split_bom(source_text);
+    let parsed = parse_json(allocator, source_text, options.variant)?;
+
+    let context = JsonFormatContext::new(
+        options,
+        parsed.wrapped_source,
+        parsed.comments,
+        parsed.source_offset,
+    );
+    let mut state = FormatState::new_with_session(context, session.clone());
+    let mut buffer = VecBuffer::new(&mut state);
+
+    write!(&mut buffer, FormatJsonEmbedded { expression: parsed.expression });
+
+    let elements = buffer.into_vec();
+    let context = state.into_context();
+
+    if let Some(err) = context.take_error() {
+        return Err(err);
+    }
+
+    // JSON never collects Tailwind classes
+    Ok(EmbeddedIr { ir: elements, tailwind_classes: Vec::new() })
+}
+
 // ---
 
 /// Emits the root expression (when present) followed by any trailing comments
@@ -70,22 +113,40 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for FormatJsonRoot<'a, '_> {
             write!(f, text("\u{feff}"));
         }
 
-        let trailing_anchor = if let Some(expression) = self.expression {
-            if f.context().options().variant == JsonVariant::JsonStringify {
-                FmtJsonStringifyValue { expression }.fmt(f);
-            } else {
-                FmtJsonValue { expression }.fmt(f);
-            }
-            expression.span().end
-        } else {
-            // Comments-only source: emit pending comments from the start of the source
-            0
-        };
-        let trailing = f.context().comments().take_remaining();
-        write_trailing_inside_comments(trailing, trailing_anchor, f);
+        write_json_content(self.expression, f);
 
         // POSIX convention: every formatted file ends with a newline.
         // Prettier does the same for all parsers.
         write!(f, hard_line_break());
     }
+}
+
+/// Emits the root expression and trailing comments only;
+/// no BOM, no final newline (the parent document owns the surrounding layout).
+struct FormatJsonEmbedded<'a, 'b> {
+    expression: Option<&'b Expression<'a>>,
+}
+
+impl<'a> Format<'a, JsonFormatContext<'a>> for FormatJsonEmbedded<'a, '_> {
+    fn fmt(&self, f: &mut JsonFormatter<'_, 'a>) {
+        write_json_content(self.expression, f);
+    }
+}
+
+/// The shared middle of both roots:
+/// the value followed by any trailing comments at the end of the document.
+fn write_json_content<'a>(expression: Option<&Expression<'a>>, f: &mut JsonFormatter<'_, 'a>) {
+    let trailing_anchor = if let Some(expression) = expression {
+        if f.context().options().variant == JsonVariant::JsonStringify {
+            FmtJsonStringifyValue { expression }.fmt(f);
+        } else {
+            FmtJsonValue { expression }.fmt(f);
+        }
+        expression.span().end
+    } else {
+        // Comments-only source: emit pending comments from the start of the source
+        0
+    };
+    let trailing = f.context().comments().take_remaining();
+    write_trailing_inside_comments(trailing, trailing_anchor, f);
 }

--- a/crates/oxc_formatter_json/src/lib.rs
+++ b/crates/oxc_formatter_json/src/lib.rs
@@ -20,7 +20,7 @@ mod separated;
 
 pub use crate::{
     context::JsonFormatContext,
-    format::format,
+    format::{format, format_to_ir},
     options::{
         BracketSpacing, Expand, JsonFormatOptions, JsonVariant, QuoteProps, SingleQuote,
         TrailingCommas,


### PR DESCRIPTION
Markdown code fences can also be written in JSDoc, and other languages can be formatted as inline code within them.