### PR TITLE
feat(oxfmt): dispatch yaml-in-css(frontmatter) to `oxc_formatter_yaml`

### DIFF
--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -44,7 +44,8 @@ Oxfmt utilizes different implementations depending on the file extension and fil
 
 NOTE: Rust written formatters never fall back to Prettier, since they exist to reduce the dependency on Prettier.
 
-Embedded languages (e.g. css-in-js) go through the `FormatDispatcher` (defined in `oxc_formatter_core`) assembled by `src/core/embed/dispatcher.rs`.
+Embedded languages (e.g. css-in-js, CSS front matter YAML) go through the `FormatDispatcher` (defined in `oxc_formatter_core`) assembled by `src/core/embed/dispatcher.rs`.
+Standalone CSS files also run on a `PhysicalFile` session with a fallback-less registry dispatcher (every build), so front matter YAML formats natively while TOML/custom languages stay verbatim like Prettier; `embeddedLanguageFormatting: off` installs no dispatcher.
 Rust formatter branches (the `NativeLanguage` registry in that file) in every build, plus the Prettier Doc→IR fallback (`embed/prettier_fallback.rs`, napi only) for the rest, the pure Rust build deliberately preserves those as-is. Per-language options are NOT built up front: `ResolvedDispatchConfig` maps them lazily at dispatch time (`OnceLock`-memoized) from the host file's resolved config, including the Prettier options JSON for the JS-side consumers. `src/core/external_formatter.rs` bridges the napi callbacks into these factories.
 
 A separate string-out channel (the `embedded_callback` in the same file, NOT the dispatcher) carries the string-in/string-out consumers:

--- a/apps/oxfmt/src/core/embed/dispatcher.rs
+++ b/apps/oxfmt/src/core/embed/dispatcher.rs
@@ -11,8 +11,10 @@ use tracing::{debug, debug_span};
 use oxc_formatter::CssInJsTemplate;
 use oxc_formatter_core::{
     CoreFormatOptions, DispatchOutcome, DispatchRequest, DispatchResult, EmbeddedIr,
-    FormatDispatcher, FormatOptions, FormatSession, PrinterOptions,
+    FormatDispatcher, FormatSession,
 };
+#[cfg(feature = "napi")]
+use oxc_formatter_core::{FormatOptions, PrinterOptions};
 use oxc_formatter_css::{CssFormatOptions, CssVariant};
 use oxc_formatter_graphql::GraphqlFormatOptions;
 use oxc_formatter_json::{JsonFormatOptions, JsonVariant};
@@ -55,6 +57,8 @@ fn native_language(language: &str) -> Option<NativeLanguage> {
 }
 
 /// Whether `language` has a native (Rust formatter) branch in the registry.
+/// (Consulted by the napi-only JSDoc string adapter; the dispatcher itself matches [`native_language`] directly.)
+#[cfg(feature = "napi")]
 pub fn is_native_language(language: &str) -> bool {
     native_language(language).is_some()
 }
@@ -145,7 +149,8 @@ impl ResolvedDispatchConfig {
     }
 
     /// Printer options from the shared resolved core bundle;
-    /// the string adapter prints dispatched child IR standalone with these.
+    /// the (napi-only) string adapter prints dispatched child IR standalone with these.
+    #[cfg(feature = "napi")]
     pub fn print_options(&self) -> PrinterOptions {
         self.core.as_print_options()
     }
@@ -294,10 +299,10 @@ fn format_css_to_ir<'a>(
     template_placeholders: bool,
 ) -> Result<DispatchResult<'a>, String> {
     debug_span!("oxfmt::external::format_css_to_ir").in_scope(|| {
-        let EmbeddedIr { ir, tailwind_classes } =
+        let embedded =
             oxc_formatter_css::format_to_ir(session, text, options, template_placeholders)
                 .map_err(|err| err.to_string())?;
-        Ok(DispatchResult { docs: vec![ir], tailwind_classes, meta: None })
+        Ok(embedded.into())
     })
 }
 

--- a/apps/oxfmt/src/core/embed/mod.rs
+++ b/apps/oxfmt/src/core/embed/mod.rs
@@ -18,9 +18,6 @@ use std::sync::Arc;
 #[cfg(feature = "napi")]
 use serde_json::Value;
 
-// In the pure Rust build the registry compiles and is tested,
-// but its production consumer (standalone CSS dispatching front-matter YAML) arrives with the FM work.
-#[cfg_attr(all(not(feature = "napi"), not(test)), expect(dead_code))]
 pub mod dispatcher;
 #[cfg(feature = "napi")]
 pub mod prettier_fallback;

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -5,9 +5,7 @@ use tracing::instrument;
 use oxc_allocator::AllocatorPool;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter::JsFormatOptions;
-#[cfg(feature = "napi")]
-use oxc_formatter_core::CoreFormatOptions;
-use oxc_formatter_core::{FormatSession, InputKind};
+use oxc_formatter_core::{CoreFormatOptions, FormatSession, InputKind};
 use oxc_formatter_css::CssFormatOptions;
 use oxc_formatter_graphql::GraphqlFormatOptions;
 use oxc_formatter_json::{JsonFormatOptions, JsonVariant};
@@ -16,13 +14,12 @@ use oxc_span::SourceType;
 use oxc_toml::Options as TomlFormatterOptions;
 
 #[cfg(feature = "napi")]
-use super::embed::dispatcher::ResolvedDispatchConfig;
-#[cfg(feature = "napi")]
 use super::options::{
-    build_external_options, inject_filepath, inject_oxfmt_plugin_payload, inject_parser,
-    inject_svelte_plugin_payload, inject_tailwind_plugin_payload, to_prettier,
+    inject_filepath, inject_oxfmt_plugin_payload, inject_parser, inject_svelte_plugin_payload,
+    inject_tailwind_plugin_payload, to_prettier,
 };
 use super::{
+    embed::dispatcher::{ResolvedDispatchConfig, build_dispatcher},
     options::{
         ValidatedOptions, to_oxc_formatter, to_oxc_formatter_css, to_oxc_formatter_graphql,
         to_oxc_formatter_json, to_oxc_formatter_yaml, to_oxc_toml, to_sort_package_json,
@@ -76,12 +73,15 @@ pub enum FormatStrategy {
         insert_final_newline: bool,
     },
     /// For CSS/SCSS/Less files formatted by `oxc_formatter_css`.
-    /// `config` is retained (napi only) to build the Tailwind class sorter options.
+    /// `config` + `core` build the dispatch config for the root's session
+    /// (front matter YAML, plus the napi Tailwind sorter options).
     OxcFormatterCss {
         path: Arc<Path>,
         format_options: Box<CssFormatOptions>,
-        #[cfg(feature = "napi")]
-        config: Box<FormatConfig>,
+        config: Arc<FormatConfig>,
+        /// The validated core bundle, carried from resolution so dispatch-config
+        /// construction never re-derives (or re-fails) it.
+        core: CoreFormatOptions,
         insert_final_newline: bool,
     },
     /// For YAML files formatted by `oxc_formatter_yaml`.
@@ -146,10 +146,6 @@ impl FormatStrategy {
     /// The Prettier `Value` for `ExternalFormatter*` is deferred to the format step:
     /// `FormatConfig` is the single SoT, no validation needed,
     /// and `Box<FormatConfig>` is materially smaller per file than a fully-built `Value`.
-    // `config` is moved into the napi-only `ExternalFormatter*` variants;
-    // when the `napi` feature is off, those branches are cfg-gated out and the
-    // value is only borrowed, but we keep the by-value signature for symmetry.
-    #[cfg_attr(not(feature = "napi"), expect(clippy::needless_pass_by_value))]
     pub(crate) fn from_format_config(
         config: FormatConfig,
         validated: &ValidatedOptions,
@@ -198,8 +194,8 @@ impl FormatStrategy {
             FileKind::OxcFormatterCss { path, variant } => Self::OxcFormatterCss {
                 path,
                 format_options: Box::new(to_oxc_formatter_css(&config, core, variant)),
-                #[cfg(feature = "napi")]
-                config: Box::new(config),
+                config: Arc::new(config),
+                core,
                 insert_final_newline,
             },
             FileKind::OxcFormatterYaml { path } => Self::OxcFormatterYaml {
@@ -326,16 +322,16 @@ impl SourceFormatter {
             FormatStrategy::OxcFormatterCss {
                 path,
                 format_options,
-                #[cfg(feature = "napi")]
                 config,
+                core,
                 insert_final_newline,
             } => (
                 self.format_by_oxc_formatter_css(
                     source_text,
                     &path,
                     *format_options,
-                    #[cfg(feature = "napi")]
                     &config,
+                    core,
                 ),
                 insert_final_newline,
             ),
@@ -522,8 +518,10 @@ impl SourceFormatter {
         Ok(printed.into_code())
     }
 
-    /// Format CSS/SCSS/Less source using `oxc_formatter_css`.
-    ///
+    /// Format CSS/SCSS/Less source using `oxc_formatter_css` on a `PhysicalFile` session,
+    /// so front matter YAML dispatches to the native registry in every build
+    /// (fallback-less: TOML and custom languages stay verbatim, matching Prettier, which never formats them either).
+    /// `embeddedLanguageFormatting: off` installs no dispatcher and the block stays verbatim wholesale.
     /// When the config enables Tailwind class sorting,
     /// the napi build passes a JS-side sorter for the `@apply` classes the formatter collects
     /// (the order itself comes from the Tailwind config, which only the JS side can resolve).
@@ -534,16 +532,27 @@ impl SourceFormatter {
         source_text: &str,
         path: &Path,
         format_options: CssFormatOptions,
-        #[cfg(feature = "napi")] config: &FormatConfig,
+        config: &Arc<FormatConfig>,
+        core: CoreFormatOptions,
     ) -> Result<String, OxcDiagnostic> {
+        let dispatch_config = ResolvedDispatchConfig::new(Arc::clone(config), core);
         #[cfg(feature = "napi")]
-        let sorter = self.tailwind_sorter(config, path);
+        let dispatch_config = dispatch_config.with_path(path.to_path_buf());
+        let dispatch_config = Arc::new(dispatch_config);
+
+        let dispatcher = config
+            .is_embedded_formatting_enabled()
+            .then(|| build_dispatcher(Arc::clone(&dispatch_config), None));
+
+        #[cfg(feature = "napi")]
+        let sorter = self.tailwind_sorter(config, &dispatch_config);
         #[cfg(not(feature = "napi"))]
         let sorter: Option<fn(Vec<String>) -> Vec<String>> = None;
 
         let allocator = self.allocator_pool.get();
-        let formatted = oxc_formatter_css::format(
-            &allocator,
+        let session = FormatSession::new(&allocator, InputKind::PhysicalFile, dispatcher);
+        let formatted = oxc_formatter_css::format_with_session(
+            &session,
             source_text,
             format_options,
             sorter.as_ref().map(|s| s as &dyn Fn(Vec<String>) -> Vec<String>),
@@ -619,10 +628,12 @@ impl SourceFormatter {
 
     /// Build the JS-side Tailwind class sorter for `oxc_formatter_css`'s `@apply` collection,
     /// or `None` when the config does not enable it.
+    /// The Prettier options JSON comes from the dispatch config's lazy cell,
+    /// so a file without `@apply` classes never pays for building it.
     fn tailwind_sorter(
         &self,
         config: &FormatConfig,
-        path: &Path,
+        dispatch_config: &Arc<ResolvedDispatchConfig>,
     ) -> Option<impl Fn(Vec<String>) -> Vec<String>> {
         config.is_tailwind_enabled().then(|| {
             let external_formatter = self
@@ -630,8 +641,8 @@ impl SourceFormatter {
                 .as_ref()
                 .expect("`external_formatter` must exist when `napi` feature is enabled");
             let sort = std::sync::Arc::clone(&external_formatter.sort_tailwindcss_classes);
-            let external_options = build_external_options(config, path);
-            move |classes: Vec<String>| sort(&external_options, classes)
+            let dispatch_config = Arc::clone(dispatch_config);
+            move |classes: Vec<String>| sort(dispatch_config.external_options(), classes)
         })
     }
 

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -297,6 +297,14 @@ impl FormatConfig {
         matches!(self.svelte, Some(SvelteUserConfig::Bool(true) | SvelteUserConfig::Object(_)))
     }
 
+    /// Whether embedded-language formatting is enabled by this config
+    /// (`embeddedLanguageFormatting` defaults to `"auto"`; only an explicit `"off"` disables it).
+    /// Every dispatcher-assembly site consults this,
+    /// so the off-semantics can never diverge between channels.
+    pub fn is_embedded_formatting_enabled(&self) -> bool {
+        !matches!(self.embedded_language_formatting, Some(EmbeddedLanguageFormattingConfig::Off))
+    }
+
     /// Whether Tailwind class sorting is enabled by this config.
     ///
     /// Enabled when `sortTailwindcss` is set to `true` or an object;

--- a/apps/oxfmt/test/api/front_matter.test.ts
+++ b/apps/oxfmt/test/api/front_matter.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { format } from "../../dist/index.js";
+
+// The behavior matrix for CSS front matter, pinned end-to-end
+// (verification lives here, not in `oxc_formatter_css`,
+// mirroring how embedded behavior is validated through oxfmt in general).
+// The composed outputs below were verified against bundled Prettier 3.9.
+describe("CSS front matter", () => {
+  it("formats a Jekyll-style YAML block and the stylesheet body", async () => {
+    const source = "---\ntitle:   Home\nlist:\n    -   1\n---\n.a { color: red }\n";
+    const result = await format("a.scss", source);
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toBe("---\ntitle: Home\nlist:\n  - 1\n---\n\n.a {\n  color: red;\n}\n");
+  });
+
+  it("re-emits an explicit `---yaml` tag", async () => {
+    const result = await format("a.css", "---yaml\ntitle:   Home\n---\na {}\n");
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toBe("---yaml\ntitle: Home\n---\n\na {\n}\n");
+  });
+
+  it("normalizes the gap after the block to exactly one blank line", async () => {
+    const none = await format("a.css", "---\na: 1\n---\nb {}\n");
+    const many = await format("a.css", "---\na: 1\n---\n\n\n\nb {}\n");
+    expect(none.code).toBe("---\na: 1\n---\n\nb {\n}\n");
+    expect(many.code).toBe(none.code);
+  });
+
+  it("prints an empty block as the delimiters alone", async () => {
+    const result = await format("a.css", "---\n---\nb {}\n");
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toBe("---\n---\n\nb {\n}\n");
+  });
+
+  it("re-emits a `...` closing delimiter", async () => {
+    const result = await format("a.css", "---\na:  1\n...\nb {}\n");
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toBe("---\na: 1\n...\n\nb {\n}\n");
+  });
+
+  it("prints a block without a body alone", async () => {
+    const result = await format("a.css", "---\na:  1\n---\n");
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toBe("---\na: 1\n---\n");
+  });
+
+  it("keeps non-YAML blocks verbatim", async () => {
+    // Custom language: never dispatched (Prettier keeps it raw too).
+    const custom = await format("a.css", "---mycustomparser\na:   1\n---\nb {}\n");
+    expect(custom.errors).toStrictEqual([]);
+    expect(custom.code).toBe("---mycustomparser\na:   1\n---\n\nb {\n}\n");
+
+    // TOML: dispatched but no native formatter, degrades to verbatim.
+    const toml = await format("a.css", "+++\na   =   1\n+++\nb {}\n");
+    expect(toml.errors).toStrictEqual([]);
+    expect(toml.code).toBe("+++\na   =   1\n+++\n\nb {\n}\n");
+  });
+
+  it("keeps the block verbatim when the YAML does not parse", async () => {
+    const result = await format("a.css", "---\nkey: [unclosed\n---\nb {}\n");
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toBe("---\nkey: [unclosed\n---\n\nb {\n}\n");
+  });
+
+  it("keeps the block verbatim under embeddedLanguageFormatting: off", async () => {
+    const result = await format("a.css", "---\ntitle:   Home\n---\nb {}\n", {
+      embeddedLanguageFormatting: "off",
+    });
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toBe("---\ntitle:   Home\n---\n\nb {\n}\n");
+  });
+
+  it("keeps a physical BOM at byte 0, before the block", async () => {
+    const result = await format("a.css", "\uFEFF---\ntitle:  Home\n---\nb {}\n");
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toBe("\uFEFF---\ntitle: Home\n---\n\nb {\n}\n");
+  });
+
+  it("normalizes CRLF input like the rest of the file", async () => {
+    const result = await format("a.css", "---\r\ntitle:  Home\r\n---\r\nb {}\r\n");
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toBe("---\ntitle: Home\n---\n\nb {\n}\n");
+  });
+
+  it("never treats a css-in-js template starting with `---` as front matter", async () => {
+    const source = "const s = css`---\ntitle: x\n---\n.a { color: red }`;\n";
+    const result = await format("a.ts", source);
+    expect(result.errors).toStrictEqual([]);
+    // The fragment is preserved wholesale (no file envelope semantics).
+    expect(result.code).toBe(source);
+  });
+
+  it("keeps a JSDoc css fence with front matter verbatim", async () => {
+    const source = [
+      "/**",
+      " * ```css",
+      " * ---",
+      " * title: x",
+      " * ---",
+      " * .a { color: red }",
+      " * ```",
+      " */",
+      "",
+    ].join("\n");
+    const result = await format("a.ts", source, { jsdoc: {} });
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toBe(source);
+  });
+});

--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -122,6 +122,10 @@ Import discipline (convention): `spec/` only imports `std`, `cow-utils`, etc.
 A pure predicate over text shared by design (e.g. `is_suppression_marker`: all formatters honor the same ignore directives) is a desired contract and belongs here.
 Unlike option types like `QuoteStyle`, where sharing would encode a coincidental contract that breaks when languages diverge.
 
+`spec/front_matter.rs` shows the same line from the envelope side:
+core owns pure detection (`parse_front_matter`, a Prettier `front-matter/parse.js` port) and byte-preserving blanking only.
+What the header language MEANS and how the block composes into output stay host policy, Astro's leading `---` is a JS component script, not YAML, so a central "every `---` is YAML" rule can never exist here.
+
 Parameterizing language differences (sharpened gate 2), when a shared helper needs to vary per language:
 
 - a value / classifier / data parameter keeps it in core (core asserts nothing)

--- a/crates/oxc_formatter_core/src/embedded.rs
+++ b/crates/oxc_formatter_core/src/embedded.rs
@@ -79,6 +79,14 @@ pub struct EmbeddedIr<'a> {
     pub tailwind_classes: Vec<String>,
 }
 
+/// The single-text case: one [`EmbeddedIr`] becomes a one-doc result,
+/// carrying the child's Tailwind classes through (hand-rolling the literal invites silently dropping them).
+impl<'a> From<EmbeddedIr<'a>> for DispatchResult<'a> {
+    fn from(embedded: EmbeddedIr<'a>) -> Self {
+        Self { docs: vec![embedded.ir], tailwind_classes: embedded.tailwind_classes, meta: None }
+    }
+}
+
 /// Result of a [`FormatDispatcher`] call.
 pub struct DispatchResult<'a> {
     /// One IR per input text (usually one; GraphQL returns one per quasi).

--- a/crates/oxc_formatter_core/src/spec/front_matter.rs
+++ b/crates/oxc_formatter_core/src/spec/front_matter.rs
@@ -1,0 +1,217 @@
+//! Front matter detection and byte-preserving blanking shared by
+//! document-envelope hosts (CSS today, Markdown later).
+//!
+//! Core owns ONLY the mechanics:
+//! what the header language MEANS (yaml? toml? an Astro component script?)
+//! and how the block composes into output are the host formatter's policy, never encoded here.
+
+/// A front matter block at byte 0 of a document.
+///
+/// The slicing rules are a faithful port of Prettier's `front-matter/parse.js` (verified against bundled 3.9);
+/// when in doubt, match that file, not intuition.
+#[derive(Debug)]
+pub struct FrontMatter<'a> {
+    /// The verbatim slice from byte 0 through the closing delimiter's last character.
+    /// Trailing text on the closing line stays OUTSIDE (in the body).
+    pub raw: &'a str,
+    /// Between the opening line's newline and the newline before the closing delimiter;
+    /// empty for `---\n---`.
+    pub value: &'a str,
+    /// `"---"` or `"+++"`.
+    pub start_delimiter: &'a str,
+    /// Same as the opening delimiter, or `"..."` via the yaml-only fallback.
+    pub end_delimiter: &'a str,
+    /// The trimmed text after the opening delimiter on its line,
+    /// if nonempty (`---yaml` → `Some("yaml")`).
+    pub explicit_language: Option<&'a str>,
+}
+
+impl<'a> FrontMatter<'a> {
+    /// The resolved language: [`Self::explicit_language`],
+    /// or the delimiter default (`---` → `"yaml"`, `+++` → `"toml"`).
+    /// What the name MEANS stays the host's decision.
+    pub fn language(&self) -> &'a str {
+        self.explicit_language.unwrap_or(if self.start_delimiter == "---" {
+            "yaml"
+        } else {
+            "toml"
+        })
+    }
+}
+
+/// Detects a [`FrontMatter`] block at byte 0 of `text`.
+///
+/// Rules (Prettier `front-matter/parse.js` parity):
+/// - only `---` / `+++` at byte 0 open a candidate, and the opening line must end in a newline
+/// - the closing delimiter is `\n` + the SAME delimiter (`---` never closes `+++`)
+/// - `\n...` closes only as a fallback: opening `---`, resolved language `yaml`,
+///   and no `\n---` found ANYWHERE (a later `\n---` beats an earlier `\n...`)
+/// - no constraint on what follows the closing delimiter on its line
+///   (parse.js's `/\s?/` check is an always-true no-op; stricter would diverge)
+pub fn parse_front_matter(text: &str) -> Option<FrontMatter<'_>> {
+    let (start_delimiter, close_pattern) = if text.starts_with("---") {
+        ("---", "\n---")
+    } else if text.starts_with("+++") {
+        ("+++", "\n+++")
+    } else {
+        return None;
+    };
+
+    // The opening line must end in a newline
+    // (`trim` also drops a CRLF's `\r` so it never leaks into the language tag).
+    let opening_newline = text.find('\n')?;
+    let explicit = text[start_delimiter.len()..opening_newline].trim();
+    let explicit_language = (!explicit.is_empty()).then_some(explicit);
+    let resolved_yaml = explicit_language.is_none_or(|language| language == "yaml");
+
+    // Search from the opening line's own newline,
+    // so `---\n---` closes immediately with an empty value.
+    let search = &text[opening_newline..];
+    let (close_offset, end_delimiter) = if let Some(offset) = search.find(close_pattern) {
+        (offset, start_delimiter)
+    } else if start_delimiter == "---" && resolved_yaml {
+        (search.find("\n...")?, "...")
+    } else {
+        return None;
+    };
+
+    // Absolute index of the newline right before the closing delimiter
+    let closing_newline = opening_newline + close_offset;
+    let raw = &text[..closing_newline + 1 + end_delimiter.len()];
+    // Clamped: for `---\n---` the closing newline IS the opening newline
+    let value = &text[(opening_newline + 1).min(closing_newline)..closing_newline];
+
+    Some(FrontMatter { raw, value, start_delimiter, end_delimiter, explicit_language })
+}
+
+/// Blanks the leading `raw_len` bytes of `text` (a [`FrontMatter::raw`] length).
+///
+/// The host's parser never sees the block, while every span,
+/// line offset, and gap after it stays byte-identical:
+/// `\n` / `\r` survive, every other byte becomes one ASCII space
+/// (multi-byte characters become runs of spaces, preserving byte length).
+pub fn blank_front_matter(text: &str, raw_len: usize) -> String {
+    let mut out = String::with_capacity(text.len());
+    for &byte in &text.as_bytes()[..raw_len] {
+        out.push(match byte {
+            b'\n' => '\n',
+            b'\r' => '\r',
+            _ => ' ',
+        });
+    }
+    out.push_str(&text[raw_len..]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{blank_front_matter, parse_front_matter};
+
+    #[test]
+    fn bare_yaml_block() {
+        let fm = parse_front_matter("---\ntitle: x\n---\nbody").unwrap();
+        assert_eq!(fm.raw, "---\ntitle: x\n---");
+        assert_eq!(fm.value, "title: x");
+        assert_eq!(fm.start_delimiter, "---");
+        assert_eq!(fm.end_delimiter, "---");
+        assert_eq!(fm.explicit_language, None);
+        assert_eq!(fm.language(), "yaml");
+    }
+
+    #[test]
+    fn toml_delimiter_defaults_to_toml() {
+        let fm = parse_front_matter("+++\na = 1\n+++\n").unwrap();
+        assert_eq!(fm.language(), "toml");
+        assert_eq!(fm.raw, "+++\na = 1\n+++");
+    }
+
+    #[test]
+    fn explicit_language_is_captured() {
+        let fm = parse_front_matter("---mycustomparser\ntitle: x\n---\n").unwrap();
+        assert_eq!(fm.explicit_language, Some("mycustomparser"));
+        assert_eq!(fm.language(), "mycustomparser");
+    }
+
+    #[test]
+    fn crlf_keeps_the_cr_out_of_the_language_and_in_the_value() {
+        let fm = parse_front_matter("---\r\ntitle: x\r\n---\r\nbody").unwrap();
+        assert_eq!(fm.explicit_language, None);
+        assert_eq!(fm.language(), "yaml");
+        assert_eq!(fm.value, "title: x\r");
+        assert_eq!(fm.raw, "---\r\ntitle: x\r\n---");
+    }
+
+    #[test]
+    fn empty_block_has_an_empty_value() {
+        let fm = parse_front_matter("---\n---\nbody").unwrap();
+        assert_eq!(fm.raw, "---\n---");
+        assert_eq!(fm.value, "");
+    }
+
+    #[test]
+    fn cross_delimiters_never_close() {
+        assert!(parse_front_matter("---\na: 1\n+++\n").is_none());
+        assert!(parse_front_matter("+++\na = 1\n---\n").is_none());
+    }
+
+    #[test]
+    fn dots_close_only_as_the_yaml_fallback() {
+        let fm = parse_front_matter("---\ntitle: x\n...\nbody").unwrap();
+        assert_eq!(fm.end_delimiter, "...");
+        assert_eq!(fm.raw, "---\ntitle: x\n...");
+
+        // A later `\n---` beats an earlier `\n...` (indexOf priority)
+        let fm = parse_front_matter("---\na: 1\n...\nb: 2\n---\n").unwrap();
+        assert_eq!(fm.end_delimiter, "---");
+        assert_eq!(fm.value, "a: 1\n...\nb: 2");
+
+        // Non-yaml language: no dots fallback.
+        assert!(parse_front_matter("---css\na {}\n...\n").is_none());
+        assert!(parse_front_matter("+++\na = 1\n...\n").is_none());
+    }
+
+    #[test]
+    fn unclosed_block_is_none() {
+        assert!(parse_front_matter("---\ntitle: x\n").is_none());
+        assert!(parse_front_matter("---").is_none());
+        assert!(parse_front_matter("---\n").is_none());
+    }
+
+    #[test]
+    fn closing_line_trailing_text_stays_in_the_body() {
+        let fm = parse_front_matter("---\ntitle: x\n---trailing\nbody").unwrap();
+        assert_eq!(fm.raw, "---\ntitle: x\n---");
+        assert_eq!(fm.value, "title: x");
+    }
+
+    #[test]
+    fn a_fence_past_byte_zero_is_not_front_matter() {
+        assert!(parse_front_matter("\n---\ntitle: x\n---\n").is_none());
+        assert!(parse_front_matter("a {}\n---\nx\n---\n").is_none());
+    }
+
+    #[test]
+    fn blanking_preserves_byte_length_and_line_offsets() {
+        let text = "---\ntitle: x\nemoji: ✨\n---\nbody { color: red }";
+        let raw_len = parse_front_matter(text).unwrap().raw.len();
+        let blanked = blank_front_matter(text, raw_len);
+
+        assert_eq!(blanked.len(), text.len());
+        let offsets = |s: &str| -> Vec<usize> {
+            s.bytes().enumerate().filter(|(_, b)| *b == b'\n').map(|(i, _)| i).collect::<Vec<_>>()
+        };
+        assert_eq!(offsets(&blanked), offsets(text));
+        // The body is untouched, the block is whitespace-only
+        assert_eq!(&blanked[raw_len..], "\nbody { color: red }");
+        assert!(blanked[..raw_len].chars().all(|c| c == ' ' || c == '\n'));
+    }
+
+    #[test]
+    fn blanking_keeps_crlf_line_structure() {
+        let text = "---\r\ntitle: x\r\n---\r\nbody";
+        let raw_len = parse_front_matter(text).unwrap().raw.len();
+        let blanked = blank_front_matter(text, raw_len);
+        assert_eq!(blanked.len(), text.len());
+        assert_eq!(&blanked[..raw_len], "   \r\n        \r\n   ");
+    }
+}

--- a/crates/oxc_formatter_core/src/spec/mod.rs
+++ b/crates/oxc_formatter_core/src/spec/mod.rs
@@ -14,12 +14,14 @@
 //! never `oxc_*` crates or engine IR types via `crate::`.
 
 mod bom;
+mod front_matter;
 mod gap;
 mod number;
 pub mod string;
 mod suppression;
 
 pub use bom::split_bom;
+pub use front_matter::{FrontMatter, blank_front_matter, parse_front_matter};
 pub use gap::{Gap, classify_gap};
 pub use number::{format_trimmed_number, is_simple_number};
 pub use string::normalize_string;

--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -9,9 +9,25 @@ Prettier compatible CSS/SCSS/Less formatter (`oxfmt`'s Tier 1 backend), using th
 - Built on `oxc_formatter_core` for the language-agnostic IR + Printer + builders + macros
   - See `crates/oxc_formatter_core/AGENTS.md` for the IR/pipeline details
 - Entry points:
-  - `format()`: standalone files (returns a printable `Formatted`); wraps a dispatcher-less session
-  - `format_with_session()`: standalone on a caller-supplied `FormatSession` (the root that will dispatch front-matter YAML once wired)
+  - `format()`: standalone files (returns a printable `Formatted`); wraps a dispatcher-less session, so front matter degrades to verbatim
+  - `format_with_session()`: standalone on a caller-supplied `FormatSession`; the session's dispatcher formats front matter YAML (oxfmt wires the native registry here)
   - `format_to_ir()`: embedded use via the dispatcher; the `template_placeholders` mode enables `${}` placeholders and `TopLevelDeclaration` (css-in-js), `false` is the strict whole-stylesheet grammar
+
+### Front matter
+
+This crate owns the CSS translation of the envelope contract;
+detection and blanking come from `oxc_formatter_core::spec::{parse_front_matter, blank_front_matter}`.
+
+- The `InputKind` matrix: `PhysicalFile` / `VirtualDocument` own front matter (blank → parse body → compose);
+  - `Fragment` (css-in-js, JSDoc fence) with a valid envelope or ANY non-physical input with a leading BOM is refused wholesale
+    (`Err` → the host's `PreserveOriginal`), never partially treated
+- Language routing: only a resolved `yaml`/`toml` is dispatched (as a `Fragment`, so FM never nests);
+  - Any other explicit language (`---css`, …) stays raw WITHOUT consulting the registry.
+  - TOML has no IR-capable formatter yet and degrades to verbatim
+- Composition: delimiter + re-emitted explicit tag (`---yaml`), child IR between hardlines, closing delimiter (`...` stays `...`), then exactly ONE blank line before a nonempty body (regardless of the source gap). An empty block prints delimiters only, no dispatch
+- Every refusal (`PreserveOriginal`, dispatch error, unparsable YAML) keeps the whole block verbatim while the CSS body still formats;
+  - the block's bytes are never partially dropped
+- Verification lives in oxfmt, like embedded behavior in general, this crate carries no dispatcher-wired FM tests
 
 ### Forked parser
 

--- a/crates/oxc_formatter_css/src/context.rs
+++ b/crates/oxc_formatter_css/src/context.rs
@@ -1,4 +1,4 @@
-use oxc_formatter_core::{FormatContext, SourceText};
+use oxc_formatter_core::{FormatContext, SourceText, TailwindCollector};
 
 use crate::{
     comments::{Comments, CssComment},
@@ -76,6 +76,14 @@ impl<'a> CssFormatContext<'a> {
     /// Returns the comment cursor.
     pub fn comments(&self) -> &Comments<'a> {
         &self.comments
+    }
+}
+
+/// Lets a dispatched child's classes remap into this host's index space (`DispatchResult::remap_tailwind_into`).
+/// A YAML front matter child returns none today, but the cross-language contract holds for any future child.
+impl TailwindCollector for CssFormatContext<'_> {
+    fn add_class(&mut self, class: String) -> usize {
+        self.add_tailwind_class(class)
     }
 }
 

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -3,9 +3,10 @@ use oxc_css_parser::{ParserBuilder, ParserOptions, TemplatePlaceholder, ast::Sty
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter_core::{
-    Buffer, Document, EmbeddedIr, Format, FormatSession, FormatState, Formatted, InputKind,
-    VecBuffer,
+    Buffer, BufferExtensions, DispatchOutcome, DispatchRequest, Document, EmbeddedIr, Format,
+    FormatElement, FormatSession, FormatState, Formatted, InputKind, VecBuffer,
     builders::{empty_line, hard_line_break, text},
+    spec::{FrontMatter, blank_front_matter, parse_front_matter},
     write,
 };
 use oxc_span::Span;
@@ -27,9 +28,8 @@ pub type TailwindSorter<'s> = &'s dyn Fn(Vec<String>) -> Vec<String>;
 
 /// Parse `source_text` as a stylesheet and build its formatter IR.
 ///
-/// `sort_tailwind_classes` sorts the `@apply` classes collected when
-/// [`CssFormatOptions::sort_tailwindcss`] is on; `None` (or an unset option)
-/// prints them as-is.
+/// `sort_tailwind_classes` sorts the `@apply` classes collected
+/// when [`CssFormatOptions::sort_tailwindcss`] is on; `None` (or an unset option) prints them as-is.
 ///
 /// # Errors
 /// Returns an [`OxcDiagnostic`] when the parse produces any error, including recoverable ones.
@@ -41,9 +41,9 @@ pub fn format<'a>(
     options: CssFormatOptions,
     sort_tailwind_classes: Option<TailwindSorter<'_>>,
 ) -> Result<Formatted<'a, CssFormatContext<'a>>, OxcDiagnostic> {
-    // NOTE: this wrapper labels the run `PhysicalFile`, so front-matter support may land on this entry.
-    // Every embedded caller (css-in-js, JSDoc fences) reaches the crate through `format_to_ir` as a `Fragment` instead,
-    // and fence content starting with `---` never acquires file envelope semantics.
+    // NOTE: this wrapper labels the run `PhysicalFile` with NO dispatcher:
+    // front matter is detected but its body degrades to verbatim (`PreserveOriginal`).
+    // Hosts that want the block formatted use `format_with_session` with a dispatcher.
     format_with_session(
         &FormatSession::new(allocator, InputKind::PhysicalFile, None),
         source_text,
@@ -52,9 +52,11 @@ pub fn format<'a>(
     )
 }
 
-/// Like [`format()`], but on a caller-supplied [`FormatSession`]:
-/// the root that lets this formatter dispatch its own embedded languages
-/// (front matter YAML, once wired) through the session's dispatcher.
+/// Like [`format()`], but on a caller-supplied [`FormatSession`].
+///
+/// The session's dispatcher formats this document's front matter body
+/// (YAML through oxfmt's native registry;
+/// see `write_front_matter` for the routing and every verbatim degradation).
 ///
 /// # Errors
 /// Same as [`format()`].
@@ -64,12 +66,22 @@ pub fn format_with_session<'a>(
     options: CssFormatOptions,
     sort_tailwind_classes: Option<TailwindSorter<'_>>,
 ) -> Result<Formatted<'a, CssFormatContext<'a>>, OxcDiagnostic> {
+    // The envelope matrix has one decision input, the session's `InputKind`:
+    // this entry is the physical-root half (owns BOM + front matter);
+    // every embedded kind goes through `format_to_ir`.
+    debug_assert!(
+        session.input_kind() == InputKind::PhysicalFile,
+        "format_with_session is the physical-root entry; embedded inputs go through format_to_ir"
+    );
     let allocator = session.allocator();
     let (has_bom, source_text) = oxc_formatter_core::spec::split_bom(source_text);
 
-    let (stylesheet, source, comments) =
-        parse_stylesheet(allocator, source_text, options, /* tolerate_placeholders */ false)?;
-    let front_matter = parse_front_matter(source);
+    // A document root owns front matter;
+    // the session's dispatcher decides whether its body actually formats (`write_front_matter`).
+    let PreparedSource { source, parse_source, front_matter } =
+        prepare_source(allocator, source_text);
+    let (stylesheet, comments) =
+        parse_stylesheet(allocator, parse_source, options, /* tolerate_placeholders */ false)?;
 
     let context =
         CssFormatContext::new(options, source, comments, /* template_placeholders */ false);
@@ -121,20 +133,41 @@ pub fn format_to_ir<'a>(
     template_placeholders: bool,
 ) -> Result<EmbeddedIr<'a>, OxcDiagnostic> {
     let allocator = session.allocator();
-    // Input hygiene: embedded sources may carry a BOM; strip it, never re-emit.
-    let (_, source_text) = oxc_formatter_core::spec::split_bom(source_text);
-    let (stylesheet, source, comments) = parse_stylesheet(
+    let input_kind = session.input_kind();
+
+    // A BOM marks a document this entry does not own: physical roots handle
+    // BOMs at `format_with_session`; an embedded input carrying one is refused
+    // wholesale (the host degrades to `PreserveOriginal`, keeping the part as-is).
+    if oxc_formatter_core::spec::split_bom(source_text).0 {
+        return Err(OxcDiagnostic::error(
+            "Embedded CSS input starts with a BOM; the part is preserved as-is",
+        ));
+    }
+
+    let prepared = prepare_source(allocator, source_text);
+    if prepared.front_matter.is_some() && input_kind != InputKind::VirtualDocument {
+        // A fragment (css-in-js, JSDoc fence) never acquires file envelope semantics:
+        // refuse the whole child instead of partially treating its head as front matter.
+        // Only a `VirtualDocument` (a complete embedded document, e.g. a fenced stylesheet) formats front matter like a root.
+        return Err(OxcDiagnostic::error(
+            "Front matter in a CSS fragment; the part is preserved as-is",
+        ));
+    }
+    let (stylesheet, comments) = parse_stylesheet(
         allocator,
-        source_text,
+        prepared.parse_source,
         options,
         /* tolerate_placeholders */ template_placeholders,
     )?;
 
-    let context = CssFormatContext::new(options, source, comments, template_placeholders);
+    let context = CssFormatContext::new(options, prepared.source, comments, template_placeholders);
     let mut state = FormatState::new_with_session(context, session.clone());
     let mut buffer = VecBuffer::new(&mut state);
 
-    write!(&mut buffer, FormatCssEmbedded { stylesheet: &stylesheet });
+    write!(
+        &mut buffer,
+        FormatCssEmbedded { stylesheet: &stylesheet, front_matter: prepared.front_matter }
+    );
 
     let elements = buffer.into_vec();
     let tailwind_classes = state.context_mut().take_tailwind_classes();
@@ -142,41 +175,48 @@ pub fn format_to_ir<'a>(
     Ok(EmbeddedIr { ir: elements, tailwind_classes })
 }
 
-/// Parse the source into an AST and collect comments, bailing out on any error.
-///
-/// Copies the source into the arena so every slice taken from it carries `'a`.
-/// Entries own the BOM strip; a leading `\u{feff}` still reaching this point is content
-/// (e.g. a doubled BOM's second copy) and is the parser's to judge.
-fn parse_stylesheet<'a>(
-    allocator: &'a Allocator,
-    source_text: &str,
-    options: CssFormatOptions,
-    tolerate_placeholders: bool,
-) -> Result<(Stylesheet<'a>, &'a str, &'a [CssComment]), OxcDiagnostic> {
+/// Normalized arena source, its front matter (when present),
+/// and the copy the CSS parser actually sees
+/// (front matter blanked byte-preservingly so every span, comment, and source-gap scan aligns with `source`).
+struct PreparedSource<'a> {
+    source: &'a str,
+    parse_source: &'a str,
+    front_matter: Option<FrontMatter<'a>>,
+}
+
+fn prepare_source<'a>(allocator: &'a Allocator, source_text: &str) -> PreparedSource<'a> {
     // NOTE: Normalize line endings BEFORE parsing like Prettier, unlike other `oxc_formatter_xxx`.
     // For CSS formatter, the printer slices verbatim text from the source in many places.
     // (comments, progid, custom properties, ...etc)
     // And a raw `\r` reaching the core `text()` builder panics.
     // Spans stay consistent because parse and print both use the normalized copy.
-    let source_text = oxc_formatter_core::normalize_newlines(source_text, ['\r']);
-    let source: &'a str = allocator.alloc_str(&source_text);
+    let normalized = oxc_formatter_core::normalize_newlines(source_text, ['\r']);
+    let source: &'a str = allocator.alloc_str(&normalized);
 
     // Front matter is not CSS:
-    // blank it out (preserving line structure so spans and gaps stay aligned)
-    // and print it verbatim from `source`.
-    let parse_source: &'a str = match parse_front_matter(source) {
-        Some(fm) => {
-            let end = fm.raw.len();
-            let mut blanked = String::with_capacity(source.len());
-            for c in source[..end].chars() {
-                blanked.push(if c == '\n' || c == '\r' { c } else { ' ' });
-            }
-            blanked.push_str(&source[end..]);
-            allocator.alloc_str(&blanked)
-        }
+    // blank it out for the parser and keep the detection for the print side
+    // (verbatim or dispatched, `write_front_matter`).
+    let front_matter = parse_front_matter(source);
+    let parse_source: &'a str = match &front_matter {
+        Some(fm) => allocator.alloc_str(&blank_front_matter(source, fm.raw.len())),
         None => source,
     };
 
+    PreparedSource { source, parse_source, front_matter }
+}
+
+/// Parse the (already normalized, front-matter-blanked) source into an AST
+/// and collect comments, bailing out on any error.
+///
+/// `parse_source` comes from [`prepare_source`]; entries own the BOM strip,
+/// and a leading `\u{feff}` still reaching this point is content
+/// (e.g. a doubled BOM's second copy) and is the parser's to judge.
+fn parse_stylesheet<'a>(
+    allocator: &'a Allocator,
+    parse_source: &'a str,
+    options: CssFormatOptions,
+    tolerate_placeholders: bool,
+) -> Result<(Stylesheet<'a>, &'a [CssComment]), OxcDiagnostic> {
     let mut parser = ParserBuilder::new(allocator, parse_source)
         .syntax(options.variant.to_css_syntax())
         .options(ParserOptions {
@@ -218,7 +258,7 @@ fn parse_stylesheet<'a>(
     )
     .into_arena_slice();
 
-    Ok((stylesheet, source, comments))
+    Ok((stylesheet, comments))
 }
 
 fn to_diagnostic(error: &oxc_css_parser::error::Error) -> OxcDiagnostic {
@@ -232,100 +272,62 @@ pub fn to_span(span: &oxc_css_parser::Span) -> Span {
     )
 }
 
-/// Prettier-style front matter
-/// (`---` / `+++` fence starting at offset 0, closed by the same fence on its own line).
+/// Writes the front matter block:
+/// dispatched through the session when its language qualifies, verbatim otherwise.
+/// Never fails, any refusal keeps the block as-is while the CSS body still formats
+/// (a document must not lose its front matter bytes over an optional embed).
 ///
-/// The opening fence may carry an explicit language tag (`---yaml`, `---mycustomparser`)
-/// captured in [`Self::language`] (empty if absent).
-struct FrontMatter<'a> {
-    /// The full verbatim slice from offset 0 to the end of the closing fence.
-    raw: &'a str,
-    /// The opening delimiter literal — `"---"` or `"+++"`.
-    delim: &'static str,
-    /// Explicit language tag from the opening fence's first line, trimmed.
-    /// Empty when the fence is a bare `---` / `+++`.
-    language: &'a str,
+/// Language routing: only a resolved `yaml` / `toml` is ever dispatched.
+/// Any other explicit language (`---css`, …) stays raw WITHOUT consulting the registry.
+/// NOTE: TOML currently has no IR-capable formatter, so it degrades to verbatim through `PreserveOriginal`.
+fn write_front_matter<'a>(fm: &FrontMatter<'a>, f: &mut CssFormatter<'_, 'a>) {
+    if matches!(fm.language(), "yaml" | "toml") {
+        let body = fm.value.trim();
+        if body.is_empty() {
+            // Empty block: the delimiters alone
+            write_front_matter_frame(fm, None, f);
+            return;
+        }
+        // The body is a Fragment:
+        // front matter inside front matter must never acquire envelope semantics (generic FM recursion).
+        let outcome = f.session().dispatch(DispatchRequest {
+            language: fm.language(),
+            texts: &[body],
+            input_kind: InputKind::Fragment,
+            parent_context: None,
+        });
+        if let Ok(DispatchOutcome::Formatted(mut result)) = outcome
+            && result.docs.len() == 1
+        {
+            result.remap_tailwind_into(f.context_mut());
+            let ir = result.docs.into_iter().next().expect("length checked above");
+            write_front_matter_frame(fm, Some(ir), f);
+            return;
+        }
+        // `PreserveOriginal`, an operational error,
+        // or an unexpected doc count: fall through to the verbatim block below.
+    }
+    write!(f, text(fm.raw));
 }
 
-/// Detects [`FrontMatter`] at the start of `source`
-/// (single parse, shared by the parse-side blanking and the print-side dispatch).
-fn parse_front_matter(source: &str) -> Option<FrontMatter<'_>> {
-    let delim = if source.starts_with("---") {
-        "---"
-    } else if source.starts_with("+++") {
-        "+++"
-    } else {
-        return None;
-    };
-
-    let first_line_end = source.find('\n')?;
-    let language = source[delim.len()..first_line_end].trim();
-    let mut line_start = first_line_end + 1;
-    while line_start < source.len() {
-        let line_end = source[line_start..].find('\n').map_or(source.len(), |i| line_start + i);
-        let line = source[line_start..line_end].trim_end_matches('\r');
-        if line.trim_end() == delim {
-            let raw_end = line_start + line.trim_end().len();
-            return Some(FrontMatter { raw: &source[..raw_end], delim, language });
-        }
-        line_start = line_end + 1;
+/// The composed shape (Prettier `embed.js` + `printer-postcss.js` css-root):
+/// opening delimiter with the explicit language re-emitted (`---yaml`),
+/// the child IR between hardlines, then the closing delimiter (a `...` closing stays `...`).
+fn write_front_matter_frame<'a>(
+    fm: &FrontMatter<'a>,
+    body: Option<ArenaVec<'a, FormatElement<'a>>>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    write!(f, text(fm.start_delimiter));
+    if let Some(language) = fm.explicit_language {
+        write!(f, text(language));
     }
-    None
-}
-
-/// Best-effort YAML front-matter normalization (Prettier reformats it with its YAML printer):
-/// `key: value` spacing and 2-space nesting indents.
-/// Returns `None` (verbatim) for any construct beyond plain mappings,
-/// sequence items and comments, e.g. block scalars, quoted keys.
-fn try_format_yaml_front_matter(front_matter: &str) -> Option<String> {
-    let inner = front_matter.strip_prefix("---")?.strip_suffix("---")?;
-    let mut out = String::with_capacity(front_matter.len());
-    out.push_str("---\n");
-    // Source indents of mapping keys awaiting nested content.
-    let mut stack: Vec<usize> = vec![];
-    for line in inner.lines().skip(1) {
-        let content = line.trim();
-        if content.is_empty() {
-            continue;
-        }
-        let indent = line.len() - line.trim_start().len();
-        while stack.last().is_some_and(|&top| indent <= top) {
-            stack.pop();
-        }
-        let level = stack.len();
-        for _ in 0..level {
-            out.push_str("  ");
-        }
-        if let Some(rest) = content.strip_prefix("- ") {
-            out.push_str("- ");
-            out.push_str(rest.trim());
-        } else if content.starts_with('#') {
-            out.push_str(content);
-        } else if let Some(colon) = content.find(':') {
-            let key = &content[..colon];
-            if key.is_empty() || key.contains([' ', '\t', '"', '\'', '{', '[', '#']) {
-                return None;
-            }
-            let value = content[colon + 1..].trim();
-            if value.is_empty() {
-                out.push_str(key);
-                out.push(':');
-                stack.push(indent);
-            } else {
-                if value.starts_with(['|', '>', '&', '*', '{', '[']) {
-                    return None;
-                }
-                out.push_str(key);
-                out.push_str(": ");
-                out.push_str(value);
-            }
-        } else {
-            return None;
-        }
-        out.push('\n');
+    if let Some(ir) = body {
+        write!(f, hard_line_break());
+        f.write_elements(ir);
     }
-    out.push_str("---");
-    Some(out)
+    write!(f, hard_line_break());
+    write!(f, text(fm.end_delimiter));
 }
 
 /// Emits the stylesheet followed by any trailing comments, and the final newline.
@@ -335,28 +337,24 @@ struct FormatCssRoot<'b, 'a> {
     front_matter: Option<FrontMatter<'a>>,
 }
 
+/// Whether anything (statements or comments) follows the envelope,
+/// deciding the front matter/body gap and the final newline.
+fn has_content(stylesheet: &Stylesheet, f: &CssFormatter<'_, '_>) -> bool {
+    !stylesheet.statements.is_empty() || f.context().comments().peek().is_some()
+}
+
 impl<'a> Format<'a, CssFormatContext<'a>> for FormatCssRoot<'_, 'a> {
     fn fmt(&self, f: &mut CssFormatter<'_, 'a>) {
         if self.has_bom {
             write!(f, text("\u{feff}"));
         }
 
-        let has_content =
-            !self.stylesheet.statements.is_empty() || f.context().comments().peek().is_some();
+        let has_content = has_content(self.stylesheet, f);
         if let Some(fm) = &self.front_matter {
-            // YAML normalization runs only for the default `---` shape (no explicit tag);
-            // `+++` (TOML) and explicit non-default languages stay verbatim.
-            // Prettier delegates them to dedicated language printers we don't bridge for now.
-            let normalized = (fm.delim == "---" && fm.language.is_empty())
-                .then(|| try_format_yaml_front_matter(fm.raw))
-                .flatten();
-            if let Some(s) = normalized {
-                write!(f, text(f.allocator().alloc_str(&s)));
-            } else {
-                write!(f, text(fm.raw));
-            }
+            write_front_matter(fm, f);
             if has_content {
-                // A hardline plus a blank line (consecutive hardlines collapse).
+                // Always exactly one blank line between the block and the body
+                // (regardless of the source gap; measured Prettier behavior).
                 write!(f, empty_line());
             } else {
                 write!(f, hard_line_break());
@@ -372,13 +370,24 @@ impl<'a> Format<'a, CssFormatContext<'a>> for FormatCssRoot<'_, 'a> {
     }
 }
 
-/// Emits the stylesheet only; no BOM, no final newline.
+/// Emits the stylesheet only; no BOM, no final newline
+/// (front matter still prints for a `VirtualDocument`, whose complete-document envelope the host hands over;
+/// the surrounding layout stays the host's).
 struct FormatCssEmbedded<'b, 'a> {
     stylesheet: &'b Stylesheet<'a>,
+    front_matter: Option<FrontMatter<'a>>,
 }
 
 impl<'a> Format<'a, CssFormatContext<'a>> for FormatCssEmbedded<'_, 'a> {
     fn fmt(&self, f: &mut CssFormatter<'_, 'a>) {
+        if let Some(fm) = &self.front_matter {
+            let has_content = has_content(self.stylesheet, f);
+            write_front_matter(fm, f);
+            if has_content {
+                write!(f, empty_line());
+            }
+        }
+
         print::write_stylesheet(self.stylesheet, f);
     }
 }

--- a/crates/oxc_formatter_css/src/lib.rs
+++ b/crates/oxc_formatter_css/src/lib.rs
@@ -37,6 +37,6 @@ pub const TEMPLATE_PLACEHOLDER_SUFFIX: &str = "`";
 
 pub use crate::{
     context::CssFormatContext,
-    format::{TailwindSorter, format, format_to_ir},
+    format::{TailwindSorter, format, format_to_ir, format_with_session},
     options::{CssFormatOptions, CssVariant, SingleQuote, TrailingCommas},
 };

--- a/crates/oxc_formatter_yaml/AGENTS.md
+++ b/crates/oxc_formatter_yaml/AGENTS.md
@@ -9,7 +9,7 @@ Prettier compatible YAML formatter (`oxfmt`'s Tier 1 backend), using the `oxc_fo
 - Built on `oxc_formatter_core` for the language-agnostic IR + Printer + builders + macros
   - See `crates/oxc_formatter_core/AGENTS.md` for the IR/pipeline details
 - Two entry points (see their docs in `src/format.rs`):
-  - `format()` for standalone files, `format_to_ir()` for embedded use via the dispatcher (e.g. yaml-in-markdown)
+  - `format()` for standalone files, `format_to_ir()` for embedded use via the dispatcher (e.g. CSS front matter, JSDoc fenced blocks)
 
 ### Parser
 

--- a/tasks/prettier_conformance/snapshots/prettier.css.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.css.snap.md
@@ -1,4 +1,4 @@
-css compatibility: 146/151 (96.69%), 17 files skipped
+css compatibility: 145/150 (96.67%), 17 files skipped
 
 # Failed
 

--- a/tasks/prettier_conformance/src/ignore_list.rs
+++ b/tasks/prettier_conformance/src/ignore_list.rs
@@ -126,6 +126,8 @@ pub const IGNORE_TESTS: &[&str] = &[
     "typescript/decorators-ts/angular.ts",
     // postcss-conditionals (archived: https://github.com/andyjansson/postcss-conditionals).
     "css/atrule/if-else.css",
+    // YAML frontmatter
+    "css/yaml/dirty.css",
     // Prettier's yaml parser rejects these (https://github.com/eemeli/yaml/issues/646),
     // so no snapshot exists (`3-style.yml` is even marked `errors` in its format.test.js).
     // oxc-yaml-parser parses them fine, but there is nothing to compare against.


### PR DESCRIPTION
Using the `Dispatcher` set up so far, detect the YAML front matter and process it using `oxc_formatter_yaml`.