### PR TITLE
perf(allocator): keep allocator pointers in registers across multiple allocations

### DIFF
--- a/crates/oxc_allocator/src/arena/alloc.rs
+++ b/crates/oxc_allocator/src/arena/alloc.rs
@@ -9,6 +9,8 @@ use std::{
     str,
 };
 
+use oxc_data_structures::assert_unchecked;
+
 use super::{Arena, bumpalo_alloc::AllocErr, utils::oom};
 
 impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
@@ -27,9 +29,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// let x = arena.alloc("hello");
     /// assert_eq!(*x, "hello");
     /// ```
+    #[expect(clippy::mut_from_ref)]
     #[inline(always)]
     pub fn alloc<T>(&self, val: T) -> &mut T {
-        self.alloc_with(|| val)
+        // SAFETY: The closure only moves out `val` (already constructed by the caller).
+        // It does not allocate from this arena or otherwise touch `Arena`, so `IMPURE_CLOSURE: false` is valid.
+        unsafe { self.alloc_with_impl::<false, _, T>(|| val) }
     }
 
     /// Try to allocate an object in this `Arena`. Returns an exclusive reference to it, if the allocation succeeds.
@@ -47,9 +52,12 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// let x = arena.try_alloc("hello");
     /// assert_eq!(x, Ok(&mut "hello"));
     /// ```
+    #[expect(clippy::mut_from_ref)]
     #[inline(always)]
     pub fn try_alloc<T>(&self, val: T) -> Result<&mut T, AllocErr> {
-        self.try_alloc_with(|| val)
+        // SAFETY: The closure only moves out `val` (already constructed by the caller).
+        // It does not allocate from this arena or otherwise touch `Arena`, so `IMPURE_CLOSURE: false` is valid.
+        unsafe { self.try_alloc_with_impl::<false, _, T>(|| val) }
     }
 
     /// Pre-allocate space for an object in this `Arena`, and initialize it using the closure.
@@ -78,6 +86,42 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     where
         F: FnOnce() -> T,
     {
+        // SAFETY: `IMPURE_CLOSURE: true` imposes no requirement on `f`
+        unsafe { self.alloc_with_impl::<true, F, T>(f) }
+    }
+
+    /// Implementation of [`alloc`] and [`alloc_with`].
+    ///
+    /// When `IMPURE_CLOSURE` is `false` ([`alloc`]), sets `cursor_ptr` *after* calling the closure
+    /// and writing the result, and asserts to compiler that the write left `start_ptr` unchanged.
+    /// This is only valid if `f` closure does not perform further allocations in this arena,
+    /// or alter `cursor_ptr` / `start_ptr` by any other means.
+    ///
+    /// This operation ordering and the assertion lets the compiler keep both `cursor_ptr` and `start_ptr` in registers
+    /// across consecutive allocations, instead of reloading them after each value write (which it otherwise cannot
+    /// prove does not alias the pointer fields). It also allows compiler to skip alignment calculations on consecutive
+    /// allocations which share the same alignment, as it can prove the bump cursor is already aligned.
+    ///
+    /// When `IMPURE_CLOSURE` is `true` ([`alloc_with`]), sets `cursor_ptr` *before* calling the closure.
+    /// The "`start_ptr` is unchanged" assertion (and the snapshot read that feeds it) are compiled away.
+    /// This makes it valid for the closure to perform further allocations.
+    ///
+    /// # SAFETY
+    ///
+    /// If `IMPURE_CLOSURE` is `false`, `f` must not allocate from this `Arena` or otherwise mutate
+    /// `cursor_ptr` or `start_ptr`.
+    ///
+    /// * [`alloc`]'s `|| val` closure satisfies this, so it passes `IMPURE_CLOSURE: false`.
+    /// * An arbitrary [`alloc_with`] closure does not, so it passes `IMPURE_CLOSURE: true`.
+    ///
+    /// [`alloc`]: Self::alloc
+    /// [`alloc_with`]: Self::alloc_with
+    #[expect(clippy::mut_from_ref)]
+    #[inline(always)]
+    unsafe fn alloc_with_impl<const IMPURE_CLOSURE: bool, F, T>(&self, f: F) -> &mut T
+    where
+        F: FnOnce() -> T,
+    {
         #[inline(always)]
         fn inner_writer<T, F>(slot: &mut MaybeUninit<T>, f: F) -> &mut T
         where
@@ -96,14 +140,41 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         }
 
         let layout = Layout::new::<T>();
-        let ptr = self.alloc_layout(layout);
+
+        // For a pure closure, defer committing `cursor_ptr` until *after* the value is written.
+        // This keeps the cursor in a register across consecutive allocations - no store-then-reload after
+        // the write, and the redundant alignment mask is dropped on subsequent same-alignment allocations.
+        // It is sound because a pure closure does not allocate, so nothing observes the arena between
+        // computing the slot and committing the cursor.
+        //
+        // For an impure closure, commit `cursor_ptr` up-front, so a re-entrant `f` (which may allocate)
+        // sees the updated pointer.
+        let ptr = self.alloc_layout_impl::<IMPURE_CLOSURE>(layout);
+
+        // Snapshot `start_ptr` as the (fast or slow) layout path left it, so the assertion below can pin it.
+        // `start_ptr` is read-only on the fast path, but the value write may alias it as far as compiler can tell,
+        // so without this it would be reloaded on the next allocation.
+        // Unused, and removed by the optimizer, when `IMPURE_CLOSURE` is `true`.
+        let start_ptr = self.start_ptr.get();
 
         // SAFETY: `ptr` was allocated with `T`'s layout, so it's correctly aligned and sized for `MaybeUninit<T>`
         // (same layout as `T`). The memory was just allocated, so no other reference aliases it,
         // and it lives for as long as the returned reference (tied to `&self`).
         // `MaybeUninit<T>` has no validity invariant, so `&mut` to this uninitialized memory is sound.
         let slot = unsafe { ptr.cast::<MaybeUninit<T>>().as_mut() };
-        inner_writer(slot, f)
+        let value = inner_writer(slot, f);
+
+        if !IMPURE_CLOSURE {
+            // Commit the cursor now, *after* the write. `ptr` is the just-allocated slot,
+            // and the arena bumps down, so `cursor_ptr` points at the object just allocated.
+            self.cursor_ptr.set(ptr.cast::<u8>());
+
+            // SAFETY: The caller guarantees `f` did not mutate `start_ptr`,
+            // so `start_ptr` still equals the value snapshotted above
+            unsafe { assert_unchecked!(self.start_ptr.get() == start_ptr) };
+        }
+
+        value
     }
 
     /// Try to pre-allocate space for an object in this `Arena`, and initialize it using the closure.
@@ -132,6 +203,45 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     where
         F: FnOnce() -> T,
     {
+        // SAFETY: `IMPURE_CLOSURE: true` imposes no requirement on `f`
+        unsafe { self.try_alloc_with_impl::<true, F, T>(f) }
+    }
+
+    /// Implementation of [`try_alloc`] and [`try_alloc_with`].
+    ///
+    /// When `IMPURE_CLOSURE` is `false` ([`try_alloc`]), sets `cursor_ptr` *after* calling the closure
+    /// and writing the result, and asserts to compiler that the write left `start_ptr` unchanged.
+    /// This is only valid if `f` closure does not perform further allocations in this arena,
+    /// or alter `cursor_ptr` / `start_ptr` by any other means.
+    ///
+    /// This operation ordering and the assertion lets the compiler keep both `cursor_ptr` and `start_ptr` in registers
+    /// across consecutive allocations, instead of reloading them after each value write (which it otherwise cannot
+    /// prove does not alias the pointer fields). It also allows compiler to skip alignment calculations on consecutive
+    /// allocations which share the same alignment, as it can prove the bump cursor is already aligned.
+    ///
+    /// When `IMPURE_CLOSURE` is `true` ([`try_alloc_with`]), sets `cursor_ptr` *before* calling the closure.
+    /// The "`start_ptr` is unchanged" assertion (and the snapshot read that feeds it) are compiled away.
+    /// This makes it valid for the closure to perform further allocations.
+    ///
+    /// # SAFETY
+    ///
+    /// If `IMPURE_CLOSURE` is `false`, `f` must not allocate from this `Arena` or otherwise mutate
+    /// `cursor_ptr` or `start_ptr`.
+    ///
+    /// * [`try_alloc`]'s `|| val` closure satisfies this, so it passes `IMPURE_CLOSURE: false`.
+    /// * An arbitrary [`try_alloc_with`] closure does not, so it passes `IMPURE_CLOSURE: true`.
+    ///
+    /// [`try_alloc`]: Self::try_alloc
+    /// [`try_alloc_with`]: Self::try_alloc_with
+    #[expect(clippy::mut_from_ref)]
+    #[inline(always)]
+    unsafe fn try_alloc_with_impl<const IMPURE_CLOSURE: bool, F, T>(
+        &self,
+        f: F,
+    ) -> Result<&mut T, AllocErr>
+    where
+        F: FnOnce() -> T,
+    {
         #[inline(always)]
         fn inner_writer<T, F>(slot: &mut MaybeUninit<T>, f: F) -> &mut T
         where
@@ -150,14 +260,41 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         }
 
         let layout = Layout::new::<T>();
-        let ptr = self.try_alloc_layout(layout)?;
+
+        // For a pure closure, defer committing `cursor_ptr` until *after* the value is written.
+        // This keeps the cursor in a register across consecutive allocations - no store-then-reload after
+        // the write, and the redundant alignment mask is dropped on subsequent same-alignment allocations.
+        // It is sound because a pure closure does not allocate, so nothing observes the arena between
+        // computing the slot and committing the cursor.
+        //
+        // For an impure closure, commit `cursor_ptr` up-front, so a re-entrant `f` (which may allocate)
+        // sees the updated pointer.
+        let ptr = self.try_alloc_layout_impl::<IMPURE_CLOSURE>(layout)?;
+
+        // Snapshot `start_ptr` as the (fast or slow) layout path left it, so the assertion below can pin it.
+        // `start_ptr` is read-only on the fast path, but the value write may alias it as far as compiler can tell,
+        // so without this it would be reloaded on the next allocation.
+        // Unused, and removed by the optimizer, when `IMPURE_CLOSURE` is `true`.
+        let start_ptr = self.start_ptr.get();
 
         // SAFETY: `ptr` was allocated with `T`'s layout, so it's correctly aligned and sized for `MaybeUninit<T>`
         // (same layout as `T`). The memory was just allocated, so no other reference aliases it,
         // and it lives for as long as the returned reference (tied to `&self`).
         // `MaybeUninit<T>` has no validity invariant, so `&mut` to this uninitialized memory is sound.
         let slot = unsafe { ptr.cast::<MaybeUninit<T>>().as_mut() };
-        Ok(inner_writer(slot, f))
+        let value = inner_writer(slot, f);
+
+        if !IMPURE_CLOSURE {
+            // Commit the cursor now, *after* the write. `ptr` is the just-allocated slot,
+            // and the arena bumps down, so `cursor_ptr` points at the object just allocated.
+            self.cursor_ptr.set(ptr.cast::<u8>());
+
+            // SAFETY: The caller guarantees `f` did not mutate `start_ptr`,
+            // so `start_ptr` still equals the value snapshotted above
+            unsafe { assert_unchecked!(self.start_ptr.get() == start_ptr) };
+        }
+
+        Ok(value)
     }
 
     /// `Copy` a slice into this `Arena` and return an exclusive reference to the copy.

--- a/crates/oxc_allocator/src/arena/alloc_impl.rs
+++ b/crates/oxc_allocator/src/arena/alloc_impl.rs
@@ -29,8 +29,18 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Panics if reserving space matching `layout` fails.
     #[inline(always)]
     pub fn alloc_layout(&self, layout: Layout) -> NonNull<u8> {
-        let ptr =
-            self.try_alloc_layout_fast(layout).unwrap_or_else(|| self.alloc_layout_slow(layout));
+        // `COMMIT: true` so that `cursor_ptr` is updated
+        self.alloc_layout_impl::<true>(layout)
+    }
+
+    /// Implementation of [`Arena::alloc_layout`].
+    ///
+    /// Only commits `cursor_ptr` on the fast path if `COMMIT == true`.
+    #[inline(always)]
+    pub(super) fn alloc_layout_impl<const COMMIT: bool>(&self, layout: Layout) -> NonNull<u8> {
+        let ptr = self
+            .try_alloc_layout_fast_impl::<COMMIT>(layout)
+            .unwrap_or_else(|| self.alloc_layout_slow(layout));
 
         #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
         self.stats.record_allocation();
@@ -49,7 +59,19 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Errors if reserving space matching `layout` fails.
     #[inline(always)]
     pub fn try_alloc_layout(&self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
-        let res = if let Some(ptr) = self.try_alloc_layout_fast(layout) {
+        // `COMMIT: true` so that `cursor_ptr` is updated
+        self.try_alloc_layout_impl::<true>(layout)
+    }
+
+    /// Implementation of [`Arena::try_alloc_layout`].
+    ///
+    /// Only commits `cursor_ptr` on the fast path if `COMMIT == true`.
+    #[inline(always)]
+    pub(super) fn try_alloc_layout_impl<const COMMIT: bool>(
+        &self,
+        layout: Layout,
+    ) -> Result<NonNull<u8>, AllocErr> {
+        let res = if let Some(ptr) = self.try_alloc_layout_fast_impl::<COMMIT>(layout) {
             Ok(ptr)
         } else {
             self.try_alloc_layout_slow(layout).ok_or(AllocErr)
@@ -66,6 +88,22 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     // Only `pub(super)` to expose it for unit tests
     #[inline(always)]
     pub(super) fn try_alloc_layout_fast(&self, layout: Layout) -> Option<NonNull<u8>> {
+        // `COMMIT: true` so that `cursor_ptr` is updated
+        self.try_alloc_layout_fast_impl::<true>(layout)
+    }
+
+    /// Fast path for all allocation methods.
+    ///
+    /// Computes the pointer for `layout` within the current chunk.
+    /// * On success:
+    ///   * Commits `cursor_ptr` if `COMMIT == true`.
+    ///   * Returns `Some(ptr)`.
+    /// * If the current chunk cannot service the request, returns `None`.
+    #[inline(always)]
+    fn try_alloc_layout_fast_impl<const COMMIT: bool>(
+        &self,
+        layout: Layout,
+    ) -> Option<NonNull<u8>> {
         let cursor_ptr = self.cursor_ptr.get().as_ptr();
         let start_ptr = self.start_ptr.get().as_ptr();
 
@@ -299,11 +337,25 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         debug_assert!(!new_ptr.is_null());
 
         // SAFETY: `start_ptr` is non-null, so if `new_ptr` was null, `new_ptr.addr().wrapping_sub(start_ptr.addr())`
-        // above would have wrapped around, and we already exited
-        let new_ptr = unsafe { NonNull::new_unchecked(new_ptr) };
+        // above would have wrapped around, and we already exited.
+        //
+        // `NonNull::new(new_ptr).unwrap_unchecked()` rather than `NonNull::new_unchecked(new_ptr)`,
+        // because `unwrap_unchecked` plants an explicit non-null assumption for the compiler
+        // (its `None` arm is `unreachable_unchecked`), whereas `NonNull::new_unchecked` is a plain transmute
+        // which asserts nothing.
+        //
+        // The assumption lets callers which `unwrap_or_else` the returned `Option` fold the `Option`'s
+        // null-niche check into the bounds check above, keeping the hot path to a single branch per allocation.
+        // Without it, they emit a redundant null-check branch when `COMMIT == false`.
+        // When `COMMIT == true`, the write to `cursor_ptr` below happens to give the compiler what it needs anyway,
+        // but the explicit assumption does not rely on that.
+        let new_ptr = unsafe { NonNull::new(new_ptr).unwrap_unchecked() };
 
-        // Update cursor
-        self.cursor_ptr.set(new_ptr);
+        // Update cursor - unless the caller defers the commit until after writing the value
+        // (used by the by-value allocation paths - see `alloc_with_impl`)
+        if COMMIT {
+            self.cursor_ptr.set(new_ptr);
+        }
 
         // Return the pointer
         Some(new_ptr)

--- a/crates/oxc_allocator/tests/arena/alloc_fill.rs
+++ b/crates/oxc_allocator/tests/arena/alloc_fill.rs
@@ -1,4 +1,4 @@
-use std::{alloc::Layout, cmp::max, mem};
+use std::{alloc::Layout, cmp::max, iter, mem, ptr};
 
 use oxc_allocator::arena::Arena;
 
@@ -36,4 +36,186 @@ fn alloc_slice_overflow() {
     let b = Arena::new();
 
     b.alloc_slice_fill_default::<u64>(usize::max_value());
+}
+
+// Constants and helper for the `*_updates_cursor` tests.
+const A: u64 = 0x1111_1111_1111_1111;
+const B: u64 = 0x2222_2222_2222_2222;
+const C: u64 = 0x3333_3333_3333_3333;
+
+fn addr<T>(r: &T) -> usize {
+    ptr::from_ref(r).addr()
+}
+
+/// `alloc_slice_fill_copy` must commit the bump pointer after each allocation,
+/// on both the fast path and the slow path (1st allocation in an empty arena has to allocate a chunk).
+#[test]
+fn alloc_slice_fill_copy_updates_cursor() {
+    // 2 consecutive allocations sit directly below one another (the arena bumps downwards),
+    // and the values don't overwrite each other
+    fn check(arena: &Arena) {
+        let a = arena.alloc_slice_fill_copy(2, A);
+        let b = arena.alloc_slice_fill_copy(2, B);
+        assert_eq!(addr(&b[0]), addr(&a[0]) - 16);
+        assert_eq!((a[0], a[1], b[0], b[1]), (A, A, B, B));
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    // Slow path
+    check(&Arena::new());
+}
+
+/// `alloc_slice_fill_with` must commit the bump pointer after each allocation,
+/// on both the fast path and the slow path (1st allocation in an empty arena has to allocate a chunk).
+///
+/// It must commit *before* calling the closure, so a closure which itself allocates from
+/// the same arena does not get overlapping memory.
+#[test]
+fn alloc_slice_fill_with_updates_cursor() {
+    // 2 consecutive allocations sit directly below one another (the arena bumps downwards),
+    // and the values don't overwrite each other
+    fn check(arena: &Arena) {
+        let a = arena.alloc_slice_fill_with(2, |i| A + i as u64);
+        let b = arena.alloc_slice_fill_with(2, |i| B + i as u64);
+        assert_eq!(addr(&b[0]), addr(&a[0]) - 16);
+        assert_eq!((a[0], a[1], b[0], b[1]), (A, A + 1, B, B + 1));
+    }
+
+    // Closure which performs another allocation from the same arena.
+    // The inner allocations must sit below the outer slice - no overlap.
+    // Each element's value is that inner allocation's address.
+    // The closure runs once per element, interleaved with the element writes,
+    // so the 1st inner allocation is 8 bytes below the slice, the 2nd is 16 bytes below.
+    fn check_reentrant(arena: &Arena) {
+        let outer = arena.alloc_slice_fill_with(2, |_| {
+            let inner = arena.alloc(C);
+            assert_eq!(*inner, C);
+            addr(inner) as u64
+        });
+        assert_eq!(outer[0], (addr(&outer[0]) - 8) as u64);
+        assert_eq!(outer[1], (addr(&outer[0]) - 16) as u64);
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    check_reentrant(&Arena::with_capacity(0x1000));
+
+    // Slow path
+    check(&Arena::new());
+    check_reentrant(&Arena::new());
+}
+
+/// `alloc_slice_fill_clone` must commit the bump pointer after each allocation,
+/// on both the fast path and the slow path (1st allocation in an empty arena has to allocate a chunk).
+///
+/// It must commit *before* cloning the elements, so a `Clone` impl which itself allocates from
+/// the same arena does not get overlapping memory.
+#[test]
+fn alloc_slice_fill_clone_updates_cursor() {
+    #[derive(Clone)]
+    struct Val(u64);
+
+    // 2 consecutive allocations sit directly below one another (the arena bumps downwards),
+    // and the values don't overwrite each other
+    fn check(arena: &Arena) {
+        let a = arena.alloc_slice_fill_clone(2, &Val(A));
+        let b = arena.alloc_slice_fill_clone(2, &Val(B));
+        assert_eq!(addr(&b[0]), addr(&a[0]) - 16);
+        assert_eq!((a[0].0, a[1].0, b[0].0, b[1].0), (A, A, B, B));
+    }
+
+    // `Clone` impl which performs another allocation from the same arena.
+    // The inner allocations must sit below the outer slice - no overlap.
+    // Each element records its inner allocation's address.
+    // `Reentrant` is 16 bytes, so the outer slice is 32 bytes. Clones run interleaved with
+    // the element writes, so the 1st inner allocation is 8 bytes below the slice, the 2nd 16 below.
+    struct Reentrant<'a> {
+        arena: &'a Arena,
+        inner_addr: usize,
+    }
+
+    impl Clone for Reentrant<'_> {
+        fn clone(&self) -> Self {
+            let inner = self.arena.alloc(C);
+            assert_eq!(*inner, C);
+            Self { arena: self.arena, inner_addr: addr(inner) }
+        }
+    }
+
+    fn check_reentrant(arena: &Arena) {
+        let value = Reentrant { arena, inner_addr: 0 };
+        let outer = arena.alloc_slice_fill_clone(2, &value);
+        assert_eq!(outer[0].inner_addr, addr(&outer[0]) - 8);
+        assert_eq!(outer[1].inner_addr, addr(&outer[0]) - 16);
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    check_reentrant(&Arena::with_capacity(0x1000));
+
+    // Slow path
+    check(&Arena::new());
+    check_reentrant(&Arena::new());
+}
+
+/// `alloc_slice_fill_iter` must commit the bump pointer after each allocation,
+/// on both the fast path and the slow path (1st allocation in an empty arena has to allocate a chunk).
+///
+/// It must commit *before* consuming the iterator, so an iterator which itself allocates from
+/// the same arena does not get overlapping memory.
+#[test]
+fn alloc_slice_fill_iter_updates_cursor() {
+    // 2 consecutive allocations sit directly below one another (the arena bumps downwards),
+    // and the values don't overwrite each other
+    fn check(arena: &Arena) {
+        let a = arena.alloc_slice_fill_iter([A, A + 1]);
+        let b = arena.alloc_slice_fill_iter([B, B + 1]);
+        assert_eq!(addr(&b[0]), addr(&a[0]) - 16);
+        assert_eq!((a[0], a[1], b[0], b[1]), (A, A + 1, B, B + 1));
+    }
+
+    // Iterator which performs another allocation from the same arena.
+    // The inner allocations must sit below the outer slice - no overlap.
+    // Each element's value is that inner allocation's address.
+    // The iterator is consumed interleaved with the element writes,
+    // so the 1st inner allocation is 8 bytes below the slice, the 2nd is 16 bytes below.
+    fn check_reentrant(arena: &Arena) {
+        let outer = arena.alloc_slice_fill_iter(
+            iter::repeat_with(|| {
+                let inner = arena.alloc(C);
+                assert_eq!(*inner, C);
+                addr(inner) as u64
+            })
+            .take(2),
+        );
+        assert_eq!(outer[0], (addr(&outer[0]) - 8) as u64);
+        assert_eq!(outer[1], (addr(&outer[0]) - 16) as u64);
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    check_reentrant(&Arena::with_capacity(0x1000));
+
+    // Slow path
+    check(&Arena::new());
+    check_reentrant(&Arena::new());
+}
+
+/// `alloc_slice_fill_default` must commit the bump pointer after each allocation,
+/// on both the fast path and the slow path (1st allocation in an empty arena has to allocate a chunk).
+#[test]
+fn alloc_slice_fill_default_updates_cursor() {
+    // 2 consecutive allocations sit directly below one another (the arena bumps downwards)
+    fn check(arena: &Arena) {
+        let a = arena.alloc_slice_fill_default::<u64>(2);
+        let b = arena.alloc_slice_fill_default::<u64>(2);
+        assert_eq!(addr(&b[0]), addr(&a[0]) - 16);
+        assert_eq!((a[0], a[1], b[0], b[1]), (0, 0, 0, 0));
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    // Slow path
+    check(&Arena::new());
 }

--- a/crates/oxc_allocator/tests/arena/alloc_with.rs
+++ b/crates/oxc_allocator/tests/arena/alloc_with.rs
@@ -4,6 +4,8 @@
 // We only run them when debug_assertions are not set, as we expect them to fail outside release
 // mode.
 
+use std::ptr;
+
 use oxc_allocator::arena::Arena;
 
 #[test]
@@ -65,4 +67,49 @@ fn alloc_with_large_enum() {
     let b = Arena::new();
 
     b.alloc_with(|| LargeEnum::Small);
+}
+
+/// `alloc_with` must commit the bump pointer after each allocation, on both the fast path
+/// and the slow path (1st allocation in an empty arena has to allocate a chunk).
+///
+/// It must commit *before* calling the closure, so a closure which itself allocates from
+/// the same arena does not get overlapping memory.
+#[test]
+fn alloc_with_updates_cursor() {
+    const A: u64 = 0x1111_1111_1111_1111;
+    const B: u64 = 0x2222_2222_2222_2222;
+    const C: u64 = 0x3333_3333_3333_3333;
+
+    fn addr<T>(r: &T) -> usize {
+        ptr::from_ref(r).addr()
+    }
+
+    // 2 consecutive allocations sit directly below one another (the arena bumps downwards),
+    // and the values don't overwrite each other
+    fn check(arena: &Arena) {
+        let a = arena.alloc_with(|| A);
+        let b = arena.alloc_with(|| B);
+        assert_eq!(addr(b), addr(a) - 8);
+        assert_eq!((*a, *b), (A, B));
+    }
+
+    // Closure which performs another allocation from the same arena.
+    // The inner allocation must sit below the outer slot - no overlap.
+    // The outer slot's value is the inner allocation's address.
+    fn check_reentrant(arena: &Arena) {
+        let outer = arena.alloc_with(|| {
+            let inner = arena.alloc(C);
+            assert_eq!(*inner, C);
+            addr(inner) as u64
+        });
+        assert_eq!(*outer, (addr(outer) - 8) as u64);
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    check_reentrant(&Arena::with_capacity(0x1000));
+
+    // Slow path
+    check(&Arena::new());
+    check_reentrant(&Arena::new());
 }

--- a/crates/oxc_allocator/tests/arena/tests.rs
+++ b/crates/oxc_allocator/tests/arena/tests.rs
@@ -116,6 +116,104 @@ fn alloc_with_strong_alignment() {
     b.alloc_layout(Layout::from_size_align(4096, 64).unwrap());
 }
 
+// Constants and helper for the `*_updates_cursor` tests.
+//
+// Each of those tests makes 2 consecutive allocations and checks:
+// 1. The 2nd allocation is placed directly below the 1st (the arena bumps downwards).
+// 2. The 2 values don't overwrite each other.
+//
+// Each runs on both the fast path (arena with spare capacity) and the slow path
+// (1st allocation in an empty arena has to allocate a chunk).
+
+const A: u64 = 0x1111_1111_1111_1111;
+const B: u64 = 0x2222_2222_2222_2222;
+const C: u64 = 0x3333_3333_3333_3333;
+
+fn addr<T>(r: &T) -> usize {
+    ptr::from_ref(r).addr()
+}
+
+#[test]
+fn alloc_updates_cursor() {
+    fn check(arena: &Arena) {
+        let a = arena.alloc(A);
+        let b = arena.alloc(B);
+        assert_eq!(addr(b), addr(a) - 8);
+        assert_eq!((*a, *b), (A, B));
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    // Slow path
+    check(&Arena::new());
+}
+
+#[test]
+fn try_alloc_updates_cursor() {
+    fn check(arena: &Arena) {
+        let a = arena.try_alloc(A).unwrap();
+        let b = arena.try_alloc(B).unwrap();
+        assert_eq!(addr(b), addr(a) - 8);
+        assert_eq!((*a, *b), (A, B));
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    // Slow path
+    check(&Arena::new());
+}
+
+#[test]
+fn alloc_layout_updates_cursor() {
+    fn check(arena: &Arena) {
+        let layout = Layout::new::<u64>();
+        let a = arena.alloc_layout(layout).cast::<u64>();
+        unsafe { a.write(A) };
+        let b = arena.alloc_layout(layout).cast::<u64>();
+        unsafe { b.write(B) };
+        assert_eq!(b.addr().get(), a.addr().get() - 8);
+        assert_eq!(unsafe { (a.read(), b.read()) }, (A, B));
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    // Slow path
+    check(&Arena::new());
+}
+
+#[test]
+fn try_alloc_layout_updates_cursor() {
+    fn check(arena: &Arena) {
+        let layout = Layout::new::<u64>();
+        let a = arena.try_alloc_layout(layout).unwrap().cast::<u64>();
+        unsafe { a.write(A) };
+        let b = arena.try_alloc_layout(layout).unwrap().cast::<u64>();
+        unsafe { b.write(B) };
+        assert_eq!(b.addr().get(), a.addr().get() - 8);
+        assert_eq!(unsafe { (a.read(), b.read()) }, (A, B));
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    // Slow path
+    check(&Arena::new());
+}
+
+#[test]
+fn alloc_str_updates_cursor() {
+    fn check(arena: &Arena) {
+        let a = arena.alloc_str("hello");
+        let b = arena.alloc_str("world!");
+        assert_eq!(b.as_ptr().addr(), a.as_ptr().addr() - 6);
+        assert_eq!((&*a, &*b), ("hello", "world!"));
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    // Slow path
+    check(&Arena::new());
+}
+
 #[test]
 fn alloc_slice_copy() {
     let b = Arena::new();
@@ -124,6 +222,21 @@ fn alloc_slice_copy() {
     let dst = b.alloc_slice_copy(src);
 
     assert_eq!(src, dst);
+}
+
+#[test]
+fn alloc_slice_copy_updates_cursor() {
+    fn check(arena: &Arena) {
+        let a = arena.alloc_slice_copy(&[A, A]);
+        let b = arena.alloc_slice_copy(&[B, B]);
+        assert_eq!(addr(&b[0]), addr(&a[0]) - 16);
+        assert_eq!((a[0], a[1], b[0], b[1]), (A, A, B, B));
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    // Slow path
+    check(&Arena::new());
 }
 
 #[test]
@@ -141,6 +254,57 @@ fn alloc_slice_clone() {
     let dst = b.alloc_slice_clone(&src);
 
     assert_eq!(src, dst);
+}
+
+/// `alloc_slice_clone` must commit the bump pointer after each allocation,
+/// on both the fast path and the slow path (1st allocation in an empty arena has to allocate a chunk).
+///
+/// It must commit *before* cloning the elements, so a `Clone` impl which itself allocates from
+/// the same arena does not get overlapping memory.
+#[test]
+fn alloc_slice_clone_updates_cursor() {
+    #[derive(Clone)]
+    struct Val(u64);
+
+    fn check(arena: &Arena) {
+        let a = arena.alloc_slice_clone(&[Val(A), Val(A)]);
+        let b = arena.alloc_slice_clone(&[Val(B), Val(B)]);
+        assert_eq!(addr(&b[0]), addr(&a[0]) - 16);
+        assert_eq!((a[0].0, a[1].0, b[0].0, b[1].0), (A, A, B, B));
+    }
+
+    // `Clone` impl which performs another allocation from the same arena.
+    // The inner allocations must sit below the outer slice - no overlap.
+    // Each element records its inner allocation's address.
+    // `Reentrant` is 16 bytes, so the outer slice is 32 bytes. Clones run interleaved with
+    // the element writes, so the 1st inner allocation is 8 bytes below the slice, the 2nd 16 below.
+    struct Reentrant<'a> {
+        arena: &'a Arena,
+        inner_addr: usize,
+    }
+
+    impl Clone for Reentrant<'_> {
+        fn clone(&self) -> Self {
+            let inner = self.arena.alloc(C);
+            assert_eq!(*inner, C);
+            Self { arena: self.arena, inner_addr: addr(inner) }
+        }
+    }
+
+    fn check_reentrant(arena: &Arena) {
+        let src = [Reentrant { arena, inner_addr: 0 }, Reentrant { arena, inner_addr: 0 }];
+        let outer = arena.alloc_slice_clone(&src);
+        assert_eq!(outer[0].inner_addr, addr(&outer[0]) - 8);
+        assert_eq!(outer[1].inner_addr, addr(&outer[0]) - 16);
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    check_reentrant(&Arena::with_capacity(0x1000));
+
+    // Slow path
+    check(&Arena::new());
+    check_reentrant(&Arena::new());
 }
 
 #[test]

--- a/crates/oxc_allocator/tests/arena/try_alloc_with.rs
+++ b/crates/oxc_allocator/tests/arena/try_alloc_with.rs
@@ -4,6 +4,8 @@
 // We only run them when debug_assertions are not set, as we expect them to fail outside release
 // mode.
 
+use std::ptr;
+
 use oxc_allocator::arena::Arena;
 
 #[test]
@@ -67,4 +69,51 @@ fn try_alloc_with_large_enum() {
     let b = Arena::new();
 
     b.try_alloc_with(|| LargeEnum::Small).unwrap();
+}
+
+/// `try_alloc_with` must commit the bump pointer after each allocation, on both the fast path
+/// and the slow path (1st allocation in an empty arena has to allocate a chunk).
+///
+/// It must commit *before* calling the closure, so a closure which itself allocates from
+/// the same arena does not get overlapping memory.
+#[test]
+fn try_alloc_with_updates_cursor() {
+    const A: u64 = 0x1111_1111_1111_1111;
+    const B: u64 = 0x2222_2222_2222_2222;
+    const C: u64 = 0x3333_3333_3333_3333;
+
+    fn addr<T>(r: &T) -> usize {
+        ptr::from_ref(r).addr()
+    }
+
+    // 2 consecutive allocations sit directly below one another (the arena bumps downwards),
+    // and the values don't overwrite each other
+    fn check(arena: &Arena) {
+        let a = arena.try_alloc_with(|| A).unwrap();
+        let b = arena.try_alloc_with(|| B).unwrap();
+        assert_eq!(addr(b), addr(a) - 8);
+        assert_eq!((*a, *b), (A, B));
+    }
+
+    // Closure which performs another allocation from the same arena.
+    // The inner allocation must sit below the outer slot - no overlap.
+    // The outer slot's value is the inner allocation's address.
+    fn check_reentrant(arena: &Arena) {
+        let outer = arena
+            .try_alloc_with(|| {
+                let inner = arena.alloc(C);
+                assert_eq!(*inner, C);
+                addr(inner) as u64
+            })
+            .unwrap();
+        assert_eq!(*outer, (addr(outer) - 8) as u64);
+    }
+
+    // Fast path
+    check(&Arena::with_capacity(0x1000));
+    check_reentrant(&Arena::with_capacity(0x1000));
+
+    // Slow path
+    check(&Arena::new());
+    check_reentrant(&Arena::new());
 }


### PR DESCRIPTION
`Arena` (and by extension `Allocator`) have a problem: all its allocation methods take an `&Arena` reference not an exclusive `&mut Arena`. This requires `Arena` to use interior mutability - all its fields are wrapped in `Cell`s.

The unfortunate side effect is that compiler is not able to optimize effectively around allocations.

An allocation is 3 steps:

1. Read `cursor_ptr` and `start_ptr`, compute the new (bumped-down, aligned) cursor, and bounds-check it against `start_ptr`. Fall back to the slow path if current chunk can't service the request.
2. Commit the new cursor - write it back to the `cursor_ptr` field.
3. Write the value into the slot.

Step 3 writes through a pointer into the arena chunk. As far as compiler is concerned, that write could alias the `Arena`'s own fields - it can't rule out that the chunk contains the `Arena` struct itself, and the pointer write may have altered the values in `Arena`'s own fields (the `Cell`s). So the value write invalidates everything it knew about `cursor_ptr` and `start_ptr`. On the next allocation it has to load both fields from memory again, and redo the alignment arithmetic, because the fact that the cursor was already aligned is lost along with everything else.

2 consecutive `alloc::<u64>` calls currently compile to this on x86-64 (fast path shown, slow-path branches omitted):

```asm
mov     rax, qword ptr [rdi]        ; load cursor_ptr
add     rax, -8                     ; bump downwards
and     rax, -8                     ; align down
cmp     rax, qword ptr [rdi + 16]   ; bounds check - load start_ptr + bounds check
js      .slow1
mov     qword ptr [rdi], rax        ; commit cursor_ptr
mov     qword ptr [rax], 123        ; write value
; -- 2nd allocation --
mov     rdx, qword ptr [rdi]        ; reload cursor_ptr
add     rdx, -8                     ; bump downwards
and     rdx, -8                     ; re-do alignment
cmp     rdx, qword ptr [rdi + 16]   ; bounds check - reload start_ptr
js      .slow2
mov     qword ptr [rdi], rdx        ; commit cursor_ptr
mov     qword ptr [rdx], 456        ; write value
```

## The fix

For the by-value methods `alloc` and `try_alloc`, swap steps 2 and 3: write the value first, commit the cursor after. Then assert to the compiler (with `assert_unchecked!`) that `start_ptr` still holds the value read in step 1.

This is sound because `alloc`'s "closure" `|| val` just moves a value that the caller already constructed. It cannot allocate from the arena or touch its fields, so nothing observes the arena in the window between computing the slot and committing the cursor.

After the reorder, the next allocation has nothing to reload. The compiler performed the `cursor_ptr` store itself with a value it knows, the assertion pins `start_ptr`, and cursor alignment is provable from the previous iteration. Both pointers stay in registers across any number of consecutive allocations, and the alignment mask is only computed once for a run of same-alignment allocations:

```asm
mov     rax, qword ptr [rdi]        ; load cursor_ptr (once)
mov     rcx, qword ptr [rdi + 16]   ; load start_ptr (once)
add     rax, -8                     ; bump downwards
and     rax, -8                     ; align down (once)
cmp     rax, rcx                    ; bounds check
js      .slow1
mov     qword ptr [rax], 123        ; write value
mov     qword ptr [rdi], rax        ; commit cursor_ptr
; -- 2nd allocation --
lea     rdx, [rax - 8]              ; bump downwards - no reload, no align
cmp     rdx, rcx                    ; bounds check - start_ptr still in register
js      .slow2
mov     qword ptr [rdx], 456        ; write value
mov     qword ptr [rdi], rdx        ; commit cursor_ptr
```

Each subsequent allocation drops from 7 instructions to 5, and from 3 memory operations (beyond the value write itself) to 1. One of the two removed loads - the reload of `cursor_ptr` - was on the critical path, previously costing ~4 cycles.

This reordering is _not_ valid for `alloc_with` and `try_alloc_with`. Their closures are arbitrary user code which may itself allocate from the same arena. A re-entrant allocation inside the closure would read a stale cursor and hand out overlapping memory. So the `_with` methods keep the original ordering: commit before calling the closure.

The two orderings share their implementation via a const param. `alloc` / `alloc_with` both forward to `alloc_with_impl::<const IMPURE_CLOSURE: bool>` (likewise the `try_` variants), and `IMPURE_CLOSURE` is threaded down through `alloc_layout_impl` / `try_alloc_layout_impl` to the fast path as `COMMIT`, which controls whether the fast path writes `cursor_ptr` itself. `IMPURE_CLOSURE: false` is an internal unsafe contract - the `_impl` methods are private, and public API is unchanged.

## Redundant stores

For a series of allocations, `cursor_ptr` is stored after each of the individual allocations (`mov qword ptr [rdi], rax` in example above). On the fast path, this store is redundant for all but the last allocation - `cursor_ptr` is not reloaded from memory before the later allocations. It'd be ideal to move this store to the cold branch (where it _is_ necessary), but I could not find any way to coax compiler to do that.

Claude informs me that transform is "partial dead store elimination" - sinking a store onto the branch where it's actually needed, but that LLVM doesn't implement it. Its dead store elimination only removes stores which are dead on _all_ paths, and each of these stores is live on one path (the slow-path call reads `cursor_ptr`), so no amount of massaging the source can produce that codegen.

## A wrinkle: `NonNull::new_unchecked` doesn't inform the compiler

Making the cursor store conditional exposed a latent weakness in the fast path. It returns `Option<NonNull<u8>>`, and `alloc_layout` unwraps it with `.unwrap_or_else(|| self.alloc_layout_slow(layout))`. `None` occupies the null niche, so `unwrap_or_else` is a null test. Previously LLVM folded that test into the fast path's bounds check, keeping the hot path to a single branch - but it turns out that fold depended on the unconditional store of the new pointer into the `NonNull<u8>`\-typed `cursor_ptr` field. With `COMMIT == false` there is no store, so LLVM could no longer prove the pointer non-null, and every allocation grew a second branch (a `je` null test alongside the `js` bounds check).

The bounds check genuinely does prove the pointer is non-null, but that reasoning is beyond LLVM, and `NonNull::new_unchecked` contributes nothing - its precondition check is a ub-check which compiles out entirely in release builds, leaving a plain transmute, with no non-null "fact" attached.

The fix is to construct the pointer with `NonNull::new(new_ptr).unwrap_unchecked()` instead, which does inform compiler of the non-null "fact".

`alloc_layout`, `try_alloc_layout`, the `_with` methods, and `alloc_str` are restructured by this commit, but their codegen is unchanged - only `alloc` and `try_alloc` compile differently.