### PR TITLE
refactor(parser): check multiple for-loop declarations

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -751,6 +751,14 @@ parser_diagnostics! {
         .with_help("Did you mean to use a for...of statement?")
     };
 
+    multiple_declarations_in_for_loop_head(is_for_in: bool, span: Span) => {
+        OxcDiagnostic::error(format!(
+            "Only a single declaration is allowed in a `for...{}` statement",
+            if is_for_in { "in" } else { "of" },
+        ))
+        .with_label(span)
+    };
+
     using_declarations_must_be_initialized(span: Span) => {
         OxcDiagnostic::error("Using declarations must have an initializer.")
             .with_label(span)

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -559,7 +559,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         init_declaration: ArenaBox<'a, VariableDeclaration<'a>>,
         r#await: bool,
     ) -> Statement<'a> {
-        match self.cur_kind() {
+        let kind = self.cur_kind();
+        if matches!(kind, Kind::In | Kind::Of) {
+            self.check_for_in_or_of_variable_declaration(&init_declaration, kind);
+        }
+
+        match kind {
             Kind::In => self.parse_for_in_loop(
                 start,
                 parenthesis_opening_span,
@@ -578,6 +583,22 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 Some(ForStatementInit::VariableDeclaration(init_declaration)),
                 r#await,
             ),
+        }
+    }
+
+    fn check_for_in_or_of_variable_declaration(
+        &mut self,
+        declaration: &VariableDeclaration<'a>,
+        kind: Kind,
+    ) {
+        debug_assert!(matches!(kind, Kind::In | Kind::Of));
+        let is_for_in = kind == Kind::In;
+
+        if declaration.declarations.len() > 1 {
+            self.error(diagnostics::multiple_declarations_in_for_loop_head(
+                is_for_in,
+                declaration.span,
+            ));
         }
     }
 

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -914,10 +914,7 @@ pub fn check_for_statement_left(
 
     // initializer is not allowed for for-in / for-of
     if decl.declarations.len() > 1 {
-        return ctx.error(diagnostics::multiple_declaration_in_for_loop_head(
-            if is_for_in { "in" } else { "of" },
-            decl.span,
-        ));
+        return;
     }
 
     let strict_mode = ctx.strict_mode();

--- a/crates/oxc_semantic/src/diagnostics.rs
+++ b/crates/oxc_semantic/src/diagnostics.rs
@@ -261,14 +261,6 @@ pub fn label_redeclaration(x0: &str, span1: Span, span2: Span) -> OxcDiagnostic 
 }
 
 #[cold]
-pub fn multiple_declaration_in_for_loop_head(x0: &str, span1: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!(
-        "Only a single declaration is allowed in a `for...{x0}` statement"
-    ))
-    .with_label(span1)
-}
-
-#[cold]
 pub fn unexpected_initializer_in_for_loop_head(x0: &str, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("{x0} loop variable declaration may not have an initializer"))
         .with_label(span1)


### PR DESCRIPTION
Moves the validation that rejects multiple declarations in `for...in` and `for...of` loop heads from semantic analysis into the parser.

Part of #25149.