### PR TITLE
fix(react_compiler): fix panic from #24710: Register scope nodes for scopes only referenced by reassignments

### DIFF
--- a/crates/oxc_react_compiler/fixtures/try-catch-ternary-test-scope-in-iife.js
+++ b/crates/oxc_react_compiler/fixtures/try-catch-ternary-test-scope-in-iife.js
@@ -1,0 +1,21 @@
+// The scope produced by `check(raw)` in the ternary test gets aligned outward to
+// span the whole inlined IIFE (both `return`s become reassignments of the IIFE
+// temporary + breaks out of the try). That scope's only own declaration lives
+// in the ternary *test*, which PruneNonEscapingScopes never visits for
+// memoization inputs, so the scope must still be registered when it is
+// associated with the reassigned temporary.
+function Component() {
+  const raw = useValue();
+  return (() => {
+    try {
+      return check(raw) ? raw : null;
+    } catch {
+      return null;
+    }
+  })();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{}],
+};

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -175,6 +175,19 @@ impl CollectState {
         );
     }
 
+    /// Records the scope and its dependencies, if not already present.
+    fn declare_scope<'a>(&mut self, env: &Environment<'a>, scope_id: ScopeId) {
+        self.scopes.entry(scope_id).or_insert_with(|| {
+            let scope_data = &env.scopes[scope_id];
+            let dependencies = scope_data
+                .dependencies
+                .iter()
+                .map(|dep| env.identifiers[dep.identifier].declaration_id)
+                .collect();
+            ScopeNode { dependencies, seen: false }
+        });
+    }
+
     /// Associates the identifier with its scope, if there is one and it is active for
     /// the given instruction id.
     fn visit_operand<'a>(
@@ -185,15 +198,7 @@ impl CollectState {
         identifier: DeclarationId,
     ) {
         if let Some(scope_id) = get_place_scope(env, id, place.identifier) {
-            self.scopes.entry(scope_id).or_insert_with(|| {
-                let scope_data = &env.scopes[scope_id];
-                let dependencies = scope_data
-                    .dependencies
-                    .iter()
-                    .map(|dep| env.identifiers[dep.identifier].declaration_id)
-                    .collect();
-                ScopeNode { dependencies, seen: false }
-            });
+            self.declare_scope(env, scope_id);
             let identifier_node = self
                 .identifiers
                 .get_mut(&identifier)
@@ -927,6 +932,14 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CollectDependenciesVisitor<'a, 'e> 
         let env = self.env;
         let scope_id = scope.scope;
         let scope_data = &env.scopes[scope_id];
+
+        // Register the scope up front. `visit_operand` only records a scope when it visits
+        // an operand declared in it, but a scope's only such operands can sit somewhere
+        // `compute_memoization_inputs` never descends into (e.g. a ternary `test`). The
+        // scope is still associated with identifiers below (reassignments) and in
+        // `visit_terminal` (returns within the scope), and `compute_memoized_identifiers`
+        // expects a node for every associated scope.
+        state.0.declare_scope(env, scope_id);
 
         // If a scope reassigns any variables, set the chain of active scopes as a dependency
         // of those variables.

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-ternary-test-scope-in-iife.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-ternary-test-scope-in-iife.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/try-catch-ternary-test-scope-in-iife.js
+---
+import { c as _c } from "react/compiler-runtime";
+// The scope produced by `check(raw)` in the ternary test gets aligned outward to
+// span the whole inlined IIFE (both `return`s become reassignments of the IIFE
+// temporary + breaks out of the try). That scope's only own declaration lives
+// in the ternary *test*, which PruneNonEscapingScopes never visits for
+// memoization inputs, so the scope must still be registered when it is
+// associated with the reassigned temporary.
+function Component() {
+	const $ = _c(2);
+	const raw = useValue();
+	let t0;
+	if ($[0] !== raw) {
+		try {
+			t0 = check(raw) ? raw : null;
+		} catch {
+			t0 = null;
+		}
+		$[0] = raw;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{}]
+};


### PR DESCRIPTION
This PR fixes a react-compiler panic first reported in #24710
```
thread '<unnamed>' (19177185) panicked at /Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/forked_react_compiler_reactive_scopes-0.2.0/src/prune_non_escaping_scopes.rs:1167:14:
Expected a node for all scopes
```

`PruneNonEscapingScopes` panicked with “Expected a node for all scopes” when a reactive scope's only own declarations sat inside a ternary `test` (which is never visited for memoization inputs) while the scope also reassigned an escaping value, e.g. an IIFE returning `check(x) ? x : null` from a try/catch.

Scope nodes were only created lazily when an operand declared in the scope was visited, but `visit_scope`/`visit_terminal` also associate scopes with identifiers. Register the node when entering the scope so every associated scope has one.

Closes #24710

Authored by Claude Code