### PR TITLE
perf(oxlint/lsp): avoid second lock for getting/removing unused directives

### DIFF
--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -834,17 +834,15 @@ impl ServerLinter {
 
         messages.append(&mut generate_inverted_diagnostics(&messages, uri));
 
+        // Take directives once to avoid separate get/remove lock acquisitions.
+        let directives = self.runner.directives_coordinator().take(path);
+
         // Add unused directives if configured
         if let Some(severity) = self.unused_directives_severity
-            && let Some(directives) = self.runner.directives_coordinator().get(path)
+            && let Some(directives) = directives
         {
             messages.extend(create_unused_directives_report(&directives, severity, source_text));
         }
-
-        // Clear any stale directives because they are no longer needed.
-        // This prevents using outdated directive spans if the new linting run fails.
-        self.runner.directives_coordinator().remove(path);
-
         Ok(messages)
     }
 

--- a/crates/oxc_linter/src/lint_runner.rs
+++ b/crates/oxc_linter/src/lint_runner.rs
@@ -127,6 +127,14 @@ impl DirectivesStore {
     pub fn remove(&self, path: &Path) {
         self.map.lock().expect("DirectivesStore mutex poisoned in remove").remove(path);
     }
+
+    /// Take and remove disable directives for a specific file in a single lock acquisition.
+    ///
+    /// # Panics
+    /// Panics if the mutex is poisoned.
+    pub fn take(&self, path: &Path) -> Option<DisableDirectives> {
+        self.map.lock().expect("DirectivesStore mutex poisoned in take").remove(path)
+    }
 }
 
 impl Default for DirectivesStore {


### PR DESCRIPTION
Avoids a second lock for `.map` inside `DirectivesStore` when consuming the directives on `--lsp` side.