### PR TITLE
perf(oxlint/lsp): preallocate fix-content vec

### DIFF
--- a/apps/oxlint/src/lsp/error_with_position.rs
+++ b/apps/oxlint/src/lsp/error_with_position.rs
@@ -169,7 +169,8 @@ pub fn message_to_lsp_diagnostic(
         data: None,
     };
 
-    let mut fixed_content = vec![];
+    let mut fixed_content = Vec::with_capacity(message.fixes.len());
+
     // Convert PossibleFixes directly to PossibleFixContent
     match message.fixes {
         PossibleFixes::None => {}


### PR DESCRIPTION
After https://github.com/oxc-project/oxc/pull/24958 we know the size of `Vec<FixedContent>` , because we are only consuming now `Messages.fixes` which are directly mapped into `FixedContent`