### PR TITLE
fix(crates/oxc_linter): fix typo

### DIFF
--- a/crates/oxc_codegen/tests/integration/snapshots/stacktrace_is_correct.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/stacktrace_is_correct.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_codegen/tests/integration/sourcemap.rs
 ---
-Node.js version: v26.5.0
+Node.js version: v26.7.0
 
 ## Input
 const fn = () => {

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/return_checker.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/return_checker.rs
@@ -10,7 +10,7 @@ use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashSet;
 
 /// `StatementReturnStatus` describes whether the CFG corresponding to
-/// the statement is termitated by return statement in all/some/nome of
+/// the statement is terminated by return statement in all/some/nome of
 /// its exit blocks.
 ///
 /// For example, an "if" statement is terminated by explicit return if and only if either:


### PR DESCRIPTION
## Fix spelling typo in code comment

Resolves a failure in the `ready` CI task caused by the `typos` linter flagging a comment.