### PR TITLE
feat(oxlint): support `--no-ignore=<KIND>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1941,6 +1941,7 @@ dependencies = [
 name = "oxc_config"
 version = "0.0.0"
 dependencies = [
+ "bpaf",
  "fast-glob",
  "ignore",
  "oxc-schemars",

--- a/apps/oxfmt/src/cli/walk.rs
+++ b/apps/oxfmt/src/cli/walk.rs
@@ -424,7 +424,7 @@ fn walk_and_stream(
 
     // Git-related settings come from the shared helper to align with Oxlint.
     // NOTE: Prettier only reads `.gitignore` in the cwd and does not respect `.git/info/exclude`.
-    configure_walk_builder(&mut inner, has_vcs_boundary)
+    configure_walk_builder(&mut inner, has_vcs_boundary, true)
         // Do not follow symlinks like Prettier does.
         // See https://github.com/prettier/prettier/pull/14627
         .follow_links(false)

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -30,7 +30,7 @@ doctest = false
 oxc_allocator = { workspace = true, features = ["fixed_size"] }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true, features = ["serialize"] }
-oxc_config = { workspace = true }
+oxc_config = { workspace = true, features = ["bpaf"] }
 oxc_diagnostics = { workspace = true }
 oxc_estree_tokens = { workspace = true }
 oxc_language_server = { workspace = true }

--- a/apps/oxlint/src/command/ignore.rs
+++ b/apps/oxlint/src/command/ignore.rs
@@ -1,14 +1,21 @@
 use std::ffi::OsString;
 
-use bpaf::{Bpaf, doc::Style};
+use bpaf::{Bpaf, Parser};
 
-pub const NO_IGNORE_HELP: &[(&str, Style)] = &[
-    ("Disable excluding files from `.eslintignore` files, ", Style::Text),
-    ("--ignore-path", Style::Literal),
-    (" flags and ", Style::Text),
-    ("--ignore-pattern", Style::Literal),
-    (" flags", Style::Text),
-];
+pub use oxc_config::NoIgnoreKinds;
+
+/// What the `cli` kind covers in Oxlint;
+/// the rest of the `--no-ignore` help text is assembled by [`oxc_config::no_ignore_kinds`].
+const CLI_KIND_HELP: &str = "`.eslintignore` files, `--ignore-path` and `--ignore-pattern` flags (those flags are ignored even when passed)";
+
+/// Tell `oxc_config` about Oxlint specific `cli` kind, and also default kind for bare `--no-ignore`.
+fn no_ignore_kinds() -> impl Parser<NoIgnoreKinds> {
+    // TODO: Change to `ALL_NAME` so that bare `--no-ignore` disables every ignore source,
+    // as the flag name promises.
+    // This is a breaking change; release notes should mention `--no-ignore=cli` as the escape hatch for the old behavior.
+    // See https://github.com/oxc-project/oxc/issues/25259
+    oxc_config::no_ignore_kinds(NoIgnoreKinds::CLI_NAME, CLI_KIND_HELP)
+}
 
 /// Ignore Files
 #[derive(Debug, Clone, Bpaf)]
@@ -24,26 +31,33 @@ pub struct IgnoreOptions {
     #[bpaf(argument("PAT"), many, hide_usage)]
     pub ignore_pattern: Vec<String>,
 
-    #[bpaf(switch, hide_usage, help(NO_IGNORE_HELP))]
-    pub no_ignore: bool,
+    #[bpaf(external(no_ignore_kinds), hide_usage)]
+    pub no_ignore: NoIgnoreKinds,
 }
 
 #[cfg(test)]
 mod ignore_options {
     use std::{ffi::OsString, path::PathBuf};
 
-    use super::{super::lint::lint_command, IgnoreOptions};
+    use super::{
+        super::lint::{LintCommand, lint_command},
+        IgnoreOptions, NoIgnoreKinds,
+    };
+
+    fn run(arg: &str) -> Result<LintCommand, bpaf::ParseFailure> {
+        let args = arg.split(' ').map(std::string::ToString::to_string).collect::<Vec<_>>();
+        lint_command().run_inner(args.as_slice())
+    }
 
     fn get_ignore_options(arg: &str) -> IgnoreOptions {
-        let args = arg.split(' ').map(std::string::ToString::to_string).collect::<Vec<_>>();
-        lint_command().run_inner(args.as_slice()).unwrap().ignore_options
+        run(arg).unwrap().ignore_options
     }
 
     #[test]
     fn default() {
         let options = get_ignore_options(".");
         assert_eq!(options.ignore_path, OsString::from(".eslintignore"));
-        assert!(!options.no_ignore);
+        assert_eq!(options.no_ignore, NoIgnoreKinds::NONE);
         assert!(options.ignore_pattern.is_empty());
     }
 
@@ -51,12 +65,6 @@ mod ignore_options {
     fn ignore_path() {
         let options = get_ignore_options("--ignore-path .xxx foo.js");
         assert_eq!(options.ignore_path, PathBuf::from(".xxx"));
-    }
-
-    #[test]
-    fn no_ignore() {
-        let options = get_ignore_options("--no-ignore foo.js");
-        assert!(options.no_ignore);
     }
 
     #[test]
@@ -69,5 +77,50 @@ mod ignore_options {
     fn multiple_ignore_pattern() {
         let options = get_ignore_options("--ignore-pattern ./test --ignore-pattern bar.js foo.js");
         assert_eq!(options.ignore_pattern, vec![String::from("./test"), String::from("bar.js")]);
+    }
+
+    #[test]
+    fn no_ignore() {
+        let options = get_ignore_options("--no-ignore foo.js");
+        assert_eq!(options.no_ignore, NoIgnoreKinds::CLI);
+    }
+
+    /// An attached `=KINDS` value reaches `NoIgnoreKinds::from_str`;
+    /// the value combinations themselves are unit-tested in `oxc_config`.
+    #[test]
+    fn no_ignore_vcs() {
+        let options = get_ignore_options("--no-ignore=vcs foo.js");
+        assert_eq!(options.no_ignore, NoIgnoreKinds { vcs: true, cli: false, config: false });
+    }
+
+    /// The kind-validation error must escape bpaf instead of being swallowed;
+    /// see the parser-composition rationale on `oxc_config::no_ignore_kinds`.
+    #[test]
+    fn no_ignore_unknown_kind() {
+        let err = run("--no-ignore=bogus foo.js").unwrap_err().unwrap_stderr();
+        assert!(err.contains("'bogus' is not a known ignore kind"), "{err}");
+    }
+
+    /// The kind list must be attached with `=`; a space-separated word after
+    /// bare `--no-ignore` is a positional path, never a kind list.
+    #[test]
+    fn no_ignore_space_separated_value_is_a_path() {
+        let options = get_ignore_options("--no-ignore vcs");
+        assert_eq!(options.no_ignore, NoIgnoreKinds::CLI);
+    }
+
+    /// Named option parsing must respect the end-of-options separator.
+    #[test]
+    fn no_ignore_after_double_dash_is_a_path() {
+        let command = run("-- --no-ignore").unwrap();
+        assert_eq!(command.ignore_options.no_ignore, NoIgnoreKinds::NONE);
+        assert_eq!(command.paths, vec![PathBuf::from("--no-ignore")]);
+    }
+
+    /// Keep `--no-ignore` in bpaf's option metadata for typo suggestions and shell completion.
+    #[test]
+    fn no_ignore_typo_suggestion() {
+        let err = run("--no-ignores foo.js").unwrap_err().unwrap_stderr();
+        assert!(err.contains("did you mean `--no-ignore`"), "{err}");
     }
 }

--- a/apps/oxlint/src/command/mod.rs
+++ b/apps/oxlint/src/command/mod.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use bpaf::Bpaf;
 
 pub use self::{
-    ignore::IgnoreOptions,
+    ignore::{IgnoreOptions, NoIgnoreKinds},
     lint::{
         DebugOption, LintCommand, OutputOptions, ReportUnusedDirectives, WarningOptions,
         lint_command,

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1,10 +1,8 @@
 use std::{
     env,
-    ffi::OsStr,
     fmt::Debug,
     io::{ErrorKind, Write},
     path::{Path, PathBuf, absolute},
-    sync::Arc,
     time::Instant,
 };
 
@@ -129,7 +127,7 @@ impl CliRunner {
 
         let mut override_builder = None;
 
-        if !ignore_options.no_ignore {
+        if !ignore_options.no_ignore.cli {
             let mut builder = OverrideBuilder::new(&self.cwd);
 
             if !ignore_options.ignore_pattern.is_empty() {
@@ -193,8 +191,10 @@ impl CliRunner {
         // NOTE: Applied regardless of `--no-ignore`.
         // Currently it only disables Oxlint's own ignore sources (`.eslintignore`, `--ignore-path`, `--ignore-pattern`),
         // not git's. (Aligns with during walk filtering behavior)
-        let mut gitignore_checker = GitignoreChecker::new();
-        paths.retain(|p| !gitignore_checker.is_gitignored_walk_root(p, &self.cwd));
+        if !ignore_options.no_ignore.vcs {
+            let mut gitignore_checker = GitignoreChecker::new();
+            paths.retain(|p| !gitignore_checker.is_gitignored_walk_root(p, &self.cwd));
+        }
 
         // If explicit paths were provided but all have been filtered,
         // or the default cwd target is gitignored, return early.
@@ -364,18 +364,17 @@ impl CliRunner {
             return crate::mode::run_rules(&lint_config, &output_formatter, stdout);
         }
 
-        let ignore_matcher = LintIgnoreMatcher::new(
-            &root_config.ignore_patterns,
-            // Without a config file there are no patterns and the root is never consulted,
-            // so the CWD fallback is an arbitrary placeholder.
-            root_config.dir().unwrap_or(&self.cwd),
-            nested_ignore_patterns,
-        );
-
-        let files_to_lint = paths
-            .into_iter()
-            .filter(|path| !ignore_matcher.should_ignore(Path::new(path)))
-            .collect::<Vec<Arc<OsStr>>>();
+        let mut files_to_lint = paths;
+        if !ignore_options.no_ignore.config {
+            let ignore_matcher = LintIgnoreMatcher::new(
+                &root_config.ignore_patterns,
+                // Without a config file there are no patterns and the root is never consulted,
+                // so the CWD fallback is an arbitrary placeholder.
+                root_config.dir().unwrap_or(&self.cwd),
+                nested_ignore_patterns,
+            );
+            files_to_lint.retain(|path| !ignore_matcher.should_ignore(Path::new(path)));
+        }
 
         if debug_files {
             return crate::mode::run_debug_files(
@@ -856,8 +855,10 @@ mod test {
         fs::write(repo_path.join("sub").join(".gitignore"), "generated\n").unwrap();
         fs::write(pkg_path.join("index.ts"), "debugger;\n").unwrap();
 
+        let run = |args: &[&str]| Tester::new().with_cwd(pkg_path.clone()).test_output(args);
+
         // Running from inside the ignored tree finds nothing.
-        let (_, result) = Tester::new().with_cwd(pkg_path.clone()).test_output(&[]);
+        let (_, result) = run(&[]);
         assert!(matches!(result, CliRunResult::LintNoFilesFound), "{result:?}");
 
         // Explicitly passed gitignored directories are skipped too.
@@ -866,10 +867,36 @@ mod test {
 
         // But an explicitly named file is linted even when gitignored;
         // `.gitignore` only scopes discovery.
-        let (stdout, result) =
-            Tester::new().with_cwd(pkg_path).test_output(&["-D", "no-debugger", "index.ts"]);
+        let (stdout, result) = run(&["-D", "no-debugger", "index.ts"]);
         assert!(matches!(result, CliRunResult::LintFoundErrors), "{result:?}\n{stdout}");
         assert!(stdout.contains("on 1 file"), "{stdout}");
+
+        // `--no-ignore=vcs` disables the gitignore layer for the walk as well.
+        // https://github.com/oxc-project/oxc/issues/25259
+        let (stdout, result) = run(&["-D", "no-debugger", "--no-ignore=vcs"]);
+        assert!(matches!(result, CliRunResult::LintFoundErrors), "{result:?}\n{stdout}");
+        let (stdout, result) = run(&["-D", "no-debugger", "--no-ignore=all"]);
+        assert!(matches!(result, CliRunResult::LintFoundErrors), "{result:?}\n{stdout}");
+    }
+
+    #[test]
+    fn no_ignore_config_disables_config_ignore_patterns() {
+        use crate::cli::CliRunResult;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root = temp_dir.path();
+        fs::write(root.join(".oxlintrc.json"), r#"{ "ignorePatterns": ["ignored"] }"#).unwrap();
+        fs::create_dir(root.join("ignored")).unwrap();
+        fs::write(root.join("ignored").join("index.js"), "debugger;\n").unwrap();
+
+        let run = |args: &[&str]| Tester::new().with_cwd(root.to_path_buf()).test_output(args);
+
+        let (_, result) = run(&["-D", "no-debugger", "ignored/index.js"]);
+        assert!(!matches!(result, CliRunResult::LintFoundErrors), "{result:?}");
+
+        let (stdout, result) =
+            run(&["-D", "no-debugger", "--no-ignore=config", "ignored/index.js"]);
+        assert!(matches!(result, CliRunResult::LintFoundErrors), "{result:?}\n{stdout}");
     }
 
     #[cfg(unix)]

--- a/apps/oxlint/src/walk.rs
+++ b/apps/oxlint/src/walk.rs
@@ -98,7 +98,7 @@ impl Walk {
             }
         }
 
-        if !options.no_ignore {
+        if !options.no_ignore.cli {
             inner.add_custom_ignore_filename(&options.ignore_path);
 
             if let Some(override_builder) = override_builder {
@@ -106,8 +106,10 @@ impl Walk {
             }
         }
 
-        let has_vcs_boundary = all_paths_have_vcs_boundary(paths, cwd);
-        let inner = configure_walk_builder(&mut inner, has_vcs_boundary)
+        let respect_gitignore = !options.no_ignore.vcs;
+        // `require_git` is inert once the git layer is off, so skip the boundary stats.
+        let has_vcs_boundary = respect_gitignore && all_paths_have_vcs_boundary(paths, cwd);
+        let inner = configure_walk_builder(&mut inner, has_vcs_boundary, respect_gitignore)
             .follow_links(true)
             // Use the same thread count as rayon (controlled by `--threads`)
             .threads(rayon::current_num_threads())
@@ -153,7 +155,7 @@ mod test {
     use ignore::overrides::OverrideBuilder;
 
     use super::{Extensions, Walk};
-    use crate::cli::IgnoreOptions;
+    use crate::cli::{IgnoreOptions, NoIgnoreKinds};
 
     fn collect_js_paths(root: &Path, ignore_options: &IgnoreOptions) -> Vec<String> {
         let override_builder = OverrideBuilder::new(root).build().unwrap();
@@ -176,7 +178,7 @@ mod test {
 
     fn empty_ignore_options() -> IgnoreOptions {
         IgnoreOptions {
-            no_ignore: false,
+            no_ignore: NoIgnoreKinds::NONE,
             ignore_path: OsString::from(".eslintignore"),
             ignore_pattern: vec![],
         }
@@ -187,7 +189,7 @@ mod test {
         let fixture = env::current_dir().unwrap().join("fixtures/cli/walk_dir");
         let fixtures = vec![fixture.clone()];
         let ignore_options = IgnoreOptions {
-            no_ignore: false,
+            no_ignore: NoIgnoreKinds::NONE,
             ignore_path: OsString::from(".gitignore"),
             ignore_pattern: vec![],
         };

--- a/crates/oxc_config/Cargo.toml
+++ b/crates/oxc_config/Cargo.toml
@@ -20,7 +20,13 @@ workspace = true
 test = true
 doctest = false
 
+[features]
+# CLI parser helpers shared between Oxlint and Oxfmt.
+# Gated so that library consumers (e.g. `napi-playground` -> `oxc_linter` -> `oxc_config`) do not pull in `bpaf`.
+bpaf = ["dep:bpaf"]
+
 [dependencies]
+bpaf = { workspace = true, optional = true }
 fast-glob = { workspace = true }
 ignore = { workspace = true }
 oxc_diagnostics = { workspace = true }

--- a/crates/oxc_config/src/lib.rs
+++ b/crates/oxc_config/src/lib.rs
@@ -3,6 +3,7 @@
 mod discovery;
 mod glob_set;
 mod ignore_patterns;
+mod no_ignore;
 mod walk;
 
 pub use discovery::{
@@ -10,4 +11,7 @@ pub use discovery::{
 };
 pub use glob_set::{GlobSet, validate_glob_pattern};
 pub use ignore_patterns::validate_ignore_pattern;
+pub use no_ignore::NoIgnoreKinds;
+#[cfg(feature = "bpaf")]
+pub use no_ignore::no_ignore_kinds;
 pub use walk::{GitignoreChecker, all_paths_have_vcs_boundary, configure_walk_builder};

--- a/crates/oxc_config/src/no_ignore.rs
+++ b/crates/oxc_config/src/no_ignore.rs
@@ -1,0 +1,166 @@
+use std::str::FromStr;
+
+#[cfg(feature = "bpaf")]
+use bpaf::{Parser, doc::Doc};
+
+/// Which ignore sources `--no-ignore` disables, grouped by where they come from.
+///
+/// Shared between Oxlint and Oxfmt so the kind names and their parsing stay in sync;
+/// what each kind concretely disables is tool-specific and documented in each tool's help text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NoIgnoreKinds {
+    /// `.gitignore` files and `$GIT_DIR/info/exclude`
+    pub vcs: bool,
+    /// The tool's own ignore files and CLI ignore flags
+    /// (e.g. Oxlint's `.eslintignore` / `--ignore-path` / `--ignore-pattern`)
+    pub cli: bool,
+    /// `ignorePatterns` from config files
+    pub config: bool,
+}
+
+impl NoIgnoreKinds {
+    pub const NONE: Self = Self { vcs: false, cli: false, config: false };
+    /// Only the `cli` sources: the historical behavior of bare `oxlint --no-ignore`.
+    pub const CLI: Self = Self { vcs: false, cli: true, config: false };
+    pub const ALL: Self = Self { vcs: true, cli: true, config: true };
+
+    pub const VCS_NAME: &str = "vcs";
+    pub const CLI_NAME: &str = "cli";
+    pub const CONFIG_NAME: &str = "config";
+    pub const ALL_NAME: &str = "all";
+}
+
+impl FromStr for NoIgnoreKinds {
+    type Err = String;
+
+    fn from_str(kinds: &str) -> Result<Self, Self::Err> {
+        let mut result = Self::NONE;
+        for kind in kinds.split(',').filter(|kind| !kind.is_empty()) {
+            match kind {
+                Self::VCS_NAME => result.vcs = true,
+                Self::CLI_NAME => result.cli = true,
+                Self::CONFIG_NAME => result.config = true,
+                Self::ALL_NAME => result = Self::ALL,
+                _ => return Err(format!("'{kind}' is not a known ignore kind")),
+            }
+        }
+        if result == Self::NONE {
+            return Err(format!(
+                "expected at least one ignore kind: `{}`, `{}`, `{}`, `{}`",
+                Self::VCS_NAME,
+                Self::CLI_NAME,
+                Self::CONFIG_NAME,
+                Self::ALL_NAME
+            ));
+        }
+        Ok(result)
+    }
+}
+
+/// Build the `--no-ignore[=KINDS]` parser shared between Oxlint and Oxfmt.
+///
+/// The flag accepts an optional attached value:
+/// bare `--no-ignore` behaves as `--no-ignore=<bare_kind_name>`, `--no-ignore=<KINDS>` disables the listed kinds.
+/// The value must be attached with `=`,
+/// so that a following positional path (`--no-ignore src/`) is never mistaken for a kind list.
+///
+/// The help text is assembled here so both tools document the flag identically;
+/// only the `cli` kind covers tool-specific sources, so its bullet body comes from `cli_kind_help`.
+///
+/// The two forms are parsed as alternatives and converted to [`NoIgnoreKinds`] only after they converge to the same type.
+/// Validating the argument before combining the parsers makes `bpaf` swallow the kind-validation error
+/// (`--no-ignore=bogus` then reports a generic "not expected in this context").
+/// The value-taking alternative is hidden from help to avoid displaying the option twice;
+/// the visible bare alternative documents both forms.
+///
+/// # Panics
+/// Panics when `bare_kind_name` is not a valid kind list.
+#[cfg(feature = "bpaf")]
+pub fn no_ignore_kinds(
+    bare_kind_name: &'static str,
+    cli_kind_help: &str,
+) -> impl Parser<NoIgnoreKinds> {
+    let bare_kinds: NoIgnoreKinds =
+        bare_kind_name.parse().expect("`bare_kind_name` must be a valid kind list");
+
+    // Pushed as flat `text()` chunks, one per line plus one per bullet lead-in,
+    // mirroring how `&[(&str, Style)]` help consts render;
+    // `Doc::doc()` splicing would render nested and break bullet indentation.
+    // Everything is plain text with backticks denoting code, matching the other flags' description style.
+    let mut help = Doc::default();
+    help.text("Disable ignore sources; without a value, disables `");
+    help.text(bare_kind_name);
+    help.text(
+        "`. Takes an optional comma-separated list of kinds attached with `=`, e.g. `--no-ignore=vcs,config`:\n",
+    );
+    help.text("  * `");
+    help.text(NoIgnoreKinds::VCS_NAME);
+    help.text("` - `.gitignore` files and `.git/info/exclude`\n");
+    help.text("  * `");
+    help.text(NoIgnoreKinds::CLI_NAME);
+    help.text("` - ");
+    help.text(cli_kind_help);
+    help.text("\n");
+    help.text("  * `");
+    help.text(NoIgnoreKinds::CONFIG_NAME);
+    help.text("` - `ignorePatterns` in config files\n");
+    help.text("  * `");
+    help.text(NoIgnoreKinds::ALL_NAME);
+    help.text("` - all of the above");
+
+    // `adjacent` requires `=KINDS`, so a following positional path is never consumed as the value.
+    // Keep this alternative hidden to render a single help entry for the option.
+    let with_kinds =
+        bpaf::long("no-ignore").argument::<String>("KINDS").adjacent().map(Some).hide();
+    let bare = bpaf::long("no-ignore").help(help).req_flag(None);
+
+    bpaf::construct!([with_kinds, bare])
+        .parse(move |kinds| match kinds {
+            None => Ok(bare_kinds),
+            Some(kinds) => kinds.parse(),
+        })
+        .fallback(NoIgnoreKinds::NONE)
+}
+
+#[cfg(test)]
+mod test {
+    use super::NoIgnoreKinds;
+
+    #[test]
+    fn from_str_single_kind() {
+        assert_eq!(
+            "vcs".parse::<NoIgnoreKinds>().unwrap(),
+            NoIgnoreKinds { vcs: true, cli: false, config: false }
+        );
+    }
+
+    #[test]
+    fn from_str_multiple_kinds() {
+        assert_eq!(
+            "vcs,config".parse::<NoIgnoreKinds>().unwrap(),
+            NoIgnoreKinds { vcs: true, cli: false, config: true }
+        );
+    }
+
+    #[test]
+    fn from_str_all() {
+        assert_eq!("all".parse::<NoIgnoreKinds>().unwrap(), NoIgnoreKinds::ALL);
+    }
+
+    #[test]
+    fn from_str_skips_interior_empties() {
+        assert_eq!("cli,,".parse::<NoIgnoreKinds>().unwrap(), NoIgnoreKinds::CLI);
+    }
+
+    #[test]
+    fn from_str_unknown_kind() {
+        let err = "bogus".parse::<NoIgnoreKinds>().unwrap_err();
+        assert!(err.contains("'bogus' is not a known ignore kind"), "{err}");
+    }
+
+    #[test]
+    fn from_str_empty() {
+        let err = "".parse::<NoIgnoreKinds>().unwrap_err();
+        assert!(err.contains("expected at least one ignore kind"), "{err}");
+    }
+}

--- a/crates/oxc_config/src/walk.rs
+++ b/crates/oxc_config/src/walk.rs
@@ -12,10 +12,15 @@ use rustc_hash::FxHashMap;
 /// `has_vcs_boundary` should be the result of [`all_paths_have_vcs_boundary`] for the walk targets.
 /// Callers that build multiple walkers from the same targets can compute it once and reuse it.
 ///
+/// `respect_gitignore` controls the git layer (nested `.gitignore` files and `$GIT_COMMON_DIR/info/exclude`);
+/// pass `false` when the tool's `--no-ignore` disables the `vcs` ignore sources.
+/// `require_git` is inert in that case, so callers can also skip computing `has_vcs_boundary` and pass `false`.
+///
 /// [`GitignoreChecker`] uses these same settings for walk-root checks.
 pub fn configure_walk_builder(
     builder: &mut WalkBuilder,
     has_vcs_boundary: bool,
+    respect_gitignore: bool,
 ) -> &mut WalkBuilder {
     builder
         // Include hidden files to lint|format; VCS directories are skipped by each tool
@@ -25,11 +30,11 @@ pub fn configure_walk_builder(
         // Ignore the user's global gitignore
         .git_global(false)
         // Respect repository-local (nested) `.gitignore` files
-        .git_ignore(true)
-        // Also look up parent directories
-        .parents(true)
+        .git_ignore(respect_gitignore)
         // Respect `$GIT_COMMON_DIR/info/exclude` as well
-        .git_exclude(true)
+        .git_exclude(respect_gitignore)
+        // Also look up parent directories; does not affect what to respect
+        .parents(true)
         // Parent `.gitignore` lookup stops at the repository boundary when targets are inside a repo
         .require_git(has_vcs_boundary)
 }
@@ -88,7 +93,7 @@ impl GitignoreChecker {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
                 let mut builder = WalkBuilder::new(entry.key());
-                configure_walk_builder(&mut builder, has_vcs_boundary);
+                configure_walk_builder(&mut builder, has_vcs_boundary, true);
                 let Some(matcher) = builder.build_matchers().pop() else { return false };
                 entry.insert(matcher)
             }
@@ -156,7 +161,7 @@ mod test {
     fn collect_walked_js_files(root: &Path) -> Vec<String> {
         let mut builder = WalkBuilder::new(root);
         let has_boundary = all_paths_have_vcs_boundary(&[root.to_path_buf()], root);
-        let mut paths: Vec<String> = configure_walk_builder(&mut builder, has_boundary)
+        let mut paths: Vec<String> = configure_walk_builder(&mut builder, has_boundary, true)
             .build()
             .filter_map(Result::ok)
             .filter_map(|entry| {

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -104,7 +104,11 @@ Arguments:
 
   The supported syntax is the same as for `.eslintignore` and `.gitignore` files. You should quote your patterns in order to avoid shell interpretation of glob patterns.
 - **`    --no-ignore`** &mdash; 
-  Disable excluding files from `.eslintignore` files, **`--ignore-path`** flags and **`--ignore-pattern`** flags
+  Disable ignore sources; without a value, disables `cli`. Takes an optional comma-separated list of kinds attached with `=`, e.g. `--no-ignore=vcs,config`:
+ * `vcs` - `.gitignore` files and `.git/info/exclude`
+ * `cli` - `.eslintignore` files, `--ignore-path` and `--ignore-pattern` flags (those flags are ignored even when passed)
+ * `config` - `ignorePatterns` in config files
+ * `all` - all of the above
 
 
 

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -61,8 +61,14 @@ Ignore Files
         --ignore-path=PATH    Specify the file to use as your `.eslintignore`
         --ignore-pattern=PAT  Specify patterns of files to ignore (in addition to those in
                               `.eslintignore`)
-        --no-ignore           Disable excluding files from `.eslintignore` files, --ignore-path
-                              flags and --ignore-pattern flags
+        --no-ignore           Disable ignore sources; without a value, disables `cli`. Takes an
+                              optional comma-separated list of kinds attached with `=`, e.g.
+                              `--no-ignore=vcs,config`:
+                               * `vcs` - `.gitignore` files and `.git/info/exclude`
+                               * `cli` - `.eslintignore` files, `--ignore-path` and
+                              `--ignore-pattern` flags (those flags are ignored even when passed)
+                               * `config` - `ignorePatterns` in config files
+                               * `all` - all of the above
 
 Handle Warnings
         --quiet               Disable reporting on warnings, only errors are reported


### PR DESCRIPTION
Fixes #25603

To lint gitignored file, now you can use `--no-ignore=vcs`.

Also introduces:

- `vcs`: `.gitignore` files and `.git/info/exclude`
- `cli`: `.eslintignore` files, `--ignore-path` and `--ignore-pattern` flags
- `config`: `ignorePatterns` in config files
- `all`: all of the above

At the moment, bare `--no-ignore` works as `--no-ignore=cli`, no breaking change.