### PR TITLE
fix(oxlint)!: change bare `--no-ignore` to disable all ignore sources

### DIFF
--- a/apps/oxlint/src/command/ignore.rs
+++ b/apps/oxlint/src/command/ignore.rs
@@ -9,12 +9,10 @@ pub use oxc_config::NoIgnoreKinds;
 const CLI_KIND_HELP: &str = "`.eslintignore` files, `--ignore-path` and `--ignore-pattern` flags (those flags are ignored even when passed)";
 
 /// Tell `oxc_config` about Oxlint specific `cli` kind, and also default kind for bare `--no-ignore`.
+/// Bare `--no-ignore` disables every ignore source, as the flag name promises;
+/// `--no-ignore=cli` is the escape hatch for the historical bare `--no-ignore` behavior.
 fn no_ignore_kinds() -> impl Parser<NoIgnoreKinds> {
-    // TODO: Change to `ALL_NAME` so that bare `--no-ignore` disables every ignore source,
-    // as the flag name promises.
-    // This is a breaking change; release notes should mention `--no-ignore=cli` as the escape hatch for the old behavior.
-    // See https://github.com/oxc-project/oxc/issues/25259
-    oxc_config::no_ignore_kinds(NoIgnoreKinds::CLI_NAME, CLI_KIND_HELP)
+    oxc_config::no_ignore_kinds(NoIgnoreKinds::ALL_NAME, CLI_KIND_HELP)
 }
 
 /// Ignore Files
@@ -82,6 +80,13 @@ mod ignore_options {
     #[test]
     fn no_ignore() {
         let options = get_ignore_options("--no-ignore foo.js");
+        assert_eq!(options.no_ignore, NoIgnoreKinds::ALL);
+    }
+
+    /// The escape hatch for the historical bare `--no-ignore` behavior.
+    #[test]
+    fn no_ignore_cli() {
+        let options = get_ignore_options("--no-ignore=cli foo.js");
         assert_eq!(options.no_ignore, NoIgnoreKinds::CLI);
     }
 
@@ -106,7 +111,7 @@ mod ignore_options {
     #[test]
     fn no_ignore_space_separated_value_is_a_path() {
         let options = get_ignore_options("--no-ignore vcs");
-        assert_eq!(options.no_ignore, NoIgnoreKinds::CLI);
+        assert_eq!(options.no_ignore, NoIgnoreKinds::ALL);
     }
 
     /// Named option parsing must respect the end-of-options separator.

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -187,10 +187,9 @@ impl CliRunner {
             paths.push(self.cwd.clone());
         }
 
-        // The walker never filters gitignored walk roots (including roots inside a gitignored directory).
-        // NOTE: Applied regardless of `--no-ignore`.
-        // Currently it only disables Oxlint's own ignore sources (`.eslintignore`, `--ignore-path`, `--ignore-pattern`),
-        // not git's. (Aligns with during walk filtering behavior)
+        // The walker never filters gitignored walk roots (including roots inside a gitignored directory),
+        // so filter them here, unless the `vcs` ignore source is disabled.
+        // (Aligns with during walk filtering behavior)
         if !ignore_options.no_ignore.vcs {
             let mut gitignore_checker = GitignoreChecker::new();
             paths.retain(|p| !gitignore_checker.is_gitignored_walk_root(p, &self.cwd));
@@ -871,9 +870,16 @@ mod test {
         assert!(matches!(result, CliRunResult::LintFoundErrors), "{result:?}\n{stdout}");
         assert!(stdout.contains("on 1 file"), "{stdout}");
 
-        // `--no-ignore=vcs` disables the gitignore layer for the walk as well.
+        // `--no-ignore=cli` (the historical bare behavior) keeps git's sources active for the walk.
+        let (_, result) = run(&["--no-ignore=cli"]);
+        assert!(matches!(result, CliRunResult::LintNoFilesFound), "{result:?}");
+
+        // `--no-ignore=vcs` disables the gitignore layer for the walk as well;
+        // bare `--no-ignore` now disables every ignore source.
         // https://github.com/oxc-project/oxc/issues/25259
         let (stdout, result) = run(&["-D", "no-debugger", "--no-ignore=vcs"]);
+        assert!(matches!(result, CliRunResult::LintFoundErrors), "{result:?}\n{stdout}");
+        let (stdout, result) = run(&["-D", "no-debugger", "--no-ignore"]);
         assert!(matches!(result, CliRunResult::LintFoundErrors), "{result:?}\n{stdout}");
         let (stdout, result) = run(&["-D", "no-debugger", "--no-ignore=all"]);
         assert!(matches!(result, CliRunResult::LintFoundErrors), "{result:?}\n{stdout}");

--- a/crates/oxc_config/src/no_ignore.rs
+++ b/crates/oxc_config/src/no_ignore.rs
@@ -20,7 +20,6 @@ pub struct NoIgnoreKinds {
 
 impl NoIgnoreKinds {
     pub const NONE: Self = Self { vcs: false, cli: false, config: false };
-    /// Only the `cli` sources: the historical behavior of bare `oxlint --no-ignore`.
     pub const CLI: Self = Self { vcs: false, cli: true, config: false };
     pub const ALL: Self = Self { vcs: true, cli: true, config: true };
 

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -104,7 +104,7 @@ Arguments:
 
   The supported syntax is the same as for `.eslintignore` and `.gitignore` files. You should quote your patterns in order to avoid shell interpretation of glob patterns.
 - **`    --no-ignore`** &mdash; 
-  Disable ignore sources; without a value, disables `cli`. Takes an optional comma-separated list of kinds attached with `=`, e.g. `--no-ignore=vcs,config`:
+  Disable ignore sources; without a value, disables `all`. Takes an optional comma-separated list of kinds attached with `=`, e.g. `--no-ignore=vcs,config`:
  * `vcs` - `.gitignore` files and `.git/info/exclude`
  * `cli` - `.eslintignore` files, `--ignore-path` and `--ignore-pattern` flags (those flags are ignored even when passed)
  * `config` - `ignorePatterns` in config files

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -61,7 +61,7 @@ Ignore Files
         --ignore-path=PATH    Specify the file to use as your `.eslintignore`
         --ignore-pattern=PAT  Specify patterns of files to ignore (in addition to those in
                               `.eslintignore`)
-        --no-ignore           Disable ignore sources; without a value, disables `cli`. Takes an
+        --no-ignore           Disable ignore sources; without a value, disables `all`. Takes an
                               optional comma-separated list of kinds attached with `=`, e.g.
                               `--no-ignore=vcs,config`:
                                * `vcs` - `.gitignore` files and `.git/info/exclude`


### PR DESCRIPTION
Changed bare `--no-ignore` behavior from `cli` to `all`.

This makes the behavior match what is described in the documentation and aligns it with existing tools like ESLint, which should be more intuitive for users.

If you need the previous behavior, please specify `--no-ignore=cli`.