### PR TITLE
fix(linter/unicorn/switch-case-braces): bound token lookup

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -150,7 +150,8 @@ impl Rule for SwitchCaseBraces {
 
             if *self.0 == SwitchCaseBracesConfig::Always && missing_braces {
                 let test_end = case.test.as_ref().map_or(case.span.start, |t| t.span().end);
-                let colon_offset = ctx.find_next_token_from(test_end, ":").unwrap();
+                let colon_offset =
+                    ctx.find_next_token_within(test_end, case.span.end, ":").unwrap();
                 let colon_pos = test_end + colon_offset;
                 let span = Span::new(case.span.start, colon_pos + 1);
 


### PR DESCRIPTION
## Summary
Bound the switch-case colon lookup to the current case span.

## Details
- Use `find_next_token_within` to locate the case colon.
- Preserve the existing diagnostic span and fix behavior.