### PR TITLE
refactor(linter): remove unbounded token lookup APIs

### DIFF
--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -111,31 +111,6 @@ impl<'a> LintContext<'a> {
         span.source_text(self.parent.semantic().source_text())
     }
 
-    /// Finds the next occurrence of the given token in the source code,
-    /// starting from the specified position, skipping over comments.
-    #[expect(clippy::cast_possible_truncation)]
-    pub fn find_next_token_from(&self, start: u32, token: &str) -> Option<u32> {
-        let source =
-            self.source_range(Span::new(start, self.parent.semantic().source_text().len() as u32));
-
-        source
-            .match_indices(token)
-            .find(|(a, _)| !self.is_inside_comment(start + *a as u32))
-            .map(|(a, _)| a as u32)
-    }
-
-    /// Finds the previous occurrence of the given token in the source code,
-    /// starting from the specified position, skipping over comments.
-    #[expect(clippy::cast_possible_truncation)]
-    pub fn find_prev_token_from(&self, start: u32, token: &str) -> Option<u32> {
-        let source = self.source_range(Span::from(0..start));
-
-        source
-            .rmatch_indices(token)
-            .find(|(a, _)| !self.is_inside_comment(*a as u32))
-            .map(|(a, _)| a as u32)
-    }
-
     /// Finds the next occurrence of the given token within a bounded span,
     /// starting from the specified position, skipping over comments.
     ///

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -192,15 +192,6 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
         self.new_fix(CompositeFix::Single(fix), message)
     }
 
-    /// Finds the next occurrence of the given token in the source code,
-    /// starting from the specified position, skipping over comments.
-    ///
-    /// Returns the offset from `start` if the token is found, otherwise `None`.
-    #[inline]
-    pub fn find_next_token_from(&self, start: u32, token: &str) -> Option<u32> {
-        self.ctx.find_next_token_from(start, token)
-    }
-
     #[inline]
     pub fn find_next_token_within(&self, start: u32, end: u32, token: &str) -> Option<u32> {
         self.ctx.find_next_token_within(start, end, token)


### PR DESCRIPTION
## Summary
- Remove the unbounded `LintContext` token lookup APIs.
- Remove the matching unbounded `RuleFixer` forwarding API.

## Details
All current callers use the bounded `find_*_token_within` helpers. These unbounded methods are dangerous as they increase the search area significantly and increase the risk that you don't get the token that you need.

