### PR TITLE
fix(linter/eslint/no-unused-vars): bound catch parameter lookup

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -465,16 +465,18 @@ fn remove_unused_catch_parameter<'a>(
     catch: &CatchParameter<'a>,
 ) -> crate::fixer::RuleFix {
     let Span { start, end, .. } = catch.span();
+    let AstKind::CatchClause(catch_clause) = ctx.nodes().parent_node(catch.node_id()).kind() else {
+        return fixer.noop();
+    };
 
-    #[expect(clippy::cast_possible_truncation)]
-    let source_end = ctx.source_text().len() as u32;
-    let (Some(paren_start), Some(paren_end_offset)) = (
-        ctx.find_prev_token_within(0, start, "("),
-        ctx.find_next_token_within(end, source_end, ")"),
+    let (Some(paren_start_offset), Some(paren_end_offset)) = (
+        ctx.find_prev_token_within(catch_clause.span.start, start, "("),
+        ctx.find_next_token_within(end, catch_clause.span.end, ")"),
     ) else {
         return fixer.noop();
     };
 
+    let paren_start = catch_clause.span.start + paren_start_offset;
     let paren_end = end + paren_end_offset;
     let delete_span = Span::new(paren_start, paren_end + 1);
     fixer.delete_range(delete_span)


### PR DESCRIPTION
## Summary
- Bound unused catch-parameter delimiter lookup to the containing `CatchClause`.

## Details
The fixer now searches only within the catch clause and converts the opening-parenthesis offset back to an absolute source position. This avoids whole-file scans while preserving the existing deletion behavior.

