### PR TITLE
fix(linter): assert token lookup invariants

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
@@ -282,8 +282,9 @@ fn can_be_fixed(target: &AssignmentTarget) -> bool {
 /// Locates `operator` within `search_span`, the gap between the two operands.
 #[expect(clippy::cast_possible_truncation)]
 fn get_operator_span(search_span: Span, operator: &str, ctx: &LintContext) -> Span {
-    let offset =
-        ctx.find_next_token_within(search_span.start, search_span.end, operator).unwrap_or(0);
+    let offset = ctx
+        .find_next_token_within(search_span.start, search_span.end, operator)
+        .expect("assignment operator must be present between the operands");
     Span::sized(search_span.start + offset, operator.len() as u32)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/prefer_template.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_template.rs
@@ -95,8 +95,9 @@ fn build_template_for_binary(
     let right = &binary.right;
 
     // Find the + operator between left and right
-    let plus_offset =
-        fixer.find_next_token_within(left.span().end, right.span().start, "+").unwrap_or(0);
+    let plus_offset = fixer
+        .find_next_token_within(left.span().end, right.span().start, "+")
+        .expect("binary expression gap must contain the `+` operator");
     let plus_pos = left.span().end + plus_offset;
     let text_before_plus = &source_text[left.span().end as usize..plus_pos as usize];
     let text_after_plus = &source_text[plus_pos as usize + 1..right.span().start as usize];

--- a/crates/oxc_linter/src/rules/eslint/require_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_await.rs
@@ -186,7 +186,9 @@ impl RequireAwait {
 
 fn get_delete_span(ctx: &LintContext, start: u32, end: u32) -> Span {
     // Find the position of "async" keyword from the start position
-    let async_pos = ctx.find_next_token_within(start, end, "async").unwrap_or(0);
+    let async_pos = ctx
+        .find_next_token_within(start, end, "async")
+        .expect("async function span must contain the `async` keyword");
     let async_start = start + async_pos;
     let async_end = async_start + 5;
     let async_key_span = Span::new(async_start, async_end);

--- a/crates/oxc_linter/src/rules/unicorn/prefer_export_from.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_export_from.rs
@@ -947,7 +947,9 @@ impl PreferExportFrom {
         } else {
             // the new specifiers go just after the `{` of `export {} from '...'`
             let span = re_export.span();
-            let offset = fixer.find_next_token_within(span.start, span.end, "{").unwrap_or(0);
+            let offset = fixer
+                .find_next_token_within(span.start, span.end, "{")
+                .expect("export-from declaration span must contain an opening brace");
             Span::new(span.start, span.start + offset + 1)
         }
     }


### PR DESCRIPTION
## Summary
- Replace silent zero-offset token lookup fallbacks with explicit `expect` checks in four linter fixers.

## Details
These lookups operate on AST-derived spans whose operators or keywords are required by the corresponding syntax. A missing match indicates an internal invariant violation, so the fixers now fail explicitly instead of silently constructing a potentially incorrect fix.
