### PR TITLE
perf(linter/vue/max-props): narrow AST dispatch

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5158,7 +5158,10 @@ impl RuleRunner for crate::rules::vue::define_props_destructuring::DefinePropsDe
 }
 
 impl RuleRunner for crate::rules::vue::max_props::MaxProps {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::CallExpression,
+        AstType::ExportDefaultDeclaration,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -740,6 +740,10 @@ mod test {
             &[Function, ArrowFunctionExpression],
         );
         assert_rule_runs_on_node_types(
+            &vue::max_props::MaxProps::default(),
+            &[CallExpression, ExportDefaultDeclaration],
+        );
+        assert_rule_runs_on_node_types(
             &eslint::prefer_named_capture_group::PreferNamedCaptureGroup,
             &[RegExpLiteral, CallExpression, NewExpression],
         );

--- a/crates/oxc_linter/src/rules/vue/max_props.rs
+++ b/crates/oxc_linter/src/rules/vue/max_props.rs
@@ -1,6 +1,9 @@
 use oxc_ast::{
     AstKind,
-    ast::{ExportDefaultDeclarationKind, Expression, TSSignature, TSType},
+    ast::{
+        CallExpression, ExportDefaultDeclaration, ExportDefaultDeclarationKind, Expression,
+        TSSignature, TSType,
+    },
 };
 
 use oxc_diagnostics::OxcDiagnostic;
@@ -90,10 +93,18 @@ impl Rule for MaxProps {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if ctx.frameworks_options() == FrameworkOptions::VueSetup {
-            self.run_on_setup(node, ctx);
-        } else {
-            self.run_on_options(node, ctx);
+        match node.kind() {
+            AstKind::CallExpression(call_expr)
+                if ctx.frameworks_options() == FrameworkOptions::VueSetup =>
+            {
+                self.run_on_setup(call_expr, ctx);
+            }
+            AstKind::ExportDefaultDeclaration(export_default_decl)
+                if ctx.frameworks_options() != FrameworkOptions::VueSetup =>
+            {
+                self.run_on_options(export_default_decl, ctx);
+            }
+            _ => {}
         }
     }
 
@@ -104,10 +115,7 @@ impl Rule for MaxProps {
 
 impl MaxProps {
     #[expect(clippy::cast_possible_truncation)] // the length of properties/arrays can't be over u32::MAX, because the source code is already limited by u32::MAX.
-    fn run_on_setup<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::CallExpression(call_expr) = node.kind() else {
-            return;
-        };
+    fn run_on_setup<'a>(&self, call_expr: &CallExpression<'a>, ctx: &LintContext<'a>) {
         let Some(ident) = call_expr.callee.get_identifier_reference() else {
             return;
         };
@@ -153,10 +161,11 @@ impl MaxProps {
     }
 
     #[expect(clippy::cast_possible_truncation)] // the length of properties can't be over u32::MAX, because the source code is already limited by u32::MAX.
-    fn run_on_options<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::ExportDefaultDeclaration(export_default_decl) = node.kind() else {
-            return;
-        };
+    fn run_on_options<'a>(
+        &self,
+        export_default_decl: &ExportDefaultDeclaration<'a>,
+        ctx: &LintContext<'a>,
+    ) {
         let ExportDefaultDeclarationKind::ObjectExpression(obj_expr) =
             &export_default_decl.declaration
         else {


### PR DESCRIPTION
## Summary

Narrow `vue/max-props` dispatch to the only AST nodes it can inspect: `CallExpression` for Vue setup files and `ExportDefaultDeclaration` for Vue options files. Regenerate runner metadata and assert the exact node-type coverage.

This avoids invoking the rule for unrelated AST nodes while preserving its existing framework-specific behavior.