### PR TITLE
fix(linter/unicorn/prefer-array-flat): fix `concat.apply` suggestions

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -373,9 +373,10 @@ fn check_array_prototype_concat_case<'a>(call_expr: &CallExpression<'a>, ctx: &L
                 && array.name != "arguments"
             {
                 let replacement = format!("{}.flat()", ctx.source_range(array.span));
-                ctx.diagnostic_with_fix(prefer_array_flat_diagnostic(call_expr.span), |fixer| {
-                    fixer.replace(call_expr.span, replacement)
-                });
+                ctx.diagnostic_with_dangerous_fix(
+                    prefer_array_flat_diagnostic(call_expr.span),
+                    |fixer| fixer.replace(call_expr.span, replacement),
+                );
             } else {
                 ctx.diagnostic(prefer_array_flat_diagnostic(call_expr.span));
             }
@@ -385,7 +386,7 @@ fn check_array_prototype_concat_case<'a>(call_expr: &CallExpression<'a>, ctx: &L
 
 #[test]
 fn test() {
-    use crate::tester::Tester;
+    use crate::{fixer::FixKind, tester::Tester};
 
     let pass = vec![
         "array.flatMap",
@@ -636,16 +637,28 @@ fn test() {
     ];
 
     let fix = vec![
-        ("array.flatMap(x => x)", "array.flat()"),
-        ("array.reduce((a, b) => a.concat(b), [])", "array.flat()"),
-        ("array.reduce((a, b) => [...a, ...b], [])", "array.flat()"),
-        ("Foo.bar.flatMap(x => x)", "Foo.bar.flat()"),
+        ("array.flatMap(x => x)", "array.flat()", None, FixKind::SafeFix),
+        ("array.reduce((a, b) => a.concat(b), [])", "array.flat()", None, FixKind::SafeFix),
+        ("array.reduce((a, b) => [...a, ...b], [])", "array.flat()", None, FixKind::SafeFix),
+        ("Foo.bar.flatMap(x => x)", "Foo.bar.flat()", None, FixKind::SafeFix),
         (
             "const values = getValues(); values.flatMap(x => x);",
             "const values = getValues(); values.flat();",
+            None,
+            FixKind::SafeFix,
         ),
-        ("const values = []; values.flatMap(x => x);", "const values = []; values.flat();"),
-        ("const Items = []; Items.flatMap(x => x);", "const Items = []; Items.flat();"),
+        (
+            "const values = []; values.flatMap(x => x);",
+            "const values = []; values.flat();",
+            None,
+            FixKind::SafeFix,
+        ),
+        (
+            "const Items = []; Items.flatMap(x => x);",
+            "const Items = []; Items.flat();",
+            None,
+            FixKind::SafeFix,
+        ),
         (
             "for (const value of values) {
                 value.flatMap(x => x);
@@ -653,13 +666,17 @@ fn test() {
             "for (const value of values) {
                 value.flat();
             }",
+            None,
+            FixKind::SafeFix,
         ),
         (
             "const Items = [] as unknown[]; Items.flatMap(x => x);",
             "const Items = [] as unknown[]; Items.flat();",
+            None,
+            FixKind::SafeFix,
         ),
-        ("/**/[].concat.apply([], array)", "/**/array.flat()"),
-        ("Array.prototype.concat.apply([], array)", "array.flat()"),
+        ("/**/[].concat.apply([], array)", "/**/array.flat()", None, FixKind::DangerousFix),
+        ("Array.prototype.concat.apply([], array)", "array.flat()", None, FixKind::DangerousFix),
     ];
 
     Tester::new(PreferArrayFlat::NAME, PreferArrayFlat::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -368,7 +368,10 @@ fn check_array_prototype_concat_case<'a>(call_expr: &CallExpression<'a>, ctx: &L
             && (is_call_call
                 || !matches!(call_expr.arguments.get(1), Some(Argument::SpreadElement(_))))
         {
-            if is_apply_call && let Some(Argument::Identifier(array)) = call_expr.arguments.get(1) {
+            if is_apply_call
+                && let Some(Argument::Identifier(array)) = call_expr.arguments.get(1)
+                && array.name != "arguments"
+            {
                 let replacement = format!("{}.flat()", ctx.source_range(array.span));
                 ctx.diagnostic_with_fix(prefer_array_flat_diagnostic(call_expr.span), |fixer| {
                     fixer.replace(call_expr.span, replacement)
@@ -565,6 +568,7 @@ fn test() {
         "[].concat.apply([], ((array)))",
         "[].concat.apply([], [foo])",
         "[].concat.apply([], [[foo]])",
+        "function flatten() { return [].concat.apply([], arguments); }",
         "[].concat.call([], maybeArray)",
         "[].concat.call([], ((0, maybeArray)))",
         "[].concat.call([], ((maybeArray)))",
@@ -581,6 +585,7 @@ fn test() {
         "Array.prototype.concat.apply([], ((array)))",
         "Array.prototype.concat.apply([], [foo])",
         "Array.prototype.concat.apply([], [[foo]])",
+        "function flatten() { return Array.prototype.concat.apply([], arguments); }",
         "Array.prototype.concat.call([], maybeArray)",
         "Array.prototype.concat.call([], ((0, maybeArray)))",
         "Array.prototype.concat.call([], ((maybeArray)))",

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -359,15 +359,23 @@ fn check_array_prototype_concat_case<'a>(call_expr: &CallExpression<'a>, ctx: &L
 
     if let Some(member_expr_obj) = member_expr.object().as_member_expression() {
         let is_call_call = is_method_call(call_expr, None, Some(&["call"]), Some(2), Some(2));
+        let is_apply_call = is_method_call(call_expr, None, Some(&["apply"]), Some(2), Some(2));
 
-        if (is_call_call || is_method_call(call_expr, None, Some(&["apply"]), Some(2), Some(2)))
+        if (is_call_call || is_apply_call)
             && is_prototype_property(member_expr_obj, "concat", Some("Array"))
             && let Some(first_argument) = call_expr.arguments[0].as_expression()
             && is_empty_array_expression(first_argument)
             && (is_call_call
                 || !matches!(call_expr.arguments.get(1), Some(Argument::SpreadElement(_))))
         {
-            ctx.diagnostic(prefer_array_flat_diagnostic(call_expr.span));
+            if is_apply_call && let Some(Argument::Identifier(array)) = call_expr.arguments.get(1) {
+                let replacement = format!("{}.flat()", ctx.source_range(array.span));
+                ctx.diagnostic_with_fix(prefer_array_flat_diagnostic(call_expr.span), |fixer| {
+                    fixer.replace(call_expr.span, replacement)
+                });
+            } else {
+                ctx.diagnostic(prefer_array_flat_diagnostic(call_expr.span));
+            }
         }
     }
 }
@@ -645,9 +653,8 @@ fn test() {
             "const Items = [] as unknown[]; Items.flatMap(x => x);",
             "const Items = [] as unknown[]; Items.flat();",
         ),
-        // TODO: Get these passing.
-        // ("/**/[].concat.apply([], array)", "/**/array.flat()"),
-        // ("Array.prototype.concat.apply([], array)", "array.flat()"),
+        ("/**/[].concat.apply([], array)", "/**/array.flat()"),
+        ("Array.prototype.concat.apply([], array)", "array.flat()"),
     ];
 
     Tester::new(PreferArrayFlat::NAME, PreferArrayFlat::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_array_flat.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_array_flat.snap
@@ -250,6 +250,13 @@ source: crates/oxc_linter/src/tester.rs
   help: Call `.flat()` on the array instead.
 
   ⚠ unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
+   ╭─[prefer_array_flat.tsx:1:29]
+ 1 │ function flatten() { return [].concat.apply([], arguments); }
+   ·                             ──────────────────────────────
+   ╰────
+  help: Call `.flat()` on the array instead.
+
+  ⚠ unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
    ╭─[prefer_array_flat.tsx:1:1]
  1 │ [].concat.call([], maybeArray)
    · ──────────────────────────────
@@ -358,6 +365,13 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[prefer_array_flat.tsx:1:1]
  1 │ Array.prototype.concat.apply([], [[foo]])
    · ─────────────────────────────────────────
+   ╰────
+  help: Call `.flat()` on the array instead.
+
+  ⚠ unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
+   ╭─[prefer_array_flat.tsx:1:29]
+ 1 │ function flatten() { return Array.prototype.concat.apply([], arguments); }
+   ·                             ───────────────────────────────────────────
    ╰────
   help: Call `.flat()` on the array instead.
 


### PR DESCRIPTION
## Summary

- Add fixes for identifier-backed `[].concat.apply([], array)` and `Array.prototype.concat.apply([], array)` cases.
- Keep other `apply` and `call` patterns diagnostic-only.
