### PR TITLE
refactor(linter): assert fixer token lookup invariants

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -131,7 +131,7 @@ impl NoCondAssign {
         let mut operator_span = Span::new(expr.left.span().end, expr.right.span().start);
         let start = ctx
             .find_next_token_within(operator_span.start, operator_span.end, operator)
-            .unwrap_or(0);
+            .expect("assignment expression operands must contain the assignment operator token");
         operator_span.start += start;
         operator_span.end = operator_span.start + operator.len() as u32;
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_imports.rs
@@ -136,12 +136,13 @@ impl NoUnusedVars {
 
         let comma_offset = fixer
             .find_next_token_within(default_spec.span().end, last_named.span().start, ",")
-            .unwrap_or(0);
+            .expect("default and named import specifiers must be separated by a comma");
         let delete_start = default_spec.span().end + comma_offset;
 
         let brace_offset = fixer
             .find_next_token_within(last_named.span().end, import.span.end, "}")
-            .map_or(0, |i| i + 1);
+            .expect("named import specifiers must be followed by a closing brace")
+            + 1;
         let delete_end = last_named.span().end + brace_offset;
 
         let span = Span::new(delete_start, delete_end);

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -108,8 +108,9 @@ impl Rule for ConsistentTypeDefinitions {
                         let start = if decl.declare {
                             let base_start = decl.span.start + 7;
 
-                            ctx.find_next_token_within(base_start, decl.span.end, "type")
-                                .map_or(base_start + 1, |v| v + base_start)
+                            ctx.find_next_token_within(base_start, decl.span.end, "type").expect(
+                                "declared type aliases must contain the `type` keyword token",
+                            ) + base_start
                         } else {
                             decl.span.start
                         };
@@ -196,7 +197,8 @@ impl Rule for ConsistentTypeDefinitions {
                     let base_start = decl.span.start + 7;
 
                     ctx.find_next_token_within(base_start, decl.span.end, "interface")
-                        .map_or(base_start + 1, |v| v + base_start)
+                        .expect("declared interfaces must contain the `interface` keyword token")
+                        + base_start
                 } else {
                     decl.span.start
                 };


### PR DESCRIPTION
## Summary

Replace silent fallback offsets with explicit token-invariant assertions in the conditional-assignment diagnostic, unused-import fixer, and consistent type definitions fixer.
