### PR TITLE
perf(linter/unicorn/prefer-default-parameters): avoid reference allocation 

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_default_parameters.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_default_parameters.rs
@@ -403,14 +403,11 @@ fn check_no_extra_references<'a>(
 
     let symbol_id = binding_ident.symbol_id();
 
-    let references: Vec<_> = ctx.scoping().get_resolved_references(symbol_id).collect();
-
-    if references.len() != 1 {
+    let [reference_id] = ctx.scoping().get_resolved_reference_ids(symbol_id) else {
         return false;
-    }
+    };
 
-    let reference = &references[0];
-    ctx.semantic().reference_span(reference) == param_ident_span
+    ctx.semantic().reference_span(ctx.scoping().get_reference(*reference_id)) == param_ident_span
 }
 
 fn check_no_extra_references_assignment<'a>(


### PR DESCRIPTION
## Summary

Avoid allocating a temporary `Vec` when `unicorn/prefer-default-parameters` checks that a parameter has exactly one resolved reference.

## Rationale

The rule previously collected every resolved reference only to validate that the collection contained one element. The semantic index already exposes those IDs as a slice, so matching its single entry preserves the diagnostic and fix-safety behavior without the allocation.

