### PR TITLE
fix(linter/unicorn/new-for-builtins): support `Float16Array`

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -25,7 +25,7 @@ declare_oxc_lint!(
     /// ### What it does
     ///
     /// Enforces the use of `new` for the following builtins: `Object`, `Array`, `ArrayBuffer`, `BigInt64Array`,
-    /// `BigUint64Array`, `DataView`, `Date`, `Error`, `Float32Array`, `Float64Array`, `Function`, `Int8Array`,
+    /// `BigUint64Array`, `DataView`, `Date`, `Error`, `Float16Array`, `Float32Array`, `Float64Array`, `Function`, `Int8Array`,
     /// `Int16Array`, `Int32Array`, `Map`, `WeakMap`, `Set`, `WeakSet`, `Promise`, `RegExp`, `Uint8Array`,
     /// `Uint16Array`, `Uint32Array`, `Uint8ClampedArray`, `SharedArrayBuffer`, `Proxy`, `WeakRef`, `FinalizationRegistry`.
     ///
@@ -139,6 +139,7 @@ const ENFORCE_NEW_FOR_BUILTINS: phf::Set<&'static str> = phf::phf_set![
     "Date",
     "Error",
     "FinalizationRegistry",
+    "Float16Array",
     "Float32Array",
     "Float64Array",
     "Function",
@@ -294,7 +295,7 @@ fn test() {
         "const foo = DataView()",
         "const foo = Error()",
         "const foo = Error('Foo bar')",
-        // "const foo = Float16Array()",
+        "const foo = Float16Array()",
         "const foo = Float32Array()",
         "const foo = Float64Array()",
         "const foo = Function()",

--- a/crates/oxc_linter/src/snapshots/unicorn_new_for_builtins.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_new_for_builtins.snap
@@ -186,6 +186,12 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────
    ╰────
 
+  ⚠ unicorn(new-for-builtins): Use `new Float16Array()` instead of `Float16Array()`
+   ╭─[new_for_builtins.tsx:1:13]
+ 1 │ const foo = Float16Array()
+   ·             ──────────────
+   ╰────
+
   ⚠ unicorn(new-for-builtins): Use `new Float32Array()` instead of `Float32Array()`
    ╭─[new_for_builtins.tsx:1:13]
  1 │ const foo = Float32Array()


### PR DESCRIPTION
## Summary
- Add `Float16Array` to the list of builtins enforced by `unicorn/new-for-builtins`
- Uncomment the corresponding test case
- Update the rule's documentation to mention `Float16Array`

## References
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/test/snapshots/new-for-builtins.js.md#invalid47-const-foo--float16array