### PR TITLE
perf(regular-expression): inline short regex buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,6 +2507,7 @@ dependencies = [
  "oxc_str",
  "phf",
  "rustc-hash",
+ "smallvec",
  "unicode-id-start",
 ]
 

--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -29,6 +29,7 @@ oxc_str = { workspace = true }
 bitflags = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }
+smallvec = { workspace = true }
 unicode-id-start = { workspace = true }
 
 [dev-dependencies]

--- a/crates/oxc_regular_expression/src/parser/reader/reader_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/reader/reader_impl.rs
@@ -1,5 +1,6 @@
 use oxc_diagnostics::Result;
 use oxc_str::Str;
+use smallvec::SmallVec;
 
 use crate::parser::reader::{
     Options,
@@ -13,7 +14,7 @@ use crate::parser::reader::{
 #[derive(Debug)]
 pub struct Reader<'a> {
     source_text: &'a str,
-    units: Vec<CodePoint>,
+    units: SmallVec<[CodePoint; 8]>,
     index: usize,
     offset: u32,
 }
@@ -40,7 +41,7 @@ impl<'a> Reader<'a> {
                     },
                 )
                 .parse()?;
-                body
+                SmallVec::from_vec(body)
             } else {
                 let StringLiteralAst::StringLiteral { body, .. } = StringLiteralParser::new(
                     source_text,
@@ -51,7 +52,7 @@ impl<'a> Reader<'a> {
                     },
                 )
                 .parse()?;
-                body
+                SmallVec::from_vec(body)
             }
         } else {
             parse_regexp_literal(source_text, span_offset, unicode_mode)

--- a/crates/oxc_regular_expression/src/parser/reader/string_literal_parser/parser_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/reader/string_literal_parser/parser_impl.rs
@@ -1,5 +1,6 @@
 use oxc_diagnostics::Result;
 use oxc_span::Span;
+use smallvec::SmallVec;
 
 use crate::parser::reader::{
     CodePoint, Options,
@@ -20,8 +21,8 @@ pub fn parse_regexp_literal(
     source_text: &str,
     span_offset: u32,
     combine_surrogate_pair: bool,
-) -> Vec<CodePoint> {
-    let mut body = vec![];
+) -> SmallVec<[CodePoint; 8]> {
+    let mut body = SmallVec::new();
 
     let mut offset = 0;
     for ch in source_text.chars() {
@@ -50,8 +51,8 @@ pub struct Parser {
 
 impl Parser {
     // This is public because it is used in `parse_regexp_literal()`.
-    pub fn handle_code_point(
-        body: &mut Vec<CodePoint>,
+    pub fn handle_code_point<T: Extend<CodePoint>>(
+        body: &mut T,
         (offsets, cp, escape_kind): OffsetsAndCp,
         span_offset: u32,
         combine_surrogate_pair: bool,
@@ -60,13 +61,15 @@ impl Parser {
 
         if combine_surrogate_pair || (0..=0xffff).contains(&cp) {
             // If the code point is in the BMP or if forced, just push it
-            body.push(CodePoint { span, value: cp, escape_kind });
+            body.extend([CodePoint { span, value: cp, escape_kind }]);
         } else {
             // Otherwise, split the code point into a surrogate pair, sharing the same span
             let (lead, trail) =
                 (0xd800 + ((cp - 0x10000) >> 10), 0xdc00 + ((cp - 0x10000) & 0x3ff));
-            body.push(CodePoint { span, value: lead, escape_kind });
-            body.push(CodePoint { span, value: trail, escape_kind });
+            body.extend([
+                CodePoint { span, value: lead, escape_kind },
+                CodePoint { span, value: trail, escape_kind },
+            ]);
         }
     }
 

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -34,7 +34,7 @@ RadixUIAdoptionSection.jsx:
 pdf.mjs:
   file size: 567296 # 567.30 kB
   sys allocs: 2467
-  sys reallocs: 205
+  sys reallocs: 203
   sys deallocs: 2467
   sys alloc bytes: 5334247 # 5.33 MB
   sys peak growth: 3693355 # 3.69 MB
@@ -44,9 +44,9 @@ pdf.mjs:
 
 antd.js:
   file size: 6686316 # 6.69 MB
-  sys allocs: 1038
-  sys reallocs: 56
-  sys deallocs: 1038
+  sys allocs: 1037
+  sys reallocs: 54
+  sys deallocs: 1037
   sys alloc bytes: 29976031 # 29.98 MB
   sys peak growth: 19934725 # 19.93 MB
   arena allocs: 371736

--- a/tasks/track_memory_allocations/allocs_parser.yaml
+++ b/tasks/track_memory_allocations/allocs_parser.yaml
@@ -1,8 +1,8 @@
 checker.ts:
   file size: 2922154 # 2.92 MB
-  sys allocs: 19
-  sys reallocs: 10
-  sys deallocs: 19
+  sys allocs: 10
+  sys reallocs: 3
+  sys deallocs: 10
   sys alloc bytes: 4820 # 4.82 kB
   sys peak growth: 2432 # 2.43 kB
   arena allocs: 262590
@@ -11,9 +11,9 @@ checker.ts:
 
 App.tsx:
   file size: 415342 # 415.34 kB
-  sys allocs: 18
-  sys reallocs: 13
-  sys deallocs: 18
+  sys allocs: 14
+  sys reallocs: 6
+  sys deallocs: 14
   sys alloc bytes: 4348 # 4.35 kB
   sys peak growth: 1868 # 1.87 kB
   arena allocs: 44037
@@ -33,9 +33,9 @@ RadixUIAdoptionSection.jsx:
 
 pdf.mjs:
   file size: 567296 # 567.30 kB
-  sys allocs: 67
-  sys reallocs: 67
-  sys deallocs: 67
+  sys allocs: 41
+  sys reallocs: 26
+  sys deallocs: 41
   sys alloc bytes: 24020 # 24.02 kB
   sys peak growth: 12140 # 12.14 kB
   arena allocs: 89857
@@ -44,10 +44,10 @@ pdf.mjs:
 
 antd.js:
   file size: 6686316 # 6.69 MB
-  sys allocs: 185
-  sys reallocs: 221
-  sys deallocs: 185
-  sys alloc bytes: 109952 # 109.95 kB
+  sys allocs: 105
+  sys reallocs: 94
+  sys deallocs: 105
+  sys alloc bytes: 104156 # 104.16 kB
   sys peak growth: 48264 # 48.26 kB
   arena allocs: 528577
   arena reallocs: 55355
@@ -66,10 +66,10 @@ binder.ts:
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
-  sys allocs: 183
-  sys reallocs: 160
-  sys deallocs: 183
-  sys alloc bytes: 34053 # 34.05 kB
+  sys allocs: 117
+  sys reallocs: 69
+  sys deallocs: 117
+  sys alloc bytes: 29253 # 29.25 kB
   sys peak growth: 3892 # 3.89 kB
   arena allocs: 136453
   arena reallocs: 11898


### PR DESCRIPTION
## Summary

- Store up to eight decoded regular-expression code points inline in `Reader`.
- Avoid system allocations and reallocations for short patterns while retaining heap spillover for larger patterns.
- Update allocation snapshots; `kitchen-sink.tsx` falls from 183 to 126 system allocations.

