### PR TITLE
fix(parser): reject comma expressions in class fields

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -699,7 +699,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.context(
                 Context::In | Context::NewTarget,
                 Context::Yield | Context::Await,
-                Self::parse_expr,
+                Self::parse_assignment_expression_or_higher,
             )
         });
 

--- a/tasks/coverage/misc/fail/class-field-comma-expression.js
+++ b/tasks/coverage/misc/fail/class-field-comma-expression.js
@@ -1,0 +1,1 @@
+class C { x = a,b }

--- a/tasks/coverage/misc/pass/class-field-comma-expression.js
+++ b/tasks/coverage/misc/pass/class-field-comma-expression.js
@@ -1,0 +1,1 @@
+class C { x = (a,b) }

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 76/76 (100.00%)
-Positive Passed: 76/76 (100.00%)
+AST Parsed     : 77/77 (100.00%)
+Positive Passed: 77/77 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 76/76 (100.00%)
-Positive Passed: 76/76 (100.00%)
+AST Parsed     : 77/77 (100.00%)
+Positive Passed: 77/77 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
-AST Parsed     : 76/76 (100.00%)
-Positive Passed: 76/76 (100.00%)
-Negative Passed: 158/158 (100.00%)
+AST Parsed     : 77/77 (100.00%)
+Positive Passed: 77/77 (100.00%)
+Negative Passed: 159/159 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval-ambient.ts:2:13]
@@ -160,6 +160,13 @@ Negative Passed: 158/158 (100.00%)
  4 │       await foo;
    ·       ─────
  5 │     }
+   ╰────
+
+  × Expected `;` but found `,`
+   ╭─[misc/fail/class-field-comma-expression.js:1:16]
+ 1 │ class C { x = a,b }
+   ·                ┬
+   ·                ╰── `;` expected
    ╰────
 
   × Cannot use export statement outside a module

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 76/76 (100.00%)
-Positive Passed: 72/76 (94.74%)
+AST Parsed     : 77/77 (100.00%)
+Positive Passed: 73/77 (94.81%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 76/76 (100.00%)
-Positive Passed: 76/76 (100.00%)
+AST Parsed     : 77/77 (100.00%)
+Positive Passed: 77/77 (100.00%)


### PR DESCRIPTION
## Summary

- parse ordinary class field initializers as `AssignmentExpression`
- reject unparenthesized comma expressions while preserving parenthesized sequence expressions
- add paired misc conformance fixtures and update the generated snapshots

## Root cause

Ordinary class field initializers used `parse_expr`, which accepts a top-level comma and constructs a sequence expression. The ECMAScript `Initializer` grammar requires an `AssignmentExpression`, so the unparenthesized comma must remain for the class-element terminator check to reject.
