### PR TITLE
refactor(lsp): add `ToolBuildResult` struct for optional client message

### DIFF
--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -8,8 +8,8 @@ use tower_lsp_server::ls_types::{Pattern, Range, ServerCapabilities, TextEdit, U
 use tracing::{debug, error, warn};
 
 use oxc_language_server::{
-    Capabilities, LanguageId, TextDocument, Tool, ToolBuilder, ToolRestartChanges,
-    offset_to_position, utils::normalize_user_config_path_to_watch_pattern,
+    Capabilities, ClientMessage, LanguageId, TextDocument, Tool, ToolBuildResult, ToolBuilder,
+    ToolRestartChanges, offset_to_position, utils::normalize_user_config_path_to_watch_pattern,
 };
 
 use crate::core::{
@@ -41,9 +41,17 @@ impl ServerFormatterBuilder {
         }
     }
 
+    /// Creates a new `ServerFormatter` instance based on the provided root URI and options.
+    /// Returns a tuple containing the `ServerFormatter` instance and an optional message to be sent to the client.
+    /// This message will be used to inform about misconfiguration.
+    ///
     /// # Panics
     /// Panics if the root URI cannot be converted to a file path.
-    pub fn build(&self, root_uri: &Uri, options: serde_json::Value) -> ServerFormatter {
+    pub fn build(
+        &self,
+        root_uri: &Uri,
+        options: serde_json::Value,
+    ) -> (ServerFormatter, Option<ClientMessage>) {
         let options = deserialize_lsp_options(options);
 
         let root_path = root_uri.to_file_path().unwrap();
@@ -74,13 +82,16 @@ impl ServerFormatterBuilder {
         let source_formatter = SourceFormatter::new(num_of_threads)
             .with_external_formatter(Some(self.external_formatter.clone()));
 
-        ServerFormatter::new(
-            root_path.to_path_buf(),
-            source_formatter,
-            JsConfigLoaderCb::clone(&self.js_config_loader),
-            prettierignore_glob,
-            explicit_config_path,
-            use_nested_config,
+        (
+            ServerFormatter::new(
+                root_path.to_path_buf(),
+                source_formatter,
+                JsConfigLoaderCb::clone(&self.js_config_loader),
+                prettierignore_glob,
+                explicit_config_path,
+                use_nested_config,
+            ),
+            None,
         )
     }
 }
@@ -95,8 +106,9 @@ impl ToolBuilder for ServerFormatterBuilder {
             Some(tower_lsp_server::ls_types::OneOf::Left(true));
     }
 
-    fn build_boxed(&self, root_uri: &Uri, options: serde_json::Value) -> Box<dyn Tool> {
-        Box::new(self.build(root_uri, options))
+    fn build(&self, root_uri: &Uri, options: serde_json::Value) -> ToolBuildResult {
+        let (tool, client_message) = self.build(root_uri, options);
+        ToolBuildResult { tool: Box::new(tool), client_message }
     }
 }
 
@@ -160,13 +172,18 @@ impl Tool for ServerFormatter {
         let new_option = deserialize_lsp_options(new_options_json.clone());
 
         if old_option == new_option {
-            return ToolRestartChanges { tool: None, watch_patterns: None };
+            return ToolRestartChanges { tool: None, watch_patterns: None, client_message: None };
         }
 
         builder.shutdown(root_uri);
-        let new_formatter = builder.build_boxed(root_uri, new_options_json.clone());
-        let watch_patterns = new_formatter.get_watcher_patterns(new_options_json);
-        ToolRestartChanges { tool: Some(new_formatter), watch_patterns: Some(watch_patterns) }
+        let ToolBuildResult { tool, client_message } =
+            builder.build(root_uri, new_options_json.clone());
+        let watch_patterns = tool.get_watcher_patterns(new_options_json);
+        ToolRestartChanges {
+            tool: Some(tool),
+            watch_patterns: Some(watch_patterns),
+            client_message,
+        }
     }
 
     fn get_watcher_patterns(&self, options: serde_json::Value) -> Vec<Pattern> {
@@ -210,7 +227,7 @@ impl Tool for ServerFormatter {
         );
         *self.state.write().expect("state rwlock poisoned") = Arc::new(new_state);
 
-        ToolRestartChanges { tool: None, watch_patterns: None }
+        ToolRestartChanges { tool: None, watch_patterns: None, client_message: None }
     }
 
     fn run_format(&self, document: &TextDocument) -> Result<Vec<TextEdit>, String> {

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
 use ignore::gitignore::Gitignore;
+use oxc_language_server::{ClientMessage, ToolBuildResult};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tower_lsp_server::ls_types::{
     CodeActionTriggerKind, DiagnosticOptions, DiagnosticServerCapabilities,
@@ -72,9 +73,17 @@ impl ServerLinterBuilder {
         }
     }
 
+    /// Creates a new `ServerLinter` instance based on the provided root URI and options.
+    /// Returns a tuple containing the `ServerLinter` instance and an optional message to be sent to the client.
+    /// This message will be used to inform about misconfiguration.
+    ///
     /// # Panics
     /// Panics if the root URI cannot be converted to a file path.
-    pub fn build(&self, root_uri: &Uri, options: serde_json::Value) -> ServerLinter {
+    pub fn build(
+        &self,
+        root_uri: &Uri,
+        options: serde_json::Value,
+    ) -> (ServerLinter, Option<ClientMessage>) {
         let options = match serde_json::from_value::<LSPLintOptions>(options) {
             Ok(opts) => opts,
             Err(e) => {
@@ -233,16 +242,19 @@ impl ServerLinterBuilder {
             }
         };
 
-        ServerLinter::new(
-            options.run,
-            root_path.to_path_buf(),
-            LintIgnoreMatcher::new(&base_patterns, &base_ignore_root, nested_ignore_patterns),
-            Self::create_ignore_glob(&root_path),
-            extended_paths,
-            runner,
-            fix_kind,
-            lint_options.report_unused_directive,
-            options.rules_customization,
+        (
+            ServerLinter::new(
+                options.run,
+                root_path.to_path_buf(),
+                LintIgnoreMatcher::new(&base_patterns, &base_ignore_root, nested_ignore_patterns),
+                Self::create_ignore_glob(&root_path),
+                extended_paths,
+                runner,
+                fix_kind,
+                lint_options.report_unused_directive,
+                options.rules_customization,
+            ),
+            None,
         )
     }
 }
@@ -288,8 +300,9 @@ impl ToolBuilder for ServerLinterBuilder {
             };
     }
 
-    fn build_boxed(&self, root_uri: &Uri, options: serde_json::Value) -> Box<dyn Tool> {
-        Box::new(self.build(root_uri, options))
+    fn build(&self, root_uri: &Uri, options: serde_json::Value) -> ToolBuildResult {
+        let (tool, client_message) = self.build(root_uri, options);
+        ToolBuildResult { tool: Box::new(tool), client_message }
     }
 
     #[expect(unused)]
@@ -432,12 +445,13 @@ impl Tool for ServerLinter {
         };
 
         if !Self::needs_restart(&old_option, &new_options) {
-            return ToolRestartChanges { tool: None, watch_patterns: None };
+            return ToolRestartChanges { tool: None, watch_patterns: None, client_message: None };
         }
 
         // get the cached files before refreshing the linter, and revalidate them after
         builder.shutdown(root_uri);
-        let new_linter = builder.build_boxed(root_uri, new_options_json.clone());
+        let ToolBuildResult { tool, client_message } =
+            builder.build(root_uri, new_options_json.clone());
 
         let patterns = {
             if old_option.config_path == new_options.config_path
@@ -446,11 +460,11 @@ impl Tool for ServerLinter {
             {
                 None
             } else {
-                Some(new_linter.get_watcher_patterns(new_options_json))
+                Some(tool.get_watcher_patterns(new_options_json))
             }
         };
 
-        ToolRestartChanges { tool: Some(new_linter), watch_patterns: patterns }
+        ToolRestartChanges { tool: Some(tool), watch_patterns: patterns, client_message }
     }
 
     fn get_watcher_patterns(&self, options: serde_json::Value) -> Vec<Pattern> {
@@ -499,12 +513,13 @@ impl Tool for ServerLinter {
     ) -> ToolRestartChanges {
         // TODO: Check if the changed file is actually a config file (including extended paths)
         builder.shutdown(root_uri);
-        let new_linter = builder.build_boxed(root_uri, options);
+        let ToolBuildResult { tool, client_message } = builder.build(root_uri, options);
 
         ToolRestartChanges {
-            tool: Some(new_linter),
+            tool: Some(tool),
             // TODO: update watch patterns if config_path changed, or the extended paths changed
             watch_patterns: None,
+            client_message,
         }
     }
 

--- a/apps/oxlint/src/lsp/tester.rs
+++ b/apps/oxlint/src/lsp/tester.rs
@@ -192,8 +192,9 @@ impl Tester<'_> {
     }
 
     pub fn create_linter(&self) -> ServerLinter {
-        ServerLinterBuilder::default()
-            .build(&Self::get_root_uri(self.relative_root_dir), self.options.clone())
+        let (linter, _client_message) = ServerLinterBuilder::default()
+            .build(&Self::get_root_uri(self.relative_root_dir), self.options.clone());
+        linter
     }
 
     pub fn get_root_uri(relative_root_dir: &str) -> Uri {

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -21,7 +21,9 @@ mod worker_manager;
 pub use crate::capabilities::{Capabilities, DiagnosticMode};
 pub use crate::language_id::LanguageId;
 pub use crate::position::offset_to_position;
-pub use crate::tool::{DiagnosticResult, Tool, ToolBuilder, ToolRestartChanges};
+pub use crate::tool::{
+    ClientMessage, DiagnosticResult, Tool, ToolBuildResult, ToolBuilder, ToolRestartChanges,
+};
 pub use crate::tool_params::CodeActionParams;
 pub use crate::worker::WorkspaceWorker;
 pub use crate::worker_manager::WorkerManager;

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -12,8 +12,10 @@ use tower_lsp_server::{
 };
 
 use crate::{
-    DiagnosticMode, TextDocument, Tool, ToolBuilder, ToolRestartChanges, WorkerManager,
-    backend::Backend, tool::DiagnosticResult,
+    DiagnosticMode, TextDocument, Tool, ToolBuildResult, ToolBuilder, ToolRestartChanges,
+    WorkerManager,
+    backend::Backend,
+    tool::{ClientMessage, DiagnosticResult},
 };
 
 #[derive(Default)]
@@ -33,8 +35,11 @@ impl FakeToolBuilder {
 }
 
 impl ToolBuilder for FakeToolBuilder {
-    fn build_boxed(&self, _root_uri: &Uri, _options: serde_json::Value) -> Box<dyn Tool> {
-        Box::new(FakeTool { cache_uris: self.cache_uris.clone() })
+    fn build(&self, _root_uri: &Uri, _options: serde_json::Value) -> ToolBuildResult {
+        ToolBuildResult {
+            tool: Box::new(FakeTool { cache_uris: self.cache_uris.clone() }),
+            client_message: None,
+        }
     }
 
     fn server_capabilities(
@@ -89,18 +94,31 @@ impl Tool for FakeTool {
         new_options_json: serde_json::Value,
     ) -> ToolRestartChanges {
         if new_options_json.as_u64() == Some(1) || new_options_json.as_u64() == Some(3) {
+            let result = builder.build(root_uri, new_options_json);
             return ToolRestartChanges {
-                tool: Some(builder.build_boxed(root_uri, new_options_json)),
+                tool: Some(result.tool),
                 watch_patterns: None,
+                client_message: result.client_message,
             };
         }
         if new_options_json.as_u64() == Some(2) {
             return ToolRestartChanges {
                 tool: None,
                 watch_patterns: Some(vec!["**/new_watcher.config".to_string()]),
+                client_message: None,
             };
         }
-        ToolRestartChanges { tool: None, watch_patterns: None }
+        if new_options_json.as_u64() == Some(4) {
+            return ToolRestartChanges {
+                tool: None,
+                watch_patterns: None,
+                client_message: Some(ClientMessage {
+                    message: "Fake misconfiguration message".to_string(),
+                    r#type: MessageType::WARNING,
+                }),
+            };
+        }
+        ToolRestartChanges { tool: None, watch_patterns: None, client_message: None }
     }
 
     fn get_watcher_patterns(
@@ -121,19 +139,22 @@ impl Tool for FakeTool {
         options: serde_json::Value,
     ) -> ToolRestartChanges {
         if changed_uri.as_str().ends_with("tool.config") {
+            let result = builder.build(root_uri, options);
             return ToolRestartChanges {
-                tool: Some(builder.build_boxed(root_uri, options)),
+                tool: Some(result.tool),
                 watch_patterns: None,
+                client_message: result.client_message,
             };
         }
         if changed_uri.as_str().ends_with("watcher.config") {
             return ToolRestartChanges {
                 tool: None,
                 watch_patterns: Some(vec!["**/new_watcher.config".to_string()]),
+                client_message: None,
             };
         }
 
-        ToolRestartChanges { tool: None, watch_patterns: None }
+        ToolRestartChanges { tool: None, watch_patterns: None, client_message: None }
     }
 
     fn get_code_actions_or_commands(

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -1,7 +1,8 @@
 use tower_lsp_server::{
     jsonrpc::ErrorCode,
     ls_types::{
-        CodeActionOrCommand, Diagnostic, Pattern, ServerCapabilities, TextEdit, Uri, WorkspaceEdit,
+        CodeActionOrCommand, Diagnostic, MessageType, Pattern, ServerCapabilities, TextEdit, Uri,
+        WorkspaceEdit,
     },
 };
 
@@ -17,7 +18,7 @@ pub trait ToolBuilder: Send + Sync {
     }
 
     /// Build a boxed instance of the tool for the given root URI and options.
-    fn build_boxed(&self, root_uri: &Uri, options: serde_json::Value) -> Box<dyn Tool>;
+    fn build(&self, root_uri: &Uri, options: serde_json::Value) -> ToolBuildResult;
 
     /// Shutdown hook for the tool. Implementors may perform any necessary cleanup here.
     fn shutdown(&self, _root_uri: &Uri) {
@@ -138,6 +139,22 @@ pub trait Tool: Send + Sync {
     }
 }
 
+pub struct ClientMessage {
+    /// The message to be sent to the client.
+    pub message: String,
+    /// The type of message to be sent to the client (e.g., error, warning).
+    pub r#type: MessageType,
+}
+
+pub struct ToolBuildResult {
+    /// The tool that was started (linter, formatter).
+    /// It should always be started and on internal errors, fallback to the default configuration of the tool.
+    pub tool: Box<dyn Tool>,
+    /// Even if the tool started successfully, it may have encountered issues during initialization.
+    /// The `client_message` field can be used to communicate any warnings or errors to the client.
+    pub client_message: Option<ClientMessage>,
+}
+
 pub struct ToolRestartChanges {
     /// The tool that was restarted (linter, formatter).
     /// If None, no tool was restarted.
@@ -145,4 +162,7 @@ pub struct ToolRestartChanges {
     /// The patterns that were added during the tool restart
     /// Old patterns will be automatically unregistered
     pub watch_patterns: Option<Vec<Pattern>>,
+    /// Even if the tool restarted successfully, it may have encountered issues during initialization.
+    /// The `client_message` field can be used to communicate any warnings or errors to the client.
+    pub client_message: Option<ClientMessage>,
 }

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -17,7 +17,7 @@ use crate::{
     CodeActionParams, TextDocument, ToolRestartChanges,
     capabilities::DiagnosticMode,
     file_system::LSPFileSystem,
-    tool::{DiagnosticResult, Tool, ToolBuilder},
+    tool::{ClientMessage, DiagnosticResult, Tool, ToolBuilder},
 };
 
 /// A worker that manages the individual tool for a specific workspace
@@ -65,10 +65,15 @@ impl WorkspaceWorker {
 
     /// Start all programs (linter, formatter) for the worker.
     /// This should be called after the client has sent the workspace configuration.
-    pub async fn start_worker(&self, options: serde_json::Value) {
-        *self.tool.write().await = Some(self.builder.build_boxed(&self.root_uri, options.clone()));
+    ///
+    /// Returns an optional message to be sent to the client.
+    pub async fn start_worker(&self, options: serde_json::Value) -> Option<ClientMessage> {
+        let result = self.builder.build(&self.root_uri, options.clone());
+        *self.tool.write().await = Some(result.tool);
 
         *self.options.lock().await = Some(options);
+
+        result.client_message
     }
 
     /// Initialize file system watchers for the workspace.


### PR DESCRIPTION
Added a new `ToolBuildResult` struct, so an optional `ClientMessage` can be passed to `Backend` (in a later PR).
This allows us later to send the custom message to the clients interface when some config errors happened on the (re)creation.

There is no message sent yet, this will be integrated in another PR too. This PR is just the base for the `ToolInterface`.