### PR TITLE
refactor(oxfmt): use dispatcher for non-napi xxx-in-js

### DIFF
--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -45,14 +45,16 @@ Oxfmt utilizes different implementations depending on the file extension and fil
 NOTE: Rust written formatters never fall back to Prettier, since they exist to reduce the dependency on Prettier.
 
 Embedded languages (e.g. css-in-js, CSS front matter YAML) go through the `FormatDispatcher` (defined in `oxc_formatter_core`) assembled by `src/core/embed/dispatcher.rs`.
-Standalone CSS files also run on a `PhysicalFile` session with a fallback-less registry dispatcher (every build), so front matter YAML formats natively while TOML/custom languages stay verbatim like Prettier; `embeddedLanguageFormatting: off` installs no dispatcher.
-Rust formatter branches (the `NativeLanguage` registry in that file) in every build, plus the Prettier Doc→IR fallback (`embed/prettier_fallback.rs`, napi only) for the rest, the pure Rust build deliberately preserves those as-is. Per-language options are NOT built up front: `ResolvedDispatchConfig` maps them lazily at dispatch time (`OnceLock`-memoized) from the host file's resolved config, including the Prettier options JSON for the JS-side consumers. `src/core/external_formatter.rs` bridges the napi callbacks into these factories.
+JS/TS and standalone CSS roots run on a `PhysicalFile` session carrying the registry dispatcher in EVERY build.
+The Vue/Svelte `<script>` root (`api/text_to_doc_api.rs`, a `VirtualDocument` session, napi only) is the 3rd assembly site: a Rust branch per `NativeLanguage` (css/graphql/yaml/json/...), plus the Prettier Doc→IR fallback (`embed/prettier_fallback.rs`, napi only) for the rest.
+The pure Rust build runs fallback-less, so non-native embeds (html-in-js, TOML/custom front matter) deliberately stay verbatim like Prettier; `embeddedLanguageFormatting: off` installs no dispatcher (every root assembles via `ResolvedDispatchConfig::for_root` + `root_dispatcher`, which owns that gate).
+Per-language options are NOT built up front: `ResolvedDispatchConfig` maps them lazily at dispatch time (`OnceLock`-memoized) from the host file's resolved config, including the Prettier options JSON for the JS-side consumers. `src/core/external_formatter.rs` bridges the napi callbacks into these factories.
 
-A separate string-out channel (the `embedded_callback` in the same file, NOT the dispatcher) carries the string-in/string-out consumers:
+A separate string-out channel (the `embedded_callback`, NOT the dispatcher) carries the string-in/string-out consumers:
 
 - JSDoc fenced code blocks: routing follows ONE rule
-  - a fence language in the `NativeLanguage` registry formats through the dispatcher via a thin string adapter (`string_channel.rs::format_native_fence`)
-  - md/html/angular fences stay on the Prettier string path (their Doc→IR conversion has unrepresentable cases);
+  - a fence language in the `NativeLanguage` registry formats through the dispatcher via a thin string adapter (`embed/fence.rs::format_native_fence`, EVERY build — the pure Rust build installs `build_native_fence_callback` directly)
+  - md/html/angular fences stay on the Prettier string path (`string_channel.rs`, napi only; their Doc→IR conversion has unrepresentable cases);
   - everything else stays verbatim
 - html-in-js fallback (`format_js_in_html_as_fallback` in `oxc_formatter/src/print/template/embed/html.rs`)
 

--- a/apps/oxfmt/src/api/text_to_doc_api.rs
+++ b/apps/oxfmt/src/api/text_to_doc_api.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 
 use serde::Deserialize;
 use serde_json::Value;
@@ -135,11 +135,11 @@ fn run_full(
 
     // Per-language options (and the Prettier options JSON with the Tailwind payload)
     // are mapped lazily at dispatch time; `core` was validated during resolution.
-    let dispatch_config =
-        Arc::new(ResolvedDispatchConfig::new(config, core).with_path(parent_filepath));
+    let dispatch_config = ResolvedDispatchConfig::for_root(&config, core, &parent_filepath);
 
-    let (external_callbacks, dispatcher) =
+    let (external_callbacks, fallback) =
         external_formatter.to_external_callbacks(&format_options, &dispatch_config);
+    let dispatcher = dispatch_config.root_dispatcher(Some(fallback));
 
     let allocator = Allocator::default();
     let session = FormatSession::new(

--- a/apps/oxfmt/src/core/embed/dispatcher.rs
+++ b/apps/oxfmt/src/core/embed/dispatcher.rs
@@ -13,7 +13,6 @@ use oxc_formatter_core::{
     CoreFormatOptions, DispatchOutcome, DispatchRequest, DispatchResult, EmbeddedIr,
     FormatDispatcher, FormatSession,
 };
-#[cfg(feature = "napi")]
 use oxc_formatter_core::{FormatOptions, PrinterOptions};
 use oxc_formatter_css::{CssFormatOptions, CssVariant};
 use oxc_formatter_graphql::GraphqlFormatOptions;
@@ -57,8 +56,7 @@ fn native_language(language: &str) -> Option<NativeLanguage> {
 }
 
 /// Whether `language` has a native (Rust formatter) branch in the registry.
-/// (Consulted by the napi-only JSDoc string adapter; the dispatcher itself matches [`native_language`] directly.)
-#[cfg(feature = "napi")]
+/// (Consulted by the JSDoc fence adapter [`super::fence`]; the dispatcher itself matches [`native_language`] directly.)
 pub fn is_native_language(language: &str) -> bool {
     native_language(language).is_some()
 }
@@ -93,7 +91,8 @@ pub struct ResolvedDispatchConfig {
 impl ResolvedDispatchConfig {
     /// `core` is the pre-validated bundle carried from the config-resolution gate (`options::validate`);
     /// it never gets re-derived here.
-    pub fn new(config: Arc<FormatConfig>, core: CoreFormatOptions) -> Self {
+    /// Private so [`Self::for_root`] stays the only construction recipe.
+    fn new(config: Arc<FormatConfig>, core: CoreFormatOptions) -> Self {
         Self {
             config,
             core,
@@ -109,12 +108,45 @@ impl ResolvedDispatchConfig {
     }
 
     /// Sets the host file path for `filepath` injection into [`Self::external_options`];
-    /// both napi construction sites chain this.
+    /// chained by [`Self::for_root`].
     #[cfg(feature = "napi")]
-    #[must_use]
-    pub fn with_path(mut self, path: std::path::PathBuf) -> Self {
+    fn with_path(mut self, path: std::path::PathBuf) -> Self {
         self.path = path;
         self
+    }
+
+    /// The one construction recipe for a root formatter run at `path`:
+    /// [`Self::new`] plus the napi-only path recording
+    /// (the pure build has no JS-side consumers, so `path` goes unused there).
+    pub fn for_root(
+        config: &Arc<FormatConfig>,
+        core: CoreFormatOptions,
+        path: &std::path::Path,
+    ) -> Arc<Self> {
+        let dispatch_config = Self::new(Arc::clone(config), core);
+        #[cfg(feature = "napi")]
+        let dispatch_config = dispatch_config.with_path(path.to_path_buf());
+        #[cfg(not(feature = "napi"))]
+        let _ = path;
+        Arc::new(dispatch_config)
+    }
+
+    /// Assembles the root's `FormatDispatcher` behind the off-gate:
+    /// `None` under `embeddedLanguageFormatting: off`,
+    /// so a root cannot install the registry without honoring the off-semantics.
+    /// `fallback` is the one build-dependent datum (the napi Prettier Doc→IR path).
+    pub fn root_dispatcher(
+        self: &Arc<Self>,
+        fallback: Option<PrettierDocFallback>,
+    ) -> Option<FormatDispatcher> {
+        self.is_embedded_formatting_enabled().then(|| build_dispatcher(Arc::clone(self), fallback))
+    }
+
+    /// The single off-predicate: [`Self::root_dispatcher`] and the string-out channel builders
+    /// (`fence::build_external_callbacks`, `ExternalFormatter::to_external_callbacks`) all consult it,
+    /// so the off-semantics can never diverge between channels or builds.
+    pub fn is_embedded_formatting_enabled(&self) -> bool {
+        self.config.is_embedded_formatting_enabled()
     }
 
     pub fn graphql_options(&self) -> GraphqlFormatOptions {
@@ -149,8 +181,7 @@ impl ResolvedDispatchConfig {
     }
 
     /// Printer options from the shared resolved core bundle;
-    /// the (napi-only) string adapter prints dispatched child IR standalone with these.
-    #[cfg(feature = "napi")]
+    /// the fence adapter ([`super::fence`]) prints dispatched child IR standalone with these.
     pub fn print_options(&self) -> PrinterOptions {
         self.core.as_print_options()
     }

--- a/apps/oxfmt/src/core/embed/fence.rs
+++ b/apps/oxfmt/src/core/embed/fence.rs
@@ -1,0 +1,105 @@
+//! Native-fence string adapter: a JSDoc fenced code block whose language has a
+//! Rust formatter branch formats through the dispatch registry, in EVERY build.
+//!
+//! This is the build-independent half of the string-out channel:
+//! the napi [`super::string_channel`] routes native fences here before its
+//! Prettier string paths; the pure Rust build installs `build_external_callbacks`
+//! directly (non-native fences stay verbatim).
+
+use std::sync::Arc;
+
+use tracing::debug_span;
+
+use oxc_allocator::Allocator;
+#[cfg(not(feature = "napi"))]
+use oxc_formatter::ExternalCallbacks;
+use oxc_formatter::TailwindCallback;
+use oxc_formatter_core::{
+    DispatchOutcome, DispatchRequest, DispatchResult, Document, FormatDispatcher, FormatSession,
+    InputKind,
+};
+
+use super::dispatcher::{self, ResolvedDispatchConfig};
+
+/// Build the dispatcher a fence callback holds for its lifetime.
+/// Fence dispatchers never take the Prettier fallback (native fences never fall
+/// back), so one is invariant across the callback's lifetime: build it once, not per fence.
+pub fn build_fence_dispatcher(dispatch_config: &Arc<ResolvedDispatchConfig>) -> FormatDispatcher {
+    dispatcher::build_dispatcher(Arc::clone(dispatch_config), None)
+}
+
+/// The pure build's `ExternalCallbacks`: just the native-fence adapter, gated by
+/// the shared off-predicate (the napi twin is `ExternalFormatter::to_external_callbacks`).
+/// Non-native fences answer `Err` — the string channel's "keep verbatim" — since
+/// no Prettier exists in this build.
+#[cfg(not(feature = "napi"))]
+pub fn build_external_callbacks(
+    dispatch_config: &Arc<ResolvedDispatchConfig>,
+) -> ExternalCallbacks {
+    let embedded_callback = dispatch_config.is_embedded_formatting_enabled().then(|| {
+        let fence_dispatcher = build_fence_dispatcher(dispatch_config);
+        let dispatch_config = Arc::clone(dispatch_config);
+        Arc::new(move |language: &str, code: &str| {
+            if !dispatcher::is_native_language(language) {
+                return Err(format!("Unsupported language: {language}"));
+            }
+            format_native_fence(language, code, &fence_dispatcher, &dispatch_config, None)
+        }) as oxc_formatter::EmbeddedFormatterCallback
+    });
+    ExternalCallbacks::new().with_embedded_formatter(embedded_callback)
+}
+
+/// Format a JSDoc fenced code block through the native dispatch registry:
+/// a string-in/string-out adapter over the IR contract.
+///
+/// Load-bearing notes:
+/// - The fence has no parent index space, so its Tailwind classes are sorted here
+///   (element-wise: the sorter reorders classes WITHIN each collected string, never the vector,
+///   keeping `TailwindClass(index)` references valid). The pure build passes no sorter.
+/// - `Err` keeps the fence verbatim, covering both `PreserveOriginal`
+///   (parse failure — never a Prettier fallback for native languages) and operational errors.
+/// - The session-less `EmbeddedFormatterCallback` contract forces a fresh root session per fence,
+///   so `dispatch_depth` resets at this string boundary (inert today: no native fence language re-dispatches).
+///   Threading the parent session through the callback is the eventual fix.
+pub fn format_native_fence(
+    language: &str,
+    code: &str,
+    fence_dispatcher: &FormatDispatcher,
+    dispatch_config: &ResolvedDispatchConfig,
+    sort_tailwind: Option<&TailwindCallback>,
+) -> Result<String, String> {
+    debug_span!("oxfmt::external::format_native_fence", language = language).in_scope(|| {
+        let allocator = Allocator::default();
+        let session =
+            FormatSession::new(&allocator, InputKind::Fragment, Some(Arc::clone(fence_dispatcher)));
+        let outcome = session.dispatch(DispatchRequest {
+            language,
+            texts: &[code],
+            input_kind: InputKind::Fragment,
+            parent_context: None,
+        })?;
+
+        let DispatchOutcome::Formatted(result) = outcome else {
+            return Err(format!("Native formatter for '{language}' kept the input as-is"));
+        };
+        let DispatchResult { mut docs, tailwind_classes, .. } = result;
+        if docs.len() != 1 {
+            return Err(format!("Expected exactly one IR, got {}", docs.len()));
+        }
+        let ir = docs.pop().unwrap();
+
+        let tailwind_classes = match sort_tailwind {
+            Some(sort) if !tailwind_classes.is_empty() => sort(tailwind_classes),
+            _ => tailwind_classes,
+        };
+
+        let mut code = Document::new(ir, tailwind_classes)
+            .print(code.len(), dispatch_config.print_options())
+            .map_err(|err| err.to_string())?
+            .into_code();
+        // The block is re-embedded line-by-line into the comment; no trailing newline
+        code.truncate(code.trim_end().len());
+
+        Ok(code)
+    })
+}

--- a/apps/oxfmt/src/core/embed/mod.rs
+++ b/apps/oxfmt/src/core/embed/mod.rs
@@ -7,9 +7,11 @@
 //! - [`dispatcher`] (every build): the native registry — `ResolvedDispatchConfig`
 //!   (lazy per-language options) + `build_dispatcher` with a Rust branch per `NativeLanguage`;
 //!   IR integrates into the parent's arena / `GroupId` space
+//! - [`fence`] (every build): the JSDoc native-fence string adapter over the registry
+//!   (the pure build's whole string-out channel)
 //! - [`prettier_fallback`] (napi only): Prettier Doc→IR path for the rest
-//! - [`string_channel`] (napi only): string-in/string-out channel
-//!   - JSDoc fenced blocks + html-in-js fallback
+//! - [`string_channel`] (napi only): the Prettier string paths of the string-out channel
+//!   - md/html/angular JSDoc fences + html-in-js fallback
 //!   - Standalone string formatting that re-embeds line-by-line
 
 #[cfg(feature = "napi")]
@@ -19,6 +21,7 @@ use std::sync::Arc;
 use serde_json::Value;
 
 pub mod dispatcher;
+pub mod fence;
 #[cfg(feature = "napi")]
 pub mod prettier_fallback;
 #[cfg(feature = "napi")]

--- a/apps/oxfmt/src/core/embed/string_channel.rs
+++ b/apps/oxfmt/src/core/embed/string_channel.rs
@@ -7,7 +7,7 @@
 //!   so the parent re-requests the same HTML via this string channel and substitutes placeholders back to `${expr}`.
 //!
 //! Fence routing follows ONE rule: a language in the native registry ([`dispatcher::is_native_language`]) formats
-//! through the dispatcher via [`format_native_fence`];
+//! through the dispatcher via [`super::fence::format_native_fence`] (the build-independent adapter);
 //! md/html/angular stay on the Prettier string path
 //! (their Doc→IR conversion has unrepresentable cases,
 //! so forcing them through the dispatcher would regress to verbatim; the wall falls with the HTML Rust port).
@@ -19,18 +19,10 @@ use std::sync::Arc;
 
 use tracing::{debug, debug_span};
 
-use oxc_allocator::Allocator;
-use oxc_formatter::EmbeddedFormatterCallback;
-use oxc_formatter_core::{
-    DispatchOutcome, DispatchRequest, DispatchResult, Document, FormatDispatcher, FormatSession,
-    InputKind,
-};
+use oxc_formatter::{EmbeddedFormatterCallback, TailwindCallback};
 
 use crate::core::{
-    embed::{
-        FormatEmbeddedWithConfigCallback, TailwindWithConfigCallback, dispatcher,
-        language_to_prettier_parser,
-    },
+    embed::{FormatEmbeddedWithConfigCallback, dispatcher, fence, language_to_prettier_parser},
     options::inject_parser,
 };
 
@@ -41,20 +33,19 @@ use crate::core::{
 /// The JSDoc fenced consumer reaches every language;
 /// the html-in-js fallback only ever passes `"html"` and therefore always lands on the Prettier branch.
 ///
-/// `dispatch_config.external_options()` already carries the Tailwind plugin payload,
-/// so the JS-side sorter can resolve class order when a CSS fence collects `@apply` classes.
+/// `sort_tailwind` is the SAME pre-bound sorter as `ExternalCallbacks`' Tailwind callback
+/// (options JSON already applied by `to_external_callbacks`),
+/// for the `@apply` classes a CSS fence collects.
 pub fn build_embedded_callback(
     format_embedded: FormatEmbeddedWithConfigCallback,
-    sort_tailwind: Option<TailwindWithConfigCallback>,
+    sort_tailwind: Option<TailwindCallback>,
     dispatch_config: Arc<dispatcher::ResolvedDispatchConfig>,
 ) -> EmbeddedFormatterCallback {
-    let fence_dispatcher = dispatcher::build_dispatcher(Arc::clone(&dispatch_config), None);
+    let fence_dispatcher = fence::build_fence_dispatcher(&dispatch_config);
     Arc::new(move |language: &str, code: &str| {
         // Native registry first (JSDoc fenced code blocks).
         if dispatcher::is_native_language(language) {
-            // Native fences never fall back to Prettier,
-            // so the dispatcher is invariant across the callback's lifetime: build it once, not per fence.
-            return format_native_fence(
+            return fence::format_native_fence(
                 language,
                 code,
                 &fence_dispatcher,
@@ -84,62 +75,5 @@ pub fn build_embedded_callback(
                     debug!("Failed to format embedded code for parser '{parser_name}': {err}");
                 })
         })
-    })
-}
-
-/// Format a JSDoc fenced code block through the native dispatch registry:
-/// a string-in/string-out adapter over the IR contract.
-///
-/// Load-bearing notes:
-/// - The fence has no parent index space, so its Tailwind classes are sorted here
-///   (element-wise: the sorter reorders classes WITHIN each collected string, never the vector,
-///   keeping `TailwindClass(index)` references valid).
-/// - `Err` keeps the fence verbatim, covering both `PreserveOriginal`
-///   (parse failure — never a Prettier fallback for native languages) and operational errors.
-/// - The session-less `EmbeddedFormatterCallback` contract forces a fresh root session per fence,
-///   so `dispatch_depth` resets at this string boundary (inert today: no native fence language re-dispatches).
-///   Threading the parent session through the callback is the eventual fix.
-fn format_native_fence(
-    language: &str,
-    code: &str,
-    fence_dispatcher: &FormatDispatcher,
-    dispatch_config: &Arc<dispatcher::ResolvedDispatchConfig>,
-    sort_tailwind: Option<&TailwindWithConfigCallback>,
-) -> Result<String, String> {
-    debug_span!("oxfmt::external::format_native_fence", language = language).in_scope(|| {
-        let allocator = Allocator::default();
-        let session =
-            FormatSession::new(&allocator, InputKind::Fragment, Some(Arc::clone(fence_dispatcher)));
-        let outcome = session.dispatch(DispatchRequest {
-            language,
-            texts: &[code],
-            input_kind: InputKind::Fragment,
-            parent_context: None,
-        })?;
-
-        let DispatchOutcome::Formatted(result) = outcome else {
-            return Err(format!("Native formatter for '{language}' kept the input as-is"));
-        };
-        let DispatchResult { mut docs, tailwind_classes, .. } = result;
-        if docs.len() != 1 {
-            return Err(format!("Expected exactly one IR, got {}", docs.len()));
-        }
-        let ir = docs.pop().unwrap();
-
-        let tailwind_classes = match sort_tailwind {
-            Some(sort) if !tailwind_classes.is_empty() => {
-                sort(dispatch_config.external_options(), tailwind_classes)
-            }
-            _ => tailwind_classes,
-        };
-
-        let mut code = Document::new(ir, tailwind_classes)
-            .print(code.len(), dispatch_config.print_options())
-            .map_err(|err| err.to_string())?
-            .into_code();
-        // The block is re-embedded line-by-line into the comment; no trailing newline
-        code.truncate(code.trim_end().len());
-
-        Ok(code)
     })
 }

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -262,26 +262,25 @@ impl ExternalFormatter {
     /// would double-sort or drop classes.
     /// `DispatchResult::remap_tailwind_into`'s printer `debug_assert` catches dropped remaps.
     ///
-    /// Also returns the `FormatDispatcher` for the root's `FormatSession`,
-    /// gated by the SAME `embeddedLanguageFormatting` predicate as the string channel
-    /// (off => `None` => embeds deliberately stay as-is): the two channels must never diverge on the off-semantics.
+    /// Also returns this formatter's Prettier Doc→IR fallback for the root dispatcher's default arm:
+    /// the caller assembles via `ResolvedDispatchConfig::root_dispatcher` (which owns the off-gate),
+    /// so the fallback-vs-fallback-less difference between builds stays data, not structure.
+    /// The string channel below consults the same off-predicate,
+    /// so the two channels never diverge on the off-semantics.
     pub fn to_external_callbacks(
         &self,
         format_options: &JsFormatOptions,
         dispatch_config: &Arc<embed::dispatcher::ResolvedDispatchConfig>,
-    ) -> (ExternalCallbacks, Option<oxc_formatter_core::FormatDispatcher>) {
-        let needs_embedded = !format_options.embedded_language_formatting.is_off();
+    ) -> (ExternalCallbacks, embed::dispatcher::PrettierDocFallback) {
+        let needs_embedded = dispatch_config.is_embedded_formatting_enabled();
         let tailwind_enabled = format_options.sort_tailwindcss.is_some();
-        let dispatcher = needs_embedded.then(|| self.build_dispatcher(dispatch_config));
+        let fallback = embed::prettier_fallback::build_prettier_fallback(
+            Arc::clone(dispatch_config),
+            Arc::clone(&self.format_embedded_doc),
+        );
 
-        let embedded_callback = needs_embedded.then(|| {
-            embed::string_channel::build_embedded_callback(
-                Arc::clone(&self.format_embedded),
-                tailwind_enabled.then(|| Arc::clone(&self.sort_tailwindcss_classes)),
-                Arc::clone(dispatch_config),
-            )
-        });
-
+        // The ONE pre-bound sorter (options JSON applied here, once);
+        // both the direct Tailwind callback and the fence adapter share it.
         let tailwind_callback: Option<TailwindCallback> = tailwind_enabled.then(|| {
             let sort = Arc::clone(&self.sort_tailwindcss_classes);
             let dispatch_config = Arc::clone(dispatch_config);
@@ -291,25 +290,20 @@ impl ExternalFormatter {
             }) as TailwindCallback
         });
 
+        let embedded_callback = needs_embedded.then(|| {
+            embed::string_channel::build_embedded_callback(
+                Arc::clone(&self.format_embedded),
+                tailwind_callback.clone(),
+                Arc::clone(dispatch_config),
+            )
+        });
+
         (
             ExternalCallbacks::new()
                 .with_embedded_formatter(embedded_callback)
                 .with_tailwind(tailwind_callback),
-            dispatcher,
+            fallback,
         )
-    }
-
-    /// Build the `FormatDispatcher` for the JS root's `FormatSession`:
-    /// the native registry plus this formatter's Prettier Doc→IR fallback.
-    fn build_dispatcher(
-        &self,
-        dispatch_config: &Arc<embed::dispatcher::ResolvedDispatchConfig>,
-    ) -> oxc_formatter_core::FormatDispatcher {
-        let fallback = embed::prettier_fallback::build_prettier_fallback(
-            Arc::clone(dispatch_config),
-            Arc::clone(&self.format_embedded_doc),
-        );
-        embed::dispatcher::build_dispatcher(Arc::clone(dispatch_config), Some(fallback))
     }
 
     #[cfg(test)]

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -19,7 +19,7 @@ use super::options::{
     inject_tailwind_plugin_payload, to_prettier,
 };
 use super::{
-    embed::dispatcher::{ResolvedDispatchConfig, build_dispatcher},
+    embed::dispatcher::ResolvedDispatchConfig,
     options::{
         ValidatedOptions, to_oxc_formatter, to_oxc_formatter_css, to_oxc_formatter_graphql,
         to_oxc_formatter_json, to_oxc_formatter_yaml, to_oxc_toml, to_sort_package_json,
@@ -38,17 +38,15 @@ use super::{
 #[derive(Debug)]
 pub enum FormatStrategy {
     /// For JS/TS files formatted by oxc_formatter.
-    /// `config` is retained so embedded callbacks (e.g., xxx-in-js) can lazily
-    /// derive Prettier options at callback time.
+    /// `config` + `core` build the dispatch config for the root's session
+    /// (native xxx-in-js in every build, plus the napi embedded callbacks / Tailwind).
     OxcFormatter {
         path: Arc<Path>,
         source_type: SourceType,
         format_options: Box<JsFormatOptions>,
-        #[cfg(feature = "napi")]
         config: Arc<FormatConfig>,
         /// The validated core bundle, carried from resolution so dispatch-config
         /// construction never re-derives (or re-fails) it.
-        #[cfg(feature = "napi")]
         core: CoreFormatOptions,
         insert_final_newline: bool,
     },
@@ -165,9 +163,7 @@ impl FormatStrategy {
                     core,
                     validated.sort_imports.clone(),
                 )),
-                #[cfg(feature = "napi")]
                 config: Arc::new(config),
-                #[cfg(feature = "napi")]
                 core,
                 insert_final_newline,
             },
@@ -279,9 +275,7 @@ impl SourceFormatter {
                 path,
                 source_type,
                 format_options,
-                #[cfg(feature = "napi")]
                 config,
-                #[cfg(feature = "napi")]
                 core,
                 insert_final_newline,
             } => (
@@ -290,9 +284,7 @@ impl SourceFormatter {
                     &path,
                     source_type,
                     *format_options,
-                    #[cfg(feature = "napi")]
                     &config,
-                    #[cfg(feature = "napi")]
                     core,
                 ),
                 insert_final_newline,
@@ -396,8 +388,10 @@ impl SourceFormatter {
         }
     }
 
-    /// Format JS/TS source code using `oxc_formatter`.
-    /// `config` is needed to derive Prettier options for embedded callbacks (xxx-in-js, Tailwind).
+    /// Format JS/TS source code using `oxc_formatter` on a `PhysicalFile` session
+    /// carrying the registry dispatcher in every build
+    /// (fallback-less without napi, so non-native embeds stay verbatim);
+    /// the napi build adds the Prettier Doc→IR fallback and the string-channel callbacks.
     #[instrument(level = "debug", name = "oxfmt::format::oxc_formatter", skip_all)]
     fn format_by_oxc_formatter(
         &self,
@@ -405,22 +399,28 @@ impl SourceFormatter {
         path: &Path,
         source_type: SourceType,
         format_options: JsFormatOptions,
-        #[cfg(feature = "napi")] config: &Arc<FormatConfig>,
-        #[cfg(feature = "napi")] core: CoreFormatOptions,
+        config: &Arc<FormatConfig>,
+        core: CoreFormatOptions,
     ) -> Result<String, OxcDiagnostic> {
         let allocator = self.allocator_pool.get();
+        let dispatch_config = ResolvedDispatchConfig::for_root(config, core, path);
 
         #[cfg(feature = "napi")]
-        let (external_callbacks, dispatcher) = {
-            let (callbacks, dispatcher) =
-                self.build_external_callbacks(&format_options, config, core, path);
-            (Some(callbacks), dispatcher)
+        let (external_callbacks, fallback) = {
+            let (callbacks, fallback) = self
+                .external_formatter
+                .as_ref()
+                .expect("`external_formatter` must exist when `napi` feature is enabled")
+                .to_external_callbacks(&format_options, &dispatch_config);
+            (Some(callbacks), Some(fallback))
         };
+        // No Prettier fallback, but JSDoc native fences still format
+        // (the string-out channel's build-independent half).
         #[cfg(not(feature = "napi"))]
-        let (external_callbacks, dispatcher) = {
-            let _ = path;
-            (None, None)
-        };
+        let (external_callbacks, fallback) =
+            (Some(super::embed::fence::build_external_callbacks(&dispatch_config)), None);
+
+        let dispatcher = dispatch_config.root_dispatcher(fallback);
 
         let session = FormatSession::new(&allocator, InputKind::PhysicalFile, dispatcher);
         let formatted = oxc_formatter::format_with_session(
@@ -535,14 +535,8 @@ impl SourceFormatter {
         config: &Arc<FormatConfig>,
         core: CoreFormatOptions,
     ) -> Result<String, OxcDiagnostic> {
-        let dispatch_config = ResolvedDispatchConfig::new(Arc::clone(config), core);
-        #[cfg(feature = "napi")]
-        let dispatch_config = dispatch_config.with_path(path.to_path_buf());
-        let dispatch_config = Arc::new(dispatch_config);
-
-        let dispatcher = config
-            .is_embedded_formatting_enabled()
-            .then(|| build_dispatcher(Arc::clone(&dispatch_config), None));
+        let dispatch_config = ResolvedDispatchConfig::for_root(config, core, path);
+        let dispatcher = dispatch_config.root_dispatcher(None);
 
         #[cfg(feature = "napi")]
         let sorter = self.tailwind_sorter(config, &dispatch_config);
@@ -646,33 +640,6 @@ impl SourceFormatter {
         })
     }
 
-    /// Build external callbacks for `oxc_formatter` from the NAPI external formatter.
-    ///
-    /// Tailwind is always considered "capable" here because `oxc_formatter` embeds the sorter internally;
-    /// the inject helper itself decides whether to fire based on user config.
-    /// Also returns the `FormatDispatcher` for the JS root's `FormatSession`
-    /// (`None` when `embeddedLanguageFormatting: off`; the gate is owned by `ExternalFormatter::to_external_callbacks`).
-    fn build_external_callbacks(
-        &self,
-        format_options: &JsFormatOptions,
-        config: &Arc<FormatConfig>,
-        core: CoreFormatOptions,
-        path: &Path,
-    ) -> (oxc_formatter::ExternalCallbacks, Option<oxc_formatter_core::FormatDispatcher>) {
-        let external_formatter = self
-            .external_formatter
-            .as_ref()
-            .expect("`external_formatter` must exist when `napi` feature is enabled");
-
-        // Per-language options are mapped lazily at dispatch time;
-        // `core` is the validated bundle carried on the strategy since resolution.
-        let dispatch_config = Arc::new(
-            ResolvedDispatchConfig::new(Arc::clone(config), core).with_path(path.to_path_buf()),
-        );
-
-        external_formatter.to_external_callbacks(format_options, &dispatch_config)
-    }
-
     /// Format non-JS/TS file using external formatter (Prettier).
     ///
     /// Plugin payloads are injected based on capability flags & user config.
@@ -724,5 +691,74 @@ impl SourceFormatter {
             };
             OxcDiagnostic::error(message)
         })
+    }
+}
+
+/// The JS root's session wiring (registry dispatcher installed / off-gate honored),
+/// which the registry-level tests in `embed::dispatcher` cannot see.
+/// The napi build runs on `ExternalFormatter::dummy()` (native branches never call JS).
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{
+        options::validate,
+        oxfmtrc::{EmbeddedLanguageFormattingConfig, JsdocUserConfig},
+    };
+
+    fn format_ts(config: FormatConfig, source: &str) -> String {
+        let validated = validate(&config).expect("default-ish config must validate");
+        let kind = FileKind::OxcFormatter {
+            path: Arc::from(Path::new("test.ts")),
+            source_type: SourceType::ts(),
+        };
+        let strategy = FormatStrategy::from_format_config(config, &validated, kind);
+        let formatter = SourceFormatter::new(1);
+        #[cfg(feature = "napi")]
+        let formatter =
+            formatter.with_external_formatter(Some(crate::core::ExternalFormatter::dummy()));
+        match formatter.format(source, strategy) {
+            FormatResult::Success { code, .. } => code,
+            FormatResult::Error(errors) => panic!("format failed: {errors:?}"),
+        }
+    }
+
+    /// The JS root carries the registry dispatcher in every build,
+    /// so native xxx-in-js formats without Prettier.
+    #[test]
+    fn js_root_installs_the_registry_dispatcher() {
+        let code = format_ts(FormatConfig::default(), "const a = css`a{color:  red}`;\n");
+        assert!(code.contains("color: red;"), "css-in-js should format natively: {code}");
+    }
+
+    /// Pure-build criterion: html has no native branch and no Prettier fallback,
+    /// so the embed deliberately stays verbatim (under napi it reaches the fallback instead).
+    #[cfg(not(feature = "napi"))]
+    #[test]
+    fn non_native_embed_stays_verbatim_without_fallback() {
+        let source = "const h = html`<div>  <p>x</p></div>`;\n";
+        assert_eq!(format_ts(FormatConfig::default(), source), source);
+    }
+
+    /// A JSDoc fence whose language is in the native registry formats through
+    /// the fence adapter in every build (no Prettier involved).
+    #[test]
+    fn jsdoc_native_fence_formats_without_prettier() {
+        let config =
+            FormatConfig { jsdoc: Some(JsdocUserConfig::Bool(true)), ..FormatConfig::default() };
+        let source = "/**\n * ```css\n * a{color:  red}\n * ```\n */\n";
+        let code = format_ts(config, source);
+        assert!(code.contains("color: red;"), "css fence should format natively: {code}");
+    }
+
+    /// `embeddedLanguageFormatting: off` installs no dispatcher:
+    /// even native embeds stay verbatim.
+    #[test]
+    fn embedded_off_keeps_native_embeds_verbatim() {
+        let config = FormatConfig {
+            embedded_language_formatting: Some(EmbeddedLanguageFormattingConfig::Off),
+            ..FormatConfig::default()
+        };
+        let source = "const a = css`a{color:  red}`;\n";
+        assert_eq!(format_ts(config, source), source);
     }
 }

--- a/apps/oxfmt/src/core/options/to_oxc_formatter.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter.rs
@@ -2,18 +2,17 @@ use rustc_hash::FxHashSet;
 
 use oxc_formatter::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, CommentLineStrategy,
-    CustomGroupDefinition, EmbeddedLanguageFormatting, Expand, GroupEntry, ImportModifier,
-    ImportSelector, JsFormatOptions, JsdocOptions, LineWrappingStyle, QuoteProperties, QuoteStyle,
-    Semicolons, SortImportsOptions, SortOrder, SortTailwindcssOptions, TrailingCommas,
+    CustomGroupDefinition, Expand, GroupEntry, ImportModifier, ImportSelector, JsFormatOptions,
+    JsdocOptions, LineWrappingStyle, QuoteProperties, QuoteStyle, Semicolons, SortImportsOptions,
+    SortOrder, SortTailwindcssOptions, TrailingCommas,
 };
 use oxc_formatter_core::{CoreFormatOptions, FormatOptions};
 
 use super::super::oxfmtrc::{
-    ArrowParensConfig, CommentLineStrategyConfig, CustomGroupItemConfig,
-    EmbeddedLanguageFormattingConfig, FormatConfig, HtmlWhitespaceSensitivityConfig,
-    JsdocUserConfig, LineWrappingStyleConfig, ObjectWrapConfig, QuotePropsConfig,
-    SortGroupItemConfig, SortImportsUserConfig, SortOrderConfig, SortTailwindcssUserConfig,
-    TrailingCommaConfig,
+    ArrowParensConfig, CommentLineStrategyConfig, CustomGroupItemConfig, FormatConfig,
+    HtmlWhitespaceSensitivityConfig, JsdocUserConfig, LineWrappingStyleConfig, ObjectWrapConfig,
+    QuotePropsConfig, SortGroupItemConfig, SortImportsUserConfig, SortOrderConfig,
+    SortTailwindcssUserConfig, TrailingCommaConfig,
 };
 
 /// Convert `FormatConfig` into `JsFormatOptions` for `oxc_formatter`.
@@ -107,14 +106,6 @@ pub fn to_oxc_formatter(
     if let Some(sensitivity) = config.html_whitespace_sensitivity {
         format_options.html_whitespace_sensitivity_ignore =
             matches!(sensitivity, HtmlWhitespaceSensitivityConfig::Ignore);
-    }
-
-    // [Prettier] embeddedLanguageFormatting: "auto" | "off"
-    if let Some(embedded_language_formatting) = config.embedded_language_formatting {
-        format_options.embedded_language_formatting = match embedded_language_formatting {
-            EmbeddedLanguageFormattingConfig::Auto => EmbeddedLanguageFormatting::Auto,
-            EmbeddedLanguageFormattingConfig::Off => EmbeddedLanguageFormatting::Off,
-        };
     }
 
     // Below are our own extensions

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -289,20 +289,20 @@ pub struct FormatConfig {
 }
 
 impl FormatConfig {
+    /// Whether embedded-language formatting is enabled by this config
+    /// (`embeddedLanguageFormatting` defaults to `"auto"`; only an explicit `"off"` disables it).
+    /// Consumers reach this through `ResolvedDispatchConfig::is_embedded_formatting_enabled`,
+    /// which owns the never-diverge invariant.
+    pub fn is_embedded_formatting_enabled(&self) -> bool {
+        !matches!(self.embedded_language_formatting, Some(EmbeddedLanguageFormattingConfig::Off))
+    }
+
     /// Whether `prettier-plugin-svelte` is enabled by this config.
     ///
     /// Enabled when `svelte` is set to `true` or an object;
     /// disabled when unset or `false`.
     pub fn is_svelte_enabled(&self) -> bool {
         matches!(self.svelte, Some(SvelteUserConfig::Bool(true) | SvelteUserConfig::Object(_)))
-    }
-
-    /// Whether embedded-language formatting is enabled by this config
-    /// (`embeddedLanguageFormatting` defaults to `"auto"`; only an explicit `"off"` disables it).
-    /// Every dispatcher-assembly site consults this,
-    /// so the off-semantics can never diverge between channels.
-    pub fn is_embedded_formatting_enabled(&self) -> bool {
-        !matches!(self.embedded_language_formatting, Some(EmbeddedLanguageFormattingConfig::Off))
     }
 
     /// Whether Tailwind class sorting is enabled by this config.

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -17,45 +17,36 @@ use crate::{
 pub struct JsFormatOptions {
     /// The indent style.
     pub indent_style: IndentStyle,
-
     /// The indent width.
     pub indent_width: IndentWidth,
-
     /// The type of line ending.
     pub line_ending: LineEnding,
-
     /// What's the max width of a line. Defaults to 100.
     pub line_width: LineWidth,
 
     /// The style for quotes. Defaults to double.
     pub quote_style: QuoteStyle,
-
     /// The style for JSX quotes. Defaults to double.
     pub jsx_quote_style: QuoteStyle,
-
     /// When properties in objects are quoted. Defaults to as-needed.
     pub quote_properties: QuoteProperties,
-
     /// Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "all".
     pub trailing_commas: TrailingCommas,
-
     /// Whether the formatter prints semicolons for all statements, class members, and type members or only when necessary because of [ASI](https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-automatic-semicolon-insertion).
     pub semicolons: Semicolons,
-
     /// Whether to add non-necessary parentheses to arrow functions. Defaults to "always".
     pub arrow_parentheses: ArrowParentheses,
-
     /// Whether to insert spaces around brackets in object literals. Defaults to true.
     pub bracket_spacing: BracketSpacing,
-
     /// Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.
     pub bracket_same_line: BracketSameLine,
-
     /// Attribute position style. By default auto.
     pub attribute_position: AttributePosition,
-
     /// Whether to expand object and array literals to multiple lines. Defaults to "auto".
     pub expand: Expand,
+    /// Whether HTML whitespace sensitivity is set to "ignore".
+    /// When true, HTML-in-JS templates always use hard line breaks for wrapping.
+    pub html_whitespace_sensitivity_ignore: bool,
 
     /// Controls the position of operators in binary expressions. [**NOT SUPPORTED YET**]
     ///
@@ -63,7 +54,6 @@ pub struct JsFormatOptions {
     /// - `"start"`: Places the operator at the beginning of the next line.
     /// - `"end"`: Places the operator at the end of the current line (default).
     pub experimental_operator_position: OperatorPosition,
-
     /// Try prettier's new ternary formatting before it becomes the default behavior. [**NOT SUPPORTED YET**]
     ///
     /// Valid options:
@@ -71,21 +61,12 @@ pub struct JsFormatOptions {
     /// - `false` - Retain the default behavior of ternaries; keep question marks on the same line as the consequent.
     pub experimental_ternaries: bool,
 
-    /// Whether HTML whitespace sensitivity is set to "ignore".
-    /// When true, HTML-in-JS templates always use hard line breaks for wrapping.
-    pub html_whitespace_sensitivity_ignore: bool,
-
-    /// Enable formatting for embedded languages (e.g., CSS, SQL, GraphQL) within template literals. Defaults to "auto".
-    pub embedded_language_formatting: EmbeddedLanguageFormatting,
-
     /// Sort import statements. By default disabled.
     pub sort_imports: Option<SortImportsOptions>,
-
     /// Enable Tailwind CSS class sorting in JSX class/className attributes.
     /// When enabled, class strings will be collected and passed to a callback for sorting.
     /// Defaults to None (disabled).
     pub sort_tailwindcss: Option<SortTailwindcssOptions>,
-
     /// Enable JSDoc comment formatting.
     /// When enabled, JSDoc comments will be normalized and reformatted.
     /// Defaults to None (disabled).
@@ -242,7 +223,6 @@ impl fmt::Display for JsFormatOptions {
         writeln!(f, "Attribute Position: {}", self.attribute_position)?;
         writeln!(f, "Expand lists: {}", self.expand)?;
         writeln!(f, "Experimental operator position: {}", self.experimental_operator_position)?;
-        writeln!(f, "Embedded language formatting: {}", self.embedded_language_formatting)?;
         writeln!(f, "Sort imports: {:?}", self.sort_imports)?;
         writeln!(f, "Sort tailwindcss: {:?}", self.sort_tailwindcss)?;
         writeln!(f, "JSDoc: {:?}", self.jsdoc)
@@ -704,47 +684,6 @@ impl fmt::Display for OperatorPosition {
         let s = match self {
             OperatorPosition::Start => "Start",
             OperatorPosition::End => "End",
-        };
-        f.write_str(s)
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-pub enum EmbeddedLanguageFormatting {
-    /// Enable formatting for embedded languages.
-    #[default]
-    Auto,
-    /// Disable formatting for embedded languages.
-    Off,
-}
-
-impl EmbeddedLanguageFormatting {
-    pub const fn is_auto(self) -> bool {
-        matches!(self, Self::Auto)
-    }
-
-    pub const fn is_off(self) -> bool {
-        matches!(self, Self::Off)
-    }
-}
-
-impl FromStr for EmbeddedLanguageFormatting {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "auto" => Ok(Self::Auto),
-            "off" => Ok(Self::Off),
-            _ => Err("Value not supported for EmbeddedLanguageFormatting"),
-        }
-    }
-}
-
-impl fmt::Display for EmbeddedLanguageFormatting {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let s = match self {
-            EmbeddedLanguageFormatting::Auto => "Auto",
-            EmbeddedLanguageFormatting::Off => "Off",
         };
         f.write_str(s)
     }


### PR DESCRIPTION
Although everything was ready in #25331, it was still behind the `napi` gate, so removed it.