### PR TITLE
fix(ci): run required checks for merge queue

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -5,6 +5,7 @@ permissions: {}
 on:
   pull_request:
     types: [opened, synchronize]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
@@ -39,6 +40,11 @@ jobs:
 
       - run: just fmt
 
+      - name: Verify no fixes are needed
+        if: ${{ github.event_name == 'merge_group' }}
+        run: git diff --exit-code
+
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,7 @@ on:
       - edited
       - synchronize
       - reopened
+  merge_group:
 
 jobs:
   pr:
@@ -16,6 +17,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Validate PR title
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
@@ -33,3 +35,7 @@ jobs:
             } >&2
             exit 1
           fi
+
+      - name: Accept merge group
+        if: ${{ github.event_name == 'merge_group' }}
+        run: "true"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
Run required workflows for `merge_group` commits so the merge queue receives status checks. Keep PR-title validation and autofix publishing limited to pull request events.

Validated with `just ready`.

AI assistance was used for this change.