### PR TITLE
refactor(formatter,oxfmt): flatten embedded dispatch contract

### DIFF
--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -44,12 +44,24 @@ Oxfmt utilizes different implementations depending on the file extension and fil
 
 NOTE: Rust written formatters never fall back to Prettier, since they exist to reduce the dependency on Prettier.
 
-Embedded languages (e.g. css-in-js, CSS front matter YAML) go through the `FormatDispatcher` (defined in `oxc_formatter_core`) assembled by `src/core/embed/dispatcher.rs`.
-JS/TS and standalone CSS roots run on a `PhysicalFile` session carrying the registry dispatcher in EVERY build.
-The Vue/Svelte `<script>` root (`api/text_to_doc_api.rs`, a `VirtualDocument` session, napi only) is the 3rd assembly site: a Rust branch per `NativeLanguage` (css/graphql/yaml/json/...), plus the Prettier Doc→IR fallback (`embed/prettier_fallback.rs`, napi only) for the rest.
-The pure Rust build runs fallback-less, so non-native embeds (html-in-js, TOML/custom front matter) deliberately stay verbatim like Prettier; `embeddedLanguageFormatting: off` installs no dispatcher (every root assembles its `SessionServices` via `ResolvedDispatchConfig::for_root` + `root_dispatcher` / `ExternalFormatter::session_services` / `fence::session_services`, all consulting the same off-gate).
-The service builders are SERVICE PROFILES, not host bindings: `ExternalFormatter::session_services` (napi standard set) / `fence::session_services` (pure native-only set) serve any host with that shape. (Future Markdown host reuses them as-is.)
-A new host picks a profile; whether a Tier 1 host's root takes the Prettier fallback for its embeds (e.g. md-in-graphql before the md Rust port) is a per-host policy decision made explicitly at that root, never a builder default (the CSS root's fallback-less literal in `format.rs` is the current example).
+#### Embedded language formatting
+
+Embedded languages (e.g. css-in-js, CSS front matter YAML) go through the `FormatDispatcher` (defined in `oxc_formatter_core`) assembled by `src/core/embed/dispatcher.rs`:
+a Rust branch per `NativeLanguage` (css/graphql/yaml/json/...), plus the Prettier Doc→IR fallback (`embed/prettier_fallback.rs`, napi only) for the rest.
+The pure Rust build runs fallback-less, so non-native embeds (html-in-js, TOML/custom front matter) deliberately stay verbatim.
+
+Three roots install `SessionServices` (each built from `ResolvedDispatchConfig::for_root`):
+
+| Root                                             | Session           | napi build                                           | pure build          |
+| ------------------------------------------------ | ----------------- | ---------------------------------------------------- | ------------------- |
+| JS/TS file (`core/format.rs`)                    | `PhysicalFile`    | standard profile                                     | native-only profile |
+| CSS file (`core/format.rs`)                      | `PhysicalFile`    | fallback-less literal (dispatcher + Tailwind sorter) | same, sorter-less   |
+| Vue/Svelte `<script>` (`api/text_to_doc_api.rs`) | `VirtualDocument` | standard profile                                     | -                   |
+
+The service builders are SERVICE PROFILES, not host bindings: `ExternalFormatter::session_services` (napi standard set) and `fence::session_services` (pure native-only set) serve any host with that shape. (a future Markdown host reuses them as-is.)
+Whether a Tier 1 host's root takes the Prettier fallback for its embeds (e.g. md-in-graphql before the md Rust port) is a per-host policy decision made explicitly at that root, never a builder default; the CSS root's fallback-less literal in `format.rs` is the current example.
+`embeddedLanguageFormatting: off` installs no dispatcher, every builder consults the same off-gate, `ResolvedDispatchConfig::is_embedded_formatting_enabled`.
+
 Per-language options are NOT built up front: `ResolvedDispatchConfig` maps them lazily at dispatch time (`OnceLock`-memoized) from the host file's resolved config, including the Prettier options JSON for the JS-side consumers. `src/core/external_formatter.rs` bridges the napi callbacks into these factories.
 
 A separate string-out channel (the session's `string_embedder` service, NOT the dispatcher) carries the string-in/string-out consumers:
@@ -63,6 +75,8 @@ A separate string-out channel (the session's `string_embedder` service, NOT the 
 NOTE: These string-out channel is temporary workaround, should be replaced by native implementations and Prettier usage should be eliminated in the future.
 JSDoc's string-out is also NOT structural: fences can move to IR-out (session dispatch inside the comment IR) once the printer grows a per-line prefix mechanism for the `*` continuation, but deferred for verification time, not by design.
 
+#### Tailwind CSS class sorting
+
 Tailwind class sorting (`sortTailwindcss`) splits responsibilities:
 
 - Rust collects classes into `FormatElement::TailwindClass`
@@ -71,9 +85,10 @@ Tailwind class sorting (`sortTailwindcss`) splits responsibilities:
   - `sortTailwindClasses` → tailwind's `getClassOrder`, which needs the resolved Tailwind config
 
 Embedded boundaries carry classes through `DispatchResult::tailwind_classes`;
-each embed site calls `DispatchResult::remap_tailwind_into(collector)` before consuming `docs`.
+each embed site consumes the doc via `DispatchResult::into_doc(collector)`, which merges them into the parent's class space.
 
-The four data paths (JS/TS top-level / standalone CSS / embedded CSS / JSDoc fenced CSS) are documented at `ExternalFormatter::session_services`. No CSS goes to Prettier for this; the pure Rust build never collects (no sorter available).
+The four data paths (JS/TS top-level / standalone CSS / embedded CSS / JSDoc fenced CSS) are documented at `ExternalFormatter::session_services`.
+No CSS goes to Prettier for this; the pure Rust build never collects at all (both mappers gate collection behind napi, since no sorter exists there).
 
 Consequently, managing these various formatter implementations and handling their respective options are also part of Oxfmt's responsibilities.
 

--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -34,7 +34,7 @@ export declare const enum Severity {
  * # Panics
  * Panics if the current working directory cannot be determined.
  */
-export declare function format(filename: string, sourceText: string, options: any | undefined | null, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<FormatResult>
+export declare function format(filename: string, sourceText: string, options: any | undefined | null, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, code: string) => Promise<string | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<FormatResult>
 
 export interface FormatResult {
   /** The formatted code. */
@@ -49,7 +49,7 @@ export interface FormatResult {
  * This API is specialized for JS/TS snippets embedded in non-JS files.
  * Unlike `format()`, it is called only for js-in-xxx `textToDoc()` flow.
  */
-export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmtPluginOptionsJson: string, parentContext: string, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<string | null>
+export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmtPluginOptionsJson: string, parentContext: string, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, code: string) => Promise<string | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<string | null>
 
 /**
  * NAPI based JS CLI entry point.
@@ -67,4 +67,4 @@ export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmt
  * - `mode`: If main logic will run in JS side, use this to indicate which mode
  * - `exitCode`: If main logic already ran in Rust side, return the exit code
  */
-export declare function runCli(args: Array<string>, loadJsConfigCb: (path: string) => Promise<any>, initExternalFormatterCb: (numThreads: number) => Promise<void>, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<[string, number | undefined | null]>
+export declare function runCli(args: Array<string>, loadJsConfigCb: (path: string) => Promise<any>, initExternalFormatterCb: (numThreads: number) => Promise<void>, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, code: string) => Promise<string | null>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<[string, number | undefined | null]>

--- a/apps/oxfmt/src-js/cli/worker-proxy.ts
+++ b/apps/oxfmt/src-js/cli/worker-proxy.ts
@@ -80,11 +80,11 @@ export function formatEmbeddedCode(
 
 export function formatEmbeddedDoc(
   options: FormatEmbeddedDocParam["options"],
-  texts: string[],
-): Promise<string[] | null> {
+  code: string,
+): Promise<string | null> {
   return toNullable(
     getPool().then((pool) =>
-      pool.run({ options, texts } satisfies FormatEmbeddedDocParam, {
+      pool.run({ options, code } satisfies FormatEmbeddedDocParam, {
         name: "formatEmbeddedDoc",
       }),
     ),

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -93,7 +93,7 @@ export async function format(fileName: string, sourceText: string, options?: For
     options ?? {},
     (options, code) => toFormatFileResult(formatFile({ options, code })),
     (options, code) => toNullable(formatEmbeddedCode({ options, code })),
-    (options, texts) => toNullable(formatEmbeddedDoc({ options, texts })),
+    (options, code) => toNullable(formatEmbeddedDoc({ options, code })),
     (options, classes) => toNullable(sortTailwindClasses({ options, classes })),
   );
 }
@@ -115,7 +115,7 @@ export async function jsTextToDoc(
     parentContext,
     () => toFormatFileResult(Promise.reject("formatFile is unavailable for jsTextToDoc")),
     (options, code) => toNullable(formatEmbeddedCode({ options, code })),
-    (options, texts) => toNullable(formatEmbeddedDoc({ options, texts })),
+    (options, code) => toNullable(formatEmbeddedDoc({ options, code })),
     (options, classes) => toNullable(sortTailwindClasses({ options, classes })),
   );
 }

--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -158,71 +158,62 @@ export async function formatEmbeddedCode({
 // ---
 
 export type FormatEmbeddedDocParam = {
-  texts: string[];
+  code: string;
   options: Options;
 };
 
 /**
- * Format non-js code snippets into Prettier `Doc` JSON strings.
- *
+ * Format a non-js code snippet into a Prettier `Doc` JSON string.
  * This makes our printer correctly handle `printWidth` even for embedded code.
- * - For gql-in-js, `texts` contains multiple parts split by `${}` in a template literal
- * - For others, `texts` always contains a single string with `${}` parts replaced by placeholders
- * However, this function does not need to be aware of that,
- * as it simply formats each text part independently and returns an array of formatted parts.
  *
- * @returns Doc JSON strings
+ * @returns `Doc` JSON string
  */
 export async function formatEmbeddedDoc({
-  texts,
+  code,
   options,
-}: FormatEmbeddedDocParam): Promise<string[]> {
+}: FormatEmbeddedDocParam): Promise<string> {
   const prettier = CACHES.prettier ?? (await loadPrettier());
 
   // Enable Tailwind CSS plugin for embedded code (e.g., html`...` in JS) if needed
   if ("_useTailwindPlugin" in options) await setupTailwindPlugin(options);
 
+  const metadata: Record<string, unknown> = {};
+
+  // html(angular)-in-js specific options: see the comment in `loadPrettier()` for rationale
+  if (options.parser === "html" || options.parser === "angular") {
+    // Any truthy value works
+    options.parentParser = "OXFMT";
+    // https://github.com/prettier/prettier/blob/90983f40dce5e20beea4e5618b5e0426a6a7f4f0/src/language-js/embed/html.js#L42-L44
+    options.__onHtmlRoot = (root: { children?: unknown[] }) =>
+      (metadata.htmlHasMultipleRootElements = (root.children?.length ?? 0) > 1);
+  }
+
+  // md-in-js specific options: see the comment in `loadPrettier()` for rationale
+  if (options.parser === "markdown") {
+    // https://github.com/prettier/prettier/blob/90983f40dce5e20beea4e5618b5e0426a6a7f4f0/src/language-js/embed/markdown.js#L21
+    options.__inJsTemplate = true;
+  }
+
   // NOTE: This will throw if:
   // - Specified parser is not available
   // - Or, code has syntax errors
   // In such cases, Rust side will fallback to original code
-  return Promise.all(
-    texts.map(async (text) => {
-      const metadata: Record<string, unknown> = {};
+  // @ts-expect-error: Use internal API, but it's necessary and only way to get `Doc`
+  const doc = await prettier.__debug.printToDoc(code, options);
 
-      // html(angular)-in-js specific options: see the comment in `loadPrettier()` for rationale
-      if (options.parser === "html" || options.parser === "angular") {
-        // Any truthy value works
-        options.parentParser = "OXFMT";
-        // https://github.com/prettier/prettier/blob/90983f40dce5e20beea4e5618b5e0426a6a7f4f0/src/language-js/embed/html.js#L42-L44
-        options.__onHtmlRoot = (root: { children?: unknown[] }) =>
-          (metadata.htmlHasMultipleRootElements = (root.children?.length ?? 0) > 1);
-      }
-
-      // md-in-js specific options: see the comment in `loadPrettier()` for rationale
-      if (options.parser === "markdown") {
-        // https://github.com/prettier/prettier/blob/90983f40dce5e20beea4e5618b5e0426a6a7f4f0/src/language-js/embed/markdown.js#L21
-        options.__inJsTemplate = true;
-      }
-
-      // @ts-expect-error: Use internal API, but it's necessary and only way to get `Doc`
-      const doc = await prettier.__debug.printToDoc(text, options);
-
-      // Serialize as [doc, metadata], handling special values:
-      // - Symbol group IDs → numeric counters
-      // - -Infinity (dedentToRoot) → marker string
-      const symbolToNumber = new Map<symbol, number>();
-      let nextId = 1;
-      return JSON.stringify([doc, metadata], (_key, value) => {
-        if (typeof value === "symbol") {
-          if (!symbolToNumber.has(value)) symbolToNumber.set(value, nextId++);
-          return symbolToNumber.get(value);
-        }
-        if (value === -Infinity) return "__NEGATIVE_INFINITY__";
-        return value;
-      });
-    }),
-  );
+  // Serialize as [doc, metadata], handling special values:
+  // - Symbol group IDs → numeric counters
+  // - -Infinity (dedentToRoot) → marker string
+  const symbolToNumber = new Map<symbol, number>();
+  let nextId = 1;
+  return JSON.stringify([doc, metadata], (_key, value) => {
+    if (typeof value === "symbol") {
+      if (!symbolToNumber.has(value)) symbolToNumber.set(value, nextId++);
+      return symbolToNumber.get(value);
+    }
+    if (value === -Infinity) return "__NEGATIVE_INFINITY__";
+    return value;
+  });
 }
 
 // ---

--- a/apps/oxfmt/src/core/embed/dispatcher.rs
+++ b/apps/oxfmt/src/core/embed/dispatcher.rs
@@ -10,8 +10,8 @@ use tracing::{debug, debug_span};
 
 use oxc_formatter::CssInJsTemplate;
 use oxc_formatter_core::{
-    CoreFormatOptions, DispatchOutcome, DispatchRequest, DispatchResult, EmbeddedIr,
-    FormatDispatcher, FormatSession,
+    CoreFormatOptions, DispatchOutcome, DispatchRequest, EmbeddedIr, FormatDispatcher,
+    FormatSession,
 };
 use oxc_formatter_core::{FormatOptions, PrinterOptions};
 use oxc_formatter_css::{CssFormatOptions, CssVariant};
@@ -30,7 +30,7 @@ use crate::core::{
 /// The native formatter registry:
 /// a request/fence language parses to its Rust formatter branch here, or it has none.
 ///
-/// [`build_dispatcher`] and the JSDoc string adapter ([`is_native_language`])
+/// [`build_dispatcher`] and the napi string channel's fence routing (`is_native_language`)
 /// both consult this single mapping, so their notions of "native" can never drift.
 enum NativeLanguage {
     Graphql,
@@ -56,7 +56,9 @@ fn native_language(language: &str) -> Option<NativeLanguage> {
 }
 
 /// Whether `language` has a native (Rust formatter) branch in the registry.
-/// (Consulted by the JSDoc fence adapter [`super::fence`]; the dispatcher itself matches [`native_language`] directly.)
+/// (Consulted by the napi string channel's routing; the dispatcher itself matches
+/// [`native_language`] directly, and the pure build's fence adapter just dispatches.)
+#[cfg(feature = "napi")]
 pub fn is_native_language(language: &str) -> bool {
     native_language(language).is_some()
 }
@@ -150,7 +152,9 @@ impl ResolvedDispatchConfig {
     }
 
     /// The single Tailwind predicate, same pattern as
-    /// [`Self::is_embedded_formatting_enabled`]: every sorter-assembly site consults it.
+    /// [`Self::is_embedded_formatting_enabled`]: every sorter-assembly site consults it
+    /// (the sorter is napi-only; the pure build has no JS-side class order source).
+    #[cfg(feature = "napi")]
     pub fn is_tailwind_enabled(&self) -> bool {
         self.config.is_tailwind_enabled()
     }
@@ -209,7 +213,7 @@ impl ResolvedDispatchConfig {
 /// Assembled only in napi builds ([`super::prettier_fallback`]);
 /// the pure Rust build passes `None` and unsupported languages are deliberately preserved as-is.
 pub type PrettierDocFallback = Arc<
-    dyn for<'a> Fn(&FormatSession<'a>, &str, &[&str]) -> Result<DispatchOutcome<'a>, String>
+    dyn for<'a> Fn(&FormatSession<'a>, &str, &str) -> Result<DispatchOutcome<'a>, String>
         + Send
         + Sync,
 >;
@@ -222,21 +226,16 @@ pub fn build_dispatcher(
     fallback: Option<PrettierDocFallback>,
 ) -> FormatDispatcher {
     Arc::new(move |session: &FormatSession<'_>, request: DispatchRequest<'_>| {
+        let text = request.text;
         match native_language(request.language) {
-            Some(NativeLanguage::Graphql) => Ok(formatted_or_preserved(
-                format_graphql_to_irs(session, request.texts, dispatch_config.graphql_options()),
-                "format_graphql_to_irs",
-            )),
+            Some(NativeLanguage::Graphql) => Ok(format_native("graphql", || {
+                oxc_formatter_graphql::format_to_ir(
+                    session,
+                    text,
+                    dispatch_config.graphql_options(),
+                )
+            })),
             Some(NativeLanguage::Css(variant)) => {
-                // A wrong text count is a host-contract violation, not a parse failure:
-                // unlike GraphQL's one-IR-per-quasi,
-                // the CSS embed joins quasis with placeholders into a single text before dispatching.
-                let [text] = request.texts else {
-                    return Err(format!(
-                        "CSS dispatch expects exactly one text, got {}",
-                        request.texts.len()
-                    ));
-                };
                 // css-in-js (typed `CssInJsTemplate` context) is always parsed as SCSS with `${}` placeholder markers.
                 // Any other caller gets the strict standalone grammar with the fence/request language's variant.
                 let (variant, template_placeholders) = if request
@@ -247,28 +246,29 @@ pub fn build_dispatcher(
                 } else {
                     (variant, false)
                 };
-                Ok(formatted_or_preserved(
-                    format_css_to_ir(
+                Ok(format_native("css", || {
+                    oxc_formatter_css::format_to_ir(
                         session,
                         text,
                         dispatch_config.css_options(variant),
                         template_placeholders,
-                    ),
-                    "format_css_to_ir",
-                ))
+                    )
+                }))
             }
-            Some(NativeLanguage::Yaml) => Ok(formatted_or_preserved(
-                format_yaml_to_irs(session, request.texts, dispatch_config.yaml_options()),
-                "format_yaml_to_irs",
-            )),
-            Some(NativeLanguage::Json(variant)) => Ok(formatted_or_preserved(
-                format_json_to_irs(session, request.texts, dispatch_config.json_options(variant)),
-                "format_json_to_irs",
-            )),
+            Some(NativeLanguage::Yaml) => Ok(format_native("yaml", || {
+                oxc_formatter_yaml::format_to_ir(session, text, dispatch_config.yaml_options())
+            })),
+            Some(NativeLanguage::Json(variant)) => Ok(format_native("json", || {
+                oxc_formatter_json::format_to_ir(
+                    session,
+                    text,
+                    dispatch_config.json_options(variant),
+                )
+            })),
             // Everything else: Prettier fallback (Doc→IR path) when available
             None => {
                 if let Some(fallback) = &fallback {
-                    fallback(session, request.language, request.texts)
+                    fallback(session, request.language, text)
                 } else {
                     // A language without a formatter is a deliberate skip.
                     debug!("No formatter for language '{}', part stays as-is", request.language);
@@ -279,87 +279,19 @@ pub fn build_dispatcher(
     })
 }
 
-/// Maps a native branch result: a parse failure is a deliberate skip
+/// Runs one native branch: a parse failure is a deliberate skip
 /// (the embedded part stays as-is), never an operational error.
-fn formatted_or_preserved<'a>(
-    result: Result<DispatchResult<'a>, String>,
-    debug_label: &str,
+/// The `From<EmbeddedIr>` conversion carries the child's Tailwind classes.
+fn format_native<'a, E: std::fmt::Display>(
+    language: &'static str,
+    format_to_ir: impl FnOnce() -> Result<EmbeddedIr<'a>, E>,
 ) -> DispatchOutcome<'a> {
-    match result {
-        Ok(result) => DispatchOutcome::Formatted(result),
+    debug_span!("oxfmt::embed::format_to_ir", language).in_scope(|| match format_to_ir() {
+        Ok(embedded) => DispatchOutcome::Formatted(embedded.into()),
         Err(err) => {
-            debug!("`{debug_label}` failed, part stays as-is: {err}");
+            debug!("native '{language}' format_to_ir failed, part stays as-is: {err}");
             DispatchOutcome::PreserveOriginal
         }
-    }
-}
-
-/// Format each text as a standalone document via `format_one`,
-/// returning one IR per text (the IR-channel contract for the per-quasi languages:
-/// graphql templates, yaml front matter bodies, and fenced blocks).
-///
-/// Any parse error fails the whole batch (an embedded template is all-or-nothing).
-fn format_texts_to_irs<'a, E: std::fmt::Display>(
-    session: &FormatSession<'a>,
-    texts: &[&str],
-    language: &'static str,
-    format_one: impl Fn(&FormatSession<'a>, &str) -> Result<EmbeddedIr<'a>, E>,
-) -> Result<DispatchResult<'a>, String> {
-    let docs = texts
-        .iter()
-        .map(|text| {
-            debug_span!("oxfmt::external::format_to_ir", language).in_scope(|| {
-                let embedded = format_one(session, text).map_err(|err| err.to_string())?;
-                Ok(embedded.ir)
-            })
-        })
-        .collect::<Result<Vec<_>, String>>()?;
-    Ok(DispatchResult { docs, tailwind_classes: Vec::new(), meta: None })
-}
-
-fn format_graphql_to_irs<'a>(
-    session: &FormatSession<'a>,
-    texts: &[&str],
-    options: GraphqlFormatOptions,
-) -> Result<DispatchResult<'a>, String> {
-    format_texts_to_irs(session, texts, "graphql", |session, text| {
-        oxc_formatter_graphql::format_to_ir(session, text, options)
-    })
-}
-
-/// Format the single joined CSS text (placeholders included) via `oxc_formatter_css`,
-/// returning one IR per call (the IR-channel contract for CSS).
-fn format_css_to_ir<'a>(
-    session: &FormatSession<'a>,
-    text: &str,
-    options: CssFormatOptions,
-    template_placeholders: bool,
-) -> Result<DispatchResult<'a>, String> {
-    debug_span!("oxfmt::external::format_css_to_ir").in_scope(|| {
-        let embedded =
-            oxc_formatter_css::format_to_ir(session, text, options, template_placeholders)
-                .map_err(|err| err.to_string())?;
-        Ok(embedded.into())
-    })
-}
-
-fn format_json_to_irs<'a>(
-    session: &FormatSession<'a>,
-    texts: &[&str],
-    options: JsonFormatOptions,
-) -> Result<DispatchResult<'a>, String> {
-    format_texts_to_irs(session, texts, "json", |session, text| {
-        oxc_formatter_json::format_to_ir(session, text, options)
-    })
-}
-
-fn format_yaml_to_irs<'a>(
-    session: &FormatSession<'a>,
-    texts: &[&str],
-    options: YamlFormatOptions,
-) -> Result<DispatchResult<'a>, String> {
-    format_texts_to_irs(session, texts, "yaml", |session, text| {
-        oxc_formatter_yaml::format_to_ir(session, text, options)
     })
 }
 
@@ -410,12 +342,12 @@ mod tests {
             };
             let outcome = session.dispatch(DispatchRequest {
                 language,
-                texts: &[text],
+                text,
                 input_kind: InputKind::Fragment,
                 parent_context: None,
             });
             assert!(
-                matches!(outcome, Ok(DispatchOutcome::Formatted(ref result)) if result.docs.len() == 1),
+                matches!(outcome, Ok(DispatchOutcome::Formatted(_))),
                 "language '{language}' did not dispatch natively"
             );
         }
@@ -436,13 +368,11 @@ mod tests {
 
         let outcome = session.dispatch(DispatchRequest {
             language: "yaml",
-            texts: &["a:   1"],
+            text: "a:   1",
             input_kind: InputKind::Fragment,
             parent_context: None,
         });
-        assert!(
-            matches!(outcome, Ok(DispatchOutcome::Formatted(ref result)) if result.docs.len() == 1)
-        );
+        assert!(matches!(outcome, Ok(DispatchOutcome::Formatted(_))));
     }
 
     #[test]
@@ -459,7 +389,7 @@ mod tests {
 
         let outcome = session.dispatch(DispatchRequest {
             language: "html",
-            texts: &["<div></div>"],
+            text: "<div></div>",
             input_kind: InputKind::Fragment,
             parent_context: None,
         });

--- a/apps/oxfmt/src/core/embed/fence.rs
+++ b/apps/oxfmt/src/core/embed/fence.rs
@@ -17,20 +17,14 @@ use oxc_formatter_core::{
     InputKind, SessionServices, TailwindSorter,
 };
 
-use super::dispatcher::{self, ResolvedDispatchConfig};
-
-/// Build the dispatcher a fence callback holds for its lifetime.
-/// Fence dispatchers never take the Prettier fallback (native fences never fall
-/// back), so one is invariant across the callback's lifetime: build it once, not per fence.
-pub fn build_fence_dispatcher(dispatch_config: &Arc<ResolvedDispatchConfig>) -> FormatDispatcher {
-    dispatcher::build_dispatcher(Arc::clone(dispatch_config), None)
-}
+use super::dispatcher::ResolvedDispatchConfig;
 
 /// The pure build's `SessionServices`: the fallback-less registry dispatcher plus
 /// the native-fence string embedder, both behind the shared off-predicate
 /// (the napi twin is `ExternalFormatter::session_services`).
-/// Non-native fences answer `Err` (the string channel's "keep verbatim"),
-/// since no Prettier exists in this build; no Tailwind sorter exists either.
+/// A non-native fence dispatches to the registry's `PreserveOriginal`,
+/// which the adapter answers as `Err` (the string channel's "keep verbatim");
+/// no Prettier exists in this build, and no Tailwind sorter either.
 #[cfg(not(feature = "napi"))]
 pub fn session_services(dispatch_config: &Arc<ResolvedDispatchConfig>) -> SessionServices {
     // A fence dispatcher and this root's dispatcher are the same fallback-less registry,
@@ -40,9 +34,6 @@ pub fn session_services(dispatch_config: &Arc<ResolvedDispatchConfig>) -> Sessio
         let fence_dispatcher = Arc::clone(dispatcher);
         let dispatch_config = Arc::clone(dispatch_config);
         Arc::new(move |language: &str, code: &str| {
-            if !dispatcher::is_native_language(language) {
-                return Err(format!("Unsupported language: {language}"));
-            }
             format_native_fence(language, code, &fence_dispatcher, &dispatch_config, None)
         }) as oxc_formatter_core::StringEmbedder
     });
@@ -68,7 +59,7 @@ pub fn format_native_fence(
     dispatch_config: &ResolvedDispatchConfig,
     sort_tailwind: Option<&TailwindSorter>,
 ) -> Result<String, String> {
-    debug_span!("oxfmt::external::format_native_fence", language = language).in_scope(|| {
+    debug_span!("oxfmt::embed::format_native_fence", language = language).in_scope(|| {
         let allocator = Allocator::default();
         let session = FormatSession::with_services(
             &allocator,
@@ -81,7 +72,7 @@ pub fn format_native_fence(
         );
         let outcome = session.dispatch(DispatchRequest {
             language,
-            texts: &[code],
+            text: code,
             input_kind: InputKind::Fragment,
             parent_context: None,
         })?;
@@ -89,11 +80,9 @@ pub fn format_native_fence(
         let DispatchOutcome::Formatted(result) = outcome else {
             return Err(format!("Native formatter for '{language}' kept the input as-is"));
         };
-        let DispatchResult { mut docs, tailwind_classes, .. } = result;
-        if docs.len() != 1 {
-            return Err(format!("Expected exactly one IR, got {}", docs.len()));
-        }
-        let ir = docs.pop().unwrap();
+        // The parent-less consumer: no index space to remap into,
+        // so the classes sort locally instead of going through `into_doc`.
+        let DispatchResult { doc: ir, tailwind_classes, .. } = result;
 
         let tailwind_classes = session.sort_tailwind_classes(tailwind_classes);
 

--- a/apps/oxfmt/src/core/embed/mod.rs
+++ b/apps/oxfmt/src/core/embed/mod.rs
@@ -11,8 +11,7 @@
 //!   plus the pure build's root `SessionServices` assembly (`session_services`)
 //! - [`prettier_fallback`] (napi only): Prettier Doc→IR path for the rest
 //! - [`string_channel`] (napi only): the Prettier string paths of the string-out channel
-//!   - md/html/angular JSDoc fences + html-in-js fallback
-//!   - Standalone string formatting that re-embeds line-by-line
+//!   (md/html/angular JSDoc fences + the html-in-js fallback; results re-embed line-by-line)
 
 #[cfg(feature = "napi")]
 use std::sync::Arc;
@@ -49,11 +48,11 @@ pub type FormatFileWithConfigCallback =
 pub type FormatEmbeddedWithConfigCallback =
     Arc<dyn Fn(Value, &str) -> Result<String, String> + Send + Sync>;
 
-/// Callback function type for formatting embedded code via Doc IR path (batch).
-/// Takes (options, texts) and returns Doc JSON strings (one per text) or an error.
+/// Callback function type for formatting embedded code via the Doc IR path.
+/// Takes (options, text) and returns a Doc JSON string or an error.
 #[cfg(feature = "napi")]
 pub type FormatEmbeddedDocWithConfigCallback =
-    Arc<dyn Fn(Value, &[&str]) -> Result<Vec<String>, String> + Send + Sync>;
+    Arc<dyn Fn(Value, &str) -> Result<String, String> + Send + Sync>;
 
 /// Internal callback type for Tailwind processing with config.
 /// Takes (options, classes) and returns sorted classes.

--- a/apps/oxfmt/src/core/embed/prettier_fallback.rs
+++ b/apps/oxfmt/src/core/embed/prettier_fallback.rs
@@ -1,6 +1,6 @@
 //! Prettier Doc→IR fallback for embedded languages without a Rust formatter.
 //!
-//! Sends texts to JS `printToDoc()`, then converts the returned Doc JSON into
+//! Sends the text to JS `printToDoc()`, then converts the returned Doc JSON into
 //! formatter IR that integrates into the parent's arena / `GroupId` space.
 //! napi-only: the pure Rust build runs the registry without this fallback.
 
@@ -31,7 +31,7 @@ pub fn build_prettier_fallback(
     dispatch_config: Arc<ResolvedDispatchConfig>,
     format_embedded_doc: FormatEmbeddedDocWithConfigCallback,
 ) -> PrettierDocFallback {
-    Arc::new(move |session: &FormatSession<'_>, language: &str, texts: &[&str]| {
+    Arc::new(move |session: &FormatSession<'_>, language: &str, text: &str| {
         let Some(parser_name) = language_to_prettier_parser(language) else {
             // An unsupported language is a deliberate skip, not an operational error.
             debug!("No Prettier parser for language '{language}', part stays as-is");
@@ -41,27 +41,22 @@ pub fn build_prettier_fallback(
             .in_scope(|| {
                 let mut options = dispatch_config.external_options().clone();
                 inject_parser(&mut options, parser_name);
-                let doc_json_strs = (format_embedded_doc)(options, texts).map_err(|err| {
+                let doc_json_str = (format_embedded_doc)(options, text).map_err(|err| {
                     format!("Failed to get Doc for embedded code (parser '{parser_name}'): {err}")
                 })?;
-                let doc_jsons = doc_json_strs
-                    .into_iter()
-                    .map(|s| {
-                        // Prettier's Doc can produce deeply nested arrays
-                        // (e.g., md-in-js with `proseWrap: preserve`, which nests each word in `[[[prev, " "], word], " "]`).
-                        // The default recursion limit of 128 is not enough for long paragraphs.
-                        // This only affects this deserialization call;
-                        // other `serde_json` usage in the codebase keeps the default limit.
-                        let mut de = serde_json::Deserializer::from_str(&s);
-                        de.disable_recursion_limit();
-                        serde_json::Value::deserialize(&mut de)
-                    })
-                    .collect::<Result<Vec<_>, _>>()
+                // Prettier's Doc can produce deeply nested arrays
+                // (e.g., md-in-js with `proseWrap: preserve`, which nests each word in `[[[prev, " "], word], " "]`).
+                // The default recursion limit of 128 is not enough for long paragraphs.
+                // This only affects this deserialization call;
+                // other `serde_json` usage in the codebase keeps the default limit.
+                let mut de = serde_json::Deserializer::from_str(&doc_json_str);
+                de.disable_recursion_limit();
+                let doc_json = serde_json::Value::deserialize(&mut de)
                     .map_err(|e| format!("Failed to parse Doc JSON: {e}"))?;
 
                 to_format_elements_for_template(
                     language,
-                    doc_jsons,
+                    doc_json,
                     session.allocator(),
                     session.group_id_builder(),
                 )
@@ -80,39 +75,27 @@ pub fn build_prettier_fallback(
 /// - Markdown: structural postprocess.
 fn to_format_elements_for_template<'a>(
     language: &str,
-    doc_jsons: Vec<Value>,
+    doc_json: Value,
     allocator: &'a Allocator,
     group_id_builder: &UniqueGroupIdBuilder,
 ) -> Result<DispatchResult<'a>, String> {
-    match language {
-        "html" | "angular" => {
-            let (mut ir, metadata) = from_prettier_doc::convert_envelope(
-                doc_jsons.into_iter().next().expect("Doc JSON for HTML"),
-                allocator,
-                group_id_builder,
-            )?;
-            let html_has_multiple_root_elements =
-                metadata.get("htmlHasMultipleRootElements").and_then(Value::as_bool);
-            from_prettier_doc::postprocess(&mut ir, allocator);
-            Ok(DispatchResult {
-                docs: vec![ir],
-                tailwind_classes: Vec::new(),
-                meta: Some(Box::new(HtmlEmbedMeta {
-                    has_multiple_root_elements: html_has_multiple_root_elements,
-                })),
-            })
-        }
-        "markdown" => {
-            let (mut ir, _) = from_prettier_doc::convert_envelope(
-                doc_jsons.into_iter().next().expect("Doc JSON for Markdown"),
-                allocator,
-                group_id_builder,
-            )?;
-            from_prettier_doc::postprocess(&mut ir, allocator);
-            Ok(DispatchResult { docs: vec![ir], tailwind_classes: Vec::new(), meta: None })
-        }
-        // NOTE: no "css" / "graphql" / "yaml" arms
-        // Those languages never reach the Prettier Doc path (their dispatcher branches are Rust-only).
+    // The language gate runs BEFORE the conversion work.
+    // NOTE: Other languages never reach the Prettier Doc path (their dispatcher branches are Rust-only).
+    let needs_html_meta = match language {
+        "html" | "angular" => true,
+        "markdown" => false,
         _ => unreachable!("Unsupported embedded_doc language: {language}"),
-    }
+    };
+
+    let (mut ir, metadata) =
+        from_prettier_doc::convert_envelope(doc_json, allocator, group_id_builder)?;
+    from_prettier_doc::postprocess(&mut ir, allocator);
+    let meta = needs_html_meta.then(|| {
+        Box::new(HtmlEmbedMeta {
+            has_multiple_root_elements: metadata
+                .get("htmlHasMultipleRootElements")
+                .and_then(Value::as_bool),
+        }) as Box<dyn std::any::Any>
+    });
+    Ok(DispatchResult { doc: ir, tailwind_classes: Vec::new(), meta })
 }

--- a/apps/oxfmt/src/core/embed/string_channel.rs
+++ b/apps/oxfmt/src/core/embed/string_channel.rs
@@ -41,7 +41,9 @@ pub fn build_string_embedder(
     sort_tailwind: Option<TailwindSorter>,
     dispatch_config: Arc<dispatcher::ResolvedDispatchConfig>,
 ) -> StringEmbedder {
-    let fence_dispatcher = fence::build_fence_dispatcher(&dispatch_config);
+    // Fence dispatchers never take the Prettier fallback (native fences never fall back),
+    // so one is invariant across the callback's lifetime: build it once, not per fence.
+    let fence_dispatcher = dispatcher::build_dispatcher(Arc::clone(&dispatch_config), None);
     Arc::new(move |language: &str, code: &str| {
         // Native registry first (JSDoc fenced code blocks).
         if dispatcher::is_native_language(language) {

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -70,16 +70,16 @@ pub type JsFormatEmbeddedCb = ThreadsafeFunction<
     false,
 >;
 
-/// Type alias for the Doc-path callback function signature (batch).
-/// Takes (options, texts[]) as arguments and returns Doc JSON string[] (one per text) or null on error.
+/// Type alias for the Doc-path callback function signature.
+/// Takes (options, code) as arguments and returns a Doc JSON string or null on error.
 /// The `options` object includes `parser` field set by Rust side.
 pub type JsFormatEmbeddedDocCb = ThreadsafeFunction<
     // Input arguments
-    FnArgs<(Value, Vec<String>)>, // (options, texts)
+    FnArgs<(Value, String)>, // (options, code)
     // Return type (what JS function returns)
-    Promise<Option<Vec<String>>>,
+    Promise<Option<String>>,
     // Arguments (repeated)
-    FnArgs<(Value, Vec<String>)>,
+    FnArgs<(Value, String)>,
     // Error status
     Status,
     // CalleeHandled
@@ -249,7 +249,7 @@ impl ExternalFormatter {
     /// 3. Embedded CSS (css-in-js + Angular `@Component({ styles })`):
     ///    `oxc_formatter_css::format_to_ir()` returns pre-sort `@apply` classes
     ///    in `DispatchResult::tailwind_classes`.
-    ///    The JS parent re-indexes them into its own collector (`remap_tailwind_into`)
+    ///    The JS parent re-indexes them into its own collector (`DispatchResult::into_doc`)
     ///    so they ride the SAME parent batch as path 1.
     ///    The standalone CSS sort closure is NOT invoked here.
     /// 4. JSDoc fenced CSS (Markdown code fence in JSDoc descriptions):
@@ -257,12 +257,12 @@ impl ExternalFormatter {
     ///    which returns a formatted string (not parent-integrated IR),
     ///    so there is no parent index space to remap into:
     ///    the adapter sorts the returned `DispatchResult::tailwind_classes` itself before printing.
-    ///    The `string_channel::build_embedded_callback` factory receives the sorter for this case.
+    ///    The `string_channel::build_string_embedder` factory receives the sorter for this case.
     ///
     /// All four paths use the SAME `sort_tailwindcss_classes` napi callback; only the wiring differs.
     /// Moving sorting to the wrong layer (e.g. sorting inside embedded CSS instead of remapping)
     /// would double-sort or drop classes.
-    /// `DispatchResult::remap_tailwind_into`'s printer `debug_assert` catches dropped remaps.
+    /// `DispatchResult::into_doc` folds the merge into doc consumption; the printer `debug_assert` backstops it.
     ///
     /// The dispatcher and the string channel consult the same off-predicate
     /// (`ResolvedDispatchConfig::is_embedded_formatting_enabled`),
@@ -330,7 +330,7 @@ impl ExternalFormatter {
             init: Arc::new(|_| Err("Dummy init called".to_string())),
             format_file: Arc::new(|_, _| Err("Dummy format_file called".to_string())),
             format_embedded: Arc::new(|_, _| Err("Dummy format_embedded called".to_string())),
-            format_embedded_doc: Arc::new(|_, _: &[&str]| {
+            format_embedded_doc: Arc::new(|_, _: &str| {
                 Err("Dummy format_embedded_doc called".to_string())
             }),
             sort_tailwindcss_classes: Arc::new(|_, _| vec![]),
@@ -454,22 +454,21 @@ fn wrap_format_embedded(
     })
 }
 
-/// Wrap JS `formatEmbeddedDoc` callback as a normal Rust function (batch).
+/// Wrap JS `formatEmbeddedDoc` callback as a normal Rust function.
 /// The `options` Value is received with `parser` already set by the caller.
 fn wrap_format_embedded_doc(
     cb_handle: Arc<RwLock<Option<JsFormatEmbeddedDocCb>>>,
 ) -> FormatEmbeddedDocWithConfigCallback {
-    Arc::new(move |options: Value, texts: &[&str]| {
+    Arc::new(move |options: Value, code: &str| {
         let guard = cb_handle.read().unwrap();
         let Some(cb) = guard.as_ref() else {
             return Err("JS callback unavailable (environment shutting down)".to_string());
         };
-        let texts_owned: Vec<String> = texts.iter().map(|t| (*t).to_string()).collect();
         let result = block_on(async {
-            let status = cb.call_async(FnArgs::from((options, texts_owned))).await;
+            let status = cb.call_async(FnArgs::from((options, code.to_string()))).await;
             match status {
                 Ok(promise) => match promise.await {
-                    Ok(Some(doc_jsons)) => Ok(doc_jsons),
+                    Ok(Some(doc_json)) => Ok(doc_json),
                     Ok(None) => Err("Embedded doc formatting failed".to_string()),
                     // JS side never rejects; it returns `null` on error instead.
                     // `Err` here would only come from a napi-rs internal failure.

--- a/apps/oxfmt/src/core/options/to_oxc_formatter.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter.rs
@@ -1,18 +1,22 @@
 use rustc_hash::FxHashSet;
 
+#[cfg(feature = "napi")]
+use oxc_formatter::SortTailwindcssOptions;
 use oxc_formatter::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, CommentLineStrategy,
     CustomGroupDefinition, Expand, GroupEntry, ImportModifier, ImportSelector, JsFormatOptions,
     JsdocOptions, LineWrappingStyle, QuoteProperties, QuoteStyle, Semicolons, SortImportsOptions,
-    SortOrder, SortTailwindcssOptions, TrailingCommas,
+    SortOrder, TrailingCommas,
 };
 use oxc_formatter_core::{CoreFormatOptions, FormatOptions};
 
+#[cfg(feature = "napi")]
+use super::super::oxfmtrc::SortTailwindcssUserConfig;
 use super::super::oxfmtrc::{
     ArrowParensConfig, CommentLineStrategyConfig, CustomGroupItemConfig, FormatConfig,
     HtmlWhitespaceSensitivityConfig, JsdocUserConfig, LineWrappingStyleConfig, ObjectWrapConfig,
     QuotePropsConfig, SortGroupItemConfig, SortImportsUserConfig, SortOrderConfig,
-    SortTailwindcssUserConfig, TrailingCommaConfig,
+    TrailingCommaConfig,
 };
 
 /// Convert `FormatConfig` into `JsFormatOptions` for `oxc_formatter`.
@@ -112,6 +116,10 @@ pub fn to_oxc_formatter(
 
     format_options.sort_imports = sort_imports;
     format_options.jsdoc = to_jsdoc(config);
+    // napi only, like the CSS mapper: collection itself normalizes whitespace,
+    // so enabling it without the JS-side sorter would apply half the feature
+    // (normalized but unsorted classes).
+    #[cfg(feature = "napi")]
     if let Some(tw_config) =
         config.sort_tailwindcss.clone().and_then(SortTailwindcssUserConfig::into_config)
     {
@@ -612,8 +620,12 @@ mod tests {
         let config: FormatConfig = serde_json::from_str(r#"{"sortImports": false}"#).unwrap();
         assert!(build(&config).unwrap().sort_imports.is_none());
 
+        // Tailwind collection maps napi-only
         let config: FormatConfig = serde_json::from_str(r#"{"sortTailwindcss": true}"#).unwrap();
+        #[cfg(feature = "napi")]
         assert!(build(&config).unwrap().sort_tailwindcss.is_some());
+        #[cfg(not(feature = "napi"))]
+        assert!(build(&config).unwrap().sort_tailwindcss.is_none());
 
         let config: FormatConfig = serde_json::from_str(r#"{"sortTailwindcss": false}"#).unwrap();
         assert!(build(&config).unwrap().sort_tailwindcss.is_none());

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -45,9 +45,7 @@ pub async fn run_cli(
     format_file_cb: JsFormatFileCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_cb: JsFormatEmbeddedCb,
-    #[napi(
-        ts_arg_type = "(options: Record<string, any>, texts: string[]) => Promise<string[] | null>"
-    )]
+    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_doc_cb: JsFormatEmbeddedDocCb,
     #[napi(
         ts_arg_type = "(options: Record<string, any>, classes: string[]) => Promise<string[] | null>"
@@ -163,9 +161,7 @@ pub async fn format(
     format_file_cb: JsFormatFileCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_cb: JsFormatEmbeddedCb,
-    #[napi(
-        ts_arg_type = "(options: Record<string, any>, texts: string[]) => Promise<string[] | null>"
-    )]
+    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_doc_cb: JsFormatEmbeddedDocCb,
     #[napi(
         ts_arg_type = "(options: Record<string, any>, classes: string[]) => Promise<string[] | null>"
@@ -205,9 +201,7 @@ pub async fn js_text_to_doc(
     format_file_cb: JsFormatFileCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_cb: JsFormatEmbeddedCb,
-    #[napi(
-        ts_arg_type = "(options: Record<string, any>, texts: string[]) => Promise<string[] | null>"
-    )]
+    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_doc_cb: JsFormatEmbeddedDocCb,
     #[napi(
         ts_arg_type = "(options: Record<string, any>, classes: string[]) => Promise<string[] | null>"

--- a/crates/oxc_formatter/src/formatter/context.rs
+++ b/crates/oxc_formatter/src/formatter/context.rs
@@ -121,7 +121,7 @@ impl std::fmt::Debug for JsFormatContext<'_> {
 }
 
 /// Lets embedded children's classes merge into this context's index space
-/// (`DispatchResult::remap_tailwind_into` at each embed site).
+/// (`DispatchResult::into_doc` at each embed site).
 impl oxc_formatter_core::TailwindCollector for JsFormatContext<'_> {
     fn add_class(&mut self, class: String) -> usize {
         self.add_tailwind_class(class)

--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -1,9 +1,6 @@
 use oxc_allocator::ArenaStringBuilder;
 use oxc_ast::ast::*;
-use oxc_formatter_core::{
-    DispatchOutcome, DispatchRequest, FormatElement, IndentWidth, InputKind,
-    format_element::TextWidth,
-};
+use oxc_formatter_core::{FormatElement, IndentWidth, format_element::TextWidth};
 
 use crate::{
     ast_nodes::AstNode,
@@ -55,16 +52,7 @@ pub(super) fn format_css_doc<'a>(
             return true;
         }
 
-        let Ok(DispatchOutcome::Formatted(mut result)) = f.session().dispatch(DispatchRequest {
-            language: "css",
-            texts: &[raw],
-            input_kind: InputKind::Fragment,
-            parent_context: Some(&CssInJsTemplate),
-        }) else {
-            return false;
-        };
-        result.remap_tailwind_into(f.context_mut());
-        let Some(ir) = result.docs.into_iter().next() else {
+        let Some(ir) = super::dispatch_fragment_ir(f, "css", raw, Some(&CssInJsTemplate)) else {
             return false;
         };
 
@@ -90,16 +78,7 @@ pub(super) fn format_css_doc<'a>(
     };
 
     // Phase 2: Format via the dispatcher (IR path)
-    let Ok(DispatchOutcome::Formatted(mut result)) = f.session().dispatch(DispatchRequest {
-        language: "css",
-        texts: &[joined],
-        input_kind: InputKind::Fragment,
-        parent_context: Some(&CssInJsTemplate),
-    }) else {
-        return false;
-    };
-    result.remap_tailwind_into(f.context_mut());
-    let Some(ir) = result.docs.into_iter().next() else {
+    let Some(ir) = super::dispatch_fragment_ir(f, "css", joined, Some(&CssInJsTemplate)) else {
         return false;
     };
 

--- a/crates/oxc_formatter/src/print/template/embed/graphql.rs
+++ b/crates/oxc_formatter/src/print/template/embed/graphql.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_formatter_core::{
-    DispatchOutcome, DispatchRequest, FormatElement, IndentWidth, InputKind,
+    FormatElement, IndentWidth,
     format_element::{LineMode, TextWidth},
 };
 
@@ -70,54 +70,24 @@ pub(super) fn format_graphql_doc<'a>(
         infos.push(QuasiInfo { text, comments_only, starts_with_blank_line, ends_with_blank_line });
     }
 
-    // Phase 2: Collect non-skip texts for batch formatting.
-    // Only send texts that actually need formatting to JS.
-    let mut texts_to_format: Vec<&str> = Vec::new();
-    let mut format_index_map: Vec<Option<usize>> = Vec::with_capacity(num_quasis);
-    for info in &infos {
-        if info.comments_only {
-            format_index_map.push(None);
-        } else {
-            format_index_map.push(Some(texts_to_format.len()));
-            texts_to_format.push(info.text);
-        }
-    }
-
-    // PERF: Batch send only non-skip texts, get IRs back.
-    let all_irs = if texts_to_format.is_empty() {
-        vec![]
-    } else {
-        let Ok(DispatchOutcome::Formatted(result)) = f.session().dispatch(DispatchRequest {
-            language: "graphql",
-            texts: &texts_to_format,
-            input_kind: InputKind::Fragment,
-            parent_context: None,
-        }) else {
-            return false;
-        };
-        // One IR per sent text is the dispatcher contract for GraphQL.
-        if result.docs.len() != texts_to_format.len() {
-            return false;
-        }
-        result.docs
-    };
-
-    // Phase 3: Build `ir_parts` by mapping formatted results back to original indices.
-    // Use `into_iter` to take ownership and avoid cloning.
+    // Phase 2+3: Build `ir_parts`, one dispatch per non-comment quas.
+    // (any failure keeps the whole template verbatim:
+    // the quasis are one interleaved template, so degradation is all-or-nothing)
+    // Comment-only quasis are synthesized locally.
     // The IR is re-inserted into a JS template literal built from `.cooked` values,
     // so template-literal characters (`` ` ``, `${`, `\`) are re-escaped here
     // for both dispatcher returned IRs and manually built comment-only IRs.
     let allocator = f.allocator();
     let indent_width = f.options().indent_width;
-    let mut irs_iter = all_irs.into_iter();
     let mut ir_parts: Vec<Option<ArenaVec<'a, FormatElement<'a>>>> = Vec::with_capacity(num_quasis);
-    for (idx, info) in infos.iter().enumerate() {
-        let mut ir = if format_index_map[idx].is_some() {
-            irs_iter.next()
-        } else if info.comments_only {
+    for info in &infos {
+        let mut ir = if info.comments_only {
             build_graphql_comment_ir(info.text, allocator, indent_width)
         } else {
-            None
+            let Some(ir) = super::dispatch_fragment_ir(f, "graphql", info.text, None) else {
+                return false;
+            };
+            Some(ir)
         };
         if let Some(ir) = ir.as_mut() {
             super::escape_template_chars_in_ir(ir, allocator, indent_width);

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -53,9 +53,9 @@ pub(super) fn format_html_doc<'a>(
         let has_leading_ws = cooked.starts_with(|c: char| c.is_ascii_whitespace());
         let has_trailing_ws = cooked.ends_with(|c: char| c.is_ascii_whitespace());
 
-        let Ok(DispatchOutcome::Formatted(mut result)) = f.session().dispatch(DispatchRequest {
+        let Ok(DispatchOutcome::Formatted(result)) = f.session().dispatch(DispatchRequest {
             language: embedded_language,
-            texts: &[cooked],
+            text: cooked,
             input_kind: InputKind::Fragment,
             parent_context: None,
         }) else {
@@ -72,10 +72,7 @@ pub(super) fn format_html_doc<'a>(
         // Remap is a no-op today (the Prettier Doc path never carries classes),
         // but the boundary contract is "merge at every embed site".
         // A Rust HTML formatter collecting `class` attributes will rely on this.
-        result.remap_tailwind_into(f.context_mut());
-        let Some(mut ir) = result.docs.into_iter().next() else {
-            return false;
-        };
+        let mut ir = result.into_doc(f.context_mut());
 
         // Re-escape template chars in `Text` runs:
         // the IR is reinserted into a JS template literal built from `.cooked` values.
@@ -120,9 +117,9 @@ pub(super) fn format_html_doc<'a>(
     let has_trailing_ws = joined.ends_with(|c: char| c.is_ascii_whitespace());
 
     // Phase 2: Format via the dispatcher (IR path)
-    let Ok(DispatchOutcome::Formatted(mut result)) = f.session().dispatch(DispatchRequest {
+    let Ok(DispatchOutcome::Formatted(result)) = f.session().dispatch(DispatchRequest {
         language: embedded_language,
-        texts: &[joined],
+        text: joined,
         input_kind: InputKind::Fragment,
         parent_context: None,
     }) else {
@@ -156,10 +153,7 @@ pub(super) fn format_html_doc<'a>(
         return false;
     };
     // See the Phase 0 note: remap is no-op today, load-bearing once `oxc_formatter_html` lands
-    result.remap_tailwind_into(f.context_mut());
-    let Some(mut ir) = result.docs.into_iter().next() else {
-        return false;
-    };
+    let mut ir = result.into_doc(f.context_mut());
 
     // Re-escape template chars in `Text` runs before counting / substituting:
     // the IR is reinserted into a JS template literal built from `.cooked` values.

--- a/crates/oxc_formatter/src/print/template/embed/markdown.rs
+++ b/crates/oxc_formatter/src/print/template/embed/markdown.rs
@@ -1,8 +1,6 @@
 use oxc_allocator::{Allocator, ArenaStringBuilder};
 use oxc_ast::ast::*;
 
-use oxc_formatter_core::{DispatchOutcome, DispatchRequest, InputKind};
-
 use crate::{ast_nodes::AstNode, format_args, formatter::prelude::*, write};
 
 /// Format a Markdown-in-JS tagged template literal via the Doc→IR path.
@@ -32,15 +30,7 @@ pub(super) fn try_embed_markdown<'a>(
     let text = if has_indent { strip_indentation(text, indentation, allocator) } else { text };
 
     // Phase 3: Get the IR from the dispatcher
-    let Ok(DispatchOutcome::Formatted(result)) = f.session().dispatch(DispatchRequest {
-        language: "markdown",
-        texts: &[text],
-        input_kind: InputKind::Fragment,
-        parent_context: None,
-    }) else {
-        return false;
-    };
-    let Some(mut ir) = result.docs.into_iter().next() else {
+    let Some(mut ir) = super::dispatch_fragment_ir(f, "markdown", text, None) else {
         return false;
     };
 

--- a/crates/oxc_formatter/src/print/template/embed/mod.rs
+++ b/crates/oxc_formatter/src/print/template/embed/mod.rs
@@ -3,9 +3,14 @@ mod graphql;
 mod html;
 mod markdown;
 
-use oxc_allocator::{Allocator, ArenaStringBuilder};
+use std::any::Any;
+
+use oxc_allocator::{Allocator, ArenaStringBuilder, ArenaVec};
 use oxc_ast::ast::*;
-use oxc_formatter_core::{FormatElement, IndentWidth, format_element::TextWidth};
+use oxc_formatter_core::{
+    DispatchOutcome, DispatchRequest, FormatElement, IndentWidth, InputKind,
+    format_element::TextWidth,
+};
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
@@ -139,6 +144,28 @@ fn is_in_css_jsx<'a>(node: &AstNode<'a, TemplateLiteral<'a>>) -> bool {
 
 /// Try to format a template literal inside Angular @Component's template/styles property.
 /// Returns `true` if formatting was performed, `false` if not applicable.
+/// Dispatches one embedded fragment and consumes the result into the parent
+/// (`InputKind::Fragment` + the `into_doc` Tailwind merge in one place,
+/// so an embed site cannot re-derive the pair and skip the merge).
+/// `None` covers `PreserveOriginal` and operational errors alike,
+/// the caller keeps the template as-is (the html sites stay manual: they read `meta` first).
+pub(super) fn dispatch_fragment_ir<'a>(
+    f: &mut JsFormatter<'_, 'a>,
+    language: &str,
+    text: &str,
+    parent_context: Option<&dyn Any>,
+) -> Option<ArenaVec<'a, FormatElement<'a>>> {
+    let Ok(DispatchOutcome::Formatted(result)) = f.session().dispatch(DispatchRequest {
+        language,
+        text,
+        input_kind: InputKind::Fragment,
+        parent_context,
+    }) else {
+        return None;
+    };
+    Some(result.into_doc(f.context_mut()))
+}
+
 pub(super) fn try_format_angular_component<'a>(
     template_literal: &AstNode<'a, TemplateLiteral<'a>>,
     f: &mut JsFormatter<'_, 'a>,

--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -83,13 +83,13 @@ The core is parameterized over a consumer-supplied context so it stays language-
 - A language crate's `format_to_ir` entry returns `EmbeddedIr` (IR + pre-sort Tailwind classes), one shape for every child language, no per-crate tuples
 - Cross-language contract data is first-class on `DispatchResult` (`tailwind_classes`)
   - Only truly language-pair specific data crosses as `dyn Any` (e.g. HTML's `has_multiple_root_elements`), core never learns concrete languages
-- Consumers access `DispatchResult.docs` directly (single-doc takes `docs.into_iter().next()`, multi-doc walks `docs`)
-  - Call `DispatchResult::remap_tailwind_into` first when the child may carry classes, the printer's `debug_assert` catches a forgotten merge
+- Consumers take the doc via `DispatchResult::into_doc(collector)`, which folds the Tailwind class merge into consumption
+  - The printer's `debug_assert` backstops any hand-rolled consumption that skips the merge
 - `FormatSession` (`session.rs`) is the execution unit:
   - One arena, one shared `GroupId` space (`Arc<UniqueGroupIdBuilder>`), the host's `SessionServices`, and the input's envelope semantics (`InputKind`), usable by standalone roots and dispatched children alike
   - `SessionServices` names the three per-run duties, one field each: `dispatcher` (IR channel), `string_embedder` (string-out channel; temporary while some languages only format via a string API), `tailwind_sorter` (print-time batch sort). Core only transports them
   - `FormatState` holds one (`new_with_session`; plain `new` wraps a service-less `PhysicalFile` session), and `Formatter::session()` exposes it during a write
-- A dispatch states its request as `DispatchRequest` (language, texts, `InputKind`, pair-specific context) and yields `Result<DispatchOutcome, String>`:
+- A dispatch states its request as `DispatchRequest` (language, text, `InputKind`, pair-specific context) and yields `Result<DispatchOutcome, String>`:
   - `DispatchOutcome::PreserveOriginal` is the DELIBERATE "keep the source as-is" answer (unsupported language, child parse failure, no dispatcher installed); `Err` is reserved for operational failures (transport / internal, recursion limit)
   - Optional-embed callers degrade the same way for both, but never conflate them at the source
   - `FormatSession::dispatch` owns the no-dispatcher case and the recursion limit (`MAX_DISPATCH_DEPTH`), and runs the callback on a `derive_child`ed session
@@ -115,7 +115,7 @@ Output targets Prettier compatibility, but the layer is defined by what it is, n
 
 Admission: core stores the service and hands it back (or applies it mechanically at finalize);
 every value crossing the closure boundary is an opaque string/vec, never a language enum or an option type, and core makes no decision from the result.
-`string_embedder` additionally carries an exit criterion: it is removed when md/html/angular gain IR-capable formatters (until then it is the string-out channel's transport; see its rustdoc).
+`string_embedder` additionally carries an exit criterion: it is removed when (a) md/html/angular gain IR-capable formatters AND (b) the host's string-out consumers (JSDoc fences) can express their re-embedding in IR (see `apps/oxfmt`'s AGENTS.md for that half); until then it is the string-out channel's transport.
 
 Three gates, all required and note "shared across languages" describes what lives here but is not the admission test.
 The gates are:

--- a/crates/oxc_formatter_core/src/embedded.rs
+++ b/crates/oxc_formatter_core/src/embedded.rs
@@ -23,9 +23,8 @@ pub struct DispatchRequest<'r> {
     /// Generic language identifier (e.g. `"css"`, `"graphql"`);
     /// the dispatcher implementation maps it to its own parser/language names.
     pub language: &'r str,
-    /// Code to format. Usually a single text;
-    /// GraphQL sends N quasis and receives N IRs back (the batch is atomic: all format or none do).
-    pub texts: &'r [&'r str],
+    /// The code to format.
+    pub text: &'r str,
     /// Envelope semantics of the child input, as declared by the host.
     pub input_kind: InputKind,
     /// Parent→child language-pair specific data,
@@ -64,12 +63,11 @@ pub type FormatDispatcher = Arc<
         + Sync,
 >;
 
-/// IR built by a language crate's embedded entry point (`format_to_ir`) for
-/// ONE input text. The orchestrator's dispatcher assembles one or more of
-/// these into a [`DispatchResult`].
+/// IR built by a language crate's embedded entry point (`format_to_ir`) for one input text.
+/// The orchestrator's dispatcher wraps it into a [`DispatchResult`].
 ///
-/// Every language crate's `format_to_ir` returns this shape, so a new child
-/// language only has to fill in the fields (no per-crate tuple conventions).
+/// Every language crate's `format_to_ir` returns this shape,
+/// so a new child language only has to fill in the fields (no per-crate tuple conventions).
 pub struct EmbeddedIr<'a> {
     /// The formatter IR, arena-allocated alongside its elements.
     pub ir: ArenaVec<'a, FormatElement<'a>>,
@@ -79,24 +77,25 @@ pub struct EmbeddedIr<'a> {
     pub tailwind_classes: Vec<String>,
 }
 
-/// The single-text case: one [`EmbeddedIr`] becomes a one-doc result,
+/// One [`EmbeddedIr`] becomes a result,
 /// carrying the child's Tailwind classes through (hand-rolling the literal invites silently dropping them).
 impl<'a> From<EmbeddedIr<'a>> for DispatchResult<'a> {
     fn from(embedded: EmbeddedIr<'a>) -> Self {
-        Self { docs: vec![embedded.ir], tailwind_classes: embedded.tailwind_classes, meta: None }
+        Self { doc: embedded.ir, tailwind_classes: embedded.tailwind_classes, meta: None }
     }
 }
 
 /// Result of a [`FormatDispatcher`] call.
+///
+/// Consume through [`Self::into_doc`] when a parent index space exists
+/// (every IR-channel embed site); only a parent-less consumer
+/// (the fence adapter, which sorts locally) destructures the fields directly.
 pub struct DispatchResult<'a> {
-    /// One IR per input text (usually one; GraphQL returns one per quasi).
-    /// Each IR is arena-allocated alongside its elements.
-    /// Single-doc consumers extract the IR via `docs.into_iter().next()` after calling
-    /// [`Self::remap_tailwind_into`]; multi-doc consumers (GraphQL) walk `docs`.
-    pub docs: Vec<ArenaVec<'a, FormatElement<'a>>>,
-    /// Pre-sort Tailwind classes referenced by the docs'
+    /// The formatted IR, arena-allocated alongside its elements.
+    pub doc: ArenaVec<'a, FormatElement<'a>>,
+    /// Pre-sort Tailwind classes referenced by the doc's
     /// `FormatElement::TailwindClass` indices (0-based, local to this result).
-    /// The receiving parent MUST merge them into its own class space via [`Self::remap_tailwind_into`] before printing,
+    /// The receiving parent MUST merge them into its own class space ([`Self::into_doc`] does);
     /// the printer's `debug_assert` catches a forgotten merge.
     pub tailwind_classes: Vec<String>,
     /// Child→parent language-specific metadata; the parent downcasts it
@@ -104,29 +103,30 @@ pub struct DispatchResult<'a> {
     pub meta: Option<Box<dyn Any>>,
 }
 
-impl DispatchResult<'_> {
-    /// Move the child's pre-sort Tailwind classes into the parent's class space
-    /// and shift the docs' `TailwindClass` indices to match. Call once per
-    /// received result before consuming `docs` (a no-op when the child collected nothing).
+impl<'a> DispatchResult<'a> {
+    /// Consumes the result:
+    /// moves the child's pre-sort Tailwind classes into the parent's class space and hands out the doc.
+    /// Folding the merge into the only way to get the doc makes a forgotten merge unrepresentable.
     /// The entry formatter's document then sorts all collected classes in one host-supplied batch.
-    pub fn remap_tailwind_into(&mut self, collector: &mut dyn TailwindCollector) {
+    pub fn into_doc(
+        mut self,
+        collector: &mut dyn TailwindCollector,
+    ) -> ArenaVec<'a, FormatElement<'a>> {
         let mut classes = std::mem::take(&mut self.tailwind_classes).into_iter();
-        let Some(first) = classes.next() else {
-            return;
-        };
-        // The collector hands out consecutive indices,
-        // so the first one is the base offset for every local index.
-        let base = collector.add_class(first);
-        for class in classes {
-            collector.add_class(class);
-        }
-        for doc in &mut self.docs {
-            for element in doc.iter_mut() {
+        if let Some(first) = classes.next() {
+            // The collector hands out consecutive indices,
+            // so the first one is the base offset for every local index.
+            let base = collector.add_class(first);
+            for class in classes {
+                collector.add_class(class);
+            }
+            for element in &mut self.doc {
                 if let FormatElement::TailwindClass(index) = element {
                     *index += base;
                 }
             }
         }
+        self.doc
     }
 }
 
@@ -135,8 +135,7 @@ impl DispatchResult<'_> {
 /// `FormatElement::TailwindClass(usize)` holds pre-sort class strings by index;
 /// sorting happens in one host-supplied batch when the entry formatter's document is finalized.
 /// A child formatter collects classes locally (0-based) and returns them in [`DispatchResult::tailwind_classes`];
-/// the receiving parent implements this trait on its format context
-/// and calls [`DispatchResult::remap_tailwind_into`] before consuming `docs`.
+/// the receiving parent implements this trait on its format context and receives them through [`DispatchResult::into_doc`].
 ///
 /// NOTE: an alternative design (threading one shared collector through [`FormatSession`]
 /// so children allocate parent indices directly) was considered and deferred:

--- a/crates/oxc_formatter_core/src/printer/mod.rs
+++ b/crates/oxc_formatter_core/src/printer/mod.rs
@@ -366,13 +366,12 @@ impl<'a> Printer<'a> {
             }
             FormatElement::TailwindClass(index) => {
                 let text = self.state.sorted_tailwind_classes.get(*index);
-                // A dangling index silently DELETES the class list from the
-                // output, so fail loudly in debug builds instead.
+                // A dangling index silently DELETES the class list from the output,
+                // so fail loudly in debug builds instead.
                 debug_assert!(
                     text.is_some(),
-                    "TailwindClass index {index} out of bounds ({} classes) — \
-                     was the embedded IR remapped into the parent's class space \
-                     (`DispatchResult::remap_tailwind_into`)?",
+                    "TailwindClass index {index} out of bounds ({} classes): \
+                     Was the embedded IR remapped into the parent's class space (`DispatchResult::into_doc`)?",
                     self.state.sorted_tailwind_classes.len(),
                 );
                 if let Some(text) = text {

--- a/crates/oxc_formatter_core/src/session.rs
+++ b/crates/oxc_formatter_core/src/session.rs
@@ -8,7 +8,8 @@ use crate::{DispatchOutcome, DispatchRequest, FormatDispatcher, UniqueGroupIdBui
 
 /// Upper bound on nested embedded dispatches;
 /// exceeding it is an operational error, catching accidental A-in-B-in-A infinite recursion.
-pub const MAX_DISPATCH_DEPTH: u16 = 32;
+/// Real nesting is shallow (css-in-md-in-js would be 3); 8 is a generous ceiling.
+const MAX_DISPATCH_DEPTH: u8 = 8;
 
 /// String-in/string-out embedded formatter: `(language, code)` to formatted code.
 ///
@@ -61,21 +62,21 @@ pub enum InputKind {
 /// The same type serves standalone roots and dispatched children,
 /// so any formatter (not just JS) can dispatch embedded languages.
 /// Cloning hands out another handle to the SAME session (shared `GroupId` space, same depth);
-/// the session for one embedded child comes from [`Self::derive_child`].
+/// the session for one embedded child is derived internally by [`Self::dispatch`].
 #[derive(Clone)]
 pub struct FormatSession<'a> {
     allocator: &'a Allocator,
     group_id_builder: Arc<UniqueGroupIdBuilder>,
     services: SessionServices,
     input_kind: InputKind,
-    dispatch_depth: u16,
+    dispatch_depth: u8,
 }
 
 impl<'a> FormatSession<'a> {
     /// Creates a service-less root session
     /// (standalone runs: embeds stay as-is, Tailwind classes print unsorted).
     /// Hosts that install services use [`Self::with_services`].
-    /// Children must come from [`Self::derive_child`], never be re-rooted,
+    /// Children are derived internally by [`Self::dispatch`], never re-rooted,
     /// so the `GroupId` space stays shared.
     pub fn new(allocator: &'a Allocator, input_kind: InputKind) -> Self {
         Self::with_services(allocator, input_kind, SessionServices::default())
@@ -98,9 +99,10 @@ impl<'a> FormatSession<'a> {
 
     /// Derives the session for one embedded child: same arena, `GroupId` space,
     /// and services; the child's envelope semantics and one more dispatch level.
-    /// The recursion limit over `dispatch_depth` is enforced by the dispatch path, not here.
+    /// Private on purpose: [`Self::dispatch`] is the only caller,
+    /// which makes "children never re-root the `GroupId` space or reset the depth" a compiler-checked fact.
     #[must_use]
-    pub fn derive_child(&self, input_kind: InputKind) -> Self {
+    fn derive_child(&self, input_kind: InputKind) -> Self {
         Self {
             allocator: self.allocator,
             group_id_builder: Arc::clone(&self.group_id_builder),
@@ -113,16 +115,12 @@ impl<'a> FormatSession<'a> {
     /// Formats one embedded-language request on a child session derived from this one.
     ///
     /// See [`DispatchOutcome`] for the outcome-vs-`Err` contract; this method adds three rules:
-    /// - no dispatcher installed (plain standalone run) counts as the deliberat `Ok(DispatchOutcome::PreserveOriginal)`
-    /// - a request text starting with U+FEFF is deliberately preserved
-    ///   - in an embedded position it is content, not a BOM, formatting must not swallow it
-    ///   - and no child entry handles it
-    /// - reaching `MAX_DISPATCH_DEPTH`
+    /// - no dispatcher installed (plain standalone run) is the deliberate `Ok(DispatchOutcome::PreserveOriginal)`
+    /// - a request text starting with U+FEFF is deliberately preserved:
+    ///   in an embedded position it is content, not a BOM (formatting must not swallow it), and no child entry handles it
+    /// - reaching `MAX_DISPATCH_DEPTH` is an `Err`
     ///
-    /// is an `Err`.
-    ///
-    /// The callback receives the derived child session;
-    /// it must not create another `GroupId` space or bump the depth again.
+    /// The callback receives the derived child session.
     ///
     /// # Errors
     /// Operational failures only (recursion limit, transport/internal errors).
@@ -130,7 +128,7 @@ impl<'a> FormatSession<'a> {
         let Some(dispatcher) = &self.services.dispatcher else {
             return Ok(DispatchOutcome::PreserveOriginal);
         };
-        if request.texts.iter().any(|text| text.starts_with('\u{feff}')) {
+        if request.text.starts_with('\u{feff}') {
             return Ok(DispatchOutcome::PreserveOriginal);
         }
         if self.dispatch_depth >= MAX_DISPATCH_DEPTH {
@@ -158,11 +156,6 @@ impl<'a> FormatSession<'a> {
     /// Envelope semantics of the input this session formats.
     pub fn input_kind(&self) -> InputKind {
         self.input_kind
-    }
-
-    /// How many dispatch boundaries deep this session is (0 for a root).
-    pub fn dispatch_depth(&self) -> u16 {
-        self.dispatch_depth
     }
 
     /// The string channel service ([`StringEmbedder`]), when this run installs one.
@@ -194,7 +187,7 @@ mod tests {
     fn request<'r>() -> DispatchRequest<'r> {
         DispatchRequest {
             language: "yaml",
-            texts: &[],
+            text: "",
             input_kind: InputKind::Fragment,
             parent_context: None,
         }
@@ -211,9 +204,9 @@ mod tests {
     #[test]
     fn dispatch_preserves_a_bom_headed_text() {
         let allocator = Allocator::default();
-        let dispatcher: FormatDispatcher = Arc::new(|_ctx, _request| {
+        let dispatcher: FormatDispatcher = Arc::new(|ctx, _request| {
             Ok(DispatchOutcome::Formatted(DispatchResult {
-                docs: Vec::new(),
+                doc: oxc_allocator::ArenaVec::new_in(&ctx.allocator()),
                 tailwind_classes: Vec::new(),
                 meta: None,
             }))
@@ -224,19 +217,19 @@ mod tests {
             SessionServices { dispatcher: Some(dispatcher), ..SessionServices::default() },
         );
 
-        let bom_request = DispatchRequest { texts: &["a: 1", "\u{feff}a: 1"], ..request() };
+        let bom_request = DispatchRequest { text: "\u{feff}a: 1", ..request() };
         assert!(matches!(session.dispatch(bom_request), Ok(DispatchOutcome::PreserveOriginal)));
         // A non-leading U+FEFF is ordinary content and formats normally
-        let inner_request = DispatchRequest { texts: &["a: \u{feff}1"], ..request() };
+        let inner_request = DispatchRequest { text: "a: \u{feff}1", ..request() };
         assert!(matches!(session.dispatch(inner_request), Ok(DispatchOutcome::Formatted(_))));
     }
 
     #[test]
     fn dispatch_stops_at_the_depth_limit() {
         let allocator = Allocator::default();
-        let dispatcher: FormatDispatcher = Arc::new(|_ctx, _request| {
+        let dispatcher: FormatDispatcher = Arc::new(|ctx, _request| {
             Ok(DispatchOutcome::Formatted(DispatchResult {
-                docs: Vec::new(),
+                doc: oxc_allocator::ArenaVec::new_in(&ctx.allocator()),
                 tailwind_classes: Vec::new(),
                 meta: None,
             }))
@@ -274,7 +267,7 @@ mod tests {
         let child = parent.derive_child(InputKind::Fragment);
 
         assert_eq!(child.input_kind(), InputKind::Fragment);
-        assert_eq!(child.dispatch_depth(), 1);
+        assert_eq!(child.dispatch_depth, 1);
         // Ids stay unique across the boundary; independent builders would
         // both hand out the same first id.
         assert_ne!(parent.group_id_builder().group_id("a"), child.group_id_builder().group_id("b"));

--- a/crates/oxc_formatter_css/src/context.rs
+++ b/crates/oxc_formatter_css/src/context.rs
@@ -79,7 +79,7 @@ impl<'a> CssFormatContext<'a> {
     }
 }
 
-/// Lets a dispatched child's classes remap into this host's index space (`DispatchResult::remap_tailwind_into`).
+/// Lets a dispatched child's classes remap into this host's index space (`DispatchResult::into_doc`).
 /// A YAML front matter child returns none today, but the cross-language contract holds for any future child.
 impl TailwindCollector for CssFormatContext<'_> {
     fn add_class(&mut self, class: String) -> usize {

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -108,7 +108,7 @@ pub fn format_with_session<'a>(
 /// [`CssFormatOptions::sort_tailwindcss`] is on).
 /// The parent document owns the batch sort,
 /// so the caller must re-index the elements into the parent's class space
-/// (`DispatchResult::remap_tailwind_into`).
+/// (`DispatchResult::into_doc`).
 ///
 /// # Errors
 /// Same as [`format()`].
@@ -273,20 +273,17 @@ fn write_front_matter<'a>(fm: &FrontMatter<'a>, f: &mut CssFormatter<'_, 'a>) {
         // front matter inside front matter must never acquire envelope semantics (generic FM recursion).
         let outcome = f.session().dispatch(DispatchRequest {
             language: fm.language(),
-            texts: &[body],
+            text: body,
             input_kind: InputKind::Fragment,
             parent_context: None,
         });
-        if let Ok(DispatchOutcome::Formatted(mut result)) = outcome
-            && result.docs.len() == 1
-        {
-            result.remap_tailwind_into(f.context_mut());
-            let ir = result.docs.into_iter().next().expect("length checked above");
+        if let Ok(DispatchOutcome::Formatted(result)) = outcome {
+            let ir = result.into_doc(f.context_mut());
             write_front_matter_frame(fm, Some(ir), f);
             return;
         }
-        // `PreserveOriginal`, an operational error,
-        // or an unexpected doc count: fall through to the verbatim block below.
+        // `PreserveOriginal` or an operational error:
+        // fall through to the verbatim block below.
     }
     write!(f, text(fm.raw));
 }


### PR DESCRIPTION
Due to historical reasons, the IR was passed as `[Doc, (Doc, ...Doc)]` only when processing `gql-in-js`, whilst for other cases such as `css-in-js` and `html-in-js`, it was always `[Doc]`.

Now, every result is single `Doc`.