### PR TITLE
feat(napi): add Emscripten bindings

### DIFF
--- a/.github/scripts/napi-emscripten/README.md
+++ b/.github/scripts/napi-emscripten/README.md
@@ -1,0 +1,47 @@
+# Emscripten NAPI bindings
+
+These scripts build the published NAPI packages for Cloudflare Workers. The
+playground package is intentionally excluded because it has no npm release
+workflow.
+
+The Rust crates are compiled as `wasm32-unknown-emscripten` static libraries,
+linked with Emnapi's single-threaded basic NAPI archive, and then linked by
+Emscripten into a worker-specialized ES module and `.wasm` file.
+
+## Local build
+
+Install and activate Emscripten `5.0.3`, then run:
+
+```sh
+rustup target add wasm32-unknown-emscripten
+pnpm build-emscripten
+```
+
+Run the direct Emnapi smoke tests and real workerd tests with:
+
+```sh
+for package in parser minify transform transform-react; do
+  pnpm -C "napi/${package}" test-emscripten
+  pnpm -C wasm/emscripten test "../../napi/${package}"
+done
+```
+
+The generated artifacts are written to `target/emscripten/<package>`.
+
+## Publishing
+
+The NAPI release workflow builds and tests Emscripten alongside the native and
+WASI targets. It publishes one companion package before each root package:
+
+- `@oxc-parser/binding-wasm32-emscripten`
+- `@oxc-minify/binding-wasm32-emscripten`
+- `@oxc-transform/binding-wasm32-emscripten`
+- `@oxc-transform-react/binding-wasm32-emscripten`
+
+The companion is added to the root package's `optionalDependencies` at the same
+version. Users continue importing the root package; Wrangler selects its
+`workerd` conditional export.
+
+Before the first automated release, each companion name must be published once
+and configured for npm trusted publishing. Subsequent releases are handled by
+`reusable_release_napi.yml`.

--- a/.github/scripts/napi-emscripten/build.mjs
+++ b/.github/scripts/napi-emscripten/build.mjs
@@ -1,0 +1,150 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+import { getConfig, TARGET } from "./config.mjs";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "../../..");
+const packageDirectory = process.cwd();
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(packageDirectory, "package.json"), "utf8"),
+);
+const config = getConfig(packageJson.name);
+const outputDirectory = path.join(repositoryRoot, "target/emscripten", config.directory);
+const targetReleaseDirectory = path.join(repositoryRoot, "target", TARGET, "release");
+
+const packageRequire = createRequire(path.join(packageDirectory, "package.json"));
+const emnapiDirectory = path.dirname(packageRequire.resolve("emnapi/package.json"));
+const emnapiArchive = path.join(emnapiDirectory, "lib/wasm32-wasip1/libemnapi-basic-napi-rs.a");
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: repositoryRoot,
+    encoding: options.encoding,
+    stdio: options.encoding ? ["ignore", "pipe", "pipe"] : "inherit",
+  });
+}
+
+for (const command of ["emcc", "emnm"]) {
+  try {
+    run(command, ["--version"], { encoding: "utf8" });
+  } catch {
+    throw new Error(`${command} is required. Activate the pinned Emscripten SDK first.`);
+  }
+}
+
+if (!fs.existsSync(emnapiArchive)) {
+  throw new Error(`Emnapi basic archive not found: ${emnapiArchive}`);
+}
+
+fs.rmSync(outputDirectory, { recursive: true, force: true });
+fs.mkdirSync(outputDirectory, { recursive: true });
+
+run("cargo", [
+  "rustc",
+  "-p",
+  config.crate,
+  "--target",
+  TARGET,
+  "--release",
+  "--lib",
+  "--",
+  "--crate-type",
+  "staticlib",
+]);
+
+const archive = [
+  path.join(targetReleaseDirectory, `lib${config.crate}.a`),
+  path.join(targetReleaseDirectory, "deps", `lib${config.crate}.a`),
+].find((candidate) => fs.existsSync(candidate));
+if (!archive) {
+  throw new Error(`Cargo did not produce a static archive for ${config.crate}`);
+}
+
+const symbols = run("emnm", ["--defined-only", "--extern-only", archive], {
+  encoding: "utf8",
+});
+const registrationFunctions = [
+  ...new Set(
+    symbols
+      .split("\n")
+      .map((line) => line.trim().split(/\s+/).at(-1))
+      .filter((name) => name?.startsWith("__napi_register__")),
+  ),
+].sort((left, right) => left.localeCompare(right));
+
+if (registrationFunctions.length === 0) {
+  throw new Error(`No N-API registration functions found in ${archive}`);
+}
+
+const exportedFunctions = [
+  ...registrationFunctions.map((name) => `_${name}`),
+  "_malloc",
+  "_free",
+  "_napi_register_wasm_v1",
+  "_node_api_module_get_api_version_v1",
+  "_emnapi_create_env",
+  "_emnapi_delete_env",
+];
+const outputGlue = path.join(outputDirectory, "binding.mjs");
+
+run("emcc", [
+  "-O2",
+  "--no-entry",
+  archive,
+  path.join(scriptDirectory, "module-api.c"),
+  emnapiArchive,
+  "-Wl,--import-undefined",
+  "-Wno-js-compiler",
+  "-sWASM_BIGINT=1",
+  "-sALLOW_MEMORY_GROWTH=1",
+  "-sALLOW_TABLE_GROWTH=1",
+  "-sFILESYSTEM=0",
+  "-sENVIRONMENT=worker",
+  "-sMODULARIZE=1",
+  "-sEXPORT_ES6=1",
+  "-sSTACK_SIZE=8MB",
+  `-sEXPORTED_FUNCTIONS=${JSON.stringify(exportedFunctions)}`,
+  "-sWARN_ON_UNDEFINED_SYMBOLS=0",
+  "-sERROR_ON_UNDEFINED_SYMBOLS=0",
+  "-o",
+  outputGlue,
+]);
+
+const outputWasm = path.join(outputDirectory, "binding.wasm");
+const glue = fs.readFileSync(outputGlue, "utf8");
+if (!glue.includes("ENVIRONMENT_IS_WORKER=true")) {
+  throw new Error("Emscripten output is not specialized for a worker environment");
+}
+if (glue.includes("WorkerGlobalScope")) {
+  throw new Error("Emscripten output contains browser-only WorkerGlobalScope detection");
+}
+
+const wasmModule = new WebAssembly.Module(fs.readFileSync(outputWasm));
+const wasmImports = WebAssembly.Module.imports(wasmModule);
+if (wasmImports.some(({ name }) => name === "memory")) {
+  throw new Error("Emscripten artifact unexpectedly imports WebAssembly memory");
+}
+
+fs.writeFileSync(
+  path.join(outputDirectory, "artifact.json"),
+  `${JSON.stringify(
+    {
+      target: TARGET,
+      rootPackage: config.packageName,
+      bindingPackage: config.bindingPackage,
+      version: packageJson.version,
+      exports: config.exports,
+      registrationFunctions,
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+process.stdout.write(
+  `Built ${config.bindingPackage} in ${path.relative(repositoryRoot, outputDirectory)}\n`,
+);

--- a/.github/scripts/napi-emscripten/config.mjs
+++ b/.github/scripts/napi-emscripten/config.mjs
@@ -1,0 +1,59 @@
+export const TARGET = "wasm32-unknown-emscripten";
+
+const CONFIGS = {
+  "oxc-parser": {
+    directory: "parser",
+    crate: "oxc_parser_napi",
+    binary: "parser",
+    bindingPackage: "@oxc-parser/binding-wasm32-emscripten",
+    exports: [
+      "Severity",
+      "ParseResult",
+      "ExportExportNameKind",
+      "ExportImportNameKind",
+      "ExportLocalNameKind",
+      "ImportNameKind",
+      "parse",
+      "parseSync",
+      "rawTransferSupported",
+    ],
+  },
+  "oxc-minify": {
+    directory: "minify",
+    crate: "oxc_minify_napi",
+    binary: "minify",
+    bindingPackage: "@oxc-minify/binding-wasm32-emscripten",
+    exports: ["LegalCommentsMode", "minify", "minifySync", "Severity"],
+  },
+  "oxc-transform": {
+    directory: "transform",
+    crate: "oxc_transform_napi",
+    binary: "transform",
+    bindingPackage: "@oxc-transform/binding-wasm32-emscripten",
+    exports: [
+      "Severity",
+      "HelperMode",
+      "isolatedDeclaration",
+      "isolatedDeclarationSync",
+      "moduleRunnerTransform",
+      "moduleRunnerTransformSync",
+      "transform",
+      "transformSync",
+    ],
+  },
+  "oxc-transform-react": {
+    directory: "transform-react",
+    crate: "oxc_transform_react_napi",
+    binary: "transform-react",
+    bindingPackage: "@oxc-transform-react/binding-wasm32-emscripten",
+    exports: ["Severity", "transform", "transformSync"],
+  },
+};
+
+export function getConfig(packageName) {
+  const config = CONFIGS[packageName];
+  if (!config) {
+    throw new Error(`Unsupported Emscripten package: ${packageName}`);
+  }
+  return { packageName, ...config };
+}

--- a/.github/scripts/napi-emscripten/module-api.c
+++ b/.github/scripts/napi-emscripten/module-api.c
@@ -1,0 +1,6 @@
+#include <stdint.h>
+
+// napi-rs registers its exports through `napi_register_wasm_v1`, but unlike
+// Node's NAPI_MODULE_INIT macro it does not emit this version getter. Emnapi
+// requires it when creating the environment.
+int32_t node_api_module_get_api_version_v1(void) { return 4; }

--- a/.github/scripts/napi-emscripten/prepare-package.mjs
+++ b/.github/scripts/napi-emscripten/prepare-package.mjs
@@ -1,0 +1,164 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+function parseArguments() {
+  const values = {};
+  for (let index = 2; index < process.argv.length; index += 2) {
+    const key = process.argv[index];
+    const value = process.argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error("Expected --package-dir, --artifacts-dir and --npm-dir arguments");
+    }
+    values[key.slice(2)] = path.resolve(value);
+  }
+  for (const key of ["package-dir", "artifacts-dir", "npm-dir"]) {
+    if (!values[key]) throw new Error(`Missing --${key}`);
+  }
+  return values;
+}
+
+function findArtifact(directory, packageName) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      const result = findArtifact(entryPath, packageName);
+      if (result) return result;
+    } else if (entry.name === "artifact.json") {
+      const metadata = JSON.parse(fs.readFileSync(entryPath, "utf8"));
+      if (metadata.rootPackage === packageName) {
+        return { directory: directory, metadata };
+      }
+    }
+  }
+  return undefined;
+}
+
+function packageEntry(exports, expectedRegistrationCount) {
+  const namedExports = exports.map((name) => `export const ${name} = binding.${name};`).join("\n");
+  return `import { createNapiModule } from "@emnapi/core";
+import { asyncWork, tsfn } from "@emnapi/core/plugins";
+import { getDefaultContext } from "@emnapi/runtime";
+import createEmscriptenModule from "./binding.mjs";
+import wasmModule from "./binding.wasm";
+
+const napiModule = createNapiModule({
+  context: getDefaultContext(),
+  asyncWorkPoolSize: 0,
+  plugins: [asyncWork, tsfn],
+});
+
+let wasmInstance;
+let initializationRandomState = 0x6d2b79f5;
+let initializing = true;
+const emscriptenModule = await createEmscriptenModule({
+  instantiateWasm(imports, done) {
+    imports.env = {
+      ...imports.env,
+      ...napiModule.imports.env,
+      ...napiModule.imports.napi,
+      ...napiModule.imports.emnapi,
+    };
+    const systemRandomGet = imports.wasi_snapshot_preview1.random_get;
+    imports.wasi_snapshot_preview1.random_get = (buffer, size) => {
+      if (!initializing) return systemRandomGet(buffer, size);
+
+      // workerd disallows random generation at module scope. NAPI-RS only requests
+      // these bytes while registering its fixed export metadata; later requests use
+      // Emscripten's system random implementation.
+      const bytes = new Uint8Array(wasmInstance.exports.memory.buffer, buffer, size);
+      for (let index = 0; index < bytes.length; index++) {
+        initializationRandomState ^= initializationRandomState << 13;
+        initializationRandomState ^= initializationRandomState >>> 17;
+        initializationRandomState ^= initializationRandomState << 5;
+        bytes[index] = initializationRandomState;
+      }
+      return 0;
+    };
+    wasmInstance = new WebAssembly.Instance(wasmModule, imports);
+    done(wasmInstance, wasmModule);
+    return wasmInstance.exports;
+  },
+});
+
+const registrationFunctions = Object.keys(emscriptenModule).filter((name) =>
+  name.startsWith("___napi_register__"),
+);
+if (registrationFunctions.length !== ${expectedRegistrationCount}) {
+  throw new Error(
+    \`Expected ${expectedRegistrationCount} N-API registration functions, found \${registrationFunctions.length}\`,
+  );
+}
+for (const name of registrationFunctions) emscriptenModule[name]();
+
+const binding = napiModule.init({ instance: wasmInstance, module: wasmModule });
+initializing = false;
+
+${namedExports}
+export default binding;
+`;
+}
+
+const args = parseArguments();
+const rootManifestPath = path.join(args["package-dir"], "package.json");
+const rootManifest = JSON.parse(fs.readFileSync(rootManifestPath, "utf8"));
+const artifact = findArtifact(args["artifacts-dir"], rootManifest.name);
+if (!artifact) {
+  throw new Error(`No Emscripten artifact found for ${rootManifest.name}`);
+}
+if (artifact.metadata.version !== rootManifest.version) {
+  throw new Error(
+    `Emscripten artifact version ${artifact.metadata.version} does not match ${rootManifest.version}`,
+  );
+}
+
+const packageRequire = createRequire(rootManifestPath);
+const coreVersion = packageRequire("@emnapi/core/package.json").version;
+const runtimeVersion = packageRequire("@emnapi/runtime/package.json").version;
+const destination = path.join(args["npm-dir"], "wasm32-emscripten");
+fs.rmSync(destination, { recursive: true, force: true });
+fs.mkdirSync(destination, { recursive: true });
+fs.copyFileSync(
+  path.join(artifact.directory, "binding.mjs"),
+  path.join(destination, "binding.mjs"),
+);
+fs.copyFileSync(
+  path.join(artifact.directory, "binding.wasm"),
+  path.join(destination, "binding.wasm"),
+);
+fs.writeFileSync(
+  path.join(destination, "index.js"),
+  packageEntry(artifact.metadata.exports, artifact.metadata.registrationFunctions.length),
+);
+
+const companionManifest = {
+  name: artifact.metadata.bindingPackage,
+  version: rootManifest.version,
+  description: `${rootManifest.description} (Emscripten binding)`,
+  license: rootManifest.license,
+  repository: rootManifest.repository,
+  type: "module",
+  main: "./index.js",
+  exports: {
+    ".": "./index.js",
+    "./binding.wasm": "./binding.wasm",
+    "./package.json": "./package.json",
+  },
+  files: ["index.js", "binding.mjs", "binding.wasm"],
+  sideEffects: true,
+  dependencies: {
+    "@emnapi/core": coreVersion,
+    "@emnapi/runtime": runtimeVersion,
+  },
+  publishConfig: rootManifest.publishConfig,
+};
+fs.writeFileSync(
+  path.join(destination, "package.json"),
+  `${JSON.stringify(companionManifest, null, 2)}\n`,
+);
+
+rootManifest.optionalDependencies ??= {};
+rootManifest.optionalDependencies[artifact.metadata.bindingPackage] = rootManifest.version;
+fs.writeFileSync(rootManifestPath, `${JSON.stringify(rootManifest, null, 2)}\n`);
+
+process.stdout.write(`Prepared ${artifact.metadata.bindingPackage}@${rootManifest.version}\n`);

--- a/.github/scripts/napi-emscripten/smoke-test.mjs
+++ b/.github/scripts/napi-emscripten/smoke-test.mjs
@@ -1,0 +1,103 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { getConfig } from "./config.mjs";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "../../..");
+const packageJsonPath = path.join(process.cwd(), "package.json");
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+const config = getConfig(packageJson.name);
+const packageRequire = createRequire(packageJsonPath);
+const { createNapiModule } = await import(pathToFileURL(packageRequire.resolve("@emnapi/core")));
+const { asyncWork, tsfn } = await import(
+  pathToFileURL(packageRequire.resolve("@emnapi/core/plugins"))
+);
+const { getDefaultContext } = await import(
+  pathToFileURL(packageRequire.resolve("@emnapi/runtime"))
+);
+const artifactDirectory = path.join(repositoryRoot, "target/emscripten", config.directory);
+const metadata = JSON.parse(fs.readFileSync(path.join(artifactDirectory, "artifact.json"), "utf8"));
+const wasmModule = new WebAssembly.Module(
+  fs.readFileSync(path.join(artifactDirectory, "binding.wasm")),
+);
+const { default: createEmscriptenModule } = await import(
+  pathToFileURL(path.join(artifactDirectory, "binding.mjs"))
+);
+const napiModule = createNapiModule({
+  context: getDefaultContext(),
+  asyncWorkPoolSize: 0,
+  plugins: [asyncWork, tsfn],
+});
+
+let wasmInstance;
+const emscriptenModule = await createEmscriptenModule({
+  instantiateWasm(imports, done) {
+    imports.env = {
+      ...imports.env,
+      ...napiModule.imports.env,
+      ...napiModule.imports.napi,
+      ...napiModule.imports.emnapi,
+    };
+    wasmInstance = new WebAssembly.Instance(wasmModule, imports);
+    done(wasmInstance, wasmModule);
+    return wasmInstance.exports;
+  },
+});
+
+const registrations = Object.keys(emscriptenModule).filter((name) =>
+  name.startsWith("___napi_register__"),
+);
+if (registrations.length !== metadata.registrationFunctions.length) {
+  throw new Error(
+    `Expected ${metadata.registrationFunctions.length} registrations, found ${registrations.length}`,
+  );
+}
+for (const name of registrations) emscriptenModule[name]();
+const binding = napiModule.init({ instance: wasmInstance, module: wasmModule });
+
+for (const name of config.exports) {
+  if (!(name in binding)) throw new Error(`Missing public export: ${name}`);
+}
+
+switch (config.packageName) {
+  case "oxc-parser": {
+    const syncResult = binding.parseSync("test.ts", "const value: number = 1", {});
+    const asyncResult = await binding.parse("test.ts", "const value: number = 1", {});
+    if (!syncResult.program.includes('"type":"Program"')) throw new Error("Invalid parser AST");
+    if (!asyncResult.program.includes('"type":"Program"')) {
+      throw new Error("Invalid async parser AST");
+    }
+    break;
+  }
+  case "oxc-minify": {
+    const syncResult = binding.minifySync("test.js", "const value = 1 + 2", {});
+    const asyncResult = await binding.minify("test.js", "const value = 1 + 2", {});
+    if (syncResult.code !== "const value=3;" || asyncResult.code !== syncResult.code) {
+      throw new Error("Invalid minifier output");
+    }
+    break;
+  }
+  case "oxc-transform": {
+    const syncResult = binding.transformSync("test.ts", "const value: number = 1", {});
+    const asyncResult = await binding.transform("test.ts", "const value: number = 1", {});
+    if (!syncResult.code.includes("const value = 1") || asyncResult.code !== syncResult.code) {
+      throw new Error("Invalid transformer output");
+    }
+    break;
+  }
+  case "oxc-transform-react": {
+    const source = "export function Component() { return <div /> }";
+    const options = { lang: "jsx", reactCompiler: false };
+    const syncResult = binding.transformSync("test.jsx", source, options);
+    const asyncResult = await binding.transform("test.jsx", source, options);
+    if (!syncResult.code.includes("jsx") || asyncResult.code !== syncResult.code) {
+      throw new Error("Invalid React transformer output");
+    }
+    break;
+  }
+}
+
+process.stdout.write(`Validated ${config.bindingPackage}\n`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,42 @@ jobs:
           pnpm run test-browser
           pnpm build-browser-bundle --npmDir npm-dir
 
+  test-wasm32-unknown-emscripten:
+    name: Test wasm32-unknown-emscripten
+    runs-on: namespace-profile-linux-x64-default
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - uses: ./.github/actions/check-changes
+        id: filter
+        with:
+          exclude: oxc_linter
+          paths: napi/parser/,napi/minify/,napi/transform/,napi/transform-react/,.github/scripts/napi-emscripten/,wasm/emscripten/,pnpm-lock.yaml,pnpm-workspace.yaml,package.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
+      - uses: oxc-project/setup-node@3dcec485ad31d30d15b1bd177eaeddf0db86320e # v1.3.2
+        if: steps.filter.outputs.changed == 'true'
+      - uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
+        if: steps.filter.outputs.changed == 'true'
+        with:
+          version: 5.0.3
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        if: steps.filter.outputs.changed == 'true'
+        with:
+          path: /home/runner/.rustup
+          cache: |
+            rust
+            pnpm
+      - name: Build and test
+        if: steps.filter.outputs.changed == 'true'
+        run: |
+          rustup target add wasm32-unknown-emscripten
+          pnpm build-emscripten
+          for package in parser minify transform transform-react; do
+            pnpm -C "napi/${package}" test-emscripten
+            pnpm -C wasm/emscripten test "../../napi/${package}"
+          done
+          git diff --exit-code # Must commit everything
+
   test-napi-compiler:
     name: Test NAPI Compiler
     runs-on: namespace-profile-linux-x64-default

--- a/.github/workflows/reusable_release_napi.yml
+++ b/.github/workflows/reusable_release_napi.yml
@@ -81,6 +81,10 @@ jobs:
             build: pnpm build-wasm
 
           - os: ubuntu-latest
+            target: wasm32-unknown-emscripten
+            build: pnpm build-emscripten
+
+          - os: ubuntu-latest
             target: s390x-unknown-linux-gnu
             build: |
               export CFLAGS="-fuse-ld=lld"
@@ -136,6 +140,11 @@ jobs:
 
       - uses: oxc-project/setup-node@3dcec485ad31d30d15b1bd177eaeddf0db86320e # v1.3.2
 
+      - uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
+        if: ${{ matrix.target == 'wasm32-unknown-emscripten' }}
+        with:
+          version: 5.0.3
+
       - run: rustup target add ${{ matrix.target }}
 
       - name: Setup OpenHarmony SDK
@@ -157,6 +166,12 @@ jobs:
           # `*-pc-windows-msvc` targets and let cc-rs pick `cl.exe`.
           TARGET_CC: ${{ !contains(matrix.target, 'pc-windows-msvc') && 'clang' || '' }} # for mimalloc
 
+      - name: Test Emscripten binding
+        if: ${{ matrix.target == 'wasm32-unknown-emscripten' }}
+        run: |
+          pnpm -C "napi/${name}" test-emscripten
+          pnpm -C wasm/emscripten test "../../napi/${name}"
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           if-no-files-found: error
@@ -165,6 +180,7 @@ jobs:
           path: |
             napi/${{ inputs.name }}/**/*.node
             napi/${{ inputs.name }}/**/*.wasm
+            target/emscripten/${{ inputs.name }}/**
 
   build-freebsd:
     needs: check
@@ -249,6 +265,13 @@ jobs:
       - run: pnpm -C ${package_path} build-browser-bundle --npmDir ../../${npm_dir}
         if: ${{ inputs.name == 'parser' }}
 
+      - name: Prepare Emscripten package
+        run: >-
+          node .github/scripts/napi-emscripten/prepare-package.mjs
+          --package-dir ${package_path}
+          --artifacts-dir artifacts
+          --npm-dir ${npm_dir}
+
       - name: Check Publish
         run: node .github/scripts/check-npm-packages.js "${npm_dir}/*" "${package_path}"
 
@@ -257,4 +280,5 @@ jobs:
           # Trusted publishing is configured, publish token is not required.
           # Publish sub-packages and adds `optionalDependencies` to `package_path`.
           pnpm napi pre-publish --no-gh-release -t npm --package-json-path ${package_path}/package.json --npm-dir ${npm_dir}
+          bash .github/scripts/publish-if-needed.sh ${npm_dir}/wasm32-emscripten ${PUBLISH_FLAGS}
           bash .github/scripts/publish-if-needed.sh ${package_path} ${PUBLISH_FLAGS}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ target/
 /plugins/node_modules/
 /tasks/e2e/tests/nestjs/node_modules/
 /npm/*/node_modules
+/wasm/*/node_modules/
 /napi/*/npm-dir
 /napi/parser/tsconfig.browser.tsbuildinfo
 

--- a/napi/minify/README.md
+++ b/napi/minify/README.md
@@ -76,3 +76,13 @@ See https://github.com/oxc-project/oxc/blob/main/crates/oxc_minifier/README.md#a
 ### Supports WASM
 
 See https://stackblitz.com/edit/oxc-minify for usage example.
+
+### Cloudflare Workers
+
+Import `oxc-minify` normally. Wrangler selects the Emscripten binding through
+the `workerd` package export; the binding package is installed automatically as
+an optional dependency.
+
+Set `compatibility_date` to `2025-05-05` or later, or enable the
+[`enable_weak_ref` compatibility flag](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#enable-finalizationregistry-and-weakref).
+The Emscripten binding is single-threaded, including its async functions.

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -27,11 +27,22 @@
     "browser.js",
     "index.d.ts",
     "index.js",
+    "workerd.js",
     "webcontainer-fallback.cjs"
   ],
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "workerd": "./workerd.js",
+      "browser": "./browser.js",
+      "default": "./index.js"
+    },
+    "./package.json": "./package.json",
+    "./*": "./*"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
@@ -44,6 +55,8 @@
     "postbuild-dev": "node scripts/patch.js",
     "build-wasm": "pnpm run build-wasm-dev --release",
     "build-wasm-dev": "pnpm run build-dev --target wasm32-wasip1-threads --dts minify.wasi.d.cts",
+    "build-emscripten": "node ../../.github/scripts/napi-emscripten/build.mjs",
+    "test-emscripten": "node ../../.github/scripts/napi-emscripten/smoke-test.mjs",
     "test": "vitest run --dir ./test"
   },
   "dependencies": {},
@@ -52,6 +65,7 @@
     "@emnapi/runtime": "catalog:",
     "@napi-rs/cli": "catalog:",
     "@types/node": "catalog:",
+    "emnapi": "catalog:",
     "publint": "catalog:",
     "vitest": "catalog:"
   },

--- a/napi/minify/workerd.js
+++ b/napi/minify/workerd.js
@@ -1,0 +1,1 @@
+export * from "@oxc-minify/binding-wasm32-emscripten";

--- a/napi/parser/README.md
+++ b/napi/parser/README.md
@@ -8,6 +8,16 @@ See [usage instructions](https://oxc.rs/docs/guide/usage/parser).
 
 See https://stackblitz.com/edit/oxc-parser for usage example.
 
+### Cloudflare Workers
+
+Import `oxc-parser` normally. Wrangler selects the Emscripten binding through
+the `workerd` package export; the binding package is installed automatically as
+an optional dependency.
+
+Set `compatibility_date` to `2025-05-05` or later, or enable the
+[`enable_weak_ref` compatibility flag](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#enable-finalizationregistry-and-weakref).
+The Emscripten binding is single-threaded, including its async functions.
+
 ### ESTree
 
 When parsing JS or JSX files, the AST returned is fully conformant with the

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -28,6 +28,7 @@
     "src-js/index.js",
     "src-js/wasm.d.ts",
     "src-js/wasm.js",
+    "src-js/workerd.js",
     "src-js/webcontainer-fallback.cjs",
     "src-js/wrap.js",
     "src-js/generated/constants.js",
@@ -55,6 +56,16 @@
   "type": "module",
   "main": "src-js/index.js",
   "browser": "src-js/wasm.js",
+  "exports": {
+    ".": {
+      "types": "./src-js/index.d.ts",
+      "workerd": "./src-js/workerd.js",
+      "browser": "./src-js/wasm.js",
+      "default": "./src-js/index.js"
+    },
+    "./package.json": "./package.json",
+    "./*": "./*"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
@@ -68,6 +79,8 @@
     "build-wasi": "napi build --config-path napi.wasm.json --target wasm32-wasip1-threads --dts parser.wasi.d.cts --no-dts-header",
     "build-wasm": "pnpm run build-wasm-dev --release",
     "build-wasm-dev": "pnpm run build-dev --target wasm32-wasip1-threads --dts parser.wasi.d.cts --no-dts-header",
+    "build-emscripten": "node ../../.github/scripts/napi-emscripten/build.mjs",
+    "test-emscripten": "node ../../.github/scripts/napi-emscripten/smoke-test.mjs",
     "build-npm-dir": "rm -rf npm-dir && napi create-npm-dirs --config-path napi.wasm.json --npm-dir npm-dir && pnpm napi artifacts --config-path napi.wasm.json --npm-dir npm-dir --output-dir src-js",
     "build-browser-bundle": "node scripts/build-browser-bundle.js",
     "test": "pnpm run test-node run",
@@ -88,6 +101,7 @@
     "@typescript-eslint/visitor-keys": "^8.54.0",
     "@vitest/browser": "4.1.10",
     "@vitest/browser-playwright": "4.1.10",
+    "emnapi": "catalog:",
     "playwright": "^1.51.0",
     "publint": "catalog:",
     "rolldown": "catalog:",

--- a/napi/parser/src-js/workerd.js
+++ b/napi/parser/src-js/workerd.js
@@ -1,0 +1,13 @@
+export * from "@oxc-parser/binding-wasm32-emscripten";
+import * as bindings from "@oxc-parser/binding-wasm32-emscripten";
+import { wrap } from "./wrap.js";
+
+export { default as visitorKeys } from "./generated/visit/keys.js";
+
+export async function parse(...args) {
+  return wrap(await bindings.parse(...args));
+}
+
+export function parseSync(filename, sourceText, options) {
+  return wrap(bindings.parseSync(filename, sourceText, options));
+}

--- a/napi/transform-react/README.md
+++ b/napi/transform-react/README.md
@@ -51,3 +51,13 @@ to leave JSX syntax in the output.
 Callback-valued options such as `logger`, function-valued `sources`, and type
 provider callbacks are not accepted by the native binding. `sources` accepts
 an array of filename substrings instead.
+
+## Cloudflare Workers
+
+Import `oxc-transform-react` normally. Wrangler selects the Emscripten binding
+through the `workerd` package export; the binding package is installed
+automatically as an optional dependency.
+
+Set `compatibility_date` to `2025-05-05` or later, or enable the
+[`enable_weak_ref` compatibility flag](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#enable-finalizationregistry-and-weakref).
+The Emscripten binding is single-threaded, including its async functions.

--- a/napi/transform-react/package.json
+++ b/napi/transform-react/package.json
@@ -28,12 +28,23 @@
     "browser.js",
     "index.d.ts",
     "index.js",
+    "workerd.js",
     "webcontainer-fallback.cjs"
   ],
   "type": "module",
   "sideEffects": false,
   "main": "index.js",
   "browser": "browser.js",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "workerd": "./workerd.js",
+      "browser": "./browser.js",
+      "default": "./index.js"
+    },
+    "./package.json": "./package.json",
+    "./*": "./*"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
@@ -46,6 +57,8 @@
     "postbuild-dev": "node scripts/patch.js",
     "build-wasm": "pnpm run build-wasm-dev --release",
     "build-wasm-dev": "pnpm run build-dev --target wasm32-wasip1-threads --dts transform-react.wasi.d.cts",
+    "build-emscripten": "node ../../.github/scripts/napi-emscripten/build.mjs",
+    "test-emscripten": "node ../../.github/scripts/napi-emscripten/smoke-test.mjs",
     "test": "vitest run --dir ./test"
   },
   "devDependencies": {
@@ -53,6 +66,7 @@
     "@emnapi/runtime": "catalog:",
     "@napi-rs/cli": "catalog:",
     "@types/node": "catalog:",
+    "emnapi": "catalog:",
     "publint": "catalog:",
     "vitest": "catalog:"
   },

--- a/napi/transform-react/workerd.js
+++ b/napi/transform-react/workerd.js
@@ -1,0 +1,1 @@
+export * from "@oxc-transform-react/binding-wasm32-emscripten";

--- a/napi/transform/README.md
+++ b/napi/transform/README.md
@@ -82,3 +82,13 @@ See `index.d.ts` for complete type definitions.
 ### Supports WASM
 
 See https://stackblitz.com/edit/oxc-transform for usage example.
+
+### Cloudflare Workers
+
+Import `oxc-transform` normally. Wrangler selects the Emscripten binding through
+the `workerd` package export; the binding package is installed automatically as
+an optional dependency.
+
+Set `compatibility_date` to `2025-05-05` or later, or enable the
+[`enable_weak_ref` compatibility flag](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#enable-finalizationregistry-and-weakref).
+The Emscripten binding is single-threaded, including its async functions.

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -28,11 +28,22 @@
     "browser.js",
     "index.d.ts",
     "index.js",
+    "workerd.js",
     "webcontainer-fallback.cjs"
   ],
   "type": "module",
   "main": "index.js",
   "browser": "browser.js",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "workerd": "./workerd.js",
+      "browser": "./browser.js",
+      "default": "./index.js"
+    },
+    "./package.json": "./package.json",
+    "./*": "./*"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
@@ -45,6 +56,8 @@
     "postbuild-dev": "node scripts/patch.js",
     "build-wasm": "pnpm run build-wasm-dev --release",
     "build-wasm-dev": "pnpm run build-dev --target wasm32-wasip1-threads --dts transform.wasi.d.cts",
+    "build-emscripten": "node ../../.github/scripts/napi-emscripten/build.mjs",
+    "test-emscripten": "node ../../.github/scripts/napi-emscripten/smoke-test.mjs",
     "test": "vitest run --dir ./test"
   },
   "devDependencies": {
@@ -52,6 +65,7 @@
     "@emnapi/runtime": "catalog:",
     "@napi-rs/cli": "catalog:",
     "@types/node": "catalog:",
+    "emnapi": "catalog:",
     "publint": "catalog:",
     "vitest": "catalog:"
   },

--- a/napi/transform/workerd.js
+++ b/napi/transform/workerd.js
@@ -1,0 +1,1 @@
+export * from "@oxc-transform/binding-wasm32-emscripten";

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build-dev": "pnpm --workspace-concurrency=1 --filter \"./napi/*\" --filter \"./apps/*\" build-dev",
     "build-test": "pnpm --workspace-concurrency=1 --filter \"./napi/*\" --filter \"./apps/*\" build-test",
     "build-wasm-dev": "pnpm --workspace-concurrency=1 --filter \"./napi/*\" build-wasm-dev",
+    "build-emscripten": "pnpm --workspace-concurrency=1 --filter oxc-parser --filter oxc-minify --filter oxc-transform --filter oxc-transform-react build-emscripten",
     "test": "pnpm --workspace-concurrency=1 --filter \"./napi/*\" --filter \"./apps/*\" test",
     "fmt": "oxfmt -c oxfmtrc.jsonc",
     "lint": "oxlint -c oxlintrc.json --deny-warnings --report-unused-disable-directives"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ catalogs:
     vitest:
       specifier: 4.1.10
       version: 4.1.10
+    wrangler:
+      specifier: 4.120.0
+      version: 4.120.0
 
 overrides:
   rolldown: 1.2.3
@@ -59,7 +62,7 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: 'catalog:'
-        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@25.0.2)
+        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@25.0.2)(supports-color@10.2.2)
       oxfmt:
         specifier: ^0.61.0
         version: 0.61.0(svelte@5.56.8(@typescript-eslint/types@8.65.0))(vite-plus@0.2.8(@arethetypeswrong/core@0.18.5)(@types/node@25.0.2)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@7.3.0(@types/node@25.0.2)(lightningcss@1.33.0)(terser@5.44.1)(tsx@4.23.1))(vitest@4.1.10))(esbuild@0.28.1)(happy-dom@20.0.11)(publint@0.3.22)(svelte@5.56.8(@typescript-eslint/types@8.65.0))(terser@5.44.1)(tsx@4.23.1)(typescript@6.0.3)(vite@7.3.0(@types/node@25.0.2)(lightningcss@1.33.0)(terser@5.44.1)(tsx@4.23.1)))
@@ -90,7 +93,7 @@ importers:
         version: 0.18.5
       '@napi-rs/cli':
         specifier: 'catalog:'
-        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)
+        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)(supports-color@10.2.2)
       '@oxapps/shared':
         specifier: workspace:*
         version: link:../shared
@@ -138,7 +141,7 @@ importers:
         version: 8.0.0
       '@napi-rs/cli':
         specifier: 'catalog:'
-        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)
+        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)(supports-color@10.2.2)
       '@oxapps/shared':
         specifier: workspace:*
         version: link:../shared
@@ -171,7 +174,7 @@ importers:
         version: 5.0.4
       '@typescript-eslint/parser':
         specifier: ^8.54.0
-        version: 8.65.0(eslint@10.8.0)(typescript@5.6.1-rc)
+        version: 8.65.0(eslint@10.8.0(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.1-rc)
       '@typescript-eslint/scope-manager':
         specifier: ^8.54.0
         version: 8.65.0
@@ -183,10 +186,10 @@ importers:
         version: 10.1.0
       eslint:
         specifier: 'catalog:'
-        version: 10.8.0
+        version: 10.8.0(supports-color@10.2.2)
       eslint-vitest-rule-tester:
         specifier: ^3.0.1
-        version: 3.1.0(eslint@10.8.0)(typescript@5.6.1-rc)(vitest@4.1.10)
+        version: 3.1.0(eslint@10.8.0(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.1-rc)(vitest@4.1.10)
       esquery:
         specifier: ^1.6.0
         version: 1.7.0
@@ -252,10 +255,13 @@ importers:
         version: 2.0.0-alpha.3
       '@napi-rs/cli':
         specifier: 'catalog:'
-        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)
+        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)(supports-color@10.2.2)
       '@types/node':
         specifier: 'catalog:'
         version: 24.1.0
+      emnapi:
+        specifier: 2.0.0-alpha.3
+        version: 2.0.0-alpha.3
       publint:
         specifier: 'catalog:'
         version: 0.3.22
@@ -271,7 +277,7 @@ importers:
     devDependencies:
       '@codspeed/vitest-plugin':
         specifier: ^5.0.0
-        version: 5.7.1(tinybench@2.9.0)(vite@7.3.0(@types/node@24.1.0)(lightningcss@1.33.0)(terser@5.44.1)(tsx@4.23.1))(vitest@4.1.10)
+        version: 5.7.1(supports-color@10.2.2)(tinybench@2.9.0)(vite@7.3.0(@types/node@24.1.0)(lightningcss@1.33.0)(terser@5.44.1)(tsx@4.23.1))(vitest@4.1.10)
       '@emnapi/core':
         specifier: 'catalog:'
         version: 2.0.0-alpha.3
@@ -280,7 +286,7 @@ importers:
         version: 2.0.0-alpha.3
       '@napi-rs/cli':
         specifier: 'catalog:'
-        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)
+        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)(supports-color@10.2.2)
       '@napi-rs/wasm-runtime':
         specifier: 'catalog:'
         version: 1.2.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
@@ -296,6 +302,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: 4.1.10
         version: 4.1.10(playwright@1.62.1)(vite@7.3.0(@types/node@24.1.0)(lightningcss@1.33.0)(terser@5.44.1)(tsx@4.23.1))(vitest@4.1.10)
+      emnapi:
+        specifier: 2.0.0-alpha.3
+        version: 2.0.0-alpha.3
       playwright:
         specifier: ^1.51.0
         version: 1.62.1
@@ -326,7 +335,7 @@ importers:
         version: 2.0.0-alpha.3
       '@napi-rs/cli':
         specifier: 'catalog:'
-        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@25.0.2)
+        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@25.0.2)(supports-color@10.2.2)
       publint:
         specifier: 'catalog:'
         version: 0.3.22
@@ -341,10 +350,13 @@ importers:
         version: 2.0.0-alpha.3
       '@napi-rs/cli':
         specifier: 'catalog:'
-        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)
+        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)(supports-color@10.2.2)
       '@types/node':
         specifier: 'catalog:'
         version: 24.1.0
+      emnapi:
+        specifier: 2.0.0-alpha.3
+        version: 2.0.0-alpha.3
       publint:
         specifier: 'catalog:'
         version: 0.3.22
@@ -362,10 +374,13 @@ importers:
         version: 2.0.0-alpha.3
       '@napi-rs/cli':
         specifier: 'catalog:'
-        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)
+        version: 3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)(supports-color@10.2.2)
       '@types/node':
         specifier: 'catalog:'
         version: 24.1.0
+      emnapi:
+        specifier: 2.0.0-alpha.3
+        version: 2.0.0-alpha.3
       publint:
         specifier: 'catalog:'
         version: 0.3.22
@@ -412,16 +427,16 @@ importers:
     devDependencies:
       '@nestjs/common':
         specifier: ^11.0.1
-        version: 11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2)
       '@nestjs/core':
         specifier: ^11.0.1
-        version: 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/platform-express@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express':
         specifier: ^11.0.1
-        version: 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)
+        version: 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.9)(supports-color@10.2.2)
       '@nestjs/testing':
         specifier: ^11.0.1
-        version: 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(@nestjs/platform-express@11.1.9)
+        version: 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.9)(@nestjs/platform-express@11.1.9)
       '@oxc-project/runtime':
         specifier: link:../../npm/runtime
         version: link:../../npm/runtime
@@ -436,7 +451,7 @@ importers:
         version: 6.1.1(date-fns@4.1.0)(luxon@3.7.2)(moment@2.30.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       axios:
         specifier: ^1.7.8
-        version: 1.18.1(debug@4.4.3)
+        version: 1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -517,7 +532,7 @@ importers:
         version: 1.9.10
       supertest:
         specifier: ^7
-        version: 7.1.4
+        version: 7.1.4(supports-color@10.2.2)
       terser:
         specifier: ^5.39.2
         version: 5.44.1
@@ -584,6 +599,12 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@25.0.2)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(happy-dom@20.0.11)(vite@7.3.0(@types/node@25.0.2)(lightningcss@1.33.0)(terser@5.44.1)(tsx@4.23.1))
+
+  wasm/emscripten:
+    devDependencies:
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.120.0
 
 packages:
 
@@ -868,6 +889,49 @@ packages:
   '@braidai/lang@1.1.2':
     resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
 
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260801.1':
+    resolution: {integrity: sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260801.1':
+    resolution: {integrity: sha512-kwoZiTpnhNrF3+APx84Q/oAqvJ3sU9yefGagwm/ASaH/2W19x0vghkW/r4qCoHCK0WW7EPugZ+aXjgPMRtlq1Q==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260801.1':
+    resolution: {integrity: sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260801.1':
+    resolution: {integrity: sha512-zWgpdZtSozvIgzQNmQiDSF8yEOQJUkRAWNsDXXzAAoy+fCn8YUoSibj3mpFSbZRvbUldeBEaW6SCdC2VEMkhNQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260801.1':
+    resolution: {integrity: sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
   '@codspeed/core@5.7.1':
     resolution: {integrity: sha512-7mrFkqaY14rXu3XHv3o7bK3btLK0LFRxfeK3bQC8dLduI/Ty9eq8Hv8rx04FAY/onQbRTx3rUUQg5xprYHpATQ==}
 
@@ -878,8 +942,15 @@ packages:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
       vitest: ^3.2 || ^4
 
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@emnapi/core@2.0.0-alpha.3':
     resolution: {integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==}
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/runtime@2.0.0-alpha.3':
     resolution: {integrity: sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==}
@@ -1254,6 +1325,168 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.35.2':
+    resolution: {integrity: sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.2':
+    resolution: {integrity: sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.2':
+    resolution: {integrity: sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.1':
+    resolution: {integrity: sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.3.1':
+    resolution: {integrity: sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
+    resolution: {integrity: sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.3.1':
+    resolution: {integrity: sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    resolution: {integrity: sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.35.2':
+    resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.2':
+    resolution: {integrity: sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.35.2':
+    resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    resolution: {integrity: sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.35.2':
+    resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.2':
+    resolution: {integrity: sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    resolution: {integrity: sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.35.2':
+    resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.2':
+    resolution: {integrity: sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.2':
+    resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.35.2':
+    resolution: {integrity: sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.2':
+    resolution: {integrity: sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@inquirer/ansi@2.0.7':
     resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
@@ -1406,6 +1639,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
@@ -2456,6 +2692,15 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
   '@publint/pack@0.1.6':
     resolution: {integrity: sha512-3uVNyGcVplhPZSLVyeIpL7+cIRn1YCSNHLG/rUIlBQMVH8YuN9++YF+5+UDIIO9RW98dujiUoTltO7RDB5bFJA==}
     engines: {node: '>=18'}
@@ -2980,9 +3225,16 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.23':
+    resolution: {integrity: sha512-iRoq6i6JDJP6Mt2A5JaPvzw0pgYHH6k92ij+yXiTrB7T2y9N789aWE3EHWj/5ztlJBokcCBja3iYLVdu5wgnkg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -3681,6 +3933,9 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   body-parser@2.2.1:
     resolution: {integrity: sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==}
     engines: {node: '>=18'}
@@ -3795,6 +4050,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -4038,6 +4297,9 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -4476,6 +4738,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -4634,6 +4900,10 @@ packages:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
     hasBin: true
+
+  miniflare@5.20260801.1-alpha:
+    resolution: {integrity: sha512-BHPVzIDA6mbx7LefxpvkXW7DHx9FKB9GorZatbnrrFTt3CVMU8zuUpbgyCuebwDKcTTOZos43ta8GQ0eMVEpxA==}
+    engines: {node: '>=22.0.0'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -4828,6 +5098,9 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
@@ -5093,6 +5366,10 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  sharp@0.35.2:
+    resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
+    engines: {node: '>=20.9.0'}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -5184,6 +5461,10 @@ packages:
   supertest@7.1.4:
     resolution: {integrity: sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==}
     engines: {node: '>=14.18.0'}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   svelte@5.56.8:
     resolution: {integrity: sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==}
@@ -5359,6 +5640,13 @@ packages:
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -5532,11 +5820,38 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  workerd@1.20260801.1:
+    resolution: {integrity: sha512-/g9JGTyqnHtoIscpBHqKD8swE2V4StBs2i69PmLiOhH45OP95jCFICl4F1hKlgN57rqfni5LiCitttoX5OOkVA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.120.0:
+    resolution: {integrity: sha512-cBmu/MeaB/fPacC0JpATs4duTOCagBxrZo+vBzuTX06tLzwSyAHE1drlHUZ8rP0VqVz1fy3ReGYTiHdKkoHltg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260801.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5562,6 +5877,12 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   yuku-ast@0.7.0:
     resolution: {integrity: sha512-W5UzqYg/Xuyz41cAyxwo/TIPpDX221OuC9U5f44+NulDAHDwtzvGE3M3Xz3mdcLEutWOmTc/WP/y7NO6ANA2gw==}
@@ -5912,9 +6233,32 @@ snapshots:
 
   '@braidai/lang@1.1.2': {}
 
-  '@codspeed/core@5.7.1':
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260801.1)':
     dependencies:
-      axios: 1.18.1(debug@4.4.3)
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260801.1
+
+  '@cloudflare/workerd-darwin-64@1.20260801.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260801.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260801.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260801.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260801.1':
+    optional: true
+
+  '@codspeed/core@5.7.1(supports-color@10.2.2)':
+    dependencies:
+      axios: 1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       find-up: 6.3.0
       form-data: 4.0.6
       node-gyp-build: 4.8.4
@@ -5923,9 +6267,9 @@ snapshots:
       - debug
       - supports-color
 
-  '@codspeed/vitest-plugin@5.7.1(tinybench@2.9.0)(vite@7.3.0(@types/node@24.1.0)(lightningcss@1.33.0)(terser@5.44.1)(tsx@4.23.1))(vitest@4.1.10)':
+  '@codspeed/vitest-plugin@5.7.1(supports-color@10.2.2)(tinybench@2.9.0)(vite@7.3.0(@types/node@24.1.0)(lightningcss@1.33.0)(terser@5.44.1)(tsx@4.23.1))(vitest@4.1.10)':
     dependencies:
-      '@codspeed/core': 5.7.1
+      '@codspeed/core': 5.7.1(supports-color@10.2.2)
       tinybench: 2.9.0
       vite: 7.3.0(@types/node@24.1.0)(lightningcss@1.33.0)(terser@5.44.1)(tsx@4.23.1)
       vitest: 4.1.10(@types/node@24.1.0)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(happy-dom@20.0.11)(vite@7.3.0(@types/node@24.1.0)(lightningcss@1.33.0)(terser@5.44.1)(tsx@4.23.1))
@@ -5933,10 +6277,19 @@ snapshots:
       - debug
       - supports-color
 
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@emnapi/core@2.0.0-alpha.3':
     dependencies:
       '@emnapi/wasi-threads': 2.0.1
       tslib: 2.8.1
+
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@emnapi/runtime@2.0.0-alpha.3':
     dependencies:
@@ -6108,17 +6461,17 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.0(supports-color@10.2.2))':
     dependencies:
-      eslint: 10.8.0
+      eslint: 10.8.0(supports-color@10.2.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.23.5(supports-color@10.2.2)':
     dependencies:
       '@eslint/object-schema': 3.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
@@ -6148,6 +6501,112 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-wasm32@0.35.2':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.2':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.2':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.2':
+    optional: true
 
   '@inquirer/ansi@2.0.7': {}
 
@@ -6407,6 +6866,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@jsdevtools/ono@7.1.3': {}
 
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
@@ -6451,10 +6915,10 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
-  '@napi-rs/cli@3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)':
+  '@napi-rs/cli@3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@24.1.0)(supports-color@10.2.2)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.1.0)
-      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(supports-color@10.2.2)
       '@napi-rs/wasm-tools': 1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       '@octokit/rest': 22.0.1
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
@@ -6484,10 +6948,10 @@ snapshots:
       - node-addon-api
       - supports-color
 
-  '@napi-rs/cli@3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@25.0.2)':
+  '@napi-rs/cli@3.8.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@25.0.2)(supports-color@10.2.2)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@25.0.2)
-      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(supports-color@10.2.2)
       '@napi-rs/wasm-tools': 1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       '@octokit/rest': 22.0.1
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
@@ -6517,11 +6981,11 @@ snapshots:
       - node-addon-api
       - supports-color
 
-  '@napi-rs/cross-toolchain@1.0.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+  '@napi-rs/cross-toolchain@1.0.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(supports-color@10.2.2)':
     dependencies:
       '@napi-rs/lzma': 1.4.5(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       '@napi-rs/tar': 1.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -6750,9 +7214,9 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2)':
     dependencies:
-      file-type: 21.1.0
+      file-type: 21.1.0(supports-color@10.2.2)
       iterare: 1.2.1
       load-esm: 1.0.3
       reflect-metadata: 0.2.2
@@ -6762,9 +7226,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/core@11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/core@11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/platform-express@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2)
       '@nuxt/opencollective': 0.4.1
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
@@ -6774,27 +7238,27 @@ snapshots:
       tslib: 2.8.1
       uid: 2.0.2
     optionalDependencies:
-      '@nestjs/platform-express': 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)
+      '@nestjs/platform-express': 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.9)(supports-color@10.2.2)
 
-  '@nestjs/platform-express@11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)':
+  '@nestjs/platform-express@11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.9)(supports-color@10.2.2)':
     dependencies:
-      '@nestjs/common': 11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2)
+      '@nestjs/core': 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/platform-express@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cors: 2.8.5
-      express: 5.1.0
+      express: 5.1.0(supports-color@10.2.2)
       multer: 2.0.2
       path-to-regexp: 8.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/testing@11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(@nestjs/platform-express@11.1.9)':
+  '@nestjs/testing@11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.9)(@nestjs/platform-express@11.1.9)':
     dependencies:
-      '@nestjs/common': 11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2)
+      '@nestjs/core': 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/platform-express@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       tslib: 2.8.1
     optionalDependencies:
-      '@nestjs/platform-express': 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)
+      '@nestjs/platform-express': 11.1.9(@nestjs/common@11.1.9(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.9)(supports-color@10.2.2)
 
   '@noble/hashes@1.8.0': {}
 
@@ -7123,6 +7587,18 @@ snapshots:
       '@noble/hashes': 1.8.0
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@publint/pack@0.1.6':
     dependencies:
@@ -7602,7 +8078,11 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@sindresorhus/is@7.2.0': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@speed-highlight/core@1.2.23': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -7625,9 +8105,9 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tokenizer/inflate@0.3.1':
+  '@tokenizer/inflate@0.3.1(supports-color@10.2.2)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       fflate: 0.8.3
       token-types: 6.1.1
     transitivePeerDependencies:
@@ -7704,32 +8184,32 @@ snapshots:
 
   '@types/whatwg-mimetype@3.0.2': {}
 
-  '@typescript-eslint/parser@8.65.0(eslint@10.8.0)(typescript@5.6.1-rc)':
+  '@typescript-eslint/parser@8.65.0(eslint@10.8.0(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.1-rc)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.6.1-rc)
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@10.2.2)(typescript@5.6.1-rc)
       '@typescript-eslint/visitor-keys': 8.65.0
-      debug: 4.4.3
-      eslint: 10.8.0
+      debug: 4.4.3(supports-color@10.2.2)
+      eslint: 10.8.0(supports-color@10.2.2)
       typescript: 5.6.1-rc
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.56.0(typescript@5.6.1-rc)':
+  '@typescript-eslint/project-service@8.56.0(supports-color@10.2.2)(typescript@5.6.1-rc)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.6.1-rc)
       '@typescript-eslint/types': 8.65.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       typescript: 5.6.1-rc
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.65.0(typescript@5.6.1-rc)':
+  '@typescript-eslint/project-service@8.65.0(supports-color@10.2.2)(typescript@5.6.1-rc)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.6.1-rc)
       '@typescript-eslint/types': 8.65.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       typescript: 5.6.1-rc
     transitivePeerDependencies:
       - supports-color
@@ -7756,13 +8236,13 @@ snapshots:
 
   '@typescript-eslint/types@8.65.0': {}
 
-  '@typescript-eslint/typescript-estree@8.56.0(typescript@5.6.1-rc)':
+  '@typescript-eslint/typescript-estree@8.56.0(supports-color@10.2.2)(typescript@5.6.1-rc)':
     dependencies:
-      '@typescript-eslint/project-service': 8.56.0(typescript@5.6.1-rc)
+      '@typescript-eslint/project-service': 8.56.0(supports-color@10.2.2)(typescript@5.6.1-rc)
       '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.6.1-rc)
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 9.0.9
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -7771,13 +8251,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.65.0(typescript@5.6.1-rc)':
+  '@typescript-eslint/typescript-estree@8.65.0(supports-color@10.2.2)(typescript@5.6.1-rc)':
     dependencies:
-      '@typescript-eslint/project-service': 8.65.0(typescript@5.6.1-rc)
+      '@typescript-eslint/project-service': 8.65.0(supports-color@10.2.2)(typescript@5.6.1-rc)
       '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.6.1-rc)
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -7786,13 +8266,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.0(eslint@10.8.0)(typescript@5.6.1-rc)':
+  '@typescript-eslint/utils@8.56.0(eslint@10.8.0(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.1-rc)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(supports-color@10.2.2))
       '@typescript-eslint/scope-manager': 8.56.0
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.6.1-rc)
-      eslint: 10.8.0
+      '@typescript-eslint/typescript-estree': 8.56.0(supports-color@10.2.2)(typescript@5.6.1-rc)
+      eslint: 10.8.0(supports-color@10.2.2)
       typescript: 5.6.1-rc
     transitivePeerDependencies:
       - supports-color
@@ -8250,9 +8730,9 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -8346,11 +8826,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.18.1(debug@4.4.3):
+  axios@1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@10.2.2))
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@10.2.2)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -8366,11 +8846,13 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  body-parser@2.2.1:
+  blake3-wasm@2.1.5: {}
+
+  body-parser@2.2.1(supports-color@10.2.2):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -8466,6 +8948,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
 
@@ -8643,9 +9127,11 @@ snapshots:
 
   dayjs@1.11.19: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   deep-is@0.1.4: {}
 
@@ -8695,6 +9181,8 @@ snapshots:
   encodeurl@2.0.0: {}
 
   entities@4.5.0: {}
+
+  error-stack-parser-es@1.0.5: {}
 
   es-define-property@1.0.1: {}
 
@@ -8792,20 +9280,20 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint-vitest-rule-tester@3.1.0(eslint@10.8.0)(typescript@5.6.1-rc)(vitest@4.1.10):
+  eslint-vitest-rule-tester@3.1.0(eslint@10.8.0(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.1-rc)(vitest@4.1.10):
     dependencies:
-      '@typescript-eslint/utils': 8.56.0(eslint@10.8.0)(typescript@5.6.1-rc)
-      eslint: 10.8.0
+      '@typescript-eslint/utils': 8.56.0(eslint@10.8.0(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.6.1-rc)
+      eslint: 10.8.0(supports-color@10.2.2)
       vitest: 4.1.10(@types/node@24.1.0)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(happy-dom@20.0.11)(vite@7.3.0(@types/node@24.1.0)(lightningcss@1.33.0)(terser@5.44.1)(tsx@4.23.1))
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint@10.8.0:
+  eslint@10.8.0(supports-color@10.2.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(supports-color@10.2.2))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
+      '@eslint/config-array': 0.23.5(supports-color@10.2.2)
       '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -8815,7 +9303,7 @@ snapshots:
       '@types/estree': 1.0.9
       ajv: 6.14.0
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -8888,19 +9376,19 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express@5.1.0:
+  express@5.1.0(supports-color@10.2.2):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.1
+      body-parser: 2.2.1(supports-color@10.2.2)
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@10.2.2)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -8911,9 +9399,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.14.0
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@10.2.2)
+      send: 1.2.1(supports-color@10.2.2)
+      serve-static: 2.2.1(supports-color@10.2.2)
       statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
@@ -8954,18 +9442,18 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-type@21.1.0:
+  file-type@21.1.0(supports-color@10.2.2):
     dependencies:
-      '@tokenizer/inflate': 0.3.1
+      '@tokenizer/inflate': 0.3.1(supports-color@10.2.2)
       strtok3: 10.3.4
       token-types: 6.1.1
       uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -8991,9 +9479,9 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  follow-redirects@1.16.0(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@10.2.2)):
     optionalDependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
 
   form-data@4.0.6:
     dependencies:
@@ -9097,10 +9585,10 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@10.2.2):
     dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -9197,6 +9685,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kleur@4.1.5: {}
 
   levn@0.4.1:
     dependencies:
@@ -9310,6 +9800,18 @@ snapshots:
       mime-db: 1.54.0
 
   mime@2.6.0: {}
+
+  miniflare@5.20260801.1-alpha:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.2
+      undici: 7.29.0
+      workerd: 1.20260801.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   minimatch@10.2.5:
     dependencies:
@@ -9685,6 +10187,8 @@ snapshots:
 
   path-key@4.0.0: {}
 
+  path-to-regexp@6.3.0: {}
+
   path-to-regexp@8.3.0: {}
 
   pathe@2.0.3: {}
@@ -9873,9 +10377,9 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.3
       fsevents: 2.3.3
 
-  router@2.2.0:
+  router@2.2.0(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -9905,9 +10409,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -9929,16 +10433,48 @@ snapshots:
 
   seroval@1.3.2: {}
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   setprototypeof@1.2.0: {}
+
+  sharp@0.35.2:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.2
+      '@img/sharp-darwin-x64': 0.35.2
+      '@img/sharp-freebsd-wasm32': 0.35.2
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+      '@img/sharp-libvips-linux-arm': 1.3.1
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+      '@img/sharp-libvips-linux-x64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+      '@img/sharp-linux-arm': 0.35.2
+      '@img/sharp-linux-arm64': 0.35.2
+      '@img/sharp-linux-ppc64': 0.35.2
+      '@img/sharp-linux-riscv64': 0.35.2
+      '@img/sharp-linux-s390x': 0.35.2
+      '@img/sharp-linux-x64': 0.35.2
+      '@img/sharp-linuxmusl-arm64': 0.35.2
+      '@img/sharp-linuxmusl-x64': 0.35.2
+      '@img/sharp-webcontainers-wasm32': 0.35.2
+      '@img/sharp-win32-arm64': 0.35.2
+      '@img/sharp-win32-ia32': 0.35.2
+      '@img/sharp-win32-x64': 0.35.2
 
   shebang-command@2.0.0:
     dependencies:
@@ -10023,11 +10559,11 @@ snapshots:
 
   stylis@4.3.6: {}
 
-  superagent@10.2.3:
+  superagent@10.2.3(supports-color@10.2.2):
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.6
       formidable: 3.5.4
@@ -10037,12 +10573,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  supertest@7.1.4:
+  supertest@7.1.4(supports-color@10.2.2):
     dependencies:
       methods: 1.1.2
-      superagent: 10.2.3
+      superagent: 10.2.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
+
+  supports-color@10.2.2: {}
 
   svelte@5.56.8(@typescript-eslint/types@8.65.0):
     dependencies:
@@ -10226,6 +10764,12 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici-types@7.8.0: {}
+
+  undici@7.29.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   unicorn-magic@0.3.0: {}
 
@@ -10614,9 +11158,35 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  workerd@1.20260801.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260801.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260801.1
+      '@cloudflare/workerd-linux-64': 1.20260801.1
+      '@cloudflare/workerd-linux-arm64': 1.20260801.1
+      '@cloudflare/workerd-windows-64': 1.20260801.1
+
+  wrangler@4.120.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260801.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 5.20260801.1-alpha
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260801.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrappy@1.0.2: {}
 
   ws@8.20.0: {}
+
+  ws@8.21.0: {}
 
   xtend@4.0.2: {}
 
@@ -10625,6 +11195,19 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   yoctocolors@2.1.2: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.23
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   yuku-ast@0.7.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ catalog:
   tsdown: 0.22.14
   vite-plus: 0.2.8
   vitest: 4.1.10
+  wrangler: 4.120.0
 
 overrides:
   rolldown: "catalog:"
@@ -34,6 +35,7 @@ allowBuilds:
   esbuild@0.27.7: true
   esbuild@0.28.1: true
   "@nestjs/core@11.1.9": false
+  workerd@1.20260801.1: true
 
 verifyDepsBeforeRun: install
 minimumReleaseAgeExclude:
@@ -57,3 +59,5 @@ minimumReleaseAgeExclude:
   - vite
   - vite-plus
   - vitest
+  - miniflare@5.20260801.1-alpha
+  - wrangler@4.120.0

--- a/wasm/emscripten/package.json
+++ b/wasm/emscripten/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "oxc-emscripten-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node test.mjs"
+  },
+  "devDependencies": {
+    "wrangler": "catalog:"
+  }
+}

--- a/wasm/emscripten/test.mjs
+++ b/wasm/emscripten/test.mjs
@@ -1,0 +1,239 @@
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+import { getConfig } from "../../.github/scripts/napi-emscripten/config.mjs";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "../..");
+const packageDirectory = path.resolve(process.argv[2] ?? "");
+const packageManifestPath = path.join(packageDirectory, "package.json");
+if (!process.argv[2] || !fs.existsSync(packageManifestPath)) {
+  throw new Error("Usage: pnpm test <path-to-napi-package>");
+}
+
+const packageManifest = JSON.parse(fs.readFileSync(packageManifestPath, "utf8"));
+const config = getConfig(packageManifest.name);
+const packageRequire = createRequire(packageManifestPath);
+const testRequire = createRequire(import.meta.url);
+const wranglerManifestPath = testRequire.resolve("wrangler/package.json");
+const wranglerManifest = JSON.parse(fs.readFileSync(wranglerManifestPath, "utf8"));
+const wranglerBin = path.resolve(
+  path.dirname(wranglerManifestPath),
+  typeof wranglerManifest.bin === "string" ? wranglerManifest.bin : wranglerManifest.bin.wrangler,
+);
+const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "oxc-emscripten-"));
+const copiedPackage = path.join(temporaryDirectory, "root-package");
+const releaseDirectory = path.join(temporaryDirectory, "release-dir");
+const nodeModules = path.join(temporaryDirectory, "node_modules");
+const port = 19_000 + Math.floor(Math.random() * 1_000);
+
+function symlinkPackage(packageName, source) {
+  const destination = path.join(nodeModules, ...packageName.split("/"));
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.symlinkSync(source, destination, "dir");
+}
+
+function workerSource(packageName) {
+  switch (packageName) {
+    case "oxc-parser":
+      return `import { parse, parseSync } from "oxc-parser";
+export default {
+  async fetch() {
+    const syncResult = parseSync("test.ts", "const value: number = 1", {});
+    const asyncResult = await parse("test.ts", "const value: number = 1", {});
+    return new Response(
+      syncResult.program.type === "Program" && asyncResult.program.type === "Program"
+        ? "ok"
+        : "invalid",
+    );
+  },
+};
+`;
+    case "oxc-minify":
+      return `import { minify, minifySync } from "oxc-minify";
+export default {
+  async fetch() {
+    const syncResult = minifySync("test.js", "const value = 1 + 2", {});
+    const asyncResult = await minify("test.js", "const value = 1 + 2", {});
+    return new Response(syncResult.code === asyncResult.code ? syncResult.code : "invalid");
+  },
+};
+`;
+    case "oxc-transform":
+      return `import { transform, transformSync } from "oxc-transform";
+export default {
+  async fetch() {
+    const syncResult = transformSync("test.ts", "const value: number = 1", {});
+    const asyncResult = await transform("test.ts", "const value: number = 1", {});
+    return new Response(syncResult.code === asyncResult.code ? syncResult.code : "invalid");
+  },
+};
+`;
+    case "oxc-transform-react":
+      return `import { transform, transformSync } from "oxc-transform-react";
+export default {
+  async fetch() {
+    const syncResult = transformSync(
+      "test.jsx",
+      "export function Component() { return <div /> }",
+      { lang: "jsx", reactCompiler: false },
+    );
+    const asyncResult = await transform(
+      "test.jsx",
+      "export function Component() { return <div /> }",
+      { lang: "jsx", reactCompiler: false },
+    );
+    return new Response(syncResult.code === asyncResult.code ? syncResult.code : "invalid");
+  },
+};
+`;
+    default:
+      throw new Error(`Missing worker fixture for ${packageName}`);
+  }
+}
+
+function validateResponse(packageName, response) {
+  switch (packageName) {
+    case "oxc-parser":
+      return response === "ok";
+    case "oxc-minify":
+      return response === "const value=3;";
+    case "oxc-transform":
+      return response.includes("const value = 1");
+    case "oxc-transform-react":
+      return response.includes("jsx");
+    default:
+      return false;
+  }
+}
+
+function waitForExit(child, timeout) {
+  if (child.exitCode !== null) return Promise.resolve();
+  return Promise.race([
+    new Promise((resolve) => child.once("exit", resolve)),
+    new Promise((resolve) => setTimeout(resolve, timeout)),
+  ]);
+}
+
+let wrangler;
+try {
+  fs.cpSync(packageDirectory, copiedPackage, {
+    recursive: true,
+    filter(source) {
+      return !["node_modules", "npm-dir"].includes(path.basename(source));
+    },
+  });
+  fs.symlinkSync(
+    path.join(packageDirectory, "node_modules"),
+    path.join(copiedPackage, "node_modules"),
+  );
+  fs.mkdirSync(releaseDirectory, { recursive: true });
+
+  const prepareResult = spawnSync(
+    process.execPath,
+    [
+      path.join(repositoryRoot, ".github/scripts/napi-emscripten/prepare-package.mjs"),
+      "--package-dir",
+      copiedPackage,
+      "--artifacts-dir",
+      path.join(repositoryRoot, "target/emscripten"),
+      "--npm-dir",
+      releaseDirectory,
+    ],
+    { cwd: repositoryRoot, encoding: "utf8" },
+  );
+  if (prepareResult.status !== 0) {
+    throw new Error(prepareResult.stderr || prepareResult.stdout || "Package preparation failed");
+  }
+
+  const companionDirectory = path.join(releaseDirectory, "wasm32-emscripten");
+  const preparedRootManifest = JSON.parse(
+    fs.readFileSync(path.join(copiedPackage, "package.json"), "utf8"),
+  );
+  const companionManifest = JSON.parse(
+    fs.readFileSync(path.join(companionDirectory, "package.json"), "utf8"),
+  );
+  if (
+    companionManifest.name !== config.bindingPackage ||
+    companionManifest.version !== packageManifest.version ||
+    preparedRootManifest.optionalDependencies[config.bindingPackage] !== packageManifest.version
+  ) {
+    throw new Error("Invalid Emscripten release package metadata");
+  }
+
+  fs.rmSync(path.join(copiedPackage, "node_modules"));
+  fs.mkdirSync(nodeModules, { recursive: true });
+  symlinkPackage(packageManifest.name, copiedPackage);
+  symlinkPackage(config.bindingPackage, companionDirectory);
+  for (const dependency of ["@emnapi/core", "@emnapi/runtime"]) {
+    symlinkPackage(dependency, path.dirname(packageRequire.resolve(`${dependency}/package.json`)));
+  }
+
+  fs.writeFileSync(path.join(temporaryDirectory, "worker.mjs"), workerSource(packageManifest.name));
+  fs.writeFileSync(
+    path.join(temporaryDirectory, "wrangler.json"),
+    `${JSON.stringify(
+      {
+        name: `oxc-${config.directory}-emscripten-test`,
+        main: "worker.mjs",
+        // NAPI object finalizers require WeakRef and FinalizationRegistry in workerd.
+        compatibility_date: "2025-05-05",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  wrangler = spawn(
+    process.execPath,
+    [wranglerBin, "dev", "--config", "wrangler.json", "--port", String(port), "--ip", "127.0.0.1"],
+    {
+      cwd: temporaryDirectory,
+      env: { ...process.env, NO_COLOR: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let logs = "";
+  wrangler.stdout.on("data", (chunk) => {
+    logs += chunk;
+  });
+  wrangler.stderr.on("data", (chunk) => {
+    logs += chunk;
+  });
+
+  async function validateWorker(attempt = 0) {
+    if (wrangler.exitCode !== null) {
+      throw new Error(`Wrangler exited with code ${wrangler.exitCode}:\n${logs}`);
+    }
+    if (attempt === 100) {
+      throw new Error(`Wrangler did not become ready:\n${logs}`);
+    }
+
+    let response;
+    try {
+      response = await fetch(`http://127.0.0.1:${port}`);
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return validateWorker(attempt + 1);
+    }
+
+    const body = await response.text();
+    if (!response.ok || !validateResponse(packageManifest.name, body)) {
+      throw new Error(`Unexpected response ${response.status}: ${body}\n${logs}`);
+    }
+    process.stdout.write(`Validated ${packageManifest.name} in workerd\n`);
+  }
+
+  await validateWorker();
+} finally {
+  if (wrangler?.exitCode === null) {
+    wrangler.kill("SIGTERM");
+    await waitForExit(wrangler, 5_000);
+    if (wrangler.exitCode === null) wrangler.kill("SIGKILL");
+  }
+  fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+}


### PR DESCRIPTION
Adds single-threaded Emscripten bindings and workerd conditional exports for the published NAPI packages.

Users can keep importing the root packages in Cloudflare Workers. Companion packages are published as optional dependencies.

Validation: just ready, Emscripten smoke checks, and Wrangler/workerd integration checks.

AI assistance: Codex was used to implement this change.