### PR TITLE
feat(lsp): send tool client messages to lsp client

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -21,7 +21,7 @@ use tower_lsp_server::{
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    ConcurrentHashMap, LanguageId,
+    ClientMessage, ConcurrentHashMap, LanguageId,
     capabilities::{Capabilities, DiagnosticMode, server_capabilities},
     file_system::LSPFileSystem,
     options::WorkspaceOption,
@@ -69,6 +69,9 @@ pub struct Backend {
     // A simple in-memory file system to store the content of open files.
     // The client will send the content of in-memory files on `textDocument/didOpen` and `textDocument/didChange`.
     file_system: Arc<LSPFileSystem>,
+    // Messages collected during `initialize` that must be deferred until `initialized`,
+    // because the LSP spec forbids server-to-client communication before the initialize response is sent.
+    pending_initialization_messages: OnceCell<Vec<ClientMessage>>,
 }
 
 impl LanguageServer for Backend {
@@ -146,6 +149,7 @@ impl LanguageServer for Backend {
         // or the client does not support `workspace/configuration` request,
         // start the linter. We do not start the linter when the client support the request,
         // we will init the linter after requesting for the workspace configuration.
+        let mut client_messages = vec![];
         if !capabilities.workspace_configuration || options.is_some() {
             let options = options.unwrap_or_default();
 
@@ -159,11 +163,17 @@ impl LanguageServer for Backend {
                     .unwrap_or_default();
 
                 debug!("starting worker in initialize with options: {option:?}");
-                worker.start_worker(option).await;
+                if let Some(message) = worker.start_worker(option).await {
+                    client_messages.push(message);
+                }
             }
         }
 
         self.worker_manager.start_manager(workers, capabilities.diagnostic_mode.clone()).await;
+
+        if capabilities.show_message && !client_messages.is_empty() {
+            let _ = self.pending_initialization_messages.set(client_messages);
+        }
 
         self.capabilities.set(capabilities).map_err(|err| {
             let message = match err {
@@ -191,6 +201,9 @@ impl LanguageServer for Backend {
     /// See: <https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialized>
     async fn initialized(&self, _params: InitializedParams) {
         debug!("oxc initialized.");
+
+        let mut client_messages =
+            self.pending_initialization_messages.get().cloned().unwrap_or_default();
         let Some(capabilities) = self.capabilities.get() else {
             return;
         };
@@ -222,7 +235,9 @@ impl LanguageServer for Backend {
                 // get the configuration from the response and start the worker
                 let configuration = configurations.get(index).unwrap_or(&serde_json::Value::Null);
                 debug!("starting worker in initialize with options: {configuration:?}");
-                worker.start_worker(configuration.clone()).await;
+                if let Some(message) = worker.start_worker(configuration.clone()).await {
+                    client_messages.push(message);
+                }
 
                 // run diagnostics for all known files in the workspace of the worker.
                 // This is necessary because the worker was not started before.
@@ -267,6 +282,12 @@ impl LanguageServer for Backend {
                 if let Err(err) = self.client.workspace_diagnostic_refresh().await {
                     warn!("sending workspace/diagnostic/refresh failed: {err}");
                 }
+            }
+        }
+
+        if capabilities.show_message {
+            for message in client_messages {
+                self.client.show_message(message.r#type, message.message).await;
             }
         }
 
@@ -326,6 +347,7 @@ impl LanguageServer for Backend {
         let mut new_diagnostics = Vec::new();
         let mut removing_registrations = vec![];
         let mut adding_registrations = vec![];
+        let mut client_messages = vec![];
 
         // when null, request configuration from client; otherwise, parse as per-workspace options or use as global configuration
         let options = if params.settings == Value::Null {
@@ -395,16 +417,19 @@ impl LanguageServer for Backend {
                 continue;
             };
 
-            let (diagnostics, registrations, unregistrations) = worker
+            let result = worker
                 .did_change_configuration(option.options, &mut needs_diagnostics_refresh, fs)
                 .await;
 
-            if let Some(diagnostics) = diagnostics {
+            if let Some(diagnostics) = result.diagnostics {
                 new_diagnostics.extend(diagnostics);
             }
 
-            removing_registrations.extend(unregistrations);
-            adding_registrations.extend(registrations);
+            removing_registrations.extend(result.removed_watchers);
+            adding_registrations.extend(result.new_watchers);
+            if let Some(client_message) = result.client_message {
+                client_messages.push(client_message);
+            }
         }
 
         if diagnostic_mode == DiagnosticMode::Push && !new_diagnostics.is_empty() {
@@ -428,6 +453,12 @@ impl LanguageServer for Backend {
         {
             warn!("sending registerCapability.didChangeWatchedFiles failed: {err}");
         }
+
+        if self.capabilities.get().is_some_and(|capabilities| capabilities.show_message) {
+            for message in client_messages {
+                self.client.show_message(message.r#type, message.message).await;
+            }
+        }
     }
 
     /// This notification is sent when a configuration file of a tool changes (example: `.oxlintrc.json`).
@@ -441,6 +472,7 @@ impl LanguageServer for Backend {
         let mut new_diagnostics = Vec::new();
         let mut removing_registrations = vec![];
         let mut adding_registrations = vec![];
+        let mut client_messages = vec![];
 
         let mut needs_diagnostics_refresh = false;
         let diagnostic_mode =
@@ -457,15 +489,18 @@ impl LanguageServer for Backend {
             // to only restart the internal linter / diagnostics for once.
             // A change can affect multiple workspaces if the file is in a shared location, for example a config file in the home directory.
             for worker in self.worker_manager.read_workspace_workers().await.iter() {
-                let (diagnostics, registrations, unregistrations) = worker
+                let result = worker
                     .did_change_watched_files(file_event, &mut needs_diagnostics_refresh, fs)
                     .await;
 
-                if let Some(diagnostics) = diagnostics {
+                if let Some(diagnostics) = result.diagnostics {
                     new_diagnostics.extend(diagnostics);
                 }
-                removing_registrations.extend(unregistrations);
-                adding_registrations.extend(registrations);
+                removing_registrations.extend(result.removed_watchers);
+                adding_registrations.extend(result.new_watchers);
+                if let Some(client_message) = result.client_message {
+                    client_messages.push(client_message);
+                }
             }
         }
 
@@ -491,6 +526,12 @@ impl LanguageServer for Backend {
                 && let Err(err) = self.client.register_capability(adding_registrations).await
             {
                 warn!("sending registerCapability.didChangeWatchedFiles failed: {err}");
+            }
+        }
+
+        if self.capabilities.get().is_some_and(|capabilities| capabilities.show_message) {
+            for message in client_messages {
+                self.client.show_message(message.r#type, message.message).await;
             }
         }
     }
@@ -520,6 +561,7 @@ impl LanguageServer for Backend {
         // === Phase 2: Shut down removed workers (no lock held) ===
         let mut cleared_diagnostics = vec![];
         let mut removed_registrations = vec![];
+        let mut client_messages = vec![];
         for worker in workers_to_shutdown {
             let (uris, unregistrations) = worker.shutdown().await;
             cleared_diagnostics.extend(uris);
@@ -541,7 +583,12 @@ impl LanguageServer for Backend {
         for (index, folder) in params.event.added.into_iter().enumerate() {
             let worker = self.worker_manager.create_worker(folder.uri, diagnostic_mode.clone());
             let options = configurations.get(index).unwrap_or(&serde_json::Value::Null);
-            worker.start_worker(options.clone()).await;
+
+            if let Some(message) = worker.start_worker(options.clone()).await
+                && capabilities.is_some_and(|cap| cap.show_message)
+            {
+                client_messages.push(message);
+            }
             added_registrations.extend(worker.init_watchers().await);
             new_workers.push(worker);
         }
@@ -565,6 +612,13 @@ impl LanguageServer for Backend {
                 && let Err(err) = self.client.unregister_capability(removed_registrations).await
             {
                 warn!("sending unregisterCapability.didChangeWatchedFiles failed: {err}");
+            }
+        }
+
+        // === Phase 6: Show messages to the client ===
+        if capabilities.is_some_and(|cap| cap.show_message) {
+            for message in client_messages {
+                self.client.show_message(message.r#type, message.message).await;
             }
         }
     }
@@ -942,6 +996,7 @@ impl Backend {
             worker_manager,
             capabilities: OnceCell::new(),
             file_system: Arc::new(LSPFileSystem::default()),
+            pending_initialization_messages: OnceCell::new(),
         }
     }
 

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -22,11 +22,12 @@ use crate::{
 pub struct FakeToolBuilder {
     diagnostic_mode: DiagnosticMode,
     cache_uris: Option<Arc<Mutex<Vec<Uri>>>>,
+    pub build_client_message: Option<ClientMessage>,
 }
 
 impl FakeToolBuilder {
     pub fn new(diagnostic_mode: DiagnosticMode) -> Self {
-        Self { diagnostic_mode, cache_uris: None }
+        Self { diagnostic_mode, cache_uris: None, build_client_message: None }
     }
 
     pub fn with_cache_tracking(self, cache_uris: Arc<Mutex<Vec<Uri>>>) -> Self {
@@ -38,7 +39,7 @@ impl ToolBuilder for FakeToolBuilder {
     fn build(&self, _root_uri: &Uri, _options: serde_json::Value) -> ToolBuildResult {
         ToolBuildResult {
             tool: Box::new(FakeTool { cache_uris: self.cache_uris.clone() }),
-            client_message: None,
+            client_message: self.build_client_message.clone(),
         }
     }
 
@@ -151,6 +152,16 @@ impl Tool for FakeTool {
                 tool: None,
                 watch_patterns: Some(vec!["**/new_watcher.config".to_string()]),
                 client_message: None,
+            };
+        }
+        if changed_uri.as_str().ends_with("misconfiguration.config") {
+            return ToolRestartChanges {
+                tool: None,
+                watch_patterns: None,
+                client_message: Some(ClientMessage {
+                    message: "Fake misconfiguration message".to_string(),
+                    r#type: MessageType::WARNING,
+                }),
             };
         }
 
@@ -398,6 +409,7 @@ struct InitializeRequestOptions {
     dynamic_watchers: bool,
     workspace_edit: bool,
     pull_mode: bool,
+    show_message: bool,
     initialization_options: Option<Value>,
     workspace_folders: Option<Vec<WorkspaceFolder>>,
     root_uri: Option<Uri>,
@@ -427,6 +439,14 @@ fn initialize_request_workspace_folders(options: InitializeRequestOptions) -> Re
                 }),
                 ..Default::default()
             }),
+            window: if options.show_message {
+                Some(WindowClientCapabilities {
+                    show_message: Some(ShowMessageRequestClientCapabilities::default()),
+                    ..Default::default()
+                })
+            } else {
+                None
+            },
             ..Default::default()
         },
         initialization_options: options.initialization_options,
@@ -625,13 +645,13 @@ mod test_suite {
     use tower_lsp_server::{
         jsonrpc::{Error, ErrorCode, Id, Response},
         ls_types::{
-            ApplyWorkspaceEditResponse, InitializeResult, PublishDiagnosticsParams, ServerInfo,
-            WorkspaceEdit, WorkspaceFolder,
+            ApplyWorkspaceEditResponse, InitializeResult, MessageType, PublishDiagnosticsParams,
+            ServerInfo, WorkspaceEdit, WorkspaceFolder,
         },
     };
 
     use crate::{
-        DiagnosticMode,
+        ClientMessage, DiagnosticMode,
         backend::Backend,
         tests::{
             FAKE_COMMAND, FakeToolBuilder, InitializeRequestOptions, TestServer, WORKSPACE,
@@ -647,6 +667,39 @@ mod test_suite {
 
     fn server_info() -> ServerInfo {
         ServerInfo { name: "oxc".to_owned(), version: Some("1.0.0".to_owned()) }
+    }
+
+    #[tokio::test]
+    async fn test_client_message_deferred_until_initialized() {
+        let builder = FakeToolBuilder {
+            build_client_message: Some(ClientMessage {
+                message: "Fake misconfiguration message".to_string(),
+                r#type: MessageType::WARNING,
+            }),
+            ..Default::default()
+        };
+        let mut server = TestServer::new(|client| {
+            Backend::new(client, server_info(), create_workspace_manager_with_builder(builder))
+        });
+
+        // initialize: worker starts here (no workspace_configuration), message must NOT be sent yet
+        server
+            .send_request(initialize_request(InitializeRequestOptions {
+                show_message: true,
+                ..Default::default()
+            }))
+            .await;
+        let initialize_result = server.recv_response().await;
+        assert!(initialize_result.is_ok());
+
+        // initialized: message must be sent now
+        server.send_request(initialized_notification()).await;
+        let show_message = server.recv_notification().await;
+        assert_eq!(show_message.method(), "window/showMessage");
+        let params = show_message.params().unwrap();
+        assert_eq!(params["message"], "Fake misconfiguration message");
+
+        server.shutdown(2).await;
     }
 
     #[tokio::test]
@@ -1054,6 +1107,52 @@ mod test_suite {
 
         // No direct response expected for notifications, client does not support workspace configuration or watchers
         server.shutdown(3).await;
+    }
+
+    #[tokio::test]
+    async fn test_workspace_added_shows_client_message() {
+        // workspace/didChangeWorkspaceFolders notification
+        let folders_changed_notification = workspace_folders_changed(
+            vec![WorkspaceFolder {
+                uri: "file:///path/to/new_folder".parse().unwrap(),
+                name: "new_folder".to_string(),
+            }],
+            vec![],
+        );
+
+        let builder = FakeToolBuilder {
+            build_client_message: Some(ClientMessage {
+                message: "Fake misconfiguration message".to_string(),
+                r#type: MessageType::WARNING,
+            }),
+            ..Default::default()
+        };
+
+        let mut server = TestServer::new_initialized(
+            |client| {
+                Backend::new(client, server_info(), create_workspace_manager_with_builder(builder))
+            },
+            initialize_request(InitializeRequestOptions {
+                show_message: true,
+                ..Default::default()
+            }),
+        )
+        .await;
+
+        // Initial worker startup message is sent on initialized; consume it first.
+        let show_message = server.recv_notification().await;
+        assert_eq!(show_message.method(), "window/showMessage");
+
+        server.send_request(folders_changed_notification).await;
+
+        // Adding a workspace starts a new worker and should surface its client message.
+        let show_message = server.recv_notification().await;
+        assert_eq!(show_message.method(), "window/showMessage");
+        let params = show_message.params().unwrap();
+        assert_eq!(params["message"], "Fake misconfiguration message");
+        assert_eq!(params["type"], json!(MessageType::WARNING));
+
+        server.shutdown(4).await;
     }
 
     #[tokio::test]

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -139,6 +139,7 @@ pub trait Tool: Send + Sync {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClientMessage {
     /// The message to be sent to the client.
     pub message: String,

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -20,6 +20,17 @@ use crate::{
     tool::{ClientMessage, DiagnosticResult, Tool, ToolBuilder},
 };
 
+pub struct WorkerToolChangeResult {
+    /// Diagnostic reports that need to be revalidated
+    pub diagnostics: Option<Vec<(Uri, Vec<Diagnostic>)>>,
+    /// New watchers that need to be registered
+    pub new_watchers: Vec<Registration>,
+    /// Watchers that need to be unregistered
+    pub removed_watchers: Vec<Unregistration>,
+    /// Optional message to be sent to the client, e.g., for misconfiguration
+    pub client_message: Option<ClientMessage>,
+}
+
 /// A worker that manages the individual tool for a specific workspace
 /// and returns back the results of the running tool.
 ///
@@ -244,14 +255,7 @@ impl WorkspaceWorker {
         file_event: &FileEvent,
         needs_diagnostic_refresh: &mut bool,
         file_system: Option<&LSPFileSystem>,
-    ) -> (
-        // Diagnostic reports that need to be revalidated
-        Option<Vec<(Uri, Vec<Diagnostic>)>>,
-        // New watchers that need to be registered
-        Vec<Registration>,
-        // Watchers that need to be unregistered
-        Vec<Unregistration>,
-    ) {
+    ) -> WorkerToolChangeResult {
         // Scope the first lock so it is dropped before the second lock
         let options = {
             let options_guard = self.options.lock().await;
@@ -273,14 +277,7 @@ impl WorkspaceWorker {
         changed_options_json: serde_json::Value,
         needs_diagnostic_refresh: &mut bool,
         file_system: Option<&LSPFileSystem>,
-    ) -> (
-        // Diagnostic reports that need to be revalidated
-        Option<Vec<(Uri, Vec<Diagnostic>)>>,
-        // New watchers that need to be registered
-        Vec<Registration>,
-        // Watchers that need to be unregistered
-        Vec<Unregistration>,
-    ) {
+    ) -> WorkerToolChangeResult {
         // Scope the first lock so it is dropped before the second lock
         let old_options = {
             let options_guard = self.options.lock().await;
@@ -320,7 +317,7 @@ impl WorkspaceWorker {
         file_system: Option<&LSPFileSystem>,
         needs_diagnostic_refresh: &mut bool,
         change_handler: F,
-    ) -> (Option<Vec<(Uri, Vec<Diagnostic>)>>, Vec<Registration>, Vec<Unregistration>)
+    ) -> WorkerToolChangeResult
     where
         F: FnOnce(&mut Box<dyn Tool>, &dyn ToolBuilder) -> ToolRestartChanges,
     {
@@ -331,7 +328,12 @@ impl WorkspaceWorker {
         let mut tools = self.tool.write().await;
         let Some(tool) = tools.as_mut() else {
             // No tool to update, return early
-            return (None, registrations, unregistrations);
+            return WorkerToolChangeResult {
+                diagnostics: None,
+                new_watchers: registrations,
+                removed_watchers: unregistrations,
+                client_message: None, // TODO: Should we return a message to the client if the tool is not initialized?
+            };
         };
         let change = change_handler(tool, self.builder.as_ref());
 
@@ -346,7 +348,12 @@ impl WorkspaceWorker {
             *needs_diagnostic_refresh = true;
 
             let Some(file_system) = file_system else {
-                return (None, registrations, unregistrations);
+                return WorkerToolChangeResult {
+                    diagnostics: None,
+                    new_watchers: registrations,
+                    removed_watchers: unregistrations,
+                    client_message: change.client_message,
+                };
             };
 
             for uri in file_system.keys() {
@@ -366,7 +373,12 @@ impl WorkspaceWorker {
             }
         }
 
-        (diagnostics, registrations, unregistrations)
+        WorkerToolChangeResult {
+            diagnostics,
+            new_watchers: registrations,
+            removed_watchers: unregistrations,
+            client_message: change.client_message,
+        }
     }
 
     /// Execute a command for the workspace.
@@ -428,14 +440,17 @@ mod tests {
     use std::sync::Arc;
     use tower_lsp_server::{
         jsonrpc::ErrorCode,
-        ls_types::{CodeActionContext, CodeActionOrCommand, FileChangeType, FileEvent, Range, Uri},
+        ls_types::{
+            CodeActionContext, CodeActionOrCommand, FileChangeType, FileEvent, MessageType, Range,
+            Uri,
+        },
     };
 
     #[cfg(unix)]
     use tower_lsp_server::ls_types::{DidChangeWatchedFilesRegistrationOptions, GlobPattern};
 
     use crate::{
-        CodeActionParams, LanguageId, TextDocument, ToolBuilder,
+        ClientMessage, CodeActionParams, LanguageId, TextDocument, ToolBuilder,
         capabilities::DiagnosticMode,
         file_system::LSPFileSystem,
         tests::{FAKE_COMMAND, FakeToolBuilder},
@@ -555,7 +570,7 @@ mod tests {
         );
         let mut needs_diagnostic_refresh = false;
 
-        let (diagnostics, registrations, unregistrations) = worker
+        let result = worker
             .did_change_watched_files(
                 &FileEvent {
                     uri: Uri::from_str("file:///root/unknown.file").unwrap(),
@@ -567,12 +582,12 @@ mod tests {
             .await;
 
         // Since FakeToolBuilder does not know about "unknown.file", no diagnostics or registrations are expected
-        assert!(diagnostics.is_none());
-        assert_eq!(registrations.len(), 0); // No new registrations expected
-        assert_eq!(unregistrations.len(), 0); // No unregistrations expected
+        assert!(result.diagnostics.is_none());
+        assert_eq!(result.new_watchers.len(), 0); // No new registrations expected
+        assert_eq!(result.removed_watchers.len(), 0); // No unregistrations expected
         assert!(!needs_diagnostic_refresh); // No need to refresh diagnostics
 
-        let (diagnostics, registrations, unregistrations) = worker
+        let result = worker
             .did_change_watched_files(
                 &FileEvent {
                     uri: Uri::from_str("file:///root/watcher.config").unwrap(),
@@ -584,14 +599,14 @@ mod tests {
             .await;
 
         // Since FakeToolBuilder knows about "watcher.config", registrations are expected
-        assert!(diagnostics.is_none());
-        assert_eq!(unregistrations.len(), 1); // One unregistration expected
-        assert_eq!(unregistrations[0].id, "watcher-file:///root/");
-        assert_eq!(registrations.len(), 1); // One new registration expected
-        assert_eq!(registrations[0].id, "watcher-file:///root/");
+        assert!(result.diagnostics.is_none());
+        assert_eq!(result.removed_watchers.len(), 1); // One unregistration expected
+        assert_eq!(result.removed_watchers[0].id, "watcher-file:///root/");
+        assert_eq!(result.new_watchers.len(), 1); // One new registration expected
+        assert_eq!(result.new_watchers[0].id, "watcher-file:///root/");
         assert!(!needs_diagnostic_refresh); // No need to refresh diagnostics
 
-        let (diagnostics, registrations, unregistrations) = worker
+        let result = worker
             .did_change_watched_files(
                 &FileEvent {
                     uri: Uri::from_str("file:///root/tool.config").unwrap(),
@@ -603,14 +618,14 @@ mod tests {
             .await;
 
         // Because we passed a file system that knows about "diagnostics.config", diagnostics are expected
-        assert!(diagnostics.is_some());
-        assert_eq!(diagnostics.unwrap().len(), 1); // One diagnostic report expected
-        assert_eq!(registrations.len(), 0); // No new registrations expected
-        assert_eq!(unregistrations.len(), 0); // No unregistrations expected
+        assert!(result.diagnostics.is_some());
+        assert_eq!(result.diagnostics.unwrap().len(), 1); // One diagnostic report expected
+        assert_eq!(result.new_watchers.len(), 0); // No new registrations expected
+        assert_eq!(result.removed_watchers.len(), 0); // No unregistrations expected
         assert!(needs_diagnostic_refresh); // Need to refresh diagnostics
 
         needs_diagnostic_refresh = false;
-        let (diagnostics, registrations, unregistrations) = worker
+        let result = worker
             .did_change_watched_files(
                 &FileEvent {
                     uri: Uri::from_str("file:///root/tool.config").unwrap(),
@@ -622,9 +637,9 @@ mod tests {
             .await;
 
         // No file system passed, so no diagnostics expected
-        assert!(diagnostics.is_none());
-        assert_eq!(registrations.len(), 0); // No new registrations expected
-        assert_eq!(unregistrations.len(), 0); // No unregistrations expected
+        assert!(result.diagnostics.is_none());
+        assert_eq!(result.new_watchers.len(), 0); // No new registrations expected
+        assert_eq!(result.removed_watchers.len(), 0); // No unregistrations expected
         assert!(needs_diagnostic_refresh); // Need to refresh diagnostics
     }
 
@@ -644,7 +659,7 @@ mod tests {
         );
         let mut needs_diagnostic_refresh = false;
 
-        let (diagnostics, registrations, unregistrations) = worker
+        let result = worker
             .did_change_configuration(
                 serde_json::json!({"some_option": false}),
                 &mut needs_diagnostic_refresh,
@@ -653,12 +668,12 @@ mod tests {
             .await;
 
         // Since FakeToolBuilder does not change anything based on configuration, no diagnostics or registrations are expected
-        assert!(diagnostics.is_none());
-        assert_eq!(registrations.len(), 0); // No new registrations expected
-        assert_eq!(unregistrations.len(), 0); // No unregistrations expected
+        assert!(result.diagnostics.is_none());
+        assert_eq!(result.new_watchers.len(), 0); // No new registrations expected
+        assert_eq!(result.removed_watchers.len(), 0); // No unregistrations expected
         assert!(!needs_diagnostic_refresh); // No need to refresh diagnostics
 
-        let (diagnostics, registrations, unregistrations) = worker
+        let result = worker
             .did_change_configuration(
                 serde_json::json!(2),
                 &mut needs_diagnostic_refresh,
@@ -667,14 +682,14 @@ mod tests {
             .await;
 
         // Since FakeToolBuilder changes watcher patterns based on configuration, registrations are expected
-        assert!(diagnostics.is_none());
-        assert_eq!(unregistrations.len(), 1); // One unregistration expected
-        assert_eq!(unregistrations[0].id, "watcher-file:///root/");
-        assert_eq!(registrations.len(), 1); // One new registration expected
-        assert_eq!(registrations[0].id, "watcher-file:///root/");
+        assert!(result.diagnostics.is_none());
+        assert_eq!(result.removed_watchers.len(), 1); // One unregistration expected
+        assert_eq!(result.removed_watchers[0].id, "watcher-file:///root/");
+        assert_eq!(result.new_watchers.len(), 1); // One new registration expected
+        assert_eq!(result.new_watchers[0].id, "watcher-file:///root/");
         assert!(!needs_diagnostic_refresh); // No need to refresh diagnostics
 
-        let (diagnostics, registrations, unregistrations) = worker
+        let result = worker
             .did_change_configuration(
                 serde_json::json!(3),
                 &mut needs_diagnostic_refresh,
@@ -683,11 +698,72 @@ mod tests {
             .await;
 
         // Since FakeToolBuilder changes diagnostics based on configuration, diagnostics are expected
-        assert!(diagnostics.is_some());
-        assert_eq!(diagnostics.unwrap().len(), 1); // One diagnostic report expected
-        assert_eq!(registrations.len(), 0); // No new registrations expected
-        assert_eq!(unregistrations.len(), 0); // No unregistrations expected
+        assert!(result.diagnostics.is_some());
+        assert_eq!(result.diagnostics.unwrap().len(), 1); // One diagnostic report expected
+        assert_eq!(result.new_watchers.len(), 0); // No new registrations expected
+        assert_eq!(result.removed_watchers.len(), 0); // No unregistrations expected
         assert!(needs_diagnostic_refresh); // Need to refresh diagnostics
+    }
+
+    #[tokio::test]
+    async fn test_client_message_on_configuration_change() {
+        let worker = WorkspaceWorker::new(
+            Uri::from_str("file:///root/").unwrap(),
+            create_builder(),
+            DiagnosticMode::None,
+        );
+        worker.start_worker(serde_json::Value::Null).await;
+
+        let mut needs_diagnostic_refresh = false;
+        let result = worker
+            .did_change_configuration(serde_json::json!(4), &mut needs_diagnostic_refresh, None)
+            .await;
+
+        assert!(result.diagnostics.is_none());
+        assert_eq!(result.new_watchers.len(), 0);
+        assert_eq!(result.removed_watchers.len(), 0);
+        assert!(!needs_diagnostic_refresh);
+        assert_eq!(
+            result.client_message,
+            Some(ClientMessage {
+                message: "Fake misconfiguration message".to_string(),
+                r#type: MessageType::WARNING,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_client_message_on_watched_file_change() {
+        let worker = WorkspaceWorker::new(
+            Uri::from_str("file:///root/").unwrap(),
+            create_builder(),
+            DiagnosticMode::None,
+        );
+        worker.start_worker(serde_json::Value::Null).await;
+
+        let mut needs_diagnostic_refresh = false;
+        let result = worker
+            .did_change_watched_files(
+                &FileEvent {
+                    uri: Uri::from_str("file:///root/misconfiguration.config").unwrap(),
+                    typ: FileChangeType::CHANGED,
+                },
+                &mut needs_diagnostic_refresh,
+                None,
+            )
+            .await;
+
+        assert!(result.diagnostics.is_none());
+        assert_eq!(result.new_watchers.len(), 0);
+        assert_eq!(result.removed_watchers.len(), 0);
+        assert!(!needs_diagnostic_refresh);
+        assert_eq!(
+            result.client_message,
+            Some(ClientMessage {
+                message: "Fake misconfiguration message".to_string(),
+                r#type: MessageType::WARNING,
+            })
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
The newly created `ClientMessage` will now be passed into `Backend` and sent to the client.
There is atm no real implementation in `oxlint` & `oxfmt`, but the LSP integration is done (expect dynamic worker creation, see #25407).