### PR TITLE
fix(lsp): remove capability check for `window/showMessage` notification

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -171,7 +171,7 @@ impl LanguageServer for Backend {
 
         self.worker_manager.start_manager(workers, capabilities.diagnostic_mode.clone()).await;
 
-        if capabilities.show_message && !client_messages.is_empty() {
+        if !client_messages.is_empty() {
             let _ = self.pending_initialization_messages.set(client_messages);
         }
 
@@ -259,9 +259,7 @@ impl LanguageServer for Backend {
                                 "running diagnostics for {} failed: {err}",
                                 document.uri.as_str()
                             );
-                            if self.capabilities.get().is_some_and(|cap| cap.show_message) {
-                                self.client.show_message(MessageType::ERROR, err).await;
-                            }
+                            self.client.show_message(MessageType::ERROR, err).await;
                         }
                         Ok(diagnostics) => new_diagnostics.extend(diagnostics),
                     }
@@ -285,10 +283,8 @@ impl LanguageServer for Backend {
             }
         }
 
-        if capabilities.show_message {
-            for message in client_messages {
-                self.client.show_message(message.r#type, message.message).await;
-            }
+        for message in client_messages {
+            self.client.show_message(message.r#type, message.message).await;
         }
 
         let mut registrations = vec![];
@@ -454,10 +450,8 @@ impl LanguageServer for Backend {
             warn!("sending registerCapability.didChangeWatchedFiles failed: {err}");
         }
 
-        if self.capabilities.get().is_some_and(|capabilities| capabilities.show_message) {
-            for message in client_messages {
-                self.client.show_message(message.r#type, message.message).await;
-            }
+        for message in client_messages {
+            self.client.show_message(message.r#type, message.message).await;
         }
     }
 
@@ -529,10 +523,8 @@ impl LanguageServer for Backend {
             }
         }
 
-        if self.capabilities.get().is_some_and(|capabilities| capabilities.show_message) {
-            for message in client_messages {
-                self.client.show_message(message.r#type, message.message).await;
-            }
+        for message in client_messages {
+            self.client.show_message(message.r#type, message.message).await;
         }
     }
 
@@ -584,9 +576,7 @@ impl LanguageServer for Backend {
             let worker = self.worker_manager.create_worker(folder.uri, diagnostic_mode.clone());
             let options = configurations.get(index).unwrap_or(&serde_json::Value::Null);
 
-            if let Some(message) = worker.start_worker(options.clone()).await
-                && capabilities.is_some_and(|cap| cap.show_message)
-            {
+            if let Some(message) = worker.start_worker(options.clone()).await {
                 client_messages.push(message);
             }
             added_registrations.extend(worker.init_watchers().await);
@@ -616,10 +606,8 @@ impl LanguageServer for Backend {
         }
 
         // === Phase 6: Show messages to the client ===
-        if capabilities.is_some_and(|cap| cap.show_message) {
-            for message in client_messages {
-                self.client.show_message(message.r#type, message.message).await;
-            }
+        for message in client_messages {
+            self.client.show_message(message.r#type, message.message).await;
         }
     }
 
@@ -642,9 +630,7 @@ impl LanguageServer for Backend {
             match worker.run_diagnostic_on_save(&document).await {
                 Err(err) => {
                     error!("running diagnostics for {} failed: {err}", uri.as_str());
-                    if self.capabilities.get().is_some_and(|cap| cap.show_message) {
-                        self.client.show_message(MessageType::ERROR, err).await;
-                    }
+                    self.client.show_message(MessageType::ERROR, err).await;
                 }
                 Ok(diagnostics) => {
                     if !diagnostics.is_empty() {
@@ -686,9 +672,7 @@ impl LanguageServer for Backend {
             match worker.run_diagnostic_on_change(&document).await {
                 Err(err) => {
                     error!("running diagnostics for {} failed: {err}", uri.as_str());
-                    if self.capabilities.get().is_some_and(|cap| cap.show_message) {
-                        self.client.show_message(MessageType::ERROR, err).await;
-                    }
+                    self.client.show_message(MessageType::ERROR, err).await;
                 }
                 Ok(diagnostics) => {
                     if !diagnostics.is_empty() {
@@ -746,9 +730,7 @@ impl LanguageServer for Backend {
             match worker.run_diagnostic(&document).await {
                 Err(err) => {
                     error!("running diagnostics for {} failed: {err}", uri.as_str());
-                    if self.capabilities.get().is_some_and(|cap| cap.show_message) {
-                        self.client.show_message(MessageType::ERROR, err).await;
-                    }
+                    self.client.show_message(MessageType::ERROR, err).await;
                 }
                 Ok(diagnostics) => {
                     if !diagnostics.is_empty() {

--- a/crates/oxc_language_server/src/capabilities.rs
+++ b/crates/oxc_language_server/src/capabilities.rs
@@ -17,7 +17,6 @@ pub struct Capabilities {
     pub workspace_apply_edit: bool,
     pub workspace_configuration: bool,
     pub dynamic_watchers: bool,
-    pub show_message: bool,
     /// The diagnostic mode the server should use, should be overridden by the tool implementation.
     /// Defaults to `None`.
     pub diagnostic_mode: DiagnosticMode,
@@ -42,10 +41,6 @@ impl From<ClientCapabilities> for Capabilities {
                 watched_files.dynamic_registration.is_some_and(|dynamic| dynamic)
             })
         });
-
-        let show_message =
-            value.window.as_ref().is_some_and(|window| window.show_message.is_some());
-
         let pull_diagnostics = value
             .text_document
             .as_ref()
@@ -61,7 +56,6 @@ impl From<ClientCapabilities> for Capabilities {
             workspace_apply_edit,
             workspace_configuration,
             dynamic_watchers,
-            show_message,
             pull_diagnostics,
             refresh_diagnostics,
             diagnostic_mode: DiagnosticMode::None,

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -409,7 +409,6 @@ struct InitializeRequestOptions {
     dynamic_watchers: bool,
     workspace_edit: bool,
     pull_mode: bool,
-    show_message: bool,
     initialization_options: Option<Value>,
     workspace_folders: Option<Vec<WorkspaceFolder>>,
     root_uri: Option<Uri>,
@@ -439,14 +438,6 @@ fn initialize_request_workspace_folders(options: InitializeRequestOptions) -> Re
                 }),
                 ..Default::default()
             }),
-            window: if options.show_message {
-                Some(WindowClientCapabilities {
-                    show_message: Some(ShowMessageRequestClientCapabilities::default()),
-                    ..Default::default()
-                })
-            } else {
-                None
-            },
             ..Default::default()
         },
         initialization_options: options.initialization_options,
@@ -683,12 +674,7 @@ mod test_suite {
         });
 
         // initialize: worker starts here (no workspace_configuration), message must NOT be sent yet
-        server
-            .send_request(initialize_request(InitializeRequestOptions {
-                show_message: true,
-                ..Default::default()
-            }))
-            .await;
+        server.send_request(initialize_request(InitializeRequestOptions::default())).await;
         let initialize_result = server.recv_response().await;
         assert!(initialize_result.is_ok());
 
@@ -1132,10 +1118,7 @@ mod test_suite {
             |client| {
                 Backend::new(client, server_info(), create_workspace_manager_with_builder(builder))
             },
-            initialize_request(InitializeRequestOptions {
-                show_message: true,
-                ..Default::default()
-            }),
+            initialize_request(InitializeRequestOptions::default()),
         )
         .await;
 


### PR DESCRIPTION
The `window/showMessage` notification is a baseline feature in LSP and does not need Client capability `window.showMessage`. This capability is only needed for the `window/showMessageRequest` request.

- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessage
- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessageRequest