### PR TITLE
refactor(lsp): show `ClientMessage` on dynamic worker creation

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -169,7 +169,11 @@ impl LanguageServer for Backend {
             }
         }
 
-        self.worker_manager.start_manager(workers, capabilities.diagnostic_mode.clone()).await;
+        if let Some(client_message) =
+            self.worker_manager.start_manager(workers, capabilities.diagnostic_mode.clone()).await
+        {
+            client_messages.push(client_message);
+        }
 
         if !client_messages.is_empty() {
             let _ = self.pending_initialization_messages.set(client_messages);
@@ -702,13 +706,19 @@ impl LanguageServer for Backend {
             let diagnostic_mode =
                 capabilities.map(|c| c.diagnostic_mode.clone()).unwrap_or_default();
             let dynamic_watchers = capabilities.is_some_and(|c| c.dynamic_watchers);
-            if let Some(registrations) = self
+            let (registrations, client_message) = self
                 .worker_manager
                 .ensure_worker_for_file_uri(&uri, diagnostic_mode, dynamic_watchers)
-                .await
+                .await;
+
+            if let Some(registrations) = registrations
                 && let Err(err) = self.client.register_capability(vec![registrations]).await
             {
                 warn!("registering file watchers for single-file workspace failed: {err}");
+            }
+
+            if let Some(client_message) = client_message {
+                self.client.show_message(client_message.r#type, client_message.message).await;
             }
         }
 

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -2026,6 +2026,49 @@ mod test_suite {
         }
 
         #[tokio::test]
+        async fn test_dynamic_workers_show_client_message_in_single_file_mode() {
+            let builder = FakeToolBuilder {
+                build_client_message: Some(ClientMessage {
+                    message: "Fake misconfiguration message".to_string(),
+                    r#type: MessageType::WARNING,
+                }),
+                ..Default::default()
+            };
+
+            let mut server = TestServer::new_initialized(
+                |client| {
+                    Backend::new(
+                        client,
+                        server_info(),
+                        create_workspace_manager_with_builder(builder),
+                    )
+                },
+                initialize_request_workspace_folders(single_file_mode_initialize()),
+            )
+            .await;
+
+            // Opening files from different parent folders creates distinct dynamic workers.
+            let file_a = "file:///path/to/dir_a/file.js";
+            let file_b = "file:///path/to/dir_b/file.js";
+
+            server.send_request(did_open(file_a, "a")).await;
+            let show_message = server.recv_notification().await;
+            assert_eq!(show_message.method(), "window/showMessage");
+            let params = show_message.params().unwrap();
+            assert_eq!(params["message"], "Fake misconfiguration message");
+            assert_eq!(params["type"], json!(MessageType::WARNING));
+
+            server.send_request(did_open(file_b, "b")).await;
+            let show_message = server.recv_notification().await;
+            assert_eq!(show_message.method(), "window/showMessage");
+            let params = show_message.params().unwrap();
+            assert_eq!(params["message"], "Fake misconfiguration message");
+            assert_eq!(params["type"], json!(MessageType::WARNING));
+
+            server.shutdown(4).await;
+        }
+
+        #[tokio::test]
         async fn test_single_file_mode_creates_worker_on_open() {
             let mut server = TestServer::new_initialized(
                 |client| Backend::new(client, server_info(), create_workspace_manager()),
@@ -2225,6 +2268,7 @@ mod test_suite {
         use crate::tests::create_dynamic_workspace_manager;
 
         use super::*;
+
         #[tokio::test]
         async fn test_dynamic_mode_pull_diagnostics() {
             let init_options = InitializeRequestOptions { pull_mode: true, ..Default::default() };

--- a/crates/oxc_language_server/src/worker_manager.rs
+++ b/crates/oxc_language_server/src/worker_manager.rs
@@ -12,7 +12,7 @@ use tower_lsp_server::{
 use tracing::debug;
 
 use crate::{
-    capabilities::DiagnosticMode, file_system::ResolvedPath, tool::ToolBuilder,
+    ClientMessage, capabilities::DiagnosticMode, file_system::ResolvedPath, tool::ToolBuilder,
     worker::WorkspaceWorker,
 };
 
@@ -97,13 +97,18 @@ impl WorkerManager {
 
     // ── Starting / Stopping ───────────────────────────────────────────────────────
 
+    /// Start the manager with the given workers and diagnostic mode.
+    ///
+    /// On dynamic workspaces, this will also start a worker for the root URI `file:///` with the given diagnostic mode.
+    /// It can return an optional [`ClientMessage`] that should be sent to the client.
+    ///
     /// # Panics
     /// If `file:///` cannot be converted to `Uri`, which should never happen.
     pub async fn start_manager(
         &self,
         workers: Vec<WorkspaceWorker>,
         diagnostic_mode: DiagnosticMode,
-    ) {
+    ) -> Option<ClientMessage> {
         *self.workers.write().await = workers;
 
         // for dynamic workspaces we need to start them manually
@@ -118,10 +123,14 @@ impl WorkerManager {
                 Arc::clone(&self.tool_builder),
                 diagnostic_mode,
             );
-            worker.start_worker(serde_json::Value::Null).await;
+            let client_message = worker.start_worker(serde_json::Value::Null).await;
 
             let _ = cell.set(worker);
+
+            return client_message;
         }
+
+        None
     }
 
     /// Shut down all workers and clear the worker list.
@@ -359,26 +368,28 @@ impl WorkerManager {
         uri: &Uri,
         diagnostic_mode: DiagnosticMode,
         dynamic_watchers: bool,
-    ) -> Option<Registration> {
+    ) -> (Option<Registration>, Option<ClientMessage>) {
         // Bail out immediately if we are not in single-file mode.
         if !self.is_single_file_mode() {
-            return None;
+            return (None, None);
         }
 
-        let parent_uri = Self::get_parent_dir_uri(uri)?;
+        let Some(parent_uri) = Self::get_parent_dir_uri(uri) else {
+            return (None, None);
+        };
 
         // Fast path: avoid a write lock when a suitable worker already exists.
         {
             let workers = self.workers.read().await;
             if Self::find_worker_for_uri(&workers, uri).is_some() {
-                return None;
+                return (None, None);
             }
         }
 
         debug!("single file mode: creating workspace worker for {}", parent_uri.as_str());
         let worker =
             WorkspaceWorker::new(parent_uri, Arc::clone(&self.tool_builder), diagnostic_mode);
-        worker.start_worker(Value::Null).await;
+        let client_message = worker.start_worker(Value::Null).await;
         let registration = if dynamic_watchers { worker.init_watchers().await } else { None };
 
         // Acquire the write lock to insert the worker.  Re-check both the mode
@@ -400,10 +411,10 @@ impl WorkerManager {
         // the caller that no new registrations are needed.
         if let Some(discarded) = worker {
             discarded.shutdown().await;
-            return None;
+            return (None, None);
         }
 
-        registration
+        (registration, client_message)
     }
 
     /// In single-file mode, shut down and remove the [`WorkspaceWorker`] whose


### PR DESCRIPTION
> ## Pull request overview
> 
> This PR updates the language server’s dynamic worker startup paths to surface `ClientMessage` warnings/errors to the client when a worker is created/started dynamically, and adds a regression test for single-file mode.
> 