### PR TITLE
fix(linter/unicorn/new-for-builtins): ignore optional chains

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -13,7 +13,10 @@ use crate::{
     AstNode,
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
-    utils::{get_boolean_ancestor, is_boolean_call, is_boolean_node, pad_fix_with_token_boundary},
+    utils::{
+        expression_uses_optional_chain, get_boolean_ancestor, is_boolean_call, is_boolean_node,
+        pad_fix_with_token_boundary,
+    },
 };
 
 fn non_zero(span: Span, prop_name: &str, op_and_rhs: &str, help: Option<String>) -> OxcDiagnostic {
@@ -121,24 +124,6 @@ fn is_compare_right(expr: &BinaryExpression, op: BinaryOperator, value: f64) -> 
             ..
         } if is_literal(right, value) && op == *operator
     )
-}
-
-fn expression_uses_optional_chain(expr: &Expression) -> bool {
-    let expr = expr.get_inner_expression();
-
-    if matches!(expr, Expression::ChainExpression(_)) {
-        return true;
-    }
-
-    if let Some(member_expr) = expr.as_member_expression() {
-        return member_expr.optional() || expression_uses_optional_chain(member_expr.object());
-    }
-
-    if let Expression::CallExpression(call_expr) = expr {
-        return call_expr.optional || expression_uses_optional_chain(&call_expr.callee);
-    }
-
-    false
 }
 
 fn get_length_check_node<'a, 'b>(

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -1,13 +1,13 @@
-use oxc_ast::{
-    AstKind,
-    ast::{CallExpression, Expression},
-};
+use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::BinaryOperator;
 
-use crate::{AstNode, context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule};
+use crate::{
+    AstNode, context::LintContext, globals::GLOBAL_OBJECT_NAMES, rule::Rule,
+    utils::call_uses_optional_chain,
+};
 
 fn enforce(span: Span, fn_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use `new {fn_name}()` instead of `{fn_name}()`")).with_label(span)
@@ -109,28 +109,6 @@ impl Rule for NewForBuiltins {
             _ => {}
         }
     }
-}
-
-fn call_uses_optional_chain(call_expr: &CallExpression) -> bool {
-    call_expr.optional || expression_uses_optional_chain(&call_expr.callee)
-}
-
-fn expression_uses_optional_chain(expr: &Expression) -> bool {
-    let expr = expr.get_inner_expression();
-
-    if matches!(expr, Expression::ChainExpression(_)) {
-        return true;
-    }
-
-    if let Some(member_expr) = expr.as_member_expression() {
-        return member_expr.optional() || expression_uses_optional_chain(member_expr.object());
-    }
-
-    if let Expression::CallExpression(call_expr) = expr {
-        return call_expr.optional || expression_uses_optional_chain(&call_expr.callee);
-    }
-
-    false
 }
 
 fn is_expr_global_builtin<'a, 'b>(

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -1,4 +1,7 @@
-use oxc_ast::{AstKind, ast::Expression};
+use oxc_ast::{
+    AstKind,
+    ast::{CallExpression, Expression},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -73,6 +76,11 @@ impl Rule for NewForBuiltins {
                 }
             }
             AstKind::CallExpression(call_expr) => {
+                // An optional chain can't be rewritten to a `new` expression, which can't be optional.
+                if call_uses_optional_chain(call_expr) {
+                    return;
+                }
+
                 let Some(builtin_name) = is_expr_global_builtin(&call_expr.callee, ctx) else {
                     return;
                 };
@@ -101,6 +109,28 @@ impl Rule for NewForBuiltins {
             _ => {}
         }
     }
+}
+
+fn call_uses_optional_chain(call_expr: &CallExpression) -> bool {
+    call_expr.optional || expression_uses_optional_chain(&call_expr.callee)
+}
+
+fn expression_uses_optional_chain(expr: &Expression) -> bool {
+    let expr = expr.get_inner_expression();
+
+    if matches!(expr, Expression::ChainExpression(_)) {
+        return true;
+    }
+
+    if let Some(member_expr) = expr.as_member_expression() {
+        return member_expr.optional() || expression_uses_optional_chain(member_expr.object());
+    }
+
+    if let Expression::CallExpression(call_expr) = expr {
+        return call_expr.optional || expression_uses_optional_chain(&call_expr.callee);
+    }
+
+    false
 }
 
 fn is_expr_global_builtin<'a, 'b>(

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -201,6 +201,10 @@ fn test() {
     let pass = vec![
         "const foo = new Object()",
         "const foo = new Array()",
+        "const foo = Array?.()",
+        "const foo = Map?.()",
+        "const foo = Date?.()",
+        "const foo = globalThis?.Date()",
         "const foo = new ArrayBuffer()",
         "const foo = new BigInt64Array()",
         "const foo = new BigUint64Array()",

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
@@ -1,8 +1,5 @@
 use cow_utils::CowUtils;
-use oxc_ast::{
-    AstKind,
-    ast::{Argument, CallExpression, Expression},
-};
+use oxc_ast::{AstKind, ast::Argument};
 use oxc_codegen::CodegenOptions;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -14,6 +11,7 @@ use crate::{
     context::LintContext,
     fixer::{RuleFix, RuleFixer},
     rule::Rule,
+    utils::call_uses_optional_chain,
 };
 
 fn set(span: Span) -> OxcDiagnostic {
@@ -239,28 +237,6 @@ fn is_value_not_usable(node: &AstNode, ctx: &LintContext) -> bool {
     if matches!(parent_kind, AstKind::ChainExpression(_)) {
         let grandparent = ctx.nodes().parent_node(parent_node.id());
         return matches!(grandparent.kind(), AstKind::ExpressionStatement(_));
-    }
-
-    false
-}
-
-fn call_uses_optional_chain(call_expr: &CallExpression) -> bool {
-    call_expr.optional || expression_uses_optional_chain(&call_expr.callee)
-}
-
-fn expression_uses_optional_chain(expr: &Expression) -> bool {
-    let expr = expr.get_inner_expression();
-
-    if matches!(expr, Expression::ChainExpression(_)) {
-        return true;
-    }
-
-    if let Some(member_expr) = expr.as_member_expression() {
-        return member_expr.optional() || expression_uses_optional_chain(member_expr.object());
-    }
-
-    if let Expression::CallExpression(call_expr) = expr {
-        return call_expr.optional || expression_uses_optional_chain(&call_expr.callee);
     }
 
     false

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -20,6 +20,9 @@ use crate::LintContext;
 mod boolean;
 pub use boolean::*;
 
+mod optional_chain;
+pub use optional_chain::*;
+
 // Built-in Error constructors
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Error_types
 pub const BUILT_IN_ERRORS: [&str; 10] = [

--- a/crates/oxc_linter/src/utils/unicorn/optional_chain.rs
+++ b/crates/oxc_linter/src/utils/unicorn/optional_chain.rs
@@ -1,0 +1,23 @@
+use oxc_ast::ast::{CallExpression, Expression};
+
+pub fn call_uses_optional_chain(call_expr: &CallExpression) -> bool {
+    call_expr.optional || expression_uses_optional_chain(&call_expr.callee)
+}
+
+pub fn expression_uses_optional_chain(expr: &Expression) -> bool {
+    let expr = expr.get_inner_expression();
+
+    if matches!(expr, Expression::ChainExpression(_)) {
+        return true;
+    }
+
+    if let Some(member_expr) = expr.as_member_expression() {
+        return member_expr.optional() || expression_uses_optional_chain(member_expr.object());
+    }
+
+    if let Expression::CallExpression(call_expr) = expr {
+        return call_expr.optional || expression_uses_optional_chain(&call_expr.callee);
+    }
+
+    false
+}

--- a/discord-question.md
+++ b/discord-question.md
@@ -1,0 +1,9 @@
+I'd like to extract some duplicated logic used in unicorn rules (a recursive check for whether an expression uses optional chaining) into a shared utility.
+Would `utils/unicorn` be the right place for this?
+
+The two rules currently duplicating this logic (GitHub URLs):
+
+- https://github.com/oxc-project/oxc/blob/9e93ba6908243fc6fa2d388c8781c9ef15405fcf/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs#L251
+-
+
+I'm also planning to use this in the `new-for-builtins` rule, so it's currently duplicated in 2 places but will become 3.

--- a/discord-question.md
+++ b/discord-question.md
@@ -1,9 +1,0 @@
-I'd like to extract some duplicated logic used in unicorn rules (a recursive check for whether an expression uses optional chaining) into a shared utility.
-Would `utils/unicorn` be the right place for this?
-
-The two rules currently duplicating this logic (GitHub URLs):
-
-- https://github.com/oxc-project/oxc/blob/9e93ba6908243fc6fa2d388c8781c9ef15405fcf/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs#L251
--
-
-I'm also planning to use this in the `new-for-builtins` rule, so it's currently duplicated in 2 places but will become 3.


### PR DESCRIPTION
## Summary

- ignore optional chains for aligning with the upstream implementation
- add test cases for optional chains

## References

- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/new-for-builtins.js
- https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/test/new-for-builtins.js

