### PR TITLE
refactor(formatter_core,formatter): enforce finalize-once behind the print

### DIFF
--- a/crates/oxc_formatter/src/print/template/mod.rs
+++ b/crates/oxc_formatter/src/print/template/mod.rs
@@ -6,9 +6,7 @@ use std::cmp;
 
 use oxc_allocator::{ArenaStringBuilder, ArenaVec};
 use oxc_ast::ast::*;
-use oxc_formatter_core::{
-    Format, FormatElement, IndentWidth, RemoveSoftLinesBuffer, VecBuffer, printer::Printer,
-};
+use oxc_formatter_core::{Format, FormatElement, IndentWidth, RemoveSoftLinesBuffer, VecBuffer};
 use oxc_span::{GetSpan, Span};
 
 use crate::{
@@ -732,10 +730,9 @@ impl<'a> EachTemplateTable<'a> {
 
             let root = Document::new(vec_buffer.into_vec(), Vec::default());
 
-            // let range = element.range();
             let print_options = f.options().as_print_options();
             // TODO: if `unwrap()` panics here, it's a internal error
-            let printed = Printer::new(print_options, &[]).print(&root).unwrap();
+            let printed = root.print(expr.span().size() as usize, print_options).unwrap();
             let text = f.allocator().alloc_str(&printed.into_code());
             let will_break = text.contains('\n');
 

--- a/crates/oxc_formatter/tests/fixtures/js/template-literals/each-table.js
+++ b/crates/oxc_formatter/tests/fixtures/js/template-literals/each-table.js
@@ -17,3 +17,11 @@ it.each`
     ${[]}
     ${[[]]}
   `("should return undefined when source is $source", ({ source }) => {});
+
+// Cells whose expressions carry `expand_parent` sources (long member chain, call arguments)
+// still measure as single-line columns; the softline removal wins
+it.each`
+  a | expected
+  ${wrapper.instance().methods().filterProp().someOtherLongMethod().value()} | ${1}
+  ${buildSomething(argumentNumberOne, argumentNumberTwo, argumentNumberThree)} | ${2}
+`("returns $expected", ({ a, expected }) => {});

--- a/crates/oxc_formatter/tests/fixtures/js/template-literals/each-table.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/template-literals/each-table.js.snap
@@ -22,6 +22,14 @@ it.each`
     ${[[]]}
   `("should return undefined when source is $source", ({ source }) => {});
 
+// Cells whose expressions carry `expand_parent` sources (long member chain, call arguments)
+// still measure as single-line columns; the softline removal wins
+it.each`
+  a | expected
+  ${wrapper.instance().methods().filterProp().someOtherLongMethod().value()} | ${1}
+  ${buildSomething(argumentNumberOne, argumentNumberTwo, argumentNumberThree)} | ${2}
+`("returns $expected", ({ a, expected }) => {});
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -46,6 +54,14 @@ it.each`
     ${[[]]}
   `("should return undefined when source is $source", ({ source }) => {});
 
+// Cells whose expressions carry `expand_parent` sources (long member chain, call arguments)
+// still measure as single-line columns; the softline removal wins
+it.each`
+  a                                                                            | expected
+  ${wrapper.instance().methods().filterProp().someOtherLongMethod().value()}   | ${1}
+  ${buildSomething(argumentNumberOne, argumentNumberTwo, argumentNumberThree)} | ${2}
+`("returns $expected", ({ a, expected }) => {});
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -68,5 +84,13 @@ it.each`
     ${[]}
     ${[[]]}
   `("should return undefined when source is $source", ({ source }) => {});
+
+// Cells whose expressions carry `expand_parent` sources (long member chain, call arguments)
+// still measure as single-line columns; the softline removal wins
+it.each`
+  a                                                                            | expected
+  ${wrapper.instance().methods().filterProp().someOtherLongMethod().value()}   | ${1}
+  ${buildSomething(argumentNumberOne, argumentNumberTwo, argumentNumberThree)} | ${2}
+`("returns $expected", ({ a, expected }) => {});
 
 ===================== End =====================

--- a/crates/oxc_formatter_core/src/builders.rs
+++ b/crates/oxc_formatter_core/src/builders.rs
@@ -814,7 +814,7 @@ impl<C> Format<'_, C> for ExpandParent {
 ///
 /// NOTE: A conditional tag is NOT an expansion boundary.
 /// An expanding element inside the content (a hard line break above all) expands
-/// the enclosing groups at build time (see [crate::Document::propagate_expand]) even when the branch is never printed.
+/// the enclosing groups at build time (see `Document::propagate_expand`) even when the branch is never printed.
 ///
 /// Prettier's `ifBreak` bodies don't have this problem only because they typically sit inside a `conditionalGroup`,
 /// whose boundary swallows the propagation;

--- a/crates/oxc_formatter_core/src/format_element/document.rs
+++ b/crates/oxc_formatter_core/src/format_element/document.rs
@@ -53,7 +53,7 @@ impl<'a> Document<'a> {
     }
 
     /// Finalizes and prints the document: propagates group expansion once
-    /// ([`Self::propagate_expand`]) and hands the elements to the [`Printer`].
+    /// (`Self::propagate_expand`) and hands the elements to the `Printer`.
     ///
     /// The single home of the finalize-once-then-print sequence:
     /// [`crate::Formatted::print`] and standalone raw-IR consumers
@@ -95,7 +95,7 @@ impl Document<'_> {
     /// [`BestFitting`]'s content expands is not propagated past the [`BestFitting`] element.
     ///
     /// [`BestFitting`]: FormatElement::BestFitting
-    pub fn propagate_expand(&self) {
+    pub(crate) fn propagate_expand(&self) {
         #[derive(Debug)]
         enum Enclosing<'a> {
             Group(&'a tag::Group),

--- a/crates/oxc_formatter_core/src/format_element/mod.rs
+++ b/crates/oxc_formatter_core/src/format_element/mod.rs
@@ -146,7 +146,7 @@ impl LineMode {
     }
 
     /// The line forces enclosing groups to expand at build time.
-    /// See [crate::Document::propagate_expand]:
+    /// See `Document::propagate_expand`:
     /// every always-breaking mode except [Self::HardWithoutExpand].
     pub const fn propagates_expand(self) -> bool {
         self.will_break() && !matches!(self, LineMode::HardWithoutExpand)

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -26,7 +26,7 @@ mod formatter;
 mod group_id;
 mod macros;
 mod options;
-pub mod printer;
+mod printer;
 mod session;
 mod simple_context;
 mod source;
@@ -65,7 +65,10 @@ pub use options::{
     CoreFormatOptions, IndentStyle, IndentWidth, IndentWidthFromIntError, LineEnding, LineWidth,
     LineWidthFromIntError, ParseFormatNumberError,
 };
-pub use printer::{PrintResult, PrintWidth, Printed, Printer, PrinterOptions};
+pub use printer::{PrintResult, PrintWidth, Printed, PrinterOptions};
+// `Printer` stays crate-internal: `Document::print` / `print_with_indent` are the only print entries,
+// which is what makes print-without-finalize unrepresentable outside core.
+pub(crate) use printer::Printer;
 pub use session::{FormatSession, InputKind, SessionServices, StringEmbedder, TailwindSorter};
 pub(crate) use simple_context::SimpleFormatContext;
 pub use source::{SourceText, SpanCursor};

--- a/crates/oxc_formatter_core/src/macros.rs
+++ b/crates/oxc_formatter_core/src/macros.rs
@@ -304,7 +304,7 @@ macro_rules! dbg_write {
 ///
 /// [crate::BestFitting] acts as an expansion boundary:
 /// an expanding element inside a variant never expands the groups enclosing the [crate::BestFitting]
-/// (see [crate::Document::propagate_expand]), it is the ONLY boundary;
+/// (see `Document::propagate_expand`), it is the ONLY boundary;
 /// conditional content tags are transparent to propagation.
 ///
 /// [`Flat`]: crate::format_element::PrintMode::Flat

--- a/crates/oxc_formatter_core/src/printer/mod.rs
+++ b/crates/oxc_formatter_core/src/printer/mod.rs
@@ -1611,9 +1611,7 @@ mod tests {
         crate::format::write(&mut buffer, Arguments::new(&[Argument::new(root)]));
 
         let elements = buffer.into_vec();
-        let document = Document::new(elements, Vec::default());
-        document.propagate_expand();
-        Printer::new(options, &[]).print(document.elements()).expect("Document to be valid")
+        Document::new(elements, Vec::default()).print(0, options).expect("Document to be valid")
     }
 
     #[test]

--- a/crates/oxc_formatter_core/src/printer/printer_options/mod.rs
+++ b/crates/oxc_formatter_core/src/printer/printer_options/mod.rs
@@ -1,6 +1,6 @@
 use crate::{IndentStyle, IndentWidth, LineEnding, LineWidth};
 
-/// Options that affect how the [crate::Printer] prints the format tokens
+/// Options that affect how the `Printer` prints the format tokens
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PrinterOptions {
     /// Width of an indent in characters.

--- a/crates/oxc_formatter_css/examples/embedded_debug.rs
+++ b/crates/oxc_formatter_css/examples/embedded_debug.rs
@@ -35,16 +35,17 @@ fn main() {
     match format_to_ir(&session, &source_text, options, /* template_placeholders */ true) {
         Ok(embedded) => {
             let document = Document::new(embedded.ir, Vec::new());
-            if std::env::var("DUMP_IR").is_ok() {
-                // Show the finalized IR (`Document::print` would re-propagate; it's idempotent).
-                document.propagate_expand();
-                for el in document.elements() {
-                    eprintln!("{el:?}");
-                }
-            }
+            // `elements` borrows the arena (not the document) and group modes are `Cell`s,
+            // so after `print` finalizes, the slice shows the finalized IR.
+            let elements = std::env::var("DUMP_IR").is_ok().then(|| document.elements());
             match document.print(source_text.len(), options.as_print_options()) {
                 Ok(printed) => println!("{}", printed.into_code()),
                 Err(err) => eprintln!("Print error: {err:?}"),
+            }
+            if let Some(elements) = elements {
+                for el in elements {
+                    eprintln!("{el:?}");
+                }
             }
         }
         Err(diagnostic) => eprintln!("Parse error: {diagnostic:?}"),

--- a/crates/oxc_formatter_css/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_css/tests/fixtures/mod.rs
@@ -70,7 +70,7 @@ impl FixtureFormatter for CssHarness {
 /// Format through `format_to_ir` and print the raw IR, mirroring what the
 /// oxfmt dispatcher + parent template printing do (minus `${}` substitution).
 fn format_embedded(source: &str, options: CssFormatOptions) -> String {
-    use oxc_formatter_core::{Document, FormatElement, FormatOptions, Printer, TextWidth};
+    use oxc_formatter_core::{Document, FormatElement, FormatOptions, TextWidth};
 
     let allocator = Allocator::default();
     let session =
@@ -79,14 +79,11 @@ fn format_embedded(source: &str, options: CssFormatOptions) -> String {
         &session, source, options, /* template_placeholders */ true,
     )
     .expect("format should succeed");
-    let document = Document::new(embedded.ir, Vec::new());
-    document.propagate_expand();
-    let (elements, tailwind_classes) = document.into_elements_and_tailwind_classes();
     // Simulate the host: replace each typed placeholder with the canonical
     // sentinel (the real host substitutes `${expr}`; tests have no expressions).
     // The printer `debug_assert`s on any surviving `EmbedPlaceholder`.
     let elements = ArenaVec::from_iter_in(
-        elements.iter().map(|element| match element {
+        embedded.ir.iter().map(|element| match element {
             FormatElement::EmbedPlaceholder(index) => {
                 let text = allocator.alloc_str(&std::format!("`PLACEHOLDER-{index}`"));
                 FormatElement::Text {
@@ -97,13 +94,11 @@ fn format_embedded(source: &str, options: CssFormatOptions) -> String {
             other => other.clone(),
         }),
         &session.allocator(),
-    )
-    .into_arena_slice();
-    let mut code =
-        Printer::with_capacity(source.len(), options.as_print_options(), &tailwind_classes)
-            .print(elements)
-            .expect("print should succeed")
-            .into_code();
+    );
+    let mut code = Document::new(elements, Vec::new())
+        .print(source.len(), options.as_print_options())
+        .expect("print should succeed")
+        .into_code();
     // The embedded entry point emits no trailing newline (the parent owns it);
     // add one so snapshots stay diff-friendly.
     code.push('\n');


### PR DESCRIPTION
Follow the rule, #25328.