### PR TITLE
fix(react_compiler): align nested ref validation

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
@@ -238,13 +238,16 @@ impl Env {
         self.changed
     }
 
+    fn operand_id(&self, key: IdentifierId) -> IdentifierId {
+        self.temporaries.get(&key).map(|p| p.identifier).unwrap_or(key)
+    }
+
     fn get(&self, key: IdentifierId) -> Option<&RefAccessType> {
-        let operand_id = self.temporaries.get(&key).map(|p| p.identifier).unwrap_or(key);
-        self.data.get(&operand_id)
+        self.data.get(&self.operand_id(key))
     }
 
     fn set(&mut self, key: IdentifierId, value: RefAccessType) {
-        let operand_id = self.temporaries.get(&key).map(|p| p.identifier).unwrap_or(key);
+        let operand_id = self.operand_id(key);
         let current = self.data.get(&operand_id);
         let widened_value = join_ref_access_types(&value, current.unwrap_or(&RefAccessType::None));
         if current.is_none() && widened_value == RefAccessType::None {
@@ -751,9 +754,18 @@ fn validate_no_ref_access_in_render_impl(
                                 if let Some(ref effects) = instr.effects {
                                     /*
                                      * For non-hook functions with known aliasing effects,
-                                     * use the effects to determine what validation to apply.
+                                     * use the effects for actual call operands to determine
+                                     * what validation to apply. Oxc effects may also contain
+                                     * transitive captures that flow into a returned function;
+                                     * those values were not passed to the call and are safe to
+                                     * capture for later invocation.
                                      * Track visited id:kind pairs to avoid duplicate errors.
                                      */
+                                    let operand_ids: FxHashSet<IdentifierId> =
+                                        canonical_each_instruction_value_operand(&instr.value, env)
+                                            .iter()
+                                            .map(|place| ref_env.operand_id(place.identifier))
+                                            .collect();
                                     let mut visited_effects: FxHashSet<String> =
                                         FxHashSet::default();
                                     for effect in effects {
@@ -807,6 +819,8 @@ fn validate_no_ref_access_in_render_impl(
                                         };
                                         if let Some(place) = place
                                             && validation != "none"
+                                            && operand_ids
+                                                .contains(&ref_env.operand_id(place.identifier))
                                         {
                                             let key = format!(
                                                 "{}:{}",

--- a/crates/oxc_react_compiler/tests/transform.rs
+++ b/crates/oxc_react_compiler/tests/transform.rs
@@ -70,6 +70,31 @@ fn memoizes_a_component_end_to_end() {
 }
 
 #[test]
+fn allows_ref_access_in_a_returned_event_handler() {
+    let source = "\
+function Component({ onChange, onInput }) {\n\
+  const lastValue = useRef(\"\");\n\
+  const wrappedEvent = (callback) => (event) => {\n\
+    const text = event.currentTarget.textContent || \"\";\n\
+    if (text !== lastValue.current) {\n\
+      lastValue.current = text;\n\
+      onChange?.(text);\n\
+    }\n\
+    callback?.(event);\n\
+  };\n\
+  return <div onInput={wrappedEvent(onInput)} />;\n\
+}\n";
+
+    let allocator = Allocator::default();
+    let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
+
+    assert!(result.changed, "component should compile; diagnostics: {:?}", result.diagnostics);
+    assert!(result.diagnostics.is_empty(), "unexpected diagnostics: {:?}", result.diagnostics);
+    let output = Codegen::new().build(&program).code;
+    assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
+}
+
+#[test]
 fn preserves_manual_memoization_guarantees() {
     let source = "\
 import { useCallback, useMemo } from 'react';


### PR DESCRIPTION
Align ref validation with Babel React Compiler 1.0 by limiting call-site alias-effect checks to values actually passed to the call. This keeps refs captured by returned event handlers valid while preserving diagnostics for refs passed to invoked functions.

Validated with `cargo test -p oxc_react_compiler`, the rebuilt `oxc-transform-react` binding against Outline’s `ContentEditable.tsx`, and `just ready`.

AI-assisted; the contributor remains responsible for review and submission.