### PR TITLE
refactor(formatter_core,formatter,oxfmt): rename embedded `meta` to `child_context`

### DIFF
--- a/apps/oxfmt/src/core/embed/prettier_doc.rs
+++ b/apps/oxfmt/src/core/embed/prettier_doc.rs
@@ -58,7 +58,7 @@ pub fn build_prettier_fallback(
                 )?;
                 from_prettier_doc::postprocess(&mut ir, allocator);
                 // HTML/Angular additionally surface `HtmlEmbedMeta` to the embed site.
-                let meta = language.wants_html_meta().then(|| {
+                let child_context = language.wants_html_meta().then(|| {
                     Box::new(HtmlEmbedMeta {
                         has_multiple_root_elements: metadata
                             .get("htmlHasMultipleRootElements")
@@ -68,7 +68,7 @@ pub fn build_prettier_fallback(
                 Ok(DispatchOutcome::Formatted(DispatchResult {
                     doc: ir,
                     tailwind_classes: Vec::new(),
-                    meta,
+                    child_context,
                 }))
             })
             .inspect_err(|err| {

--- a/crates/oxc_formatter/src/embed_context.rs
+++ b/crates/oxc_formatter/src/embed_context.rs
@@ -12,14 +12,14 @@
 /// it is JS↔CSS pair-specific, and `oxc_formatter` must never depend on language crates.
 pub struct CssInJsTemplate;
 
-/// Child→parent metadata for HTML/Angular formatted as an embedded child.
+/// Child→parent pair context for HTML/Angular formatted as an embedded child.
 ///
 /// NOTE: This lives here permanently, NOT in a future HTML formatter crate:
 /// the consumer is this crate's `embed/html.rs` (the JS side of html-in-js),
 /// and `oxc_formatter` must never depend on language crates. Cross-language
 /// contract fields (placeholder counts, Tailwind classes) are first-class on
 /// `DispatchResult` in `oxc_formatter_core` instead; only what is truly
-/// specific to the JS↔HTML pair stays here as `dyn Any` metadata.
+/// specific to the JS↔HTML pair travels as the `dyn Any` child context.
 pub struct HtmlEmbedMeta {
     /// Whether the parsed HTML has more than one root element.
     /// Used to decide whether to `indent` the template content.

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -62,9 +62,9 @@ pub(super) fn format_html_doc<'a>(
             return false;
         };
         let Some(html_has_multiple_root_elements) = result
-            .meta
+            .child_context
             .as_ref()
-            .and_then(|meta| meta.downcast_ref::<HtmlEmbedMeta>())
+            .and_then(|context| context.downcast_ref::<HtmlEmbedMeta>())
             .map(|meta| meta.has_multiple_root_elements)
         else {
             return false;
@@ -145,9 +145,9 @@ pub(super) fn format_html_doc<'a>(
     };
 
     let Some(html_has_multiple_root_elements) = result
-        .meta
+        .child_context
         .as_ref()
-        .and_then(|meta| meta.downcast_ref::<HtmlEmbedMeta>())
+        .and_then(|context| context.downcast_ref::<HtmlEmbedMeta>())
         .map(|meta| meta.has_multiple_root_elements)
     else {
         return false;

--- a/crates/oxc_formatter/src/print/template/embed/mod.rs
+++ b/crates/oxc_formatter/src/print/template/embed/mod.rs
@@ -148,7 +148,7 @@ fn is_in_css_jsx<'a>(node: &AstNode<'a, TemplateLiteral<'a>>) -> bool {
 /// (`InputKind::Fragment` + the `into_doc` Tailwind merge in one place,
 /// so an embed site cannot re-derive the pair and skip the merge).
 /// `None` covers `PreserveOriginal` and operational errors alike,
-/// the caller keeps the template as-is (the html sites stay manual: they read `meta` first).
+/// the caller keeps the template as-is (the html sites stay manual: they read `child_context` first).
 pub(super) fn dispatch_fragment_ir<'a>(
     f: &mut JsFormatter<'_, 'a>,
     language: &str,

--- a/crates/oxc_formatter_core/src/embedded.rs
+++ b/crates/oxc_formatter_core/src/embedded.rs
@@ -28,7 +28,9 @@ pub struct DispatchRequest<'r> {
     /// Envelope semantics of the child input, as declared by the host.
     pub input_kind: InputKind,
     /// Parent→child language-pair specific data,
-    /// downcast by the implementation (`None` for most pairs).
+    /// downcast by the implementation (`None` for most pairs; e.g. JS's `CssInJsTemplate`).
+    /// The borrowed counterpart of [`DispatchResult::child_context`]
+    /// (borrowed because the parent outlives the dispatch call).
     pub parent_context: Option<&'r dyn Any>,
 }
 
@@ -81,7 +83,7 @@ pub struct EmbeddedIr<'a> {
 /// carrying the child's Tailwind classes through (hand-rolling the literal invites silently dropping them).
 impl<'a> From<EmbeddedIr<'a>> for DispatchResult<'a> {
     fn from(embedded: EmbeddedIr<'a>) -> Self {
-        Self { doc: embedded.ir, tailwind_classes: embedded.tailwind_classes, meta: None }
+        Self { doc: embedded.ir, tailwind_classes: embedded.tailwind_classes, child_context: None }
     }
 }
 
@@ -98,9 +100,11 @@ pub struct DispatchResult<'a> {
     /// The receiving parent MUST merge them into its own class space ([`Self::into_doc`] does);
     /// the printer's `debug_assert` catches a forgotten merge.
     pub tailwind_classes: Vec<String>,
-    /// Child→parent language-specific metadata; the parent downcasts it
-    /// (e.g. HTML's `has_multiple_root_elements`).
-    pub meta: Option<Box<dyn Any>>,
+    /// Child→parent language-pair specific data,
+    /// downcast by the parent (`None` for most pairs; e.g. HTML's `has_multiple_root_elements`).
+    /// The owned counterpart of [`DispatchRequest::parent_context`]
+    /// (owned because it outlives the child's stack frame).
+    pub child_context: Option<Box<dyn Any>>,
 }
 
 impl<'a> DispatchResult<'a> {

--- a/crates/oxc_formatter_core/src/session.rs
+++ b/crates/oxc_formatter_core/src/session.rs
@@ -247,7 +247,7 @@ mod tests {
             Ok(DispatchOutcome::Formatted(DispatchResult {
                 doc: oxc_allocator::ArenaVec::new_in(&ctx.allocator()),
                 tailwind_classes: Vec::new(),
-                meta: None,
+                child_context: None,
             }))
         });
         let session = FormatSession::with_services(
@@ -270,7 +270,7 @@ mod tests {
             Ok(DispatchOutcome::Formatted(DispatchResult {
                 doc: oxc_allocator::ArenaVec::new_in(&ctx.allocator()),
                 tailwind_classes: Vec::new(),
-                meta: None,
+                child_context: None,
             }))
         });
         let mut session = FormatSession::with_services(


### PR DESCRIPTION
`parent_context` <-> `child_context` is more intuitive.