### PR TITLE
refactor(oxfmt): rename `external_formatter` to `external_services`

### DIFF
--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -52,13 +52,13 @@ Routing is ONE table (`dispatcher::route`): `Native` languages (css/graphql/yaml
 Vocabulary: "fallback" = the dispatcher's optional `PrettierDocFallback` slot (a build/root may not install one); "recovery" = the html-in-js after-failure string rescue.
 The pure Rust build runs fallback-less, so non-native embeds (html-in-js, TOML/custom front matter) deliberately stay verbatim.
 
-Three roots install `SessionServices`, all via `embed/services.rs::for_root` (one definition per build; the napi one takes the `ExternalFormatter` transport, and adds the Prettier fallback / string embedder / Tailwind sorter to the registry dispatcher): the JS/TS and CSS file roots (`core/format.rs`, `PhysicalFile` sessions, both builds) and the Vue/Svelte `<script>` root (`api/text_to_doc_api.rs`, `VirtualDocument` session, napi only).
+Three roots install `SessionServices`, all via `embed/services.rs::for_root` (one definition per build; the napi one takes the `ExternalServices` transport, and adds the Prettier fallback / string embedder / Tailwind sorter to the registry dispatcher): the JS/TS and CSS file roots (`core/format.rs`, `PhysicalFile` sessions, both builds) and the Vue/Svelte `<script>` root (`api/text_to_doc_api.rs`, `VirtualDocument` session, napi only).
 
 Which languages may dispatch AT ALL from a given host is the host crate's own gate (e.g. `oxc_formatter_css` dispatches only `yaml`/`toml` front matter); the shared `route()` table then decides who serves the language. Adding a dispatch call to a host crate is therefore a routing decision (check `route()` and the embedded conformance when doing so. A root needing a bespoke service set would assemble the `SessionServices` struct literally), none does today.
 `embeddedLanguageFormatting: off` installs no dispatcher, every builder consults the same off-gate, `ResolvedDispatchConfig::is_embedded_formatting_enabled`.
 Tracing span namespaces: `oxfmt::embed::` = pure Rust work, `oxfmt::external::` = napi-crossing calls.
 
-Per-language options are NOT built up front: `ResolvedDispatchConfig` maps them lazily at dispatch time (`OnceLock`-memoized) from the host file's resolved config, including the Prettier options JSON for the JS-side consumers. `src/core/external_formatter.rs` bridges the napi callbacks into these factories.
+Per-language options are NOT built up front: `ResolvedDispatchConfig` maps them lazily at dispatch time (`OnceLock`-memoized) from the host file's resolved config, including the Prettier options JSON for the JS-side consumers. `src/core/external_services.rs` bridges the napi callbacks into these factories.
 
 A separate string-out channel (the session's `string_embedder` service, NOT the dispatcher) carries the string-in/string-out consumers:
 

--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -58,7 +58,7 @@ export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmt
  * JS side passes in:
  * 1. `args`: Command line arguments (process.argv.slice(2))
  * 2. `load_js_config_cb`: Callback to load JS/TS config files
- * 3. `init_external_formatter_cb`: Callback to initialize external formatter (JS worker pool)
+ * 3. `init_external_services_cb`: Callback to initialize external services (JS worker pool)
  * 4. `format_file_cb`: Callback to format files
  * 5. `format_embedded_cb`: Callback to format embedded code in templates
  * 6. `sort_tailwindcss_classes_cb`: Callback to sort Tailwind classes
@@ -67,4 +67,4 @@ export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmt
  * - `mode`: If main logic will run in JS side, use this to indicate which mode
  * - `exitCode`: If main logic already ran in Rust side, return the exit code
  */
-export declare function runCli(args: Array<string>, loadJsConfigCb: (path: string) => Promise<any>, initExternalFormatterCb: (numThreads: number) => Promise<void>, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, code: string) => Promise<string | null>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<[string, number | undefined | null]>
+export declare function runCli(args: Array<string>, loadJsConfigCb: (path: string) => Promise<any>, initExternalServicesCb: (numThreads: number) => Promise<void>, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, code: string) => Promise<string | null>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<[string, number | undefined | null]>

--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -1,7 +1,7 @@
 import { runCli } from "./bindings";
 import {
-  initExternalFormatter,
-  disposeExternalFormatter,
+  initExternalServices,
+  disposeExternalServices,
   formatFile,
   formatEmbeddedCode,
   formatEmbeddedDoc,
@@ -41,7 +41,7 @@ void (async () => {
   const [mode, exitCode] = await runCli(
     args,
     process.env.VP_VERSION ? loadVitePlusConfig : loadJsConfig,
-    initExternalFormatter,
+    initExternalServices,
     formatFile,
     formatEmbeddedCode,
     formatEmbeddedDoc,
@@ -65,7 +65,7 @@ void (async () => {
   // Other modes are handled by Rust, just need to set `exitCode`
 
   // Clean up worker pool to not V8 crashes on process exit
-  await disposeExternalFormatter();
+  await disposeExternalServices();
 
   // NOTE: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
   // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.

--- a/apps/oxfmt/src-js/cli/worker-proxy.ts
+++ b/apps/oxfmt/src-js/cli/worker-proxy.ts
@@ -12,7 +12,7 @@ import type {
 let pool: Tinypool | null = null;
 let poolSize: number | null = null;
 
-export async function initExternalFormatter(numThreads: number): Promise<void> {
+export async function initExternalServices(numThreads: number): Promise<void> {
   // In LSP mode, this can be called repeatedly for the lifetime of the process.
   // e.g. on every workspace folder build, config-triggered rebuild, etc
   // The process-wide pool must never be recreated or destroyed on re-init:
@@ -26,8 +26,8 @@ export async function initExternalFormatter(numThreads: number): Promise<void> {
 // so runs that never delegate to Prettier spawn no `child_process` workers at all.
 // (e.g. Rust-tier files only)
 async function getPool(): Promise<Tinypool> {
-  // Rust always calls `initExternalFormatter` before formatting, so this is defensive.
-  if (poolSize === null) throw new Error("External formatter is not initialized");
+  // Rust always calls `initExternalServices` before formatting, so this is defensive.
+  if (poolSize === null) throw new Error("External services are not initialized");
 
   pool ??= new Tinypool({
     filename: new URL("./cli-worker.js", import.meta.url).href,
@@ -44,7 +44,7 @@ async function getPool(): Promise<Tinypool> {
   return pool;
 }
 
-export async function disposeExternalFormatter(): Promise<void> {
+export async function disposeExternalServices(): Promise<void> {
   await pool?.destroy();
   pool = null;
   poolSize = null;

--- a/apps/oxfmt/src/api/format_api.rs
+++ b/apps/oxfmt/src/api/format_api.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use oxc_napi::OxcError;
 
 use crate::core::{
-    ExternalFormatter, FormatResult, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb, JsFormatFileCb,
+    ExternalServices, FormatResult, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb, JsFormatFileCb,
     JsSortTailwindClassesCb, ResolveOutcome, SourceFormatter, classify_file_kind, resolve_for_api,
     utils,
 };
@@ -34,7 +34,7 @@ pub fn run(
     let cwd = env::current_dir().expect("Failed to get current working directory");
     let num_of_threads = 1;
 
-    let external_formatter = ExternalFormatter::new(
+    let external_services = ExternalServices::new(
         format_file_cb,
         format_embedded_cb,
         format_embedded_doc_cb,
@@ -43,7 +43,7 @@ pub fn run(
 
     let filepath = utils::normalize_relative_path(&cwd, Path::new(filename));
     let Some(kind) = classify_file_kind(Arc::from(filepath)) else {
-        external_formatter.cleanup();
+        external_services.cleanup();
         return ApiFormatResult {
             code: source_text,
             errors: vec![OxcError::new(format!("Unsupported file type: {filename}"))],
@@ -52,7 +52,7 @@ pub fn run(
     let strategy = match resolve_for_api(options.unwrap_or_default(), kind, &cwd) {
         Ok(ResolveOutcome::Format(strategy)) => strategy,
         Ok(ResolveOutcome::MissingPlugin(plugin)) => {
-            external_formatter.cleanup();
+            external_services.cleanup();
             return ApiFormatResult {
                 code: source_text,
                 errors: vec![OxcError::new(format!(
@@ -61,7 +61,7 @@ pub fn run(
             };
         }
         Err(err) => {
-            external_formatter.cleanup();
+            external_services.cleanup();
             return ApiFormatResult {
                 code: source_text,
                 errors: vec![OxcError::new(format!("Failed to parse configuration: {err}"))],
@@ -71,7 +71,7 @@ pub fn run(
 
     // Create formatter and format
     let formatter = SourceFormatter::new(num_of_threads)
-        .with_external_formatter(Some(external_formatter.clone()));
+        .with_external_services(Some(external_services.clone()));
 
     // Use `block_in_place()` to avoid nested async runtime access
     let result = match tokio::task::block_in_place(|| formatter.format(&source_text, strategy)) {
@@ -84,7 +84,7 @@ pub fn run(
 
     // Explicitly drop ThreadsafeFunctions before returning to prevent
     // use-after-free during V8 cleanup (Node.js issue with TSFN cleanup timing)
-    external_formatter.cleanup();
+    external_services.cleanup();
 
     result
 }

--- a/apps/oxfmt/src/api/text_to_doc_api.rs
+++ b/apps/oxfmt/src/api/text_to_doc_api.rs
@@ -11,7 +11,7 @@ use oxc_span::SourceType;
 
 use crate::{
     core::{
-        EmbeddedCallbackResolved, ExternalFormatter, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb,
+        EmbeddedCallbackResolved, ExternalServices, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb,
         JsFormatFileCb, JsSortTailwindClassesCb,
         embed::{self, dispatcher::ResolvedDispatchConfig},
         oxfmtrc::FormatConfig,
@@ -124,7 +124,7 @@ fn run_full(
     // so no `cwd` is threaded through here.
     let (config, parent_filepath) = parse_payload(oxfmt_plugin_options_json);
 
-    let external_formatter = ExternalFormatter::new(
+    let external_services = ExternalServices::new(
         format_file_cb,
         format_embedded_cb,
         format_embedded_doc_cb,
@@ -139,7 +139,7 @@ fn run_full(
     // are mapped lazily at dispatch time; `core` was validated during resolution.
     let dispatch_config = ResolvedDispatchConfig::for_root(&config, core, &parent_filepath);
 
-    let services = embed::services::for_root(&external_formatter, &dispatch_config);
+    let services = embed::services::for_root(&external_services, &dispatch_config);
 
     let allocator = Allocator::default();
     let session = FormatSession::with_services(
@@ -155,7 +155,7 @@ fn run_full(
         Ok(formatted) => formatted,
         Err(err) => {
             debug!("`oxc_formatter::format()` failed for {source_type:?}: {err:?}");
-            external_formatter.cleanup();
+            external_services.cleanup();
             return None;
         }
     };
@@ -163,7 +163,7 @@ fn run_full(
     let (elements, sorted_tailwind_classes) =
         formatted.into_final_document().into_elements_and_tailwind_classes();
 
-    external_formatter.cleanup();
+    external_services.cleanup();
     Some(
         to_prettier_doc::format_elements_to_prettier_doc(elements, &sorted_tailwind_classes)
             .expect("Formatter IR to Prettier Doc conversion should not fail"),
@@ -189,7 +189,7 @@ fn run_fragment(
 ) -> Option<Value> {
     let (config, parent_filepath) = parse_payload(oxfmt_plugin_options_json);
     // Reuses the same config resolver as `run_full()`, but only `format_options` is needed here,
-    // since `run_fragment()` does not dispatch external formatter callbacks.
+    // since `run_fragment()` does not dispatch external services callbacks.
     let resolved = resolve_for_embedded_js(config, parent_filepath)
         .expect("`_oxfmtPluginOptionsJson` should contain valid config");
     let format_options = resolved.format_options;

--- a/apps/oxfmt/src/cli/stdin_runner.rs
+++ b/apps/oxfmt/src/cli/stdin_runner.rs
@@ -10,7 +10,7 @@ use super::{
     resolve::{build_global_ignore_matchers, is_ignored, resolve_ignore_paths},
 };
 use crate::core::{
-    ConfigResolver, ExternalFormatter, FormatResult, JsConfigLoaderCb, NestedConfigCtx,
+    ConfigResolver, ExternalServices, FormatResult, JsConfigLoaderCb, NestedConfigCtx,
     ResolveOutcome, SourceFormatter, classify_file_kind, resolve_editorconfig_path,
     resolve_file_scope_config, utils,
 };
@@ -19,7 +19,7 @@ pub struct StdinRunner {
     options: FormatCommand,
     cwd: PathBuf,
     js_config_loader: JsConfigLoaderCb,
-    external_formatter: ExternalFormatter,
+    external_services: ExternalServices,
 }
 
 impl StdinRunner {
@@ -30,13 +30,13 @@ impl StdinRunner {
     pub fn new(
         options: FormatCommand,
         js_config_loader: JsConfigLoaderCb,
-        external_formatter: ExternalFormatter,
+        external_services: ExternalServices,
     ) -> Self {
         Self {
             options,
             cwd: env::current_dir().expect("Failed to get current working directory"),
             js_config_loader,
-            external_formatter,
+            external_services,
         }
     }
 
@@ -84,12 +84,9 @@ impl StdinRunner {
 
         // Use `block_in_place()` to avoid nested async runtime access
         if let Err(err) =
-            tokio::task::block_in_place(|| self.external_formatter.init(num_of_threads))
+            tokio::task::block_in_place(|| self.external_services.init(num_of_threads))
         {
-            utils::print_and_flush(
-                stderr,
-                &format!("Failed to setup external formatter.\n{err}\n"),
-            );
+            utils::print_and_flush(stderr, &format!("Failed to setup external services.\n{err}\n"));
             return CliRunResult::InvalidOptionConfig;
         }
 
@@ -154,7 +151,7 @@ impl StdinRunner {
 
         // Create formatter and format
         let source_formatter = SourceFormatter::new(num_of_threads)
-            .with_external_formatter(Some(self.external_formatter));
+            .with_external_services(Some(self.external_services));
 
         // Use `block_in_place()` to avoid nested async runtime access
         match tokio::task::block_in_place(|| source_formatter.format(&source_text, strategy)) {

--- a/apps/oxfmt/src/cli/walk_runner.rs
+++ b/apps/oxfmt/src/cli/walk_runner.rs
@@ -27,7 +27,7 @@ pub struct WalkRunner {
     options: FormatCommand,
     cwd: PathBuf,
     #[cfg(feature = "napi")]
-    external_formatter: Option<crate::core::ExternalFormatter>,
+    external_services: Option<crate::core::ExternalServices>,
     #[cfg(feature = "napi")]
     js_config_loader: Option<JsConfigLoaderCb>,
 }
@@ -42,7 +42,7 @@ impl WalkRunner {
             options,
             cwd: env::current_dir().expect("Failed to get current working directory"),
             #[cfg(feature = "napi")]
-            external_formatter: None,
+            external_services: None,
             #[cfg(feature = "napi")]
             js_config_loader: None,
         }
@@ -50,11 +50,11 @@ impl WalkRunner {
 
     #[cfg(feature = "napi")]
     #[must_use]
-    pub fn with_external_formatter(
+    pub fn with_external_services(
         mut self,
-        external_formatter: Option<crate::core::ExternalFormatter>,
+        external_services: Option<crate::core::ExternalServices>,
     ) -> Self {
-        self.external_formatter = external_formatter;
+        self.external_services = external_services;
         self
     }
 
@@ -66,7 +66,7 @@ impl WalkRunner {
     }
 
     /// # Panics
-    /// Panics if `napi` feature is enabled but external_formatter is not set.
+    /// Panics if `napi` feature is enabled but external_services is not set.
     pub fn run(self) -> CliRunResult {
         // stdio is blocked by `LineWriter`, use a `BufWriter` to reduce syscalls.
         // See https://github.com/rust-lang/rust/issues/60673
@@ -111,15 +111,12 @@ impl WalkRunner {
         // Use `block_in_place()` to avoid nested async runtime access
         #[cfg(feature = "napi")]
         if let Err(err) = tokio::task::block_in_place(|| {
-            self.external_formatter
+            self.external_services
                 .as_ref()
-                .expect("External formatter must be set when `napi` feature is enabled")
+                .expect("External services must be set when `napi` feature is enabled")
                 .init(num_of_threads)
         }) {
-            utils::print_and_flush(
-                stderr,
-                &format!("Failed to setup external formatter.\n{err}\n"),
-            );
+            utils::print_and_flush(stderr, &format!("Failed to setup external services.\n{err}\n"));
             return CliRunResult::InvalidOptionConfig;
         }
 
@@ -151,7 +148,7 @@ impl WalkRunner {
         // Create `SourceFormatter` instance
         let source_formatter = SourceFormatter::new(num_of_threads);
         #[cfg(feature = "napi")]
-        let source_formatter = source_formatter.with_external_formatter(self.external_formatter);
+        let source_formatter = source_formatter.with_external_services(self.external_services);
 
         let cwd_for_format = cwd.clone();
         // Clone `tx_error` so both the walk threads and the format service can report errors

--- a/apps/oxfmt/src/core/embed/mod.rs
+++ b/apps/oxfmt/src/core/embed/mod.rs
@@ -31,9 +31,9 @@ pub mod services;
 // --- Cross-module callback types ---
 //
 // These describe the shape of the napi-wrapped callbacks the orchestration builders consume.
-// NOTE: They live here (not in `external_formatter`),
+// NOTE: They live here (not in `external_services`),
 // so the `prettier_doc` / `prettier_string` factories stay independent of the napi boundary.
-// `external_formatter` is the producer of these types via its `wrap_*` functions, and orchestration is the consumer.
+// `external_services` is the producer of these types via its `wrap_*` functions, and orchestration is the consumer.
 
 /// Callback function type for formatting embedded code with config.
 /// Takes (options, code) and returns formatted code or an error.

--- a/apps/oxfmt/src/core/embed/services.rs
+++ b/apps/oxfmt/src/core/embed/services.rs
@@ -1,6 +1,6 @@
 //! Root `SessionServices` assembly: [`for_root`] builds the build's default service set,
 //! installed by every session-taking root (JS / CSS / Vue-Svelte script; a future Markdown host too).
-//! One name, one definition per build; the napi one additionally takes the `ExternalFormatter` transport.
+//! One name, one definition per build; the napi one additionally takes the `ExternalServices` transport.
 //!
 //! "Which languages may dispatch at all from this host" is the host crate's own gate
 //! (e.g. the CSS crate's front matter gate dispatches only `yaml` / `toml`), not a concern here;
@@ -17,7 +17,7 @@ use oxc_formatter_core::TailwindSorter;
 use tracing::debug_span;
 
 #[cfg(feature = "napi")]
-use crate::core::ExternalFormatter;
+use crate::core::ExternalServices;
 
 use super::dispatcher::ResolvedDispatchConfig;
 
@@ -55,7 +55,7 @@ pub fn for_root(dispatch_config: &Arc<ResolvedDispatchConfig>) -> SessionService
 /// per-language options are mapped lazily at dispatch time (see [`ResolvedDispatchConfig`]).
 ///
 /// This is the assembly point only: closure factories live in `embed::{prettier_string, dispatcher, prettier_doc}`,
-/// and the napi callback `Arc`s come from the transport ([`ExternalFormatter`]).
+/// and the napi callback `Arc`s come from the transport ([`ExternalServices`]).
 ///
 /// NOTE: Tailwind data paths
 /// `sort_tailwindcss_classes` is wired into THREE distinct callback slots,
@@ -82,7 +82,7 @@ pub fn for_root(dispatch_config: &Arc<ResolvedDispatchConfig>) -> SessionService
 /// `DispatchResult::into_doc` folds the merge into doc consumption; the printer `debug_assert` backstops it.
 #[cfg(feature = "napi")]
 pub fn for_root(
-    external_formatter: &ExternalFormatter,
+    external_services: &ExternalServices,
     dispatch_config: &Arc<ResolvedDispatchConfig>,
 ) -> SessionServices {
     let needs_embedded = dispatch_config.is_embedded_formatting_enabled();
@@ -91,14 +91,14 @@ pub fn for_root(
     let fallback = needs_embedded.then(|| {
         super::prettier_doc::build_prettier_fallback(
             Arc::clone(dispatch_config),
-            Arc::clone(&external_formatter.format_embedded_doc),
+            Arc::clone(&external_services.format_embedded_doc),
         )
     });
 
     // The ONE pre-bound Tailwind sorter (options JSON applied here, once);
     // the string embedder receives a clone of the same sorter for fence-collected classes.
     let sorter = dispatch_config.is_tailwind_enabled().then(|| {
-        let sort = Arc::clone(&external_formatter.sort_tailwindcss_classes);
+        let sort = Arc::clone(&external_services.sort_tailwindcss_classes);
         let dispatch_config = Arc::clone(dispatch_config);
         Arc::new(move |classes: Vec<String>| {
             debug_span!("oxfmt::external::sort_tailwind", classes_count = classes.len())
@@ -108,7 +108,7 @@ pub fn for_root(
 
     let string_embedder = needs_embedded.then(|| {
         super::prettier_string::build_string_embedder(
-            Arc::clone(&external_formatter.format_embedded),
+            Arc::clone(&external_services.format_embedded),
             sorter.clone(),
             Arc::clone(dispatch_config),
         )

--- a/apps/oxfmt/src/core/external_services.rs
+++ b/apps/oxfmt/src/core/external_services.rs
@@ -1,9 +1,9 @@
 //! Transport between napi-rs `ThreadsafeFunction`s and plain Rust callback shapes;
 //! no assembly logic (the napi `SessionServices` profiles live in `core::embed::services`).
 //!
-//! [`ExternalFormatter`] wraps the JS callbacks as `Arc<dyn Fn>`s (private `wrap_*` helpers), serving:
-//! - [`ExternalFormatter::init`]: JS-side worker-pool setup
-//! - [`ExternalFormatter::format_file`]: Tier 3/4 whole-file delegation (`core::format`)
+//! [`ExternalServices`] wraps the JS callbacks as `Arc<dyn Fn>`s (private `wrap_*` helpers), serving:
+//! - [`ExternalServices::init`]: JS-side worker-pool setup
+//! - [`ExternalServices::format_file`]: Tier 3/4 whole-file delegation (`core::format`)
 //! - the embed callback `Arc`s (`format_embedded` / `format_embedded_doc` / `sort_tailwindcss_classes`),
 //!   consumed by the `core::embed::services` profiles
 
@@ -28,9 +28,9 @@ use crate::core::embed::{
 pub type FormatFileWithConfigCallback =
     Arc<dyn Fn(Value, &str) -> Result<String, String> + Send + Sync>;
 
-/// Type alias for the init external formatter callback function signature.
+/// Type alias for the init external services callback function signature.
 /// Takes num_threads as argument; signals JS to perform any one-time setup before formatting.
-pub type JsInitExternalFormatterCb = ThreadsafeFunction<
+pub type JsInitExternalServicesCb = ThreadsafeFunction<
     // Input arguments
     FnArgs<(u32,)>, // (num_threads,)
     // Return type (what JS function returns)
@@ -110,7 +110,7 @@ pub type JsSortTailwindClassesCb = ThreadsafeFunction<
 /// only read from the Option (common path), while only `cleanup()` needs write access.
 #[derive(Clone)]
 struct TsfnHandles {
-    init: Arc<RwLock<Option<JsInitExternalFormatterCb>>>,
+    init: Arc<RwLock<Option<JsInitExternalServicesCb>>>,
     format_file: Arc<RwLock<Option<JsFormatFileCb>>>,
     format_embedded: Arc<RwLock<Option<JsFormatEmbeddedCb>>>,
     format_embedded_doc: Arc<RwLock<Option<JsFormatEmbeddedDocCb>>>,
@@ -128,25 +128,26 @@ impl TsfnHandles {
     }
 }
 
-/// Callback function type for init external formatter.
+/// Callback function type for init external services.
 /// Takes num_threads.
-type InitExternalFormatterCallback = Arc<dyn Fn(usize) -> Result<(), String> + Send + Sync>;
+type InitExternalServicesCallback = Arc<dyn Fn(usize) -> Result<(), String> + Send + Sync>;
 
-/// External formatter that wraps a JS callback.
+/// Transport handle to the JS-side services (Prettier formatting, Tailwind sorting),
+/// each wrapped as a plain Rust callback.
 #[derive(Clone)]
-pub struct ExternalFormatter {
+pub struct ExternalServices {
     /// Handles to raw ThreadsafeFunctions for explicit cleanup
     handles: TsfnHandles,
-    pub init: InitExternalFormatterCallback,
+    pub init: InitExternalServicesCallback,
     pub format_file: FormatFileWithConfigCallback,
     pub format_embedded: FormatEmbeddedWithConfigCallback,
     pub format_embedded_doc: FormatEmbeddedDocWithConfigCallback,
     pub sort_tailwindcss_classes: TailwindWithConfigCallback,
 }
 
-impl std::fmt::Debug for ExternalFormatter {
+impl std::fmt::Debug for ExternalServices {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ExternalFormatter")
+        f.debug_struct("ExternalServices")
             .field("init", &"<callback>")
             .field("format_file", &"<callback>")
             .field("format_embedded", &"<callback>")
@@ -156,8 +157,8 @@ impl std::fmt::Debug for ExternalFormatter {
     }
 }
 
-impl ExternalFormatter {
-    /// Create an [`ExternalFormatter`] from JS callbacks.
+impl ExternalServices {
+    /// Create an [`ExternalServices`] from JS callbacks.
     ///
     /// The ThreadsafeFunctions are wrapped in `Arc<Mutex<Option<...>>>` to allow
     /// explicit cleanup via the `cleanup()` method. This prevents use-after-free
@@ -184,7 +185,7 @@ impl ExternalFormatter {
             sort_tailwind: Arc::clone(&sort_tailwind_handle),
         };
 
-        let rust_init = wrap_init_external_formatter(init_handle);
+        let rust_init = wrap_init_external_services(init_handle);
         let rust_format_file = wrap_format_file(format_file_handle);
         let rust_format_embedded = wrap_format_embedded(Arc::clone(&format_embedded_handle));
         let rust_format_embedded_doc = wrap_format_embedded_doc(format_embedded_doc_handle);
@@ -201,7 +202,7 @@ impl ExternalFormatter {
 
     /// Attach the init callback. Only paths that own a JS-side worker pool (CLI/LSP/Stdin) need this;
     /// the Node.js API path constructs without it and never calls [`Self::init`].
-    pub fn with_init_cb(self, init_cb: JsInitExternalFormatterCb) -> Self {
+    pub fn with_init_cb(self, init_cb: JsInitExternalServicesCb) -> Self {
         *self.handles.init.write().unwrap() = Some(init_cb);
         self
     }
@@ -215,7 +216,7 @@ impl ExternalFormatter {
         self.handles.cleanup();
     }
 
-    /// Initialize external formatter using the JS callback.
+    /// Initialize the JS-side services (worker pool) using the JS callback.
     pub fn init(&self, num_threads: usize) -> Result<(), String> {
         debug_span!("oxfmt::external::init", num_threads = num_threads)
             .in_scope(|| (self.init)(num_threads))
@@ -229,8 +230,8 @@ impl ExternalFormatter {
 
     #[cfg(test)]
     pub fn dummy() -> Self {
-        // Currently, LSP tests are implemented in Rust, while our external formatter relies on JS.
-        // Therefore, just provides a dummy external formatter that consistently returns errors.
+        // Currently, LSP tests are implemented in Rust, while the external services rely on JS.
+        // Therefore, just provides a dummy that consistently returns errors.
         Self {
             handles: TsfnHandles {
                 init: Arc::new(RwLock::new(None)),
@@ -264,10 +265,10 @@ impl ExternalFormatter {
 // Therefore, `block_in_place()` is used at the call site
 // to temporarily convert the current async task into a blocking context.
 
-/// Wrap JS `initExternalFormatter` callback as a normal Rust function.
-fn wrap_init_external_formatter(
-    cb_handle: Arc<RwLock<Option<JsInitExternalFormatterCb>>>,
-) -> InitExternalFormatterCallback {
+/// Wrap JS `initExternalServices` callback as a normal Rust function.
+fn wrap_init_external_services(
+    cb_handle: Arc<RwLock<Option<JsInitExternalServicesCb>>>,
+) -> InitExternalServicesCallback {
     Arc::new(move |num_threads: usize| {
         let guard = cb_handle.read().unwrap();
         let Some(cb) = guard.as_ref() else {

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -244,7 +244,7 @@ pub enum FormatResult {
 pub struct SourceFormatter {
     allocator_pool: AllocatorPool,
     #[cfg(feature = "napi")]
-    external_formatter: Option<super::ExternalFormatter>,
+    external_services: Option<super::ExternalServices>,
 }
 
 impl SourceFormatter {
@@ -252,7 +252,7 @@ impl SourceFormatter {
         Self {
             allocator_pool: AllocatorPool::new(num_of_threads),
             #[cfg(feature = "napi")]
-            external_formatter: None,
+            external_services: None,
         }
     }
 
@@ -262,7 +262,7 @@ impl SourceFormatter {
     fn root_services(&self, dispatch_config: &Arc<ResolvedDispatchConfig>) -> SessionServices {
         #[cfg(feature = "napi")]
         {
-            super::embed::services::for_root(self.external_formatter(), dispatch_config)
+            super::embed::services::for_root(self.external_services(), dispatch_config)
         }
         #[cfg(not(feature = "napi"))]
         {
@@ -608,19 +608,19 @@ impl SourceFormatter {
 #[cfg(feature = "napi")]
 impl SourceFormatter {
     #[must_use]
-    pub fn with_external_formatter(
+    pub fn with_external_services(
         mut self,
-        external_formatter: Option<super::ExternalFormatter>,
+        external_services: Option<super::ExternalServices>,
     ) -> Self {
-        self.external_formatter = external_formatter;
+        self.external_services = external_services;
         self
     }
 
-    /// The napi transport, installed by [`Self::with_external_formatter`] before any format run.
-    fn external_formatter(&self) -> &super::ExternalFormatter {
-        self.external_formatter
+    /// The napi transport, installed by [`Self::with_external_services`] before any format run.
+    fn external_services(&self) -> &super::ExternalServices {
+        self.external_services
             .as_ref()
-            .expect("`external_formatter` must exist when `napi` feature is enabled")
+            .expect("`external_services` must exist when `napi` feature is enabled")
     }
 
     /// Format non-JS/TS file using external formatter (Prettier).
@@ -651,8 +651,8 @@ impl SourceFormatter {
             inject_svelte_plugin_payload(&mut external_options, config);
         }
 
-        self.external_formatter().format_file(external_options, source_text).map_err(|err| {
-            // NOTE: We are trying to make the error from oxc_formatter(_xxx) and external_formatter (Prettier) look similar.
+        self.external_services().format_file(external_options, source_text).map_err(|err| {
+            // NOTE: We are trying to make the error from oxc_formatter(_xxx) and external_services (Prettier) look similar.
             // Ideally, we would unify them into `OxcDiagnostic`, which would eliminate the need for relative path conversion.
             // However, doing so would require:
             // - Parsing Prettier's error messages
@@ -674,7 +674,7 @@ impl SourceFormatter {
 
 /// The JS root's session wiring (registry dispatcher installed / off-gate honored),
 /// which the registry-level tests in `embed::dispatcher` cannot see.
-/// The napi build runs on `ExternalFormatter::dummy()` (native branches never call JS).
+/// The napi build runs on `ExternalServices::dummy()` (native branches never call JS).
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -693,7 +693,7 @@ mod tests {
         let formatter = SourceFormatter::new(1);
         #[cfg(feature = "napi")]
         let formatter =
-            formatter.with_external_formatter(Some(crate::core::ExternalFormatter::dummy()));
+            formatter.with_external_services(Some(crate::core::ExternalServices::dummy()));
         match formatter.format(source, strategy) {
             FormatResult::Success { code, .. } => code,
             FormatResult::Error(errors) => panic!("format failed: {errors:?}"),

--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -7,7 +7,7 @@ mod support;
 pub mod utils;
 
 #[cfg(feature = "napi")]
-mod external_formatter;
+mod external_services;
 
 pub use config::{
     ConfigResolver, NestedConfigCtx, ResolveOutcome, resolve_editorconfig_path,
@@ -25,7 +25,7 @@ pub use format::{FormatResult, FormatStrategy, SourceFormatter};
 pub use support::classify_file_kind;
 
 #[cfg(feature = "napi")]
-pub use external_formatter::{
-    ExternalFormatter, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb, JsFormatFileCb,
-    JsInitExternalFormatterCb, JsSortTailwindClassesCb,
+pub use external_services::{
+    ExternalServices, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb, JsFormatFileCb,
+    JsInitExternalServicesCb, JsSortTailwindClassesCb,
 };

--- a/apps/oxfmt/src/lsp/mod.rs
+++ b/apps/oxfmt/src/lsp/mod.rs
@@ -7,7 +7,7 @@ use std::{
 use oxc_language_server::{LanguageId, run_server};
 use tower_lsp_server::ls_types::Uri;
 
-use crate::core::{ExternalFormatter, JsConfigLoaderCb, utils};
+use crate::core::{ExternalServices, JsConfigLoaderCb, utils};
 
 mod options;
 mod server_formatter;
@@ -60,7 +60,7 @@ pub fn create_fake_file_path_from_language_id(
 }
 
 /// Run the language server
-pub async fn run_lsp(js_config_loader: JsConfigLoaderCb, external_formatter: ExternalFormatter) {
+pub async fn run_lsp(js_config_loader: JsConfigLoaderCb, external_services: ExternalServices) {
     let version = {
         let mut version = env!("CARGO_PKG_VERSION").to_string();
         if let Some(vp_version) = utils::vp_version() {
@@ -73,7 +73,7 @@ pub async fn run_lsp(js_config_loader: JsConfigLoaderCb, external_formatter: Ext
         "oxfmt".to_string(),
         version,
         oxc_language_server::WorkerManager::new_dynamic(Arc::new(
-            server_formatter::ServerFormatterBuilder::new(js_config_loader, external_formatter),
+            server_formatter::ServerFormatterBuilder::new(js_config_loader, external_services),
         )),
     )
     .await;

--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -13,7 +13,7 @@ use oxc_language_server::{
 };
 
 use crate::core::{
-    ConfigResolver, ExternalFormatter, FormatResult, JsConfigLoaderCb, NestedConfigCtx,
+    ConfigResolver, ExternalServices, FormatResult, JsConfigLoaderCb, NestedConfigCtx,
     ResolveOutcome, SourceFormatter, classify_file_kind, config_discovery,
     resolve_editorconfig_path, resolve_file_scope_config, utils,
 };
@@ -22,12 +22,12 @@ use crate::lsp::options::FormatOptions as LSPFormatOptions;
 
 pub struct ServerFormatterBuilder {
     js_config_loader: JsConfigLoaderCb,
-    external_formatter: ExternalFormatter,
+    external_services: ExternalServices,
 }
 
 impl ServerFormatterBuilder {
-    pub fn new(js_config_loader: JsConfigLoaderCb, external_formatter: ExternalFormatter) -> Self {
-        Self { js_config_loader, external_formatter }
+    pub fn new(js_config_loader: JsConfigLoaderCb, external_services: ExternalServices) -> Self {
+        Self { js_config_loader, external_services }
     }
 
     /// Create a dummy `ServerFormatterBuilder` for testing.
@@ -37,7 +37,7 @@ impl ServerFormatterBuilder {
             js_config_loader: std::sync::Arc::new(|_| {
                 Err("JS config not supported in tests".to_string())
             }),
-            external_formatter: ExternalFormatter::dummy(),
+            external_services: ExternalServices::dummy(),
         }
     }
 
@@ -75,12 +75,12 @@ impl ServerFormatterBuilder {
         let num_of_threads = 1; // Single threaded for LSP
         // Use `block_in_place()` to avoid nested async runtime access
         if let Err(err) =
-            tokio::task::block_in_place(|| self.external_formatter.init(num_of_threads))
+            tokio::task::block_in_place(|| self.external_services.init(num_of_threads))
         {
-            error!("Failed to setup external formatter.\n{err}\n");
+            error!("Failed to setup external services.\n{err}\n");
         }
         let source_formatter = SourceFormatter::new(num_of_threads)
-            .with_external_formatter(Some(self.external_formatter.clone()));
+            .with_external_services(Some(self.external_services.clone()));
 
         (
             ServerFormatter::new(

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -10,8 +10,8 @@ use crate::{
     api::{format_api, text_to_doc_api},
     cli::{MigrateSource, Mode, StdinRunner, WalkRunner, format_command, init_miette, init_rayon},
     core::{
-        ExternalFormatter, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb, JsFormatFileCb,
-        JsInitExternalFormatterCb, JsLoadJsConfigCb, JsSortTailwindClassesCb,
+        ExternalServices, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb, JsFormatFileCb,
+        JsInitExternalServicesCb, JsLoadJsConfigCb, JsSortTailwindClassesCb,
         create_js_config_loader, utils,
     },
     lsp::run_lsp,
@@ -23,7 +23,7 @@ use crate::{
 /// JS side passes in:
 /// 1. `args`: Command line arguments (process.argv.slice(2))
 /// 2. `load_js_config_cb`: Callback to load JS/TS config files
-/// 3. `init_external_formatter_cb`: Callback to initialize external formatter (JS worker pool)
+/// 3. `init_external_services_cb`: Callback to initialize external services (JS worker pool)
 /// 4. `format_file_cb`: Callback to format files
 /// 5. `format_embedded_cb`: Callback to format embedded code in templates
 /// 6. `sort_tailwindcss_classes_cb`: Callback to sort Tailwind classes
@@ -38,7 +38,7 @@ pub async fn run_cli(
     args: Vec<String>,
     #[napi(ts_arg_type = "(path: string) => Promise<any>")] load_js_config_cb: JsLoadJsConfigCb,
     #[napi(ts_arg_type = "(numThreads: number) => Promise<void>")]
-    init_external_formatter_cb: JsInitExternalFormatterCb,
+    init_external_services_cb: JsInitExternalServicesCb,
     #[napi(
         ts_arg_type = "(options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>"
     )]
@@ -83,31 +83,28 @@ pub async fn run_cli(
 
     // Otherwise, handle modes that require Rust side processing
 
-    let external_formatter = ExternalFormatter::new(
+    let external_services = ExternalServices::new(
         format_file_cb,
         format_embedded_cb,
         format_embedded_doc_cb,
         sort_tailwindcss_classes_cb,
     )
-    .with_init_cb(init_external_formatter_cb);
+    .with_init_cb(init_external_services_cb);
     let js_config_loader = create_js_config_loader(load_js_config_cb);
 
     utils::init_tracing();
     let result = match command.mode {
         Mode::Lsp => {
-            run_lsp(js_config_loader, external_formatter.clone()).await;
+            run_lsp(js_config_loader, external_services.clone()).await;
 
             ("lsp".to_string(), Some(0))
         }
         Mode::Stdin(_) => {
             init_miette();
 
-            let result = StdinRunner::new(
-                command,
-                Arc::clone(&js_config_loader),
-                external_formatter.clone(),
-            )
-            .run();
+            let result =
+                StdinRunner::new(command, Arc::clone(&js_config_loader), external_services.clone())
+                    .run();
 
             ("stdin".to_string(), Some(result.exit_code()))
         }
@@ -116,7 +113,7 @@ pub async fn run_cli(
             init_rayon(command.runtime_options.threads);
 
             let result = WalkRunner::new(command)
-                .with_external_formatter(Some(external_formatter.clone()))
+                .with_external_services(Some(external_services.clone()))
                 .with_js_config_loader(Arc::clone(&js_config_loader))
                 .run();
 
@@ -127,7 +124,7 @@ pub async fn run_cli(
 
     // Explicitly drop ThreadsafeFunctions before returning to prevent
     // use-after-free during V8 cleanup (Node.js issue with TSFN cleanup timing)
-    external_formatter.cleanup();
+    external_services.cleanup();
 
     result
 }


### PR DESCRIPTION
`ExternalFormatter` is merely a transport that calls the JS side via napi; it is not referred to as a formatter.