### PR TITLE
refactor(oxfmt): rename "external_formatter" to "prettier"

### DIFF
--- a/apps/oxfmt/src/core/config/mod.rs
+++ b/apps/oxfmt/src/core/config/mod.rs
@@ -145,7 +145,7 @@ pub fn resolve_for_api(
     format_config.resolve_tailwind_paths(cwd);
     // Validate eagerly, as the single gate for every option (core + js/sortImports):
     // downstream mapping consumes the derived artifacts and cannot re-fail,
-    // and `ExternalFormatter*` kinds have no later chance before values reach Prettier.
+    // and `Prettier` kinds have no later chance before values reach Prettier.
     let validated = validate(&format_config)?;
     if let Some(plugin) = kind.requires_plugin(&format_config) {
         return Ok(ResolveOutcome::MissingPlugin(plugin));
@@ -460,7 +460,7 @@ impl ConfigResolver {
     /// Fast path: reuses the snapshot + gate artifacts cached by [`Self::build_and_validate`].
     /// Slow path: always validates the merged config here
     ///   the single gate for every kind (downstream carving is infallible;
-    ///   for `ExternalFormatter*` kinds this is also the only safety net before values reach Prettier).
+    ///   for `Prettier` kinds this is also the only safety net before values reach Prettier).
     ///
     /// # Errors
     /// Returns `Err` when overrides introduce invalid values, including:
@@ -609,7 +609,7 @@ mod tests_slow_path_validation {
     /// Without it, `printWidth: 1000` (above LineWidth::MAX = 320) would silently leak into the Prettier options.
     #[test]
     #[cfg(feature = "napi")]
-    fn override_only_invalid_value_is_rejected_for_external_formatter() {
+    fn override_only_invalid_value_is_rejected_for_prettier() {
         let resolver = resolver_from_json(serde_json::json!({
             "printWidth": 80,
             "overrides": [
@@ -618,7 +618,7 @@ mod tests_slow_path_validation {
         }));
 
         // Slow path triggers because the override matches.
-        let kind = FileKind::ExternalFormatter {
+        let kind = FileKind::Prettier {
             path: Arc::from(PathBuf::from("data.json").as_path()),
             parser_name: "json",
             supports_tailwind: false,
@@ -655,13 +655,13 @@ mod tests_slow_path_validation {
         assert!(resolver.resolve(kind).is_ok());
     }
 
-    /// `resolve_for_api` must validate even for `ExternalFormatter*` kinds.
+    /// `resolve_for_api` must validate even for `Prettier` kinds.
     /// Without the eager `validate()` call,
     /// `printWidth: 1000` would silently flow through to Prettier via the NAPI `format()` API.
     #[test]
     #[cfg(feature = "napi")]
-    fn resolve_for_api_rejects_invalid_value_for_external_formatter() {
-        let kind = FileKind::ExternalFormatter {
+    fn resolve_for_api_rejects_invalid_value_for_prettier() {
+        let kind = FileKind::Prettier {
             path: Arc::from(PathBuf::from("page.vue").as_path()),
             parser_name: "vue",
             supports_tailwind: true,

--- a/apps/oxfmt/src/core/embed/dispatcher.rs
+++ b/apps/oxfmt/src/core/embed/dispatcher.rs
@@ -125,15 +125,15 @@ pub struct ResolvedDispatchConfig {
     yaml: OnceLock<YamlFormatOptions>,
     /// One cell per fence-reachable [`JsonVariant`] (json / jsonc / json5; `JsonStringify` is `package.json`-only).
     json: [OnceLock<JsonFormatOptions>; 3],
-    /// The options handed to the external formatter; see [`ExternalOptions`].
+    /// The options handed to Prettier; see [`PrettierOptions`].
     #[cfg(feature = "napi")]
-    external: ExternalOptions,
+    prettier: PrettierOptions,
 }
 
-/// The lazily-built options JSON handed to the external formatter (Prettier + plugins),
+/// The lazily-built options JSON handed to Prettier (+ plugins),
 /// consumed by the Doc→IR / string paths and the Tailwind sorter.
 /// `path` is an ingredient, not a sibling datum: it becomes the JSON's `filepath` at last
-/// (see [`crate::core::options::build_external_options`]).
+/// (see [`crate::core::options::build_prettier_options`]).
 ///
 /// NOTE: The late merge is load-bearing: the JSON must derive from the RESOLVED per-file config
 /// (a pre-built Value loses overrides, #18246), and `path` is the one per-file ingredient,
@@ -141,7 +141,7 @@ pub struct ResolvedDispatchConfig {
 /// Lazy so an embed-free file never builds the JSON at all.
 #[cfg(feature = "napi")]
 #[derive(Default)]
-struct ExternalOptions {
+struct PrettierOptions {
     path: std::path::PathBuf,
     options: OnceLock<serde_json::Value>,
 }
@@ -159,7 +159,7 @@ impl ResolvedDispatchConfig {
             yaml: OnceLock::new(),
             json: [OnceLock::new(), OnceLock::new(), OnceLock::new()],
             #[cfg(feature = "napi")]
-            external: ExternalOptions::default(),
+            prettier: PrettierOptions::default(),
         }
     }
 
@@ -235,13 +235,13 @@ impl ResolvedDispatchConfig {
     }
 }
 
-/// Napi-only methods: the [`ExternalOptions`] accessors and the Tailwind predicate.
+/// Napi-only methods: the [`PrettierOptions`] accessors and the Tailwind predicate.
 #[cfg(feature = "napi")]
 impl ResolvedDispatchConfig {
-    /// Sets the host file path for `filepath` injection into [`Self::external_options`];
+    /// Sets the host file path for `filepath` injection into [`Self::prettier_options`];
     /// chained by [`Self::for_root`].
     fn with_path(mut self, path: std::path::PathBuf) -> Self {
-        self.external.path = path;
+        self.prettier.path = path;
         self
     }
 
@@ -252,11 +252,11 @@ impl ResolvedDispatchConfig {
         self.config.is_tailwind_enabled()
     }
 
-    /// The options JSON handed to the external formatter
-    /// (see [`crate::core::options::build_external_options`]).
-    pub fn external_options(&self) -> &serde_json::Value {
-        self.external.options.get_or_init(|| {
-            crate::core::options::build_external_options(&self.config, &self.external.path)
+    /// The options JSON handed to Prettier
+    /// (see [`crate::core::options::build_prettier_options`]).
+    pub fn prettier_options(&self) -> &serde_json::Value {
+        self.prettier.options.get_or_init(|| {
+            crate::core::options::build_prettier_options(&self.config, &self.prettier.path)
         })
     }
 }

--- a/apps/oxfmt/src/core/embed/prettier_doc.rs
+++ b/apps/oxfmt/src/core/embed/prettier_doc.rs
@@ -35,7 +35,7 @@ pub fn build_prettier_fallback(
         let parser_name = language.parser();
         debug_span!("oxfmt::external::format_embedded_doc", parser = parser_name)
             .in_scope(|| {
-                let mut options = dispatch_config.external_options().clone();
+                let mut options = dispatch_config.prettier_options().clone();
                 inject_parser(&mut options, parser_name);
                 let doc_json_str = (format_embedded_doc)(options, text).map_err(|err| {
                     format!("Failed to get Doc for embedded code (parser '{parser_name}'): {err}")

--- a/apps/oxfmt/src/core/embed/prettier_string.rs
+++ b/apps/oxfmt/src/core/embed/prettier_string.rs
@@ -70,7 +70,7 @@ pub fn build_string_embedder(
         debug_span!("oxfmt::external::format_embedded", parser = parser_name).in_scope(|| {
             // `clone()` is unavoidable here,
             // because there may be multiple embedded sections in one JS/TS file.
-            let mut options = dispatch_config.external_options().clone();
+            let mut options = dispatch_config.prettier_options().clone();
             inject_parser(&mut options, parser_name);
             // The same effective width the native branch prints at
             inject_print_width(&mut options, print_width);

--- a/apps/oxfmt/src/core/embed/services.rs
+++ b/apps/oxfmt/src/core/embed/services.rs
@@ -102,7 +102,7 @@ pub fn for_root(
         let dispatch_config = Arc::clone(dispatch_config);
         Arc::new(move |classes: Vec<String>| {
             debug_span!("oxfmt::external::sort_tailwind", classes_count = classes.len())
-                .in_scope(|| (sort)(dispatch_config.external_options(), classes))
+                .in_scope(|| (sort)(dispatch_config.prettier_options(), classes))
         }) as TailwindSorter
     });
 

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -99,16 +99,16 @@ pub enum FormatStrategy {
     },
     /// For TOML files.
     OxfmtToml { path: Arc<Path>, toml_options: TomlFormatterOptions, insert_final_newline: bool },
-    /// For non-JS files formatted by external formatter (Prettier).
+    /// For non-JS files formatted by delegating to Prettier (Tier 3/4).
     ///
-    /// `supports_xxx` are capability flags carried over from [`FileKind::ExternalFormatter`].
+    /// `supports_xxx` are capability flags carried over from [`FileKind::Prettier`].
     /// The format step injects the corresponding payload (`_useXxxPlugin`) only when
     /// the capability AND the user config both enable the plugin.
     ///
     /// When `supports_oxfmt` is true, `config` doubles as the host Prettier options
     /// source AND the `_oxfmtPluginOptionsJson` payload — single SoT for both.
     #[cfg(feature = "napi")]
-    ExternalFormatter {
+    Prettier {
         path: Arc<Path>,
         parser_name: &'static str,
         config: Box<FormatConfig>,
@@ -131,7 +131,7 @@ impl FormatStrategy {
             | Self::OxcFormatterYamlRc { path, .. }
             | Self::OxfmtToml { path, .. } => path,
             #[cfg(feature = "napi")]
-            Self::ExternalFormatter { path, .. } => path,
+            Self::Prettier { path, .. } => path,
         }
     }
 
@@ -141,7 +141,7 @@ impl FormatStrategy {
     /// every fallible conversion already ran at the gate (`options::validate`),
     /// whose derived values arrive as `validated`; the option mappers below are pure field translation.
     ///
-    /// The Prettier `Value` for `ExternalFormatter*` is deferred to the format step:
+    /// The Prettier `Value` for the `Prettier` kind is deferred to the format step:
     /// `FormatConfig` is the single SoT, no validation needed,
     /// and `Box<FormatConfig>` is materially smaller per file than a fully-built `Value`.
     pub(crate) fn from_format_config(
@@ -215,13 +215,13 @@ impl FormatStrategy {
                 insert_final_newline,
             },
             #[cfg(feature = "napi")]
-            FileKind::ExternalFormatter {
+            FileKind::Prettier {
                 path,
                 parser_name,
                 supports_tailwind,
                 supports_oxfmt,
                 supports_svelte,
-            } => Self::ExternalFormatter {
+            } => Self::Prettier {
                 path,
                 parser_name,
                 config: Box::new(config),
@@ -363,7 +363,7 @@ impl SourceFormatter {
                 (Ok(Self::format_by_toml(source_text, toml_options)), insert_final_newline)
             }
             #[cfg(feature = "napi")]
-            FormatStrategy::ExternalFormatter {
+            FormatStrategy::Prettier {
                 path,
                 parser_name,
                 config,
@@ -372,7 +372,7 @@ impl SourceFormatter {
                 supports_svelte,
                 insert_final_newline,
             } => (
-                self.format_by_external_formatter(
+                self.format_by_prettier(
                     source_text,
                     &path,
                     parser_name,
@@ -603,7 +603,7 @@ impl SourceFormatter {
 
 /// NAPI-only methods for `SourceFormatter`.
 ///
-/// These methods handle external formatter (Prettier) integration,
+/// These methods handle Prettier delegation,
 /// which is only available when running through the Node.js NAPI bridge.
 #[cfg(feature = "napi")]
 impl SourceFormatter {
@@ -623,11 +623,11 @@ impl SourceFormatter {
             .expect("`external_services` must exist when `napi` feature is enabled")
     }
 
-    /// Format non-JS/TS file using external formatter (Prettier).
+    /// Format non-JS/TS file by delegating to Prettier.
     ///
     /// Plugin payloads are injected based on capability flags & user config.
-    #[instrument(level = "debug", name = "oxfmt::format::external_formatter", skip_all, fields(parser = %parser_name))]
-    fn format_by_external_formatter(
+    #[instrument(level = "debug", name = "oxfmt::format::prettier", skip_all, fields(parser = %parser_name))]
+    fn format_by_prettier(
         &self,
         source_text: &str,
         path: &Path,
@@ -637,22 +637,22 @@ impl SourceFormatter {
         supports_oxfmt: bool,
         supports_svelte: bool,
     ) -> Result<String, OxcDiagnostic> {
-        let mut external_options = to_prettier(config);
-        inject_parser(&mut external_options, parser_name);
-        inject_filepath(&mut external_options, path);
+        let mut prettier_options = to_prettier(config);
+        inject_parser(&mut prettier_options, parser_name);
+        inject_filepath(&mut prettier_options, path);
 
         if supports_tailwind {
-            inject_tailwind_plugin_payload(&mut external_options, config);
+            inject_tailwind_plugin_payload(&mut prettier_options, config);
         }
         if supports_oxfmt {
-            inject_oxfmt_plugin_payload(&mut external_options, config, path);
+            inject_oxfmt_plugin_payload(&mut prettier_options, config, path);
         }
         if supports_svelte {
-            inject_svelte_plugin_payload(&mut external_options, config);
+            inject_svelte_plugin_payload(&mut prettier_options, config);
         }
 
-        self.external_services().format_file(external_options, source_text).map_err(|err| {
-            // NOTE: We are trying to make the error from oxc_formatter(_xxx) and external_services (Prettier) look similar.
+        self.external_services().format_file(prettier_options, source_text).map_err(|err| {
+            // NOTE: We are trying to make the error from oxc_formatter(_xxx) and Prettier look similar.
             // Ideally, we would unify them into `OxcDiagnostic`, which would eliminate the need for relative path conversion.
             // However, doing so would require:
             // - Parsing Prettier's error messages

--- a/apps/oxfmt/src/core/options/mod.rs
+++ b/apps/oxfmt/src/core/options/mod.rs
@@ -33,7 +33,7 @@ pub use to_oxc_formatter_yaml::to_oxc_formatter_yaml;
 pub use to_oxc_toml::to_oxc_toml;
 #[cfg(feature = "napi")]
 pub use to_prettier::{
-    build_external_options, inject_filepath, inject_oxfmt_plugin_payload, inject_parser,
+    build_prettier_options, inject_filepath, inject_oxfmt_plugin_payload, inject_parser,
     inject_print_width, inject_svelte_plugin_payload, inject_tailwind_plugin_payload, to_prettier,
 };
 pub use validate::{ValidatedOptions, validate};

--- a/apps/oxfmt/src/core/options/to_prettier.rs
+++ b/apps/oxfmt/src/core/options/to_prettier.rs
@@ -210,11 +210,11 @@ pub fn inject_tailwind_plugin_payload(opts: &mut Value, config: &FormatConfig) {
 
 /// Build the Prettier options JSON shared by the embedded callbacks and the Tailwind sorter:
 /// resolved config + `filepath` + the Tailwind plugin payload (which the JS-side sorter resolves the class order from).
-pub fn build_external_options(config: &FormatConfig, path: &Path) -> Value {
-    let mut external_options = to_prettier(config);
-    inject_filepath(&mut external_options, path);
-    inject_tailwind_plugin_payload(&mut external_options, config);
-    external_options
+pub fn build_prettier_options(config: &FormatConfig, path: &Path) -> Value {
+    let mut prettier_options = to_prettier(config);
+    inject_filepath(&mut prettier_options, path);
+    inject_tailwind_plugin_payload(&mut prettier_options, config);
+    prettier_options
 }
 
 /// Inject Svelte plugin keys derived from `config.svelte`.

--- a/apps/oxfmt/src/core/options/validate.rs
+++ b/apps/oxfmt/src/core/options/validate.rs
@@ -18,7 +18,7 @@ pub struct ValidatedOptions {
 }
 
 /// The eager validation gate during config resolution.
-/// For `ExternalFormatter*` kinds, it is the only safety net before values reach Prettier.
+/// For `Prettier` kinds, it is the only safety net before values reach Prettier.
 ///
 /// This runs every fallible conversion and returns the derived artifacts
 /// (enumerated options are already rejected at deserialize time,

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -71,14 +71,14 @@ pub fn classify_file_kind(path: Arc<Path>) -> Option<FileKind> {
         return Some(FileKind::OxcFormatterYaml { path });
     }
 
-    // External formatter files are only supported with the `napi` feature
+    // Prettier-delegated files are only supported with the `napi` feature
     #[cfg(feature = "napi")]
     {
-        if let Some(parser_name) = get_external_parser_name(file_name, extension) {
+        if let Some(parser_name) = get_prettier_parser_name(file_name, extension) {
             let supports_tailwind = TAILWIND_PARSERS.contains(parser_name);
             let supports_oxfmt = OXFMT_PARSERS.contains(parser_name);
             let supports_svelte = SVELTE_PARSERS.contains(parser_name);
-            return Some(FileKind::ExternalFormatter {
+            return Some(FileKind::Prettier {
                 path,
                 parser_name,
                 supports_tailwind,
@@ -115,14 +115,14 @@ pub enum FileKind {
     OxcFormatterYamlRc { path: Arc<Path> },
     /// TOML files formatted by taplo (Pure Rust).
     OxfmtToml { path: Arc<Path> },
-    /// Files formatted by external formatter (Prettier).
+    /// Files formatted by delegating to Prettier (Tier 3/4).
     ///
     /// `supports_tailwind` / `supports_oxfmt` / `supports_svelte` are capability
     /// flags that say "this file kind CAN use the corresponding plugin".
     /// Whether the plugin is actually activated is decided at the format step by resolved config.
     /// Only available with the `napi` feature; without it, the classifier rejects such files.
     #[cfg(feature = "napi")]
-    ExternalFormatter {
+    Prettier {
         path: Arc<Path>,
         parser_name: &'static str,
         supports_tailwind: bool,
@@ -143,7 +143,7 @@ impl FileKind {
             | Self::OxcFormatterYamlRc { path }
             | Self::OxfmtToml { path } => path,
             #[cfg(feature = "napi")]
-            Self::ExternalFormatter { path, .. } => path,
+            Self::Prettier { path, .. } => path,
         }
     }
 
@@ -156,7 +156,7 @@ impl FileKind {
     /// [`super::ResolveOutcome::MissingPlugin`] in that case.
     #[cfg(feature = "napi")]
     pub fn requires_plugin(&self, config: &FormatConfig) -> Option<&'static str> {
-        if let Self::ExternalFormatter { parser_name: "svelte", .. } = self
+        if let Self::Prettier { parser_name: "svelte", .. } = self
             && !config.is_svelte_enabled()
         {
             return Some("svelte");
@@ -414,10 +414,10 @@ static YAML_EXTENSIONS: phf::Set<&'static str> = phf_set! {
 
 // ---
 
-/// Returns parser name for external formatter, if supported.
+/// Returns the Prettier parser name for the file, if supported.
 /// See also `prettier --support-info | jq '.languages[]'`
 #[cfg(feature = "napi")]
-fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<&'static str> {
+fn get_prettier_parser_name(file_name: &str, extension: Option<&str>) -> Option<&'static str> {
     // Markdown and variants
     if MARKDOWN_FILENAMES.contains(file_name) {
         return Some("markdown");
@@ -625,11 +625,11 @@ mod tests {
 
     #[test]
     #[cfg(feature = "napi")]
-    fn test_get_external_parser_name() {
+    fn test_get_prettier_parser_name() {
         fn get_parser_name(file_name: &str) -> Option<&'static str> {
             let path = Path::new(file_name);
             let extension = path.extension().and_then(|ext| ext.to_str());
-            get_external_parser_name(file_name, extension)
+            get_prettier_parser_name(file_name, extension)
         }
 
         let test_cases = vec![

--- a/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/nodes.rs
+++ b/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/nodes.rs
@@ -759,7 +759,8 @@ fn format_code_value<'a>(
     width: usize,
     opts: &SerializeOptions<'_>,
 ) -> Cow<'a, str> {
-    // For fenced code with an explicit non-JS/TS lang, try external formatter (CSS, HTML, etc.)
+    // Fenced code with an explicit non-JS/TS lang: route through the session's string embedder
+    // (the host decides who serves the language); verbatim when absent or it fails.
     if let Some(l) = lang
         && !is_js_ts_lang(l)
     {

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -1,8 +1,11 @@
 use cow_utils::CowUtils;
 
-use oxc_allocator::ArenaStringBuilder;
+use oxc_allocator::{Allocator, ArenaStringBuilder};
 use oxc_ast::ast::*;
-use oxc_formatter_core::{DispatchOutcome, DispatchRequest, FormatElement, InputKind};
+use oxc_formatter_core::{
+    DispatchOutcome, DispatchRequest, FormatElement, IndentWidth, InputKind,
+    format_element::TextWidth,
+};
 use oxc_syntax::line_terminator::LineTerminatorSplitter;
 
 use crate::{
@@ -184,12 +187,7 @@ pub(super) fn format_html_doc<'a>(
                     for (i, part) in parts.iter().enumerate() {
                         if i.is_multiple_of(2) {
                             if !part.is_empty() {
-                                super::write_text_with_line_breaks(
-                                    f,
-                                    part,
-                                    allocator,
-                                    indent_width,
-                                );
+                                write_text_with_line_breaks(f, part, allocator, indent_width);
                             }
                         } else if let Some(idx) = part.parse::<usize>().ok()
                             && let Some(expr) = expressions.get(idx)
@@ -319,4 +317,30 @@ fn format_js_in_html_as_fallback<'a>(
 
     write!(f, ["`", block_indent(&format_content), "`"]);
     true
+}
+
+/// Emit text with newlines converted to literal line breaks (`replaceEndOfLine()` equivalent).
+///
+/// Uses [`literal_line_break`] instead of `hard_line_break()` to avoid adding indentation:
+/// the returned HTML Doc already carries its indentation in the text content,
+/// so the surrounding `block_indent` must not add more.
+fn write_text_with_line_breaks<'a>(
+    f: &mut JsFormatter<'_, 'a>,
+    text: &str,
+    allocator: &'a Allocator,
+    indent_width: IndentWidth,
+) {
+    let mut first = true;
+    // Splitting on `\n` is safe because `Doc` only contains normalized linebreaks.
+    for line in text.split('\n') {
+        if !first {
+            write!(f, [literal_line_break()]);
+        }
+        first = false;
+        if !line.is_empty() {
+            let arena_text = allocator.alloc_str(line);
+            let width = TextWidth::from_text(arena_text, indent_width);
+            f.write_element(FormatElement::Text { text: arena_text, width });
+        }
+    }
 }

--- a/crates/oxc_formatter/src/print/template/embed/mod.rs
+++ b/crates/oxc_formatter/src/print/template/embed/mod.rs
@@ -15,7 +15,6 @@ use oxc_formatter_core::{
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::prelude::*,
-    write,
 };
 
 /// Try to format a tagged template with the embedded formatter if supported.
@@ -290,33 +289,6 @@ fn split_on_placeholders<'a>(text: &'a str, prefix: &str, suffix: &str) -> Vec<&
     }
 
     result
-}
-
-/// Emit text with newlines converted to literal line breaks (`replaceEndOfLine()` equivalent).
-///
-/// Uses [`literal_line_break`] instead of `hard_line_break()` to avoid adding indentation.
-///
-/// The external formatter has already computed proper indentation in the text content,
-/// so we must not add extra indent from the surrounding `block_indent`.
-fn write_text_with_line_breaks<'a>(
-    f: &mut JsFormatter<'_, 'a>,
-    text: &str,
-    allocator: &'a Allocator,
-    indent_width: IndentWidth,
-) {
-    let mut first = true;
-    // Splitting on `\n` is safe because `Doc` only contains normalized linebreaks.
-    for line in text.split('\n') {
-        if !first {
-            write!(f, [literal_line_break()]);
-        }
-        first = false;
-        if !line.is_empty() {
-            let arena_text = allocator.alloc_str(line);
-            let width = TextWidth::from_text(arena_text, indent_width);
-            f.write_element(FormatElement::Text { text: arena_text, width });
-        }
-    }
 }
 
 // ---


### PR DESCRIPTION
Use explicit wording.