### PR TITLE
refactor(oxfmt,formatter): split `sortImports` validation and use type enum

### DIFF
--- a/apps/oxfmt/src-js/config.generated.ts
+++ b/apps/oxfmt/src-js/config.generated.ts
@@ -19,6 +19,26 @@ export type GlobSet = string[];
 export type ProseWrapConfig = "always" | "never" | "preserve";
 export type QuotePropsConfig = "as-needed" | "consistent" | "preserve";
 export type SortImportsUserConfig = boolean | SortImportsConfig;
+/**
+ * Modifier matching the import characteristics in `customGroups` (see `sortImports.groups` for semantics).
+ */
+export type ImportModifierConfig = "side_effect" | "type" | "value" | "default" | "wildcard" | "named";
+/**
+ * Selector matching the import kind in `customGroups` (see `sortImports.groups` for semantics).
+ */
+export type ImportSelectorConfig =
+  | "type"
+  | "side_effect_style"
+  | "side_effect"
+  | "style"
+  | "index"
+  | "sibling"
+  | "parent"
+  | "subpath"
+  | "internal"
+  | "builtin"
+  | "external"
+  | "import";
 export type SortGroupItemConfig = NewlinesBetweenMarker | string | string[];
 export type SortOrderConfig = "asc" | "desc";
 export type SortPackageJsonUserConfig = boolean | SortPackageJsonConfig;
@@ -732,17 +752,12 @@ export interface CustomGroupItemConfig {
   /**
    * Modifiers to match the import characteristics.
    * All specified modifiers must be present (AND logic).
-   *
-   * Possible values: `"side_effect"`, `"type"`, `"value"`, `"default"`, `"wildcard"`, `"named"`
    */
-  modifiers?: string[];
+  modifiers?: ImportModifierConfig[];
   /**
    * Selector to match the import kind.
-   *
-   * Possible values: `"type"`, `"side_effect_style"`, `"side_effect"`, `"style"`, `"index"`,
-   * `"sibling"`, `"parent"`, `"subpath"`, `"internal"`, `"builtin"`, `"external"`, `"import"`
    */
-  selector?: string;
+  selector?: ImportSelectorConfig;
   [k: string]: unknown;
 }
 /**

--- a/apps/oxfmt/src/core/options/to_oxc_formatter.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter.rs
@@ -1,5 +1,3 @@
-use rustc_hash::FxHashSet;
-
 #[cfg(feature = "napi")]
 use oxc_formatter::SortTailwindcssOptions;
 use oxc_formatter::{
@@ -13,10 +11,10 @@ use oxc_formatter_core::{CoreFormatOptions, FormatOptions};
 #[cfg(feature = "napi")]
 use super::super::oxfmtrc::SortTailwindcssUserConfig;
 use super::super::oxfmtrc::{
-    ArrowParensConfig, CommentLineStrategyConfig, CustomGroupItemConfig, FormatConfig,
-    HtmlWhitespaceSensitivityConfig, JsdocUserConfig, LineWrappingStyleConfig, ObjectWrapConfig,
-    QuotePropsConfig, SortGroupItemConfig, SortImportsUserConfig, SortOrderConfig,
-    TrailingCommaConfig,
+    ArrowParensConfig, CommentLineStrategyConfig, FormatConfig, HtmlWhitespaceSensitivityConfig,
+    ImportModifierConfig, ImportSelectorConfig, JsdocUserConfig, LineWrappingStyleConfig,
+    ObjectWrapConfig, QuotePropsConfig, SortGroupItemConfig, SortImportsUserConfig,
+    SortOrderConfig, TrailingCommaConfig,
 };
 
 /// Convert `FormatConfig` into `JsFormatOptions` for `oxc_formatter`.
@@ -136,12 +134,16 @@ pub fn to_oxc_formatter(
     format_options
 }
 
-/// Parse and validate `sortImports` into [`SortImportsOptions`].
+/// Derive [`SortImportsOptions`] from the resolved config;
+/// the gate ([`super::validate::validate()`]) runs it once, like `to_core_options`.
 ///
-/// If possible, all validations should happen when deserializing `Oxfmtrc`.
-/// However, these options become problematic depending on their combinations.
-/// Also, since it cannot be known until `overrides` are resolved, the validation is done here.
-/// the gate ([`super::validate::validate()`]) runs it once and hands the artifact to [`to_oxc_formatter()`].
+/// NOTE: Combination validity is a property of the resolved config
+/// (overrides deep-merge field-wise, so two individually valid configs can compose into an invalid one),
+/// which is why none of these checks can run at deserialize time.
+/// Each rule lives with its owner and this function only converts and invokes them:
+/// marker grammar on `SortGroupItemConfig` (the flat-list syntax's type),
+/// combination / reference invariants on `SortImportsOptions` (the formatter's type),
+/// enumerated values (selector / modifiers) at deserialize.
 ///
 /// # Errors
 /// Returns an error if the `sortImports` configuration is invalid.
@@ -178,84 +180,46 @@ pub(super) fn to_sort_imports(config: &FormatConfig) -> Result<Option<SortImport
     if let Some(v) = sort_imports_config.internal_pattern {
         sort_imports.internal_pattern = v;
     }
-    // Validate and parse `customGroups` first, since `groups` may refer to custom group names.
     if let Some(v) = sort_imports_config.custom_groups {
-        let mut custom_groups = Vec::with_capacity(v.len());
-        for cg in v {
-            let CustomGroupItemConfig { group_name, element_name_pattern, .. } = cg;
-            let selector = match cg.selector.as_deref() {
-                Some(s) => match ImportSelector::parse(s) {
-                    Some(parsed) => Some(parsed),
-                    None => {
-                        return Err(format!(
-                            "Invalid `sortImports` configuration: unknown selector: `{s}` in customGroups: `{group_name}`"
-                        ));
-                    }
-                },
-                None => None,
-            };
-            let raw_modifiers = cg.modifiers.unwrap_or_default();
-            let mut modifiers = Vec::with_capacity(raw_modifiers.len());
-            for m in &raw_modifiers {
-                match ImportModifier::parse(m) {
-                    Some(parsed) => modifiers.push(parsed),
-                    None => {
-                        return Err(format!(
-                            "Invalid `sortImports` configuration: unknown modifier: `{m}` in customGroups: `{group_name}`"
-                        ));
-                    }
-                }
-            }
-            custom_groups.push(CustomGroupDefinition {
-                group_name,
-                element_name_pattern,
-                selector,
-                modifiers,
-            });
-        }
-        sort_imports.custom_groups = custom_groups;
+        sort_imports.custom_groups = v
+            .into_iter()
+            .map(|cg| CustomGroupDefinition {
+                group_name: cg.group_name,
+                element_name_pattern: cg.element_name_pattern,
+                selector: cg.selector.map(to_import_selector),
+                modifiers: cg
+                    .modifiers
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(to_import_modifier)
+                    .collect(),
+            })
+            .collect();
     }
     if let Some(v) = sort_imports_config.groups {
-        let custom_group_names: FxHashSet<&str> =
-            sort_imports.custom_groups.iter().map(|g| g.group_name.as_str()).collect();
+        SortGroupItemConfig::validate_markers(&v)
+            .map_err(|e| format!("Invalid `sortImports` configuration: {e}"))?;
+
         let mut groups = Vec::new();
         let mut newline_boundary_overrides: Vec<Option<bool>> = Vec::new();
         let mut pending_override: Option<bool> = None;
-
         for item in v {
             match item {
                 SortGroupItemConfig::NewlinesBetween(marker) => {
-                    if groups.is_empty() {
-                        return Err("Invalid `sortImports` configuration: `{ \"newlinesBetween\" }` marker cannot appear at the start of `groups`".to_string());
-                    }
-                    if pending_override.is_some() {
-                        return Err("Invalid `sortImports` configuration: consecutive `{ \"newlinesBetween\" }` markers are not allowed in `groups`".to_string());
-                    }
+                    // `validate_markers` ruled out leading/adjacent markers,
+                    // so no override can be pending here.
+                    debug_assert!(pending_override.is_none());
                     pending_override = Some(marker.newlines_between);
                 }
                 other => {
                     if !groups.is_empty() {
                         newline_boundary_overrides.push(pending_override.take());
                     }
-                    let mut entries = Vec::new();
-                    for name in other.into_vec() {
-                        let entry = GroupEntry::parse(&name);
-                        if let GroupEntry::Custom(ref n) = entry
-                            && !custom_group_names.contains(n.as_str())
-                        {
-                            return Err(format!(
-                                "Invalid `sortImports` configuration: unknown group name `{name}` in `groups`"
-                            ));
-                        }
-                        entries.push(entry);
-                    }
-                    groups.push(entries);
+                    groups.push(
+                        other.into_vec().iter().map(|name| GroupEntry::parse(name)).collect(),
+                    );
                 }
             }
-        }
-
-        if pending_override.is_some() {
-            return Err("Invalid `sortImports` configuration: `{ \"newlinesBetween\" }` marker cannot appear at the end of `groups`".to_string());
         }
 
         sort_imports.groups = groups;
@@ -265,6 +229,36 @@ pub(super) fn to_sort_imports(config: &FormatConfig) -> Result<Option<SortImport
     sort_imports.validate().map_err(|e| format!("Invalid `sortImports` configuration: {e}"))?;
 
     Ok(Some(sort_imports))
+}
+
+/// Pure field translation (unknown values are rejected at deserialize time).
+fn to_import_selector(config: ImportSelectorConfig) -> ImportSelector {
+    match config {
+        ImportSelectorConfig::Type => ImportSelector::Type,
+        ImportSelectorConfig::SideEffectStyle => ImportSelector::SideEffectStyle,
+        ImportSelectorConfig::SideEffect => ImportSelector::SideEffect,
+        ImportSelectorConfig::Style => ImportSelector::Style,
+        ImportSelectorConfig::Index => ImportSelector::Index,
+        ImportSelectorConfig::Sibling => ImportSelector::Sibling,
+        ImportSelectorConfig::Parent => ImportSelector::Parent,
+        ImportSelectorConfig::Subpath => ImportSelector::Subpath,
+        ImportSelectorConfig::Internal => ImportSelector::Internal,
+        ImportSelectorConfig::Builtin => ImportSelector::Builtin,
+        ImportSelectorConfig::External => ImportSelector::External,
+        ImportSelectorConfig::Import => ImportSelector::Import,
+    }
+}
+
+/// Pure field translation (unknown values are rejected at deserialize time).
+fn to_import_modifier(config: ImportModifierConfig) -> ImportModifier {
+    match config {
+        ImportModifierConfig::SideEffect => ImportModifier::SideEffect,
+        ImportModifierConfig::Type => ImportModifier::Type,
+        ImportModifierConfig::Value => ImportModifier::Value,
+        ImportModifierConfig::Default => ImportModifier::Default,
+        ImportModifierConfig::Wildcard => ImportModifier::Wildcard,
+        ImportModifierConfig::Named => ImportModifier::Named,
+    }
 }
 
 /// Convert `jsdoc` into [`oxc_formatter::JsdocOptions`].
@@ -322,7 +316,7 @@ pub(super) fn to_jsdoc(config: &FormatConfig) -> Option<JsdocOptions> {
 
 #[cfg(test)]
 mod tests {
-    use oxc_formatter::{Expand, GroupName};
+    use oxc_formatter::{Expand, GroupEntry, GroupName};
 
     use super::super::validate::validate;
     use super::*;
@@ -331,6 +325,28 @@ mod tests {
     fn build(config: &FormatConfig) -> Result<JsFormatOptions, String> {
         let validated = validate(config)?;
         Ok(to_oxc_formatter(config, validated.core, validated.sort_imports))
+    }
+
+    /// The config enums mirror `oxc_formatter`'s (which deliberately carries no
+    /// serde/schemars dependency). A config-side variant without a formatter
+    /// counterpart cannot compile (the mapper match forces it), but a formatter-side
+    /// addition missing its mirror is silent — this round-trip turns that into a failure.
+    #[test]
+    fn config_enums_mirror_formatter_enums() {
+        for selector in ImportSelector::ALL_SELECTORS {
+            let config: ImportSelectorConfig =
+                serde_json::from_value(serde_json::json!(selector.name())).unwrap_or_else(|_| {
+                    panic!("selector `{}` is missing from ImportSelectorConfig", selector.name())
+                });
+            assert_eq!(to_import_selector(config), *selector);
+        }
+        for modifier in ImportModifier::ALL_MODIFIERS {
+            let config: ImportModifierConfig =
+                serde_json::from_value(serde_json::json!(modifier.name())).unwrap_or_else(|_| {
+                    panic!("modifier `{}` is missing from ImportModifierConfig", modifier.name())
+                });
+            assert_eq!(to_import_modifier(config), *modifier);
+        }
     }
 
     #[test]

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -626,6 +626,34 @@ impl SortGroupItemConfig {
             }
         }
     }
+
+    /// Validate the flat `groups` list's marker grammar: a `{ "newlinesBetween" }`
+    /// marker must sit BETWEEN two groups, so it may not lead, trail, or neighbor another marker.
+    ///
+    /// These are rules of this syntax (the parallel-vec target cannot even represent a violation),
+    /// so their owner is this type, mirroring `SortImportsOptions::validate` on the formatter side.
+    ///
+    /// # Errors
+    /// Returns an error naming the violated position rule.
+    pub(super) fn validate_markers(items: &[Self]) -> Result<(), String> {
+        let is_marker = |item: &Self| matches!(item, Self::NewlinesBetween(_));
+        if items.first().is_some_and(is_marker) {
+            return Err("`{ \"newlinesBetween\" }` marker cannot appear at the start of `groups`"
+                .to_string());
+        }
+        if items.last().is_some_and(is_marker) {
+            return Err(
+                "`{ \"newlinesBetween\" }` marker cannot appear at the end of `groups`".to_string()
+            );
+        }
+        if items.windows(2).any(|pair| is_marker(&pair[0]) && is_marker(&pair[1])) {
+            return Err(
+                "consecutive `{ \"newlinesBetween\" }` markers are not allowed in `groups`"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
@@ -636,17 +664,42 @@ pub struct CustomGroupItemConfig {
     /// List of glob patterns to match import sources for this group.
     pub element_name_pattern: Vec<String>,
     /// Selector to match the import kind.
-    ///
-    /// Possible values: `"type"`, `"side_effect_style"`, `"side_effect"`, `"style"`, `"index"`,
-    /// `"sibling"`, `"parent"`, `"subpath"`, `"internal"`, `"builtin"`, `"external"`, `"import"`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub selector: Option<String>,
+    pub selector: Option<ImportSelectorConfig>,
     /// Modifiers to match the import characteristics.
     /// All specified modifiers must be present (AND logic).
-    ///
-    /// Possible values: `"side_effect"`, `"type"`, `"value"`, `"default"`, `"wildcard"`, `"named"`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub modifiers: Option<Vec<String>>,
+    pub modifiers: Option<Vec<ImportModifierConfig>>,
+}
+
+/// Selector matching the import kind in `customGroups` (see `sortImports.groups` for semantics).
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportSelectorConfig {
+    Type,
+    SideEffectStyle,
+    SideEffect,
+    Style,
+    Index,
+    Sibling,
+    Parent,
+    Subpath,
+    Internal,
+    Builtin,
+    External,
+    Import,
+}
+
+/// Modifier matching the import characteristics in `customGroups` (see `sortImports.groups` for semantics).
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportModifierConfig {
+    SideEffect,
+    Type,
+    Value,
+    Default,
+    Wildcard,
+    Named,
 }
 
 // ---

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/group_config.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/group_config.rs
@@ -18,8 +18,8 @@ impl GroupEntry {
     /// - Valid predefined name: `GroupEntry::Predefined(..)`
     /// - Anything else: `GroupEntry::Custom(..)`
     ///
-    /// NOTE: This does NOT validate whether custom group names are actually defined.
-    /// That validation should be done at the config layer.
+    /// NOTE: This does NOT validate whether custom group names are actually defined;
+    /// `SortImportsOptions::validate` checks the built option set for dangling names.
     pub fn parse(name: &str) -> Self {
         if name == "unknown" {
             return Self::Unknown;

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
@@ -39,14 +39,17 @@ pub struct SortImportsOptions {
     /// Per-boundary newline overrides.
     /// `newline_boundary_overrides[i]` = override for boundary between `groups[i]` and `groups[i+1]`.
     /// `None` means "use global `newlines_between`".
+    /// Either empty (no overrides anywhere) or exactly `groups.len() - 1` entries
+    /// ([`Self::validate`] checks this pairing).
     pub newline_boundary_overrides: Vec<Option<bool>>,
 }
 
 impl SortImportsOptions {
-    /// Validate option combinations.
+    /// Validate option combinations and cross-field references.
     ///
     /// # Errors
-    /// Returns an error message if incompatible options are set.
+    /// Returns an error message if incompatible options are set,
+    /// or `groups` references an undefined custom group name.
     pub fn validate(&self) -> Result<(), String> {
         if self.partition_by_newline && self.newline_boundary_overrides.iter().any(Option::is_some)
         {
@@ -57,6 +60,25 @@ impl SortImportsOptions {
                 "`partitionByNewline: true` and `newlinesBetween: true` cannot be used together"
                     .to_string(),
             );
+        }
+        // A dangling name would silently match nothing at runtime.
+        for entry in self.groups.iter().flatten() {
+            if let GroupEntry::Custom(name) = entry
+                && !self.custom_groups.iter().any(|g| g.group_name == *name)
+            {
+                return Err(format!("unknown group name `{name}` in `groups`"));
+            }
+        }
+        // A short/long vec would silently fall back to the global setting for tail boundaries.
+        if !self.newline_boundary_overrides.is_empty()
+            && self.newline_boundary_overrides.len() + 1 != self.groups.len()
+        {
+            return Err(format!(
+                "`newline_boundary_overrides` must be empty or hold exactly one entry per group boundary ({} groups need {}, got {})",
+                self.groups.len(),
+                self.groups.len().saturating_sub(1),
+                self.newline_boundary_overrides.len()
+            ));
         }
         Ok(())
     }

--- a/crates/oxc_formatter/tests/ir_transform/mod.rs
+++ b/crates/oxc_formatter/tests/ir_transform/mod.rs
@@ -183,6 +183,7 @@ fn parse_test_config(json: &str) -> JsFormatOptions {
                 })
                 .collect();
         }
+        sort_imports.validate().expect("fixture `options.json` holds an invalid sortImports set");
         options.sort_imports = Some(sort_imports);
     }
 

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -234,17 +234,21 @@
           "markdownDescription": "Name of the custom group, used in the `groups` option."
         },
         "modifiers": {
-          "description": "Modifiers to match the import characteristics.\nAll specified modifiers must be present (AND logic).\n\nPossible values: `\"side_effect\"`, `\"type\"`, `\"value\"`, `\"default\"`, `\"wildcard\"`, `\"named\"`",
+          "description": "Modifiers to match the import characteristics.\nAll specified modifiers must be present (AND logic).",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/ImportModifierConfig"
           },
-          "markdownDescription": "Modifiers to match the import characteristics.\nAll specified modifiers must be present (AND logic).\n\nPossible values: `\"side_effect\"`, `\"type\"`, `\"value\"`, `\"default\"`, `\"wildcard\"`, `\"named\"`"
+          "markdownDescription": "Modifiers to match the import characteristics.\nAll specified modifiers must be present (AND logic)."
         },
         "selector": {
-          "description": "Selector to match the import kind.\n\nPossible values: `\"type\"`, `\"side_effect_style\"`, `\"side_effect\"`, `\"style\"`, `\"index\"`,\n`\"sibling\"`, `\"parent\"`, `\"subpath\"`, `\"internal\"`, `\"builtin\"`, `\"external\"`, `\"import\"`",
-          "type": "string",
-          "markdownDescription": "Selector to match the import kind.\n\nPossible values: `\"type\"`, `\"side_effect_style\"`, `\"side_effect\"`, `\"style\"`, `\"index\"`,\n`\"sibling\"`, `\"parent\"`, `\"subpath\"`, `\"internal\"`, `\"builtin\"`, `\"external\"`, `\"import\"`"
+          "description": "Selector to match the import kind.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ImportSelectorConfig"
+            }
+          ],
+          "markdownDescription": "Selector to match the import kind."
         }
       }
     },
@@ -459,6 +463,38 @@
         "strict",
         "ignore"
       ]
+    },
+    "ImportModifierConfig": {
+      "description": "Modifier matching the import characteristics in `customGroups` (see `sortImports.groups` for semantics).",
+      "type": "string",
+      "enum": [
+        "side_effect",
+        "type",
+        "value",
+        "default",
+        "wildcard",
+        "named"
+      ],
+      "markdownDescription": "Modifier matching the import characteristics in `customGroups` (see `sortImports.groups` for semantics)."
+    },
+    "ImportSelectorConfig": {
+      "description": "Selector matching the import kind in `customGroups` (see `sortImports.groups` for semantics).",
+      "type": "string",
+      "enum": [
+        "type",
+        "side_effect_style",
+        "side_effect",
+        "style",
+        "index",
+        "sibling",
+        "parent",
+        "subpath",
+        "internal",
+        "builtin",
+        "external",
+        "import"
+      ],
+      "markdownDescription": "Selector matching the import kind in `customGroups` (see `sortImports.groups` for semantics)."
     },
     "JsdocConfig": {
       "type": "object",

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -694,24 +694,27 @@ Name of the custom group, used in the `groups` option.
 
 ######## overrides[n].options.sortImports.customGroups[n].modifiers
 
-type: `string[]`
+type: `array`
 
 
 Modifiers to match the import characteristics.
 All specified modifiers must be present (AND logic).
 
-Possible values: `"side_effect"`, `"type"`, `"value"`, `"default"`, `"wildcard"`, `"named"`
+
+######### overrides[n].options.sortImports.customGroups[n].modifiers[n]
+
+type: `"side_effect" | "type" | "value" | "default" | "wildcard" | "named"`
+
+
+Modifier matching the import characteristics in `customGroups` (see `sortImports.groups` for semantics).
 
 
 ######## overrides[n].options.sortImports.customGroups[n].selector
 
-type: `string`
+type: `"type" | "side_effect_style" | "side_effect" | "style" | "index" | "sibling" | "parent" | "subpath" | "internal" | "builtin" | "external" | "import"`
 
 
 Selector to match the import kind.
-
-Possible values: `"type"`, `"side_effect_style"`, `"side_effect"`, `"style"`, `"index"`,
-`"sibling"`, `"parent"`, `"subpath"`, `"internal"`, `"builtin"`, `"external"`, `"import"`
 
 
 ###### overrides[n].options.sortImports.groups
@@ -1239,24 +1242,27 @@ Name of the custom group, used in the `groups` option.
 
 ##### sortImports.customGroups[n].modifiers
 
-type: `string[]`
+type: `array`
 
 
 Modifiers to match the import characteristics.
 All specified modifiers must be present (AND logic).
 
-Possible values: `"side_effect"`, `"type"`, `"value"`, `"default"`, `"wildcard"`, `"named"`
+
+###### sortImports.customGroups[n].modifiers[n]
+
+type: `"side_effect" | "type" | "value" | "default" | "wildcard" | "named"`
+
+
+Modifier matching the import characteristics in `customGroups` (see `sortImports.groups` for semantics).
 
 
 ##### sortImports.customGroups[n].selector
 
-type: `string`
+type: `"type" | "side_effect_style" | "side_effect" | "style" | "index" | "sibling" | "parent" | "subpath" | "internal" | "builtin" | "external" | "import"`
 
 
 Selector to match the import kind.
-
-Possible values: `"type"`, `"side_effect_style"`, `"side_effect"`, `"style"`, `"index"`,
-`"sibling"`, `"parent"`, `"subpath"`, `"internal"`, `"builtin"`, `"external"`, `"import"`
 
 
 ### sortImports.groups


### PR DESCRIPTION
Reduce runtime validation.

Also, by using type `enum`, IDE and TS types are also covered.