### PR TITLE
refactor(formatter_core): share frontmatter writer in core

### DIFF
--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -1,6 +1,8 @@
 use oxc_allocator::ArenaStringBuilder;
 use oxc_ast::ast::*;
-use oxc_formatter_core::{FormatElement, IndentWidth, format_element::TextWidth};
+use oxc_formatter_core::{
+    FormatElement, IndentWidth, dispatch_fragment_ir, format_element::TextWidth,
+};
 
 use crate::{
     ast_nodes::AstNode,
@@ -52,7 +54,7 @@ pub(super) fn format_css_doc<'a>(
             return true;
         }
 
-        let Some(ir) = super::dispatch_fragment_ir(f, "css", raw, Some(&CssInJsTemplate)) else {
+        let Some(ir) = dispatch_fragment_ir(f, "css", raw, Some(&CssInJsTemplate)) else {
             return false;
         };
 
@@ -78,7 +80,7 @@ pub(super) fn format_css_doc<'a>(
     };
 
     // Phase 2: Format via the dispatcher (IR path)
-    let Some(ir) = super::dispatch_fragment_ir(f, "css", joined, Some(&CssInJsTemplate)) else {
+    let Some(ir) = dispatch_fragment_ir(f, "css", joined, Some(&CssInJsTemplate)) else {
         return false;
     };
 

--- a/crates/oxc_formatter/src/print/template/embed/graphql.rs
+++ b/crates/oxc_formatter/src/print/template/embed/graphql.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_formatter_core::{
-    FormatElement, IndentWidth,
+    FormatElement, IndentWidth, dispatch_fragment_ir,
     format_element::{LineMode, TextWidth},
 };
 
@@ -85,7 +85,7 @@ pub(super) fn format_graphql_doc<'a>(
         let mut ir = if info.comments_only {
             build_graphql_comment_ir(info.text, allocator, indent_width)
         } else {
-            let Some(ir) = super::dispatch_fragment_ir(f, "graphql", info.text, None) else {
+            let Some(ir) = dispatch_fragment_ir(f, "graphql", info.text, None) else {
                 return false;
             };
             Some(ir)

--- a/crates/oxc_formatter/src/print/template/embed/markdown.rs
+++ b/crates/oxc_formatter/src/print/template/embed/markdown.rs
@@ -1,5 +1,6 @@
 use oxc_allocator::{Allocator, ArenaStringBuilder};
 use oxc_ast::ast::*;
+use oxc_formatter_core::dispatch_fragment_ir;
 
 use crate::{ast_nodes::AstNode, format_args, formatter::prelude::*, write};
 
@@ -30,7 +31,7 @@ pub(super) fn try_embed_markdown<'a>(
     let text = if has_indent { strip_indentation(text, indentation, allocator) } else { text };
 
     // Phase 3: Get the IR from the dispatcher
-    let Some(mut ir) = super::dispatch_fragment_ir(f, "markdown", text, None) else {
+    let Some(mut ir) = dispatch_fragment_ir(f, "markdown", text, None) else {
         return false;
     };
 

--- a/crates/oxc_formatter/src/print/template/embed/mod.rs
+++ b/crates/oxc_formatter/src/print/template/embed/mod.rs
@@ -3,14 +3,9 @@ mod graphql;
 mod html;
 mod markdown;
 
-use std::any::Any;
-
-use oxc_allocator::{Allocator, ArenaStringBuilder, ArenaVec};
+use oxc_allocator::{Allocator, ArenaStringBuilder};
 use oxc_ast::ast::*;
-use oxc_formatter_core::{
-    DispatchOutcome, DispatchRequest, FormatElement, IndentWidth, InputKind,
-    format_element::TextWidth,
-};
+use oxc_formatter_core::{FormatElement, IndentWidth, format_element::TextWidth};
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
@@ -143,28 +138,6 @@ fn is_in_css_jsx<'a>(node: &AstNode<'a, TemplateLiteral<'a>>) -> bool {
 
 /// Try to format a template literal inside Angular @Component's template/styles property.
 /// Returns `true` if formatting was performed, `false` if not applicable.
-/// Dispatches one embedded fragment and consumes the result into the parent
-/// (`InputKind::Fragment` + the `into_doc` Tailwind merge in one place,
-/// so an embed site cannot re-derive the pair and skip the merge).
-/// `None` covers `PreserveOriginal` and operational errors alike,
-/// the caller keeps the template as-is (the html sites stay manual: they read `child_context` first).
-pub(super) fn dispatch_fragment_ir<'a>(
-    f: &mut JsFormatter<'_, 'a>,
-    language: &str,
-    text: &str,
-    parent_context: Option<&dyn Any>,
-) -> Option<ArenaVec<'a, FormatElement<'a>>> {
-    let Ok(DispatchOutcome::Formatted(result)) = f.session().dispatch(DispatchRequest {
-        language,
-        text,
-        input_kind: InputKind::Fragment,
-        parent_context,
-    }) else {
-        return None;
-    };
-    Some(result.into_doc(f.context_mut()))
-}
-
 pub(super) fn try_format_angular_component<'a>(
     template_literal: &AstNode<'a, TemplateLiteral<'a>>,
     f: &mut JsFormatter<'_, 'a>,

--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -97,7 +97,7 @@ The core is parameterized over a consumer-supplied context so it stays language-
 
 ## What belongs in core (the boundary)
 
-Four layers, four admission rules. A type/fn that fits none of them belongs in a consumer crate.
+Five layers, five admission rules. A type/fn that fits none of them belongs in a consumer crate.
 
 - (1) engine: The IR + Printer + the option types the `Printer` actually consumes
   - `PrinterOptions`: `IndentStyle`, `IndentWidth`, `LineWidth`, `LineEnding`
@@ -118,6 +118,10 @@ Admission: core stores the service and hands it back (or applies it mechanically
 every value crossing the closure boundary is an opaque string/vec, never a language enum or an option type, and core makes no decision from the result.
 `string_embedder` additionally carries an exit criterion: it is removed when (a) md/html/angular gain IR-capable formatters AND (b) the host's string-out consumers (JSDoc fences) can express their re-embedding in IR (see `apps/oxfmt`'s AGENTS.md for that half); until then it is the string-out channel's transport.
 
+- (5) `envelope.rs`: IR-composing behavior shared by document-envelope hosts (`write_front_matter`)
+
+Admission: the host opts in by CALLING, and every language difference arrives as a data parameter (`embeddable_languages`); core asserts nothing about what the names mean. Unlike `spec/`, this layer writes IR and drives the dispatcher.
+
 Three gates, all required and note "shared across languages" describes what lives here but is not the admission test.
 The gates are:
 
@@ -131,8 +135,9 @@ A pure predicate over text shared by design (e.g. `is_suppression_marker`: all f
 Unlike option types like `QuoteStyle`, where sharing would encode a coincidental contract that breaks when languages diverge.
 
 `spec/front_matter.rs` shows the same line from the envelope side:
-core owns pure detection (`parse_front_matter`, a Prettier `front-matter/parse.js` port) and byte-preserving blanking only.
-What the header language MEANS and how the block composes into output stay host policy, Astro's leading `---` is a JS component script, not YAML, so a central "every `---` is YAML" rule can never exist here.
+core owns pure detection (`parse_front_matter`, a Prettier `front-matter/parse.js` port) and byte-preserving blanking; the IR half is layer (5).
+What the header language MEANS stays host policy: a host opts in by calling and passes its embeddable set as data.
+Astro's leading `---` is a JS component script, not YAML, so its host simply never calls — a central "every `---` is YAML" rule cannot exist in core.
 
 Parameterizing language differences (sharpened gate 2), when a shared helper needs to vary per language:
 

--- a/crates/oxc_formatter_core/src/embedded.rs
+++ b/crates/oxc_formatter_core/src/embedded.rs
@@ -16,7 +16,7 @@ use std::{any::Any, sync::Arc};
 
 use oxc_allocator::ArenaVec;
 
-use crate::{FormatElement, FormatSession, InputKind};
+use crate::{FormatContext, FormatElement, FormatSession, Formatter, InputKind};
 
 /// One embedded-language formatting request, as the host formatter states it.
 pub struct DispatchRequest<'r> {
@@ -166,6 +166,33 @@ fn has_nested_tailwind_class(elements: &[FormatElement<'_>]) -> bool {
         }
     }
     elements.iter().any(descends)
+}
+
+/// Dispatches one embedded fragment and consumes the result into the parent.
+///
+/// `InputKind::Fragment` + the [`DispatchResult::into_doc`] Tailwind merge in one place,
+/// so an embed site cannot re-derive the pair and skip the merge.
+/// `None` covers [`DispatchOutcome::PreserveOriginal`] and operational errors alike;
+/// the caller keeps its original source.
+/// Embed sites that must inspect [`DispatchResult::child_context`] first stay manual.
+pub fn dispatch_fragment_ir<'a, C>(
+    f: &mut Formatter<'_, 'a, C>,
+    language: &str,
+    text: &str,
+    parent_context: Option<&dyn Any>,
+) -> Option<ArenaVec<'a, FormatElement<'a>>>
+where
+    C: FormatContext + TailwindCollector,
+{
+    let Ok(DispatchOutcome::Formatted(result)) = f.session().dispatch(DispatchRequest {
+        language,
+        text,
+        input_kind: InputKind::Fragment,
+        parent_context,
+    }) else {
+        return None;
+    };
+    Some(result.into_doc(f.context_mut()))
 }
 
 /// Index-space provider for batched Tailwind class sorting.

--- a/crates/oxc_formatter_core/src/envelope.rs
+++ b/crates/oxc_formatter_core/src/envelope.rs
@@ -1,0 +1,71 @@
+//! Front matter WRITING shared by document-envelope hosts (CSS today, Markdown later);
+//! detection stays in [`crate::spec::front_matter`] (pure text mechanics),
+//! this module owns the IR side: dispatching the block's body through the session and composing the frame.
+//!
+//! Core encodes no language meaning: a host opts in by calling, and its embeddable set arrives as data.
+//! That set is load-bearing: dispatching every resolved language would let e.g. `---json` format through a native branch,
+//! where Prettier keeps it verbatim.
+
+use oxc_allocator::ArenaVec;
+
+use crate::{
+    Buffer as _, BufferExtensions as _, FormatContext, FormatElement, Formatter, TailwindCollector,
+    builders::{hard_line_break, text},
+    embedded::dispatch_fragment_ir,
+    spec::FrontMatter,
+    write,
+};
+
+/// Writes a front matter block.
+///
+/// The body dispatches through the session when its resolved language is in `embeddable_languages`,
+/// the whole block stays verbatim otherwise.
+/// Membership means "gets the frame treatment", not "gets formatted":
+/// a member language without a serving formatter keeps its body verbatim (`PreserveOriginal`),
+/// but its EMPTY block still normalizes through the frame.
+/// Never fails; any refusal (`PreserveOriginal`, operational error, non-embeddable language) keeps the block's bytes as-is
+/// while the host document still formats.
+///
+/// The composed shape (Prettier `embed.js` + its css/markdown printers):
+/// opening delimiter with the explicit language re-emitted (`---yaml`),
+/// the body IR between hardlines, then the closing delimiter (a `...` closing stays `...`).
+/// Spacing between the block and the host's body stays the caller's concern.
+pub fn write_front_matter<'a, C>(
+    fm: &FrontMatter<'a>,
+    embeddable_languages: &[&str],
+    f: &mut Formatter<'_, 'a, C>,
+) where
+    C: FormatContext + TailwindCollector,
+{
+    let language = fm.language();
+    if embeddable_languages.contains(&language) {
+        let body = fm.value.trim();
+        if body.is_empty() {
+            write_frame(fm, None, f);
+            return;
+        }
+        // The body is a Fragment:
+        // front matter inside front matter must never acquire envelope semantics
+        // (generic FM recursion).
+        if let Some(ir) = dispatch_fragment_ir(f, language, body, None) {
+            write_frame(fm, Some(ir), f);
+            return;
+        }
+        // `PreserveOriginal` or an operational error:
+        // fall through to the verbatim block below.
+    }
+    write!(f, text(fm.raw));
+}
+
+fn write_frame<'a, C: FormatContext>(
+    fm: &FrontMatter<'a>,
+    body: Option<ArenaVec<'a, FormatElement<'a>>>,
+    f: &mut Formatter<'_, 'a, C>,
+) {
+    write!(f, [text(fm.start_delimiter), fm.explicit_language.map(text)]);
+    if let Some(ir) = body {
+        write!(f, hard_line_break());
+        f.write_elements(ir);
+    }
+    write!(f, [hard_line_break(), text(fm.end_delimiter)]);
+}

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod buffer;
 pub mod builders;
 mod diagnostics;
 mod embedded;
+mod envelope;
 pub mod format;
 pub mod format_element;
 mod format_extensions;
@@ -45,8 +46,9 @@ pub use buffer::{
 pub use diagnostics::{ActualStart, FormatError, InvalidDocumentError, PrintError};
 pub use embedded::{
     DispatchOutcome, DispatchRequest, DispatchResult, EmbeddedIr, FormatDispatcher,
-    TailwindCollector,
+    TailwindCollector, dispatch_fragment_ir,
 };
+pub use envelope::write_front_matter;
 pub use format::{Format, write};
 pub use format_element::debug::DisplayDocument;
 pub use format_element::document::Document;

--- a/crates/oxc_formatter_core/src/session.rs
+++ b/crates/oxc_formatter_core/src/session.rs
@@ -61,6 +61,15 @@ pub enum InputKind {
     Fragment,
 }
 
+impl InputKind {
+    /// Whether this input kind formats a leading front matter block as an envelope:
+    /// `true` for roots and complete embedded documents,
+    /// `false` for a [`Self::Fragment`] (its head is content, not an envelope).
+    pub fn owns_front_matter(self) -> bool {
+        matches!(self, Self::PhysicalFile | Self::VirtualDocument)
+    }
+}
+
 /// Execution unit threaded through a formatting run: one arena, one `GroupId` space,
 /// the run's [`SessionServices`], plus the input's envelope semantics.
 ///

--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -9,25 +9,9 @@ Prettier compatible CSS/SCSS/Less formatter (`oxfmt`'s Tier 1 backend), using th
 - Built on `oxc_formatter_core` for the language-agnostic IR + Printer + builders + macros
   - See `crates/oxc_formatter_core/AGENTS.md` for the IR/pipeline details
 - Entry points:
-  - `format()`: standalone files (returns a printable `Formatted`); wraps a dispatcher-less session, so front matter degrades to verbatim
-  - `format_with_session()`: standalone on a caller-supplied `FormatSession`; the session's dispatcher formats front matter YAML (oxfmt wires the native registry here)
-  - `format_to_ir()`: embedded use via the dispatcher; the `template_placeholders` mode enables `${}` placeholders and `TopLevelDeclaration` (css-in-js), `false` is the strict whole-stylesheet grammar
-
-### Front matter
-
-This crate owns the CSS translation of the envelope contract;
-detection and blanking come from `oxc_formatter_core::spec::{parse_front_matter, blank_front_matter}`.
-
-- The `InputKind` matrix: `PhysicalFile` / `VirtualDocument` own front matter (blank → parse body → compose);
-  - `Fragment` (css-in-js, JSDoc fence) with a valid envelope or ANY non-physical input with a leading BOM is refused wholesale
-    (`Err` → the host's `PreserveOriginal`), never partially treated
-- Language routing: only a resolved `yaml`/`toml` is dispatched (as a `Fragment`, so FM never nests);
-  - Any other explicit language (`---css`, …) stays raw WITHOUT consulting the registry.
-  - TOML has no IR-capable formatter yet and degrades to verbatim
-- Composition: delimiter + re-emitted explicit tag (`---yaml`), child IR between hardlines, closing delimiter (`...` stays `...`), then exactly ONE blank line before a nonempty body (regardless of the source gap). An empty block prints delimiters only, no dispatch
-- Every refusal (`PreserveOriginal`, dispatch error, unparsable YAML) keeps the whole block verbatim while the CSS body still formats;
-  - the block's bytes are never partially dropped
-- Verification lives in oxfmt, like embedded behavior in general, this crate carries no dispatcher-wired FM tests
+  - `format()`: standalone files, on a service-less session
+  - `format_with_session()`: standalone, on the caller's `FormatSession`
+  - `format_to_ir()`: embedded use via the dispatcher (`template_placeholders` = the css-in-js parse mode)
 
 ### Forked parser
 
@@ -131,6 +115,11 @@ the exact set of supported positions (incl. id / attribute-value / class selecto
   - The JS host (`oxc_formatter`) counts these and substitutes them inline through its `Text`-sentinel branch, a deliberate string-scan fallback at the edges of the typed path
 
 `tests/fixtures/embedded/scss/*-placeholders.scss` is the source of truth for which positions parse and how they print (the `embedded/` harness runs `format_to_ir` with the option on); add a fixture there when extending coverage.
+
+### Front matter (yaml-in-css)
+
+The envelope contract (host opt-in, detection, frame composition, refusal semantics) is core's (`write_front_matter` / `spec::front_matter`; boundary layer 5 in `oxc_formatter_core`'s AGENTS.md); this crate's side (the embeddable set, blank-and-compose wiring, the gap rule) lives in `format.rs`.
+FM behavior is verified through oxfmt; this crate carries no dispatcher-wired FM tests.
 
 ## Prettier mapping
 

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -3,8 +3,8 @@ use oxc_css_parser::{ParserBuilder, ParserOptions, TemplatePlaceholder, ast::Sty
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter_core::{
-    Buffer, BufferExtensions, DispatchOutcome, DispatchRequest, Document, EmbeddedIr, Format,
-    FormatElement, FormatSession, FormatState, Formatted, InputKind, VecBuffer,
+    Buffer, Document, EmbeddedIr, Format, FormatSession, FormatState, Formatted, InputKind,
+    VecBuffer,
     builders::{empty_line, hard_line_break, text},
     spec::{FrontMatter, blank_front_matter, parse_front_matter},
     write,
@@ -122,10 +122,9 @@ pub fn format_to_ir<'a>(
     let input_kind = session.input_kind();
 
     let prepared = prepare_source(allocator, source_text);
-    if prepared.front_matter.is_some() && input_kind != InputKind::VirtualDocument {
+    if prepared.front_matter.is_some() && !input_kind.owns_front_matter() {
         // A fragment (css-in-js, JSDoc fence) never acquires file envelope semantics:
         // refuse the whole child instead of partially treating its head as front matter.
-        // Only a `VirtualDocument` (a complete embedded document, e.g. a fenced stylesheet) formats front matter like a root.
         return Err(OxcDiagnostic::error(
             "Front matter in a CSS fragment; the part is preserved as-is",
         ));
@@ -253,59 +252,10 @@ pub fn to_span(span: &oxc_css_parser::Span) -> Span {
     )
 }
 
-/// Writes the front matter block:
-/// dispatched through the session when its language qualifies, verbatim otherwise.
-/// Never fails, any refusal keeps the block as-is while the CSS body still formats
-/// (a document must not lose its front matter bytes over an optional embed).
-///
-/// Language routing: only a resolved `yaml` / `toml` is ever dispatched.
-/// Any other explicit language (`---css`, …) stays raw WITHOUT consulting the registry.
-/// NOTE: TOML currently has no IR-capable formatter, so it degrades to verbatim through `PreserveOriginal`.
 fn write_front_matter<'a>(fm: &FrontMatter<'a>, f: &mut CssFormatter<'_, 'a>) {
-    if matches!(fm.language(), "yaml" | "toml") {
-        let body = fm.value.trim();
-        if body.is_empty() {
-            // Empty block: the delimiters alone
-            write_front_matter_frame(fm, None, f);
-            return;
-        }
-        // The body is a Fragment:
-        // front matter inside front matter must never acquire envelope semantics (generic FM recursion).
-        let outcome = f.session().dispatch(DispatchRequest {
-            language: fm.language(),
-            text: body,
-            input_kind: InputKind::Fragment,
-            parent_context: None,
-        });
-        if let Ok(DispatchOutcome::Formatted(result)) = outcome {
-            let ir = result.into_doc(f.context_mut());
-            write_front_matter_frame(fm, Some(ir), f);
-            return;
-        }
-        // `PreserveOriginal` or an operational error:
-        // fall through to the verbatim block below.
-    }
-    write!(f, text(fm.raw));
-}
-
-/// The composed shape (Prettier `embed.js` + `printer-postcss.js` css-root):
-/// opening delimiter with the explicit language re-emitted (`---yaml`),
-/// the child IR between hardlines, then the closing delimiter (a `...` closing stays `...`).
-fn write_front_matter_frame<'a>(
-    fm: &FrontMatter<'a>,
-    body: Option<ArenaVec<'a, FormatElement<'a>>>,
-    f: &mut CssFormatter<'_, 'a>,
-) {
-    write!(f, text(fm.start_delimiter));
-    if let Some(language) = fm.explicit_language {
-        write!(f, text(language));
-    }
-    if let Some(ir) = body {
-        write!(f, hard_line_break());
-        f.write_elements(ir);
-    }
-    write!(f, hard_line_break());
-    write!(f, text(fm.end_delimiter));
+    // NOTE: TOML currently has no IR-capable formatter, so it degrades to verbatim through `PreserveOriginal`.
+    // Still need to specify here since blank TOML frontmatter will be normalized.
+    oxc_formatter_core::write_front_matter(fm, &["yaml", "toml"], f);
 }
 
 /// Emits the stylesheet followed by any trailing comments, and the final newline.


### PR DESCRIPTION
FM support will be needed by Markdown formatting too.