### PR TITLE
refactor(formatter_core): rename `DispatchXxx`

### DIFF
--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -81,8 +81,8 @@ Tailwind class sorting (`sortTailwindcss`) splits responsibilities:
 - and the JS side sorts them in one batch
   - `sortTailwindClasses` → tailwind's `getClassOrder`, which needs the resolved Tailwind config
 
-Embedded boundaries carry classes through `DispatchResult::tailwind_classes`;
-each embed site consumes the doc via `DispatchResult::into_doc(collector)`, which merges them into the parent's class space.
+Embedded boundaries carry classes through `DispatchPayload::tailwind_classes`;
+each embed site consumes the doc via `DispatchPayload::into_doc(collector)`, which merges them into the parent's class space.
 
 The four data paths (JS/TS top-level / standalone CSS / embedded CSS / JSDoc fenced CSS) are documented at `embed::services::for_root` (napi definition).
 No CSS goes to Prettier for this; the pure Rust build never collects at all (both mappers gate collection behind napi, since no sorter exists there).

--- a/apps/oxfmt/src/core/embed/dispatcher.rs
+++ b/apps/oxfmt/src/core/embed/dispatcher.rs
@@ -10,7 +10,7 @@ use tracing::{debug, debug_span};
 
 use oxc_formatter::CssInJsTemplate;
 use oxc_formatter_core::{
-    CoreFormatOptions, DispatchOutcome, DispatchRequest, EmbeddedIr, FormatDispatcher,
+    CoreFormatOptions, DispatchRequest, DispatchResponse, EmbeddedIr, FormatDispatcher,
     FormatSession,
 };
 use oxc_formatter_core::{FormatOptions, PrinterOptions};
@@ -273,7 +273,7 @@ pub type PrettierDocFallback = Arc<
             &FormatSession<'a>,
             PrettierLanguage,
             &str,
-        ) -> Result<DispatchOutcome<'a>, String>
+        ) -> Result<DispatchResponse<'a>, String>
         + Send
         + Sync,
 >;
@@ -336,14 +336,14 @@ pub fn build_dispatcher(
                         "No fallback for Prettier language '{}' in this build, part stays as-is",
                         request.language
                     );
-                    Ok(DispatchOutcome::PreserveOriginal)
+                    Ok(DispatchResponse::PreserveOriginal)
                 }
             }
 
             // A language without a formatter is a deliberate skip, in every build.
             Route::Unsupported => {
                 debug!("No formatter for language '{}', part stays as-is", request.language);
-                Ok(DispatchOutcome::PreserveOriginal)
+                Ok(DispatchResponse::PreserveOriginal)
             }
         }
     })
@@ -355,12 +355,12 @@ pub fn build_dispatcher(
 fn format_native<'a, E: std::fmt::Display>(
     language: &'static str,
     format_to_ir: impl FnOnce() -> Result<EmbeddedIr<'a>, E>,
-) -> DispatchOutcome<'a> {
+) -> DispatchResponse<'a> {
     debug_span!("oxfmt::embed::format_to_ir", language).in_scope(|| match format_to_ir() {
-        Ok(embedded) => DispatchOutcome::Formatted(embedded.into()),
+        Ok(embedded) => DispatchResponse::Formatted(embedded.into()),
         Err(err) => {
             debug!("native '{language}' format_to_ir failed, part stays as-is: {err}");
-            DispatchOutcome::PreserveOriginal
+            DispatchResponse::PreserveOriginal
         }
     })
 }
@@ -371,7 +371,7 @@ mod tests {
 
     use oxc_allocator::Allocator;
     use oxc_formatter_core::{
-        CoreFormatOptions, DispatchOutcome, DispatchRequest, FormatSession, InputKind,
+        CoreFormatOptions, DispatchRequest, DispatchResponse, FormatSession, InputKind,
         SessionServices,
     };
 
@@ -410,14 +410,14 @@ mod tests {
                 "json" | "jsonc" | "json5" => "{ \"a\": 1 }",
                 other => panic!("no sample input for native language '{other}'"),
             };
-            let outcome = session.dispatch(DispatchRequest {
+            let response = session.dispatch(DispatchRequest {
                 language,
                 text,
                 input_kind: InputKind::Fragment,
                 parent_context: None,
             });
             assert!(
-                matches!(outcome, Ok(DispatchOutcome::Formatted(_))),
+                matches!(response, Ok(DispatchResponse::Formatted(_))),
                 "language '{language}' did not dispatch natively"
             );
         }
@@ -436,13 +436,13 @@ mod tests {
             },
         );
 
-        let outcome = session.dispatch(DispatchRequest {
+        let response = session.dispatch(DispatchRequest {
             language: "yaml",
             text: "a:   1",
             input_kind: InputKind::Fragment,
             parent_context: None,
         });
-        assert!(matches!(outcome, Ok(DispatchOutcome::Formatted(_))));
+        assert!(matches!(response, Ok(DispatchResponse::Formatted(_))));
     }
 
     /// Both non-native routes preserve without a fallback installed:
@@ -460,14 +460,14 @@ mod tests {
         );
 
         for (language, text) in [("html", "<div></div>"), ("toml", "a = 1")] {
-            let outcome = session.dispatch(DispatchRequest {
+            let response = session.dispatch(DispatchRequest {
                 language,
                 text,
                 input_kind: InputKind::Fragment,
                 parent_context: None,
             });
             assert!(
-                matches!(outcome, Ok(DispatchOutcome::PreserveOriginal)),
+                matches!(response, Ok(DispatchResponse::PreserveOriginal)),
                 "language '{language}' should be preserved without a fallback"
             );
         }

--- a/apps/oxfmt/src/core/embed/mod.rs
+++ b/apps/oxfmt/src/core/embed/mod.rs
@@ -1,7 +1,7 @@
 //! Embedded-language formatting orchestration.
 //!
 //! `oxc_formatter_core` holds the abstract contract
-//! (`FormatSession`, `FormatDispatcher`, `DispatchRequest`/`DispatchOutcome`, `TailwindCollector`);
+//! (`FormatSession`, `FormatDispatcher`, `DispatchRequest`/`DispatchResponse`, `TailwindCollector`);
 //! this module is its concrete counterpart owned by the orchestrator (Oxfmt).
 //!
 //! - [`dispatcher`] (every build):

--- a/apps/oxfmt/src/core/embed/prettier_doc.rs
+++ b/apps/oxfmt/src/core/embed/prettier_doc.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use tracing::{debug, debug_span};
 
 use oxc_formatter::HtmlEmbedMeta;
-use oxc_formatter_core::{DispatchOutcome, DispatchResult, FormatSession};
+use oxc_formatter_core::{DispatchPayload, DispatchResponse, FormatSession};
 
 use crate::{
     core::{
@@ -65,7 +65,7 @@ pub fn build_prettier_fallback(
                             .and_then(Value::as_bool),
                     }) as Box<dyn std::any::Any>
                 });
-                Ok(DispatchOutcome::Formatted(DispatchResult {
+                Ok(DispatchResponse::Formatted(DispatchPayload {
                     doc: ir,
                     tailwind_classes: Vec::new(),
                     child_context,

--- a/apps/oxfmt/src/core/embed/services.rs
+++ b/apps/oxfmt/src/core/embed/services.rs
@@ -68,18 +68,18 @@ pub fn for_root(dispatch_config: &Arc<ResolvedDispatchConfig>) -> SessionService
 ///    the CSS root's session carries the same sorter (`CssFormatOptions::sort_tailwindcss` only switches collection);
 ///    classes sort once at finalize, no embedded boundary involved.
 /// 3. Embedded CSS (css-in-js + Angular `@Component({ styles })`):
-///    `oxc_formatter_css::format_to_ir()` returns pre-sort `@apply` classes in `DispatchResult::tailwind_classes`.
-///    The JS parent re-indexes them into its own collector (`DispatchResult::into_doc`), so they ride the SAME parent batch as path 1.
+///    `oxc_formatter_css::format_to_ir()` returns pre-sort `@apply` classes in `DispatchPayload::tailwind_classes`.
+///    The JS parent re-indexes them into its own collector (`DispatchPayload::into_doc`), so they ride the SAME parent batch as path 1.
 ///    The standalone CSS sort closure is NOT invoked here.
 /// 4. JSDoc fenced CSS (Markdown code fence in JSDoc descriptions):
 ///    Goes through the string embedder's fence adapter, which returns a formatted string (not parent-integrated IR),
 ///    so there is no parent index space to remap into:
-///    the adapter sorts the returned `DispatchResult::tailwind_classes` itself before printing.
+///    the adapter sorts the returned `DispatchPayload::tailwind_classes` itself before printing.
 ///    The `prettier_string::build_string_embedder` factory receives the sorter for this case.
 ///
 /// All four paths use the SAME `sort_tailwindcss_classes` napi callback; only the wiring differs.
 /// Moving sorting to the wrong layer (e.g. sorting inside embedded CSS instead of remapping) would double-sort or drop classes.
-/// `DispatchResult::into_doc` folds the merge into doc consumption; the printer `debug_assert` backstops it.
+/// `DispatchPayload::into_doc` folds the merge into doc consumption; the printer `debug_assert` backstops it.
 #[cfg(feature = "napi")]
 pub fn for_root(
     external_services: &ExternalServices,

--- a/crates/oxc_formatter/src/embed_context.rs
+++ b/crates/oxc_formatter/src/embed_context.rs
@@ -18,7 +18,7 @@ pub struct CssInJsTemplate;
 /// the consumer is this crate's `embed/html.rs` (the JS side of html-in-js),
 /// and `oxc_formatter` must never depend on language crates. Cross-language
 /// contract fields (placeholder counts, Tailwind classes) are first-class on
-/// `DispatchResult` in `oxc_formatter_core` instead; only what is truly
+/// `DispatchPayload` in `oxc_formatter_core` instead; only what is truly
 /// specific to the JS↔HTML pair travels as the `dyn Any` child context.
 pub struct HtmlEmbedMeta {
     /// Whether the parsed HTML has more than one root element.

--- a/crates/oxc_formatter/src/formatter/context.rs
+++ b/crates/oxc_formatter/src/formatter/context.rs
@@ -121,7 +121,7 @@ impl std::fmt::Debug for JsFormatContext<'_> {
 }
 
 /// Lets embedded children's classes merge into this context's index space
-/// (`DispatchResult::into_doc` at each embed site).
+/// (`DispatchPayload::into_doc` at each embed site).
 impl oxc_formatter_core::TailwindCollector for JsFormatContext<'_> {
     fn add_class(&mut self, class: String) -> usize {
         self.add_tailwind_class(class)

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -3,7 +3,7 @@ use cow_utils::CowUtils;
 use oxc_allocator::{Allocator, ArenaStringBuilder};
 use oxc_ast::ast::*;
 use oxc_formatter_core::{
-    DispatchOutcome, DispatchRequest, FormatElement, IndentWidth, InputKind,
+    DispatchRequest, DispatchResponse, FormatElement, IndentWidth, InputKind,
     format_element::TextWidth,
 };
 use oxc_syntax::line_terminator::LineTerminatorSplitter;
@@ -56,7 +56,7 @@ pub(super) fn format_html_doc<'a>(
         let has_leading_ws = cooked.starts_with(|c: char| c.is_ascii_whitespace());
         let has_trailing_ws = cooked.ends_with(|c: char| c.is_ascii_whitespace());
 
-        let Ok(DispatchOutcome::Formatted(result)) = f.session().dispatch(DispatchRequest {
+        let Ok(DispatchResponse::Formatted(result)) = f.session().dispatch(DispatchRequest {
             language: embedded_language,
             text: cooked,
             input_kind: InputKind::Fragment,
@@ -120,7 +120,7 @@ pub(super) fn format_html_doc<'a>(
     let has_trailing_ws = joined.ends_with(|c: char| c.is_ascii_whitespace());
 
     // Phase 2: Format via the dispatcher (IR path)
-    let Ok(DispatchOutcome::Formatted(result)) = f.session().dispatch(DispatchRequest {
+    let Ok(DispatchResponse::Formatted(result)) = f.session().dispatch(DispatchRequest {
         language: embedded_language,
         text: joined,
         input_kind: InputKind::Fragment,

--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -75,23 +75,23 @@ The core is parameterized over a consumer-supplied context so it stays language-
 
 ### Embedded-language infrastructure (`embedded.rs`, `session.rs`)
 
-`FormatSession` / `FormatDispatcher` / `DispatchRequest` / `DispatchResult` / `TailwindCollector` let one formatter's IR be built inside another's document (e.g. graphql-in-js):
+`FormatSession` / `FormatDispatcher` / `DispatchRequest` / `DispatchPayload` / `TailwindCollector` let one formatter's IR be built inside another's document (e.g. graphql-in-js):
 
 - The orchestrator (oxfmt) assembles the dispatcher, mapping language names to formatter implementations (or a Prettier fallback)
   - Formatter crates only invoke it via `FormatSession::dispatch`
 - Parent and child share one arena and one `GroupId` space through the session
 - A language crate's `format_to_ir` entry returns `EmbeddedIr` (IR + pre-sort Tailwind classes), one shape for every child language, no per-crate tuples
-- Cross-language contract data is first-class on `DispatchResult` (`tailwind_classes`)
+- Cross-language contract data is first-class on `DispatchPayload` (`tailwind_classes`)
   - Only truly language-pair specific data crosses as `dyn Any` (e.g. HTML's `has_multiple_root_elements`), core never learns concrete languages
-- Consumers take the doc via `DispatchResult::into_doc(collector)`, which folds the Tailwind class merge into consumption
+- Consumers take the doc via `DispatchPayload::into_doc(collector)`, which folds the Tailwind class merge into consumption
   - The printer's `debug_assert` backstops any hand-rolled consumption that skips the merge
 - `FormatSession` (`session.rs`) is the execution unit:
   - One arena, one shared `GroupId` space (`Arc<UniqueGroupIdBuilder>`), the host's `SessionServices`, and the input's envelope semantics (`InputKind`), usable by standalone roots and dispatched children alike
   - `SessionServices` names the three per-run duties, one field each: `dispatcher` (IR channel), `string_embedder` (string-out channel, `(language, code, print_width)`; temporary while some languages only format via a string API), `tailwind_sorter` (print-time batch sort). Core only transports them
   - `FormatSession::dispatch_to_string(request, printer_options)` is the string-out counterpart of `dispatch` (caller supplies the printer options; `Ok(None)` = deliberate keep; see its rustdoc)
   - `FormatState` holds one (`new_with_session`; plain `new` wraps a service-less `PhysicalFile` session), and `Formatter::session()` exposes it during a write
-- A dispatch states its request as `DispatchRequest` (language, text, `InputKind`, pair-specific context) and yields `Result<DispatchOutcome, String>`:
-  - `DispatchOutcome::PreserveOriginal` is the DELIBERATE "keep the source as-is" answer (unsupported language, child parse failure, no dispatcher installed); `Err` is reserved for operational failures (transport / internal, recursion limit)
+- A dispatch states its request as `DispatchRequest` (language, text, `InputKind`, pair-specific context) and yields `Result<DispatchResponse, String>`:
+  - `DispatchResponse::PreserveOriginal` is the DELIBERATE "keep the source as-is" answer (unsupported language, child parse failure, no dispatcher installed); `Err` is reserved for operational failures (transport / internal, recursion limit)
   - Optional-embed callers degrade the same way for both, but never conflate them at the source
   - `FormatSession::dispatch` owns the no-dispatcher case and the recursion limit (`MAX_DISPATCH_DEPTH`), and runs the callback on a `derive_child`ed session
 

--- a/crates/oxc_formatter_core/src/embedded.rs
+++ b/crates/oxc_formatter_core/src/embedded.rs
@@ -8,7 +8,7 @@
 //! mapping a language name to a formatter implementation (or a fallback).
 //!
 //! Core only carries the shared plumbing (arena, group-id space, recursion handle)
-//! and the cross-language contract field ([`DispatchResult::tailwind_classes`]);
+//! and the cross-language contract field ([`DispatchPayload::tailwind_classes`]);
 //! anything truly language-pair specific crosses as a `dyn Any` passthrough.
 //! Core knows nothing about any concrete language.
 
@@ -29,12 +29,12 @@ pub struct DispatchRequest<'r> {
     pub input_kind: InputKind,
     /// Parent→child language-pair specific data,
     /// downcast by the implementation (`None` for most pairs; e.g. JS's `CssInJsTemplate`).
-    /// The borrowed counterpart of [`DispatchResult::child_context`]
+    /// The borrowed counterpart of [`DispatchPayload::child_context`]
     /// (borrowed because the parent outlives the dispatch call).
     pub parent_context: Option<&'r dyn Any>,
 }
 
-/// What a dispatch produced.
+/// The dispatcher's answer to a [`DispatchRequest`].
 ///
 /// [`Self::PreserveOriginal`] is the DELIBERATE "do not format" answer
 /// (unsupported language, child parse failure, an envelope the child refuses,
@@ -42,9 +42,9 @@ pub struct DispatchRequest<'r> {
 /// `Result::Err` around this enum is reserved for operational failures (transport / internal errors);
 /// optional-embed callers degrade the same way for both,
 /// but the two must never be conflated at the source.
-pub enum DispatchOutcome<'a> {
-    /// The child formatted the request; consume [`DispatchResult`].
-    Formatted(DispatchResult<'a>),
+pub enum DispatchResponse<'a> {
+    /// The child formatted the request; consume [`DispatchPayload`].
+    Formatted(DispatchPayload<'a>),
     /// Deliberately not formatted; keep the original source untouched.
     PreserveOriginal,
 }
@@ -60,13 +60,13 @@ pub type FormatDispatcher = Arc<
     dyn for<'a, 'r> Fn(
             &FormatSession<'a>,
             DispatchRequest<'r>,
-        ) -> Result<DispatchOutcome<'a>, String>
+        ) -> Result<DispatchResponse<'a>, String>
         + Send
         + Sync,
 >;
 
 /// IR built by a language crate's embedded entry point (`format_to_ir`) for one input text.
-/// The orchestrator's dispatcher wraps it into a [`DispatchResult`].
+/// The orchestrator's dispatcher wraps it into a [`DispatchPayload`].
 ///
 /// Every language crate's `format_to_ir` returns this shape,
 /// so a new child language only has to fill in the fields (no per-crate tuple conventions).
@@ -79,20 +79,20 @@ pub struct EmbeddedIr<'a> {
     pub tailwind_classes: Vec<String>,
 }
 
-/// One [`EmbeddedIr`] becomes a result,
+/// One [`EmbeddedIr`] becomes a payload,
 /// carrying the child's Tailwind classes through (hand-rolling the literal invites silently dropping them).
-impl<'a> From<EmbeddedIr<'a>> for DispatchResult<'a> {
+impl<'a> From<EmbeddedIr<'a>> for DispatchPayload<'a> {
     fn from(embedded: EmbeddedIr<'a>) -> Self {
         Self { doc: embedded.ir, tailwind_classes: embedded.tailwind_classes, child_context: None }
     }
 }
 
-/// Result of a [`FormatDispatcher`] call.
+/// The child's formatted product, carried by [`DispatchResponse::Formatted`].
 ///
 /// Consume through [`Self::into_doc`] when a parent index space exists
 /// (every IR-channel embed site); only a parent-less consumer
 /// (the fence adapter, which sorts locally) destructures the fields directly.
-pub struct DispatchResult<'a> {
+pub struct DispatchPayload<'a> {
     /// The formatted IR, arena-allocated alongside its elements.
     pub doc: ArenaVec<'a, FormatElement<'a>>,
     /// Pre-sort Tailwind classes referenced by the doc's
@@ -107,7 +107,7 @@ pub struct DispatchResult<'a> {
     pub child_context: Option<Box<dyn Any>>,
 }
 
-impl<'a> DispatchResult<'a> {
+impl<'a> DispatchPayload<'a> {
     /// Consumes the result:
     /// moves the child's pre-sort Tailwind classes into the parent's class space and hands out the doc.
     /// Folding the merge into the only way to get the doc makes a forgotten merge unrepresentable.
@@ -150,7 +150,7 @@ impl<'a> DispatchResult<'a> {
 }
 
 /// Whether a `TailwindClass` sits below an `Interned` / `BestFitting` boundary,
-/// where [`DispatchResult::into_doc`]'s flat remap cannot rewrite it
+/// where [`DispatchPayload::into_doc`]'s flat remap cannot rewrite it
 /// (a top-level `TailwindClass` is the remap's normal input, not a hit).
 fn has_nested_tailwind_class(elements: &[FormatElement<'_>]) -> bool {
     fn contains(element: &FormatElement<'_>) -> bool {
@@ -170,11 +170,11 @@ fn has_nested_tailwind_class(elements: &[FormatElement<'_>]) -> bool {
 
 /// Dispatches one embedded fragment and consumes the result into the parent.
 ///
-/// `InputKind::Fragment` + the [`DispatchResult::into_doc`] Tailwind merge in one place,
+/// `InputKind::Fragment` + the [`DispatchPayload::into_doc`] Tailwind merge in one place,
 /// so an embed site cannot re-derive the pair and skip the merge.
-/// `None` covers [`DispatchOutcome::PreserveOriginal`] and operational errors alike;
+/// `None` covers [`DispatchResponse::PreserveOriginal`] and operational errors alike;
 /// the caller keeps its original source.
-/// Embed sites that must inspect [`DispatchResult::child_context`] first stay manual.
+/// Embed sites that must inspect [`DispatchPayload::child_context`] first stay manual.
 pub fn dispatch_fragment_ir<'a, C>(
     f: &mut Formatter<'_, 'a, C>,
     language: &str,
@@ -184,7 +184,7 @@ pub fn dispatch_fragment_ir<'a, C>(
 where
     C: FormatContext + TailwindCollector,
 {
-    let Ok(DispatchOutcome::Formatted(result)) = f.session().dispatch(DispatchRequest {
+    let Ok(DispatchResponse::Formatted(result)) = f.session().dispatch(DispatchRequest {
         language,
         text,
         input_kind: InputKind::Fragment,
@@ -199,8 +199,8 @@ where
 ///
 /// `FormatElement::TailwindClass(usize)` holds pre-sort class strings by index;
 /// sorting happens in one host-supplied batch when the entry formatter's document is finalized.
-/// A child formatter collects classes locally (0-based) and returns them in [`DispatchResult::tailwind_classes`];
-/// the receiving parent implements this trait on its format context and receives them through [`DispatchResult::into_doc`].
+/// A child formatter collects classes locally (0-based) and returns them in [`DispatchPayload::tailwind_classes`];
+/// the receiving parent implements this trait on its format context and receives them through [`DispatchPayload::into_doc`].
 ///
 /// NOTE: an alternative design (threading one shared collector through [`FormatSession`]
 /// so children allocate parent indices directly) was considered and deferred:

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -45,7 +45,7 @@ pub use buffer::{
 };
 pub use diagnostics::{ActualStart, FormatError, InvalidDocumentError, PrintError};
 pub use embedded::{
-    DispatchOutcome, DispatchRequest, DispatchResult, EmbeddedIr, FormatDispatcher,
+    DispatchPayload, DispatchRequest, DispatchResponse, EmbeddedIr, FormatDispatcher,
     TailwindCollector, dispatch_fragment_ir,
 };
 pub use envelope::write_front_matter;

--- a/crates/oxc_formatter_core/src/printer/mod.rs
+++ b/crates/oxc_formatter_core/src/printer/mod.rs
@@ -371,7 +371,7 @@ impl<'a> Printer<'a> {
                 debug_assert!(
                     text.is_some(),
                     "TailwindClass index {index} out of bounds ({} classes): \
-                     Was the embedded IR remapped into the parent's class space (`DispatchResult::into_doc`)?",
+                     Was the embedded IR remapped into the parent's class space (`DispatchPayload::into_doc`)?",
                     self.state.sorted_tailwind_classes.len(),
                 );
                 if let Some(text) = text {

--- a/crates/oxc_formatter_core/src/session.rs
+++ b/crates/oxc_formatter_core/src/session.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use oxc_allocator::Allocator;
 
 use crate::{
-    DispatchOutcome, DispatchRequest, DispatchResult, Document, FormatDispatcher, PrinterOptions,
+    DispatchPayload, DispatchRequest, DispatchResponse, Document, FormatDispatcher, PrinterOptions,
     UniqueGroupIdBuilder,
 };
 
@@ -128,8 +128,8 @@ impl<'a> FormatSession<'a> {
 
     /// Formats one embedded-language request on a child session derived from this one.
     ///
-    /// See [`DispatchOutcome`] for the outcome-vs-`Err` contract; this method adds three rules:
-    /// - no dispatcher installed (plain standalone run) is the deliberate `Ok(DispatchOutcome::PreserveOriginal)`
+    /// See [`DispatchResponse`] for the `PreserveOriginal`-vs-`Err` contract; this method adds three rules:
+    /// - no dispatcher installed (plain standalone run) is the deliberate `Ok(DispatchResponse::PreserveOriginal)`
     /// - a request text starting with U+FEFF is deliberately preserved:
     ///   in an embedded position it is content, not a BOM (formatting must not swallow it), and no child entry handles it
     /// - reaching `MAX_DISPATCH_DEPTH` is an `Err`
@@ -138,12 +138,12 @@ impl<'a> FormatSession<'a> {
     ///
     /// # Errors
     /// Operational failures only (recursion limit, transport/internal errors).
-    pub fn dispatch(&self, request: DispatchRequest<'_>) -> Result<DispatchOutcome<'a>, String> {
+    pub fn dispatch(&self, request: DispatchRequest<'_>) -> Result<DispatchResponse<'a>, String> {
         let Some(dispatcher) = &self.services.dispatcher else {
-            return Ok(DispatchOutcome::PreserveOriginal);
+            return Ok(DispatchResponse::PreserveOriginal);
         };
         if request.text.starts_with('\u{feff}') {
-            return Ok(DispatchOutcome::PreserveOriginal);
+            return Ok(DispatchResponse::PreserveOriginal);
         }
         if self.dispatch_depth >= MAX_DISPATCH_DEPTH {
             return Err(format!(
@@ -166,7 +166,7 @@ impl<'a> FormatSession<'a> {
     /// through this session's sorter instead of merging upward.
     ///
     /// Returns `Ok(None)` when the dispatch deliberately preserved the input
-    /// (see [`DispatchOutcome::PreserveOriginal`]); the caller keeps its original text.
+    /// (see [`DispatchResponse::PreserveOriginal`]); the caller keeps its original text.
     ///
     /// # Errors
     /// Operational failures only (dispatch transport, recursion limit, print).
@@ -176,7 +176,7 @@ impl<'a> FormatSession<'a> {
         printer_options: PrinterOptions,
     ) -> Result<Option<String>, String> {
         let text_len = request.text.len();
-        let DispatchOutcome::Formatted(DispatchResult { doc, tailwind_classes, .. }) =
+        let DispatchResponse::Formatted(DispatchPayload { doc, tailwind_classes, .. }) =
             self.dispatch(request)?
         else {
             return Ok(None);
@@ -230,7 +230,9 @@ mod tests {
     use oxc_allocator::Allocator;
 
     use super::{FormatSession, InputKind, MAX_DISPATCH_DEPTH, SessionServices};
-    use crate::{DispatchOutcome, DispatchRequest, DispatchResult, FormatDispatcher, FormatState};
+    use crate::{
+        DispatchPayload, DispatchRequest, DispatchResponse, FormatDispatcher, FormatState,
+    };
 
     fn request<'r>() -> DispatchRequest<'r> {
         DispatchRequest {
@@ -246,14 +248,14 @@ mod tests {
         let allocator = Allocator::default();
         let session = FormatSession::new(&allocator, InputKind::PhysicalFile);
 
-        assert!(matches!(session.dispatch(request()), Ok(DispatchOutcome::PreserveOriginal)));
+        assert!(matches!(session.dispatch(request()), Ok(DispatchResponse::PreserveOriginal)));
     }
 
     #[test]
     fn dispatch_preserves_a_bom_headed_text() {
         let allocator = Allocator::default();
         let dispatcher: FormatDispatcher = Arc::new(|ctx, _request| {
-            Ok(DispatchOutcome::Formatted(DispatchResult {
+            Ok(DispatchResponse::Formatted(DispatchPayload {
                 doc: oxc_allocator::ArenaVec::new_in(&ctx.allocator()),
                 tailwind_classes: Vec::new(),
                 child_context: None,
@@ -266,17 +268,17 @@ mod tests {
         );
 
         let bom_request = DispatchRequest { text: "\u{feff}a: 1", ..request() };
-        assert!(matches!(session.dispatch(bom_request), Ok(DispatchOutcome::PreserveOriginal)));
+        assert!(matches!(session.dispatch(bom_request), Ok(DispatchResponse::PreserveOriginal)));
         // A non-leading U+FEFF is ordinary content and formats normally
         let inner_request = DispatchRequest { text: "a: \u{feff}1", ..request() };
-        assert!(matches!(session.dispatch(inner_request), Ok(DispatchOutcome::Formatted(_))));
+        assert!(matches!(session.dispatch(inner_request), Ok(DispatchResponse::Formatted(_))));
     }
 
     #[test]
     fn dispatch_stops_at_the_depth_limit() {
         let allocator = Allocator::default();
         let dispatcher: FormatDispatcher = Arc::new(|ctx, _request| {
-            Ok(DispatchOutcome::Formatted(DispatchResult {
+            Ok(DispatchResponse::Formatted(DispatchPayload {
                 doc: oxc_allocator::ArenaVec::new_in(&ctx.allocator()),
                 tailwind_classes: Vec::new(),
                 child_context: None,
@@ -288,7 +290,7 @@ mod tests {
             SessionServices { dispatcher: Some(dispatcher), ..SessionServices::default() },
         );
 
-        assert!(matches!(session.dispatch(request()), Ok(DispatchOutcome::Formatted(_))));
+        assert!(matches!(session.dispatch(request()), Ok(DispatchResponse::Formatted(_))));
         for _ in 0..MAX_DISPATCH_DEPTH {
             session = session.derive_child(InputKind::Fragment);
         }

--- a/crates/oxc_formatter_css/src/context.rs
+++ b/crates/oxc_formatter_css/src/context.rs
@@ -79,7 +79,7 @@ impl<'a> CssFormatContext<'a> {
     }
 }
 
-/// Lets a dispatched child's classes remap into this host's index space (`DispatchResult::into_doc`).
+/// Lets a dispatched child's classes remap into this host's index space (`DispatchPayload::into_doc`).
 /// A YAML front matter child returns none today, but the cross-language contract holds for any future child.
 impl TailwindCollector for CssFormatContext<'_> {
     fn add_class(&mut self, class: String) -> usize {

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -108,7 +108,7 @@ pub fn format_with_session<'a>(
 /// [`CssFormatOptions::sort_tailwindcss`] is on).
 /// The parent document owns the batch sort,
 /// so the caller must re-index the elements into the parent's class space
-/// (`DispatchResult::into_doc`).
+/// (`DispatchPayload::into_doc`).
 ///
 /// # Errors
 /// Same as [`format()`].


### PR DESCRIPTION
Pure renaming.

- `DispatchOutcome` -> `DispatchResponse` (counter part of `DispatchRequest`)
- `DispatchResult` -> `DispatchPayload` (lives in `DispatchResponse`)
