### PR TITLE
refactor(linter): reuse `ThisFinder`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_extra_bind.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_bind.rs
@@ -1,14 +1,15 @@
 use oxc_ast::{
     AstKind,
-    ast::{Argument, Expression, Function, ThisExpression},
+    ast::{Argument, Expression},
 };
-use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::ScopeFlags;
 use oxc_span::Span;
 
-use crate::{AstNode, ast_util::is_method_call, context::LintContext, rule::Rule};
+use crate::{
+    AstNode, ast_util::is_method_call, context::LintContext, rule::Rule,
+    utils::function_body_contains_this,
+};
 
 fn no_extra_bind_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("The function binding is unnecessary.")
@@ -90,10 +91,8 @@ impl Rule for NoExtraBind {
                 let Some(body) = &func_expr.body else {
                     return;
                 };
-                let mut finder = ThisFinder { found: false };
-                finder.visit_function_body(body);
                 // don't use this expression
-                if !finder.found {
+                if !function_body_contains_this(body) {
                     ctx.diagnostic(no_extra_bind_diagnostic(span));
                 }
             }
@@ -103,18 +102,6 @@ impl Rule for NoExtraBind {
             _ => {}
         }
     }
-}
-
-struct ThisFinder {
-    found: bool,
-}
-
-impl<'a> VisitJs<'a> for ThisFinder {
-    fn visit_this_expression(&mut self, _expr: &ThisExpression) {
-        self.found = true;
-    }
-
-    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
 }
 
 #[test]

--- a/crates/oxc_linter/src/utils/this_expression.rs
+++ b/crates/oxc_linter/src/utils/this_expression.rs
@@ -1,8 +1,8 @@
 use oxc_ast::{
     AstKind,
     ast::{
-        BindingPattern, Expression, Function, IdentifierReference, PropertyDefinition, StaticBlock,
-        ThisExpression, VariableDeclarationKind,
+        BindingPattern, Expression, Function, FunctionBody, IdentifierReference,
+        PropertyDefinition, StaticBlock, ThisExpression, VariableDeclarationKind,
     },
 };
 use oxc_ast_visit::{VisitJs, walk_js};
@@ -13,6 +13,14 @@ use crate::{
     ast_util::get_declaration_from_reference_id, ast_util::variable_declaration_kind,
     context::LintContext,
 };
+
+/// Checks whether a function body contains a `this` expression without traversing into nested
+/// functions.
+pub fn function_body_contains_this(body: &FunctionBody) -> bool {
+    let mut finder = ThisExpressionFinder::new();
+    finder.visit_function_body(body);
+    !finder.spans.is_empty()
+}
 
 /// Finds `this` expressions without traversing into nested functions.
 pub struct ThisExpressionFinder {


### PR DESCRIPTION
## Summary

- Extract the JS-only function-body `this` check into `utils::function_body_contains_this`.
- Reuse it in `no-extra-bind` and remove the duplicate rule-local visitor.

## Details

The helper reuses the existing `VisitJs` traversal, preserving the merged PR's behavior of ignoring type-space `this` and nested function receivers. Other `visit_this_expression` implementations were reviewed and retained because they track additional lexical state or intentionally traverse type-space nodes.
