### PR TITLE
fix(codegen): preserve TypeScript comparison grouping

### DIFF
--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -10,7 +10,13 @@ use oxc_syntax::{
     precedence::{GetPrecedence, Precedence},
 };
 
-use crate::{Codegen, Context, Operator, cjs_module_lexer, r#gen::GenExpr};
+use crate::{
+    Codegen, Context, Operator, cjs_module_lexer,
+    r#gen::GenExpr,
+    typescript::{
+        expression_ends_with_ts_type_argument_open, expression_starts_with_ts_type_argument_close,
+    },
+};
 
 #[derive(Clone, Copy)]
 pub enum Binaryish<'a> {
@@ -214,11 +220,55 @@ impl<'a> BinaryExpressionVisitor<'a> {
                     self.left_precedence = Precedence::Call;
                 }
             }
-            BinaryishOperator::Binary(BinaryOperator::BitwiseOR | BinaryOperator::BitwiseAnd) => {
+            BinaryishOperator::Binary(
+                BinaryOperator::GreaterThan
+                | BinaryOperator::ShiftRight
+                | BinaryOperator::ShiftRightZeroFill,
+            ) if p.is_typescript
+                && expression_ends_with_ts_type_argument_open(
+                    e.left(),
+                    self.left_precedence,
+                    self.ctx,
+                ) =>
+            {
+                // TypeScript can reinterpret `<...>`, `<...>>`, and `<...>>>` as type
+                // arguments. Isolate an opening angle before emitting a possible closer.
+                self.left_precedence = Precedence::Shift;
+            }
+            BinaryishOperator::Binary(BinaryOperator::LessThan | BinaryOperator::ShiftLeft)
+                if p.is_typescript
+                    && expression_starts_with_ts_type_argument_close(
+                        e.right(),
+                        self.right_precedence,
+                        self.ctx,
+                    ) =>
+            {
+                // A right shift can be re-lexed into multiple generic closers. Keep it
+                // grouped when the current operator can supply the matching opener.
+                self.right_precedence = Precedence::Shift;
+            }
+            BinaryishOperator::Binary(BinaryOperator::BitwiseOR | BinaryOperator::BitwiseAnd)
+                if p.is_typescript =>
+            {
                 // Without parentheses, `|` or `&` becomes part of the type in
                 // `(value satisfies Type) | other` or `(value satisfies Type) & other`.
                 if matches!(e.left(), Expression::TSSatisfiesExpression(_)) {
                     self.left_precedence = Precedence::Compare;
+                }
+
+                if expression_ends_with_ts_type_argument_open(
+                    e.left(),
+                    self.left_precedence,
+                    self.ctx,
+                ) {
+                    self.left_precedence = Precedence::Shift;
+                }
+                if expression_ends_with_ts_type_argument_open(
+                    e.right(),
+                    self.right_precedence,
+                    self.ctx,
+                ) {
+                    self.right_precedence = Precedence::Shift;
                 }
             }
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -45,6 +45,7 @@ pub trait GenExpr: GetSpan {
 impl Gen for Program<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.is_jsx = self.source_type.is_jsx();
+        p.is_typescript = self.source_type.is_typescript();
 
         // Allow for inserting comments to the top of the file.
         p.print_comments_at(0);

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -14,6 +14,7 @@ use crate::{
     binary_expr_visitor::{BinaryExpressionVisitor, Binaryish, BinaryishOperator},
     cjs_module_lexer,
     comment::AnnotationKind,
+    typescript,
 };
 
 /// Generate source code for an AST node.
@@ -1644,8 +1645,15 @@ impl Gen for SpreadElement<'_> {
 }
 
 impl Gen for ArrayExpression<'_> {
-    fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+    fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
         let is_multi_line = self.elements.len() > 2;
+        let type_argument_list = typescript::TypeArgumentList::new(
+            p.is_typescript,
+            &self.elements,
+            ArrayExpressionElement::as_expression,
+            Precedence::Comma,
+            Context::empty(),
+        );
         p.add_source_mapping(self.span);
         p.print_ascii_byte(b'[');
         if is_multi_line {
@@ -1661,7 +1669,13 @@ impl Gen for ArrayExpression<'_> {
             } else if i != 0 {
                 p.print_soft_space();
             }
-            item.print(p, ctx);
+            let expression = match item {
+                ArrayExpressionElement::SpreadElement(element) => Some(&element.argument),
+                ArrayExpressionElement::Elision(_) => None,
+                _ => Some(item.to_expression()),
+            };
+            let precedence = type_argument_list.precedence_for(i, expression);
+            p.print_array_element(item, precedence);
             if i == self.elements.len() - 1 && matches!(item, ArrayExpressionElement::Elision(_)) {
                 p.print_comma();
             }
@@ -2282,7 +2296,22 @@ impl Gen for AssignmentTargetRest<'_> {
 impl GenExpr for SequenceExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.wrap(precedence >= self.precedence(), |p| {
-            p.print_expressions(&self.expressions, Precedence::Lowest, ctx.and_forbid_call(false));
+            let expression_ctx = ctx.and_forbid_call(false);
+            let type_argument_list = typescript::TypeArgumentList::new(
+                p.is_typescript,
+                &self.expressions,
+                |expression| Some(expression),
+                Precedence::Lowest,
+                expression_ctx,
+            );
+            for (index, expression) in self.expressions.iter().enumerate() {
+                if index > 0 {
+                    p.print_comma();
+                    p.print_soft_space();
+                }
+                let precedence = type_argument_list.precedence_for(index, Some(expression));
+                expression.print_expr(p, precedence, expression_ctx);
+            }
         });
     }
 }
@@ -2290,6 +2319,15 @@ impl GenExpr for SequenceExpression<'_> {
 impl GenExpr for ImportExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let wrap = precedence >= Precedence::New || ctx.intersects(Context::FORBID_CALL);
+        let expressions = [Some(&self.source), self.options.as_ref()];
+        let expressions = &expressions[..if self.options.is_some() { 2 } else { 1 }];
+        let type_argument_list = typescript::TypeArgumentList::new(
+            p.is_typescript,
+            expressions,
+            |expression| *expression,
+            Precedence::Comma,
+            Context::empty(),
+        );
 
         let has_comment_before_right_paren = p.options.print_annotation_comment()
             && self.span.end > 0
@@ -2320,7 +2358,11 @@ impl GenExpr for ImportExpression<'_> {
                 p.print_soft_newline();
                 p.print_indent();
             }
-            self.source.print_expr(p, Precedence::Comma, Context::empty());
+            self.source.print_expr(
+                p,
+                type_argument_list.precedence_for(0, Some(&self.source)),
+                Context::empty(),
+            );
             if let Some(options) = &self.options {
                 p.print_comma();
                 if has_comment {
@@ -2329,7 +2371,11 @@ impl GenExpr for ImportExpression<'_> {
                 } else {
                     p.print_soft_space();
                 }
-                options.gen_expr(p, Precedence::Comma, Context::empty());
+                options.gen_expr(
+                    p,
+                    type_argument_list.precedence_for(1, Some(options)),
+                    Context::empty(),
+                );
             }
             if has_comment {
                 // Handle `/* comment */);`

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -32,6 +32,7 @@ mod options;
 #[cfg(feature = "sourcemap")]
 mod sourcemap_builder;
 mod str;
+mod typescript;
 
 use binary_expr_visitor::BinaryExpressionVisitor;
 use comment::CommentsMap;
@@ -109,6 +110,9 @@ pub struct Codegen<'a> {
     /// Indicates the output is JSX type, it is set in [`Program::gen`] and the result
     /// is obtained by [`oxc_span::SourceType::is_jsx`]
     is_jsx: bool,
+    /// Whether the output is TypeScript, set in [`Program::gen`] or
+    /// [`Codegen::with_source_type`] for expression fragments.
+    is_typescript: bool,
 
     /// For avoiding `;` if the previous statement ends with `}`.
     needs_semicolon: bool,
@@ -192,6 +196,7 @@ impl<'a> Codegen<'a> {
             start_of_arrow_expr: 0,
             start_of_default_export: 0,
             is_jsx: false,
+            is_typescript: false,
             indent: 0,
             quote: Quote::Double,
             comments: CommentsMap::default(),
@@ -222,6 +227,7 @@ impl<'a> Codegen<'a> {
     #[must_use]
     pub fn with_source_type(mut self, source_type: SourceType) -> Self {
         self.is_jsx = source_type.is_jsx();
+        self.is_typescript = source_type.is_typescript();
         self
     }
 

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -765,21 +765,19 @@ impl<'a> Codegen<'a> {
         }
     }
 
-    #[inline]
-    fn print_expressions<T: GenExpr>(&mut self, items: &[T], precedence: Precedence, ctx: Context) {
-        let Some((first, rest)) = items.split_first() else {
-            return;
-        };
-        first.print_expr(self, precedence, ctx);
-        for item in rest {
-            self.print_comma();
-            self.print_soft_space();
-            item.print_expr(self, precedence, ctx);
-        }
-    }
-
-    fn print_arguments(&mut self, span: Span, arguments: &[Argument<'_>], ctx: Context) {
+    fn print_arguments(&mut self, span: Span, arguments: &[Argument<'_>], _ctx: Context) {
         self.print_ascii_byte(b'(');
+
+        let type_argument_list = typescript::TypeArgumentList::new(
+            self.is_typescript,
+            arguments,
+            |argument| match argument {
+                Argument::SpreadElement(_) => None,
+                _ => Some(argument.to_expression()),
+            },
+            Precedence::Comma,
+            Context::empty(),
+        );
 
         let has_comment_before_right_paren = span.end > 0 && self.has_comment(span.end - 1);
 
@@ -788,7 +786,9 @@ impl<'a> Codegen<'a> {
 
         if has_comment {
             self.indent();
-            self.print_list_with_comments(arguments, ctx);
+        }
+        self.print_argument_list(arguments, &type_argument_list, has_comment);
+        if has_comment {
             // Handle `/* comment */);`
             if !has_comment_before_right_paren
                 || (span.end > 0 && !self.print_expr_comments(span.end - 1))
@@ -797,8 +797,6 @@ impl<'a> Codegen<'a> {
             }
             self.dedent();
             self.print_indent();
-        } else {
-            self.print_list(arguments, ctx);
         }
         // End mapping at the gen position OF `)`, not past it. Matches
         // esbuild/Babel and avoids shadowing the next AST node's start.
@@ -806,27 +804,67 @@ impl<'a> Codegen<'a> {
         self.print_ascii_byte(b')');
     }
 
-    fn print_list_with_comments(&mut self, items: &[Argument<'_>], ctx: Context) {
-        let Some((first, rest)) = items.split_first() else {
-            return;
-        };
-        if self.print_expr_comments(first.span().start) {
-            self.print_indent();
-        } else {
-            self.print_soft_newline();
-            self.print_indent();
-        }
-        first.print(self, ctx);
-        for item in rest {
-            self.print_comma();
-            if self.print_expr_comments(item.span().start) {
-                self.print_indent();
-            } else {
-                self.print_soft_newline();
-                self.print_indent();
+    fn print_argument_list(
+        &mut self,
+        arguments: &[Argument<'_>],
+        type_argument_list: &typescript::TypeArgumentList,
+        has_comment: bool,
+    ) {
+        for (index, argument) in arguments.iter().enumerate() {
+            if index > 0 {
+                self.print_comma();
+                if !has_comment {
+                    self.print_soft_space();
+                }
             }
-            item.print(self, ctx);
+            if has_comment {
+                if self.print_expr_comments(argument.span().start) {
+                    self.print_indent();
+                } else {
+                    self.print_soft_newline();
+                    self.print_indent();
+                }
+            }
+            let precedence =
+                type_argument_list.precedence_for(index, Some(Self::argument_expression(argument)));
+            self.print_argument(argument, precedence);
         }
+    }
+
+    fn argument_expression<'b, 'c>(argument: &'c Argument<'b>) -> &'c Expression<'b> {
+        match argument {
+            Argument::SpreadElement(element) => &element.argument,
+            _ => argument.to_expression(),
+        }
+    }
+
+    fn print_argument(&mut self, argument: &Argument<'_>, precedence: Precedence) {
+        match argument {
+            Argument::SpreadElement(element) => {
+                self.print_spread_element(element, precedence);
+            }
+            _ => argument.to_expression().print_expr(self, precedence, Context::empty()),
+        }
+    }
+
+    fn print_array_element(
+        &mut self,
+        element: &ArrayExpressionElement<'_>,
+        precedence: Precedence,
+    ) {
+        match element {
+            ArrayExpressionElement::SpreadElement(element) => {
+                self.print_spread_element(element, precedence);
+            }
+            ArrayExpressionElement::Elision(_) => {}
+            _ => element.to_expression().print_expr(self, precedence, Context::empty()),
+        }
+    }
+
+    fn print_spread_element(&mut self, element: &SpreadElement<'_>, precedence: Precedence) {
+        self.add_source_mapping(element.span);
+        self.print_ellipsis();
+        element.argument.print_expr(self, precedence, Context::empty());
     }
 
     #[inline]

--- a/crates/oxc_codegen/src/typescript.rs
+++ b/crates/oxc_codegen/src/typescript.rs
@@ -1,0 +1,319 @@
+//! TypeScript-specific expression ambiguity helpers.
+//!
+//! TypeScript may reinterpret `<`, `>`, `>>`, and `>>>` tokens as the
+//! delimiters of type arguments. These helpers identify unparenthesized angle
+//! tokens at the edges of emitted expressions. They deliberately do not try to
+//! predict whether the token after a closing angle will make TypeScript commit
+//! to that interpretation: grouping a structurally matched pair is smaller and
+//! less fragile than duplicating the parser and printer here.
+
+use oxc_ast::ast::Expression;
+use oxc_syntax::{
+    operator::{BinaryOperator, LogicalOperator},
+    precedence::{GetPrecedence, Precedence},
+};
+
+use crate::Context;
+
+/// Returns whether the emitted suffix of `expression` exposes a `<` or `<<`
+/// token that TypeScript can reinterpret as the start of type arguments.
+///
+/// For example, when printing `(a < b) > /x/`, this returns true for the left
+/// expression `a < b`. The printer retains the parentheses instead of emitting
+/// the ambiguous `a < b > /x/`.
+///
+/// The walk follows emitted suffixes and is iterative for deeply associated
+/// binary trees. The worklist is only allocated for an unwrapped nested
+/// sequence, where any flattened item can carry the opening token.
+pub fn expression_ends_with_ts_type_argument_open(
+    expression: &Expression<'_>,
+    precedence: Precedence,
+    ctx: Context,
+) -> bool {
+    let (mut expression, mut precedence, mut ctx) = (expression, precedence, ctx);
+    let mut pending = Vec::new();
+
+    loop {
+        loop {
+            expression = expression.without_parentheses();
+
+            match expression {
+                Expression::BinaryExpression(binary) => {
+                    let operator_precedence = binary.operator.precedence();
+                    if precedence >= operator_precedence
+                        || (binary.operator == BinaryOperator::In && ctx.forbid_in())
+                    {
+                        break;
+                    }
+
+                    if matches!(
+                        binary.operator,
+                        BinaryOperator::LessThan | BinaryOperator::ShiftLeft
+                    ) {
+                        return true;
+                    }
+
+                    if matches!(
+                        binary.operator,
+                        BinaryOperator::BitwiseOR | BinaryOperator::BitwiseAnd
+                    ) {
+                        // The binary printer protects exposed opening operands
+                        // of `|` and `&`, so none escape this subtree.
+                        break;
+                    }
+
+                    precedence = if operator_precedence.is_left_associative() {
+                        operator_precedence
+                    } else {
+                        binary.operator.lower_precedence()
+                    };
+                    expression = &binary.right;
+                }
+
+                Expression::LogicalExpression(logical) => {
+                    let operator_precedence = logical.operator.precedence();
+                    if precedence > operator_precedence {
+                        break;
+                    }
+
+                    precedence = if logical.operator == LogicalOperator::Coalesce
+                        && matches!(
+                            logical.right.without_parentheses(),
+                            Expression::LogicalExpression(right)
+                                if matches!(
+                                    right.operator,
+                                    LogicalOperator::And | LogicalOperator::Or
+                                )
+                        ) {
+                        Precedence::Prefix
+                    } else {
+                        operator_precedence
+                    };
+                    expression = &logical.right;
+                }
+
+                Expression::SequenceExpression(sequence) => {
+                    if precedence < Precedence::Comma {
+                        let expression_ctx = ctx.and_forbid_call(false);
+                        pending.extend(
+                            sequence
+                                .expressions
+                                .iter()
+                                .map(|expression| (expression, Precedence::Lowest, expression_ctx)),
+                        );
+                    }
+                    break;
+                }
+
+                Expression::AssignmentExpression(assignment) => {
+                    if precedence >= Precedence::Assign {
+                        break;
+                    }
+                    expression = &assignment.right;
+                    precedence = Precedence::Comma;
+                }
+
+                Expression::ArrowFunctionExpression(arrow) => {
+                    if arrow.pife || precedence >= Precedence::Assign {
+                        break;
+                    }
+                    let Some(body) = arrow.body.as_expression() else { break };
+                    expression = body;
+                    precedence = Precedence::Comma;
+                }
+
+                Expression::YieldExpression(yield_expression) => {
+                    if precedence >= Precedence::Assign {
+                        break;
+                    }
+                    let Some(argument) = &yield_expression.argument else { break };
+                    expression = argument;
+                    precedence = Precedence::Yield;
+                    ctx = Context::empty();
+                }
+
+                Expression::ConditionalExpression(conditional) => {
+                    if precedence >= Precedence::Conditional {
+                        break;
+                    }
+                    expression = &conditional.alternate;
+                    precedence = Precedence::Yield;
+                    ctx &= Context::FORBID_IN;
+                }
+
+                Expression::PrivateInExpression(private_in) => {
+                    if precedence >= Precedence::Compare {
+                        break;
+                    }
+                    expression = &private_in.right;
+                    precedence = Precedence::Equals;
+                    ctx = Context::FORBID_IN;
+                }
+
+                _ => break,
+            }
+        }
+
+        let Some(next) = pending.pop() else { break };
+        (expression, precedence, ctx) = next;
+    }
+
+    false
+}
+
+/// Returns whether the emitted type-compatible prefix of `expression`
+/// exposes a `>`, `>>`, or `>>>` token.
+///
+/// For example, when printing `(a < b) < (c >> /x/)`, this returns true for the
+/// right expression `c >> /x/`. The printer retains the parentheses instead of
+/// emitting the ambiguous `a < b < c >> /x/`. It also finds exposed closers in
+/// expressions such as `(c > d) | T` and `T & (c >>> d)`.
+///
+/// `|` and `&` are valid TypeScript type separators, so both operands are
+/// searched. Other operators only expose their emitted left edge before they
+/// form a grammar barrier. The traversal is iterative for deep binary trees.
+pub fn expression_starts_with_ts_type_argument_close(
+    expression: &Expression<'_>,
+    precedence: Precedence,
+    ctx: Context,
+) -> bool {
+    let (mut expression, mut precedence, mut ctx) = (expression, precedence, ctx);
+    let mut pending = Vec::new();
+
+    loop {
+        loop {
+            expression = expression.without_parentheses();
+
+            match expression {
+                Expression::BinaryExpression(binary) => {
+                    let operator_precedence = binary.operator.precedence();
+                    if precedence >= operator_precedence
+                        || (binary.operator == BinaryOperator::In && ctx.forbid_in())
+                    {
+                        break;
+                    }
+
+                    if matches!(
+                        binary.operator,
+                        BinaryOperator::GreaterThan
+                            | BinaryOperator::ShiftRight
+                            | BinaryOperator::ShiftRightZeroFill
+                    ) {
+                        return true;
+                    }
+
+                    let left_precedence = if operator_precedence.is_right_associative() {
+                        operator_precedence
+                    } else {
+                        binary.operator.lower_precedence()
+                    };
+
+                    if matches!(
+                        binary.operator,
+                        BinaryOperator::BitwiseOR | BinaryOperator::BitwiseAnd
+                    ) {
+                        let right_precedence = if operator_precedence.is_left_associative() {
+                            operator_precedence
+                        } else {
+                            binary.operator.lower_precedence()
+                        };
+                        pending.push((&binary.right, right_precedence, ctx));
+                    }
+
+                    expression = &binary.left;
+                    precedence = left_precedence;
+                }
+
+                Expression::LogicalExpression(logical) => {
+                    let operator_precedence = logical.operator.precedence();
+                    if precedence > operator_precedence {
+                        break;
+                    }
+
+                    let left_precedence = logical.operator.lower_precedence();
+                    if (logical.operator == LogicalOperator::Coalesce
+                        && matches!(
+                            logical.left.without_parentheses(),
+                            Expression::LogicalExpression(left)
+                                if matches!(
+                                    left.operator,
+                                    LogicalOperator::And | LogicalOperator::Or
+                                )
+                        ))
+                        || matches!(
+                            logical.left.without_parentheses(),
+                            Expression::LogicalExpression(left)
+                                if left_precedence >= left.operator.precedence()
+                        )
+                    {
+                        break;
+                    }
+
+                    expression = &logical.left;
+                    precedence = left_precedence;
+                }
+
+                Expression::SequenceExpression(sequence) => {
+                    if precedence < Precedence::Comma {
+                        let expression_ctx = ctx.and_forbid_call(false);
+                        pending.extend(
+                            sequence
+                                .expressions
+                                .iter()
+                                .map(|expression| (expression, Precedence::Lowest, expression_ctx)),
+                        );
+                    }
+                    break;
+                }
+
+                Expression::ConditionalExpression(conditional) => {
+                    if precedence >= Precedence::Conditional {
+                        break;
+                    }
+                    expression = &conditional.test;
+                    precedence = if matches!(
+                        conditional.test.without_parentheses(),
+                        Expression::TSAsExpression(_) | Expression::TSSatisfiesExpression(_)
+                    ) {
+                        Precedence::Compare
+                    } else {
+                        Precedence::Conditional
+                    };
+                    ctx &= Context::FORBID_IN;
+                }
+
+                Expression::ArrowFunctionExpression(arrow) => {
+                    if arrow.r#async || arrow.pife || precedence >= Precedence::Assign {
+                        break;
+                    }
+                    let Some(body) = arrow.body.as_expression() else { break };
+                    expression = body;
+                    precedence = Precedence::Comma;
+                }
+
+                Expression::TSAsExpression(as_expression) => {
+                    if precedence >= Precedence::Compare {
+                        break;
+                    }
+                    expression = &as_expression.expression;
+                    precedence = Precedence::Exponentiation;
+                }
+
+                Expression::TSSatisfiesExpression(satisfies_expression) => {
+                    if precedence >= Precedence::Compare {
+                        break;
+                    }
+                    expression = &satisfies_expression.expression;
+                    precedence = Precedence::Exponentiation;
+                }
+
+                _ => break,
+            }
+        }
+
+        let Some(next) = pending.pop() else { break };
+        (expression, precedence, ctx) = next;
+    }
+
+    false
+}

--- a/crates/oxc_codegen/src/typescript.rs
+++ b/crates/oxc_codegen/src/typescript.rs
@@ -15,6 +15,48 @@ use oxc_syntax::{
 
 use crate::Context;
 
+/// Determines which expressions in a comma-separated list need parentheses to
+/// prevent TypeScript from interpreting them as type arguments.
+pub struct TypeArgumentList {
+    last_closer: Option<usize>,
+    precedence: Precedence,
+    ctx: Context,
+}
+
+impl TypeArgumentList {
+    pub fn new<'a, T>(
+        is_typescript: bool,
+        items: &[T],
+        close_expression: impl for<'b> Fn(&'b T) -> Option<&'b Expression<'a>>,
+        precedence: Precedence,
+        ctx: Context,
+    ) -> Self {
+        let last_closer = (is_typescript && items.len() > 1)
+            .then(|| {
+                items.iter().rposition(|item| {
+                    close_expression(item).is_some_and(|expression| {
+                        expression_starts_with_ts_type_argument_close(expression, precedence, ctx)
+                    })
+                })
+            })
+            .flatten();
+
+        Self { last_closer, precedence, ctx }
+    }
+
+    pub fn precedence_for(&self, index: usize, expression: Option<&Expression<'_>>) -> Precedence {
+        if self.last_closer.is_some_and(|closer| index < closer)
+            && expression.is_some_and(|expression| {
+                expression_ends_with_ts_type_argument_open(expression, self.precedence, self.ctx)
+            })
+        {
+            Precedence::Shift
+        } else {
+            self.precedence
+        }
+    }
+}
+
 /// Returns whether the emitted suffix of `expression` exposes a `<` or `<<`
 /// token that TypeScript can reinterpret as the start of type arguments.
 ///

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -1,11 +1,12 @@
 use oxc_allocator::Allocator;
 use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_codegen::{Codegen, CodegenOptions, IndentChar};
-use oxc_span::SPAN;
+use oxc_span::{SPAN, SourceType};
 
 use crate::tester::{
-    test, test_minify, test_minify_same, test_options, test_same, test_same_ignore_parse_errors,
-    test_unambiguous, test_with_parse_options,
+    default_options, test, test_minify, test_minify_same, test_options,
+    test_reparse_with_source_type, test_same, test_same_ignore_parse_errors, test_unambiguous,
+    test_with_parse_options,
 };
 
 #[test]
@@ -13,6 +14,34 @@ fn cases() {
     test_same_ignore_parse_errors("class C {\n\t@foo static accessor A = @bar class {};\n}\n");
     test_same_ignore_parse_errors("function foo(@foo x = @bar class {}) {}\n");
     test_same_ignore_parse_errors("function foo(@foo ...rest) {}\n");
+}
+
+#[test]
+fn comparison_type_argument_parentheses_are_typescript_only() {
+    let test_js = |source, expected| {
+        test_reparse_with_source_type(
+            source,
+            expected,
+            SourceType::unambiguous(),
+            default_options(),
+        );
+    };
+
+    test_js("(a < b) > /x/;", "a < b > /x/;\n");
+    test_js("(a < b) > /x/.source;", "a < b > /x/.source;\n");
+    test_js("(a < b) > /x/ + 1;", "a < b > /x/ + 1;\n");
+    test_js("(a < b) > `x`.length;", "a < b > `x`.length;\n");
+    test_js("(a < b) > (c == d);", "a < b > (c == d);\n");
+    test_js("(a < b) > c;", "a < b > c;\n");
+    test_js("(a < b) < (c >> /x/);", "a < b < c >> /x/;\n");
+    test_js("((a < b) < c) < (d >>> `x`);", "a < b < c < d >>> `x`;\n");
+
+    test_js("(a < b) | c & d > /x/;", "a < b | c & d > /x/;\n");
+    test_js("a | (b < c);", "a | b < c;\n");
+    test_js("a & (b < c);", "a & b < c;\n");
+    test_js("((a < b) | c) | d > /x/;", "a < b | c | d > /x/;\n");
+    test_js("(((a < b) < c) | (d >> /x/));", "a < b < c | d >> /x/;\n");
+    test_js("((((a < b) < c) < d) & (e >>> `x`));", "a < b < c < d & e >>> `x`;\n");
 }
 
 #[test]

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -45,6 +45,31 @@ fn comparison_type_argument_parentheses_are_typescript_only() {
 }
 
 #[test]
+fn comparison_type_argument_list_parentheses_are_typescript_only() {
+    let test_js = |source, expected| {
+        test_reparse_with_source_type(
+            source,
+            expected,
+            SourceType::unambiguous(),
+            default_options(),
+        );
+    };
+
+    test_js("(\"hello\" < false), null > /a/;", "\"hello\" < false, null > /a/;\n");
+    test_js("(x = a < b), c > /x/;", "x = a < b, c > /x/;\n");
+    test_js("foo((a < b), c > /x/);", "foo(a < b, c > /x/);\n");
+    test_js("foo((a < b), (c) => d > /x/);", "foo(a < b, (c) => d > /x/);\n");
+    test_js("new Foo((a < b), c > /x/);", "new Foo(a < b, c > /x/);\n");
+    test_js("[(a < b), c > /x/];", "[a < b, c > /x/];\n");
+    test_js("import((a < b), c > /x/);", "import(a < b, c > /x/);\n");
+    test_js("((a < b) < c), d >> /x/;", "a < b < c, d >> /x/;\n");
+    test_js("foo(((a < b) < c), d >> /x/);", "foo(a < b < c, d >> /x/);\n");
+    test_js("new Foo((((a < b) < c) < d), e >>> `x`);", "new Foo(a < b < c < d, e >>> `x`);\n");
+    test_js("[((a < b) < c), d >> /x/];", "[a < b < c, d >> /x/];\n");
+    test_js("import((((a < b) < c) < d), e >>> `x`);", "import(a < b < c < d, e >>> `x`);\n");
+}
+
+#[test]
 fn decl() {
     test_same("const [foo, ...bar] = qux;\n");
     test_same("const { foo, ...bar } = qux;\n");

--- a/crates/oxc_codegen/tests/integration/tester.rs
+++ b/crates/oxc_codegen/tests/integration/tester.rs
@@ -2,7 +2,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::Comment;
 use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_parser::{ParseOptions, Parser};
-use oxc_span::SourceType;
+use oxc_span::{ContentEq, SourceType};
 
 pub fn default_options() -> CodegenOptions {
     // Ensure sourcemap do not crash.
@@ -51,6 +51,36 @@ pub fn test_options_with_source_type(
     assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
     let result = Codegen::new().with_options(options).build(&ret.program).code;
     assert_eq!(result, expected, "\nfor source: {source_text:?}");
+}
+
+/// Assert both the exact output and that reparsing it produces the same AST.
+#[track_caller]
+pub fn test_reparse_with_source_type(
+    source_text: &str,
+    expected: &str,
+    source_type: SourceType,
+    options: CodegenOptions,
+) {
+    let parse_options = ParseOptions { preserve_parens: false, ..ParseOptions::default() };
+
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, source_text, source_type).with_options(parse_options).parse();
+    assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
+
+    let result = Codegen::new().with_options(options).build(&ret.program).code;
+    assert_eq!(result, expected, "\nfor source: {source_text:?}");
+
+    let allocator2 = Allocator::default();
+    let ret2 = Parser::new(&allocator2, &result, source_type).with_options(parse_options).parse();
+    assert!(
+        ret2.diagnostics.is_empty(),
+        "Parse errors after codegen: {:?}\nfor source: {source_text:?}\ngenerated:\n{result}",
+        ret2.diagnostics
+    );
+    assert!(
+        ret.program.content_eq(&ret2.program),
+        "AST changed after codegen\nsource:\n{source_text}\ngenerated:\n{result}"
+    );
 }
 
 /// Test with unambiguous source type (like .js files)

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -1,12 +1,14 @@
-use oxc_codegen::CodegenOptions;
-use oxc_parser::ParseOptions;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Statement;
+use oxc_codegen::{Codegen, CodegenOptions};
+use oxc_parser::{ParseOptions, Parser};
 use oxc_span::SourceType;
 
 use crate::{
     snapshot, snapshot_options,
     tester::{
-        default_options, test_idempotency, test_options_with_source_type, test_same, test_tsx,
-        test_with_parse_options,
+        default_options, test_idempotency, test_options_with_source_type,
+        test_reparse_with_source_type, test_same, test_tsx, test_with_parse_options,
     },
 };
 
@@ -71,6 +73,86 @@ fn tsx() {
     test_tsx("<T,>() => {}", "<T,>() => {};\n");
     test_tsx("<T, B>() => {}", "<\n\tT,\n\tB\n>() => {};\n");
     test_tsx("<Foo<T> />", "<Foo<T> />;\n");
+}
+
+#[test]
+fn comparison_must_not_become_type_arguments() {
+    let test_ts = |source, expected| {
+        test_reparse_with_source_type(source, expected, SourceType::ts(), default_options());
+    };
+
+    // A structural close (`>`, `>>`, or `>>>`) groups an exposed-open expression on its left.
+    // The rule does not try to predict which token can follow speculative type arguments.
+    test_ts("(a < b) > /x/;", "(a < b) > /x/;\n");
+    test_ts("(a < b) > /x/.source;", "(a < b) > /x/.source;\n");
+    test_ts("(a < b) > /x/ + 1;", "(a < b) > /x/ + 1;\n");
+    test_ts("(a < b) > `x`;", "(a < b) > `x`;\n");
+    test_ts("(a < b) > `x`.length;", "(a < b) > `x`.length;\n");
+    test_ts("(a < b) > (c == d);", "(a < b) > (c == d);\n");
+    test_ts("(a < b) > c;", "(a < b) > c;\n");
+    test_ts("(a < b) > +c;", "(a < b) > +c;\n");
+    test_ts("(a < b) > -c;", "(a < b) > -c;\n");
+
+    // Conversely, a structural open (`<` or `<<`) groups a close-exposing right operand. These
+    // are the `>>` and `>>>` cases that ordinary precedence would otherwise print ungrouped.
+    test_ts("(a < b) < (c >> /x/);", "a < b < (c >> /x/);\n");
+    test_ts("((a < b) < c) < (d >>> `x`);", "a < b < c < (d >>> `x`);\n");
+
+    // `>=`, `<=`, an inner `>`, and an unmatched `<` do not form an open/close pair.
+    test_ts("(a < b) < /x/;", "a < b < /x/;\n");
+    test_ts("(a > b) > /x/;", "a > b > /x/;\n");
+    test_ts("(a > b) < /x/;", "a > b < /x/;\n");
+    test_ts("(a <= b) > /x/;", "a <= b > /x/;\n");
+    test_ts("(a < b) >= /x/;", "a < b >= /x/;\n");
+
+    test_reparse_with_source_type(
+        "(a < b) > /x/;",
+        "(a < b) > /x/;\n",
+        SourceType::tsx(),
+        default_options(),
+    );
+    test_reparse_with_source_type(
+        "(a < b) > /x/;",
+        "(a<b)>/x/;",
+        SourceType::ts(),
+        CodegenOptions::minify(),
+    );
+    // Minification may intentionally change a string literal into a template literal.
+    test_options_with_source_type(
+        "(a < b) > \"x\";",
+        "(a<b)>`x`;",
+        SourceType::ts(),
+        CodegenOptions::minify(),
+    );
+
+    // `|` and `&` group an operand whenever that operand exposes a dangling `<` suffix.
+    test_ts("(a < b) | c & d > /x/;", "(a < b) | c & d > /x/;\n");
+    test_ts("a | (b < c);", "a | (b < c);\n");
+    test_ts("a & (b < c);", "a & (b < c);\n");
+    test_ts("((a < b) | c) | d > /x/;", "(a < b) | c | d > /x/;\n");
+    test_ts("((a < b) | c) & d > /x/;", "((a < b) | c) & d > /x/;\n");
+    test_ts("(((a < b) < c) | (d >> /x/));", "(a < b < c) | d >> /x/;\n");
+    test_ts("((((a < b) < c) < d) & (e >>> `x`));", "(a < b < c < d) & e >>> `x`;\n");
+}
+
+#[test]
+fn comparison_type_argument_ambiguity_in_expression_fragment() {
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, "(a < b) > /x/;", SourceType::ts())
+        .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
+        .parse();
+    assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
+    let Statement::ExpressionStatement(statement) = &ret.program.body[0] else {
+        unreachable!();
+    };
+
+    let mut codegen = Codegen::new().with_source_type(SourceType::ts());
+    codegen.print_expression(&statement.expression);
+    assert_eq!(codegen.into_source_text(), "(a < b) > /x/");
+
+    let mut codegen = Codegen::new().with_source_type(SourceType::mjs());
+    codegen.print_expression(&statement.expression);
+    assert_eq!(codegen.into_source_text(), "a < b > /x/");
 }
 
 #[test]

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -136,6 +136,62 @@ fn comparison_must_not_become_type_arguments() {
 }
 
 #[test]
+fn comparison_type_argument_ambiguity_across_expression_lists() {
+    let test_ts = |source, expected| {
+        test_reparse_with_source_type(source, expected, SourceType::ts(), default_options());
+    };
+
+    // A non-final item that exposes `<` is grouped when a later item structurally exposes `>`,
+    // `>>`, or `>>>`. This is independent of the token following the close.
+    test_ts("(\"hello\" < false), null > /a/;", "(\"hello\" < false), null > /a/;\n");
+    test_ts("(a < b), c > d;", "(a < b), c > d;\n");
+    test_ts("foo((a < b), c > /x/);", "foo((a < b), c > /x/);\n");
+    test_ts("foo((a < b), (c) => d > /x/);", "foo((a < b), (c) => d > /x/);\n");
+    test_ts("foo((a < b), <T>(c: T) => d > /x/);", "foo((a < b), <T>(c: T) => d > /x/);\n");
+    test_ts("(a < b), (c) => d > /x/;", "(a < b), (c) => d > /x/;\n");
+    test_ts(
+        "foo((a < b), c > /x/ /* before close */);",
+        "foo(\n\t(a < b),\n\tc > /x/\n\t/* before close */\n);\n",
+    );
+    test_ts("new Foo((a < b), c > /x/);", "new Foo((a < b), c > /x/);\n");
+    test_ts("[(a < b), c > /x/];", "[(a < b), c > /x/];\n");
+    test_ts("import((a < b), c > /x/);", "import((a < b), c > /x/);\n");
+
+    // The open suffix may be exposed through enclosing expression nodes.
+    test_ts("(x = a < b), c > /x/;", "(x = a < b), c > /x/;\n");
+    test_ts("foo((x => a < b), c > /x/);", "foo(((x) => a < b), c > /x/);\n");
+    test_ts("foo(x && (a < b), c > /x/);", "foo((x && a < b), c > /x/);\n");
+    test_ts("foo(...(a < b), c > /x/);", "foo(...(a < b), c > /x/);\n");
+
+    // Without a later structural close, comma containers retain their normal minimal output.
+    test_ts("(a < b), c;", "a < b, c;\n");
+    test_ts("foo((a < b), c);", "foo(a < b, c);\n");
+    test_ts("new Foo((a < b), c);", "new Foo(a < b, c);\n");
+    test_ts("[(a < b), c];", "[a < b, c];\n");
+    test_ts("import((a < b), c);", "import(a < b, c);\n");
+
+    // Final items and non-final items without an exposed open also stay minimal.
+    test_ts("foo(a, (b < c));", "foo(a, b < c);\n");
+    test_ts("x = 1, c > /x/;", "x = 1, c > /x/;\n");
+    test_ts("foo(x = 1, c > /x/);", "foo(x = 1, c > /x/);\n");
+    test_ts("foo((a < b), c >= d);", "foo(a < b, c >= d);\n");
+
+    // Exercise multi-character structural closes after each comma-list boundary.
+    test_ts("((a < b) < c), d >> /x/;", "(a < b < c), d >> /x/;\n");
+    test_ts("foo(((a < b) < c), d >> /x/);", "foo((a < b < c), d >> /x/);\n");
+    test_ts("new Foo((((a < b) < c) < d), e >>> `x`);", "new Foo((a < b < c < d), e >>> `x`);\n");
+    test_ts("[((a < b) < c), d >> /x/];", "[(a < b < c), d >> /x/];\n");
+    test_ts("import((((a < b) < c) < d), e >>> `x`);", "import((a < b < c < d), e >>> `x`);\n");
+
+    test_reparse_with_source_type(
+        "import((a < b), c > /x/);",
+        "import((a<b),c>/x/);",
+        SourceType::ts(),
+        CodegenOptions::minify(),
+    );
+}
+
+#[test]
 fn comparison_type_argument_ambiguity_in_expression_fragment() {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, "(a < b) > /x/;", SourceType::ts())


### PR DESCRIPTION
## Summary

- preserve TypeScript comparison grouping when emitted `<`, `>`, `>>`, and `>>>` tokens could be reparsed as type-argument delimiters
- handle direct comparisons, `|`/`&` regions, and comma-separated expression owners without changing JavaScript output
- use iterative structural edge analysis instead of predicting regular expressions, templates, comments, or minified token choices

## Notes for reviewers

The grouping is intentionally conservative for TypeScript: structurally matched angle boundaries are isolated even when a particular following token would make the flattened form safe. This keeps the fix independent of future printer/token changes and avoids the recursive analyzers from the superseded PRs.

Part of #25111.
Fixes #25116.
Fixes #25120.
Supersedes #25118 and #25121.
