### PR TITLE
fix(react_compiler): materialize compound assignment reads

### DIFF
--- a/crates/oxc_react_compiler/fixtures/constant-propagation-compound-assignment.tsx
+++ b/crates/oxc_react_compiler/fixtures/constant-propagation-compound-assignment.tsx
@@ -1,0 +1,13 @@
+function Component({suffix, offset}: {suffix: string | null; offset: number | null}) {
+  let text = 'prefix';
+  let count = 10;
+
+  if (suffix) {
+    text += suffix;
+  }
+  if (offset) {
+    count -= offset;
+  }
+
+  return <div>{text}: {count}</div>;
+}

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -4299,6 +4299,15 @@ fn lower_assignment_expression<'a>(
                 let ident_span = ident.span;
                 let symbol = builder.scope().resolve_reference(ident);
                 let left_place = lower_identifier(builder, ident.name, ident_span, symbol)?;
+                let is_context_identifier = builder.is_context_identifier(symbol);
+                let left_place = lower_value_to_temporary(
+                    builder,
+                    if is_context_identifier {
+                        InstructionValue::LoadContext { place: left_place, span: Some(ident_span) }
+                    } else {
+                        InstructionValue::LoadLocal { place: left_place, span: Some(ident_span) }
+                    },
+                )?;
                 let right = lower_expression_to_temporary(builder, &assign.right)?;
                 let binary_place = lower_value_to_temporary(
                     builder,

--- a/crates/oxc_react_compiler/tests/snapshots/constant-propagation-compound-assignment.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/constant-propagation-compound-assignment.snap
@@ -1,0 +1,27 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/constant-propagation-compound-assignment.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+function Component(t0) {
+	const $ = _c(3);
+	const { suffix, offset } = t0;
+	let text = "prefix";
+	let count = 10;
+	if (suffix) {
+		text = "prefix" + suffix;
+	}
+	if (offset) {
+		count = 10 - offset;
+	}
+	let t1;
+	if ($[0] !== count || $[1] !== text) {
+		t1 = <div>{text}: {count}</div>;
+		$[0] = count;
+		$[1] = text;
+		$[2] = t1;
+	} else {
+		t1 = $[2];
+	}
+	return t1;
+}


### PR DESCRIPTION
Materializes identifier reads before compound-assignment binary operations so constant propagation matches the upstream React Compiler. AI-assisted.