### PR TITLE
feat(formatter,oxfmt): add jsxBlankLines option

### DIFF
--- a/apps/oxfmt/src-js/config.generated.ts
+++ b/apps/oxfmt/src-js/config.generated.ts
@@ -10,6 +10,7 @@ export type HtmlWhitespaceSensitivityConfig = "css" | "strict" | "ignore";
 export type JsdocUserConfig = boolean | JsdocConfig;
 export type CommentLineStrategyConfig = "singleLine" | "multiline" | "keep";
 export type LineWrappingStyleConfig = "greedy" | "balance";
+export type JsxBlankLinesConfig = "preserve" | "remove";
 export type ObjectWrapConfig = "preserve" | "collapse";
 /**
  * A set of glob patterns.
@@ -128,6 +129,19 @@ export interface Oxfmtrc {
    * - Default: Disabled
    */
   jsdoc?: JsdocUserConfig;
+  /**
+   * Whether to keep blank lines between JSX children.
+   *
+   * `"preserve"` keeps a single blank line wherever one was written, matching Prettier.
+   * `"remove"` drops them, printing children one per line — the shape already used
+   * when a JSX element has a meaningful text child.
+   *
+   * Blank lines between statements are unaffected.
+   *
+   * - Languages: JSX, TSX
+   * - Default: `"preserve"`
+   */
+  jsxBlankLines?: JsxBlankLinesConfig;
   /**
    * Use single quotes instead of double quotes in JSX.
    *
@@ -448,6 +462,19 @@ export interface FormatConfig {
    * - Default: Disabled
    */
   jsdoc?: JsdocUserConfig;
+  /**
+   * Whether to keep blank lines between JSX children.
+   *
+   * `"preserve"` keeps a single blank line wherever one was written, matching Prettier.
+   * `"remove"` drops them, printing children one per line — the shape already used
+   * when a JSX element has a meaningful text child.
+   *
+   * Blank lines between statements are unaffected.
+   *
+   * - Languages: JSX, TSX
+   * - Default: `"preserve"`
+   */
+  jsxBlankLines?: JsxBlankLinesConfig;
   /**
    * Use single quotes instead of double quotes in JSX.
    *

--- a/apps/oxfmt/src/core/options/to_oxc_formatter.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter.rs
@@ -3,8 +3,8 @@ use oxc_formatter::SortTailwindcssOptions;
 use oxc_formatter::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, CommentLineStrategy,
     CustomGroupDefinition, Expand, GroupEntry, ImportModifier, ImportSelector, JsFormatOptions,
-    JsdocOptions, LineWrappingStyle, QuoteProperties, QuoteStyle, Semicolons, SortImportsOptions,
-    SortOrder, TrailingCommas,
+    JsdocOptions, JsxBlankLines, LineWrappingStyle, QuoteProperties, QuoteStyle, Semicolons,
+    SortImportsOptions, SortOrder, TrailingCommas,
 };
 use oxc_formatter_core::{CoreFormatOptions, FormatOptions};
 
@@ -12,9 +12,9 @@ use oxc_formatter_core::{CoreFormatOptions, FormatOptions};
 use super::super::oxfmtrc::SortTailwindcssUserConfig;
 use super::super::oxfmtrc::{
     ArrowParensConfig, CommentLineStrategyConfig, FormatConfig, HtmlWhitespaceSensitivityConfig,
-    ImportModifierConfig, ImportSelectorConfig, JsdocUserConfig, LineWrappingStyleConfig,
-    ObjectWrapConfig, QuotePropsConfig, SortGroupItemConfig, SortImportsUserConfig,
-    SortOrderConfig, TrailingCommaConfig,
+    ImportModifierConfig, ImportSelectorConfig, JsdocUserConfig, JsxBlankLinesConfig,
+    LineWrappingStyleConfig, ObjectWrapConfig, QuotePropsConfig, SortGroupItemConfig,
+    SortImportsUserConfig, SortOrderConfig, TrailingCommaConfig,
 };
 
 /// Convert `FormatConfig` into `JsFormatOptions` for `oxc_formatter`.
@@ -44,6 +44,14 @@ pub fn to_oxc_formatter(
     if let Some(jsx_single_quote) = config.jsx_single_quote {
         format_options.jsx_quote_style =
             if jsx_single_quote { QuoteStyle::Single } else { QuoteStyle::Double };
+    }
+
+    // [Oxfmt] jsxBlankLines: "preserve" | "remove"
+    if let Some(jsx_blank_lines) = config.jsx_blank_lines {
+        format_options.jsx_blank_lines = match jsx_blank_lines {
+            JsxBlankLinesConfig::Preserve => JsxBlankLines::Preserve,
+            JsxBlankLinesConfig::Remove => JsxBlankLines::Remove,
+        };
     }
 
     // [Prettier] quoteProps: "as-needed" | "consistent" | "preserve"
@@ -347,6 +355,22 @@ mod tests {
                 });
             assert_eq!(to_import_modifier(config), *modifier);
         }
+    }
+
+    /// Omitting the key must leave Prettier's behaviour in place, so the default
+    /// case is asserted alongside the two explicit ones.
+    #[test]
+    fn jsx_blank_lines_maps_from_config() {
+        let preserve: FormatConfig =
+            serde_json::from_str(r#"{ "jsxBlankLines": "preserve" }"#).unwrap();
+        assert!(build(&preserve).unwrap().jsx_blank_lines.is_preserve());
+
+        let remove: FormatConfig =
+            serde_json::from_str(r#"{ "jsxBlankLines": "remove" }"#).unwrap();
+        assert!(build(&remove).unwrap().jsx_blank_lines.is_remove());
+
+        let omitted: FormatConfig = serde_json::from_str("{}").unwrap();
+        assert!(build(&omitted).unwrap().jsx_blank_lines.is_preserve());
     }
 
     #[test]

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -272,6 +272,19 @@ pub struct FormatConfig {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub jsdoc: Option<JsdocUserConfig>,
 
+    /// Whether to keep blank lines between JSX children.
+    ///
+    /// `"preserve"` keeps a single blank line wherever one was written, matching Prettier.
+    /// `"remove"` drops them, printing children one per line — the shape already used
+    /// when a JSX element has a meaningful text child.
+    ///
+    /// Blank lines between statements are unaffected.
+    ///
+    /// - Languages: JSX, TSX
+    /// - Default: `"preserve"`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jsx_blank_lines: Option<JsxBlankLinesConfig>,
+
     /// Options for `prettier-plugin-svelte`.
     ///
     /// Pass `true` or an object to enable `.svelte` file formatting,
@@ -399,6 +412,13 @@ pub enum TrailingCommaConfig {
     All,
     Es5,
     None,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum JsxBlankLinesConfig {
+    Preserve,
+    Remove,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema)]

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -71,6 +71,57 @@ pub struct JsFormatOptions {
     /// When enabled, JSDoc comments will be normalized and reformatted.
     /// Defaults to None (disabled).
     pub jsdoc: Option<JsdocOptions>,
+    /// Whether blank lines between JSX children are kept. Defaults to preserving them.
+    pub jsx_blank_lines: JsxBlankLines,
+}
+
+/// Whether blank lines between JSX children are kept.
+///
+/// Prettier has no equivalent and always preserves them, so `Preserve` is the default.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub enum JsxBlankLines {
+    /// Keep a single blank line wherever the author wrote one.
+    #[default]
+    Preserve,
+    /// Drop them, printing children one per line.
+    ///
+    /// This is the shape already produced when a JSX element has a meaningful text
+    /// child, which switches its children to a filled text flow.
+    Remove,
+}
+
+impl JsxBlankLines {
+    pub const fn is_remove(self) -> bool {
+        matches!(self, Self::Remove)
+    }
+
+    pub const fn is_preserve(self) -> bool {
+        matches!(self, Self::Preserve)
+    }
+}
+
+impl FromStr for JsxBlankLines {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "preserve" => Ok(Self::Preserve),
+            "remove" => Ok(Self::Remove),
+            _ => Err(
+                "Value not supported for JsxBlankLines. Supported values are 'preserve' and 'remove'.",
+            ),
+        }
+    }
+}
+
+impl fmt::Display for JsxBlankLines {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            JsxBlankLines::Preserve => "Preserve",
+            JsxBlankLines::Remove => "Remove",
+        };
+        f.write_str(s)
+    }
 }
 
 /// How to format JSDoc comment blocks: single-line, multi-line, or preserve original.

--- a/crates/oxc_formatter/src/print/jsx/child_list.rs
+++ b/crates/oxc_formatter/src/print/jsx/child_list.rs
@@ -243,7 +243,10 @@ impl FormatJsxChildList {
                     //   <div>Second</div>
                     //   Third
                     // </>
-                    if children_meta.meaningful_text {
+                    //
+                    // `jsxBlankLines: "remove"` asks for that same shape for every
+                    // element, not only the ones that happen to contain text.
+                    if children_meta.meaningful_text || f.options().jsx_blank_lines.is_remove() {
                         multiline.write_separator(&hard_line_break(), f);
                     } else {
                         multiline.write_separator(&empty_line(), f);

--- a/crates/oxc_formatter/tests/README.md
+++ b/crates/oxc_formatter/tests/README.md
@@ -99,6 +99,7 @@ The following format options are supported in `options.json`:
 - `bracketSpacing`: `true` | `false` - Object literal spacing
 - `bracketSameLine`: `true` | `false` - JSX bracket on same line
 - `jsxBracketSameLine`: `true` | `false` - (alias for bracketSameLine)
+- `jsxBlankLines`: `"preserve"` | `"remove"` - Blank lines between JSX children
 
 ## Running Tests
 

--- a/crates/oxc_formatter/tests/fixtures/js/jsx-blank-lines/options.json
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx-blank-lines/options.json
@@ -1,0 +1,8 @@
+[
+  {
+    "jsxBlankLines": "preserve"
+  },
+  {
+    "jsxBlankLines": "remove"
+  }
+]

--- a/crates/oxc_formatter/tests/fixtures/js/jsx-blank-lines/siblings.jsx
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx-blank-lines/siblings.jsx
@@ -1,0 +1,52 @@
+const elements = (
+  <>
+
+    <Alpha />
+
+    <Beta />
+
+
+
+    <Gamma />
+    <Delta />
+
+  </>
+);
+
+const expressions = (
+  <div>
+    {failure && <Failure />}
+
+    <Status />
+
+    {done && (
+      <>
+        <Result />
+        <Track />
+      </>
+    )}
+  </div>
+);
+
+// A meaningful text child already drops blank lines under either setting.
+const withText = (
+  <>
+    <Alpha />
+
+    <Beta />
+
+    Third
+  </>
+);
+
+const nested = (
+  <section>
+    <header>
+      <h1>Title</h1>
+
+      <p>Lede</p>
+    </header>
+
+    <footer />
+  </section>
+);

--- a/crates/oxc_formatter/tests/fixtures/js/jsx-blank-lines/siblings.jsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx-blank-lines/siblings.jsx.snap
@@ -1,0 +1,247 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+const elements = (
+  <>
+
+    <Alpha />
+
+    <Beta />
+
+
+
+    <Gamma />
+    <Delta />
+
+  </>
+);
+
+const expressions = (
+  <div>
+    {failure && <Failure />}
+
+    <Status />
+
+    {done && (
+      <>
+        <Result />
+        <Track />
+      </>
+    )}
+  </div>
+);
+
+// A meaningful text child already drops blank lines under either setting.
+const withText = (
+  <>
+    <Alpha />
+
+    <Beta />
+
+    Third
+  </>
+);
+
+const nested = (
+  <section>
+    <header>
+      <h1>Title</h1>
+
+      <p>Lede</p>
+    </header>
+
+    <footer />
+  </section>
+);
+
+==================== Output ====================
+---------------------------------------------
+{ jsxBlankLines: "preserve", printWidth: 80 }
+---------------------------------------------
+const elements = (
+  <>
+    <Alpha />
+
+    <Beta />
+
+    <Gamma />
+    <Delta />
+  </>
+);
+
+const expressions = (
+  <div>
+    {failure && <Failure />}
+
+    <Status />
+
+    {done && (
+      <>
+        <Result />
+        <Track />
+      </>
+    )}
+  </div>
+);
+
+// A meaningful text child already drops blank lines under either setting.
+const withText = (
+  <>
+    <Alpha />
+    <Beta />
+    Third
+  </>
+);
+
+const nested = (
+  <section>
+    <header>
+      <h1>Title</h1>
+
+      <p>Lede</p>
+    </header>
+
+    <footer />
+  </section>
+);
+
+----------------------------------------------
+{ jsxBlankLines: "preserve", printWidth: 100 }
+----------------------------------------------
+const elements = (
+  <>
+    <Alpha />
+
+    <Beta />
+
+    <Gamma />
+    <Delta />
+  </>
+);
+
+const expressions = (
+  <div>
+    {failure && <Failure />}
+
+    <Status />
+
+    {done && (
+      <>
+        <Result />
+        <Track />
+      </>
+    )}
+  </div>
+);
+
+// A meaningful text child already drops blank lines under either setting.
+const withText = (
+  <>
+    <Alpha />
+    <Beta />
+    Third
+  </>
+);
+
+const nested = (
+  <section>
+    <header>
+      <h1>Title</h1>
+
+      <p>Lede</p>
+    </header>
+
+    <footer />
+  </section>
+);
+
+-------------------------------------------
+{ jsxBlankLines: "remove", printWidth: 80 }
+-------------------------------------------
+const elements = (
+  <>
+    <Alpha />
+    <Beta />
+    <Gamma />
+    <Delta />
+  </>
+);
+
+const expressions = (
+  <div>
+    {failure && <Failure />}
+    <Status />
+    {done && (
+      <>
+        <Result />
+        <Track />
+      </>
+    )}
+  </div>
+);
+
+// A meaningful text child already drops blank lines under either setting.
+const withText = (
+  <>
+    <Alpha />
+    <Beta />
+    Third
+  </>
+);
+
+const nested = (
+  <section>
+    <header>
+      <h1>Title</h1>
+      <p>Lede</p>
+    </header>
+    <footer />
+  </section>
+);
+
+--------------------------------------------
+{ jsxBlankLines: "remove", printWidth: 100 }
+--------------------------------------------
+const elements = (
+  <>
+    <Alpha />
+    <Beta />
+    <Gamma />
+    <Delta />
+  </>
+);
+
+const expressions = (
+  <div>
+    {failure && <Failure />}
+    <Status />
+    {done && (
+      <>
+        <Result />
+        <Track />
+      </>
+    )}
+  </div>
+);
+
+// A meaningful text child already drops blank lines under either setting.
+const withText = (
+  <>
+    <Alpha />
+    <Beta />
+    Third
+  </>
+);
+
+const nested = (
+  <section>
+    <header>
+      <h1>Title</h1>
+      <p>Lede</p>
+    </header>
+    <footer />
+  </section>
+);
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter/tests/fixtures/mod.rs
@@ -86,6 +86,13 @@ impl FixtureFormatter for JsHarness {
                 "jsdoc" if value.is_object() => {
                     options.jsdoc = Some(JsdocOptions::default());
                 }
+                "jsxBlankLines" => {
+                    if let Some(s) = value.as_str()
+                        && let Ok(parsed) = s.parse()
+                    {
+                        options.jsx_blank_lines = parsed;
+                    }
+                }
                 _ => {}
             }
         }

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -72,6 +72,15 @@
       ],
       "markdownDescription": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled"
     },
+    "jsxBlankLines": {
+      "description": "Whether to keep blank lines between JSX children.\n\n`\"preserve\"` keeps a single blank line wherever one was written, matching Prettier.\n`\"remove\"` drops them, printing children one per line — the shape already used\nwhen a JSX element has a meaningful text child.\n\nBlank lines between statements are unaffected.\n\n- Languages: JSX, TSX\n- Default: `\"preserve\"`",
+      "allOf": [
+        {
+          "$ref": "#/definitions/JsxBlankLinesConfig"
+        }
+      ],
+      "markdownDescription": "Whether to keep blank lines between JSX children.\n\n`\"preserve\"` keeps a single blank line wherever one was written, matching Prettier.\n`\"remove\"` drops them, printing children one per line — the shape already used\nwhen a JSX element has a meaningful text child.\n\nBlank lines between statements are unaffected.\n\n- Languages: JSX, TSX\n- Default: `\"preserve\"`"
+    },
     "jsxSingleQuote": {
       "description": "Use single quotes instead of double quotes in JSX.\n\n- Languages: JSX, TSX\n- Default: `false`",
       "type": "boolean",
@@ -330,6 +339,15 @@
           ],
           "markdownDescription": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled"
         },
+        "jsxBlankLines": {
+          "description": "Whether to keep blank lines between JSX children.\n\n`\"preserve\"` keeps a single blank line wherever one was written, matching Prettier.\n`\"remove\"` drops them, printing children one per line — the shape already used\nwhen a JSX element has a meaningful text child.\n\nBlank lines between statements are unaffected.\n\n- Languages: JSX, TSX\n- Default: `\"preserve\"`",
+          "allOf": [
+            {
+              "$ref": "#/definitions/JsxBlankLinesConfig"
+            }
+          ],
+          "markdownDescription": "Whether to keep blank lines between JSX children.\n\n`\"preserve\"` keeps a single blank line wherever one was written, matching Prettier.\n`\"remove\"` drops them, printing children one per line — the shape already used\nwhen a JSX element has a meaningful text child.\n\nBlank lines between statements are unaffected.\n\n- Languages: JSX, TSX\n- Default: `\"preserve\"`"
+        },
         "jsxSingleQuote": {
           "description": "Use single quotes instead of double quotes in JSX.\n\n- Languages: JSX, TSX\n- Default: `false`",
           "type": "boolean",
@@ -572,6 +590,13 @@
         {
           "$ref": "#/definitions/JsdocConfig"
         }
+      ]
+    },
+    "JsxBlankLinesConfig": {
+      "type": "string",
+      "enum": [
+        "preserve",
+        "remove"
       ]
     },
     "LineWrappingStyleConfig": {

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -240,6 +240,23 @@ Add blank lines between different tag groups (e.g. between `@param` and `@return
 - Default: `false`
 
 
+## jsxBlankLines
+
+type: `"preserve" | "remove"`
+
+
+Whether to keep blank lines between JSX children.
+
+`"preserve"` keeps a single blank line wherever one was written, matching Prettier.
+`"remove"` drops them, printing children one per line — the shape already used
+when a JSX element has a meaningful text child.
+
+Blank lines between statements are unaffected.
+
+- Languages: JSX, TSX
+- Default: `"preserve"`
+
+
 ## jsxSingleQuote
 
 type: `boolean`
@@ -528,6 +545,23 @@ type: `boolean`
 Add blank lines between different tag groups (e.g. between `@param` and `@returns`).
 
 - Default: `false`
+
+
+##### overrides[n].options.jsxBlankLines
+
+type: `"preserve" | "remove"`
+
+
+Whether to keep blank lines between JSX children.
+
+`"preserve"` keeps a single blank line wherever one was written, matching Prettier.
+`"remove"` drops them, printing children one per line — the shape already used
+when a JSX element has a meaningful text child.
+
+Blank lines between statements are unaffected.
+
+- Languages: JSX, TSX
+- Default: `"preserve"`
 
 
 ##### overrides[n].options.jsxSingleQuote


### PR DESCRIPTION
In JSX child lists without meaningful text, a single blank line between siblings is always preserved, and no setting changes that. Indentation already encodes the tree, so a blank line between two siblings carries no structural meaning; what it carries instead is undefined, and drifts between files.

The behaviour already existed, gated on `children_meta.meaningful_text` in the JSX child list printer: an element with a meaningful text child switches its children to a filled text flow, which drops blank lines. `jsxBlankLines: "remove"` widens that condition so the same shape is reachable for every element, rather than only the ones that happen to contain text.

`empty_line()` occurs exactly once in the JSX printer, so no other branch needed the same treatment.

Defaults to "preserve", leaving Prettier's behaviour in place unless the option is set. The default is asserted alongside both explicit values in the config mapping test, so a change to it cannot pass unnoticed.

Closes #25452