### PR TITLE
feat(react_compiler): recognize oxlint suppressions

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/suppression.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/suppression.rs
@@ -38,6 +38,7 @@ fn comment_value(comment: Comment, source_text: &str) -> &str {
 fn matches_eslint_disable_next_line(value: &str, rule_names: &[String]) -> bool {
     value
         .strip_prefix("eslint-disable-next-line ")
+        .or_else(|| value.strip_prefix("oxlint-disable-next-line "))
         .is_some_and(|rest| rule_names.iter().any(|name| rest.starts_with(name.as_str())))
 }
 
@@ -45,6 +46,7 @@ fn matches_eslint_disable_next_line(value: &str, rule_names: &[String]) -> bool 
 fn matches_eslint_disable(value: &str, rule_names: &[String]) -> bool {
     value
         .strip_prefix("eslint-disable ")
+        .or_else(|| value.strip_prefix("oxlint-disable "))
         .is_some_and(|rest| rule_names.iter().any(|name| rest.starts_with(name.as_str())))
 }
 
@@ -52,6 +54,7 @@ fn matches_eslint_disable(value: &str, rule_names: &[String]) -> bool {
 fn matches_eslint_enable(value: &str, rule_names: &[String]) -> bool {
     value
         .strip_prefix("eslint-enable ")
+        .or_else(|| value.strip_prefix("oxlint-enable "))
         .is_some_and(|rest| rule_names.iter().any(|name| rest.starts_with(name.as_str())))
 }
 

--- a/crates/oxc_react_compiler/tests/transform.rs
+++ b/crates/oxc_react_compiler/tests/transform.rs
@@ -1,5 +1,6 @@
 //! End-to-end integration tests: oxc parse + semantic -> compile -> codegen.
 
+use cow_utils::CowUtils;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{ModuleExportName, Program, Statement};
 use oxc_codegen::Codegen;
@@ -140,7 +141,7 @@ fn skips_non_react_code() {
 }
 
 #[test]
-fn default_eslint_suppressions_bail_out() {
+fn default_lint_suppressions_bail_out() {
     let fixtures = [
         (
             "eslint-disable-next-line",
@@ -152,15 +153,18 @@ fn default_eslint_suppressions_bail_out() {
         ),
     ];
 
-    for (kind, source) in fixtures {
-        let allocator = Allocator::default();
-        let (_program, result) =
-            transform_source(source, SourceType::tsx(), &allocator, PluginOptions::default());
+    for prefix in ["eslint", "oxlint"] {
+        for (kind, source) in fixtures {
+            let source = source.cow_replace("eslint", prefix);
+            let allocator = Allocator::default();
+            let (_program, result) =
+                transform_source(&source, SourceType::tsx(), &allocator, PluginOptions::default());
 
-        assert!(!result.changed, "{kind} must prevent compilation");
-        assert!(!result.fatal, "{kind} must not produce a fatal result");
-        assert_eq!(result.diagnostics.len(), 1);
-        assert!(result.diagnostics[0].message.contains("[ReactCompiler] Suppression"));
+            assert!(!result.changed, "{prefix} {kind} must prevent compilation");
+            assert!(!result.fatal, "{prefix} {kind} must not produce a fatal result");
+            assert_eq!(result.diagnostics.len(), 1);
+            assert!(result.diagnostics[0].message.contains("[ReactCompiler] Suppression"));
+        }
     }
 }
 


### PR DESCRIPTION
Recognize `oxlint-disable*` and `oxlint-enable` comments wherever React Compiler accepts their ESLint-prefixed equivalents.

AI-assisted.