### PR TITLE
fix(react_compiler): preserve source spans

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2269,6 +2269,7 @@ impl Gen for AssignmentTargetPropertyProperty<'_> {
 
 impl Gen for AssignmentTargetRest<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.add_source_mapping(self.span);
         p.print_ellipsis();
         self.target.print(p, ctx);
     }
@@ -2733,12 +2734,14 @@ impl Gen for JSXAttributeValue<'_> {
 
 impl Gen for JSXSpreadAttribute<'_> {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
+        p.add_source_mapping(self.span);
         p.print_ascii_byte(b'{');
         if p.print_comments_in_range(self.span.start, self.argument.span().start) {
             p.print_indent();
         }
         p.print_str("...");
         self.argument.print_expr(p, Precedence::Comma, Context::empty());
+        p.add_source_mapping_end(self.span);
         p.print_ascii_byte(b'}');
     }
 }

--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -49,7 +49,7 @@ smallvec = { workspace = true }
 [dev-dependencies]
 # The example and integration tests parse source and print the compiled program; the
 # library itself takes an already-parsed `Program` and never parses or codegens.
-oxc_codegen = { workspace = true }
+oxc_codegen = { workspace = true, features = ["sourcemap"] }
 oxc_parser = { workspace = true }
 
 # Snapshot testing of the compiler over the upstream fixture corpus (tests/snapshot.rs).

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -2106,10 +2106,7 @@ impl<'a> CompileOutput<'a> {
 
 /// Drop comments left dangling by compilation.
 ///
-/// The compiled functions were rebuilt with fresh spans, so a comment that
-/// pointed inside one no longer lines up with any statement and codegen would
-/// re-emit it at a stale position. Keep only the comments still anchored to a
-/// top-level statement.
+/// Rewritten functions may no longer contain the statements comments were attached to.
 fn prune_inner_comments(program: &mut Program<'_>) {
     if program.comments.is_empty() {
         return;
@@ -2157,7 +2154,7 @@ fn ox_build_function<'a>(
     fn_type: FunctionType,
 ) -> ArenaBox<'a, Function<'a>> {
     Function::boxed(
-        SPAN,
+        codegen.span.unwrap_or_default(),
         fn_type,
         codegen.id.clone_in_with_semantic_ids(ast.allocator()),
         codegen.generator,
@@ -2181,7 +2178,7 @@ fn ox_build_compiled_expression<'a>(
 ) -> Expression<'a> {
     match original_kind {
         OriginalFnKind::ArrowFunctionExpression => Expression::new_arrow_function_expression(
-            SPAN,
+            codegen.span.unwrap_or_default(),
             codegen.is_async,
             None,
             codegen.params.clone_in_with_semantic_ids(ast.allocator()),
@@ -2220,7 +2217,11 @@ fn ox_replace_function<'a>(
         func.return_type = None;
         func.this_param = None;
     }
+    let source_id_span = func.id.as_ref().map(|id| id.span);
     func.id = codegen.id.clone_in_with_semantic_ids(ast.allocator());
+    if let (Some(id), Some(span)) = (&mut func.id, source_id_span) {
+        id.span = span;
+    }
     func.params = params;
     func.body = Some(codegen.body.clone_in_with_semantic_ids(ast.allocator()));
     func.generator = codegen.generator;
@@ -2255,17 +2256,19 @@ fn ox_build_gated_const_decl<'a>(
     ast: &AstBuilder<'a>,
     gating_expression: &Expression<'a>,
     name: &str,
+    name_span: Span,
+    declaration_span: Span,
 ) -> Statement<'a> {
     let declarator = VariableDeclarator::new(
-        SPAN,
-        BindingPattern::new_binding_identifier(SPAN, ox_atom(ast, name), ast),
+        declaration_span,
+        BindingPattern::new_binding_identifier(name_span, ox_atom(ast, name), ast),
         None,
         Some(gating_expression.clone_in_with_semantic_ids(ast.allocator())),
         false,
         ast,
     );
     Statement::new_variable_declaration(
-        SPAN,
+        declaration_span,
         VariableDeclarationKind::Const,
         [declarator],
         false,
@@ -2316,6 +2319,8 @@ enum OxcVisitMode<'a, 'b> {
     FindOriginalFn { scope_id: ScopeId, found: Option<Expression<'a>> },
 }
 
+type GatedStatementMatch<'a> = (Option<(Ident<'a>, Span)>, Option<Span>);
+
 impl<'a> OxcVisitor<'a, '_> {
     /// In [`OxcVisitMode::ReplaceWithGated`]: if `stmt` is the target function
     /// declaration (bare, `export`-wrapped, or `export default`), substitute
@@ -2334,28 +2339,29 @@ impl<'a> OxcVisitor<'a, '_> {
         let scope_id = *scope_id;
         let gating_expression = *gating_expression;
         // FunctionDeclaration → `const Foo = gating() ? ... : ...;`
-        let replace_name: Option<Option<Ident<'a>>> = match &*stmt {
+        let replacement: Option<GatedStatementMatch<'a>> = match &*stmt {
             Statement::FunctionDeclaration(f) if f.scope_id.get() == Some(scope_id) => {
-                Some(f.id.as_ref().map(|id| id.name))
+                Some((f.id.as_ref().map(|id| (id.name, id.span)), None))
             }
             Statement::ExportDeclaration(e) => match &e.declaration {
                 Declaration::FunctionDeclaration(f) if f.scope_id.get() == Some(scope_id) => {
-                    Some(f.id.as_ref().map(|id| id.name))
+                    Some((f.id.as_ref().map(|id| (id.name, id.span)), Some(e.span)))
                 }
                 _ => None,
             },
             _ => None,
         };
-        if let Some(name) = replace_name {
-            let name = name.as_deref().unwrap_or("anonymous");
-            let is_export = matches!(stmt, Statement::ExportDeclaration(_));
-            let const_decl = ox_build_gated_const_decl(ast, gating_expression, name);
-            if is_export {
+        if let Some((name, export_span)) = replacement {
+            let (name, name_span) =
+                name.map_or(("anonymous", SPAN), |(name, span)| (name.as_str(), span));
+            let const_decl =
+                ox_build_gated_const_decl(ast, gating_expression, name, name_span, SPAN);
+            if let Some(export_span) = export_span {
                 let decl = match const_decl {
                     Statement::VariableDeclaration(d) => Declaration::VariableDeclaration(d),
                     _ => unreachable!(),
                 };
-                *stmt = Statement::new_export_declaration(SPAN, decl, ast);
+                *stmt = Statement::new_export_declaration(export_span, decl, ast);
             } else {
                 *stmt = const_decl;
             }
@@ -2367,12 +2373,20 @@ impl<'a> OxcVisitor<'a, '_> {
             && let ExportDefaultDeclarationKind::FunctionDeclaration(f) = &e.declaration
             && f.scope_id.get() == Some(scope_id)
         {
-            if let Some(id) = f.id.as_ref().map(|id| id.name) {
-                *stmt = ox_build_gated_const_decl(ast, gating_expression, id.as_str());
-                *export_default_name = Some(id);
+            let export_span = e.span;
+            let id = f.id.as_ref().map(|id| (id.name, id.span));
+            if let Some((name, name_span)) = id {
+                *stmt = ox_build_gated_const_decl(
+                    ast,
+                    gating_expression,
+                    name.as_str(),
+                    name_span,
+                    export_span,
+                );
+                *export_default_name = Some(name);
             } else {
                 *stmt = Statement::new_export_default_declaration(
-                    SPAN,
+                    export_span,
                     ExportDefaultDeclarationKind::from(
                         gating_expression.clone_in_with_semantic_ids(ast.allocator()),
                     ),
@@ -2409,7 +2423,7 @@ impl<'a> oxc_ast_visit::VisitMut<'a> for OxcVisitor<'a, '_> {
                 }
                 if func.scope_id.get() == Some(*scope_id) {
                     let f = Function::boxed(
-                        SPAN,
+                        func.span,
                         FunctionType::FunctionExpression,
                         func.id.clone_in_with_semantic_ids(ast.allocator()),
                         func.generator,

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -174,7 +174,9 @@ impl std::fmt::Display for FloatValue {
 #[derive(Debug)]
 pub struct HirFunction<'a> {
     pub span: Option<Span>,
+    pub body_span: Option<Span>,
     pub id: Option<Ident<'a>>,
+    pub id_span: Option<Span>,
     pub name_hint: Option<Ident<'a>>,
     pub fn_type: ReactFunctionType,
     pub params: ArenaVec<'a, ParamPattern>,
@@ -184,8 +186,15 @@ pub struct HirFunction<'a> {
     pub instructions: ArenaVec<'a, Instruction<'a>>,
     pub generator: bool,
     pub is_async: bool,
-    pub directives: ArenaVec<'a, Str<'a>>,
+    pub directives: ArenaVec<'a, FunctionDirective<'a>>,
     pub aliasing_effects: Option<ArenaVec<'a, AliasingEffect<'a>>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FunctionDirective<'a> {
+    pub value: Str<'a>,
+    pub span: Span,
+    pub expression_span: Span,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -280,7 +289,9 @@ pub enum Terminal<'a> {
     If {
         test: Place,
         consequent: BlockId,
+        consequent_span: Option<Span>,
         alternate: BlockId,
+        alternate_span: Option<Span>,
         fallthrough: BlockId,
         id: EvaluationOrder,
         span: Option<Span>,
@@ -302,6 +313,7 @@ pub enum Terminal<'a> {
     },
     DoWhile {
         loop_block: BlockId,
+        loop_block_span: Option<Span>,
         test: BlockId,
         fallthrough: BlockId,
         id: EvaluationOrder,
@@ -310,6 +322,7 @@ pub enum Terminal<'a> {
     While {
         test: BlockId,
         loop_block: BlockId,
+        loop_block_span: Option<Span>,
         fallthrough: BlockId,
         id: EvaluationOrder,
         span: Option<Span>,
@@ -319,6 +332,7 @@ pub enum Terminal<'a> {
         test: BlockId,
         update: Option<BlockId>,
         loop_block: BlockId,
+        loop_block_span: Option<Span>,
         fallthrough: BlockId,
         id: EvaluationOrder,
         span: Option<Span>,
@@ -327,6 +341,8 @@ pub enum Terminal<'a> {
         init: BlockId,
         test: BlockId,
         loop_block: BlockId,
+        loop_block_span: Option<Span>,
+        left_span: Option<Span>,
         fallthrough: BlockId,
         id: EvaluationOrder,
         span: Option<Span>,
@@ -334,6 +350,8 @@ pub enum Terminal<'a> {
     ForIn {
         init: BlockId,
         loop_block: BlockId,
+        loop_block_span: Option<Span>,
+        left_span: Option<Span>,
         fallthrough: BlockId,
         id: EvaluationOrder,
         span: Option<Span>,
@@ -360,6 +378,7 @@ pub enum Terminal<'a> {
     },
     Label {
         block: BlockId,
+        block_span: Option<Span>,
         fallthrough: BlockId,
         id: EvaluationOrder,
         span: Option<Span>,
@@ -379,8 +398,10 @@ pub enum Terminal<'a> {
     },
     Try {
         block: BlockId,
+        block_span: Option<Span>,
         handler_binding: Option<Place>,
         handler: BlockId,
+        handler_span: Option<Span>,
         fallthrough: BlockId,
         id: EvaluationOrder,
         span: Option<Span>,
@@ -502,6 +523,7 @@ pub enum GotoVariant {
 pub struct Case {
     pub test: Option<Place>,
     pub block: BlockId,
+    pub span: Option<Span>,
 }
 
 // =============================================================================
@@ -630,7 +652,9 @@ pub enum InstructionValue<'a> {
         children: Option<ArenaVec<'a, Place>>,
         span: Option<Span>,
         opening_span: Option<Span>,
+        opening_name_span: Option<Span>,
         closing_span: Option<Span>,
+        closing_name_span: Option<Span>,
     },
     ObjectExpression {
         properties: ArenaVec<'a, ObjectPropertyOrSpread<'a>>,
@@ -647,6 +671,8 @@ pub enum InstructionValue<'a> {
     JsxFragment {
         children: ArenaVec<'a, Place>,
         span: Option<Span>,
+        opening_span: Option<Span>,
+        closing_span: Option<Span>,
     },
     RegExpLiteral {
         pattern: Str<'a>,
@@ -661,17 +687,20 @@ pub enum InstructionValue<'a> {
     PropertyStore {
         object: Place,
         property: PropertyLiteral<'a>,
+        property_span: Option<Span>,
         value: Place,
         span: Option<Span>,
     },
     PropertyLoad {
         object: Place,
         property: PropertyLiteral<'a>,
+        property_span: Option<Span>,
         span: Option<Span>,
     },
     PropertyDelete {
         object: Place,
         property: PropertyLiteral<'a>,
+        property_span: Option<Span>,
         span: Option<Span>,
     },
     ComputedStore {
@@ -701,6 +730,7 @@ pub enum InstructionValue<'a> {
     },
     FunctionExpression {
         name: Option<Ident<'a>>,
+        name_span: Option<Span>,
         name_hint: Option<Ident<'a>>,
         lowered_func: LoweredFunction,
         expr_type: FunctionExpressionType,
@@ -714,6 +744,7 @@ pub enum InstructionValue<'a> {
         // interpolations (a deliberate divergence from the TS reference).
         quasis: ArenaVec<'a, TemplateQuasi<'a>>,
         subexprs: ArenaVec<'a, Place>,
+        quasi_span: Option<Span>,
         span: Option<Span>,
     },
     TemplateLiteral {
@@ -875,6 +906,7 @@ pub enum FunctionExpressionType {
 pub struct TemplateQuasi<'a> {
     pub raw: Str<'a>,
     pub cooked: Option<Str<'a>>,
+    pub span: Span,
 }
 
 #[derive(Debug)]
@@ -1005,6 +1037,7 @@ impl std::fmt::Display for Effect {
 #[derive(Debug, Clone, Copy)]
 pub struct SpreadPattern {
     pub place: Place,
+    pub span: Option<Span>,
 }
 
 #[derive(Debug)]
@@ -1041,9 +1074,19 @@ pub struct ObjectProperty<'a> {
 
 #[derive(Debug, Clone, Copy)]
 pub enum ObjectPropertyKey<'a> {
-    String { name: Ident<'a> },
-    Identifier { name: Ident<'a> },
-    Computed { name: Place },
+    String { name: Ident<'a>, span: Option<Span> },
+    Identifier { name: Ident<'a>, span: Option<Span> },
+    Computed { name: Place, span: Option<Span> },
+}
+
+impl ObjectPropertyKey<'_> {
+    pub fn span(&self) -> Option<Span> {
+        match self {
+            Self::String { span, .. }
+            | Self::Identifier { span, .. }
+            | Self::Computed { span, .. } => *span,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1113,8 +1156,8 @@ pub enum JsxTag<'a> {
 
 #[derive(Debug, Clone, Copy)]
 pub enum JsxAttribute<'a> {
-    SpreadAttribute { argument: Place },
-    Attribute { name: Ident<'a>, place: Place },
+    SpreadAttribute { argument: Place, span: Option<Span> },
+    Attribute { name: Ident<'a>, name_span: Option<Span>, place: Place },
 }
 
 // =============================================================================
@@ -1412,7 +1455,9 @@ impl<'a> CloneIn<'a> for HirFunction<'a> {
     fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
         HirFunction {
             span: self.span,
+            body_span: self.body_span,
             id: self.id,
+            id_span: self.id_span,
             name_hint: self.name_hint,
             fn_type: self.fn_type,
             params: self.params.clone_in_impl(sem, alloc),
@@ -1424,6 +1469,17 @@ impl<'a> CloneIn<'a> for HirFunction<'a> {
             is_async: self.is_async,
             directives: self.directives.clone_in_impl(sem, alloc),
             aliasing_effects: self.aliasing_effects.as_ref().map(|v| v.clone_in_impl(sem, alloc)),
+        }
+    }
+}
+
+impl<'a> CloneIn<'a> for FunctionDirective<'a> {
+    type Cloned = FunctionDirective<'a>;
+    fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
+        FunctionDirective {
+            value: self.value.clone_in_impl(sem, alloc),
+            span: self.span,
+            expression_span: self.expression_span,
         }
     }
 }
@@ -1478,10 +1534,21 @@ impl<'a> CloneIn<'a> for Terminal<'a> {
             Terminal::Goto { block, variant, id, span } => {
                 Terminal::Goto { block: *block, variant: *variant, id: *id, span: *span }
             }
-            Terminal::If { test, consequent, alternate, fallthrough, id, span } => Terminal::If {
+            Terminal::If {
+                test,
+                consequent,
+                consequent_span,
+                alternate,
+                alternate_span,
+                fallthrough,
+                id,
+                span,
+            } => Terminal::If {
                 test: *test,
                 consequent: *consequent,
+                consequent_span: *consequent_span,
                 alternate: *alternate,
+                alternate_span: *alternate_span,
                 fallthrough: *fallthrough,
                 id: *id,
                 span: *span,
@@ -1503,42 +1570,77 @@ impl<'a> CloneIn<'a> for Terminal<'a> {
                 id: *id,
                 span: *span,
             },
-            Terminal::DoWhile { loop_block, test, fallthrough, id, span } => Terminal::DoWhile {
-                loop_block: *loop_block,
-                test: *test,
-                fallthrough: *fallthrough,
-                id: *id,
-                span: *span,
-            },
-            Terminal::While { test, loop_block, fallthrough, id, span } => Terminal::While {
-                test: *test,
-                loop_block: *loop_block,
-                fallthrough: *fallthrough,
-                id: *id,
-                span: *span,
-            },
-            Terminal::For { init, test, update, loop_block, fallthrough, id, span } => {
-                Terminal::For {
-                    init: *init,
-                    test: *test,
-                    update: *update,
+            Terminal::DoWhile { loop_block, loop_block_span, test, fallthrough, id, span } => {
+                Terminal::DoWhile {
                     loop_block: *loop_block,
+                    loop_block_span: *loop_block_span,
+                    test: *test,
                     fallthrough: *fallthrough,
                     id: *id,
                     span: *span,
                 }
             }
-            Terminal::ForOf { init, test, loop_block, fallthrough, id, span } => Terminal::ForOf {
+            Terminal::While { test, loop_block, loop_block_span, fallthrough, id, span } => {
+                Terminal::While {
+                    test: *test,
+                    loop_block: *loop_block,
+                    loop_block_span: *loop_block_span,
+                    fallthrough: *fallthrough,
+                    id: *id,
+                    span: *span,
+                }
+            }
+            Terminal::For {
+                init,
+                test,
+                update,
+                loop_block,
+                loop_block_span,
+                fallthrough,
+                id,
+                span,
+            } => Terminal::For {
                 init: *init,
                 test: *test,
+                update: *update,
                 loop_block: *loop_block,
+                loop_block_span: *loop_block_span,
                 fallthrough: *fallthrough,
                 id: *id,
                 span: *span,
             },
-            Terminal::ForIn { init, loop_block, fallthrough, id, span } => Terminal::ForIn {
+            Terminal::ForOf {
+                init,
+                test,
+                loop_block,
+                loop_block_span,
+                left_span,
+                fallthrough,
+                id,
+                span,
+            } => Terminal::ForOf {
+                init: *init,
+                test: *test,
+                loop_block: *loop_block,
+                loop_block_span: *loop_block_span,
+                left_span: *left_span,
+                fallthrough: *fallthrough,
+                id: *id,
+                span: *span,
+            },
+            Terminal::ForIn {
+                init,
+                loop_block,
+                loop_block_span,
+                left_span,
+                fallthrough,
+                id,
+                span,
+            } => Terminal::ForIn {
                 init: *init,
                 loop_block: *loop_block,
+                loop_block_span: *loop_block_span,
+                left_span: *left_span,
                 fallthrough: *fallthrough,
                 id: *id,
                 span: *span,
@@ -1560,9 +1662,13 @@ impl<'a> CloneIn<'a> for Terminal<'a> {
                 id: *id,
                 span: *span,
             },
-            Terminal::Label { block, fallthrough, id, span } => {
-                Terminal::Label { block: *block, fallthrough: *fallthrough, id: *id, span: *span }
-            }
+            Terminal::Label { block, block_span, fallthrough, id, span } => Terminal::Label {
+                block: *block,
+                block_span: *block_span,
+                fallthrough: *fallthrough,
+                id: *id,
+                span: *span,
+            },
             Terminal::Sequence { block, fallthrough, id, span } => Terminal::Sequence {
                 block: *block,
                 fallthrough: *fallthrough,
@@ -1578,16 +1684,25 @@ impl<'a> CloneIn<'a> for Terminal<'a> {
                     effects: effects.as_ref().map(|v| v.clone_in_impl(sem, alloc)),
                 }
             }
-            Terminal::Try { block, handler_binding, handler, fallthrough, id, span } => {
-                Terminal::Try {
-                    block: *block,
-                    handler_binding: *handler_binding,
-                    handler: *handler,
-                    fallthrough: *fallthrough,
-                    id: *id,
-                    span: *span,
-                }
-            }
+            Terminal::Try {
+                block,
+                block_span,
+                handler_binding,
+                handler,
+                handler_span,
+                fallthrough,
+                id,
+                span,
+            } => Terminal::Try {
+                block: *block,
+                block_span: *block_span,
+                handler_binding: *handler_binding,
+                handler: *handler,
+                handler_span: *handler_span,
+                fallthrough: *fallthrough,
+                id: *id,
+                span: *span,
+            },
             Terminal::Scope { fallthrough, block, scope, id, span } => Terminal::Scope {
                 fallthrough: *fallthrough,
                 block: *block,
@@ -1677,21 +1792,28 @@ impl<'a> CloneIn<'a> for InstructionValue<'a> {
             InstructionValue::MetaProperty { meta, property, span } => {
                 InstructionValue::MetaProperty { meta: *meta, property: *property, span: *span }
             }
-            InstructionValue::PropertyStore { object, property, value, span } => {
+            InstructionValue::PropertyStore { object, property, property_span, value, span } => {
                 InstructionValue::PropertyStore {
                     object: *object,
                     property: *property,
+                    property_span: *property_span,
                     value: *value,
                     span: *span,
                 }
             }
-            InstructionValue::PropertyLoad { object, property, span } => {
-                InstructionValue::PropertyLoad { object: *object, property: *property, span: *span }
+            InstructionValue::PropertyLoad { object, property, property_span, span } => {
+                InstructionValue::PropertyLoad {
+                    object: *object,
+                    property: *property,
+                    property_span: *property_span,
+                    span: *span,
+                }
             }
-            InstructionValue::PropertyDelete { object, property, span } => {
+            InstructionValue::PropertyDelete { object, property, property_span, span } => {
                 InstructionValue::PropertyDelete {
                     object: *object,
                     property: *property,
+                    property_span: *property_span,
                     span: *span,
                 }
             }
@@ -1721,12 +1843,14 @@ impl<'a> CloneIn<'a> for InstructionValue<'a> {
             }
             InstructionValue::FunctionExpression {
                 name,
+                name_span,
                 name_hint,
                 lowered_func,
                 expr_type,
                 span,
             } => InstructionValue::FunctionExpression {
                 name: *name,
+                name_span: *name_span,
                 name_hint: *name_hint,
                 lowered_func: *lowered_func,
                 expr_type: *expr_type,
@@ -1809,14 +1933,18 @@ impl<'a> CloneIn<'a> for InstructionValue<'a> {
                 children,
                 span,
                 opening_span,
+                opening_name_span,
                 closing_span,
+                closing_name_span,
             } => InstructionValue::JsxExpression {
                 tag: *tag,
                 props: props.clone_in_impl(sem, alloc),
                 children: children.as_ref().map(|v| v.clone_in_impl(sem, alloc)),
                 span: *span,
                 opening_span: *opening_span,
+                opening_name_span: *opening_name_span,
                 closing_span: *closing_span,
+                closing_name_span: *closing_name_span,
             },
             InstructionValue::ObjectExpression { properties, span } => {
                 InstructionValue::ObjectExpression {
@@ -1830,18 +1958,27 @@ impl<'a> CloneIn<'a> for InstructionValue<'a> {
                     span: *span,
                 }
             }
-            InstructionValue::JsxFragment { children, span } => InstructionValue::JsxFragment {
-                children: children.clone_in_impl(sem, alloc),
-                span: *span,
-            },
-            InstructionValue::TaggedTemplateExpression { tag, quasis, subexprs, span } => {
-                InstructionValue::TaggedTemplateExpression {
-                    tag: *tag,
-                    quasis: quasis.clone_in_impl(sem, alloc),
-                    subexprs: subexprs.clone_in_impl(sem, alloc),
+            InstructionValue::JsxFragment { children, span, opening_span, closing_span } => {
+                InstructionValue::JsxFragment {
+                    children: children.clone_in_impl(sem, alloc),
                     span: *span,
+                    opening_span: *opening_span,
+                    closing_span: *closing_span,
                 }
             }
+            InstructionValue::TaggedTemplateExpression {
+                tag,
+                quasis,
+                subexprs,
+                quasi_span,
+                span,
+            } => InstructionValue::TaggedTemplateExpression {
+                tag: *tag,
+                quasis: quasis.clone_in_impl(sem, alloc),
+                subexprs: subexprs.clone_in_impl(sem, alloc),
+                quasi_span: *quasi_span,
+                span: *span,
+            },
             InstructionValue::TemplateLiteral { subexprs, quasis, span } => {
                 InstructionValue::TemplateLiteral {
                     subexprs: subexprs.clone_in_impl(sem, alloc),

--- a/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
@@ -15,10 +15,10 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
 
-use oxc_str::{Ident, Str};
+use oxc_str::Ident;
 
 use crate::react_compiler_hir::{
-    BlockId, EvaluationOrder, InstructionValue, ParamPattern, Place, ScopeId,
+    BlockId, EvaluationOrder, FunctionDirective, InstructionValue, ParamPattern, Place, ScopeId,
 };
 use oxc_allocator::{Allocator, Box as ArenaBox, CloneIn, CloneInSemanticIds, Vec as ArenaVec};
 use oxc_ast::ast::LogicalOperator;
@@ -33,13 +33,15 @@ use oxc_span::Span;
 #[derive(Debug)]
 pub struct ReactiveFunction<'a> {
     pub span: Option<Span>,
+    pub body_span: Option<Span>,
     pub id: Option<Ident<'a>>,
+    pub id_span: Option<Span>,
     pub name_hint: Option<Ident<'a>>,
     pub params: Vec<ParamPattern>,
     pub generator: bool,
     pub is_async: bool,
     pub body: ReactiveBlock<'a>,
-    pub directives: Vec<Str<'a>>,
+    pub directives: Vec<FunctionDirective<'a>>,
     // No env field — passed separately per established Rust convention
 }
 
@@ -113,6 +115,7 @@ pub enum ReactiveValue<'a> {
 pub struct ReactiveTerminalStatement<'a> {
     pub terminal: ReactiveTerminal<'a>,
     pub label: Option<ReactiveLabel>,
+    pub span: Span,
 }
 
 #[derive(Debug, Clone)]
@@ -165,12 +168,14 @@ pub enum ReactiveTerminal<'a> {
     },
     DoWhile {
         loop_block: ReactiveBlock<'a>,
+        loop_block_span: Option<Span>,
         test: ReactiveValue<'a>,
         id: EvaluationOrder,
     },
     While {
         test: ReactiveValue<'a>,
         loop_block: ReactiveBlock<'a>,
+        loop_block_span: Option<Span>,
         id: EvaluationOrder,
     },
     For {
@@ -178,35 +183,45 @@ pub enum ReactiveTerminal<'a> {
         test: ReactiveValue<'a>,
         update: Option<ReactiveValue<'a>>,
         loop_block: ReactiveBlock<'a>,
+        loop_block_span: Option<Span>,
         id: EvaluationOrder,
     },
     ForOf {
         init: ReactiveValue<'a>,
         test: ReactiveValue<'a>,
         loop_block: ReactiveBlock<'a>,
+        loop_block_span: Option<Span>,
+        left_span: Option<Span>,
         id: EvaluationOrder,
         span: Option<Span>,
     },
     ForIn {
         init: ReactiveValue<'a>,
         loop_block: ReactiveBlock<'a>,
+        loop_block_span: Option<Span>,
+        left_span: Option<Span>,
         id: EvaluationOrder,
         span: Option<Span>,
     },
     If {
         test: Place,
         consequent: ReactiveBlock<'a>,
+        consequent_span: Option<Span>,
         alternate: Option<ReactiveBlock<'a>>,
+        alternate_span: Option<Span>,
         id: EvaluationOrder,
     },
     Label {
         block: ReactiveBlock<'a>,
+        block_span: Option<Span>,
         id: EvaluationOrder,
     },
     Try {
         block: ReactiveBlock<'a>,
+        block_span: Option<Span>,
         handler_binding: Option<Place>,
         handler: ReactiveBlock<'a>,
+        handler_span: Option<Span>,
         id: EvaluationOrder,
     },
 }
@@ -215,6 +230,7 @@ pub enum ReactiveTerminal<'a> {
 pub struct ReactiveSwitchCase<'a> {
     pub test: Option<Place>,
     pub block: Option<ReactiveBlock<'a>>,
+    pub span: Option<Span>,
 }
 
 // =============================================================================
@@ -264,7 +280,9 @@ impl<'a> CloneIn<'a> for ReactiveFunction<'a> {
     fn clone_in_impl(&self, sem: CloneInSemanticIds, alloc: &'a Allocator) -> Self {
         ReactiveFunction {
             span: self.span,
+            body_span: self.body_span,
             id: self.id,
+            id_span: self.id_span,
             name_hint: self.name_hint,
             params: self.params.clone(),
             generator: self.generator,
@@ -358,6 +376,7 @@ impl<'a> CloneIn<'a> for ReactiveTerminalStatement<'a> {
         ReactiveTerminalStatement {
             terminal: self.terminal.clone_in_impl(sem, alloc),
             label: self.label.clone(),
+            span: self.span,
         }
     }
 }
@@ -390,58 +409,96 @@ impl<'a> CloneIn<'a> for ReactiveTerminal<'a> {
                 ),
                 id: *id,
             },
-            ReactiveTerminal::DoWhile { loop_block, test, id } => ReactiveTerminal::DoWhile {
-                loop_block: clone_reactive_block_in(loop_block, sem, alloc),
-                test: test.clone_in_impl(sem, alloc),
-                id: *id,
-            },
-            ReactiveTerminal::While { test, loop_block, id } => ReactiveTerminal::While {
-                test: test.clone_in_impl(sem, alloc),
-                loop_block: clone_reactive_block_in(loop_block, sem, alloc),
-                id: *id,
-            },
-            ReactiveTerminal::For { init, test, update, loop_block, id } => ReactiveTerminal::For {
-                init: init.clone_in_impl(sem, alloc),
-                test: test.clone_in_impl(sem, alloc),
-                update: update.as_ref().map(|value| value.clone_in_impl(sem, alloc)),
-                loop_block: clone_reactive_block_in(loop_block, sem, alloc),
-                id: *id,
-            },
-            ReactiveTerminal::ForOf { init, test, loop_block, id, span } => {
-                ReactiveTerminal::ForOf {
-                    init: init.clone_in_impl(sem, alloc),
+            ReactiveTerminal::DoWhile { loop_block, loop_block_span, test, id } => {
+                ReactiveTerminal::DoWhile {
+                    loop_block: clone_reactive_block_in(loop_block, sem, alloc),
+                    loop_block_span: *loop_block_span,
+                    test: test.clone_in_impl(sem, alloc),
+                    id: *id,
+                }
+            }
+            ReactiveTerminal::While { test, loop_block, loop_block_span, id } => {
+                ReactiveTerminal::While {
                     test: test.clone_in_impl(sem, alloc),
                     loop_block: clone_reactive_block_in(loop_block, sem, alloc),
+                    loop_block_span: *loop_block_span,
+                    id: *id,
+                }
+            }
+            ReactiveTerminal::For { init, test, update, loop_block, loop_block_span, id } => {
+                ReactiveTerminal::For {
+                    init: init.clone_in_impl(sem, alloc),
+                    test: test.clone_in_impl(sem, alloc),
+                    update: update.as_ref().map(|value| value.clone_in_impl(sem, alloc)),
+                    loop_block: clone_reactive_block_in(loop_block, sem, alloc),
+                    loop_block_span: *loop_block_span,
+                    id: *id,
+                }
+            }
+            ReactiveTerminal::ForOf {
+                init,
+                test,
+                loop_block,
+                loop_block_span,
+                left_span,
+                id,
+                span,
+            } => ReactiveTerminal::ForOf {
+                init: init.clone_in_impl(sem, alloc),
+                test: test.clone_in_impl(sem, alloc),
+                loop_block: clone_reactive_block_in(loop_block, sem, alloc),
+                loop_block_span: *loop_block_span,
+                left_span: *left_span,
+                id: *id,
+                span: *span,
+            },
+            ReactiveTerminal::ForIn { init, loop_block, loop_block_span, left_span, id, span } => {
+                ReactiveTerminal::ForIn {
+                    init: init.clone_in_impl(sem, alloc),
+                    loop_block: clone_reactive_block_in(loop_block, sem, alloc),
+                    loop_block_span: *loop_block_span,
+                    left_span: *left_span,
                     id: *id,
                     span: *span,
                 }
             }
-            ReactiveTerminal::ForIn { init, loop_block, id, span } => ReactiveTerminal::ForIn {
-                init: init.clone_in_impl(sem, alloc),
-                loop_block: clone_reactive_block_in(loop_block, sem, alloc),
-                id: *id,
-                span: *span,
-            },
-            ReactiveTerminal::If { test, consequent, alternate, id } => ReactiveTerminal::If {
+            ReactiveTerminal::If {
+                test,
+                consequent,
+                consequent_span,
+                alternate,
+                alternate_span,
+                id,
+            } => ReactiveTerminal::If {
                 test: *test,
                 consequent: clone_reactive_block_in(consequent, sem, alloc),
+                consequent_span: *consequent_span,
                 alternate: alternate
                     .as_ref()
                     .map(|block| clone_reactive_block_in(block, sem, alloc)),
+                alternate_span: *alternate_span,
                 id: *id,
             },
-            ReactiveTerminal::Label { block, id } => ReactiveTerminal::Label {
+            ReactiveTerminal::Label { block, block_span, id } => ReactiveTerminal::Label {
                 block: clone_reactive_block_in(block, sem, alloc),
+                block_span: *block_span,
                 id: *id,
             },
-            ReactiveTerminal::Try { block, handler_binding, handler, id } => {
-                ReactiveTerminal::Try {
-                    block: clone_reactive_block_in(block, sem, alloc),
-                    handler_binding: *handler_binding,
-                    handler: clone_reactive_block_in(handler, sem, alloc),
-                    id: *id,
-                }
-            }
+            ReactiveTerminal::Try {
+                block,
+                block_span,
+                handler_binding,
+                handler,
+                handler_span,
+                id,
+            } => ReactiveTerminal::Try {
+                block: clone_reactive_block_in(block, sem, alloc),
+                block_span: *block_span,
+                handler_binding: *handler_binding,
+                handler: clone_reactive_block_in(handler, sem, alloc),
+                handler_span: *handler_span,
+                id: *id,
+            },
         }
     }
 }
@@ -452,6 +509,7 @@ impl<'a> CloneIn<'a> for ReactiveSwitchCase<'a> {
         ReactiveSwitchCase {
             test: self.test,
             block: self.block.as_ref().map(|block| clone_reactive_block_in(block, sem, alloc)),
+            span: self.span,
         }
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
@@ -199,7 +199,7 @@ pub fn each_instruction_value_operand_with_functions(
             for property in properties {
                 match property {
                     ObjectPropertyOrSpread::Property(prop) => {
-                        if let ObjectPropertyKey::Computed { name } = &prop.key {
+                        if let ObjectPropertyKey::Computed { name, .. } = &prop.key {
                             result.push(*name);
                         }
                         result.push(prop.place);
@@ -942,7 +942,7 @@ pub fn for_each_instruction_value_operand_mut(
             for property in properties.iter_mut() {
                 match property {
                     ObjectPropertyOrSpread::Property(prop) => {
-                        if let ObjectPropertyKey::Computed { name } = &mut prop.key {
+                        if let ObjectPropertyKey::Computed { name, .. } = &mut prop.key {
                             f(name);
                         }
                         f(&mut prop.place);

--- a/crates/oxc_react_compiler/src/react_compiler_inference/flatten_scopes_with_hooks_or_use_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/flatten_scopes_with_hooks_or_use_hir.rs
@@ -108,7 +108,7 @@ pub fn flatten_scopes_with_hooks_or_use_hir(
         {
             // This was a scope just for a hook call, which doesn't need memoization.
             // Flatten it away. We rely on PruneUnusedLabels to do the actual flattening.
-            Terminal::Label { block: scope_block, fallthrough, id: eval_id, span }
+            Terminal::Label { block: scope_block, block_span: None, fallthrough, id: eval_id, span }
         } else {
             Terminal::PrunedScope { block: scope_block, fallthrough, scope, id: eval_id, span }
         };

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -2481,7 +2481,7 @@ fn compute_effects_for_legacy_signature<'a>(
             match arg {
                 PlaceOrSpreadOrHole::Hole => continue,
                 PlaceOrSpreadOrHole::Place(place)
-                | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
+                | PlaceOrSpreadOrHole::Spread(SpreadPattern { place, .. }) => {
                     effects.push(AliasingEffect::ImmutableCapture { from: *place, into: *lvalue });
                 }
             }
@@ -2532,7 +2532,7 @@ fn compute_effects_for_legacy_signature<'a>(
         match arg {
             PlaceOrSpreadOrHole::Hole => continue,
             PlaceOrSpreadOrHole::Place(place)
-            | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
+            | PlaceOrSpreadOrHole::Spread(SpreadPattern { place, .. }) => {
                 let is_spread = matches!(arg, PlaceOrSpreadOrHole::Spread(_));
                 let sig_effect = if !is_spread && i < signature.positional_params.len() {
                     signature.positional_params[i]
@@ -2602,7 +2602,7 @@ fn are_arguments_immutable_and_non_mutating(
         match arg {
             PlaceOrSpreadOrHole::Hole => continue,
             PlaceOrSpreadOrHole::Place(place)
-            | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
+            | PlaceOrSpreadOrHole::Spread(SpreadPattern { place, .. }) => {
                 // Check if it's a function type with a known signature
                 let is_place = matches!(arg, PlaceOrSpreadOrHole::Place(_));
                 if is_place {
@@ -2693,7 +2693,7 @@ fn compute_effects_for_aliasing_signature_config<'a>(
         match arg {
             PlaceOrSpreadOrHole::Hole => continue,
             PlaceOrSpreadOrHole::Place(place)
-            | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
+            | PlaceOrSpreadOrHole::Spread(SpreadPattern { place, .. }) => {
                 if i < config.params.len() && !matches!(arg, PlaceOrSpreadOrHole::Spread(_)) {
                     substitutions.insert(config.params[i].to_string(), vec![*place]);
                 } else if let Some(rest) = config.rest {
@@ -2935,7 +2935,7 @@ fn compute_effects_for_aliasing_signature<'a>(
         match arg {
             PlaceOrSpreadOrHole::Hole => continue,
             PlaceOrSpreadOrHole::Place(place)
-            | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
+            | PlaceOrSpreadOrHole::Spread(SpreadPattern { place, .. }) => {
                 let is_spread = matches!(arg, PlaceOrSpreadOrHole::Spread(_));
                 if !is_spread && i < signature.params.len() {
                     substitutions.insert(signature.params[i], vec![*place]);
@@ -3104,6 +3104,7 @@ fn compute_effects_for_aliasing_signature<'a>(
                                 {
                                     apply_args.push(PlaceOrSpreadOrHole::Spread(SpreadPattern {
                                         place: *place,
+                                        span: sp.span,
                                     }));
                                 }
                             }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -278,13 +278,16 @@ fn collect_temporaries_sidemap_impl<'a>(
             let used_outside = used_outside_declaring_scope.contains(&lvalue_decl_id);
 
             match &instr.value {
-                InstructionValue::PropertyLoad { object, property, span, .. } if !used_outside => {
+                InstructionValue::PropertyLoad { object, property, property_span, span }
+                    if !used_outside =>
+                {
                     if inner_fn_context.is_none() || temporaries[object.identifier].is_some() {
                         let prop = get_property(
                             object,
                             property,
                             false,
                             *span,
+                            *property_span,
                             temporaries,
                             env.allocator,
                         );
@@ -348,13 +351,15 @@ fn get_property<'a>(
     property_name: &PropertyLiteral<'a>,
     optional: bool,
     span: Option<Span>,
+    property_span: Option<Span>,
     temporaries: &TemporariesMap<'a>,
     alloc: &'a Allocator,
 ) -> ReactiveScopeDependency<'a> {
+    let property_span = property_span.or(span);
     let resolved = temporaries[object.identifier].as_ref();
     if let Some(resolved) = resolved {
         let mut path = resolved.path.clone_in(alloc);
-        path.push(DependencyPathEntry { property: *property_name, optional, span });
+        path.push(DependencyPathEntry { property: *property_name, optional, span: property_span });
         ReactiveScopeDependency {
             identifier: resolved.identifier,
             reactive: resolved.reactive,
@@ -366,7 +371,7 @@ fn get_property<'a>(
             identifier: object.identifier,
             reactive: object.reactive,
             path: ArenaVec::from_array_in(
-                [DependencyPathEntry { property: *property_name, optional, span }],
+                [DependencyPathEntry { property: *property_name, optional, span: property_span }],
                 &alloc,
             ),
             span,
@@ -458,6 +463,7 @@ struct MatchConsequentResult<'a> {
     store_local_lvalue_id: IdentifierId,
     consequent_goto: BlockId,
     property_load_span: Option<Span>,
+    property_span: Option<Span>,
 }
 
 fn match_optional_test_block<'a>(
@@ -477,8 +483,10 @@ fn match_optional_test_block<'a>(
     let instr0 = &func.instructions[consequent_block.instructions[0].index()];
     let instr1 = &func.instructions[consequent_block.instructions[1].index()];
 
-    let (property_load_object, property, property_load_span) = match &instr0.value {
-        InstructionValue::PropertyLoad { object, property, span } => (object, property, span),
+    let (property_load_object, property, property_load_span, property_span) = match &instr0.value {
+        InstructionValue::PropertyLoad { object, property, property_span, span } => {
+            (object, property, span, property_span)
+        }
         _ => return None,
     };
 
@@ -520,6 +528,7 @@ fn match_optional_test_block<'a>(
                 store_local_lvalue_id: instr1.lvalue.identifier,
                 consequent_goto: *goto_block,
                 property_load_span: *property_load_span,
+                property_span: *property_span,
             })
         }
         _ => None,
@@ -561,13 +570,13 @@ fn traverse_optional_block<'a>(
                 let curr_instr = &func.instructions[maybe_test_block.instructions[i].index()];
                 let prev_instr = &func.instructions[maybe_test_block.instructions[i - 1].index()];
                 match &curr_instr.value {
-                    InstructionValue::PropertyLoad { object, property, span, .. }
+                    InstructionValue::PropertyLoad { object, property, property_span, span }
                         if object.identifier == prev_instr.lvalue.identifier =>
                     {
                         path.push(DependencyPathEntry {
                             property: *property,
                             optional: false,
-                            span: *span,
+                            span: property_span.or(*span),
                         });
                     }
                     _ => return None,
@@ -669,7 +678,7 @@ fn traverse_optional_block<'a>(
             p.push(DependencyPathEntry {
                 property: match_result.property,
                 optional: is_optional,
-                span: match_result.property_load_span,
+                span: match_result.property_span.or(match_result.property_load_span),
             });
             p
         },
@@ -1743,9 +1752,18 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
         property: &PropertyLiteral<'a>,
         optional: bool,
         span: Option<Span>,
+        property_span: Option<Span>,
         env: &mut Environment<'a>,
     ) {
-        let dep = get_property(object, property, optional, span, self.temporaries, env.allocator);
+        let dep = get_property(
+            object,
+            property,
+            optional,
+            span,
+            property_span,
+            self.temporaries,
+            env.allocator,
+        );
         self.visit_dependency(dep, env);
     }
 
@@ -1916,8 +1934,8 @@ fn handle_instruction<'a>(
     }
 
     match &instr.value {
-        InstructionValue::PropertyLoad { object, property, span, .. } => {
-            ctx.visit_property(object, property, false, *span, env);
+        InstructionValue::PropertyLoad { object, property, property_span, span } => {
+            ctx.visit_property(object, property, false, *span, *property_span, env);
         }
         InstructionValue::StoreLocal { value: val, lvalue, .. } => {
             ctx.visit_operand(val, env);

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -550,7 +550,7 @@ pub fn lower<'a>(
     // Note: `id` param may include inferred names (e.g., from `const Foo = () => {}`),
     // but the HIR function's `id` field should only include the function's own AST id
     // (FunctionDeclaration.id or FunctionExpression.id, NOT arrow functions).
-    let (params, body, generator, is_async, span, ast_id) = match func {
+    let (params, body, generator, is_async, span, ast_id, ast_id_span) = match func {
         FunctionNode::Function(f) => {
             let body_ref = f.body.as_deref().expect("component function has a body");
             (
@@ -560,6 +560,7 @@ pub fn lower<'a>(
                 f.r#async,
                 f.span,
                 f.id.as_ref().map(|id| id.name),
+                f.id.as_ref().map(|id| id.span),
             )
         }
         FunctionNode::Arrow(arrow) => {
@@ -567,7 +568,7 @@ pub fn lower<'a>(
                 || FunctionBody::Block(arrow.get_function_body().unwrap()),
                 FunctionBody::Expression,
             );
-            (arrow.params.as_ref(), body, false, arrow.r#async, arrow.span, None)
+            (arrow.params.as_ref(), body, false, arrow.r#async, arrow.span, None, None)
         }
     };
 
@@ -588,6 +589,7 @@ pub fn lower<'a>(
         params,
         body,
         ast_id,
+        ast_id_span,
         generator,
         is_async,
         span,
@@ -616,6 +618,7 @@ fn lower_inner<'a>(
     params: &oxc::FormalParameters<'a>,
     body: FunctionBody<'_, 'a>,
     id: Option<Ident<'a>>,
+    id_span: Option<Span>,
     generator: bool,
     is_async: bool,
     span: Span,
@@ -721,7 +724,7 @@ fn lower_inner<'a>(
         let param_span = param.span;
         let place = build_temporary_place(&mut builder, Some(param_span));
         promote_temporary(&mut builder, place.identifier);
-        hir_params.push(ParamPattern::Place(place));
+        hir_params.push(ParamPattern::Place(Place { span: None, ..place }));
         let value = if let Some(initializer) = &param.initializer {
             lower_default_to_temp(&mut builder, param_span, initializer, place)?
         } else {
@@ -743,7 +746,7 @@ fn lower_inner<'a>(
     if let Some(rest) = &params.rest {
         let rest_span = rest.span;
         let place = build_temporary_place(&mut builder, Some(rest_span));
-        hir_params.push(ParamPattern::Spread(SpreadPattern { place }));
+        hir_params.push(ParamPattern::Spread(SpreadPattern { place, span: Some(rest_span) }));
         lower_binding_assignment(
             &mut builder,
             rest_span,
@@ -755,6 +758,7 @@ fn lower_inner<'a>(
     }
 
     // Lower the body
+    let mut body_span = None;
     let mut directives = ArenaVec::new_in(&alloc);
     match body {
         FunctionBody::Expression(expr) => {
@@ -772,8 +776,15 @@ fn lower_inner<'a>(
             );
         }
         FunctionBody::Block(block) => {
-            directives =
-                ArenaVec::from_iter_in(block.directives.iter().map(|d| d.expression.value), &alloc);
+            body_span = Some(block.span);
+            directives = ArenaVec::from_iter_in(
+                block.directives.iter().map(|d| FunctionDirective {
+                    value: d.expression.value,
+                    span: d.span,
+                    expression_span: d.expression.span,
+                }),
+                &alloc,
+            );
             // A function body shares the function's scope (the scope cell lives on
             // the function node, not the block), so pass it as the scope override.
             lower_block_statement_with_scope(&mut builder, &block.statements, function_scope)?;
@@ -806,7 +817,9 @@ fn lower_inner<'a>(
     Ok((
         HirFunction {
             span: Some(span),
+            body_span,
             id,
+            id_span,
             name_hint: None,
             fn_type: if is_top_level { env.fn_type } else { ReactFunctionType::Other },
             params: hir_params,
@@ -902,6 +915,7 @@ enum MemberProperty<'a> {
 struct LoweredMemberExpression<'a> {
     object: Place,
     property: MemberProperty<'a>,
+    property_span: Option<Span>,
     value: InstructionValue<'a>,
 }
 
@@ -922,15 +936,22 @@ fn lower_member_expression_impl<'a>(
     match member {
         oxc::MemberExpression::StaticMemberExpression(m) => {
             let span = Some(m.span);
+            let property_span = Some(m.property.span);
             let object = match lowered_object {
                 Some(obj) => obj,
                 None => lower_expression_to_temporary(builder, &m.object)?,
             };
             let prop_literal = PropertyLiteral::String(m.property.name);
-            let value = InstructionValue::PropertyLoad { object, property: prop_literal, span };
+            let value = InstructionValue::PropertyLoad {
+                object,
+                property: prop_literal,
+                property_span,
+                span,
+            };
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Literal(prop_literal),
+                property_span,
                 value,
             })
         }
@@ -942,11 +963,18 @@ fn lower_member_expression_impl<'a>(
             };
             // A numeric computed index is treated as a PropertyLoad (matches TS).
             if let oxc::Expression::NumericLiteral(lit) = &m.expression {
+                let property_span = Some(lit.span);
                 let prop_literal = PropertyLiteral::Number(FloatValue::new(lit.value));
-                let value = InstructionValue::PropertyLoad { object, property: prop_literal, span };
+                let value = InstructionValue::PropertyLoad {
+                    object,
+                    property: prop_literal,
+                    property_span,
+                    span,
+                };
                 return Ok(LoweredMemberExpression {
                     object,
                     property: MemberProperty::Literal(prop_literal),
+                    property_span,
                     value,
                 });
             }
@@ -955,6 +983,7 @@ fn lower_member_expression_impl<'a>(
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Computed(property),
+                property_span: property.span,
                 value,
             })
         }
@@ -974,6 +1003,7 @@ fn lower_member_expression_impl<'a>(
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Literal(PropertyLiteral::String(Ident::empty())),
+                property_span: None,
                 value: InstructionValue::Primitive { value: PrimitiveValue::Undefined, span },
             })
         }
@@ -982,7 +1012,7 @@ fn lower_member_expression_impl<'a>(
 
 /// Build a HIR `TemplateQuasi` from an oxc `TemplateElement`.
 fn template_quasi_from_oxc<'a>(q: &oxc::TemplateElement<'a>) -> TemplateQuasi<'a> {
-    TemplateQuasi { raw: q.value.raw, cooked: q.value.cooked }
+    TemplateQuasi { raw: q.value.raw, cooked: q.value.cooked, span: q.span }
 }
 
 /// Lower the `import` keyword callee of an `ImportExpression`. The original Babel
@@ -1091,12 +1121,19 @@ fn lower_member_expression_from_simple_target<'a>(
     match target {
         oxc::SimpleAssignmentTarget::StaticMemberExpression(m) => {
             let span = Some(m.span);
+            let property_span = Some(m.property.span);
             let object = lower_expression_to_temporary(builder, &m.object)?;
             let prop_literal = PropertyLiteral::String(m.property.name);
-            let value = InstructionValue::PropertyLoad { object, property: prop_literal, span };
+            let value = InstructionValue::PropertyLoad {
+                object,
+                property: prop_literal,
+                property_span,
+                span,
+            };
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Literal(prop_literal),
+                property_span,
                 value,
             })
         }
@@ -1104,11 +1141,18 @@ fn lower_member_expression_from_simple_target<'a>(
             let span = Some(m.span);
             let object = lower_expression_to_temporary(builder, &m.object)?;
             if let oxc::Expression::NumericLiteral(lit) = &m.expression {
+                let property_span = Some(lit.span);
                 let prop_literal = PropertyLiteral::Number(FloatValue::new(lit.value));
-                let value = InstructionValue::PropertyLoad { object, property: prop_literal, span };
+                let value = InstructionValue::PropertyLoad {
+                    object,
+                    property: prop_literal,
+                    property_span,
+                    span,
+                };
                 return Ok(LoweredMemberExpression {
                     object,
                     property: MemberProperty::Literal(prop_literal),
+                    property_span,
                     value,
                 });
             }
@@ -1117,6 +1161,7 @@ fn lower_member_expression_from_simple_target<'a>(
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Computed(property),
+                property_span: property.span,
                 value,
             })
         }
@@ -1131,6 +1176,7 @@ fn lower_member_expression_from_simple_target<'a>(
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Literal(PropertyLiteral::String(Ident::empty())),
+                property_span: None,
                 value: InstructionValue::Primitive { value: PrimitiveValue::Undefined, span },
             })
         }
@@ -1150,7 +1196,8 @@ fn lower_arguments<'a>(
         match arg {
             oxc::Argument::SpreadElement(spread) => {
                 let place = lower_expression_to_temporary(builder, &spread.argument)?;
-                result.push(PlaceOrSpread::Spread(SpreadPattern { place }));
+                result
+                    .push(PlaceOrSpread::Spread(SpreadPattern { place, span: Some(spread.span) }));
             }
             _ => {
                 let expr = arg.as_expression().expect("non-spread argument is an expression");
@@ -1390,14 +1437,17 @@ fn lower_binding_assignment<'a>(
                                 builder.scope().resolve_binding_identifier(id),
                             )? {
                                 Some(IdentifierForAssignment::Place(place)) => {
-                                    items
-                                        .push(ArrayPatternElement::Spread(SpreadPattern { place }));
+                                    items.push(ArrayPatternElement::Spread(SpreadPattern {
+                                        place,
+                                        span: Some(rest.span),
+                                    }));
                                 }
                                 Some(IdentifierForAssignment::Global { .. }) => {
                                     let temp = build_temporary_place(builder, Some(rest.span));
                                     promote_temporary(builder, temp.identifier);
                                     items.push(ArrayPatternElement::Spread(SpreadPattern {
                                         place: temp,
+                                        span: Some(rest.span),
                                     }));
                                     followups.push((temp, &rest.argument));
                                 }
@@ -1406,14 +1456,20 @@ fn lower_binding_assignment<'a>(
                         } else {
                             let temp = build_temporary_place(builder, Some(rest.span));
                             promote_temporary(builder, temp.identifier);
-                            items.push(ArrayPatternElement::Spread(SpreadPattern { place: temp }));
+                            items.push(ArrayPatternElement::Spread(SpreadPattern {
+                                place: temp,
+                                span: Some(rest.span),
+                            }));
                             followups.push((temp, &rest.argument));
                         }
                     }
                     _ => {
                         let temp = build_temporary_place(builder, Some(rest.span));
                         promote_temporary(builder, temp.identifier);
-                        items.push(ArrayPatternElement::Spread(SpreadPattern { place: temp }));
+                        items.push(ArrayPatternElement::Spread(SpreadPattern {
+                            place: temp,
+                            span: Some(rest.span),
+                        }));
                         followups.push((temp, &rest.argument));
                     }
                 }
@@ -1538,7 +1594,7 @@ fn lower_binding_assignment<'a>(
                             )? {
                                 Some(IdentifierForAssignment::Place(place)) => {
                                     properties.push(ObjectPropertyOrSpread::Spread(
-                                        SpreadPattern { place },
+                                        SpreadPattern { place, span: Some(rest.span) },
                                     ));
                                 }
                                 Some(IdentifierForAssignment::Global { .. }) => {
@@ -1554,6 +1610,7 @@ fn lower_binding_assignment<'a>(
                             promote_temporary(builder, temp.identifier);
                             properties.push(ObjectPropertyOrSpread::Spread(SpreadPattern {
                                 place: temp,
+                                span: Some(rest.span),
                             }));
                             followups.push((temp, &rest.argument));
                         }
@@ -1738,6 +1795,7 @@ fn lower_member_assignment_target<'a>(
                 InstructionValue::PropertyStore {
                     object,
                     property: PropertyLiteral::String(member.property.name),
+                    property_span: Some(member.property.span),
                     value,
                     span: Some(span),
                 },
@@ -1754,6 +1812,7 @@ fn lower_member_assignment_target<'a>(
                     InstructionValue::PropertyStore {
                         object,
                         property: PropertyLiteral::Number(FloatValue::new(num.value)),
+                        property_span: Some(num.span),
                         value,
                         span: Some(span),
                     },
@@ -1992,14 +2051,17 @@ fn lower_assignment_target<'a>(
                                 builder.scope().resolve_reference(id),
                             )? {
                                 Some(IdentifierForAssignment::Place(place)) => {
-                                    items
-                                        .push(ArrayPatternElement::Spread(SpreadPattern { place }));
+                                    items.push(ArrayPatternElement::Spread(SpreadPattern {
+                                        place,
+                                        span: Some(rest.span),
+                                    }));
                                 }
                                 Some(IdentifierForAssignment::Global { .. }) => {
                                     let temp = build_temporary_place(builder, Some(rest.span));
                                     promote_temporary(builder, temp.identifier);
                                     items.push(ArrayPatternElement::Spread(SpreadPattern {
                                         place: temp,
+                                        span: Some(rest.span),
                                     }));
                                     followups.push((temp, FollowupTarget::Target(&rest.target)));
                                 }
@@ -2008,14 +2070,20 @@ fn lower_assignment_target<'a>(
                         } else {
                             let temp = build_temporary_place(builder, Some(rest.span));
                             promote_temporary(builder, temp.identifier);
-                            items.push(ArrayPatternElement::Spread(SpreadPattern { place: temp }));
+                            items.push(ArrayPatternElement::Spread(SpreadPattern {
+                                place: temp,
+                                span: Some(rest.span),
+                            }));
                             followups.push((temp, FollowupTarget::Target(&rest.target)));
                         }
                     }
                     _ => {
                         let temp = build_temporary_place(builder, Some(rest.span));
                         promote_temporary(builder, temp.identifier);
-                        items.push(ArrayPatternElement::Spread(SpreadPattern { place: temp }));
+                        items.push(ArrayPatternElement::Spread(SpreadPattern {
+                            place: temp,
+                            span: Some(rest.span),
+                        }));
                         followups.push((temp, FollowupTarget::Target(&rest.target)));
                     }
                 }
@@ -2090,7 +2158,10 @@ fn lower_assignment_target<'a>(
             for prop in &pattern.properties {
                 match prop {
                     oxc::AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(p) => {
-                        let key = ObjectPropertyKey::Identifier { name: p.binding.name };
+                        let key = ObjectPropertyKey::Identifier {
+                            name: p.binding.name,
+                            span: Some(p.binding.span),
+                        };
                         let id = &p.binding;
                         if let Some(default) = &p.init {
                             // `{foo = d}` — Babel shorthand AssignmentPattern. Lower
@@ -2251,7 +2322,7 @@ fn lower_assignment_target<'a>(
                             )? {
                                 Some(IdentifierForAssignment::Place(place)) => {
                                     properties.push(ObjectPropertyOrSpread::Spread(
-                                        SpreadPattern { place },
+                                        SpreadPattern { place, span: Some(rest.span) },
                                     ));
                                 }
                                 Some(IdentifierForAssignment::Global { .. }) => {
@@ -2267,6 +2338,7 @@ fn lower_assignment_target<'a>(
                             promote_temporary(builder, temp.identifier);
                             properties.push(ObjectPropertyOrSpread::Spread(SpreadPattern {
                                 place: temp,
+                                span: Some(rest.span),
                             }));
                             followups.push((temp, FollowupTarget::Target(&rest.target)));
                         }
@@ -2928,17 +3000,16 @@ fn lower_function_to_value<'a>(
     func: FunctionNode<'_, 'a>,
     expr_type: FunctionExpressionType,
 ) -> Result<InstructionValue<'a>, OxcDiagnostic> {
-    let span = match func {
-        FunctionNode::Arrow(arrow) => Some(arrow.span),
-        FunctionNode::Function(f) => Some(f.span),
-    };
-    let name = match func {
-        FunctionNode::Function(f) => f.id.as_ref().map(|id| id.name),
-        FunctionNode::Arrow(_) => None,
+    let (span, name, name_span) = match func {
+        FunctionNode::Arrow(arrow) => (Some(arrow.span), None, None),
+        FunctionNode::Function(f) => {
+            (Some(f.span), f.id.as_ref().map(|id| id.name), f.id.as_ref().map(|id| id.span))
+        }
     };
     let lowered_func = lower_function(builder, func)?;
     Ok(InstructionValue::FunctionExpression {
         name,
+        name_span,
         name_hint: None,
         lowered_func,
         expr_type,
@@ -2953,13 +3024,13 @@ fn lower_function<'a>(
     func: FunctionNode<'_, 'a>,
 ) -> Result<LoweredFunction, OxcDiagnostic> {
     // Extract function parts from the AST node
-    let (params, body, id, generator, is_async, func_span) = match func {
+    let (params, body, id, id_span, generator, is_async, func_span) = match func {
         FunctionNode::Arrow(arrow) => {
             let body = arrow.get_expression().map_or_else(
                 || FunctionBody::Block(arrow.get_function_body().unwrap()),
                 FunctionBody::Expression,
             );
-            (arrow.params.as_ref(), body, None, false, arrow.r#async, arrow.span)
+            (arrow.params.as_ref(), body, None, None, false, arrow.r#async, arrow.span)
         }
         FunctionNode::Function(f) => {
             let body_ref = f.body.as_deref().expect("function expression has a body");
@@ -2967,6 +3038,7 @@ fn lower_function<'a>(
                 f.params.as_ref(),
                 FunctionBody::Block(body_ref),
                 f.id.as_ref().map(|id| id.name),
+                f.id.as_ref().map(|id| id.span),
                 f.generator,
                 f.r#async,
                 f.span,
@@ -3001,6 +3073,7 @@ fn lower_function<'a>(
         params,
         body,
         id,
+        id_span,
         generator,
         is_async,
         func_span,
@@ -3062,6 +3135,7 @@ fn lower_function_declaration<'a>(
         func_decl.params.as_ref(),
         FunctionBody::Block(body_ref),
         func_decl.id.as_ref().map(|id| id.name),
+        func_decl.id.as_ref().map(|id| id.span),
         func_decl.generator,
         func_decl.r#async,
         span,
@@ -3086,6 +3160,7 @@ fn lower_function_declaration<'a>(
     // Emit FunctionExpression instruction
     let fn_value = InstructionValue::FunctionExpression {
         name: func_name,
+        name_span: func_decl.id.as_ref().map(|id| id.span),
         name_hint: None,
         lowered_func,
         expr_type: FunctionExpressionType::FunctionDeclaration,
@@ -3234,6 +3309,7 @@ fn lower_function_for_object_method<'a>(
     let (hir_func, child_used_names, child_bindings) = lower_inner(
         params,
         FunctionBody::Block(body),
+        None,
         None,
         generator,
         is_async,
@@ -3413,11 +3489,13 @@ fn lower_expression<'a>(
                         unary.argument.without_parentheses().as_member_expression()
                     {
                         let lowered = lower_member_expression(builder, member)?;
+                        let property_span = lowered.property_span;
                         match lowered.property {
                             MemberProperty::Literal(property) => {
                                 Ok(InstructionValue::PropertyDelete {
                                     object: lowered.object,
                                     property,
+                                    property_span,
                                     span,
                                 })
                             }
@@ -3698,6 +3776,7 @@ fn lower_expression<'a>(
         }
         oxc::Expression::TaggedTemplateExpression(tagged) => {
             let span = Some(tagged.span);
+            let quasi_span = Some(tagged.quasi.span);
             // Upstream React Compiler bails on any interpolation here; the oxc port
             // instead lowers the tag plus every quasi and every `${...}`
             // subexpression (mirroring `TemplateLiteral`). This is a deliberate
@@ -3731,7 +3810,13 @@ fn lower_expression<'a>(
                 tagged.quasi.quasis.iter().map(template_quasi_from_oxc),
                 &alloc,
             );
-            Ok(InstructionValue::TaggedTemplateExpression { tag, quasis, subexprs, span })
+            Ok(InstructionValue::TaggedTemplateExpression {
+                tag,
+                quasis,
+                subexprs,
+                quasi_span,
+                span,
+            })
         }
         oxc::Expression::AwaitExpression(await_expr) => {
             let span = Some(await_expr.span);
@@ -3842,6 +3927,7 @@ fn lower_expression<'a>(
                         lower_member_expression_from_simple_target(builder, &update.argument)?;
                     let object = lowered.object;
                     let lowered_property = lowered.property;
+                    let property_span = lowered.property_span;
                     let prev_value = lower_value_to_temporary(builder, lowered.value)?;
 
                     let one = lower_value_to_temporary(
@@ -3870,6 +3956,7 @@ fn lower_expression<'a>(
                             InstructionValue::PropertyStore {
                                 object,
                                 property: prop_literal,
+                                property_span,
                                 value: updated,
                                 span: member_span,
                             },
@@ -4046,7 +4133,10 @@ fn lower_expression<'a>(
                     }
                     oxc::ObjectPropertyKind::SpreadProperty(spread) => {
                         let place = lower_expression_to_temporary(builder, &spread.argument)?;
-                        properties.push(ObjectPropertyOrSpread::Spread(SpreadPattern { place }));
+                        properties.push(ObjectPropertyOrSpread::Spread(SpreadPattern {
+                            place,
+                            span: Some(spread.span),
+                        }));
                     }
                 }
             }
@@ -4063,7 +4153,10 @@ fn lower_expression<'a>(
                     }
                     oxc::ArrayExpressionElement::SpreadElement(spread) => {
                         let place = lower_expression_to_temporary(builder, &spread.argument)?;
-                        elements.push(ArrayElement::Spread(SpreadPattern { place }));
+                        elements.push(ArrayElement::Spread(SpreadPattern {
+                            place,
+                            span: Some(spread.span),
+                        }));
                     }
                     _ => {
                         let expr = element.to_expression();
@@ -4190,6 +4283,7 @@ fn lower_assignment_expression<'a>(
                             InstructionValue::PropertyStore {
                                 object,
                                 property: PropertyLiteral::String(member.property.name),
+                                property_span: Some(member.property.span),
                                 value: right,
                                 span: left_span,
                             },
@@ -4203,6 +4297,7 @@ fn lower_assignment_expression<'a>(
                                 InstructionValue::PropertyStore {
                                     object,
                                     property: PropertyLiteral::Number(FloatValue::new(num.value)),
+                                    property_span: Some(num.span),
                                     value: right,
                                     span: left_span,
                                 },
@@ -4367,6 +4462,7 @@ fn lower_assignment_expression<'a>(
                 let lowered = lower_member_expression_from_simple_target(builder, simple)?;
                 let object = lowered.object;
                 let lowered_property = lowered.property;
+                let property_span = lowered.property_span;
                 let current_value = lower_value_to_temporary(builder, lowered.value)?;
                 let right = lower_expression_to_temporary(builder, &assign.right)?;
                 let result = lower_value_to_temporary(
@@ -4382,6 +4478,7 @@ fn lower_assignment_expression<'a>(
                     MemberProperty::Literal(prop_literal) => Ok(InstructionValue::PropertyStore {
                         object,
                         property: prop_literal,
+                        property_span,
                         value: result,
                         span: member_span,
                     }),
@@ -4418,7 +4515,9 @@ fn lower_jsx_element_expr<'a>(
 ) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = Some(jsx_element.span);
     let opening_span = Some(jsx_element.opening_element.span);
+    let opening_name_span = Some(jsx_element.opening_element.name.span());
     let closing_span = jsx_element.closing_element.as_ref().map(|c| c.span);
+    let closing_name_span = jsx_element.closing_element.as_ref().map(|c| c.name.span());
 
     // Lower the tag name
     let tag = lower_jsx_element_name(builder, &jsx_element.opening_element.name)?;
@@ -4430,7 +4529,7 @@ fn lower_jsx_element_expr<'a>(
         match attr_item {
             oxc::JSXAttributeItem::SpreadAttribute(spread) => {
                 let argument = lower_expression_to_temporary(builder, &spread.argument)?;
-                props.push(JsxAttribute::SpreadAttribute { argument });
+                props.push(JsxAttribute::SpreadAttribute { argument, span: Some(spread.span) });
             }
             oxc::JSXAttributeItem::Attribute(attr) => {
                 // Get the attribute name
@@ -4509,7 +4608,11 @@ fn lower_jsx_element_expr<'a>(
                     }
                 };
 
-                props.push(JsxAttribute::Attribute { name: prop_name, place: value });
+                props.push(JsxAttribute::Attribute {
+                    name: prop_name,
+                    name_span: Some(attr.name.span()),
+                    place: value,
+                });
             }
         }
     }
@@ -4611,7 +4714,9 @@ fn lower_jsx_element_expr<'a>(
         children: if children.is_empty() { None } else { Some(children) },
         span,
         opening_span,
+        opening_name_span,
         closing_span,
+        closing_name_span,
     })
 }
 
@@ -4622,6 +4727,8 @@ fn lower_jsx_fragment_expr<'a>(
     jsx_fragment: &oxc::JSXFragment<'a>,
 ) -> Result<InstructionValue<'a>, OxcDiagnostic> {
     let span = Some(jsx_fragment.span);
+    let opening_span = Some(jsx_fragment.opening_fragment.span);
+    let closing_span = Some(jsx_fragment.closing_fragment.span);
 
     // Lower children
     let alloc = builder.environment().allocator;
@@ -4636,7 +4743,7 @@ fn lower_jsx_fragment_expr<'a>(
         &alloc,
     );
 
-    Ok(InstructionValue::JsxFragment { children, span })
+    Ok(InstructionValue::JsxFragment { children, span, opening_span, closing_span })
 }
 
 /// Lower a JSX element name into a `JsxTag`. Faithful translation of the original
@@ -4746,6 +4853,7 @@ fn lower_jsx_member_expression<'a>(
     let value = InstructionValue::PropertyLoad {
         object,
         property: PropertyLiteral::String(Ident::from(prop_name)),
+        property_span: Some(expr.property.span),
         span: expr_span,
     };
     lower_value_to_temporary(builder, value)
@@ -4785,23 +4893,29 @@ fn lower_jsx_element<'a>(
             // Since the fbt transform runs after, preserve all whitespace
             // in FBT subtrees as is.
             let value = if builder.fbt_depth > 0 {
-                Some(match decoded {
-                    Cow::Borrowed(text) => Str::from(text),
-                    Cow::Owned(ref text) => {
-                        Str::from_str_in(text, &builder.environment().allocator)
-                    }
-                })
+                Some((
+                    match decoded {
+                        Cow::Borrowed(text) => Str::from(text),
+                        Cow::Owned(ref text) => {
+                            Str::from_str_in(text, &builder.environment().allocator)
+                        }
+                    },
+                    0,
+                ))
             } else {
-                trim_jsx_text(&decoded)
-                    .map(|text| Str::from_str_in(&text, &builder.environment().allocator))
+                trim_jsx_text(&decoded).map(|(text, start)| {
+                    (Str::from_str_in(&text, &builder.environment().allocator), start)
+                })
             };
             match value {
                 None => Ok(None),
-                Some(value) => {
-                    let span = Some(text.span);
+                Some((value, start)) => {
+                    let mut span = text.span;
+                    span.start +=
+                        source_offset_for_decoded_jsx_text(text.value.as_str(), start) as u32;
                     let place = lower_value_to_temporary(
                         builder,
-                        InstructionValue::JSXText { value, span },
+                        InstructionValue::JSXText { value, span: Some(span) },
                     )?;
                     Ok(Some(place))
                 }
@@ -5111,7 +5225,7 @@ fn split_line_endings(s: &str) -> Vec<&str> {
 
 /// Trims whitespace according to the JSX spec.
 /// Implementation ported from Babel's cleanJSXElementLiteralChild.
-fn trim_jsx_text(original: &str) -> Option<String> {
+fn trim_jsx_text(original: &str) -> Option<(String, usize)> {
     // Split on \r\n, \n, or \r to handle all line ending styles (matching TS split(/\r\n|\n|\r/))
     let lines: Vec<&str> = split_line_endings(original);
 
@@ -5126,6 +5240,8 @@ fn trim_jsx_text(original: &str) -> Option<String> {
     }
 
     let mut str = String::new();
+    let mut first_retained_offset = None;
+    let mut line_offset = 0;
 
     for (i, line) in lines.iter().enumerate() {
         let is_first_line = i == 0;
@@ -5134,10 +5250,13 @@ fn trim_jsx_text(original: &str) -> Option<String> {
 
         // Replace rendered whitespace tabs with spaces
         let mut trimmed_line = line.cow_replace('\t', " ").into_owned();
+        let mut leading_trimmed = 0;
 
         // Trim whitespace touching a newline (leading whitespace on non-first lines)
         if !is_first_line {
+            let original_len = trimmed_line.len();
             trimmed_line = trimmed_line.trim_start_matches(' ').to_string();
+            leading_trimmed = original_len - trimmed_line.len();
         }
 
         // Trim whitespace touching an endline (trailing whitespace on non-last lines)
@@ -5146,14 +5265,63 @@ fn trim_jsx_text(original: &str) -> Option<String> {
         }
 
         if !trimmed_line.is_empty() {
+            first_retained_offset.get_or_insert(line_offset + leading_trimmed);
             if !is_last_non_empty_line {
                 trimmed_line.push(' ');
             }
             str.push_str(&trimmed_line);
         }
+
+        line_offset += line.len();
+        if !is_last_line {
+            line_offset += if original.as_bytes().get(line_offset) == Some(&b'\r')
+                && original.as_bytes().get(line_offset + 1) == Some(&b'\n')
+            {
+                2
+            } else {
+                1
+            };
+        }
     }
 
-    if str.is_empty() { None } else { Some(str) }
+    first_retained_offset.map(|offset| (str, offset))
+}
+
+fn source_offset_for_decoded_jsx_text(source: &str, target_offset: usize) -> usize {
+    // Decoded entities can make a byte offset in the normalized value differ
+    // from the corresponding offset in the raw JSX source.
+    if target_offset == 0 || !source.contains('&') {
+        return target_offset;
+    }
+
+    let mut source_offset = 0;
+    let mut decoded_offset = 0;
+
+    while decoded_offset < target_offset && source_offset < source.len() {
+        let remaining = &source[source_offset..];
+        if let Some(entity) = remaining.strip_prefix('&')
+            && let Some(end) = entity.find(';')
+        {
+            let word = &entity[..end];
+            if !word.contains('&')
+                && let Some(decoded) = decode_jsx_entity(word)
+            {
+                let decoded_len = decoded.len_utf8();
+                if decoded_offset + decoded_len > target_offset {
+                    return source_offset;
+                }
+                decoded_offset += decoded_len;
+                source_offset += end + 2;
+                continue;
+            }
+        }
+
+        let char_len = remaining.chars().next().unwrap().len_utf8();
+        decoded_offset += char_len;
+        source_offset += char_len;
+    }
+
+    source_offset
 }
 
 /// Decode XML/HTML entities in JSX text (`&amp;` → `&`, `&gt;` → `>`, `&#123;`
@@ -5186,16 +5354,7 @@ fn decode_jsx_entities(s: &str) -> Cow<'_, str> {
         out.push_str(&s[prev..start]);
         prev = end + 1;
         let word = &s[start + 1..end];
-        let decoded = if let Some(num) = word.strip_prefix('#') {
-            if let Some(hex) = num.strip_prefix(['x', 'X']) {
-                u32::from_str_radix(hex, 16).ok().and_then(char::from_u32)
-            } else {
-                num.parse::<u32>().ok().and_then(char::from_u32)
-            }
-        } else {
-            oxc_syntax::xml_entities::XML_ENTITIES.get(word).copied()
-        };
-        match decoded {
+        match decode_jsx_entity(word) {
             Some(c) => out.push(c),
             // Not a recognized entity — keep the `&…;` literal.
             None => {
@@ -5207,6 +5366,18 @@ fn decode_jsx_entities(s: &str) -> Cow<'_, str> {
     }
     out.push_str(&s[prev..]);
     Cow::Owned(out)
+}
+
+fn decode_jsx_entity(word: &str) -> Option<char> {
+    if let Some(num) = word.strip_prefix('#') {
+        if let Some(hex) = num.strip_prefix(['x', 'X']) {
+            u32::from_str_radix(hex, 16).ok().and_then(char::from_u32)
+        } else {
+            num.parse::<u32>().ok().and_then(char::from_u32)
+        }
+    } else {
+        oxc_syntax::xml_entities::XML_ENTITIES.get(word).copied()
+    }
 }
 
 /// Get the Babel-style type name of an oxc `Expression` node. Mirrors the
@@ -5292,7 +5463,7 @@ fn lower_object_method<'a>(
     }
 
     let key = lower_object_property_key(builder, &method.key, method.computed)?
-        .unwrap_or(ObjectPropertyKey::String { name: Ident::empty() });
+        .unwrap_or(ObjectPropertyKey::String { name: Ident::empty(), span: None });
 
     let func = match &method.value {
         oxc::Expression::FunctionExpression(func) => func,
@@ -5323,23 +5494,25 @@ fn lower_object_property_key<'a>(
     computed: bool,
 ) -> Result<Option<ObjectPropertyKey<'a>>, OxcDiagnostic> {
     match key {
-        oxc::PropertyKey::StringLiteral(lit) => {
-            Ok(Some(ObjectPropertyKey::String { name: Ident::from(lit.value.as_str()) }))
-        }
+        oxc::PropertyKey::StringLiteral(lit) => Ok(Some(ObjectPropertyKey::String {
+            name: Ident::from(lit.value.as_str()),
+            span: Some(lit.span),
+        })),
         oxc::PropertyKey::StaticIdentifier(ident) if !computed => {
-            Ok(Some(ObjectPropertyKey::Identifier { name: ident.name }))
+            Ok(Some(ObjectPropertyKey::Identifier { name: ident.name, span: Some(ident.span) }))
         }
         oxc::PropertyKey::Identifier(ident) if !computed => {
-            Ok(Some(ObjectPropertyKey::Identifier { name: ident.name }))
+            Ok(Some(ObjectPropertyKey::Identifier { name: ident.name, span: Some(ident.span) }))
         }
         oxc::PropertyKey::NumericLiteral(lit) if !computed => {
             Ok(Some(ObjectPropertyKey::Identifier {
                 name: format_ident!(builder.environment().allocator, "{}", lit.value),
+                span: Some(lit.span),
             }))
         }
         _ if computed => {
             let place = lower_expression_to_temporary(builder, key.to_expression())?;
-            Ok(Some(ObjectPropertyKey::Computed { name: place }))
+            Ok(Some(ObjectPropertyKey::Computed { name: place, span: Some(key.span()) }))
         }
         _ => {
             let span = match key {
@@ -5525,6 +5698,13 @@ fn is_reorderable_expression(
     }
 }
 
+fn source_block_span(stmt: &oxc::Statement<'_>) -> Option<Span> {
+    match stmt {
+        oxc::Statement::BlockStatement(block) => Some(block.span),
+        _ => None,
+    }
+}
+
 fn lower_statement<'a>(
     builder: &mut HirBuilder<'a, '_>,
     stmt: &oxc::Statement<'a>,
@@ -5596,7 +5776,7 @@ fn lower_statement<'a>(
             let continuation_id = continuation_block.id;
 
             // Block for the consequent (if the test is truthy)
-            let consequent_span = Some(if_stmt.consequent.span());
+            let consequent_span = source_block_span(&if_stmt.consequent);
             let consequent_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
                 lower_statement(builder, &if_stmt.consequent, None, parent_scope)?;
                 Ok(Terminal::Goto {
@@ -5608,8 +5788,8 @@ fn lower_statement<'a>(
             })?;
 
             // Block for the alternate (if the test is not truthy)
+            let alternate_span = if_stmt.alternate.as_ref().and_then(source_block_span);
             let alternate_block = if let Some(alternate) = &if_stmt.alternate {
-                let alternate_span = Some(alternate.span());
                 builder.try_enter(BlockKind::Block, |builder, _block_id| {
                     lower_statement(builder, alternate, None, parent_scope)?;
                     Ok(Terminal::Goto {
@@ -5629,7 +5809,9 @@ fn lower_statement<'a>(
                 Terminal::If {
                     test,
                     consequent: consequent_block,
+                    consequent_span,
                     alternate: alternate_block,
+                    alternate_span,
                     fallthrough: continuation_id,
                     id: EvaluationOrder::UNSET,
                     span,
@@ -5701,7 +5883,7 @@ fn lower_statement<'a>(
 
             // Loop body block
             let continue_target = update_block_id.unwrap_or(test_block_id);
-            let body_span = Some(for_stmt.body.span());
+            let body_span = source_block_span(&for_stmt.body);
             let body_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
                 builder.loop_scope(label, continue_target, continuation_id, |builder| {
                     lower_statement(builder, &for_stmt.body, None, parent_scope)?;
@@ -5721,6 +5903,7 @@ fn lower_statement<'a>(
                     test: test_block_id,
                     update: update_block_id,
                     loop_block: body_block,
+                    loop_block_span: body_span,
                     fallthrough: continuation_id,
                     id: EvaluationOrder::UNSET,
                     span,
@@ -5775,7 +5958,7 @@ fn lower_statement<'a>(
             let continuation_id = continuation_block.id;
 
             // Loop body
-            let body_span = Some(while_stmt.body.span());
+            let body_span = source_block_span(&while_stmt.body);
             let loop_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
                 builder.loop_scope(label, conditional_id, continuation_id, |builder| {
                     lower_statement(builder, &while_stmt.body, None, parent_scope)?;
@@ -5793,6 +5976,7 @@ fn lower_statement<'a>(
                 Terminal::While {
                     test: conditional_id,
                     loop_block,
+                    loop_block_span: body_span,
                     fallthrough: continuation_id,
                     id: EvaluationOrder::UNSET,
                     span,
@@ -5824,7 +6008,7 @@ fn lower_statement<'a>(
             let continuation_id = continuation_block.id;
 
             // Loop body, executed at least once unconditionally prior to exit
-            let body_span = Some(do_while_stmt.body.span());
+            let body_span = source_block_span(&do_while_stmt.body);
             let loop_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
                 builder.loop_scope(label, conditional_id, continuation_id, |builder| {
                     lower_statement(builder, &do_while_stmt.body, None, parent_scope)?;
@@ -5841,6 +6025,7 @@ fn lower_statement<'a>(
             builder.terminate_with_continuation(
                 Terminal::DoWhile {
                     loop_block,
+                    loop_block_span: body_span,
                     test: conditional_id,
                     fallthrough: continuation_id,
                     id: EvaluationOrder::UNSET,
@@ -5865,12 +6050,13 @@ fn lower_statement<'a>(
         }
         oxc::Statement::ForInStatement(for_in) => {
             let span = Some(for_in.span);
+            let left_span = for_in.left.span();
             let continuation_block = builder.reserve(BlockKind::Block);
             let continuation_id = continuation_block.id;
             let init_block = builder.reserve(BlockKind::Loop);
             let init_block_id = init_block.id;
 
-            let body_span = Some(for_in.body.span());
+            let body_span = source_block_span(&for_in.body);
             let loop_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
                 builder.loop_scope(label, init_block_id, continuation_id, |builder| {
                     lower_statement(builder, &for_in.body, None, parent_scope)?;
@@ -5888,6 +6074,8 @@ fn lower_statement<'a>(
                 Terminal::ForIn {
                     init: init_block_id,
                     loop_block,
+                    loop_block_span: body_span,
+                    left_span: Some(left_span),
                     fallthrough: continuation_id,
                     id: EvaluationOrder::UNSET,
                     span,
@@ -5896,7 +6084,6 @@ fn lower_statement<'a>(
             );
 
             // Lower the init: NextPropertyOf + assignment
-            let left_span = for_in.left.span();
             let next_property = lower_value_to_temporary(
                 builder,
                 InstructionValue::NextPropertyOf { value, span: Some(left_span) },
@@ -5924,6 +6111,7 @@ fn lower_statement<'a>(
         }
         oxc::Statement::ForOfStatement(for_of) => {
             let span = Some(for_of.span);
+            let left_span = for_of.left.span();
             let continuation_block = builder.reserve(BlockKind::Block);
             let continuation_id = continuation_block.id;
             let init_block = builder.reserve(BlockKind::Loop);
@@ -5940,7 +6128,7 @@ fn lower_statement<'a>(
                 return Ok(());
             }
 
-            let body_span = Some(for_of.body.span());
+            let body_span = source_block_span(&for_of.body);
             let loop_block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
                 builder.loop_scope(label, init_block_id, continuation_id, |builder| {
                     lower_statement(builder, &for_of.body, None, parent_scope)?;
@@ -5959,6 +6147,8 @@ fn lower_statement<'a>(
                     init: init_block_id,
                     test: test_block_id,
                     loop_block,
+                    loop_block_span: body_span,
+                    left_span: Some(left_span),
                     fallthrough: continuation_id,
                     id: EvaluationOrder::UNSET,
                     span,
@@ -5982,7 +6172,6 @@ fn lower_statement<'a>(
             );
 
             // Test block: IteratorNext, assign, branch
-            let left_span = for_of.left.span();
             let advance_iterator = lower_value_to_temporary(
                 builder,
                 InstructionValue::IteratorNext {
@@ -6063,7 +6252,7 @@ fn lower_statement<'a>(
                     None
                 };
 
-                cases.push(Case { test, block });
+                cases.push(Case { test, block, span: case_span });
                 fallthrough = block;
             }
 
@@ -6072,7 +6261,7 @@ fn lower_statement<'a>(
 
             // If no default case, add one that jumps to continuation
             if !has_default {
-                cases.push(Case { test: None, block: continuation_id });
+                cases.push(Case { test: None, block: continuation_id, span: None });
             }
 
             let test = lower_expression_to_temporary(builder, &switch_stmt.discriminant)?;
@@ -6220,8 +6409,10 @@ fn lower_statement<'a>(
             builder.terminate_with_continuation(
                 Terminal::Try {
                     block: try_block,
+                    block_span: try_body_span,
                     handler_binding: handler_binding_info.map(|(place, _)| place),
                     handler: handler_block,
+                    handler_span: Some(handler_clause.body.span),
                     fallthrough: continuation_id,
                     id: EvaluationOrder::UNSET,
                     span,
@@ -6277,7 +6468,7 @@ fn lower_statement<'a>(
                     // All other statements create a continuation block to allow `break`
                     let continuation_block = builder.reserve(BlockKind::Block);
                     let continuation_id = continuation_block.id;
-                    let body_span = Some(labeled_stmt.body.span());
+                    let body_span = source_block_span(&labeled_stmt.body);
                     let block = builder.try_enter(BlockKind::Block, |builder, _block_id| {
                         builder.label_scope(label_name, continuation_id, |builder| {
                             lower_statement(builder, &labeled_stmt.body, None, parent_scope)?;
@@ -6294,6 +6485,7 @@ fn lower_statement<'a>(
                     builder.terminate_with_continuation(
                         Terminal::Label {
                             block,
+                            block_span: body_span,
                             fallthrough: continuation_id,
                             id: EvaluationOrder::UNSET,
                             span,

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -288,17 +288,29 @@ fn evaluate_instruction<'a>(
                 match prim {
                     PrimitiveValue::String(s) if is_valid_identifier(s.as_str()) => {
                         let object = *object;
+                        let property_span = property.span;
                         let span = *span;
                         let new_property = PropertyLiteral::String(Ident::from(s.as_str()));
                         func.instructions[instr_id.index()].value =
-                            InstructionValue::PropertyLoad { object, property: new_property, span };
+                            InstructionValue::PropertyLoad {
+                                object,
+                                property: new_property,
+                                property_span,
+                                span,
+                            };
                     }
                     PrimitiveValue::Number(n) => {
                         let object = *object;
+                        let property_span = property.span;
                         let span = *span;
                         let new_property = PropertyLiteral::Number(*n);
                         func.instructions[instr_id.index()].value =
-                            InstructionValue::PropertyLoad { object, property: new_property, span };
+                            InstructionValue::PropertyLoad {
+                                object,
+                                property: new_property,
+                                property_span,
+                                span,
+                            };
                     }
                     PrimitiveValue::Null
                     | PrimitiveValue::Undefined
@@ -314,6 +326,7 @@ fn evaluate_instruction<'a>(
                 match prim {
                     PrimitiveValue::String(s) if is_valid_identifier(s.as_str()) => {
                         let object = *object;
+                        let property_span = property.span;
                         let store_value = *value;
                         let span = *span;
                         let new_property = PropertyLiteral::String(Ident::from(s.as_str()));
@@ -321,12 +334,14 @@ fn evaluate_instruction<'a>(
                             InstructionValue::PropertyStore {
                                 object,
                                 property: new_property,
+                                property_span,
                                 value: store_value,
                                 span,
                             };
                     }
                     PrimitiveValue::Number(n) => {
                         let object = *object;
+                        let property_span = property.span;
                         let store_value = *value;
                         let span = *span;
                         let new_property = PropertyLiteral::Number(*n);
@@ -334,6 +349,7 @@ fn evaluate_instruction<'a>(
                             InstructionValue::PropertyStore {
                                 object,
                                 property: new_property,
+                                property_span,
                                 value: store_value,
                                 span,
                             };
@@ -449,7 +465,7 @@ fn evaluate_instruction<'a>(
             }
             None
         }
-        InstructionValue::PropertyLoad { object, property, span } => {
+        InstructionValue::PropertyLoad { object, property, span, .. } => {
             let object_value = read(constants, object);
             if let Some(Constant::Primitive { value: PrimitiveValue::String(ref s), .. }) =
                 object_value

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
@@ -384,12 +384,16 @@ fn collect_maybe_memo_dependencies<'a>(
             path: ArenaVec::new_in(&env.allocator),
             span: *span,
         }),
-        InstructionValue::PropertyLoad { object, property, span, .. } => {
+        InstructionValue::PropertyLoad { object, property, property_span, span } => {
             maybe_deps.get(&object.identifier).map(|object_dep| ManualMemoDependency {
                 root: object_dep.root,
                 path: {
                     let mut path = object_dep.path.clone_in(env.allocator);
-                    path.push(DependencyPathEntry { property: *property, optional, span: *span });
+                    path.push(DependencyPathEntry {
+                        property: *property,
+                        optional,
+                        span: property_span.or(*span),
+                    });
                     path
                 },
                 span: *span,

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/inline_iifes.rs
@@ -224,6 +224,7 @@ pub fn inline_immediately_invoked_function_expressions<'a>(
                         // Set block terminal to Label
                         func.body.blocks.get_mut(&block_id).unwrap().terminal = Terminal::Label {
                             block: inner_entry,
+                            block_span: None,
                             id: EvaluationOrder::UNSET,
                             fallthrough: continuation_block_id,
                             span: block_terminal_span,

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
@@ -189,7 +189,7 @@ fn name_anonymous_functions_impl<'a>(
                     for attr in props {
                         match attr {
                             JsxAttribute::SpreadAttribute { .. } => continue,
-                            JsxAttribute::Attribute { name: attr_name, place } => {
+                            JsxAttribute::Attribute { name: attr_name, place, .. } => {
                                 if let Some(&node_idx) = functions.get(&place.identifier) {
                                     let node = &mut nodes[node_idx];
                                     if node.generated_name.is_none() {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
@@ -13,6 +13,7 @@ use crate::react_compiler_utils::ordered_map::ArenaOrderedSet;
 use oxc_allocator::CloneIn;
 use oxc_allocator::Vec as ArenaVec;
 use oxc_index::IndexVec;
+use oxc_span::Span;
 use oxc_str::{Ident, IdentHashSet, format_ident};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -51,6 +52,7 @@ struct JsxInstrInfo {
 struct OutlinedJsxAttribute<'a> {
     original_name: Ident<'a>,
     new_name: Ident<'a>,
+    name_span: Option<Span>,
     place: Place,
 }
 
@@ -274,11 +276,12 @@ fn collect_props<'a>(
             for attr in props {
                 match attr {
                     JsxAttribute::SpreadAttribute { .. } => return None,
-                    JsxAttribute::Attribute { name, place } => {
+                    JsxAttribute::Attribute { name, name_span, place } => {
                         let new_name = generate_name(*name);
                         attributes.push(OutlinedJsxAttribute {
                             original_name: *name,
                             new_name,
+                            name_span: *name_span,
                             place: *place,
                         });
                     }
@@ -308,6 +311,7 @@ fn collect_props<'a>(
                     attributes.push(OutlinedJsxAttribute {
                         original_name: child_name,
                         new_name,
+                        name_span: None,
                         place: *child,
                     });
                 }
@@ -326,7 +330,11 @@ fn emit_outlined_jsx<'a>(
     outlined_tag: Ident<'a>,
 ) -> Option<Vec<Instruction<'a>>> {
     let props = ArenaVec::from_iter_in(
-        outlined_props.iter().map(|p| JsxAttribute::Attribute { name: p.new_name, place: p.place }),
+        outlined_props.iter().map(|p| JsxAttribute::Attribute {
+            name: p.new_name,
+            name_span: None,
+            place: p.place,
+        }),
         &env.allocator,
     );
 
@@ -363,7 +371,9 @@ fn emit_outlined_jsx<'a>(
             children: None,
             span: None,
             opening_span: None,
+            opening_name_span: None,
             closing_span: None,
+            closing_name_span: None,
         },
         span: None,
         effects: None,
@@ -440,7 +450,9 @@ fn emit_outlined_fn<'a>(
     blocks.insert(BlockId::ENTRY, block);
 
     let outlined_fn = HirFunction {
+        body_span: None,
         id: None,
+        id_span: None,
         name_hint: None,
         fn_type: ReactFunctionType::Other,
         params: ArenaVec::from_array_in([ParamPattern::Place(props_obj)], &env.allocator),
@@ -493,7 +505,9 @@ fn emit_updated_jsx<'a>(
             children,
             span,
             opening_span,
+            opening_name_span,
             closing_span,
+            closing_name_span,
         } = &instr.value
         {
             let mut new_props = ArenaVec::new_in(&alloc);
@@ -501,7 +515,7 @@ fn emit_updated_jsx<'a>(
                 // TS: invariant(prop.kind === 'JsxAttribute', ...)
                 // Spread attributes would have caused collectProps to return null earlier
                 let (name, place) = match prop {
-                    JsxAttribute::Attribute { name, place } => (name, place),
+                    JsxAttribute::Attribute { name, place, .. } => (name, place),
                     JsxAttribute::SpreadAttribute { .. } => {
                         unreachable!("Expected only JsxAttribute, not spread")
                     }
@@ -515,6 +529,7 @@ fn emit_updated_jsx<'a>(
                     .expect("Expected a new property for identifier");
                 new_props.push(JsxAttribute::Attribute {
                     name: new_prop.original_name,
+                    name_span: new_prop.name_span,
                     place: new_prop.place,
                 });
             }
@@ -545,7 +560,9 @@ fn emit_updated_jsx<'a>(
                     children: new_children,
                     span: *span,
                     opening_span: *opening_span,
+                    opening_name_span: *opening_name_span,
                     closing_span: *closing_span,
+                    closing_name_span: *closing_name_span,
                 },
                 span: instr.span,
                 effects: instr.effects.as_ref().map(|v| v.clone_in(alloc)),
@@ -578,6 +595,7 @@ fn create_old_to_new_props_mapping<'a>(
             OutlinedJsxAttribute {
                 original_name: old_prop.original_name,
                 new_name: old_prop.new_name,
+                name_span: old_prop.name_span,
                 place: new_place,
             },
         );
@@ -594,7 +612,7 @@ fn emit_destructure_props<'a>(
     let mut properties = ArenaVec::new_in(&env.allocator);
     for prop in old_to_new_props.values() {
         properties.push(ObjectPropertyOrSpread::Property(ObjectProperty {
-            key: ObjectPropertyKey::String { name: prop.new_name },
+            key: ObjectPropertyKey::String { name: prop.new_name, span: None },
             property_type: ObjectPropertyType::Property,
             place: prop.place,
         }));

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -39,7 +39,9 @@ pub fn build_reactive_function<'a>(
 
     Ok(ReactiveFunction {
         span: hir.span,
+        body_span: hir.body_span,
         id: hir.id,
+        id_span: hir.id_span,
         name_hint: hir.name_hint,
         params: hir.params.iter().copied().collect(),
         generator: hir.generator,
@@ -312,6 +314,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
             let block_id_val = block.id;
             let instructions: Vec<_> = block.instructions.iter().copied().collect();
             let terminal = block.terminal.clone_in(self.env.allocator);
+            let terminal_source_span = terminal.span().copied().unwrap_or_default();
 
             if !self.cx.emitted.insert(block_id_val) {
                 return Err(ErrorCategory::Invariant
@@ -334,7 +337,16 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
             let mut next_block: Option<BlockId> = None;
 
             match &terminal {
-                Terminal::If { test, consequent, alternate, fallthrough, id, .. } => {
+                Terminal::If {
+                    test,
+                    consequent,
+                    consequent_span,
+                    alternate,
+                    alternate_span,
+                    fallthrough,
+                    id,
+                    ..
+                } => {
                     // TS: reachable(fallthrough) && !isScheduled(fallthrough)
                     let fallthrough_id =
                         if self.cx.reachable(*fallthrough) && !self.cx.is_scheduled(*fallthrough) {
@@ -378,11 +390,14 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                             terminal: ReactiveTerminal::If {
                                 test: *test,
                                 consequent: consequent_block,
+                                consequent_span: *consequent_span,
                                 alternate: alternate_block,
+                                alternate_span: *alternate_span,
                                 id: *id,
                             },
                             label:
                                 fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            span: terminal_source_span,
                         },
                     )));
 
@@ -420,8 +435,11 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                         let case_schedule_id = self.cx.schedule(case_block_id, "case")?;
                         schedule_ids.push(case_schedule_id);
 
-                        reactive_cases
-                            .push(ReactiveSwitchCase { test: case.test, block: Some(consequent) });
+                        reactive_cases.push(ReactiveSwitchCase {
+                            test: case.test,
+                            block: Some(consequent),
+                            span: case.span,
+                        });
                     }
                     reactive_cases.reverse();
 
@@ -435,13 +453,14 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                             },
                             label:
                                 fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            span: terminal_source_span,
                         },
                     )));
 
                     next_block = fallthrough_id;
                 }
 
-                Terminal::DoWhile { loop_block, test, fallthrough, id, span } => {
+                Terminal::DoWhile { loop_block, loop_block_span, test, fallthrough, id, span } => {
                     let fallthrough_id =
                         if !self.cx.is_scheduled(*fallthrough) { Some(*fallthrough) } else { None };
                     let loop_id =
@@ -471,18 +490,20 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::DoWhile {
                                 loop_block: loop_body,
+                                loop_block_span: *loop_block_span,
                                 test: test_result.value,
                                 id: *id,
                             },
                             label:
                                 fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            span: terminal_source_span,
                         },
                     )));
 
                     next_block = fallthrough_id;
                 }
 
-                Terminal::While { test, loop_block, fallthrough, id, span } => {
+                Terminal::While { test, loop_block, loop_block_span, fallthrough, id, span } => {
                     // TS: reachable(fallthrough) && !isScheduled(fallthrough)
                     let fallthrough_id =
                         if self.cx.reachable(*fallthrough) && !self.cx.is_scheduled(*fallthrough) {
@@ -518,17 +539,28 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                             terminal: ReactiveTerminal::While {
                                 test: test_result.value,
                                 loop_block: loop_body,
+                                loop_block_span: *loop_block_span,
                                 id: *id,
                             },
                             label:
                                 fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            span: terminal_source_span,
                         },
                     )));
 
                     next_block = fallthrough_id;
                 }
 
-                Terminal::For { init, test, update, loop_block, fallthrough, id, span } => {
+                Terminal::For {
+                    init,
+                    test,
+                    update,
+                    loop_block,
+                    loop_block_span,
+                    fallthrough,
+                    id,
+                    span,
+                } => {
                     let loop_id =
                         if !self.cx.is_scheduled(*loop_block) && *loop_block != *fallthrough {
                             Some(*loop_block)
@@ -572,17 +604,28 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                                 test: test_result.value,
                                 update: update_result.map(|r| r.value),
                                 loop_block: loop_body,
+                                loop_block_span: *loop_block_span,
                                 id: *id,
                             },
                             label:
                                 fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            span: terminal_source_span,
                         },
                     )));
 
                     next_block = fallthrough_id;
                 }
 
-                Terminal::ForOf { init, test, loop_block, fallthrough, id, span } => {
+                Terminal::ForOf {
+                    init,
+                    test,
+                    loop_block,
+                    loop_block_span,
+                    left_span,
+                    fallthrough,
+                    id,
+                    span,
+                } => {
                     let loop_id =
                         if !self.cx.is_scheduled(*loop_block) && *loop_block != *fallthrough {
                             Some(*loop_block)
@@ -621,18 +664,29 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                                 init: init_value,
                                 test: test_value,
                                 loop_block: loop_body,
+                                loop_block_span: *loop_block_span,
+                                left_span: *left_span,
                                 id: *id,
                                 span: *span,
                             },
                             label:
                                 fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            span: terminal_source_span,
                         },
                     )));
 
                     next_block = fallthrough_id;
                 }
 
-                Terminal::ForIn { init, loop_block, fallthrough, id, span } => {
+                Terminal::ForIn {
+                    init,
+                    loop_block,
+                    loop_block_span,
+                    left_span,
+                    fallthrough,
+                    id,
+                    span,
+                } => {
                     let loop_id =
                         if !self.cx.is_scheduled(*loop_block) && *loop_block != *fallthrough {
                             Some(*loop_block)
@@ -666,18 +720,21 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                             terminal: ReactiveTerminal::ForIn {
                                 init: init_value,
                                 loop_block: loop_body,
+                                loop_block_span: *loop_block_span,
+                                left_span: *left_span,
                                 id: *id,
                                 span: *span,
                             },
                             label:
                                 fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            span: terminal_source_span,
                         },
                     )));
 
                     next_block = fallthrough_id;
                 }
 
-                Terminal::Label { block: label_block, fallthrough, id, .. } => {
+                Terminal::Label { block: label_block, block_span, fallthrough, id, .. } => {
                     // TS: reachable(fallthrough) && !isScheduled(fallthrough)
                     let fallthrough_id =
                         if self.cx.reachable(*fallthrough) && !self.cx.is_scheduled(*fallthrough) {
@@ -699,9 +756,14 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     self.cx.unschedule_all(&schedule_ids)?;
                     block_value.push(ReactiveStatement::Terminal(self.box_in(
                         ReactiveTerminalStatement {
-                            terminal: ReactiveTerminal::Label { block: label_body, id: *id },
+                            terminal: ReactiveTerminal::Label {
+                                block: label_body,
+                                block_span: *block_span,
+                                id: *id,
+                            },
                             label:
                                 fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            span: terminal_source_span,
                         },
                     )));
 
@@ -740,12 +802,15 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 Terminal::Goto { block: goto_block, variant, id, .. } => {
                     match variant {
                         GotoVariant::Break => {
-                            if let Some(stmt) = self.visit_break(*goto_block, *id)? {
+                            if let Some(stmt) =
+                                self.visit_break(*goto_block, *id, terminal_source_span)?
+                            {
                                 block_value.push(stmt);
                             }
                         }
                         GotoVariant::Continue => {
-                            let stmt = self.visit_continue(*goto_block, *id)?;
+                            let stmt =
+                                self.visit_continue(*goto_block, *id, terminal_source_span)?;
                             block_value.push(stmt);
                         }
                         GotoVariant::Try => {
@@ -762,8 +827,10 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
 
                 Terminal::Try {
                     block: try_block,
+                    block_span,
                     handler_binding,
                     handler,
+                    handler_span,
                     fallthrough,
                     id,
                     ..
@@ -787,12 +854,15 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::Try {
                                 block: try_body,
+                                block_span: *block_span,
                                 handler_binding: *handler_binding,
                                 handler: handler_body,
+                                handler_span: *handler_span,
                                 id: *id,
                             },
                             label:
                                 fallthrough_id.map(|ft| ReactiveLabel { id: ft, implicit: false }),
+                            span: terminal_source_span,
                         },
                     )));
 
@@ -852,6 +922,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::Return { value: *value, id: *id },
                             label: None,
+                            span: terminal_source_span,
                         },
                     )));
                 }
@@ -861,6 +932,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::Throw { value: *value, id: *id },
                             label: None,
+                            span: terminal_source_span,
                         },
                     )));
                 }
@@ -872,7 +944,9 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                 Terminal::Branch { test, consequent, alternate, id, .. } => {
                     let alloc = self.env.allocator;
                     let consequent_block = if self.cx.is_scheduled(*consequent) {
-                        if let Some(stmt) = self.visit_break(*consequent, *id)? {
+                        if let Some(stmt) =
+                            self.visit_break(*consequent, *id, terminal_source_span)?
+                        {
                             ArenaVec::from_iter_in([stmt], &alloc)
                         } else {
                             ArenaVec::new_in(&alloc)
@@ -894,9 +968,12 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                                 test: *test,
                                 consequent: consequent_block,
                                 alternate: Some(alternate_block),
+                                consequent_span: None,
+                                alternate_span: None,
                                 id: *id,
                             },
                             label: None,
+                            span: terminal_source_span,
                         },
                     )));
                 }
@@ -1305,6 +1382,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         &self,
         block: BlockId,
         id: EvaluationOrder,
+        span: Span,
     ) -> Result<Option<ReactiveStatement<'a>>, OxcDiagnostic> {
         let (target_block, target_kind) = self.cx.get_break_target(block)?;
         if self.cx.scope_fallthroughs.contains(&target_block) {
@@ -1317,6 +1395,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         Ok(Some(ReactiveStatement::Terminal(self.box_in(ReactiveTerminalStatement {
             terminal: ReactiveTerminal::Break { target: target_block, id, target_kind },
             label: None,
+            span,
         }))))
     }
 
@@ -1324,6 +1403,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         &self,
         block: BlockId,
         id: EvaluationOrder,
+        span: Span,
     ) -> Result<ReactiveStatement<'a>, OxcDiagnostic> {
         let (target_block, target_kind) = match self.cx.get_continue_target(block) {
             Some(result) => result,
@@ -1338,6 +1418,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
         Ok(ReactiveStatement::Terminal(self.box_in(ReactiveTerminalStatement {
             terminal: ReactiveTerminal::Continue { target: target_block, id, target_kind },
             label: None,
+            span,
         })))
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -48,7 +48,7 @@ use crate::react_compiler_hir::reactive::ReactiveTerminal;
 use crate::react_compiler_hir::reactive::ReactiveTerminalTargetKind;
 use crate::react_compiler_hir::reactive::ReactiveValue;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_span::{GetSpanMut, Span};
+use oxc_span::{GetSpan, GetSpanMut, Span};
 
 use crate::react_compiler_reactive_scopes::build_reactive_function::build_reactive_function;
 use crate::react_compiler_reactive_scopes::prune_hoisted_contexts::prune_hoisted_contexts;
@@ -121,7 +121,7 @@ pub fn codegen_function<'a>(
             SPAN,
             oxc_ast::ast::Expression::new_identifier(SPAN, memo_cache_name, ast),
             None,
-            [oxc_ast::ast::Argument::from(ox_number(ast, cache_count as f64))],
+            [oxc_ast::ast::Argument::from(ox_number(ast, cache_count as f64, SPAN))],
             false,
             ast,
         );
@@ -152,7 +152,13 @@ pub fn codegen_function<'a>(
         compiled.body.statements = new_body;
     }
 
-    let id = func.id.map(|name| oxc_ast::ast::BindingIdentifier::new(SPAN, name, ast));
+    let id = func.id.map(|name| {
+        oxc_ast::ast::BindingIdentifier::new(
+            func.id_span.or(func.span).unwrap_or_default(),
+            name,
+            ast,
+        )
+    });
 
     // Release the borrow of `env` held by `cx` so the outlined functions can be
     // compiled with fresh contexts (mirrors TS `codegenFunction`).
@@ -235,6 +241,18 @@ use oxc_allocator::CloneIn;
 enum OxValue<'a> {
     Expression(oxc::Expression<'a>),
     JsxText(oxc_allocator::Box<'a, oxc::JSXText<'a>>),
+}
+
+fn ox_apply_span_to_value(value: &mut OxValue<'_>, span: Option<Span>) {
+    let Some(span) = span else { return };
+    match value {
+        OxValue::Expression(expr) => *expr.span_mut() = span,
+        OxValue::JsxText(text) => text.span = span,
+    }
+}
+
+fn ox_statements_span(statements: &[oxc::Statement<'_>]) -> Option<Span> {
+    statements.iter().map(GetSpan::span).filter(|span| !span.is_empty()).reduce(Span::merge)
 }
 
 impl<'a> OxValue<'a> {
@@ -352,8 +370,12 @@ enum LvalueRef<'a> {
     Pattern(&'a Pattern<'a>),
 }
 
-fn ox_number<'a>(ast: &oxc_ast::builder::AstBuilder<'a>, value: f64) -> oxc::Expression<'a> {
-    oxc_ast::ast::Expression::new_numeric_literal(SPAN, value, None, oxc::NumberBase::Decimal, ast)
+fn ox_number<'a>(
+    ast: &oxc_ast::builder::AstBuilder<'a>,
+    value: f64,
+    span: Span,
+) -> oxc::Expression<'a> {
+    oxc_ast::ast::Expression::new_numeric_literal(span, value, None, oxc::NumberBase::Decimal, ast)
 }
 
 /// Allocate a `&'a str` in the arena (satisfies the builders' `IntoIn` slots for
@@ -426,7 +448,7 @@ fn ox_cache_index<'a>(
     oxc::Expression::from(oxc_ast::ast::MemberExpression::new_computed_member_expression(
         SPAN,
         oxc_ast::ast::Expression::new_identifier(SPAN, ox_str(ast, cache_name), ast),
-        ox_number(ast, index as f64),
+        ox_number(ast, index as f64, SPAN),
         false,
         ast,
     ))
@@ -454,9 +476,14 @@ fn ox_codegen_reactive_function<'a>(
     let directives = oxc_allocator::ArenaVec::from_iter_in(
         func.directives.iter().map(|d| {
             oxc_ast::ast::Directive::new(
-                SPAN,
-                oxc_ast::ast::StringLiteral::new(SPAN, ox_str(&cx.ast, d), None, &cx.ast),
-                ox_str(&cx.ast, d),
+                d.span,
+                oxc_ast::ast::StringLiteral::new(
+                    d.expression_span,
+                    ox_str(&cx.ast, &d.value),
+                    None,
+                    &cx.ast,
+                ),
+                ox_str(&cx.ast, &d.value),
                 &cx.ast,
             )
         }),
@@ -473,7 +500,8 @@ fn ox_codegen_reactive_function<'a>(
     let (memo_blocks, memo_values, pruned_memo_blocks, pruned_memo_values) =
         count_memo_blocks(func, cx.env);
 
-    let body = oxc_ast::ast::FunctionBody::boxed(SPAN, directives, statements, &cx.ast);
+    let body_span = func.body_span.or_else(|| ox_statements_span(&statements)).unwrap_or_default();
+    let body = oxc_ast::ast::FunctionBody::boxed(body_span, directives, statements, &cx.ast);
 
     Ok(OxcCompiledFunction {
         params,
@@ -497,9 +525,13 @@ fn ox_convert_parameters<'a>(
     for param in params {
         match param {
             ParamPattern::Place(place) => {
-                let binding = ox_binding_for_identifier(cx, place.identifier)?;
+                let binding = if place.span.is_some() {
+                    ox_binding_for_identifier(cx, place.identifier, place.span)?
+                } else {
+                    ox_binding_for_identifier_at_span(cx, place.identifier, SPAN)?
+                };
                 items.push(oxc_ast::ast::FormalParameter::new(
-                    SPAN,
+                    place.span.unwrap_or_default(),
                     [],
                     binding,
                     None,
@@ -512,10 +544,15 @@ fn ox_convert_parameters<'a>(
                 ));
             }
             ParamPattern::Spread(spread) => {
-                let binding = ox_binding_for_identifier(cx, spread.place.identifier)?;
-                let rest_elem = oxc_ast::ast::BindingRestElement::new(SPAN, binding, &cx.ast);
+                let binding =
+                    ox_binding_for_identifier(cx, spread.place.identifier, spread.place.span)?;
+                let rest_elem = oxc_ast::ast::BindingRestElement::new(
+                    spread.span.or(spread.place.span).unwrap_or_default(),
+                    binding,
+                    &cx.ast,
+                );
                 rest = Some(oxc_ast::ast::FormalParameterRest::boxed(
-                    SPAN,
+                    spread.span.or(spread.place.span).unwrap_or_default(),
                     [],
                     rest_elem,
                     None,
@@ -525,8 +562,13 @@ fn ox_convert_parameters<'a>(
         }
     }
     let items_vec = oxc_allocator::ArenaVec::from_iter_in(items, &cx.ast);
+    let params_span = items_vec
+        .first()
+        .zip(items_vec.last())
+        .map(|(first, last)| first.span.merge(last.span))
+        .or_else(|| rest.as_ref().map(|rest| rest.span));
     Ok(oxc_ast::ast::FormalParameters::boxed(
-        SPAN,
+        params_span.unwrap_or_default(),
         oxc::FormalParameterKind::FormalParameter,
         items_vec,
         rest,
@@ -537,9 +579,19 @@ fn ox_convert_parameters<'a>(
 fn ox_binding_for_identifier<'a>(
     cx: &OxcContext<'a, '_>,
     identifier_id: IdentifierId,
+    span: Option<Span>,
+) -> Result<oxc::BindingPattern<'a>, OxcDiagnostic> {
+    let span = cx.env.identifiers[identifier_id].span.or(span).unwrap_or_default();
+    ox_binding_for_identifier_at_span(cx, identifier_id, span)
+}
+
+fn ox_binding_for_identifier_at_span<'a>(
+    cx: &OxcContext<'a, '_>,
+    identifier_id: IdentifierId,
+    span: Span,
 ) -> Result<oxc::BindingPattern<'a>, OxcDiagnostic> {
     let name = ox_identifier_name(cx.env, identifier_id)?;
-    Ok(oxc_ast::ast::BindingPattern::new_binding_identifier(SPAN, name, &cx.ast))
+    Ok(oxc_ast::ast::BindingPattern::new_binding_identifier(span, name, &cx.ast))
 }
 
 fn ox_identifier_name<'a>(
@@ -594,7 +646,7 @@ fn ox_codegen_block_no_reset<'a>(
                 cx.temp = temp_snapshot;
             }
             ReactiveStatement::Terminal(term_stmt) => {
-                let stmt = ox_codegen_terminal(cx, &term_stmt.terminal)?;
+                let stmt = ox_codegen_terminal(cx, &term_stmt.terminal, term_stmt.span)?;
                 let Some(stmt) = stmt else {
                     continue;
                 };
@@ -646,9 +698,11 @@ fn ox_codegen_block_no_reset<'a>(
 fn ox_codegen_block_statement<'a>(
     cx: &mut OxcContext<'a, '_>,
     block: &ReactiveBlock<'a>,
+    source_span: Option<Span>,
 ) -> Result<oxc_allocator::Box<'a, oxc::BlockStatement<'a>>, OxcDiagnostic> {
     let body = ox_codegen_block(cx, block)?;
-    Ok(oxc_ast::ast::BlockStatement::boxed(SPAN, body, &cx.ast))
+    let span = source_span.unwrap_or_default();
+    Ok(oxc_ast::ast::BlockStatement::boxed(span, body, &cx.ast))
 }
 
 // =============================================================================
@@ -717,18 +771,9 @@ fn ox_codegen_reactive_scope<'a>(
         }
         let name = ox_identifier_name(cx.env, decl.identifier)?;
         if !cx.has_declared(decl.identifier) {
-            let declarator = oxc_ast::ast::VariableDeclarator::new(
-                SPAN,
-                oxc_ast::ast::BindingPattern::new_binding_identifier(
-                    SPAN,
-                    ox_str(&cx.ast, &name),
-                    &cx.ast,
-                ),
-                None,
-                None,
-                false,
-                &cx.ast,
-            );
+            let binding = ox_binding_for_identifier(cx, decl.identifier, None)?;
+            let declarator =
+                oxc_ast::ast::VariableDeclarator::new(SPAN, binding, None, None, false, &cx.ast);
             statements.push(oxc::Statement::VariableDeclaration(
                 oxc_ast::ast::VariableDeclaration::boxed(
                     SPAN,
@@ -867,7 +912,7 @@ fn ast_member_target<'a>(
     oxc_ast::ast::MemberExpression::new_computed_member_expression(
         SPAN,
         oxc_ast::ast::Expression::new_identifier(SPAN, ox_str(ast, cache_name), ast),
-        ox_number(ast, index as f64),
+        ox_number(ast, index as f64, SPAN),
         false,
         ast,
     )
@@ -880,6 +925,7 @@ fn ast_member_target<'a>(
 fn ox_codegen_terminal<'a>(
     cx: &mut OxcContext<'a, '_>,
     terminal: &ReactiveTerminal<'a>,
+    source_span: Span,
 ) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     match terminal {
         ReactiveTerminal::Break { target, target_kind, .. } => {
@@ -895,7 +941,7 @@ fn ox_codegen_terminal<'a>(
             } else {
                 None
             };
-            Ok(Some(oxc_ast::ast::Statement::new_break_statement(SPAN, label, &cx.ast)))
+            Ok(Some(oxc_ast::ast::Statement::new_break_statement(source_span, label, &cx.ast)))
         }
         ReactiveTerminal::Continue { target, target_kind, .. } => {
             if *target_kind == ReactiveTerminalTargetKind::Implicit {
@@ -910,7 +956,7 @@ fn ox_codegen_terminal<'a>(
             } else {
                 None
             };
-            Ok(Some(oxc_ast::ast::Statement::new_continue_statement(SPAN, label, &cx.ast)))
+            Ok(Some(oxc_ast::ast::Statement::new_continue_statement(source_span, label, &cx.ast)))
         }
         ReactiveTerminal::Return { value, .. } => {
             let expr = ox_codegen_place_to_expression(cx, value)?;
@@ -918,31 +964,49 @@ fn ox_codegen_terminal<'a>(
                 && ident.name == "undefined"
             {
                 return Ok(Some(oxc_ast::ast::Statement::new_return_statement(
-                    SPAN, None, &cx.ast,
+                    source_span,
+                    None,
+                    &cx.ast,
                 )));
             }
-            Ok(Some(oxc_ast::ast::Statement::new_return_statement(SPAN, Some(expr), &cx.ast)))
+            Ok(Some(oxc_ast::ast::Statement::new_return_statement(
+                source_span,
+                Some(expr),
+                &cx.ast,
+            )))
         }
         ReactiveTerminal::Throw { value, .. } => {
             let expr = ox_codegen_place_to_expression(cx, value)?;
-            Ok(Some(oxc_ast::ast::Statement::new_throw_statement(SPAN, expr, &cx.ast)))
+            Ok(Some(oxc_ast::ast::Statement::new_throw_statement(source_span, expr, &cx.ast)))
         }
-        ReactiveTerminal::If { test, consequent, alternate, .. } => {
+        ReactiveTerminal::If {
+            test,
+            consequent,
+            consequent_span,
+            alternate,
+            alternate_span,
+            ..
+        } => {
             let test_expr = ox_codegen_place_to_expression(cx, test)?;
-            let consequent_block = ox_codegen_block_statement(cx, consequent)?;
+            let consequent_block = ox_codegen_block_statement(cx, consequent, *consequent_span)?;
             let consequent = oxc::Statement::BlockStatement(consequent_block);
             let alternate = if let Some(alt) = alternate {
                 let body = ox_codegen_block(cx, alt)?;
                 if body.is_empty() {
                     None
                 } else {
-                    Some(oxc::Statement::new_block_statement(SPAN, body, &cx.ast))
+                    let block_span = alternate_span.unwrap_or_default();
+                    Some(oxc::Statement::new_block_statement(block_span, body, &cx.ast))
                 }
             } else {
                 None
             };
             Ok(Some(oxc_ast::ast::Statement::new_if_statement(
-                SPAN, test_expr, consequent, alternate, &cx.ast,
+                source_span,
+                test_expr,
+                consequent,
+                alternate,
+                &cx.ast,
             )))
         }
         ReactiveTerminal::Switch { test, cases, .. } => {
@@ -972,41 +1036,53 @@ fn ox_codegen_terminal<'a>(
                     ),
                     None => oxc_allocator::ArenaVec::new_in(&cx.ast),
                 };
-                switch_cases
-                    .push(oxc_ast::ast::SwitchCase::new(SPAN, case_test, consequent, &cx.ast));
+                switch_cases.push(oxc_ast::ast::SwitchCase::new(
+                    case.span.unwrap_or_default(),
+                    case_test,
+                    consequent,
+                    &cx.ast,
+                ));
             }
             Ok(Some(oxc_ast::ast::Statement::new_switch_statement(
-                SPAN,
+                source_span,
                 test_expr,
                 switch_cases,
                 &cx.ast,
             )))
         }
-        ReactiveTerminal::DoWhile { loop_block, test, .. } => {
+        ReactiveTerminal::DoWhile { loop_block, loop_block_span, test, .. } => {
             let test_expr = ox_codegen_instruction_value_to_expression(cx, test)?;
-            let body = ox_codegen_block_statement(cx, loop_block)?;
+            let body = ox_codegen_block_statement(cx, loop_block, *loop_block_span)?;
             let body = oxc::Statement::BlockStatement(body);
             Ok(Some(oxc_ast::ast::Statement::new_do_while_statement(
-                SPAN, body, test_expr, &cx.ast,
+                source_span,
+                body,
+                test_expr,
+                &cx.ast,
             )))
         }
-        ReactiveTerminal::While { test, loop_block, .. } => {
+        ReactiveTerminal::While { test, loop_block, loop_block_span, .. } => {
             let test_expr = ox_codegen_instruction_value_to_expression(cx, test)?;
-            let body = ox_codegen_block_statement(cx, loop_block)?;
+            let body = ox_codegen_block_statement(cx, loop_block, *loop_block_span)?;
             let body = oxc::Statement::BlockStatement(body);
-            Ok(Some(oxc_ast::ast::Statement::new_while_statement(SPAN, test_expr, body, &cx.ast)))
+            Ok(Some(oxc_ast::ast::Statement::new_while_statement(
+                source_span,
+                test_expr,
+                body,
+                &cx.ast,
+            )))
         }
-        ReactiveTerminal::For { init, test, update, loop_block, .. } => {
+        ReactiveTerminal::For { init, test, update, loop_block, loop_block_span, .. } => {
             let init_val = ox_codegen_for_init(cx, init)?;
             let test_expr = ox_codegen_instruction_value_to_expression(cx, test)?;
             let update_expr = update
                 .as_ref()
                 .map(|u| ox_codegen_instruction_value_to_expression(cx, u))
                 .transpose()?;
-            let body = ox_codegen_block_statement(cx, loop_block)?;
+            let body = ox_codegen_block_statement(cx, loop_block, *loop_block_span)?;
             let body = oxc::Statement::BlockStatement(body);
             Ok(Some(oxc_ast::ast::Statement::new_for_statement(
-                SPAN,
+                source_span,
                 init_val,
                 Some(test_expr),
                 update_expr,
@@ -1014,32 +1090,45 @@ fn ox_codegen_terminal<'a>(
                 &cx.ast,
             )))
         }
-        ReactiveTerminal::ForIn { init, loop_block, span, .. } => {
-            ox_codegen_for_in(cx, init, loop_block, *span)
+        ReactiveTerminal::ForIn { init, loop_block, loop_block_span, left_span, span, .. } => {
+            ox_codegen_for_in(cx, init, loop_block, *span, *loop_block_span, *left_span)
         }
-        ReactiveTerminal::ForOf { init, test, loop_block, span, .. } => {
-            ox_codegen_for_of(cx, init, test, loop_block, *span)
-        }
-        ReactiveTerminal::Label { block, .. } => {
-            let body = ox_codegen_block_statement(cx, block)?;
+        ReactiveTerminal::ForOf {
+            init,
+            test,
+            loop_block,
+            loop_block_span,
+            left_span,
+            span,
+            ..
+        } => ox_codegen_for_of(cx, init, test, loop_block, *span, *loop_block_span, *left_span),
+        ReactiveTerminal::Label { block, block_span, .. } => {
+            let body = ox_codegen_block_statement(cx, block, *block_span)?;
             Ok(Some(oxc::Statement::BlockStatement(body)))
         }
-        ReactiveTerminal::Try { block, handler_binding, handler, .. } => {
+        ReactiveTerminal::Try {
+            block, block_span, handler_binding, handler, handler_span, ..
+        } => {
             let catch_param = match handler_binding.as_ref() {
                 Some(binding) => {
                     let ident = &cx.env.identifiers[binding.identifier];
                     cx.temp.insert(ident.declaration_id, None);
-                    let pattern = ox_binding_for_identifier(cx, binding.identifier)?;
-                    Some(oxc_ast::ast::CatchParameter::new(SPAN, pattern, None, &cx.ast))
+                    let pattern = ox_binding_for_identifier(cx, binding.identifier, binding.span)?;
+                    Some(oxc_ast::ast::CatchParameter::new(
+                        binding.span.unwrap_or_default(),
+                        pattern,
+                        None,
+                        &cx.ast,
+                    ))
                 }
                 None => None,
             };
-            let try_block = ox_codegen_block_statement(cx, block)?;
-            let handler_block = ox_codegen_block_statement(cx, handler)?;
+            let try_block = ox_codegen_block_statement(cx, block, *block_span)?;
+            let handler_block = ox_codegen_block_statement(cx, handler, *handler_span)?;
             let handler =
-                oxc_ast::ast::CatchClause::boxed(SPAN, catch_param, handler_block, &cx.ast);
+                oxc_ast::ast::CatchClause::boxed(source_span, catch_param, handler_block, &cx.ast);
             Ok(Some(oxc_ast::ast::Statement::new_try_statement(
-                SPAN,
+                source_span,
                 try_block,
                 Some(handler),
                 None,
@@ -1054,6 +1143,8 @@ fn ox_codegen_for_in<'a>(
     init: &ReactiveValue<'a>,
     loop_block: &ReactiveBlock<'a>,
     span: Option<Span>,
+    loop_block_span: Option<Span>,
+    left_span: Option<Span>,
 ) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     let ReactiveValue::SequenceExpression { instructions, .. } = init else {
         return Err(invariant_err("Expected a sequence expression init for for..in", None));
@@ -1067,15 +1158,24 @@ fn ox_codegen_for_in<'a>(
     let iterable_collection = &instructions[0];
     let iterable_item = &instructions[1];
     let instr_value = get_instruction_value(&iterable_item.value)?;
-    let (lval, var_decl_kind) = ox_extract_for_in_of_lval(cx, instr_value, "for..in", span)?;
+    let (lval, var_decl_kind) =
+        ox_extract_for_in_of_lval(cx, instr_value, "for..in", left_span, span)?;
     let right = ox_codegen_instruction_value_to_expression(cx, &iterable_collection.value)?;
-    let body = ox_codegen_block_statement(cx, loop_block)?;
+    let body = ox_codegen_block_statement(cx, loop_block, loop_block_span)?;
     let body = oxc::Statement::BlockStatement(body);
-    let declarator = oxc_ast::ast::VariableDeclarator::new(SPAN, lval, None, None, false, &cx.ast);
-    let decl =
-        oxc_ast::ast::VariableDeclaration::boxed(SPAN, var_decl_kind, [declarator], false, &cx.ast);
+    let source_span = span.unwrap_or_default();
+    let declaration_span = left_span.unwrap_or(source_span);
+    let declarator =
+        oxc_ast::ast::VariableDeclarator::new(declaration_span, lval, None, None, false, &cx.ast);
+    let decl = oxc_ast::ast::VariableDeclaration::boxed(
+        declaration_span,
+        var_decl_kind,
+        [declarator],
+        false,
+        &cx.ast,
+    );
     let left = oxc::ForStatementLeft::VariableDeclaration(decl);
-    Ok(Some(oxc_ast::ast::Statement::new_for_in_statement(SPAN, left, right, body, &cx.ast)))
+    Ok(Some(oxc_ast::ast::Statement::new_for_in_statement(source_span, left, right, body, &cx.ast)))
 }
 
 fn ox_codegen_for_of<'a>(
@@ -1084,6 +1184,8 @@ fn ox_codegen_for_of<'a>(
     test: &ReactiveValue<'a>,
     loop_block: &ReactiveBlock<'a>,
     span: Option<Span>,
+    loop_block_span: Option<Span>,
+    left_span: Option<Span>,
 ) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     let ReactiveValue::SequenceExpression { instructions: init_instrs, .. } = init else {
         return Err(invariant_err("Expected a sequence expression init for for..of", None));
@@ -1110,36 +1212,65 @@ fn ox_codegen_for_of<'a>(
     }
     let iterable_item = &test_instrs[1];
     let instr_value = get_instruction_value(&iterable_item.value)?;
-    let (lval, var_decl_kind) = ox_extract_for_in_of_lval(cx, instr_value, "for..of", span)?;
+    let (lval, var_decl_kind) =
+        ox_extract_for_in_of_lval(cx, instr_value, "for..of", left_span, span)?;
 
     let right = ox_codegen_place_to_expression(cx, collection)?;
-    let body = ox_codegen_block_statement(cx, loop_block)?;
+    let body = ox_codegen_block_statement(cx, loop_block, loop_block_span)?;
     let body = oxc::Statement::BlockStatement(body);
-    let declarator = oxc_ast::ast::VariableDeclarator::new(SPAN, lval, None, None, false, &cx.ast);
-    let decl =
-        oxc_ast::ast::VariableDeclaration::boxed(SPAN, var_decl_kind, [declarator], false, &cx.ast);
+    let source_span = span.unwrap_or_default();
+    let declaration_span = left_span.unwrap_or(source_span);
+    let declarator =
+        oxc_ast::ast::VariableDeclarator::new(declaration_span, lval, None, None, false, &cx.ast);
+    let decl = oxc_ast::ast::VariableDeclaration::boxed(
+        declaration_span,
+        var_decl_kind,
+        [declarator],
+        false,
+        &cx.ast,
+    );
     let left = oxc::ForStatementLeft::VariableDeclaration(decl);
-    Ok(Some(oxc_ast::ast::Statement::new_for_of_statement(SPAN, false, left, right, body, &cx.ast)))
+    Ok(Some(oxc_ast::ast::Statement::new_for_of_statement(
+        source_span,
+        false,
+        left,
+        right,
+        body,
+        &cx.ast,
+    )))
 }
 
 fn ox_extract_for_in_of_lval<'a>(
     cx: &mut OxcContext<'a, '_>,
     instr_value: &InstructionValue,
     context_name: &str,
-    span: Option<Span>,
+    lvalue_span: Option<Span>,
+    diagnostic_span: Option<Span>,
 ) -> Result<(oxc::BindingPattern<'a>, oxc::VariableDeclarationKind), OxcDiagnostic> {
     let (lval, kind) = match instr_value {
-        InstructionValue::StoreLocal { lvalue, .. } => {
-            (ox_codegen_lvalue(cx, &LvalueRef::Place(&lvalue.place), span)?, lvalue.kind)
-        }
-        InstructionValue::Destructure { lvalue, .. } => {
-            (ox_codegen_lvalue(cx, &LvalueRef::Pattern(&lvalue.pattern), span)?, lvalue.kind)
-        }
+        InstructionValue::StoreLocal { lvalue, .. } => (
+            ox_codegen_lvalue(
+                cx,
+                &LvalueRef::Place(&lvalue.place),
+                lvalue_span,
+                OxLvalueContext::Binding,
+            )?,
+            lvalue.kind,
+        ),
+        InstructionValue::Destructure { lvalue, .. } => (
+            ox_codegen_lvalue(
+                cx,
+                &LvalueRef::Pattern(&lvalue.pattern),
+                lvalue_span,
+                OxLvalueContext::Binding,
+            )?,
+            lvalue.kind,
+        ),
         InstructionValue::StoreContext { .. } => {
             cx.record_error(
                 ErrorCategory::Todo
                     .diagnostic(format!("Support non-trivial {} inits", context_name))
-                    .with_labels(span),
+                    .with_labels(diagnostic_span),
             )?;
             return Ok((
                 oxc_ast::ast::BindingPattern::new_binding_identifier(SPAN, "_", &cx.ast),
@@ -1229,8 +1360,9 @@ fn ox_codegen_for_init<'a>(
         if declarators.is_empty() {
             return Err(invariant_err("Expected a variable declaration in for-init", None));
         }
+        let span = declarators.first().unwrap().span.merge(declarators.last().unwrap().span);
         let decl =
-            oxc_ast::ast::VariableDeclaration::boxed(SPAN, kind, declarators, false, &cx.ast);
+            oxc_ast::ast::VariableDeclaration::boxed(span, kind, declarators, false, &cx.ast);
         Ok(Some(oxc::ForStatementInit::VariableDeclaration(decl)))
     } else {
         let expr = ox_codegen_instruction_value_to_expression(cx, init)?;
@@ -1245,9 +1377,6 @@ fn ox_codegen_for_init<'a>(
 // `codegen_store_or_declare`, `emit_store`, `codegen_instruction_value`,
 // `codegen_base_instruction_value`, `codegen_place`, `codegen_lvalue`,
 // `codegen_argument`, `codegen_dependency`) to build oxc nodes via `AstBuilder`.
-// The HIR-driven control flow is identical; only node construction differs. Since
-// oxc tracks positions by `Span` (not Babel-style locs), the per-node span
-// propagation (`apply_loc_to_value` / place-span overrides) collapses to `SPAN`.
 // =============================================================================
 
 fn ox_convert_value_to_expression<'a>(
@@ -1257,7 +1386,7 @@ fn ox_convert_value_to_expression<'a>(
     match value {
         OxValue::Expression(e) => e,
         OxValue::JsxText(text) => {
-            oxc_ast::ast::Expression::new_string_literal(SPAN, text.value.as_str(), None, ast)
+            oxc_ast::ast::Expression::new_string_literal(text.span, text.value.as_str(), None, ast)
         }
     }
 }
@@ -1285,7 +1414,10 @@ fn ox_codegen_instruction_nullable<'a>(
                 return Ok(None);
             }
             InstructionValue::Debugger { .. } => {
-                return Ok(Some(oxc_ast::ast::Statement::new_debugger_statement(SPAN, &cx.ast)));
+                return Ok(Some(oxc_ast::ast::Statement::new_debugger_statement(
+                    instr.span.unwrap_or_default(),
+                    &cx.ast,
+                )));
             }
             InstructionValue::ObjectMethod { span, .. } => {
                 invariant(
@@ -1301,7 +1433,8 @@ fn ox_codegen_instruction_nullable<'a>(
             _ => {}
         }
     }
-    let expr_value = ox_codegen_instruction_value(cx, &instr.value)?;
+    let mut expr_value = ox_codegen_instruction_value(cx, &instr.value)?;
+    ox_apply_span_to_value(&mut expr_value, instr.span);
     let stmt = ox_codegen_instruction(cx, instr, expr_value)?;
     if matches!(stmt, oxc::Statement::EmptyStatement(_)) { Ok(None) } else { Ok(Some(stmt)) }
 }
@@ -1363,11 +1496,17 @@ fn ox_emit_store<'a>(
                     instr.span,
                 ));
             }
-            let lval = ox_codegen_lvalue(cx, lvalue, instr.span)?;
-            Ok(Some(ox_make_var_decl(cx, oxc::VariableDeclarationKind::Const, lval, value)))
+            let lval = ox_codegen_lvalue(cx, lvalue, instr.span, OxLvalueContext::Binding)?;
+            Ok(Some(ox_make_var_decl(
+                cx,
+                oxc::VariableDeclarationKind::Const,
+                lval,
+                value,
+                instr.span,
+            )))
         }
         InstructionKind::Function => {
-            let lval = ox_codegen_lvalue(cx, lvalue, instr.span)?;
+            let lval = ox_codegen_lvalue(cx, lvalue, instr.span, OxLvalueContext::Binding)?;
             let oxc::BindingPattern::BindingIdentifier(fn_id) = lval else {
                 return Err(invariant_err(
                     "Expected an identifier as function declaration lvalue",
@@ -1384,7 +1523,7 @@ fn ox_emit_store<'a>(
                 oxc::Expression::FunctionExpression(func_expr) => {
                     let func_expr = func_expr.unbox();
                     let decl = oxc_ast::ast::Function::boxed(
-                        SPAN,
+                        instr.span.unwrap_or_default(),
                         oxc::FunctionType::FunctionDeclaration,
                         Some(fn_id.unbox()),
                         func_expr.generator,
@@ -1413,17 +1552,24 @@ fn ox_emit_store<'a>(
                     instr.span,
                 ));
             }
-            let lval = ox_codegen_lvalue(cx, lvalue, instr.span)?;
-            Ok(Some(ox_make_var_decl(cx, oxc::VariableDeclarationKind::Let, lval, value)))
+            let lval = ox_codegen_lvalue(cx, lvalue, instr.span, OxLvalueContext::Binding)?;
+            Ok(Some(ox_make_var_decl(
+                cx,
+                oxc::VariableDeclarationKind::Let,
+                lval,
+                value,
+                instr.span,
+            )))
         }
         InstructionKind::Reassign => {
             let Some(rhs) = value else {
                 return Err(invariant_err("Expected a value for reassignment", None));
             };
-            let lval = ox_codegen_lvalue(cx, lvalue, instr.span)?;
+            let lval =
+                ox_codegen_lvalue(cx, lvalue, instr.span, OxLvalueContext::AssignmentTarget)?;
             let target = ox_binding_pattern_to_assignment_target(cx, lval)?;
             let expr = oxc_ast::ast::Expression::new_assignment_expression(
-                SPAN,
+                instr.span.unwrap_or_default(),
                 oxc::AssignmentOperator::Assign,
                 target,
                 rhs,
@@ -1445,7 +1591,11 @@ fn ox_emit_store<'a>(
                 }
                 return Ok(Some(stmt));
             }
-            Ok(Some(oxc_ast::ast::Statement::new_expression_statement(SPAN, expr, &cx.ast)))
+            Ok(Some(oxc_ast::ast::Statement::new_expression_statement(
+                instr.span.unwrap_or_default(),
+                expr,
+                &cx.ast,
+            )))
         }
         InstructionKind::Catch => {
             Ok(Some(oxc_ast::ast::Statement::new_empty_statement(SPAN, &cx.ast)))
@@ -1465,10 +1615,12 @@ fn ox_make_var_decl<'a>(
     kind: oxc::VariableDeclarationKind,
     id: oxc::BindingPattern<'a>,
     init: Option<oxc::Expression<'a>>,
+    span: Option<Span>,
 ) -> oxc::Statement<'a> {
-    let declarator = oxc_ast::ast::VariableDeclarator::new(SPAN, id, None, init, false, &cx.ast);
+    let span = span.unwrap_or_default();
+    let declarator = oxc_ast::ast::VariableDeclarator::new(span, id, None, init, false, &cx.ast);
     oxc::Statement::VariableDeclaration(oxc_ast::ast::VariableDeclaration::boxed(
-        SPAN,
+        span,
         kind,
         [declarator],
         false,
@@ -1481,9 +1633,10 @@ fn ox_codegen_instruction<'a>(
     instr: &ReactiveInstruction<'a>,
     value: OxValue<'a>,
 ) -> Result<oxc::Statement<'a>, OxcDiagnostic> {
+    let span = instr.span.unwrap_or_default();
     let Some(ref lvalue) = instr.lvalue else {
         let expr = ox_convert_value_to_expression(&cx.ast, value);
-        return Ok(oxc_ast::ast::Statement::new_expression_statement(SPAN, expr, &cx.ast));
+        return Ok(oxc_ast::ast::Statement::new_expression_statement(span, expr, &cx.ast));
     };
     let ident = &cx.env.identifiers[lvalue.identifier];
     if ident.name.is_none() {
@@ -1494,23 +1647,29 @@ fn ox_codegen_instruction<'a>(
     let name = ox_identifier_name(cx.env, lvalue.identifier)?;
     if cx.has_declared(lvalue.identifier) {
         let target = oxc::AssignmentTarget::AssignmentTargetIdentifier(
-            oxc_ast::ast::IdentifierReference::boxed(SPAN, ox_str(&cx.ast, &name), &cx.ast),
+            oxc_ast::ast::IdentifierReference::boxed(span, ox_str(&cx.ast, &name), &cx.ast),
         );
         let expr = oxc_ast::ast::Expression::new_assignment_expression(
-            SPAN,
+            span,
             oxc::AssignmentOperator::Assign,
             target,
             expr_value,
             &cx.ast,
         );
-        Ok(oxc_ast::ast::Statement::new_expression_statement(SPAN, expr, &cx.ast))
+        Ok(oxc_ast::ast::Statement::new_expression_statement(span, expr, &cx.ast))
     } else {
         let id = oxc_ast::ast::BindingPattern::new_binding_identifier(
-            SPAN,
+            span,
             ox_str(&cx.ast, &name),
             &cx.ast,
         );
-        Ok(ox_make_var_decl(cx, oxc::VariableDeclarationKind::Const, id, Some(expr_value)))
+        Ok(ox_make_var_decl(
+            cx,
+            oxc::VariableDeclarationKind::Const,
+            id,
+            Some(expr_value),
+            instr.span,
+        ))
     }
 }
 
@@ -1535,16 +1694,18 @@ fn ox_codegen_instruction_value<'a>(
         ReactiveValue::LogicalExpression { operator, left, right, .. } => {
             let left_expr = ox_codegen_instruction_value_to_expression(cx, left)?;
             let right_expr = ox_codegen_instruction_value_to_expression(cx, right)?;
+            let span = left_expr.span().merge(right_expr.span());
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_logical_expression(
-                SPAN, left_expr, *operator, right_expr, &cx.ast,
+                span, left_expr, *operator, right_expr, &cx.ast,
             )))
         }
         ReactiveValue::ConditionalExpression { test, consequent, alternate, .. } => {
             let test_expr = ox_codegen_instruction_value_to_expression(cx, test)?;
             let cons_expr = ox_codegen_instruction_value_to_expression(cx, consequent)?;
             let alt_expr = ox_codegen_instruction_value_to_expression(cx, alternate)?;
+            let span = test_expr.span().merge(alt_expr.span());
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_conditional_expression(
-                SPAN, test_expr, cons_expr, alt_expr, &cx.ast,
+                span, test_expr, cons_expr, alt_expr, &cx.ast,
             )))
         }
         ReactiveValue::SequenceExpression { instructions, value, .. } => {
@@ -1558,6 +1719,7 @@ fn ox_codegen_instruction_value<'a>(
             let mut expressions: oxc_allocator::Vec<'a, oxc::Expression<'a>> =
                 oxc_allocator::ArenaVec::new_in(&cx.ast);
             for stmt in body {
+                let span = stmt.span();
                 match stmt {
                     oxc::Statement::ExpressionStatement(es) => {
                         expressions.push(es.unbox().expression);
@@ -1567,7 +1729,7 @@ fn ox_codegen_instruction_value<'a>(
                             "(CodegenReactiveFunction::codegenInstructionValue) Cannot declare variables in a value block",
                         ))?;
                         expressions.push(oxc_ast::ast::Expression::new_string_literal(
-                            SPAN,
+                            span,
                             "TODO handle declaration",
                             None,
                             &cx.ast,
@@ -1578,7 +1740,7 @@ fn ox_codegen_instruction_value<'a>(
                             "(CodegenReactiveFunction::codegenInstructionValue) Handle conversion of statement to expression",
                         ))?;
                         expressions.push(oxc_ast::ast::Expression::new_string_literal(
-                            SPAN,
+                            span,
                             "TODO handle statement",
                             None,
                             &cx.ast,
@@ -1591,8 +1753,10 @@ fn ox_codegen_instruction_value<'a>(
                 Ok(OxValue::Expression(final_expr))
             } else {
                 expressions.push(final_expr);
+                let span =
+                    expressions.first().unwrap().span().merge(expressions.last().unwrap().span());
                 Ok(OxValue::Expression(oxc_ast::ast::Expression::new_sequence_expression(
-                    SPAN,
+                    span,
                     expressions,
                     &cx.ast,
                 )))
@@ -1642,6 +1806,7 @@ fn ox_make_optional<'a>(
     expr: oxc::Expression<'a>,
     optional: bool,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
+    let span = expr.span();
     let chain_element: oxc::ChainElement<'a> = match expr {
         oxc::Expression::ChainExpression(chain) => {
             // Already a chain; update the optional flag on the head element.
@@ -1675,7 +1840,7 @@ fn ox_make_optional<'a>(
             let mut call = call.unbox();
             call.callee = ox_unwrap_chain(call.callee);
             oxc::ChainElement::CallExpression(oxc_ast::ast::CallExpression::boxed(
-                SPAN,
+                span,
                 call.callee,
                 call.type_arguments,
                 call.arguments,
@@ -1687,7 +1852,7 @@ fn ox_make_optional<'a>(
             let m = m.unbox();
             oxc::ChainElement::ComputedMemberExpression(
                 oxc_ast::ast::ComputedMemberExpression::boxed(
-                    SPAN,
+                    span,
                     ox_unwrap_chain(m.object),
                     m.expression,
                     optional,
@@ -1698,7 +1863,7 @@ fn ox_make_optional<'a>(
         oxc::Expression::StaticMemberExpression(m) => {
             let m = m.unbox();
             oxc::ChainElement::StaticMemberExpression(oxc_ast::ast::StaticMemberExpression::boxed(
-                SPAN,
+                span,
                 ox_unwrap_chain(m.object),
                 m.property,
                 optional,
@@ -1713,7 +1878,7 @@ fn ox_make_optional<'a>(
         }
     };
     Ok(OxValue::Expression(oxc_ast::ast::Expression::new_chain_expression(
-        SPAN,
+        span,
         chain_element,
         &cx.ast,
     )))
@@ -1723,21 +1888,22 @@ fn ox_codegen_base_instruction_value<'a>(
     cx: &mut OxcContext<'a, '_>,
     iv: &InstructionValue<'a>,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
+    let span = iv.span().copied().unwrap_or_default();
     match iv {
         InstructionValue::Primitive { value, .. } => {
-            Ok(OxValue::Expression(ox_codegen_primitive_value(&cx.ast, value)))
+            Ok(OxValue::Expression(ox_codegen_primitive_value(&cx.ast, value, span)))
         }
         InstructionValue::BinaryExpression { operator, left, right, .. } => {
             let left_expr = ox_codegen_place_to_expression(cx, left)?;
             let right_expr = ox_codegen_place_to_expression(cx, right)?;
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_binary_expression(
-                SPAN, left_expr, *operator, right_expr, &cx.ast,
+                span, left_expr, *operator, right_expr, &cx.ast,
             )))
         }
         InstructionValue::UnaryExpression { operator, value, .. } => {
             let arg = ox_codegen_place_to_expression(cx, value)?;
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_unary_expression(
-                SPAN,
+                span,
                 ox_convert_unary_operator(operator),
                 arg,
                 &cx.ast,
@@ -1748,12 +1914,13 @@ fn ox_codegen_base_instruction_value<'a>(
             Ok(OxValue::Expression(expr))
         }
         InstructionValue::LoadGlobal { binding, .. } => Ok(OxValue::Expression(
-            oxc_ast::ast::Expression::new_identifier(SPAN, binding.name(), &cx.ast),
+            oxc_ast::ast::Expression::new_identifier(span, binding.name(), &cx.ast),
         )),
         InstructionValue::CallExpression { callee, args, .. } => {
             let callee_expr = ox_codegen_place_to_expression(cx, callee)?;
             let arguments = ox_codegen_arguments(cx, args)?;
-            let call = ox_create_call_expression(cx, callee_expr, arguments, callee.identifier);
+            let call =
+                ox_create_call_expression(cx, callee_expr, arguments, callee.identifier, span);
             Ok(OxValue::Expression(call))
         }
         InstructionValue::MethodCall { property, args, .. } => {
@@ -1767,14 +1934,15 @@ fn ox_codegen_base_instruction_value<'a>(
                     .with_labels(property.span.map(|s| s.label(msg))));
             }
             let arguments = ox_codegen_arguments(cx, args)?;
-            let call = ox_create_call_expression(cx, member_expr, arguments, property.identifier);
+            let call =
+                ox_create_call_expression(cx, member_expr, arguments, property.identifier, span);
             Ok(OxValue::Expression(call))
         }
         InstructionValue::NewExpression { callee, args, .. } => {
             let callee_expr = ox_codegen_place_to_expression(cx, callee)?;
             let arguments = ox_codegen_arguments(cx, args)?;
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_new_expression(
-                SPAN,
+                span,
                 callee_expr,
                 None,
                 arguments,
@@ -1793,45 +1961,49 @@ fn ox_codegen_base_instruction_value<'a>(
                     ArrayElement::Spread(spread) => {
                         let arg = ox_codegen_place_to_expression(cx, &spread.place)?;
                         elems.push(oxc::ArrayExpressionElement::SpreadElement(
-                            oxc_ast::ast::SpreadElement::boxed(SPAN, arg, &cx.ast),
+                            oxc_ast::ast::SpreadElement::boxed(
+                                spread.span.or(spread.place.span).unwrap_or_default(),
+                                arg,
+                                &cx.ast,
+                            ),
                         ));
                     }
                     ArrayElement::Hole => {
                         elems
-                            .push(oxc_ast::ast::ArrayExpressionElement::new_elision(SPAN, &cx.ast));
+                            .push(oxc_ast::ast::ArrayExpressionElement::new_elision(span, &cx.ast));
                     }
                 }
             }
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_array_expression(
-                SPAN, elems, &cx.ast,
+                span, elems, &cx.ast,
             )))
         }
         InstructionValue::ObjectExpression { properties, .. } => {
-            ox_codegen_object_expression(cx, properties)
+            ox_codegen_object_expression(cx, properties, span)
         }
-        InstructionValue::PropertyLoad { object, property, .. } => {
+        InstructionValue::PropertyLoad { object, property, property_span, .. } => {
             let obj = ox_codegen_place_to_expression(cx, object)?;
-            let member = ox_property_member(cx, obj, property);
+            let member = ox_property_member(cx, obj, property, span, *property_span);
             Ok(OxValue::Expression(oxc::Expression::from(member)))
         }
-        InstructionValue::PropertyStore { object, property, value, .. } => {
+        InstructionValue::PropertyStore { object, property, property_span, value, .. } => {
             let obj = ox_codegen_place_to_expression(cx, object)?;
-            let member = ox_property_member(cx, obj, property);
+            let member = ox_property_member(cx, obj, property, span, *property_span);
             let val = ox_codegen_place_to_expression(cx, value)?;
             let target = oxc::AssignmentTarget::from(oxc::SimpleAssignmentTarget::from(member));
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_assignment_expression(
-                SPAN,
+                span,
                 oxc::AssignmentOperator::Assign,
                 target,
                 val,
                 &cx.ast,
             )))
         }
-        InstructionValue::PropertyDelete { object, property, .. } => {
+        InstructionValue::PropertyDelete { object, property, property_span, .. } => {
             let obj = ox_codegen_place_to_expression(cx, object)?;
-            let member = ox_property_member(cx, obj, property);
+            let member = ox_property_member(cx, obj, property, span, *property_span);
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_unary_expression(
-                SPAN,
+                span,
                 oxc::UnaryOperator::Delete,
                 oxc::Expression::from(member),
                 &cx.ast,
@@ -1841,7 +2013,7 @@ fn ox_codegen_base_instruction_value<'a>(
             let obj = ox_codegen_place_to_expression(cx, object)?;
             let prop = ox_codegen_place_to_expression(cx, property)?;
             let member = oxc_ast::ast::MemberExpression::new_computed_member_expression(
-                SPAN, obj, prop, false, &cx.ast,
+                span, obj, prop, false, &cx.ast,
             );
             Ok(OxValue::Expression(oxc::Expression::from(member)))
         }
@@ -1849,12 +2021,12 @@ fn ox_codegen_base_instruction_value<'a>(
             let obj = ox_codegen_place_to_expression(cx, object)?;
             let prop = ox_codegen_place_to_expression(cx, property)?;
             let member = oxc_ast::ast::MemberExpression::new_computed_member_expression(
-                SPAN, obj, prop, false, &cx.ast,
+                span, obj, prop, false, &cx.ast,
             );
             let val = ox_codegen_place_to_expression(cx, value)?;
             let target = oxc::AssignmentTarget::from(oxc::SimpleAssignmentTarget::from(member));
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_assignment_expression(
-                SPAN,
+                span,
                 oxc::AssignmentOperator::Assign,
                 target,
                 val,
@@ -1865,10 +2037,10 @@ fn ox_codegen_base_instruction_value<'a>(
             let obj = ox_codegen_place_to_expression(cx, object)?;
             let prop = ox_codegen_place_to_expression(cx, property)?;
             let member = oxc_ast::ast::MemberExpression::new_computed_member_expression(
-                SPAN, obj, prop, false, &cx.ast,
+                span, obj, prop, false, &cx.ast,
             );
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_unary_expression(
-                SPAN,
+                span,
                 oxc::UnaryOperator::Delete,
                 oxc::Expression::from(member),
                 &cx.ast,
@@ -1884,18 +2056,18 @@ fn ox_codegen_base_instruction_value<'a>(
                 flags: regex_flags,
             };
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_reg_exp_literal(
-                SPAN, regex, None, &cx.ast,
+                span, regex, None, &cx.ast,
             )))
         }
         InstructionValue::MetaProperty { meta, property, .. } => {
             debug_assert_eq!(meta.as_str(), "import");
             debug_assert_eq!(property.as_str(), "meta");
-            Ok(OxValue::Expression(oxc_ast::ast::Expression::new_import_meta(SPAN, &cx.ast)))
+            Ok(OxValue::Expression(oxc_ast::ast::Expression::new_import_meta(span, &cx.ast)))
         }
         InstructionValue::Await { value, .. } => {
             let arg = ox_codegen_place_to_expression(cx, value)?;
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_await_expression(
-                SPAN, arg, &cx.ast,
+                span, arg, &cx.ast,
             )))
         }
         InstructionValue::GetIterator { collection, .. } => {
@@ -1914,27 +2086,32 @@ fn ox_codegen_base_instruction_value<'a>(
             let arg = ox_codegen_place_to_expression(cx, lvalue)?;
             let target = ox_expression_to_simple_assignment_target(cx, arg)?;
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_update_expression(
-                SPAN, *operation, false, target, &cx.ast,
+                span, *operation, false, target, &cx.ast,
             )))
         }
         InstructionValue::PrefixUpdate { operation, lvalue, .. } => {
             let arg = ox_codegen_place_to_expression(cx, lvalue)?;
             let target = ox_expression_to_simple_assignment_target(cx, arg)?;
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_update_expression(
-                SPAN, *operation, true, target, &cx.ast,
+                span, *operation, true, target, &cx.ast,
             )))
         }
-        InstructionValue::StoreLocal { lvalue, value, span } => {
+        InstructionValue::StoreLocal { lvalue, value, span: instruction_span } => {
             invariant(
                 lvalue.kind == InstructionKind::Reassign,
                 "Unexpected StoreLocal in codegenInstructionValue",
                 None,
             )?;
-            let lval = ox_codegen_lvalue(cx, &LvalueRef::Place(&lvalue.place), *span)?;
+            let lval = ox_codegen_lvalue(
+                cx,
+                &LvalueRef::Place(&lvalue.place),
+                *instruction_span,
+                OxLvalueContext::AssignmentTarget,
+            )?;
             let target = ox_binding_pattern_to_assignment_target(cx, lval)?;
             let rhs = ox_codegen_place_to_expression(cx, value)?;
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_assignment_expression(
-                SPAN,
+                span,
                 oxc::AssignmentOperator::Assign,
                 target,
                 rhs,
@@ -1944,10 +2121,10 @@ fn ox_codegen_base_instruction_value<'a>(
         InstructionValue::StoreGlobal { name, value, .. } => {
             let rhs = ox_codegen_place_to_expression(cx, value)?;
             let target = oxc::AssignmentTarget::AssignmentTargetIdentifier(
-                oxc_ast::ast::IdentifierReference::boxed(SPAN, ox_str(&cx.ast, name), &cx.ast),
+                oxc_ast::ast::IdentifierReference::boxed(span, ox_str(&cx.ast, name), &cx.ast),
             );
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_assignment_expression(
-                SPAN,
+                span,
                 oxc::AssignmentOperator::Assign,
                 target,
                 rhs,
@@ -1955,18 +2132,33 @@ fn ox_codegen_base_instruction_value<'a>(
             )))
         }
         InstructionValue::FunctionExpression {
-            name, name_hint, lowered_func, expr_type, ..
-        } => ox_codegen_function_expression(cx, name, name_hint, lowered_func, expr_type),
-        InstructionValue::TaggedTemplateExpression { tag, quasis, subexprs, .. } => {
+            name,
+            name_span,
+            name_hint,
+            lowered_func,
+            expr_type,
+            ..
+        } => ox_codegen_function_expression(
+            cx,
+            name,
+            *name_span,
+            name_hint,
+            lowered_func,
+            expr_type,
+            span,
+        ),
+        InstructionValue::TaggedTemplateExpression {
+            tag, quasis, subexprs, quasi_span, ..
+        } => {
             let tag_expr = ox_codegen_place_to_expression(cx, tag)?;
             let mut exprs: oxc_allocator::Vec<'a, oxc::Expression<'a>> =
                 oxc_allocator::ArenaVec::new_in(&cx.ast);
             for p in subexprs {
                 exprs.push(ox_codegen_place_to_expression(cx, p)?);
             }
-            let quasi = ox_template_literal(cx, quasis, exprs);
+            let quasi = ox_template_literal(cx, quasis, exprs, quasi_span.unwrap_or_default());
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_tagged_template_expression(
-                SPAN, tag_expr, None, quasi, &cx.ast,
+                span, tag_expr, None, quasi, &cx.ast,
             )))
         }
         InstructionValue::TemplateLiteral { subexprs, quasis, .. } => {
@@ -1975,7 +2167,7 @@ fn ox_codegen_base_instruction_value<'a>(
             for p in subexprs {
                 exprs.push(ox_codegen_place_to_expression(cx, p)?);
             }
-            let template = ox_template_literal(cx, quasis, exprs);
+            let template = ox_template_literal(cx, quasis, exprs, span);
             Ok(OxValue::Expression(oxc::Expression::TemplateLiteral(
                 oxc_allocator::ArenaBox::new_in(template, &cx.ast),
             )))
@@ -1987,13 +2179,13 @@ fn ox_codegen_base_instruction_value<'a>(
             // re-wrap the inner expression, matching the baseline output.
             let wrapped = match cast {
                 TypeCast::Satisfies(ta) => oxc_ast::ast::Expression::new_ts_satisfies_expression(
-                    SPAN,
+                    span,
                     expr,
                     ox_reemit_ts_type(cx, ta),
                     &cx.ast,
                 ),
                 TypeCast::As(ta) => oxc_ast::ast::Expression::new_ts_as_expression(
-                    SPAN,
+                    span,
                     expr,
                     ox_reemit_ts_type(cx, ta),
                     &cx.ast,
@@ -2002,21 +2194,42 @@ fn ox_codegen_base_instruction_value<'a>(
             Ok(OxValue::Expression(wrapped))
         }
         InstructionValue::JSXText { value, .. } => Ok(OxValue::JsxText(
-            oxc_ast::ast::JSXText::boxed(SPAN, ox_str(&cx.ast, value), None, &cx.ast),
+            oxc_ast::ast::JSXText::boxed(span, ox_str(&cx.ast, value), None, &cx.ast),
         )),
-        InstructionValue::JsxExpression { tag, props, children, .. } => {
-            ox_codegen_jsx_expression(cx, tag, props, children)
-        }
-        InstructionValue::JsxFragment { children, .. } => {
+        InstructionValue::JsxExpression {
+            tag,
+            props,
+            children,
+            span,
+            opening_span,
+            opening_name_span,
+            closing_span,
+            closing_name_span,
+        } => ox_codegen_jsx_expression(
+            cx,
+            tag,
+            props,
+            children,
+            JsxSourceSpans {
+                element: *span,
+                opening: *opening_span,
+                opening_name: *opening_name_span,
+                closing: *closing_span,
+                closing_name: *closing_name_span,
+            },
+        ),
+        InstructionValue::JsxFragment { children, opening_span, closing_span, .. } => {
             let mut child_nodes: oxc_allocator::Vec<'a, oxc::JSXChild<'a>> =
                 oxc_allocator::ArenaVec::new_in(&cx.ast);
             for child in children {
                 child_nodes.push(ox_codegen_jsx_element(cx, child)?);
             }
-            let opening = oxc_ast::ast::JSXOpeningFragment::new(SPAN, &cx.ast);
-            let closing = oxc_ast::ast::JSXClosingFragment::new(SPAN, &cx.ast);
+            let opening =
+                oxc_ast::ast::JSXOpeningFragment::new(opening_span.unwrap_or(span), &cx.ast);
+            let closing =
+                oxc_ast::ast::JSXClosingFragment::new(closing_span.unwrap_or(span), &cx.ast);
             let fragment =
-                oxc_ast::ast::JSXFragment::new(SPAN, opening, child_nodes, closing, &cx.ast);
+                oxc_ast::ast::JSXFragment::new(span, opening, child_nodes, closing, &cx.ast);
             Ok(OxValue::Expression(oxc::Expression::JSXFragment(oxc_allocator::ArenaBox::new_in(
                 fragment, &cx.ast,
             ))))
@@ -2040,20 +2253,23 @@ fn ox_property_member<'a>(
     cx: &OxcContext<'a, '_>,
     object: oxc::Expression<'a>,
     property: &PropertyLiteral,
+    span: Span,
+    property_span: Option<Span>,
 ) -> oxc::MemberExpression<'a> {
+    let property_span = property_span.unwrap_or(span);
     match property {
         PropertyLiteral::String(s) => oxc_ast::ast::MemberExpression::new_static_member_expression(
-            SPAN,
+            span,
             object,
-            oxc_ast::ast::IdentifierName::new(SPAN, ox_str(&cx.ast, s), &cx.ast),
+            oxc_ast::ast::IdentifierName::new(property_span, ox_str(&cx.ast, s), &cx.ast),
             false,
             &cx.ast,
         ),
         PropertyLiteral::Number(n) => {
             oxc_ast::ast::MemberExpression::new_computed_member_expression(
-                SPAN,
+                span,
                 object,
-                ox_number(&cx.ast, n.value()),
+                ox_number(&cx.ast, n.value(), property_span),
                 false,
                 &cx.ast,
             )
@@ -2065,6 +2281,7 @@ fn ox_template_literal<'a>(
     cx: &OxcContext<'a, '_>,
     quasis: &[crate::react_compiler_hir::TemplateQuasi],
     expressions: oxc_allocator::Vec<'a, oxc::Expression<'a>>,
+    span: Span,
 ) -> oxc::TemplateLiteral<'a> {
     let mut quasi_vec: oxc_allocator::Vec<'a, oxc::TemplateElement<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
@@ -2074,9 +2291,9 @@ fn ox_template_literal<'a>(
             raw: ox_str(&cx.ast, &q.raw).into(),
             cooked: q.cooked.as_deref().map(|c| ox_str(&cx.ast, c).into()),
         };
-        quasi_vec.push(oxc_ast::ast::TemplateElement::new(SPAN, value, i == len - 1, &cx.ast));
+        quasi_vec.push(oxc_ast::ast::TemplateElement::new(q.span, value, i == len - 1, &cx.ast));
     }
-    oxc_ast::ast::TemplateLiteral::new(SPAN, quasi_vec, expressions, &cx.ast)
+    oxc_ast::ast::TemplateLiteral::new(span, quasi_vec, expressions, &cx.ast)
 }
 
 fn ox_codegen_arguments<'a>(
@@ -2102,7 +2319,9 @@ fn ox_codegen_argument<'a>(
         PlaceOrSpread::Spread(spread) => {
             let expr = ox_codegen_place_to_expression(cx, &spread.place)?;
             Ok(oxc::Argument::SpreadElement(oxc_ast::ast::SpreadElement::boxed(
-                SPAN, expr, &cx.ast,
+                spread.span.or(spread.place.span).unwrap_or_default(),
+                expr,
+                &cx.ast,
             )))
         }
     }
@@ -2165,7 +2384,7 @@ fn ox_codegen_place<'a>(
     }
     let name = ox_identifier_name(cx.env, place.identifier)?;
     Ok(OxValue::Expression(oxc_ast::ast::Expression::new_identifier(
-        place.span.unwrap_or(SPAN),
+        place.span.unwrap_or_default(),
         ox_str(&cx.ast, &name),
         &cx.ast,
     )))
@@ -2175,15 +2394,22 @@ fn ox_codegen_lvalue<'a>(
     cx: &mut OxcContext<'a, '_>,
     pattern: &LvalueRef,
     fallback_span: Option<Span>,
+    context: OxLvalueContext,
 ) -> Result<oxc::BindingPattern<'a>, OxcDiagnostic> {
     let (pattern, span) = match pattern {
         LvalueRef::Place(place) => {
-            (ox_binding_for_identifier(cx, place.identifier), place.span.or(fallback_span))
+            let span = ox_lvalue_identifier_span(cx, place, fallback_span, context);
+            (
+                ox_binding_for_identifier_at_span(cx, place.identifier, span.unwrap_or_default()),
+                span,
+            )
         }
         LvalueRef::Pattern(pat) => match pat {
-            Pattern::Array(arr) => (ox_codegen_array_pattern(cx, arr), arr.span.or(fallback_span)),
+            Pattern::Array(arr) => {
+                (ox_codegen_array_pattern(cx, arr, context), arr.span.or(fallback_span))
+            }
             Pattern::Object(obj) => {
-                (ox_codegen_object_pattern(cx, obj), obj.span.or(fallback_span))
+                (ox_codegen_object_pattern(cx, obj, context), obj.span.or(fallback_span))
             }
         },
     };
@@ -2194,9 +2420,29 @@ fn ox_codegen_lvalue<'a>(
     Ok(pattern)
 }
 
+#[derive(Clone, Copy)]
+enum OxLvalueContext {
+    Binding,
+    AssignmentTarget,
+}
+
+fn ox_lvalue_identifier_span(
+    cx: &OxcContext<'_, '_>,
+    place: &Place,
+    fallback_span: Option<Span>,
+    context: OxLvalueContext,
+) -> Option<Span> {
+    let declaration_span = cx.env.identifiers[place.identifier].span;
+    match context {
+        OxLvalueContext::Binding => declaration_span.or(place.span).or(fallback_span),
+        OxLvalueContext::AssignmentTarget => place.span.or(fallback_span).or(declaration_span),
+    }
+}
+
 fn ox_codegen_array_pattern<'a>(
     cx: &mut OxcContext<'a, '_>,
     pattern: &ArrayPattern,
+    context: OxLvalueContext,
 ) -> Result<oxc::BindingPattern<'a>, OxcDiagnostic> {
     let mut elements: oxc_allocator::Vec<'a, Option<oxc::BindingPattern<'a>>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
@@ -2204,23 +2450,43 @@ fn ox_codegen_array_pattern<'a>(
     for item in &pattern.items {
         match item {
             crate::react_compiler_hir::ArrayPatternElement::Place(place) => {
-                elements.push(Some(ox_binding_for_identifier(cx, place.identifier)?));
+                let span = ox_lvalue_identifier_span(cx, place, pattern.span, context);
+                elements.push(Some(ox_binding_for_identifier_at_span(
+                    cx,
+                    place.identifier,
+                    span.unwrap_or_default(),
+                )?));
             }
             crate::react_compiler_hir::ArrayPatternElement::Spread(spread) => {
-                let inner = ox_binding_for_identifier(cx, spread.place.identifier)?;
-                rest = Some(oxc_ast::ast::BindingRestElement::boxed(SPAN, inner, &cx.ast));
+                let span = ox_lvalue_identifier_span(cx, &spread.place, pattern.span, context);
+                let inner = ox_binding_for_identifier_at_span(
+                    cx,
+                    spread.place.identifier,
+                    span.unwrap_or_default(),
+                )?;
+                rest = Some(oxc_ast::ast::BindingRestElement::boxed(
+                    spread.span.or(spread.place.span).unwrap_or_default(),
+                    inner,
+                    &cx.ast,
+                ));
             }
             crate::react_compiler_hir::ArrayPatternElement::Hole => {
                 elements.push(None);
             }
         }
     }
-    Ok(oxc_ast::ast::BindingPattern::new_array_pattern(SPAN, elements, rest, &cx.ast))
+    Ok(oxc_ast::ast::BindingPattern::new_array_pattern(
+        pattern.span.unwrap_or_default(),
+        elements,
+        rest,
+        &cx.ast,
+    ))
 }
 
 fn ox_codegen_object_pattern<'a>(
     cx: &mut OxcContext<'a, '_>,
     pattern: &ObjectPattern,
+    context: OxLvalueContext,
 ) -> Result<oxc::BindingPattern<'a>, OxcDiagnostic> {
     let mut properties: oxc_allocator::Vec<'a, oxc::BindingProperty<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
@@ -2228,8 +2494,20 @@ fn ox_codegen_object_pattern<'a>(
     for prop in &pattern.properties {
         match prop {
             ObjectPropertyOrSpread::Property(obj_prop) => {
-                let (key, computed) = ox_codegen_object_property_key(cx, &obj_prop.key)?;
-                let value = ox_binding_for_identifier(cx, obj_prop.place.identifier)?;
+                let property_span = obj_prop
+                    .key
+                    .span()
+                    .or(obj_prop.place.span)
+                    .or(pattern.span)
+                    .unwrap_or_default();
+                let (key, computed) =
+                    ox_codegen_object_property_key(cx, &obj_prop.key, property_span)?;
+                let span = ox_lvalue_identifier_span(cx, &obj_prop.place, pattern.span, context);
+                let value = ox_binding_for_identifier_at_span(
+                    cx,
+                    obj_prop.place.identifier,
+                    span.unwrap_or_default(),
+                )?;
                 let shorthand = !computed
                     && matches!(
                         (&key, &value),
@@ -2239,38 +2517,59 @@ fn ox_codegen_object_pattern<'a>(
                         ) if k.name == v.name
                     );
                 properties.push(oxc_ast::ast::BindingProperty::new(
-                    SPAN, key, value, shorthand, computed, &cx.ast,
+                    obj_prop.place.span.unwrap_or_default(),
+                    key,
+                    value,
+                    shorthand,
+                    computed,
+                    &cx.ast,
                 ));
             }
             ObjectPropertyOrSpread::Spread(spread) => {
-                let inner = ox_binding_for_identifier(cx, spread.place.identifier)?;
-                rest = Some(oxc_ast::ast::BindingRestElement::boxed(SPAN, inner, &cx.ast));
+                let span = ox_lvalue_identifier_span(cx, &spread.place, pattern.span, context);
+                let inner = ox_binding_for_identifier_at_span(
+                    cx,
+                    spread.place.identifier,
+                    span.unwrap_or_default(),
+                )?;
+                rest = Some(oxc_ast::ast::BindingRestElement::boxed(
+                    spread.span.or(spread.place.span).unwrap_or_default(),
+                    inner,
+                    &cx.ast,
+                ));
             }
         }
     }
-    Ok(oxc_ast::ast::BindingPattern::new_object_pattern(SPAN, properties, rest, &cx.ast))
+    Ok(oxc_ast::ast::BindingPattern::new_object_pattern(
+        pattern.span.unwrap_or_default(),
+        properties,
+        rest,
+        &cx.ast,
+    ))
 }
 
 /// Build an object pattern key, returning `(key, computed)`.
 fn ox_codegen_object_property_key<'a>(
     cx: &mut OxcContext<'a, '_>,
     key: &ObjectPropertyKey,
+    span: Span,
 ) -> Result<(oxc::PropertyKey<'a>, bool), OxcDiagnostic> {
+    let span = key.span().unwrap_or(span);
     match key {
-        ObjectPropertyKey::String { name } => Ok((
+        ObjectPropertyKey::String { name, .. } => Ok((
             oxc::PropertyKey::from(oxc_ast::ast::Expression::new_string_literal(
-                SPAN,
+                span,
                 ox_str(&cx.ast, name),
                 None,
                 &cx.ast,
             )),
             false,
         )),
-        ObjectPropertyKey::Identifier { name } => Ok((
-            oxc_ast::ast::PropertyKey::new_static_identifier(SPAN, ox_str(&cx.ast, name), &cx.ast),
+        ObjectPropertyKey::Identifier { name, .. } => Ok((
+            oxc_ast::ast::PropertyKey::new_static_identifier(span, ox_str(&cx.ast, name), &cx.ast),
             false,
         )),
-        ObjectPropertyKey::Computed { name } => {
+        ObjectPropertyKey::Computed { name, .. } => {
             let expr = ox_codegen_place_to_expression(cx, name)?;
             Ok((oxc::PropertyKey::from(expr), true))
         }
@@ -2282,8 +2581,9 @@ fn ox_codegen_dependency<'a>(
     dep: &crate::react_compiler_hir::ReactiveScopeDependency,
 ) -> Result<oxc::Expression<'a>, OxcDiagnostic> {
     let name = ox_identifier_name(cx.env, dep.identifier)?;
+    let span = dep.span.unwrap_or_default();
     let mut object =
-        oxc_ast::ast::Expression::new_identifier(SPAN, ox_str(&cx.ast, &name), &cx.ast);
+        oxc_ast::ast::Expression::new_identifier(span, ox_str(&cx.ast, &name), &cx.ast);
     if !dep.path.is_empty() {
         let has_optional = dep.path.iter().any(|p| p.optional);
         // Build every member as a plain member expression carrying its own optional
@@ -2292,13 +2592,14 @@ fn ox_codegen_dependency<'a>(
         // plain members whose `optional` flags are preserved. Wrapping each step in
         // its own `ChainExpression` would force spurious parens such as `(((a.b)?.c).d)?.e`.
         for path_entry in &dep.path {
-            let member = ox_property_member(cx, object, &path_entry.property);
+            let member =
+                ox_property_member(cx, object, &path_entry.property, span, path_entry.span);
             object = match member {
                 oxc::MemberExpression::StaticMemberExpression(m) => {
                     let m = m.unbox();
                     oxc::Expression::StaticMemberExpression(
                         oxc_ast::ast::StaticMemberExpression::boxed(
-                            SPAN,
+                            span,
                             m.object,
                             m.property,
                             path_entry.optional,
@@ -2310,7 +2611,7 @@ fn ox_codegen_dependency<'a>(
                     let m = m.unbox();
                     oxc::Expression::ComputedMemberExpression(
                         oxc_ast::ast::ComputedMemberExpression::boxed(
-                            SPAN,
+                            span,
                             m.object,
                             m.expression,
                             path_entry.optional,
@@ -2338,7 +2639,7 @@ fn ox_codegen_dependency<'a>(
                 }
                 other => return Ok(other),
             };
-            object = oxc_ast::ast::Expression::new_chain_expression(SPAN, chain, &cx.ast);
+            object = oxc_ast::ast::Expression::new_chain_expression(span, chain, &cx.ast);
         }
     }
     Ok(object)
@@ -2359,10 +2660,11 @@ fn ox_binding_pattern_to_assignment_target<'a>(
     match pattern {
         oxc::BindingPattern::BindingIdentifier(id) => {
             let id = id.unbox();
-            Ok(oxc::AssignmentTarget::new_assignment_target_identifier(SPAN, id.name, &cx.ast))
+            Ok(oxc::AssignmentTarget::new_assignment_target_identifier(id.span, id.name, &cx.ast))
         }
         oxc::BindingPattern::ArrayPattern(arr) => {
             let arr = arr.unbox();
+            let span = arr.span;
             let mut elements: oxc_allocator::Vec<
                 'a,
                 Option<oxc::AssignmentTargetMaybeDefault<'a>>,
@@ -2374,17 +2676,18 @@ fn ox_binding_pattern_to_assignment_target<'a>(
                 }
             }
             let rest = ox_binding_rest_to_assignment_rest(cx, arr.rest)?;
-            Ok(oxc::AssignmentTarget::new_array_assignment_target(SPAN, elements, rest, &cx.ast))
+            Ok(oxc::AssignmentTarget::new_array_assignment_target(span, elements, rest, &cx.ast))
         }
         oxc::BindingPattern::ObjectPattern(obj) => {
             let obj = obj.unbox();
+            let span = obj.span;
             let mut properties: oxc_allocator::Vec<'a, oxc::AssignmentTargetProperty<'a>> =
                 oxc_allocator::ArenaVec::new_in(&cx.ast);
             for prop in obj.properties {
                 properties.push(ox_binding_property_to_assignment_property(cx, prop)?);
             }
             let rest = ox_binding_rest_to_assignment_rest(cx, obj.rest)?;
-            Ok(oxc::AssignmentTarget::new_object_assignment_target(SPAN, properties, rest, &cx.ast))
+            Ok(oxc::AssignmentTarget::new_object_assignment_target(span, properties, rest, &cx.ast))
         }
         // A top-level default (`x = 1`) is not a valid assignment target on its own;
         // defaults only appear nested and are handled by `ox_binding_pattern_to_maybe_default`.
@@ -2403,9 +2706,10 @@ fn ox_binding_pattern_to_maybe_default<'a>(
     match pattern {
         oxc::BindingPattern::AssignmentPattern(assign) => {
             let assign = assign.unbox();
+            let span = assign.span;
             let binding = ox_binding_pattern_to_assignment_target(cx, assign.left)?;
             Ok(oxc::AssignmentTargetMaybeDefault::new_assignment_target_with_default(
-                SPAN,
+                span,
                 binding,
                 assign.right,
                 &cx.ast,
@@ -2423,6 +2727,7 @@ fn ox_binding_property_to_assignment_property<'a>(
     cx: &OxcContext<'a, '_>,
     prop: oxc::BindingProperty<'a>,
 ) -> Result<oxc::AssignmentTargetProperty<'a>, OxcDiagnostic> {
+    let span = prop.span;
     if prop.shorthand {
         let (binding, init) = match prop.value {
             oxc::BindingPattern::BindingIdentifier(id) => (id.unbox(), None),
@@ -2443,14 +2748,14 @@ fn ox_binding_property_to_assignment_property<'a>(
                 ));
             }
         };
-        let reference = oxc_ast::ast::IdentifierReference::new(SPAN, binding.name, &cx.ast);
+        let reference = oxc_ast::ast::IdentifierReference::new(binding.span, binding.name, &cx.ast);
         return Ok(oxc::AssignmentTargetProperty::new_assignment_target_property_identifier(
-            SPAN, reference, init, &cx.ast,
+            span, reference, init, &cx.ast,
         ));
     }
     let binding = ox_binding_pattern_to_maybe_default(cx, prop.value)?;
     Ok(oxc::AssignmentTargetProperty::new_assignment_target_property_property(
-        SPAN,
+        span,
         prop.key,
         binding,
         prop.computed,
@@ -2465,8 +2770,10 @@ fn ox_binding_rest_to_assignment_rest<'a>(
 ) -> Result<Option<oxc_allocator::Box<'a, oxc::AssignmentTargetRest<'a>>>, OxcDiagnostic> {
     match rest {
         Some(rest) => {
-            let target = ox_binding_pattern_to_assignment_target(cx, rest.unbox().argument)?;
-            Ok(Some(oxc_ast::ast::AssignmentTargetRest::boxed(SPAN, target, &cx.ast)))
+            let rest = rest.unbox();
+            let span = rest.span;
+            let target = ox_binding_pattern_to_assignment_target(cx, rest.argument)?;
+            Ok(Some(oxc_ast::ast::AssignmentTargetRest::boxed(span, target, &cx.ast)))
         }
         None => Ok(None),
     }
@@ -2481,7 +2788,7 @@ fn ox_expression_to_simple_assignment_target<'a>(
         oxc::Expression::Identifier(id) => {
             let id = id.unbox();
             Ok(oxc::SimpleAssignmentTarget::AssignmentTargetIdentifier(
-                oxc_ast::ast::IdentifierReference::boxed(SPAN, id.name, &cx.ast),
+                oxc_ast::ast::IdentifierReference::boxed(id.span, id.name, &cx.ast),
             ))
         }
         oxc::Expression::StaticMemberExpression(m) => {
@@ -2501,9 +2808,11 @@ fn ox_expression_to_simple_assignment_target<'a>(
 fn ox_codegen_function_expression<'a>(
     cx: &mut OxcContext<'a, '_>,
     name: &Option<Ident<'a>>,
+    name_span: Option<Span>,
     name_hint: &Option<Ident<'a>>,
     lowered_func: &crate::react_compiler_hir::LoweredFunction,
     expr_type: &FunctionExpressionType,
+    span: Span,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
     let mut reactive_fn = build_reactive_function(&cx.env.functions[lowered_func.func], cx.env)?;
     prune_unused_labels(&mut reactive_fn, cx.env)?;
@@ -2534,21 +2843,27 @@ fn ox_codegen_function_expression<'a>(
                     fn_result.params,
                     oxc::ArrowFunctionBody::from(arg),
                     fn_result.is_async,
+                    span,
                 ),
                 None => ox_build_arrow(
                     cx,
                     fn_result.params,
                     oxc::ArrowFunctionBody::FunctionBody(fn_result.body),
                     fn_result.is_async,
+                    span,
                 ),
             }
         }
         _ => {
-            let id = name
-                .as_ref()
-                .map(|n| oxc_ast::ast::BindingIdentifier::new(SPAN, ox_str(&cx.ast, n), &cx.ast));
+            let id = name.as_ref().map(|n| {
+                oxc_ast::ast::BindingIdentifier::new(
+                    name_span.unwrap_or(span),
+                    ox_str(&cx.ast, n),
+                    &cx.ast,
+                )
+            });
             let func = oxc_ast::ast::Function::new(
-                SPAN,
+                span,
                 oxc::FunctionType::FunctionExpression,
                 id,
                 fn_result.generator,
@@ -2608,9 +2923,10 @@ fn ox_build_arrow<'a>(
     params: oxc_allocator::Box<'a, oxc::FormalParameters<'a>>,
     body: oxc::ArrowFunctionBody<'a>,
     is_async: bool,
+    span: Span,
 ) -> oxc::Expression<'a> {
     oxc_ast::ast::Expression::new_arrow_function_expression(
-        SPAN, is_async, None, params, None, body, &cx.ast,
+        span, is_async, None, params, None, body, &cx.ast,
     )
 }
 
@@ -2633,13 +2949,16 @@ fn ox_codegen_inner_function<'a>(
 fn ox_codegen_object_expression<'a>(
     cx: &mut OxcContext<'a, '_>,
     properties: &[ObjectPropertyOrSpread],
+    span: Span,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
     let mut props: oxc_allocator::Vec<'a, oxc::ObjectPropertyKind<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
     for prop in properties {
         match prop {
             ObjectPropertyOrSpread::Property(obj_prop) => {
-                let (key, key_computed) = ox_codegen_object_property_key(cx, &obj_prop.key)?;
+                let property_span = obj_prop.key.span().or(obj_prop.place.span).unwrap_or(span);
+                let (key, key_computed) =
+                    ox_codegen_object_property_key(cx, &obj_prop.key, property_span)?;
                 match obj_prop.property_type {
                     ObjectPropertyType::Property => {
                         let value = ox_codegen_place_to_expression(cx, &obj_prop.place)?;
@@ -2652,7 +2971,7 @@ fn ox_codegen_object_expression<'a>(
                                 ) if k.name == v.name
                             );
                         let p = oxc_ast::ast::ObjectProperty::new(
-                            SPAN,
+                            obj_prop.place.span.unwrap_or_default(),
                             oxc::PropertyKind::Init,
                             key,
                             value,
@@ -2683,7 +3002,7 @@ fn ox_codegen_object_expression<'a>(
 
                         let fn_result = ox_codegen_inner_function(cx, &reactive_fn)?;
                         let method = oxc_ast::ast::Function::new(
-                            SPAN,
+                            property_span,
                             oxc::FunctionType::FunctionExpression,
                             None,
                             fn_result.generator,
@@ -2700,7 +3019,7 @@ fn ox_codegen_object_expression<'a>(
                             oxc_allocator::ArenaBox::new_in(method, &cx.ast),
                         );
                         let p = oxc_ast::ast::ObjectProperty::new(
-                            SPAN,
+                            obj_prop.place.span.unwrap_or_default(),
                             oxc::PropertyKind::Init,
                             key,
                             func_expr,
@@ -2717,26 +3036,42 @@ fn ox_codegen_object_expression<'a>(
             }
             ObjectPropertyOrSpread::Spread(spread) => {
                 let arg = ox_codegen_place_to_expression(cx, &spread.place)?;
-                let spread_el = oxc_ast::ast::SpreadElement::new(SPAN, arg, &cx.ast);
+                let spread_el = oxc_ast::ast::SpreadElement::new(
+                    spread.span.or(spread.place.span).unwrap_or_default(),
+                    arg,
+                    &cx.ast,
+                );
                 props.push(oxc::ObjectPropertyKind::SpreadProperty(
                     oxc_allocator::ArenaBox::new_in(spread_el, &cx.ast),
                 ));
             }
         }
     }
-    Ok(OxValue::Expression(oxc_ast::ast::Expression::new_object_expression(SPAN, props, &cx.ast)))
+    Ok(OxValue::Expression(oxc_ast::ast::Expression::new_object_expression(span, props, &cx.ast)))
 }
 
 // =============================================================================
 // JSX codegen (oxc)
 // =============================================================================
 
+#[derive(Clone, Copy)]
+struct JsxSourceSpans {
+    element: Option<Span>,
+    opening: Option<Span>,
+    opening_name: Option<Span>,
+    closing: Option<Span>,
+    closing_name: Option<Span>,
+}
+
 fn ox_codegen_jsx_expression<'a>(
     cx: &mut OxcContext<'a, '_>,
     tag: &JsxTag,
     props: &[JsxAttribute],
     children: &Option<oxc_allocator::Vec<'a, Place>>,
+    spans: JsxSourceSpans,
 ) -> Result<OxValue<'a>, OxcDiagnostic> {
+    let opening_span = spans.opening.or(spans.element).unwrap_or_default();
+    let opening_name_span = spans.opening_name.unwrap_or(opening_span);
     let mut attributes: oxc_allocator::Vec<'a, oxc::JSXAttributeItem<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
     for attr in props {
@@ -2749,7 +3084,7 @@ fn ox_codegen_jsx_expression<'a>(
             let is_fbt = SINGLE_CHILD_FBT_TAGS.contains(&builtin.name.as_str());
             (
                 oxc_ast::ast::Expression::new_string_literal(
-                    SPAN,
+                    opening_name_span,
                     ox_str(&cx.ast, &builtin.name),
                     None,
                     &cx.ast,
@@ -2759,7 +3094,7 @@ fn ox_codegen_jsx_expression<'a>(
         }
     };
 
-    let opening_name = ox_expression_to_jsx_tag(cx, &tag_value)?;
+    let opening_name = ox_expression_to_jsx_tag(cx, &tag_value, opening_name_span)?;
 
     let mut child_nodes: oxc_allocator::Vec<'a, oxc::JSXChild<'a>> =
         oxc_allocator::ArenaVec::new_in(&cx.ast);
@@ -2774,15 +3109,28 @@ fn ox_codegen_jsx_expression<'a>(
     }
 
     let is_self_closing = children.is_none();
-    let opening =
-        oxc_ast::ast::JSXOpeningElement::boxed(SPAN, opening_name, None, attributes, &cx.ast);
+    let opening = oxc_ast::ast::JSXOpeningElement::boxed(
+        opening_span,
+        opening_name,
+        None,
+        attributes,
+        &cx.ast,
+    );
     let closing = if is_self_closing {
         None
     } else {
-        let closing_name = ox_expression_to_jsx_tag(cx, &tag_value)?;
-        Some(oxc_ast::ast::JSXClosingElement::boxed(SPAN, closing_name, &cx.ast))
+        let closing_span = spans.closing.or(spans.element).unwrap_or_default();
+        let closing_name_span = spans.closing_name.unwrap_or(closing_span);
+        let closing_name = ox_expression_to_jsx_tag(cx, &tag_value, closing_name_span)?;
+        Some(oxc_ast::ast::JSXClosingElement::boxed(closing_span, closing_name, &cx.ast))
     };
-    let element = oxc::Expression::new_jsx_element(SPAN, opening, child_nodes, closing, &cx.ast);
+    let element = oxc::Expression::new_jsx_element(
+        spans.element.unwrap_or_default(),
+        opening,
+        child_nodes,
+        closing,
+        &cx.ast,
+    );
     Ok(OxValue::Expression(element))
 }
 
@@ -2819,16 +3167,25 @@ fn ox_codegen_jsx_attribute<'a>(
     attr: &JsxAttribute,
 ) -> Result<oxc::JSXAttributeItem<'a>, OxcDiagnostic> {
     match attr {
-        JsxAttribute::Attribute { name, place } => {
+        JsxAttribute::Attribute { name, name_span, place } => {
+            let name_span = name_span.or(place.span).unwrap_or_default();
+            let value_span = place.span.unwrap_or(name_span);
+            let span = name_span.merge(value_span);
             let prop_name = if name.contains(':') {
                 let parts: Vec<&str> = name.splitn(2, ':').collect();
                 let namespace =
-                    oxc_ast::ast::JSXIdentifier::new(SPAN, ox_str(&cx.ast, parts[0]), &cx.ast);
+                    oxc_ast::ast::JSXIdentifier::new(name_span, ox_str(&cx.ast, parts[0]), &cx.ast);
                 let local =
-                    oxc_ast::ast::JSXIdentifier::new(SPAN, ox_str(&cx.ast, parts[1]), &cx.ast);
-                oxc_ast::ast::JSXAttributeName::new_namespaced_name(SPAN, namespace, local, &cx.ast)
+                    oxc_ast::ast::JSXIdentifier::new(name_span, ox_str(&cx.ast, parts[1]), &cx.ast);
+                oxc_ast::ast::JSXAttributeName::new_namespaced_name(
+                    name_span, namespace, local, &cx.ast,
+                )
             } else {
-                oxc_ast::ast::JSXAttributeName::new_identifier(SPAN, ox_str(&cx.ast, name), &cx.ast)
+                oxc_ast::ast::JSXAttributeName::new_identifier(
+                    name_span,
+                    ox_str(&cx.ast, name),
+                    &cx.ast,
+                )
             };
 
             let is_fbt_operand = cx.fbt_operands.contains(&place.identifier);
@@ -2839,21 +3196,25 @@ fn ox_codegen_jsx_attribute<'a>(
                 {
                     let value = s.value;
                     Some(oxc_ast::ast::JSXAttributeValue::new_string_literal(
-                        SPAN, value, None, &cx.ast,
+                        value_span, value, None, &cx.ast,
                     ))
                 }
                 _ => {
                     let expr = oxc::JSXExpression::from(inner_value);
                     Some(oxc_ast::ast::JSXAttributeValue::new_expression_container(
-                        SPAN, expr, &cx.ast,
+                        value_span, expr, &cx.ast,
                     ))
                 }
             };
-            Ok(oxc_ast::ast::JSXAttributeItem::new_attribute(SPAN, prop_name, attr_value, &cx.ast))
+            Ok(oxc_ast::ast::JSXAttributeItem::new_attribute(span, prop_name, attr_value, &cx.ast))
         }
-        JsxAttribute::SpreadAttribute { argument } => {
+        JsxAttribute::SpreadAttribute { argument, span } => {
             let expr = ox_codegen_place_to_expression(cx, argument)?;
-            Ok(oxc_ast::ast::JSXAttributeItem::new_spread_attribute(SPAN, expr, &cx.ast))
+            Ok(oxc_ast::ast::JSXAttributeItem::new_spread_attribute(
+                span.or(argument.span).unwrap_or_default(),
+                expr,
+                &cx.ast,
+            ))
         }
     }
 }
@@ -2865,28 +3226,29 @@ fn ox_codegen_jsx_element<'a>(
     let value = ox_codegen_place(cx, place)?;
     match value {
         OxValue::JsxText(text) => {
+            let span = text.span;
             let raw = text.value.as_str();
             if raw.contains(JSX_TEXT_CHILD_REQUIRES_EXPR_CONTAINER_PATTERN) {
                 let lit = oxc_ast::ast::Expression::new_string_literal(
-                    SPAN,
+                    span,
                     ox_str(&cx.ast, raw),
                     None,
                     &cx.ast,
                 );
                 Ok(oxc_ast::ast::JSXChild::new_expression_container(
-                    SPAN,
+                    span,
                     oxc::JSXExpression::from(lit),
                     &cx.ast,
                 ))
             } else {
                 let encoded = ox_encode_jsx_text(raw);
-                Ok(oxc_ast::ast::JSXChild::new_text(SPAN, ox_str(&cx.ast, &encoded), None, &cx.ast))
+                Ok(oxc_ast::ast::JSXChild::new_text(span, ox_str(&cx.ast, &encoded), None, &cx.ast))
             }
         }
         OxValue::Expression(oxc::Expression::JSXElement(elem)) => {
             let elem = elem.unbox();
             Ok(oxc_ast::ast::JSXChild::new_element(
-                SPAN,
+                elem.span,
                 elem.opening_element,
                 elem.children,
                 elem.closing_element,
@@ -2896,18 +3258,21 @@ fn ox_codegen_jsx_element<'a>(
         OxValue::Expression(oxc::Expression::JSXFragment(frag)) => {
             let frag = frag.unbox();
             Ok(oxc_ast::ast::JSXChild::new_fragment(
-                SPAN,
+                frag.span,
                 frag.opening_fragment,
                 frag.children,
                 frag.closing_fragment,
                 &cx.ast,
             ))
         }
-        OxValue::Expression(expr) => Ok(oxc_ast::ast::JSXChild::new_expression_container(
-            SPAN,
-            oxc::JSXExpression::from(expr),
-            &cx.ast,
-        )),
+        OxValue::Expression(expr) => {
+            let span = expr.span();
+            Ok(oxc_ast::ast::JSXChild::new_expression_container(
+                span,
+                oxc::JSXExpression::from(expr),
+                &cx.ast,
+            ))
+        }
     }
 }
 
@@ -2918,24 +3283,28 @@ fn ox_codegen_jsx_fbt_child_element<'a>(
     let value = ox_codegen_place(cx, place)?;
     match value {
         OxValue::JsxText(text) => {
+            let span = text.span;
             let encoded = ox_encode_jsx_text(text.value.as_str());
-            Ok(oxc_ast::ast::JSXChild::new_text(SPAN, ox_str(&cx.ast, &encoded), None, &cx.ast))
+            Ok(oxc_ast::ast::JSXChild::new_text(span, ox_str(&cx.ast, &encoded), None, &cx.ast))
         }
         OxValue::Expression(oxc::Expression::JSXElement(elem)) => {
             let elem = elem.unbox();
             Ok(oxc_ast::ast::JSXChild::new_element(
-                SPAN,
+                elem.span,
                 elem.opening_element,
                 elem.children,
                 elem.closing_element,
                 &cx.ast,
             ))
         }
-        OxValue::Expression(expr) => Ok(oxc_ast::ast::JSXChild::new_expression_container(
-            SPAN,
-            oxc::JSXExpression::from(expr),
-            &cx.ast,
-        )),
+        OxValue::Expression(expr) => {
+            let span = expr.span();
+            Ok(oxc_ast::ast::JSXChild::new_expression_container(
+                span,
+                oxc::JSXExpression::from(expr),
+                &cx.ast,
+            ))
+        }
     }
 }
 
@@ -2944,14 +3313,17 @@ fn ox_codegen_jsx_fbt_child_element<'a>(
 fn ox_expression_to_jsx_tag<'a>(
     cx: &OxcContext<'a, '_>,
     expr: &oxc::Expression<'a>,
+    span: Span,
 ) -> Result<oxc::JSXElementName<'a>, OxcDiagnostic> {
     match expr {
-        oxc::Expression::Identifier(ident) => Ok(ox_jsx_element_name_from_ident(cx, &ident.name)),
+        oxc::Expression::Identifier(ident) => {
+            Ok(ox_jsx_element_name_from_ident(cx, &ident.name, span))
+        }
         oxc::Expression::StaticMemberExpression(_)
         | oxc::Expression::ComputedMemberExpression(_) => {
-            let member = ox_convert_member_expression_to_jsx(cx, expr)?;
+            let member = ox_convert_member_expression_to_jsx(cx, expr, span)?;
             Ok(oxc_ast::ast::JSXElementName::new_member_expression(
-                SPAN, member.0, member.1, &cx.ast,
+                span, member.0, member.1, &cx.ast,
             ))
         }
         oxc::Expression::StringLiteral(s) => {
@@ -2959,14 +3331,14 @@ fn ox_expression_to_jsx_tag<'a>(
             if tag_text.contains(':') {
                 let parts: Vec<&str> = tag_text.splitn(2, ':').collect();
                 let namespace =
-                    oxc_ast::ast::JSXIdentifier::new(SPAN, ox_str(&cx.ast, parts[0]), &cx.ast);
+                    oxc_ast::ast::JSXIdentifier::new(span, ox_str(&cx.ast, parts[0]), &cx.ast);
                 let name =
-                    oxc_ast::ast::JSXIdentifier::new(SPAN, ox_str(&cx.ast, parts[1]), &cx.ast);
+                    oxc_ast::ast::JSXIdentifier::new(span, ox_str(&cx.ast, parts[1]), &cx.ast);
                 Ok(oxc_ast::ast::JSXElementName::new_namespaced_name(
-                    SPAN, namespace, name, &cx.ast,
+                    span, namespace, name, &cx.ast,
                 ))
             } else {
-                Ok(ox_jsx_element_name_from_ident(cx, tag_text))
+                Ok(ox_jsx_element_name_from_ident(cx, tag_text, span))
             }
         }
         _ => Err(invariant_err("Expected JSX tag to be an identifier or string", None)),
@@ -2976,12 +3348,13 @@ fn ox_expression_to_jsx_tag<'a>(
 fn ox_jsx_element_name_from_ident<'a>(
     cx: &OxcContext<'a, '_>,
     name: &str,
+    span: Span,
 ) -> oxc::JSXElementName<'a> {
     let first_char = name.chars().next().unwrap_or('a');
     if first_char.is_uppercase() || name.contains('.') {
-        oxc_ast::ast::JSXElementName::new_identifier_reference(SPAN, ox_str(&cx.ast, name), &cx.ast)
+        oxc_ast::ast::JSXElementName::new_identifier_reference(span, ox_str(&cx.ast, name), &cx.ast)
     } else {
-        oxc_ast::ast::JSXElementName::new_identifier(SPAN, ox_str(&cx.ast, name), &cx.ast)
+        oxc_ast::ast::JSXElementName::new_identifier(span, ox_str(&cx.ast, name), &cx.ast)
     }
 }
 
@@ -2990,24 +3363,25 @@ fn ox_jsx_element_name_from_ident<'a>(
 fn ox_convert_member_expression_to_jsx<'a>(
     cx: &OxcContext<'a, '_>,
     expr: &oxc::Expression<'a>,
+    span: Span,
 ) -> Result<(oxc::JSXMemberExpressionObject<'a>, oxc::JSXIdentifier<'a>), OxcDiagnostic> {
     let oxc::Expression::StaticMemberExpression(me) = expr else {
         return Err(invariant_err("Expected JSX member expression property to be a string", None));
     };
     let property =
-        oxc_ast::ast::JSXIdentifier::new(SPAN, ox_str(&cx.ast, me.property.name.as_str()), &cx.ast);
+        oxc_ast::ast::JSXIdentifier::new(span, ox_str(&cx.ast, me.property.name.as_str()), &cx.ast);
     let object = match &me.object {
         oxc::Expression::Identifier(ident) => {
             oxc_ast::ast::JSXMemberExpressionObject::new_identifier_reference(
-                SPAN,
+                span,
                 ox_str(&cx.ast, &ident.name),
                 &cx.ast,
             )
         }
         oxc::Expression::StaticMemberExpression(_) => {
-            let inner = ox_convert_member_expression_to_jsx(cx, &me.object)?;
+            let inner = ox_convert_member_expression_to_jsx(cx, &me.object, span)?;
             oxc_ast::ast::JSXMemberExpressionObject::new_member_expression(
-                SPAN, inner.0, inner.1, &cx.ast,
+                span, inner.0, inner.1, &cx.ast,
             )
         }
         _ => {
@@ -3040,7 +3414,7 @@ fn ox_dispatcher_guard_stmt<'a>(
         SPAN,
         oxc_ast::ast::Expression::new_identifier(SPAN, guard_name, ast),
         None,
-        [oxc_ast::ast::Argument::from(ox_number(ast, kind as u8 as f64))],
+        [oxc_ast::ast::Argument::from(ox_number(ast, kind as u8 as f64, SPAN))],
         false,
         ast,
     );
@@ -3079,10 +3453,11 @@ fn ox_create_call_expression<'a>(
     callee: oxc::Expression<'a>,
     arguments: oxc_allocator::ArenaVec<'a, oxc::Argument<'a>>,
     callee_id: IdentifierId,
+    span: Span,
 ) -> oxc::Expression<'a> {
     let ast = &cx.ast;
     let call_expr =
-        oxc_ast::ast::Expression::new_call_expression(SPAN, callee, None, arguments, false, ast);
+        oxc_ast::ast::Expression::new_call_expression(span, callee, None, arguments, false, ast);
     // The hook-kind lookup only runs with guards enabled, keeping the default
     // codegen path free of per-call shape probing.
     let Some(guard_name) = cx.env.hook_guard_name.as_deref() else {
@@ -3157,41 +3532,42 @@ fn ox_convert_unary_operator(op: &crate::react_compiler_hir::UnaryOperator) -> o
 fn ox_codegen_primitive_value<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
     value: &PrimitiveValue,
+    span: Span,
 ) -> oxc::Expression<'a> {
     match value {
         PrimitiveValue::Number(n) => {
             let f = n.value();
             if f.is_nan() {
-                oxc_ast::ast::Expression::new_identifier(SPAN, "NaN", ast)
+                oxc_ast::ast::Expression::new_identifier(span, "NaN", ast)
             } else if f.is_infinite() {
                 if f > 0.0 {
-                    oxc_ast::ast::Expression::new_identifier(SPAN, "Infinity", ast)
+                    oxc_ast::ast::Expression::new_identifier(span, "Infinity", ast)
                 } else {
                     oxc_ast::ast::Expression::new_unary_expression(
-                        SPAN,
+                        span,
                         oxc::UnaryOperator::UnaryNegation,
-                        oxc_ast::ast::Expression::new_identifier(SPAN, "Infinity", ast),
+                        oxc_ast::ast::Expression::new_identifier(span, "Infinity", ast),
                         ast,
                     )
                 }
             } else if f < 0.0 {
                 oxc_ast::ast::Expression::new_unary_expression(
-                    SPAN,
+                    span,
                     oxc::UnaryOperator::UnaryNegation,
-                    ox_number(ast, -f),
+                    ox_number(ast, -f, span),
                     ast,
                 )
             } else {
-                ox_number(ast, f)
+                ox_number(ast, f, span)
             }
         }
-        PrimitiveValue::Boolean(b) => oxc_ast::ast::Expression::new_boolean_literal(SPAN, *b, ast),
+        PrimitiveValue::Boolean(b) => oxc_ast::ast::Expression::new_boolean_literal(span, *b, ast),
         PrimitiveValue::String(s) => {
-            oxc_ast::ast::Expression::new_string_literal(SPAN, ox_str(ast, s.as_str()), None, ast)
+            oxc_ast::ast::Expression::new_string_literal(span, ox_str(ast, s.as_str()), None, ast)
         }
-        PrimitiveValue::Null => oxc_ast::ast::Expression::new_null_literal(SPAN, ast),
+        PrimitiveValue::Null => oxc_ast::ast::Expression::new_null_literal(span, ast),
         PrimitiveValue::Undefined => {
-            oxc_ast::ast::Expression::new_identifier(SPAN, "undefined", ast)
+            oxc_ast::ast::Expression::new_identifier(span, "undefined", ast)
         }
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
@@ -124,7 +124,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                 existing.clone()
             } else {
                 // Create a new early return identifier
-                let identifier_id = create_temporary_place_id(self.env, span);
+                let identifier_id = create_generated_temporary_place_id(self.env);
                 promote_temporary(self.env, identifier_id);
                 let label = self.env.next_block_id();
                 EarlyReturnInfo { value: identifier_id, span, label }
@@ -164,6 +164,7 @@ impl<'a, 'e> ReactiveFunctionTransform<'a> for Transform<'a, 'e> {
                             target_kind: ReactiveTerminalTargetKind::Labeled,
                         },
                         label: None,
+                        span: span.unwrap_or_default(),
                     },
                     &alloc,
                 )),
@@ -186,7 +187,6 @@ fn apply_early_return_to_scope<'a>(
     early_return: &EarlyReturnInfo,
 ) {
     let scope_id = scope_block.scope;
-    let span = early_return.span;
 
     // Set early return value on the scope
     env.scopes[scope_id].early_return_value = Some(ReactiveScopeEarlyReturn {
@@ -202,10 +202,10 @@ fn apply_early_return_to_scope<'a>(
     ));
 
     // Create temporary places for the sentinel initialization
-    let sentinel_temp = create_temporary_place_id(env, span);
-    let symbol_temp = create_temporary_place_id(env, span);
-    let for_temp = create_temporary_place_id(env, span);
-    let arg_temp = create_temporary_place_id(env, span);
+    let sentinel_temp = create_generated_temporary_place_id(env);
+    let symbol_temp = create_generated_temporary_place_id(env);
+    let for_temp = create_generated_temporary_place_id(env);
+    let arg_temp = create_generated_temporary_place_id(env);
 
     let alloc = env.allocator;
     let original_instructions = replace(&mut scope_block.instructions, ArenaVec::new_in(&alloc));
@@ -223,9 +223,9 @@ fn apply_early_return_to_scope<'a>(
                 }),
                 value: ReactiveValue::Instruction(InstructionValue::LoadGlobal {
                     binding: NonLocalBinding::Global { name: Ident::from("Symbol") },
-                    span,
+                    span: None,
                 }),
-                span,
+                span: None,
             }),
             // PropertyLoad Symbol.for
             ReactiveStatement::Instruction(ReactiveInstruction {
@@ -244,9 +244,10 @@ fn apply_early_return_to_scope<'a>(
                         span: None, // GeneratedSource
                     },
                     property: PropertyLiteral::String(Ident::from("for")),
-                    span,
+                    property_span: None,
+                    span: None,
                 }),
-                span,
+                span: None,
             }),
             // Primitive: the sentinel string
             ReactiveStatement::Instruction(ReactiveInstruction {
@@ -259,9 +260,9 @@ fn apply_early_return_to_scope<'a>(
                 }),
                 value: ReactiveValue::Instruction(InstructionValue::Primitive {
                     value: PrimitiveValue::String(EARLY_RETURN_SENTINEL.into()),
-                    span,
+                    span: None,
                 }),
-                span,
+                span: None,
             }),
             // MethodCall: Symbol.for("react.early_return_sentinel")
             ReactiveStatement::Instruction(ReactiveInstruction {
@@ -294,9 +295,9 @@ fn apply_early_return_to_scope<'a>(
                         })],
                         &alloc,
                     ),
-                    span,
+                    span: None,
                 }),
-                span,
+                span: None,
             }),
             // StoreLocal: let earlyReturnValue = sentinel
             ReactiveStatement::Instruction(ReactiveInstruction {
@@ -309,7 +310,7 @@ fn apply_early_return_to_scope<'a>(
                             identifier: early_return.value,
                             effect: Effect::ConditionallyMutate,
                             reactive: true,
-                            span,
+                            span: None,
                         },
                     },
                     value: Place {
@@ -318,9 +319,9 @@ fn apply_early_return_to_scope<'a>(
                         reactive: false,
                         span: None, // GeneratedSource
                     },
-                    span,
+                    span: None,
                 }),
-                span,
+                span: None,
             }),
             // Label terminal wrapping the original instructions
             ReactiveStatement::Terminal(ArenaBox::new_in(
@@ -328,8 +329,10 @@ fn apply_early_return_to_scope<'a>(
                     label: Some(ReactiveLabel { id: early_return.label, implicit: false }),
                     terminal: ReactiveTerminal::Label {
                         block: original_instructions,
+                        block_span: None,
                         id: EvaluationOrder::UNSET,
                     },
+                    span: Span::default(),
                 },
                 &alloc,
             )),
@@ -342,10 +345,8 @@ fn apply_early_return_to_scope<'a>(
 // Helper: create a temporary place identifier
 // =============================================================================
 
-fn create_temporary_place_id(env: &mut Environment, span: Option<Span>) -> IdentifierId {
-    let id = env.next_identifier_id();
-    env.identifiers[id].span = span;
-    id
+fn create_generated_temporary_place_id(env: &mut Environment) -> IdentifierId {
+    env.next_identifier_id()
 }
 
 fn promote_temporary<'a>(env: &mut Environment<'a>, identifier_id: IdentifierId) {

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
@@ -308,6 +308,7 @@ fn enter_ssa_impl<'a>(
                     ParamPattern::Place(p) => ParamPattern::Place(builder.define_place(&p, env)?),
                     ParamPattern::Spread(s) => ParamPattern::Spread(SpreadPattern {
                         place: builder.define_place(&s.place, env)?,
+                        span: s.span,
                     }),
                 });
             }
@@ -399,6 +400,7 @@ fn enter_ssa_impl<'a>(
                         }
                         ParamPattern::Spread(s) => ParamPattern::Spread(SpreadPattern {
                             place: builder.define_place(&s.place, env)?,
+                            span: s.span,
                         }),
                     });
                 }
@@ -456,7 +458,9 @@ fn enter_ssa_impl<'a>(
 pub fn placeholder_function<'a>(alloc: &'a Allocator) -> HirFunction<'a> {
     HirFunction {
         span: None,
+        body_span: None,
         id: None,
+        id_span: None,
         name_hint: None,
         fn_type: ReactFunctionType::Other,
         params: ArenaVec::new_in(&alloc),

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -575,7 +575,7 @@ fn generate_instruction_types<'a>(
         InstructionValue::ObjectExpression { properties, .. } => {
             for prop in properties {
                 if let ObjectPropertyOrSpread::Property(obj_prop) = prop
-                    && let ObjectPropertyKey::Computed { name } = &obj_prop.key
+                    && let ObjectPropertyKey::Computed { name, .. } = &obj_prop.key
                 {
                     let name_type = get_type(name.identifier, identifiers);
                     unifier.unify(name_type, Type::Primitive, shapes)?;
@@ -671,8 +671,8 @@ fn generate_instruction_types<'a>(
                 for prop in &object_pattern.properties {
                     if let ObjectPropertyOrSpread::Property(obj_prop) = prop {
                         match &obj_prop.key {
-                            ObjectPropertyKey::Identifier { name }
-                            | ObjectPropertyKey::String { name } => {
+                            ObjectPropertyKey::Identifier { name, .. }
+                            | ObjectPropertyKey::String { name, .. } => {
                                 let prop_place_type =
                                     get_type(obj_prop.place.identifier, identifiers);
                                 let value_type = get_type(value.identifier, identifiers);
@@ -757,7 +757,7 @@ fn generate_instruction_types<'a>(
         InstructionValue::JsxExpression { props, .. } => {
             if unifier.enable_treat_ref_like_identifiers_as_refs {
                 for prop in props {
-                    if let JsxAttribute::Attribute { name, place } = prop
+                    if let JsxAttribute::Attribute { name, place, .. } = prop
                         && name == "ref"
                     {
                         let ref_type = get_type(place.identifier, identifiers);
@@ -1062,7 +1062,7 @@ fn apply_instruction_operands<'a>(
                 match prop {
                     ObjectPropertyOrSpread::Property(obj_prop) => {
                         resolve_identifier(obj_prop.place.identifier, identifiers, types, unifier);
-                        if let ObjectPropertyKey::Computed { name } = &obj_prop.key {
+                        if let ObjectPropertyKey::Computed { name, .. } = &obj_prop.key {
                             resolve_identifier(name.identifier, identifiers, types, unifier);
                         }
                     }
@@ -1094,7 +1094,7 @@ fn apply_instruction_operands<'a>(
                     JsxAttribute::Attribute { place, .. } => {
                         resolve_identifier(place.identifier, identifiers, types, unifier);
                     }
-                    JsxAttribute::SpreadAttribute { argument } => {
+                    JsxAttribute::SpreadAttribute { argument, .. } => {
                         resolve_identifier(argument.identifier, identifiers, types, unifier);
                     }
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -664,7 +664,7 @@ fn collect_dependencies<'a>(
                         }
                     }
                 }
-                InstructionValue::PropertyLoad { object, property, .. } => {
+                InstructionValue::PropertyLoad { object, property, property_span, .. } => {
                     // Number properties or ref.current: visit the object directly
                     let is_numeric = matches!(property, PropertyLiteral::Number(_));
                     let is_ref_current =
@@ -689,7 +689,7 @@ fn collect_dependencies<'a>(
                             new_path.push(DependencyPathEntry {
                                 optional,
                                 property: *property,
-                                span: instr.value.span().copied(),
+                                span: property_span.or_else(|| instr.value.span().copied()),
                             });
                             temporaries.insert(
                                 lvalue_id,

--- a/crates/oxc_react_compiler/tests/snapshots/gating__gating-preserves-function-properties.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/gating__gating-preserves-function-properties.snap
@@ -4,6 +4,7 @@ input_file: crates/oxc_react_compiler/fixtures/gating/gating-preserves-function-
 ---
 import { c as _c } from "react/compiler-runtime";
 import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag";
+// @gating
 const Component = isForgetEnabled_Fixtures() ? function Component() {
 	const $ = _c(1);
 	let t0;

--- a/crates/oxc_react_compiler/tests/snapshots/gating__gating-test-export-default-function.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/gating__gating-test-export-default-function.snap
@@ -4,6 +4,7 @@ input_file: crates/oxc_react_compiler/fixtures/gating/gating-test-export-default
 ---
 import { c as _c } from "react/compiler-runtime";
 import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag";
+// @gating @compilationMode:"annotation"
 const Bar = isForgetEnabled_Fixtures() ? function Bar(props) {
 	"use forget";
 	const $ = _c(2);

--- a/crates/oxc_react_compiler/tests/snapshots/gating__gating-test-export-function-and-default.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/gating__gating-test-export-function-and-default.snap
@@ -4,6 +4,7 @@ input_file: crates/oxc_react_compiler/fixtures/gating/gating-test-export-functio
 ---
 import { c as _c } from "react/compiler-runtime";
 import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag";
+// @gating @compilationMode:"annotation"
 const Bar = isForgetEnabled_Fixtures() ? function Bar(props) {
 	"use forget";
 	const $ = _c(2);

--- a/crates/oxc_react_compiler/tests/snapshots/gating__gating-test-export-function.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/gating__gating-test-export-function.snap
@@ -4,6 +4,7 @@ input_file: crates/oxc_react_compiler/fixtures/gating/gating-test-export-functio
 ---
 import { c as _c } from "react/compiler-runtime";
 import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag";
+// @gating @compilationMode:"annotation"
 export const Bar = isForgetEnabled_Fixtures() ? function Bar(props) {
 	"use forget";
 	const $ = _c(2);


### PR DESCRIPTION
React Compiler rebuilt source-derived AST nodes with empty spans, so compiled function bodies had no useful source mappings. Preserve retained HIR and reactive spans during codegen while keeping synthetic memoization scaffolding unmapped.

AI-assisted: implementation used Codex; the author remains responsible for review.