### PR TITLE
fix(react-compiler): compile parenthesized arrow components

### DIFF
--- a/crates/oxc_react_compiler/fixtures/infer-component-doubly-parenthesized-arrow.tsx
+++ b/crates/oxc_react_compiler/fixtures/infer-component-doubly-parenthesized-arrow.tsx
@@ -1,0 +1,5 @@
+type Props = { original: string };
+
+export const DiffEditor = (({ original }: Props) => {
+  return <div>{original}</div>;
+});

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -1531,11 +1531,11 @@ impl<'a, 'b, 'ast> DiscoveryWalker<'a, 'b, 'ast> {
 
     fn walk_variable_declaration(&mut self, decl: &'b VariableDeclaration<'ast>) {
         for declarator in &decl.declarations {
-            // Only infer the declarator name when the init is a direct function
-            // expression, arrow, or call expression (for forwardRef/memo wrappers).
+            // Ignore parenthesis nodes when deciding whether the declarator name
+            // flows into a function or forwardRef/memo wrapper.
             if let Some(init) = &declarator.init {
                 if matches!(
-                    init,
+                    init.without_parentheses(),
                     Expression::FunctionExpression(_)
                         | Expression::ArrowFunctionExpression(_)
                         | Expression::CallExpression(_)
@@ -2016,15 +2016,16 @@ fn has_wrapper_callee_reference(scoping: &Scoping, nodes: &AstNodes, symbol_id: 
     })
 }
 
-/// The `const Foo = <fn>` name for a function/arrow node, iff the declarator's
-/// init is directly this node — the same direct-init rule the discovery walker
-/// applies. A function whose direct parent is the declarator can only be its
-/// init (wrappers like parens or TS casts introduce an intermediate parent and
-/// break the inference there too).
-fn declarator_name_for<'a>(nodes: &AstNodes<'a>, node_id: NodeId) -> Option<&'a str> {
-    match nodes.parent_kind(node_id) {
-        AstKind::VariableDeclarator(decl) => get_declarator_name(decl),
-        _ => None,
+/// The `const Foo = <fn>` name for a function/arrow node, ignoring any parenthesis
+/// nodes between the function and declarator.
+fn declarator_name_for<'a>(nodes: &AstNodes<'a>, mut node_id: NodeId) -> Option<&'a str> {
+    loop {
+        let parent = nodes.parent_node(node_id);
+        match parent.kind() {
+            AstKind::ParenthesizedExpression(_) => node_id = parent.id(),
+            AstKind::VariableDeclarator(decl) => return get_declarator_name(decl),
+            _ => return None,
+        }
     }
 }
 

--- a/crates/oxc_react_compiler/tests/snapshots/infer-component-doubly-parenthesized-arrow.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/infer-component-doubly-parenthesized-arrow.snap
@@ -1,0 +1,21 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/infer-component-doubly-parenthesized-arrow.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+type Props = {
+	original: string;
+};
+export const DiffEditor = ((t0) => {
+	const $ = _c(2);
+	const { original } = t0;
+	let t1;
+	if ($[0] !== original) {
+		t1 = <div>{original}</div>;
+		$[0] = original;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	return t1;
+});


### PR DESCRIPTION
Compile parenthesized arrow components by preserving declarator name inference through nested parentheses.

Adds a React Compiler fixture for the ecosystem reproduction.

Created with assistance from Codex.