### PR TITLE
fix(react-compiler): compile forwardRef callbacks with non-ref param names

### DIFF
--- a/crates/oxc_react_compiler/fixtures/infer-forwardref-callback-with-non-ref-param.tsx
+++ b/crates/oxc_react_compiler/fixtures/infer-forwardref-callback-with-non-ref-param.tsx
@@ -1,0 +1,12 @@
+// @compilationMode:"infer"
+import { forwardRef } from 'react';
+
+type Props = { text: string };
+
+const TopStoriesItem = forwardRef<HTMLDivElement, Props>(
+  ({ text }, viewTracker) => {
+    return <div ref={viewTracker}>{text}</div>;
+  },
+);
+
+export default TopStoriesItem;

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -1532,13 +1532,11 @@ impl<'a, 'b, 'ast> DiscoveryWalker<'a, 'b, 'ast> {
     fn walk_variable_declaration(&mut self, decl: &'b VariableDeclaration<'ast>) {
         for declarator in &decl.declarations {
             // Ignore parenthesis nodes when deciding whether the declarator name
-            // flows into a function or forwardRef/memo wrapper.
+            // flows into a function expression.
             if let Some(init) = &declarator.init {
                 if matches!(
                     init.without_parentheses(),
-                    Expression::FunctionExpression(_)
-                        | Expression::ArrowFunctionExpression(_)
-                        | Expression::CallExpression(_)
+                    Expression::FunctionExpression(_) | Expression::ArrowFunctionExpression(_)
                 ) {
                     self.current_declarator_name = get_declarator_name(declarator);
                 }
@@ -1680,20 +1678,18 @@ impl<'a, 'b, 'ast> DiscoveryWalker<'a, 'b, 'ast> {
             }
             Expression::CallExpression(node) => {
                 let callee_name = get_callee_name_if_react_api(&node.callee);
-                // The declarator name only flows through forwardRef/memo calls; for
-                // any other call, clear it so nested functions don't inherit it.
-                if callee_name.is_none() {
-                    self.current_declarator_name = None;
-                }
+                // Upstream `getFunctionName` only consults a function's direct parent
+                // (declarator/assignment/property), so a declarator name never names
+                // a function nested in call arguments; forwardRef/memo callbacks are
+                // detected as anonymous functions via `parent_callee_stack` instead,
+                // which skips the component-name param/return checks.
+                self.current_declarator_name = None;
                 self.parent_callee_stack.push(callee_name);
                 self.walk_expression(&node.callee);
                 for arg in &node.arguments {
                     self.walk_argument(arg);
                 }
-                let was_react_api = self.parent_callee_stack.pop().flatten().is_some();
-                if was_react_api {
-                    self.current_declarator_name = None;
-                }
+                self.parent_callee_stack.pop();
             }
             Expression::ChainExpression(node) => self.walk_chain_element(&node.expression),
             Expression::StaticMemberExpression(node) => self.walk_expression(&node.object),

--- a/crates/oxc_react_compiler/tests/snapshots/infer-forwardref-callback-with-non-ref-param.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/infer-forwardref-callback-with-non-ref-param.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/infer-forwardref-callback-with-non-ref-param.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+// @compilationMode:"infer"
+import { forwardRef } from "react";
+type Props = {
+	text: string;
+};
+const TopStoriesItem = forwardRef<HTMLDivElement, Props>((t0, viewTracker) => {
+	const $ = _c(3);
+	const { text } = t0;
+	let t1;
+	if ($[0] !== text || $[1] !== viewTracker) {
+		t1 = <div ref={viewTracker}>{text}</div>;
+		$[0] = text;
+		$[1] = viewTracker;
+		$[2] = t1;
+	} else {
+		t1 = $[2];
+	}
+	return t1;
+});
+export default TopStoriesItem;


### PR DESCRIPTION
The discovery walker let a declarator name flow through `forwardRef`/`memo` calls, so `const Foo = forwardRef((props, viewTracker) => ...)` was treated as a named component and rejected by the component param check (a second param must look like a ref). Upstream only names a function from its direct parent (declarator/assignment/property); a function in call arguments is anonymous and is detected through the forwardRef/memo callback branch, which never checks params.

Fixes the two Simorgh files from the ecosystem comparison (`TopStoriesItem`, `LatestMediaItem`): both now compile with output matching upstream, including identical memo cache sizes. Adds a fixture for the pattern; no existing fixture snapshots change.

Created with assistance from Claude.