### PR TITLE
refactor(formatter_yaml,formatter_tests): move out prettier YAML conformance from tasks/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
       - uses: oxc-project/setup-node@d59b270414aa7d0eed947eed4eb5b0b8a675f01d # v1.4.0
       - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
-          path: /home/runner/.rustup
+          path: |
+            /home/runner/.rustup
+            ./crates/oxc_formatter_tests/prettier
           cache: |
             rust
             pnpm
@@ -132,7 +134,8 @@ jobs:
           tool: cross
       # `--lib --bins --tests` to skip doctests which are very slow to run via `cross`.
       # https://github.com/cross-rs/cross/issues/1703
-      - run: cross test --lib --bins --tests --all-features --target s390x-unknown-linux-gnu
+      # `--skip prettier_conformance`: suite provisioning needs curl/tar, absent in the cross container
+      - run: cross test --lib --bins --tests --all-features --target s390x-unknown-linux-gnu -- --skip prettier_conformance
 
   test-32bit:
     if: ${{ github.ref_name == 'main' }}
@@ -149,7 +152,8 @@ jobs:
           tool: cross
       # `--lib --bins --tests` to skip doctests which are very slow to run via `cross`.
       # https://github.com/cross-rs/cross/issues/1703
-      - run: cross test --workspace --lib --bins --tests --all-features --exclude oxc_language_server --exclude oxc_linter --exclude oxlint --target armv7-unknown-linux-gnueabihf
+      # `--skip prettier_conformance`: suite provisioning needs curl/tar, absent in the cross container
+      - run: cross test --workspace --lib --bins --tests --all-features --exclude oxc_language_server --exclude oxc_linter --exclude oxlint --target armv7-unknown-linux-gnueabihf -- --skip prettier_conformance
 
   test-wasm32-wasip1-threads:
     name: Test wasm32-wasip1-threads

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,8 +2135,17 @@ dependencies = [
 name = "oxc_formatter_tests"
 version = "0.62.0"
 dependencies = [
+ "cow-utils",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
  "oxc_formatter_core",
+ "oxc_parser",
+ "oxc_span",
+ "rustc-hash",
  "serde_json",
+ "similar 3.1.2",
+ "walkdir",
 ]
 
 [[package]]
@@ -2472,7 +2481,6 @@ dependencies = [
  "oxc_formatter_graphql",
  "oxc_formatter_json",
  "oxc_formatter_tests",
- "oxc_formatter_yaml",
  "oxc_parser",
  "oxc_span",
  "oxc_tasks_common",

--- a/crates/oxc_formatter_core/FORMATTER_POLICY.md
+++ b/crates/oxc_formatter_core/FORMATTER_POLICY.md
@@ -125,11 +125,17 @@ Every expected output must be verified against Prettier, except fixtures pinning
 
 ### Prettier conformance
 
-Compares output against Prettier's snapshots and tracks failures (not passes); results live in `tasks/prettier_conformance/snapshots/`.
+Compares output against Prettier's snapshots and tracks failures (not passes).
+
+Language crates own their conformance as a `tests/conformance.rs` target (via `oxc_formatter_tests::conformance`, report pinned with `insta`) — currently yaml; the remaining languages still run through the central task runner during the migration:
 
 ```sh
+# Per-crate (yaml)
+cargo test -p oxc_formatter_yaml --test conformance
+PRETTIER_FILTER=<path> cargo test -p oxc_formatter_yaml --test conformance -- --nocapture
+
+# Central runner (js/ts/json/css/graphql)
 cargo run -p oxc_prettier_conformance
-# Debug a specific test
 cargo run -p oxc_prettier_conformance -- --filter <path>
 ```
 

--- a/crates/oxc_formatter_tests/AGENTS.md
+++ b/crates/oxc_formatter_tests/AGENTS.md
@@ -5,13 +5,16 @@ Test infrastructure shared by the formatter crates (e.g. `oxc_formatter`, `oxc_f
 - `codegen`: build-script helper — consumers call `generate_tests` from `build.rs` via `[build-dependencies]` to emit one `#[test]` per fixture file
 - `harness`: fixture runtime — consumers implement `FixtureFormatter` in `tests/fixtures/mod.rs` via `[dev-dependencies]`
 - `suite`: Prettier test-suite provisioning — `ensure_prettier_suite()` maintains the pinned suite at `prettier/` (gitignored), no separate clone step anywhere
+- `conformance` (feature `conformance`): Prettier-conformance machinery — spec parsing, snapshot matching, report building. Consumers add a `tests/conformance.rs` target with a `ConformanceConfig` + format callback and pin the report with `insta`. Feature-gated because spec parsing needs `oxc_parser`; `[build-dependencies]` consumers must never pull that into their build closure, so only `[dev-dependencies]` enable it
 
 ## Prettier suite
 
 The pin is the `prettier` version in `apps/oxfmt/package.json` — the same Prettier oxfmt bundles as the oracle, so suite and oracle cannot drift. Provisioning is degit-style: the release tarball from codeload, `tests/format/` extracted only (~40MB, no git objects), `.version` stamp written last. A warm suite is verified offline by reading the stamp; a stale one is wiped and re-extracted. Tarball extraction always yields LF content, so Windows needs no autocrlf care. CI only mounts `prettier/` as a cache volume — there is no clone step to keep in sync.
 
 - Bumping Prettier = bump `apps/oxfmt/package.json` + regenerate conformance snapshots (one change set; the suite re-provisions itself on the next run)
-- Fixture-test callers treat provisioning `Err` (offline, no curl/tar) as skip, not failure; the conformance runner fails loudly
+- Provisioning failure is a loud failure everywhere it runs (a silent skip would let conformance rot green; needs network + curl/tar)
+  - Environments that cannot provision opt out in `ci.yml`, not in crate code: CI's cross jobs (s390x/armv7) pass `-- --skip prettier_conformance`
+    - Every consumer names its conformance test fn `prettier_conformance`, that name is the contract the skip filter relies on
 - Requires `curl` and `tar` on PATH (standard on macOS, Linux, and Windows 10+)
 
 ## Dependency rule

--- a/crates/oxc_formatter_tests/Cargo.toml
+++ b/crates/oxc_formatter_tests/Cargo.toml
@@ -21,6 +21,33 @@ oxc_formatter_core = { workspace = true }
 
 serde_json = { workspace = true }
 
+oxc_allocator = { workspace = true, optional = true }
+oxc_ast = { workspace = true, optional = true }
+oxc_ast_visit = { workspace = true, optional = true }
+oxc_parser = { workspace = true, optional = true }
+oxc_span = { workspace = true, optional = true }
+
+cow-utils = { workspace = true, optional = true }
+rustc-hash = { workspace = true, optional = true }
+similar = { workspace = true, optional = true }
+walkdir = { workspace = true, optional = true }
+
+[features]
+# Prettier-conformance machinery (spec parsing needs the JS parser).
+# Kept off by default so `[build-dependencies]` consumers (fixture codegen)
+# never pull the parser into their build closure; enable from `[dev-dependencies]` only.
+conformance = [
+  "dep:cow-utils",
+  "dep:oxc_allocator",
+  "dep:oxc_ast",
+  "dep:oxc_ast_visit",
+  "dep:oxc_parser",
+  "dep:oxc_span",
+  "dep:rustc-hash",
+  "dep:similar",
+  "dep:walkdir",
+]
+
 [lib]
 doctest = false
 test = false

--- a/crates/oxc_formatter_tests/src/conformance.rs
+++ b/crates/oxc_formatter_tests/src/conformance.rs
@@ -1,0 +1,649 @@
+//! Prettier-conformance machinery.
+//!
+//! Runs a language formatter over the Prettier repository's own test suite (`tests/format/<dir>`)
+//! and compares the output byte-for-byte against Prettier's committed jest snapshots.
+//! Language specifics arrive through [`ConformanceConfig`] (which fixture dirs, which parser names, what to ignore)
+//! and the `format` callback (spec options → typed options → formatted output),
+//! so this module never depends on a language crate.
+//!
+//! A spec dir looks like:
+//!
+//! ```text
+//! yaml/flow-mapping
+//! ├── __snapshots__/format.test.js.snap   <- Prettier's expected outputs
+//! ├── format.test.js                      <- `runFormatTest(import.meta, ["yaml"], {...})` calls
+//! └── *.yml                               <- inputs, one snapshot section per file × option set
+//! ```
+//!
+//! Debugging: `PRETTIER_FILTER=<substring>` formats only matching files
+//! and prints per-option-set diffs instead of producing a report.
+
+// Printing is this module's debug/summary UX (run under `cargo test -- --nocapture` or `PRETTIER_FILTER`)
+#![expect(clippy::print_stdout)]
+
+use std::{
+    env,
+    fmt::Write as _,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use cow_utils::CowUtils;
+use rustc_hash::FxHashSet;
+use similar::{ChangeTag, TextDiff};
+use walkdir::WalkDir;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    Argument, ArrayExpressionElement, CallExpression, Expression, ObjectPropertyKind,
+    VariableDeclarator,
+};
+use oxc_ast_visit::VisitMut;
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
+
+use crate::{OptionSet, ensure_prettier_suite};
+
+const FORMAT_TEST_SPEC_NAME: &str = "format.test.js";
+const SNAPSHOT_DIR_NAME: &str = "__snapshots__";
+const SNAPSHOT_FILE_NAME: &str = "format.test.js.snap";
+
+/// Spec dirs every language skips: parser error message snapshots
+/// (added in Prettier v3.9.1) are not a formatter concern.
+const UNIVERSAL_IGNORE: &str = "/_errors_/";
+
+/// Language-specific wiring for [`run_conformance`].
+pub struct ConformanceConfig<'a> {
+    /// Display name used in the report summary (e.g. `"yaml"`).
+    pub language: &'a str,
+    /// Fixture roots relative to the suite's `tests/format/` (e.g. `&["yaml"]`).
+    pub fixture_roots: &'a [&'a str],
+    /// When set, only `runFormatTest` calls whose parser list contains this name are exercised
+    /// (a shared `format.test.js` may target several parsers).
+    /// `None` accepts every call (JS/TS).
+    pub exact_parser: Option<&'a str>,
+    /// Path substrings to skip (unsupported constructs, no snapshot to compare, ...).
+    pub ignore: &'a [&'a str],
+    /// When set, spec calls for which this returns `true` are dropped entirely
+    /// (e.g. option combinations the formatter does not support yet).
+    pub skip_spec: Option<fn(&OptionSet) -> bool>,
+}
+
+/// Runs the conformance comparison and returns the report to snapshot,
+/// or `None` when `PRETTIER_FILTER` is set (debug mode prints diffs instead).
+///
+/// Provisioning needs network + curl/tar. Environments without them (CI's
+/// cross-compiled s390x/armv7 jobs) opt out in ci.yml via
+/// `-- --skip prettier_conformance` — which is why every consumer names its
+/// test fn `prettier_conformance`.
+///
+/// # Panics
+/// Panics when the suite cannot be provisioned (network/curl/tar failure) and on
+/// malformed suite content (unreadable spec/snapshot files); neither is a
+/// formatter bug, and a silent skip would let conformance rot green.
+pub fn run_conformance<F>(config: &ConformanceConfig, mut format: F) -> Option<String>
+where
+    F: FnMut(&Path, &str, &OptionSet) -> Option<String>,
+{
+    let suite_root = ensure_prettier_suite()
+        .unwrap_or_else(|err| panic!("failed to provision the Prettier suite: {err}"));
+    let format_root = suite_root.join("tests").join("format");
+
+    let fixture_roots =
+        config.fixture_roots.iter().map(|dir| format_root.join(dir)).collect::<Vec<_>>();
+    let test_dirs = collect_test_dirs(&fixture_roots);
+
+    let filter = env::var("PRETTIER_FILTER").ok();
+    if let Some(filter) = filter.as_deref() {
+        for dir in &test_dirs {
+            let inputs = collect_test_files(dir, config.ignore, Some(filter));
+            if !inputs.is_empty() {
+                test_snapshots(config, &mut format, dir, &inputs, true);
+            }
+        }
+        return None;
+    }
+
+    let mut total_tested_file_count = 0;
+    let mut total_failed_file_count = 0;
+    let mut total_skipped_files = vec![];
+    let mut failed_reports = String::new();
+    failed_reports.push_str("# Failed\n");
+    failed_reports.push('\n');
+    failed_reports.push_str("| Spec path | Failed or Passed | Match ratio |\n");
+    failed_reports.push_str("| :-------- | :--------------: | :---------: |\n");
+    for dir in &test_dirs {
+        let inputs = collect_test_files(dir, config.ignore, None);
+        // `None`: no spec call targets this language config (shared dir, or every combination skipped).
+        // The files were never exercised, keep them out of the totals instead of counting them as passed.
+        let Some(results) = test_snapshots(config, &mut format, dir, &inputs, false) else {
+            continue;
+        };
+
+        total_tested_file_count += inputs.len();
+        total_failed_file_count += results.failed_files.len();
+        total_skipped_files.extend(results.skipped_files);
+
+        for (path, (failed, passed, ratio)) in results.failed_files {
+            writeln!(
+                failed_reports,
+                "| {} | {}{} | {:.2}% |",
+                report_path(&path, &format_root),
+                "💥".repeat(failed),
+                "✨".repeat(passed),
+                ratio * 100.0
+            )
+            .unwrap();
+        }
+    }
+
+    let passed = total_tested_file_count - total_failed_file_count;
+    #[expect(clippy::cast_precision_loss)]
+    let percentage = (passed as f64 / total_tested_file_count as f64) * 100.0;
+    // Files the formatter cannot parse are counted as passed above
+    // (they have no diff to report); surface them so the gap is visible.
+    let summary = format!(
+        "{} compatibility: {passed}/{total_tested_file_count} ({percentage:.2}%), {} files skipped",
+        config.language,
+        total_skipped_files.len()
+    );
+    println!("{summary}");
+
+    let mut report = format!("{summary}\n\n{failed_reports}");
+    if !total_skipped_files.is_empty() {
+        report.push_str("\n# Skipped (parse error, TODO: should be ignored or supported)\n\n");
+        for path in &total_skipped_files {
+            writeln!(report, "- {}", report_path(path, &format_root)).unwrap();
+        }
+    }
+
+    Some(report)
+}
+
+/// Suite-relative path with `/` separators, so reports are identical on Windows.
+fn report_path(path: &Path, format_root: &Path) -> String {
+    path.strip_prefix(format_root).unwrap().to_string_lossy().cow_replace('\\', "/").into_owned()
+}
+
+/// Read the first level of directories that contain `__snapshots__` and `format.test.js`
+/// ```text
+/// js/arrows <------------------------------- THIS
+/// ├── __snapshots__
+/// ├── arrow-chain-with-trailing-comments.js
+/// ├── format.test.js
+/// ├── semi <-------------------------------- AND THIS
+/// │   ├── __snapshots__
+/// │   ├── format.test.js
+/// │   └── semi.js
+/// └── tuple-and-record.js
+/// ```
+fn collect_test_dirs(fixture_roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut test_dirs = FxHashSet::default();
+
+    for fixture_root in fixture_roots {
+        let dirs = WalkDir::new(fixture_root)
+            .min_depth(1)
+            .into_iter()
+            .filter_map(Result::ok)
+            .map(|e| {
+                let mut path = e.into_path();
+                if path.is_file()
+                    && let Some(parent_path) = path.parent()
+                {
+                    path = parent_path.into();
+                }
+                path
+            })
+            .filter(|path| {
+                path.join(SNAPSHOT_DIR_NAME).exists() && path.join(FORMAT_TEST_SPEC_NAME).exists()
+            })
+            .collect::<Vec<_>>();
+
+        test_dirs.extend(dirs);
+    }
+
+    let mut test_dirs = test_dirs.into_iter().collect::<Vec<_>>();
+    test_dirs.sort_unstable();
+
+    test_dirs
+}
+
+/// Read all test files in the directory with applying ignore + filter
+fn collect_test_files(dir: &Path, ignore: &[&str], filter: Option<&str>) -> Vec<PathBuf> {
+    let mut test_files: Vec<PathBuf> = WalkDir::new(dir)
+        .min_depth(1)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| !e.file_type().is_dir())
+        .filter(|e| e.path().file_name().is_none_or(|name| name != FORMAT_TEST_SPEC_NAME))
+        .filter(|e| {
+            let path = e.path().to_string_lossy();
+            let path = path.cow_replace('\\', "/");
+            !path.contains(UNIVERSAL_IGNORE) && !ignore.iter().any(|s| path.contains(s))
+        })
+        .filter(|e| filter.is_none_or(|name| e.path().to_string_lossy().contains(name)))
+        .map(|e| e.path().to_path_buf())
+        .collect();
+    test_files.sort_unstable();
+
+    test_files
+}
+
+#[derive(Default)]
+struct SnapshotResults {
+    /// `(path, (failed_count, passed_count, diff_ratio))` per file with at least one mismatch
+    failed_files: Vec<(PathBuf, (usize, usize, f32))>,
+    /// Files the formatter failed to parse for at least one options combination
+    skipped_files: Vec<PathBuf>,
+}
+
+/// Run the formatter and compare the output with the Prettier's snapshot.
+///
+/// Returns `None` when no spec call applies to this language config.
+fn test_snapshots<F>(
+    config: &ConformanceConfig,
+    format: &mut F,
+    dir: &Path,
+    test_files: &[PathBuf],
+    debug: bool,
+) -> Option<SnapshotResults>
+where
+    F: FnMut(&Path, &str, &OptionSet) -> Option<String>,
+{
+    // Parse all `runFormatTest()` calls and collect format options
+    let spec_path = &dir.join(FORMAT_TEST_SPEC_NAME);
+    let (mut spec_calls, saw_run_format_test) = parse_spec(spec_path, config.exact_parser);
+    debug_assert!(
+        saw_run_format_test,
+        "There is no `runFormatTest()` in {}, please check if it is correct?",
+        spec_path.to_string_lossy()
+    );
+    if let Some(skip_spec) = config.skip_spec {
+        spec_calls.retain(|call| !skip_spec(&call.options));
+    }
+    if spec_calls.is_empty() {
+        return None;
+    }
+
+    let snapshots =
+        fs::read_to_string(dir.join(SNAPSHOT_DIR_NAME).join(SNAPSHOT_FILE_NAME)).unwrap();
+
+    let mut results = SnapshotResults::default();
+    for path in test_files {
+        if debug {
+            println!("Test: {}", path.to_string_lossy());
+        }
+        // Single source text is used for multiple options
+        let source_text = fs::read_to_string(path).unwrap();
+
+        let mut failed_count = 0;
+        let mut skipped_count = 0;
+        let mut total_diff_ratio = 0.0;
+        // Check every combination of options!
+        for call in &spec_calls {
+            // Single snapshot file contains multiple test cases, so need to find the right one
+            let expected = find_output_from_snapshots(
+                &snapshots,
+                path.file_name().unwrap().to_string_lossy().as_ref(),
+                &call.snapshot_options,
+            )
+            .unwrap();
+
+            let Some(actual) = format(path, &source_text, &call.options) else {
+                // Skip the test if parsing failed
+                skipped_count += 1;
+                if debug {
+                    println!("  => Skipped (parsing failed)");
+                }
+                continue;
+            };
+
+            let actual = replace_escape_and_eol(
+                &actual,
+                expected.contains("LF>") || expected.contains("<CR"),
+            );
+
+            let result = expected == actual;
+            if !result {
+                failed_count += 1;
+                total_diff_ratio += TextDiff::from_lines(&expected, &actual).ratio();
+            }
+
+            if debug {
+                println!(
+                    "Options: {{ {} }}",
+                    call.snapshot_options
+                        .iter()
+                        .filter(|(k, _)| k != "parsers")
+                        .map(|(k, v)| format!("{k}: {v}"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+
+                if result {
+                    println!("Passed ✅");
+                } else {
+                    println!("Failed ❌");
+                    print_text_diff(&TextDiff::from_lines(&expected, &actual));
+                }
+                println!();
+            }
+        }
+
+        if failed_count != 0 {
+            let total_count = spec_calls.len();
+            let passed_count = total_count - failed_count;
+            #[expect(clippy::cast_precision_loss)]
+            let max_diff_ratio = total_count as f32;
+            results.failed_files.push((
+                path.clone(),
+                (failed_count, passed_count, total_diff_ratio / max_diff_ratio),
+            ));
+        }
+        if skipped_count != 0 {
+            results.skipped_files.push(path.clone());
+        }
+    }
+
+    Some(results)
+}
+
+fn print_text_diff(diff: &TextDiff<'_, '_, str>) {
+    for change in diff.iter_all_changes() {
+        let sign = match change.tag() {
+            ChangeTag::Delete => "-",
+            ChangeTag::Insert => "+",
+            ChangeTag::Equal => " ",
+        };
+        print!("{sign}{change}");
+    }
+}
+
+/// Extract single output section from snapshot file which contains multiple test cases.
+///
+/// Format is like below:
+/// ```text
+/// filename1
+/// ===optionsA===
+/// ====input1====
+/// ===output1A===
+/// ==============
+/// filename1
+/// ===optionsB===
+/// ====input1====
+/// ===output1B===
+/// ==============
+///
+/// filename2
+/// ===optionsA===
+/// ====input2====
+/// ===output2A===
+/// ==============
+/// ```
+///
+/// There are also options-like strings after the filename, but it seems that format is not guaranteed...
+/// Thus, we need to find the right section by filename and options for sure.
+fn find_output_from_snapshots(
+    snap_content: &str,
+    file_name: &str,
+    snapshot_options: &[(String, String)],
+) -> Option<String> {
+    let filename_started = snap_content.find(&format!("exports[`{file_name} "))?;
+    let after_filename = &snap_content[filename_started..];
+
+    // Anchor on the options block (header + key:value lines). The line that
+    // follows is a `printWidth` visualization whose exact rendering varies by
+    // Prettier version, so we skip it by jumping to the following
+    // `=====input=====`. To disambiguate between blocks where one options
+    // list is a prefix of another (e.g. `parsers: [...]` vs
+    // `parsers: [...] + singleQuote: true`), we require the gap between the
+    // matched options and the input marker to be exactly one line (the
+    // visualization), retrying past the false match otherwise.
+    let options_pattern = format!(
+        "====================================options=====================================
+{}
+",
+        snapshot_options.iter().map(|(k, v)| format!("{k}: {v}")).collect::<Vec<_>>().join("\n"),
+    );
+    let input_marker =
+        "\n=====================================input======================================\n";
+    let mut search_from = 0;
+    let expected = loop {
+        let pos = after_filename[search_from..].find(&options_pattern)?;
+        let after_options = search_from + pos + options_pattern.len();
+        let input_pos = after_filename[after_options..].find(input_marker)?;
+        let between = &after_filename[after_options..after_options + input_pos];
+        if !between.contains('\n') {
+            break &after_filename[after_options + input_pos..];
+        }
+        search_from = after_options;
+    };
+
+    let output_start_line =
+        "=====================================output=====================================\n";
+    let output_started = expected.find(output_start_line)?;
+    let output_end_line =
+        "\n================================================================================";
+    let output_ended = expected.find(output_end_line)?;
+
+    let output = expected[output_started..output_ended]
+        .trim_start_matches(output_start_line)
+        .trim_end_matches(output_end_line);
+
+    Some(output.to_string())
+}
+
+/// Apply the same escape rules as Prettier does.
+/// If Prettier's snapshot contains `<LF>`, `<CR>` or `<CRLF>`, we also need to visualize.
+fn replace_escape_and_eol(input: &str, need_eol_visualized: bool) -> String {
+    let input = input
+        .cow_replace("\\", "\\\\")
+        .cow_replace("`", "\\`")
+        .cow_replace("${", "\\${")
+        .into_owned();
+
+    if need_eol_visualized {
+        let mut chars = input.chars();
+        let mut result = String::new();
+
+        while let Some(char) = chars.next() {
+            match char {
+                '\u{a}' => result.push_str("<LF>\n"),
+                '\u{d}' => {
+                    let next = chars.clone().next();
+                    if next == Some('\u{a}') {
+                        result.push_str("<CRLF>\n");
+                        chars.next();
+                    } else {
+                        result.push_str("<CR>\n");
+                    }
+                }
+                _ => {
+                    result.push(char);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    input
+}
+
+/// One `runFormatTest(import.meta, parsers, opts)` call from a spec file.
+struct SpecCall {
+    /// The literal options from the call's third argument, as an [`OptionSet`]
+    /// (same shape the fixture harness feeds `parse_options`).
+    options: OptionSet,
+    /// `(key, raw source text)` pairs used to locate the matching snapshot
+    /// section (Prettier renders them verbatim into the snapshot header).
+    snapshot_options: Vec<(String, String)>,
+}
+
+fn string_elements(arr: &oxc_ast::ast::ArrayExpression) -> Vec<String> {
+    arr.elements
+        .iter()
+        .filter_map(|el| match el {
+            ArrayExpressionElement::StringLiteral(literal) => Some(literal.value.to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Returns the matching calls plus whether ANY `runFormatTest()` call was seen
+/// (even for other parsers) — an all-absent spec signals a suite layout change.
+fn parse_spec(spec: &Path, exact_parser: Option<&str>) -> (Vec<SpecCall>, bool) {
+    let mut parser = SpecParser { exact_parser, ..SpecParser::default() };
+    parser.parse(spec);
+    (parser.calls, parser.saw_run_format_test)
+}
+
+#[derive(Default)]
+struct SpecParser<'a> {
+    source_text: String,
+    parsers: Vec<String>,
+    calls: Vec<SpecCall>,
+    exact_parser: Option<&'a str>,
+    saw_run_format_test: bool,
+}
+
+impl SpecParser<'_> {
+    fn parse(&mut self, spec: &Path) {
+        let spec_content = fs::read_to_string(spec).unwrap_or_default();
+
+        self.source_text.clone_from(&spec_content);
+
+        let allocator = Allocator::default();
+        let mut source_type = SourceType::from_path(spec).unwrap_or_default();
+        if source_type.is_javascript() {
+            source_type = source_type.with_jsx(true);
+        }
+
+        let mut ret = Parser::new(&allocator, &spec_content, source_type).parse();
+        assert!(ret.diagnostics.is_empty());
+        self.visit_program(&mut ret.program);
+    }
+}
+
+impl VisitMut<'_> for SpecParser<'_> {
+    // Some test cases use a variable to store the parsers.
+    //
+    // ```js
+    // const parser = ["babel"];
+    //
+    // runFormatTest(import.meta, parser, {});
+    // runFormatTest(import.meta, parser, { semi: false });
+    // ```
+    fn visit_variable_declarator(&mut self, decl: &mut VariableDeclarator<'_>) {
+        let Some(name) = decl.id.get_identifier_name() else { return };
+        if !matches!(name.as_str(), "parser" | "parsers") {
+            return;
+        }
+
+        debug_assert!(self.parsers.is_empty(), "`parsers` is already defined");
+        if let Some(Expression::ArrayExpression(arr_expr)) = &decl.init {
+            self.parsers = string_elements(arr_expr);
+        }
+    }
+
+    // The `runFormatTest()` function is used on prettier's test cases.
+    // We need to collect all calls and get the options and parsers.
+    fn visit_call_expression(&mut self, expr: &mut CallExpression<'_>) {
+        let Some(ident) = expr.callee.get_identifier_reference() else { return };
+        if ident.name != "runFormatTest" {
+            return;
+        }
+        self.saw_run_format_test = true;
+
+        let mut snapshot_options: Vec<(String, String)> = vec![];
+        let mut parsers = vec![];
+
+        // Get parsers
+        if let Some(argument) = expr.arguments.get(1) {
+            let Some(argument_expr) = argument.as_expression() else {
+                return;
+            };
+
+            // If inlined array
+            if let Expression::ArrayExpression(arr_expr) = argument_expr {
+                parsers = string_elements(arr_expr);
+            }
+            // If variable
+            if let Expression::Identifier(_) = argument_expr {
+                debug_assert!(
+                    !self.parsers.is_empty(),
+                    "`parsers` is not collected, check variable name"
+                );
+                parsers.clone_from(&self.parsers);
+            }
+        } else {
+            return;
+        }
+
+        // A single `format.test.js` may list several parsers (e.g. `with-comment/`),
+        // so languages with an exact parser name keep only their own calls.
+        if let Some(exact) = self.exact_parser
+            && !parsers.iter().any(|p| p == exact)
+        {
+            return;
+        }
+
+        // Collect the literal options; non-literal values (e.g. the `errors`
+        // object) never influence formatting and are left out.
+        let mut options = OptionSet::new();
+        if let Some(Argument::ObjectExpression(obj_expr)) = expr.arguments.get(2) {
+            obj_expr.properties.iter().for_each(|item| {
+                if let ObjectPropertyKind::ObjectProperty(obj_prop) = item
+                    && let Some(name) = obj_prop.key.static_name()
+                {
+                    let value = match &obj_prop.value {
+                        Expression::BooleanLiteral(literal) => {
+                            Some(serde_json::Value::Bool(literal.value))
+                        }
+                        Expression::NumericLiteral(literal) => {
+                            // Integral options (printWidth/tabWidth) must round-trip
+                            // through `as_u64`, so avoid `Number::from_f64`.
+                            #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                            if literal.value.fract() == 0.0 && literal.value >= 0.0 {
+                                Some(serde_json::Value::Number((literal.value as u64).into()))
+                            } else {
+                                serde_json::Number::from_f64(literal.value)
+                                    .map(serde_json::Value::Number)
+                            }
+                        }
+                        Expression::StringLiteral(literal) => {
+                            Some(serde_json::Value::String(literal.value.to_string()))
+                        }
+                        _ => None,
+                    };
+                    if let Some(value) = value {
+                        options.insert(name.to_string(), value);
+                    }
+
+                    if name != "errors" {
+                        snapshot_options.push((
+                            name.to_string(),
+                            obj_prop.value.span().source_text(&self.source_text).to_string(),
+                        ));
+                    }
+                }
+            });
+        }
+
+        debug_assert!(!parsers.is_empty(), "`parsers` should not be empty");
+        snapshot_options.push((
+            "parsers".to_string(),
+            format!(
+                "[{}]",
+                parsers.iter().map(|p| format!("\"{p}\"")).collect::<Vec<_>>().join(", ")
+            ),
+        ));
+
+        // Prettier omits `printWidth` from the options block when it equals the
+        // default (80); the value is only shown in the trailing visualization line.
+        snapshot_options.sort_by(|a, b| a.0.cmp(&b.0));
+
+        self.calls.push(SpecCall { options, snapshot_options });
+    }
+}

--- a/crates/oxc_formatter_tests/src/harness.rs
+++ b/crates/oxc_formatter_tests/src/harness.rs
@@ -28,9 +28,9 @@ pub type OptionSet = serde_json::Map<String, serde_json::Value>;
 ///
 /// Covers `printWidth` / `tabWidth` / `useTabs` / `endOfLine`;
 /// language-specific keys are the caller's [`FixtureFormatter::parse_options`].
-/// Fixture files are hand-authored, so parsing is lenient: unknown or invalid
-/// values are ignored. Values already set on `options` survive when the
-/// `OptionSet` doesn't mention their key (the current values seed the bundle).
+/// Fixture files are hand-authored, so parsing is lenient: unknown or invalid values are ignored.
+/// Values already set on `options` survive when the `OptionSet` doesn't mention their key
+/// (the current values seed the bundle).
 pub fn apply_core_options<O: FormatOptions>(options: &mut O, json: &OptionSet) {
     let mut core = CoreFormatOptions {
         indent_style: options.indent_style(),

--- a/crates/oxc_formatter_tests/src/lib.rs
+++ b/crates/oxc_formatter_tests/src/lib.rs
@@ -8,6 +8,8 @@
 //! `oxc_formatter_core`, never on language crates, so both directions stay cycle-free.
 
 mod codegen;
+#[cfg(feature = "conformance")]
+pub mod conformance;
 mod harness;
 mod suite;
 

--- a/crates/oxc_formatter_tests/src/suite.rs
+++ b/crates/oxc_formatter_tests/src/suite.rs
@@ -40,9 +40,9 @@ pub fn prettier_suite_root() -> &'static Path {
 /// advisory lock on the package.json handle; within a process the result is memoized.
 ///
 /// # Errors
-/// Any download/extraction failure, as a display string. Fixture-test callers skip on
-/// `Err` so offline `cargo test` runs stay green; the conformance runner fails
-/// loudly instead.
+/// Any download/extraction failure, as a display string.
+/// Conformance callers fail loudly on `Err`
+/// (non-conformance targets never reach provisioning; see `conformance::run_conformance`'s target gate).
 pub fn ensure_prettier_suite() -> Result<&'static Path, String> {
     static RESULT: OnceLock<Result<(), String>> = OnceLock::new();
     RESULT.get_or_init(provision).clone()?;
@@ -64,17 +64,15 @@ fn provision() -> Result<(), String> {
         return Ok(());
     }
 
-    // Wipe-and-extract keeps this convergent; the stamp is written last, so a
-    // half-provisioned tree is always re-done. Only the CONTENTS are wiped: in CI
-    // the root is a cache-volume mount point, and removing it fails with EBUSY.
-    if root.exists() {
-        for entry in fs::read_dir(root).map_err(|e| format!("read {}: {e}", root.display()))? {
-            let path = entry.map_err(|e| format!("read {}: {e}", root.display()))?.path();
-            if path.is_dir() { fs::remove_dir_all(&path) } else { fs::remove_file(&path) }
-                .map_err(|e| format!("remove {}: {e}", path.display()))?;
-        }
-    } else {
-        fs::create_dir_all(root).map_err(|e| format!("create {}: {e}", root.display()))?;
+    // Wipe-and-extract keeps this convergent;
+    // the stamp is written last, so a half-provisioned tree is always re-done.
+    // Only the CONTENTS are wiped: in CI the root is a cache-volume mount point, and removing it fails with EBUSY.
+    fs::create_dir_all(root).map_err(|e| format!("create {}: {e}", root.display()))?;
+    let read_err = |e| format!("read {}: {e}", root.display());
+    for entry in fs::read_dir(root).map_err(read_err)? {
+        let path = entry.map_err(read_err)?.path();
+        if path.is_dir() { fs::remove_dir_all(&path) } else { fs::remove_file(&path) }
+            .map_err(|e| format!("remove {}: {e}", path.display()))?;
     }
 
     let tarball = std::env::temp_dir().join(format!("oxc-prettier-{version}.tar.gz"));

--- a/crates/oxc_formatter_yaml/Cargo.toml
+++ b/crates/oxc_formatter_yaml/Cargo.toml
@@ -26,7 +26,7 @@ oxc_span = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
-oxc_formatter_tests = { workspace = true }
+oxc_formatter_tests = { workspace = true, features = ["conformance"] }
 oxc_tasks_common = { workspace = true }
 pico-args = { workspace = true }
 

--- a/crates/oxc_formatter_yaml/tests/conformance.rs
+++ b/crates/oxc_formatter_yaml/tests/conformance.rs
@@ -1,0 +1,62 @@
+//! Prettier conformance for YAML.
+//!
+//! Compares output against the Prettier suite's `tests/format/yaml` snapshots via `oxc_formatter_tests::conformance`;
+//! the failure report is pinned with `insta` (update after intentional changes: `cargo insta review`).
+//!
+//! Debug a specific test: `PRETTIER_FILTER=<substring> cargo test -p oxc_formatter_yaml --test conformance -- --nocapture`
+
+use std::path::Path;
+
+use oxc_allocator::Allocator;
+use oxc_formatter_core::{CoreFormatOptions, FormatOptions as _, LineWidth};
+use oxc_formatter_tests::{
+    OptionSet,
+    conformance::{ConformanceConfig, run_conformance},
+};
+use oxc_formatter_yaml::{YamlFormatOptions, format};
+
+#[path = "fixtures/options.rs"]
+mod options;
+use options::apply_yaml_options;
+
+const CONFIG: ConformanceConfig = ConformanceConfig {
+    language: "yaml",
+    fixture_roots: &["yaml"],
+    exact_parser: Some("yaml"),
+    ignore: &[
+        // Prettier's yaml parser rejects these (https://github.com/eemeli/yaml/issues/646),
+        // so no snapshot exists (`3-style.yml` is even marked `errors` in its format.test.js).
+        // oxc-yaml-parser parses them fine, but there is nothing to compare against.
+        "yaml/mapping/3-style.yml",
+        "yaml/spec/spec-example-2-11-mapping-between-sequences.yml",
+        // Pragma support (`@format` insertion / require)
+        "yaml/insert-pragma/",
+        "yaml/require-pragma/",
+    ],
+    skip_spec: None,
+};
+
+fn parse_options(spec: &OptionSet) -> YamlFormatOptions {
+    let mut options = YamlFormatOptions::default();
+    // Prettier's default `printWidth` is 80 (oxc defaults to 100); the spec's own
+    // `printWidth`/`tabWidth`/`useTabs`/`endOfLine` then override inside `apply_yaml_options`.
+    options.apply_core(CoreFormatOptions {
+        line_width: LineWidth::try_from(80).unwrap(),
+        ..CoreFormatOptions::default()
+    });
+    apply_yaml_options(&mut options, spec);
+    options
+}
+
+fn format_yaml(_path: &Path, source_text: &str, spec: &OptionSet) -> Option<String> {
+    let options = parse_options(spec);
+    let allocator = Allocator::default();
+    let formatted = format(&allocator, source_text, options).ok()?;
+    Some(formatted.print().ok()?.into_code())
+}
+
+#[test]
+fn prettier_conformance() {
+    let Some(report) = run_conformance(&CONFIG, format_yaml) else { return };
+    insta::assert_snapshot!("prettier", report);
+}

--- a/crates/oxc_formatter_yaml/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_yaml/tests/fixtures/mod.rs
@@ -2,10 +2,11 @@ use std::path::Path;
 
 use oxc_allocator::Allocator;
 use oxc_formatter_core::LineEnding;
-use oxc_formatter_tests::{
-    FixtureFormatter, OptionSet, apply_core_options, build_fixture_snapshot,
-};
-use oxc_formatter_yaml::{ProseWrap, YamlFormatOptions, format};
+use oxc_formatter_tests::{FixtureFormatter, OptionSet, build_fixture_snapshot};
+use oxc_formatter_yaml::{YamlFormatOptions, format};
+
+mod options;
+use options::apply_yaml_options;
 
 struct YamlHarness;
 
@@ -14,42 +15,7 @@ impl FixtureFormatter for YamlHarness {
 
     fn parse_options(json: &OptionSet) -> Self::Options {
         let mut options = YamlFormatOptions::default();
-        apply_core_options(&mut options, json);
-
-        for (key, value) in json {
-            match key.as_str() {
-                "proseWrap" => {
-                    if let Some(s) = value.as_str() {
-                        options.prose_wrap = match s {
-                            "always" => ProseWrap::Always,
-                            "never" => ProseWrap::Never,
-                            _ => ProseWrap::Preserve,
-                        };
-                    }
-                }
-                "singleQuote" => {
-                    if let Some(b) = value.as_bool() {
-                        options.single_quote = b.into();
-                    }
-                }
-                "bracketSpacing" => {
-                    if let Some(b) = value.as_bool() {
-                        options.bracket_spacing = b.into();
-                    }
-                }
-                "trailingComma" => {
-                    if let Some(s) = value.as_str() {
-                        options.trailing_commas = if s == "none" {
-                            oxc_formatter_yaml::TrailingCommas::Never
-                        } else {
-                            oxc_formatter_yaml::TrailingCommas::Always
-                        };
-                    }
-                }
-                _ => {}
-            }
-        }
-
+        apply_yaml_options(&mut options, json);
         options
     }
 

--- a/crates/oxc_formatter_yaml/tests/fixtures/options.rs
+++ b/crates/oxc_formatter_yaml/tests/fixtures/options.rs
@@ -1,0 +1,45 @@
+//! Prettier option-set → `YamlFormatOptions` mapping.
+//!
+//! Shared by the fixture harness (`fixtures/mod.rs`) and the conformance target (`conformance.rs`) via `#[path]`,
+//! integration-test targets are separate crates, so each compiles this file;
+//! the SOURCE is the single copy that keeps the two parsers from drifting.
+
+use oxc_formatter_tests::{OptionSet, apply_core_options};
+use oxc_formatter_yaml::{ProseWrap, TrailingCommas, YamlFormatOptions};
+
+/// Applies the four core options plus the YAML-specific keys onto `options`.
+/// Parsing is lenient like `apply_core_options`: unknown or invalid values are ignored.
+pub fn apply_yaml_options(options: &mut YamlFormatOptions, json: &OptionSet) {
+    apply_core_options(options, json);
+
+    for (key, value) in json {
+        match key.as_str() {
+            "proseWrap" => {
+                if let Some(s) = value.as_str() {
+                    options.prose_wrap = match s {
+                        "always" => ProseWrap::Always,
+                        "never" => ProseWrap::Never,
+                        _ => ProseWrap::Preserve,
+                    };
+                }
+            }
+            "singleQuote" => {
+                if let Some(b) = value.as_bool() {
+                    options.single_quote = b.into();
+                }
+            }
+            "bracketSpacing" => {
+                if let Some(b) = value.as_bool() {
+                    options.bracket_spacing = b.into();
+                }
+            }
+            "trailingComma" => {
+                if let Some(s) = value.as_str() {
+                    options.trailing_commas =
+                        if s == "none" { TrailingCommas::Never } else { TrailingCommas::Always };
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/oxc_formatter_yaml/tests/snapshots/conformance__prettier.snap
+++ b/crates/oxc_formatter_yaml/tests/snapshots/conformance__prettier.snap
@@ -1,3 +1,7 @@
+---
+source: crates/oxc_formatter_yaml/tests/conformance.rs
+expression: report
+---
 yaml compatibility: 346/354 (97.74%), 0 files skipped
 
 # Failed

--- a/tasks/prettier_conformance/Cargo.toml
+++ b/tasks/prettier_conformance/Cargo.toml
@@ -32,7 +32,6 @@ oxc_formatter_css = { workspace = true }
 oxc_formatter_graphql = { workspace = true }
 oxc_formatter_json = { workspace = true }
 oxc_formatter_tests = { workspace = true }
-oxc_formatter_yaml = { workspace = true }
 oxc_parser = { workspace = true }
 oxc_span = { workspace = true }
 oxc_tasks_common = { workspace = true }

--- a/tasks/prettier_conformance/src/ignore_list.rs
+++ b/tasks/prettier_conformance/src/ignore_list.rs
@@ -128,12 +128,4 @@ pub const IGNORE_TESTS: &[&str] = &[
     "css/atrule/if-else.css",
     // YAML frontmatter
     "css/yaml/dirty.css",
-    // Prettier's yaml parser rejects these (https://github.com/eemeli/yaml/issues/646),
-    // so no snapshot exists (`3-style.yml` is even marked `errors` in its format.test.js).
-    // oxc-yaml-parser parses them fine, but there is nothing to compare against.
-    "yaml/mapping/3-style.yml",
-    "yaml/spec/spec-example-2-11-mapping-between-sequences.yml",
-    // Pragma support (`@format` insertion / require)
-    "yaml/insert-pragma/",
-    "yaml/require-pragma/",
 ];

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -24,7 +24,6 @@ use oxc_formatter::JsFormatOptions;
 use oxc_formatter_css::CssFormatOptions;
 use oxc_formatter_graphql::GraphqlFormatOptions;
 use oxc_formatter_json::JsonFormatOptions;
-use oxc_formatter_yaml::YamlFormatOptions;
 use oxc_span::SourceType;
 
 use crate::{
@@ -256,10 +255,7 @@ impl TestRunner {
                     !options.experimental_operator_position.is_start()
                         && !options.experimental_ternaries
                 }
-                SpecOptions::Json(_)
-                | SpecOptions::Graphql(_)
-                | SpecOptions::Css(_)
-                | SpecOptions::Yaml(_) => true,
+                SpecOptions::Json(_) | SpecOptions::Graphql(_) | SpecOptions::Css(_) => true,
             })
             .collect::<Vec<_>>();
 
@@ -465,7 +461,7 @@ impl TestRunner {
     }
 
     /// Dispatches by language: JS/TS via `oxc_formatter`, JSON via `oxc_formatter_json`,
-    /// GraphQL via `oxc_formatter_graphql`, YAML via `oxc_formatter_yaml`.
+    /// GraphQL via `oxc_formatter_graphql`.
     fn run_formatter(
         path: &Path,
         source_text: &str,
@@ -476,7 +472,6 @@ impl TestRunner {
             SpecOptions::Json(opts) => Self::run_json_formatter(source_text, opts),
             SpecOptions::Graphql(opts) => Self::run_graphql_formatter(source_text, opts),
             SpecOptions::Css(opts) => Self::run_css_formatter(source_text, opts),
-            SpecOptions::Yaml(opts) => Self::run_yaml_formatter(source_text, opts),
         }
     }
 
@@ -514,13 +509,6 @@ impl TestRunner {
     fn run_css_formatter(source_text: &str, format_options: CssFormatOptions) -> Option<String> {
         let allocator = Allocator::default();
         let formatted = oxc_formatter_css::format(&allocator, source_text, format_options).ok()?;
-        let printed = formatted.print().ok()?;
-        Some(printed.into_code())
-    }
-
-    fn run_yaml_formatter(source_text: &str, format_options: YamlFormatOptions) -> Option<String> {
-        let allocator = Allocator::default();
-        let formatted = oxc_formatter_yaml::format(&allocator, source_text, format_options).ok()?;
         let printed = formatted.print().ok()?;
         Some(printed.into_code())
     }

--- a/tasks/prettier_conformance/src/main.rs
+++ b/tasks/prettier_conformance/src/main.rs
@@ -25,7 +25,6 @@ fn main() {
         TestLanguage::Css,
         TestLanguage::Scss,
         TestLanguage::Less,
-        TestLanguage::Yaml,
     ] {
         TestRunner::new(TestRunnerOptions { language, debug, filter: filter.clone() }).run();
     }

--- a/tasks/prettier_conformance/src/options.rs
+++ b/tasks/prettier_conformance/src/options.rs
@@ -20,7 +20,6 @@ pub enum TestLanguage {
     Css,
     Scss,
     Less,
-    Yaml,
 }
 
 impl TestLanguage {
@@ -36,7 +35,6 @@ impl TestLanguage {
             Self::Css => "css",
             Self::Scss => "scss",
             Self::Less => "less",
-            Self::Yaml => "yaml",
         }
     }
 
@@ -71,7 +69,6 @@ impl TestLanguage {
             Self::Css => vec![base.join("css")],
             Self::Scss => vec![base.join("scss")],
             Self::Less => vec![base.join("less")],
-            Self::Yaml => vec![base.join("yaml")],
         }
     }
 }

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -16,7 +16,6 @@ use oxc_formatter_core::{
 use oxc_formatter_css::{CssFormatOptions, CssVariant};
 use oxc_formatter_graphql::GraphqlFormatOptions;
 use oxc_formatter_json::{JsonFormatOptions, JsonVariant, QuoteProps};
-use oxc_formatter_yaml::{ProseWrap, YamlFormatOptions};
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
 
@@ -36,7 +35,6 @@ pub enum SpecOptions {
     Json(JsonFormatOptions),
     Graphql(GraphqlFormatOptions),
     Css(CssFormatOptions),
-    Yaml(YamlFormatOptions),
 }
 
 pub fn parse_spec(spec: &Path, language: TestLanguage) -> Vec<(SpecOptions, SnapshotOptions)> {
@@ -133,22 +131,12 @@ impl VisitMut<'_> for SpecParser {
             return;
         }
 
-        // NOTE: The JSON-family languages (and GraphQL) each accept only their own parser's calls
+        // NOTE: Every language except JS/TS accepts only its own parser's calls
         // (the parser name is exactly `TestLanguage::as_str()`).
         // A single `format.test.js` may list several parsers (e.g. `with-comment/`),
         // so we filter per-language.
-        let is_exact_parser_language = matches!(
-            self.language,
-            TestLanguage::Json
-                | TestLanguage::Jsonc
-                | TestLanguage::Json5
-                | TestLanguage::JsonStringify
-                | TestLanguage::Graphql
-                | TestLanguage::Css
-                | TestLanguage::Scss
-                | TestLanguage::Less
-                | TestLanguage::Yaml
-        );
+        let is_exact_parser_language =
+            !matches!(self.language, TestLanguage::Js | TestLanguage::Ts);
         if is_exact_parser_language && !parsers.iter().any(|p| p == self.language.as_str()) {
             return;
         }
@@ -178,7 +166,6 @@ impl VisitMut<'_> for SpecParser {
             },
             ..Default::default()
         };
-        let mut yaml_options = YamlFormatOptions::default();
 
         // Get options
         if let Some(Argument::ObjectExpression(obj_expr)) = expr.arguments.get(2) {
@@ -197,7 +184,6 @@ impl VisitMut<'_> for SpecParser {
                             } else if name == "bracketSpacing" {
                                 js_options.bracket_spacing = BracketSpacing::from(literal.value);
                                 graphql_options.bracket_spacing = literal.value.into();
-                                yaml_options.bracket_spacing = literal.value.into();
                             } else if matches!(
                                 name.as_ref(),
                                 "jsxBracketSameLine" | "bracketSameLine"
@@ -212,7 +198,6 @@ impl VisitMut<'_> for SpecParser {
                                 };
                                 json_options.single_quote = literal.value.into();
                                 css_options.single_quote = literal.value.into();
-                                yaml_options.single_quote = literal.value.into();
                             } else if name == "jsxSingleQuote" {
                                 js_options.jsx_quote_style = if literal.value {
                                     QuoteStyle::Single
@@ -263,23 +248,11 @@ impl VisitMut<'_> for SpecParser {
                                         "none" => oxc_formatter_css::TrailingCommas::Never,
                                         _ => unreachable!("Prettier's trailingComma should be 'all' | 'es5' | 'none'"),
                                     };
-                                    yaml_options.trailing_commas = match s {
-                                        "all" | "es5" => oxc_formatter_yaml::TrailingCommas::Always,
-                                        "none" => oxc_formatter_yaml::TrailingCommas::Never,
-                                        _ => unreachable!("Prettier's trailingComma should be 'all' | 'es5' | 'none'"),
-                                    };
                                 }
                                 "endOfLine" => {
                                     // TODO: change `unwrap_or_default` to `unwrap`
                                     core_options.line_ending =
                                         LineEnding::from_str(s).unwrap_or_default();
-                                }
-                                "proseWrap" => {
-                                    yaml_options.prose_wrap = match s {
-                                        "always" => ProseWrap::Always,
-                                        "never" => ProseWrap::Never,
-                                        _ => ProseWrap::Preserve,
-                                    };
                                 }
                                 "quoteProps" => {
                                     // TODO: change `unwrap_or_default` to `unwrap`
@@ -359,10 +332,6 @@ impl VisitMut<'_> for SpecParser {
             TestLanguage::Css | TestLanguage::Scss | TestLanguage::Less => {
                 css_options.apply_core(core_options);
                 SpecOptions::Css(css_options)
-            }
-            TestLanguage::Yaml => {
-                yaml_options.apply_core(core_options);
-                SpecOptions::Yaml(yaml_options)
             }
             TestLanguage::Js | TestLanguage::Ts => {
                 js_options.apply_core(core_options);


### PR DESCRIPTION
Migration from `tasks/prettier_conformance` to each crate test using `oxc_formatter_tests`, for YAML.
