### PR TITLE
chore(coverage): update stale test262 runtime snapshot

### DIFF
--- a/tasks/coverage/snapshots/runtime.snap
+++ b/tasks/coverage/snapshots/runtime.snap
@@ -2,7 +2,7 @@ commit: b363f29d
 
 runtime Summary:
 AST Parsed     : 18277/18277 (100.00%)
-Positive Passed: 17304/18277 (94.68%)
+Positive Passed: 17306/18277 (94.69%)
 minify Error: tasks/coverage/test262/test/language/computed-property-names/class/static/generator-prototype.js
 Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
 
@@ -68,9 +68,6 @@ Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
 
 minify Error: tasks/coverage/test262/test/language/expressions/arrow-function/dstr/obj-ptrn-id-init-fn-name-gen.js
 Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
-
-transform Error: tasks/coverage/test262/test/language/expressions/arrow-function/name.js
-timeout: global
 
 minify Error: tasks/coverage/test262/test/language/expressions/assignment/dstr/array-elem-init-fn-name-class.js
 Test262Error: Expected true but got false
@@ -1370,9 +1367,6 @@ TypeError: Cannot read properties of undefined (reading 'enumerable')
 
 minify Error: tasks/coverage/test262/test/language/expressions/optional-chaining/member-expression.js
 Test262Error: Expected SameValue(«"a"», «""») to be true
-
-codegen Error: tasks/coverage/test262/test/language/function-code/10.4.3-1-13-s.js
-timeout: global
 
 minify Error: tasks/coverage/test262/test/language/function-code/block-decl-onlystrict.js
 TypeError: Cannot read properties of undefined (reading 'constructor')


### PR DESCRIPTION
The automated submodule bump #25261 regenerated `runtime.snap` on a loaded CI runner where two tests hit the global timeout, recording transient `timeout: global` failures (`expressions/arrow-function/name.js`, `function-code/10.4.3-1-13-s.js`) and dropping the pass count from 17306 to 17304. Both tests pass on a normal run, so monitor-oxc's Test262 drift check has failed on every run since ([example](https://github.com/oxc-project/monitor-oxc/actions/runs/31359248351/job/93364683855)).

This restores the snapshot to what `cargo coverage runtime` actually produces. Rather than regenerating locally (which could bake in this machine's own timeouts), the CI-reported diff was applied directly and verified byte-identical to CI's output (`git hash-object` matches the diff's `65e3fa9` blob).

Timeouts can get baked in again whenever an automated regen lands on a slow runner; retrying timed-out tests before recording them would close that hole and is left for a follow-up.

This PR was assisted by Claude.