### PR TITLE
fix(linter/vitest/prefer-expect-assertions): handle parameterized Vitest assertion suggestions

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_expect_assertions.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_expect_assertions.rs
@@ -235,9 +235,14 @@ pub trait PreferExpectAssertionsRuleImpl {
                 );
             }
             JestGeneralFnKind::Test => {
+                let is_parameterized = general
+                    .members
+                    .iter()
+                    .any(|member| member.is_name_equal("each") || member.is_name_equal("for"));
                 self.check_test(
                     call_expr,
                     node.id(),
+                    is_parameterized,
                     file_expect_prefix,
                     covered_describe_ids,
                     ctx,
@@ -293,6 +298,7 @@ pub trait PreferExpectAssertionsRuleImpl {
         &self,
         call_expr: &'a CallExpression<'a>,
         test_node_id: NodeId,
+        is_parameterized: bool,
         file_expect_prefix: &str,
         covered_describe_ids: &[NodeId],
         ctx: &LintContext<'a>,
@@ -313,14 +319,25 @@ pub trait PreferExpectAssertionsRuleImpl {
             return;
         }
 
-        let Some(expected_resolved) = self.resolve_expect(callback, file_expect_prefix, ctx) else {
+        let expected_resolved = if is_parameterized {
+            self.resolve_expect_for_parameterized_test(call_expr, callback, file_expect_prefix, ctx)
+        } else {
+            self.resolve_expect(callback, file_expect_prefix, ctx)
+        };
+        let Some(expected_resolved) = expected_resolved else {
             ctx.diagnostic(expect_shadowed_by_parameter(call_expr.callee.span()));
             return;
         };
 
         let prefix = expected_resolved.as_ref();
 
-        if self.has_options() && !self.should_check_node(body, is_async_callback(callback), prefix)
+        if self.has_options()
+            && !self.should_check_node_with_file_expect(
+                body,
+                is_async_callback(callback),
+                prefix,
+                file_expect_prefix,
+            )
         {
             return;
         }
@@ -388,6 +405,15 @@ pub trait PreferExpectAssertionsRuleImpl {
         file_expect_prefix: &'r str,
         ctx: &LintContext<'a>,
     ) -> Option<Cow<'r, str>>;
+    fn resolve_expect_for_parameterized_test<'a, 'r>(
+        &self,
+        _call_expr: &CallExpression<'a>,
+        callback: &Expression<'a>,
+        file_expect_prefix: &'r str,
+        ctx: &LintContext<'a>,
+    ) -> Option<Cow<'r, str>> {
+        self.resolve_expect(callback, file_expect_prefix, ctx)
+    }
     fn report_have_expect_assertions(
         &self,
         span: Span,
@@ -397,6 +423,15 @@ pub trait PreferExpectAssertionsRuleImpl {
     );
 
     fn should_check_node(&self, body: CallbackBody<'_>, is_async: bool, prefix: &str) -> bool;
+    fn should_check_node_with_file_expect(
+        &self,
+        body: CallbackBody<'_>,
+        is_async: bool,
+        prefix: &str,
+        _file_expect_prefix: &str,
+    ) -> bool {
+        self.should_check_node(body, is_async, prefix)
+    }
 }
 
 fn is_covered_by_hook(

--- a/crates/oxc_linter/src/rules/vitest/prefer_expect_assertions.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_expect_assertions.rs
@@ -2,7 +2,10 @@ use std::borrow::Cow;
 
 use serde::Deserialize;
 
-use oxc_ast::ast::{BindingPattern, Expression};
+use oxc_ast::ast::{
+    Argument, ArrayExpressionElement, BindingPattern, CallExpression, Expression, MemberExpression,
+};
+use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
@@ -17,7 +20,7 @@ use crate::{
         CallbackBody, DOCUMENTATION, PreferExpectAssertionsConfig, PreferExpectAssertionsRuleImpl,
         resolve_expect_local_name, should_check,
     },
-    utils::collect_possible_jest_call_node,
+    utils::{collect_possible_jest_call_node, get_node_name},
 };
 
 fn have_expect_assertions(span: Span, prefix: &str) -> OxcDiagnostic {
@@ -84,11 +87,31 @@ impl PreferExpectAssertionsRuleImpl for PreferExpectAssertions {
         file_expect_prefix: &'r str,
         _ctx: &LintContext<'a>,
     ) -> Option<Cow<'r, str>> {
-        let Some(expect_param) = resolve_expect_parameter_prefix(callback) else {
+        let Some(expect_param) = resolve_expect_parameter_prefix(callback, 0) else {
             return Some(Cow::Borrowed(file_expect_prefix));
         };
 
         Some(Cow::Owned(expect_param.to_string()))
+    }
+
+    fn resolve_expect_for_parameterized_test<'a, 'r>(
+        &self,
+        call_expr: &CallExpression<'a>,
+        callback: &Expression<'a>,
+        file_expect_prefix: &'r str,
+        _ctx: &LintContext<'a>,
+    ) -> Option<Cow<'r, str>> {
+        if let Some(context_index) = parameterized_context_parameter_index(call_expr)
+            && let Some(expect_param) = resolve_expect_parameter_prefix(callback, context_index)
+        {
+            return Some(Cow::Owned(expect_param.to_string()));
+        }
+
+        if let Some(expect_param) = resolve_used_parameterized_context_prefix(callback) {
+            return Some(Cow::Owned(expect_param.to_string()));
+        }
+
+        Some(Cow::Borrowed(file_expect_prefix))
     }
 
     fn report_have_expect_assertions(
@@ -104,18 +127,130 @@ impl PreferExpectAssertionsRuleImpl for PreferExpectAssertions {
     fn should_check_node(&self, body: CallbackBody<'_>, is_async: bool, prefix: &str) -> bool {
         should_check(self.0.as_ref(), body, is_async, prefix)
     }
+
+    fn should_check_node_with_file_expect(
+        &self,
+        body: CallbackBody<'_>,
+        is_async: bool,
+        prefix: &str,
+        file_expect_prefix: &str,
+    ) -> bool {
+        should_check(self.0.as_ref(), body, is_async, prefix)
+            || (prefix != file_expect_prefix
+                && should_check(self.0.as_ref(), body, is_async, file_expect_prefix))
+    }
 }
 
-fn resolve_expect_parameter_prefix(callback: &Expression<'_>) -> Option<CompactStr> {
+fn callback_uses_expect_prefix(callback: &Expression<'_>, prefix: &str) -> bool {
+    let mut scanner = ExpectPrefixScanner {
+        prefix,
+        prefix_dot: CompactStr::from(format!("{prefix}.")),
+        found: false,
+    };
+    scanner.visit_expression(callback);
+    scanner.found
+}
+
+fn resolve_used_parameterized_context_prefix(callback: &Expression<'_>) -> Option<CompactStr> {
     let params = match callback {
         Expression::FunctionExpression(func) => &func.params,
         Expression::ArrowFunctionExpression(func) => &func.params,
         _ => return None,
     };
 
-    let first_param = params.items.first()?;
+    params.items.iter().enumerate().rev().find_map(|(index, param)| {
+        if index == 0 && !matches!(&param.pattern, BindingPattern::ObjectPattern(_)) {
+            return None;
+        }
 
-    match &first_param.pattern {
+        let prefix = resolve_expect_parameter_prefix_from_pattern(&param.pattern)?;
+        callback_uses_expect_prefix(callback, &prefix).then_some(prefix)
+    })
+}
+
+struct ExpectPrefixScanner<'p> {
+    prefix: &'p str,
+    prefix_dot: CompactStr,
+    found: bool,
+}
+
+impl<'a> VisitJs<'a> for ExpectPrefixScanner<'_> {
+    fn visit_call_expression(&mut self, call_expr: &CallExpression<'a>) {
+        if self.found {
+            return;
+        }
+
+        let name = get_node_name(&call_expr.callee);
+        if name == self.prefix || name.starts_with(self.prefix_dot.as_str()) {
+            self.found = true;
+            return;
+        }
+
+        oxc_ast_visit::walk_js::walk_call_expression(self, call_expr);
+    }
+}
+
+fn parameterized_context_parameter_index(call_expr: &CallExpression<'_>) -> Option<usize> {
+    let Expression::CallExpression(parameterized_call) = &call_expr.callee else {
+        return None;
+    };
+    let method = parameterized_call
+        .callee
+        .as_member_expression()
+        .and_then(MemberExpression::static_property_name)?;
+
+    if method == "for" {
+        return Some(1);
+    }
+    if method != "each" {
+        return None;
+    }
+
+    let Some(Expression::ArrayExpression(rows)) = parameterized_call
+        .arguments
+        .first()
+        .and_then(Argument::as_expression)
+        .map(Expression::get_inner_expression)
+    else {
+        return None;
+    };
+
+    let mut argument_counts = rows.elements.iter().map(each_row_argument_count);
+    let argument_count = argument_counts.next()??;
+    argument_counts.all(|count| count == Some(argument_count)).then_some(argument_count)
+}
+
+fn each_row_argument_count(row: &ArrayExpressionElement<'_>) -> Option<usize> {
+    let expression = row.as_expression()?.get_inner_expression();
+    let Expression::ArrayExpression(arguments) = expression else {
+        return Some(1);
+    };
+    arguments
+        .elements
+        .iter()
+        .all(|argument| !argument.is_spread())
+        .then_some(arguments.elements.len())
+}
+
+fn resolve_expect_parameter_prefix(
+    callback: &Expression<'_>,
+    parameter_index: usize,
+) -> Option<CompactStr> {
+    let params = match callback {
+        Expression::FunctionExpression(func) => &func.params,
+        Expression::ArrowFunctionExpression(func) => &func.params,
+        _ => return None,
+    };
+
+    let context_param = params.items.get(parameter_index)?;
+
+    resolve_expect_parameter_prefix_from_pattern(&context_param.pattern)
+}
+
+fn resolve_expect_parameter_prefix_from_pattern(
+    pattern: &BindingPattern<'_>,
+) -> Option<CompactStr> {
+    match pattern {
         BindingPattern::BindingIdentifier(id) => {
             Some(CompactStr::from(format!("{}.expect", id.name)))
         }
@@ -358,6 +493,32 @@ fn test() {
             Some(serde_json::json!([{ "onlyFunctionsWithExpectInLoop": true }])),
         ),
         (
+            r#"test.each([[1]])("case", (value, { expect: e }) => {
+                consume(() => e(value).toBe(1));
+            });"#,
+            Some(serde_json::json!([{ "onlyFunctionsWithExpectInCallback": true }])),
+        ),
+        (
+            r#"test.each([{ value: 1 }])("case", ({ value }, ctx) => {
+                consume(() => expect(value).toBe(1));
+            });"#,
+            Some(serde_json::json!([{ "onlyFunctionsWithExpectInCallback": true }])),
+        ),
+        (
+            r#"test.each([{ value: 1 }])("case", ({ value }, ctx) => {
+                ctx.expect(value).toBe(1);
+                consume(() => expect(value).toBe(1));
+            });"#,
+            Some(serde_json::json!([{ "onlyFunctionsWithExpectInCallback": true }])),
+        ),
+        (
+            r#"const rows = [[1]];
+            test.each(rows)("case", (value, { expect: e }) => {
+                consume(() => e(value).toBe(1));
+            });"#,
+            Some(serde_json::json!([{ "onlyFunctionsWithExpectInCallback": true }])),
+        ),
+        (
             r#"it("it1", () => {
                 const foo = { bar({ baz }) { baz(); } };
               });
@@ -583,6 +744,148 @@ fn test() {
             it('missing assertions', (ctx) => {ctx.expect.assertions();
               ctx.expect(true).toBe(true);
             })",
+            ),
+        ),
+        // Direct test callbacks always receive TestContext first.
+        (
+            r#"test("x", ({ expect: e }) => doWork())"#,
+            (
+                r#"test("x", ({ expect: e }) => {e.hasAssertions();return doWork();})"#,
+                r#"test("x", ({ expect: e }) => {e.assertions();return doWork();})"#,
+            ),
+        ),
+        // The first parameter of a parameterized test is iteration data.
+        (
+            r#"it.each([{ abc: 123 }])("$abc", async (props) => {
+              await expect(Promise.resolve(props.abc)).resolves.toBe(props.abc);
+            });"#,
+            (
+                r#"it.each([{ abc: 123 }])("$abc", async (props) => {expect.hasAssertions();
+              await expect(Promise.resolve(props.abc)).resolves.toBe(props.abc);
+            });"#,
+                r#"it.each([{ abc: 123 }])("$abc", async (props) => {expect.assertions();
+              await expect(Promise.resolve(props.abc)).resolves.toBe(props.abc);
+            });"#,
+            ),
+        ),
+        (
+            r#"test.only.for([{ abc: 123 }])("$abc", async (props) => {
+              await expect(Promise.resolve(props.abc)).resolves.toBe(props.abc);
+            });"#,
+            (
+                r#"test.only.for([{ abc: 123 }])("$abc", async (props) => {expect.hasAssertions();
+              await expect(Promise.resolve(props.abc)).resolves.toBe(props.abc);
+            });"#,
+                r#"test.only.for([{ abc: 123 }])("$abc", async (props) => {expect.assertions();
+              await expect(Promise.resolve(props.abc)).resolves.toBe(props.abc);
+            });"#,
+            ),
+        ),
+        // Parameterized tests append TestContext after the iteration values.
+        (
+            r#"test.each([[1]])("case", (value, { expect: e }) => {
+              e(value).toBe(1);
+            });"#,
+            (
+                r#"test.each([[1]])("case", (value, { expect: e }) => {e.hasAssertions();
+              e(value).toBe(1);
+            });"#,
+                r#"test.each([[1]])("case", (value, { expect: e }) => {e.assertions();
+              e(value).toBe(1);
+            });"#,
+            ),
+        ),
+        (
+            r#"test.for([[1]])("case", (value, ctx) => {
+              ctx.expect(value).toEqual([1]);
+            });"#,
+            (
+                r#"test.for([[1]])("case", (value, ctx) => {ctx.expect.hasAssertions();
+              ctx.expect(value).toEqual([1]);
+            });"#,
+                r#"test.for([[1]])("case", (value, ctx) => {ctx.expect.assertions();
+              ctx.expect(value).toEqual([1]);
+            });"#,
+            ),
+        ),
+        // A declared context remains a valid suggestion target when global expect is used.
+        (
+            r#"test.each([{ value: 1 }])("case", ({ value }, ctx) => {
+              expect(value).toBe(1);
+            });"#,
+            (
+                r#"test.each([{ value: 1 }])("case", ({ value }, ctx) => {ctx.expect.hasAssertions();
+              expect(value).toBe(1);
+            });"#,
+                r#"test.each([{ value: 1 }])("case", ({ value }, ctx) => {ctx.expect.assertions();
+              expect(value).toBe(1);
+            });"#,
+            ),
+        ),
+        // Nonliteral and tagged tables resolve a used trailing TestContext.
+        (
+            r#"const rows = [[1]];
+            test.each(rows)("case", (value, { expect: e }) => {
+              e(value).toBe(1);
+            });"#,
+            (
+                r#"const rows = [[1]];
+            test.each(rows)("case", (value, { expect: e }) => {e.hasAssertions();
+              e(value).toBe(1);
+            });"#,
+                r#"const rows = [[1]];
+            test.each(rows)("case", (value, { expect: e }) => {e.assertions();
+              e(value).toBe(1);
+            });"#,
+            ),
+        ),
+        (
+            r#"test.each`
+              value
+              ${1}
+            `("case", ({ value }, { expect: e }) => {
+              e(value).toBe(1);
+            });"#,
+            (
+                r#"test.each`
+              value
+              ${1}
+            `("case", ({ value }, { expect: e }) => {e.hasAssertions();
+              e(value).toBe(1);
+            });"#,
+                r#"test.each`
+              value
+              ${1}
+            `("case", ({ value }, { expect: e }) => {e.assertions();
+              e(value).toBe(1);
+            });"#,
+            ),
+        ),
+        // With no row arguments, `.each` passes TestContext first.
+        (
+            r#"test.each([[]])("uses context", ({ expect: e }) => {
+              e(value).toBe(value);
+            });"#,
+            (
+                r#"test.each([[]])("uses context", ({ expect: e }) => {e.hasAssertions();
+              e(value).toBe(value);
+            });"#,
+                r#"test.each([[]])("uses context", ({ expect: e }) => {e.assertions();
+              e(value).toBe(value);
+            });"#,
+            ),
+        ),
+        (
+            r#"test.each([[]] as const)("uses context", (ctx) => {
+              ctx.expect(value).toBe(value);
+            });"#,
+            (
+                r#"test.each([[]] as const)("uses context", (ctx) => {ctx.expect.hasAssertions();
+              ctx.expect(value).toBe(value);
+            });"#,
+                r#"test.each([[]] as const)("uses context", (ctx) => {ctx.expect.assertions();
+              ctx.expect(value).toBe(value);
+            });"#,
             ),
         ),
     ];

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_expect_assertions.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_expect_assertions.snap
@@ -153,6 +153,40 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Add `expect.hasAssertions()` or `expect.assertions(<number>)` as the first statement in this test.
 
+  ⚠ vitest(prefer-expect-assertions): This test should have either `e.assertions(<number of assertions>)` or `e.hasAssertions()` as its first expression.
+   ╭─[prefer_expect_assertions.tsx:1:1]
+ 1 │ ╭─▶ test.each([[1]])("case", (value, { expect: e }) => {
+ 2 │ │                   consume(() => e(value).toBe(1));
+ 3 │ ╰─▶             });
+   ╰────
+  help: Add `e.hasAssertions()` or `e.assertions(<number>)` as the first statement in this test.
+
+  ⚠ vitest(prefer-expect-assertions): This test should have either `ctx.expect.assertions(<number of assertions>)` or `ctx.expect.hasAssertions()` as its first expression.
+   ╭─[prefer_expect_assertions.tsx:1:1]
+ 1 │ ╭─▶ test.each([{ value: 1 }])("case", ({ value }, ctx) => {
+ 2 │ │                   consume(() => expect(value).toBe(1));
+ 3 │ ╰─▶             });
+   ╰────
+  help: Add `ctx.expect.hasAssertions()` or `ctx.expect.assertions(<number>)` as the first statement in this test.
+
+  ⚠ vitest(prefer-expect-assertions): This test should have either `ctx.expect.assertions(<number of assertions>)` or `ctx.expect.hasAssertions()` as its first expression.
+   ╭─[prefer_expect_assertions.tsx:1:1]
+ 1 │ ╭─▶ test.each([{ value: 1 }])("case", ({ value }, ctx) => {
+ 2 │ │                   ctx.expect(value).toBe(1);
+ 3 │ │                   consume(() => expect(value).toBe(1));
+ 4 │ ╰─▶             });
+   ╰────
+  help: Add `ctx.expect.hasAssertions()` or `ctx.expect.assertions(<number>)` as the first statement in this test.
+
+  ⚠ vitest(prefer-expect-assertions): This test should have either `e.assertions(<number of assertions>)` or `e.hasAssertions()` as its first expression.
+   ╭─[prefer_expect_assertions.tsx:2:13]
+ 1 │     const rows = [[1]];
+ 2 │ ╭─▶             test.each(rows)("case", (value, { expect: e }) => {
+ 3 │ │                   consume(() => e(value).toBe(1));
+ 4 │ ╰─▶             });
+   ╰────
+  help: Add `e.hasAssertions()` or `e.assertions(<number>)` as the first statement in this test.
+
   ⚠ vitest(prefer-expect-assertions): This test should have either `expect.assertions(<number of assertions>)` or `expect.hasAssertions()` as its first expression.
    ╭─[prefer_expect_assertions.tsx:1:1]
  1 │ ╭─▶ it("it1", () => {


### PR DESCRIPTION
## Summary

- detect parameterized Vitest tests using the parsed `.each` / `.for` call chain
- use the file-level `expect` prefix instead of treating the first iteration parameter as `TestContext`
- preserve context-aware assertion suggestions for direct Vitest test callbacks
- add regression coverage for `.each` and modified `.for` calls

This matches upstream behavior: Jest always suggests the global `expect`, while Vitest only uses a context prefix when it resolves a genuine direct-test context reference.

Closes #25455

