### PR TITLE
fix(react_compiler): model tagged templates as calls

### DIFF
--- a/crates/oxc_react_compiler/fixtures/tagged-template-mutable-result.js
+++ b/crates/oxc_react_compiler/fixtures/tagged-template-mutable-result.js
@@ -1,0 +1,17 @@
+// @compilationMode:annotation
+function tag(strings, value) {
+  return {value};
+}
+
+function Component({value}) {
+  'use memo';
+  const result = tag`${value}`;
+  result.value++;
+  return result.value;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 1}],
+  sequentialRenders: [{value: 1}, {value: 1}],
+};

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -2067,6 +2067,24 @@ fn compute_signature_for_instruction<'a>(
             effects.push(AliasingEffect::MutateTransitiveConditionally { value: *await_value });
             effects.push(AliasingEffect::Capture { from: *await_value, into: *lvalue });
         }
+        InstructionValue::TaggedTemplateExpression { tag, subexprs, span, .. } => {
+            // A tagged template is a function call whose first argument is the
+            // call-site's frozen template object, followed by the interpolated
+            // expressions. There is no HIR place for the implicit template object,
+            // so preserve its parameter position with a hole.
+            let mut args = ArenaVec::new_in(&alloc);
+            args.push(PlaceOrSpreadOrHole::Hole);
+            args.extend(subexprs.iter().copied().map(PlaceOrSpreadOrHole::Place));
+            effects.push(AliasingEffect::Apply {
+                receiver: *tag,
+                function: *tag,
+                mutates_function: true,
+                args,
+                into: *lvalue,
+                signature: Some(env.identifiers[tag.identifier].type_),
+                span: *span,
+            });
+        }
         InstructionValue::NewExpression { callee, args, span } => {
             effects.push(AliasingEffect::Apply {
                 receiver: *callee,
@@ -2390,8 +2408,7 @@ fn compute_signature_for_instruction<'a>(
             });
         }
         // All primitive-creating instructions
-        InstructionValue::TaggedTemplateExpression { .. }
-        | InstructionValue::BinaryExpression { .. }
+        InstructionValue::BinaryExpression { .. }
         | InstructionValue::Debugger { .. }
         | InstructionValue::JSXText { .. }
         | InstructionValue::MetaProperty { .. }

--- a/crates/oxc_react_compiler/tests/snapshots/tagged-template-mutable-result.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/tagged-template-mutable-result.snap
@@ -1,0 +1,29 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/tagged-template-mutable-result.js
+---
+import { c as _c } from "react/compiler-runtime";
+// @compilationMode:annotation
+function tag(strings, value) {
+	return { value };
+}
+function Component(t0) {
+	"use memo";
+	const $ = _c(2);
+	const { value } = t0;
+	let result;
+	if ($[0] !== value) {
+		result = tag`${value}`;
+		result.value = result.value + 1;
+		$[0] = value;
+		$[1] = result;
+	} else {
+		result = $[1];
+	}
+	return result.value;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ value: 1 }],
+	sequentialRenders: [{ value: 1 }, { value: 1 }]
+};


### PR DESCRIPTION
Model tagged-template expressions as function applications during mutation and alias inference. This keeps mutations of returned objects within the memoization scope and preserves the implicit template argument position.

Checked with `cargo test -p oxc_react_compiler` and the transform-react NAPI suite.

AI-assisted.