### PR TITLE
fix(codegen): output newline after `export default interface`

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1275,7 +1275,10 @@ impl Gen for ExportDefaultDeclarationKind<'_> {
                 class.print(p, ctx);
                 p.print_soft_newline();
             }
-            Self::TSInterfaceDeclaration(interface) => interface.print(p, ctx),
+            Self::TSInterfaceDeclaration(interface) => {
+                interface.print(p, ctx);
+                p.print_soft_newline();
+            }
             _ => {
                 p.start_of_default_export = p.code_len();
                 self.to_expression().print_expr(p, Precedence::Comma, Context::empty());

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -56,6 +56,13 @@ fn cases() {
 }
 
 #[test]
+fn export_default_interface() {
+    // A newline must follow, or the next statement gets glued on,
+    // as it does for `export default class` / `export default function`.
+    test_same("export default interface X {}\nconst y = 1;\n");
+}
+
+#[test]
 fn decorators() {
     test_same("@a abstract class C {}\n");
     test_tsx("@a @b export default abstract class {}", "export default @a @b abstract class {}\n");

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -57,8 +57,6 @@ fn cases() {
 
 #[test]
 fn export_default_interface() {
-    // A newline must follow, or the next statement gets glued on,
-    // as it does for `export default class` / `export default function`.
     test_same("export default interface X {}\nconst y = 1;\n");
 }
 


### PR DESCRIPTION
Fix a small bug in `oxc_codegen` in pretty-print mode.

No newline was printed after a `TSInterfaceDeclaration` which is default export.

Before:

```typescript
export default interface X {}let foo;
```

After:

```typescript
export default interface X {}
let foo;
```