### PR TITLE
fix(semantic): resolve merged enum member references

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -89,6 +89,14 @@ pub struct SemanticBuilder<'a> {
     /// declarations in that scope can still detect redeclarations via `check_redeclaration`.
     /// A single flat map avoids allocating a per-scope inner map for every hoisting scope.
     pub(crate) hoisting_variables: FxHashMap<(ScopeId, Ident<'a>), SymbolId>,
+    /// Body scopes for each enum symbol. Multiple scopes belong to the same symbol when enum
+    /// declarations merge.
+    enum_body_scopes: FxHashMap<SymbolId, SmallVec<[ScopeId; 1]>>,
+    /// Reverse lookup for [`Self::enum_body_scopes`], used while walking a reference's scope
+    /// chain to identify enum body scopes.
+    enum_symbol_by_body_scope: FxHashMap<ScopeId, SymbolId>,
+    /// Enum symbols whose bodies are currently being visited.
+    enum_symbol_stack: SmallVec<[SymbolId; 1]>,
 
     // builders
     /// Node-id counter, current-node cursor/flags, and the node storage (full
@@ -157,6 +165,9 @@ impl<'a> SemanticBuilder<'a> {
             module_instance_state_cache: FxHashMap::default(),
             node_store: AstNodeStore::default(),
             hoisting_variables: FxHashMap::default(),
+            enum_body_scopes: FxHashMap::default(),
+            enum_symbol_by_body_scope: FxHashMap::default(),
+            enum_symbol_stack: SmallVec::new(),
             scoping,
             unresolved_references: UnresolvedReferences::new(),
             unresolved_references_checkpoint: 0,
@@ -660,6 +671,25 @@ impl<'a> SemanticBuilder<'a> {
             {
                 return true;
             }
+
+            if !self.enum_symbol_by_body_scope.is_empty()
+                && let Some(enum_symbol_id) = self.enum_symbol_by_body_scope.get(&sid).copied()
+            {
+                let sibling_symbol_id =
+                    self.enum_body_scopes.get(&enum_symbol_id).and_then(|body_scopes| {
+                        body_scopes.iter().find_map(|&body_scope_id| {
+                            (body_scope_id != sid)
+                                .then(|| self.scoping.get_binding(body_scope_id, name))
+                                .flatten()
+                        })
+                    });
+                if let Some(symbol_id) = sibling_symbol_id
+                    && self.try_resolve_reference(reference_id, symbol_id)
+                {
+                    return true;
+                }
+            }
+
             scope_id = self.scoping.scope_parent_id(sid);
         }
         false
@@ -2730,13 +2760,31 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         decl.bind(self);
         self.visit_span(&decl.span);
         self.visit_binding_identifier(&decl.id);
+        self.enum_symbol_stack.push(decl.id.symbol_id.get().expect("enum declaration is bound"));
         self.visit_ts_enum_body(&decl.body);
+        self.enum_symbol_stack.pop();
         // Evaluate enum member values after all members are bound
         if self.enum_eval {
             crate::ts_enum::eval::evaluate_enum_members(decl, &mut self.scoping);
         }
         self.leave_node(kind);
         self.leave_ambient_context(decl.declare);
+    }
+
+    fn visit_ts_enum_body(&mut self, body: &TSEnumBody<'a>) {
+        let kind = AstKind::TSEnumBody(self.alloc(body));
+        self.enter_node(kind);
+        self.enter_scope(ScopeFlags::empty(), &body.scope_id);
+
+        let enum_symbol_id = *self.enum_symbol_stack.last().expect("enum body has an enum symbol");
+        let scope_id = self.current_scope_id;
+        self.enum_body_scopes.entry(enum_symbol_id).or_default().push(scope_id);
+        self.enum_symbol_by_body_scope.insert(scope_id, enum_symbol_id);
+
+        self.visit_span(&body.span);
+        self.visit_ts_enum_members(&body.members);
+        self.leave_scope();
+        self.leave_node(kind);
     }
 
     fn visit_ts_enum_member(&mut self, member: &TSEnumMember<'a>) {

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/issue-25364.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/issue-25364.snap
@@ -1,0 +1,67 @@
+---
+source: crates/oxc_semantic/tests/main.rs
+input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/issue-25364.ts
+---
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "flags": "ScopeFlags(0x0)",
+        "id": 1,
+        "node": "TSEnumBody",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(EnumMember)",
+            "id": 2,
+            "name": "B",
+            "node": "TSEnumMember",
+            "references": [
+              {
+                "flags": "ReferenceFlags(Read)",
+                "id": 0,
+                "name": "B",
+                "node_id": 15,
+                "scope_id": 2
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "children": [],
+        "flags": "ScopeFlags(0x0)",
+        "id": 2,
+        "node": "TSEnumBody",
+        "symbols": [
+          {
+            "flags": "SymbolFlags(EnumMember)",
+            "id": 3,
+            "name": "C",
+            "node": "TSEnumMember",
+            "references": []
+          }
+        ]
+      }
+    ],
+    "flags": "ScopeFlags(Top)",
+    "id": 0,
+    "node": "Program",
+    "symbols": [
+      {
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "id": 0,
+        "name": "B",
+        "node": "VariableDeclarator(B)",
+        "references": []
+      },
+      {
+        "flags": "SymbolFlags(RegularEnum)",
+        "id": 1,
+        "name": "A",
+        "node": "TSEnumDeclaration(A)",
+        "references": []
+      }
+    ]
+  }
+]

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/issue-25364.ts
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/issue-25364.ts
@@ -1,0 +1,9 @@
+const B = 0;
+
+enum A {
+  B,
+}
+
+enum A {
+  C = B,
+}

--- a/crates/oxc_semantic/tests/integration/scopes.rs
+++ b/crates/oxc_semantic/tests/integration/scopes.rs
@@ -209,6 +209,125 @@ fn test_enums() {
 }
 
 #[test]
+fn test_merged_enum_member_references() {
+    let tester = SemanticTester::ts(
+        "
+        const B = 0;
+        enum A { B }
+        enum A { C = B }
+        ",
+    );
+    let semantic = tester.build();
+    let scoping = semantic.scoping();
+
+    let outer_b = scoping
+        .get_binding(scoping.root_scope_id(), "B".into())
+        .expect("Expected the outer `B` binding");
+    assert!(scoping.get_resolved_reference_ids(outer_b).is_empty());
+
+    let enum_member_b = scoping
+        .symbol_ids()
+        .find(|&symbol_id| {
+            scoping.symbol_name(symbol_id) == "B"
+                && scoping.symbol_flags(symbol_id).is_enum_member()
+        })
+        .expect("Expected the first enum's `B` member");
+    assert_eq!(scoping.get_resolved_reference_ids(enum_member_b).len(), 1);
+    assert!(!scoping.root_unresolved_references().contains_key("B"));
+}
+
+#[test]
+fn test_enum_member_parameter_defaults_resolve_before_function_body() {
+    let tester = SemanticTester::ts(
+        "
+        const B = 0;
+        enum A { C = (function (p = B) { var B = 1; return p; })() }
+        ",
+    );
+    let semantic = tester.build();
+    let scoping = semantic.scoping();
+
+    let outer_b = scoping
+        .get_binding(scoping.root_scope_id(), "B".into())
+        .expect("Expected the outer `B` binding");
+    assert_eq!(scoping.get_resolved_reference_ids(outer_b).len(), 1);
+}
+
+#[test]
+fn test_enum_member_catch_parameters_resolve_before_function_body() {
+    let tester = SemanticTester::ts(
+        "
+        const B = 0;
+        enum A {
+            C = (() => {
+                try {} catch ({ [B]: p }) {
+                    var B = 1;
+                    return p;
+                }
+                return 0;
+            })()
+        }
+        ",
+    );
+    let semantic = tester.build();
+    let scoping = semantic.scoping();
+
+    let outer_b = scoping
+        .get_binding(scoping.root_scope_id(), "B".into())
+        .expect("Expected the outer `B` binding");
+    assert_eq!(scoping.get_resolved_reference_ids(outer_b).len(), 1);
+}
+
+#[test]
+fn test_merged_enum_member_references_from_parameter_defaults() {
+    let tester = SemanticTester::ts(
+        "
+        const B = 0;
+        enum A { B }
+        enum A { C = (function (p = B) { return p; })() }
+        ",
+    );
+    let semantic = tester.build();
+    let scoping = semantic.scoping();
+
+    let outer_b = scoping
+        .get_binding(scoping.root_scope_id(), "B".into())
+        .expect("Expected the outer `B` binding");
+    assert!(scoping.get_resolved_reference_ids(outer_b).is_empty());
+
+    let enum_member_b = scoping
+        .symbol_ids()
+        .find(|&symbol_id| {
+            scoping.symbol_name(symbol_id) == "B"
+                && scoping.symbol_flags(symbol_id).is_enum_member()
+        })
+        .expect("Expected the first enum's `B` member");
+    assert_eq!(scoping.get_resolved_reference_ids(enum_member_b).len(), 1);
+}
+
+#[test]
+fn test_merged_enum_member_forward_references() {
+    let tester = SemanticTester::ts(
+        "
+        enum A { C = B }
+        enum A { B }
+        ",
+    );
+    let semantic = tester.build();
+    let scoping = semantic.scoping();
+
+    let enum_member_b = scoping
+        .symbol_ids()
+        .find(|&symbol_id| {
+            scoping.symbol_name(symbol_id) == "B"
+                && scoping.symbol_flags(symbol_id).is_enum_member()
+        })
+        .expect("Expected the second enum's `B` member");
+    assert_eq!(scoping.get_resolved_reference_ids(enum_member_b).len(), 1);
+    assert!(!scoping.root_unresolved_references().contains_key("B"));
+}
+
+#[test]
 fn var_hoisting() {
     SemanticTester::js(
         "


### PR DESCRIPTION
Closes #25364.

## Summary

- resolve references to enum members across same-file merged enum declarations
- preserve local scope precedence while allowing merged enum members to take precedence over enclosing lexical bindings
- retain early parameter and catch resolution, with regression coverage for function-body bindings, nested merged enums, and forward references

## Testing

- `cargo test -p oxc_semantic --tests`
- `cargo clippy -p oxc_semantic --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `cargo insta pending-snapshots`

## AI assistance

Codex was used as help for this PR.