### PR TITLE
fix(react_compiler): preserve underscore-prefixed JSX components

### DIFF
--- a/crates/oxc_react_compiler/fixtures/context-variable-as-jsx-element-tag.js
+++ b/crates/oxc_react_compiler/fixtures/context-variable-as-jsx-element-tag.js
@@ -3,13 +3,13 @@ import {useMemo} from 'react';
 import {Stringify} from 'shared-runtime';
 
 function Component(props) {
-  let Component = Stringify;
+  let _Component = Stringify;
 
-  Component = useMemo(() => {
-    return Component;
-  }, [Component]);
+  _Component = useMemo(() => {
+    return _Component;
+  }, [_Component]);
 
-  return <Component {...props} />;
+  return <_Component {...props} />;
 }
 
 export const FIXTURE_ENTRYPOINT = {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -4754,14 +4754,17 @@ fn lower_jsx_element_name<'a>(
     builder: &mut HirBuilder<'a, '_>,
     name: &oxc::JSXElementName<'a>,
 ) -> Result<JsxTag<'a>, OxcDiagnostic> {
-    // Lower a simple JSX tag identifier (component-vs-builtin split on case).
+    // Lower a simple JSX tag identifier. The parser has already classified the tag as an
+    // identifier reference (component) or a plain identifier (builtin), so preserve that
+    // distinction instead of inferring it again from the name.
     fn lower_tag_identifier<'a>(
         builder: &mut HirBuilder<'a, '_>,
         tag: Ident<'a>,
         span: oxc_span::Span,
         symbol: Option<SymbolId>,
+        is_reference: bool,
     ) -> Result<JsxTag<'a>, OxcDiagnostic> {
-        if tag.starts_with(|c: char| c.is_ascii_uppercase()) {
+        if is_reference {
             // Component tag: resolve as identifier and load
             let place = lower_identifier(builder, tag, span, symbol)?;
             let load_value = if builder.is_context_identifier(symbol) {
@@ -4779,15 +4782,15 @@ fn lower_jsx_element_name<'a>(
 
     match name {
         oxc::JSXElementName::Identifier(id) => {
-            lower_tag_identifier(builder, Ident::from(id.name.as_str()), id.span, None)
+            lower_tag_identifier(builder, Ident::from(id.name.as_str()), id.span, None, false)
         }
         oxc::JSXElementName::IdentifierReference(id) => {
             let symbol = builder.scope().resolve_reference(id);
-            lower_tag_identifier(builder, id.name, id.span, symbol)
+            lower_tag_identifier(builder, id.name, id.span, symbol, true)
         }
         oxc::JSXElementName::ThisExpression(this) => {
             // `<this.Foo />`-style `this` tag lowers as the identifier "this".
-            lower_tag_identifier(builder, Ident::from("this"), this.span, None)
+            lower_tag_identifier(builder, Ident::from("this"), this.span, None, false)
         }
         oxc::JSXElementName::MemberExpression(member) => {
             let place = lower_jsx_member_expression(builder, member)?;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -3308,8 +3308,8 @@ fn ox_codegen_jsx_fbt_child_element<'a>(
     }
 }
 
-/// Build a `JSXElementName` from a tag expression following the TS compiler's
-/// identifier-reference rule (uppercase / contains-`.` names become references).
+/// Build a `JSXElementName` from a tag expression, preserving the HIR distinction between
+/// component references (identifier expressions) and builtin tags (string literals).
 fn ox_expression_to_jsx_tag<'a>(
     cx: &OxcContext<'a, '_>,
     expr: &oxc::Expression<'a>,
@@ -3317,7 +3317,11 @@ fn ox_expression_to_jsx_tag<'a>(
 ) -> Result<oxc::JSXElementName<'a>, OxcDiagnostic> {
     match expr {
         oxc::Expression::Identifier(ident) => {
-            Ok(ox_jsx_element_name_from_ident(cx, &ident.name, span))
+            Ok(oxc_ast::ast::JSXElementName::new_identifier_reference(
+                span,
+                ox_str(&cx.ast, &ident.name),
+                &cx.ast,
+            ))
         }
         oxc::Expression::StaticMemberExpression(_)
         | oxc::Expression::ComputedMemberExpression(_) => {
@@ -3338,23 +3342,14 @@ fn ox_expression_to_jsx_tag<'a>(
                     span, namespace, name, &cx.ast,
                 ))
             } else {
-                Ok(ox_jsx_element_name_from_ident(cx, tag_text, span))
+                Ok(oxc_ast::ast::JSXElementName::new_identifier(
+                    span,
+                    ox_str(&cx.ast, tag_text),
+                    &cx.ast,
+                ))
             }
         }
         _ => Err(invariant_err("Expected JSX tag to be an identifier or string", None)),
-    }
-}
-
-fn ox_jsx_element_name_from_ident<'a>(
-    cx: &OxcContext<'a, '_>,
-    name: &str,
-    span: Span,
-) -> oxc::JSXElementName<'a> {
-    let first_char = name.chars().next().unwrap_or('a');
-    if first_char.is_uppercase() || name.contains('.') {
-        oxc_ast::ast::JSXElementName::new_identifier_reference(span, ox_str(&cx.ast, name), &cx.ast)
-    } else {
-        oxc_ast::ast::JSXElementName::new_identifier(span, ox_str(&cx.ast, name), &cx.ast)
     }
 }
 

--- a/crates/oxc_react_compiler/tests/snapshots/context-variable-as-jsx-element-tag.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/context-variable-as-jsx-element-tag.snap
@@ -8,18 +8,18 @@ import { useMemo } from "react";
 import { Stringify } from "shared-runtime";
 function Component(props) {
 	const $ = _c(3);
-	let Component;
+	let _Component;
 	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		Component = Stringify;
-		Component;
-		Component = Component;
-		$[0] = Component;
+		_Component = Stringify;
+		_Component;
+		_Component = _Component;
+		$[0] = _Component;
 	} else {
-		Component = $[0];
+		_Component = $[0];
 	}
 	let t0;
 	if ($[1] !== props) {
-		t0 = <Component {...props} />;
+		t0 = <_Component {...props} />;
 		$[1] = props;
 		$[2] = t0;
 	} else {


### PR DESCRIPTION
Preserve JSX component classification through React Compiler HIR and codegen so underscore-prefixed components are emitted as identifiers instead of intrinsic string tags.

Update the existing context-variable JSX fixture to cover `_Component`.

Validated with the React Compiler crate suite, NAPI suite, and all six ecosystem reproductions.

AI assistance was used.