### PR TITLE
fix(react_compiler): preserve caught property loads

### DIFF
--- a/crates/oxc_react_compiler/fixtures/try-catch-unused-throwing-value.js
+++ b/crates/oxc_react_compiler/fixtures/try-catch-unused-throwing-value.js
@@ -1,0 +1,22 @@
+// @compilationMode:annotation
+function Component({count, maybe}) {
+  'use memo';
+  const value = {count};
+  try {
+    const unused = maybe.item;
+    value.count++;
+  } catch {
+    value.count += 10;
+  }
+  return value.count;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{count: 1, maybe: null}],
+  sequentialRenders: [
+    {count: 1, maybe: null},
+    {count: 1, maybe: null},
+    {count: 1, maybe: {item: 'ok'}},
+  ],
+};

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -28,6 +28,7 @@ use crate::react_compiler_hir::{
     PlaceOrSpread, PropertyLiteral, ReactFunctionType, ReactiveScopeDeclaration,
     ReactiveScopeDependency, ScopeId, Terminal, Type, is_ref_value_type, is_use_ref_type, visitors,
 };
+use crate::react_compiler_optimization::dead_code_elimination::is_catch_observable_property_load;
 use oxc_span::Span;
 
 // =============================================================================
@@ -2087,6 +2088,21 @@ fn handle_function_deps<'a>(
                 }
                 _ => {
                     handle_instruction(instr, ctx, env);
+                }
+            }
+        }
+
+        // A caught throw is an observable result of a read even when its produced value is not
+        // used. Record the read's root operands as dependencies so a cached scope re-runs when
+        // the throw outcome can change. Using the roots also avoids hoisting the potentially
+        // throwing property access itself outside of the try/catch.
+        if matches!(block.terminal, Terminal::MaybeThrow { handler: Some(_), .. }) {
+            for &instr_id in &block.instructions {
+                let instr = &func.instructions[instr_id.index()];
+                if is_catch_observable_property_load(&instr.value) {
+                    for operand in visitors::each_instruction_value_operand(&instr.value, env) {
+                        ctx.visit_operand(&operand, env);
+                    }
                 }
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
@@ -21,7 +21,7 @@ use crate::react_compiler_hir::object_shape::HookKind;
 use crate::react_compiler_hir::visitors;
 use crate::react_compiler_hir::{
     ArrayPatternElement, BlockId, BlockKind, HirFunction, Identifier, IdentifierId, IdentifierName,
-    InstructionId, InstructionKind, InstructionValue, ObjectPropertyOrSpread, Pattern,
+    InstructionId, InstructionKind, InstructionValue, ObjectPropertyOrSpread, Pattern, Terminal,
 };
 
 /// Implements dead-code elimination, eliminating instructions whose values are unused.
@@ -151,6 +151,12 @@ fn find_referenced_identifiers<'a>(func: &HirFunction<'a>, env: &Environment<'a>
                         reference(&mut state, &env.identifiers, place.identifier);
                     }
                 } else if is_id_or_name_used(&state, &env.identifiers, instr.lvalue.identifier)
+                    // Throwing is observable inside try/catch even when the produced value is
+                    // unused. Keep the instruction until its MaybeThrow edge is proven dead.
+                    || (matches!(
+                        block.terminal,
+                        Terminal::MaybeThrow { handler: Some(_), .. }
+                    ) && is_catch_observable_property_load(&instr.value))
                     || !pruneable_value(&instr.value, &state, env)
                 {
                     reference(&mut state, &env.identifiers, instr.lvalue.identifier);
@@ -187,6 +193,11 @@ fn find_referenced_identifiers<'a>(func: &HirFunction<'a>, env: &Environment<'a>
     }
 
     state
+}
+
+/// Property loads are read-only for DCE, but can throw and transfer control to a catch handler.
+pub(crate) fn is_catch_observable_property_load(value: &InstructionValue) -> bool {
+    matches!(value, InstructionValue::PropertyLoad { .. } | InstructionValue::ComputedLoad { .. })
 }
 
 /// Rewrite a retained instruction (destructuring cleanup, StoreLocal -> DeclareLocal).

--- a/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__try-catch-try-value-modified-in-catch-escaping.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__try-catch-try-value-modified-in-catch-escaping.snap
@@ -6,9 +6,9 @@ import { c as _c } from "react/compiler-runtime";
 // @enablePropagateDepsInHIR
 const { throwInput } = require("shared-runtime");
 function Component(props) {
-	const $ = _c(3);
+	const $ = _c(2);
 	let x;
-	if ($[0] !== props.e || $[1] !== props.y) {
+	if ($[0] !== props) {
 		try {
 			const y = [];
 			y.push(props.y);
@@ -18,11 +18,10 @@ function Component(props) {
 			e.push(props.e);
 			x = e;
 		}
-		$[0] = props.e;
-		$[1] = props.y;
-		$[2] = x;
+		$[0] = props;
+		$[1] = x;
 	} else {
-		x = $[2];
+		x = $[1];
 	}
 	return x;
 }

--- a/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__try-catch-try-value-modified-in-catch.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__try-catch-try-value-modified-in-catch.snap
@@ -6,9 +6,9 @@ import { c as _c } from "react/compiler-runtime";
 // @enablePropagateDepsInHIR
 const { throwInput } = require("shared-runtime");
 function Component(props) {
-	const $ = _c(3);
+	const $ = _c(2);
 	let t0;
-	if ($[0] !== props.e || $[1] !== props.y) {
+	if ($[0] !== props) {
 		t0 = Symbol.for("react.early_return_sentinel");
 		bb0: {
 			try {
@@ -22,11 +22,10 @@ function Component(props) {
 				break bb0;
 			}
 		}
-		$[0] = props.e;
-		$[1] = props.y;
-		$[2] = t0;
+		$[0] = props;
+		$[1] = t0;
 	} else {
-		t0 = $[2];
+		t0 = $[1];
 	}
 	if (t0 !== Symbol.for("react.early_return_sentinel")) {
 		return t0;

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-try-value-modified-in-catch-escaping.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-try-value-modified-in-catch-escaping.snap
@@ -5,9 +5,9 @@ input_file: crates/oxc_react_compiler/fixtures/try-catch-try-value-modified-in-c
 import { c as _c } from "react/compiler-runtime";
 const { throwInput } = require("shared-runtime");
 function Component(props) {
-	const $ = _c(3);
+	const $ = _c(2);
 	let x;
-	if ($[0] !== props.e || $[1] !== props.y) {
+	if ($[0] !== props) {
 		try {
 			const y = [];
 			y.push(props.y);
@@ -17,11 +17,10 @@ function Component(props) {
 			e.push(props.e);
 			x = e;
 		}
-		$[0] = props.e;
-		$[1] = props.y;
-		$[2] = x;
+		$[0] = props;
+		$[1] = x;
 	} else {
-		x = $[2];
+		x = $[1];
 	}
 	return x;
 }

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-try-value-modified-in-catch.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-try-value-modified-in-catch.snap
@@ -5,9 +5,9 @@ input_file: crates/oxc_react_compiler/fixtures/try-catch-try-value-modified-in-c
 import { c as _c } from "react/compiler-runtime";
 const { throwInput } = require("shared-runtime");
 function Component(props) {
-	const $ = _c(3);
+	const $ = _c(2);
 	let t0;
-	if ($[0] !== props.e || $[1] !== props.y) {
+	if ($[0] !== props) {
 		t0 = Symbol.for("react.early_return_sentinel");
 		bb0: {
 			try {
@@ -21,11 +21,10 @@ function Component(props) {
 				break bb0;
 			}
 		}
-		$[0] = props.e;
-		$[1] = props.y;
-		$[2] = t0;
+		$[0] = props;
+		$[1] = t0;
 	} else {
-		t0 = $[2];
+		t0 = $[1];
 	}
 	if (t0 !== Symbol.for("react.early_return_sentinel")) {
 		return t0;

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-unused-throwing-value.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-unused-throwing-value.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/try-catch-unused-throwing-value.js
+---
+import { c as _c } from "react/compiler-runtime";
+// @compilationMode:annotation
+function Component(t0) {
+	"use memo";
+	const $ = _c(3);
+	const { count, maybe } = t0;
+	let value;
+	if ($[0] !== count || $[1] !== maybe) {
+		value = { count };
+		try {
+			maybe.item;
+			value.count = value.count + 1;
+		} catch {
+			value.count = value.count + 10;
+		}
+		$[0] = count;
+		$[1] = maybe;
+		$[2] = value;
+	} else {
+		value = $[2];
+	}
+	return value.count;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{
+		count: 1,
+		maybe: null
+	}],
+	sequentialRenders: [
+		{
+			count: 1,
+			maybe: null
+		},
+		{
+			count: 1,
+			maybe: null
+		},
+		{
+			count: 1,
+			maybe: { item: "ok" }
+		}
+	]
+};


### PR DESCRIPTION
Preserve catch-observable property and computed loads during dead-code elimination, and record their root operands as reactive-scope dependencies so throwing reads remain inside `try`.

This prevents memoization from suppressing catch behavior or hoisting potentially throwing property access into cache guards.

Validated with the React Compiler crate suite, NAPI transform suite, and original-vs-compiled runtime cases.

AI assistance was used to investigate and implement this change.
