### PR TITLE
refactor(diagnostics): clean up vendored renderer

### DIFF
--- a/apps/oxlint/src/lsp/error_with_position.rs
+++ b/apps/oxlint/src/lsp/error_with_position.rs
@@ -67,7 +67,7 @@ impl TryFrom<RuleCustomizationSeverity> for DiagnosticSeverity {
     }
 }
 
-fn miette_severity_to_lsp_severity(value: Severity) -> DiagnosticSeverity {
+fn severity_to_lsp_severity(value: Severity) -> DiagnosticSeverity {
     match value {
         Severity::Error => DiagnosticSeverity::ERROR,
         Severity::Warning => DiagnosticSeverity::WARNING,
@@ -85,10 +85,10 @@ pub fn message_to_lsp_diagnostic(
             // filter off rules early
             DiagnosticSeverity::try_from(severity).ok()?
         } else {
-            miette_severity_to_lsp_severity(message.error.severity)
+            severity_to_lsp_severity(message.error.severity)
         }
     } else {
-        miette_severity_to_lsp_severity(message.error.severity)
+        severity_to_lsp_severity(message.error.severity)
     };
 
     let related_information = if message.error.labels.is_empty() {

--- a/crates/oxc_diagnostics/src/handlers/graphical/handler.rs
+++ b/crates/oxc_diagnostics/src/handlers/graphical/handler.rs
@@ -10,20 +10,15 @@ use crate::GraphicalTheme;
 #[derive(Debug, Clone)]
 pub struct GraphicalReportHandler {
     /// How to render links.
-    ///
-    /// Default: [`LinkStyle::Link`]
-    pub(crate) links: LinkStyle,
+    pub(super) links: LinkStyle,
     /// Terminal width to wrap at.
-    ///
-    /// Default: `400`
-    pub(crate) termwidth: usize,
-    /// How to style reports
-    pub(crate) theme: GraphicalTheme,
+    pub(super) termwidth: usize,
+    /// How to style reports.
+    pub(super) theme: GraphicalTheme,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[expect(clippy::redundant_pub_crate, reason = "prevents accidental glob re-export")]
-pub(crate) enum LinkStyle {
+pub(super) enum LinkStyle {
     Link,
     Text,
 }

--- a/crates/oxc_diagnostics/src/handlers/graphical/label.rs
+++ b/crates/oxc_diagnostics/src/handlers/graphical/label.rs
@@ -96,6 +96,14 @@ struct LabelText<'a> {
     render_mode: LabelRenderMode,
 }
 
+struct LabelContext<'a, 'source, 'label> {
+    line: &'a Line<'source>,
+    line_number_width: usize,
+    max_gutter: usize,
+    all_highlights: &'a [FancySpan<'label>],
+    vertical_bars: &'a [(&'a FancySpan<'label>, usize)],
+}
+
 impl fmt::Display for LabelText<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let chars = self.chars;
@@ -165,103 +173,63 @@ impl GraphicalReportHandler {
         }
         f.write_char('\n')?;
 
+        let context = LabelContext {
+            line,
+            line_number_width: linum_width,
+            max_gutter,
+            all_highlights,
+            vertical_bars: &vbar_offsets,
+        };
         for &hl in single_liners.iter().rev() {
             if let Some(label) = hl.label() {
-                let mut lines = label.split('\n');
+                let mut lines = label.split('\n').peekable();
                 let first = lines.next().expect("split always yields at least one item");
-                if let Some(second) = lines.next() {
-                    self.write_label_text(
-                        f,
-                        line,
-                        linum_width,
-                        max_gutter,
-                        all_highlights,
-                        chars,
-                        &vbar_offsets,
-                        hl,
-                        first,
-                        LabelRenderMode::BlockFirst,
-                    )?;
-                    self.write_label_text(
-                        f,
-                        line,
-                        linum_width,
-                        max_gutter,
-                        all_highlights,
-                        chars,
-                        &vbar_offsets,
-                        hl,
-                        second,
-                        LabelRenderMode::BlockRest,
-                    )?;
-                    for label_line in lines {
-                        self.write_label_text(
-                            f,
-                            line,
-                            linum_width,
-                            max_gutter,
-                            all_highlights,
-                            chars,
-                            &vbar_offsets,
-                            hl,
-                            label_line,
-                            LabelRenderMode::BlockRest,
-                        )?;
-                    }
+                let first_mode = if lines.peek().is_some() {
+                    LabelRenderMode::BlockFirst
                 } else {
-                    self.write_label_text(
-                        f,
-                        line,
-                        linum_width,
-                        max_gutter,
-                        all_highlights,
-                        chars,
-                        &vbar_offsets,
-                        hl,
-                        first,
-                        LabelRenderMode::SingleLine,
-                    )?;
+                    LabelRenderMode::SingleLine
+                };
+                self.write_label_text(f, &context, hl, first, first_mode)?;
+                for label_line in lines {
+                    self.write_label_text(f, &context, hl, label_line, LabelRenderMode::BlockRest)?;
                 }
             }
         }
         Ok(())
     }
 
-    // I know it's not good practice, but making this a function makes a lot of sense
-    // and making a struct for this does not...
-    #[expect(clippy::too_many_arguments)]
-    pub(super) fn write_label_text(
+    fn write_label_text(
         &self,
         f: &mut impl fmt::Write,
-        line: &Line<'_>,
-        linum_width: usize,
-        max_gutter: usize,
-        all_highlights: &[FancySpan],
-        chars: &ThemeCharacters,
-        vbar_offsets: &[(&FancySpan, usize)],
+        context: &LabelContext<'_, '_, '_>,
         hl: &FancySpan,
         label: &str,
         render_mode: LabelRenderMode,
     ) -> fmt::Result {
-        self.write_no_linum(f, linum_width)?;
+        self.write_no_linum(f, context.line_number_width)?;
         self.render_highlight_gutter(
             f,
-            max_gutter,
-            line,
-            all_highlights,
+            context.max_gutter,
+            context.line,
+            context.all_highlights,
             LabelRenderMode::SingleLine,
         )?;
         let mut curr_offset = 1usize;
-        for (offset_hl, vbar_offset) in vbar_offsets {
+        for (offset_hl, vbar_offset) in context.vertical_bars {
             let padding = (*vbar_offset + 1).saturating_sub(curr_offset);
             write_padding(f, padding)?;
             curr_offset += padding;
             if *offset_hl == hl {
-                let line = LabelText { chars, label, style: hl.style, render_mode };
+                let line = LabelText {
+                    chars: &self.theme.characters,
+                    label,
+                    style: hl.style,
+                    render_mode,
+                };
                 writeln!(f, "{}", line.style(hl.style))?;
                 break;
             }
-            write!(f, "{}", chars.vbar.style(offset_hl.style))?;
+            write!(f, "{}", self.theme.characters.vbar.style(offset_hl.style))?;
             curr_offset += 1;
         }
         Ok(())
@@ -276,74 +244,44 @@ impl GraphicalReportHandler {
         line: &Line<'_>,
         label: &FancySpan,
     ) -> fmt::Result {
-        // no line number!
         self.write_no_linum(f, linum_width)?;
 
         if let Some(label_text) = label.label() {
-            let mut lines = label_text.split('\n');
+            let mut lines = label_text.split('\n').peekable();
             let first = lines.next().expect("split always yields at least one item");
-
-            if let Some(second) = lines.next() {
-                // gutter _again_
-                self.render_highlight_gutter(
-                    f,
-                    max_gutter,
-                    line,
-                    labels,
-                    LabelRenderMode::BlockFirst,
-                )?;
-
-                self.render_multi_line_end_single(
-                    f,
-                    first,
-                    label.style,
-                    LabelRenderMode::BlockFirst,
-                )?;
-                for label_line in std::iter::once(second).chain(lines) {
-                    // no line number!
-                    self.write_no_linum(f, linum_width)?;
-                    // gutter _again_
-                    self.render_highlight_gutter(
-                        f,
-                        max_gutter,
-                        line,
-                        labels,
-                        LabelRenderMode::BlockRest,
-                    )?;
-                    self.render_multi_line_end_single(
-                        f,
-                        label_line,
-                        label.style,
-                        LabelRenderMode::BlockRest,
-                    )?;
-                }
+            let first_mode = if lines.peek().is_some() {
+                LabelRenderMode::BlockFirst
             } else {
-                // gutter _again_
+                LabelRenderMode::SingleLine
+            };
+            self.render_highlight_gutter(f, max_gutter, line, labels, first_mode)?;
+            self.render_multi_line_end_single(f, first, label.style, first_mode)?;
+
+            for label_line in lines {
+                self.write_no_linum(f, linum_width)?;
                 self.render_highlight_gutter(
                     f,
                     max_gutter,
                     line,
                     labels,
-                    LabelRenderMode::SingleLine,
+                    LabelRenderMode::BlockRest,
                 )?;
                 self.render_multi_line_end_single(
                     f,
-                    first,
+                    label_line,
                     label.style,
-                    LabelRenderMode::SingleLine,
+                    LabelRenderMode::BlockRest,
                 )?;
             }
         } else {
-            // gutter _again_
             self.render_highlight_gutter(f, max_gutter, line, labels, LabelRenderMode::SingleLine)?;
-            // has no label
             writeln!(f, "{}", self.theme.characters.hbar.style(label.style))?;
         }
 
         Ok(())
     }
 
-    pub(super) fn render_multi_line_end_single(
+    fn render_multi_line_end_single(
         &self,
         f: &mut impl fmt::Write,
         label: &str,

--- a/crates/oxc_diagnostics/src/handlers/graphical/line.rs
+++ b/crates/oxc_diagnostics/src/handlers/graphical/line.rs
@@ -32,30 +32,30 @@ impl Line<'_> {
     }
 
     /// Returns whether `span` should be visible on this line, either in the gutter or under the
-    /// text on this line
+    /// text on this line.
     pub(super) fn span_applies(&self, span: &FancySpan) -> bool {
-        let spanlen = if span.len() == 0 { 1 } else { span.len() };
-        // Span starts in this line
+        let span_len = span.len().max(1);
+        let span_end = span.offset() + span_len;
+        let line_end = self.offset + self.length;
 
         (span.offset() >= self.offset && span.offset() < self.offset + self.length)
             // Span passes through this line
-            || (span.offset() < self.offset && span.offset() + spanlen > self.offset + self.length) //todo
+            || (span.offset() < self.offset && span_end > line_end)
             // Span ends on this line
-            || (span.offset() + spanlen > self.offset && span.offset() + spanlen <= self.offset + self.length)
+            || (span_end > self.offset && span_end <= line_end)
     }
 
     /// Returns whether `span` should be visible on this line in the gutter (so this excludes spans
-    /// that are only visible on this line and do not span multiple lines)
+    /// that are only visible on this line and do not span multiple lines).
     pub(super) fn span_applies_gutter(&self, span: &FancySpan) -> bool {
-        let spanlen = if span.len() == 0 { 1 } else { span.len() };
-        // Span starts in this line
+        let span_len = span.len().max(1);
+        let span_end = span.offset() + span_len;
+        let line_end = self.offset + self.length;
+        let starts_on_line = span.offset() >= self.offset && span.offset() < line_end;
+        let ends_on_line = span_end > self.offset && span_end <= line_end;
         self.span_applies(span)
-            && !(
-                // as long as it doesn't start *and* end on this line
-                (span.offset() >= self.offset && span.offset() < self.offset + self.length)
-                    && (span.offset() + spanlen > self.offset
-                        && span.offset() + spanlen <= self.offset + self.length)
-            )
+            // Exclude spans that start and end on this line.
+            && !(starts_on_line && ends_on_line)
     }
 
     // A 'flyby' is a multi-line span that technically covers this line, but
@@ -203,8 +203,7 @@ impl GraphicalReportHandler {
     }
 
     /// Splits already-scanned span contents into [`Line`]s.
-    #[expect(clippy::unused_self, reason = "kept as a renderer method for call-site consistency")]
-    pub(super) fn get_lines<'a>(&self, context_data: &SpanContents<'a>) -> Vec<Line<'a>> {
+    pub(super) fn get_lines<'a>(context_data: &SpanContents<'a>) -> Vec<Line<'a>> {
         let context = from_utf8(context_data.data()).expect("Bad utf8 detected");
         let mut line = context_data.line();
         let base = context_data.span().start as usize;
@@ -273,7 +272,6 @@ mod tests {
             ("a\r", &[(4, BASE, 2, "a\r")]),
             ("é\n火", &[(5, BASE, 3, "é"), (6, BASE + 3, 3, "火")]),
         ];
-        let handler = GraphicalReportHandler::new();
         for &(text, expected) in cases {
             let contents = SpanContents::new(
                 text.as_bytes(),
@@ -282,8 +280,7 @@ mod tests {
                 2,
                 expected.len(),
             );
-            let actual = handler
-                .get_lines(&contents)
+            let actual = GraphicalReportHandler::get_lines(&contents)
                 .iter()
                 .map(|line| (line.number, line.offset, line.length, line.text))
                 .collect::<Vec<_>>();
@@ -296,7 +293,7 @@ mod tests {
         let source = "before\ntarget\nafter\nrest";
         let mut scanner = SpanScanner::new(source.as_bytes(), 1, 1);
         let contents = scanner.read_span(Span::sized(7, 6)).unwrap();
-        let lines = GraphicalReportHandler::new().get_lines(&contents);
+        let lines = GraphicalReportHandler::get_lines(&contents);
 
         assert_eq!(lines.len(), 3);
         assert_eq!(lines.capacity(), 3);

--- a/crates/oxc_diagnostics/src/handlers/graphical/snippet.rs
+++ b/crates/oxc_diagnostics/src/handlers/graphical/snippet.rs
@@ -60,14 +60,13 @@ impl GraphicalReportHandler {
         for &right in labels {
             let right_conts = read(right.span()).ok_or(fmt::Error)?;
 
-            if contexts.is_empty() {
+            let Some((left, left_contents)) = contexts.last() else {
                 contexts.push((Cow::Borrowed(right), right_conts));
                 continue;
-            }
+            };
 
-            let (left, left_conts) = contexts.last().unwrap();
-            if left_conts.line() + left_conts.line_count() >= right_conts.line() {
-                // The snippets will overlap, so we create one Big Chunky Boi
+            if left_contents.line() + left_contents.line_count() >= right_conts.line() {
+                // Merge overlapping snippets into one context.
                 let left_end = left.offset() + left.len();
                 let right_end = right.offset() + right.len();
                 let new_end = max(left_end, right_end);
@@ -77,7 +76,7 @@ impl GraphicalReportHandler {
                     left.offset(),
                     new_end - left.offset(),
                 );
-                // Check that the two contexts can be combined
+                // Check that the two contexts can be combined.
                 if let Some(new_conts) = read(new_span.span()) {
                     contexts.pop();
                     contexts.push((Cow::Owned(new_span), new_conts));
@@ -102,25 +101,23 @@ impl GraphicalReportHandler {
         labels: &[&LabeledSpan],
         source_name: Option<&str>,
     ) -> fmt::Result {
-        let lines = self.get_lines(contents);
+        let lines = Self::get_lines(contents);
 
-        // only consider labels from the context as primary label
-        let ctx_labels =
+        // Only labels within this context can be its primary label.
+        let mut ctx_labels =
             labels.iter().filter(|label| context.span().contains_inclusive(label.span()));
         let primary_label =
-            ctx_labels.clone().find(|label| label.primary()).or_else(|| ctx_labels.clone().next());
+            ctx_labels.clone().find(|label| label.primary()).or_else(|| ctx_labels.next());
 
-        // sorting is your friend
+        // Assign styles after sorting labels by source position.
         let labels = labels
             .iter()
             .copied()
             .zip(self.theme.styles.highlights.iter().copied().cycle())
-            .map(|(label, st)| FancySpan::new(label.label(), label.span(), st))
+            .map(|(label, style)| FancySpan::new(label.label(), label.span(), style))
             .collect::<Vec<_>>();
 
-        // The max number of gutter-lines that will be active at any given
-        // point. We need this to figure out indentation, so we do one loop
-        // over the lines to see what the damage is gonna be.
+        // Find the maximum number of active gutter lines to determine indentation.
         let mut max_gutter = 0usize;
         for line in &lines {
             let mut num_highlights = 0;
@@ -132,8 +129,7 @@ impl GraphicalReportHandler {
             max_gutter = max(max_gutter, num_highlights);
         }
 
-        // Oh and one more thing: We need to figure out how much room our line
-        // numbers need!
+        // Determine the width of the line-number column.
         let linum_width = lines
             .last()
             .map_or(1, |line| line.number.checked_ilog10().map_or(1, |width| width as usize + 1));
@@ -168,28 +164,17 @@ impl GraphicalReportHandler {
             }
         }
 
-        // Now it's time for the fun part--actually rendering everything!
         for line in &lines {
-            // Line number, appropriately padded.
             self.write_linum(f, linum_width, line.number)?;
-
-            // Then, we need to print the gutter, along with any fly-bys We
-            // have separate gutters depending on whether we're on the actual
-            // line, or on one of the "highlight lines" below it.
             self.render_line_gutter(f, max_gutter, line, &labels)?;
-
-            // And _now_ we can print out the line text itself!
             Self::render_line_text(f, line.text)?;
 
-            // Next, we write all the highlights that apply to this particular line.
             let (single_line, multi_line): (Vec<_>, Vec<_>) = labels
                 .iter()
                 .filter(|hl| line.span_applies(hl))
                 .partition(|hl| line.span_line_only(hl));
             if !single_line.is_empty() {
-                // no line number!
                 self.write_no_linum(f, linum_width)?;
-                // gutter _again_
                 self.render_highlight_gutter(
                     f,
                     max_gutter,

--- a/crates/oxc_diagnostics/src/handlers/json.rs
+++ b/crates/oxc_diagnostics/src/handlers/json.rs
@@ -2,10 +2,8 @@ use std::fmt::{self, Write};
 
 use crate::{Severity, protocol::Diagnostic, source_impls::SpanScanner};
 
-/**
-Renders diagnostics as machine-readable JSON.
-*/
-#[derive(Debug, Clone)]
+/// Renders diagnostics as machine-readable JSON.
+#[derive(Debug, Clone, Default)]
 pub struct JSONReportHandler;
 
 impl JSONReportHandler {
@@ -17,31 +15,21 @@ impl JSONReportHandler {
     }
 }
 
-impl Default for JSONReportHandler {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 struct Escape<'a>(&'a str);
 
 impl fmt::Display for Escape<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for c in self.0.chars() {
-            let escape = match c {
-                '\\' => Some(r"\\"),
-                '"' => Some(r#"\""#),
-                '\r' => Some(r"\r"),
-                '\n' => Some(r"\n"),
-                '\t' => Some(r"\t"),
-                '\u{08}' => Some(r"\b"),
-                '\u{0c}' => Some(r"\f"),
-                _ => None,
-            };
-            if let Some(escape) = escape {
-                f.write_str(escape)?;
-            } else {
-                f.write_char(c)?;
+        for character in self.0.chars() {
+            match character {
+                '\\' => f.write_str(r"\\")?,
+                '"' => f.write_str(r#"\""#)?,
+                '\r' => f.write_str(r"\r")?,
+                '\n' => f.write_str(r"\n")?,
+                '\t' => f.write_str(r"\t")?,
+                '\u{08}' => f.write_str(r"\b")?,
+                '\u{0c}' => f.write_str(r"\f")?,
+                '\u{00}'..='\u{1f}' => write!(f, r"\u{:04x}", character as u32)?,
+                _ => f.write_char(character)?,
             }
         }
         Ok(())
@@ -73,9 +61,9 @@ impl JSONReportHandler {
             Some(Severity::Warning) => "warning",
             Some(Severity::Advice) => "advice",
         };
-        write!(f, r#""severity": "{severity:}","#)?;
+        write!(f, r#""severity": "{severity}","#)?;
         if let Some(url) = diagnostic.url() {
-            write!(f, r#""url": "{url}","#)?;
+            write!(f, r#""url": "{}","#, escape(&url))?;
         }
         if let Some(help) = diagnostic.help() {
             write!(f, r#""help": "{}","#, escape(&help))?;
@@ -87,38 +75,32 @@ impl JSONReportHandler {
         if let Some(source) = source {
             write!(f, r#""filename": "{}","#, escape(source.name().unwrap_or_default()))?;
         }
-        {
-            write!(f, r#""labels": ["#)?;
-            let mut scanner = source.map(|source| SpanScanner::new(source.data(), 0, 0));
-            let mut add_comma = false;
-            for label in diagnostic.labels() {
-                if add_comma {
-                    write!(f, ",")?;
-                } else {
-                    add_comma = true;
-                }
-                write!(f, "{{")?;
-                if let Some(label_name) = label.label() {
-                    write!(f, r#""label": "{}","#, escape(label_name))?;
-                }
-                write!(f, r#""span": {{"#)?;
-                write!(f, r#""offset": {},"#, label.offset())?;
-                write!(f, r#""length": {},"#, label.len())?;
-
-                if let Some(location) =
-                    scanner.as_mut().and_then(|scanner| scanner.read_span(label.span()))
-                {
-                    write!(f, r#""line": {},"#, location.line() + 1)?;
-                    write!(f, r#""column": {}"#, location.column() + 1)?;
-                } else {
-                    write!(f, r#""line": null,"column": null"#)?;
-                }
-
-                write!(f, "}}}}")?;
+        f.write_str(r#""labels": ["#)?;
+        let mut scanner = source.map(|source| SpanScanner::new(source.data(), 0, 0));
+        for (index, label) in diagnostic.labels().iter().enumerate() {
+            if index > 0 {
+                f.write_char(',')?;
             }
-            write!(f, "]")?;
+            f.write_char('{')?;
+            if let Some(label_name) = label.label() {
+                write!(f, r#""label": "{}","#, escape(label_name))?;
+            }
+            f.write_str(r#""span": {"#)?;
+            write!(f, r#""offset": {},"#, label.offset())?;
+            write!(f, r#""length": {},"#, label.len())?;
+
+            if let Some(location) =
+                scanner.as_mut().and_then(|scanner| scanner.read_span(label.span()))
+            {
+                write!(f, r#""line": {},"#, location.line() + 1)?;
+                write!(f, r#""column": {}"#, location.column() + 1)?;
+            } else {
+                f.write_str(r#""line": null,"column": null"#)?;
+            }
+
+            f.write_str("}}")?;
         }
-        write!(f, "}}")
+        f.write_str("]}")
     }
 }
 

--- a/crates/oxc_diagnostics/src/handlers/mod.rs
+++ b/crates/oxc_diagnostics/src/handlers/mod.rs
@@ -1,12 +1,9 @@
-/*!
-Renderers included with `oxc_diagnostics`.
-*/
+//! Renderers included with `oxc_diagnostics`.
 
-pub use graphical::*;
-pub use json::*;
+pub use graphical::GraphicalReportHandler;
+pub use json::JSONReportHandler;
 pub use theme::GraphicalTheme;
 
 mod graphical;
 mod json;
-#[expect(clippy::redundant_pub_crate, reason = "prevents public glob re-export")]
-pub(crate) mod theme;
+mod theme;

--- a/crates/oxc_diagnostics/src/handlers/theme.rs
+++ b/crates/oxc_diagnostics/src/handlers/theme.rs
@@ -10,13 +10,13 @@ use owo_colors::Style;
 /// Use one of the predefined constructors below.
 #[derive(Debug, Clone)]
 pub struct GraphicalTheme {
-    pub(crate) characters: ThemeCharacters,
-    pub(crate) styles: ThemeStyles,
+    pub(super) characters: ThemeCharacters,
+    pub(super) styles: ThemeStyles,
 }
 
 fn force_color() -> bool {
     // Assume CI can always print colors.
-    env::var("CI").is_ok() || env::var("FORCE_COLOR").is_ok_and(|env| env != "0")
+    env::var_os("CI").is_some() || env::var_os("FORCE_COLOR").is_some_and(|value| value != "0")
 }
 
 impl Default for GraphicalTheme {
@@ -28,13 +28,13 @@ impl Default for GraphicalTheme {
 impl GraphicalTheme {
     /// Chooses a graphical theme based on terminal and environment support.
     #[must_use]
-    pub(crate) fn new(is_terminal: bool) -> Self {
+    pub(super) fn new(is_terminal: bool) -> Self {
         if force_color() {
             return Self::unicode();
         }
-        match env::var("NO_COLOR") {
+        match env::var_os("NO_COLOR") {
             _ if !is_terminal => Self::none(),
-            Ok(string) if string != "0" => Self::unicode_nocolor(),
+            Some(value) if value != "0" => Self::unicode_nocolor(),
             _ => Self::unicode(),
         }
     }
@@ -74,16 +74,15 @@ impl GraphicalTheme {
 }
 
 #[derive(Debug, Clone)]
-#[expect(clippy::redundant_pub_crate, reason = "prevents public glob re-export")]
-pub(crate) struct ThemeStyles {
-    pub(crate) error: Style,
-    pub(crate) warning: Style,
-    pub(crate) advice: Style,
-    pub(crate) help: Style,
-    pub(crate) note: Style,
-    pub(crate) link: Style,
-    pub(crate) linum: Style,
-    pub(crate) highlights: [Style; 3],
+pub(super) struct ThemeStyles {
+    pub(super) error: Style,
+    pub(super) warning: Style,
+    pub(super) advice: Style,
+    pub(super) help: Style,
+    pub(super) note: Style,
+    pub(super) link: Style,
+    pub(super) linum: Style,
+    pub(super) highlights: [Style; 3],
 }
 
 fn style() -> Style {
@@ -93,7 +92,7 @@ fn style() -> Style {
 impl ThemeStyles {
     fn rgb() -> Self {
         Self {
-            error: style().fg_rgb::<225, 80, 80>().bold(), // CHANGED: <255, 30, 30>
+            error: style().fg_rgb::<225, 80, 80>().bold(),
             warning: style().fg_rgb::<244, 191, 117>().bold(),
             advice: style().fg_rgb::<106, 159, 181>(),
             help: style().fg_rgb::<106, 159, 181>(),
@@ -127,27 +126,26 @@ impl ThemeStyles {
 // https://github.com/zesterer/ariadne/blob/e3cb394cb56ecda116a0a1caecd385a49e7f6662/src/draw.rs
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[expect(clippy::redundant_pub_crate, reason = "prevents public glob re-export")]
-pub(crate) struct ThemeCharacters {
-    pub(crate) hbar: char,
-    pub(crate) vbar: char,
-    pub(crate) vbar_break: char,
+pub(super) struct ThemeCharacters {
+    pub(super) hbar: char,
+    pub(super) vbar: char,
+    pub(super) vbar_break: char,
 
-    pub(crate) uarrow: char,
-    pub(crate) rarrow: char,
+    pub(super) uarrow: char,
+    pub(super) rarrow: char,
 
-    pub(crate) ltop: char,
-    pub(crate) lbot: char,
+    pub(super) ltop: char,
+    pub(super) lbot: char,
 
-    pub(crate) lcross: char,
-    pub(crate) rcross: char,
+    pub(super) lcross: char,
+    pub(super) rcross: char,
 
-    pub(crate) underbar: char,
-    pub(crate) underline: char,
+    pub(super) underbar: char,
+    pub(super) underline: char,
 
-    pub(crate) error: &'static str,
-    pub(crate) warning: &'static str,
-    pub(crate) advice: &'static str,
+    pub(super) error: &'static str,
+    pub(super) warning: &'static str,
+    pub(super) advice: &'static str,
 }
 
 impl ThemeCharacters {

--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -91,7 +91,7 @@ pub type Labels = smallvec::SmallVec<[LabeledSpan; 2]>;
 pub struct Diagnostics(Vec<OxcDiagnostic>);
 
 impl Diagnostics {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(Vec::new())
     }
 
@@ -214,6 +214,7 @@ pub struct OxcCode {
 }
 
 impl OxcCode {
+    #[must_use]
     pub fn is_some(&self) -> bool {
         self.scope.is_some() || self.number.is_some()
     }
@@ -242,7 +243,7 @@ pub struct OxcDiagnosticInner {
 }
 
 impl Display for OxcDiagnostic {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.message.fmt(f)
     }
 }
@@ -338,10 +339,7 @@ impl OxcDiagnostic {
     /// Use [`OxcDiagnostic::with_error_code`] to set both the scope and number at once.
     #[inline]
     pub fn with_error_code_scope<T: Into<Cow<'static, str>>>(mut self, code_scope: T) -> Self {
-        self.inner.code.scope = match self.inner.code.scope {
-            Some(scope) => Some(scope),
-            None => Some(code_scope.into()),
-        };
+        self.inner.code.scope.get_or_insert_with(|| code_scope.into());
         debug_assert!(
             self.inner.code.scope.as_ref().is_some_and(|s| !s.is_empty()),
             "Error code scopes cannot be empty"
@@ -355,10 +353,7 @@ impl OxcDiagnostic {
     /// Use [`OxcDiagnostic::with_error_code`] to set both the scope and number at once.
     #[inline]
     pub fn with_error_code_num<T: Into<Cow<'static, str>>>(mut self, code_num: T) -> Self {
-        self.inner.code.number = match self.inner.code.number {
-            Some(num) => Some(num),
-            None => Some(code_num.into()),
-        };
+        self.inner.code.number.get_or_insert_with(|| code_num.into());
         debug_assert!(
             self.inner.code.number.as_ref().is_some_and(|n| !n.is_empty()),
             "Error code numbers cannot be empty"
@@ -475,14 +470,13 @@ impl OxcDiagnostic {
     /// Add source code to this diagnostic and convert it into an [`Error`].
     ///
     /// You should use a [`NamedSource`] if you have a file name as well as the source code.
-    pub fn with_source_code<T: SourceCode + Send + Sync + 'static>(self, code: T) -> Error {
-        Box::new(DiagnosticWithSource { diagnostic: self, source_code: Box::new(code) })
+    pub fn with_source_code<T: SourceCode + 'static>(self, source_code: T) -> Error {
+        Box::new(DiagnosticWithSource { diagnostic: self, source_code })
     }
 
     /// Attach source code and render using Oxc's deterministic non-interactive style.
-    pub fn render_with_source_code<T: SourceCode + Send + Sync + 'static>(self, code: T) -> String {
-        let diagnostic = self.with_source_code(code);
-        render(diagnostic.as_ref())
+    pub fn render_with_source_code<T: SourceCode>(self, source_code: T) -> String {
+        render(&DiagnosticWithSource { diagnostic: self, source_code })
     }
 
     /// Consumes the diagnostic and returns the inner owned data.
@@ -497,26 +491,26 @@ impl From<OxcDiagnostic> for Error {
     }
 }
 
-struct DiagnosticWithSource {
+struct DiagnosticWithSource<S> {
     diagnostic: OxcDiagnostic,
-    source_code: Box<dyn SourceCode>,
+    source_code: S,
 }
 
-impl fmt::Debug for DiagnosticWithSource {
+impl<S> fmt::Debug for DiagnosticWithSource<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self.diagnostic, f)
     }
 }
 
-impl Display for DiagnosticWithSource {
+impl<S> Display for DiagnosticWithSource<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.diagnostic, f)
     }
 }
 
-impl std::error::Error for DiagnosticWithSource {}
+impl<S> std::error::Error for DiagnosticWithSource<S> {}
 
-impl Diagnostic for DiagnosticWithSource {
+impl<S: SourceCode> Diagnostic for DiagnosticWithSource<S> {
     fn code(&self) -> Option<Cow<'_, str>> {
         self.diagnostic.code()
     }
@@ -542,6 +536,6 @@ impl Diagnostic for DiagnosticWithSource {
     }
 
     fn source_code(&self) -> Option<&dyn SourceCode> {
-        Some(self.source_code.as_ref())
+        Some(&self.source_code)
     }
 }

--- a/crates/oxc_diagnostics/src/named_source.rs
+++ b/crates/oxc_diagnostics/src/named_source.rs
@@ -6,31 +6,30 @@ use crate::SourceCode;
 /// implement `name`. For example [`String`]. Or if you want to override the
 /// `name` returned by the `SourceCode`.
 #[derive(Clone)]
-pub struct NamedSource<S: SourceCode + 'static> {
+pub struct NamedSource<S: SourceCode> {
     source: S,
     name: String,
 }
 
 impl<S: SourceCode> fmt::Debug for NamedSource<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NamedSource").field("name", &self.name).field("source", &"<redacted>");
-        Ok(())
+        f.debug_struct("NamedSource")
+            .field("name", &self.name)
+            .field("source", &"<redacted>")
+            .finish()
     }
 }
 
-impl<S: SourceCode + 'static> NamedSource<S> {
+impl<S: SourceCode> NamedSource<S> {
     /// Create a new `NamedSource` using a regular [`SourceCode`] and giving it
     /// a name.
     #[must_use]
-    pub fn new(name: impl AsRef<str>, source: S) -> Self
-    where
-        S: Send + Sync,
-    {
+    pub fn new(name: impl AsRef<str>, source: S) -> Self {
         Self { source, name: name.as_ref().to_string() }
     }
 }
 
-impl<S: SourceCode + 'static> SourceCode for NamedSource<S> {
+impl<S: SourceCode> SourceCode for NamedSource<S> {
     fn data(&self) -> &[u8] {
         self.source.data()
     }

--- a/crates/oxc_diagnostics/src/protocol.rs
+++ b/crates/oxc_diagnostics/src/protocol.rs
@@ -1,6 +1,4 @@
-/*!
-This module defines the core diagnostic protocol used by Oxc's renderers.
-*/
+//! Core diagnostic protocol used by Oxc's renderers.
 use std::{borrow::Cow, error::Error};
 
 use oxc_span::LabeledSpan;
@@ -9,7 +7,7 @@ use oxc_span::LabeledSpan;
 pub trait Diagnostic: Error {
     /// Unique diagnostic code that can be used to look up more information
     /// about this `Diagnostic`. Ideally also globally unique, and documented
-    /// in the toplevel crate's documentation for easy searching. Rust path
+    /// in the top-level crate's documentation for easy searching. Rust path
     /// format (`foo::bar::baz`) is recommended, but more classic codes like
     /// `E0123` or enums will work just fine.
     fn code(&self) -> Option<Cow<'_, str>> {
@@ -24,8 +22,7 @@ pub trait Diagnostic: Error {
         None
     }
 
-    /// Additional help text related to this `Diagnostic`. Do you have any
-    /// advice for the poor soul who's just run into this issue?
+    /// Additional help text related to this diagnostic.
     fn help(&self) -> Option<Cow<'_, str>> {
         None
     }
@@ -57,18 +54,15 @@ pub trait Diagnostic: Error {
     }
 }
 
-/**
-[`Diagnostic`] severity. Renderers use this to change the way diagnostics are
-displayed. Defaults to [`Severity::Error`].
-*/
+/// [`Diagnostic`] severity. Renderers use this to change the way diagnostics are
+/// displayed. Defaults to [`Severity::Error`].
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Default)]
 pub enum Severity {
-    /// Just some help. Here's how you could be doing it better.
+    /// Advice for improving the reported code.
     Advice,
-    /// Warning. Please take note.
+    /// A non-fatal warning.
     Warning,
-    /// Critical failure. The program cannot continue.
-    /// This is the default severity, if you don't specify another one.
+    /// An error. This is the default severity.
     #[default]
     Error,
 }

--- a/crates/oxc_diagnostics/src/service.rs
+++ b/crates/oxc_diagnostics/src/service.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 pub type DiagnosticSender = mpsc::Sender<Vec<Error>>;
-pub type DiagnosticReceiver = mpsc::Receiver<Vec<Error>>;
+type DiagnosticReceiver = mpsc::Receiver<Vec<Error>>;
 
 /// Listens for diagnostics sent over a [channel](DiagnosticSender) by some job, and
 /// formats/reports them to the user.
@@ -27,37 +27,33 @@ pub type DiagnosticReceiver = mpsc::Receiver<Vec<Error>>;
 ///
 /// # Example
 /// ```rust,ignore
-/// use std::{path::PathBuf, thread};
-/// use oxc_diagnostics::{Error, OxcDiagnostic, DiagnosticService, GraphicalReportHandler};
+/// use std::{io, thread};
+/// use oxc_diagnostics::{OxcDiagnostic, DiagnosticService, GraphicalReportHandler};
 ///
 /// // Create a service with a graphical reporter
 /// let (mut service, sender) = DiagnosticService::new(Box::new(GraphicalReportHandler::new()));
 ///
 /// // Spawn a thread that does work and reports diagnostics
 /// thread::spawn(move || {
-///     sender.send((
-///         PathBuf::from("file.txt"),
-///         vec![OxcDiagnostic::error("Something went wrong").into()],
-///     ));
+///     sender.send(vec![OxcDiagnostic::error("Something went wrong").into()]).unwrap();
 ///
 ///     // The service will stop listening when all senders are dropped.
 ///     // No explicit termination signal is needed.
 /// });
 ///
 /// // Listen for and process messages
-/// service.run()
+/// service.run(&mut io::stdout().lock());
 /// ```
 pub struct DiagnosticService {
     reporter: Box<dyn DiagnosticReporter>,
 
-    /// Disable reporting on warnings, only errors are reported
+    /// Whether to suppress warnings and report only errors.
     quiet: bool,
 
-    /// Do not display any diagnostics
+    /// Whether to suppress all diagnostics.
     silent: bool,
 
-    /// Specify a warning threshold,
-    /// which can be used to force exit with an error status if there are too many warning-level rule violations in your project
+    /// Warning threshold used to determine the exit status.
     max_warnings: Option<usize>,
 
     receiver: DiagnosticReceiver,
@@ -113,9 +109,7 @@ impl DiagnosticService {
         self.max_warnings.is_some_and(|max_warnings| warnings_count > max_warnings)
     }
 
-    /// Wrap [diagnostics] with the source code and path, converting them into [Error]s.
-    ///
-    /// [diagnostics]: OxcDiagnostic
+    /// Attach the source code and path to diagnostics, converting them into [`Error`]s.
     pub fn wrap_diagnostics<C: AsRef<Path>, P: AsRef<Path>>(
         cwd: C,
         path: P,
@@ -146,11 +140,8 @@ impl DiagnosticService {
     ///
     /// * When the writer fails to write
     ///
-    /// ToDo:
-    /// We are passing [`DiagnosticResult`] to the [`DiagnosticReporter`] already
-    /// currently for the GraphicalReporter there is another extra output,
-    /// which does some more things. This is the reason why we are returning it.
-    /// Let's check at first it we can easily change for the default output before removing this return.
+    /// The result is also passed to the reporter, but remains part of this API because callers use
+    /// it to determine their exit status.
     pub fn run(&mut self, writer: &mut dyn Write) -> DiagnosticResult {
         let mut warnings_count: usize = 0;
         let mut errors_count: usize = 0;
@@ -159,21 +150,18 @@ impl DiagnosticService {
         while let Ok(diagnostics) = self.receiver.recv() {
             let mut is_minified = false;
             for diagnostic in diagnostics {
-                let severity = diagnostic.severity();
-                let is_warning = severity == Some(Severity::Warning);
-                let is_error = severity == Some(Severity::Error) || severity.is_none();
-                if is_warning || is_error {
-                    if is_warning {
+                match diagnostic.severity() {
+                    Some(Severity::Warning) => {
                         warnings_count += 1;
+                        // `--quiet` follows ESLint by suppressing warnings but not errors.
+                        if self.quiet {
+                            continue;
+                        }
                     }
-                    if is_error {
+                    Some(Severity::Error) | None => {
                         errors_count += 1;
                     }
-                    // The --quiet flag follows ESLint's --quiet behavior as documented here: https://eslint.org/docs/latest/use/command-line-interface#--quiet
-                    // Note that it does not disable ALL diagnostics, only Warning diagnostics
-                    else if self.quiet {
-                        continue;
-                    }
+                    Some(Severity::Advice) => {}
                 }
 
                 if self.silent || is_minified {

--- a/crates/oxc_diagnostics/src/source_impls.rs
+++ b/crates/oxc_diagnostics/src/source_impls.rs
@@ -1,6 +1,4 @@
-/*!
-Default trait implementations for [`SourceCode`].
-*/
+//! Default trait implementations for [`SourceCode`].
 #[cfg(test)]
 use std::str::from_utf8;
 use std::{collections::VecDeque, sync::Arc};
@@ -722,18 +720,13 @@ impl<'index, 'source> IndexedReader<'index, 'source> {
 /// origin fall back to a standalone [`SpanReader`].
 ///
 /// [`GraphicalReportHandler`]: crate::handlers::GraphicalReportHandler
-#[expect(clippy::redundant_pub_crate, reason = "keeps the renderer fast path crate-private")]
-pub(crate) struct SpanScanner<'a> {
+pub struct SpanScanner<'a> {
     context: ContextLines,
     index: LineIndex<'a>,
 }
 
 impl<'a> SpanScanner<'a> {
-    pub(crate) fn new(
-        input: &'a [u8],
-        context_lines_before: usize,
-        context_lines_after: usize,
-    ) -> Self {
+    pub fn new(input: &'a [u8], context_lines_before: usize, context_lines_after: usize) -> Self {
         Self {
             context: ContextLines::new(context_lines_before, context_lines_after),
             index: LineIndex::new(input),
@@ -741,7 +734,7 @@ impl<'a> SpanScanner<'a> {
     }
 
     /// Read a span while scanning only source bytes no earlier query scanned.
-    pub(crate) fn read_span(&mut self, span: Span) -> Option<SpanContents<'a>> {
+    pub fn read_span(&mut self, span: Span) -> Option<SpanContents<'a>> {
         let request = SpanRequest::new(span);
         let cut = request.prefix_end(self.index.input);
         if self.index.is_empty() {
@@ -772,7 +765,7 @@ impl SourceCode for str {
     }
 }
 
-/// Makes `src: &'static str` or `struct S<'a> { src: &'a str }` usable.
+/// Supports borrowed source text in generic contexts.
 impl SourceCode for &str {
     fn data(&self) -> &[u8] {
         self.as_bytes()

--- a/crates/oxc_span/src/labeled_span.rs
+++ b/crates/oxc_span/src/labeled_span.rs
@@ -9,36 +9,35 @@ pub struct LabeledSpan {
 }
 
 impl LabeledSpan {
-    /// Makes a new labeled span.
+    /// Creates a labeled span.
     #[must_use]
     pub const fn new(label: Option<String>, offset: u32, len: u32) -> Self {
         Self { label, span: Span::sized(offset, len), primary: false }
     }
 
-    /// Makes a new labeled span using an existing span.
+    /// Creates a labeled span from an existing span.
     #[must_use]
     pub fn new_with_span(label: Option<String>, span: impl Into<Span>) -> Self {
         Self { label, span: span.into(), primary: false }
     }
 
-    /// Makes a new labeled primary span using an existing span.
+    /// Creates a primary labeled span from an existing span.
     #[must_use]
     pub fn new_primary_with_span(label: Option<String>, span: impl Into<Span>) -> Self {
         Self { label, span: span.into(), primary: true }
     }
 
-    /// Change the offset of the span.
+    /// Changes the offset of the span while preserving its length.
     pub fn set_span_offset(&mut self, offset: u32) {
         self.span = Span::sized(offset, self.span.size());
     }
 
-    /// Makes a new label at specified span
+    /// Creates a label for the specified span.
     ///
     /// # Examples
     /// ```
     /// use oxc_span::LabeledSpan;
     ///
-    /// let source = "Cpp is the best";
     /// let label = LabeledSpan::at(0..3, "should be Rust");
     /// assert_eq!(
     ///     label,
@@ -50,13 +49,12 @@ impl LabeledSpan {
         Self::new_with_span(Some(label.into()), span)
     }
 
-    /// Makes a new label without text, that underlines a specific span.
+    /// Creates an unlabeled underline for the specified span.
     ///
     /// # Examples
     /// ```
     /// use oxc_span::LabeledSpan;
     ///
-    /// let source = "You have an error here";
     /// let label = LabeledSpan::underline(12..16);
     /// assert_eq!(label, LabeledSpan::new(None, 12, 4))
     /// ```
@@ -65,7 +63,7 @@ impl LabeledSpan {
         Self::new_with_span(None, span)
     }
 
-    /// Gets the (optional) label string for this `LabeledSpan`.
+    /// Returns the label text, if present.
     #[must_use]
     pub fn label(&self) -> Option<&str> {
         self.label.as_deref()


### PR DESCRIPTION
Clean up the diagnostics renderer vendored after removing `oxc-miette`: simplify source attachment and multiline labels, tighten visibility, and correct JSON escaping and debug formatting.

Validated with `just ready`.

AI-assisted; contributor review is required before merge.