### PR TITLE
fix(react_compiler): bail out instead of panicking on "Expected a node for all scopes"

### DIFF
--- a/crates/oxc_linter/src/rules/react/react_compiler.rs
+++ b/crates/oxc_linter/src/rules/react/react_compiler.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use oxc_diagnostics::Severity;
 use oxc_macros::declare_oxc_lint;
-use oxc_react_compiler::{CompilerOutputMode, EnvironmentConfig, PluginOptions};
+use oxc_react_compiler::{CompilerOutputMode, EnvironmentConfig, ErrorCategory, PluginOptions};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -131,7 +131,13 @@ impl Rule for ReactCompiler {
         } else {
             diagnostics
                 .into_iter()
-                .filter(|diagnostic| diagnostic.severity == Severity::Error)
+                .filter(|diagnostic| {
+                    // Internal invariant violations are compiler bugs, not rule
+                    // violations; the eslint plugin's `invariant` rule is off in
+                    // every preset, so the function is silently skipped.
+                    diagnostic.severity == Severity::Error
+                        && !ErrorCategory::Invariant.matches(diagnostic)
+                })
                 .collect::<Vec<_>>()
         };
 
@@ -229,6 +235,41 @@ function Component(props) {
             "
 class Foo {
   #bar() {}
+}
+",
+            None,
+        ),
+        // The compiler fails an internal invariant on this input
+        // (PruneNonEscapingScopes); the function is skipped without
+        // reporting, matching the eslint plugin, instead of crashing.
+        (
+            "
+export const Component = () => {
+  const raw = useValue();
+  return (() => {
+    try {
+      return check(raw) ? raw : null;
+    } catch {
+      return null;
+    }
+  })();
+};
+",
+            None,
+        ),
+        // The compiler fails an internal invariant on a `for` loop without a
+        // variable-declaration initializer (CodegenReactiveFunction).
+        // https://github.com/oxc-project/oxc/issues/24842
+        (
+            "
+function Component() {
+  useEffect(() => {
+    let i = 0;
+    for (; i < 3; i++) {
+      console.log(i);
+    }
+  });
+  return null;
 }
 ",
             None,
@@ -517,6 +558,35 @@ function useConditional2(props) {
             "function Component() {
                 const fbt = 'span';
                 return <fbt desc='label'>Hello</fbt>;
+            }",
+            Some(json!([{ "reportAllBailouts": true }])),
+        ),
+        // An internal invariant bail-out also surfaces under
+        // `reportAllBailouts`.
+        (
+            "export const Component = () => {
+                const raw = useValue();
+                return (() => {
+                    try {
+                        return check(raw) ? raw : null;
+                    } catch {
+                        return null;
+                    }
+                })();
+            };",
+            Some(json!([{ "reportAllBailouts": true }])),
+        ),
+        // The for-init invariant bail-out (issue #24842) also surfaces
+        // under `reportAllBailouts`.
+        (
+            "function Component() {
+                useEffect(() => {
+                    let i = 0;
+                    for (; i < 3; i++) {
+                        console.log(i);
+                    }
+                });
+                return null;
             }",
             Some(json!([{ "reportAllBailouts": true }])),
         ),

--- a/crates/oxc_linter/src/snapshots/react_react_compiler.snap
+++ b/crates/oxc_linter/src/snapshots/react_react_compiler.snap
@@ -229,3 +229,30 @@ source: crates/oxc_linter/src/tester.rs
  3 │                 return <fbt desc='label'>Hello</fbt>;
    ╰────
   help: Local variables named `fbt` may conflict with the fbt plugin and are not yet supported
+
+  ⚠ react(react-compiler): Invariant: Expected a node for all scopes
+    ╭─[react_compiler.tsx:1:26]
+  1 │ ╭─▶ export const Component = () => {
+  2 │ │                   const raw = useValue();
+  3 │ │                   return (() => {
+  4 │ │                       try {
+  5 │ │                           return check(raw) ? raw : null;
+  6 │ │                       } catch {
+  7 │ │                           return null;
+  8 │ │                       }
+  9 │ │                   })();
+ 10 │ ╰─▶             };
+    ╰────
+
+  ⚠ react(react-compiler): Invariant: Expected a variable declaration
+   ╭─[react_compiler.tsx:1:1]
+ 1 │ ╭─▶ function Component() {
+ 2 │ │                   useEffect(() => {
+ 3 │ │                       let i = 0;
+ 4 │ │                       for (; i < 3; i++) {
+ 5 │ │                           console.log(i);
+ 6 │ │                       }
+ 7 │ │                   });
+ 8 │ │                   return null;
+ 9 │ ╰─▶             }
+   ╰────

--- a/crates/oxc_react_compiler/fixtures/error.bug-prune-non-escaping-scopes-iife-try-catch-ternary.js
+++ b/crates/oxc_react_compiler/fixtures/error.bug-prune-non-escaping-scopes-iife-try-catch-ternary.js
@@ -1,0 +1,21 @@
+// PruneNonEscapingScopes associates the inlined IIFE's scope with the returned
+// temporary only through reassignments, while the scope's own declarations sit
+// in the ternary `test` inside `try`, which is never visited as a memoization
+// input — so no node is registered for the scope. Upstream fails the same
+// "Expected a node for all scopes" invariant on this input; the function must
+// bail out rather than crash.
+export const Component = () => {
+  const raw = useValue();
+  return (() => {
+    try {
+      return check(raw) ? raw : null;
+    } catch {
+      return null;
+    }
+  })();
+};
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -23,6 +23,7 @@ use crate::react_compiler::entrypoint::program::compile_program;
 pub use crate::react_compiler::entrypoint::compile_result::CompileResult;
 pub use crate::react_compiler::entrypoint::program::CompileOutput;
 
+pub use crate::diagnostics::ErrorCategory;
 // Re-exported so integrations needn't depend on the upstream `react_compiler` crates.
 pub use crate::options::{
     CompilationMode, CompilerOutputMode, CompilerTarget, DynamicGatingConfig, GatingConfig,

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -13,6 +13,7 @@ use rustc_hash::FxHashSet;
 
 use oxc_diagnostics::OxcDiagnostic;
 
+use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::ArrayPatternElement;
 use crate::react_compiler_hir::DeclarationId;
 use crate::react_compiler_hir::Effect;
@@ -77,7 +78,7 @@ pub fn prune_non_escaping_scopes<'a>(
     let (state, _) = visitor_state;
 
     // Then walk outward from the returned values and find all captured operands.
-    let memoized = compute_memoized_identifiers(&state);
+    let memoized = compute_memoized_identifiers(&state)?;
 
     // Prune scopes that do not declare/reassign any escaping values
     let mut transform = PruneScopesTransform {
@@ -951,7 +952,9 @@ impl<'a, 'e> ReactiveFunctionVisitor<'a> for CollectDependenciesVisitor<'a, 'e> 
 // computeMemoizedIdentifiers
 // =============================================================================
 
-fn compute_memoized_identifiers(state: &CollectState) -> FxHashSet<DeclarationId> {
+fn compute_memoized_identifiers(
+    state: &CollectState,
+) -> Result<FxHashSet<DeclarationId>, OxcDiagnostic> {
     let mut memoized = FxHashSet::default();
 
     // We need mutable access to the nodes, so we clone the state into mutable structures
@@ -984,12 +987,14 @@ fn compute_memoized_identifiers(state: &CollectState) -> FxHashSet<DeclarationId
         identifier_nodes: &mut IdentifierMemoNodes,
         scope_nodes: &mut ScopeMemoNodes,
         memoized: &mut FxHashSet<DeclarationId>,
-    ) -> bool {
+    ) -> Result<bool, OxcDiagnostic> {
         let Some(&(level, _, _, _, seen)) = identifier_nodes.get(&id) else {
-            return false;
+            // Upstream raises an "Expected a node for all identifiers" invariant
+            // here; this port has always been lenient instead.
+            return Ok(false);
         };
         if seen {
-            return identifier_nodes.get(&id).unwrap().1;
+            return Ok(identifier_nodes.get(&id).unwrap().1);
         }
 
         // Mark as seen, temporarily mark as non-memoized
@@ -1001,7 +1006,7 @@ fn compute_memoized_identifiers(state: &CollectState) -> FxHashSet<DeclarationId
             identifier_nodes.get(&id).unwrap().2.iter().copied().collect();
         let mut has_memoized_dependency = false;
         for dep in deps {
-            let is_dep_memoized = visit(dep, false, identifier_nodes, scope_nodes, memoized);
+            let is_dep_memoized = visit(dep, false, identifier_nodes, scope_nodes, memoized)?;
             has_memoized_dependency |= is_dep_memoized;
         }
 
@@ -1015,10 +1020,15 @@ fn compute_memoized_identifiers(state: &CollectState) -> FxHashSet<DeclarationId
             let scopes: Vec<ScopeId> =
                 identifier_nodes.get(&id).unwrap().3.iter().copied().collect();
             for scope_id in scopes {
-                force_memoize_scope_dependencies(scope_id, identifier_nodes, scope_nodes, memoized);
+                force_memoize_scope_dependencies(
+                    scope_id,
+                    identifier_nodes,
+                    scope_nodes,
+                    memoized,
+                )?;
             }
         }
-        identifier_nodes.get(&id).unwrap().1
+        Ok(identifier_nodes.get(&id).unwrap().1)
     }
 
     fn force_memoize_scope_dependencies(
@@ -1026,26 +1036,36 @@ fn compute_memoized_identifiers(state: &CollectState) -> FxHashSet<DeclarationId
         identifier_nodes: &mut IdentifierMemoNodes,
         scope_nodes: &mut ScopeMemoNodes,
         memoized: &mut FxHashSet<DeclarationId>,
-    ) {
-        let seen = scope_nodes.get(&id).expect("Expected a node for all scopes").1;
+    ) -> Result<(), OxcDiagnostic> {
+        // A scope can be associated with an identifier (via a reassignment or a
+        // return inside the scope) without any of its own declarations having
+        // been visited as a memoization input, in which case no node was ever
+        // registered for it. Upstream hits the same invariant on such inputs
+        // (e.g. an inlined IIFE whose scope's only declarations sit in a
+        // ternary `test` inside `try`/`catch`); it must bail out the function,
+        // not abort the process.
+        let Some(&(_, seen)) = scope_nodes.get(&id) else {
+            return Err(ErrorCategory::Invariant.diagnostic("Expected a node for all scopes"));
+        };
         if seen {
-            return;
+            return Ok(());
         }
         scope_nodes.get_mut(&id).unwrap().1 = true; // seen = true
 
         let deps: Vec<DeclarationId> = scope_nodes.get(&id).unwrap().0.clone();
         for dep in deps {
-            visit(dep, true, identifier_nodes, scope_nodes, memoized);
+            visit(dep, true, identifier_nodes, scope_nodes, memoized)?;
         }
+        Ok(())
     }
 
     // Walk from the "roots" aka returned/escaping identifiers
     let escaping: Vec<DeclarationId> = state.escaping_values.iter().copied().collect();
     for value in escaping {
-        visit(value, false, &mut identifier_nodes, &mut scope_nodes, &mut memoized);
+        visit(value, false, &mut identifier_nodes, &mut scope_nodes, &mut memoized)?;
     }
 
-    memoized
+    Ok(memoized)
 }
 
 // =============================================================================

--- a/crates/oxc_react_compiler/tests/snapshots/error.bug-prune-non-escaping-scopes-iife-try-catch-ternary.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.bug-prune-non-escaping-scopes-iife-try-catch-ternary.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/error.bug-prune-non-escaping-scopes-iife-try-catch-ternary.js
+---
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Invariant: Expected a node for all scopes", labels: [LabeledSpan { label: None, span: Span { start: 451, end: 599 }, primary: false }], help: None, note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.


### PR DESCRIPTION
## Summary

`oxlint` with `react/react-compiler` enabled aborted the whole process with

```
panicked at .../prune_non_escaping_scopes.rs:
Expected a node for all scopes
```

on inputs like:

```ts
export const Component = () => {
  const raw = useValue();
  return (() => {
    try {
      return check(raw) ? raw : null;
    } catch {
      return null;
    }
  })();
};
```

## Root cause

Running the same input through the version-matched `babel-plugin-react-compiler` fails the **identical invariant** (still present at facebook/react HEAD), so the analysis inconsistency is an upstream bug the port reproduces faithfully:

- IIFE inlining turns both inner `return`s into reassignments of a temporary, and scope alignment widens the `check(raw)` scope over the try/catch, so `visit_scope` associates the temporary with that scope;
- the scope's only own declarations sit in the ternary *test*, which `computeMemoizationInputs` deliberately never descends into ("Conditionals do not alias their test value"), so `visit_operand` — the only place scope nodes are registered — never fires for it;
- when the escaping temporary is memoized, `force_memoize_scope_dependencies` looks up the unregistered scope and fails the invariant.

The port's actual defect is the error channel: upstream raises a *catchable* `CompilerError`, so with `panicThreshold: 'none'` (what linting uses) the function is silently skipped and the rest of the file proceeds. The port had written this invariant as `.expect()`, turning the per-function bail-out into a process abort.

## Fix

- `compute_memoized_identifiers` and its recursive helpers now return `Result`; the invariant becomes `Err(ErrorCategory::Invariant.diagnostic(...))` and flows through the existing per-function `handle_error` / `panic_threshold` path — the same observable behavior as Babel (function skipped, everything else still compiles/lints).
- The `react/react-compiler` rule now drops `Invariant`-category diagnostics unless `reportAllBailouts` is enabled, matching the eslint plugin where the `invariant` rule is `preset: Off` ("only meant for the compiler team's consumption"); without this, the fix would have replaced the crash with a spurious error-level report on valid code. `ErrorCategory` is now exported from `oxc_react_compiler` for this check.
- New fixture `error.bug-prune-non-escaping-scopes-iife-try-catch-ternary.js` (upstream's `error.bug-*` convention for known compiler bugs) plus rule tests covering both configs.

With the rule enabled, `oxlint` on the repro now exits cleanly with no report — identical to ESLint on the same input.

## Also fixes #24842

The rule-side filter resolves #24842 as well: `react/react-compiler` reported `Invariant: Expected a variable declaration` on a `for` loop without a variable-declaration initializer (`for (; i < 3; i++)`). Same pattern, different stage: that invariant fires in `codegenForInit` and already flowed through the catchable `Err` channel, so it surfaced as a spurious error report rather than a panic. It too reproduces upstream faithfully — the version-matched `babel-plugin-react-compiler` fails the identical invariant (`Got ExpressionStatement`) and upstream's own `error.todo-kitchensink` fixture expects it; by default Babel silently skips the function and ESLint reports nothing. The #24842 repro is added to the rule tests (clean by default, surfaced under `reportAllBailouts`).

## Relation to #25347

#25347 diagnosed this accurately (thanks @controversial!) but fixes it by registering scope nodes eagerly so compilation succeeds and emits memoized output. That would make oxc compile an input every upstream compiler version refuses to compile, producing memoization decisions with no upstream validation, exactly where upstream's invariant declares its internal model inconsistent — a wrong scope association would then surface as a missed invalidation (stale UI) instead of a crash, and the pass would permanently diverge from upstream for future syncs. The behavioral fix belongs upstream in facebook/react; this PR restores upstream's bail-out semantics so oxlint no longer crashes, and the port will inherit the upstream fix when it lands.

Closes #24710
Closes #24842
Closes #25347

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

