### PR TITLE
fix(linter/react/exhaustive-deps): treat binary expressions as a stable dependency

### DIFF
--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -781,12 +781,17 @@ fn is_expression_referentially_unique(expr: &Expression) -> bool {
             is_expression_referentially_unique(&logical.left)
                 || is_expression_referentially_unique(&logical.right)
         }
-        Expression::BinaryExpression(bin_expr) => {
-            is_expression_referentially_unique(&bin_expr.right)
-        }
         Expression::AssignmentExpression(assignment) => {
             is_expression_referentially_unique(&assignment.right)
         }
+        // A BinaryExpression is deliberately absent: the arms above recurse
+        // because those expressions evaluate *to* one of their operands, which
+        // a binary expression never does. Every binary operator -- arithmetic,
+        // comparison, bitwise, `in`, `instanceof` -- yields a primitive, so the
+        // result is stable however unstable the operands are. Recursing into
+        // the right operand made `new Date(a) > new Date()` inherit
+        // "referentially unique" from the NewExpression and reported a boolean
+        // as changing every render.
         _ => false,
     }
 }
@@ -2894,9 +2899,43 @@ const Component = ({ filter }) => {
 
           return <div>test</div>;
         };",
+        // A binary expression always evaluates to a primitive, however
+        // unstable its operands are, so the result is a stable dependency.
+        // https://github.com/oxc-project/oxc/issues/25029
+        r"function MyComponent() {
+          const condition = new Date('2026-01-01') > new Date();
+          useCallback(() => {
+            return condition;
+          }, [condition]);
+        }",
+        r"function MyComponent() {
+          const label = 'total: ' + [1, 2, 3].length;
+          useCallback(() => {
+            return label;
+          }, [label]);
+        }",
+        r"function MyComponent(props) {
+          const isError = props.value instanceof Error;
+          useMemo(() => isError, [isError]);
+        }",
     ];
 
     let fail = vec![
+        // The conditional and logical arms must keep recursing: unlike a
+        // binary expression, those evaluate *to* one of their operands, so an
+        // object literal on either side really is a new reference each render.
+        r"function MyComponent(props) {
+          const value = props.flag ? {} : {};
+          useCallback(() => {
+            return value;
+          }, [value]);
+        }",
+        r"function MyComponent(props) {
+          const value = props.cached || {};
+          useCallback(() => {
+            return value;
+          }, [value]);
+        }",
         r"function MyComponent(props) {
           useCallback(() => {
             console.log(props.foo?.toString());

--- a/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
+++ b/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
@@ -2,6 +2,36 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
+  ⚠ react-hooks(exhaustive-deps): React hook useCallback depends on `value`, which changes every render
+   ╭─[exhaustive_deps.tsx:5:15]
+ 1 │ function MyComponent(props) {
+ 2 │           const value = props.flag ? {} : {};
+   ·                 ──┬──
+   ·                   ╰── `value` is declared here
+ 3 │           useCallback(() => {
+ 4 │             return value;
+ 5 │           }, [value]);
+   ·               ──┬──
+   ·                 ╰── it will always cause this hook to re-evaluate
+ 6 │         }
+   ╰────
+  help: Try memoizing this variable with `useRef` or `useCallback`.
+
+  ⚠ react-hooks(exhaustive-deps): React hook useCallback depends on `value`, which changes every render
+   ╭─[exhaustive_deps.tsx:5:15]
+ 1 │ function MyComponent(props) {
+ 2 │           const value = props.cached || {};
+   ·                 ──┬──
+   ·                   ╰── `value` is declared here
+ 3 │           useCallback(() => {
+ 4 │             return value;
+ 5 │           }, [value]);
+   ·               ──┬──
+   ·                 ╰── it will always cause this hook to re-evaluate
+ 6 │         }
+   ╰────
+  help: Try memoizing this variable with `useRef` or `useCallback`.
+
   ⚠ react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo'
    ╭─[exhaustive_deps.tsx:4:14]
  2 │           useCallback(() => {


### PR DESCRIPTION
Closes #25029

`is_expression_referentially_unique` recursed into the right operand of a `BinaryExpression`, so `new Date(a) > new Date()` inherited "referentially unique" from the `NewExpression` and the boolean it produces was reported as changing every render.

### Why the arm is wrong rather than incomplete

No binary operator can produce a fresh reference. All 22 of them — `==` `!=` `===` `!==` `<` `<=` `>` `>=` `+` `-` `*` `/` `%` `**` `<<` `>>` `>>>` `|` `^` `&` `in` `instanceof` — evaluate to a number, string, boolean or bigint, whatever the operands are.

The neighbouring arms that do recurse are correct for a different reason: a conditional, logical or assignment expression evaluates **to** one of its operands, so an object literal there really is a new reference each render. A binary expression never does, so the arm is removed and it falls through to `false`.

### Tests

Three passing cases — comparison (the issue's own example), string concatenation, and `instanceof` — plus two failing ones that pin the conditional and logical arms, so the removal cannot be widened to them later.

### Verification

- `cargo test -p oxc_linter --lib exhaustive_deps`: 2 passed, 0 failed
- revert-checked: restoring the arm with the tests kept reproduces the reported diagnostic exactly
- **the snapshot gains 30 lines and loses none**, so nothing that was reported before stopped being reported
- `cargo fmt --check` and `clippy` clean
