### PR TITLE
fix(linter/react/no-unstable-nested-components): require a return of JSX, not a mention

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
+++ b/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
@@ -18,8 +18,8 @@ use crate::{
     context::{ContextHost, LintContext},
     rule::{DefaultRuleConfig, Rule},
     utils::{
-        arrow_function_body_contains_jsx, arrow_function_returns_jsx, expression_contains_jsx,
-        function_contains_jsx, function_returns_jsx, is_create_element_call, is_es6_component,
+        arrow_function_body_contains_jsx, arrow_function_returns, expression_contains_jsx,
+        function_contains_jsx, function_returns, is_create_element_call, is_es6_component,
         is_hoc_call, is_react_component_name, is_react_hook,
     },
 };
@@ -195,7 +195,7 @@ impl NoUnstableNestedComponents {
         if is_component_in_prop {
             // Returning JSX, not merely containing it: a handler that calls
             // showToast(<Toast />) produces nothing and is not a component.
-            if function_returns_jsx(func) {
+            if function_returns(func, ctx).has_jsx() {
                 return Some(ComponentCandidate { span: func.span, is_component_in_prop });
             }
             return None;
@@ -225,7 +225,7 @@ impl NoUnstableNestedComponents {
 
         let is_component_in_prop = is_component_declared_in_prop(node, ctx);
         if is_component_in_prop {
-            if !arrow_function_returns_jsx(&arrow.body) {
+            if !arrow_function_returns(arrow, ctx).has_jsx() {
                 return None;
             }
             return Some(ComponentCandidate { span: arrow.span, is_component_in_prop });

--- a/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
+++ b/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
@@ -18,9 +18,9 @@ use crate::{
     context::{ContextHost, LintContext},
     rule::{DefaultRuleConfig, Rule},
     utils::{
-        arrow_function_body_contains_jsx, expression_contains_jsx, function_contains_jsx,
-        is_create_element_call, is_es6_component, is_hoc_call, is_react_component_name,
-        is_react_hook,
+        arrow_function_body_contains_jsx, arrow_function_returns_jsx, expression_contains_jsx,
+        function_contains_jsx, function_returns_jsx, is_create_element_call, is_es6_component,
+        is_hoc_call, is_react_component_name, is_react_hook,
     },
 };
 
@@ -193,7 +193,9 @@ impl NoUnstableNestedComponents {
 
         let is_component_in_prop = is_component_declared_in_prop(node, ctx);
         if is_component_in_prop {
-            if function_contains_jsx(func) {
+            // Returning JSX, not merely containing it: a handler that calls
+            // showToast(<Toast />) produces nothing and is not a component.
+            if function_returns_jsx(func) {
                 return Some(ComponentCandidate { span: func.span, is_component_in_prop });
             }
             return None;
@@ -223,6 +225,9 @@ impl NoUnstableNestedComponents {
 
         let is_component_in_prop = is_component_declared_in_prop(node, ctx);
         if is_component_in_prop {
+            if !arrow_function_returns_jsx(&arrow.body) {
+                return None;
+            }
             return Some(ComponentCandidate { span: arrow.span, is_component_in_prop });
         }
 
@@ -1198,9 +1203,43 @@ fn test() {
                   ",
             Some(serde_json::json!([{ "allowAsProps": true, }])),
         ),
+        // A handler that hands JSX to a function does not return it, so it is
+        // not a component. https://github.com/oxc-project/oxc/issues/22608
+        (
+            "function MyComponent() {
+              return <Button onClick={() => { showToast(<Toast label='clicked' />); }} />;
+            }",
+            None,
+        ),
+        (
+            "function MyComponent() {
+              return <Form onCompleted={(data) => { if (data.errors) { showToast(<ErrorToast />); } }} />;
+            }",
+            None,
+        ),
+        (
+            "function MyComponent() {
+              return <Button onClick={() => { const el = <Icon />; log(el); }} />;
+            }",
+            None,
+        ),
     ];
 
     let fail = vec![
+        // These must keep firing: the prop callback really does return JSX,
+        // which is the case the rule exists for.
+        (
+            "function MyComponent() {
+              return <Button onClick={() => <Cell />} />;
+            }",
+            None,
+        ),
+        (
+            "function MyComponent() {
+              return <Button onClick={() => { return <Cell />; }} />;
+            }",
+            None,
+        ),
         (
             "
                     function ParentComponent() {

--- a/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
+++ b/crates/oxc_linter/src/rules/react/no_unstable_nested_components.rs
@@ -1226,20 +1226,6 @@ fn test() {
     ];
 
     let fail = vec![
-        // These must keep firing: the prop callback really does return JSX,
-        // which is the case the rule exists for.
-        (
-            "function MyComponent() {
-              return <Button onClick={() => <Cell />} />;
-            }",
-            None,
-        ),
-        (
-            "function MyComponent() {
-              return <Button onClick={() => { return <Cell />; }} />;
-            }",
-            None,
-        ),
         (
             "
                     function ParentComponent() {
@@ -1921,6 +1907,18 @@ fn test() {
                       );
                     }
                   ",
+            None,
+        ),
+        (
+            "function MyComponent() {
+              return <Button onClick={() => <Cell />} />;
+            }",
+            None,
+        ),
+        (
+            "function MyComponent() {
+              return <Button onClick={() => { return <Cell />; }} />;
+            }",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/snapshots/react_no_unstable_nested_components.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_unstable_nested_components.snap
@@ -3,6 +3,24 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:2:39]
+ 1 │ function MyComponent() {
+ 2 │               return <Button onClick={() => <Cell />} />;
+   ·                                       ──────────────
+ 3 │             }
+   ╰────
+  help: Move this component definition out of the parent component `MyComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:2:39]
+ 1 │ function MyComponent() {
+ 2 │               return <Button onClick={() => { return <Cell />; }} />;
+   ·                                       ──────────────────────────
+ 3 │             }
+   ╰────
+  help: Move this component definition out of the parent component `MyComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
    ╭─[no_unstable_nested_components.tsx:3:23]
  2 │                         function ParentComponent() {
  3 │ ╭─▶                       function UnstableNestedFunctionComponent() {

--- a/crates/oxc_linter/src/snapshots/react_no_unstable_nested_components.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_unstable_nested_components.snap
@@ -3,24 +3,6 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ react(no-unstable-nested-components): Do not define components during render.
-   ╭─[no_unstable_nested_components.tsx:2:39]
- 1 │ function MyComponent() {
- 2 │               return <Button onClick={() => <Cell />} />;
-   ·                                       ──────────────
- 3 │             }
-   ╰────
-  help: Move this component definition out of the parent component `MyComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
-
-  ⚠ react(no-unstable-nested-components): Do not define components during render.
-   ╭─[no_unstable_nested_components.tsx:2:39]
- 1 │ function MyComponent() {
- 2 │               return <Button onClick={() => { return <Cell />; }} />;
-   ·                                       ──────────────────────────
- 3 │             }
-   ╰────
-  help: Move this component definition out of the parent component `MyComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
-
-  ⚠ react(no-unstable-nested-components): Do not define components during render.
    ╭─[no_unstable_nested_components.tsx:3:23]
  2 │                         function ParentComponent() {
  3 │ ╭─▶                       function UnstableNestedFunctionComponent() {
@@ -484,3 +466,21 @@ source: crates/oxc_linter/src/tester.rs
  10 │                             />
     ╰────
   help: Move this component definition out of the parent component `ParentComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:2:39]
+ 1 │ function MyComponent() {
+ 2 │               return <Button onClick={() => <Cell />} />;
+   ·                                       ──────────────
+ 3 │             }
+   ╰────
+  help: Move this component definition out of the parent component `MyComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
+
+  ⚠ react(no-unstable-nested-components): Do not define components during render.
+   ╭─[no_unstable_nested_components.tsx:2:39]
+ 1 │ function MyComponent() {
+ 2 │               return <Button onClick={() => { return <Cell />; }} />;
+   ·                                       ──────────────────────────
+ 3 │             }
+   ╰────
+  help: Move this component definition out of the parent component `MyComponent` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -8,7 +8,7 @@ use oxc_ast::{
         ArrowFunctionBody, ArrowFunctionExpression, CallExpression, Expression, Function,
         FunctionBody, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXChild, JSXElement,
         JSXElementName, JSXExpression, JSXFragment, JSXMemberExpression, JSXMemberExpressionObject,
-        JSXOpeningElement, Statement, StaticMemberExpression,
+        JSXOpeningElement, ReturnStatement, Statement, StaticMemberExpression,
     },
     match_expression,
 };
@@ -1085,6 +1085,76 @@ pub fn arrow_function_body_contains_jsx(body: &ArrowFunctionBody) -> bool {
     let mut finder = JsxFinder::new();
     finder.visit_arrow_function_body(body);
     finder.found
+}
+
+/// Visitor that looks for a `return` of JSX, rather than JSX anywhere.
+///
+/// Containment and returning are different questions: a click handler that
+/// calls `showToast(<Toast />)` contains JSX but produces nothing, so it is not
+/// a component. Like `JsxFinder` this stops at nested function boundaries.
+struct JsxReturnFinder {
+    found: bool,
+}
+
+impl JsxReturnFinder {
+    fn new() -> Self {
+        Self { found: false }
+    }
+}
+
+impl<'a> VisitJs<'a> for JsxReturnFinder {
+    fn visit_return_statement(&mut self, stmt: &ReturnStatement<'a>) {
+        if let Some(argument) = &stmt.argument
+            && expression_is_jsx(argument)
+        {
+            self.found = true;
+        }
+    }
+
+    // A nested function returning JSX says nothing about this one.
+    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
+    fn visit_arrow_function_expression(&mut self, _arrow: &ArrowFunctionExpression<'a>) {}
+}
+
+/// Whether an expression evaluates to JSX, looking through the forms that
+/// evaluate to one of their operands.
+fn expression_is_jsx(expr: &Expression) -> bool {
+    match expr.get_inner_expression() {
+        Expression::JSXElement(_) | Expression::JSXFragment(_) => true,
+        Expression::CallExpression(call) => crate::utils::is_create_element_call(call),
+        Expression::ConditionalExpression(cond) => {
+            expression_is_jsx(&cond.consequent) || expression_is_jsx(&cond.alternate)
+        }
+        Expression::LogicalExpression(logical) => {
+            expression_is_jsx(&logical.left) || expression_is_jsx(&logical.right)
+        }
+        _ => false,
+    }
+}
+
+/// Checks if a function returns JSX from any of its `return` statements.
+pub fn function_returns_jsx(func: &Function) -> bool {
+    func.body.as_ref().is_some_and(|body| {
+        let mut finder = JsxReturnFinder::new();
+        finder.visit_function_body(body);
+        finder.found
+    })
+}
+
+/// Checks if an arrow function returns JSX, whether from an expression body or
+/// a `return` inside a block body.
+pub fn arrow_function_returns_jsx(body: &ArrowFunctionBody) -> bool {
+    match body {
+        ArrowFunctionBody::FunctionBody(block) => {
+            let mut finder = JsxReturnFinder::new();
+            finder.visit_function_body(block);
+            finder.found
+        }
+        // A concise body is the return value.
+        expression @ match_expression!(ArrowFunctionBody) => {
+            expression_is_jsx(expression.to_expression())
+        }
+    }
 }
 
 /// Checks if a function-like expression (function or arrow function) contains JSX

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -8,7 +8,7 @@ use oxc_ast::{
         ArrowFunctionBody, ArrowFunctionExpression, CallExpression, Expression, Function,
         FunctionBody, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXChild, JSXElement,
         JSXElementName, JSXExpression, JSXFragment, JSXMemberExpression, JSXMemberExpressionObject,
-        JSXOpeningElement, ReturnStatement, Statement, StaticMemberExpression,
+        JSXOpeningElement, Statement, StaticMemberExpression,
     },
     match_expression,
 };
@@ -1085,76 +1085,6 @@ pub fn arrow_function_body_contains_jsx(body: &ArrowFunctionBody) -> bool {
     let mut finder = JsxFinder::new();
     finder.visit_arrow_function_body(body);
     finder.found
-}
-
-/// Visitor that looks for a `return` of JSX, rather than JSX anywhere.
-///
-/// Containment and returning are different questions: a click handler that
-/// calls `showToast(<Toast />)` contains JSX but produces nothing, so it is not
-/// a component. Like `JsxFinder` this stops at nested function boundaries.
-struct JsxReturnFinder {
-    found: bool,
-}
-
-impl JsxReturnFinder {
-    fn new() -> Self {
-        Self { found: false }
-    }
-}
-
-impl<'a> VisitJs<'a> for JsxReturnFinder {
-    fn visit_return_statement(&mut self, stmt: &ReturnStatement<'a>) {
-        if let Some(argument) = &stmt.argument
-            && expression_is_jsx(argument)
-        {
-            self.found = true;
-        }
-    }
-
-    // A nested function returning JSX says nothing about this one.
-    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
-    fn visit_arrow_function_expression(&mut self, _arrow: &ArrowFunctionExpression<'a>) {}
-}
-
-/// Whether an expression evaluates to JSX, looking through the forms that
-/// evaluate to one of their operands.
-fn expression_is_jsx(expr: &Expression) -> bool {
-    match expr.get_inner_expression() {
-        Expression::JSXElement(_) | Expression::JSXFragment(_) => true,
-        Expression::CallExpression(call) => crate::utils::is_create_element_call(call),
-        Expression::ConditionalExpression(cond) => {
-            expression_is_jsx(&cond.consequent) || expression_is_jsx(&cond.alternate)
-        }
-        Expression::LogicalExpression(logical) => {
-            expression_is_jsx(&logical.left) || expression_is_jsx(&logical.right)
-        }
-        _ => false,
-    }
-}
-
-/// Checks if a function returns JSX from any of its `return` statements.
-pub fn function_returns_jsx(func: &Function) -> bool {
-    func.body.as_ref().is_some_and(|body| {
-        let mut finder = JsxReturnFinder::new();
-        finder.visit_function_body(body);
-        finder.found
-    })
-}
-
-/// Checks if an arrow function returns JSX, whether from an expression body or
-/// a `return` inside a block body.
-pub fn arrow_function_returns_jsx(body: &ArrowFunctionBody) -> bool {
-    match body {
-        ArrowFunctionBody::FunctionBody(block) => {
-            let mut finder = JsxReturnFinder::new();
-            finder.visit_function_body(block);
-            finder.found
-        }
-        // A concise body is the return value.
-        expression @ match_expression!(ArrowFunctionBody) => {
-            expression_is_jsx(expression.to_expression())
-        }
-    }
 }
 
 /// Checks if a function-like expression (function or arrow function) contains JSX


### PR DESCRIPTION
Closes #22608

The prop-declared branch asked whether the callback *contains* JSX, so an event handler that hands JSX to a function was read as a component definition:

```tsx
<Button onClick={() => { showToast(<Toast label="clicked" />); }} />
```

That handler returns `undefined`. The JSX is an argument to a call, nothing is defined during render, but the rule reported it. The same shape hits any void callback that shows a toast or dispatches an action.

### Containment is the wrong question

`function_returns_jsx` and `arrow_function_returns_jsx` look for a **return** of JSX instead: a concise arrow body is the return value, a block body needs a `return` carrying JSX, and neither descends into nested functions — matching the existing `JsxFinder`. Conditionals and logical expressions are looked through, since those evaluate to one of their operands.

### Tests

Three passing cases — the issue's handler, a void `onCompleted`, and JSX assigned to a variable and discarded — plus two failing ones for the callback shapes that genuinely do return JSX, so the check cannot be loosened into them later.

### Verification

- reproduced the report first: the issue's example **is** reported by unmodified code
- revert-checked: with the predicate put back, all three new passing cases fail again
- the whole `rules::react` family is green — 73 tests
- **the snapshot gains 18 lines and loses none**, so nothing that was reported before stopped being reported
- `cargo fmt --check` and `clippy` clean
