### PR TITLE
fix(react_compiler): support computed string destructuring keys

### DIFF
--- a/crates/oxc_react_compiler/fixtures/destructure-computed-string-literal-property-key.tsx
+++ b/crates/oxc_react_compiler/fixtures/destructure-computed-string-literal-property-key.tsx
@@ -1,0 +1,6 @@
+export const Example: FC<any> = (props) => {
+  const {
+    ['data-testid']: testId,
+  } = props;
+  return <div data-testid={testId}>Hello</div>;
+};

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -1505,7 +1505,10 @@ fn lower_binding_assignment<'a>(
             let mut followups: Vec<(Place, &oxc::BindingPattern)> = Vec::new();
 
             for prop in &pattern.properties {
-                if prop.computed {
+                // Computed string literals can be normalized to static property keys. Other
+                // computed keys need to remain expressions, which destructuring does not support
+                // yet.
+                if prop.computed && !is_static_property_key(&prop.key) {
                     builder.record_error(
                         ErrorCategory::Todo
                             .diagnostic("(BuildHIR::lowerAssignment) Handle computed properties in ObjectPattern").with_label(prop.span),
@@ -1513,7 +1516,7 @@ fn lower_binding_assignment<'a>(
                     continue;
                 }
 
-                let key = match lower_object_property_key(builder, &prop.key, false)? {
+                let key = match lower_object_property_key(builder, &prop.key, prop.computed)? {
                     Some(k) => k,
                     None => continue,
                 };
@@ -2228,14 +2231,14 @@ fn lower_assignment_target<'a>(
                         }
                     }
                     oxc::AssignmentTargetProperty::AssignmentTargetPropertyProperty(p) => {
-                        if p.computed {
+                        if p.computed && !is_static_property_key(&p.name) {
                             builder.record_error(
                                 ErrorCategory::Todo
                                     .diagnostic("(BuildHIR::lowerAssignment) Handle computed properties in ObjectPattern").with_label(p.span),
                             )?;
                             continue;
                         }
-                        let key = match lower_object_property_key(builder, &p.name, false)? {
+                        let key = match lower_object_property_key(builder, &p.name, p.computed)? {
                             Some(k) => k,
                             None => continue,
                         };
@@ -5531,6 +5534,11 @@ fn lower_object_property_key<'a>(
             Ok(None)
         }
     }
+}
+
+/// Whether a computed property key can be represented without evaluating an expression.
+fn is_static_property_key(key: &oxc::PropertyKey<'_>) -> bool {
+    matches!(key, oxc::PropertyKey::StringLiteral(_))
 }
 
 /// Lower a reorderable expression. Faithful to the original

--- a/crates/oxc_react_compiler/tests/snapshots/destructure-computed-string-literal-property-key.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/destructure-computed-string-literal-property-key.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/destructure-computed-string-literal-property-key.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+export const Example: FC<any> = (props) => {
+	const $ = _c(2);
+	const { "data-testid": testId } = props;
+	let t0;
+	if ($[0] !== testId) {
+		t0 = <div data-testid={testId}>Hello</div>;
+		$[0] = testId;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+};


### PR DESCRIPTION
Normalize computed string-literal destructuring keys before React Compiler HIR lowering so aliased bindings are initialized correctly.

Fixes #23750.

AI assistance: Codex was used to investigate, implement, and validate this change.