### PR TITLE
fix(codegen): preserve TypeScript comparison grouping

### DIFF
--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -73,16 +73,28 @@ fn binary_operator(expression: &Expression<'_>) -> Option<BinaryOperator> {
 }
 
 fn is_ts_type_argument_open(operator: BinaryOperator) -> bool {
-    matches!(operator, BinaryOperator::LessThan | BinaryOperator::ShiftLeft)
+    ts_type_argument_open_count(operator) > 0
 }
 
 fn is_ts_type_argument_close(operator: BinaryOperator) -> bool {
-    matches!(
-        operator,
-        BinaryOperator::GreaterThan
-            | BinaryOperator::ShiftRight
-            | BinaryOperator::ShiftRightZeroFill
-    )
+    ts_type_argument_close_count(operator) > 0
+}
+
+fn ts_type_argument_open_count(operator: BinaryOperator) -> u8 {
+    match operator {
+        BinaryOperator::LessThan => 1,
+        BinaryOperator::ShiftLeft => 2,
+        _ => 0,
+    }
+}
+
+fn ts_type_argument_close_count(operator: BinaryOperator) -> u8 {
+    match operator {
+        BinaryOperator::GreaterThan => 1,
+        BinaryOperator::ShiftRight => 2,
+        BinaryOperator::ShiftRightZeroFill => 3,
+        _ => 0,
+    }
 }
 
 impl BinaryishOperator {
@@ -243,13 +255,28 @@ impl<'a> BinaryExpressionVisitor<'a> {
                 // arguments. Make the left child bind less tightly so it is grouped.
                 self.left_precedence = Precedence::Shift;
             }
-            BinaryishOperator::Binary(BinaryOperator::LessThan | BinaryOperator::ShiftLeft)
-                if p.is_typescript
-                    && binary_operator(e.right()).is_some_and(is_ts_type_argument_close) =>
+            BinaryishOperator::Binary(
+                operator @ (BinaryOperator::LessThan | BinaryOperator::ShiftLeft),
+            ) if p.is_typescript
+                && binary_operator(e.right()).is_some_and(is_ts_type_argument_close) =>
             {
                 // A right shift can be re-lexed into multiple generic closers. Make the
                 // right child bind less tightly so the current opener cannot consume it.
                 self.right_precedence = Precedence::Shift;
+
+                // If the left child supplies an earlier opener and the right child has
+                // enough closing angles to reach it, isolate the entire earlier chain too.
+                // For example, `a < b < (c >> (d, e))` can otherwise be reparsed as a
+                // generic call instead of the original comparisons and shift.
+                if let Some(left_operator) = binary_operator(e.left())
+                    && let Some(close_operator) = binary_operator(e.right())
+                    && ts_type_argument_open_count(left_operator) > 0
+                    && ts_type_argument_close_count(close_operator)
+                        >= ts_type_argument_open_count(left_operator)
+                            + ts_type_argument_open_count(operator)
+                {
+                    self.left_precedence = Precedence::Shift;
+                }
             }
             BinaryishOperator::Binary(BinaryOperator::BitwiseOR | BinaryOperator::BitwiseAnd) => {
                 // Without parentheses, `|` or `&` becomes part of the type in

--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -67,16 +67,16 @@ fn print_binary_operator(op: BinaryOperator, p: &mut Codegen) {
     }
 }
 
-pub fn binary_operator(expression: &Expression<'_>) -> Option<BinaryOperator> {
+fn binary_operator(expression: &Expression<'_>) -> Option<BinaryOperator> {
     let Expression::BinaryExpression(expression) = expression else { return None };
     Some(expression.operator)
 }
 
-pub fn is_ts_type_argument_open(operator: BinaryOperator) -> bool {
+fn is_ts_type_argument_open(operator: BinaryOperator) -> bool {
     matches!(operator, BinaryOperator::LessThan | BinaryOperator::ShiftLeft)
 }
 
-pub fn is_ts_type_argument_close(operator: BinaryOperator) -> bool {
+fn is_ts_type_argument_close(operator: BinaryOperator) -> bool {
     matches!(
         operator,
         BinaryOperator::GreaterThan

--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -67,6 +67,24 @@ fn print_binary_operator(op: BinaryOperator, p: &mut Codegen) {
     }
 }
 
+fn binary_operator(expression: &Expression<'_>) -> Option<BinaryOperator> {
+    let Expression::BinaryExpression(expression) = expression else { return None };
+    Some(expression.operator)
+}
+
+fn is_ts_type_argument_open(operator: BinaryOperator) -> bool {
+    matches!(operator, BinaryOperator::LessThan | BinaryOperator::ShiftLeft)
+}
+
+fn is_ts_type_argument_close(operator: BinaryOperator) -> bool {
+    matches!(
+        operator,
+        BinaryOperator::GreaterThan
+            | BinaryOperator::ShiftRight
+            | BinaryOperator::ShiftRightZeroFill
+    )
+}
+
 impl BinaryishOperator {
     fn r#gen(self, p: &mut Codegen) {
         match self {
@@ -214,11 +232,39 @@ impl<'a> BinaryExpressionVisitor<'a> {
                     self.left_precedence = Precedence::Call;
                 }
             }
+            BinaryishOperator::Binary(
+                BinaryOperator::GreaterThan
+                | BinaryOperator::ShiftRight
+                | BinaryOperator::ShiftRightZeroFill,
+            ) if p.is_typescript
+                && binary_operator(e.left()).is_some_and(is_ts_type_argument_open) =>
+            {
+                // TypeScript can reinterpret `<...>`, `<...>>`, and `<...>>>` as type
+                // arguments. Make the left child bind less tightly so it is grouped.
+                self.left_precedence = Precedence::Shift;
+            }
+            BinaryishOperator::Binary(BinaryOperator::LessThan | BinaryOperator::ShiftLeft)
+                if p.is_typescript
+                    && binary_operator(e.right()).is_some_and(is_ts_type_argument_close) =>
+            {
+                // A right shift can be re-lexed into multiple generic closers. Make the
+                // right child bind less tightly so the current opener cannot consume it.
+                self.right_precedence = Precedence::Shift;
+            }
             BinaryishOperator::Binary(BinaryOperator::BitwiseOR | BinaryOperator::BitwiseAnd) => {
                 // Without parentheses, `|` or `&` becomes part of the type in
                 // `(value satisfies Type) | other` or `(value satisfies Type) & other`.
                 if matches!(e.left(), Expression::TSSatisfiesExpression(_)) {
                     self.left_precedence = Precedence::Compare;
+                }
+
+                if p.is_typescript {
+                    if binary_operator(e.left()).is_some_and(is_ts_type_argument_open) {
+                        self.left_precedence = Precedence::Shift;
+                    }
+                    if binary_operator(e.right()).is_some_and(is_ts_type_argument_open) {
+                        self.right_precedence = Precedence::Shift;
+                    }
                 }
             }
 

--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -67,16 +67,16 @@ fn print_binary_operator(op: BinaryOperator, p: &mut Codegen) {
     }
 }
 
-fn binary_operator(expression: &Expression<'_>) -> Option<BinaryOperator> {
+pub fn binary_operator(expression: &Expression<'_>) -> Option<BinaryOperator> {
     let Expression::BinaryExpression(expression) = expression else { return None };
     Some(expression.operator)
 }
 
-fn is_ts_type_argument_open(operator: BinaryOperator) -> bool {
+pub fn is_ts_type_argument_open(operator: BinaryOperator) -> bool {
     matches!(operator, BinaryOperator::LessThan | BinaryOperator::ShiftLeft)
 }
 
-fn is_ts_type_argument_close(operator: BinaryOperator) -> bool {
+pub fn is_ts_type_argument_close(operator: BinaryOperator) -> bool {
     matches!(
         operator,
         BinaryOperator::GreaterThan

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -45,6 +45,7 @@ pub trait GenExpr: GetSpan {
 impl Gen for Program<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.is_jsx = self.source_type.is_jsx();
+        p.is_typescript = self.source_type.is_typescript();
 
         // Allow for inserting comments to the top of the file.
         p.print_comments_at(0);

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -11,10 +11,7 @@ use oxc_syntax::{
 
 use crate::{
     Codegen, Context, Operator, Quote,
-    binary_expr_visitor::{
-        BinaryExpressionVisitor, Binaryish, BinaryishOperator, binary_operator,
-        is_ts_type_argument_close,
-    },
+    binary_expr_visitor::{BinaryExpressionVisitor, Binaryish, BinaryishOperator},
     cjs_module_lexer,
     comment::AnnotationKind,
 };
@@ -1649,12 +1646,6 @@ impl Gen for SpreadElement<'_> {
 impl Gen for ArrayExpression<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         let is_multi_line = self.elements.len() > 2;
-        let last_type_argument_close = p.last_ts_type_argument_close(&self.elements, |element| {
-            element.as_expression().is_some_and(|expression| {
-                binary_operator(expression.without_parentheses())
-                    .is_some_and(is_ts_type_argument_close)
-            })
-        });
         p.add_source_mapping(self.span);
         p.print_ascii_byte(b'[');
         if is_multi_line {
@@ -1670,17 +1661,7 @@ impl Gen for ArrayExpression<'_> {
             } else if i != 0 {
                 p.print_soft_space();
             }
-            if let Some(expression) = item.as_expression() {
-                let precedence = Codegen::ts_type_argument_precedence(
-                    expression,
-                    i,
-                    last_type_argument_close,
-                    Precedence::Comma,
-                );
-                expression.print_expr(p, precedence, Context::empty());
-            } else {
-                item.print(p, ctx);
-            }
+            item.print(p, ctx);
             if i == self.elements.len() - 1 && matches!(item, ArrayExpressionElement::Elision(_)) {
                 p.print_comma();
             }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -11,7 +11,10 @@ use oxc_syntax::{
 
 use crate::{
     Codegen, Context, Operator, Quote,
-    binary_expr_visitor::{BinaryExpressionVisitor, Binaryish, BinaryishOperator},
+    binary_expr_visitor::{
+        BinaryExpressionVisitor, Binaryish, BinaryishOperator, binary_operator,
+        is_ts_type_argument_close,
+    },
     cjs_module_lexer,
     comment::AnnotationKind,
 };
@@ -1646,6 +1649,12 @@ impl Gen for SpreadElement<'_> {
 impl Gen for ArrayExpression<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         let is_multi_line = self.elements.len() > 2;
+        let last_type_argument_close = p.last_ts_type_argument_close(&self.elements, |element| {
+            element.as_expression().is_some_and(|expression| {
+                binary_operator(expression.without_parentheses())
+                    .is_some_and(is_ts_type_argument_close)
+            })
+        });
         p.add_source_mapping(self.span);
         p.print_ascii_byte(b'[');
         if is_multi_line {
@@ -1661,7 +1670,17 @@ impl Gen for ArrayExpression<'_> {
             } else if i != 0 {
                 p.print_soft_space();
             }
-            item.print(p, ctx);
+            if let Some(expression) = item.as_expression() {
+                let precedence = Codegen::ts_type_argument_precedence(
+                    expression,
+                    i,
+                    last_type_argument_close,
+                    Precedence::Comma,
+                );
+                expression.print_expr(p, precedence, Context::empty());
+            } else {
+                item.print(p, ctx);
+            }
             if i == self.elements.len() - 1 && matches!(item, ArrayExpressionElement::Elision(_)) {
                 p.print_comma();
             }

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -109,6 +109,9 @@ pub struct Codegen<'a> {
     /// Indicates the output is JSX type, it is set in [`Program::gen`] and the result
     /// is obtained by [`oxc_span::SourceType::is_jsx`]
     is_jsx: bool,
+    /// Whether the output is TypeScript, set in [`Program::gen`] or
+    /// [`Codegen::with_source_type`] for expression fragments.
+    is_typescript: bool,
 
     /// For avoiding `;` if the previous statement ends with `}`.
     needs_semicolon: bool,
@@ -192,6 +195,7 @@ impl<'a> Codegen<'a> {
             start_of_arrow_expr: 0,
             start_of_default_export: 0,
             is_jsx: false,
+            is_typescript: false,
             indent: 0,
             quote: Quote::Double,
             comments: CommentsMap::default(),
@@ -222,6 +226,7 @@ impl<'a> Codegen<'a> {
     #[must_use]
     pub fn with_source_type(mut self, source_type: SourceType) -> Self {
         self.is_jsx = source_type.is_jsx();
+        self.is_typescript = source_type.is_typescript();
         self
     }
 

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -33,9 +33,7 @@ mod options;
 mod sourcemap_builder;
 mod str;
 
-use binary_expr_visitor::{
-    BinaryExpressionVisitor, binary_operator, is_ts_type_argument_close, is_ts_type_argument_open,
-};
+use binary_expr_visitor::BinaryExpressionVisitor;
 use comment::CommentsMap;
 use operator::Operator;
 #[cfg(feature = "sourcemap")]
@@ -767,43 +765,20 @@ impl<'a> Codegen<'a> {
     }
 
     #[inline]
-    fn print_expressions(
-        &mut self,
-        items: &[Expression<'_>],
-        precedence: Precedence,
-        ctx: Context,
-    ) {
+    fn print_expressions<T: GenExpr>(&mut self, items: &[T], precedence: Precedence, ctx: Context) {
         let Some((first, rest)) = items.split_first() else {
             return;
         };
-        let last_type_argument_close = self.last_ts_type_argument_close(items, |expression| {
-            binary_operator(expression.without_parentheses()).is_some_and(is_ts_type_argument_close)
-        });
-        let first_precedence =
-            Self::ts_type_argument_precedence(first, 0, last_type_argument_close, precedence);
-        first.print_expr(self, first_precedence, ctx);
-        for (index, item) in rest.iter().enumerate() {
+        first.print_expr(self, precedence, ctx);
+        for item in rest {
             self.print_comma();
             self.print_soft_space();
-            let item_precedence = Self::ts_type_argument_precedence(
-                item,
-                index + 1,
-                last_type_argument_close,
-                precedence,
-            );
-            item.print_expr(self, item_precedence, ctx);
+            item.print_expr(self, precedence, ctx);
         }
     }
 
     fn print_arguments(&mut self, span: Span, arguments: &[Argument<'_>], ctx: Context) {
         self.print_ascii_byte(b'(');
-
-        let last_type_argument_close = self.last_ts_type_argument_close(arguments, |argument| {
-            argument.as_expression().is_some_and(|expression| {
-                binary_operator(expression.without_parentheses())
-                    .is_some_and(is_ts_type_argument_close)
-            })
-        });
 
         let has_comment_before_right_paren = span.end > 0 && self.has_comment(span.end - 1);
 
@@ -812,7 +787,7 @@ impl<'a> Codegen<'a> {
 
         if has_comment {
             self.indent();
-            self.print_arguments_with_comments(arguments, last_type_argument_close, ctx);
+            self.print_list_with_comments(arguments, ctx);
             // Handle `/* comment */);`
             if !has_comment_before_right_paren
                 || (span.end > 0 && !self.print_expr_comments(span.end - 1))
@@ -822,7 +797,7 @@ impl<'a> Codegen<'a> {
             self.dedent();
             self.print_indent();
         } else {
-            self.print_argument_list(arguments, last_type_argument_close, ctx);
+            self.print_list(arguments, ctx);
         }
         // End mapping at the gen position OF `)`, not past it. Matches
         // esbuild/Babel and avoids shadowing the next AST node's start.
@@ -830,30 +805,8 @@ impl<'a> Codegen<'a> {
         self.print_ascii_byte(b')');
     }
 
-    fn print_argument_list(
-        &mut self,
-        arguments: &[Argument<'_>],
-        last_type_argument_close: Option<usize>,
-        ctx: Context,
-    ) {
-        let Some((first, rest)) = arguments.split_first() else {
-            return;
-        };
-        self.print_argument(first, 0, last_type_argument_close, ctx);
-        for (index, argument) in rest.iter().enumerate() {
-            self.print_comma();
-            self.print_soft_space();
-            self.print_argument(argument, index + 1, last_type_argument_close, ctx);
-        }
-    }
-
-    fn print_arguments_with_comments(
-        &mut self,
-        arguments: &[Argument<'_>],
-        last_type_argument_close: Option<usize>,
-        ctx: Context,
-    ) {
-        let Some((first, rest)) = arguments.split_first() else {
+    fn print_list_with_comments(&mut self, items: &[Argument<'_>], ctx: Context) {
+        let Some((first, rest)) = items.split_first() else {
             return;
         };
         if self.print_expr_comments(first.span().start) {
@@ -862,75 +815,16 @@ impl<'a> Codegen<'a> {
             self.print_soft_newline();
             self.print_indent();
         }
-        self.print_argument(first, 0, last_type_argument_close, ctx);
-        for (index, argument) in rest.iter().enumerate() {
+        first.print(self, ctx);
+        for item in rest {
             self.print_comma();
-            if self.print_expr_comments(argument.span().start) {
+            if self.print_expr_comments(item.span().start) {
                 self.print_indent();
             } else {
                 self.print_soft_newline();
                 self.print_indent();
             }
-            self.print_argument(argument, index + 1, last_type_argument_close, ctx);
-        }
-    }
-
-    fn print_argument(
-        &mut self,
-        argument: &Argument<'_>,
-        index: usize,
-        last_type_argument_close: Option<usize>,
-        ctx: Context,
-    ) {
-        let expression = match argument {
-            Argument::SpreadElement(element) => &element.argument,
-            _ => argument.to_expression(),
-        };
-        let precedence = Self::ts_type_argument_precedence(
-            expression,
-            index,
-            last_type_argument_close,
-            Precedence::Comma,
-        );
-
-        if precedence == Precedence::Comma {
-            argument.print(self, ctx);
-            return;
-        }
-
-        match argument {
-            Argument::SpreadElement(element) => {
-                self.add_source_mapping(element.span);
-                self.print_ellipsis();
-                element.argument.print_expr(self, precedence, Context::empty());
-            }
-            _ => expression.print_expr(self, precedence, Context::empty()),
-        }
-    }
-
-    fn last_ts_type_argument_close<T>(
-        &self,
-        items: &[T],
-        is_close: impl Fn(&T) -> bool,
-    ) -> Option<usize> {
-        if self.is_typescript { items.iter().rposition(is_close) } else { None }
-    }
-
-    fn ts_type_argument_precedence(
-        expression: &Expression<'_>,
-        index: usize,
-        last_type_argument_close: Option<usize>,
-        precedence: Precedence,
-    ) -> Precedence {
-        // A comma between expressions can become a type-argument separator in TypeScript.
-        // Parenthesize each possible opener before a later closing angle token.
-        if last_type_argument_close.is_some_and(|close| index < close)
-            && binary_operator(expression.without_parentheses())
-                .is_some_and(is_ts_type_argument_open)
-        {
-            Precedence::Shift
-        } else {
-            precedence
+            item.print(self, ctx);
         }
     }
 

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -33,7 +33,9 @@ mod options;
 mod sourcemap_builder;
 mod str;
 
-use binary_expr_visitor::BinaryExpressionVisitor;
+use binary_expr_visitor::{
+    BinaryExpressionVisitor, binary_operator, is_ts_type_argument_close, is_ts_type_argument_open,
+};
 use comment::CommentsMap;
 use operator::Operator;
 #[cfg(feature = "sourcemap")]
@@ -765,20 +767,43 @@ impl<'a> Codegen<'a> {
     }
 
     #[inline]
-    fn print_expressions<T: GenExpr>(&mut self, items: &[T], precedence: Precedence, ctx: Context) {
+    fn print_expressions(
+        &mut self,
+        items: &[Expression<'_>],
+        precedence: Precedence,
+        ctx: Context,
+    ) {
         let Some((first, rest)) = items.split_first() else {
             return;
         };
-        first.print_expr(self, precedence, ctx);
-        for item in rest {
+        let last_type_argument_close = self.last_ts_type_argument_close(items, |expression| {
+            binary_operator(expression.without_parentheses()).is_some_and(is_ts_type_argument_close)
+        });
+        let first_precedence =
+            Self::ts_type_argument_precedence(first, 0, last_type_argument_close, precedence);
+        first.print_expr(self, first_precedence, ctx);
+        for (index, item) in rest.iter().enumerate() {
             self.print_comma();
             self.print_soft_space();
-            item.print_expr(self, precedence, ctx);
+            let item_precedence = Self::ts_type_argument_precedence(
+                item,
+                index + 1,
+                last_type_argument_close,
+                precedence,
+            );
+            item.print_expr(self, item_precedence, ctx);
         }
     }
 
     fn print_arguments(&mut self, span: Span, arguments: &[Argument<'_>], ctx: Context) {
         self.print_ascii_byte(b'(');
+
+        let last_type_argument_close = self.last_ts_type_argument_close(arguments, |argument| {
+            argument.as_expression().is_some_and(|expression| {
+                binary_operator(expression.without_parentheses())
+                    .is_some_and(is_ts_type_argument_close)
+            })
+        });
 
         let has_comment_before_right_paren = span.end > 0 && self.has_comment(span.end - 1);
 
@@ -787,7 +812,7 @@ impl<'a> Codegen<'a> {
 
         if has_comment {
             self.indent();
-            self.print_list_with_comments(arguments, ctx);
+            self.print_arguments_with_comments(arguments, last_type_argument_close, ctx);
             // Handle `/* comment */);`
             if !has_comment_before_right_paren
                 || (span.end > 0 && !self.print_expr_comments(span.end - 1))
@@ -797,7 +822,7 @@ impl<'a> Codegen<'a> {
             self.dedent();
             self.print_indent();
         } else {
-            self.print_list(arguments, ctx);
+            self.print_argument_list(arguments, last_type_argument_close, ctx);
         }
         // End mapping at the gen position OF `)`, not past it. Matches
         // esbuild/Babel and avoids shadowing the next AST node's start.
@@ -805,8 +830,30 @@ impl<'a> Codegen<'a> {
         self.print_ascii_byte(b')');
     }
 
-    fn print_list_with_comments(&mut self, items: &[Argument<'_>], ctx: Context) {
-        let Some((first, rest)) = items.split_first() else {
+    fn print_argument_list(
+        &mut self,
+        arguments: &[Argument<'_>],
+        last_type_argument_close: Option<usize>,
+        ctx: Context,
+    ) {
+        let Some((first, rest)) = arguments.split_first() else {
+            return;
+        };
+        self.print_argument(first, 0, last_type_argument_close, ctx);
+        for (index, argument) in rest.iter().enumerate() {
+            self.print_comma();
+            self.print_soft_space();
+            self.print_argument(argument, index + 1, last_type_argument_close, ctx);
+        }
+    }
+
+    fn print_arguments_with_comments(
+        &mut self,
+        arguments: &[Argument<'_>],
+        last_type_argument_close: Option<usize>,
+        ctx: Context,
+    ) {
+        let Some((first, rest)) = arguments.split_first() else {
             return;
         };
         if self.print_expr_comments(first.span().start) {
@@ -815,16 +862,75 @@ impl<'a> Codegen<'a> {
             self.print_soft_newline();
             self.print_indent();
         }
-        first.print(self, ctx);
-        for item in rest {
+        self.print_argument(first, 0, last_type_argument_close, ctx);
+        for (index, argument) in rest.iter().enumerate() {
             self.print_comma();
-            if self.print_expr_comments(item.span().start) {
+            if self.print_expr_comments(argument.span().start) {
                 self.print_indent();
             } else {
                 self.print_soft_newline();
                 self.print_indent();
             }
-            item.print(self, ctx);
+            self.print_argument(argument, index + 1, last_type_argument_close, ctx);
+        }
+    }
+
+    fn print_argument(
+        &mut self,
+        argument: &Argument<'_>,
+        index: usize,
+        last_type_argument_close: Option<usize>,
+        ctx: Context,
+    ) {
+        let expression = match argument {
+            Argument::SpreadElement(element) => &element.argument,
+            _ => argument.to_expression(),
+        };
+        let precedence = Self::ts_type_argument_precedence(
+            expression,
+            index,
+            last_type_argument_close,
+            Precedence::Comma,
+        );
+
+        if precedence == Precedence::Comma {
+            argument.print(self, ctx);
+            return;
+        }
+
+        match argument {
+            Argument::SpreadElement(element) => {
+                self.add_source_mapping(element.span);
+                self.print_ellipsis();
+                element.argument.print_expr(self, precedence, Context::empty());
+            }
+            _ => expression.print_expr(self, precedence, Context::empty()),
+        }
+    }
+
+    fn last_ts_type_argument_close<T>(
+        &self,
+        items: &[T],
+        is_close: impl Fn(&T) -> bool,
+    ) -> Option<usize> {
+        if self.is_typescript { items.iter().rposition(is_close) } else { None }
+    }
+
+    fn ts_type_argument_precedence(
+        expression: &Expression<'_>,
+        index: usize,
+        last_type_argument_close: Option<usize>,
+        precedence: Precedence,
+    ) -> Precedence {
+        // A comma between expressions can become a type-argument separator in TypeScript.
+        // Parenthesize each possible opener before a later closing angle token.
+        if last_type_argument_close.is_some_and(|close| index < close)
+            && binary_operator(expression.without_parentheses())
+                .is_some_and(is_ts_type_argument_open)
+        {
+            Precedence::Shift
+        } else {
+            precedence
         }
     }
 

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -1,11 +1,12 @@
 use oxc_allocator::Allocator;
 use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_codegen::{Codegen, CodegenOptions, IndentChar};
-use oxc_span::SPAN;
+use oxc_span::{SPAN, SourceType};
 
 use crate::tester::{
-    test, test_minify, test_minify_same, test_options, test_same, test_same_ignore_parse_errors,
-    test_unambiguous, test_with_parse_options,
+    default_options, test, test_minify, test_minify_same, test_options,
+    test_reparse_with_source_type, test_same, test_same_ignore_parse_errors, test_unambiguous,
+    test_with_parse_options,
 };
 
 #[test]
@@ -13,7 +14,27 @@ fn cases() {
     test_same_ignore_parse_errors("class C {\n\t@foo static accessor A = @bar class {};\n}\n");
     test_same_ignore_parse_errors("function foo(@foo x = @bar class {}) {}\n");
     test_same_ignore_parse_errors("function foo(@foo ...rest) {}\n");
-    test_unambiguous("(a < b) > /x/;", "a < b > /x/;\n");
+}
+
+#[test]
+fn comparison_type_argument_parentheses_are_typescript_only() {
+    for (source, expected) in [
+        // One JavaScript control for each TypeScript-only precedence adjustment.
+        ("(a < b) > /x/;", "a < b > /x/;\n"),
+        ("(a << b) >> /x/;", "a << b >> /x/;\n"),
+        ("(a < b) < (c >> /x/);", "a < b < c >> /x/;\n"),
+        ("(a < b) | c;", "a < b | c;\n"),
+        ("a & (b < c);", "a & b < c;\n"),
+        ("((a < b) < (c >> (d, e)));", "a < b < c >> (d, e);\n"),
+        ("((a << b) < (c >>> (d, e)));", "a << b < c >>> (d, e);\n"),
+    ] {
+        test_reparse_with_source_type(
+            source,
+            expected,
+            SourceType::unambiguous(),
+            default_options(),
+        );
+    }
 }
 
 #[test]

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -1,11 +1,12 @@
 use oxc_allocator::Allocator;
 use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_codegen::{Codegen, CodegenOptions, IndentChar};
-use oxc_span::SPAN;
+use oxc_span::{SPAN, SourceType};
 
 use crate::tester::{
-    test, test_minify, test_minify_same, test_options, test_same, test_same_ignore_parse_errors,
-    test_unambiguous, test_with_parse_options,
+    default_options, test, test_minify, test_minify_same, test_options,
+    test_reparse_with_source_type, test_same, test_same_ignore_parse_errors, test_unambiguous,
+    test_with_parse_options,
 };
 
 #[test]
@@ -13,6 +14,25 @@ fn cases() {
     test_same_ignore_parse_errors("class C {\n\t@foo static accessor A = @bar class {};\n}\n");
     test_same_ignore_parse_errors("function foo(@foo x = @bar class {}) {}\n");
     test_same_ignore_parse_errors("function foo(@foo ...rest) {}\n");
+}
+
+#[test]
+fn comparison_type_argument_parentheses_are_typescript_only() {
+    for (source, expected) in [
+        // One JavaScript control for each TypeScript-only precedence adjustment.
+        ("(a < b) > /x/;", "a < b > /x/;\n"),
+        ("(a << b) >> /x/;", "a << b >> /x/;\n"),
+        ("(a < b) < (c >> /x/);", "a < b < c >> /x/;\n"),
+        ("(a < b) | c;", "a < b | c;\n"),
+        ("a & (b < c);", "a & b < c;\n"),
+    ] {
+        test_reparse_with_source_type(
+            source,
+            expected,
+            SourceType::unambiguous(),
+            default_options(),
+        );
+    }
 }
 
 #[test]

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -1,12 +1,11 @@
 use oxc_allocator::Allocator;
 use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_codegen::{Codegen, CodegenOptions, IndentChar};
-use oxc_span::{SPAN, SourceType};
+use oxc_span::SPAN;
 
 use crate::tester::{
-    default_options, test, test_minify, test_minify_same, test_options,
-    test_reparse_with_source_type, test_same, test_same_ignore_parse_errors, test_unambiguous,
-    test_with_parse_options,
+    test, test_minify, test_minify_same, test_options, test_same, test_same_ignore_parse_errors,
+    test_unambiguous, test_with_parse_options,
 };
 
 #[test]
@@ -14,25 +13,7 @@ fn cases() {
     test_same_ignore_parse_errors("class C {\n\t@foo static accessor A = @bar class {};\n}\n");
     test_same_ignore_parse_errors("function foo(@foo x = @bar class {}) {}\n");
     test_same_ignore_parse_errors("function foo(@foo ...rest) {}\n");
-}
-
-#[test]
-fn comparison_type_argument_parentheses_are_typescript_only() {
-    for (source, expected) in [
-        // One JavaScript control for each TypeScript-only precedence adjustment.
-        ("(a < b) > /x/;", "a < b > /x/;\n"),
-        ("(a << b) >> /x/;", "a << b >> /x/;\n"),
-        ("(a < b) < (c >> /x/);", "a < b < c >> /x/;\n"),
-        ("(a < b) | c;", "a < b | c;\n"),
-        ("a & (b < c);", "a & b < c;\n"),
-    ] {
-        test_reparse_with_source_type(
-            source,
-            expected,
-            SourceType::unambiguous(),
-            default_options(),
-        );
-    }
+    test_unambiguous("(a < b) > /x/;", "a < b > /x/;\n");
 }
 
 #[test]

--- a/crates/oxc_codegen/tests/integration/tester.rs
+++ b/crates/oxc_codegen/tests/integration/tester.rs
@@ -2,7 +2,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::Comment;
 use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_parser::{ParseOptions, Parser};
-use oxc_span::SourceType;
+use oxc_span::{ContentEq, SourceType};
 
 pub fn default_options() -> CodegenOptions {
     // Ensure sourcemap do not crash.
@@ -51,6 +51,36 @@ pub fn test_options_with_source_type(
     assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
     let result = Codegen::new().with_options(options).build(&ret.program).code;
     assert_eq!(result, expected, "\nfor source: {source_text:?}");
+}
+
+/// Assert both the exact output and that reparsing it produces the same AST.
+#[track_caller]
+pub fn test_reparse_with_source_type(
+    source_text: &str,
+    expected: &str,
+    source_type: SourceType,
+    options: CodegenOptions,
+) {
+    let parse_options = ParseOptions { preserve_parens: false, ..ParseOptions::default() };
+
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, source_text, source_type).with_options(parse_options).parse();
+    assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
+
+    let result = Codegen::new().with_options(options).build(&ret.program).code;
+    assert_eq!(result, expected, "\nfor source: {source_text:?}");
+
+    let allocator2 = Allocator::default();
+    let ret2 = Parser::new(&allocator2, &result, source_type).with_options(parse_options).parse();
+    assert!(
+        ret2.diagnostics.is_empty(),
+        "Parse errors after codegen: {:?}\nfor source: {source_text:?}\ngenerated:\n{result}",
+        ret2.diagnostics
+    );
+    assert!(
+        ret.program.content_eq(&ret2.program),
+        "AST changed after codegen\nsource:\n{source_text}\ngenerated:\n{result}"
+    );
 }
 
 /// Test with unambiguous source type (like .js files)

--- a/crates/oxc_codegen/tests/integration/tester.rs
+++ b/crates/oxc_codegen/tests/integration/tester.rs
@@ -2,7 +2,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::Comment;
 use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_parser::{ParseOptions, Parser};
-use oxc_span::{ContentEq, SourceType};
+use oxc_span::SourceType;
 
 pub fn default_options() -> CodegenOptions {
     // Ensure sourcemap do not crash.
@@ -51,36 +51,6 @@ pub fn test_options_with_source_type(
     assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
     let result = Codegen::new().with_options(options).build(&ret.program).code;
     assert_eq!(result, expected, "\nfor source: {source_text:?}");
-}
-
-/// Assert both the exact output and that reparsing it produces the same AST.
-#[track_caller]
-pub fn test_reparse_with_source_type(
-    source_text: &str,
-    expected: &str,
-    source_type: SourceType,
-    options: CodegenOptions,
-) {
-    let parse_options = ParseOptions { preserve_parens: false, ..ParseOptions::default() };
-
-    let allocator = Allocator::default();
-    let ret = Parser::new(&allocator, source_text, source_type).with_options(parse_options).parse();
-    assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
-
-    let result = Codegen::new().with_options(options).build(&ret.program).code;
-    assert_eq!(result, expected, "\nfor source: {source_text:?}");
-
-    let allocator2 = Allocator::default();
-    let ret2 = Parser::new(&allocator2, &result, source_type).with_options(parse_options).parse();
-    assert!(
-        ret2.diagnostics.is_empty(),
-        "Parse errors after codegen: {:?}\nfor source: {source_text:?}\ngenerated:\n{result}",
-        ret2.diagnostics
-    );
-    assert!(
-        ret.program.content_eq(&ret2.program),
-        "AST changed after codegen\nsource:\n{source_text}\ngenerated:\n{result}"
-    );
 }
 
 /// Test with unambiguous source type (like .js files)

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -5,8 +5,8 @@ use oxc_span::SourceType;
 use crate::{
     snapshot, snapshot_options,
     tester::{
-        default_options, test_idempotency, test_options_with_source_type, test_same, test_tsx,
-        test_with_parse_options,
+        default_options, test, test_idempotency, test_options_with_source_type, test_same,
+        test_tsx, test_with_parse_options,
     },
 };
 
@@ -85,6 +85,10 @@ fn comparison_must_not_become_type_arguments() {
 
     test_same("(a < b) | c;\n");
     test_same("a & (b << c);\n");
+
+    test_same("foo((a < b), c > (d, e));\n");
+    test_same("[(a < b), c > (d, e)];\n");
+    test("((a < b), c > (d, e));", "(a < b), c > (d, e);\n");
 }
 
 #[test]

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -1,12 +1,14 @@
-use oxc_codegen::CodegenOptions;
-use oxc_parser::ParseOptions;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Statement;
+use oxc_codegen::{Codegen, CodegenOptions};
+use oxc_parser::{ParseOptions, Parser};
 use oxc_span::SourceType;
 
 use crate::{
     snapshot, snapshot_options,
     tester::{
-        default_options, test_idempotency, test_options_with_source_type, test_same, test_tsx,
-        test_with_parse_options,
+        default_options, test_idempotency, test_options_with_source_type,
+        test_reparse_with_source_type, test_same, test_tsx, test_with_parse_options,
     },
 };
 
@@ -75,16 +77,136 @@ fn tsx() {
 
 #[test]
 fn comparison_must_not_become_type_arguments() {
-    test_same("(a < b) > /x/;\n");
-    test_same("(a << b) >> /x/;\n");
-    test_same("(a < b) >>> /x/;\n");
+    let test_ts = |source, expected| {
+        test_reparse_with_source_type(source, expected, SourceType::ts(), default_options());
+    };
 
-    test_same("a < (b > /x/);\n");
-    test_same("a << (b >> /x/);\n");
-    test_same("a < (b >>> /x/);\n");
+    // A structural close (`>`, `>>`, or `>>>`) groups an exposed-open expression on its left.
+    // The rule does not try to predict which token can follow speculative type arguments.
+    test_ts("(a < b) > /x/;", "(a < b) > /x/;\n");
+    test_ts("(a < b) > /x/.source;", "(a < b) > /x/.source;\n");
+    test_ts("(a < b) > /x/ + 1;", "(a < b) > /x/ + 1;\n");
+    test_ts("(a < b) > `x`;", "(a < b) > `x`;\n");
+    test_ts("(a < b) > `x`.length;", "(a < b) > `x`.length;\n");
+    test_ts("(a < b) > (c == d);", "(a < b) > (c == d);\n");
+    test_ts("(a < b) > c;", "(a < b) > c;\n");
+    test_ts("(a < b) > +c;", "(a < b) > +c;\n");
+    test_ts("(a < b) > -c;", "(a < b) > -c;\n");
 
-    test_same("(a < b) | c;\n");
-    test_same("a & (b << c);\n");
+    // Conversely, a structural open (`<` or `<<`) groups a close-exposing right operand. These
+    // are the `>>` and `>>>` cases that ordinary precedence would otherwise print ungrouped.
+    test_ts("(a < b) < (c >> /x/);", "(a < b) < (c >> /x/);\n");
+    test_ts("((a < b) < c) < (d >>> `x`);", "(a < b < c) < (d >>> `x`);\n");
+
+    // `>=`, `<=`, an inner `>`, and an unmatched `<` do not form an open/close pair.
+    test_ts("(a < b) < /x/;", "a < b < /x/;\n");
+    test_ts("(a > b) > /x/;", "a > b > /x/;\n");
+    test_ts("(a > b) < /x/;", "a > b < /x/;\n");
+    test_ts("(a <= b) > /x/;", "a <= b > /x/;\n");
+    test_ts("(a < b) >= /x/;", "a < b >= /x/;\n");
+
+    test_reparse_with_source_type(
+        "(a < b) > /x/;",
+        "(a < b) > /x/;\n",
+        SourceType::tsx(),
+        default_options(),
+    );
+    test_reparse_with_source_type(
+        "(a < b) > /x/;",
+        "(a<b)>/x/;",
+        SourceType::ts(),
+        CodegenOptions::minify(),
+    );
+    // Minification may intentionally change a string literal into a template literal.
+    test_options_with_source_type(
+        "(a < b) > \"x\";",
+        "(a<b)>`x`;",
+        SourceType::ts(),
+        CodegenOptions::minify(),
+    );
+
+    // `|` and `&` group an operand whenever that operand exposes a dangling `<` suffix.
+    test_ts("(a < b) | c & d > /x/;", "(a < b) | c & d > /x/;\n");
+    test_ts("a | (b < c);", "a | (b < c);\n");
+    test_ts("a & (b < c);", "a & (b < c);\n");
+    test_ts("((a < b) | c) | d > /x/;", "(a < b) | c | d > /x/;\n");
+    test_ts("((a < b) | c) & d > /x/;", "((a < b) | c) & d > /x/;\n");
+    test_ts("(((a < b) < c) | (d >> /x/));", "(a < b < c) | d >> /x/;\n");
+    test_ts("((((a < b) < c) < d) & (e >>> `x`));", "(a < b < c < d) & e >>> `x`;\n");
+}
+
+#[test]
+fn nested_openers_with_less_than_must_not_become_type_arguments() {
+    test_reparse_with_source_type(
+        "((a < b) < (c >> (d, e)));",
+        "(a < b) < (c >> (d, e));\n",
+        SourceType::ts(),
+        default_options(),
+    );
+    test_reparse_with_source_type(
+        "((a < b) < (c >> (d, e)));",
+        "(a<b)<(c>>(d,e));",
+        SourceType::ts(),
+        CodegenOptions::minify(),
+    );
+    test_reparse_with_source_type(
+        "((a < b) < (c >> (d, e)));",
+        "(a < b) < (c >> (d, e));\n",
+        SourceType::tsx(),
+        default_options(),
+    );
+
+    // A single closing angle cannot reach the earlier opener.
+    test_reparse_with_source_type(
+        "((a < b) < (c > (d, e)));",
+        "a < b < (c > (d, e));\n",
+        SourceType::ts(),
+        default_options(),
+    );
+}
+
+#[test]
+fn nested_openers_with_shift_left_must_not_become_type_arguments() {
+    test_reparse_with_source_type(
+        "((a << b) < (c >>> (d, e)));",
+        "(a << b) < (c >>> (d, e));\n",
+        SourceType::ts(),
+        default_options(),
+    );
+    test_reparse_with_source_type(
+        "((a < b) << (c >>> (d, e)));",
+        "(a < b) << (c >>> (d, e));\n",
+        SourceType::ts(),
+        default_options(),
+    );
+
+    // Two closing angles cannot consume the earlier `<<` and the current `<`.
+    test_reparse_with_source_type(
+        "((a << b) < (c >> (d, e)));",
+        "a << b < (c >> (d, e));\n",
+        SourceType::ts(),
+        default_options(),
+    );
+}
+
+#[test]
+fn comparison_type_argument_ambiguity_in_expression_fragment() {
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, "(a < b) > /x/;", SourceType::ts())
+        .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
+        .parse();
+    assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
+    let Statement::ExpressionStatement(statement) = &ret.program.body[0] else {
+        unreachable!();
+    };
+
+    let mut codegen = Codegen::new().with_source_type(SourceType::ts());
+    codegen.print_expression(&statement.expression);
+    assert_eq!(codegen.into_source_text(), "(a < b) > /x/");
+
+    let mut codegen = Codegen::new().with_source_type(SourceType::mjs());
+    codegen.print_expression(&statement.expression);
+    assert_eq!(codegen.into_source_text(), "a < b > /x/");
 }
 
 #[test]

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -1,14 +1,12 @@
-use oxc_allocator::Allocator;
-use oxc_ast::ast::Statement;
-use oxc_codegen::{Codegen, CodegenOptions};
-use oxc_parser::{ParseOptions, Parser};
+use oxc_codegen::CodegenOptions;
+use oxc_parser::ParseOptions;
 use oxc_span::SourceType;
 
 use crate::{
     snapshot, snapshot_options,
     tester::{
-        default_options, test_idempotency, test_options_with_source_type,
-        test_reparse_with_source_type, test_same, test_tsx, test_with_parse_options,
+        default_options, test_idempotency, test_options_with_source_type, test_same, test_tsx,
+        test_with_parse_options,
     },
 };
 
@@ -77,81 +75,16 @@ fn tsx() {
 
 #[test]
 fn comparison_must_not_become_type_arguments() {
-    fn test_ts(source: &str, expected: &str) {
-        test_reparse_with_source_type(source, expected, SourceType::ts(), default_options());
-    }
-    fn test_ts_same(source: &str) {
-        test_ts(source, &format!("{source}\n"));
-    }
+    test_same("(a < b) > /x/;\n");
+    test_same("(a << b) >> /x/;\n");
+    test_same("(a < b) >>> /x/;\n");
 
-    // Exercise every opener and closer in both operand directions.
-    for open in ["<", "<<"] {
-        for close in [">", ">>", ">>>"] {
-            test_ts_same(&format!("(a {open} b) {close} /x/;"));
+    test_same("a < (b > /x/);\n");
+    test_same("a << (b >> /x/);\n");
+    test_same("a < (b >>> /x/);\n");
 
-            let source = format!("(a < z) {open} (b {close} /x/);");
-            let left = if open == "<" { "a < z" } else { "(a < z)" };
-            test_ts(&source, &format!("{left} {open} (b {close} /x/);\n"));
-        }
-    }
-
-    // A generic call and tagged template are valid but different parses without grouping.
-    for right in ["(c, d)", "`x`"] {
-        test_ts_same(&format!("(a < b) > {right};"));
-    }
-
-    // `>=`, `<=`, an inner `>`, and an unmatched `<` do not form an open/close pair.
-    for (source, expected) in [
-        ("(a < b) < /x/;", "a < b < /x/;\n"),
-        ("(a > b) > /x/;", "a > b > /x/;\n"),
-        ("(a <= b) > /x/;", "a <= b > /x/;\n"),
-        ("(a < b) >= /x/;", "a < b >= /x/;\n"),
-    ] {
-        test_ts(source, expected);
-    }
-
-    for (source_type, options, expected) in [
-        (SourceType::tsx(), default_options(), "(a < b) > /x/;\n"),
-        (SourceType::ts(), CodegenOptions::minify(), "(a<b)>/x/;"),
-    ] {
-        test_reparse_with_source_type("(a < b) > /x/;", expected, source_type, options);
-    }
-    // Minification may intentionally change a string literal into a template literal.
-    test_options_with_source_type(
-        "(a < b) > \"x\";",
-        "(a<b)>`x`;",
-        SourceType::ts(),
-        CodegenOptions::minify(),
-    );
-
-    // Exercise both bitwise operators with the opener on either operand.
-    for operator in ["|", "&"] {
-        test_ts_same(&format!("(a < b) {operator} c;"));
-        test_ts_same(&format!("a {operator} (b < c);"));
-    }
-
-    // A nested bitwise tree applies the local rule once and retains normal associativity.
-    test_ts("((a < b) | c) | d > /x/;", "(a < b) | c | d > /x/;\n");
-}
-
-#[test]
-fn comparison_type_argument_ambiguity_in_expression_fragment() {
-    let allocator = Allocator::default();
-    let ret = Parser::new(&allocator, "(a < b) > /x/;", SourceType::ts())
-        .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
-        .parse();
-    assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
-    let Statement::ExpressionStatement(statement) = &ret.program.body[0] else {
-        unreachable!();
-    };
-
-    let mut codegen = Codegen::new().with_source_type(SourceType::ts());
-    codegen.print_expression(&statement.expression);
-    assert_eq!(codegen.into_source_text(), "(a < b) > /x/");
-
-    let mut codegen = Codegen::new().with_source_type(SourceType::mjs());
-    codegen.print_expression(&statement.expression);
-    assert_eq!(codegen.into_source_text(), "a < b > /x/");
+    test_same("(a < b) | c;\n");
+    test_same("a & (b << c);\n");
 }
 
 #[test]

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -5,8 +5,8 @@ use oxc_span::SourceType;
 use crate::{
     snapshot, snapshot_options,
     tester::{
-        default_options, test, test_idempotency, test_options_with_source_type, test_same,
-        test_tsx, test_with_parse_options,
+        default_options, test_idempotency, test_options_with_source_type, test_same, test_tsx,
+        test_with_parse_options,
     },
 };
 
@@ -85,10 +85,6 @@ fn comparison_must_not_become_type_arguments() {
 
     test_same("(a < b) | c;\n");
     test_same("a & (b << c);\n");
-
-    test_same("foo((a < b), c > (d, e));\n");
-    test_same("[(a < b), c > (d, e)];\n");
-    test("((a < b), c > (d, e));", "(a < b), c > (d, e);\n");
 }
 
 #[test]

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -1,12 +1,14 @@
-use oxc_codegen::CodegenOptions;
-use oxc_parser::ParseOptions;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Statement;
+use oxc_codegen::{Codegen, CodegenOptions};
+use oxc_parser::{ParseOptions, Parser};
 use oxc_span::SourceType;
 
 use crate::{
     snapshot, snapshot_options,
     tester::{
-        default_options, test_idempotency, test_options_with_source_type, test_same, test_tsx,
-        test_with_parse_options,
+        default_options, test_idempotency, test_options_with_source_type,
+        test_reparse_with_source_type, test_same, test_tsx, test_with_parse_options,
     },
 };
 
@@ -71,6 +73,85 @@ fn tsx() {
     test_tsx("<T,>() => {}", "<T,>() => {};\n");
     test_tsx("<T, B>() => {}", "<\n\tT,\n\tB\n>() => {};\n");
     test_tsx("<Foo<T> />", "<Foo<T> />;\n");
+}
+
+#[test]
+fn comparison_must_not_become_type_arguments() {
+    fn test_ts(source: &str, expected: &str) {
+        test_reparse_with_source_type(source, expected, SourceType::ts(), default_options());
+    }
+    fn test_ts_same(source: &str) {
+        test_ts(source, &format!("{source}\n"));
+    }
+
+    // Exercise every opener and closer in both operand directions.
+    for open in ["<", "<<"] {
+        for close in [">", ">>", ">>>"] {
+            test_ts_same(&format!("(a {open} b) {close} /x/;"));
+
+            let source = format!("(a < z) {open} (b {close} /x/);");
+            let left = if open == "<" { "a < z" } else { "(a < z)" };
+            test_ts(&source, &format!("{left} {open} (b {close} /x/);\n"));
+        }
+    }
+
+    // A generic call and tagged template are valid but different parses without grouping.
+    for right in ["(c, d)", "`x`"] {
+        test_ts_same(&format!("(a < b) > {right};"));
+    }
+
+    // `>=`, `<=`, an inner `>`, and an unmatched `<` do not form an open/close pair.
+    for (source, expected) in [
+        ("(a < b) < /x/;", "a < b < /x/;\n"),
+        ("(a > b) > /x/;", "a > b > /x/;\n"),
+        ("(a <= b) > /x/;", "a <= b > /x/;\n"),
+        ("(a < b) >= /x/;", "a < b >= /x/;\n"),
+    ] {
+        test_ts(source, expected);
+    }
+
+    for (source_type, options, expected) in [
+        (SourceType::tsx(), default_options(), "(a < b) > /x/;\n"),
+        (SourceType::ts(), CodegenOptions::minify(), "(a<b)>/x/;"),
+    ] {
+        test_reparse_with_source_type("(a < b) > /x/;", expected, source_type, options);
+    }
+    // Minification may intentionally change a string literal into a template literal.
+    test_options_with_source_type(
+        "(a < b) > \"x\";",
+        "(a<b)>`x`;",
+        SourceType::ts(),
+        CodegenOptions::minify(),
+    );
+
+    // Exercise both bitwise operators with the opener on either operand.
+    for operator in ["|", "&"] {
+        test_ts_same(&format!("(a < b) {operator} c;"));
+        test_ts_same(&format!("a {operator} (b < c);"));
+    }
+
+    // A nested bitwise tree applies the local rule once and retains normal associativity.
+    test_ts("((a < b) | c) | d > /x/;", "(a < b) | c | d > /x/;\n");
+}
+
+#[test]
+fn comparison_type_argument_ambiguity_in_expression_fragment() {
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, "(a < b) > /x/;", SourceType::ts())
+        .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
+        .parse();
+    assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
+    let Statement::ExpressionStatement(statement) = &ret.program.body[0] else {
+        unreachable!();
+    };
+
+    let mut codegen = Codegen::new().with_source_type(SourceType::ts());
+    codegen.print_expression(&statement.expression);
+    assert_eq!(codegen.into_source_text(), "(a < b) > /x/");
+
+    let mut codegen = Codegen::new().with_source_type(SourceType::mjs());
+    codegen.print_expression(&statement.expression);
+    assert_eq!(codegen.into_source_text(), "a < b > /x/");
 }
 
 #[test]


### PR DESCRIPTION
Preserve TypeScript comparison grouping when angle tokens could be reinterpreted as type arguments. Keep JavaScript output unchanged.

Closes #25502.

AI-assisted.