### PR TITLE
fix(linter): allow capitalized built-in calls

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -5117,12 +5117,23 @@ export interface PreferFunctionComponent {
 }
 export interface ReactCompilerConfig {
   /**
+   * React Compiler environment options supported by this rule.
+   */
+  environment?: ReactCompilerEnvironmentConfig;
+  /**
    * Also report compiler bail-outs — places where React Compiler skipped a
    * component or hook (for example because of unsupported syntax) without
    * finding a rule violation. These do not indicate incorrect code, only
    * code that the compiler declined to optimize.
    */
   reportAllBailouts?: boolean;
+}
+export interface ReactCompilerEnvironmentConfig {
+  /**
+   * Additional capitalized global functions that are known not to be React
+   * components. These names will not be reported by `CapitalizedCalls`.
+   */
+  validateNoCapitalizedCalls?: string[];
 }
 export interface SelfClosingComp {
   /**

--- a/crates/oxc_linter/src/rules/react/react_compiler.rs
+++ b/crates/oxc_linter/src/rules/react/react_compiler.rs
@@ -14,7 +14,7 @@ use crate::{
 /// The compiler options `eslint-plugin-react-compiler` lints with — `lint`
 /// output mode plus validations that are off by default in the compiler.
 /// Mirrors `COMPILER_OPTIONS` in the plugin's `src/shared/RunReactCompiler.ts`.
-fn react_compiler_options() -> PluginOptions {
+fn react_compiler_options(config: &ReactCompilerConfig) -> PluginOptions {
     PluginOptions {
         output_mode: Some(CompilerOutputMode::Lint),
         // Don't emit errors on Flow suppressions — Flow already gave a signal.
@@ -30,7 +30,9 @@ fn react_compiler_options() -> PluginOptions {
             validate_static_components: true,
             validate_no_freezing_known_mutable_functions: true,
             validate_no_void_use_memo: true,
-            validate_no_capitalized_calls: Some(vec![]),
+            validate_no_capitalized_calls: Some(
+                config.environment.validate_no_capitalized_calls.clone(),
+            ),
             validate_hooks_usage: true,
             validate_no_derived_computations_in_effects: true,
             ..EnvironmentConfig::default()
@@ -58,6 +60,17 @@ pub struct ReactCompilerConfig {
     /// finding a rule violation. These do not indicate incorrect code, only
     /// code that the compiler declined to optimize.
     report_all_bailouts: bool,
+
+    /// React Compiler environment options supported by this rule.
+    environment: ReactCompilerEnvironmentConfig,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReactCompilerEnvironmentConfig {
+    /// Additional capitalized global functions that are known not to be React
+    /// components. These names will not be reported by `CapitalizedCalls`.
+    validate_no_capitalized_calls: Vec<String>,
 }
 
 declare_oxc_lint!(
@@ -121,7 +134,7 @@ impl Rule for ReactCompiler {
 
     fn run_once(&self, ctx: &LintContext) {
         let program = ctx.nodes().program();
-        let options = react_compiler_options();
+        let options = react_compiler_options(self);
 
         let result = oxc_react_compiler::lint(program, ctx.semantic(), ctx.allocator(), options);
 
@@ -349,6 +362,41 @@ function Component(props) {
             }",
             None,
         ),
+        // Capitalized built-in globals are not components.
+        (
+            "function Component(value) {
+                const bigInt = BigInt(value);
+                const boolean = Boolean(value);
+                const number = Number(value);
+                const string = String(value);
+                const symbol = Symbol(value);
+                const array = Array(value);
+                const object = Object(value);
+                const date = Date();
+                return <div>{String([
+                    bigInt,
+                    boolean,
+                    number,
+                    string,
+                    symbol,
+                    array,
+                    object,
+                    date,
+                ])}</div>;
+            }",
+            None,
+        ),
+        // Projects can allowlist additional capitalized global functions.
+        (
+            "function Component() {
+                return <div>{CustomFactory()}</div>;
+            }",
+            Some(json!([{
+                "environment": {
+                    "validateNoCapitalizedCalls": ["CustomFactory"]
+                }
+            }])),
+        ),
     ];
 
     let fail = vec![
@@ -553,6 +601,13 @@ function useConditional2(props) {
             None,
         ),
         // ---- oxlint-specific ----
+        // A custom capitalized global is reported unless it is allowlisted.
+        (
+            "function Component() {
+                return <div>{CustomFactory()}</div>;
+            }",
+            None,
+        ),
         // Bail-outs are reported when `reportAllBailouts` is enabled.
         (
             "function Component() {

--- a/crates/oxc_linter/src/snapshots/react_react_compiler.snap
+++ b/crates/oxc_linter/src/snapshots/react_react_compiler.snap
@@ -221,6 +221,15 @@ source: crates/oxc_linter/src/tester.rs
  9 │ }
    ╰────
 
+  ⚠ react(react-compiler): CapitalizedCalls: Capitalized functions are reserved for components, which must be invoked with JSX. If this is a component, render it with JSX. Otherwise, ensure that it has no hook calls and rename it to begin with a lowercase letter. Alternatively, if you know for a fact that this function is not a component, you can allowlist it via the compiler config
+   ╭─[react_compiler.tsx:2:30]
+ 1 │ function Component() {
+ 2 │                 return <div>{CustomFactory()}</div>;
+   ·                              ───────────────
+ 3 │             }
+   ╰────
+  help: CustomFactory may be a component
+
   ⚠ react(react-compiler): Todo: Support local variables named `fbt`
    ╭─[react_compiler.tsx:2:23]
  1 │ function Component() {

--- a/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
@@ -1711,9 +1711,11 @@ const TYPED_GLOBAL_OBJECTS: &[GlobalObjectDef] = &[
 
 /// Simple global functions returning Primitive.
 const PRIMITIVE_GLOBAL_FNS: &[&str] = &[
+    "BigInt",
     "Boolean",
     "Number",
     "String",
+    "Symbol",
     "parseInt",
     "parseFloat",
     "isNaN",

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -18227,11 +18227,38 @@
     "ReactCompilerConfig": {
       "type": "object",
       "properties": {
+        "environment": {
+          "description": "React Compiler environment options supported by this rule.",
+          "default": {
+            "validateNoCapitalizedCalls": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ReactCompilerEnvironmentConfig"
+            }
+          ],
+          "markdownDescription": "React Compiler environment options supported by this rule."
+        },
         "reportAllBailouts": {
           "description": "Also report compiler bail-outs — places where React Compiler skipped a\ncomponent or hook (for example because of unsupported syntax) without\nfinding a rule violation. These do not indicate incorrect code, only\ncode that the compiler declined to optimize.",
           "default": false,
           "type": "boolean",
           "markdownDescription": "Also report compiler bail-outs — places where React Compiler skipped a\ncomponent or hook (for example because of unsupported syntax) without\nfinding a rule violation. These do not indicate incorrect code, only\ncode that the compiler declined to optimize."
+        }
+      },
+      "additionalProperties": false
+    },
+    "ReactCompilerEnvironmentConfig": {
+      "type": "object",
+      "properties": {
+        "validateNoCapitalizedCalls": {
+          "description": "Additional capitalized global functions that are known not to be React\ncomponents. These names will not be reported by `CapitalizedCalls`.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Additional capitalized global functions that are known not to be React\ncomponents. These names will not be reported by `CapitalizedCalls`."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Fixes #24405.

The React Compiler global registry omitted `BigInt` and `Symbol`, causing `CapitalizedCalls` false positives. Register both primitives and expose the upstream-compatible `environment.validateNoCapitalizedCalls` option.

Validated with `just ready`.

AI-assisted: Codex was used to investigate and implement this change.