### PR TITLE
fix(react_compiler): allow callback ref member expressions

### DIFF
--- a/crates/oxc_react_compiler/fixtures/allow-jsx-callback-ref-member-expression.tsx
+++ b/crates/oxc_react_compiler/fixtures/allow-jsx-callback-ref-member-expression.tsx
@@ -1,0 +1,11 @@
+// @validateRefAccessDuringRender
+
+function App() {
+  const {refs, floatingStyles} = useFloating();
+  return (
+    <>
+      <div ref={refs.setReference} />
+      <div ref={refs.setFloating} style={floatingStyles} />
+    </>
+  );
+}

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
@@ -478,8 +478,12 @@ fn collect_temporaries_sidemap(
                     env.define(lvalue.place.identifier, temp);
                 }
                 InstructionValue::PropertyLoad { object, property, .. } => {
-                    if is_ref_type(object.identifier, identifiers, types)
-                        && property.is_string("current")
+                    // JSX ref attributes infer their values as ref-like, including callback
+                    // member expressions. Keep such a property result separate from its receiver
+                    // so `refs.setReference` does not make sibling properties look like ref values.
+                    if is_ref_type(instr.lvalue.identifier, identifiers, types)
+                        || (is_ref_type(object.identifier, identifiers, types)
+                            && property.is_string("current"))
                     {
                         continue;
                     }

--- a/crates/oxc_react_compiler/tests/snapshots/allow-jsx-callback-ref-member-expression.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/allow-jsx-callback-ref-member-expression.snap
@@ -1,0 +1,37 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/allow-jsx-callback-ref-member-expression.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+// @validateRefAccessDuringRender
+function App() {
+	const $ = _c(8);
+	const { refs, floatingStyles } = useFloating();
+	let t0;
+	if ($[0] !== refs.setReference) {
+		t0 = <div ref={refs.setReference} />;
+		$[0] = refs.setReference;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	let t1;
+	if ($[2] !== floatingStyles || $[3] !== refs.setFloating) {
+		t1 = <div ref={refs.setFloating} style={floatingStyles} />;
+		$[2] = floatingStyles;
+		$[3] = refs.setFloating;
+		$[4] = t1;
+	} else {
+		t1 = $[4];
+	}
+	let t2;
+	if ($[5] !== t0 || $[6] !== t1) {
+		t2 = <>{t0}{t1}</>;
+		$[5] = t0;
+		$[6] = t1;
+		$[7] = t2;
+	} else {
+		t2 = $[7];
+	}
+	return t2;
+}


### PR DESCRIPTION
Prevent JSX callback-ref member expressions from marking their receiver as a React ref. Add a compiler fixture covering the regression.

Fixes #23753.

Validated with `just ready`.

AI assistance was used to prepare this change.