### PR TITLE
fix(formatter_css): keep multi value function args intact after leading comment

### DIFF
--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -679,9 +679,6 @@ pub(super) fn write_value_groups<'a>(
                 // The declaration tail belongs to the LAST group only
                 let gctx = if is_last { ctx } else { ValueContext { tail_bound: None, ..ctx } };
                 let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
-                    if let Some(first) = group_values.first() {
-                        flush_value_comments(to_span(first.span()).start, f);
-                    }
                     write_comma_group(group_values, gctx, f);
                     if !is_last {
                         write_group_comma(comma, f);
@@ -798,10 +795,13 @@ pub(super) fn write_comma_group<'a>(
     if values.is_empty() {
         return;
     }
+    // Comments leading the FIRST value flush at this level, before any group/indent opens:
+    // `//` comment's forced hardline inside `indent(&body)` would drop the value one level deeper
+    // and break the fill run after it.
+    flush_value_comments(to_span(values[0].span()).start, f);
     // Prettier's `flattenGroups`:
     // a single-element comma group collapses to the element itself (no extra group/indent level).
     if values.len() == 1 && ctx.tail_bound.is_none() {
-        flush_value_comments(to_span(values[0].span()).start, f);
         // EXCEPT a sass interpolation:
         // route through a fill entry to get the chunk-isolated fit (see `is_single_sass_interpolation`).
         if is_single_sass_interpolation(values) {

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/inline-comment-before-multivalue-arg.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/inline-comment-before-multivalue-arg.scss
@@ -1,0 +1,29 @@
+// A comment leading a MULTI-value argument flushes at the argument level:
+// the `//`'s forced hardline must not indent the value deeper
+// nor split the space-separated run (`#e46c2c 20%` stays together).
+// https://github.com/oxc-project/oxc/issues/25480
+.bar::after {
+	background: linear-gradient(
+		90deg,
+		transparent 0%,
+		// TODO: test comments
+		#e46c2c 20%,
+		transparent 100%
+	);
+}
+// Same-line `//` and block-comment variants keep their layout too
+.a {
+	background: linear-gradient(
+		90deg, // same-line comment
+		#e46c2c 20%,
+		transparent 100%
+	);
+}
+.b {
+	background: linear-gradient(
+		90deg,
+		/* block own-line */
+		#e46c2c 20%,
+		transparent 100%
+	);
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/inline-comment-before-multivalue-arg.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/inline-comment-before-multivalue-arg.scss.snap
@@ -1,0 +1,98 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A comment leading a MULTI-value argument flushes at the argument level:
+// the `//`'s forced hardline must not indent the value deeper
+// nor split the space-separated run (`#e46c2c 20%` stays together).
+// https://github.com/oxc-project/oxc/issues/25480
+.bar::after {
+	background: linear-gradient(
+		90deg,
+		transparent 0%,
+		// TODO: test comments
+		#e46c2c 20%,
+		transparent 100%
+	);
+}
+// Same-line `//` and block-comment variants keep their layout too
+.a {
+	background: linear-gradient(
+		90deg, // same-line comment
+		#e46c2c 20%,
+		transparent 100%
+	);
+}
+.b {
+	background: linear-gradient(
+		90deg,
+		/* block own-line */
+		#e46c2c 20%,
+		transparent 100%
+	);
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A comment leading a MULTI-value argument flushes at the argument level:
+// the `//`'s forced hardline must not indent the value deeper
+// nor split the space-separated run (`#e46c2c 20%` stays together).
+// https://github.com/oxc-project/oxc/issues/25480
+.bar::after {
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    // TODO: test comments
+    #e46c2c 20%,
+    transparent 100%
+  );
+}
+// Same-line `//` and block-comment variants keep their layout too
+.a {
+  background: linear-gradient(
+    90deg,
+    // same-line comment
+    #e46c2c 20%,
+    transparent 100%
+  );
+}
+.b {
+  background: linear-gradient(
+    90deg,
+    /* block own-line */ #e46c2c 20%,
+    transparent 100%
+  );
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A comment leading a MULTI-value argument flushes at the argument level:
+// the `//`'s forced hardline must not indent the value deeper
+// nor split the space-separated run (`#e46c2c 20%` stays together).
+// https://github.com/oxc-project/oxc/issues/25480
+.bar::after {
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    // TODO: test comments
+    #e46c2c 20%,
+    transparent 100%
+  );
+}
+// Same-line `//` and block-comment variants keep their layout too
+.a {
+  background: linear-gradient(
+    90deg,
+    // same-line comment
+    #e46c2c 20%,
+    transparent 100%
+  );
+}
+.b {
+  background: linear-gradient(90deg, /* block own-line */ #e46c2c 20%, transparent 100%);
+}
+
+===================== End =====================


### PR DESCRIPTION
Fixes #25480
