### PR TITLE
fix(formatter_yaml): consistent chomped eos behavior

### DIFF
--- a/crates/oxc_formatter_yaml/AGENTS.md
+++ b/crates/oxc_formatter_yaml/AGENTS.md
@@ -48,6 +48,8 @@ Admission reasons and rules: see FORMATTER_POLICY.md "Known divergences". Curren
 - anchor/tag order (prettier#19524): source order is preserved, never reordered
 - EOF blank lines: the file always ends with exactly one newline, like every other formatter crate
   (`|+` keep-chomped verbatim tails excepted); Prettier YAML alone preserves EOF blank lines verbatim
+- keep-chomped tail at a space-only EOF line (no final newline): the line holds no line break, so it adds nothing to the kept tail;
+  - Prettier counts it and prints one newline too many, changing the value `"\n"` → `"\n\n"` (prettier#19256 is the nearest issue)
 - `# prettier-ignore` range (prettier#13008): suppresses exactly one node, never every following node
 - anchor next-line comments (prettier#10518 / #9327): structurally avoided, the positional cursor makes them the next node's leading comments
 - blank lines (prettier#15528): one unified rule:

--- a/crates/oxc_formatter_yaml/src/print/block.rs
+++ b/crates/oxc_formatter_yaml/src/print/block.rs
@@ -143,6 +143,7 @@ pub fn write_block_scalar<'a>(
             // Raw text keeps them exempt from EVERY layout normalization,
             // including the state effects a line element would have on the following separator.
             // NOT `exact_line_breaks`: the tail may hold space-only lines, which are part of the value too.
+            // `ends_with_keep_chomped_block` mirrors this guard for the root's final newline.
             if blanks > 0 || (is_last_descendant && wrote_any) {
                 write!(f, dedent_to_root(&text(arena_newlines(blanks + 1, f))));
             }
@@ -211,7 +212,7 @@ fn block_value_line_contents<'s>(
         fold_lines(&stripped, prose_wrap)
     };
 
-    let mut lines = remove_unnecessary_trailing_newlines(block, content, is_last_descendant, lines);
+    let mut lines = remove_unnecessary_trailing_newlines(block, is_last_descendant, lines);
     // Trailing spaces on the LAST content line are dropped (Prettier does the same);
     // intermediate lines keep theirs, they are part of the value under every chomping mode.
     // The core printer never trims, so drop them here.
@@ -299,12 +300,14 @@ fn fold_lines<'s>(stripped: &[&'s str], prose_wrap: ProseWrap) -> Vec<Vec<Cow<'s
 /// Mirrors Prettier's `removeUnnecessaryTrailingNewlines`.
 fn remove_unnecessary_trailing_newlines<'s>(
     block: &BlockScalar,
-    content: &str,
     is_last_descendant: bool,
     mut lines: Vec<Vec<Cow<'s, str>>>,
 ) -> Vec<Vec<Cow<'s, str>>> {
     if block.chomping == Chomping::Keep {
-        if content.ends_with('\n') && lines.last().is_some_and(Vec::is_empty) {
+        // NOTE: The fragment after the last break holds no line break, so it is not a kept line:
+        // either the empty artifact `split('\n')` yields after a final break,
+        // or a break-less space-only EOF line (a known divergence: Prettier counts it).
+        if lines.last().is_some_and(|words| is_blank_line(words)) {
             lines.pop();
         }
         return lines;
@@ -326,16 +329,29 @@ fn remove_unnecessary_trailing_newlines<'s>(
     lines
 }
 
-/// Returns `true` when the stream's last descendant is a keep-chomped (`+`) block scalar.
-/// Its verbatim content already ends with the kept newlines,
+/// Returns `true` when the stream's last descendant is a keep-chomped (`+`) block scalar
+/// whose verbatim content ends with the kept newlines,
 /// so the caller must not append the usual final `hard_line_break()`
 /// (mirrors Prettier's `shouldPrintHardline` gate).
-pub fn ends_with_keep_chomped_block(root: &Root<'_>) -> bool {
+///
+/// Returns `false` when the scalar emits no tail of its own,
+/// no content characters and no kept line break (empty, or one break-less space-only EOF line);
+/// the caller's final newline stands.
+pub fn ends_with_keep_chomped_block(root: &Root<'_>, f: &YamlFormatter<'_, '_>) -> bool {
     root.children
         .last()
         .and_then(|document| document.body.content.as_deref())
         .and_then(last_descendant_block_scalar)
-        .is_some_and(|block| block.chomping == Chomping::Keep)
+        .is_some_and(|block| {
+            // Content characters guarantee a tail;
+            // an empty content region emits one exactly when its trailing run holds a line break.
+            block.chomping == Chomping::Keep
+                && (block.content_end > block.content_start
+                    || f.context()
+                        .source_text()
+                        .bytes_range(block.content_end, block.span.end)
+                        .contains(&b'\n'))
+        })
 }
 
 /// The block scalar the node's last descendant resolves to, if any.

--- a/crates/oxc_formatter_yaml/src/print/document.rs
+++ b/crates/oxc_formatter_yaml/src/print/document.rs
@@ -24,7 +24,7 @@ use crate::{
 /// Returns whether the stream ends with a keep-chomped block scalar (computed here anyway),
 /// so `format()` doesn't re-walk the tree for its final newline.
 pub fn write_root<'a>(root: &'a Root<'a>, f: &mut YamlFormatter<'_, 'a>) -> bool {
-    let keep_chomped_tail = ends_with_keep_chomped_block(root);
+    let keep_chomped_tail = ends_with_keep_chomped_block(root, f);
     let documents = root.children.as_slice();
 
     for (i, document) in documents.iter().enumerate() {

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/keep-chomped-eos-spaces-only.yaml
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/keep-chomped-eos-spaces-only.yaml
@@ -1,0 +1,5 @@
+# DIVERGES from Prettier (and yaml@2's reading): a space-only EOF line alone
+# materializes no kept break -- the value is "" (psych/PyYAML agree), so the
+# scalar has no verbatim tail and the file gets the standard final newline.
+key: |+
+  

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/keep-chomped-eos-spaces-only.yaml.snap
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/keep-chomped-eos-spaces-only.yaml.snap
@@ -1,0 +1,27 @@
+---
+source: crates/oxc_formatter_yaml/tests/fixtures/mod.rs
+---
+==================== Input ====================
+# DIVERGES from Prettier (and yaml@2's reading): a space-only EOF line alone
+# materializes no kept break -- the value is "" (psych/PyYAML agree), so the
+# scalar has no verbatim tail and the file gets the standard final newline.
+key: |+
+  
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+# DIVERGES from Prettier (and yaml@2's reading): a space-only EOF line alone
+# materializes no kept break -- the value is "" (psych/PyYAML agree), so the
+# scalar has no verbatim tail and the file gets the standard final newline.
+key: |+
+
+-------------------
+{ printWidth: 100 }
+-------------------
+# DIVERGES from Prettier (and yaml@2's reading): a space-only EOF line alone
+# materializes no kept break -- the value is "" (psych/PyYAML agree), so the
+# scalar has no verbatim tail and the file gets the standard final newline.
+key: |+
+
+===================== End =====================

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/keep-chomped-eos-trailing-spaces.yaml
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/keep-chomped-eos-trailing-spaces.yaml
@@ -1,0 +1,6 @@
+# DIVERGES from Prettier: it prints an extra newline here (value "\n" -> "\n\n";
+# its own --debug-check flags it). The space-only EOF line holds no line break,
+# so it adds nothing to the kept tail.
+key: |+
+
+  

--- a/crates/oxc_formatter_yaml/tests/fixtures/yaml/keep-chomped-eos-trailing-spaces.yaml.snap
+++ b/crates/oxc_formatter_yaml/tests/fixtures/yaml/keep-chomped-eos-trailing-spaces.yaml.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_formatter_yaml/tests/fixtures/mod.rs
+---
+==================== Input ====================
+# DIVERGES from Prettier: it prints an extra newline here (value "\n" -> "\n\n";
+# its own --debug-check flags it). The space-only EOF line holds no line break,
+# so it adds nothing to the kept tail.
+key: |+
+
+  
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+# DIVERGES from Prettier: it prints an extra newline here (value "\n" -> "\n\n";
+# its own --debug-check flags it). The space-only EOF line holds no line break,
+# so it adds nothing to the kept tail.
+key: |+
+
+
+-------------------
+{ printWidth: 100 }
+-------------------
+# DIVERGES from Prettier: it prints an extra newline here (value "\n" -> "\n\n";
+# its own --debug-check flags it). The space-only EOF line holds no line break,
+# so it adds nothing to the kept tail.
+key: |+
+
+
+===================== End =====================


### PR DESCRIPTION
```yaml
key: |+
  
```

(Last empty line contains trailing spaces.)
