### PR TITLE
fix(react_compiler): handle local self-references in memo deps

### DIFF
--- a/crates/oxc_react_compiler/fixtures/repro-useCallback-local-self-reference.js
+++ b/crates/oxc_react_compiler/fixtures/repro-useCallback-local-self-reference.js
@@ -1,0 +1,8 @@
+// @validateExhaustiveMemoizationDependencies
+function Component() {
+  useCallback(() => {
+    const bar = () => {
+      console.log(bar);
+    };
+  }, []);
+}

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -15,7 +15,7 @@ use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::ReactFunctionType;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::environment::OutputMode;
-use crate::react_compiler_hir::environment_config::EnvironmentConfig;
+use crate::react_compiler_hir::environment_config::{EnvironmentConfig, ExhaustiveEffectDepsMode};
 use crate::react_compiler_inference::align_method_call_scopes;
 use crate::react_compiler_inference::align_object_method_scopes;
 use crate::react_compiler_inference::align_reactive_scopes_to_block_scopes_hir;
@@ -243,7 +243,10 @@ fn run_pipeline<'a>(
 
     infer_reactive_places(&mut hir, &mut env)?;
 
-    if env.enable_validations() {
+    if env.enable_validations()
+        && (env.config.validate_exhaustive_memoization_dependencies
+            || env.config.validate_exhaustive_effect_dependencies != ExhaustiveEffectDepsMode::Off)
+    {
         validate_exhaustive_dependencies(&mut hir, &mut env)?;
     }
 

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -619,6 +619,7 @@ fn collect_dependencies<'a>(
                             span: decl_lv.place.span,
                         },
                     );
+                    locals.insert(decl_lv.place.identifier);
                 }
                 InstructionValue::StoreContext { lvalue: store_lv, value: store_val, .. } => {
                     visit_candidate_dependency(

--- a/crates/oxc_react_compiler/tests/snapshots/repro-useCallback-local-self-reference.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/repro-useCallback-local-self-reference.snap
@@ -1,0 +1,11 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/repro-useCallback-local-self-reference.js
+---
+// @validateExhaustiveMemoizationDependencies
+function Component() {}
+function _temp() {
+	const bar = () => {
+		console.log(bar);
+	};
+}


### PR DESCRIPTION
Fixes #25049.

Register `DeclareContext` bindings as locals before analyzing nested functions so local self-references are not treated as missing memo dependencies. Skip exhaustive dependency validation when both modes are disabled.

Validation: `just ready`

AI assistance was used to investigate and implement this change.