### PR TITLE
fix(react-compiler): handle tagged template hooks

### DIFF
--- a/crates/oxc_react_compiler/fixtures/error.invalid-conditional-tagged-template-hook.js
+++ b/crates/oxc_react_compiler/fixtures/error.invalid-conditional-tagged-template-hook.js
@@ -1,0 +1,9 @@
+import {useMotionTemplate} from 'framer-motion';
+
+function Component({cond}) {
+  let value;
+  if (cond) {
+    value = useMotionTemplate`static`;
+  }
+  return value;
+}

--- a/crates/oxc_react_compiler/fixtures/error.invalid-dynamic-tagged-template-hook.js
+++ b/crates/oxc_react_compiler/fixtures/error.invalid-dynamic-tagged-template-hook.js
@@ -1,0 +1,3 @@
+function Component({useTag}) {
+  return useTag`static`;
+}

--- a/crates/oxc_react_compiler/fixtures/error.invalid-hook-reference-in-tagged-template-interpolation.js
+++ b/crates/oxc_react_compiler/fixtures/error.invalid-hook-reference-in-tagged-template-interpolation.js
@@ -1,0 +1,9 @@
+import {useState} from 'react';
+
+function tag(strings, value) {
+  return value;
+}
+
+function Component() {
+  return tag`${useState}`;
+}

--- a/crates/oxc_react_compiler/fixtures/error.invalid-tagged-template-hook-in-function-expression.js
+++ b/crates/oxc_react_compiler/fixtures/error.invalid-tagged-template-hook-in-function-expression.js
@@ -1,0 +1,6 @@
+import {useMotionTemplate} from 'framer-motion';
+
+function Component() {
+  const callback = () => useMotionTemplate`static`;
+  return callback;
+}

--- a/crates/oxc_react_compiler/fixtures/tagged-template-hook.jsx
+++ b/crates/oxc_react_compiler/fixtures/tagged-template-hook.jsx
@@ -1,0 +1,17 @@
+import {useState} from 'react';
+
+function useTagged(strings, value) {
+  useState(0);
+  return `${strings[0]}${value}${strings[1]}`;
+}
+
+function Component({value}) {
+  const text = useTagged`value: ${value}`;
+  return <div>{text}</div>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 0}],
+  sequentialRenders: [{value: 0}, {value: 0}],
+};

--- a/crates/oxc_react_compiler/src/react_compiler_inference/flatten_scopes_with_hooks_or_use_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/flatten_scopes_with_hooks_or_use_hir.rs
@@ -58,7 +58,8 @@ pub fn flatten_scopes_with_hooks_or_use_hir(
         for instr_id in &block.instructions {
             let instr = &func.instructions[instr_id.index()];
             match &instr.value {
-                InstructionValue::CallExpression { callee, .. } => {
+                InstructionValue::CallExpression { callee, .. }
+                | InstructionValue::TaggedTemplateExpression { tag: callee, .. } => {
                     let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                     if is_hook_or_use(env, callee_ty)? {
                         // All active scopes must be pruned

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -1095,7 +1095,8 @@ fn find_non_mutated_destructure_spreads(
                     // Properties must be frozen since the original value was frozen
                 }
                 InstructionValue::CallExpression { callee, .. }
-                | InstructionValue::MethodCall { property: callee, .. } => {
+                | InstructionValue::MethodCall { property: callee, .. }
+                | InstructionValue::TaggedTemplateExpression { tag: callee, .. } => {
                     let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                     if get_hook_kind_for_type(env, callee_ty).ok().flatten().is_some() {
                         if !is_ref_or_ref_value_for_id(env, lvalue_id) {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
@@ -141,7 +141,8 @@ pub fn infer_reactive_places(
 
                 // Hooks and `use` operator are sources of reactivity
                 match value {
-                    InstructionValue::CallExpression { callee, .. } => {
+                    InstructionValue::CallExpression { callee, .. }
+                    | InstructionValue::TaggedTemplateExpression { tag: callee, .. } => {
                         let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                         if get_hook_kind_for_type(env, callee_ty)?.is_some()
                             || is_use_operator_type(callee_ty)
@@ -282,7 +283,8 @@ impl StableSidemap {
         let value = &instr.value;
 
         match value {
-            InstructionValue::CallExpression { callee, .. } => {
+            InstructionValue::CallExpression { callee, .. }
+            | InstructionValue::TaggedTemplateExpression { tag: callee, .. } => {
                 let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                 if evaluates_to_stable_type_or_container(env, callee_ty) {
                     let lvalue_ty = &env.types[env.identifiers[lvalue_id].type_];
@@ -583,7 +585,8 @@ fn apply_reactive_flags_replay(
 
             // Check hooks/use
             match &instr.value {
-                InstructionValue::CallExpression { callee, .. } => {
+                InstructionValue::CallExpression { callee, .. }
+                | InstructionValue::TaggedTemplateExpression { tag: callee, .. } => {
                     let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                     if get_hook_kind_for_type(env, callee_ty).ok().flatten().is_some()
                         || is_use_operator_type(callee_ty)

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
@@ -153,6 +153,23 @@ fn record_dynamic_hook_usage_error(
     Ok(())
 }
 
+fn validate_hook_call(
+    callee: &Place,
+    is_unconditional: bool,
+    value_kinds: &mut ValueKinds,
+    errors_by_span: &mut FxIndexMap<Span, OxcDiagnostic>,
+    env: &mut Environment,
+) -> Result<(), OxcDiagnostic> {
+    let callee_kind = get_kind_for_place(callee, value_kinds, &env.identifiers);
+    let is_hook_callee = callee_kind == Kind::KnownHook || callee_kind == Kind::PotentialHook;
+    if is_hook_callee && !is_unconditional {
+        record_conditional_hook_error(callee, value_kinds, errors_by_span, env)?;
+    } else if callee_kind == Kind::PotentialHook {
+        record_dynamic_hook_usage_error(callee, errors_by_span, env)?;
+    }
+    Ok(())
+}
+
 /// Validates hooks usage rules for a function.
 pub fn validate_hooks_usage(
     func: &HirFunction,
@@ -261,19 +278,13 @@ pub fn validate_hooks_usage(
                     value_kinds[lvalue_id] = Some(kind);
                 }
                 InstructionValue::CallExpression { callee, args, .. } => {
-                    let callee_kind = get_kind_for_place(callee, &value_kinds, &env.identifiers);
-                    let is_hook_callee =
-                        callee_kind == Kind::KnownHook || callee_kind == Kind::PotentialHook;
-                    if is_hook_callee && !unconditional_blocks.contains(&block.id) {
-                        record_conditional_hook_error(
-                            callee,
-                            &mut value_kinds,
-                            &mut errors_by_span,
-                            env,
-                        )?;
-                    } else if callee_kind == Kind::PotentialHook {
-                        record_dynamic_hook_usage_error(callee, &mut errors_by_span, env)?;
-                    }
+                    validate_hook_call(
+                        callee,
+                        unconditional_blocks.contains(&block.id),
+                        &mut value_kinds,
+                        &mut errors_by_span,
+                        env,
+                    )?;
                     // Visit all operands except callee
                     for arg in args {
                         let place = match arg {
@@ -284,19 +295,13 @@ pub fn validate_hooks_usage(
                     }
                 }
                 InstructionValue::MethodCall { receiver, property, args, .. } => {
-                    let callee_kind = get_kind_for_place(property, &value_kinds, &env.identifiers);
-                    let is_hook_callee =
-                        callee_kind == Kind::KnownHook || callee_kind == Kind::PotentialHook;
-                    if is_hook_callee && !unconditional_blocks.contains(&block.id) {
-                        record_conditional_hook_error(
-                            property,
-                            &mut value_kinds,
-                            &mut errors_by_span,
-                            env,
-                        )?;
-                    } else if callee_kind == Kind::PotentialHook {
-                        record_dynamic_hook_usage_error(property, &mut errors_by_span, env)?;
-                    }
+                    validate_hook_call(
+                        property,
+                        unconditional_blocks.contains(&block.id),
+                        &mut value_kinds,
+                        &mut errors_by_span,
+                        env,
+                    )?;
                     // Visit receiver and args (not property)
                     visit_place(receiver, &value_kinds, &mut errors_by_span, env)?;
                     for arg in args {
@@ -305,6 +310,20 @@ pub fn validate_hooks_usage(
                             PlaceOrSpread::Spread(s) => &s.place,
                         };
                         visit_place(place, &value_kinds, &mut errors_by_span, env)?;
+                    }
+                }
+                InstructionValue::TaggedTemplateExpression { tag, subexprs, .. } => {
+                    validate_hook_call(
+                        tag,
+                        unconditional_blocks.contains(&block.id),
+                        &mut value_kinds,
+                        &mut errors_by_span,
+                        env,
+                    )?;
+                    // The tag is the callee and was validated above. Interpolations
+                    // are ordinary operands and may not reference hooks as values.
+                    for subexpr in subexprs {
+                        visit_place(subexpr, &value_kinds, &mut errors_by_span, env)?;
                     }
                 }
                 InstructionValue::Destructure { lvalue, value, .. } => {
@@ -401,6 +420,9 @@ fn visit_function_expression(
                 }
                 InstructionValue::MethodCall { property, .. } => {
                     items.push(Item::Call(property.identifier, property.span));
+                }
+                InstructionValue::TaggedTemplateExpression { tag, .. } => {
+                    items.push(Item::Call(tag.identifier, tag.span));
                 }
                 _ => {}
             }

--- a/crates/oxc_react_compiler/tests/snapshots/error.invalid-conditional-tagged-template-hook.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.invalid-conditional-tagged-template-hook.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/error.invalid-conditional-tagged-template-hook.js
+---
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Hooks: Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)", labels: [LabeledSpan { label: None, span: Span { start: 118, end: 135 }, primary: false }], help: None, note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/error.invalid-dynamic-tagged-template-hook.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.invalid-dynamic-tagged-template-hook.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/error.invalid-dynamic-tagged-template-hook.js
+---
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Hooks: Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks", labels: [LabeledSpan { label: None, span: Span { start: 40, end: 46 }, primary: false }], help: None, note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/error.invalid-hook-reference-in-tagged-template-interpolation.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.invalid-hook-reference-in-tagged-template-interpolation.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/error.invalid-hook-reference-in-tagged-template-interpolation.js
+---
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Hooks: Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values", labels: [LabeledSpan { label: None, span: Span { start: 121, end: 129 }, primary: false }], help: None, note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/error.invalid-tagged-template-hook-in-function-expression.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.invalid-tagged-template-hook-in-function-expression.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/error.invalid-tagged-template-hook-in-function-expression.js
+---
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Hooks: Hooks must be called at the top level in the body of a function component or custom hook, and may not be called within function expressions. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)", labels: [LabeledSpan { label: None, span: Span { start: 98, end: 115 }, primary: false }], help: Some("Cannot call hook within a function expression"), note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/tagged-template-hook.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/tagged-template-hook.snap
@@ -1,0 +1,29 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/tagged-template-hook.jsx
+---
+import { c as _c } from "react/compiler-runtime";
+import { useState } from "react";
+function useTagged(strings, value) {
+	useState(0);
+	return `${strings[0]}${value}${strings[1]}`;
+}
+function Component(t0) {
+	const $ = _c(2);
+	const { value } = t0;
+	const text = useTagged`value: ${value}`;
+	let t1;
+	if ($[0] !== text) {
+		t1 = <div>{text}</div>;
+		$[0] = text;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	return t1;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ value: 0 }],
+	sequentialRenders: [{ value: 0 }, { value: 0 }]
+};


### PR DESCRIPTION
Fix tagged template hooks so they are validated and treated like hook calls, including unconditional execution across renders.

Closes #24473.

AI-assisted: Codex was used to investigate and implement this change. I reviewed and take responsibility for it.