### PR TITLE
fix(formatter): keep unary comment and print only needed parens

### DIFF
--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -149,10 +149,14 @@ Accepted edges (byte-identical to Prettier, semantically inert, idempotent):
 ## Known divergences
 
 Admission reasons and rules: see FORMATTER_POLICY.md "Known divergences".
-Entries documented in this file so far — both of the comment-attachment-artifact class, details in "Comment placement invariants" above; this is not yet an exhaustive audit against the conformance snapshots:
+Entries documented in this file so far (all of the comment-attachment-artifact class, details in "Comment placement invariants" above) is not yet an exhaustive audit against the conformance snapshots:
 
 - A comment after a trailing array hole stays in place; Prettier relocates it backward across commas to the last real element
 - Asymmetric attachment like `export type T = string /* c */;` (comment moved behind `;` only in the exported form): one uniform rule instead of emulating the asymmetry
+- A trailing comment before a closing paren never breaks the operand chain: `!(a &&\n b // c)` collapses to `a && b // c`, as both formatters already do in every other paren-surviving position (return/throw argument, call argument, assignment, arrow body)
+  - Prettier preserves the source break only in the unary position and only when the last operand was alone on its source line (attachment binds the comment to that operand)
+  - Internal inconsistency plus source-layout sensitivity, overridden by the uniform rule
+  - Conditions are a separate shared rule (logical operands always break)
 
 ## Verification
 

--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -374,6 +374,15 @@ impl<'a> Comments<'a> {
             .any(|comment| comment.followed_by_newline())
     }
 
+    /// Position-based variant of [`Self::has_comment_in_range`],
+    /// considering ALL comments, including already-printed ones:
+    /// whether the first comment at or after `start` ends within `end`.
+    /// Same discipline as [`Self::has_own_line_comment_in_range`].
+    pub fn has_any_comment_in_range(&self, start: u32, end: u32) -> bool {
+        let first = self.inner.partition_point(|comment| comment.span.start < start);
+        self.inner.get(first).is_some_and(|comment| comment.span.end <= end)
+    }
+
     pub fn has_end_of_line_comment_after(&self, pos: u32) -> bool {
         !self.end_of_line_comments_after(pos).is_empty()
     }

--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -6,7 +6,7 @@ use oxc_span::GetSpan;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{JsFormatter, JsFormatterExt as _},
-    print::{BinaryLikeExpression, should_flatten},
+    print::{BinaryLikeExpression, should_flatten, unary_argument_takes_comment_parens},
     utils::expression::ExpressionLeftSide,
 };
 
@@ -443,7 +443,7 @@ impl NeedsParentheses<'_> for AstNode<'_, BinaryExpression<'_>> {
             return true;
         }
 
-        binary_like_needs_parens(BinaryLikeExpression::BinaryExpression(self))
+        binary_like_needs_parens(BinaryLikeExpression::BinaryExpression(self), f)
     }
 }
 
@@ -536,7 +536,7 @@ impl NeedsParentheses<'_> for AstNode<'_, LogicalExpression<'_>> {
         {
             true
         } else {
-            binary_like_needs_parens(BinaryLikeExpression::LogicalExpression(self))
+            binary_like_needs_parens(BinaryLikeExpression::LogicalExpression(self), f)
         }
     }
 }
@@ -971,12 +971,21 @@ impl NeedsParentheses<'_> for AstNode<'_, TSInstantiationExpression<'_>> {
     }
 }
 
-fn binary_like_needs_parens(binary_like: BinaryLikeExpression<'_, '_>) -> bool {
+fn binary_like_needs_parens(
+    binary_like: BinaryLikeExpression<'_, '_>,
+    f: &JsFormatter<'_, '_>,
+) -> bool {
     let parent = match binary_like.parent() {
+        // NOTE: The unary adds the parentheses itself when comments are involved.
+        // Deliberately binary-like-only: Prettier keeps the inner parentheses for every other argument type (`!((x, y) /* c */)`)
+        // (Seems a leftover of prettier#18397's narrow scope, not a principle.)
+        // If upstream extends the fix, add the same exemption to those types' `needs_parentheses`.
+        AstNodes::UnaryExpression(unary) => {
+            return !unary_argument_takes_comment_parens(unary, f);
+        }
         AstNodes::TSAsExpression(_)
         | AstNodes::TSSatisfiesExpression(_)
         | AstNodes::TSTypeAssertion(_)
-        | AstNodes::UnaryExpression(_)
         | AstNodes::AwaitExpression(_)
         | AstNodes::TSNonNullExpression(_)
         | AstNodes::SpreadElement(_)

--- a/crates/oxc_formatter/src/print/binary_like_expression.rs
+++ b/crates/oxc_formatter/src/print/binary_like_expression.rs
@@ -6,6 +6,7 @@ use crate::{
     Format,
     ast_nodes::{AstNode, AstNodes},
     formatter::JsFormatter,
+    print::unary_argument_takes_comment_parens,
 };
 
 use crate::{format_args, formatter::prelude::*, write};
@@ -198,19 +199,18 @@ impl<'a> Format<'a, JsFormatContext<'a>> for BinaryLikeExpression<'a, '_> {
         let parent = self.parent();
         let is_inside_condition = self.is_inside_condition(parent);
 
-        // Don't indent inside of conditions because conditions add their own indent and grouping.
+        // Don't indent inside of conditions because conditions add their own indent and grouping
         if is_inside_condition {
-            return write!(
-                f,
-                [&format_with(|f| {
-                    format_flattened_logical_expression(*self, is_inside_condition, f);
-                })]
-            );
+            return format_flattened_logical_expression(*self, true, f);
         }
 
         // Add a group with a soft block indent in cases where it is necessary to parenthesize the binary expression.
         // For example, `(a+b)(call)`, `!(a + b)`, `(a + b).test`.
         let is_inside_parenthesis = match parent {
+            // The unary's own comment parens already provide the group and indent
+            AstNodes::UnaryExpression(unary) if unary_argument_takes_comment_parens(unary, f) => {
+                return format_flattened_logical_expression(*self, false, f);
+            }
             AstNodes::StaticMemberExpression(_) | AstNodes::UnaryExpression(_) => true,
             _ => parent.is_call_like_callee_span(self.span()),
         };

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -303,16 +303,33 @@ impl<'a> FormatWrite<'a> for AstNode<'a, UpdateExpression<'a>> {
     }
 }
 
+/// Whether a `UnaryExpression` wraps its argument in its own parentheses
+/// to keep the comments around the argument inside them.
+/// Two comment positions qualify:
+/// - before the argument: `!(/* c */ a && b)`
+/// - after it, before the closing source paren: `!(a && b /* c */)`
+///
+/// When this holds, these parentheses are the only pair:
+/// the argument must skip its own `needs_parentheses` and any paren-driven indent layout.
+/// Evaluated at several stages of the same node's formatting, hence the printed-state-independent comment queries.
+pub fn unary_argument_takes_comment_parens(
+    unary: &AstNode<'_, UnaryExpression<'_>>,
+    f: &JsFormatter<'_, '_>,
+) -> bool {
+    let unary_span = unary.span();
+    let argument_span = unary.argument.span();
+    let comments = f.comments();
+    comments.has_any_comment_in_range(unary_span.start, argument_span.start)
+        || comments.has_any_comment_in_range(argument_span.end, unary_span.end)
+}
+
 impl<'a> FormatWrite<'a> for AstNode<'a, UnaryExpression<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         write!(f, self.operator().as_str());
         if self.operator().is_keyword() {
             write!(f, space());
         }
-        let Span { start, end, .. } = self.argument.span();
-        if f.comments().has_comment_before(start)
-            || f.comments().has_comment_in_range(end, self.span().end)
-        {
+        if unary_argument_takes_comment_parens(self, f) {
             write!(
                 f,
                 [group(&format_args!(token("("), soft_block_indent(self.argument()), token(")")))]

--- a/crates/oxc_formatter/tests/fixtures/js/comments/unary-argument-parens.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/unary-argument-parens.js
@@ -1,0 +1,37 @@
+// https://github.com/oxc-project/oxc/issues/25494
+// When comments sit before the argument or between the argument and the closing paren,
+// the unary provides the single pair of parentheses and the comments stay inside.
+function foo() {
+  return !(
+    a && // A
+    b // B
+  );
+}
+
+// Known divergence: a trailing comment before the closing paren does not break
+// the operand chain, so pre-broken operands collapse (`a && b // B`) — the same
+// behavior both formatters have for return/throw arguments, call arguments,
+// assignments, and arrow bodies. Only here Prettier preserves the source break
+// (attachment binds the comment to the last operand when alone on its line);
+// with the same code on one line, Prettier also keeps it flat (see below).
+!(
+  a &&
+  b // B
+);
+!(
+  a +
+  b // B
+);
+
+// Same shapes on one line: flat, matching Prettier.
+!(x && y // B
+);
+!(x + y // B
+);
+
+!(a // B
+);
+
+!(/* L */ a && b);
+
+!(a && b /* B */);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/unary-argument-parens.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/unary-argument-parens.js.snap
@@ -1,0 +1,128 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// https://github.com/oxc-project/oxc/issues/25494
+// When comments sit before the argument or between the argument and the closing paren,
+// the unary provides the single pair of parentheses and the comments stay inside.
+function foo() {
+  return !(
+    a && // A
+    b // B
+  );
+}
+
+// Known divergence: a trailing comment before the closing paren does not break
+// the operand chain, so pre-broken operands collapse (`a && b // B`) — the same
+// behavior both formatters have for return/throw arguments, call arguments,
+// assignments, and arrow bodies. Only here Prettier preserves the source break
+// (attachment binds the comment to the last operand when alone on its line);
+// with the same code on one line, Prettier also keeps it flat (see below).
+!(
+  a &&
+  b // B
+);
+!(
+  a +
+  b // B
+);
+
+// Same shapes on one line: flat, matching Prettier.
+!(x && y // B
+);
+!(x + y // B
+);
+
+!(a // B
+);
+
+!(/* L */ a && b);
+
+!(a && b /* B */);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// https://github.com/oxc-project/oxc/issues/25494
+// When comments sit before the argument or between the argument and the closing paren,
+// the unary provides the single pair of parentheses and the comments stay inside.
+function foo() {
+  return !(
+    a && // A
+    b // B
+  );
+}
+
+// Known divergence: a trailing comment before the closing paren does not break
+// the operand chain, so pre-broken operands collapse (`a && b // B`) — the same
+// behavior both formatters have for return/throw arguments, call arguments,
+// assignments, and arrow bodies. Only here Prettier preserves the source break
+// (attachment binds the comment to the last operand when alone on its line);
+// with the same code on one line, Prettier also keeps it flat (see below).
+!(
+  a && b // B
+);
+!(
+  a + b // B
+);
+
+// Same shapes on one line: flat, matching Prettier.
+!(
+  x && y // B
+);
+!(
+  x + y // B
+);
+
+!(
+  a // B
+);
+
+!(/* L */ a && b);
+
+!(a && b /* B */);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// https://github.com/oxc-project/oxc/issues/25494
+// When comments sit before the argument or between the argument and the closing paren,
+// the unary provides the single pair of parentheses and the comments stay inside.
+function foo() {
+  return !(
+    a && // A
+    b // B
+  );
+}
+
+// Known divergence: a trailing comment before the closing paren does not break
+// the operand chain, so pre-broken operands collapse (`a && b // B`) — the same
+// behavior both formatters have for return/throw arguments, call arguments,
+// assignments, and arrow bodies. Only here Prettier preserves the source break
+// (attachment binds the comment to the last operand when alone on its line);
+// with the same code on one line, Prettier also keeps it flat (see below).
+!(
+  a && b // B
+);
+!(
+  a + b // B
+);
+
+// Same shapes on one line: flat, matching Prettier.
+!(
+  x && y // B
+);
+!(
+  x + y // B
+);
+
+!(
+  a // B
+);
+
+!(/* L */ a && b);
+
+!(a && b /* B */);
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_formatter/tests/conformance.rs
 expression: report
 ---
-js compatibility: 774/810 (95.56%), 23 files skipped
+js compatibility: 776/810 (95.80%), 23 files skipped
 
 # Failed
 
@@ -11,10 +11,9 @@ js compatibility: 774/810 (95.56%), 23 files skipped
 | js/arrows/issue-17421.js | 💥💥 | 90.43% |
 | js/assignment-comments/indentable-block-comment.js | 💥 | 12.50% |
 | js/call/no-argument/no-arguments.js | 💥 | 57.53% |
-| js/comments/15661.js | 💥💥 | 43.53% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/if.js | 💥💥 | 97.99% |
-| js/comments/return-statement-2.js | 💥💥 | 77.78% |
+| js/comments/return-statement-2.js | 💥💥 | 87.32% |
 | js/comments/return-statement.js | 💥💥 | 97.25% |
 | js/comments/tagged-template-literal.js | 💥💥 | 89.66% |
 | js/comments/between-head-and-body/between-head-and-body.js | 💥 | 33.10% |
@@ -37,13 +36,12 @@ js compatibility: 774/810 (95.56%), 23 files skipped
 | js/if/comment-between-condition-and-body.js | 💥 | 92.11% |
 | js/if/if_comments.js | 💥 | 91.89% |
 | js/if/condition-break/boolean-expression.js | 💥 | 94.03% |
-| js/if/condition-break/unary-expression.js | 💥 | 59.59% |
+| js/if/condition-break/unary-expression.js | 💥 | 61.38% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 0.00% |
-| js/logical-expressions/in-unary-expression.js | 💥 | 33.33% |
+| js/logical-expressions/in-unary-expression.js | 💥 | 79.49% |
 | js/template-literals/expression-break.js | 💥 | 80.00% |
 | js/template-literals/expressions.js | 💥 | 97.64% |
 | js/test-declarations/jest-each.js | 💥💥 | 95.71% |
-| js/unary-expression/comments.js | 💥 | 96.47% |
 
 # Skipped (parse error, TODO: should be ignored or supported)
 


### PR DESCRIPTION
Fixes #25494
