### PR TITLE
fix(linter/promise/no-multiple-resolved): ignore unresolved globals

### DIFF
--- a/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
+++ b/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
@@ -732,7 +732,9 @@ impl<'a> VisitJs<'a> for ResolveFinder<'a> {
         match &call_expr.callee {
             Expression::Identifier(ident) => {
                 let symbol_id = self.scoping.get_reference(ident.reference_id()).symbol_id();
-                if symbol_id == self.resolve_symbol_id || symbol_id == self.reject_symbol_id {
+                if symbol_id.is_some_and(|id| {
+                    Some(id) == self.resolve_symbol_id || Some(id) == self.reject_symbol_id
+                }) {
                     self.resolved.push(self.alloc(call_expr));
                 } else {
                     self.record_throwable_expr_span(call_expr.span);
@@ -914,6 +916,45 @@ fn test() {
     } catch (error) {
         reject(error);
     }
+})",
+        "new Promise(resolve => {
+    let timer;
+    const finish = () => {
+        clearTimeout(timer);
+        resolve();
+    };
+    timer = setTimeout(finish, ms);
+})",
+        "const abortableDelay = (ms, signal) =>
+    new Promise(resolve => {
+        let timer;
+        const finish = () => {
+            clearTimeout(timer);
+            signal?.removeEventListener('abort', finish);
+            resolve();
+        };
+        timer = setTimeout(finish, ms);
+        if (signal?.aborted) {
+            finish();
+            return;
+        }
+        signal?.addEventListener('abort', finish);
+    })",
+        "new Promise(resolve => {
+    let timer;
+    const finish = () => {
+        clearInterval(timer);
+        resolve();
+    };
+    timer = setInterval(finish, ms);
+})",
+        "new Promise(resolve => {
+    let frame;
+    const finish = () => {
+        cancelAnimationFrame(frame);
+        resolve();
+    };
+    frame = requestAnimationFrame(finish);
 })",
     ];
 


### PR DESCRIPTION
## Summary

Fixes false positives in `promise/no-multiple-resolved` when a `setTimeout` callback contains both a timer-clear call (`clearTimeout`, `clearInterval`, `cancelAnimationFrame`) and an explicit `resolve()`.

Fixes #25528

## Root cause

When a Promise executor has no `reject` parameter, `reject_symbol_id` is `None`. Unresolved global calls (e.g. `clearTimeout`) also have `symbol_id == None`, so they were incorrectly treated as reject calls and flagged as duplicate resolve sites alongside the real `resolve()`.

## Fix

Only match resolve/reject identifier calls when `symbol_id` is `Some`.

## Test plan

- [x] Added pass cases for `clearTimeout`/`clearInterval`/`cancelAnimationFrame` + `resolve()` in setTimeout callbacks
- [x] Added pass case for abortable delay pattern with `AbortSignal`
- [x] `cargo test -p oxc_linter no_multiple_resolved` passes

Made with [Cursor](https://cursor.com)