### PR TITLE
fix(oxlint,oxfmt): apply .gitignore only to walk targets, not explicitly named files

### DIFF
--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -97,6 +97,21 @@ Oxfmt shares code with Oxlint regarding its CLI implementation.
 
 Please exercise extra caution when making changes to these files.
 
+### Ignore model
+
+Two independent layers, AND-ed:
+
+- Tool-owned (`.prettierignore` / `--ignore-path`, config `ignorePatterns`, CLI `!` prefixed): hard
+  - blocks even explicitly named files, on every entry point
+- Git-derived (`.gitignore` / `.git/info/exclude`): discovery-only
+  - applies while walking (directory targets, cwd, oxfmt-expanded globs)
+  - An explicitly requested document (named CLI file, stdin, LSP) is formatted even when gitignored
+
+CLI enforcement of the git-derived layer: `oxc_config::GitignoreChecker::is_gitignored_walk_root` (directory-only gate, shared with Oxlint).
+
+NOTE: The git-derived check is pattern-based, not tracking-aware.
+A tracked file matching an ignore pattern is not ignored by git itself; excluding such files is the tool-owned layer's job.
+
 ## Verification
 
 ```sh

--- a/apps/oxfmt/src/cli/stdin_runner.rs
+++ b/apps/oxfmt/src/cli/stdin_runner.rs
@@ -116,7 +116,9 @@ impl StdinRunner {
             }
         };
 
-        // Check if the file is ignored by global ignores or config's `ignorePatterns`
+        // Check if the file is ignored by tool-ignores or config's `ignorePatterns`.
+        // `.gitignore` is deliberately not consulted,
+        // stdin is an explicitly requested document. (See "Ignore model" in AGENTS.md)
         let global_matchers = match resolve_ignore_paths(&cwd, &ignore_options.ignore_path)
             .and_then(|paths| build_global_ignore_matchers(&cwd, &[], &paths))
         {

--- a/apps/oxfmt/src/cli/walk.rs
+++ b/apps/oxfmt/src/cli/walk.rs
@@ -152,7 +152,7 @@ impl ScopedWalker {
                 }
                 // Also, the walker never filters gitignored walk roots.
                 // (including roots inside a gitignored directory)
-                if gitignore_checker.is_gitignored(path, &self.cwd) {
+                if gitignore_checker.is_gitignored_walk_root(path, &self.cwd) {
                     continue;
                 }
 

--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -524,9 +524,7 @@ fn compute_minimal_text_edit<'a>(
 // Almost the same as `cli::walk::load_ignore_paths`, but does not handle custom ignore files.
 //
 // NOTE: `.gitignore` is intentionally NOT included here.
-// In LSP, every file is explicitly opened by the user (like directly specifying a file in CLI),
-// so `.gitignore` should not prevent formatting.
-// Only formatter-specific ignore files apply.
+// LSP document is explicitly formatted by the user. (See "Ignore model" in AGENTS.md)
 fn load_ignore_paths(cwd: &Path) -> Vec<PathBuf> {
     let path = cwd.join(".prettierignore");
     if path.exists() { vec![path] } else { vec![] }

--- a/apps/oxfmt/test/cli/gitignore/2.snap.md
+++ b/apps/oxfmt/test/cli/gitignore/2.snap.md
@@ -2,17 +2,20 @@
 
 ## Command
 ```
-oxfmt --check index.ts
+oxfmt --check ignored-by-root.js
 ```
 
 ## File tree
 ```
-- fixtures/
-  - sub/
-    - .gitignore
-    - generated/
-      - pkg/ <CWD>
-        - index.ts
+- fixtures/ <CWD>
+  - .gitignore
+  - another/
+    - another.js
+  - ignored-by-root.js
+  - root.js
+  - subdir/
+    - ignored-by-subdir.js
+    - sub.js
 ```
 
 # Result
@@ -24,7 +27,7 @@ oxfmt --check index.ts
 ```
 Checking formatting...
 
-index.ts (<time>)
+ignored-by-root.js (<time>)
 
 Format issues found in above 1 files. Run without `--check` to fix.
 Finished in <time> on 1 files using 1 threads.

--- a/apps/oxfmt/test/cli/gitignore/options.json
+++ b/apps/oxfmt/test/cli/gitignore/options.json
@@ -11,5 +11,11 @@
       ".gitignore": "ignored-by-root.js",
       "subdir/.gitignore": "ignored-by-subdir.js\n"
     }
+  },
+  {
+    "args": ["--check", "ignored-by-root.js"],
+    "gitignore": {
+      ".gitignore": "ignored-by-root.js\nsubdir/"
+    }
   }
 ]

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -194,7 +194,7 @@ impl CliRunner {
         // Currently it only disables Oxlint's own ignore sources (`.eslintignore`, `--ignore-path`, `--ignore-pattern`),
         // not git's. (Aligns with during walk filtering behavior)
         let mut gitignore_checker = GitignoreChecker::new();
-        paths.retain(|p| !gitignore_checker.is_gitignored(p, &self.cwd));
+        paths.retain(|p| !gitignore_checker.is_gitignored_walk_root(p, &self.cwd));
 
         // If explicit paths were provided but all have been filtered,
         // or the default cwd target is gitignored, return early.
@@ -860,13 +860,16 @@ mod test {
         let (_, result) = Tester::new().with_cwd(pkg_path.clone()).test_output(&[]);
         assert!(matches!(result, CliRunResult::LintNoFilesFound), "{result:?}");
 
-        // Explicitly passed gitignored targets are skipped too;
-        // `--no-ignore` only disables Oxlint's own ignore sources, not git's.
-        let (_, result) = Tester::new().with_cwd(pkg_path.clone()).test_output(&["index.ts"]);
+        // Explicitly passed gitignored directories are skipped too.
+        let (_, result) = Tester::new().with_cwd(repo_path).test_output(&["sub/generated/pkg"]);
         assert!(matches!(result, CliRunResult::LintNoFilesFound), "{result:?}");
-        let (_, result) =
-            Tester::new().with_cwd(pkg_path).test_output(&["--no-ignore", "index.ts"]);
-        assert!(matches!(result, CliRunResult::LintNoFilesFound), "{result:?}");
+
+        // But an explicitly named file is linted even when gitignored;
+        // `.gitignore` only scopes discovery.
+        let (stdout, result) =
+            Tester::new().with_cwd(pkg_path).test_output(&["-D", "no-debugger", "index.ts"]);
+        assert!(matches!(result, CliRunResult::LintFoundErrors), "{result:?}\n{stdout}");
+        assert!(stdout.contains("on 1 file"), "{stdout}");
     }
 
     #[cfg(unix)]

--- a/crates/oxc_config/src/walk.rs
+++ b/crates/oxc_config/src/walk.rs
@@ -92,6 +92,15 @@ impl GitignoreChecker {
         };
         matcher.matched(relative, is_dir).is_ignore()
     }
+
+    /// Walk-root variant of [`Self::is_gitignored`]: `true` only for gitignored directory targets.
+    /// `.gitignore` scopes discovery, an explicitly named file target is processed even when gitignored.
+    ///
+    /// Dir-ness follows symlinks (= whether the walker would descend into the target);
+    /// pattern matching itself still uses the symlink type via [`Self::is_gitignored`].
+    pub fn is_gitignored_walk_root(&mut self, path: &Path, cwd: &Path) -> bool {
+        resolve_against_cwd(path, cwd).is_dir() && self.is_gitignored(path, cwd)
+    }
 }
 
 /// Return `true` when every path is inside a Git or Jujutsu repository.
@@ -295,6 +304,25 @@ mod test {
         assert!(checker.is_gitignored(&repo_path.join("sub").join("generated"), &repo_path));
         // Sibling of the ignored directory is not
         assert!(!checker.is_gitignored(&repo_path.join("sub"), &repo_path));
+    }
+
+    #[test]
+    fn walk_root_check_only_filters_directory_targets() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_path = temp_dir.path().join("repo");
+        let target = repo_path.join("sub").join("generated").join("pkg");
+
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir(repo_path.join(".git")).unwrap();
+        fs::write(repo_path.join("sub").join(".gitignore"), "generated\n").unwrap();
+        fs::write(target.join("index.ts"), "").unwrap();
+
+        let mut checker = GitignoreChecker::new();
+        // Directory targets inside the ignored tree are filtered
+        assert!(checker.is_gitignored_walk_root(&target, &repo_path));
+        // An explicitly named file is not, even though `is_gitignored` matches it
+        assert!(!checker.is_gitignored_walk_root(&target.join("index.ts"), &repo_path));
+        assert!(checker.is_gitignored(&target.join("index.ts"), &repo_path));
     }
 
     #[test]


### PR DESCRIPTION
Possibly fixes #25259, and partial revert of #25133.

---

- `.gitignore` applies only to discovery (walking directory targets, cwd, globs)
- An explicitly named file target is linted / formatted even when gitignored
  - = Restoring the pre-[#25133]() behavior for files, while fully keeping the [#25107]() fix for walk roots

| Target | Current | This PR |
| --- | --- | --- |
| Explicit file (`oxlint dist/a.js`) | skipped | linted |
| Explicit directory (`oxlint dist`) | skipped | skipped |
| cwd inside ignored tree | skipped | skipped |

The underlying principle:

> `.gitignore` is a message addressed to git, not to tools.
> Borrowing it to scope discovery is a useful heuristic, and a heuristic may narrow what the walk finds, but never refuse what the user names.
> Only tool's own ignore config can refuse. (which remain hard for the husky staged-file case).

This also re-aligns the CLI with stdin and LSP, which deliberately do not consult `.gitignore` (#19206).
👉🏻 This is the main motivation.

### Why not full revert

A directory target names where to search, not what to process.
The files under it are still discovered by the walk, so discovery rules apply.
Reverting that would bring back [#25107](), whose old behavior was not even a statable spec: whether running inside an ignored tree processed anything depended on the ignore pattern's form (bare `generated` did, `generated/**` didn't), an artifact of walker pruning, not a design.

### Regarding to `--no-ignore`

This flag remains orthogonal as a walk-level opt-out (`--no-ignore=vcs dist`) and for filling gap between existing tools.

However, with explicit files working again, I'm inclined to close those PRs and revisit if demand shows up.

For [#25259]()'s use case: name the files, e.g. `oxlint dist/foo.js` (or shell-expanded glob).