### PR TITLE
fix(parser): preserve fatal errors during await reparse

### DIFF
--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -809,7 +809,9 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
         // we need to reparse statements that were originally parsed with `await` as identifier.
         // TypeScript's behavior: initially parse `await /x/` as division, then reparse as
         // await expression with regex when ESM is detected.
-        if self.source_type.is_unambiguous()
+        // Preserve a fatal error from the initial parse instead of rewinding past it.
+        if self.fatal_error.is_none()
+            && self.source_type.is_unambiguous()
             && self.module_record_builder.has_module_syntax()
             && !self.state.potential_await_reparse.is_empty()
         {

--- a/tasks/coverage/misc/fail/oxc-23681.js
+++ b/tasks/coverage/misc/fail/oxc-23681.js
@@ -1,0 +1,4 @@
+await
+foo();
+var prefix = 'fas';
+export()s.height = height;

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 77/77 (100.00%)
 Positive Passed: 77/77 (100.00%)
-Negative Passed: 159/159 (100.00%)
+Negative Passed: 160/160 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval-ambient.ts:2:13]
@@ -3804,6 +3804,13 @@ Negative Passed: 159/159 (100.00%)
    ·     ────────────────
    ╰────
   help: Wrap this with parenthesis
+
+  × Unexpected token
+   ╭─[misc/fail/oxc-23681.js:4:7]
+ 3 │ var prefix = 'fas';
+ 4 │ export()s.height = height;
+   ·       ─
+   ╰────
 
   × Expected 'with' in import type options
     ╭─[misc/fail/oxc-2394.ts:20:22]


### PR DESCRIPTION
Fixes #23681.

Preserve initial fatal parser errors during top-level `await` reparsing, preventing malformed recovery AST nodes from reaching Oxlint.

Validated with parser unit/conformance suites and allocation snapshots. `just ready` only fails three unrelated ANSI snapshot checks in the current environment.

AI-assisted.