### PR TITLE
fix(docs): cap generated Markdown heading depth

### DIFF
--- a/tasks/website_common/src/schema_markdown.rs
+++ b/tasks/website_common/src/schema_markdown.rs
@@ -35,6 +35,10 @@ default: `{{default}}`
 {{/each}}
 ";
 
+fn heading(depth: usize) -> String {
+    "#".repeat(depth.min(6))
+}
+
 /// Data passed to [`ROOT`] hbs template
 #[derive(Serialize)]
 struct Root {
@@ -353,7 +357,7 @@ impl Renderer {
                 };
 
                 return vec![Section {
-                    level: "#".repeat(depth),
+                    level: heading(depth),
                     title: key.into(),
                     instance_type: union_type,
                     default: Self::render_default(schema),
@@ -370,7 +374,7 @@ impl Renderer {
             if !primitive_types.is_empty() {
                 let union_type = primitive_types.join(" | ");
                 return vec![Section {
-                    level: "#".repeat(depth),
+                    level: heading(depth),
                     title: key.into(),
                     instance_type: Some(union_type),
                     default: Self::render_default(schema),
@@ -436,7 +440,7 @@ impl Renderer {
                     let sections: Vec<Section> = enum_variants
                         .into_iter()
                         .map(|(value, description)| Section {
-                            level: "#".repeat(depth + 1),
+                            level: heading(depth + 1),
                             title: format!(r#"`"{value}"`"#),
                             instance_type: None,
                             default: None,
@@ -446,7 +450,7 @@ impl Renderer {
                         .collect();
 
                     return Section {
-                        level: "#".repeat(depth),
+                        level: heading(depth),
                         title: key.into(),
                         instance_type,
                         default: Self::render_default(ref_schema)
@@ -521,7 +525,7 @@ impl Renderer {
         };
 
         Section {
-            level: "#".repeat(depth),
+            level: heading(depth),
             title: key.into(),
             instance_type,
             default: Self::render_default(ref_schema).or_else(|| Self::render_default(schema)),

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -1,5 +1,6 @@
 ---
 source: tasks/website_formatter/src/json_schema.rs
+assertion_line: 30
 expression: snapshot
 ---
 ---
@@ -666,7 +667,7 @@ all conditions must be met for an import to match the custom group (AND logic).
 - Default: `[]`
 
 
-####### overrides[n].options.sortImports.customGroups[n]
+###### overrides[n].options.sortImports.customGroups[n]
 
 type: `object`
 
@@ -674,7 +675,7 @@ type: `object`
 
 
 
-######## overrides[n].options.sortImports.customGroups[n].elementNamePattern
+###### overrides[n].options.sortImports.customGroups[n].elementNamePattern
 
 type: `string[]`
 
@@ -683,7 +684,7 @@ default: `[]`
 List of glob patterns to match import sources for this group.
 
 
-######## overrides[n].options.sortImports.customGroups[n].groupName
+###### overrides[n].options.sortImports.customGroups[n].groupName
 
 type: `string`
 
@@ -692,7 +693,7 @@ default: `""`
 Name of the custom group, used in the `groups` option.
 
 
-######## overrides[n].options.sortImports.customGroups[n].modifiers
+###### overrides[n].options.sortImports.customGroups[n].modifiers
 
 type: `array`
 
@@ -701,7 +702,7 @@ Modifiers to match the import characteristics.
 All specified modifiers must be present (AND logic).
 
 
-######### overrides[n].options.sortImports.customGroups[n].modifiers[n]
+###### overrides[n].options.sortImports.customGroups[n].modifiers[n]
 
 type: `"side_effect" | "type" | "value" | "default" | "wildcard" | "named"`
 
@@ -709,7 +710,7 @@ type: `"side_effect" | "type" | "value" | "default" | "wildcard" | "named"`
 Modifier matching the import characteristics in `customGroups` (see `sortImports.groups` for semantics).
 
 
-######## overrides[n].options.sortImports.customGroups[n].selector
+###### overrides[n].options.sortImports.customGroups[n].selector
 
 type: `"type" | "side_effect_style" | "side_effect" | "style" | "index" | "sibling" | "parent" | "subpath" | "internal" | "builtin" | "external" | "import"`
 
@@ -781,7 +782,7 @@ Also, you can override the global `newlinesBetween` setting for specific group b
 by including a `{ "newlinesBetween": boolean }` marker object in the `groups` list at the desired position.
 
 
-####### overrides[n].options.sortImports.groups[n]
+###### overrides[n].options.sortImports.groups[n]
 
 type: `object | array | string`
 
@@ -789,7 +790,7 @@ type: `object | array | string`
 
 
 
-######## overrides[n].options.sortImports.groups[n].newlinesBetween
+###### overrides[n].options.sortImports.groups[n].newlinesBetween
 
 type: `boolean`
 


### PR DESCRIPTION
`#` was repeated for each level without a max, which created this problem
https://oxc.rs/docs/guide/usage/formatter/config-file-reference.html
<img width="1452" height="1154" alt="Screenshot 2026-08-12 at 18-24-43" src="https://github.com/user-attachments/assets/9f1ac473-2e7b-4514-81a4-d528c7b6c0e6" />

capped `#` at max of 6