### PR TITLE
fix(react_compiler): insert outlined functions as siblings at any nesting depth

### DIFF
--- a/crates/oxc_react_compiler/fixtures/gating-with-function-outlining.js
+++ b/crates/oxc_react_compiler/fixtures/gating-with-function-outlining.js
@@ -1,0 +1,12 @@
+// @gating
+import { useEffect } from 'react';
+
+// The outlined effect callback is inserted immediately after the gated
+// declaration (upstream inserts it before gating rewrites the statement),
+// not appended at the end of the program.
+function Component() {
+  useEffect(() => {
+    console.log('mounted');
+  }, []);
+  return null;
+}

--- a/crates/oxc_react_compiler/fixtures/outlined-function-in-nested-block.js
+++ b/crates/oxc_react_compiler/fixtures/outlined-function-in-nested-block.js
@@ -1,0 +1,19 @@
+// @compilationMode:"infer"
+import { useEffect } from 'react';
+
+// Like outlined-function-in-nested-declaration, but the compiled component sits
+// in a block statement: the outlined callback is inserted into that block,
+// mirroring Babel `insertAfter` on the enclosing statement list.
+export function makeProbe(flag) {
+  let mounts = 0;
+  if (flag) {
+    function MountCounter() {
+      useEffect(() => {
+        mounts += 1;
+      }, []);
+      return null;
+    }
+    return { MountCounter, read: () => mounts };
+  }
+  return null;
+}

--- a/crates/oxc_react_compiler/fixtures/outlined-function-in-nested-declaration.js
+++ b/crates/oxc_react_compiler/fixtures/outlined-function-in-nested-declaration.js
@@ -1,0 +1,17 @@
+// @compilationMode:"infer"
+import { useEffect } from 'react';
+
+// The outlined effect callback references `mounts`, a binding of the function
+// enclosing the compiled component. It must be inserted as a sibling of the
+// component (where `mounts` is still in scope), not hoisted to module scope.
+// https://github.com/oxc-project/oxc/issues/25536
+export function makeProbe() {
+  let mounts = 0;
+  function MountCounter() {
+    useEffect(() => {
+      mounts += 1;
+    }, []);
+    return null;
+  }
+  return { MountCounter, read: () => mounts };
+}

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -2317,6 +2317,18 @@ enum OxcVisitMode<'a, 'b> {
     /// (a declaration becomes a `FunctionExpression`), for
     /// [`ox_clone_original_fn_as_expression`]. Mutates nothing.
     FindOriginalFn { scope_id: ScopeId, found: Option<Expression<'a>> },
+    /// Insert outlined function declarations immediately after the statement
+    /// declaring the function with scope `scope_id`, in whatever statement
+    /// list that statement lives (program body, function body, nested block),
+    /// for [`ox_insert_outlined_after`]. Mirrors Babel
+    /// `originalFn.insertAfter(...)` for `FunctionDeclaration` originals,
+    /// which inserts into the enclosing statement list at any nesting depth.
+    InsertOutlinedAfter {
+        scope_id: ScopeId,
+        /// Declarations to insert; drained on insertion, so leftovers mean
+        /// the original statement was not found.
+        decls: Vec<Statement<'a>>,
+    },
 }
 
 type GatedStatementMatch<'a> = (Option<(Ident<'a>, Span)>, Option<Span>);
@@ -2417,6 +2429,12 @@ impl<'a> oxc_ast_visit::VisitMut<'a> for OxcVisitor<'a, '_> {
                 }
             }
             OxcVisitMode::ReplaceWithGated { .. } => {}
+            OxcVisitMode::InsertOutlinedAfter { decls, .. } => {
+                // Prune the walk once the declarations have been inserted.
+                if decls.is_empty() {
+                    return;
+                }
+            }
             OxcVisitMode::FindOriginalFn { scope_id, found } => {
                 if found.is_some() {
                     return;
@@ -2460,6 +2478,12 @@ impl<'a> oxc_ast_visit::VisitMut<'a> for OxcVisitor<'a, '_> {
                 }
             }
             OxcVisitMode::ReplaceWithGated { .. } => {}
+            OxcVisitMode::InsertOutlinedAfter { decls, .. } => {
+                // Prune the walk once the declarations have been inserted.
+                if decls.is_empty() {
+                    return;
+                }
+            }
             OxcVisitMode::FindOriginalFn { scope_id, found } => {
                 if found.is_some() {
                     return;
@@ -2477,6 +2501,23 @@ impl<'a> oxc_ast_visit::VisitMut<'a> for OxcVisitor<'a, '_> {
     }
 
     fn visit_statements(&mut self, stmts: &mut ArenaVec<'a, Statement<'a>>) {
+        if let OxcVisitMode::InsertOutlinedAfter { scope_id, decls } = &mut self.mode {
+            if decls.is_empty() {
+                return;
+            }
+            let scope_id = *scope_id;
+            if let Some(idx) = stmts.iter().position(|s| ox_declares_fn_with_scope(s, scope_id)) {
+                // Babel inserts each outlined function via `originalFn.insertAfter(...)`,
+                // anchored at the same original node, so repeated insertions reverse the
+                // emitted order. Insert each at `idx + 1` to reproduce that.
+                for stmt in std::mem::take(decls) {
+                    stmts.insert(idx + 1, stmt);
+                }
+                return;
+            }
+            oxc_ast_visit::walk_mut::walk_statements(self, stmts);
+            return;
+        }
         if !matches!(self.mode, OxcVisitMode::ReplaceWithGated { .. }) {
             oxc_ast_visit::walk_mut::walk_statements(self, stmts);
             return;
@@ -2640,10 +2681,12 @@ fn ox_transform_program<'a>(
     // original function's syntactic kind, mirroring `insertNewOutlinedFunctionNode`
     // in TS `Program.ts`:
     //   - FunctionDeclaration originals: inserted as a sibling immediately after the
-    //     original function (Babel `insertAfter`).
+    //     original function (Babel `insertAfter`), however deeply nested it is.
     //   - (Arrow)FunctionExpression originals: appended at the end of the program
     //     body (Babel `pushContainer('body', ...)`), since inserting as a sibling
-    //     would corrupt the parent expression.
+    //     would corrupt the parent expression. For a nested original this can hoist
+    //     the outlined function past bindings it references — upstream has the same
+    //     behavior, so we reproduce it rather than diverge.
     let mut appended_outlined_decls: Vec<Statement<'a>> = Vec::new();
 
     // Substitute every non-gated compiled function into its original in a single
@@ -2676,12 +2719,16 @@ fn ox_transform_program<'a>(
             }
         }
 
-        if let Some(ref gating_config) = replacement.gating {
-            ox_apply_gated_conditional(ast, program, replacement, gating_config, context);
+        // Insert outlined declarations before applying gating: upstream inserts
+        // them during the compile-queue loop, before any original is replaced,
+        // so they anchor to the original statement — gating rewrites it into a
+        // `const`, which no longer matches the function's scope.
+        if !sibling_outlined_decls.is_empty() {
+            ox_insert_outlined_after(ast, program, replacement.fn_scope_id, sibling_outlined_decls);
         }
 
-        if !sibling_outlined_decls.is_empty() {
-            ox_insert_outlined_after(program, replacement.fn_scope_id, sibling_outlined_decls);
+        if let Some(ref gating_config) = replacement.gating {
+            ox_apply_gated_conditional(ast, program, replacement, gating_config, context);
         }
     }
 
@@ -2697,44 +2744,49 @@ fn ox_transform_program<'a>(
     ox_add_imports_to_program(ast, program, context);
 }
 
-/// Insert outlined function declarations immediately after the top-level statement
-/// that declares the function with scope `scope_id`. Mirrors Babel's
-/// `originalFn.insertAfter(...)` for `FunctionDeclaration` originals. The statement
-/// may be a bare `FunctionDeclaration` or one wrapped in an `export`.
+/// Insert outlined function declarations immediately after the statement that
+/// declares the function with scope `scope_id`, in whatever statement list
+/// that statement lives (program body, a function body, a nested block).
+/// Mirrors Babel's `originalFn.insertAfter(...)` for `FunctionDeclaration`
+/// originals, which inserts into the enclosing statement list at any nesting
+/// depth. Placement matters for correctness: an outlined function may reference
+/// bindings of the functions enclosing the original (free variables of the
+/// compiled function are plain loads/stores in its HIR, so outlining does not
+/// count them as context), and every name visible to the original is also
+/// visible at its sibling position — but not necessarily at module scope. The
+/// statement may be a bare `FunctionDeclaration` or one wrapped in an `export`.
 fn ox_insert_outlined_after<'a>(
+    ast: &AstBuilder<'a>,
     program: &mut Program<'a>,
     scope_id: ScopeId,
     outlined_decls: Vec<Statement<'a>>,
 ) {
-    let matches = |stmt: &Statement<'a>| -> bool {
-        let is_target = |f: &Function<'a>| -> bool { f.scope_id.get() == Some(scope_id) };
-        match stmt {
-            Statement::FunctionDeclaration(f) => is_target(f),
-            Statement::ExportDeclaration(e) => {
-                matches!(&e.declaration, Declaration::FunctionDeclaration(f) if is_target(f))
-            }
-            Statement::ExportDefaultDeclaration(e) => {
-                matches!(&e.declaration, ExportDefaultDeclarationKind::FunctionDeclaration(f) if is_target(f))
-            }
-            _ => false,
-        }
+    let mut visitor = OxcVisitor {
+        ast,
+        mode: OxcVisitMode::InsertOutlinedAfter { scope_id, decls: outlined_decls },
     };
+    oxc_ast_visit::VisitMut::visit_program(&mut visitor, program);
+    let OxcVisitMode::InsertOutlinedAfter { decls, .. } = visitor.mode else { unreachable!() };
+    // A `FunctionDeclaration` sits directly in a statement list everywhere in
+    // module code, so the walk finds it; the exception is sloppy-mode annex-B
+    // positions (`if (c) function F() {}`), where we degrade to appending at
+    // the top level rather than dropping the functions.
+    program.body.extend(decls);
+}
 
-    let index = program.body.iter().position(matches);
-    match index {
-        Some(idx) => {
-            // Babel inserts each outlined function via `originalFn.insertAfter(...)`,
-            // anchored at the same original node, so repeated insertions reverse the
-            // emitted order. Insert each at `idx + 1` to reproduce that.
-            for stmt in outlined_decls {
-                program.body.insert(idx + 1, stmt);
-            }
+/// Whether `stmt` declares the function with scope `scope_id` — a bare
+/// `FunctionDeclaration` or one wrapped in an `export` / `export default`.
+fn ox_declares_fn_with_scope(stmt: &Statement<'_>, scope_id: ScopeId) -> bool {
+    let is_target = |f: &Function<'_>| -> bool { f.scope_id.get() == Some(scope_id) };
+    match stmt {
+        Statement::FunctionDeclaration(f) => is_target(f),
+        Statement::ExportDeclaration(e) => {
+            matches!(&e.declaration, Declaration::FunctionDeclaration(f) if is_target(f))
         }
-        None => {
-            // Function is nested (not a direct program-body statement); fall back to
-            // appending at the top level.
-            program.body.extend(outlined_decls);
+        Statement::ExportDefaultDeclaration(e) => {
+            matches!(&e.declaration, ExportDefaultDeclarationKind::FunctionDeclaration(f) if is_target(f))
         }
+        _ => false,
     }
 }
 

--- a/crates/oxc_react_compiler/tests/snapshots/gating-with-function-outlining.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/gating-with-function-outlining.snap
@@ -1,0 +1,28 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/gating-with-function-outlining.js
+---
+import { c as _c } from "react/compiler-runtime";
+import { isForgetEnabled_Fixtures } from "ReactForgetFeatureFlag";
+// @gating
+import { useEffect } from "react";
+const Component = isForgetEnabled_Fixtures() ? function Component() {
+	const $ = _c(1);
+	let t0;
+	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		t0 = [];
+		$[0] = t0;
+	} else {
+		t0 = $[0];
+	}
+	useEffect(_temp, t0);
+	return null;
+} : function Component() {
+	useEffect(() => {
+		console.log("mounted");
+	}, []);
+	return null;
+};
+function _temp() {
+	console.log("mounted");
+}

--- a/crates/oxc_react_compiler/tests/snapshots/outlined-function-in-nested-block.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/outlined-function-in-nested-block.snap
@@ -1,0 +1,35 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/outlined-function-in-nested-block.js
+---
+import { c as _c } from "react/compiler-runtime";
+// @compilationMode:"infer"
+import { useEffect } from "react";
+// Like outlined-function-in-nested-declaration, but the compiled component sits
+// in a block statement: the outlined callback is inserted into that block,
+// mirroring Babel `insertAfter` on the enclosing statement list.
+export function makeProbe(flag) {
+	let mounts = 0;
+	if (flag) {
+		function MountCounter() {
+			const $ = _c(1);
+			let t0;
+			if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+				t0 = [];
+				$[0] = t0;
+			} else {
+				t0 = $[0];
+			}
+			useEffect(_temp, t0);
+			return null;
+		}
+		function _temp() {
+			mounts = mounts + 1;
+		}
+		return {
+			MountCounter,
+			read: () => mounts
+		};
+	}
+	return null;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/outlined-function-in-nested-declaration.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/outlined-function-in-nested-declaration.snap
@@ -1,0 +1,33 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/outlined-function-in-nested-declaration.js
+---
+import { c as _c } from "react/compiler-runtime";
+// @compilationMode:"infer"
+import { useEffect } from "react";
+// The outlined effect callback references `mounts`, a binding of the function
+// enclosing the compiled component. It must be inserted as a sibling of the
+// component (where `mounts` is still in scope), not hoisted to module scope.
+// https://github.com/oxc-project/oxc/issues/25536
+export function makeProbe() {
+	let mounts = 0;
+	function MountCounter() {
+		const $ = _c(1);
+		let t0;
+		if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+			t0 = [];
+			$[0] = t0;
+		} else {
+			t0 = $[0];
+		}
+		useEffect(_temp, t0);
+		return null;
+	}
+	function _temp() {
+		mounts = mounts + 1;
+	}
+	return {
+		MountCounter,
+		read: () => mounts
+	};
+}


### PR DESCRIPTION
Closes #25536

## Problem

With `enableFunctionOutlining` (default on), the compiler outlines function expressions whose lowered **context** is empty. Context only counts variables captured from scopes inside the function being compiled — a free variable of the whole compiled function (e.g. a binding of an *enclosing* function) is modeled as a plain global load/store in HIR, so a callback referencing one still gets outlined. Correctness then depends entirely on where the outlined declaration is inserted: upstream uses Babel `originalFn.insertAfter(...)`, which splices into the statement list containing the original at **any nesting depth**, preserving the invariant that every name visible to the original is visible at its sibling position.

`ox_insert_outlined_after` searched only `program.body`. For a component declared inside another function, the search missed and the fallback appended the outlined declaration at module scope:

```js
export function makeProbe() {
  let mounts = 0;
  function MountCounter() {
    useEffect(() => { mounts += 1; }, []);
    return null;
  }
  return { MountCounter, read: () => mounts };
}
```

compiled to

```js
export function makeProbe() { /* ... useEffect(_temp, t0) ... */ }
function _temp() {
  mounts = mounts + 1; // ReferenceError: mounts is not defined
}
```

with no diagnostic — a silent miscompilation that only fails when the effect fires.

A second instance of the same shape: gating ran before outlined insertion. The gating rewrite replaces the declaration statement with a `const`, destroying the scope-id anchor, so gated components' outlined functions always fell to the end-of-program fallback (upstream inserts them during the compile-queue loop, before any replacement, so they land right after the gated `const`).

## Fix

- `ox_insert_outlined_after` locates the declaring statement through a new `InsertOutlinedAfter` mode on the shared `OxcVisitor`, scanning each statement list before descending into it. Top-level originals (the common case) cost the same as before — the target is found in the first list scanned with no descent — and the walk prunes itself once insertion happens. Matching by `scope_id` cell stays sound because `ox_replace_function` mutates originals in place and discovery skips compiled bodies, so the anchor statement is always original AST. The top-level append survives only as a fallback for sloppy-mode annex-B positions (`if (c) function F() {}`).
- Outlined insertion now runs before `ox_apply_gated_conditional`, restoring upstream's sequencing.

Arrow/function-expression originals still append at module scope: upstream does the same (`program.pushContainer('body', ...)`) — including for nested originals, where upstream's own output breaks the same way — and the port reproduces upstream behavior rather than diverging (now documented in the placement comment).

Placement in all three added fixtures (nested declaration = the issue repro, nested block, gating + outlining) is byte-identical to `babel-plugin-react-compiler` built from react @ 22e4f993c7 with matching options; the existing 1310 fixture snapshots are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)