### PR TITLE
fix(codegen): surface conformance reference panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,6 +336,12 @@ lto = "thin" # Faster compile time with thin LTO
 debug-assertions = true # Make sure `debug_assert!`s pass
 overflow-checks = true # Catch arithmetic overflow errors
 
+# Profile for the codegen conformance addon. It catches panics and converts them to JS errors, so
+# it must unwind rather than inherit the release profile's `panic = "abort"` setting.
+[profile.codegen-conformance]
+inherits = "coverage"
+panic = "unwind"
+
 # Profile for linting with release mode-like settings.
 # Catches lint errors which only appear in release mode.
 # `cargo lint --profile dev-no-debug-assertions` is about 35% faster than `cargo lint --release`.

--- a/tasks/codegen_conformance/index.d.ts
+++ b/tasks/codegen_conformance/index.d.ts
@@ -8,6 +8,10 @@
  *
  * Comments are not printed. `oxc-codegen` does not print comments, and the ESTree AST the JS side
  * works from carries no comment data anyway.
+ *
+ * # Errors
+ *
+ * Returns any panics as errors to avoid aborting the whole Node process.
  */
 export declare function codegen(filename: string, sourceText: string, options?: Options | undefined | null): string | null
 

--- a/tasks/codegen_conformance/package.json
+++ b/tasks/codegen_conformance/package.json
@@ -14,8 +14,8 @@
   "main": "index.js",
   "scripts": {
     "build-dev": "napi build --esm --platform",
-    "build-test": "pnpm run build-dev --profile coverage",
-    "build": "pnpm run build-dev --release"
+    "build-test": "pnpm run build-dev --profile codegen-conformance",
+    "build": "pnpm run build-test"
   },
   "devDependencies": {
     "@napi-rs/cli": "catalog:"

--- a/tasks/codegen_conformance/src/lib.rs
+++ b/tasks/codegen_conformance/src/lib.rs
@@ -46,15 +46,25 @@ pub struct Options {
 ///
 /// Comments are not printed. `oxc-codegen` does not print comments, and the ESTree AST the JS side
 /// works from carries no comment data anyway.
+///
+/// # Errors
+///
+/// Returns any panics as errors to avoid aborting the whole Node process.
 #[napi]
-pub fn codegen(filename: String, source_text: String, options: Option<Options>) -> Option<String> {
+#[expect(clippy::allow_attributes)]
+#[allow(clippy::needless_pass_by_value)]
+pub fn codegen(
+    filename: String,
+    source_text: String,
+    options: Option<Options>,
+) -> napi::Result<Option<String>> {
     let options =
         options.unwrap_or(Options { lang: None, source_type: None, preserve_parens: None });
 
     // Oxc should never panic, but a panic in a Node addon aborts the process, which would throw
-    // away a whole conformance run over ~58,000 fixtures. Contain it instead - the fixture is
-    // reported as unprintable, and the run continues.
-    catch_unwind(AssertUnwindSafe(move || {
+    // away the whole conformance run. Contain it, surfacing it as a JS error. `null` is reserved
+    // for source text which could not be parsed cleanly and the JS side skips.
+    catch_unwind(AssertUnwindSafe(|| {
         codegen_impl(
             &filename,
             &source_text,
@@ -63,7 +73,7 @@ pub fn codegen(filename: String, source_text: String, options: Option<Options>) 
             options.preserve_parens.unwrap_or(false),
         )
     }))
-    .unwrap_or(None)
+    .map_err(|_| napi::Error::from_reason(format!("Oxc code generator panicked for {filename}")))
 }
 
 fn codegen_impl(


### PR DESCRIPTION
## Summary

Make Codegen conformance failures visible when the Rust reference panics.

- Preserve `null` for source text with parser diagnostics.
- Return a N-API error for a caught reference panic.
- Let Vitest fail the affected fixture instead of silently skipping it.
