### PR TITLE
feat(oxlint): support multiple output formats

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -276,10 +276,15 @@ pub struct WarningOptions {
 /// Output
 #[derive(Debug, Clone, Bpaf)]
 pub struct OutputOptions {
-    /// Use a specific output format. Possible values:
+    /// Use a specific output format. When `--output-file` is set, this format is written to the
+    /// file and stdout keeps its default format. Possible values:
     /// `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`, `stylish`, `unix`
     #[bpaf(long, short, fallback_with(default_output_format), hide_usage)]
     pub format: OutputFormat,
+
+    /// Write the formatted lint report to a file while keeping the default format on stdout
+    #[bpaf(long("output-file"), short('o'), argument("PATH"), hide_usage)]
+    pub output_file: Option<PathBuf>,
 
     #[bpaf(
         long("debug"),
@@ -289,6 +294,12 @@ pub struct OutputOptions {
         hide_usage
     )]
     pub debug: DebugOptions,
+}
+
+impl OutputOptions {
+    pub fn stdout_format(&self) -> OutputFormat {
+        if self.output_file.is_some() { detected_output_format() } else { self.format }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -369,14 +380,18 @@ impl FromStr for DebugOptions {
 
 #[expect(clippy::unnecessary_wraps)]
 fn default_output_format() -> Result<OutputFormat, std::convert::Infallible> {
+    Ok(detected_output_format())
+}
+
+fn detected_output_format() -> OutputFormat {
     if cfg!(debug_assertions) {
-        Ok(OutputFormat::Default)
+        OutputFormat::Default
     } else if !cfg!(test) && crate::agent_detection::is_agent() {
-        Ok(OutputFormat::Agent)
+        OutputFormat::Agent
     } else if std::env::var("GITHUB_ACTIONS").is_ok_and(|value| value == "true") {
-        Ok(OutputFormat::Github)
+        OutputFormat::Github
     } else {
-        Ok(OutputFormat::Default)
+        OutputFormat::Default
     }
 }
 
@@ -715,6 +730,19 @@ mod lint_options {
 
         let options = get_lint_options("-f agent");
         assert_eq!(options.output_options.format, OutputFormat::Agent);
+    }
+
+    #[test]
+    fn output_file() {
+        let options = get_lint_options("--format json --output-file report.json src");
+        assert_eq!(options.output_options.format, OutputFormat::Json);
+        assert_eq!(options.output_options.output_file, Some(PathBuf::from("report.json")));
+        assert_eq!(options.output_options.stdout_format(), OutputFormat::Default);
+        assert_eq!(options.paths, vec![PathBuf::from("src")]);
+
+        let options = get_lint_options("-f gitlab -o gl-codequality.json src");
+        assert_eq!(options.output_options.format, OutputFormat::Gitlab);
+        assert_eq!(options.output_options.output_file, Some(PathBuf::from("gl-codequality.json")));
     }
 
     #[test]

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -75,10 +75,25 @@ impl CliRunner {
 
     /// # Panics
     pub fn run(self, stdout: &mut dyn Write) -> CliRunResult {
-        let format_str = self.options.output_options.format;
+        let format_str = self.options.output_options.stdout_format();
+        let output_file_format = self.options.output_options.format;
+        let output_file = self
+            .options
+            .output_options
+            .output_file
+            .as_ref()
+            .map(|path| if path.is_absolute() { path.clone() } else { self.cwd.join(path) });
         let debug_files = self.options.output_options.debug.contains(DebugOption::Files);
         let debug_timings = self.options.output_options.debug.contains(DebugOption::Timings);
-        let output_formatter = OutputFormatter::new(format_str);
+        let output_formatter = if output_file.is_some() {
+            OutputFormatter::new_with_additional_output(
+                format_str,
+                output_file_format,
+                self.options.misc_options.silent,
+            )
+        } else {
+            OutputFormatter::new(format_str)
+        };
 
         let LintCommand {
             paths,
@@ -458,6 +473,7 @@ impl CliRunner {
             &warning_options,
             &misc_options,
             max_warnings,
+            output_file.is_some(),
         );
 
         // Send JS plugins config to JS side
@@ -592,6 +608,19 @@ impl CliRunner {
             print_and_flush_stdout(stdout, &end);
         }
 
+        if let Some(output_file) = output_file {
+            let output = output_formatter
+                .take_additional_output()
+                .expect("output formatter should contain the requested file output");
+            if let Err(error) = std::fs::write(&output_file, output) {
+                print_and_flush_stdout(
+                    stdout,
+                    &format!("Failed to write output file '{}': {error}\n", output_file.display()),
+                );
+                return CliRunResult::OutputFileError;
+            }
+        }
+
         // When --suppress-all is used and the file was written successfully,
         // exit with success (matching ESLint behavior: suppressing is a success action).
         if suppress_all_succeeded {
@@ -633,12 +662,13 @@ impl CliRunner {
         warning_options: &WarningOptions,
         misc_options: &MiscOptions,
         max_warnings: Option<usize>,
+        has_additional_output: bool,
     ) -> (DiagnosticService, DiagnosticSender) {
         let (service, sender) = DiagnosticService::new(reporter.get_diagnostic_reporter());
         (
             service
                 .with_quiet(warning_options.quiet)
-                .with_silent(misc_options.silent)
+                .with_silent(misc_options.silent && !has_additional_output)
                 .with_max_warnings(max_warnings),
             sender,
         )
@@ -755,9 +785,13 @@ fn render_config_builder_error(
 
 #[cfg(test)]
 mod test {
-    use std::fs;
+    use std::{fs, path::Path};
 
-    use crate::{DEFAULT_OXLINTRC_NAME, tester::Tester};
+    use crate::{
+        DEFAULT_OXLINTRC_NAME,
+        cli::{CliRunResult, CliRunner, lint_command},
+        tester::Tester,
+    };
     use oxc_linter::rules::RULES;
 
     fn markdown_rule_row<'a>(output: &'a str, plugin: &str, name: &str) -> Vec<&'a str> {
@@ -768,6 +802,122 @@ mod test {
                 (cells.len() == 5 && cells[0] == name && cells[1] == plugin).then_some(cells)
             })
             .unwrap_or_else(|| panic!("Missing rule row for {plugin}/{name}"))
+    }
+
+    fn run_in(cwd: &Path, args: &[&str]) -> (String, CliRunResult) {
+        let options = lint_command().run_inner(args).unwrap();
+        let mut stdout = Vec::new();
+        let result = CliRunner::new(options, None).with_cwd(cwd.to_path_buf()).run(&mut stdout);
+        (String::from_utf8(stdout).unwrap(), result)
+    }
+
+    #[test]
+    fn output_file_keeps_default_stdout() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(temp_dir.path().join("test.js"), "debugger;\n").unwrap();
+
+        let (stdout, result) = run_in(
+            temp_dir.path(),
+            &["--format", "json", "--output-file", "report.json", "-D", "no-debugger", "test.js"],
+        );
+
+        assert!(matches!(result, CliRunResult::LintFoundErrors), "{result:?}\n{stdout}");
+        assert!(stdout.contains("eslint(no-debugger)"), "{stdout}");
+        assert!(!stdout.trim_start().starts_with('{'), "{stdout}");
+
+        let report = fs::read_to_string(temp_dir.path().join("report.json")).unwrap();
+        let report: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert_eq!(report["diagnostics"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn output_file_supports_all_formats() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(temp_dir.path().join("test.js"), "debugger;\n").unwrap();
+
+        for format in [
+            "agent",
+            "checkstyle",
+            "default",
+            "github",
+            "gitlab",
+            "json",
+            "junit",
+            "sarif",
+            "stylish",
+            "unix",
+        ] {
+            let output_file = format!("report.{format}");
+            let (stdout, result) = run_in(
+                temp_dir.path(),
+                &[
+                    "--format",
+                    format,
+                    "--output-file",
+                    &output_file,
+                    "-D",
+                    "no-debugger",
+                    "test.js",
+                ],
+            );
+
+            assert!(matches!(result, CliRunResult::LintFoundErrors), "{format}: {result:?}");
+            assert!(stdout.contains("eslint(no-debugger)"), "{format}: {stdout}");
+            assert!(!fs::read_to_string(temp_dir.path().join(output_file)).unwrap().is_empty());
+        }
+    }
+
+    #[test]
+    fn silent_still_writes_output_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(temp_dir.path().join("test.js"), "debugger;\n").unwrap();
+
+        let (stdout, result) = run_in(
+            temp_dir.path(),
+            &[
+                "--silent",
+                "--format",
+                "json",
+                "--output-file",
+                "report.json",
+                "-D",
+                "no-debugger",
+                "test.js",
+            ],
+        );
+
+        assert!(matches!(result, CliRunResult::LintFoundErrors), "{result:?}\n{stdout}");
+        assert!(!stdout.contains("eslint(no-debugger)"), "{stdout}");
+        let report = fs::read_to_string(temp_dir.path().join("report.json")).unwrap();
+        let report: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert_eq!(report["diagnostics"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn output_file_write_failure_is_an_error() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs::write(temp_dir.path().join("test.js"), "debugger;\n").unwrap();
+
+        let (stdout, result) = run_in(
+            temp_dir.path(),
+            &["--format", "json", "--output-file", "missing/report.json", "test.js"],
+        );
+
+        assert!(matches!(result, CliRunResult::OutputFileError), "{result:?}\n{stdout}");
+        assert!(stdout.contains("Failed to write output file"), "{stdout}");
+    }
+
+    #[test]
+    fn early_exit_does_not_create_output_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let (_, result) = run_in(
+            temp_dir.path(),
+            &["--format", "json", "--output-file", "report.json", "missing.js"],
+        );
+
+        assert!(matches!(result, CliRunResult::LintNoFilesFound), "{result:?}");
+        assert!(!temp_dir.path().join("report.json").exists());
     }
 
     // lints the full directory of fixtures,

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -10,23 +10,35 @@ mod stylish;
 mod unix;
 mod xml_utils;
 
-use std::str::FromStr;
-use std::time::Duration;
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    error::Error as StdError,
+    fmt::{self, Debug, Display},
+    rc::Rc,
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
+
+use oxc_diagnostics::{
+    Diagnostic, Error, SourceCode,
+    reporter::{DiagnosticReporter, DiagnosticResult},
+};
+use oxc_linter::{OxlintSuppressionFileAction, RuleTimingRecord};
+use oxc_span::LabeledSpan;
+use rustc_hash::FxHashSet;
+
+use crate::output_formatter::{default::DefaultOutputFormatter, json::JsonOutputFormatter};
 
 use agent::AgentOutputFormatter;
 use checkstyle::CheckStyleOutputFormatter;
 use github::GithubOutputFormatter;
 use gitlab::GitlabOutputFormatter;
 use junit::JUnitOutputFormatter;
-use oxc_linter::{OxlintSuppressionFileAction, RuleTimingRecord};
-use rustc_hash::FxHashSet;
 use sarif::SarifOutputFormatter;
 use stylish::StylishOutputFormatter;
 use unix::UnixOutputFormatter;
-
-use oxc_diagnostics::reporter::DiagnosticReporter;
-
-use crate::output_formatter::{default::DefaultOutputFormatter, json::JsonOutputFormatter};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum OutputFormat {
@@ -146,11 +158,33 @@ trait InternalFormatter {
 
 pub struct OutputFormatter {
     internal: Box<dyn InternalFormatter>,
+    additional: Option<AdditionalOutputFormatter>,
+}
+
+struct AdditionalOutputFormatter {
+    internal: Box<dyn InternalFormatter>,
+    output: Rc<RefCell<String>>,
+    silent_primary: bool,
 }
 
 impl OutputFormatter {
     pub fn new(format: OutputFormat) -> Self {
-        Self { internal: Self::get_internal_formatter(format) }
+        Self { internal: Self::get_internal_formatter(format), additional: None }
+    }
+
+    pub fn new_with_additional_output(
+        format: OutputFormat,
+        additional_format: OutputFormat,
+        silent_primary: bool,
+    ) -> Self {
+        Self {
+            internal: Self::get_internal_formatter(format),
+            additional: Some(AdditionalOutputFormatter {
+                internal: Self::get_internal_formatter(additional_format),
+                output: Rc::default(),
+                silent_primary,
+            }),
+        }
     }
 
     fn get_internal_formatter(format: OutputFormat) -> Box<dyn InternalFormatter> {
@@ -176,21 +210,179 @@ impl OutputFormatter {
 
     /// At the end of the Lint command we may output extra information.
     pub fn lint_command_info(&self, lint_command_info: &LintCommandInfo) -> Option<String> {
+        if let Some(additional) = &self.additional
+            && let Some(output) = additional.internal.lint_command_info(lint_command_info)
+        {
+            additional.output.borrow_mut().push_str(&output);
+        }
         self.internal.lint_command_info(lint_command_info)
     }
 
     /// Returns the [`DiagnosticReporter`] which then will be used by [`DiagnosticService`](oxc_diagnostics::DiagnosticService)
     /// See [`InternalFormatter::get_diagnostic_reporter`] for more details.
     pub fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {
-        self.internal.get_diagnostic_reporter()
+        let primary = self.internal.get_diagnostic_reporter();
+        if let Some(additional) = &self.additional {
+            Box::new(AdditionalOutputReporter {
+                primary,
+                additional: additional.internal.get_diagnostic_reporter(),
+                output: Rc::clone(&additional.output),
+                silent_primary: additional.silent_primary,
+            })
+        } else {
+            primary
+        }
+    }
+
+    pub fn take_additional_output(&self) -> Option<String> {
+        self.additional.as_ref().map(|additional| {
+            let mut output = additional.output.borrow_mut();
+            std::mem::take(&mut *output)
+        })
+    }
+}
+
+struct AdditionalOutputReporter {
+    primary: Box<dyn DiagnosticReporter>,
+    additional: Box<dyn DiagnosticReporter>,
+    output: Rc<RefCell<String>>,
+    silent_primary: bool,
+}
+
+impl DiagnosticReporter for AdditionalOutputReporter {
+    fn finish(&mut self, result: &DiagnosticResult) -> Option<String> {
+        if let Some(output) = self.additional.finish(result) {
+            self.output.borrow_mut().push_str(&output);
+        }
+
+        self.primary.finish(result)
+    }
+
+    fn supports_minified_file_fallback(&self) -> bool {
+        // The additional formatter must receive every original diagnostic. The service-level
+        // fallback replaces diagnostics based on primary output and can make the file incomplete.
+        false
+    }
+
+    fn render_error(&mut self, error: Error) -> Option<String> {
+        let error: Arc<dyn Diagnostic + Send + Sync> = error.into();
+        let primary_output = if self.silent_primary {
+            None
+        } else {
+            self.primary.render_error(Box::new(SharedDiagnostic(Arc::clone(&error))))
+        };
+
+        if let Some(output) = self.additional.render_error(Box::new(SharedDiagnostic(error))) {
+            self.output.borrow_mut().push_str(&output);
+        }
+
+        primary_output
+    }
+}
+
+struct SharedDiagnostic(Arc<dyn Diagnostic + Send + Sync>);
+
+impl Debug for SharedDiagnostic {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(self.0.as_ref(), formatter)
+    }
+}
+
+impl Display for SharedDiagnostic {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(self.0.as_ref(), formatter)
+    }
+}
+
+impl StdError for SharedDiagnostic {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.0.source()
+    }
+}
+
+impl Diagnostic for SharedDiagnostic {
+    fn code(&self) -> Option<Cow<'_, str>> {
+        self.0.code()
+    }
+
+    fn severity(&self) -> Option<oxc_diagnostics::Severity> {
+        self.0.severity()
+    }
+
+    fn help(&self) -> Option<Cow<'_, str>> {
+        self.0.help()
+    }
+
+    fn note(&self) -> Option<Cow<'_, str>> {
+        self.0.note()
+    }
+
+    fn url(&self) -> Option<Cow<'_, str>> {
+        self.0.url()
+    }
+
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        self.0.source_code()
+    }
+
+    fn labels(&self) -> &[LabeledSpan] {
+        self.0.labels()
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::tester::Tester;
+    use std::time::Duration;
+
+    use oxc_diagnostics::{DiagnosticService, NamedSource, OxcDiagnostic};
+    use oxc_linter::OxlintSuppressionFileAction;
+    use oxc_span::Span;
+
+    use crate::{
+        output_formatter::{LintCommandInfo, OutputFormat, OutputFormatter},
+        tester::Tester,
+    };
 
     const TEST_CWD: &str = "fixtures/cli/output_formatter_diagnostic";
+
+    #[test]
+    fn writes_the_same_diagnostic_in_two_formats() {
+        let formatter = OutputFormatter::new_with_additional_output(
+            OutputFormat::Default,
+            OutputFormat::Json,
+            false,
+        );
+        let (mut service, sender) = DiagnosticService::new(formatter.get_diagnostic_reporter());
+        sender
+            .send(vec![
+                OxcDiagnostic::warn("test warning")
+                    .with_label(Span::new(0, 8))
+                    .with_source_code(NamedSource::new("test.js", "debugger;")),
+            ])
+            .unwrap();
+        drop(sender);
+
+        let mut stdout = Vec::new();
+        service.run(&mut stdout);
+        let info = LintCommandInfo {
+            number_of_files: 1,
+            number_of_rules: Some(1),
+            threads_count: 1,
+            start_time: Duration::ZERO,
+            oxlint_suppression_file_action: OxlintSuppressionFileAction::None,
+            rule_timings: None,
+        };
+        stdout.extend(formatter.lint_command_info(&info).unwrap().bytes());
+
+        let stdout = String::from_utf8(stdout).unwrap();
+        assert!(stdout.contains("test warning"));
+
+        let additional = formatter.take_additional_output().unwrap();
+        let report: serde_json::Value = serde_json::from_str(&additional).unwrap();
+        let diagnostics = report["diagnostics"].as_array().unwrap();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0]["message"], "test warning");
+    }
 
     #[test]
     fn test_output_formatter_diagnostic_formats() {

--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -22,6 +22,7 @@ pub enum CliRunResult {
     ConfigFileInitFailed,
     ConfigFileInitSucceeded,
     TsGoLintError,
+    OutputFileError,
 }
 
 impl Termination for CliRunResult {
@@ -46,7 +47,8 @@ impl Termination for CliRunResult {
             | Self::InvalidOptionSeverityWithoutPluginName
             | Self::InvalidOptionSeverityWithoutRuleName
             | Self::LintUnprunedSuppressions
-            | Self::TsGoLintError => ExitCode::FAILURE,
+            | Self::TsGoLintError
+            | Self::OutputFileError => ExitCode::FAILURE,
         }
     }
 }

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -120,7 +120,9 @@ Arguments:
 
 ## Output
 - **`-f`**, **`--format`**=_`ARG`_ &mdash; 
-  Use a specific output format. Possible values: `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`, `stylish`, `unix`
+  Use a specific output format. When `--output-file` is set, this format is written to the file and stdout keeps its default format. Possible values: `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`, `stylish`, `unix`
+- **`-o`**, **`--output-file`**=_`PATH`_ &mdash; 
+  Write the formatted lint report to a file while keeping the default format on stdout
 - **`    --debug`**=_`OPTIONS`_ &mdash; 
   Enable debug output options. Options are comma-separated. Possible values:
  * `files` - Print the list of files that will be linted, then exit.

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -72,9 +72,12 @@ Handle Warnings
                               your project
 
 Output
-    -f, --format=ARG          Use a specific output format. Possible values: `checkstyle`,
-                              `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`,
-                              `stylish`, `unix`
+    -f, --format=ARG          Use a specific output format. When `--output-file` is set, this format
+                              is written to the file and stdout keeps its default format. Possible
+                              values: `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`,
+                              `junit`, `sarif`, `stylish`, `unix`
+    -o, --output-file=PATH    Write the formatted lint report to a file while keeping the default
+                              format on stdout
         --debug=OPTIONS       Enable debug output options. Options are comma-separated. Possible
                               values:
                                * `files` - Print the list of files that will be linted, then exit.


### PR DESCRIPTION
## Summary

- add `--output-file PATH` and `-o PATH` to Oxlint
- keep the detected human-readable format on stdout while writing the selected `--format` to the file
- support all existing output formats without changing the public diagnostic reporter API
- report output-file write failures and avoid creating the file on early lint failures

This supports local terminal output and machine-readable CI artifacts from one lint run.

Closes #21574.

## Validation

- `cargo test -p oxlint`
- `cargo test -p website_linter cli`
- `cargo fmt --all -- --check`
- manual human-output plus JSON-file run
- `env -u NO_COLOR fnm exec --using 26.5.0 just ready`: formatting, code generation, dependency checks, workspace checks, and the complete all-feature test suite pass. The final warnings-as-errors lint stage stops on the existing `unused-unsafe` warning in `crates/oxc_ecmascript/src/to_int_32.rs`.

## AI assistance

OpenAI Codex was used to implement and test this change. The human contributor remains responsible for reviewing and understanding the code before the pull request is marked ready.