### PR TITLE
chore(codegen,parser,tasks): pin benchmark fixtures by sha

### DIFF
--- a/napi/parser/bench.bench.js
+++ b/napi/parser/bench.bench.js
@@ -17,7 +17,7 @@ import { getVisitorsArr, Visitor } from "./src-js/raw-transfer/visitor.js";
 let fixtureUrls = [
   "https://cdn.jsdelivr.net/gh/microsoft/TypeScript@v5.3.3/src/compiler/checker.ts",
   "https://cdn.jsdelivr.net/gh/excalidraw/excalidraw@f6d85bc80fe328e8f472636eb0d541f7bb891aa0/packages/excalidraw/components/App.tsx",
-  "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx",
+  "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@cd3bc3d431452b640f5dfcabbc22a8d8a388f393/RadixUIAdoptionSection.jsx",
   "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs",
   "https://cdn.jsdelivr.net/npm/antd@4.16.1/dist/antd.js",
 ];

--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -80,7 +80,7 @@ const benchFixtureUrls = [
   // Real world app tsx (415KB) — excalidraw App.tsx (master @ f6d85bc8)
   "https://cdn.jsdelivr.net/gh/excalidraw/excalidraw@f6d85bc80fe328e8f472636eb0d541f7bb891aa0/packages/excalidraw/components/App.tsx",
   // Real world content-heavy app jsx (3K)
-  "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx",
+  "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@cd3bc3d431452b640f5dfcabbc22a8d8a388f393/RadixUIAdoptionSection.jsx",
   // Heavy with classes (554K)
   "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs",
   // ES5 (3.9M)

--- a/packages/codegen/bench.bench.ts
+++ b/packages/codegen/bench.bench.ts
@@ -17,11 +17,11 @@ import { printSync as oxcPrintSync } from "./dist/index.js";
 // `TestFiles::minimal()` from `tasks/common/src/test_file.rs`, which the Rust `codegen` benchmark
 // uses, plus 2 larger pure-JS files from `TestFiles::minifier()` for throughput on real bundles.
 const FIXTURE_URLS = [
-  "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx",
+  "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@cd3bc3d431452b640f5dfcabbc22a8d8a388f393/RadixUIAdoptionSection.jsx",
   "https://cdn.jsdelivr.net/npm/react@17.0.2/cjs/react.development.js",
   "https://cdn.jsdelivr.net/gh/excalidraw/excalidraw@f6d85bc80fe328e8f472636eb0d541f7bb891aa0/packages/excalidraw/components/App.tsx",
   "https://cdn.jsdelivr.net/gh/microsoft/TypeScript@v5.3.3/src/compiler/binder.ts",
-  "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@ac5609a8fe9ae8d1a1de0f2ef251d562630c77e0/kitchen-sink.tsx",
+  "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@cd3bc3d431452b640f5dfcabbc22a8d8a388f393/kitchen-sink.tsx",
   "https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.js",
   "https://cdn.jsdelivr.net/npm/antd@4.16.1/dist/antd.js",
 ];

--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -38,7 +38,7 @@ impl TestFiles {
         Self {
             files: [
                 // Small JSX (61L / 2.46KB)
-                "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx",
+                "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@cd3bc3d431452b640f5dfcabbc22a8d8a388f393/RadixUIAdoptionSection.jsx",
                 // Small TS (191L / 8.23KB)
                 "https://cdn.jsdelivr.net/gh/vuejs/core@v3.5.24/packages/compiler-core/src/errors.ts",
                 // Medium TSX (389L / 11.7KB)
@@ -62,7 +62,7 @@ impl TestFiles {
     pub fn minimal() -> Self {
         Self {
             files: [
-                "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx",
+                "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@cd3bc3d431452b640f5dfcabbc22a8d8a388f393/RadixUIAdoptionSection.jsx",
                 "https://cdn.jsdelivr.net/npm/react@17.0.2/cjs/react.development.js",
                 // Real world app tsx (415KB) — excalidraw App.tsx (master @ f6d85bc8)
                 "https://cdn.jsdelivr.net/gh/excalidraw/excalidraw@f6d85bc80fe328e8f472636eb0d541f7bb891aa0/packages/excalidraw/components/App.tsx",
@@ -72,7 +72,7 @@ impl TestFiles {
                 // bench results are reproducible. To bump, update both call sites and re-run
                 // `cargo allocs`.
                 // <https://github.com/oxc-project/benchmark-files/blob/main/kitchen-sink.tsx>
-                "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@ac5609a8fe9ae8d1a1de0f2ef251d562630c77e0/kitchen-sink.tsx",
+                "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@cd3bc3d431452b640f5dfcabbc22a8d8a388f393/kitchen-sink.tsx",
             ].into_iter().map(TestFile::new).collect(),
         }
     }
@@ -85,7 +85,7 @@ impl TestFiles {
                 // Real world app tsx (415KB) — excalidraw App.tsx (master @ f6d85bc8)
                 "https://cdn.jsdelivr.net/gh/excalidraw/excalidraw@f6d85bc80fe328e8f472636eb0d541f7bb891aa0/packages/excalidraw/components/App.tsx",
                 // Real world content-heavy app jsx (3K)
-                "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@main/RadixUIAdoptionSection.jsx",
+                "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@cd3bc3d431452b640f5dfcabbc22a8d8a388f393/RadixUIAdoptionSection.jsx",
                 // Heavy with classes (554K)
                 "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs",
                 // ES5 (6.7M)
@@ -95,7 +95,7 @@ impl TestFiles {
                 // Hand-written synthetic fixture covering every AST node, transformer plugin,
                 // minifier optimization, and semantic step (~733K, ~21k lines, ~133k AST nodes)
                 // — pinned for reproducibility.
-                "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@ac5609a8fe9ae8d1a1de0f2ef251d562630c77e0/kitchen-sink.tsx",
+                "https://cdn.jsdelivr.net/gh/oxc-project/benchmark-files@cd3bc3d431452b640f5dfcabbc22a8d8a388f393/kitchen-sink.tsx",
             ].into_iter().map(TestFile::new).collect(),
         }
     }


### PR DESCRIPTION
Pin the Codegen benchmark fixture to an immutable `benchmark-files` commit. This makes benchmark inputs reproducible and prevents `main` updates from silently changing results.
