### PR TITLE
fix(linter/plugins): parse rule-less directive justifications

### DIFF
--- a/apps/oxlint/src-js/plugins/directives.ts
+++ b/apps/oxlint/src-js/plugins/directives.ts
@@ -47,7 +47,12 @@ export function getDisableDirectives(): { problems: Problem[]; directives: Direc
   for (; i < comments.length; i++) {
     const comment = comments[i];
 
-    const match = LABEL_PATTERN.exec(comment.value);
+    const sepMatch = JUSTIFICATION_SEP_PATTERN.exec(comment.value);
+    const directivePart = (
+      sepMatch === null ? comment.value : comment.value.slice(0, sepMatch.index)
+    ).trim();
+
+    const match = LABEL_PATTERN.exec(directivePart);
     if (match === null) continue;
 
     const label = match[1];
@@ -63,16 +68,9 @@ export function getDisableDirectives(): { problems: Problem[]; directives: Direc
       continue;
     }
 
-    // Split text after the directive into rule list and justification (`rules -- justification`)
-    const rest = comment.value.slice(match[0].length).trim();
-    const sepMatch = JUSTIFICATION_SEP_PATTERN.exec(rest);
-
-    let value = rest;
-    let justification = "";
-    if (sepMatch !== null) {
-      value = rest.slice(0, sepMatch.index).trim();
-      justification = rest.slice(sepMatch.index + sepMatch[0].length).trim();
-    }
+    const value = directivePart.slice(match[0].length).trim();
+    const justification =
+      sepMatch === null ? "" : comment.value.slice(sepMatch.index + sepMatch[0].length).trim();
 
     directives.push({ type, node: comment, value, justification });
   }

--- a/apps/oxlint/test/fixtures/getDisableDirectives/files/test.js
+++ b/apps/oxlint/test/fixtures/getDisableDirectives/files/test.js
@@ -24,3 +24,12 @@ let g;
 let h;
 /* oxlint-enable no-unused-vars */
 /* eslint-enable no-unused-vars */
+
+/* oxlint-disable -- rule-less oxlint block */
+/* oxlint-enable -- rule-less oxlint enable */
+/* eslint-disable -- rule-less eslint block */
+/* eslint-enable -- rule-less eslint enable */
+// oxlint-disable-next-line -- rule-less oxlint next-line
+// eslint-disable-next-line -- rule-less eslint next-line
+// oxlint-disable-line -- rule-less oxlint line
+// eslint-disable-line -- rule-less eslint line

--- a/apps/oxlint/test/fixtures/getDisableDirectives/output.snap.md
+++ b/apps/oxlint/test/fixtures/getDisableDirectives/output.snap.md
@@ -4,39 +4,17 @@
 # stdout
 ```
   x get-disable-directives-plugin(get-disable-directives): getDisableDirectives:
-  |   total: 12
-  |   block: 6
-  |   line: 2
-  |   next-line: 2
-  |   enable: 2
-    ,-[files/test.js:2:1]
-  1 |     // oxlint-disable no-unused-vars
-  2 | ,-> let a;
-  3 | |   
-  4 | |   // eslint-disable no-unused-vars
-  5 | |   let b;
-  6 | |   
-  7 | |   // oxlint-disable-next-line no-console
-  8 | |   console.log("test");
-  9 | |   
- 10 | |   // eslint-disable-next-line no-console
- 11 | |   console.log("test2");
- 12 | |   
- 13 | |   let c; // oxlint-disable-line no-unused-vars
- 14 | |   let d; // eslint-disable-line no-unused-vars
- 15 | |   
- 16 | |   // eslint-disable no-foo -- justification for disabling no-foo
- 17 | |   // oxlint-disable no-bar -- justification for disabling no-bar
- 18 | |   let e;
- 19 | |   let f;
- 20 | |   
- 21 | |   /* oxlint-disable no-unused-vars */
- 22 | |   /* eslint-disable no-unused-vars */
- 23 | |   let g;
- 24 | |   let h;
- 25 | |   /* oxlint-enable no-unused-vars */
- 26 | `-> /* eslint-enable no-unused-vars */
-    `----
+  |   total: 20
+  |   block: 8
+  |   line: 4
+  |   next-line: 4
+  |   enable: 4
+   ,-[files/test.js:2:1]
+ 1 | // oxlint-disable no-unused-vars
+ 2 | let a;
+   : ^^^^^^
+ 3 | 
+   `----
 
 Found 0 warnings and 1 error.
 Finished in Xms on 1 file with 97 rules using X threads.

--- a/apps/oxlint/test/fixtures/getDisableDirectives/plugin.ts
+++ b/apps/oxlint/test/fixtures/getDisableDirectives/plugin.ts
@@ -34,6 +34,21 @@ const rule: Rule = {
     assert(nextLineDirectivesCount > 0, "Expected next-line directives");
     assert(enableDirectivesCount > 0, "Expected enable directives");
 
+    const expectedRulelessDirectives = [
+      { type: "disable", value: "", justification: "rule-less oxlint block" },
+      { type: "enable", value: "", justification: "rule-less oxlint enable" },
+      { type: "disable", value: "", justification: "rule-less eslint block" },
+      { type: "enable", value: "", justification: "rule-less eslint enable" },
+      { type: "disable-next-line", value: "", justification: "rule-less oxlint next-line" },
+      { type: "disable-next-line", value: "", justification: "rule-less eslint next-line" },
+      { type: "disable-line", value: "", justification: "rule-less oxlint line" },
+      { type: "disable-line", value: "", justification: "rule-less eslint line" },
+    ];
+    const rulelessDirectives = directives
+      .filter(({ justification }) => justification.startsWith("rule-less"))
+      .map(({ type, value, justification }) => ({ type, value, justification }));
+    assert.deepStrictEqual(rulelessDirectives, expectedRulelessDirectives);
+
     // Test that all directives have required fields
     for (const directive of directives) {
       assert(
@@ -52,7 +67,7 @@ const rule: Rule = {
         `  line: ${lineDirectivesCount}\n` +
         `  next-line: ${nextLineDirectivesCount}\n` +
         `  enable: ${enableDirectivesCount}`,
-      node: sourceCode.ast,
+      node: sourceCode.ast.body[0],
     });
 
     return {};


### PR DESCRIPTION
## Summary

- extract directive justifications before parsing directive labels, matching ESLint
- return an empty rule value for rule-less directives while preserving their justification
- cover block, enable, line, and next-line directives with both eslint and oxlint prefixes

Closes #25556