### PR TITLE
test(codegen): clarify raw transfer Node requirement

### DIFF
--- a/packages/codegen/test/utils/common.ts
+++ b/packages/codegen/test/utils/common.ts
@@ -87,6 +87,8 @@ export function checkFixture(
       lang,
       sourceType,
       astType,
+      // This conformance harness requires Node.js 22+ for `experimentalRawTransfer`.
+      // `oxc-codegen` itself still supports Node.js 20 with ordinary parser ASTs.
       // @ts-expect-error `experimentalRawTransfer` is experimental, so is not in `ParserOptions`
       experimentalRawTransfer: true,
     });


### PR DESCRIPTION
## Summary

- Clarify that this conformance harness needs Node.js 22+ for experimentalRawTransfer.
- Note that this does not affect oxc-codegen Node.js 20 support for ordinary parser ASTs.

## Testing

- git diff --check

## AI usage

This pull request was prepared with assistance from OpenAI Codex. I reviewed the change and take full responsibility for it.