### PR TITLE
feat(minifier): POC collpase nested branches in block stmts

### DIFF
--- a/crates/oxc_minifier/src/generated/ancestor.rs
+++ b/crates/oxc_minifier/src/generated/ancestor.rs
@@ -2780,6 +2780,14 @@ impl<'a, 't> ProgramWithoutBody<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_PROGRAM_SCOPE_ID) as *const Cell<Option<ScopeId>>)
         }
     }
+
+    #[inline]
+    pub fn last_statement_address(self) -> Option<Address> {
+        let statements = unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_BODY) as *const ArenaVec<'a, Statement<'a>>)
+        };
+        statements.last().map(GetAddress::address)
+    }
 }
 
 impl<'a, 't> GetAddress for ProgramWithoutBody<'a, 't> {
@@ -5155,6 +5163,15 @@ impl<'a, 't> BlockStatementWithoutBody<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_BLOCK_STATEMENT_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+
+    #[inline]
+    pub fn last_statement_address(self) -> Option<Address> {
+        let statements = unsafe {
+            &*((self.0 as *const u8).add(OFFSET_BLOCK_STATEMENT_BODY)
+                as *const ArenaVec<'a, Statement<'a>>)
+        };
+        statements.last().map(GetAddress::address)
     }
 }
 
@@ -8640,6 +8657,15 @@ impl<'a, 't> FunctionBodyWithoutStatements<'a, 't> {
                 as *const ArenaVec<'a, Directive<'a>>)
         }
     }
+
+    #[inline]
+    pub fn last_statement_address(self) -> Option<Address> {
+        let statements = unsafe {
+            &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY_STATEMENTS)
+                as *const ArenaVec<'a, Statement<'a>>)
+        };
+        statements.last().map(GetAddress::address)
+    }
 }
 
 impl<'a, 't> GetAddress for FunctionBodyWithoutStatements<'a, 't> {
@@ -10388,6 +10414,15 @@ impl<'a, 't> StaticBlockWithoutBody<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_STATIC_BLOCK_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+
+    #[inline]
+    pub fn last_statement_address(self) -> Option<Address> {
+        let statements = unsafe {
+            &*((self.0 as *const u8).add(OFFSET_STATIC_BLOCK_BODY)
+                as *const ArenaVec<'a, Statement<'a>>)
+        };
+        statements.last().map(GetAddress::address)
     }
 }
 
@@ -16526,6 +16561,15 @@ impl<'a, 't> TSModuleBlockWithoutBody<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_MODULE_BLOCK_DIRECTIVES)
                 as *const ArenaVec<'a, Directive<'a>>)
         }
+    }
+
+    #[inline]
+    pub fn last_statement_address(self) -> Option<Address> {
+        let statements = unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_MODULE_BLOCK_BODY)
+                as *const ArenaVec<'a, Statement<'a>>)
+        };
+        statements.last().map(GetAddress::address)
     }
 }
 

--- a/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
@@ -1,12 +1,12 @@
-use oxc_allocator::TakeIn;
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::ast::*;
 
+use super::PeepholeOptimizations;
+use crate::TraverseCtx;
+use crate::generated::ancestor::Ancestor;
+use crate::is_terminated::IsTerminated;
 use oxc_semantic::ScopeFlags;
 use oxc_span::GetSpan;
-
-use crate::TraverseCtx;
-
-use super::PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
     /// `MangleIf`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_parser/js_parser.go#L9860>
@@ -127,6 +127,50 @@ impl<'a> PeepholeOptimizations {
             Statement::BlockStatement(block_stmt) if block_stmt.body.is_empty() => true,
             Statement::EmptyStatement(_) => true,
             _ => false,
+        }
+    }
+
+    /// Returns true when the current statement position accepts only a single
+    /// statement, so rewriting to multiple statements requires a block wrapper.
+    fn parent_requires_single_statement(ctx: &TraverseCtx<'a>) -> bool {
+        matches!(
+            ctx.parent(),
+            Ancestor::ForStatementBody(_)
+                | Ancestor::ForInStatementBody(_)
+                | Ancestor::ForOfStatementBody(_)
+                | Ancestor::WhileStatementBody(_)
+                | Ancestor::DoWhileStatementBody(_)
+                | Ancestor::IfStatementConsequent(_)
+                | Ancestor::IfStatementAlternate(_)
+                | Ancestor::LabeledStatementBody(_)
+        )
+    }
+
+    /// Turns `if (test) terminated; else stmt` into an `if` statement followed by
+    /// `stmt` when the `else` branch can be moved out without changing scope
+    /// behavior.
+    pub fn try_unfold_if_else(stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+        if let Statement::IfStatement(if_stmt) = stmt
+            && Self::parent_requires_single_statement(ctx)
+            && !if_stmt.alternate.as_ref().is_none_or(Self::statement_cares_about_scope)
+            && if_stmt.consequent.is_terminated()
+            && let Some(alternate) = if_stmt.alternate.take()
+        {
+            let new_stmts = match alternate {
+                Statement::BlockStatement(block_stmt)
+                    if !block_stmt.body.iter().any(Self::statement_cares_about_scope) =>
+                {
+                    let mut new_stmts = ArenaVec::from_value_in(stmt.take_in(ctx), ctx);
+                    new_stmts.append(&mut block_stmt.unbox().body);
+                    new_stmts
+                }
+                alternate => ArenaVec::from_array_in([stmt.take_in(ctx), alternate], ctx),
+            };
+
+            let scope_id = ctx.create_child_scope_of_current(ScopeFlags::empty());
+            let new_stmt =
+                Statement::new_block_statement_with_scope_id(stmt.span(), new_stmts, scope_id, ctx);
+            ctx.replace_statement(stmt, new_stmt);
         }
     }
 }

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -105,7 +105,7 @@ impl<'a> PeepholeOptimizations {
 
         // Drop a trailing unconditional jump statement if applicable
         if let Some(last_stmt) = stmts.last()
-            && Self::can_remove_termination_statement(last_stmt, ctx)
+            && Self::can_remove_termination_statement(last_stmt, true, ctx)
         {
             let dropped = stmts.pop().unwrap();
             ctx.drop_statement(&dropped);
@@ -610,7 +610,7 @@ impl<'a> PeepholeOptimizations {
                     ctx.drop_statement(&previous.consequent);
                 }
 
-                if Self::can_remove_termination_statement(&if_stmt.consequent, ctx) {
+                if Self::can_remove_termination_statement(&if_stmt.consequent, true, ctx) {
                     // Don't do this transformation if the branch condition could
                     // potentially access symbols declared later on on this scope below.
                     // If so, inverting the branch condition and nesting statements after
@@ -1935,10 +1935,16 @@ impl<'a> PeepholeOptimizations {
     /// - Bare `return` statements that terminate a function body
     /// - Unlabeled `break` statements that terminate a `do...while` body whose test is statically `false`
     ///
+    /// skip_first_transparent_body: is used to ignore the first block Statement if we checked it before
+    ///
     /// Limitations:
     /// A single wrapping block is also transparent (caller guarantees it is the last statement),
     /// but deeper nested block (statements) are not — we cannot verify they are last in their parent.
-    fn can_remove_termination_statement(stmt: &Statement<'a>, ctx: &TraverseCtx<'a>) -> bool {
+    pub fn can_remove_termination_statement(
+        stmt: &Statement<'a>,
+        skip_first_transparent_body: bool,
+        ctx: &TraverseCtx<'a>,
+    ) -> bool {
         match stmt {
             // unlabeled `continue;` that terminates a `for`, `for...in`, `for...of`, `while`, `do...while` body.
             Statement::ContinueStatement(stmt) if stmt.label.is_none() => {
@@ -1951,7 +1957,8 @@ impl<'a> PeepholeOptimizations {
                         | Ancestor::DoWhileStatementBody(_) => {
                             return true;
                         }
-                        Ancestor::BlockStatementBody(_) if index == 0 => {}
+                        Ancestor::BlockStatementBody(_)
+                            if skip_first_transparent_body && index == 0 => {}
                         Ancestor::IfStatementConsequent(_)
                         | Ancestor::IfStatementAlternate(_)
                         | Ancestor::LabeledStatementBody(_) => {}
@@ -1967,7 +1974,8 @@ impl<'a> PeepholeOptimizations {
                         Ancestor::DoWhileStatementBody(do_while) => {
                             return do_while.test().get_side_free_boolean_value(ctx) == Some(false);
                         }
-                        Ancestor::BlockStatementBody(_) if index == 0 => {}
+                        Ancestor::BlockStatementBody(_)
+                            if skip_first_transparent_body && index == 0 => {}
                         Ancestor::IfStatementConsequent(_)
                         | Ancestor::IfStatementAlternate(_)
                         | Ancestor::LabeledStatementBody(_) => {}

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1968,17 +1968,21 @@ impl<'a> PeepholeOptimizations {
                 false
             }
             // unlabeled `break;` that terminates a `do...while` body if test is false.
-            Statement::BreakStatement(stmt) if stmt.label.is_none() => {
+            Statement::BreakStatement(stmt) => {
                 for (index, ancestor) in ctx.ancestors().enumerate() {
                     match ancestor {
                         Ancestor::DoWhileStatementBody(do_while) => {
-                            return do_while.test().get_side_free_boolean_value(ctx) == Some(false);
+                            return stmt.label.is_none()
+                                && do_while.test().get_side_free_boolean_value(ctx) == Some(false);
                         }
                         Ancestor::BlockStatementBody(_)
                             if skip_first_transparent_body && index == 0 => {}
-                        Ancestor::IfStatementConsequent(_)
-                        | Ancestor::IfStatementAlternate(_)
-                        | Ancestor::LabeledStatementBody(_) => {}
+                        Ancestor::LabeledStatementBody(label_stmt) => {
+                            if let Some(label) = &stmt.label {
+                                return label.name == label_stmt.label().name;
+                            }
+                        }
+                        Ancestor::IfStatementConsequent(_) | Ancestor::IfStatementAlternate(_) => {}
                         _ => return false,
                     }
                 }

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1933,29 +1933,48 @@ impl<'a> PeepholeOptimizations {
     /// safely removed:
     /// - Unlabeled `continue` statements that terminate a loop body
     /// - Bare `return` statements that terminate a function body
+    /// - Unlabeled `break` statements that terminate a `do...while` body whose test is statically `false`
+    ///
+    /// Limitations:
+    /// A single wrapping block is also transparent (caller guarantees it is the last statement),
+    /// but deeper nested block (statements) are not — we cannot verify they are last in their parent.
     fn can_remove_termination_statement(stmt: &Statement<'a>, ctx: &TraverseCtx<'a>) -> bool {
         match stmt {
             // unlabeled `continue;` that terminates a `for`, `for...in`, `for...of`, `while`, `do...while` body.
             Statement::ContinueStatement(stmt) if stmt.label.is_none() => {
-                matches!(
-                    ctx.ancestors().nth(1),
-                    Some(
+                for (index, ancestor) in ctx.ancestors().enumerate() {
+                    match ancestor {
                         Ancestor::ForStatementBody(_)
-                            | Ancestor::ForInStatementBody(_)
-                            | Ancestor::ForOfStatementBody(_)
-                            | Ancestor::WhileStatementBody(_)
-                            | Ancestor::DoWhileStatementBody(_)
-                    )
-                )
+                        | Ancestor::ForInStatementBody(_)
+                        | Ancestor::ForOfStatementBody(_)
+                        | Ancestor::WhileStatementBody(_)
+                        | Ancestor::DoWhileStatementBody(_) => {
+                            return true;
+                        }
+                        Ancestor::BlockStatementBody(_) if index == 0 => {}
+                        Ancestor::IfStatementConsequent(_)
+                        | Ancestor::IfStatementAlternate(_)
+                        | Ancestor::LabeledStatementBody(_) => {}
+                        _ => return false,
+                    }
+                }
+                false
             }
             // unlabeled `break;` that terminates a `do...while` body if test is false.
             Statement::BreakStatement(stmt) if stmt.label.is_none() => {
-                match ctx.ancestors().nth(1) {
-                    Some(Ancestor::DoWhileStatementBody(do_while)) => {
-                        do_while.test().get_side_free_boolean_value(ctx) == Some(false)
+                for (index, ancestor) in ctx.ancestors().enumerate() {
+                    match ancestor {
+                        Ancestor::DoWhileStatementBody(do_while) => {
+                            return do_while.test().get_side_free_boolean_value(ctx) == Some(false);
+                        }
+                        Ancestor::BlockStatementBody(_) if index == 0 => {}
+                        Ancestor::IfStatementConsequent(_)
+                        | Ancestor::IfStatementAlternate(_)
+                        | Ancestor::LabeledStatementBody(_) => {}
+                        _ => return false,
                     }
-                    _ => false,
                 }
+                false
             }
             // bare `return;` in function-body scope.
             Statement::ReturnStatement(stmt) if stmt.argument.is_none() => {

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1958,7 +1958,8 @@ impl<'a> PeepholeOptimizations {
                             return true;
                         }
                         Ancestor::BlockStatementBody(_)
-                            if skip_first_transparent_body && index == 0 => {}
+                            if (skip_first_transparent_body && index == 0)
+                                || ctx.is_last_in_statement_list(index) => {}
                         Ancestor::IfStatementConsequent(_)
                         | Ancestor::IfStatementAlternate(_)
                         | Ancestor::LabeledStatementBody(_) => {}
@@ -1976,7 +1977,8 @@ impl<'a> PeepholeOptimizations {
                                 && do_while.test().get_side_free_boolean_value(ctx) == Some(false);
                         }
                         Ancestor::BlockStatementBody(_)
-                            if skip_first_transparent_body && index == 0 => {}
+                            if (skip_first_transparent_body && index == 0)
+                                || ctx.is_last_in_statement_list(index) => {}
                         Ancestor::LabeledStatementBody(label_stmt) => {
                             if let Some(label) = &stmt.label {
                                 return label.name == label_stmt.label().name;
@@ -1990,7 +1992,21 @@ impl<'a> PeepholeOptimizations {
             }
             // bare `return;` in function-body scope.
             Statement::ReturnStatement(stmt) if stmt.argument.is_none() => {
-                ctx.parent().is_function_body()
+                for (index, ancestor) in ctx.ancestors().enumerate() {
+                    match ancestor {
+                        Ancestor::BlockStatementBody(_) if ctx.is_last_in_statement_list(index) => {
+                        }
+                        Ancestor::FunctionBodyStatements(_) => {
+                            return (skip_first_transparent_body && index == 0)
+                                || ctx.is_last_in_statement_list(index);
+                        }
+                        Ancestor::IfStatementConsequent(_)
+                        | Ancestor::IfStatementAlternate(_)
+                        | Ancestor::LabeledStatementBody(_) => {}
+                        _ => return false,
+                    }
+                }
+                false
             }
             _ => false,
         }

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -444,6 +444,7 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
                     {
                         ctx.replace_statement(stmt, folded_stmt);
                     }
+                    Self::try_unfold_if_else(stmt, ctx);
                 }
                 Statement::WhileStatement(s) => {
                     Self::minimize_expression_in_boolean_context(&mut s.test, ctx);

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -428,6 +428,9 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
                 Statement::ImportDeclaration(_) => {
                     Self::remove_unused_import_specifiers(stmt, ctx);
                 }
+                Statement::BreakStatement(_) | Statement::ContinueStatement(_) => {
+                    Self::try_remove_jump_statement(stmt, ctx);
+                }
                 _ => {}
             }
         } else {
@@ -469,6 +472,9 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
                     Self::remove_unused_class_declaration(stmt, ctx);
                 }
                 Statement::ImportDeclaration(_) => Self::remove_unused_import_specifiers(stmt, ctx),
+                Statement::BreakStatement(_) | Statement::ContinueStatement(_) => {
+                    Self::try_remove_jump_statement(stmt, ctx);
+                }
                 _ => {}
             }
             Self::try_fold_expression_stmt(stmt, ctx);

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -270,7 +270,7 @@ impl<'a> PeepholeOptimizations {
         match &mut s.body {
             Statement::BreakStatement(break_stmt)
                 if break_stmt.label.as_ref().is_some_and(|l| l.name.as_str() == id) => {}
-            Statement::BlockStatement(block) if block.body.first().is_some_and(|first| matches!(first, Statement::BreakStatement(break_stmt) if break_stmt.label.as_ref().is_some_and(|l| l.name.as_str() == id))) => {}
+            Statement::BlockStatement(block) if block.body.is_empty() || block.body.first().is_some_and(|first| matches!(first, Statement::BreakStatement(break_stmt) if break_stmt.label.as_ref().is_some_and(|l| l.name.as_str() == id))) => {}
             Statement::EmptyStatement(_) => {
                 let new_stmt = Statement::new_empty_statement(s.span, ctx);
                 ctx.replace_statement(stmt, new_stmt);

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -468,6 +468,13 @@ impl<'a> PeepholeOptimizations {
         ctx.replace_expression(expr, new_expr);
     }
 
+    /// Attempt to replace jump statements with empty statements when the parent is not a block-like statement.
+    pub fn try_remove_jump_statement(stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+        if Self::can_remove_termination_statement(stmt, false, ctx) {
+            ctx.replace_statement(stmt, Statement::new_empty_statement(stmt.span(), ctx));
+        }
+    }
+
     pub fn remove_sequence_expression(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::SequenceExpression(e) = expr else { return };
         let should_keep_as_sequence_expr = e

--- a/crates/oxc_minifier/src/traverse_context/ancestry.rs
+++ b/crates/oxc_minifier/src/traverse_context/ancestry.rs
@@ -141,13 +141,11 @@ impl<'a> TraverseAncestry<'a> {
         let current = self.ancestor(level - 1);
         let parent = self.ancestor(level);
 
-        let Some(last_statement_address) = (match parent {
+        let last_statement_address = match parent {
             Ancestor::ProgramBody(program) => program.last_statement_address(),
             Ancestor::FunctionBodyStatements(body) => body.last_statement_address(),
             Ancestor::BlockStatementBody(block) => block.last_statement_address(),
-            _ => None,
-        }) else {
-            return false;
+            _ => return false,
         };
 
         last_statement_address == current.address()

--- a/crates/oxc_minifier/src/traverse_context/ancestry.rs
+++ b/crates/oxc_minifier/src/traverse_context/ancestry.rs
@@ -1,5 +1,6 @@
 use std::mem::transmute;
 
+use oxc_allocator::GetAddress;
 use oxc_data_structures::stack::NonEmptyStack;
 
 use crate::generated::ancestor::{Ancestor, AncestorType};
@@ -129,6 +130,27 @@ impl<'a> TraverseAncestry<'a> {
     #[inline]
     pub fn ancestors_depth(&self) -> usize {
         self.stack.len()
+    }
+
+    #[inline]
+    pub fn is_last_in_statement_list(&self, level: usize) -> bool {
+        if level == 0 {
+            return false;
+        }
+
+        let current = self.ancestor(level - 1);
+        let parent = self.ancestor(level);
+
+        let Some(last_statement_address) = (match parent {
+            Ancestor::ProgramBody(program) => program.last_statement_address(),
+            Ancestor::FunctionBodyStatements(body) => body.last_statement_address(),
+            Ancestor::BlockStatementBody(block) => block.last_statement_address(),
+            _ => None,
+        }) else {
+            return false;
+        };
+
+        last_statement_address == current.address()
     }
 }
 

--- a/crates/oxc_minifier/src/traverse_context/ancestry.rs
+++ b/crates/oxc_minifier/src/traverse_context/ancestry.rs
@@ -141,11 +141,13 @@ impl<'a> TraverseAncestry<'a> {
         let current = self.ancestor(level - 1);
         let parent = self.ancestor(level);
 
-        let last_statement_address = match parent {
+        let Some(last_statement_address) = (match parent {
             Ancestor::ProgramBody(program) => program.last_statement_address(),
             Ancestor::FunctionBodyStatements(body) => body.last_statement_address(),
             Ancestor::BlockStatementBody(block) => block.last_statement_address(),
-            _ => return false,
+            _ => None,
+        }) else {
+            return false;
         };
 
         last_statement_address == current.address()

--- a/crates/oxc_minifier/src/traverse_context/mod.rs
+++ b/crates/oxc_minifier/src/traverse_context/mod.rs
@@ -181,6 +181,11 @@ impl<'a, State> TraverseCtx<'a, State> {
         self.ancestry.ancestors_depth()
     }
 
+    #[inline]
+    pub fn is_last_in_statement_list(&self, level: usize) -> bool {
+        self.ancestry.is_last_in_statement_list(level)
+    }
+
     /// Get current scope ID.
     ///
     /// Shortcut for `ctx.scoping.current_scope_id`.

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -211,7 +211,7 @@ fn js_parser_test() {
     test("while (x) { debugger; if (1) { if (1) continue; z() } }", "for (; x; ) debugger;");
     // test("while (x()) continue", "for (; x(); ) ;");
     test("while (x) { y(); continue }", "for (; x; ) y();");
-    test("while (x) { if (y) { z(); continue } }", "for (; x; ) if (y) { z(); continue; }");
+    test("while (x) { if (y) { z(); continue } }", "for (; x; ) y && z();");
     test(
         "label: while (x) while (y) { z(); continue label }",
         "label: for (; x; ) for (; y; ) { z(); continue label;}",

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -819,7 +819,7 @@ fn js_parser_test() {
     );
     test(
         "function _() { if (a) x: { if (b) break x } else return c }",
-        "function _() { if (a) { x: if (b) break x;} else return c; }",
+        "function _() { if (a) x: b; else return c; }",
     );
     test(
         "function _() { let a = foo(); return a != null ? a.b : undefined }",
@@ -2285,7 +2285,7 @@ fn test_remove_dead_expr_other() {
     test("if (1) a(); else { let b }", "a();");
     test("if (1) a(); else { throw b }", "a();");
     test("if (1) a(); else { return b }", "a();");
-    test("b: { if (x) a(); else { break b } }", "b: if (x) a(); else break b;");
+    test("b: { if (x) a(); else { break b } }", "b: x && a();");
     // test("b: { if (1) a(); else { break b } }", "a();");
     test("b: { if (0) a(); else { break b } }", "");
     test(

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -209,7 +209,7 @@ fn js_parser_test() {
         "for (; x; ) { debugger; break; }",
     );
     test("while (x) { debugger; if (1) { if (1) continue; z() } }", "for (; x; ) debugger;");
-    // test("while (x()) continue", "for (; x(); ) ;");
+    test("while (x()) continue", "for (; x(); ) ;");
     test("while (x) { y(); continue }", "for (; x; ) y();");
     test("while (x) { if (y) { z(); continue } }", "for (; x; ) y && z();");
     test(

--- a/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
@@ -787,12 +787,9 @@ fn test_remove_else_cause2() {
 
 #[test]
 fn test_remove_else_cause3() {
-    test(
-        "function f() { a: { if (x) break a; else f() } }",
-        "function f() { a: { if (x) break a; f() } }",
-    );
-    test("function f() { if (x) { a:{ break a } } else f() }", "function f() { x || f() }");
-    test("function f() { if (x) a:{ break a } else f() }", "function f() { x || f() }");
+    test("function f() { a: { if (x) break a; else f() } }", "function f() { a: x || f(); }");
+    test("function f() { if (x) { a:{ break a } } else f() }", "function f() { x || f(); }");
+    test("function f() { if (x) a:{ break a } else f() }", "function f() { x || f(); }");
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
@@ -59,10 +59,13 @@ fn test_function_return_optimization() {
     test("f=()=>{return}", "f=()=>{}");
     test("function f(){if(a()){b();if(c())return;}}", "function f(){a()&&(b(),c());}");
     test("f=()=>{if(a()){b();if(c())return;}}", "f=()=>{a()&&(b(),c());}");
+    test("function f(){if(x){return;} b();}", "function f(){x||b()}");
+    test("function f(){if(x){if(y){return;}} b();}", "function f(){x&&y||b()}");
     test("function f(){if(x)return; x=3; return; }", "function f(){ x||=3;}");
     test("function f(){if(true){a();return;}else;b();}", "function f(){a();}");
     test("function f(){if(false){a();return;}else;b();return;}", "function f(){b();}");
     test("function f(){if(a()){b();return;}else;c();}", "function f(){if(a()){b();return}c()}"); // function f(){a()?b():c()}
+    test("function f(){if(a()){b();return;}}", "function f(){if(a()){b();return}}"); // function f(){a()?b():c()}
     test(
         "function f(){if(a()){b()}else{c();return;}}",
         "function f(){if(a())b();else{c();return}}",
@@ -171,14 +174,14 @@ fn test_while_continue_optimization() {
     test("while(true){if(true){a();continue;}else;b();}", "for(;;)a();");
     test("while(true){if(false){a();continue;}else;b();continue;}", "for(;;)b();");
     test("while(true){if(a()){b();continue;}else;c();}", "for(;;){if(a()){b();continue}c()}"); // for(;;)a()?b():c();
-    test("while(true){if(a()){b();}else{c();continue;}}", "for(;;)if(a())b();else{c();continue}"); // for(;;)a()?b():c();
-    test("while(true){if(a()){b();continue;}else;}", "for (;;) if(a()){b();continue;}"); // for(;;)a()&&b();
+    test("while(true){if(a()){b();}else{c();continue;}}", "for(;;)a()?b():c();");
+    test("while(true){if(a()){b();continue;}else;}", "for(;;)a()&&b();");
     test("while(true){if(a()){continue;}else{continue;} continue;}", "for(;;)a();");
     test("while(true){if(a()){continue;}else{continue;} b();}", "for(;;)a();");
     test(
         "while(true){d();if(a()){continue;}else if(b()){c();continue;}else{continue;}}",
-        "for(;;)if(d(),!a()&&b()){c();continue}",
-    ); // for(;;)d(),!a()&&b()&&c();
+        "for(;;)d(),!a()&&b()&&c();",
+    );
 
     test("while(true)while(a())continue;", "for(;;)for(;a();)continue;"); // for(;;)for(;a(););
     test("while(true)for(x in a())continue", "for(;;)for(x in a())continue;"); // for(;;)for(x in a());
@@ -199,14 +202,8 @@ fn test_while_continue_optimization() {
         "while(true){g:if(a()){continue;}else{continue;} continue;}",
         "for(;;)g:if(a())continue;else continue;",
     ); // for (;;)g:a();
-    test(
-        "while(true){g:{if(a()){continue;}else{continue;} continue;}}",
-        "for(;;)g:{if(a())continue;continue}",
-    ); // for(;;)g:a();
-    test(
-        "while(true){g:{a();if(b()){continue;}else{continue;} continue;}}",
-        "for(;;)g:{if(a(),b())continue;continue}",
-    ); // for(;;)g:a(),b();
+    test("while(true){g:{if(a()){continue;}else{continue;} continue;}}", "for(;;)g:a();");
+    test("while(true){g:{a();if(b()){continue;}else{continue;} continue;}}", "for(;;)g:a(),b();");
 }
 
 #[test]
@@ -216,11 +213,8 @@ fn test_do_continue_optimization() {
     test("do{if(true){a();continue;}else;b();}while(true)", "do a();while(1)");
     test("do{if(false){a();continue;}else;b();continue;}while(true)", "do b();while(1)");
     test("do{if(a()){b();continue;}else;c();}while(true)", "do{if(a()){b();continue}c()}while(1);"); // do a()?b():c();while(1)
-    test(
-        "do{if(a()){b();}else{c();continue;}}while(true)",
-        "do if(a())b();else{c();continue}while(1);",
-    ); // do a()?b():c();while(1)
-    test("do{if(a()){b();continue;}else;}while(true)", "do if(a()){b();continue}while(1);"); // do a()&&b();while(1)
+    test("do{if(a()){b();}else{c();continue;}}while(true)", "do a()?b():c();while(1);");
+    test("do{if(a()){b();continue;}else;}while(true)", "do a()&&b();while(1);");
     test("do{if(a()){continue;}else{continue;} continue;}while(true)", "do a();while(1)");
     test("do{if(a()){continue;}else{continue;} b();}while(true)", "do a();while(1)");
 
@@ -252,6 +246,11 @@ fn test_do_continue_optimization() {
     test("do{break}while(fn());", "do break; while(fn());");
     test("do{break}while(true);", "do break; while(1);"); // do while(0);
     test("do{break}while(!new Date());", "do;while(0);");
+    test("do{if(a)break;}while(false)", "do a;while(0)");
+    test("do if(a)break;while(false)", "do if(a)break;while(0)"); // do a;while(0)
+    test("do{if(a)break;b();} while(false)", "do a||b();while(0)");
+    test("do if(a)break;while(true)", "do if(a)break;while(1)");
+    test("do if(a){if(b)break;} while(false)", "do a&&b;while (0);");
 
     test(
         "do { foo(); switch (x) { case 1: break; default: f()} } while(false)",
@@ -266,20 +265,14 @@ fn test_for_continue_optimization() {
     test("for(x in y){if(true){a();continue;}else;b();}", "for(x in y)a()");
     test("for(x in y){if(false){a();continue;}else;b();continue;}", "for(x in y)b()");
     test("for(x in y){if(a()){b();continue;}else;c();}", "for(x in y){if(a()){b();continue}c()}"); // for(x in y)a()?b():c()
-    test(
-        "for(x in y){if(a()){b();}else{c();continue;}}",
-        "for(x in y)if(a())b();else{c();continue}",
-    ); // for(x in y)a()?b():c()
+    test("for(x in y){if(a()){b();}else{c();continue;}}", "for(x in y)a()?b():c()");
 
     test("for(x of y){if(x)continue; x=3; continue; }", "for(x of y)x||=3");
     test("for(x of y){a();continue;b()}", "for(x of y)a()");
     test("for(x of y){if(true){a();continue;}else;b();}", "for(x of y)a()");
     test("for(x of y){if(false){a();continue;}else;b();continue;}", "for(x of y)b()");
     test("for(x of y){if(a()){b();continue;}else;c();}", "for(x of y){if(a()){b();continue}c()}"); // for(x of y)a()?b():c()
-    test(
-        "for(x of y){if(a()){b();}else{c();continue;}}",
-        "for(x of y)if(a())b();else{c();continue}",
-    ); // for(x of y)a()?b():c()
+    test("for(x of y){if(a()){b();}else{c();continue;}}", "for(x of y)a()?b():c()");
 
     test(
         "r=async () => { for await (x of y){if(x)continue; x=3; continue; }}",
@@ -303,10 +296,10 @@ fn test_for_continue_optimization() {
     ); // r=async () => { for await(x of y)a()?b():c()};
     test(
         "r=async () => { for await (x of y){if(a()){b();}else{c();continue;}}}",
-        "r=async() => { for await(x of y)if(a())b();else{c();continue}};",
-    ); // r=async () => { for await (x of y) a() ? b() : c() };
+        "r=async () => { for await (x of y)a()?b():c();};",
+    );
 
-    test("for(x=0;x<y;x++){if(a()){b();continue;}else;}", "for(x=0;x<y;x++)if(a()){b();continue}"); // for(x=0;x<y;x++)a()&&b()
+    test("for(x=0;x<y;x++){if(a()){b();continue;}else;}", "for(x=0;x<y;x++)a()&&b()");
     test("for(x=0;x<y;x++){if(a()){continue;}else{continue;} continue;}", "for(x=0;x<y;x++)a()");
     test("for(x=0;x<y;x++){if(a()){continue;}else{continue;} b();}", "for(x=0;x<y;x++)a();");
 
@@ -333,11 +326,11 @@ fn test_for_continue_optimization() {
     ); // for(x=0;x<y;x++)g:a();
     test(
         "for(x=0;x<y;x++){g:{if(a()){continue;}else{continue;} continue;}}",
-        "for(x=0;x<y;x++)g:{if(a())continue;continue;}",
-    ); // for(x=0;x<y;x++)g:a();
+        "for(x=0;x<y;x++)g:a();",
+    );
     test(
         "for(x=0;x<y;x++){g:{a();if(b()){continue;}else{continue;} continue;}}",
-        "for(x=0;x<y;x++)g:{if(a(),b())continue;continue}",
+        "for(x=0;x<y;x++)g:a(),b();",
     );
 }
 

--- a/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
@@ -109,10 +109,7 @@ fn test_function_return_optimization() {
 
     test_same("function f(){g:return}"); // function f(){}
     test("function f(){g:{return}}", "function f(){g:return}"); // function f(){}
-    test(
-        "function f(){g:if(a()){return;}else{return;} return;}",
-        "function f(){g:if(a())return;else return}",
-    ); // function f(){g:a()}
+    test("function f(){g:if(a()){return;}else{return;} return;}", "function f(){g:{a();return;}}"); // function f(){g:a()}
     test("function f(){g:{if(a()){return;}else{return;} return;}}", "function f(){g:{a();return}}"); // function f(){g:a()}
     test(
         "function f(){g:{a();if(b()){return;}else{return;} return;}}",

--- a/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
@@ -178,7 +178,7 @@ fn test_while_continue_optimization() {
     test("while(true){if(a()){continue;}else{continue;} b();}", "for(;;)a();");
     test(
         "while(true){d();if(a()){continue;}else if(b()){c();continue;}else{continue;}}",
-        "for(;;)d(),!a()&&b()&&c();",
+        "for(;;)d(),a()||b()&&c();",
     );
 
     test("while(true)while(a())continue;", "for(;;)for(;a(););");

--- a/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
@@ -2,12 +2,12 @@ use crate::{test, test_same};
 
 #[test]
 fn test_break_optimization() {
-    test("f:{if(true){a();break f;}else;b();}", "f:{a();break f}"); // f:a();
-    test("f:{if(false){a();break f;}else;b();break f;}", "f:{b();break f}"); // f:b();
+    test("f:{if(true){a();break f;}else;b();}", "f:a();");
+    test("f:{if(false){a();break f;}else;b();break f;}", "f:b();");
     test("f:{if(a()){b();break f;}else;c();}", "f:{if(a()){b();break f}c()}"); // f:a()?b():c();
-    test("f:{if(a()){b()}else{c();break f;}}", "f:if(a())b();else{c();break f}"); // f:a()?b():c();
-    test("f:{if(a()){b();break f;}else;}", "f:if(a()){b();break f}"); // f:a()&&b();
-    test("f:{if(a()){break f;}else;}", "f:if(a())break f;"); // f:a();
+    test("f:{if(a()){b()}else{c();break f;}}", "f:a()?b():c();");
+    test("f:{if(a()){b();break f;}else;}", "f:a()&&b();");
+    test("f:{if(a()){break f;}else;}", "f:a();");
 
     test("f:while(a())break f;", "f:for(;a();)break f;");
     test_same("f:for(x in a())break f");
@@ -25,7 +25,8 @@ fn test_break_optimization() {
     test("f:g:{if(a()){break f;}else{break f;} break f;}", "f:g:{if(a())break f;break f}"); // f:g:a();
     test("function f() { a: break a; }", "function f() {}");
     test("function f() { a: { break a; } }", "function f() {}");
-    test_same("function f() { a: { b(); break a; } c(); }");
+    test("function f() { a: { b(); break a; } c(); }", "function f() { a: b(); c(); }");
+    test_same("function f() { a: { b(); break b; } c(); }");
     test_same("function f() { a: { b(); return; } c(); }");
 }
 

--- a/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_exit_points.rs
@@ -183,8 +183,8 @@ fn test_while_continue_optimization() {
         "for(;;)d(),!a()&&b()&&c();",
     );
 
-    test("while(true)while(a())continue;", "for(;;)for(;a();)continue;"); // for(;;)for(;a(););
-    test("while(true)for(x in a())continue", "for(;;)for(x in a())continue;"); // for(;;)for(x in a());
+    test("while(true)while(a())continue;", "for(;;)for(;a(););");
+    test("while(true)for(x in a())continue", "for(;;)for(x in a());");
 
     test("while(true)while(a())break;", "for(;;)for(;a();)break");
     test("while(true)for(x in a())break", "for(;;)for(x in a())break");
@@ -195,13 +195,10 @@ fn test_while_continue_optimization() {
         "for(;;)try{if(a())continue;continue}catch{}",
     ); // for(;;)try{a()}catch{}
 
-    test("while(true){g:continue}", "for(;;) g:continue;"); // for(;;);
-    test("while(true){g:{continue}}", "for(;;) g:continue;"); // for(;;);
+    test("while(true){g:continue}", "for(;;);");
+    test("while(true){g:{continue}}", "for(;;);");
     // This case could be improved.
-    test(
-        "while(true){g:if(a()){continue;}else{continue;} continue;}",
-        "for(;;)g:if(a())continue;else continue;",
-    ); // for (;;)g:a();
+    test("while(true){g:if(a()){continue;}else{continue;} continue;}", "for(;;)g:a();");
     test("while(true){g:{if(a()){continue;}else{continue;} continue;}}", "for(;;)g:a();");
     test("while(true){g:{a();if(b()){continue;}else{continue;} continue;}}", "for(;;)g:a(),b();");
 }
@@ -218,8 +215,8 @@ fn test_do_continue_optimization() {
     test("do{if(a()){continue;}else{continue;} continue;}while(true)", "do a();while(1)");
     test("do{if(a()){continue;}else{continue;} b();}while(true)", "do a();while(1)");
 
-    test("do{while(a())continue;}while(true)", "do for(;a();)continue;while(1);"); // do for(;a(););while(1)
-    test("do{for(x in a())continue}while(true)", "do for(x in a())continue;while(1);"); // do for(x in a());while(1)
+    test("do{while(a())continue;}while(true)", "do for(;a(););while(1);");
+    test("do{for(x in a())continue}while(true)", "do for(x in a());while(1);");
 
     test("do{while(a())break;}while(true)", "do for(;a();)break;while(1)");
     test("do for(x in a())break;while(true)", "do for(x in a())break;while(1)");
@@ -233,12 +230,9 @@ fn test_do_continue_optimization() {
         "do try{if(a())continue;continue}catch{}while(1);",
     ); // do try{a()}catch{}while(1);
 
-    test("do{g:continue}while(true)", "do g:continue;while(1);"); // do;while(1);
+    test("do{g:continue}while(true)", "do;while(1);");
     // This case could be improved.
-    test(
-        "do{g:if(a()){continue;}else{continue;} continue;}while(true)",
-        "do g:if(a())continue;else continue;while(1);",
-    ); // do g:a();while(1);
+    test("do{g:if(a()){continue;}else{continue;} continue;}while(true)", "do g:a();while(1);");
 
     test("do { foo(); continue; } while(false)", "do foo();while(0)");
     test("do { foo(); break; } while(false)", "do foo();while(0)");
@@ -247,7 +241,7 @@ fn test_do_continue_optimization() {
     test("do{break}while(true);", "do break; while(1);"); // do while(0);
     test("do{break}while(!new Date());", "do;while(0);");
     test("do{if(a)break;}while(false)", "do a;while(0)");
-    test("do if(a)break;while(false)", "do if(a)break;while(0)"); // do a;while(0)
+    test("do if(a)break;while(false)", "do a;while(0)");
     test("do{if(a)break;b();} while(false)", "do a||b();while(0)");
     test("do if(a)break;while(true)", "do if(a)break;while(1)");
     test("do if(a){if(b)break;} while(false)", "do a&&b;while (0);");
@@ -303,8 +297,8 @@ fn test_for_continue_optimization() {
     test("for(x=0;x<y;x++){if(a()){continue;}else{continue;} continue;}", "for(x=0;x<y;x++)a()");
     test("for(x=0;x<y;x++){if(a()){continue;}else{continue;} b();}", "for(x=0;x<y;x++)a();");
 
-    test("for(x=0;x<y;x++)while(a())continue;", "for(x=0;x<y;x++)for(;a();)continue;"); // for(x=0;x<y;x++)for(;a(););
-    test("for(x=0;x<y;x++)for(x in a())continue", "for(x=0;x<y;x++)for(x in a())continue;"); // for(x=0;x<y;x++)for(x in a());
+    test("for(x=0;x<y;x++)while(a())continue;", "for(x=0;x<y;x++)for(;a(););");
+    test("for(x=0;x<y;x++)for(x in a())continue", "for(x=0;x<y;x++)for(x in a());");
 
     test("for(x=0;x<y;x++)while(a())break;", "for(x=0;x<y;x++)for(;a();)break");
     test_same("for(x=0;x<y;x++)for(x in a())break");
@@ -318,12 +312,12 @@ fn test_for_continue_optimization() {
         "for(x=0;x<y;x++)try{if(a())continue;continue}catch{}",
     ); // for(x=0;x<y;x++)try{a()}catch{}
 
-    test("for(x=0;x<y;x++){g:continue}", "for(x=0;x<y;x++)g:continue;"); // for(x=0;x<y;x++);
-    test("for(x=0;x<y;x++){g:{continue}}", "for(x=0;x<y;x++)g:continue;"); // for(x=0;x<y;x++);
+    test("for(x=0;x<y;x++){g:continue}", "for(x=0;x<y;x++);");
+    test("for(x=0;x<y;x++){g:{continue}}", "for(x=0;x<y;x++);");
     test(
         "for(x=0;x<y;x++){g:if(a()){continue;}else{continue;} continue;}",
-        "for(x=0;x<y;x++)g:if(a())continue;else continue;",
-    ); // for(x=0;x<y;x++)g:a();
+        "for(x=0;x<y;x++)g:a();",
+    );
     test(
         "for(x=0;x<y;x++){g:{if(a()){continue;}else{continue;} continue;}}",
         "for(x=0;x<y;x++)g:a();",

--- a/crates/oxc_minifier/tests/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_if_statement.rs
@@ -40,9 +40,10 @@ fn test_minimize_if() {
           }
         }",
         "function bar() {
-          if (!x) return null;
-          if (y) return foo;
-          if (z) return bar;
+          if (x) {
+            if (y) return foo;
+            if (z) return bar;
+          } else return null;
         }",
     );
 

--- a/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
@@ -56,6 +56,7 @@ fn test_fold_block() {
 
 #[test]
 fn test_remove_no_op_labelled_statement() {
+    test("a: {}", "");
     test("a: break a;", "");
     test("a: { break a; }", "");
 

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -2780,6 +2780,14 @@ impl<'a, 't> ProgramWithoutBody<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_PROGRAM_SCOPE_ID) as *const Cell<Option<ScopeId>>)
         }
     }
+
+    #[inline]
+    pub fn last_statement_address(self) -> Option<Address> {
+        let statements = unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_BODY) as *const ArenaVec<'a, Statement<'a>>)
+        };
+        statements.last().map(GetAddress::address)
+    }
 }
 
 impl<'a, 't> GetAddress for ProgramWithoutBody<'a, 't> {
@@ -5155,6 +5163,15 @@ impl<'a, 't> BlockStatementWithoutBody<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_BLOCK_STATEMENT_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+
+    #[inline]
+    pub fn last_statement_address(self) -> Option<Address> {
+        let statements = unsafe {
+            &*((self.0 as *const u8).add(OFFSET_BLOCK_STATEMENT_BODY)
+                as *const ArenaVec<'a, Statement<'a>>)
+        };
+        statements.last().map(GetAddress::address)
     }
 }
 
@@ -8640,6 +8657,15 @@ impl<'a, 't> FunctionBodyWithoutStatements<'a, 't> {
                 as *const ArenaVec<'a, Directive<'a>>)
         }
     }
+
+    #[inline]
+    pub fn last_statement_address(self) -> Option<Address> {
+        let statements = unsafe {
+            &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY_STATEMENTS)
+                as *const ArenaVec<'a, Statement<'a>>)
+        };
+        statements.last().map(GetAddress::address)
+    }
 }
 
 impl<'a, 't> GetAddress for FunctionBodyWithoutStatements<'a, 't> {
@@ -10388,6 +10414,15 @@ impl<'a, 't> StaticBlockWithoutBody<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_STATIC_BLOCK_SCOPE_ID)
                 as *const Cell<Option<ScopeId>>)
         }
+    }
+
+    #[inline]
+    pub fn last_statement_address(self) -> Option<Address> {
+        let statements = unsafe {
+            &*((self.0 as *const u8).add(OFFSET_STATIC_BLOCK_BODY)
+                as *const ArenaVec<'a, Statement<'a>>)
+        };
+        statements.last().map(GetAddress::address)
     }
 }
 
@@ -16526,6 +16561,15 @@ impl<'a, 't> TSModuleBlockWithoutBody<'a, 't> {
             &*((self.0 as *const u8).add(OFFSET_TS_MODULE_BLOCK_DIRECTIVES)
                 as *const ArenaVec<'a, Directive<'a>>)
         }
+    }
+
+    #[inline]
+    pub fn last_statement_address(self) -> Option<Address> {
+        let statements = unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_MODULE_BLOCK_BODY)
+                as *const ArenaVec<'a, Statement<'a>>)
+        };
+        statements.last().map(GetAddress::address)
     }
 }
 

--- a/tasks/ast_tools/src/generators/traverse/ancestor.rs
+++ b/tasks/ast_tools/src/generators/traverse/ancestor.rs
@@ -106,6 +106,35 @@ pub fn generate_ancestor(schema: &Schema) -> TokenStream {
                 });
             }
 
+            let field_name = field.name();
+            if field_name == "body" || field_name == "statements" {
+                let field_type = field.type_def(schema);
+                if let TypeDef::Vec(vec_def) = field_type {
+                    let inner_type = vec_def.inner_type(schema);
+                    if inner_type.name() == "Statement" {
+                        let type_snake_name = struct_def.snake_name();
+                        let type_screaming_name = type_snake_name.cow_to_ascii_uppercase();
+                        let field_offset = format_ident!(
+                            "OFFSET_{}_{}",
+                            type_screaming_name,
+                            field_name.cow_to_ascii_uppercase()
+                        );
+
+                        let field_ty = field.type_def(schema).ty(schema);
+                        methods_code.extend(quote! {
+                            ///@@line_break
+                            #[inline]
+                            pub fn last_statement_address(self) -> Option<Address> {
+                                let statements = unsafe {
+                                    &*((self.0 as *const u8).add(#field_offset) as *const #field_ty)
+                                };
+                                statements.last().map(GetAddress::address)
+                            }
+                        });
+                    }
+                }
+            }
+
             // Lifetimes for Without struct
             let lifetimes = if has_lifetime { quote!(<'a, 't>) } else { quote!(<'t>) };
 

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -13,9 +13,9 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 555.77 kB  | 262.74 kB  | 270.13 kB  | 87.66 kB   | 90.80 kB   |          2 | d3.js
 
-1.01 MB    | 435.94 kB  | 458.89 kB  | 121.78 kB  | 126.71 kB  |          2 | bundle.min.js
+1.01 MB    | 435.89 kB  | 458.89 kB  | 121.77 kB  | 126.71 kB  |          2 | bundle.min.js
 
-1.25 MB    | 634.39 kB  | 646.76 kB  | 158.43 kB  | 163.73 kB  |          2 | three.js
+1.25 MB    | 634.35 kB  | 646.76 kB  | 158.42 kB  | 163.73 kB  |          2 | three.js
 
 2.14 MB    | 707.64 kB  | 724.14 kB  | 160.07 kB  | 181.07 kB  |          2 | victory.js
 
@@ -23,5 +23,5 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 6.69 MB    | 2.12 MB    | 2.31 MB    | 453.44 kB  | 488.28 kB  |          5 | antd.js
 
-10.95 MB   | 3.31 MB    | 3.49 MB    | 849.98 kB  | 915.50 kB  |          4 | typescript.js
+10.95 MB   | 3.31 MB    | 3.49 MB    | 849.95 kB  | 915.50 kB  |          4 | typescript.js
 

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -5,23 +5,23 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 173.90 kB  | 55.50 kB   | 59.82 kB   | 18.77 kB   | 19.33 kB   |          2 | moment.js
 
-287.63 kB  | 89.01 kB   | 90.07 kB   | 30.85 kB   | 31.95 kB   |          2 | jquery.js
+287.63 kB  | 89 kB      | 90.07 kB   | 30.86 kB   | 31.95 kB   |          2 | jquery.js
 
-342.15 kB  | 114.80 kB  | 118.14 kB  | 42.71 kB   | 44.37 kB   |          2 | vue.js
+342.15 kB  | 114.79 kB  | 118.14 kB  | 42.70 kB   | 44.37 kB   |          2 | vue.js
 
 544.10 kB  | 69.88 kB   | 72.48 kB   | 25.58 kB   | 26.20 kB   |          2 | lodash.js
 
-555.77 kB  | 262.75 kB  | 270.13 kB  | 87.66 kB   | 90.80 kB   |          2 | d3.js
+555.77 kB  | 262.74 kB  | 270.13 kB  | 87.66 kB   | 90.80 kB   |          2 | d3.js
 
-1.01 MB    | 435.99 kB  | 458.89 kB  | 121.78 kB  | 126.71 kB  |          2 | bundle.min.js
+1.01 MB    | 435.95 kB  | 458.89 kB  | 121.78 kB  | 126.71 kB  |          2 | bundle.min.js
 
 1.25 MB    | 634.39 kB  | 646.76 kB  | 158.43 kB  | 163.73 kB  |          2 | three.js
 
-2.14 MB    | 707.63 kB  | 724.14 kB  | 160.08 kB  | 181.07 kB  |          2 | victory.js
+2.14 MB    | 707.64 kB  | 724.14 kB  | 160.07 kB  | 181.07 kB  |          2 | victory.js
 
-3.20 MB    | 958.89 kB  | 1.01 MB    | 317.07 kB  | 331.56 kB  |          2 | echarts.js
+3.20 MB    | 958.91 kB  | 1.01 MB    | 317.08 kB  | 331.56 kB  |          2 | echarts.js
 
 6.69 MB    | 2.12 MB    | 2.31 MB    | 453.44 kB  | 488.28 kB  |          5 | antd.js
 
-10.95 MB   | 3.31 MB    | 3.49 MB    | 849.97 kB  | 915.50 kB  |          4 | typescript.js
+10.95 MB   | 3.31 MB    | 3.49 MB    | 849.98 kB  | 915.50 kB  |          4 | typescript.js
 

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -13,7 +13,7 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 555.77 kB  | 262.74 kB  | 270.13 kB  | 87.66 kB   | 90.80 kB   |          2 | d3.js
 
-1.01 MB    | 435.95 kB  | 458.89 kB  | 121.78 kB  | 126.71 kB  |          2 | bundle.min.js
+1.01 MB    | 435.94 kB  | 458.89 kB  | 121.78 kB  | 126.71 kB  |          2 | bundle.min.js
 
 1.25 MB    | 634.39 kB  | 646.76 kB  | 158.43 kB  | 163.73 kB  |          2 | three.js
 

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 150
   sys alloc bytes: 14996600 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 143570
-  arena reallocs: 28269
-  arena size: 19100024 # 19.10 MB
+  arena allocs: 143932
+  arena reallocs: 28327
+  arena size: 19113400 # 19.11 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,8 +16,8 @@ App.tsx:
   sys deallocs: 61
   sys alloc bytes: 2128555 # 2.13 MB
   sys peak growth: 1612427 # 1.61 MB
-  arena allocs: 15652
-  arena reallocs: 2709
+  arena allocs: 15664
+  arena reallocs: 2711
   arena size: 2879680 # 2.88 MB
 
 RadixUIAdoptionSection.jsx:
@@ -38,8 +38,8 @@ pdf.mjs:
   sys deallocs: 2427
   sys alloc bytes: 5334247 # 5.33 MB
   sys peak growth: 3693355 # 3.69 MB
-  arena allocs: 44756
-  arena reallocs: 7699
+  arena allocs: 44762
+  arena reallocs: 7700
   arena size: 6304256 # 6.30 MB
 
 antd.js:
@@ -49,7 +49,7 @@ antd.js:
   sys deallocs: 1038
   sys alloc bytes: 29976031 # 29.98 MB
   sys peak growth: 19934725 # 19.93 MB
-  arena allocs: 351162
+  arena allocs: 351171
   arena reallocs: 75941
   arena size: 48738712 # 48.74 MB
 
@@ -60,7 +60,7 @@ binder.ts:
   sys deallocs: 33
   sys alloc bytes: 963008 # 963.01 kB
   sys peak growth: 657404 # 657.40 kB
-  arena allocs: 6789
+  arena allocs: 6798
   arena reallocs: 834
   arena size: 1162400 # 1.16 MB
 
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 1854
   sys alloc bytes: 5307512 # 5.31 MB
   sys peak growth: 3707425 # 3.71 MB
-  arena allocs: 64841
-  arena reallocs: 12169
+  arena allocs: 64862
+  arena reallocs: 12175
   arena size: 9384568 # 9.38 MB

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,7 +5,7 @@ checker.ts:
   sys deallocs: 150
   sys alloc bytes: 14996600 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 143560
+  arena allocs: 143570
   arena reallocs: 28269
   arena size: 19100024 # 19.10 MB
 

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,7 +5,7 @@ checker.ts:
   sys deallocs: 150
   sys alloc bytes: 14996600 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 143932
+  arena allocs: 143924
   arena reallocs: 28327
   arena size: 19113400 # 19.11 MB
 
@@ -16,8 +16,8 @@ App.tsx:
   sys deallocs: 61
   sys alloc bytes: 2128555 # 2.13 MB
   sys peak growth: 1612427 # 1.61 MB
-  arena allocs: 15664
-  arena reallocs: 2711
+  arena allocs: 15671
+  arena reallocs: 2708
   arena size: 2879680 # 2.88 MB
 
 RadixUIAdoptionSection.jsx:
@@ -49,8 +49,8 @@ antd.js:
   sys deallocs: 1038
   sys alloc bytes: 29976031 # 29.98 MB
   sys peak growth: 19934725 # 19.93 MB
-  arena allocs: 351171
-  arena reallocs: 75941
+  arena allocs: 351154
+  arena reallocs: 75935
   arena size: 48738712 # 48.74 MB
 
 binder.ts:
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 1854
   sys alloc bytes: 5307512 # 5.31 MB
   sys peak growth: 3707425 # 3.71 MB
-  arena allocs: 64862
-  arena reallocs: 12175
+  arena allocs: 64858
+  arena reallocs: 12172
   arena size: 9384568 # 9.38 MB

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 1854
   sys alloc bytes: 5307512 # 5.31 MB
   sys peak growth: 3707425 # 3.71 MB
-  arena allocs: 64844
-  arena reallocs: 12187
-  arena size: 9385624 # 9.39 MB
+  arena allocs: 64841
+  arena reallocs: 12169
+  arena size: 9384568 # 9.38 MB


### PR DESCRIPTION
I do not like this implementation as it breaks `Without` based on changes from #25132

any feedback related this would be appreciated

```diff
-            for (; (o = t.indexOf(e, o)), o !== -1;) {
-              if (o >= i.start && o < i.end) {
-                o = i.end;
-                continue;
-              }
-              if (r && !a.has(o)) {
-                o++;
-                continue;
-              }
-              break;
-            }
+            for (; (o = t.indexOf(e, o)), o !== -1;)
+              if (o >= i.start && o < i.end) o = i.end;
+              else if (r && !a.has(o)) o++;
+              else break;
```

```diff
 		for (let enclosed of pulled_scope.enclosed) {
 			if (pulled_scope.variables.has(enclosed.name)) continue;
 			let looked_up = scope.find_variable(enclosed.name);
-			if (looked_up) {
-				if (looked_up === enclosed) continue;
-				return !0;
-			}
+			if (looked_up && looked_up !== enclosed) return !0;
 		}
```

TODO: 
- [ ] find a cleaner way to verify if smtm is last
- [ ] add unit tests
- [ ] expand this to switch/cases

#### changes in stack:
- #25567 👈
- #25132 
- #25213 
- #25159 
- #25128 
- `main`