### PR TITLE
fix(linter/lsp): prevent tsgolint from holding onto processes

### DIFF
--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -536,6 +536,7 @@ impl TsGoLintState {
 
         // Kill the child process if it's still running to avoid zombie processes
         let _ = child.kill();
+        let _ = child.wait();
 
         diagnostics
     }


### PR DESCRIPTION
Attempts to address:
- oxc-project/oxc#17070
- oxc-project/oxc#21402,
- oxc-project/oxc-vscode#264

I recently started enabling the type-aware rules as part of my editor's linter (zed). I quickly started hitting resource exhaustion limits on macOS. Listing processes showed thousands of zombie tsgolint entries with oxlint as the parent.

Doing a little digging, I found the above issues listing similar resource exhaustion. oxc-project/oxc#24670 attempted to solve this issue by calling `child.kill` on the tsgolint process, but this is not enough on macOS. From [the `Child` docs](https://doc.rust-lang.org/std/process/struct.Child.html):

> On some systems, calling wait or similar is necessary for the OS to release resources. A process that terminated but has not been waited on is still around as a “zombie”. Leaving too many zombies around may exhaust global resources (for example process IDs).
>
> The standard library does not automatically wait on child processes (not even if the Child is dropped), it is up to the application developer to do so. As a consequence, dropping Child handles without waiting on them first is not recommended in long-running applications.

This change follows this advice and adds a `wait` after the existing `kill`.