### PR TITLE
fix(ci): add jsdoc fixtures to gitattrs entry

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 crates/oxc_formatter/tests/fixtures/** text=auto eol=lf
 crates/oxc_formatter/tests/fixtures/js/crlf/** text=auto eol=crlf
+crates/oxc_formatter/tests/jsdoc/fixtures/** text=auto eol=lf
 crates/oxc_formatter_json/tests/fixtures/** text=auto eol=lf
 crates/oxc_formatter_json/tests/fixtures/jsonc/crlf/** text=auto eol=crlf
 crates/oxc_formatter_graphql/tests/fixtures/** text=auto eol=lf


### PR DESCRIPTION
Fixes Windows CI issue: https://github.com/oxc-project/oxc/actions/runs/31656149983/job/94310931760
