### PR TITLE
fix(semantic): allow legacy escapes in JSX attributes

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -420,7 +420,7 @@ pub fn check_string_literal(lit: &StringLiteral, ctx: &SemanticBuilder<'_>) {
     //   legacy_octalEscapeSequence
     //   non_octal_decimal_escape_sequence
     // It is a Syntax Error if the source text matched by this production is strict mode code.
-    if !ctx.strict_mode() {
+    if !ctx.strict_mode() || matches!(ctx.ancestry().parent_kind(), AstKind::JSXAttribute(_)) {
         return;
     }
     let raw = lit.span.source_text(ctx.source_text);

--- a/tasks/coverage/misc/pass/jsx-attribute-legacy-escapes.tsx
+++ b/tasks/coverage/misc/pass/jsx-attribute-legacy-escapes.tsx
@@ -1,0 +1,4 @@
+export {};
+
+<Component mask="+4\9 99 999 99" />;
+<Component mask="+5\5 (99) 99999-9999" />;

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 77/77 (100.00%)
-Positive Passed: 77/77 (100.00%)
+AST Parsed     : 78/78 (100.00%)
+Positive Passed: 78/78 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 77/77 (100.00%)
-Positive Passed: 77/77 (100.00%)
+AST Parsed     : 78/78 (100.00%)
+Positive Passed: 78/78 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 77/77 (100.00%)
-Positive Passed: 77/77 (100.00%)
+AST Parsed     : 78/78 (100.00%)
+Positive Passed: 78/78 (100.00%)
 Negative Passed: 161/161 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 77/77 (100.00%)
-Positive Passed: 73/77 (94.81%)
+AST Parsed     : 78/78 (100.00%)
+Positive Passed: 74/78 (94.87%)
 semantic Error: tasks/coverage/misc/pass/declare-let-private.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["private"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 77/77 (100.00%)
-Positive Passed: 77/77 (100.00%)
+AST Parsed     : 78/78 (100.00%)
+Positive Passed: 78/78 (100.00%)


### PR DESCRIPTION
Quoted JSX attribute values do not use ECMAScript escape sequences. Skip strict-mode legacy escape validation for JSX attributes and cover the behavior in misc conformance.

AI-assisted by Codex.