### PR TITLE
fix(formatter_css): keep trailing comma and indent after comment-preceded last map value

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -267,6 +267,11 @@ Admission reasons and rules: see FORMATTER_POLICY.md "Known divergences". Notabl
   - Prettier double-indents it (closing `)` floating between levels) when the nearest
     at-rule ancestor is a control directive (`@if`/`@else`/`@for`/`@each`/`@while`; selector blocks in between don't shield)
     = identical source, different indent per context
+- SCSS: A comment-preceded block map value also prints at the normal nested-map indent
+  - Prettier double-indents it (`+6` body / `+4` `)`)
+  - Its dedent applies only when the pair doc is a plain `group(indent(fill))`, and a leading comment changes the doc shape
+  - Comment presence must not change layout; same dedent-skip artifact class as the entries above
+    (paren-block KEYS still keep the pair indent, matching Prettier: that trigger is content, not trivia)
 - SCSS: The map-item break (one element per line + trailing comma) applies ONLY to parens whose contents are already a comma-separated list (semantics)
   - `(x,)` is a single-element list in Sass, so the added comma is a semantic no-op for a comma list and NOWHERE else
   - Prettier 3.9.6 changes `key: ($a + $b)` from a number to a list,

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -257,7 +257,6 @@ pub(super) fn write_sass_map<'a>(
     let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
         write!(f, hard_line_break());
         let source = f.context().source_text();
-        let mut last_item_block_with_comment = false;
         let mut first_item_has_leading_comment = false;
         for (i, item) in map.items.iter().enumerate() {
             if i > 0 {
@@ -308,13 +307,6 @@ pub(super) fn write_sass_map<'a>(
                 first_item_has_leading_comment = had_leading_comment;
             }
             let key_is_block = is_paren_block(&item.key);
-            if i + 1 == map.items.len() {
-                // Suppressed only when the source ALSO had a trailing comma
-                // (the comment lands inside the last comma_group in postcss).
-                last_item_block_with_comment = value_is_block
-                    && had_leading_comment
-                    && map.comma_spans.len() >= map.items.len();
-            }
             if key_is_block && !value_is_block {
                 // Block keys never break before their value (`): "v",`).
                 value::write_component_value(&item.key, key_ctx, f);
@@ -323,14 +315,15 @@ pub(super) fn write_sass_map<'a>(
             } else if value_is_block {
                 value::write_component_value(&item.key, key_ctx, f);
                 write!(f, [":", space()]);
-                // A paren/map KEY (or a leading comment) keeps the pair's indent on the value
-                // (Prettier's dedent applies only when the doc is a plain `group(indent(fill))`).
-                // NOTE: Prettier ALSO skips the dedent inside `@if`/`@each`/... and double-indents the value.
-                // (prettier#16607 crash-guard artifact we deliberately do NOT match)
                 let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                     write_top_level_value(&item.value, val_ctx, f);
                 });
-                if key_is_block || had_leading_comment {
+                // Prettier's dedent applies only when the pair doc is a plain `group(indent(fill))`;
+                // a paren/map KEY changes that shape, so it keeps the pair's indent on the value.
+                // NOTE: two more dedent skips are deliberately NOT matched here (see "Known divergences" in AGENTS.md):
+                // - LEADING COMMENT (also changes the doc shape; trivia must not change layout)
+                // - `@if`/`@each`/... ancestor (an explicit prettier#16607 crash-guard, not doc shape: SAME source, different indent per context)
+                if key_is_block {
                     write!(f, indent(&body));
                 } else {
                     write!(f, body);
@@ -369,15 +362,12 @@ pub(super) fn write_sass_map<'a>(
             .comments()
             .iter_before(r_paren)
             .any(|c| c.span.start >= last_item_end && value::comment_is_own_line(c, source));
-        // Prettier drops the trailing comma after a comment-preceded block value
-        // (the pair doc isn't the plain dedent shape).
-        // A comment before the FIRST item also drops it:
+        // A comment before the FIRST item drops the trailing comma:
         // the comment becomes `groups[0]` of the paren group,
-        // so `isKeyValuePairInParenGroupNode` no longer sees a key-value pair
-        // and the group stops being an SCSS map item.
-        let printed_comma =
-            (trailing && !last_item_block_with_comment && !first_item_has_leading_comment)
-                || has_ownline_tail;
+        // so `isKeyValuePairInParenGroupNode` no longer sees a key-value pair and the group stops being an SCSS map item.
+        // A comment before a LATER item never does
+        // (Prettier keeps the comma there whether or not the source had one — required for idempotency).
+        let printed_comma = (trailing && !first_item_has_leading_comment) || has_ownline_tail;
         if printed_comma {
             write!(f, ",");
         }

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/map-comment-block-value-comma.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/map-comment-block-value-comma.scss
@@ -1,0 +1,42 @@
+// A comment-preceded block value in LAST position always keeps the trailing comma,
+// whether or not the source had one
+// (Prettier does the same; a source-comma-dependent comma would flip on every re-format = not idempotent).
+// Both sources below must converge to the same commaed output;
+// conformance's scss/parens/2.scss covers only the comma-less source with `(` on its own line.
+//
+// DIVERGENCE (see AGENTS.md): the `b:` bodies print at the normal nested-map indent;
+// Prettier double-indents them (`+6` body / `+4` `)`, its dedent-skip doc-shape artifact).
+$with-comment_n_comma: (
+  a: (
+    x: 1,
+  ),
+  /* c */
+  b: (
+    x: 2,
+  ),
+);
+$with-comment_only: (
+  a: (
+    x: 1,
+  ),
+  /* c */
+  b: (
+    x: 2,
+  )
+);
+$with-comma_only: (
+  a: (
+    x: 1,
+  ),
+  b: (
+    x: 2,
+  ),
+);
+$without-both: (
+  a: (
+    x: 1,
+  ),
+  b: (
+    x: 2,
+  )
+);

--- a/crates/oxc_formatter_css/tests/fixtures/format/scss/map-comment-block-value-comma.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/scss/map-comment-block-value-comma.scss.snap
@@ -1,0 +1,141 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A comment-preceded block value in LAST position always keeps the trailing comma,
+// whether or not the source had one
+// (Prettier does the same; a source-comma-dependent comma would flip on every re-format = not idempotent).
+// Both sources below must converge to the same commaed output;
+// conformance's scss/parens/2.scss covers only the comma-less source with `(` on its own line.
+//
+// DIVERGENCE (see AGENTS.md): the `b:` bodies print at the normal nested-map indent;
+// Prettier double-indents them (`+6` body / `+4` `)`, its dedent-skip doc-shape artifact).
+$with-comment_n_comma: (
+  a: (
+    x: 1,
+  ),
+  /* c */
+  b: (
+    x: 2,
+  ),
+);
+$with-comment_only: (
+  a: (
+    x: 1,
+  ),
+  /* c */
+  b: (
+    x: 2,
+  )
+);
+$with-comma_only: (
+  a: (
+    x: 1,
+  ),
+  b: (
+    x: 2,
+  ),
+);
+$without-both: (
+  a: (
+    x: 1,
+  ),
+  b: (
+    x: 2,
+  )
+);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A comment-preceded block value in LAST position always keeps the trailing comma,
+// whether or not the source had one
+// (Prettier does the same; a source-comma-dependent comma would flip on every re-format = not idempotent).
+// Both sources below must converge to the same commaed output;
+// conformance's scss/parens/2.scss covers only the comma-less source with `(` on its own line.
+//
+// DIVERGENCE (see AGENTS.md): the `b:` bodies print at the normal nested-map indent;
+// Prettier double-indents them (`+6` body / `+4` `)`, its dedent-skip doc-shape artifact).
+$with-comment_n_comma: (
+  a: (
+    x: 1,
+  ),
+  /* c */
+  b: (
+    x: 2,
+  ),
+);
+$with-comment_only: (
+  a: (
+    x: 1,
+  ),
+  /* c */
+  b: (
+    x: 2,
+  ),
+);
+$with-comma_only: (
+  a: (
+    x: 1,
+  ),
+  b: (
+    x: 2,
+  ),
+);
+$without-both: (
+  a: (
+    x: 1,
+  ),
+  b: (
+    x: 2,
+  ),
+);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A comment-preceded block value in LAST position always keeps the trailing comma,
+// whether or not the source had one
+// (Prettier does the same; a source-comma-dependent comma would flip on every re-format = not idempotent).
+// Both sources below must converge to the same commaed output;
+// conformance's scss/parens/2.scss covers only the comma-less source with `(` on its own line.
+//
+// DIVERGENCE (see AGENTS.md): the `b:` bodies print at the normal nested-map indent;
+// Prettier double-indents them (`+6` body / `+4` `)`, its dedent-skip doc-shape artifact).
+$with-comment_n_comma: (
+  a: (
+    x: 1,
+  ),
+  /* c */
+  b: (
+    x: 2,
+  ),
+);
+$with-comment_only: (
+  a: (
+    x: 1,
+  ),
+  /* c */
+  b: (
+    x: 2,
+  ),
+);
+$with-comma_only: (
+  a: (
+    x: 1,
+  ),
+  b: (
+    x: 2,
+  ),
+);
+$without-both: (
+  a: (
+    x: 1,
+  ),
+  b: (
+    x: 2,
+  ),
+);
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-scss.snap
+++ b/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-scss.snap
@@ -2,14 +2,16 @@
 source: crates/oxc_formatter_css/tests/conformance.rs
 expression: report
 ---
-scss compatibility: 86/90 (95.56%), 6 files skipped
+scss compatibility: 84/90 (93.33%), 6 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
 | scss/comments/4878.scss | 💥 | 89.39% |
+| scss/map/comment.scss | 💥💥 | 73.91% |
 | scss/map/function-argument/functional-argument.scss | 💥 | 96.00% |
+| scss/parens/2.scss | 💥 | 75.00% |
 | scss/parens/issue-16594.scss | 💥 | 71.43% |
 | scss/variables/apply-rule.scss | 💥 | 87.88% |
 
@@ -21,7 +23,3 @@ scss compatibility: 86/90 (95.56%), 6 files skipped
 - scss/math/3945.scss
 - scss/no-semicolon/url.scss
 - scss/parens/parens.scss
-
-# Not idempotent
-
-- scss/parens/2.scss


### PR DESCRIPTION
Fixed idempotency issue.

```scss
$with-comment_n_comma: (
  a: (
    x: 1,
  ),
  /* This comment should not affect trailing comma, indent depth */
  b: (
    x: 2,
  ),
);
```
