### PR TITLE
fix(formatter_css): fill own-line block comments inside space-separated values

### DIFF
--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -58,8 +58,9 @@ they are collected via `ParserBuilder::comments()` into a positional cursor over
 
 - Statement-level comments: flushed before each statement (`flush_leading_comments`);
   consecutive same-line comments stay glued (`*/ /*!`), but a comment is always followed by a line break before a node
-- Value-level comments: flushed inside fill entries before the component they precede (`flush_value_comments`);
-  `//` comments expand the parent group and force a hardline after
+- Value-level comments: block comments between fill runs are standalone fill items (own-line or not);
+  the rest (leads before the first component, own-line `//`) flush at the next entry's head (`flush_value_comments`),
+  where `//` comments expand the parent group and force a hardline after
 - Trailing (`value /* c */;`): flushed by `write_declaration` with the source gap before `;` preserved
 - After each statement, the sequence DISCARDS unclaimed comments inside the statement span
   (cursor must never point before a printed position)
@@ -79,7 +80,9 @@ The shared invariants (FORMATTER_POLICY.md "Comment placement invariants") apply
 - The positional cursor makes ownership a bounds discipline, not an attachment one:
   - a flush's upper bound must never extend past the next piece of user content,
   - and a declaration's `tail_bound` may only be consumed by the LAST comma group (`write_value_groups` clears it for every other group)
-- Line-boundary rule in CSS terms: `//` comments force a hardline after; own-line comments stay own-line
+- Line-boundary rule in CSS terms: `//` comments force a hardline after;
+  - own-line comments stay own-line at statement and trailing level, but a value-level own-line BLOCK comment is a plain fill item (joins the line when it fits):
+    - it carries no line-based semantics, and freezing it own-line would pin a wrapped layout (= not idempotent)
 
 ### Line endings
 

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -940,23 +940,17 @@ pub(super) fn write_comma_group<'a>(
                     filler.entry(&soft_line_break_or_space(), &content);
                 }
             }
-            // Trailing same-line comments become their own fill items
-            // (they wrap independently when the line is too long).
+            // Block comments between runs become their own fill items, own-line ones included:
+            // keeping those own-line would freeze a previously wrapped layout (= not idempotent).
             if !is_last_run {
                 let next_start = to_span(values[run_end].span()).start;
                 for &comment in pending.iter().filter(|c| {
-                    !c.inline
-                        && c.span.start >= run_end_pos
-                        && c.span.end <= next_start
-                        && !comment_is_own_line(**c, source)
+                    !c.inline && c.span.start >= run_end_pos && c.span.end <= next_start
                 }) {
                     let entry = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                         if f.context().comments().peek().is_some_and(|c| c.span == comment.span) {
                             f.context().comments().take_before(comment.span.end);
                             comments::write_single_comment(comment, f);
-                            if comment.inline {
-                                write!(f, expand_parent());
-                            }
                         }
                     });
                     filler.entry(&soft_line_break_or_space(), &entry);

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/value-own-line-comment-fill.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/value-own-line-comment-fill.css
@@ -1,0 +1,19 @@
+/* An own-line block comment inside a space-separated value is a plain fill item:
+   it joins the line when it fits and wraps independently when it does not
+   (gluing it to the next value would freeze a previously wrapped layout = not idempotent).
+   Conformance's css/comments/17479.css covers only the all-inline source;
+   these pin the own-line sources.
+ */
+.a {
+  b:
+    1px
+    /* c */
+    2px;
+}
+.b {
+  box-shadow:
+    1000px
+      /* long long long long long long long long long long long long comment */
+      1000px 2px gray,
+    1px 1px red;
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/value-own-line-comment-fill.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/value-own-line-comment-fill.css.snap
@@ -1,0 +1,64 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+/* An own-line block comment inside a space-separated value is a plain fill item:
+   it joins the line when it fits and wraps independently when it does not
+   (gluing it to the next value would freeze a previously wrapped layout = not idempotent).
+   Conformance's css/comments/17479.css covers only the all-inline source;
+   these pin the own-line sources.
+ */
+.a {
+  b:
+    1px
+    /* c */
+    2px;
+}
+.b {
+  box-shadow:
+    1000px
+      /* long long long long long long long long long long long long comment */
+      1000px 2px gray,
+    1px 1px red;
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+/* An own-line block comment inside a space-separated value is a plain fill item:
+   it joins the line when it fits and wraps independently when it does not
+   (gluing it to the next value would freeze a previously wrapped layout = not idempotent).
+   Conformance's css/comments/17479.css covers only the all-inline source;
+   these pin the own-line sources.
+ */
+.a {
+  b: 1px /* c */ 2px;
+}
+.b {
+  box-shadow:
+    1000px
+      /* long long long long long long long long long long long long comment */
+      1000px 2px gray,
+    1px 1px red;
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+/* An own-line block comment inside a space-separated value is a plain fill item:
+   it joins the line when it fits and wraps independently when it does not
+   (gluing it to the next value would freeze a previously wrapped layout = not idempotent).
+   Conformance's css/comments/17479.css covers only the all-inline source;
+   these pin the own-line sources.
+ */
+.a {
+  b: 1px /* c */ 2px;
+}
+.b {
+  box-shadow:
+    1000px /* long long long long long long long long long long long long comment */ 1000px 2px gray,
+    1px 1px red;
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-css.snap
+++ b/crates/oxc_formatter_css/tests/snapshots/conformance__prettier-css.snap
@@ -34,7 +34,3 @@ css compatibility: 145/151 (96.03%), 17 files skipped
 - css/selector-list/selectors.css
 - css/selector-string/string.css
 - css/stylefmt-repo/ie-hacks/ie-hacks.css
-
-# Not idempotent
-
-- css/comments/17479.css


### PR DESCRIPTION
Fixed idempotency issue.

Block comment is a normal fill item in values.
