### PR TITLE
feat(formatter): implement `operatorPosition` option

### DIFF
--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -149,7 +149,7 @@ Accepted edges (byte-identical to Prettier, semantically inert, idempotent):
 ## Known divergences
 
 Admission reasons and rules: see FORMATTER_POLICY.md "Known divergences".
-Entries documented in this file so far (all of the comment-attachment-artifact class, details in "Comment placement invariants" above) is not yet an exhaustive audit against the conformance snapshots:
+The entries documented so far are not yet an exhaustive audit against the conformance snapshots:
 
 - A comment after a trailing array hole stays in place; Prettier relocates it backward across commas to the last real element
 - Asymmetric attachment like `export type T = string /* c */;` (comment moved behind `;` only in the exported form): one uniform rule instead of emulating the asymmetry
@@ -157,6 +157,10 @@ Entries documented in this file so far (all of the comment-attachment-artifact c
   - Prettier preserves the source break only in the unary position and only when the last operand was alone on its source line (attachment binds the comment to that operand)
   - Internal inconsistency plus source-layout sensitivity, overridden by the uniform rule
   - Conditions are a separate shared rule (logical operands always break)
+- `experimentalOperatorPosition: "start"`, binary-like chains: a single space before the previous operand's flushed trailing line comment (`prev // c`); Prettier emits two (`prev  // c`)
+  - Artifact of its comment-extraction doc surgery: an unconditional separator space that its end-of-line trimming can only remove when no line-suffix comment flushes behind it
+- `experimentalOperatorPosition: "start"`, intersection types: a leading own-line comment stays own-line, above the leading `&`; Prettier prints it behind `& `, losing its own-line-ness and idempotency (the second pass inlines the type with the comment behind `;`)
+  - Binary-like chains hoist the comment in both formatters; one uniform rule (and the own-line invariant) over Prettier's internal inconsistency
 
 ## Verification
 

--- a/crates/oxc_formatter/src/formatter/prelude.rs
+++ b/crates/oxc_formatter/src/formatter/prelude.rs
@@ -1,7 +1,7 @@
 pub use super::{
     JoinBuilderJsExt as _, JsFormatContext, JsFormatter, JsFormatterExt as _,
     builders::*,
-    trivia::{format_dangling_comments, format_leading_comments},
+    trivia::{format_dangling_comments, format_hoisted_leading_comments, format_leading_comments},
 };
 pub use crate::source_text::SourceTextExt as _;
 pub use oxc_formatter_core::{

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -160,6 +160,44 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatLeadingComments<'a> {
     }
 }
 
+/// Leading comments of the node at `span`, hoisted above a leading operator
+/// (binary-like chains and intersection types under `operatorPosition: start`).
+/// Union `|` chains apply the same rule with trailing-style rendering instead:
+/// Prettier preserves a blank line before the hoisted comment there,
+/// while collapsing it in the chains served here (see the note in `union_type.rs`).
+///
+/// Writes only when an own-line comment is pending,
+/// keeping it own-line instead of trailing the operator (`&& `);
+/// otherwise same-line comments stay with the operand, after the operator.
+#[inline]
+pub const fn format_hoisted_leading_comments(span: Span) -> FormatHoistedLeadingComments {
+    FormatHoistedLeadingComments(span)
+}
+
+/// See [`format_hoisted_leading_comments`].
+#[derive(Debug, Copy, Clone)]
+pub struct FormatHoistedLeadingComments(Span);
+
+impl<'a> Format<'a, JsFormatContext<'a>> for FormatHoistedLeadingComments {
+    fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
+        let hoist = {
+            let comments = f.comments();
+            comments.has_leading_own_line_comment(self.0.start)
+                && !comments
+                    .comments_before_iter(self.0.start)
+                    // Type-cast comments are never hoisted, even when it ends its source line
+                    // ```js
+                    // b || /** @type {string} */
+                    // (c)
+                    // ```
+                    .any(|comment| comments.is_type_cast_comment(comment))
+        };
+        if hoist {
+            FormatLeadingComments::Node(self.0).fmt(f);
+        }
+    }
+}
+
 /// Formats the trailing comments of `node`.
 #[inline]
 pub const fn format_trailing_comments<'a>(

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -48,12 +48,12 @@ pub struct JsFormatOptions {
     /// When true, HTML-in-JS templates always use hard line breaks for wrapping.
     pub html_whitespace_sensitivity_ignore: bool,
 
-    /// Controls the position of operators in binary expressions. [**NOT SUPPORTED YET**]
+    /// Controls the position of operators in binary expressions.
     ///
     /// Accepted values are:
     /// - `"start"`: Places the operator at the beginning of the next line.
     /// - `"end"`: Places the operator at the end of the current line (default).
-    pub experimental_operator_position: OperatorPosition,
+    pub operator_position: OperatorPosition,
     /// Try prettier's new ternary formatting before it becomes the default behavior. [**NOT SUPPORTED YET**]
     ///
     /// Valid options:
@@ -222,7 +222,7 @@ impl fmt::Display for JsFormatOptions {
         writeln!(f, "Bracket same line: {}", self.bracket_same_line.value())?;
         writeln!(f, "Attribute Position: {}", self.attribute_position)?;
         writeln!(f, "Expand lists: {}", self.expand)?;
-        writeln!(f, "Experimental operator position: {}", self.experimental_operator_position)?;
+        writeln!(f, "Operator position: {}", self.operator_position)?;
         writeln!(f, "Sort imports: {:?}", self.sort_imports)?;
         writeln!(f, "Sort tailwindcss: {:?}", self.sort_tailwindcss)?;
         writeln!(f, "JSDoc: {:?}", self.jsdoc)

--- a/crates/oxc_formatter/src/print/binary_like_expression.rs
+++ b/crates/oxc_formatter/src/print/binary_like_expression.rs
@@ -1,5 +1,5 @@
 use oxc_ast::ast::*;
-use oxc_span::GetSpan;
+use oxc_span::{GetSpan, Span};
 use oxc_syntax::precedence::{GetPrecedence, Precedence};
 
 use crate::{
@@ -404,36 +404,26 @@ impl<'a> Format<'a, JsFormatContext<'a>> for BinaryLeftOrRightSide<'a, '_> {
                         && let Some(operator) = logical_operator
                         && operator == right_logical.operator()
                     {
-                        write!(
-                            f,
-                            [
-                                space(),
-                                operator.as_str(),
-                                soft_line_break_or_space(),
-                                format_with(|f| {
-                                    // If the left side of the right logical expression is still a logical expression with
-                                    // the same operator, we need to recursively format it inline.
-                                    // This way, we can ensure that all parts are in the same group.
-                                    // We format directly instead of allocating a Vec via split_into_left_and_right_sides.
-                                    let left_child = right_logical.left();
-                                    if let AstNodes::LogicalExpression(left_logical_child) =
-                                        left_child.as_ast_nodes()
-                                        && operator == left_logical_child.operator()
-                                    {
-                                        // Format the nested logical expression inline without Vec allocation
-                                        format_flattened_logical_expression(
-                                            BinaryLikeExpression::LogicalExpression(
-                                                left_logical_child,
-                                            ),
-                                            *inside_parenthesis,
-                                            f,
-                                        );
-                                    } else {
-                                        left_child.fmt(f);
-                                    }
-                                })
-                            ]
-                        );
+                        format_operator_and_break(operator.into(), right_logical.left().span(), f);
+
+                        // If the left side of the right logical expression is still a logical expression with the same operator,
+                        // we need to recursively format it inline.
+                        // This way, we can ensure that all parts are in the same group.
+                        // We format directly instead of allocating a Vec via `split_into_left_and_right_sides`.
+                        let left_child = right_logical.left();
+                        if let AstNodes::LogicalExpression(left_logical_child) =
+                            left_child.as_ast_nodes()
+                            && operator == left_logical_child.operator()
+                        {
+                            // Format the nested logical expression inline without Vec allocation
+                            format_flattened_logical_expression(
+                                BinaryLikeExpression::LogicalExpression(left_logical_child),
+                                *inside_parenthesis,
+                                f,
+                            );
+                        } else {
+                            left_child.fmt(f);
+                        }
 
                         binary_like_expression =
                             BinaryLikeExpression::LogicalExpression(right_logical);
@@ -445,12 +435,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for BinaryLeftOrRightSide<'a, '_> {
                 let right = binary_like_expression.right();
 
                 let operator_and_right_expression = format_with(|f| {
-                    write!(f, [space(), binary_like_expression.operator()]);
-
-                    let should_inline = binary_like_expression.should_inline_logical_expression();
-
-                    if should_inline {
-                        write!(f, [space()]);
+                    if binary_like_expression.should_inline_logical_expression() {
+                        write!(f, [space(), binary_like_expression.operator(), space()]);
 
                         if !right.is_jsx()
                             && f.comments().has_leading_own_line_comment(right.span().start)
@@ -458,7 +444,11 @@ impl<'a> Format<'a, JsFormatContext<'a>> for BinaryLeftOrRightSide<'a, '_> {
                             return write!(f, soft_line_indent_or_space(right));
                         }
                     } else {
-                        write!(f, [soft_line_break_or_space()]);
+                        format_operator_and_break(
+                            binary_like_expression.operator(),
+                            right.span(),
+                            f,
+                        );
                     }
 
                     write!(f, right);
@@ -579,6 +569,33 @@ fn split_into_left_and_right_sides<'a, 'b>(
     split_into_left_and_right_sides_inner(binary, inside_condition, &mut items);
 
     items
+}
+
+/// Writes the operator and the break around it for one operand of a binary-like chain, per `operatorPosition`.
+///
+/// If `operatorPosition: end`, `<space><operator><soft break>`: the operator trails the previous line.
+///
+/// If `operatorPosition: start`, `<soft break><operator><space>`: with the operand's leading own-line comments hoisted above the operator.
+/// NOTE: Prettier additionally emits a stray second space before the previous operand's flushed trailing line comment
+/// (`prev  // comment`), but we don't.
+fn format_operator_and_break(
+    operator: BinaryLikeOperator,
+    operand_span: Span,
+    f: &mut JsFormatter<'_, '_>,
+) {
+    if f.options().operator_position.is_end() {
+        write!(f, [space(), operator, soft_line_break_or_space()]);
+    } else {
+        write!(
+            f,
+            [
+                soft_line_break_or_space(),
+                format_hoisted_leading_comments(operand_span),
+                operator,
+                space()
+            ]
+        );
+    }
 }
 
 /// There are cases where the parent decides to inline the element; in

--- a/crates/oxc_formatter/src/print/intersection_type.rs
+++ b/crates/oxc_formatter/src/print/intersection_type.rs
@@ -3,8 +3,8 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    ast_nodes::AstNode, formatter::prelude::*, parentheses::NeedsParentheses, print::FormatWrite,
-    utils::typescript::is_object_like_type, write,
+    ast_nodes::AstNode, format_args, formatter::prelude::*, parentheses::NeedsParentheses,
+    print::FormatWrite, utils::typescript::is_object_like_type, write,
 };
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSIntersectionType<'a>> {
@@ -15,11 +15,21 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSIntersectionType<'a>> {
 }
 
 // [Prettier applies]: https://github.com/prettier/prettier/blob/cd3e530c2e51fb8296c0fb7738a9afdd3a3a4410/src/language-js/print/type-annotation.js#L93-L120
+//
+// NOTE: The trailing `&` here vs union's leading `|` is a long-standing, undecided Prettier inconsistency
+// (prettier#3986: the 2018 unifying PR was rejected as "current behavior is desired"; maintainers are split again as of 2025-12, no decision).
+//
+// `operatorPosition: "start"` resolves only the operator half,
+// the chain still hangs off the first line instead of breaking after `=` into a full union-style member list.
+//
+// Planned (product decision, pending the union 3.8-stay decision in `union_type.rs`): unify this printer into the union layout.
+// One member per line with leading `&`, object members treated like any other member (NO hug special case).
+// Until that lands, this follows Prettier's current output.
 fn format_intersection_types<'a>(
     node: &AstNode<'a, ArenaVec<'a, TSType<'a>>>,
     f: &mut JsFormatter<'_, 'a>,
 ) {
-    let last_index = node.len().saturating_sub(1);
+    let operator_leads_break = f.options().operator_position.is_start();
     let mut is_prev_object_like = false;
     let mut is_chain_indented = false;
 
@@ -40,9 +50,23 @@ fn format_intersection_types<'a>(
                     }
                     write!(f, item);
                 });
-                write!(f, soft_line_indent_or_space(&content));
+                if operator_leads_break {
+                    // The hoist keeps own-line comments own-line, like binary-like chains.
+                    // NOTE: Prettier prints them behind `& `, losing that (and idempotency).
+                    write!(
+                        f,
+                        soft_line_indent_or_space(&format_args!(
+                            format_hoisted_leading_comments(item.span()),
+                            "&",
+                            space(),
+                            content
+                        ))
+                    );
+                } else {
+                    write!(f, [space(), "&", soft_line_indent_or_space(&content)]);
+                }
             } else {
-                write!(f, space());
+                write!(f, [space(), "&", space()]);
 
                 if !is_prev_object_like || !is_object_like {
                     // indent if we move from object to non-object or vice versa, otherwise keep inline
@@ -55,11 +79,6 @@ fn format_intersection_types<'a>(
                     write!(f, item);
                 }
             }
-        }
-
-        // Add separator if not the last element
-        if index < last_index {
-            write!(f, [space(), "&"]);
         }
 
         is_prev_object_like = is_object_like;

--- a/crates/oxc_formatter/src/print/union_type.rs
+++ b/crates/oxc_formatter/src/print/union_type.rs
@@ -1,3 +1,13 @@
+//! NOTE: This printer deliberately stays on Prettier 3.8-style expansion (one member per line with leading `|`)
+//! and will probably NOT follow Prettier 3.9's fit-to-width rewrite
+//! (prettier#18827: collapse when it fits, changed `=` comment placement, conditional-type `? |` hugging).
+//!
+//! Not final yet, but that is the working assumption:
+//! the per-member layout is the diff-friendly output, and the rewrite is still contested upstream (prettier#19733, open).
+//! Most `typescript/union/**` conformance failures are this one cluster;
+//! once the decision is final, reclassify them as a Known divergence entry instead of catch-up backlog.
+//! Planned: intersection types unify INTO this printer's layout (see the NOTE in `intersection_type.rs`).
+
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
@@ -297,6 +307,15 @@ fn format_union_types<'a>(
             // ```
             // If there is a leading own line comment between `|` and the next node, we need to put printing comments
             // before `|` instead of after it.
+            //
+            // NOTE: this is the same hoist rule as `format_hoisted_leading_comments`, but it must stay trailing-style:
+            // Prettier preserves a blank line before the comment in union chains (`lines_before`-driven),
+            // while collapsing it in binary-like chains (leading-style).
+            // One shared rendering would diverge on one of the two.
+            //
+            // The asymmetry is an attachment artifact on Prettier's side:
+            // only its trailing-comment printer preserves the empty line (`printTrailingComment`),
+            // and this comment attaches as trailing there, leading in binary-like chains.
             if f.comments().has_leading_own_line_comment(next_node_span.start) {
                 let comments = f.context().comments().comments_before(next_node_span.start);
                 FormatTrailingComments::Comments(comments).fmt(f);

--- a/crates/oxc_formatter/tests/conformance.rs
+++ b/crates/oxc_formatter/tests/conformance.rs
@@ -119,8 +119,7 @@ const IGNORE: &[&str] = &[
 
 /// Option combinations not supported yet; dropped from the test population entirely.
 fn skip_unsupported_options(spec: &OptionSet) -> bool {
-    spec.get("experimentalOperatorPosition").and_then(serde_json::Value::as_str) == Some("start")
-        || spec.get("experimentalTernaries").and_then(serde_json::Value::as_bool) == Some(true)
+    spec.get("experimentalTernaries").and_then(serde_json::Value::as_bool) == Some(true)
 }
 
 const JS: ConformanceConfig = ConformanceConfig {

--- a/crates/oxc_formatter/tests/fixtures/js/operator-position/binary-like.js
+++ b/crates/oxc_formatter/tests/fixtures/js/operator-position/binary-like.js
@@ -1,0 +1,11 @@
+// `start` puts operators at the head of continuation lines; `end` leaves them trailing.
+const result = aaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbb + cccccccccccccccccccccccc;
+
+const condition = aaaaaaaaaaaaaaaaaaaaaa && bbbbbbbbbbbbbbbbbbbbbbbb && cccccccccccccccccccccccccc;
+
+// Inlined logical right side (non-empty object literal):
+// the operator stays trailing in either mode.
+const inlined = someLongLongLongLongLongLongCondition && { foo: "bar", baz: "qux", quux: "corge" };
+
+// Binary `&` with an object literal is NOT inlined; it breaks like any binary chain.
+const masked = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & { cause: unknown, foo: barbarbar };

--- a/crates/oxc_formatter/tests/fixtures/js/operator-position/binary-like.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/operator-position/binary-like.js.snap
@@ -1,0 +1,102 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// `start` puts operators at the head of continuation lines; `end` leaves them trailing.
+const result = aaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbb + cccccccccccccccccccccccc;
+
+const condition = aaaaaaaaaaaaaaaaaaaaaa && bbbbbbbbbbbbbbbbbbbbbbbb && cccccccccccccccccccccccccc;
+
+// Inlined logical right side (non-empty object literal):
+// the operator stays trailing in either mode.
+const inlined = someLongLongLongLongLongLongCondition && { foo: "bar", baz: "qux", quux: "corge" };
+
+// Binary `&` with an object literal is NOT inlined; it breaks like any binary chain.
+const masked = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & { cause: unknown, foo: barbarbar };
+
+==================== Output ====================
+---------------------------------------------------------
+{ experimentalOperatorPosition: "start", printWidth: 80 }
+---------------------------------------------------------
+// `start` puts operators at the head of continuation lines; `end` leaves them trailing.
+const result =
+  aaaaaaaaaaaaaaaaaaaaaaaa
+  + bbbbbbbbbbbbbbbbbbbbbbbb
+  + cccccccccccccccccccccccc;
+
+const condition =
+  aaaaaaaaaaaaaaaaaaaaaa
+  && bbbbbbbbbbbbbbbbbbbbbbbb
+  && cccccccccccccccccccccccccc;
+
+// Inlined logical right side (non-empty object literal):
+// the operator stays trailing in either mode.
+const inlined = someLongLongLongLongLongLongCondition && {
+  foo: "bar",
+  baz: "qux",
+  quux: "corge",
+};
+
+// Binary `&` with an object literal is NOT inlined; it breaks like any binary chain.
+const masked =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  & { cause: unknown, foo: barbarbar };
+
+----------------------------------------------------------
+{ experimentalOperatorPosition: "start", printWidth: 100 }
+----------------------------------------------------------
+// `start` puts operators at the head of continuation lines; `end` leaves them trailing.
+const result = aaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbb + cccccccccccccccccccccccc;
+
+const condition = aaaaaaaaaaaaaaaaaaaaaa && bbbbbbbbbbbbbbbbbbbbbbbb && cccccccccccccccccccccccccc;
+
+// Inlined logical right side (non-empty object literal):
+// the operator stays trailing in either mode.
+const inlined = someLongLongLongLongLongLongCondition && { foo: "bar", baz: "qux", quux: "corge" };
+
+// Binary `&` with an object literal is NOT inlined; it breaks like any binary chain.
+const masked = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & { cause: unknown, foo: barbarbar };
+
+-------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 80 }
+-------------------------------------------------------
+// `start` puts operators at the head of continuation lines; `end` leaves them trailing.
+const result =
+  aaaaaaaaaaaaaaaaaaaaaaaa +
+  bbbbbbbbbbbbbbbbbbbbbbbb +
+  cccccccccccccccccccccccc;
+
+const condition =
+  aaaaaaaaaaaaaaaaaaaaaa &&
+  bbbbbbbbbbbbbbbbbbbbbbbb &&
+  cccccccccccccccccccccccccc;
+
+// Inlined logical right side (non-empty object literal):
+// the operator stays trailing in either mode.
+const inlined = someLongLongLongLongLongLongCondition && {
+  foo: "bar",
+  baz: "qux",
+  quux: "corge",
+};
+
+// Binary `&` with an object literal is NOT inlined; it breaks like any binary chain.
+const masked =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  { cause: unknown, foo: barbarbar };
+
+--------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 100 }
+--------------------------------------------------------
+// `start` puts operators at the head of continuation lines; `end` leaves them trailing.
+const result = aaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbb + cccccccccccccccccccccccc;
+
+const condition = aaaaaaaaaaaaaaaaaaaaaa && bbbbbbbbbbbbbbbbbbbbbbbb && cccccccccccccccccccccccccc;
+
+// Inlined logical right side (non-empty object literal):
+// the operator stays trailing in either mode.
+const inlined = someLongLongLongLongLongLongCondition && { foo: "bar", baz: "qux", quux: "corge" };
+
+// Binary `&` with an object literal is NOT inlined; it breaks like any binary chain.
+const masked = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & { cause: unknown, foo: barbarbar };
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/operator-position/comments.js
+++ b/crates/oxc_formatter/tests/fixtures/js/operator-position/comments.js
@@ -1,0 +1,29 @@
+// A leading own-line comment on an operand stays on its own line
+// (above the operator with `start`).
+x = aaaaaaaaaaaaaaaaaaaaaa && bbbbbbbbbbbbbbbbbbbbbbbb &&
+// own line comment
+cccccccccccccccccccccccccc;
+
+// `start` only: Prettier emits a double space before the flushed trailing line
+// comment here (`bbbb  // same line`, a separator-space artifact); we
+// deliberately emit a single one (see "Known divergences").
+y = aaaaaaaaaaaaaaaaaaaaaa && bbbbbbbbbbbbbbbbbbbbbbbb && // same line
+// own line comment
+cccccccccccccccccccccccccc;
+
+// Same interplay through the right-nested (rebalanced) chain path.
+z = aaaaaaaaaaaaaaaaaaaaaa && ( // same line
+// own line comment
+bbbbbbbbbbbbbbbbbbbbbbbb && cccccccccccccccccccccccccc);
+
+// A type-cast comment is never hoisted, even when it ends its source line:
+// it must stay attached to its parenthesized target.
+var w = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb || /** @type {string} */
+    (cccccccccccccccccccccccccc);
+
+// A blank line before the hoisted comment collapses, like Prettier
+// (union types preserve it instead, also like Prettier).
+v = aaaaaaaaaaaaaaaaaaaaaa && bbbbbbbbbbbbbbbbbbbbbbbb &&
+
+// own line after blank
+cccccccccccccccccccccccccc;

--- a/crates/oxc_formatter/tests/fixtures/js/operator-position/comments.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/operator-position/comments.js.snap
@@ -1,0 +1,200 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A leading own-line comment on an operand stays on its own line
+// (above the operator with `start`).
+x = aaaaaaaaaaaaaaaaaaaaaa && bbbbbbbbbbbbbbbbbbbbbbbb &&
+// own line comment
+cccccccccccccccccccccccccc;
+
+// `start` only: Prettier emits a double space before the flushed trailing line
+// comment here (`bbbb  // same line`, a separator-space artifact); we
+// deliberately emit a single one (see "Known divergences").
+y = aaaaaaaaaaaaaaaaaaaaaa && bbbbbbbbbbbbbbbbbbbbbbbb && // same line
+// own line comment
+cccccccccccccccccccccccccc;
+
+// Same interplay through the right-nested (rebalanced) chain path.
+z = aaaaaaaaaaaaaaaaaaaaaa && ( // same line
+// own line comment
+bbbbbbbbbbbbbbbbbbbbbbbb && cccccccccccccccccccccccccc);
+
+// A type-cast comment is never hoisted, even when it ends its source line:
+// it must stay attached to its parenthesized target.
+var w = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb || /** @type {string} */
+    (cccccccccccccccccccccccccc);
+
+// A blank line before the hoisted comment collapses, like Prettier
+// (union types preserve it instead, also like Prettier).
+v = aaaaaaaaaaaaaaaaaaaaaa && bbbbbbbbbbbbbbbbbbbbbbbb &&
+
+// own line after blank
+cccccccccccccccccccccccccc;
+
+==================== Output ====================
+---------------------------------------------------------
+{ experimentalOperatorPosition: "start", printWidth: 80 }
+---------------------------------------------------------
+// A leading own-line comment on an operand stays on its own line
+// (above the operator with `start`).
+x =
+  aaaaaaaaaaaaaaaaaaaaaa
+  && bbbbbbbbbbbbbbbbbbbbbbbb
+  // own line comment
+  && cccccccccccccccccccccccccc;
+
+// `start` only: Prettier emits a double space before the flushed trailing line
+// comment here (`bbbb  // same line`, a separator-space artifact); we
+// deliberately emit a single one (see "Known divergences").
+y =
+  aaaaaaaaaaaaaaaaaaaaaa
+  && bbbbbbbbbbbbbbbbbbbbbbbb // same line
+  // own line comment
+  && cccccccccccccccccccccccccc;
+
+// Same interplay through the right-nested (rebalanced) chain path.
+z =
+  aaaaaaaaaaaaaaaaaaaaaa // same line
+  // own line comment
+  && bbbbbbbbbbbbbbbbbbbbbbbb
+  && cccccccccccccccccccccccccc;
+
+// A type-cast comment is never hoisted, even when it ends its source line:
+// it must stay attached to its parenthesized target.
+var w =
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  || /** @type {string} */
+  (cccccccccccccccccccccccccc);
+
+// A blank line before the hoisted comment collapses, like Prettier
+// (union types preserve it instead, also like Prettier).
+v =
+  aaaaaaaaaaaaaaaaaaaaaa
+  && bbbbbbbbbbbbbbbbbbbbbbbb
+  // own line after blank
+  && cccccccccccccccccccccccccc;
+
+----------------------------------------------------------
+{ experimentalOperatorPosition: "start", printWidth: 100 }
+----------------------------------------------------------
+// A leading own-line comment on an operand stays on its own line
+// (above the operator with `start`).
+x =
+  aaaaaaaaaaaaaaaaaaaaaa
+  && bbbbbbbbbbbbbbbbbbbbbbbb
+  // own line comment
+  && cccccccccccccccccccccccccc;
+
+// `start` only: Prettier emits a double space before the flushed trailing line
+// comment here (`bbbb  // same line`, a separator-space artifact); we
+// deliberately emit a single one (see "Known divergences").
+y =
+  aaaaaaaaaaaaaaaaaaaaaa
+  && bbbbbbbbbbbbbbbbbbbbbbbb // same line
+  // own line comment
+  && cccccccccccccccccccccccccc;
+
+// Same interplay through the right-nested (rebalanced) chain path.
+z =
+  aaaaaaaaaaaaaaaaaaaaaa // same line
+  // own line comment
+  && bbbbbbbbbbbbbbbbbbbbbbbb
+  && cccccccccccccccccccccccccc;
+
+// A type-cast comment is never hoisted, even when it ends its source line:
+// it must stay attached to its parenthesized target.
+var w =
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb || /** @type {string} */ (cccccccccccccccccccccccccc);
+
+// A blank line before the hoisted comment collapses, like Prettier
+// (union types preserve it instead, also like Prettier).
+v =
+  aaaaaaaaaaaaaaaaaaaaaa
+  && bbbbbbbbbbbbbbbbbbbbbbbb
+  // own line after blank
+  && cccccccccccccccccccccccccc;
+
+-------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 80 }
+-------------------------------------------------------
+// A leading own-line comment on an operand stays on its own line
+// (above the operator with `start`).
+x =
+  aaaaaaaaaaaaaaaaaaaaaa &&
+  bbbbbbbbbbbbbbbbbbbbbbbb &&
+  // own line comment
+  cccccccccccccccccccccccccc;
+
+// `start` only: Prettier emits a double space before the flushed trailing line
+// comment here (`bbbb  // same line`, a separator-space artifact); we
+// deliberately emit a single one (see "Known divergences").
+y =
+  aaaaaaaaaaaaaaaaaaaaaa &&
+  bbbbbbbbbbbbbbbbbbbbbbbb && // same line
+  // own line comment
+  cccccccccccccccccccccccccc;
+
+// Same interplay through the right-nested (rebalanced) chain path.
+z =
+  aaaaaaaaaaaaaaaaaaaaaa && // same line
+  // own line comment
+  bbbbbbbbbbbbbbbbbbbbbbbb &&
+  cccccccccccccccccccccccccc;
+
+// A type-cast comment is never hoisted, even when it ends its source line:
+// it must stay attached to its parenthesized target.
+var w =
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ||
+  /** @type {string} */
+  (cccccccccccccccccccccccccc);
+
+// A blank line before the hoisted comment collapses, like Prettier
+// (union types preserve it instead, also like Prettier).
+v =
+  aaaaaaaaaaaaaaaaaaaaaa &&
+  bbbbbbbbbbbbbbbbbbbbbbbb &&
+  // own line after blank
+  cccccccccccccccccccccccccc;
+
+--------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 100 }
+--------------------------------------------------------
+// A leading own-line comment on an operand stays on its own line
+// (above the operator with `start`).
+x =
+  aaaaaaaaaaaaaaaaaaaaaa &&
+  bbbbbbbbbbbbbbbbbbbbbbbb &&
+  // own line comment
+  cccccccccccccccccccccccccc;
+
+// `start` only: Prettier emits a double space before the flushed trailing line
+// comment here (`bbbb  // same line`, a separator-space artifact); we
+// deliberately emit a single one (see "Known divergences").
+y =
+  aaaaaaaaaaaaaaaaaaaaaa &&
+  bbbbbbbbbbbbbbbbbbbbbbbb && // same line
+  // own line comment
+  cccccccccccccccccccccccccc;
+
+// Same interplay through the right-nested (rebalanced) chain path.
+z =
+  aaaaaaaaaaaaaaaaaaaaaa && // same line
+  // own line comment
+  bbbbbbbbbbbbbbbbbbbbbbbb &&
+  cccccccccccccccccccccccccc;
+
+// A type-cast comment is never hoisted, even when it ends its source line:
+// it must stay attached to its parenthesized target.
+var w =
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb || /** @type {string} */ (cccccccccccccccccccccccccc);
+
+// A blank line before the hoisted comment collapses, like Prettier
+// (union types preserve it instead, also like Prettier).
+v =
+  aaaaaaaaaaaaaaaaaaaaaa &&
+  bbbbbbbbbbbbbbbbbbbbbbbb &&
+  // own line after blank
+  cccccccccccccccccccccccccc;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/operator-position/options.json
+++ b/crates/oxc_formatter/tests/fixtures/js/operator-position/options.json
@@ -1,0 +1,8 @@
+[
+  {
+    "experimentalOperatorPosition": "start"
+  },
+  {
+    "experimentalOperatorPosition": "end"
+  }
+]

--- a/crates/oxc_formatter/tests/fixtures/options.rs
+++ b/crates/oxc_formatter/tests/fixtures/options.rs
@@ -94,8 +94,7 @@ pub fn apply_js_options(options: &mut JsFormatOptions, json: &OptionSet) {
             }
             "experimentalOperatorPosition" => {
                 if let Some(s) = value.as_str() {
-                    options.experimental_operator_position =
-                        OperatorPosition::from_str(s).unwrap_or_default();
+                    options.operator_position = OperatorPosition::from_str(s).unwrap_or_default();
                 }
             }
             // NOTE: Not a Prettier option

--- a/crates/oxc_formatter/tests/fixtures/ts/operator-position/intersection.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/operator-position/intersection.ts
@@ -1,0 +1,13 @@
+// `start` puts `&` at the head of continuation lines when a non-object chain breaks.
+type Long = AAAAAAAAAAAAAAAAAAAAAAAA & BBBBBBBBBBBBBBBBBBBBBBBB & CCCCCCCCCCCCCCCCCCCCCCCC;
+
+// Adjacent object types stay inline.
+type State = { sharedProperty: any } & { discriminant: "FOO"; foo: any } & { discriminant: "BAR"; bar: any };
+
+// A leading own-line comment forces the break. With `start` we keep it own-line
+// above the leading `&` (idempotent), like binary-like chains do; Prettier prints
+// it behind `& `, losing own-line-ness and idempotency — a deliberate divergence
+// (see "Known divergences").
+type WithComment = SerializedProps &
+  // own line comment
+  { cause: unknown };

--- a/crates/oxc_formatter/tests/fixtures/ts/operator-position/intersection.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/operator-position/intersection.ts.snap
@@ -1,0 +1,104 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// `start` puts `&` at the head of continuation lines when a non-object chain breaks.
+type Long = AAAAAAAAAAAAAAAAAAAAAAAA & BBBBBBBBBBBBBBBBBBBBBBBB & CCCCCCCCCCCCCCCCCCCCCCCC;
+
+// Adjacent object types stay inline.
+type State = { sharedProperty: any } & { discriminant: "FOO"; foo: any } & { discriminant: "BAR"; bar: any };
+
+// A leading own-line comment forces the break. With `start` we keep it own-line
+// above the leading `&` (idempotent), like binary-like chains do; Prettier prints
+// it behind `& `, losing own-line-ness and idempotency — a deliberate divergence
+// (see "Known divergences").
+type WithComment = SerializedProps &
+  // own line comment
+  { cause: unknown };
+
+==================== Output ====================
+---------------------------------------------------------
+{ experimentalOperatorPosition: "start", printWidth: 80 }
+---------------------------------------------------------
+// `start` puts `&` at the head of continuation lines when a non-object chain breaks.
+type Long = AAAAAAAAAAAAAAAAAAAAAAAA
+  & BBBBBBBBBBBBBBBBBBBBBBBB
+  & CCCCCCCCCCCCCCCCCCCCCCCC;
+
+// Adjacent object types stay inline.
+type State = { sharedProperty: any } & { discriminant: "FOO"; foo: any } & {
+  discriminant: "BAR";
+  bar: any;
+};
+
+// A leading own-line comment forces the break. With `start` we keep it own-line
+// above the leading `&` (idempotent), like binary-like chains do; Prettier prints
+// it behind `& `, losing own-line-ness and idempotency — a deliberate divergence
+// (see "Known divergences").
+type WithComment = SerializedProps
+  // own line comment
+  & { cause: unknown };
+
+----------------------------------------------------------
+{ experimentalOperatorPosition: "start", printWidth: 100 }
+----------------------------------------------------------
+// `start` puts `&` at the head of continuation lines when a non-object chain breaks.
+type Long = AAAAAAAAAAAAAAAAAAAAAAAA & BBBBBBBBBBBBBBBBBBBBBBBB & CCCCCCCCCCCCCCCCCCCCCCCC;
+
+// Adjacent object types stay inline.
+type State = { sharedProperty: any } & { discriminant: "FOO"; foo: any } & {
+  discriminant: "BAR";
+  bar: any;
+};
+
+// A leading own-line comment forces the break. With `start` we keep it own-line
+// above the leading `&` (idempotent), like binary-like chains do; Prettier prints
+// it behind `& `, losing own-line-ness and idempotency — a deliberate divergence
+// (see "Known divergences").
+type WithComment = SerializedProps
+  // own line comment
+  & { cause: unknown };
+
+-------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 80 }
+-------------------------------------------------------
+// `start` puts `&` at the head of continuation lines when a non-object chain breaks.
+type Long = AAAAAAAAAAAAAAAAAAAAAAAA &
+  BBBBBBBBBBBBBBBBBBBBBBBB &
+  CCCCCCCCCCCCCCCCCCCCCCCC;
+
+// Adjacent object types stay inline.
+type State = { sharedProperty: any } & { discriminant: "FOO"; foo: any } & {
+  discriminant: "BAR";
+  bar: any;
+};
+
+// A leading own-line comment forces the break. With `start` we keep it own-line
+// above the leading `&` (idempotent), like binary-like chains do; Prettier prints
+// it behind `& `, losing own-line-ness and idempotency — a deliberate divergence
+// (see "Known divergences").
+type WithComment = SerializedProps &
+  // own line comment
+  { cause: unknown };
+
+--------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 100 }
+--------------------------------------------------------
+// `start` puts `&` at the head of continuation lines when a non-object chain breaks.
+type Long = AAAAAAAAAAAAAAAAAAAAAAAA & BBBBBBBBBBBBBBBBBBBBBBBB & CCCCCCCCCCCCCCCCCCCCCCCC;
+
+// Adjacent object types stay inline.
+type State = { sharedProperty: any } & { discriminant: "FOO"; foo: any } & {
+  discriminant: "BAR";
+  bar: any;
+};
+
+// A leading own-line comment forces the break. With `start` we keep it own-line
+// above the leading `&` (idempotent), like binary-like chains do; Prettier prints
+// it behind `& `, losing own-line-ness and idempotency — a deliberate divergence
+// (see "Known divergences").
+type WithComment = SerializedProps &
+  // own line comment
+  { cause: unknown };
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/operator-position/options.json
+++ b/crates/oxc_formatter/tests/fixtures/ts/operator-position/options.json
@@ -1,0 +1,8 @@
+[
+  {
+    "experimentalOperatorPosition": "start"
+  },
+  {
+    "experimentalOperatorPosition": "end"
+  }
+]

--- a/crates/oxc_formatter/tests/fixtures/ts/operator-position/union.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/operator-position/union.ts
@@ -1,0 +1,15 @@
+// `operatorPosition` does NOT apply to unions: `|` leads the members in either
+// mode (both option sections below must stay identical; see NOTE in union_type.rs).
+type Long = AAAAAAAAAAAAAAAAAAAAAAAA | BBBBBBBBBBBBBBBBBBBBBBBB | CCCCCCCCCCCCCCCCCCCCCCCC;
+
+// A leading own-line comment stays own-line, above the leading `|`.
+type WithComment = SerializedProps |
+  // own line comment
+  { cause: unknown };
+
+// A blank line before the hoisted comment is preserved (trailing-style rendering);
+// binary chains and intersections collapse it instead, like Prettier does.
+type WithBlank = AAAAAAAAAAAAAAAAAAAAAAAA |
+
+  // own line after blank
+  BBBBBBBBBBBBBBBBBBBBBBBB | CCCCCCCCCCCCCCCCCCCCCCCC;

--- a/crates/oxc_formatter/tests/fixtures/ts/operator-position/union.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/operator-position/union.ts.snap
@@ -1,0 +1,116 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// `operatorPosition` does NOT apply to unions: `|` leads the members in either
+// mode (both option sections below must stay identical; see NOTE in union_type.rs).
+type Long = AAAAAAAAAAAAAAAAAAAAAAAA | BBBBBBBBBBBBBBBBBBBBBBBB | CCCCCCCCCCCCCCCCCCCCCCCC;
+
+// A leading own-line comment stays own-line, above the leading `|`.
+type WithComment = SerializedProps |
+  // own line comment
+  { cause: unknown };
+
+// A blank line before the hoisted comment is preserved (trailing-style rendering);
+// binary chains and intersections collapse it instead, like Prettier does.
+type WithBlank = AAAAAAAAAAAAAAAAAAAAAAAA |
+
+  // own line after blank
+  BBBBBBBBBBBBBBBBBBBBBBBB | CCCCCCCCCCCCCCCCCCCCCCCC;
+
+==================== Output ====================
+---------------------------------------------------------
+{ experimentalOperatorPosition: "start", printWidth: 80 }
+---------------------------------------------------------
+// `operatorPosition` does NOT apply to unions: `|` leads the members in either
+// mode (both option sections below must stay identical; see NOTE in union_type.rs).
+type Long =
+  | AAAAAAAAAAAAAAAAAAAAAAAA
+  | BBBBBBBBBBBBBBBBBBBBBBBB
+  | CCCCCCCCCCCCCCCCCCCCCCCC;
+
+// A leading own-line comment stays own-line, above the leading `|`.
+type WithComment =
+  | SerializedProps
+  // own line comment
+  | { cause: unknown };
+
+// A blank line before the hoisted comment is preserved (trailing-style rendering);
+// binary chains and intersections collapse it instead, like Prettier does.
+type WithBlank =
+  | AAAAAAAAAAAAAAAAAAAAAAAA
+
+  // own line after blank
+  | BBBBBBBBBBBBBBBBBBBBBBBB
+  | CCCCCCCCCCCCCCCCCCCCCCCC;
+
+----------------------------------------------------------
+{ experimentalOperatorPosition: "start", printWidth: 100 }
+----------------------------------------------------------
+// `operatorPosition` does NOT apply to unions: `|` leads the members in either
+// mode (both option sections below must stay identical; see NOTE in union_type.rs).
+type Long = AAAAAAAAAAAAAAAAAAAAAAAA | BBBBBBBBBBBBBBBBBBBBBBBB | CCCCCCCCCCCCCCCCCCCCCCCC;
+
+// A leading own-line comment stays own-line, above the leading `|`.
+type WithComment =
+  | SerializedProps
+  // own line comment
+  | { cause: unknown };
+
+// A blank line before the hoisted comment is preserved (trailing-style rendering);
+// binary chains and intersections collapse it instead, like Prettier does.
+type WithBlank =
+  | AAAAAAAAAAAAAAAAAAAAAAAA
+
+  // own line after blank
+  | BBBBBBBBBBBBBBBBBBBBBBBB
+  | CCCCCCCCCCCCCCCCCCCCCCCC;
+
+-------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 80 }
+-------------------------------------------------------
+// `operatorPosition` does NOT apply to unions: `|` leads the members in either
+// mode (both option sections below must stay identical; see NOTE in union_type.rs).
+type Long =
+  | AAAAAAAAAAAAAAAAAAAAAAAA
+  | BBBBBBBBBBBBBBBBBBBBBBBB
+  | CCCCCCCCCCCCCCCCCCCCCCCC;
+
+// A leading own-line comment stays own-line, above the leading `|`.
+type WithComment =
+  | SerializedProps
+  // own line comment
+  | { cause: unknown };
+
+// A blank line before the hoisted comment is preserved (trailing-style rendering);
+// binary chains and intersections collapse it instead, like Prettier does.
+type WithBlank =
+  | AAAAAAAAAAAAAAAAAAAAAAAA
+
+  // own line after blank
+  | BBBBBBBBBBBBBBBBBBBBBBBB
+  | CCCCCCCCCCCCCCCCCCCCCCCC;
+
+--------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 100 }
+--------------------------------------------------------
+// `operatorPosition` does NOT apply to unions: `|` leads the members in either
+// mode (both option sections below must stay identical; see NOTE in union_type.rs).
+type Long = AAAAAAAAAAAAAAAAAAAAAAAA | BBBBBBBBBBBBBBBBBBBBBBBB | CCCCCCCCCCCCCCCCCCCCCCCC;
+
+// A leading own-line comment stays own-line, above the leading `|`.
+type WithComment =
+  | SerializedProps
+  // own line comment
+  | { cause: unknown };
+
+// A blank line before the hoisted comment is preserved (trailing-style rendering);
+// binary chains and intersections collapse it instead, like Prettier does.
+type WithBlank =
+  | AAAAAAAAAAAAAAAAAAAAAAAA
+
+  // own line after blank
+  | BBBBBBBBBBBBBBBBBBBBBBBB
+  | CCCCCCCCCCCCCCCCCCCCCCCC;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_formatter/tests/conformance.rs
 expression: report
 ---
-js compatibility: 776/810 (95.80%), 23 files skipped
+js compatibility: 775/810 (95.68%), 23 files skipped
 
 # Failed
 
@@ -10,6 +10,7 @@ js compatibility: 776/810 (95.80%), 23 files skipped
 | :-------- | :--------------: | :---------: |
 | js/arrows/issue-17421.js | 💥💥 | 90.43% |
 | js/assignment-comments/indentable-block-comment.js | 💥 | 12.50% |
+| js/binary-expressions/mutiple-comments/17192.js | 💥✨ | 45.83% |
 | js/call/no-argument/no-arguments.js | 💥 | 57.53% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/if.js | 💥💥 | 97.99% |

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-ts.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-ts.snap
@@ -20,7 +20,7 @@ ts compatibility: 624/659 (94.69%), 16 files skipped
 | typescript/conformance/types/union/unionTypeCallSignatures.ts | 💥 | 85.25% |
 | typescript/conformance/types/union/unionTypeConstructSignatures.ts | 💥 | 91.62% |
 | typescript/conformance/types/union/unionTypeIndexSignature.ts | 💥 | 83.64% |
-| typescript/intersection/intersection-parens.ts | 💥💥 | 85.64% |
+| typescript/intersection/intersection-parens.ts | 💥💥💥 | 85.46% |
 | typescript/intersection/consistent-with-flow/intersection-parens.ts | 💥 | 67.44% |
 | typescript/intersection/consistent-with-flow/single-member.ts | 💥 | 78.00% |
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -5,7 +5,7 @@ checker.ts:
   sys deallocs: 19382
   sys alloc bytes: 6767781 # 6.77 MB
   sys peak growth: 2973674 # 2.97 MB
-  arena allocs: 1064047
+  arena allocs: 1064052
   arena reallocs: 927
   arena size: 90009696 # 90.01 MB
 
@@ -49,7 +49,7 @@ antd.js:
   sys deallocs: 90042
   sys alloc bytes: 76472316 # 76.47 MB
   sys peak growth: 50737424 # 50.74 MB
-  arena allocs: 2503924
+  arena allocs: 2503926
   arena reallocs: 1889
   arena size: 244471376 # 244.47 MB
 
@@ -60,7 +60,7 @@ binder.ts:
   sys deallocs: 972
   sys alloc bytes: 356005 # 356.00 kB
   sys peak growth: 195149 # 195.15 kB
-  arena allocs: 63389
+  arena allocs: 63391
   arena reallocs: 38
   arena size: 5676752 # 5.68 MB
 


### PR DESCRIPTION
NOTE: For now, behavior is the same as Prettier.

- Default is `end`
- This works on intersection(`&`) type, but has no effect on union(`|`) type

For future refs: https://github.com/oxc-project/oxc/issues/16367