### PR TITLE
fix(react-compiler): scope forwardRef discovery context

### DIFF
--- a/crates/oxc_react_compiler/fixtures/infer-forwardref-does-not-mark-nested-function-as-component.jsx
+++ b/crates/oxc_react_compiler/fixtures/infer-forwardref-does-not-mark-nested-function-as-component.jsx
@@ -1,0 +1,14 @@
+// @compilationMode:"infer"
+import { forwardRef } from 'react';
+
+const Grid = forwardRef(({ label }, ref) => {
+  const renderGridComponent = () => <div ref={ref}>{label}</div>;
+  return renderGridComponent();
+});
+
+const List = forwardRef(function ({ items }, ref) {
+  const renderListComponent = () => <ul ref={ref}>{items}</ul>;
+  return renderListComponent();
+});
+
+export { Grid, List };

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -1611,10 +1611,14 @@ impl<'a, 'b, 'ast> DiscoveryWalker<'a, 'b, 'ast> {
             // functions are descended to find nested declarations. Parameters
             // are visited before the body because their defaults may contain a
             // compilable function (for example, `Wrapper = memo(() => ...)`).
+            // The enclosing call identifies only its direct function argument;
+            // nested functions must not inherit `memo` / `forwardRef` context.
+            self.parent_callee_stack.push(None);
             self.walk_formal_parameters(&func.params);
             if let Some(body) = &func.body {
                 self.walk_function_body_block(body);
             }
+            self.parent_callee_stack.pop();
         }
 
         if pushed {
@@ -1649,6 +1653,9 @@ impl<'a, 'b, 'ast> DiscoveryWalker<'a, 'b, 'ast> {
         };
 
         if !skip_body {
+            // The enclosing call identifies only its direct function argument;
+            // nested functions must not inherit `memo` / `forwardRef` context.
+            self.parent_callee_stack.push(None);
             self.walk_formal_parameters(&arrow.params);
             if let Some(expression) = arrow.get_expression() {
                 self.walk_expression(expression);
@@ -1657,6 +1664,7 @@ impl<'a, 'b, 'ast> DiscoveryWalker<'a, 'b, 'ast> {
                     self.walk_statement(stmt);
                 }
             }
+            self.parent_callee_stack.pop();
         }
 
         if pushed {

--- a/crates/oxc_react_compiler/tests/snapshots/infer-forwardref-does-not-mark-nested-function-as-component.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/infer-forwardref-does-not-mark-nested-function-as-component.snap
@@ -1,0 +1,15 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/infer-forwardref-does-not-mark-nested-function-as-component.jsx
+---
+// @compilationMode:"infer"
+import { forwardRef } from "react";
+const Grid = forwardRef(({ label }, ref) => {
+	const renderGridComponent = () => <div ref={ref}>{label}</div>;
+	return renderGridComponent();
+});
+const List = forwardRef(function({ items }, ref) {
+	const renderListComponent = () => <ul ref={ref}>{items}</ul>;
+	return renderListComponent();
+});
+export { Grid, List };


### PR DESCRIPTION
Scopes `forwardRef`/`memo` discovery context to the direct callback so nested helpers are not incorrectly compiled with stale caches. Adds regression coverage for arrow and function callbacks.

Validated with `just ready`.

AI-assisted.