### PR TITLE
fix(react_compiler): preserve caught throw semantics

### DIFF
--- a/crates/oxc_react_compiler/fixtures/try-catch-property-dependency.tsx
+++ b/crates/oxc_react_compiler/fixtures/try-catch-property-dependency.tsx
@@ -1,0 +1,8 @@
+function Component({name}: {name: string}) {
+  try {
+    const url = new URL(name);
+    return <div>{url.search}{url.hash}</div>;
+  } catch {
+    return null;
+  }
+}

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -28,7 +28,7 @@ use crate::react_compiler_hir::{
     PlaceOrSpread, PropertyLiteral, ReactFunctionType, ReactiveScopeDeclaration,
     ReactiveScopeDependency, ScopeId, Terminal, Type, is_ref_value_type, is_use_ref_type, visitors,
 };
-use crate::react_compiler_optimization::dead_code_elimination::is_catch_observable_property_load;
+use crate::react_compiler_optimization::dead_code_elimination::find_semantic_only_caught_instructions;
 use oxc_span::Span;
 
 // =============================================================================
@@ -1747,6 +1747,24 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
         self.visit_dependency(dep, env);
     }
 
+    fn visit_operand_root(&mut self, place: &Place, env: &mut Environment<'a>) {
+        let dep = self.temporaries[place.identifier]
+            .as_ref()
+            .map(|resolved| ReactiveScopeDependency {
+                identifier: resolved.identifier,
+                reactive: resolved.reactive,
+                path: ArenaVec::new_in(&env.allocator),
+                span: resolved.span,
+            })
+            .unwrap_or_else(|| ReactiveScopeDependency {
+                identifier: place.identifier,
+                reactive: place.reactive,
+                path: ArenaVec::new_in(&env.allocator),
+                span: place.span,
+            });
+        self.visit_dependency(dep, env);
+    }
+
     fn visit_property(
         &mut self,
         object: &Place,
@@ -1860,6 +1878,9 @@ fn visit_inner_function_blocks<'a>(
     ctx: &mut DependencyCollectionContext<'a, '_>,
     env: &mut Environment<'a>,
 ) {
+    let semantic_only_caught_instructions =
+        find_semantic_only_caught_instructions(&env.functions[func_id], env);
+
     // Clone inner function's instructions and block structure to avoid
     // borrow conflicts when mutating env through handle_instruction.
     let inner_instrs = env.functions[func_id].instructions.clone_in(env.allocator);
@@ -1907,7 +1928,12 @@ fn visit_inner_function_blocks<'a>(
                     visit_inner_function_blocks(lowered_func.func, ctx, env);
                 }
                 _ => {
-                    handle_instruction(inner_instr, ctx, env);
+                    handle_instruction(
+                        inner_instr,
+                        semantic_only_caught_instructions.as_ref().is_some_and(|loads| loads[iid]),
+                        ctx,
+                        env,
+                    );
                 }
             }
         }
@@ -1923,12 +1949,22 @@ fn visit_inner_function_blocks<'a>(
 
 fn handle_instruction<'a>(
     instr: &Instruction<'a>,
+    semantic_only_caught_instruction: bool,
     ctx: &mut DependencyCollectionContext<'a, '_>,
     env: &mut Environment<'a>,
 ) {
     let id = instr.id;
     let scope_stack_copy = ctx.scope_stack.clone();
     ctx.declare(instr.lvalue.identifier, Decl { id, scope_stack: scope_stack_copy }, env);
+
+    if semantic_only_caught_instruction {
+        // The operation must remain inside the try/catch, so use its root operands as
+        // dependencies instead of hoisting the potentially throwing operation into a cache guard.
+        for operand in visitors::each_instruction_value_operand(&instr.value, env) {
+            ctx.visit_operand_root(&operand, env);
+        }
+        return;
+    }
 
     if ctx.is_deferred_dependency_instr(instr) {
         return;
@@ -1999,6 +2035,7 @@ fn collect_dependencies<'a>(
     temporaries: &TemporariesMap<'a>,
     processed_instrs_in_optional: &FxHashSet<ProcessedInstr>,
 ) -> FxIndexMap<ScopeId, Vec<ReactiveScopeDependency<'a>>> {
+    let semantic_only_caught_instructions = find_semantic_only_caught_instructions(func, env);
     let mut ctx = DependencyCollectionContext::new(
         env.identifiers.len(),
         temporaries,
@@ -2027,7 +2064,13 @@ fn collect_dependencies<'a>(
 
     let mut traversal = ScopeBlockTraversal::new();
 
-    handle_function_deps(func, env, &mut ctx, &mut traversal);
+    handle_function_deps(
+        func,
+        env,
+        semantic_only_caught_instructions.as_ref(),
+        &mut ctx,
+        &mut traversal,
+    );
 
     ctx.deps
 }
@@ -2035,6 +2078,7 @@ fn collect_dependencies<'a>(
 fn handle_function_deps<'a>(
     func: &HirFunction<'a>,
     env: &mut Environment<'a>,
+    semantic_only_caught_instructions: Option<&IndexVec<InstructionId, bool>>,
     ctx: &mut DependencyCollectionContext<'a, '_>,
     traversal: &mut ScopeBlockTraversal,
 ) {
@@ -2087,22 +2131,13 @@ fn handle_function_deps<'a>(
                     ctx.inner_fn_context = prev_inner;
                 }
                 _ => {
-                    handle_instruction(instr, ctx, env);
-                }
-            }
-        }
-
-        // A caught throw is an observable result of a read even when its produced value is not
-        // used. Record the read's root operands as dependencies so a cached scope re-runs when
-        // the throw outcome can change. Using the roots also avoids hoisting the potentially
-        // throwing property access itself outside of the try/catch.
-        if matches!(block.terminal, Terminal::MaybeThrow { handler: Some(_), .. }) {
-            for &instr_id in &block.instructions {
-                let instr = &func.instructions[instr_id.index()];
-                if is_catch_observable_property_load(&instr.value) {
-                    for operand in visitors::each_instruction_value_operand(&instr.value, env) {
-                        ctx.visit_operand(&operand, env);
-                    }
+                    handle_instruction(
+                        instr,
+                        semantic_only_caught_instructions
+                            .is_some_and(|instructions| instructions[instr_id]),
+                        ctx,
+                        env,
+                    );
                 }
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
@@ -12,7 +12,7 @@
 //! Ported from TypeScript `src/Optimization/DeadCodeElimination.ts`.
 
 use oxc_allocator::Vec as ArenaVec;
-use oxc_index::IndexSlice;
+use oxc_index::{IndexSlice, IndexVec};
 use oxc_str::IdentHashSet;
 use rustc_hash::FxHashSet;
 
@@ -23,6 +23,7 @@ use crate::react_compiler_hir::{
     ArrayPatternElement, BlockId, BlockKind, HirFunction, Identifier, IdentifierId, IdentifierName,
     InstructionId, InstructionKind, InstructionValue, ObjectPropertyOrSpread, Pattern, Terminal,
 };
+use crate::react_compiler_optimization::prune_maybe_throws::value_may_throw;
 
 /// Implements dead-code elimination, eliminating instructions whose values are unused.
 ///
@@ -31,11 +32,11 @@ use crate::react_compiler_hir::{
 /// Corresponds to TS `deadCodeElimination(fn: HIRFunction): void`.
 pub fn dead_code_elimination<'a>(func: &mut HirFunction<'a>, env: &Environment<'a>) {
     // Phase 1: Find/mark all referenced identifiers
-    let state = find_referenced_identifiers(func, env);
+    let state = find_referenced_identifiers(func, env, true);
 
     // Phase 2: Prune / sweep unreferenced identifiers and instructions
     // Collect instructions to rewrite (two-phase: collect then apply to avoid borrow conflicts)
-    let mut instructions_to_rewrite: Vec<InstructionId> = Vec::new();
+    let mut instructions_to_rewrite: Vec<(InstructionId, bool)> = Vec::new();
 
     for (_block_id, block) in &mut func.body.blocks {
         // Remove unused phi nodes
@@ -52,14 +53,21 @@ pub fn dead_code_elimination<'a>(func: &mut HirFunction<'a>, env: &Environment<'
         for i in 0..retained_count {
             let is_block_value = block.kind != BlockKind::Block && i == retained_count - 1;
             if !is_block_value {
-                instructions_to_rewrite.push(block.instructions[i]);
+                let instr_id = block.instructions[i];
+                let preserve_destructure =
+                    matches!(block.terminal, Terminal::MaybeThrow { handler: Some(_), .. })
+                        && matches!(
+                            func.instructions[instr_id.index()].value,
+                            InstructionValue::Destructure { .. }
+                        );
+                instructions_to_rewrite.push((instr_id, preserve_destructure));
             }
         }
     }
 
     // Apply rewrites
-    for instr_id in instructions_to_rewrite {
-        rewrite_instruction(func, instr_id, &state, env);
+    for (instr_id, preserve_destructure) in instructions_to_rewrite {
+        rewrite_instruction(func, instr_id, preserve_destructure, &state, env);
     }
 
     // Remove unused context variables
@@ -117,7 +125,11 @@ fn is_id_used(state: &State, identifier_id: IdentifierId) -> bool {
 }
 
 /// Phase 1: Find all referenced identifiers via fixed-point iteration.
-fn find_referenced_identifiers<'a>(func: &HirFunction<'a>, env: &Environment<'a>) -> State<'a> {
+fn find_referenced_identifiers<'a>(
+    func: &HirFunction<'a>,
+    env: &Environment<'a>,
+    preserve_caught_throws: bool,
+) -> State<'a> {
     let has_loop = has_back_edge(func);
     // Collect block ids in reverse order (postorder - successors before predecessors)
     let reversed_block_ids: Vec<BlockId> = func.body.blocks.keys().rev().copied().collect();
@@ -153,10 +165,12 @@ fn find_referenced_identifiers<'a>(func: &HirFunction<'a>, env: &Environment<'a>
                 } else if is_id_or_name_used(&state, &env.identifiers, instr.lvalue.identifier)
                     // Throwing is observable inside try/catch even when the produced value is
                     // unused. Keep the instruction until its MaybeThrow edge is proven dead.
-                    || (matches!(
-                        block.terminal,
-                        Terminal::MaybeThrow { handler: Some(_), .. }
-                    ) && is_catch_observable_property_load(&instr.value))
+                    || (preserve_caught_throws
+                        && matches!(
+                            block.terminal,
+                            Terminal::MaybeThrow { handler: Some(_), .. }
+                        )
+                        && value_may_throw(&instr.value))
                     || !pruneable_value(&instr.value, &state, env)
                 {
                     reference(&mut state, &env.identifiers, instr.lvalue.identifier);
@@ -195,22 +209,56 @@ fn find_referenced_identifiers<'a>(func: &HirFunction<'a>, env: &Environment<'a>
     state
 }
 
-/// Property loads are read-only for DCE, but can throw and transfer control to a catch handler.
-pub(crate) fn is_catch_observable_property_load(value: &InstructionValue) -> bool {
-    matches!(value, InstructionValue::PropertyLoad { .. } | InstructionValue::ComputedLoad { .. })
+/// Finds caught instructions retained only because their throw is observable.
+///
+/// Re-running the mark phase without catch preservation distinguishes dead operations from
+/// ordinary used values. Dependency inference uses this to add safe root dependencies only for
+/// the former, leaving normal dependencies precise.
+pub(crate) fn find_semantic_only_caught_instructions(
+    func: &HirFunction,
+    env: &Environment,
+) -> Option<IndexVec<InstructionId, bool>> {
+    let mut candidates = Vec::new();
+    for block in func.body.blocks.values() {
+        if !matches!(block.terminal, Terminal::MaybeThrow { handler: Some(_), .. }) {
+            continue;
+        }
+        for &instr_id in &block.instructions {
+            let instr = &func.instructions[instr_id.index()];
+            if value_may_throw(&instr.value) {
+                candidates.push(instr_id);
+            }
+        }
+    }
+
+    if candidates.is_empty() {
+        return None;
+    }
+
+    let state = find_referenced_identifiers(func, env, false);
+    let mut semantic_only = IndexVec::from_vec(vec![false; func.instructions.len()]);
+    for instr_id in candidates {
+        let instr = &func.instructions[instr_id.index()];
+        if !is_id_or_name_used(&state, &env.identifiers, instr.lvalue.identifier) {
+            semantic_only[instr_id] = true;
+        }
+    }
+
+    Some(semantic_only)
 }
 
 /// Rewrite a retained instruction (destructuring cleanup, StoreLocal -> DeclareLocal).
 fn rewrite_instruction<'a>(
     func: &mut HirFunction<'a>,
     instr_id: InstructionId,
+    preserve_destructure: bool,
     state: &State,
     env: &Environment<'a>,
 ) {
     let instr = &mut func.instructions[instr_id.index()];
 
     match &mut instr.value {
-        InstructionValue::Destructure { lvalue, .. } => {
+        InstructionValue::Destructure { lvalue, .. } if !preserve_destructure => {
             match &mut lvalue.pattern {
                 Pattern::Array(arr) => {
                     // For arrays, replace unused items with holes, truncate trailing holes

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
@@ -5,8 +5,8 @@
 
 //! Prunes `MaybeThrow` terminals for blocks that can provably never throw.
 //!
-//! Currently very conservative: only affects blocks with primitives or
-//! array/object literals. Even a variable reference could throw due to TDZ.
+//! Currently conservative: only removes handlers when every instruction is known not to throw.
+//! Even a variable reference could throw due to TDZ.
 //!
 //! Analogous to TS `Optimization/PruneMaybeThrows.ts`.
 
@@ -17,7 +17,8 @@ use oxc_diagnostics::OxcDiagnostic;
 
 use crate::diagnostics::ErrorCategory;
 use crate::react_compiler_hir::{
-    BlockId, FunctionId, HirFunction, Instruction, InstructionValue, Terminal,
+    ArrayElement, BlockId, FunctionId, HirFunction, InstructionValue, ObjectPropertyKey,
+    ObjectPropertyOrSpread, Terminal,
 };
 use crate::react_compiler_lowering::{
     get_reverse_postordered_blocks, mark_instruction_ids, remove_dead_do_while_statements,
@@ -98,7 +99,7 @@ fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<IndexVec<BlockId, O
         let can_throw = block
             .instructions
             .iter()
-            .any(|instr_id| instruction_may_throw(&instructions[instr_id.index()]));
+            .any(|instr_id| value_may_throw(&instructions[instr_id.index()].value));
 
         if !can_throw {
             let source = terminal_mapping[block.id].unwrap_or(block.id);
@@ -117,11 +118,40 @@ fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<IndexVec<BlockId, O
     if mapped_any { Some(terminal_mapping) } else { None }
 }
 
-fn instruction_may_throw(instr: &Instruction) -> bool {
-    !matches!(
-        &instr.value,
-        InstructionValue::Primitive { .. }
-            | InstructionValue::ArrayExpression { .. }
-            | InstructionValue::ObjectExpression { .. }
-    )
+/// Returns whether evaluating an instruction value can throw.
+///
+/// Operand evaluation is represented by separate HIR instructions, so plain array/object
+/// construction is safe once its operands exist. Spreads and computed object keys remain part of
+/// the construction operation and can invoke user code.
+pub(crate) fn value_may_throw(value: &InstructionValue) -> bool {
+    match value {
+        InstructionValue::DeclareLocal { .. }
+        | InstructionValue::DeclareContext { .. }
+        | InstructionValue::Primitive { .. }
+        | InstructionValue::JSXText { .. }
+        | InstructionValue::TypeCastExpression { .. }
+        | InstructionValue::ObjectMethod { .. }
+        | InstructionValue::FunctionExpression { .. }
+        | InstructionValue::RegExpLiteral { .. }
+        | InstructionValue::MetaProperty { .. }
+        | InstructionValue::Debugger { .. }
+        | InstructionValue::StartMemoize { .. }
+        | InstructionValue::FinishMemoize { .. } => false,
+        InstructionValue::StoreLocal { lvalue, .. }
+        | InstructionValue::StoreContext { lvalue, .. } => {
+            lvalue.kind == crate::react_compiler_hir::InstructionKind::Reassign
+        }
+        InstructionValue::ArrayExpression { elements, .. } => {
+            elements.iter().any(|element| matches!(element, ArrayElement::Spread(_)))
+        }
+        InstructionValue::ObjectExpression { properties, .. } => {
+            properties.iter().any(|property| match property {
+                ObjectPropertyOrSpread::Property(property) => {
+                    matches!(property.key, ObjectPropertyKey::Computed { .. })
+                }
+                ObjectPropertyOrSpread::Spread(_) => true,
+            })
+        }
+        _ => true,
+    }
 }

--- a/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__try-catch-try-value-modified-in-catch-escaping.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__try-catch-try-value-modified-in-catch-escaping.snap
@@ -6,9 +6,9 @@ import { c as _c } from "react/compiler-runtime";
 // @enablePropagateDepsInHIR
 const { throwInput } = require("shared-runtime");
 function Component(props) {
-	const $ = _c(2);
+	const $ = _c(3);
 	let x;
-	if ($[0] !== props) {
+	if ($[0] !== props.e || $[1] !== props.y) {
 		try {
 			const y = [];
 			y.push(props.y);
@@ -18,10 +18,11 @@ function Component(props) {
 			e.push(props.e);
 			x = e;
 		}
-		$[0] = props;
-		$[1] = x;
+		$[0] = props.e;
+		$[1] = props.y;
+		$[2] = x;
 	} else {
-		x = $[1];
+		x = $[2];
 	}
 	return x;
 }

--- a/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__try-catch-try-value-modified-in-catch.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__try-catch-try-value-modified-in-catch.snap
@@ -6,9 +6,9 @@ import { c as _c } from "react/compiler-runtime";
 // @enablePropagateDepsInHIR
 const { throwInput } = require("shared-runtime");
 function Component(props) {
-	const $ = _c(2);
+	const $ = _c(3);
 	let t0;
-	if ($[0] !== props) {
+	if ($[0] !== props.e || $[1] !== props.y) {
 		t0 = Symbol.for("react.early_return_sentinel");
 		bb0: {
 			try {
@@ -22,10 +22,11 @@ function Component(props) {
 				break bb0;
 			}
 		}
-		$[0] = props;
-		$[1] = t0;
+		$[0] = props.e;
+		$[1] = props.y;
+		$[2] = t0;
 	} else {
-		t0 = $[1];
+		t0 = $[2];
 	}
 	if (t0 !== Symbol.for("react.early_return_sentinel")) {
 		return t0;

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-property-dependency.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-property-dependency.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/try-catch-property-dependency.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+function Component(t0) {
+	const $ = _c(5);
+	const { name } = t0;
+	try {
+		let t1;
+		if ($[0] !== name) {
+			t1 = new URL(name);
+			$[0] = name;
+			$[1] = t1;
+		} else {
+			t1 = $[1];
+		}
+		const url = t1;
+		let t2;
+		if ($[2] !== url.hash || $[3] !== url.search) {
+			t2 = <div>{url.search}{url.hash}</div>;
+			$[2] = url.hash;
+			$[3] = url.search;
+			$[4] = t2;
+		} else {
+			t2 = $[4];
+		}
+		return t2;
+	} catch {
+		return null;
+	}
+}

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-try-value-modified-in-catch-escaping.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-try-value-modified-in-catch-escaping.snap
@@ -5,9 +5,9 @@ input_file: crates/oxc_react_compiler/fixtures/try-catch-try-value-modified-in-c
 import { c as _c } from "react/compiler-runtime";
 const { throwInput } = require("shared-runtime");
 function Component(props) {
-	const $ = _c(2);
+	const $ = _c(3);
 	let x;
-	if ($[0] !== props) {
+	if ($[0] !== props.e || $[1] !== props.y) {
 		try {
 			const y = [];
 			y.push(props.y);
@@ -17,10 +17,11 @@ function Component(props) {
 			e.push(props.e);
 			x = e;
 		}
-		$[0] = props;
-		$[1] = x;
+		$[0] = props.e;
+		$[1] = props.y;
+		$[2] = x;
 	} else {
-		x = $[1];
+		x = $[2];
 	}
 	return x;
 }

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-try-value-modified-in-catch.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-try-value-modified-in-catch.snap
@@ -5,9 +5,9 @@ input_file: crates/oxc_react_compiler/fixtures/try-catch-try-value-modified-in-c
 import { c as _c } from "react/compiler-runtime";
 const { throwInput } = require("shared-runtime");
 function Component(props) {
-	const $ = _c(2);
+	const $ = _c(3);
 	let t0;
-	if ($[0] !== props) {
+	if ($[0] !== props.e || $[1] !== props.y) {
 		t0 = Symbol.for("react.early_return_sentinel");
 		bb0: {
 			try {
@@ -21,10 +21,11 @@ function Component(props) {
 				break bb0;
 			}
 		}
-		$[0] = props;
-		$[1] = t0;
+		$[0] = props.e;
+		$[1] = props.y;
+		$[2] = t0;
 	} else {
-		t0 = $[1];
+		t0 = $[2];
 	}
 	if (t0 !== Symbol.for("react.early_return_sentinel")) {
 		return t0;


### PR DESCRIPTION
Preserve potentially throwing operations inside try/catch when dead-code elimination would otherwise remove their unused results. Share the throw classifier with try-edge pruning, retain caught destructuring, and use safe root dependencies without hoisting throwing operations outside their handlers.

This preserves source runtime behavior for property and computed reads, coercions, destructuring, computed keys, and spreads. Latest React Compiler currently has the same DCE divergence, so this follows JavaScript semantics rather than its incorrect output.

Validated with `just ready` and React Compiler’s Sprout evaluator.

AI assistance was used to investigate and implement this change.
