### PR TITLE
fix(react_compiler): preserve Symbol identity

### DIFF
--- a/crates/oxc_react_compiler/fixtures/symbol-call.js
+++ b/crates/oxc_react_compiler/fixtures/symbol-call.js
@@ -1,0 +1,4 @@
+function Component() {
+  const historyKey = Symbol('history');
+  return <Widget historyKey={historyKey} />;
+}

--- a/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
@@ -302,6 +302,15 @@ const PURE_PRIMITIVE_FN: MethodDef = MethodDef {
     ..MethodDef::DEFAULT
 };
 
+/// `Symbol()` returns a primitive with unique identity. Model the result as
+/// identity-bearing internally so escaping symbols are memoized.
+const SYMBOL_FN: MethodDef = MethodDef {
+    rest_param: Some(Effect::Read),
+    return_type: TypeDef::Poly,
+    return_value_kind: ValueKind::Mutable,
+    ..MethodDef::DEFAULT
+};
+
 /// Shorthand for a function freezing its arguments and returning a frozen value.
 const FREEZE_ARGS_FN: MethodDef = MethodDef {
     rest_param: Some(Effect::Freeze),
@@ -1715,7 +1724,6 @@ const PRIMITIVE_GLOBAL_FNS: &[&str] = &[
     "Boolean",
     "Number",
     "String",
-    "Symbol",
     "parseInt",
     "parseFloat",
     "isNaN",
@@ -1757,6 +1765,10 @@ fn build_typed_globals(
         typed_globals.push((Ident::from(*name), f.clone()));
         globals.insert(Ident::from(*name), f);
     }
+
+    let symbol = add_method(shapes, &SYMBOL_FN, None, false);
+    typed_globals.push((Ident::from("Symbol"), symbol.clone()));
+    globals.insert(Ident::from("Symbol"), symbol);
 
     // Primitive globals
     typed_globals.push((Ident::from("Infinity"), Type::Primitive));

--- a/crates/oxc_react_compiler/tests/snapshots/symbol-call.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/symbol-call.snap
@@ -1,0 +1,17 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/symbol-call.js
+---
+import { c as _c } from "react/compiler-runtime";
+function Component() {
+	const $ = _c(1);
+	let t0;
+	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		const historyKey = Symbol("history");
+		t0 = <Widget historyKey={historyKey} />;
+		$[0] = t0;
+	} else {
+		t0 = $[0];
+	}
+	return t0;
+}


### PR DESCRIPTION
Model `Symbol()` as identity-bearing so escaping symbols are memoized, matching Babel. The regression came from registering `Symbol` with copy-like primitive globals while allowing capitalized built-in calls.

Validation: `cargo test -p oxc_react_compiler`; Babel output comparison; runtime identity check. `just ready` is blocked by three unrelated ANSI-sensitive Oxlint snapshot mismatches in this environment.

AI-assisted: Codex was used to investigate, implement, verify, and prepare this PR.