### PR TITLE
chore(semantic): gate cfg example behind feature

### DIFF
--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -19,6 +19,10 @@ workspace = true
 [lib]
 doctest = true
 
+[[example]]
+name = "cfg"
+required-features = ["cfg"]
+
 [dependencies]
 oxc_allocator = { workspace = true, features = ["bitset"] }
 oxc_ast = { workspace = true }


### PR DESCRIPTION
Before, when running semantic's CFG example, we would get a cryptic message talking about the problem.
```
$ cargo run -p oxc_semantic --example cfg --
   Compiling oxc_semantic v0.144.0 (/Users/cameron/.codex/worktrees/6012/oxc/crates/oxc_semantic)
error[E0601]: `main` function not found in crate `cfg`
   --> crates/oxc_semantic/examples/cfg.rs:169:2
    |
169 | }
    |  ^ consider adding a `main` function to `crates/oxc_semantic/examples/cfg.rs`

For more information about this error, try `rustc --explain E0601`.
error: could not compile `oxc_semantic` (example "cfg") due to 1 previous error
```


After, we get a clear message explaining how to fix the issue and run the example.
```
$ cargo run -p oxc_semantic --example cfg --
error: target `cfg` in package `oxc_semantic` requires the features: `cfg`
Consider enabling them by passing, e.g., `--features="cfg
```

Docs: https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-required-features-field