### PR TITLE
fix(minifier): avoid merging `if` to `for` in sloppy mode when containing function declaration

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
@@ -38,6 +38,7 @@ impl<'a> PeepholeOptimizations {
         if body_has_function_declaration {
             return;
         }
+        let is_sloppy_mode = !ctx.current_scope_flags().is_strict_mode();
 
         // "for (;;) if (x) break;" => "for (; !x;) ;"
         // "for (; a;) if (x) break;" => "for (; a && !x;) ;"
@@ -45,6 +46,12 @@ impl<'a> PeepholeOptimizations {
         // "for (; a;) if (x) break; else y();" => "for (; a && !x;) y();"
         if let Some(Statement::BreakStatement(break_stmt)) = if_stmt.consequent.get_one_child() {
             if break_stmt.label.is_some() {
+                return;
+            }
+            // Annex B gives a direct function declaration in an `if` branch an implicit scope.
+            if is_sloppy_mode
+                && if_stmt.alternate.as_ref().is_some_and(Self::statement_has_function_declaration)
+            {
                 return;
             }
 
@@ -83,6 +90,10 @@ impl<'a> PeepholeOptimizations {
             if_stmt.alternate.as_ref().and_then(|stmt| stmt.get_one_child())
         {
             if break_stmt.label.is_some() {
+                return;
+            }
+            // Annex B gives a direct function declaration in an `if` branch an implicit scope.
+            if is_sloppy_mode && Self::statement_has_function_declaration(&if_stmt.consequent) {
                 return;
             }
 

--- a/crates/oxc_minifier/tests/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_statements.rs
@@ -1,6 +1,8 @@
 use std::fmt::Write;
 
-use crate::{test, test_same};
+use oxc_span::SourceType;
+
+use crate::{default_options, test, test_options_source_type, test_same};
 
 #[test]
 fn test_for_variable_declaration() {
@@ -48,6 +50,62 @@ fn test_for_break_preserves_block_function_scope_in_module() {
     test(
         "for (;;) { if (x) break; let y = foo(); bar(y); bar(y); }",
         "for (; !x;) { let y = foo(); bar(y), bar(y); }",
+    );
+}
+
+#[test]
+fn test_for_break_preserves_annex_b_function_scope() {
+    let options = default_options();
+    test_options_source_type(
+        "for (var i = 0; i++ < 1;) {
+            if (x) break;
+            else function f() {}
+            f = 0;
+        }
+        console.log(typeof f, f);",
+        "for (var i = 0; i++ < 1;) {
+            if (x) break;
+            else function f() {}
+            f = 0;
+        }
+        console.log(typeof f, f);",
+        SourceType::script(),
+        &options,
+    );
+    test_options_source_type(
+        "for (var i = 0; i++ < 1;) {
+            if (x) function f() {}
+            else break;
+            f = 0;
+        }
+        console.log(typeof f, f);",
+        "for (var i = 0; i++ < 1;) {
+            if (x) function f() {}
+            else break;
+            f = 0;
+        }
+        console.log(typeof f, f);",
+        SourceType::script(),
+        &options,
+    );
+
+    test_options_source_type(
+        "for (;;) {
+            if (x) break;
+            else { function f() {} }
+        }",
+        "for (; !x;) { function f() {} }",
+        SourceType::mjs(),
+        &options,
+    );
+    test_options_source_type(
+        "for (;;) {
+            if (x) { function f() {} }
+            else break;
+        }",
+        "for (; x;) { function f() {} }",
+        SourceType::mjs(),
+        &options,
     );
 }
 


### PR DESCRIPTION
```js
for (var i = 0; i++ < 1;) {
    if (x) break;
    else function f() {}
    f = 0;
}
console.log(typeof f, f);
```
was compressed to
```js
for (var i = 0; i++ < 1 && !x;) {
	function f() {}
	f = 0;
}
console.log(typeof f, f);
```
But this is wrong in sloppy mode. The output changes `number 0` / `undefined undefined` to `function f() {}`.

This PR fixes that.

I used AI to generate the code and then reviewed the code and added tests.
