### PR TITLE
fix(napi): disable reuseWorker in browser bindings

### DIFF
--- a/napi/disable-reused-workers.mjs
+++ b/napi/disable-reused-workers.mjs
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+
+const REUSED_WORKERS = "reuseWorker: { size: __asyncWorkPoolSize + __workerPoolSize },";
+const DISABLED_REUSED_WORKERS = "reuseWorker: false,";
+
+export function disableReusedWorkers(path) {
+  let data = fs.readFileSync(path, "utf-8");
+
+  // The pool is initialized eagerly, but browsers reject its worker URL when a binding is loaded
+  // from a cross-origin CDN because workers must be loaded from the page's origin.
+  if (data.includes(REUSED_WORKERS)) {
+    data = data.replace(REUSED_WORKERS, DISABLED_REUSED_WORKERS);
+    fs.writeFileSync(path, data);
+  } else if (!data.includes(DISABLED_REUSED_WORKERS)) {
+    throw new Error(`Could not find the reuseWorker option in ${path}`);
+  }
+}

--- a/napi/minify/minify.wasi-browser.js
+++ b/napi/minify/minify.wasi-browser.js
@@ -565,7 +565,7 @@ try {
   } = await __emnapiInstantiateNapiModule(__wasmFile, {
     context: __emnapiContext,
     asyncWorkPoolSize: __asyncWorkPoolSize,
-    reuseWorker: { size: __asyncWorkPoolSize + __workerPoolSize },
+    reuseWorker: false,
     plugins: [__emnapiAsyncWorkPlugin, __emnapiTSFNPlugin],
     wasi: __wasi,
     onCreateWorker() {

--- a/napi/minify/scripts/patch.js
+++ b/napi/minify/scripts/patch.js
@@ -1,7 +1,12 @@
 import fs from "node:fs";
 import { join as pathJoin } from "node:path";
 
-const path = pathJoin(import.meta.dirname, "../index.js");
+import { disableReusedWorkers } from "../../disable-reused-workers.mjs";
+
+const packageDir = pathJoin(import.meta.dirname, "..");
+disableReusedWorkers(pathJoin(packageDir, "minify.wasi-browser.js"));
+
+const path = pathJoin(packageDir, "index.js");
 
 let data = fs.readFileSync(path, "utf-8");
 data = data.replace(

--- a/napi/parser/scripts/build-browser-bundle.js
+++ b/napi/parser/scripts/build-browser-bundle.js
@@ -6,6 +6,7 @@ import { rolldown } from "rolldown";
 // Rollup-compatible bundlers reserve `\0`-prefixed IDs for plugin virtual modules,
 // so Rolldown will not try to resolve these generated `?url` asset modules as files.
 const NEW_URL_ASSET_PREFIX = "\0new-url-asset:";
+const WASI_BROWSER_BINDING = path.resolve("./src-js/parser.wasi-browser.js");
 
 async function main() {
   const args = parseArgs({
@@ -23,7 +24,7 @@ async function main() {
     platform: "browser",
     resolve: {
       alias: {
-        "@oxc-parser/binding-wasm32-wasi": path.resolve("./src-js/parser.wasi-browser.js"),
+        "@oxc-parser/binding-wasm32-wasi": WASI_BROWSER_BINDING,
       },
     },
     plugins: [

--- a/napi/parser/scripts/patch.js
+++ b/napi/parser/scripts/patch.js
@@ -1,6 +1,12 @@
 import fs from "node:fs";
+import { join as pathJoin } from "node:path";
 
-const filename = "./src-js/bindings.js";
+import { disableReusedWorkers } from "../../disable-reused-workers.mjs";
+
+const packageDir = pathJoin(import.meta.dirname, "..");
+disableReusedWorkers(pathJoin(packageDir, "src-js/parser.wasi-browser.js"));
+
+const filename = pathJoin(packageDir, "src-js/bindings.js");
 let data = fs.readFileSync(filename, "utf-8");
 
 data = data.replace(

--- a/napi/parser/src-js/parser.wasi-browser.js
+++ b/napi/parser/src-js/parser.wasi-browser.js
@@ -565,7 +565,7 @@ try {
   } = await __emnapiInstantiateNapiModule(__wasmFile, {
     context: __emnapiContext,
     asyncWorkPoolSize: __asyncWorkPoolSize,
-    reuseWorker: { size: __asyncWorkPoolSize + __workerPoolSize },
+    reuseWorker: false,
     plugins: [__emnapiAsyncWorkPlugin, __emnapiTSFNPlugin],
     wasi: __wasi,
     onCreateWorker() {

--- a/napi/playground/package.json
+++ b/napi/playground/package.json
@@ -28,6 +28,7 @@
     "build-dev": "pnpm run build-wasm-dev && node scripts/patch.js",
     "build": "pnpm run build-wasm-dev --release && node scripts/patch.js",
     "build-wasm-dev": "napi build --platform --esm --target wasm32-wasip1-threads --dts playground.wasi.d.cts",
+    "postbuild-wasm-dev": "node scripts/patch-wasi-browser.js",
     "postbuild": "publint"
   },
   "dependencies": {

--- a/napi/playground/playground.wasi-browser.js
+++ b/napi/playground/playground.wasi-browser.js
@@ -565,7 +565,7 @@ try {
   } = await __emnapiInstantiateNapiModule(__wasmFile, {
     context: __emnapiContext,
     asyncWorkPoolSize: __asyncWorkPoolSize,
-    reuseWorker: { size: __asyncWorkPoolSize + __workerPoolSize },
+    reuseWorker: false,
     plugins: [__emnapiAsyncWorkPlugin, __emnapiTSFNPlugin],
     wasi: __wasi,
     onCreateWorker() {

--- a/napi/playground/scripts/patch-wasi-browser.js
+++ b/napi/playground/scripts/patch-wasi-browser.js
@@ -1,0 +1,5 @@
+import { join as pathJoin } from "node:path";
+
+import { disableReusedWorkers } from "../../disable-reused-workers.mjs";
+
+disableReusedWorkers(pathJoin(import.meta.dirname, "../playground.wasi-browser.js"));

--- a/napi/playground/scripts/patch.js
+++ b/napi/playground/scripts/patch.js
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import { join as pathJoin } from "node:path";
 
-const path = pathJoin(import.meta.dirname, "../playground.wasi-browser.js");
+import "./patch-wasi-browser.js";
+
+const packageDir = pathJoin(import.meta.dirname, "..");
+const path = pathJoin(packageDir, "playground.wasi-browser.js");
 
 let data = fs.readFileSync(path, "utf-8");
 data = data.replace(

--- a/napi/transform-react/scripts/patch.js
+++ b/napi/transform-react/scripts/patch.js
@@ -1,7 +1,11 @@
 import fs from "node:fs";
 import { join as pathJoin } from "node:path";
 
+import { disableReusedWorkers } from "../../disable-reused-workers.mjs";
+
 const packageDir = pathJoin(import.meta.dirname, "..");
+disableReusedWorkers(pathJoin(packageDir, "transform-react.wasi-browser.js"));
+
 const path = pathJoin(packageDir, "index.js");
 
 let data = fs.readFileSync(path, "utf-8");

--- a/napi/transform-react/transform-react.wasi-browser.js
+++ b/napi/transform-react/transform-react.wasi-browser.js
@@ -565,7 +565,7 @@ try {
   } = await __emnapiInstantiateNapiModule(__wasmFile, {
     context: __emnapiContext,
     asyncWorkPoolSize: __asyncWorkPoolSize,
-    reuseWorker: { size: __asyncWorkPoolSize + __workerPoolSize },
+    reuseWorker: false,
     plugins: [__emnapiAsyncWorkPlugin, __emnapiTSFNPlugin],
     wasi: __wasi,
     onCreateWorker() {

--- a/napi/transform-relay/scripts/patch.js
+++ b/napi/transform-relay/scripts/patch.js
@@ -1,7 +1,11 @@
 import fs from "node:fs";
 import { join as pathJoin } from "node:path";
 
+import { disableReusedWorkers } from "../../disable-reused-workers.mjs";
+
 const packageDir = pathJoin(import.meta.dirname, "..");
+disableReusedWorkers(pathJoin(packageDir, "transform-relay.wasi-browser.js"));
+
 const path = pathJoin(packageDir, "index.js");
 
 let data = fs.readFileSync(path, "utf-8");

--- a/napi/transform-relay/transform-relay.wasi-browser.js
+++ b/napi/transform-relay/transform-relay.wasi-browser.js
@@ -565,7 +565,7 @@ try {
   } = await __emnapiInstantiateNapiModule(__wasmFile, {
     context: __emnapiContext,
     asyncWorkPoolSize: __asyncWorkPoolSize,
-    reuseWorker: { size: __asyncWorkPoolSize + __workerPoolSize },
+    reuseWorker: false,
     plugins: [__emnapiAsyncWorkPlugin, __emnapiTSFNPlugin],
     wasi: __wasi,
     onCreateWorker() {

--- a/napi/transform/scripts/patch.js
+++ b/napi/transform/scripts/patch.js
@@ -1,7 +1,12 @@
 import fs from "node:fs";
 import { join as pathJoin } from "node:path";
 
-const path = pathJoin(import.meta.dirname, "../index.js");
+import { disableReusedWorkers } from "../../disable-reused-workers.mjs";
+
+const packageDir = pathJoin(import.meta.dirname, "..");
+disableReusedWorkers(pathJoin(packageDir, "transform.wasi-browser.js"));
+
+const path = pathJoin(packageDir, "index.js");
 
 let data = fs.readFileSync(path, "utf-8");
 data = data.replace(

--- a/napi/transform/transform.wasi-browser.js
+++ b/napi/transform/transform.wasi-browser.js
@@ -565,7 +565,7 @@ try {
   } = await __emnapiInstantiateNapiModule(__wasmFile, {
     context: __emnapiContext,
     asyncWorkPoolSize: __asyncWorkPoolSize,
-    reuseWorker: { size: __asyncWorkPoolSize + __workerPoolSize },
+    reuseWorker: false,
     plugins: [__emnapiAsyncWorkPlugin, __emnapiTSFNPlugin],
     wasi: __wasi,
     onCreateWorker() {


### PR DESCRIPTION
Fixes #25610

AI assistance: Codex was used to implement this change.