### PR TITLE
fix(react_compiler): retry after caught throws

### DIFF
--- a/crates/oxc_react_compiler/fixtures/try-catch-retry-after-throw.js
+++ b/crates/oxc_react_compiler/fixtures/try-catch-retry-after-throw.js
@@ -1,0 +1,32 @@
+// @compilationMode:annotation @panicThreshold:none
+
+function Component(params) {
+  'use memo';
+  const selectedOptions = (() => {
+    try {
+      const channel = params.parse()?.channel;
+      return channel ? [{label: `#${channel}`, value: channel}] : [];
+    } catch {
+      return [];
+    }
+  })();
+  return selectedOptions;
+}
+
+const input = {
+  value: 'success',
+  shouldThrow: true,
+  parse() {
+    if (this.shouldThrow) {
+      this.shouldThrow = false;
+      throw new Error('oops');
+    }
+    return {channel: this.value};
+  },
+};
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [input],
+  sequentialRenders: [input, input],
+};

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
@@ -99,7 +99,7 @@ fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<IndexVec<BlockId, O
         let can_throw = block
             .instructions
             .iter()
-            .any(|instr_id| value_may_throw(&instructions[instr_id.index()].value));
+            .any(|instr_id| value_may_throw_when_pruning(&instructions[instr_id.index()].value));
 
         if !can_throw {
             let source = terminal_mapping[block.id].unwrap_or(block.id);
@@ -116,6 +116,16 @@ fn prune_maybe_throws_impl(func: &mut HirFunction) -> Option<IndexVec<BlockId, O
     }
 
     if mapped_any { Some(terminal_mapping) } else { None }
+}
+
+/// Returns whether a `MaybeThrow` edge must be retained during CFG pruning.
+///
+/// Local stores cannot throw by themselves, but value blocks end with a store.
+/// Removing that final handler edge can reorder the catch block ahead of the
+/// successful fallthrough, causing reactive scopes to span both paths.
+fn value_may_throw_when_pruning(value: &InstructionValue) -> bool {
+    matches!(value, InstructionValue::StoreLocal { .. } | InstructionValue::StoreContext { .. })
+        || value_may_throw(value)
 }
 
 /// Returns whether evaluating an instruction value can throw.

--- a/crates/oxc_react_compiler/tests/snapshots/try-catch-retry-after-throw.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/try-catch-retry-after-throw.snap
@@ -1,0 +1,61 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/try-catch-retry-after-throw.js
+---
+import { c as _c } from "react/compiler-runtime";
+// @compilationMode:annotation @panicThreshold:none
+function Component(params) {
+	"use memo";
+	const $ = _c(5);
+	let t0;
+	try {
+		let t1;
+		if ($[0] !== params) {
+			t1 = params.parse()?.channel;
+			$[0] = params;
+			$[1] = t1;
+		} else {
+			t1 = $[1];
+		}
+		const channel = t1;
+		let t2;
+		if ($[2] !== channel) {
+			t2 = channel ? [{
+				label: `#${channel}`,
+				value: channel
+			}] : [];
+			$[2] = channel;
+			$[3] = t2;
+		} else {
+			t2 = $[3];
+		}
+		t0 = t2;
+	} catch {
+		let t1;
+		if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
+			t1 = [];
+			$[4] = t1;
+		} else {
+			t1 = $[4];
+		}
+		t0 = t1;
+	}
+	const selectedOptions = t0;
+	return selectedOptions;
+}
+const input = {
+	value: "success",
+	shouldThrow: true,
+	parse() {
+		if (this.shouldThrow) {
+			this.shouldThrow = false;
+			throw new Error("oops");
+		}
+		return { channel: this.value };
+	}
+};
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [input],
+	sequentialRenders: [input, input]
+};


### PR DESCRIPTION
Retain exception-handler edges for value-block stores so caught throws do not commit the input/result memo entry. This preserves retries for identical inputs after a transient throw.

Adds a sequential-render evaluator fixture covering throw-once behavior.

Validated with `env -u NO_COLOR just ready` and a Sprout runtime comparison.

AI assistance was used to investigate and implement this change.