### PR TITLE
fix(react-compiler): remove redundant compound assignment expressions

### DIFF
--- a/crates/oxc_react_compiler/fixtures/compound-assignment-context-result.js
+++ b/crates/oxc_react_compiler/fixtures/compound-assignment-context-result.js
@@ -1,0 +1,14 @@
+function Component({values}) {
+  let count = 0;
+  values.forEach(value => {
+    count += value;
+    const result = count += value;
+    console.log(result);
+  });
+  return count;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{values: [1, 2]}],
+};

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -585,6 +585,9 @@ pub enum InstructionValue<'a> {
     LoadContext {
         place: Place,
         span: Option<Span>,
+        /// This load materializes the value of a preceding compound assignment.
+        /// Keep it through analysis, but omit it during codegen when its result is unused.
+        is_compound_assignment_result: bool,
     },
     DeclareLocal {
         lvalue: LValue,
@@ -1748,8 +1751,12 @@ impl<'a> CloneIn<'a> for InstructionValue<'a> {
             InstructionValue::LoadLocal { place, span } => {
                 InstructionValue::LoadLocal { place: *place, span: *span }
             }
-            InstructionValue::LoadContext { place, span } => {
-                InstructionValue::LoadContext { place: *place, span: *span }
+            InstructionValue::LoadContext { place, span, is_compound_assignment_result } => {
+                InstructionValue::LoadContext {
+                    place: *place,
+                    span: *span,
+                    is_compound_assignment_result: *is_compound_assignment_result,
+                }
             }
             InstructionValue::DeclareLocal { lvalue, span } => {
                 InstructionValue::DeclareLocal { lvalue: *lvalue, span: *span }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -3461,7 +3461,11 @@ fn lower_expression<'a>(
             let symbol = builder.scope().resolve_reference(ident);
             let place = lower_identifier(builder, ident.name, ident.span, symbol)?;
             if builder.is_context_identifier(symbol) {
-                Ok(InstructionValue::LoadContext { place, span })
+                Ok(InstructionValue::LoadContext {
+                    place,
+                    span,
+                    is_compound_assignment_result: false,
+                })
             } else {
                 Ok(InstructionValue::LoadLocal { place, span })
             }
@@ -4417,7 +4421,11 @@ fn lower_assignment_expression<'a>(
                 let left_place = lower_value_to_temporary(
                     builder,
                     if is_context_identifier {
-                        InstructionValue::LoadContext { place: left_place, span: Some(ident_span) }
+                        InstructionValue::LoadContext {
+                            place: left_place,
+                            span: Some(ident_span),
+                            is_compound_assignment_result: false,
+                        }
                     } else {
                         InstructionValue::LoadLocal { place: left_place, span: Some(ident_span) }
                     },
@@ -4450,7 +4458,11 @@ fn lower_assignment_expression<'a>(
                                     span,
                                 },
                             )?;
-                            Ok(InstructionValue::LoadContext { place, span })
+                            Ok(InstructionValue::LoadContext {
+                                place,
+                                span,
+                                is_compound_assignment_result: true,
+                            })
                         } else {
                             lower_value_to_temporary(
                                 builder,
@@ -4787,7 +4799,11 @@ fn lower_jsx_element_name<'a>(
             // Component tag: resolve as identifier and load
             let place = lower_identifier(builder, tag, span, symbol)?;
             let load_value = if builder.is_context_identifier(symbol) {
-                InstructionValue::LoadContext { place, span: Some(span) }
+                InstructionValue::LoadContext {
+                    place,
+                    span: Some(span),
+                    is_compound_assignment_result: false,
+                }
             } else {
                 InstructionValue::LoadLocal { place, span: Some(span) }
             };
@@ -4893,7 +4909,11 @@ fn lower_jsx_member_object_identifier<'a>(
 ) -> Result<Place, OxcDiagnostic> {
     let place = lower_identifier(builder, name, span, symbol)?;
     let load_value = if builder.is_context_identifier(symbol) {
-        InstructionValue::LoadContext { place, span: *expr_span }
+        InstructionValue::LoadContext {
+            place,
+            span: *expr_span,
+            is_compound_assignment_result: false,
+        }
     } else {
         InstructionValue::LoadLocal { place, span: *expr_span }
     };

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -1395,6 +1395,14 @@ fn ox_codegen_instruction_nullable<'a>(
 ) -> Result<Option<oxc::Statement<'a>>, OxcDiagnostic> {
     if let ReactiveValue::Instruction(ref value) = instr.value {
         match value {
+            InstructionValue::LoadContext { is_compound_assignment_result: true, .. }
+                if instr.lvalue.is_none() =>
+            {
+                // The assignment itself was already emitted. This synthetic load exists so
+                // analysis can track the compound assignment's result, but an expression
+                // statement does not use that result.
+                return Ok(None);
+            }
             InstructionValue::StoreLocal { .. }
             | InstructionValue::StoreContext { .. }
             | InstructionValue::Destructure { .. }

--- a/crates/oxc_react_compiler/tests/snapshots/compound-assignment-context-result.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/compound-assignment-context-result.snap
@@ -1,0 +1,28 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/compound-assignment-context-result.js
+---
+import { c as _c } from "react/compiler-runtime";
+function Component(t0) {
+	const $ = _c(2);
+	const { values } = t0;
+	let count;
+	if ($[0] !== values) {
+		count = 0;
+		values.forEach((value) => {
+			count = count + value;
+			count = count + value;
+			const result = count;
+			console.log(result);
+		});
+		$[0] = values;
+		$[1] = count;
+	} else {
+		count = $[1];
+	}
+	return count;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ values: [1, 2] }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/hoisting-invalid-tdz-let.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/hoisting-invalid-tdz-let.snap
@@ -15,7 +15,6 @@ function Foo() {
 	} else {
 		getX = $[0];
 	}
-	x;
 	let t0;
 	if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
 		t0 = <Stringify getX={getX} shouldInvokeFns={true} />;

--- a/crates/oxc_react_compiler/tests/snapshots/hoisting-reassigned-let-declaration.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/hoisting-reassigned-let-declaration.snap
@@ -14,7 +14,6 @@ function useHook(t0) {
 		let x = CONST_NUMBER0;
 		if (cond) {
 			x = x + CONST_NUMBER1;
-			x;
 		}
 		t1 = <Stringify getX={getX} shouldInvokeFns={true} />;
 		$[0] = cond;

--- a/crates/oxc_react_compiler/tests/snapshots/hoisting-reassigned-twice-let-declaration.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/hoisting-reassigned-twice-let-declaration.snap
@@ -14,7 +14,6 @@ function useHook(t0) {
 		let x = CONST_NUMBER0;
 		if (cond) {
 			x = x + CONST_NUMBER1;
-			x;
 			x = Math.min(x, 100);
 		}
 		t1 = <Stringify getX={getX} shouldInvokeFns={true} />;

--- a/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__repro-scope-missing-mutable-range.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/propagate-scope-deps-hir-fork__repro-scope-missing-mutable-range.snap
@@ -13,7 +13,6 @@ function HomeDiscoStoreItemTileRating(props) {
 		const aggregates = item?.aggregates || [];
 		aggregates.forEach((aggregate) => {
 			count = count + (aggregate.count || 0);
-			count;
 		});
 		$[0] = item?.aggregates;
 		$[1] = count;

--- a/crates/oxc_react_compiler/tests/snapshots/repro-scope-missing-mutable-range.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/repro-scope-missing-mutable-range.snap
@@ -12,7 +12,6 @@ function HomeDiscoStoreItemTileRating(props) {
 		const aggregates = item?.aggregates || [];
 		aggregates.forEach((aggregate) => {
 			count = count + (aggregate.count || 0);
-			count;
 		});
 		$[0] = item?.aggregates;
 		$[1] = count;


### PR DESCRIPTION
Removes synthetic expression statements emitted after captured compound assignments when their value is unused. The lowering-created context load is tagged so analysis retains it, while codegen can omit it after the lvalue is pruned. Consumed assignment results are preserved.

Validated with `env -u NO_COLOR just ready`.

AI assistance: Codex was used to investigate, implement, and validate this change.