### PR TITLE
fix(formatter): keep nested awaited-paren member chain grouped in call arguments

### DIFF
--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -456,37 +456,44 @@ impl<'a> FormatWrite<'a> for AstNode<'a, AwaitExpression<'a>> {
             _ => self.parent().is_call_like_callee_span(self.span),
         };
 
-        if is_callee_or_object {
-            let mut await_expression = None;
-            for ancestor in self.ancestors().skip(1) {
-                match ancestor {
-                    AstNodes::ArrowFunctionExpression(_)
-                    | AstNodes::BlockStatement(_)
-                    | AstNodes::FunctionBody(_)
-                    | AstNodes::SwitchCase(_)
-                    | AstNodes::Program(_)
-                    | AstNodes::TSModuleBlock(_) => break,
-                    AstNodes::AwaitExpression(expr) => await_expression = Some(expr),
-                    _ => {}
-                }
-            }
-
-            let indented = format_with(|f| write!(f, [soft_block_indent(&format_inner)]));
-
-            return if let Some(expr) = await_expression.take() {
-                if !expr.needs_parentheses(f)
-                    && ExpressionLeftSide::leftmost(expr.argument()).span() != self.span()
-                {
-                    return write!(f, [group(&indented)]);
-                }
-
-                write!(f, [indented]);
-            } else {
-                write!(f, [group(&indented)]);
-            };
+        if !is_callee_or_object {
+            write!(f, [format_inner]);
+            return;
         }
 
-        write!(f, [format_inner]);
+        // Only the nearest enclosing `await` matters:
+        // the leftmost walk below never crosses a statement or function boundary.
+        let enclosing_await = self
+            .ancestors()
+            .skip(1)
+            // PERF: Early exit only; past any of these, the leftmost check below always fails.
+            .take_while(|ancestor| {
+                !matches!(
+                    ancestor,
+                    AstNodes::ArrowFunctionExpression(_)
+                        | AstNodes::BlockStatement(_)
+                        | AstNodes::FunctionBody(_)
+                        | AstNodes::SwitchCase(_)
+                        | AstNodes::Program(_)
+                        | AstNodes::TSModuleBlock(_)
+                )
+            })
+            .find_map(|ancestor| match ancestor {
+                AstNodes::AwaitExpression(expr) => Some(expr),
+                _ => None,
+            });
+
+        let indented = format_with(|f| write!(f, [soft_block_indent(&format_inner)]));
+
+        // Group unless the enclosing `await`'s argument starts with this expression,
+        // to avoid printing `await (await` on one line.
+        let should_group = enclosing_await
+            .is_none_or(|expr| ExpressionLeftSide::leftmost(expr.argument()).span() != self.span());
+        if should_group {
+            write!(f, [group(&indented)]);
+        } else {
+            write!(f, [indented]);
+        }
     }
 }
 

--- a/crates/oxc_formatter/tests/fixtures/js/awaits/nested.mjs
+++ b/crates/oxc_formatter/tests/fixtures/js/awaits/nested.mjs
@@ -3,3 +3,7 @@ vite = await (
 ).createServer({
   appType
 })
+
+const x = (
+  await mapLimit((await cache.getAllAccounts()).accounts, 10, async (account) => account)
+).flat()

--- a/crates/oxc_formatter/tests/fixtures/js/awaits/nested.mjs.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/awaits/nested.mjs.snap
@@ -7,6 +7,11 @@ vite = await (
 ).createServer({
   appType
 })
+
+const x = (
+  await mapLimit((await cache.getAllAccounts()).accounts, 10, async (account) => account)
+).flat()
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -17,6 +22,14 @@ vite = await (
   appType,
 });
 
+const x = (
+  await mapLimit(
+    (await cache.getAllAccounts()).accounts,
+    10,
+    async (account) => account,
+  )
+).flat();
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -25,5 +38,9 @@ vite = await (
 ).createServer({
   appType,
 });
+
+const x = (
+  await mapLimit((await cache.getAllAccounts()).accounts, 10, async (account) => account)
+).flat();
 
 ===================== End =====================


### PR DESCRIPTION
Found by real-world repo testing for `operatorPosition`.

- Check the nearest nested `await` is enough
- `needs_parens` check is not needed

Now aligned with Prettier's output.