### PR TITLE
fix(linter/eslint/prefer-promise-reject-errors): report on spread arguments

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
@@ -140,6 +140,7 @@ fn check_reject_call(call_expr: &CallExpression, ctx: &LintContext, allow_empty_
     }
 
     if call_expr.arguments.is_empty()
+        || matches!(&call_expr.arguments[0], Argument::SpreadElement(_))
         || call_expr.arguments[0].as_expression().is_some_and(|e| !could_be_error(e))
         || is_undefined(&call_expr.arguments[0], ctx)
     {
@@ -319,6 +320,14 @@ fn test() {
         // evaluates either to a falsy value of `foo` (which, then, cannot be an Error object), or to `5`
         ("Promise.reject(foo && 5)", None),
         ("Promise.reject(foo &&= 5)", None),
+        // Spread arguments
+        ("Promise.reject(...args)", None),
+        (
+            "new Promise((resolve, reject) => {
+                somePromise.catch((...args) => reject(...args));
+            })",
+            None,
+        ),
         ("new Promise(function (resolve, ...rest) { rest[0](5); });", None),
         ("new Promise(function (...rest) { rest[1](5); });", None),
         ("new Promise(function (...rest) { (rest[1])(5); });", None),

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_promise_reject_errors.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_promise_reject_errors.snap
@@ -278,6 +278,22 @@ source: crates/oxc_linter/src/tester.rs
   help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
+   ╭─[prefer_promise_reject_errors.tsx:1:1]
+ 1 │ Promise.reject(...args)
+   · ───────────────────────
+   ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
+
+  ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
+   ╭─[prefer_promise_reject_errors.tsx:2:48]
+ 1 │ new Promise((resolve, reject) => {
+ 2 │                 somePromise.catch((...args) => reject(...args));
+   ·                                                ───────────────
+ 3 │             })
+   ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
+
+  ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:43]
  1 │ new Promise(function (resolve, ...rest) { rest[0](5); });
    ·                                           ──────────


### PR DESCRIPTION
fixes #25620. Matches upstream: https://eslint.org/play/#eyJ0ZXh0IjoiXG5uZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG5cdHNvbWVQcm9taXNlLmNhdGNoKCguLi5hcmdzKSA9PiB7XG5cdFx0cmVqZWN0KC4uLmFyZ3MpXG5cdH0pXG59KSIsIm9wdGlvbnMiOnsicnVsZXMiOnsibm8tbG9uZS1ibG9ja3MiOiJlcnJvciIsInByZWZlci1wcm9taXNlLXJlamVjdC1lcnJvcnMiOlsiZXJyb3IiXX0sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6eyJqc3giOnRydWV9fX19fQ==