### PR TITLE
fix(linter/jest/expect-expect): detect assertions in nested function declarations

### DIFF
--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -46,6 +46,15 @@ fn test() {
         ("it('should pass', () => somePromise().then(() => expect(true).toBeDefined()))", None),
         ("it('should pass', myTest); function myTest() { expect(true).toBeDefined() }", None),
         (
+            "test('via function declaration', async () => {
+                async function check() {
+                    expect(1 + 1).toBe(2);
+                }
+                await check();
+            });",
+            None,
+        ),
+        (
             "
             test('should pass', () => {
                 expect(true).toBeDefined();

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
@@ -367,7 +367,13 @@ impl<'a> VisitJs<'a> for AssertionVisitor<'a, '_> {
         }
     }
 
-    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
+    fn visit_function(&mut self, func: &Function<'a>, _flags: ScopeFlags) {
+        if func.is_declaration()
+            && let Some(body) = &func.body
+        {
+            self.visit_function_body(body);
+        }
+    }
 
     fn visit_formal_parameter(&mut self, _param: &FormalParameter<'a>) {}
 }


### PR DESCRIPTION
## Summary
- traverse nested function declaration bodies while looking for test assertions
- align nested function declarations with existing arrow-function behavior
- add focused regression coverage for an async nested helper

Fixes #25635