### PR TITLE
fix(linter/eslint/no-multi-assign): handle parenthesized declarator initializers

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_multi_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_multi_assign.rs
@@ -118,14 +118,22 @@ impl Rule for NoMultiAssign {
         match node.kind() {
             // e.g. `var a = b = c;`
             AstKind::VariableDeclarator(declarator) => {
-                let Some(Expression::AssignmentExpression(assign_expr)) = &declarator.init else {
+                let Some(init) = &declarator.init else {
+                    return;
+                };
+                let Expression::AssignmentExpression(assign_expr) = init.without_parentheses()
+                else {
                     return;
                 };
                 ctx.diagnostic(no_multi_assign_diagnostic(assign_expr.span));
             }
             // e.g. `class A { a = b = 1; }`
             AstKind::PropertyDefinition(prop_def) => {
-                let Some(Expression::AssignmentExpression(assign_expr)) = &prop_def.value else {
+                let Some(value) = &prop_def.value else {
+                    return;
+                };
+                let Expression::AssignmentExpression(assign_expr) = value.without_parentheses()
+                else {
                     return;
                 };
                 ctx.diagnostic(no_multi_assign_diagnostic(assign_expr.span));
@@ -135,7 +143,9 @@ impl Rule for NoMultiAssign {
                 if self.ignore_non_declaration {
                     return;
                 }
-                let Expression::AssignmentExpression(expr) = &parent_expr.right else {
+                let Expression::AssignmentExpression(expr) =
+                    parent_expr.right.without_parentheses()
+                else {
                     return;
                 };
                 ctx.diagnostic(no_multi_assign_diagnostic(expr.span));
@@ -183,6 +193,7 @@ fn test() {
         ), // { "ecmaVersion": 6 },
         ("let a, b;a = b = 1", Some(serde_json::json!([{ "ignoreNonDeclaration": true }]))), // { "ecmaVersion": 6 },
         ("class C { [foo = 0] = 0 }", None), // { "ecmaVersion": 2022 }
+        ("/* eslint-disable no-multi-assign */ const x = (obj.y = z);", None),
     ];
 
     let fail = vec![
@@ -220,7 +231,23 @@ fn test() {
         (
             "class C { field = foo = 0 }",
             Some(serde_json::json!([{ "ignoreNonDeclaration": true }])),
-        ), // { "ecmaVersion": 2022 }
+        ), // { "ecmaVersion": 2022 },
+        (
+            "class C {
+                hash: unknown
+                done = false
+                run() {
+                    const currentLoadHash = (this.hash = {})
+                    const loadComplete = (this.done = true)
+                    let a, b, c
+                    a = b = c = 1
+                    return [currentLoadHash, loadComplete, a, b, c]
+                }
+            }",
+            None,
+        ),
+        ("class C { field = (foo = 0) }", None), // { "ecmaVersion": 2022 },
+        ("let a, b; a = (b = 1)", None),
     ];
 
     Tester::new(NoMultiAssign::NAME, NoMultiAssign::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/eslint_no_multi_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_multi_assign.snap
@@ -158,3 +158,53 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───────
    ╰────
   help: Separate each assignment into its own statement
+
+  ⚠ eslint(no-multi-assign): Do not use chained assignment
+   ╭─[no_multi_assign.tsx:5:46]
+ 4 │                 run() {
+ 5 │                     const currentLoadHash = (this.hash = {})
+   ·                                              ──────────────
+ 6 │                     const loadComplete = (this.done = true)
+   ╰────
+  help: Separate each assignment into its own statement
+
+  ⚠ eslint(no-multi-assign): Do not use chained assignment
+   ╭─[no_multi_assign.tsx:6:43]
+ 5 │                     const currentLoadHash = (this.hash = {})
+ 6 │                     const loadComplete = (this.done = true)
+   ·                                           ────────────────
+ 7 │                     let a, b, c
+   ╰────
+  help: Separate each assignment into its own statement
+
+  ⚠ eslint(no-multi-assign): Do not use chained assignment
+   ╭─[no_multi_assign.tsx:8:25]
+ 7 │                     let a, b, c
+ 8 │                     a = b = c = 1
+   ·                         ─────────
+ 9 │                     return [currentLoadHash, loadComplete, a, b, c]
+   ╰────
+  help: Separate each assignment into its own statement
+
+  ⚠ eslint(no-multi-assign): Do not use chained assignment
+   ╭─[no_multi_assign.tsx:8:29]
+ 7 │                     let a, b, c
+ 8 │                     a = b = c = 1
+   ·                             ─────
+ 9 │                     return [currentLoadHash, loadComplete, a, b, c]
+   ╰────
+  help: Separate each assignment into its own statement
+
+  ⚠ eslint(no-multi-assign): Do not use chained assignment
+   ╭─[no_multi_assign.tsx:1:20]
+ 1 │ class C { field = (foo = 0) }
+   ·                    ───────
+   ╰────
+  help: Separate each assignment into its own statement
+
+  ⚠ eslint(no-multi-assign): Do not use chained assignment
+   ╭─[no_multi_assign.tsx:1:16]
+ 1 │ let a, b; a = (b = 1)
+   ·                ─────
+   ╰────
+  help: Separate each assignment into its own statement


### PR DESCRIPTION
## Summary

- treat parenthesized assignment expressions as direct children in the three contexts covered by ESLint's no-multi-assign rule
- add regression coverage for the reported TypeScript declarator initializers, class fields, assignment right-hand sides, and disable directives

Fixes #25617.