### PR TITLE
fix(linter/eslint/max-classes-per-file): anchor diagnostic at program start

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -1,8 +1,6 @@
-use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
-use oxc_syntax::class::ClassId;
+use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -118,12 +116,12 @@ impl Rule for MaxClassesPerFile {
             return;
         }
 
-        let node_id = ctx.classes().get_node_id(ClassId::new(self.max as usize));
-        let span = if let AstKind::Class(class) = ctx.nodes().kind(node_id) {
-            class.span
-        } else {
-            Span::new(0, 0)
-        };
+        let program = ctx.nodes().program();
+        let start = program.directives.first().map_or_else(
+            || program.body.first().map_or(program.span.start, |statement| statement.span().start),
+            |directive| directive.span.start,
+        );
+        let span = Span::sized(start, 1);
 
         ctx.diagnostic(max_classes_per_file_diagnostic(class_count, self.max, span));
     }

--- a/crates/oxc_linter/src/snapshots/eslint_max_classes_per_file.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_max_classes_per_file.snap
@@ -3,65 +3,65 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint(max-classes-per-file): File has too many classes (2). Maximum allowed is 1
-   ╭─[max_classes_per_file.tsx:2:13]
+   ╭─[max_classes_per_file.tsx:1:1]
  1 │ class Foo {}
+   · ─
  2 │             class Bar {}
-   ·             ────────────
    ╰────
   help: Reduce the number of classes in this file
 
   ⚠ eslint(max-classes-per-file): File has too many classes (2). Maximum allowed is 1
-   ╭─[max_classes_per_file.tsx:2:34]
+   ╭─[max_classes_per_file.tsx:1:1]
  1 │ class Foo {}
+   · ─
  2 │             const myExpression = class {}
-   ·                                  ────────
    ╰────
   help: Reduce the number of classes in this file
 
   ⚠ eslint(max-classes-per-file): File has too many classes (2). Maximum allowed is 1
-   ╭─[max_classes_per_file.tsx:2:21]
+   ╭─[max_classes_per_file.tsx:1:1]
  1 │ var x = class {};
+   · ─
  2 │             var y = class {};
-   ·                     ────────
    ╰────
   help: Reduce the number of classes in this file
 
   ⚠ eslint(max-classes-per-file): File has too many classes (2). Maximum allowed is 1
-   ╭─[max_classes_per_file.tsx:2:21]
+   ╭─[max_classes_per_file.tsx:1:1]
  1 │ class Foo {}
+   · ─
  2 │             var x = class {};
-   ·                     ────────
    ╰────
   help: Reduce the number of classes in this file
 
   ⚠ eslint(max-classes-per-file): File has too many classes (2). Maximum allowed is 1
-   ╭─[max_classes_per_file.tsx:1:14]
+   ╭─[max_classes_per_file.tsx:1:1]
  1 │ class Foo {} class Bar {}
-   ·              ────────────
+   · ─
    ╰────
   help: Reduce the number of classes in this file
 
   ⚠ eslint(max-classes-per-file): File has too many classes (3). Maximum allowed is 2
-   ╭─[max_classes_per_file.tsx:1:27]
+   ╭─[max_classes_per_file.tsx:1:1]
  1 │ class Foo {} class Bar {} class Baz {}
-   ·                           ────────────
+   · ─
    ╰────
   help: Reduce the number of classes in this file
 
   ⚠ eslint(max-classes-per-file): File has too many classes (2). Maximum allowed is 1
-   ╭─[max_classes_per_file.tsx:3:17]
+   ╭─[max_classes_per_file.tsx:2:17]
+ 1 │ 
  2 │                 class Foo {}
+   ·                 ─
  3 │                 class Bar {}
-   ·                 ────────────
- 4 │                 const myExpression = class {}
    ╰────
   help: Reduce the number of classes in this file
 
   ⚠ eslint(max-classes-per-file): File has too many classes (3). Maximum allowed is 2
-   ╭─[max_classes_per_file.tsx:4:17]
+   ╭─[max_classes_per_file.tsx:2:17]
+ 1 │ 
+ 2 │                 class Foo {}
+   ·                 ─
  3 │                 class Bar {}
- 4 │                 class Baz {}
-   ·                 ────────────
- 5 │                 const myExpression = class {}
    ╰────
   help: Reduce the number of classes in this file


### PR DESCRIPTION
## Summary

- anchor max-classes-per-file diagnostics at the first program token to match ESLint behavior
- update diagnostic snapshots to assert the program-level location
- preserve disable-next-line behavior for top-of-file directives

Fixes #25629.
