### PR TITLE
fix(linter/react/no-direct-mutation-state): detect computed state mutations

### DIFF
--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -933,31 +933,20 @@ pub fn get_function_name_with_kind<'a>(node: &AstNode<'a>, parent_node: &AstNode
     tokens.join(" ")
 }
 
-// get the top iterator
-// example: this.state.a.b.c.d => this.state
+/// Get the innermost static member expression in an assignment target.
+///
+/// For example, both `this.state.a.b.c` and `this.state.a[key].c` return `this.state`.
 pub fn get_outer_member_expression<'a, 'b>(
     assignment: &'b SimpleAssignmentTarget<'a>,
 ) -> Option<&'b StaticMemberExpression<'a>> {
-    match assignment {
-        SimpleAssignmentTarget::StaticMemberExpression(expr) => {
-            let mut node = &**expr;
-            loop {
-                if node.object.is_null() {
-                    return Some(node);
-                }
+    let mut member = assignment.as_member_expression()?;
 
-                if let Some(MemberExpression::StaticMemberExpression(object)) =
-                    node.object.as_member_expression()
-                    && !object.property.name.is_empty()
-                {
-                    node = object;
+    while let Some(object) = member.object().as_member_expression() {
+        member = object;
+    }
 
-                    continue;
-                }
-
-                return Some(node);
-            }
-        }
+    match member {
+        MemberExpression::StaticMemberExpression(expression) => Some(expression),
         _ => None,
     }
 }

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -358,6 +358,17 @@ fn test() {
             }
           }
         "#,
+        r"
+          class Hello extends React.Component {
+            update(id) {
+              this.state.x[id] = 1;
+              this.state.x[id].y = 1;
+              this.state.items[id].prop = {};
+              this.state.x[id]++;
+              this.state.items[id].prop++;
+            }
+          }
+        ",
     ];
 
     Tester::new(NoDirectMutationState::NAME, NoDirectMutationState::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/react_no_direct_mutation_state.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_direct_mutation_state.snap
@@ -154,3 +154,48 @@ source: crates/oxc_linter/src/tester.rs
  5 │             }
    ╰────
   help: Calling `setState()` afterwards will replace the mutations you made via `this.state`.
+
+  ⚠ react(no-direct-mutation-state): Never mutate `this.state` directly.
+   ╭─[no_direct_mutation_state.tsx:4:15]
+ 3 │             update(id) {
+ 4 │               this.state.x[id] = 1;
+   ·               ────────────────
+ 5 │               this.state.x[id].y = 1;
+   ╰────
+  help: Calling `setState()` afterwards will replace the mutations you made via `this.state`.
+
+  ⚠ react(no-direct-mutation-state): Never mutate `this.state` directly.
+   ╭─[no_direct_mutation_state.tsx:5:15]
+ 4 │               this.state.x[id] = 1;
+ 5 │               this.state.x[id].y = 1;
+   ·               ──────────────────
+ 6 │               this.state.items[id].prop = {};
+   ╰────
+  help: Calling `setState()` afterwards will replace the mutations you made via `this.state`.
+
+  ⚠ react(no-direct-mutation-state): Never mutate `this.state` directly.
+   ╭─[no_direct_mutation_state.tsx:6:15]
+ 5 │               this.state.x[id].y = 1;
+ 6 │               this.state.items[id].prop = {};
+   ·               ─────────────────────────
+ 7 │               this.state.x[id]++;
+   ╰────
+  help: Calling `setState()` afterwards will replace the mutations you made via `this.state`.
+
+  ⚠ react(no-direct-mutation-state): Never mutate `this.state` directly.
+   ╭─[no_direct_mutation_state.tsx:7:15]
+ 6 │               this.state.items[id].prop = {};
+ 7 │               this.state.x[id]++;
+   ·               ──────────────────
+ 8 │               this.state.items[id].prop++;
+   ╰────
+  help: Calling `setState()` afterwards will replace the mutations you made via `this.state`.
+
+  ⚠ react(no-direct-mutation-state): Never mutate `this.state` directly.
+   ╭─[no_direct_mutation_state.tsx:8:15]
+ 7 │               this.state.x[id]++;
+ 8 │               this.state.items[id].prop++;
+   ·               ───────────────────────────
+ 9 │             }
+   ╰────
+  help: Calling `setState()` afterwards will replace the mutations you made via `this.state`.


### PR DESCRIPTION
## Summary

- traverse member-expression chains across computed accesses before checking for `this.state`
- add regression coverage for computed assignment and update targets

Fixes #25625
