### PR TITLE
fix(linter/unicorn/no-abusive-eslint-disable): use directive prefix in diagnostic

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
@@ -2,14 +2,27 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, disable_directives::RuleCommentType, rule::Rule};
+use crate::{
+    context::LintContext,
+    disable_directives::{DirectivePrefix, RuleCommentType},
+    rule::Rule,
+};
 
-fn no_abusive_eslint_disable_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(
-        "Unexpected `eslint-disable` comment that does not specify any rules to disable.",
-    )
-    .with_help("Specify the rules you want to disable.")
-    .with_label(span)
+fn no_abusive_eslint_disable_diagnostic(
+    span: Span,
+    directive_prefix: DirectivePrefix,
+) -> OxcDiagnostic {
+    let message = match directive_prefix {
+        DirectivePrefix::Eslint => {
+            "Unexpected `eslint-disable` comment that does not specify any rules to disable."
+        }
+        DirectivePrefix::Oxlint => {
+            "Unexpected `oxlint-disable` comment that does not specify any rules to disable."
+        }
+    };
+    OxcDiagnostic::warn(message)
+        .with_help("Specify the rules you want to disable.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -82,12 +95,18 @@ impl Rule for NoAbusiveEslintDisable {
         for comment in ctx.disable_directives().disable_rule_comments() {
             match &comment.r#type {
                 RuleCommentType::All => {
-                    ctx.diagnostic(no_abusive_eslint_disable_diagnostic(comment.span));
+                    ctx.diagnostic(no_abusive_eslint_disable_diagnostic(
+                        comment.span,
+                        comment.directive_prefix,
+                    ));
                 }
                 RuleCommentType::Single(rules) => {
                     for rule in rules {
                         if !is_valid_rule_name(&rule.rule_name) {
-                            ctx.diagnostic(no_abusive_eslint_disable_diagnostic(comment.span));
+                            ctx.diagnostic(no_abusive_eslint_disable_diagnostic(
+                                comment.span,
+                                comment.directive_prefix,
+                            ));
                         }
                     }
                 }
@@ -135,6 +154,10 @@ fn test() {
         eval(); // eslint-disable-line
         ",
         r"
+        /* oxlint-disable no-abusive-eslint-disable */
+        eval(); // oxlint-disable-line
+        ",
+        r"
         foo();
         // eslint-disable-line no-eval
         eval();
@@ -161,6 +184,7 @@ fn test() {
         // eslint-disable-next-line @scopewithoutplugin
         eval();
         ",
+        "// oxlint-disable-next-line @scopewithoutplugin\neval();",
         "eval(); // eslint-disable-line",
         "eval(); // oxlint-disable-line",
         r"

--- a/crates/oxc_linter/src/snapshots/unicorn_no_abusive_eslint_disable.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_abusive_eslint_disable.snap
@@ -11,6 +11,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Specify the rules you want to disable.
 
+  ⚠ unicorn(no-abusive-eslint-disable): Unexpected `oxlint-disable` comment that does not specify any rules to disable.
+   ╭─[no_abusive_eslint_disable.tsx:1:3]
+ 1 │ // oxlint-disable-next-line @scopewithoutplugin
+   ·   ─────────────────────────────────────────────
+ 2 │ eval();
+   ╰────
+  help: Specify the rules you want to disable.
+
   ⚠ unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.
    ╭─[no_abusive_eslint_disable.tsx:1:11]
  1 │ eval(); // eslint-disable-line
@@ -18,7 +26,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Specify the rules you want to disable.
 
-  ⚠ unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.
+  ⚠ unicorn(no-abusive-eslint-disable): Unexpected `oxlint-disable` comment that does not specify any rules to disable.
    ╭─[no_abusive_eslint_disable.tsx:1:11]
  1 │ eval(); // oxlint-disable-line
    ·           ────────────────────
@@ -41,7 +49,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Specify the rules you want to disable.
 
-  ⚠ unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.
+  ⚠ unicorn(no-abusive-eslint-disable): Unexpected `oxlint-disable` comment that does not specify any rules to disable.
    ╭─[no_abusive_eslint_disable.tsx:1:3]
  1 │ /* oxlint-disable */
    ·   ────────────────
@@ -57,7 +65,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Specify the rules you want to disable.
 
-  ⚠ unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.
+  ⚠ unicorn(no-abusive-eslint-disable): Unexpected `oxlint-disable` comment that does not specify any rules to disable.
    ╭─[no_abusive_eslint_disable.tsx:3:11]
  2 │         foo();
  3 │         /* oxlint-disable */
@@ -84,7 +92,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Specify the rules you want to disable.
 
-  ⚠ unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.
+  ⚠ unicorn(no-abusive-eslint-disable): Unexpected `oxlint-disable` comment that does not specify any rules to disable.
    ╭─[no_abusive_eslint_disable.tsx:3:11]
  2 │         foo();
  3 │         /* oxlint-disable-next-line */
@@ -93,7 +101,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Specify the rules you want to disable.
 
-  ⚠ unicorn(no-abusive-eslint-disable): Unexpected `eslint-disable` comment that does not specify any rules to disable.
+  ⚠ unicorn(no-abusive-eslint-disable): Unexpected `oxlint-disable` comment that does not specify any rules to disable.
    ╭─[no_abusive_eslint_disable.tsx:2:11]
  1 │ 
  2 │         // oxlint-disable-next-line


### PR DESCRIPTION
## Summary

- report oxlint-disable for diagnostics triggered by oxlint directives
- preserve eslint-disable wording for ESLint directives
- add regression coverage for malformed directives and rule suppression

Fixes #25647
