### PR TITLE
fix(linter/eslint/no-irregular-whitespace): check comments by default

### DIFF
--- a/apps/oxlint/fixtures/cli/report_unused_directives/.oxlintrc-with-rudd.json
+++ b/apps/oxlint/fixtures/cli/report_unused_directives/.oxlintrc-with-rudd.json
@@ -4,6 +4,7 @@
     },
     "rules": {
         "no-console": "warn",
-        "no-debugger": "warn"
+        "no-debugger": "warn",
+        "no-irregular-whitespace": "warn"
     }
 }

--- a/apps/oxlint/fixtures/cli/report_unused_directives/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cli/report_unused_directives/.oxlintrc.json
@@ -1,6 +1,7 @@
 {
     "rules": {
         "no-console": "warn",
-        "no-debugger": "warn"
+        "no-debugger": "warn",
+        "no-irregular-whitespace": "warn"
     }
 }

--- a/apps/oxlint/fixtures/cli/report_unused_directives/test.js
+++ b/apps/oxlint/fixtures/cli/report_unused_directives/test.js
@@ -13,8 +13,8 @@ debugger;
 const unusedVariable2 = 100;
 
 function testFunction() {
-    // eslint-disable-next-line no-console
-    console.log('Inside test function');
+    // eslint-disable-next-line no-console, no-irregular-whitespace
+    console.log('Inside test function'); // '​'
 }
 
 // eslint-disable-next-line no-console, no-debugger

--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -42,7 +42,7 @@ impl Default for NoIrregularWhitespaceConfig {
     fn default() -> Self {
         Self {
             skip_strings: true,
-            skip_comments: true,
+            skip_comments: false,
             skip_reg_exps: true,
             skip_templates: true,
             skip_jsx_text: true,
@@ -139,6 +139,9 @@ impl Rule for NoIrregularWhitespace {
         // Report irregular whitespace inside comments when not skipping them.
         if !self.skip_comments {
             let source_text = ctx.semantic().source_text();
+            if let Some(hashbang) = &ctx.nodes().program().hashbang {
+                report_irregular_whitespace_in_span(ctx, source_text, hashbang.span);
+            }
             for comment in ctx.semantic().comments() {
                 report_irregular_whitespace_in_span(ctx, source_text, comment.span);
             }
@@ -221,50 +224,51 @@ fn test() {
         ("' ';", None),
         ("' ';", None),
         ("'　';", None),
-        ("// ", None),
-        ("// ", None),
-        ("// ", None),
-        ("//  ", None),
-        ("// ᠎", None),
-        ("// ﻿", None),
-        ("//  ", None),
-        ("//  ", None),
-        ("//  ", None),
-        ("//  ", None),
-        ("//  ", None),
-        ("//  ", None),
-        ("//  ", None),
-        ("//  ", None),
-        ("//  ", None),
-        ("//  ", None),
-        ("//  ", None),
-        ("// ​", None),
-        ("//  ", None),
-        ("//  ", None),
-        ("// 　", None),
-        ("/*  */", None),
-        ("/*  */", None),
-        ("/*  */", None),
-        ("/*   */", None),
-        ("/* ᠎ */", None),
-        ("/* ﻿ */", None),
-        ("/*   */", None),
-        ("/*   */", None),
-        ("/*   */", None),
-        ("/*   */", None),
-        ("/*   */", None),
-        ("/*   */", None),
-        ("/*   */", None),
-        ("/*   */", None),
-        ("/*   */", None),
-        ("/*   */", None),
-        ("/*   */", None),
-        ("/* ​ */", None),
-        ("/*   */", None),
-        ("/*   */", None),
-        ("/*   */", None),
-        ("/*   */", None),
-        ("/* 　 */", None),
+        ("// ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("// ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("// ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("// ᠎", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("// ﻿", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("// ​", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("//  ", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("// 　", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*  */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*  */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*  */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/* ᠎ */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/* ﻿ */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/* ​ */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/*   */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("/* 　 */", Some(serde_json::json!([{ "skipComments": true }]))),
+        ("#!/usr/bin/env​node", Some(serde_json::json!([{ "skipComments": true }]))),
         ("//", None),
         ("//", None),
         ("//", None),
@@ -462,8 +466,8 @@ fn test() {
             None,
         ),
         ("foo ", None),
-        ("// 　", Some(serde_json::json!([{ "skipComments": false }]))),
-        ("/* 　 */", Some(serde_json::json!([{ "skipComments": false }]))),
+        ("// 　", None),
+        ("/* 　 */", None),
         ("var any = /　/, other = /​/;", Some(serde_json::json!([{ "skipRegExps": false }]))),
         ("var any = `　`, other = `​`;", Some(serde_json::json!([{ "skipTemplates": false }]))),
         ("<div>　</div>;", Some(serde_json::json!([{ "skipJSXText": false }]))),
@@ -471,4 +475,15 @@ fn test() {
 
     Tester::new(NoIrregularWhitespace::NAME, NoIrregularWhitespace::PLUGIN, pass, fail)
         .test_and_snapshot();
+
+    Tester::new(
+        NoIrregularWhitespace::NAME,
+        NoIrregularWhitespace::PLUGIN,
+        vec![],
+        vec![
+            ("export const ZERO_SPACE = String.fromCharCode(0x200b) // '​'", None),
+            ("#!/usr/bin/env​node", None),
+        ],
+    )
+    .test();
 }

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -14648,7 +14648,7 @@
       "properties": {
         "skipComments": {
           "description": "Whether to skip irregular whitespace in comments.",
-          "default": true,
+          "default": false,
           "type": "boolean",
           "markdownDescription": "Whether to skip irregular whitespace in comments."
         },


### PR DESCRIPTION
## Summary

- align the skipComments default with ESLint
- report irregular whitespace in line and block comments by default
- preserve the skipComments: true opt-out
- verify suppressed comment diagnostics count disable directives as used
- regenerate the published configuration schema

Fixes #25616.