### PR TITLE
fix(linter/import/no-named-default): flag type-only named defaults

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -146,8 +146,9 @@ impl RuleRunner for crate::rules::import::no_named_as_default_member::NoNamedAsD
 }
 
 impl RuleRunner for crate::rules::import::no_named_default::NoNamedDefault {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ImportDeclaration]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::import::no_named_export::NoNamedExport {

--- a/crates/oxc_linter/src/rules/import/no_named_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_default.rs
@@ -1,8 +1,13 @@
+use oxc_ast::{
+    AstKind,
+    ast::{ImportDeclarationSpecifier, ImportOrExportKind},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
+use oxc_semantic::AstNode;
+use oxc_span::{GetSpan, Span};
 
-use crate::{context::LintContext, module_record::ImportImportName, rule::Rule};
+use crate::{context::LintContext, rule::Rule};
 
 fn no_named_default_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Replace default import with named import.")
@@ -44,15 +49,21 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNamedDefault {
-    fn run_once(&self, ctx: &LintContext) {
-        ctx.module_record().import_entries.iter().for_each(|entry| {
-            let ImportImportName::Name(import_name) = &entry.import_name else {
-                return;
-            };
-            if import_name.name() == "default" && !entry.is_type {
-                ctx.diagnostic(no_named_default_diagnostic(import_name.span));
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if let AstKind::ImportDeclaration(import_decl) = node.kind()
+            && let Some(specifiers) = &import_decl.specifiers
+        {
+            for specifier in specifiers {
+                let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier else {
+                    continue;
+                };
+                if matches!(specifier.import_kind, ImportOrExportKind::Value)
+                    && specifier.imported.name() == "default"
+                {
+                    ctx.diagnostic(no_named_default_diagnostic(specifier.imported.span()));
+                }
             }
-        });
+        }
     }
 }
 
@@ -64,6 +75,8 @@ fn test() {
         r#"import bar from "./bar";"#,
         r#"import bar, { foo } from "./bar";"#,
         r#"import { type default as Foo } from "./bar";"#,
+        r#"// oxlint-disable-next-line import/no-named-default
+import type { default as Foo } from "./bar";"#,
     ];
 
     let unicorn_pass = vec![
@@ -78,6 +91,8 @@ fn test() {
         r#"import { default as bar } from "./bar";"#,
         r#"import { foo, default as bar } from "./bar";"#,
         r#"import { "default" as bar } from "./bar";"#,
+        r#"import type { default as Quill, Delta } from "quill";
+export type T = Quill | Delta;"#,
     ];
 
     let unicorn_fail = vec![

--- a/crates/oxc_linter/src/snapshots/import_no_named_default.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_named_default.snap
@@ -24,6 +24,14 @@ source: crates/oxc_linter/src/tester.rs
   help: Forbid named default exports.
 
   ⚠ import(no-named-default): Replace default import with named import.
+   ╭─[no_named_default.tsx:1:15]
+ 1 │ import type { default as Quill, Delta } from "quill";
+   ·               ───────
+ 2 │ export type T = Quill | Delta;
+   ╰────
+  help: Forbid named default exports.
+
+  ⚠ import(no-named-default): Replace default import with named import.
    ╭─[no_named_default.tsx:1:9]
  1 │ import {default as named} from "foo";
    ·         ───────

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -207,7 +207,7 @@ import/no-empty-named-blocks                               |    103
 import/no-mutable-exports                                  |     64
 import/no-named-as-default                                 |      7
 import/no-named-as-default-member                          |      7
-import/no-named-default                                    |      7
+import/no-named-default                                    |    103
 import/no-named-export                                     |     68
 import/no-namespace                                        |      7
 import/no-nodejs-modules                                   |  62734


### PR DESCRIPTION
## Summary

- flag declaration-level TypeScript type-only named default imports
- preserve inline type specifier behavior to match eslint-plugin-import
- add regression and disable-directive coverage
- regenerate rule dispatch and timing metadata

Closes #25613
