### PR TITLE
fix(linter/react/display-name): report curried HOC inner component

### DIFF
--- a/crates/oxc_linter/src/rules/react/display_name.rs
+++ b/crates/oxc_linter/src/rules/react/display_name.rs
@@ -505,15 +505,20 @@ fn is_react_component_node<'a>(
                 // Check if it's a HOF pattern
                 if !returns_jsx && let Some(innermost) = find_innermost_function_with_jsx(expr, ctx)
                 {
-                    let inner_has_name = match innermost {
-                        InnermostFunction::Function(func) => func.id.is_some(),
-                        InnermostFunction::ArrowFunction => false,
+                    let inner_span = match innermost {
+                        InnermostFunction::Function(func) => func
+                            .id
+                            .is_none()
+                            .then_some(Span::new(func.span.start, func.params.span.end)),
+                        InnermostFunction::ArrowFunction(func) => {
+                            Some(Span::new(func.span.start, func.params.span.end))
+                        }
                     };
 
                     // Only treat as HOF if inner function is unnamed
-                    if !inner_has_name {
+                    if let Some(span) = inner_span {
                         return Some(ReactComponentInfo {
-                            span: decl.id.span(),
+                            span,
                             is_context: false,
                             name: None, // HOF doesn't use variable name
                         });
@@ -1783,6 +1788,20 @@ fn test() {
             Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             None,
         ),
+        (
+            "
+                    import React from 'react';
+
+                    type Props = { onSubmit: () => void };
+                    type HOCProps = { label: string };
+
+                    export const HOC =
+                      ({ label }: HOCProps) =>
+                      // eslint-disable-next-line react/display-name
+                      ({ onSubmit }: Props): JSX.Element => <button onClick={onSubmit}>{label}</button>;",
+            None,
+            None,
+        ),
     ];
 
     let fail = vec![
@@ -2144,10 +2163,25 @@ fn test() {
         ),
         (
             "
-                    const renderer = a => listItem => (
-                      <div>{a} {listItem}</div>
-                    );
-                  ",
+                    import React from 'react';
+
+                    type Props = { onSubmit: () => void };
+                    type HOCProps = { label: string };
+
+                    export const HOC =
+                      ({ label }: HOCProps) =>
+                      ({ onSubmit }: Props): JSX.Element => <button onClick={onSubmit}>{label}</button>;",
+            None,
+            None,
+        ),
+        (
+            "
+                    const HOC = () =>
+                      (props) => {
+                        /* eslint-disable react/display-name */
+                        return <div />;
+                        /* eslint-enable react/display-name */
+                      };",
             None,
             None,
         ),

--- a/crates/oxc_linter/src/snapshots/react_display_name.snap
+++ b/crates/oxc_linter/src/snapshots/react_display_name.snap
@@ -297,11 +297,19 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:27]
- 1 │ 
- 2 │                     const renderer = a => listItem => (
-   ·                           ────────
- 3 │                       <div>{a} {listItem}</div>
+   ╭─[display_name.tsx:9:23]
+ 8 │                       ({ label }: HOCProps) =>
+ 9 │                       ({ onSubmit }: Props): JSX.Element => <button onClick={onSubmit}>{label}</button>;
+   ·                       ─────────────────────
+   ╰────
+  help: Add a `displayName` property to the component.
+
+  ⚠ react(display-name): Component definition is missing display name.
+   ╭─[display_name.tsx:3:23]
+ 2 │                     const HOC = () =>
+ 3 │                       (props) => {
+   ·                       ───────
+ 4 │                         /* eslint-disable react/display-name */
    ╰────
   help: Add a `displayName` property to the component.
 

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -972,8 +972,7 @@ fn cfg_returns(node_id: NodeId, ctx: &LintContext<'_>) -> FunctionReturns {
 #[derive(Debug)]
 pub enum InnermostFunction<'a> {
     Function(&'a Function<'a>),
-    /// Arrow functions never have an id, so we don't need to store the reference
-    ArrowFunction,
+    ArrowFunction(&'a ArrowFunctionExpression<'a>),
 }
 
 pub fn find_innermost_function_with_jsx<'a>(
@@ -1004,7 +1003,7 @@ pub fn find_innermost_function_with_jsx<'a>(
         }
         Expression::ArrowFunctionExpression(arrow_func) => {
             if arrow_function_returns(arrow_func, ctx).has_jsx() {
-                Some(InnermostFunction::ArrowFunction)
+                Some(InnermostFunction::ArrowFunction(arrow_func))
             } else {
                 match &arrow_func.body {
                     ArrowFunctionBody::FunctionBody(body) => {


### PR DESCRIPTION
## Summary

- retain the innermost JSX-returning arrow node when detecting HOF components
- report react/display-name on the anonymous inner component instead of the outer HOC factory
- cover the TypeScript curried-HOC reproduction and its disable-next-line behavior

Closes #25618.