### PR TITLE
fix(linter/eslint/no-unused-vars): report bare underscore parameters

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -3861,10 +3861,10 @@ export interface NoUnusedVarsOptions {
    * Specifies exceptions to this rule for unused arguments. Arguments whose
    * names match this pattern will be ignored.
    *
-   * By default, this pattern is `^_` unless options are configured with an
-   * object. In this case it will default to [`None`]. Note that this
-   * behavior deviates from both ESLint and TypeScript-ESLint, which never
-   * provide a default pattern.
+   * By default, names starting with `_` are ignored, except for the bare `_`
+   * parameter. If options are configured with an object, this will default
+   * to [`None`]. Note that this behavior deviates from both ESLint and
+   * TypeScript-ESLint, which never provide a default pattern.
    *
    * #### Example
    *

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/diagnostic.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/diagnostic.rs
@@ -42,7 +42,7 @@ where
 
     let help_suffix = match pat {
         IgnorePattern::None => ".".into(),
-        IgnorePattern::Default => {
+        IgnorePattern::Default | IgnorePattern::PrefixUnderscore => {
             name.strip_prefix('_').map_or(".".into(), |name| format!(" to '{name}'."))
         }
         IgnorePattern::Some(r) => {
@@ -116,7 +116,11 @@ where
     R: fmt::Display,
 {
     let name = symbol.name();
-    let suffix = pat.diagnostic_help("parameters");
+    let suffix = if name == "_" && pat.is_default() {
+        std::borrow::Cow::Borrowed("")
+    } else {
+        pat.diagnostic_help("parameters")
+    };
 
     OxcDiagnostic::warn(if only_used_as_type {
         format!("Parameter '{name}' is declared but only used as a type.{suffix}")

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_conflicts.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_conflicts.rs
@@ -39,7 +39,7 @@ impl NoUnusedVars {
         let scope_id = symbol.scope_id();
         let ignored_name: String = match ignore_pattern.as_ref() {
             // TODO: support more patterns
-            IgnorePattern::Default => {
+            IgnorePattern::Default | IgnorePattern::PrefixUnderscore => {
                 format!("_{}", symbol.name())
             }
             IgnorePattern::Some(re) if re.as_str() == "^_" => {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/ignored.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/ignored.rs
@@ -421,7 +421,8 @@ impl NoUnusedVars {
     #[inline]
     pub(super) fn is_ignored_arg(&self, name: &str) -> Ignored {
         Ignored::new(
-            Self::is_none_or_match(self.args_ignore_pattern.as_ref(), name),
+            !(name == "_" && self.args_ignore_pattern.is_default())
+                && Self::is_none_or_match(self.args_ignore_pattern.as_ref(), name),
             IgnoreReason::NamePattern,
         )
     }
@@ -451,7 +452,7 @@ impl NoUnusedVars {
         match re {
             IgnorePattern::None => false,
             IgnorePattern::Some(re) => re.is_match(haystack),
-            IgnorePattern::Default => haystack.starts_with('_'),
+            IgnorePattern::Default | IgnorePattern::PrefixUnderscore => haystack.starts_with('_'),
         }
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
@@ -36,10 +36,10 @@ pub struct NoUnusedVarsOptions {
     /// Specifies exceptions to this rule for unused arguments. Arguments whose
     /// names match this pattern will be ignored.
     ///
-    /// By default, this pattern is `^_` unless options are configured with an
-    /// object. In this case it will default to [`None`]. Note that this
-    /// behavior deviates from both ESLint and TypeScript-ESLint, which never
-    /// provide a default pattern.
+    /// By default, names starting with `_` are ignored, except for the bare `_`
+    /// parameter. If options are configured with an object, this will default
+    /// to [`None`]. Note that this behavior deviates from both ESLint and
+    /// TypeScript-ESLint, which never provide a default pattern.
     ///
     /// #### Example
     ///
@@ -267,18 +267,18 @@ impl NoUnusedVarsFixMode {
     }
 }
 
-// Represents an `Option<Regex>` with an additional `Default` variant,
-// which represents the default ignore pattern for when no pattern is
-// explicitly provided.
+// Represents an `Option<Regex>` with variants for implicit defaults and an optimized `^_` pattern.
 #[derive(Debug, Clone, Copy, JsonSchema)]
 #[serde(untagged)]
 pub enum IgnorePattern<R> {
-    /// No ignore pattern was provided, use the default pattern. This
-    /// means that the pattern is `^_`.
+    /// No ignore pattern was provided; use the field-specific default behavior.
     #[serde(skip)]
     // skip serialization since this is only a marker for default behavior, not an actual pattern to be used.
     // The schema generation would produce two `null` options.
     Default,
+    /// The explicitly configured pattern is `^_`.
+    #[serde(skip)]
+    PrefixUnderscore,
     /// The ignore pattern is explicitly none.
     None,
     /// The ignore pattern is a regex.
@@ -298,10 +298,10 @@ impl<R> IgnorePattern<R> {
         matches!(self, Self::None)
     }
 
-    /// Returns `true` if the pattern is [`IgnorePattern::Some`] or [`IgnorePattern::Default`].
+    /// Returns `true` if the pattern is not [`IgnorePattern::None`].
     #[inline]
     pub fn is_some(&self) -> bool {
-        matches!(self, Self::Some(_) | Self::Default)
+        !self.is_none()
     }
 
     /// Returns the inner value if it is [`IgnorePattern::Some`], otherwise
@@ -331,6 +331,7 @@ impl<R> IgnorePattern<R> {
     pub fn as_ref(&self) -> IgnorePattern<&R> {
         match self {
             Self::Default => IgnorePattern::Default,
+            Self::PrefixUnderscore => IgnorePattern::PrefixUnderscore,
             Self::None => IgnorePattern::None,
             Self::Some(r) => IgnorePattern::Some(r),
         }
@@ -343,7 +344,7 @@ where
     pub(super) fn diagnostic_help(&self, symbol_kind_plural: &str) -> Cow<'static, str> {
         match self {
             Self::None => Cow::Borrowed(""),
-            Self::Default => {
+            Self::Default | Self::PrefixUnderscore => {
                 Cow::Owned(format!(" Unused {symbol_kind_plural} should start with a '_'."))
             }
             Self::Some(reg) => {
@@ -359,7 +360,7 @@ impl TryFrom<Option<&str>> for IgnorePattern<Regex> {
     fn try_from(value: Option<&str>) -> Result<Self, Self::Error> {
         match value {
             None => Ok(Self::None),
-            Some("^_") => Ok(Self::Default),
+            Some("^_") => Ok(Self::PrefixUnderscore),
             Some(pattern) => RegexBuilder::new(pattern).build().map(Self::Some),
         }
     }
@@ -743,12 +744,16 @@ mod tests {
         .unwrap();
 
         assert_eq!(rule.vars, VarsOption::Local);
-        assert!(rule.vars_ignore_pattern.is_default());
+        assert!(rule.vars_ignore_pattern.is_some());
+        assert!(!rule.vars_ignore_pattern.is_default());
         assert_eq!(rule.args, ArgsOption::All);
-        assert!(rule.args_ignore_pattern.is_default());
+        assert!(rule.args_ignore_pattern.is_some());
+        assert!(!rule.args_ignore_pattern.is_default());
         assert_eq!(rule.caught_errors, CaughtErrors::all());
-        assert!(rule.caught_errors_ignore_pattern.is_default());
-        assert!(rule.destructured_array_ignore_pattern.is_default());
+        assert!(rule.caught_errors_ignore_pattern.is_some());
+        assert!(!rule.caught_errors_ignore_pattern.is_default());
+        assert!(rule.destructured_array_ignore_pattern.is_some());
+        assert!(!rule.destructured_array_ignore_pattern.is_default());
         assert!(rule.ignore_rest_siblings);
         assert!(!rule.ignore_class_with_static_init_block);
         assert!(!rule.ignore_using_declarations);
@@ -768,7 +773,7 @@ mod tests {
         .unwrap();
         // option object provided, no default varsIgnorePattern
         assert!(rule.vars_ignore_pattern.is_none());
-        assert!(rule.args_ignore_pattern.is_default());
+        assert!(matches!(rule.args_ignore_pattern, IgnorePattern::PrefixUnderscore));
 
         let rule: NoUnusedVarsOptions = json!([
             {
@@ -779,7 +784,7 @@ mod tests {
         .unwrap();
 
         // option object provided, no default argsIgnorePattern
-        assert!(matches!(rule.vars_ignore_pattern, IgnorePattern::Default));
+        assert!(matches!(rule.vars_ignore_pattern, IgnorePattern::PrefixUnderscore));
         assert!(rule.args_ignore_pattern.is_none());
     }
 
@@ -850,7 +855,7 @@ mod tests {
         parse_unicode_rule(Some(&pat)).expect("json strings should get parsed into a regex");
 
         let pat = json!("^_");
-        assert!(parse_unicode_rule(Some(&pat)).unwrap().is_default());
+        assert!(matches!(parse_unicode_rule(Some(&pat)).unwrap(), IgnorePattern::PrefixUnderscore));
     }
 
     #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1089,6 +1089,7 @@ fn test_arguments() {
     let pass = vec![
         ("function foo(a) { return a } foo()", None),
         ("function foo(a, b) { return b } foo()", Some(json!([{ "args": "after-used" }]))),
+        ("function foo(_) {} foo()", Some(json!([{ "argsIgnorePattern": "^_" }]))),
         ("let a; a = function(a = a) {}; a();", None),
         ("let ids = arr.map(el => el.id); f(ids)", None),
         (
@@ -1152,6 +1153,7 @@ fn test_arguments() {
     ];
     let fail = vec![
         ("function foo(a) {} foo()", None),
+        ("window.addEventListener('logModel', function (_) { doSomething() })", None),
         ("function foo(a: number) {} foo()", None),
         ("function foo({ a }, b) { return b } foo()", Some(json!([{ "args": "after-used" }]))),
         ("function foo(...args: typeof args) {} foo()", None),

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-arguments.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-arguments.snap
@@ -10,6 +10,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this parameter.
 
+  ⚠ eslint(no-unused-vars): Parameter '_' is declared but never used.
+   ╭─[no_unused_vars.tsx:1:47]
+ 1 │ window.addEventListener('logModel', function (_) { doSomething() })
+   ·                                               ┬
+   ·                                               ╰── '_' is declared here
+   ╰────
+  help: Consider removing this parameter.
+
   ⚠ eslint(no-unused-vars): Parameter 'a' is declared but never used. Unused parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:14]
  1 │ function foo(a: number) {} foo()

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -16128,13 +16128,13 @@
           "markdownDescription": "Controls how unused arguments are checked."
         },
         "argsIgnorePattern": {
-          "description": "Specifies exceptions to this rule for unused arguments. Arguments whose\nnames match this pattern will be ignored.\n\nBy default, this pattern is `^_` unless options are configured with an\nobject. In this case it will default to [`None`]. Note that this\nbehavior deviates from both ESLint and TypeScript-ESLint, which never\nprovide a default pattern.\n\n#### Example\n\nExamples of **correct** code for this option when the pattern is `^_`:\n\n```javascript\nfunction foo(_a, b) {\nconsole.log(b);\n}\nfoo(1, 2);\n```",
+          "description": "Specifies exceptions to this rule for unused arguments. Arguments whose\nnames match this pattern will be ignored.\n\nBy default, names starting with `_` are ignored, except for the bare `_`\nparameter. If options are configured with an object, this will default\nto [`None`]. Note that this behavior deviates from both ESLint and\nTypeScript-ESLint, which never provide a default pattern.\n\n#### Example\n\nExamples of **correct** code for this option when the pattern is `^_`:\n\n```javascript\nfunction foo(_a, b) {\nconsole.log(b);\n}\nfoo(1, 2);\n```",
           "allOf": [
             {
               "$ref": "#/definitions/IgnorePattern_for_String"
             }
           ],
-          "markdownDescription": "Specifies exceptions to this rule for unused arguments. Arguments whose\nnames match this pattern will be ignored.\n\nBy default, this pattern is `^_` unless options are configured with an\nobject. In this case it will default to [`None`]. Note that this\nbehavior deviates from both ESLint and TypeScript-ESLint, which never\nprovide a default pattern.\n\n#### Example\n\nExamples of **correct** code for this option when the pattern is `^_`:\n\n```javascript\nfunction foo(_a, b) {\nconsole.log(b);\n}\nfoo(1, 2);\n```"
+          "markdownDescription": "Specifies exceptions to this rule for unused arguments. Arguments whose\nnames match this pattern will be ignored.\n\nBy default, names starting with `_` are ignored, except for the bare `_`\nparameter. If options are configured with an object, this will default\nto [`None`]. Note that this behavior deviates from both ESLint and\nTypeScript-ESLint, which never provide a default pattern.\n\n#### Example\n\nExamples of **correct** code for this option when the pattern is `^_`:\n\n```javascript\nfunction foo(_a, b) {\nconsole.log(b);\n}\nfoo(1, 2);\n```"
         },
         "caughtErrors": {
           "description": "Used for `catch` block validation.",

--- a/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
+++ b/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
@@ -225,10 +225,10 @@ type: `string`
 Specifies exceptions to this rule for unused arguments. Arguments whose
 names match this pattern will be ignored.
 
-By default, this pattern is `^_` unless options are configured with an
-object. In this case it will default to [`None`]. Note that this
-behavior deviates from both ESLint and TypeScript-ESLint, which never
-provide a default pattern.
+By default, names starting with `_` are ignored, except for the bare `_`
+parameter. If options are configured with an object, this will default
+to [`None`]. Note that this behavior deviates from both ESLint and
+TypeScript-ESLint, which never provide a default pattern.
 
 #### Example
 


### PR DESCRIPTION
## Summary

- report a bare underscore parameter when no args ignore pattern is configured
- preserve the optimized underscore-prefix behavior for explicit argsIgnorePattern configuration
- update focused rule coverage and generated documentation

Closes #25626
