### PR TITLE
fix(linter/typescript/no-var-requires): run rule on JavaScript

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -3,12 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{
-    AstNode,
-    ast_util::is_global_require_call,
-    context::{ContextHost, LintContext},
-    rule::Rule,
-};
+use crate::{AstNode, ast_util::is_global_require_call, context::LintContext, rule::Rule};
 
 fn no_var_requires_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Require statement not part of import statement.")
@@ -70,10 +65,6 @@ impl Rule for NoVarRequires {
                 ctx.diagnostic(no_var_requires_diagnostic(node.kind().span()));
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -513,7 +513,7 @@ typescript/no-unnecessary-type-constraint                  |    362
 typescript/no-unsafe-declaration-merging                   |    500
 typescript/no-unsafe-function-type                         |  13199
 typescript/no-useless-empty-export                         |      5
-typescript/no-var-requires                                 |  24652
+typescript/no-var-requires                                 |  62606
 typescript/no-wrapper-object-types                         |  13199
 typescript/parameter-properties                            |   1070
 typescript/prefer-as-const                                 |  12866


### PR DESCRIPTION
## Summary
- run typescript/no-var-requires on JavaScript files
- match typescript-eslint behavior and prevent false unused-disable diagnostics

Fixes #25623.