### PR TITLE
fix(formatter): fix comment and indent issues around unions

### DIFF
--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -161,6 +161,17 @@ The entries documented so far are not yet an exhaustive audit against the confor
   - Artifact of its comment-extraction doc surgery: an unconditional separator space that its end-of-line trimming can only remove when no line-suffix comment flushes behind it
 - `experimentalOperatorPosition: "start"`, intersection types: a leading own-line comment stays own-line, above the leading `&`; Prettier prints it behind `& `, losing its own-line-ness and idempotency (the second pass inlines the type with the comment behind `;`)
   - Binary-like chains hoist the comment in both formatters; one uniform rule (and the own-line invariant) over Prettier's internal inconsistency
+- Inline comments around a union's formatter-added `(` keep their source side (`keyof /* c */ (A | B)` stays as-is)
+  - Prettier moves the comment inside for `keyof`/type-operator operands while keeping it outside in array/indexed-access positions
+- An end-of-line line comment right after `=`/`:` keeps its position (`= // c` + mandatory break)
+  - Prettier treats the same shape three ways:
+    - JS keeps it only when the right-hand side breaks and flushes it past a fitting one (prettier#14617-family attachment artifact)
+    - TS type aliases and union-valued property signatures get it own-lined (the 3.9 union rewrite)
+    - simple-typed property signatures get it flushed past the member and its `;` separator
+  - Not yet covered: default parameters, destructuring defaults, enum members (different formatting paths still flush, Prettier-compatible)
+- A union's leading comments normalize to behind the leading `|` (`| /* c */ A`) whenever no comment ends its source line, regardless of the source shape
+  - Prettier does the same except for nested single-member paren sources (`| (/* c */ | A ...`) and multiline block comments starting their line, where it keeps `/* c */ | A`
+    - An output it then reformats into `| /* c */ A` itself for the first shape, not idempotent
 
 ## Verification
 

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -16,7 +16,10 @@ use crate::{
     print::{FormatFunctionOptions, FormatJsArrowFunctionExpressionOptions, FormatWrite},
     utils::{
         suppressed::FormatSuppressedNode,
-        typecast::{format_leading_comments_and_open_paren, format_type_cast_comment_node},
+        typecast::{
+            format_leading_comments_and_open_paren, format_outer_leading_comments_and_open_paren,
+            format_type_cast_comment_node,
+        },
     },
 };
 
@@ -4424,9 +4427,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnionType<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        if needs_parentheses {
-            "(".fmt(f);
-        }
+        format_outer_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
             self.format_leading_comments(f);
             FormatSuppressedNode(self.span()).fmt(f);

--- a/crates/oxc_formatter/src/print/intersection_type.rs
+++ b/crates/oxc_formatter/src/print/intersection_type.rs
@@ -3,8 +3,8 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    ast_nodes::AstNode, format_args, formatter::prelude::*, parentheses::NeedsParentheses,
-    print::FormatWrite, utils::typescript::is_object_like_type, write,
+    ast_nodes::AstNode, format_args, formatter::prelude::*, print::FormatWrite,
+    utils::typescript::is_object_like_type, write,
 };
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSIntersectionType<'a>> {
@@ -44,12 +44,6 @@ fn format_intersection_types<'a>(
             if !(is_prev_object_like || is_object_like)
                 || f.comments().has_leading_own_line_comment(item.span().start)
             {
-                let content = format_with(|f| {
-                    if item.needs_parentheses(f) {
-                        write!(f, format_leading_comments(item.span()));
-                    }
-                    write!(f, item);
-                });
                 if operator_leads_break {
                     // The hoist keeps own-line comments own-line, like binary-like chains.
                     // NOTE: Prettier prints them behind `& `, losing that (and idempotency).
@@ -59,11 +53,11 @@ fn format_intersection_types<'a>(
                             format_hoisted_leading_comments(item.span()),
                             "&",
                             space(),
-                            content
+                            item
                         ))
                     );
                 } else {
-                    write!(f, [space(), "&", soft_line_indent_or_space(&content)]);
+                    write!(f, [space(), "&", soft_line_indent_or_space(&item)]);
                 }
             } else {
                 write!(f, [space(), "&", space()]);

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -40,6 +40,9 @@ pub use arrow_function_expression::{
 pub use binary_like_expression::{BinaryLikeExpression, should_flatten};
 pub use fragment::{FormatFunctionParams, FormatTypeParameters};
 pub use function::FormatFunctionOptions;
+pub use union_type::{
+    alias_union_breaks_after_operator, is_trailing_own_line_jsdoc_comment, type_alias_left_end,
+};
 
 use cow_utils::CowUtils;
 

--- a/crates/oxc_formatter/src/print/union_type.rs
+++ b/crates/oxc_formatter/src/print/union_type.rs
@@ -1,12 +1,12 @@
 //! NOTE: This printer deliberately stays on Prettier 3.8-style expansion (one member per line with leading `|`)
 //! and will probably NOT follow Prettier 3.9's fit-to-width rewrite
-//! (prettier#18827: collapse when it fits, changed `=` comment placement, conditional-type `? |` hugging).
+//! (prettier#18827: collapse when it fits, conditional-type `? |` hugging).
 //!
 //! Not final yet, but that is the working assumption:
 //! the per-member layout is the diff-friendly output, and the rewrite is still contested upstream (prettier#19733, open).
-//! Most `typescript/union/**` conformance failures are this one cluster;
-//! once the decision is final, reclassify them as a Known divergence entry instead of catch-up backlog.
-//! Planned: intersection types unify INTO this printer's layout (see the NOTE in `intersection_type.rs`).
+//! The remaining `typescript/union/**` conformance failures are this collapse cluster plus the documented comment-placement divergences;
+//! once the collapse decision is final, reclassify that cluster as an entry too.
+//! Current plan: intersection types unify INTO this printer's layout (see the NOTE in `intersection_type.rs`).
 
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
@@ -16,7 +16,7 @@ use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{
-        JsFormatter,
+        Comments, JsFormatter,
         prelude::*,
         trivia::{FormatLeadingComments, FormatTrailingComments},
     },
@@ -97,13 +97,78 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
         } else {
             f.context().comments().comments_before(self.span().start)
         };
-        let comment_info = LeadingCommentsInfo::from_comments(leading_comments);
         let mut union_type_at_top = self;
         while let AstNodes::TSUnionType(parent) = union_type_at_top.parent()
             && parent.types().len() == 1
         {
             union_type_at_top = parent;
         }
+
+        // Where leading comments print relative to the synthesized leading `|`:
+        // comments go behind it, one canonical form regardless of the source shape.
+        // ```ts
+        // type X = /* c */ A | B_Long;
+        // // also
+        // type X = | /* c */ A | B_Long;
+        // // also
+        // type X =
+        //   /* c */ A
+        //   | B_Long;
+        //
+        // // will be
+        // type X =
+        //   | /* c */ A
+        //   | B_Long;
+        // ```
+        // NOTE: Prettier keeps the comment before the `|` for nested single-member paren sources (`| (/* c */ | A ...`),
+        // yet reformats that own output into the canonical form above;
+        // we normalize directly to the fixed point.
+        //
+        // Only comments that END their source line stay before the `|`:
+        // moving one would force a break between the `|` and its member.
+        // ```ts
+        // type X = /* c */
+        //   A | B_Long;
+        //
+        // // will be
+        // type X =
+        //   /* c */
+        //   A | B_Long;
+        // ```
+        // This also keeps own-line comments own-line, and line comments harmless (`| // c` would swallow the member).
+        //
+        // All-or-nothing: a partial move would reorder comments or split a same-line group,
+        // so one line-ending comment keeps the whole list before the `|`.
+        //
+        // The guard is about the printed `|`.
+        // A single plain member prints no operator, so a line-ending BLOCK comment there inlines with the member instead
+        // (`= | /* c */\n'A'` gives `= /* c */ 'A'`, matching Prettier).
+        // The sibling rule for the formatter-added `(` is `format_outer_leading_comments_and_open_paren`,
+        // keyed on the source `(` instead.
+        let comment_info = LeadingCommentsInfo::from_comments(leading_comments);
+        let all_inline = !comment_info.has_end_of_line_comment;
+        let (before_pipe_comments, inline_member_comments) = if all_inline {
+            (&leading_comments[..0], leading_comments)
+        } else {
+            (leading_comments, &leading_comments[..0])
+        };
+
+        // A `?`/`:` branch hugs its leading comments behind the operator,
+        // like conditional expressions do: no break before the comments, and no union indent on top of the conditional's alignment
+        // (the content must sit one level under `?`, not one level under the comment)
+        // ```ts
+        // type T = X extends Y
+        //   ? /** c */
+        //     A | B
+        //   : Z;
+        // ```
+        let is_conditional_branch = match union_type_at_top.parent() {
+            AstNodes::TSConditionalType(conditional) => {
+                let span = union_type_at_top.span();
+                conditional.true_type.span() == span || conditional.false_type.span() == span
+            }
+            _ => false,
+        };
 
         let should_indent = {
             let parent = union_type_at_top.parent();
@@ -116,6 +181,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
                 AstNodes::TSTypeAssertion(_)
                 | AstNodes::TSTupleType(_)
                 | AstNodes::TSTypeParameterInstantiation(_) => false,
+                // A check/extends-position union falls through to `_ => true`
+                AstNodes::TSConditionalType(_) if is_conditional_branch => {
+                    before_pipe_comments.is_empty()
+                }
                 _ => true,
             }
         };
@@ -129,7 +198,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
             let suppressed_node_span =
                 if is_suppressed { self.types.first().unwrap().span() } else { Span::default() };
 
-            let leading_soft_line_break_or_space = should_indent && !comment_info.has_comments();
+            let leading_soft_line_break_or_space = should_indent && before_pipe_comments.is_empty();
 
             let separator = format_with(|f| {
                 if leading_soft_line_break_or_space {
@@ -139,6 +208,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
             });
 
             write!(f, [if_group_breaks(&separator)]);
+            FormatLeadingComments::Comments(inline_member_comments).fmt(f);
 
             format_union_types(types, suppressed_node_span, false, f);
         });
@@ -179,15 +249,24 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
             let has_own_line_comment = comment_info.has_own_line_comment
                 || (matches!(union_type_at_top.parent(), AstNodes::TSTypeAliasDeclaration(_))
                     && comment_info.has_trailing_own_line_non_jsdoc_block_comment);
+            // An own-line leading comment breaks BEFORE itself and stays above the first member
+            // ```ts
+            // type A =
+            //   /* c */
+            //   | A
+            //   | B;
+            // ```
+            // breaking after instead would hoist the comment onto the `=` line
+            // (`type A = /* c */`), which is not own-line anymore and not idempotent.
+            // Conditional branches hug instead (no break, see `is_conditional_branch`).
+            let breaks_before_comments = (has_own_line_comment
+                || (comment_info.has_end_of_line_comment && only_type))
+                && !is_conditional_branch;
             write!(
                 f,
                 [
-                    ((has_own_line_comment && !only_type)
-                        || (comment_info.has_end_of_line_comment && only_type))
-                        .then(soft_line_break),
-                    FormatLeadingComments::Comments(leading_comments),
-                    (!comment_info.has_end_of_line_comment && has_own_line_comment && only_type)
-                        .then(soft_line_break),
+                    breaks_before_comments.then(soft_line_break),
+                    FormatLeadingComments::Comments(before_pipe_comments),
                     group(&content)
                 ]
             );
@@ -203,7 +282,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
 
 #[derive(Clone, Copy, Debug, Default)]
 struct LeadingCommentsInfo {
-    has_comments: bool,
     has_own_line_comment: bool,
     has_end_of_line_comment: bool,
     has_trailing_own_line_non_jsdoc_block_comment: bool,
@@ -212,7 +290,7 @@ struct LeadingCommentsInfo {
 
 impl LeadingCommentsInfo {
     fn from_comments(comments: &[Comment]) -> Self {
-        let mut info = Self { has_comments: !comments.is_empty(), ..Self::default() };
+        let mut info = Self::default();
         for comment in comments {
             info.has_own_line_comment |= comment.preceded_by_newline();
             info.has_end_of_line_comment |= comment.followed_by_newline();
@@ -220,18 +298,49 @@ impl LeadingCommentsInfo {
                 && comment.is_trailing()
                 && comment.followed_by_newline()
                 && !matches!(comment.content, CommentContent::Jsdoc | CommentContent::JsdocLegal);
-            info.has_trailing_own_line_jsdoc_comment |=
-                matches!(comment.content, CommentContent::Jsdoc | CommentContent::JsdocLegal)
-                    && comment.is_trailing()
-                    && comment.followed_by_newline();
+            info.has_trailing_own_line_jsdoc_comment |= is_trailing_own_line_jsdoc_comment(comment);
         }
         info
     }
+}
 
-    #[inline]
-    fn has_comments(self) -> bool {
-        self.has_comments
-    }
+pub fn is_trailing_own_line_jsdoc_comment(comment: &Comment) -> bool {
+    matches!(comment.content, CommentContent::Jsdoc | CommentContent::JsdocLegal)
+        && comment.is_trailing()
+        && comment.followed_by_newline()
+}
+
+/// End of a type alias's left-hand side:
+/// after the type parameters when present, after the name otherwise.
+pub fn type_alias_left_end(decl: &TSTypeAliasDeclaration) -> u32 {
+    decl.type_parameters
+        .as_ref()
+        .map_or(decl.id.span.end, |type_parameters| type_parameters.span.end)
+}
+
+/// Whether an alias-level union relies on the assignment's operator-side break + indent
+/// instead of owning them itself (`should_indent_alias_union` is the negation).
+/// True when a comment ends the `=` line:
+/// - a trailing own-line JSDoc comment, still pending for the union's leading-comments pass
+///   the caller decides the comment range to scan, which differs per site
+///   ```ts
+///   type A = (/** ... */
+///   | A
+///   | B);
+///   ```
+/// - an end-of-line comment already consumed by the assignment's left side
+///   (hence a printed-comments check, usable after write_left has run);
+///   any comment ending the `=` line counts, eol block comments included
+///   (`type A = // c` and `type A = /* c */ // c`)
+pub fn alias_union_breaks_after_operator(
+    decl: &TSTypeAliasDeclaration,
+    has_trailing_own_line_jsdoc_comment: bool,
+    comments: &Comments,
+) -> bool {
+    has_trailing_own_line_jsdoc_comment
+        || comments.printed_comments().last().is_some_and(|comment| {
+            comment.span.start > type_alias_left_end(decl) && comment.followed_by_newline()
+        })
 }
 
 fn should_indent_alias_union<'a>(
@@ -239,20 +348,11 @@ fn should_indent_alias_union<'a>(
     comment_info: LeadingCommentsInfo,
     f: &JsFormatter<'_, 'a>,
 ) -> bool {
-    // When a union starts after a trailing own-line JSDoc comment
-    // (e.g. `=(/** ... */\n| A)`),
-    // type-alias indentation is already applied by the parent assignment printer.
-    if comment_info.has_trailing_own_line_jsdoc_comment {
-        return false;
-    }
-
-    !f.comments().printed_comments().last().is_some_and(|comment| {
-        comment.span.start
-            > alias
-                .type_parameters()
-                .map_or(alias.id.span.end, |type_parameters| type_parameters.span.end)
-            && comment.followed_by_newline()
-    })
+    !alias_union_breaks_after_operator(
+        alias,
+        comment_info.has_trailing_own_line_jsdoc_comment,
+        f.comments(),
+    )
 }
 
 fn format_union_types<'a>(

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -5,11 +5,14 @@ use oxc_span::GetSpan;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{
-        JsFormatter,
+        Comments, JsFormatter,
         prelude::{FormatElements, format_once, line_suffix_boundary, *},
         trivia::FormatTrailingComments,
     },
-    print::{BinaryLikeExpression, FormatJsArrowFunctionExpressionOptions, FormatWrite},
+    print::{
+        BinaryLikeExpression, FormatJsArrowFunctionExpressionOptions, FormatWrite,
+        alias_union_breaks_after_operator, is_trailing_own_line_jsdoc_comment, type_alias_left_end,
+    },
     utils::{
         format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
         member_chain::is_member_call_chain,
@@ -155,23 +158,6 @@ fn format_left_trailing_comments(
     };
 
     FormatTrailingComments::Comments(comments).fmt(f);
-}
-
-fn is_simple_single_member_union_or_intersection_type(type_to_check: &TSType) -> bool {
-    // For single-element union/intersection types (e.g., `type A = /*1*/ | C`),
-    // Prettier relocates the single leading comment to after the identifier,
-    // producing `type A /*1*/ = C;`. Skip complex nested cases.
-    match type_to_check {
-        TSType::TSUnionType(u) if u.types.len() == 1 => !matches!(
-            u.types.first().unwrap(),
-            TSType::TSParenthesizedType(_) | TSType::TSUnionType(_)
-        ),
-        TSType::TSIntersectionType(i) if i.types.len() == 1 => !matches!(
-            i.types.first().unwrap(),
-            TSType::TSParenthesizedType(_) | TSType::TSIntersectionType(_)
-        ),
-        _ => false,
-    }
 }
 
 fn should_print_as_leading(expr: &Expression) -> bool {
@@ -332,47 +318,21 @@ impl<'a> AssignmentLike<'a, '_> {
             AssignmentLike::TSTypeAliasDeclaration(declaration) => {
                 write!(f, [declaration.declare.then_some("declare "), "type "]);
 
-                let start = if let Some(type_parameters) = &declaration.type_parameters() {
+                if let Some(type_parameters) = &declaration.type_parameters() {
                     write!(
                         f,
                         [declaration.id(), FormatNodeWithoutTrailingComments(type_parameters)]
                     );
-                    type_parameters.span.end
                 } else {
                     write!(f, [FormatNodeWithoutTrailingComments(declaration.id())]);
-                    declaration.id.span.end
-                };
-
-                if is_simple_single_member_union_or_intersection_type(&declaration.type_annotation)
-                {
-                    let comments_in_span =
-                        f.context().comments().comments_in_range(start, declaration.span.end);
-                    let end_index = comments_in_span
-                        .iter()
-                        .take_while(|comment| {
-                            // Case 1: Own-line comments shouldn't be trailing
-                            !comment.preceded_by_newline()
-                                // Case 2: End-of-line comments are trailing unless
-                                // they're block comments.
-                                && (comment.followed_by_newline() && !comment.is_block()
-                                    // Case 3: Inline comments are leading when they're
-                                    // only separated by whitespace or other comments
-                                    // from the following node. Consider them trailing
-                                    // if they come before the `&` or `|` symbol, as
-                                    // they can't be leading in that case.
-                                    || (!comment.followed_by_newline()
-                                        && comment.span.end
-                                            <= declaration.type_annotation.span().start))
-                        })
-                        .count();
-                    write!(f, [FormatTrailingComments::Comments(&comments_in_span[..end_index])]);
-                } else {
-                    format_left_trailing_comments(
-                        start,
-                        matches!(&declaration.type_annotation, TSType::TSTypeLiteral(_)),
-                        f,
-                    );
                 }
+                let start = type_alias_left_end(declaration);
+
+                format_left_trailing_comments(
+                    start,
+                    matches!(&declaration.type_annotation, TSType::TSTypeLiteral(_)),
+                    f,
+                );
 
                 false
             }
@@ -482,6 +442,17 @@ impl<'a> AssignmentLike<'a, '_> {
             return AssignmentLikeLayout::BreakLeftHandSide;
         }
 
+        // An alias-level union owns its break and indentation (leading soft line break per member, one indent level);
+        // the fluid group would stack a second indent on top when a long left-hand side makes it break before the union does.
+        // (The end-of-line-comment case takes `BreakAfterOperator` above.)
+        if matches!(
+            self,
+            AssignmentLike::TSTypeAliasDeclaration(decl)
+                if matches!(decl.type_annotation, TSType::TSUnionType(_))
+        ) {
+            return AssignmentLikeLayout::NeverBreakAfterOperator;
+        }
+
         if !left_may_break
             && (is_left_short
                 || matches!(
@@ -514,8 +485,43 @@ impl<'a> AssignmentLike<'a, '_> {
         }
     }
 
-    /// Checks that a [AssignmentLike] consists only of the left part
-    /// usually, when a [variable declarator](VariableDeclarator) doesn't have initializer
+    /// End of the left-hand side (type annotation included), before the operator and any comments around it:
+    /// the boundary a printed comment must be past to count as operator-side.
+    /// Distinct from the comment-scan start in `write_left`, which begins at the id.
+    fn left_end(&self) -> u32 {
+        match self {
+            Self::VariableDeclarator(declarator) => declarator
+                .type_annotation
+                .as_ref()
+                .map_or(declarator.id.span().end, |annotation| annotation.span.end),
+            Self::AssignmentExpression(assignment) => assignment.left.span().end,
+            Self::ObjectProperty(property) => property.key.span().end,
+            Self::BindingProperty(property) => property.key.span().end,
+            Self::PropertyDefinition(property) => property
+                .type_annotation
+                .as_ref()
+                .map_or(property.key.span().end, |annotation| annotation.span.end),
+            Self::AccessorProperty(property) => property
+                .type_annotation
+                .as_ref()
+                .map_or(property.key.span().end, |annotation| annotation.span.end),
+            Self::TSTypeAliasDeclaration(declaration) => type_alias_left_end(declaration),
+        }
+    }
+
+    /// Whether `write_left` printed an end-of-line line comment after the left side (`const a = // c`).
+    /// Such a comment is a pending `line_suffix`:
+    /// the operator side MUST break right after it, or it flushes past the right-hand side.
+    /// Layout runs after `write_left`, hence a printed-comments check, cursor-based queries no longer see the comment.
+    fn left_printed_eol_line_comment(&self, comments: &Comments) -> bool {
+        comments
+            .printed_comments()
+            .last()
+            .is_some_and(|comment| comment.is_line() && comment.span.start > self.left_end())
+    }
+
+    /// Checks that a [AssignmentLike] consists only of the left part usually,
+    /// when a [variable declarator](VariableDeclarator) doesn't have initializer.
     fn has_only_left_hand_side(&self) -> bool {
         match self {
             Self::AssignmentExpression(_) | Self::TSTypeAliasDeclaration(_) => false,
@@ -619,6 +625,9 @@ impl<'a> AssignmentLike<'a, '_> {
         f: &mut JsFormatter<'_, 'a>,
     ) -> bool {
         let comments = f.context().comments();
+        if self.left_printed_eol_line_comment(comments) {
+            return true;
+        }
         if let Some(right_expression) = right_expression {
             should_break_after_operator(right_expression, is_left_short, f)
         } else if let AssignmentLike::TSTypeAliasDeclaration(decl) = self {
@@ -639,13 +648,19 @@ impl<'a> AssignmentLike<'a, '_> {
                         || is_generic(&conditional_type.extends_type)
                         || comments.has_leading_own_line_comment(annotation_start)
                 }
-                // `TSUnionType` has its own indentation logic
-                TSType::TSUnionType(_) => false,
-                // For a single-member `TSIntersectionType`, we need to check for
-                // leading own-line comments before the type inside the
-                // `TSIntersectionType`. This is because Prettier treats a single-member
-                // `TSIntersectionType` as the literal type inside of it, so it checks
-                // whether there's a leading own-line comment before the start of the literal type.
+                // `TSUnionType` has its own indentation logic,
+                // EXCEPT when the union suppresses it and relies on the operator-side break + indent instead.
+                TSType::TSUnionType(_) => alias_union_breaks_after_operator(
+                    decl,
+                    comments
+                        .comments_before_iter(annotation_start)
+                        .any(is_trailing_own_line_jsdoc_comment),
+                    comments,
+                ),
+                // For a single-member `TSIntersectionType`,
+                // we need to check for leading own-line comments before the type inside the `TSIntersectionType`.
+                // This is because Prettier treats a single-member `TSIntersectionType` as the literal type inside of it,
+                // so it checks whether there's a leading own-line comment before the start of the literal type.
                 TSType::TSIntersectionType(intersection_type)
                     if intersection_type.types.len() == 1 =>
                 {
@@ -852,6 +867,17 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AssignmentLike<'a, '_> {
             let layout = self.layout(is_left_short, left_may_break, f);
             let right = format_with(|f| self.write_right(f, layout));
 
+            // Whether `BreakAfterOperator` must keep the comment order around the operator (`line_suffix_boundary` + no group):
+            // when the left side printed an end-of-line line comment, and for non-conditional type aliases,
+            // those also reach the arm via own-line-comment paths where nothing was printed,
+            // and their union interplay needs the ungrouped variant.
+            let keeps_comment_order = matches!(
+                self,
+                AssignmentLike::TSTypeAliasDeclaration(decl)
+                    if !matches!(decl.type_annotation, TSType::TSConditionalType(_))
+            ) || self
+                .left_printed_eol_line_comment(f.context().comments());
+
             let inner_content = format_with(|f| {
                 if matches!(&layout, AssignmentLikeLayout::BreakLeftHandSide) {
                     write!(f, [left]);
@@ -878,22 +904,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AssignmentLike<'a, '_> {
                         );
                     }
                     AssignmentLikeLayout::BreakAfterOperator => {
-                        // Preserve the original order of trailing line comments after `=`
-                        // by flushing them via `line_suffix_boundary()`.
-                        // Otherwise the line comment gets pushed past the right-hand side,
-                        // changing which token the comment semantically attaches to.
-                        //
-                        // NOTE: Currently scoped to non-conditional `TSTypeAliasDeclaration`
-                        // and non-simple single member union/intersection types (which have
-                        // their own comment formatting logic for this case).
-                        // Expanding the condition would preserve the order in other nodes too.
-                        // (e.g. `VariableDeclarator`) But for those we follow Prettier's current behavior.
-                        // See also https://github.com/prettier/prettier/issues/14617
-                        if matches!(
-                            self,
-                            AssignmentLike::TSTypeAliasDeclaration(decl)
-                                if !matches!(decl.type_annotation, TSType::TSConditionalType(_)) && !is_simple_single_member_union_or_intersection_type(&decl.type_annotation)
-                        ) {
+                        // NOTE: Prettier instead lets the comment flush past a fitting right-hand side (prettier#14617 family)
+                        if keeps_comment_order {
                             write!(f, [line_suffix_boundary(), soft_line_indent_or_space(&right)]);
                         } else {
                             write!(f, [group(&soft_line_indent_or_space(&right))]);

--- a/crates/oxc_formatter/src/utils/typecast.rs
+++ b/crates/oxc_formatter/src/utils/typecast.rs
@@ -182,6 +182,63 @@ pub fn format_leading_comments_and_open_paren(
     }
 }
 
+/// Variant of [`format_leading_comments_and_open_paren`] for nodes
+/// that print their own leading comments in `write` (the generator's `AST_NODE_WITHOUT_PRINTING_LEADING_COMMENTS_LIST`):
+/// prints the leading comments that belong OUTSIDE the formatter-added `(`,
+/// and leaves the rest pending for the node's own leading-comments pass.
+///
+/// Outside are:
+/// - inline comments that preceded the node's source `(`
+///   inline comments keep their source side (`X & /* outside */ (/* inside */ A | B)`)
+/// - own-line comments, even from inside the source parentheses
+///   they stay own-line ABOVE the paren, or the paren line would end in a line comment and force a layout the source never had
+///   ```ts
+///   type T = X & (
+///     // c
+///     A | B
+///   );
+///   // ->
+///   type T = X &
+///     // c
+///     (A | B);
+///   ```
+///
+/// The source `(` is precedence-required wherever such a node needs formatter parentheses,
+/// so the split at the last `(`-bearing gap between pending comments reproduces each inline comment's source side.
+/// When no gap contains a `(`, the paren precedes every pending comment.
+/// Comment bodies are never scanned (a `(` inside a comment cannot false-positive: gaps run between comment bounds).
+///
+/// NOTE: Prettier normalizes `keyof /* c */ (A | B)` to `keyof (/* c */ A | B)`
+/// while keeping the same comment outside in array/indexed-access positions;
+/// one source-side rule instead of emulating that inconsistency (Known divergence, layout-only).
+///
+/// NOTE: The own-line hoist can detach a next-line directive (`@ts-expect-error`, ...) written inside the parens:
+/// when the node expands, the added `(` takes the directive's former target line.
+/// Matches Prettier; keeping such comments inside would need a `(`-then-break block rendering that does not exist today.
+///
+/// No type-cast handling ([`TypeCast::BindsInner`]): casts target expressions, and this path currently serves only `TSUnionType`.
+pub fn format_outer_leading_comments_and_open_paren(
+    span: Span,
+    needs_parentheses: bool,
+    f: &mut JsFormatter<'_, '_>,
+) {
+    if !needs_parentheses {
+        return;
+    }
+    let leading = f.context().comments().comments_before(span.start);
+    let mut outside_len = 0;
+    for (index, comment) in leading.iter().enumerate() {
+        let gap_end = leading.get(index + 1).map_or(span.start, |next| next.span.start);
+        if f.source_text().bytes_contain(comment.span.end, gap_end, b'(') {
+            outside_len = index + 1;
+        }
+    }
+    while leading.get(outside_len).is_some_and(|comment| comment.preceded_by_newline()) {
+        outside_len += 1;
+    }
+    write!(f, [FormatLeadingComments::Comments(&leading[..outside_len]), "("]);
+}
+
 /// What the source between a cast comment and the node start contains.
 ///
 /// Where the cast parenthesis closes is derived from this gap plus the span,

--- a/crates/oxc_formatter/tests/fixtures/js/comments/assignment-eol-line-comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/assignment-eol-line-comment.js
@@ -1,0 +1,25 @@
+// An end-of-line line comment right after `=`/`:` keeps its position
+// (`= // c` + mandatory break). Prettier flushes it past a FITTING right-hand
+// side (`const v1 = 1; // c`, crossing the value) while keeping the order when
+// the right-hand side breaks — one rule for both shapes
+// (Known divergence, see AGENTS.md).
+
+const v1 = // c
+  1;
+
+v2 = // c
+  1;
+
+const o = {
+  p: // c
+    1,
+};
+
+class C {
+  f = // c
+    1;
+}
+
+// Breaking right-hand side: Prettier keeps the order here too (no divergence)
+const v3 = // c
+  someLongFunctionCall(argumentOne, argumentTwo, argumentThree, argumentFours);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/assignment-eol-line-comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/assignment-eol-line-comment.js.snap
@@ -1,0 +1,90 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// An end-of-line line comment right after `=`/`:` keeps its position
+// (`= // c` + mandatory break). Prettier flushes it past a FITTING right-hand
+// side (`const v1 = 1; // c`, crossing the value) while keeping the order when
+// the right-hand side breaks — one rule for both shapes
+// (Known divergence, see AGENTS.md).
+
+const v1 = // c
+  1;
+
+v2 = // c
+  1;
+
+const o = {
+  p: // c
+    1,
+};
+
+class C {
+  f = // c
+    1;
+}
+
+// Breaking right-hand side: Prettier keeps the order here too (no divergence)
+const v3 = // c
+  someLongFunctionCall(argumentOne, argumentTwo, argumentThree, argumentFours);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// An end-of-line line comment right after `=`/`:` keeps its position
+// (`= // c` + mandatory break). Prettier flushes it past a FITTING right-hand
+// side (`const v1 = 1; // c`, crossing the value) while keeping the order when
+// the right-hand side breaks — one rule for both shapes
+// (Known divergence, see AGENTS.md).
+
+const v1 = // c
+  1;
+
+v2 = // c
+  1;
+
+const o = {
+  p: // c
+    1,
+};
+
+class C {
+  f = // c
+    1;
+}
+
+// Breaking right-hand side: Prettier keeps the order here too (no divergence)
+const v3 = // c
+  someLongFunctionCall(argumentOne, argumentTwo, argumentThree, argumentFours);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// An end-of-line line comment right after `=`/`:` keeps its position
+// (`= // c` + mandatory break). Prettier flushes it past a FITTING right-hand
+// side (`const v1 = 1; // c`, crossing the value) while keeping the order when
+// the right-hand side breaks — one rule for both shapes
+// (Known divergence, see AGENTS.md).
+
+const v1 = // c
+  1;
+
+v2 = // c
+  1;
+
+const o = {
+  p: // c
+    1,
+};
+
+class C {
+  f = // c
+    1;
+}
+
+// Breaking right-hand side: Prettier keeps the order here too (no divergence)
+const v3 = // c
+  someLongFunctionCall(argumentOne, argumentTwo, argumentThree, argumentFours);
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/operator-eol-line-comment.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/operator-eol-line-comment.ts
@@ -1,0 +1,25 @@
+// An end-of-line line comment right after `=`/`:` keeps its position
+// (`= // c` + mandatory break). Known divergence, see AGENTS.md:
+// Prettier own-lines it for type aliases and union-valued property signatures,
+// and flushes it past the member and its `;` for simple-typed ones
+// (`simple: Value; // c`).
+//
+// `Value` below is NOT indented an extra level: annotation content after a `:`
+// break gets no indent of its own — same family as variable/parameter/return
+// type annotations, which are Prettier-identical in that shape. The union
+// members ARE indented, by the union printer itself.
+
+type Alias = // c
+  "VALUE";
+
+type AliasUnion = // c
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines
+  | BmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines;
+
+interface I {
+  simple: // c
+  Value;
+  union: // c
+    | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines
+    | BmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines;
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/operator-eol-line-comment.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/operator-eol-line-comment.ts.snap
@@ -1,0 +1,90 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// An end-of-line line comment right after `=`/`:` keeps its position
+// (`= // c` + mandatory break). Known divergence, see AGENTS.md:
+// Prettier own-lines it for type aliases and union-valued property signatures,
+// and flushes it past the member and its `;` for simple-typed ones
+// (`simple: Value; // c`).
+//
+// `Value` below is NOT indented an extra level: annotation content after a `:`
+// break gets no indent of its own — same family as variable/parameter/return
+// type annotations, which are Prettier-identical in that shape. The union
+// members ARE indented, by the union printer itself.
+
+type Alias = // c
+  "VALUE";
+
+type AliasUnion = // c
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines
+  | BmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines;
+
+interface I {
+  simple: // c
+  Value;
+  union: // c
+    | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines
+    | BmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines;
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// An end-of-line line comment right after `=`/`:` keeps its position
+// (`= // c` + mandatory break). Known divergence, see AGENTS.md:
+// Prettier own-lines it for type aliases and union-valued property signatures,
+// and flushes it past the member and its `;` for simple-typed ones
+// (`simple: Value; // c`).
+//
+// `Value` below is NOT indented an extra level: annotation content after a `:`
+// break gets no indent of its own — same family as variable/parameter/return
+// type annotations, which are Prettier-identical in that shape. The union
+// members ARE indented, by the union printer itself.
+
+type Alias = // c
+  "VALUE";
+
+type AliasUnion = // c
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines
+  | BmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines;
+
+interface I {
+  simple: // c
+  Value;
+  union: // c
+    | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines
+    | BmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines;
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// An end-of-line line comment right after `=`/`:` keeps its position
+// (`= // c` + mandatory break). Known divergence, see AGENTS.md:
+// Prettier own-lines it for type aliases and union-valued property signatures,
+// and flushes it past the member and its `;` for simple-typed ones
+// (`simple: Value; // c`).
+//
+// `Value` below is NOT indented an extra level: annotation content after a `:`
+// break gets no indent of its own — same family as variable/parameter/return
+// type annotations, which are Prettier-identical in that shape. The union
+// members ARE indented, by the union printer itself.
+
+type Alias = // c
+  "VALUE";
+
+type AliasUnion = // c
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines
+  | BmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines;
+
+interface I {
+  simple: // c
+  Value;
+  union: // c
+    | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines
+    | BmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines;
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/type-alias.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/type-alias.ts.snap
@@ -40,17 +40,21 @@ type TypeRef = // Comment1
   /* Block2 */ SomeType;
 
 // Conditional type aliases keep Prettier's existing trailing placement.
-type ConditionalLine = Foo<T> extends Bar ? Baz : Qux; // Comment
-type ConditionalLineBlock = /* Block2 */ Foo<T> extends Bar ? Baz : Qux; // Comment1
+type ConditionalLine = // Comment
+  Foo<T> extends Bar ? Baz : Qux;
+type ConditionalLineBlock = // Comment1
+  /* Block2 */ Foo<T> extends Bar ? Baz : Qux;
 
 // Value assignments and assignment expressions move the line comment to the
 // end of line, reordering it past the block comment and value. This is likely
 // not intentional but we match Prettier here until the upstream behavior settles
 // (see prettier/prettier#14617).
-const value = /* Comment2 */ "VALUE"; // Comment1
+const value = // Comment1
+  /* Comment2 */ "VALUE";
 
 let target;
-target = /* Comment2 */ "VALUE"; // Comment1
+target = // Comment1
+  /* Comment2 */ "VALUE";
 
 -------------------
 { printWidth: 100 }
@@ -64,16 +68,20 @@ type TypeRef = // Comment1
   /* Block2 */ SomeType;
 
 // Conditional type aliases keep Prettier's existing trailing placement.
-type ConditionalLine = Foo<T> extends Bar ? Baz : Qux; // Comment
-type ConditionalLineBlock = /* Block2 */ Foo<T> extends Bar ? Baz : Qux; // Comment1
+type ConditionalLine = // Comment
+  Foo<T> extends Bar ? Baz : Qux;
+type ConditionalLineBlock = // Comment1
+  /* Block2 */ Foo<T> extends Bar ? Baz : Qux;
 
 // Value assignments and assignment expressions move the line comment to the
 // end of line, reordering it past the block comment and value. This is likely
 // not intentional but we match Prettier here until the upstream behavior settles
 // (see prettier/prettier#14617).
-const value = /* Comment2 */ "VALUE"; // Comment1
+const value = // Comment1
+  /* Comment2 */ "VALUE";
 
 let target;
-target = /* Comment2 */ "VALUE"; // Comment1
+target = // Comment1
+  /* Comment2 */ "VALUE";
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/union.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/union.ts.snap
@@ -36,25 +36,8 @@ interface _KeywordDef {
   type?: JSONType | JSONType[]; // data types that keyword applies to
 }
 
-type C1 = /* 1 */ /*1*/
-  | A
-  // A comment to force break
-  | B;
-
-type C2 =
-  /* 1 */ /*1*/
-  /* 1 */ | A
-  // A comment to force break
-  | B;
-
----------- Not idempotent (second pass) ----------
-interface _KeywordDef {
-  type?: JSONType | JSONType[]; // data types that keyword applies to
-}
-
 type C1 =
-  /* 1 */ /*1*/
-  | A
+  | /* 1 */ /*1*/ A
   // A comment to force break
   | B;
 
@@ -71,25 +54,8 @@ interface _KeywordDef {
   type?: JSONType | JSONType[]; // data types that keyword applies to
 }
 
-type C1 = /* 1 */ /*1*/
-  | A
-  // A comment to force break
-  | B;
-
-type C2 =
-  /* 1 */ /*1*/
-  /* 1 */ | A
-  // A comment to force break
-  | B;
-
----------- Not idempotent (second pass) ----------
-interface _KeywordDef {
-  type?: JSONType | JSONType[]; // data types that keyword applies to
-}
-
 type C1 =
-  /* 1 */ /*1*/
-  | A
+  | /* 1 */ /*1*/ A
   // A comment to force break
   | B;
 

--- a/crates/oxc_formatter/tests/fixtures/ts/conditional-type/branch-comments.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/conditional-type/branch-comments.ts
@@ -1,0 +1,31 @@
+// Comments on a `?`/`:` branch hug behind the operator (like conditional
+// expressions), and the branch content sits one level under the `?`,
+// with no extra union indent stacked on top.
+
+type BlockComment = any extends B
+  ? /**
+     * Comment
+     */
+    B | C
+  : D;
+
+type AlternateSide = any extends B
+  ? D
+  : /**
+     * Comment
+     */
+    B | C;
+
+// Line comment stays on the `?` line, content one level under (zen-fs/core shape)
+type LineComment = T extends number
+  ? // resolved as number
+    { size: number } | { other: bigint }
+  : { size: bigint };
+
+// An own-line comment before the `?` in source also hugs behind it (prettier#18647)
+type HugFromOwnLine = any extends B
+  /**
+   * Comment
+   */
+  ? B | C
+  : D;

--- a/crates/oxc_formatter/tests/fixtures/ts/conditional-type/branch-comments.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/conditional-type/branch-comments.ts.snap
@@ -1,0 +1,108 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Comments on a `?`/`:` branch hug behind the operator (like conditional
+// expressions), and the branch content sits one level under the `?`,
+// with no extra union indent stacked on top.
+
+type BlockComment = any extends B
+  ? /**
+     * Comment
+     */
+    B | C
+  : D;
+
+type AlternateSide = any extends B
+  ? D
+  : /**
+     * Comment
+     */
+    B | C;
+
+// Line comment stays on the `?` line, content one level under (zen-fs/core shape)
+type LineComment = T extends number
+  ? // resolved as number
+    { size: number } | { other: bigint }
+  : { size: bigint };
+
+// An own-line comment before the `?` in source also hugs behind it (prettier#18647)
+type HugFromOwnLine = any extends B
+  /**
+   * Comment
+   */
+  ? B | C
+  : D;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Comments on a `?`/`:` branch hug behind the operator (like conditional
+// expressions), and the branch content sits one level under the `?`,
+// with no extra union indent stacked on top.
+
+type BlockComment = any extends B
+  ? /**
+     * Comment
+     */
+    B | C
+  : D;
+
+type AlternateSide = any extends B
+  ? D
+  : /**
+     * Comment
+     */
+    B | C;
+
+// Line comment stays on the `?` line, content one level under (zen-fs/core shape)
+type LineComment = T extends number
+  ? // resolved as number
+    { size: number } | { other: bigint }
+  : { size: bigint };
+
+// An own-line comment before the `?` in source also hugs behind it (prettier#18647)
+type HugFromOwnLine = any extends B
+  ? /**
+     * Comment
+     */
+    B | C
+  : D;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Comments on a `?`/`:` branch hug behind the operator (like conditional
+// expressions), and the branch content sits one level under the `?`,
+// with no extra union indent stacked on top.
+
+type BlockComment = any extends B
+  ? /**
+     * Comment
+     */
+    B | C
+  : D;
+
+type AlternateSide = any extends B
+  ? D
+  : /**
+     * Comment
+     */
+    B | C;
+
+// Line comment stays on the `?` line, content one level under (zen-fs/core shape)
+type LineComment = T extends number
+  ? // resolved as number
+    { size: number } | { other: bigint }
+  : { size: bigint };
+
+// An own-line comment before the `?` in source also hugs behind it (prettier#18647)
+type HugFromOwnLine = any extends B
+  ? /**
+     * Comment
+     */
+    B | C
+  : D;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/intersection-type/single-member.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/intersection-type/single-member.ts
@@ -1,3 +1,8 @@
+// NOTE: line-ending BLOCK comments (cType, jType) inline with the member
+// (`= /* Comment */ "VALUE"`): with no `&`/`|` printed for a single member, the
+// multi-member "line-ending comments stay before the operator" guard does not
+// apply (matches Prettier; the guard's rationale lives in `union_type.rs`).
+
 export type aType = & // Comment
 "VALUE";
 

--- a/crates/oxc_formatter/tests/fixtures/ts/intersection-type/single-member.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/intersection-type/single-member.ts.snap
@@ -2,6 +2,11 @@
 source: crates/oxc_formatter/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
+// NOTE: line-ending BLOCK comments (cType, jType) inline with the member
+// (`= /* Comment */ "VALUE"`): with no `&`/`|` printed for a single member, the
+// multi-member "line-ending comments stay before the operator" guard does not
+// apply (matches Prettier; the guard's rationale lives in `union_type.rs`).
+
 export type aType = & // Comment
 "VALUE";
 
@@ -58,7 +63,13 @@ type oType = // Comment
 ------------------
 { printWidth: 80 }
 ------------------
-export type aType = // Comment
+// NOTE: line-ending BLOCK comments (cType, jType) inline with the member
+// (`= /* Comment */ "VALUE"`): with no `&`/`|` printed for a single member, the
+// multi-member "line-ending comments stay before the operator" guard does not
+// apply (matches Prettier; the guard's rationale lives in `union_type.rs`).
+
+export type aType =
+  // Comment
   "VALUE";
 
 export type bType =
@@ -83,7 +94,7 @@ export type gType =
 
 export type hType = "VALUE";
 
-export type iType /* Comment */ /* Comment */ = "VALUE";
+export type iType = /* Comment */ /* Comment */ "VALUE";
 
 export type jType = /* Comment */ /* Comment */ "VALUE";
 
@@ -92,60 +103,14 @@ export type kType =
   // Comment
   "VALUE";
 
-export type lType /* Comment */ =
-  // Comment
+export type lType =
+  /* Comment */ // Comment
   "VALUE";
 
 export type mType = "VALUE"; /* Comment */
 
-export type nType = /* Comment */ "VALUE"; // Comment
-
-type oType = // Comment
-// Comment
-  "VALUE";
-
----------- Not idempotent (second pass) ----------
-export type aType = // Comment
-  "VALUE";
-
-export type bType =
-  // Comment
-  "VALUE";
-
-export type cType = /* Comment */ "VALUE";
-
-export type dType = /* Comment */ "VALUE";
-
-export type eType = // Comment
-  "VALUE";
-
-export type fType =
-  /* Comment */
-  "VALUE";
-
-export type gType =
-  // Comment
-  // Comment
-  "VALUE";
-
-export type hType = "VALUE";
-
-export type iType /* Comment */ /* Comment */ = "VALUE";
-
-export type jType = /* Comment */ /* Comment */ "VALUE";
-
-export type kType =
-  /* Comment */
-  // Comment
-  "VALUE";
-
-export type lType /* Comment */ =
-  // Comment
-  "VALUE";
-
-export type mType = "VALUE"; /* Comment */
-
-export type nType = /* Comment */ "VALUE"; // Comment
+export type nType = // Comment
+  /* Comment */ "VALUE";
 
 type oType = // Comment
   // Comment
@@ -154,7 +119,13 @@ type oType = // Comment
 -------------------
 { printWidth: 100 }
 -------------------
-export type aType = // Comment
+// NOTE: line-ending BLOCK comments (cType, jType) inline with the member
+// (`= /* Comment */ "VALUE"`): with no `&`/`|` printed for a single member, the
+// multi-member "line-ending comments stay before the operator" guard does not
+// apply (matches Prettier; the guard's rationale lives in `union_type.rs`).
+
+export type aType =
+  // Comment
   "VALUE";
 
 export type bType =
@@ -179,7 +150,7 @@ export type gType =
 
 export type hType = "VALUE";
 
-export type iType /* Comment */ /* Comment */ = "VALUE";
+export type iType = /* Comment */ /* Comment */ "VALUE";
 
 export type jType = /* Comment */ /* Comment */ "VALUE";
 
@@ -188,60 +159,14 @@ export type kType =
   // Comment
   "VALUE";
 
-export type lType /* Comment */ =
-  // Comment
+export type lType =
+  /* Comment */ // Comment
   "VALUE";
 
 export type mType = "VALUE"; /* Comment */
 
-export type nType = /* Comment */ "VALUE"; // Comment
-
-type oType = // Comment
-// Comment
-  "VALUE";
-
----------- Not idempotent (second pass) ----------
-export type aType = // Comment
-  "VALUE";
-
-export type bType =
-  // Comment
-  "VALUE";
-
-export type cType = /* Comment */ "VALUE";
-
-export type dType = /* Comment */ "VALUE";
-
-export type eType = // Comment
-  "VALUE";
-
-export type fType =
-  /* Comment */
-  "VALUE";
-
-export type gType =
-  // Comment
-  // Comment
-  "VALUE";
-
-export type hType = "VALUE";
-
-export type iType /* Comment */ /* Comment */ = "VALUE";
-
-export type jType = /* Comment */ /* Comment */ "VALUE";
-
-export type kType =
-  /* Comment */
-  // Comment
-  "VALUE";
-
-export type lType /* Comment */ =
-  // Comment
-  "VALUE";
-
-export type mType = "VALUE"; /* Comment */
-
-export type nType = /* Comment */ "VALUE"; // Comment
+export type nType = // Comment
+  /* Comment */ "VALUE";
 
 type oType = // Comment
   // Comment

--- a/crates/oxc_formatter/tests/fixtures/ts/union/issue-20219.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/issue-20219.ts
@@ -28,5 +28,5 @@ type IntersectionComment =
   /** JSDoc */
   & 'VALUE';
 
-// Inline comment should still be relocated (not own-line)
+// Inline comment stays after `=` (not own-line, never moved before `=`)
 type InlineComment = /*1*/ | C;

--- a/crates/oxc_formatter/tests/fixtures/ts/union/issue-20219.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/issue-20219.ts.snap
@@ -32,7 +32,7 @@ type IntersectionComment =
   /** JSDoc */
   & 'VALUE';
 
-// Inline comment should still be relocated (not own-line)
+// Inline comment stays after `=` (not own-line, never moved before `=`)
 type InlineComment = /*1*/ | C;
 
 ==================== Output ====================
@@ -69,8 +69,8 @@ type IntersectionComment =
   /** JSDoc */
   "VALUE";
 
-// Inline comment should still be relocated (not own-line)
-type InlineComment /*1*/ = C;
+// Inline comment stays after `=` (not own-line, never moved before `=`)
+type InlineComment = /*1*/ C;
 
 -------------------
 { printWidth: 100 }
@@ -105,7 +105,7 @@ type IntersectionComment =
   /** JSDoc */
   "VALUE";
 
-// Inline comment should still be relocated (not own-line)
-type InlineComment /*1*/ = C;
+// Inline comment stays after `=` (not own-line, never moved before `=`)
+type InlineComment = /*1*/ C;
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/union/issue-21792.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/issue-21792.ts.snap
@@ -24,38 +24,44 @@ type LongType = | // This is a really long comment that might exceed the print w
 { printWidth: 80 }
 ------------------
 // Issue #21792 - same-line comment after pipe in single member union
-export type myType = // Comment
+export type myType =
+  // Comment
   "A";
 
 // Block comment same-line after pipe
 type BlockComment = /* block */ "B";
 
 // Same-line comment then own-line comment
-type Mixed = // first
+type Mixed =
+  // first
   // second
   "C";
 
 // Long line comment that exceeds printWidth on the `=` line
-type LongType = // This is a really long comment that might exceed the print width limit
+type LongType =
+  // This is a really long comment that might exceed the print width limit
   "A";
 
 -------------------
 { printWidth: 100 }
 -------------------
 // Issue #21792 - same-line comment after pipe in single member union
-export type myType = // Comment
+export type myType =
+  // Comment
   "A";
 
 // Block comment same-line after pipe
 type BlockComment = /* block */ "B";
 
 // Same-line comment then own-line comment
-type Mixed = // first
+type Mixed =
+  // first
   // second
   "C";
 
 // Long line comment that exceeds printWidth on the `=` line
-type LongType = // This is a really long comment that might exceed the print width limit
+type LongType =
+  // This is a really long comment that might exceed the print width limit
   "A";
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/union/leading-pipe-comments.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/leading-pipe-comments.ts
@@ -1,0 +1,40 @@
+// Comments around a union's leading `|`: whenever no leading comment ends its
+// source line, they all normalize to behind the `|` (`| /* c */ A`) — one
+// canonical form regardless of the source shape.
+
+type MidLine = /* c */ "A" | AmemberLongEnoughToMakeTheUnionBreakIntoMultipleLines;
+type ExplicitPipe = | /* c */ "A" | AmemberLongEnoughToMakeTheUnionBreakIntoMultipleLines;
+type LineStart =
+  /* c */ A
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+type LineStartExplicitPipe =
+  /* c */ | A
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+type CommentGroup =
+  /* 1 */ /* 2 */ A
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+
+// NOTE: Known divergence — for the two sources below (nested single-member
+// parens; multiline block comment starting its line), Prettier keeps the
+// comment before the `|`, yet reformats the first shape's own output into the
+// canonical form (not idempotent); we normalize directly
+// (see AGENTS.md "Known divergences").
+type NestedParens = | (
+  /* c */ | (
+    | (
+      | A
+      // A comment to force break
+      | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines
+    )
+  )
+);
+type MultilineBlock =
+  /**
+  comment
+  */ A
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+
+// A comment that ENDS its source line stays before the `|`:
+// moving it behind would force a break between the `|` and its member.
+type LineEnd = /* c */
+  A | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;

--- a/crates/oxc_formatter/tests/fixtures/ts/union/leading-pipe-comments.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/leading-pipe-comments.ts.snap
@@ -1,0 +1,125 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Comments around a union's leading `|`: whenever no leading comment ends its
+// source line, they all normalize to behind the `|` (`| /* c */ A`) — one
+// canonical form regardless of the source shape.
+
+type MidLine = /* c */ "A" | AmemberLongEnoughToMakeTheUnionBreakIntoMultipleLines;
+type ExplicitPipe = | /* c */ "A" | AmemberLongEnoughToMakeTheUnionBreakIntoMultipleLines;
+type LineStart =
+  /* c */ A
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+type LineStartExplicitPipe =
+  /* c */ | A
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+type CommentGroup =
+  /* 1 */ /* 2 */ A
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+
+// NOTE: Known divergence — for the two sources below (nested single-member
+// parens; multiline block comment starting its line), Prettier keeps the
+// comment before the `|`, yet reformats the first shape's own output into the
+// canonical form (not idempotent); we normalize directly
+// (see AGENTS.md "Known divergences").
+type NestedParens = | (
+  /* c */ | (
+    | (
+      | A
+      // A comment to force break
+      | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines
+    )
+  )
+);
+type MultilineBlock =
+  /**
+  comment
+  */ A
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+
+// A comment that ENDS its source line stays before the `|`:
+// moving it behind would force a break between the `|` and its member.
+type LineEnd = /* c */
+  A | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Comments around a union's leading `|`: whenever no leading comment ends its
+// source line, they all normalize to behind the `|` (`| /* c */ A`) — one
+// canonical form regardless of the source shape.
+
+type MidLine =
+  | /* c */ "A"
+  | AmemberLongEnoughToMakeTheUnionBreakIntoMultipleLines;
+type ExplicitPipe =
+  | /* c */ "A"
+  | AmemberLongEnoughToMakeTheUnionBreakIntoMultipleLines;
+type LineStart =
+  | /* c */ A
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+type LineStartExplicitPipe =
+  | /* c */ A
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+type CommentGroup =
+  | /* 1 */ /* 2 */ A
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+
+// NOTE: Known divergence — for the two sources below (nested single-member
+// parens; multiline block comment starting its line), Prettier keeps the
+// comment before the `|`, yet reformats the first shape's own output into the
+// canonical form (not idempotent); we normalize directly
+// (see AGENTS.md "Known divergences").
+type NestedParens =
+  | /* c */ A
+  // A comment to force break
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines;
+type MultilineBlock =
+  | /**
+  comment
+  */ A
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+
+// A comment that ENDS its source line stays before the `|`:
+// moving it behind would force a break between the `|` and its member.
+type LineEnd =
+  /* c */
+  A | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Comments around a union's leading `|`: whenever no leading comment ends its
+// source line, they all normalize to behind the `|` (`| /* c */ A`) — one
+// canonical form regardless of the source shape.
+
+type MidLine = /* c */ "A" | AmemberLongEnoughToMakeTheUnionBreakIntoMultipleLines;
+type ExplicitPipe = /* c */ "A" | AmemberLongEnoughToMakeTheUnionBreakIntoMultipleLines;
+type LineStart = /* c */ A | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+type LineStartExplicitPipe =
+  /* c */ A | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+type CommentGroup =
+  /* 1 */ /* 2 */ A | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+
+// NOTE: Known divergence — for the two sources below (nested single-member
+// parens; multiline block comment starting its line), Prettier keeps the
+// comment before the `|`, yet reformats the first shape's own output into the
+// canonical form (not idempotent); we normalize directly
+// (see AGENTS.md "Known divergences").
+type NestedParens =
+  | /* c */ A
+  // A comment to force break
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLines;
+type MultilineBlock =
+  | /**
+  comment
+  */ A
+  | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+
+// A comment that ENDS its source line stays before the `|`:
+// moving it behind would force a break between the `|` and its member.
+type LineEnd = /* c */ A | AmemberLongEnoughToMakeTheUnionTypeBreakIntoMultipleLinesForThisCase;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/union/paren-comments.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/paren-comments.ts
@@ -1,0 +1,35 @@
+// Comments around a union's formatter-added parentheses:
+// inline comments keep their source side of the `(`, own-line comments stay above it.
+
+type AO = /* c */ (A | B)[];
+type AI = (/* c */ A | B)[];
+// NOTE: Known divergence — Prettier prints `keyof (/* c */ A | B)`, normalizing only
+// this context to inside while keeping array/indexed-access outside; we keep the
+// source side everywhere (see AGENTS.md "Known divergences").
+type KO = keyof /* c */ (A | B);
+type KI = keyof (/* c */ A | B);
+type IO = /* c */ (A | B)["k"];
+type II = (/* c */ A | B)["k"];
+type OO = [/* c */ (A | B)?];
+type OI = [(/* c */ A | B)?];
+type XO = X & /* c */ (A | B);
+type XI = X & (/* c */ A | B);
+type UO = U | /* c */ (A | B);
+type UI = U | (/* c */ A | B);
+
+// Own-line comments hoist out of the added paren (matches Prettier, prettier#18379)
+type OL = (
+  A | B // comment 1
+) & (
+  // comment2
+  A | B
+);
+
+// Known limitation of the hoist (matches Prettier): when the union expands, the added
+// `(` takes its own line between a next-line directive and its former target line,
+// detaching the directive (here: the first member's line is no longer covered, and
+// `@ts-expect-error` turns into an "Unused directive" error). Collapsed unions are safe.
+type DirectiveWindow = X & (
+  // @ts-expect-error
+  AaaaaaaaaaaaaaaaaaaaaaaaaaaaMember | BbbbbbbbbbbbbbbbbbbbbbbbbbbbMember | CcccccccccccccccccccccccccccMember
+);

--- a/crates/oxc_formatter/tests/fixtures/ts/union/paren-comments.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/paren-comments.ts.snap
@@ -1,0 +1,126 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Comments around a union's formatter-added parentheses:
+// inline comments keep their source side of the `(`, own-line comments stay above it.
+
+type AO = /* c */ (A | B)[];
+type AI = (/* c */ A | B)[];
+// NOTE: Known divergence — Prettier prints `keyof (/* c */ A | B)`, normalizing only
+// this context to inside while keeping array/indexed-access outside; we keep the
+// source side everywhere (see AGENTS.md "Known divergences").
+type KO = keyof /* c */ (A | B);
+type KI = keyof (/* c */ A | B);
+type IO = /* c */ (A | B)["k"];
+type II = (/* c */ A | B)["k"];
+type OO = [/* c */ (A | B)?];
+type OI = [(/* c */ A | B)?];
+type XO = X & /* c */ (A | B);
+type XI = X & (/* c */ A | B);
+type UO = U | /* c */ (A | B);
+type UI = U | (/* c */ A | B);
+
+// Own-line comments hoist out of the added paren (matches Prettier, prettier#18379)
+type OL = (
+  A | B // comment 1
+) & (
+  // comment2
+  A | B
+);
+
+// Known limitation of the hoist (matches Prettier): when the union expands, the added
+// `(` takes its own line between a next-line directive and its former target line,
+// detaching the directive (here: the first member's line is no longer covered, and
+// `@ts-expect-error` turns into an "Unused directive" error). Collapsed unions are safe.
+type DirectiveWindow = X & (
+  // @ts-expect-error
+  AaaaaaaaaaaaaaaaaaaaaaaaaaaaMember | BbbbbbbbbbbbbbbbbbbbbbbbbbbbMember | CcccccccccccccccccccccccccccMember
+);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Comments around a union's formatter-added parentheses:
+// inline comments keep their source side of the `(`, own-line comments stay above it.
+
+type AO = /* c */ (A | B)[];
+type AI = (/* c */ A | B)[];
+// NOTE: Known divergence — Prettier prints `keyof (/* c */ A | B)`, normalizing only
+// this context to inside while keeping array/indexed-access outside; we keep the
+// source side everywhere (see AGENTS.md "Known divergences").
+type KO = keyof /* c */ (A | B);
+type KI = keyof (/* c */ A | B);
+type IO = /* c */ (A | B)["k"];
+type II = (/* c */ A | B)["k"];
+type OO = [/* c */ (A | B)?];
+type OI = [(/* c */ A | B)?];
+type XO = X & /* c */ (A | B);
+type XI = X & (/* c */ A | B);
+type UO = U | /* c */ (A | B);
+type UI = U | (/* c */ A | B);
+
+// Own-line comments hoist out of the added paren (matches Prettier, prettier#18379)
+type OL = (
+  | A
+  | B // comment 1
+) &
+  // comment2
+  (A | B);
+
+// Known limitation of the hoist (matches Prettier): when the union expands, the added
+// `(` takes its own line between a next-line directive and its former target line,
+// detaching the directive (here: the first member's line is no longer covered, and
+// `@ts-expect-error` turns into an "Unused directive" error). Collapsed unions are safe.
+type DirectiveWindow = X &
+  // @ts-expect-error
+  (
+    | AaaaaaaaaaaaaaaaaaaaaaaaaaaaMember
+    | BbbbbbbbbbbbbbbbbbbbbbbbbbbbMember
+    | CcccccccccccccccccccccccccccMember
+  );
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Comments around a union's formatter-added parentheses:
+// inline comments keep their source side of the `(`, own-line comments stay above it.
+
+type AO = /* c */ (A | B)[];
+type AI = (/* c */ A | B)[];
+// NOTE: Known divergence — Prettier prints `keyof (/* c */ A | B)`, normalizing only
+// this context to inside while keeping array/indexed-access outside; we keep the
+// source side everywhere (see AGENTS.md "Known divergences").
+type KO = keyof /* c */ (A | B);
+type KI = keyof (/* c */ A | B);
+type IO = /* c */ (A | B)["k"];
+type II = (/* c */ A | B)["k"];
+type OO = [/* c */ (A | B)?];
+type OI = [(/* c */ A | B)?];
+type XO = X & /* c */ (A | B);
+type XI = X & (/* c */ A | B);
+type UO = U | /* c */ (A | B);
+type UI = U | (/* c */ A | B);
+
+// Own-line comments hoist out of the added paren (matches Prettier, prettier#18379)
+type OL = (
+  | A
+  | B // comment 1
+) &
+  // comment2
+  (A | B);
+
+// Known limitation of the hoist (matches Prettier): when the union expands, the added
+// `(` takes its own line between a next-line directive and its former target line,
+// detaching the directive (here: the first member's line is no longer covered, and
+// `@ts-expect-error` turns into an "Unused directive" error). Collapsed unions are safe.
+type DirectiveWindow = X &
+  // @ts-expect-error
+  (
+    | AaaaaaaaaaaaaaaaaaaaaaaaaaaaMember
+    | BbbbbbbbbbbbbbbbbbbbbbbbbbbbMember
+    | CcccccccccccccccccccccccccccMember
+  );
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_formatter/tests/conformance.rs
 expression: report
 ---
-js compatibility: 775/810 (95.68%), 23 files skipped
+js compatibility: 773/810 (95.43%), 23 files skipped
 
 # Failed
 
@@ -10,6 +10,7 @@ js compatibility: 775/810 (95.68%), 23 files skipped
 | :-------- | :--------------: | :---------: |
 | js/arrows/issue-17421.js | 💥💥 | 90.43% |
 | js/assignment-comments/indentable-block-comment.js | 💥 | 12.50% |
+| js/assignment-comments/string.js | 💥 | 96.59% |
 | js/binary-expressions/mutiple-comments/17192.js | 💥✨ | 45.83% |
 | js/call/no-argument/no-arguments.js | 💥 | 57.53% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
@@ -17,6 +18,7 @@ js compatibility: 775/810 (95.68%), 23 files skipped
 | js/comments/return-statement-2.js | 💥💥 | 87.32% |
 | js/comments/return-statement.js | 💥💥 | 97.25% |
 | js/comments/tagged-template-literal.js | 💥💥 | 89.66% |
+| js/comments/assignment/variable-declarator.js | 💥 | 88.00% |
 | js/comments/between-head-and-body/between-head-and-body.js | 💥 | 33.10% |
 | js/comments/between-head-and-body/empty-statement.js | 💥 | 51.25% |
 | js/comments/between-head-and-body/non-block.js | 💥 | 82.86% |

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-ts.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-ts.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_formatter/tests/conformance.rs
 expression: report
 ---
-ts compatibility: 624/659 (94.69%), 16 files skipped
+ts compatibility: 629/659 (95.45%), 16 files skipped
 
 # Failed
 
@@ -16,13 +16,12 @@ ts compatibility: 624/659 (94.69%), 16 files skipped
 | typescript/comments/method_types.ts | 💥 | 82.05% |
 | typescript/comments/type-parameters.ts | 💥 | 81.82% |
 | typescript/comments/first-argument/first-argument.ts | 💥 | 81.16% |
-| typescript/conditional-types/comments.ts | 💥 | 90.83% |
 | typescript/conformance/types/union/unionTypeCallSignatures.ts | 💥 | 85.25% |
 | typescript/conformance/types/union/unionTypeConstructSignatures.ts | 💥 | 91.62% |
 | typescript/conformance/types/union/unionTypeIndexSignature.ts | 💥 | 83.64% |
-| typescript/intersection/intersection-parens.ts | 💥💥💥 | 85.46% |
-| typescript/intersection/consistent-with-flow/intersection-parens.ts | 💥 | 67.44% |
-| typescript/intersection/consistent-with-flow/single-member.ts | 💥 | 78.00% |
+| typescript/intersection/intersection-parens.ts | 💥💥✨ | 65.96% |
+| typescript/intersection/consistent-with-flow/intersection-parens.ts | 💥 | 97.67% |
+| typescript/intersection/consistent-with-flow/single-member.ts | 💥 | 88.24% |
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |
 | typescript/property-signature/consistent-with-flow/union.ts | 💥 | 80.00% |
 | typescript/template-literals/member-expression.ts | 💥 | 65.12% |
@@ -32,17 +31,13 @@ ts compatibility: 624/659 (94.69%), 16 files skipped
 | typescript/type-parameters-arguments/constraints-and-default.ts | 💥 | 91.67% |
 | typescript/type-parameters-arguments/issue-6858.ts | 💥 | 60.61% |
 | typescript/union/5849.ts | 💥 | 95.38% |
-| typescript/union/union-parens.ts | 💥 | 90.23% |
+| typescript/union/union-parens.ts | 💥 | 97.67% |
 | typescript/union/comments/18106.ts | 💥 | 86.36% |
-| typescript/union/comments/18389.ts | 💥 | 90.48% |
-| typescript/union/consistent-with-flow/18647.ts | 💥 | 76.92% |
 | typescript/union/consistent-with-flow/81-characters.ts | 💥 | 53.85% |
-| typescript/union/consistent-with-flow/comment.ts | 💥 | 75.00% |
+| typescript/union/consistent-with-flow/comment.ts | 💥 | 87.50% |
 | typescript/union/consistent-with-flow/conditional.ts | 💥 | 54.55% |
-| typescript/union/consistent-with-flow/leading-comments.ts | 💥 | 85.71% |
-| typescript/union/consistent-with-flow/single-type.ts | 💥 | 95.00% |
-| typescript/union/single-type/comments.ts | 💥 | 11.11% |
-| typescript/union/single-type/single-type-2.ts | 💥 | 72.73% |
+| typescript/union/consistent-with-flow/leading-comments.ts | 💥 | 90.14% |
+| typescript/union/consistent-with-flow/single-type.ts | 💥 | 97.50% |
 
 # Skipped (parse error, TODO: should be ignored or supported)
 
@@ -70,7 +65,5 @@ ts compatibility: 624/659 (94.69%), 16 files skipped
 - typescript/as/comments/17407.ts
 - typescript/as/comments/18160.ts
 - typescript/call/callee-comments.ts
-- typescript/intersection/consistent-with-flow/single-member.ts
 - typescript/method-chain/object/issue-17239.ts
 - typescript/satisfies-operators/comments-unstable.ts
-- typescript/union/consistent-with-flow/single-type.ts

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -123,7 +123,7 @@ impl Generator for FormatterFormatGenerator {
                 formatter::{JsFormatContext, JsFormatter, JsFormatterExt as _, trivia::{format_leading_comments, format_trailing_comments}},
                 parentheses::NeedsParentheses,
                 ast_nodes::AstNode,
-                utils::{suppressed::FormatSuppressedNode, typecast::{format_type_cast_comment_node, format_leading_comments_and_open_paren}},
+                utils::{suppressed::FormatSuppressedNode, typecast::{format_type_cast_comment_node, format_leading_comments_and_open_paren, format_outer_leading_comments_and_open_paren}},
                 print::{FormatWrite #(#options)*},
             };
 
@@ -166,12 +166,22 @@ fn generate_struct_implementation(
     });
 
     let needs_parentheses_before = if needs_parentheses {
-        if do_not_print_leading_comment {
+        if do_not_print_comment {
+            // The node owns ALL its comment printing (leading and trailing) in `write`;
+            // keep the added paren bare and leave every comment to it.
             quote! {
                 let needs_parentheses = self.needs_parentheses(f);
                 if needs_parentheses {
                     "(".fmt(f);
                 }
+            }
+        } else if do_not_print_leading_comment {
+            // The node prints its own leading comments in `write`,
+            // but the ones that belong outside the formatter-added paren (source side / own-line) must
+            // print first (`X & /* c */ (A | B)` keeps `c` outside).
+            quote! {
+                let needs_parentheses = self.needs_parentheses(f);
+                format_outer_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
             }
         } else {
             // A leading type cast comment must stay adjacent to the `(` of its cast target inside this node;

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -5,7 +5,7 @@ checker.ts:
   sys deallocs: 19382
   sys alloc bytes: 6767781 # 6.77 MB
   sys peak growth: 2973674 # 2.97 MB
-  arena allocs: 1064052
+  arena allocs: 1064030
   arena reallocs: 927
   arena size: 90009696 # 90.01 MB
 
@@ -49,7 +49,7 @@ antd.js:
   sys deallocs: 90042
   sys alloc bytes: 76472316 # 76.47 MB
   sys peak growth: 50737424 # 50.74 MB
-  arena allocs: 2503926
+  arena allocs: 2503922
   arena reallocs: 1889
   arena size: 244471376 # 244.47 MB
 
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 17087
   sys alloc bytes: 4436340 # 4.44 MB
   sys peak growth: 1491796 # 1.49 MB
-  arena allocs: 555537
+  arena allocs: 555469
   arena reallocs: 1041
-  arena size: 38314984 # 38.31 MB
+  arena size: 38312384 # 38.31 MB


### PR DESCRIPTION
Fixes comment-placement bugs, idempotency and also inconsistency around unions/intersections, type aliases, conditional types, and assignment-likes.

- Fix invariant violations where comments crossed `=`, the value, or `;`
  - removed the relocation logic emulating old Prettier 3.8 behavior
- Normalize a union's leading comments to one canonical form behind the synthesized leading `|`, independent of the source shape
- Comments around a formatter-added `(` keep their source side of the `(`
- Hug conditional-type branch comments behind `?`/`:` with the content one level under the operator, matching conditional expressions
- Extend `= // c` position preservation from type aliases to all of JS