### PR TITLE
fix(react_compiler): lower lowercase JSX tags as strings

### DIFF
--- a/crates/oxc_react_compiler/fixtures/lowercase-context-variable-as-jsx-element-tag.js
+++ b/crates/oxc_react_compiler/fixtures/lowercase-context-variable-as-jsx-element-tag.js
@@ -1,0 +1,11 @@
+const navTitle = getTitle();
+
+function NavTitle() {
+  const Title = navTitle;
+  return <Title value={1} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: NavTitle,
+  params: [],
+};

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -3321,8 +3321,11 @@ fn ox_codegen_jsx_fbt_child_element<'a>(
     }
 }
 
-/// Build a `JSXElementName` from a tag expression, preserving the HIR distinction between
-/// component references (identifier expressions) and builtin tags (string literals).
+/// Build a `JSXElementName` from a tag expression.
+///
+/// JSX determines whether an identifier tag is intrinsic from its spelling. React Compiler may
+/// rewrite a component reference to a lowercase identifier, so reconstruct that distinction here
+/// instead of preserving the expression kind from HIR.
 fn ox_expression_to_jsx_tag<'a>(
     cx: &OxcContext<'a, '_>,
     expr: &oxc::Expression<'a>,
@@ -3330,11 +3333,12 @@ fn ox_expression_to_jsx_tag<'a>(
 ) -> Result<oxc::JSXElementName<'a>, OxcDiagnostic> {
     match expr {
         oxc::Expression::Identifier(ident) => {
-            Ok(oxc_ast::ast::JSXElementName::new_identifier_reference(
-                span,
-                ox_str(&cx.ast, &ident.name),
-                &cx.ast,
-            ))
+            let name = ox_str(&cx.ast, &ident.name);
+            if ident.name.as_bytes().first().is_some_and(u8::is_ascii_lowercase) {
+                Ok(oxc_ast::ast::JSXElementName::new_identifier(span, name, &cx.ast))
+            } else {
+                Ok(oxc_ast::ast::JSXElementName::new_identifier_reference(span, name, &cx.ast))
+            }
         }
         oxc::Expression::StaticMemberExpression(_)
         | oxc::Expression::ComputedMemberExpression(_) => {

--- a/crates/oxc_react_compiler/tests/snapshots/lowercase-context-variable-as-jsx-element-tag.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/lowercase-context-variable-as-jsx-element-tag.snap
@@ -1,0 +1,21 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/lowercase-context-variable-as-jsx-element-tag.js
+---
+import { c as _c } from "react/compiler-runtime";
+const navTitle = getTitle();
+function NavTitle() {
+	const $ = _c(1);
+	let t0;
+	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		t0 = <navTitle value={1} />;
+		$[0] = t0;
+	} else {
+		t0 = $[0];
+	}
+	return t0;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: NavTitle,
+	params: []
+};


### PR DESCRIPTION
React Compiler's JSX reconstruction preserved the HIR identifier expression kind, causing compiler-generated lowercase aliases such as `navTitle` to lower as variable references. Classify reconstructed tags by their emitted JSX spelling while preserving underscore-prefixed component references.

Validation: `cargo test -p oxc_react_compiler`, `cargo clippy -p oxc_react_compiler --all-targets -- -D warnings`, and the transform-react NAPI suite.

AI assistance: OpenAI Codex was used to investigate, implement, and validate this change.