### PR TITLE
fix(linter/react/exhaustive-deps): handle destructured object dependencies

### DIFF
--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -12,7 +12,6 @@ use oxc_ast::{
         Argument, ArrayExpressionElement, ArrowFunctionBody, ArrowFunctionExpression,
         BindingPattern, CallExpression, ChainElement, Expression, FormalParameters, Function,
         FunctionBody, IdentifierReference, StaticMemberExpression, VariableDeclarationKind,
-        VariableDeclarator,
     },
     match_expression,
 };
@@ -711,7 +710,15 @@ impl Rule for ExhaustiveDeps {
             });
 
             for dep in declared_dependencies.difference(&found_dependencies) {
-                if found_dependencies.iter().any(|found_dep| found_dep.contains(dep)) {
+                if found_dependencies.iter().any(|found_dep| found_dep.contains(dep))
+                    || undeclared_deps
+                        .iter()
+                        .copied()
+                        .any(|undeclared_dep| dep.contains(undeclared_dep))
+                    || declared_dependencies
+                        .iter()
+                        .any(|declared_dep| declared_dep != dep && dep.contains(declared_dep))
+                {
                     continue;
                 }
 
@@ -1267,12 +1274,6 @@ fn func_call_without_react_namespace<'a>(call_expr: &'a CallExpression<'a>) -> O
 struct ExhaustiveDepsVisitor<'a, 'b> {
     semantic: &'b Semantic<'a>,
     stack: Vec<AstType>,
-    /// Variable declarations above the current node. Only populated in initializers.
-    ///
-    /// NOTE: I don't expect this stack to ever have more than 1 element, since
-    /// variable declarators cannot be nested. However, having this as a stack
-    /// is definitely safer.
-    decl_stack: Vec<&'a VariableDeclarator<'a>>,
     skip_reporting_dependency: bool,
     set_state_call: bool,
     is_callee_of_call_expr: bool,
@@ -1285,75 +1286,12 @@ impl<'a, 'b> ExhaustiveDepsVisitor<'a, 'b> {
         Self {
             semantic,
             stack: vec![],
-            decl_stack: vec![],
             skip_reporting_dependency: false,
             set_state_call: false,
             is_callee_of_call_expr: false,
             found_dependencies: FxHashSet::default(),
             refs_inside_cleanups: vec![],
         }
-    }
-
-    fn iter_destructure_bindings<F>(&self, mut cb: F) -> Option<bool>
-    where
-        F: FnMut(std::borrow::Cow<'a, str>),
-    {
-        // check for object destructuring
-        // `const { foo } = props;`
-        // allow `props.foo` to be a dependency
-        let Some(VariableDeclarator { id: BindingPattern::ObjectPattern(obj), .. }) =
-            self.decl_stack.last()
-        else {
-            return None;
-        };
-
-        // Only apply destructuring logic when the identifier is directly the RHS of
-        // the destructuring assignment, not when it's nested inside another expression
-        // like a function call.
-        // For example:
-        // - `const { headers } = props` -> props.headers is the dependency
-        // - `const { headers } = fn(booleanValue)` -> booleanValue is the dependency, not booleanValue.headers
-        if self.stack.contains(&AstType::CallExpression) {
-            return None;
-        }
-
-        if obj.rest.is_some() {
-            return Some(true);
-        }
-
-        let mut needs_full_identifier = false;
-        for prop in &obj.properties {
-            if prop.computed {
-                needs_full_identifier = true;
-                continue;
-            }
-            match &prop.value {
-                BindingPattern::BindingIdentifier(id) => {
-                    cb(id.name.into());
-                }
-                BindingPattern::AssignmentPattern(pat) => {
-                    if let Some(id) = pat.left.get_binding_identifier() {
-                        cb(id.name.into());
-                    } else {
-                        // `const { idk: { thing } = { } } = props;`
-                        // not sure what to do
-                        needs_full_identifier = true;
-                    }
-                }
-                BindingPattern::ArrayPattern(_) | BindingPattern::ObjectPattern(_) => {
-                    // `const { foo: [bar] } = props;`
-                    // `const { foo: { bar } } = props;`
-                    // foo.bar is sufficient as a dependency
-                    if let Some(key) = prop.key.name() {
-                        cb(key);
-                    } else {
-                        needs_full_identifier = true;
-                    }
-                }
-            }
-        }
-
-        Some(needs_full_identifier)
     }
 }
 
@@ -1363,29 +1301,6 @@ impl<'a> VisitJs<'a> for ExhaustiveDepsVisitor<'a, '_> {
     }
 
     fn leave_node(&mut self, _kind: AstKind<'a>) {
-        self.stack.pop();
-    }
-
-    fn visit_variable_declarator(&mut self, decl: &VariableDeclarator<'a>) {
-        self.stack.push(AstType::VariableDeclarator);
-        // NOTE: decl_stack is only appended when visiting initializer
-        // expression.
-        self.visit_binding_pattern(&decl.id);
-        if let Some(init) = &decl.init {
-            // SAFETY:
-            // 1. All nodes live inside the arena, which has a lifetime of 'a.
-            //    The arena lives longer than any Rule pass, so this visitor
-            //    will drop before the node does.
-            // 2. This visitor is read-only, and it drops all references after
-            //    visiting the node.  Therefore, no mutable references will be
-            //    created before this stack is dropped.
-            let decl = unsafe {
-                std::mem::transmute::<&VariableDeclarator<'_>, &'a VariableDeclarator<'a>>(decl)
-            };
-            self.decl_stack.push(decl);
-            self.visit_expression(init);
-            self.decl_stack.pop();
-        }
         self.stack.pop();
     }
 
@@ -1451,56 +1366,26 @@ impl<'a> VisitJs<'a> for ExhaustiveDepsVisitor<'a, '_> {
                     self.found_dependencies.insert(source);
                 } else {
                     let new_chain = Vec::from([Str::from(it.property.name)]);
-
-                    let mut destructured_props: Vec<Str<'a>> = vec![];
-                    let mut did_see_ref = false;
-                    let needs_full_chain = self
-                        .iter_destructure_bindings(|id| {
-                            if let Cow::Borrowed(id) = id {
-                                if id == "current" {
-                                    did_see_ref = true;
-                                } else {
-                                    destructured_props.push(id.into());
-                                }
-                            } else {
-                                // todo
-                            }
-                        })
-                        .unwrap_or(true);
-
                     let symbol_id =
                         self.semantic.scoping().get_reference(source.reference_id).symbol_id();
-                    if needs_full_chain || (destructured_props.is_empty() && !did_see_ref) {
-                        if it.property.name == "current" {
-                            // Track base object (`ref`) alongside `.current` reads so missing dep
-                            // diagnostics can prefer the reactive identity over the mutable field.
-                            self.found_dependencies.insert(Dependency {
-                                name: source.name,
-                                reference_id: source.reference_id,
-                                span: source.span,
-                                chain: source.chain.clone(),
-                                symbol_id,
-                            });
-                        }
+                    if it.property.name == "current" {
+                        // Track base object (`ref`) alongside `.current` reads so missing dep
+                        // diagnostics can prefer the reactive identity over the mutable field.
                         self.found_dependencies.insert(Dependency {
                             name: source.name,
                             reference_id: source.reference_id,
                             span: source.span,
-                            chain: [source.chain.clone(), new_chain].concat(),
+                            chain: source.chain.clone(),
                             symbol_id,
                         });
-                    } else {
-                        for prop in destructured_props {
-                            self.found_dependencies.insert(Dependency {
-                                name: source.name,
-                                reference_id: source.reference_id,
-                                span: source.span,
-                                chain: [source.chain.clone(), new_chain.clone(), vec![prop]]
-                                    .concat(),
-                                symbol_id,
-                            });
-                        }
                     }
+                    self.found_dependencies.insert(Dependency {
+                        name: source.name,
+                        reference_id: source.reference_id,
+                        span: source.span,
+                        chain: [source.chain.clone(), new_chain].concat(),
+                        symbol_id,
+                    });
                 }
             }
 
@@ -1524,41 +1409,13 @@ impl<'a> VisitJs<'a> for ExhaustiveDepsVisitor<'a, '_> {
         }
         let reference_id = ident.reference_id();
         let symbol_id = self.semantic.scoping().get_reference(reference_id).symbol_id();
-
-        let mut destructured_props: Vec<Str<'a>> = vec![];
-        let mut did_see_ref = false;
-        let needs_full_identifier = self
-            .iter_destructure_bindings(|id| {
-                if let Cow::Borrowed(id) = id {
-                    if id == "current" {
-                        did_see_ref = true;
-                    } else {
-                        destructured_props.push(id.into());
-                    }
-                } else {
-                    // todo: arena allocate
-                }
-            })
-            .unwrap_or(true);
-        if needs_full_identifier || (destructured_props.is_empty() && !did_see_ref) {
-            self.found_dependencies.insert(Dependency {
-                name: ident.name.into(),
-                reference_id,
-                span: ident.span,
-                chain: vec![],
-                symbol_id,
-            });
-        } else {
-            for prop in destructured_props {
-                self.found_dependencies.insert(Dependency {
-                    name: ident.name.into(),
-                    reference_id,
-                    span: ident.span,
-                    chain: vec![prop],
-                    symbol_id,
-                });
-            }
-        }
+        self.found_dependencies.insert(Dependency {
+            name: ident.name.into(),
+            reference_id,
+            span: ident.span,
+            chain: vec![],
+            symbol_id,
+        });
 
         if let Some(decl) = get_declaration_of_variable(ident, self.semantic) {
             let is_set_state_call = match decl.kind() {
@@ -1845,26 +1702,13 @@ fn test() {
             const { foo, bar } = props;
             console.log(foo);
             console.log(bar);
-          }, [props.foo, props.bar]);
-        }",
-        r"function MyComponent(props) {
-          useEffect(() => {
-            const { bar } = props.foo;
-            console.log(bar);
-          }, [props.foo.bar]);
-        }",
-        r"function MyComponent(props) {
-          useEffect(() => {
-            const { foo, bar } = props;
-            console.log(foo);
-            console.log(bar);
           }, [props]);
         }",
-        r"function MyComponent(props) {
-          useEffect(() => {
-            const { foo: { bar } } = props;
-            console.log(bar);
-          }, [props.foo]);
+        r"function useThing(context) {
+          return useCallback(() => {
+            const { paramsLoader } = context;
+            paramsLoader();
+          }, [context]);
         }",
         r"function MyComponent(props) {
           useEffect(() => {
@@ -4422,6 +4266,38 @@ const Component = ({ filter }) => {
               return flag ? obj.a : obj.b;
             })();
           }, []);
+        }",
+        // https://github.com/oxc-project/oxc/issues/25621
+        r"import React from 'react';
+        export function useThing(context: { paramsLoader: () => void }) {
+          return React.useCallback(() => {
+            const { paramsLoader } = context;
+            paramsLoader();
+          }, [context.paramsLoader]);
+        }",
+        // Destructuring reads its entire initializer, not only the bound properties.
+        r"function MyComponent(props) {
+          useEffect(() => {
+            const { foo, bar } = props;
+            console.log(foo);
+            console.log(bar);
+          }, [props.foo, props.bar]);
+        }",
+        r"function MyComponent(props) {
+          useEffect(() => {
+            const { bar } = props.foo;
+            console.log(bar);
+          }, [props.foo.bar]);
+        }",
+        r"function MyComponent(props) {
+          useEffect(() => {
+            const { foo: { bar } } = props;
+            console.log(bar);
+          }, [props.foo]);
+        }",
+        r"function MyComponent() {
+          const [, setState] = useState(0);
+          useCallback(() => setState(1), [setState.foo]);
         }",
     ];
 

--- a/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
+++ b/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
@@ -687,12 +687,12 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo'
+  ⚠ react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props'
    ╭─[exhaustive_deps.tsx:5:14]
  2 │           useCallback(() => {
  3 │             const { foo } = props;
    ·                             ──┬──
-   ·                               ╰── useCallback uses `props.foo` here
+   ·                               ╰── useCallback uses `props` here
  4 │             console.log(foo);
  5 │           }, [props.bar]);
    ·              ───────────
@@ -700,30 +700,12 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react-hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.bar
-   ╭─[exhaustive_deps.tsx:5:14]
- 4 │             console.log(foo);
- 5 │           }, [props.bar]);
-   ·              ───────────
- 6 │         }
-   ╰────
-  help: Either include it or remove the dependency array.
-
-  ⚠ react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props.foo'
+  ⚠ react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'props'
    ╭─[exhaustive_deps.tsx:5:14]
  2 │           useCallback(() => {
  3 │             const { foo: { bar } } = props;
    ·                                      ──┬──
-   ·                                        ╰── useCallback uses `props.foo` here
- 4 │             console.log(bar);
- 5 │           }, [props.foo.bar]);
-   ·              ───────────────
- 6 │         }
-   ╰────
-  help: Either include it or remove the dependency array.
-
-  ⚠ react-hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo.bar
-   ╭─[exhaustive_deps.tsx:5:14]
+   ·                                        ╰── useCallback uses `props` here
  4 │             console.log(bar);
  5 │           }, [props.foo.bar]);
    ·              ───────────────
@@ -764,24 +746,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                           ╰── useCallback uses `local` here
  5 │           }, [local.id]);
    ·              ──────────
- 6 │         }
-   ╰────
-  help: Either include it or remove the dependency array.
-
-  ⚠ react-hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: local.id
-   ╭─[exhaustive_deps.tsx:5:14]
- 4 │             console.log(local);
- 5 │           }, [local.id]);
-   ·              ──────────
- 6 │         }
-   ╰────
-  help: Either include it or remove the dependency array.
-
-  ⚠ react-hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: local.id
-   ╭─[exhaustive_deps.tsx:5:14]
- 4 │             console.log(local);
- 5 │           }, [local.id, local]);
-   ·              ─────────────────
  6 │         }
    ╰────
   help: Either include it or remove the dependency array.
@@ -877,15 +841,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ react-hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo.bar.baz
-   ╭─[exhaustive_deps.tsx:4:14]
- 3 │             console.log(props.foo.bar);
- 4 │           }, [props.foo.bar.baz]);
-   ·              ───────────────────
- 5 │         }
-   ╰────
-  help: Either include it or remove the dependency array.
-
   ⚠ react-hooks(exhaustive-deps): React Hook useCallback has missing dependencies: 'props.hello', and 'props'
    ╭─[exhaustive_deps.tsx:5:14]
  2 │           const fn = useCallback(() => {
@@ -893,15 +848,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────
  4 │             console.log(props.hello);
    ·                         ─────
- 5 │           }, [props.foo.bar.baz]);
-   ·              ───────────────────
- 6 │         }
-   ╰────
-  help: Either include it or remove the dependency array.
-
-  ⚠ react-hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo.bar.baz
-   ╭─[exhaustive_deps.tsx:5:14]
- 4 │             console.log(props.hello);
  5 │           }, [props.foo.bar.baz]);
    ·              ───────────────────
  6 │         }
@@ -3163,6 +3109,68 @@ source: crates/oxc_linter/src/tester.rs
  6 │           }, []);
    ·              ──
  7 │         }
+   ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'context'
+   ╭─[exhaustive_deps.tsx:6:14]
+ 3 │           return React.useCallback(() => {
+ 4 │             const { paramsLoader } = context;
+   ·                                      ───┬───
+   ·                                         ╰── useCallback uses `context` here
+ 5 │             paramsLoader();
+ 6 │           }, [context.paramsLoader]);
+   ·              ──────────────────────
+ 7 │         }
+   ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props'
+   ╭─[exhaustive_deps.tsx:6:14]
+ 2 │           useEffect(() => {
+ 3 │             const { foo, bar } = props;
+   ·                                  ──┬──
+   ·                                    ╰── useEffect uses `props` here
+ 4 │             console.log(foo);
+ 5 │             console.log(bar);
+ 6 │           }, [props.foo, props.bar]);
+   ·              ──────────────────────
+ 7 │         }
+   ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props.foo'
+   ╭─[exhaustive_deps.tsx:5:14]
+ 2 │           useEffect(() => {
+ 3 │             const { bar } = props.foo;
+   ·                             ──┬──
+   ·                               ╰── useEffect uses `props.foo` here
+ 4 │             console.log(bar);
+ 5 │           }, [props.foo.bar]);
+   ·              ───────────────
+ 6 │         }
+   ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'props'
+   ╭─[exhaustive_deps.tsx:5:14]
+ 2 │           useEffect(() => {
+ 3 │             const { foo: { bar } } = props;
+   ·                                      ──┬──
+   ·                                        ╰── useEffect uses `props` here
+ 4 │             console.log(bar);
+ 5 │           }, [props.foo]);
+   ·              ───────────
+ 6 │         }
+   ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ react-hooks(exhaustive-deps): React Hook useCallback has unnecessary dependency: setState.foo
+   ╭─[exhaustive_deps.tsx:3:42]
+ 2 │           const [, setState] = useState(0);
+ 3 │           useCallback(() => setState(1), [setState.foo]);
+   ·                                          ──────────────
+ 4 │         }
    ╰────
   help: Either include it or remove the dependency array.
 


### PR DESCRIPTION
## Summary

- treat destructuring initializers as whole-object dependencies
- avoid reporting narrower declared paths as unnecessary while their reactive ancestor is missing
- preserve unnecessary-dependency diagnostics for stable ancestors such as state setters

Fixes #25621