### PR TITLE
fix(linter/react/rules-of-hooks): report hooks inside try blocks

### DIFF
--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -412,18 +412,23 @@ impl Rule for RulesOfHooks {
             return;
         }
 
-        if !cfg.is_reachable(func_cfg_id, node_cfg_id) {
-            if !is_inside_try_catch(nodes, node.id(), parent_func.id()) {
-                return;
-            }
-
-            if has_conditional_path_accept_throw(ctx.nodes(), cfg, parent_func, node) {
-                return ctx.diagnostic(diagnostics::conditional_hook(
+        if is_inside_try_catch(nodes, node.id(), parent_func.id()) {
+            if cfg.is_cyclic(node_cfg_id) {
+                return ctx.diagnostic(diagnostics::loop_hook(
                     span,
+                    loop_keyword_span(ctx, ctx.nodes(), node.id(), parent_func.id()),
                     hook_name,
-                    conditional_context(ctx, node.id(), span, parent_func.id()),
                 ));
             }
+
+            return ctx.diagnostic(diagnostics::conditional_hook(
+                span,
+                hook_name,
+                conditional_context(ctx, node.id(), span, parent_func.id()),
+            ));
+        }
+
+        if !cfg.is_reachable(func_cfg_id, node_cfg_id) {
             return;
         }
 
@@ -1578,26 +1583,9 @@ fn test() {
     "
         function Foo() {
           try {
-            useCustomHook();
-          } catch (error) {
-            console.error(error);
-          }
-        }
-    ",
-    "
-        function Foo() {
-          try {
             f();
           } catch {}
           useState();
-        }
-    ",
-    "
-        function Foo() {
-          try {
-            const value = 1;
-            useState(value);
-          } catch {}
         }
     ",
         r"
@@ -2197,6 +2185,35 @@ fn test() {
                     try {
                         f();
                         useState();
+                    } catch {}
+                }
+        ",
+        // https://github.com/oxc-project/oxc/issues/25631
+        "
+                function TestChild() {
+                    let captured = null;
+                    try {
+                        captured = useTooltipContext();
+                        return null;
+                    } catch (error) {
+                        return null;
+                    }
+                }
+        ",
+        "
+                function ComponentWithHookInsideLoop() {
+                    try {
+                        while (cond) {
+                            useState();
+                        }
+                    } catch {}
+                }
+        ",
+        "
+                function Foo() {
+                    try {
+                        const value = 1;
+                        useState(value);
                     } catch {}
                 }
         ",

--- a/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
@@ -699,6 +699,38 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
+  ⚠ react-hooks(rules-of-hooks): React Hook "useTooltipContext" is called conditionally. React Hooks must be called in the exact same order in every component render.
+   ╭─[rules_of_hooks.tsx:5:36]
+ 4 │                     try {
+ 5 │                         captured = useTooltipContext();
+   ·                                    ─────────┬─────────
+   ·                                             ╰── This Hook call is not reachable on every render path.
+ 6 │                         return null;
+   ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
+
+  ⚠ react-hooks(rules-of-hooks): React Hook "useState" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
+   ╭─[rules_of_hooks.tsx:5:29]
+ 3 │                     try {
+ 4 │                         while (cond) {
+   ·                         ──┬──
+   ·                           ╰── This loop may execute the Hook more than once.
+ 5 │                             useState();
+   ·                             ─────┬────
+   ·                                  ╰── Hook is called here
+ 6 │                         }
+   ╰────
+
+  ⚠ react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
+   ╭─[rules_of_hooks.tsx:5:25]
+ 4 │                         const value = 1;
+ 5 │                         useState(value);
+   ·                         ───────┬───────
+   ·                                ╰── This Hook call is not reachable on every render path.
+ 6 │                     } catch {}
+   ╰────
+  help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
+
   ⚠ react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:25]
  4 │                         const value = f();


### PR DESCRIPTION
## Summary
- report custom Hooks inside try/catch blocks as conditional
- preserve the same-CFG fast path for ordinary top-level Hooks
- add focused regression coverage for the reported first-operation-in-try case

Closes #25631