### PR TITLE
fix(linter): eslint-disable-line to cover whole line

### DIFF
--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -347,9 +347,13 @@ impl DisableDirectives {
                 // For next-line directives, only check if the diagnostic starts within the interval
                 // We intentionally only check span.start (not span.end) to avoid suppressing
                 // diagnostics for large constructs that merely contain the disabled line
+                // A directive never suppresses a diagnostic about its own comment
+                // (e.g. unicorn/no-abusive-eslint-disable)
                 #[expect(clippy::suspicious_operation_groupings)]
                 {
-                    span.start >= interval.start && span.start < interval.stop
+                    span.start >= interval.start
+                        && span.start < interval.stop
+                        && !interval.val.comment_span().contains_inclusive(span)
                 }
             } else {
                 // For regular disable directives, check if there's any overlap
@@ -669,12 +673,14 @@ impl DisableDirectivesBuilder {
                     }
                 }
                 DirectiveKind::DisableLine => {
-                    // Get the span between the preceding newline to this comment
+                    // Get the span of the whole line containing the comment
                     let start = source_text[..comment_span.start as usize]
                         .lines()
                         .next_back()
                         .map_or(0, |line| comment_span.start - line.len() as u32);
-                    let stop = comment_span.start;
+                    let rest_of_line = &source_text[comment_span.end as usize..];
+                    let stop = comment_span.end
+                        + rest_of_line.find('\n').unwrap_or(rest_of_line.len()) as u32;
 
                     if rule_names.is_empty() {
                         self.add_interval(
@@ -1153,11 +1159,18 @@ no-debugger
             /* {prefix}-enablefoo, no-debugger, no-console */
                 debugger;
             "
-            )
+            ),
+            // The directive may appear anywhere on the line, including before the violation
+            format!("/* {prefix}-disable-line */ debugger;"),
+            format!("/* {prefix}-disable-line no-debugger */ debugger;"),
+            format!("debugger; /* {prefix}-disable-line no-debugger */ debugger;"),
         ];
 
         let fail = vec![
             "debugger".to_string(),
+            // `disable-line` only affects its own line, not adjacent lines
+            format!("/* {prefix}-disable-line */\ndebugger;"),
+            format!("debugger;\n/* {prefix}-disable-line */"),
             format!(
                 "
             debugger; // {prefix}-disable-line no-alert


### PR DESCRIPTION
Closes #25633

My (human) understanding of the issue is that current approach is to apply diagnostic rule suppression from the beginning of the comment line to the start of the comment span, which in case of usual usage at the end of the line would have the diagnostic position (col where diagnostic detected a rule violation) fall within the interval `[start, stop]`, but positioning the comment as in the repro steps of the issue - before the diagnostic col, would not fall within the interval, leading to diagnostic suppression not applied.

The proposed fix is to get a reference to the rest of the line and set the stop at the end of the line by looking up the newline break, or falling back to the last index. By including the comment, however, we would cause diagnostics on the comment itself to be suppressed, to avoid that, a check is added so that a directive does not suppress a diagnostic inside its own comment.
Ported ESLint's `apply-disable-directives` test cases to cover it.

I used Claude Code to research the issue claim's validity, compare implementation with ESLint (which I understand implemented it by using col 1 of the line as starting position, and next line's column 0 as stopping position, they do it with type disable/enable though), implement the change and verify the test suite. Every line of the code was read and understood by me personally.

Edit: I also checked if the docs needs to be updated, but they already describe the fixed behavior:
> [Disable one or more rules on the current line](https://oxc.rs/docs/guide/usage/linter/ignore-comments.html#oxlint-disable-line)
