### PR TITLE
fix(react-compiler): match upstream inline enum handling

### DIFF
--- a/crates/oxc_react_compiler/fixtures/ts-enum-inline-block-scopes.tsx
+++ b/crates/oxc_react_compiler/fixtures/ts-enum-inline-block-scopes.tsx
@@ -1,0 +1,25 @@
+function Component() {
+  let first;
+  let second;
+
+  {
+    enum NumberValue {
+      Value = 1,
+    }
+    first = NumberValue;
+  }
+
+  {
+    enum NumberValue {
+      Value = 2,
+    }
+    second = NumberValue;
+  }
+
+  return <span>{first === second ? 'same' : 'different'}</span>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};

--- a/crates/oxc_react_compiler/fixtures/ts-enum-inline-captured-binding.tsx
+++ b/crates/oxc_react_compiler/fixtures/ts-enum-inline-captured-binding.tsx
@@ -1,0 +1,16 @@
+function Component(props: {value: number}) {
+  function Inner() {
+    enum NumberValue {
+      Value = props.value,
+    }
+
+    return <span>{NumberValue.Value}</span>;
+  }
+
+  return <Inner />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 1}],
+};

--- a/crates/oxc_react_compiler/fixtures/ts-enum-inline-member-mutation.tsx
+++ b/crates/oxc_react_compiler/fixtures/ts-enum-inline-member-mutation.tsx
@@ -1,0 +1,16 @@
+function Child(props: {items: Array<number>}) {
+  return <span>{props.items.length}</span>;
+}
+
+function Component(props: {items: Array<number>}) {
+  enum Result {
+    Length = props.items.push(1),
+  }
+
+  return <Child items={props.items} />;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{items: []}],
+};

--- a/crates/oxc_react_compiler/fixtures/ts-enum-inline-member-reference.tsx
+++ b/crates/oxc_react_compiler/fixtures/ts-enum-inline-member-reference.tsx
@@ -1,0 +1,13 @@
+function Component(props: {value: number}) {
+  enum NumberValue {
+    First = 1,
+    Second = First,
+  }
+
+  return <span>{NumberValue.Second + props.value}</span>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 1}],
+};

--- a/crates/oxc_react_compiler/fixtures/ts-enum-inline-merged.tsx
+++ b/crates/oxc_react_compiler/fixtures/ts-enum-inline-merged.tsx
@@ -1,0 +1,15 @@
+function Component() {
+  enum NumberValue {
+    First = 1,
+  }
+  enum NumberValue {
+    Second = 2,
+  }
+
+  return <span>{NumberValue.First + NumberValue.Second}</span>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};

--- a/crates/oxc_react_compiler/fixtures/ts-enum-inline-reactive-member.tsx
+++ b/crates/oxc_react_compiler/fixtures/ts-enum-inline-reactive-member.tsx
@@ -1,0 +1,12 @@
+function Component(props: {value: number}) {
+  enum NumberValue {
+    Value = props.value,
+  }
+
+  return <span>{NumberValue.Value}</span>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 1}],
+};

--- a/crates/oxc_react_compiler/fixtures/ts-enum-inline-shadowed-local.tsx
+++ b/crates/oxc_react_compiler/fixtures/ts-enum-inline-shadowed-local.tsx
@@ -1,0 +1,15 @@
+function Component(value: number) {
+  {
+    const value = 42;
+    enum NumberValue {
+      Value = value,
+    }
+
+    return <span>{NumberValue.Value}</span>;
+  }
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [0],
+};

--- a/crates/oxc_react_compiler/fixtures/ts-enum-inline-switch-case.tsx
+++ b/crates/oxc_react_compiler/fixtures/ts-enum-inline-switch-case.tsx
@@ -1,0 +1,17 @@
+function Component(props: {action: string}) {
+  enum Action {
+    Select,
+  }
+
+  switch (props.action) {
+    case String(Action.Select):
+      return <span>selected</span>;
+    default:
+      return <span>unknown</span>;
+  }
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{action: '0'}],
+};

--- a/crates/oxc_react_compiler/fixtures/ts-enum-inline-unused-side-effect.tsx
+++ b/crates/oxc_react_compiler/fixtures/ts-enum-inline-unused-side-effect.tsx
@@ -1,0 +1,16 @@
+function createValue(value: number): number {
+  return value;
+}
+
+function Component(props: {value: number}) {
+  enum Unused {
+    Value = createValue(props.value),
+  }
+
+  return <span>{props.value}</span>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 1}],
+};

--- a/crates/oxc_react_compiler/fixtures/ts-enum-inline-write.tsx
+++ b/crates/oxc_react_compiler/fixtures/ts-enum-inline-write.tsx
@@ -1,0 +1,13 @@
+function Component() {
+  let count = 0;
+  enum Counter {
+    Value = count++,
+  }
+
+  return <span>{count}</span>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -790,6 +790,15 @@ pub enum InstructionValue<'a> {
     Debugger {
         span: Option<Span>,
     },
+    /// A TypeScript enum declaration preserved as an opaque pass-through node.
+    ///
+    /// This is the oxc-specific equivalent of upstream's `UnsupportedNode`:
+    /// the compiler retains the runtime statement without modeling its binding
+    /// or initializer expressions in HIR.
+    TSEnumDeclaration {
+        declaration: &'a oxc_ast::ast::TSEnumDeclaration<'a>,
+        span: Option<Span>,
+    },
     StartMemoize {
         manual_memo_id: u32,
         deps: Option<ArenaVec<'a, ManualMemoDependency<'a>>>,
@@ -859,6 +868,7 @@ impl<'a> InstructionValue<'a> {
             | InstructionValue::PrefixUpdate { span, .. }
             | InstructionValue::PostfixUpdate { span, .. }
             | InstructionValue::Debugger { span, .. }
+            | InstructionValue::TSEnumDeclaration { span, .. }
             | InstructionValue::StartMemoize { span, .. }
             | InstructionValue::FinishMemoize { span, .. } => span.as_ref(),
         }
@@ -1909,6 +1919,14 @@ impl<'a> CloneIn<'a> for InstructionValue<'a> {
                 }
             }
             // --- Arena-carrying variants: recurse ---
+            InstructionValue::TSEnumDeclaration { declaration, span } => {
+                InstructionValue::TSEnumDeclaration {
+                    // Keep the preserved AST reference so semantic reference IDs
+                    // survive ordinary HIR clones, matching `TypeCast` above.
+                    declaration,
+                    span: *span,
+                }
+            }
             InstructionValue::Destructure { lvalue, value, span } => {
                 InstructionValue::Destructure {
                     lvalue: lvalue.clone_in_impl(sem, alloc),

--- a/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
@@ -85,6 +85,7 @@ pub fn each_instruction_value_lvalue(value: &InstructionValue) -> PlaceList {
         | InstructionValue::IteratorNext { .. }
         | InstructionValue::NextPropertyOf { .. }
         | InstructionValue::Debugger { .. }
+        | InstructionValue::TSEnumDeclaration { .. }
         | InstructionValue::StartMemoize { .. }
         | InstructionValue::FinishMemoize { .. } => {}
     }
@@ -274,6 +275,7 @@ pub fn each_instruction_value_operand_with_functions(
             result.push(*decl);
         }
         InstructionValue::Debugger { .. }
+        | InstructionValue::TSEnumDeclaration { .. }
         | InstructionValue::RegExpLiteral { .. }
         | InstructionValue::MetaProperty { .. }
         | InstructionValue::LoadGlobal { .. }
@@ -1014,6 +1016,7 @@ pub fn for_each_instruction_value_operand_mut(
             f(decl);
         }
         InstructionValue::Debugger { .. }
+        | InstructionValue::TSEnumDeclaration { .. }
         | InstructionValue::RegExpLiteral { .. }
         | InstructionValue::MetaProperty { .. }
         | InstructionValue::LoadGlobal { .. }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -2423,6 +2423,7 @@ fn compute_signature_for_instruction<'a>(
         // All primitive-creating instructions
         InstructionValue::BinaryExpression { .. }
         | InstructionValue::Debugger { .. }
+        | InstructionValue::TSEnumDeclaration { .. }
         | InstructionValue::JSXText { .. }
         | InstructionValue::MetaProperty { .. }
         | InstructionValue::Primitive { .. }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
@@ -199,6 +199,7 @@ fn may_allocate(value: &InstructionValue, lvalue_type_is_primitive: bool) -> boo
         | InstructionValue::JsxFragment { .. }
         | InstructionValue::NewExpression { .. }
         | InstructionValue::ObjectExpression { .. }
+        | InstructionValue::TSEnumDeclaration { .. }
         | InstructionValue::ObjectMethod { .. }
         | InstructionValue::FunctionExpression { .. } => true,
     }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -18,6 +18,7 @@ use oxc_allocator::CloneIn;
 use oxc_allocator::Vec as ArenaVec;
 use oxc_ast::ast as oxc;
 use oxc_ast::ast::BinaryOperator;
+use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
 use oxc_str::{Ident, Str, format_ident, static_ident};
@@ -3375,7 +3376,8 @@ fn gather_captured_context(
     > = rustc_hash::FxHashMap::default();
 
     for symbol_id in scope.symbols() {
-        // Skip type-only bindings
+        // Inline enums are opaque pass-through nodes, matching upstream's
+        // `UnsupportedNode`, so their bindings are not context operands.
         if matches!(
             scope.decl_kind(symbol_id),
             DeclKind::TSTypeAliasDeclaration | DeclKind::TSEnumDeclaration
@@ -3449,6 +3451,46 @@ fn capture_scopes(
         current = scope.scope_parent(scope_id);
     }
     result
+}
+
+struct TSEnumCaptureVisitor<'b, 'a> {
+    scope: &'b ScopeResolver<'b, 'a>,
+    captured_scopes: FxIndexSet<ScopeId>,
+    found: bool,
+}
+
+impl<'a> Visit<'a> for TSEnumCaptureVisitor<'_, 'a> {
+    fn visit_identifier_reference(&mut self, ident: &oxc::IdentifierReference<'a>) {
+        if self.found {
+            return;
+        }
+        self.found = self.scope.resolve_reference(ident).is_some_and(|symbol_id| {
+            self.captured_scopes.contains(&self.scope.symbol_scope(symbol_id))
+        });
+    }
+}
+
+/// Whether preserving an enum as an opaque node would hide a capture from the
+/// nested function's HIR. Top-level component enums cannot capture component
+/// state, and module bindings are outside the captured scope range.
+fn ts_enum_has_captured_reference<'a>(
+    builder: &HirBuilder<'a, '_>,
+    declaration: &oxc::TSEnumDeclaration<'a>,
+) -> bool {
+    let function_scope = builder.function_scope();
+    if function_scope == builder.component_scope() {
+        return false;
+    }
+    let Some(parent_scope) = builder.scope().scope_parent(function_scope) else {
+        return false;
+    };
+    let mut visitor = TSEnumCaptureVisitor {
+        scope: builder.scope(),
+        captured_scopes: capture_scopes(builder.scope(), parent_scope, builder.component_scope()),
+        found: false,
+    };
+    visitor.visit_ts_enum_declaration(declaration);
+    visitor.found
 }
 
 fn lower_expression<'a>(
@@ -5681,8 +5723,10 @@ fn is_reorderable_expression(
                 match builder.scope().resolve_reference(ident) {
                     None => true, // global
                     Some(symbol_id) => {
-                        // Module-scope bindings (ModuleLocal, imports) are safe to reorder
+                        // Module-scope bindings (ModuleLocal, imports) and inline enum
+                        // objects are safe to read while lowering reorderable case tests.
                         builder.scope().symbol_scope(symbol_id) == builder.scope().program_scope()
+                            || builder.scope().decl_kind(symbol_id) == DeclKind::TSEnumDeclaration
                     }
                 }
             } else {
@@ -6568,12 +6612,37 @@ fn lower_statement<'a>(
                     .diagnostic("JavaScript `import` and `export` statements may only appear at the top level of a module").with_label(stmt.span()),
             )?;
         }
-        oxc::Statement::TSEnumDeclaration(_) => {
-            // Inline TS `enum` has runtime semantics but no HIR representation, and
-            // the compiled body is rebuilt from HIR. Flag the function to be skipped
-            // (silently, no diagnostic) once lowering finishes, rather than dropping
-            // the enum from the output. Other functions in the file are unaffected.
-            builder.environment_mut().skip_compilation = true;
+        oxc::Statement::TSEnumDeclaration(enum_decl) => {
+            let binding_scope = enum_decl
+                .id
+                .symbol_id
+                .get()
+                .map(|symbol_id| builder.scope().symbol_scope(symbol_id));
+            let loses_lexical_scope = binding_scope.is_some_and(|scope_id| {
+                builder.scope().scope_kind(scope_id) != ScopeKind::Function
+            });
+
+            // Opaque statements are emitted into the flattened HIR statement stream.
+            // Skip compilation when that would erase an enum's lexical block, or
+            // when an enum-only reference would hide a nested-function capture.
+            // This retains upstream's operand-free UnsupportedNode representation
+            // without changing the source program's runtime semantics.
+            if loses_lexical_scope || ts_enum_has_captured_reference(builder, enum_decl) {
+                builder.environment_mut().skip_compilation = true;
+            }
+
+            // Upstream preserves inline enums as an opaque `UnsupportedNode`.
+            // Keep the declaration as a pass-through HIR instruction with an
+            // unnamed temporary result; its binding and initializers deliberately
+            // remain outside HIR analysis.
+            let span = Some(enum_decl.span);
+            let allocator = builder.environment().allocator;
+            let declaration =
+                allocator.alloc(enum_decl.as_ref().clone_in_with_semantic_ids(allocator));
+            lower_value_to_temporary(
+                builder,
+                InstructionValue::TSEnumDeclaration { declaration, span },
+            )?;
         }
         _ => {
             // Remaining statements are skipped: bodyless FunctionDeclaration

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -767,11 +767,10 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
             // No binding found: this is a global
             return Ok(VariableBinding::Global { name });
         };
-        // Treat type-only declarations as globals so the compiler
-        // doesn't try to create/initialize HIR bindings for them.
-        // TSEnumDeclaration is included because a function with an inline
-        // enum is skipped (`skip_compilation`) and the enum binding is
-        // never initialized in HIR.
+        // Treat type-only declarations as globals so the compiler doesn't try to
+        // create or initialize HIR bindings for them. Inline enums are opaque
+        // pass-through instructions, matching upstream's `UnsupportedNode`, so
+        // their references also remain global from HIR's perspective.
         if matches!(
             self.scope.decl_kind(symbol_id),
             DeclKind::TSTypeAliasDeclaration

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -627,6 +627,7 @@ fn evaluate_instruction<'a>(
         | InstructionValue::IteratorNext { .. }
         | InstructionValue::NextPropertyOf { .. }
         | InstructionValue::Debugger { .. }
+        | InstructionValue::TSEnumDeclaration { .. }
         | InstructionValue::FinishMemoize { .. } => None,
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
@@ -367,6 +367,10 @@ fn pruneable_value(value: &InstructionValue, state: &State, env: &Environment) -
             // explicitly retain debugger statements
             false
         }
+        InstructionValue::TSEnumDeclaration { .. } => {
+            // Enum initializers can have arbitrary runtime side effects.
+            false
+        }
         InstructionValue::CallExpression { callee, .. } => {
             if env.output_mode == OutputMode::Ssr {
                 let callee_ty = &env.types[env.identifiers[callee.identifier].type_];

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -361,6 +361,19 @@ enum LvalueRef<'a> {
     Pattern(&'a Pattern<'a>),
 }
 
+struct BindingReferenceRenamer<'a, 'env> {
+    allocator: &'a oxc_allocator::Allocator,
+    renames: &'env FxHashMap<oxc_syntax::reference::ReferenceId, Ident<'env>>,
+}
+
+impl<'a> oxc_ast_visit::VisitMut<'a> for BindingReferenceRenamer<'a, '_> {
+    fn visit_identifier_reference(&mut self, reference: &mut oxc::IdentifierReference<'a>) {
+        if let Some(renamed) = reference.reference_id.get().and_then(|id| self.renames.get(&id)) {
+            reference.name = renamed.as_str().into_in(self.allocator);
+        }
+    }
+}
+
 fn ox_number<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
     value: f64,
@@ -388,20 +401,26 @@ fn ox_reemit_ts_type<'a>(cx: &OxcContext<'a, '_>, ty: &oxc::TSType<'_>) -> oxc::
         return ty.clone_in_with_semantic_ids(cx.ast.allocator());
     }
 
-    struct Renamer<'a, 'env> {
-        allocator: &'a oxc_allocator::Allocator,
-        renames: &'env FxHashMap<oxc_syntax::reference::ReferenceId, Ident<'env>>,
-    }
-    impl<'a> oxc_ast_visit::VisitMut<'a> for Renamer<'a, '_> {
-        fn visit_identifier_reference(&mut self, it: &mut oxc::IdentifierReference<'a>) {
-            if let Some(renamed) = it.reference_id.get().and_then(|id| self.renames.get(&id)) {
-                it.name = renamed.as_str().into_in(self.allocator);
-            }
-        }
-    }
     let mut cloned = ty.clone_in_with_semantic_ids(cx.ast.allocator());
-    let mut renamer = Renamer { allocator: cx.ast.allocator(), renames: &cx.env.renames };
+    let mut renamer =
+        BindingReferenceRenamer { allocator: cx.ast.allocator(), renames: &cx.env.renames };
     oxc_ast_visit::VisitMut::visit_ts_type(&mut renamer, &mut cloned);
+    cloned
+}
+
+/// Re-emit an opaque TypeScript enum pass-through node. Binding renames are
+/// applied because, unlike Babel, oxc's semantic renames do not mutate the
+/// preserved source AST in place.
+fn ox_reemit_ts_enum_declaration<'a>(
+    cx: &OxcContext<'a, '_>,
+    declaration: &oxc::TSEnumDeclaration<'_>,
+) -> oxc::TSEnumDeclaration<'a> {
+    let mut cloned = declaration.clone_in_with_semantic_ids(cx.ast.allocator());
+    if !cx.env.renames.is_empty() {
+        let mut renamer =
+            BindingReferenceRenamer { allocator: cx.ast.allocator(), renames: &cx.env.renames };
+        oxc_ast_visit::VisitMut::visit_ts_enum_declaration(&mut renamer, &mut cloned);
+    }
     cloned
 }
 
@@ -1425,6 +1444,13 @@ fn ox_codegen_instruction_nullable<'a>(
                     &cx.ast,
                 )));
             }
+            InstructionValue::TSEnumDeclaration { declaration, .. } => {
+                let declaration = ox_reemit_ts_enum_declaration(cx, declaration);
+                return Ok(Some(oxc::Statement::TSEnumDeclaration(oxc_allocator::Box::new_in(
+                    declaration,
+                    &cx.ast,
+                ))));
+            }
             InstructionValue::ObjectMethod { span, .. } => {
                 invariant(
                     instr.lvalue.is_some(),
@@ -2245,6 +2271,7 @@ fn ox_codegen_base_instruction_value<'a>(
         InstructionValue::StartMemoize { .. }
         | InstructionValue::FinishMemoize { .. }
         | InstructionValue::Debugger { .. }
+        | InstructionValue::TSEnumDeclaration { .. }
         | InstructionValue::DeclareLocal { .. }
         | InstructionValue::DeclareContext { .. }
         | InstructionValue::Destructure { .. }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -449,6 +449,12 @@ impl<'a, 'e> CollectDependenciesVisitor<'a, 'e> {
                 };
                 (lvalues, rvalues)
             }
+            InstructionValue::TSEnumDeclaration { .. } => {
+                let lvalues = lvalue.map_or_else(Vec::new, |place_identifier| {
+                    vec![LValueMemoization { place_identifier, level: MemoizationLevel::Never }]
+                });
+                (lvalues, vec![])
+            }
             InstructionValue::NextPropertyOf { .. }
             | InstructionValue::StartMemoize { .. }
             | InstructionValue::FinishMemoize { .. }

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -814,6 +814,7 @@ fn generate_instruction_types<'a>(
         | InstructionValue::GetIterator { .. }
         | InstructionValue::IteratorNext { .. }
         | InstructionValue::Debugger { .. }
+        | InstructionValue::TSEnumDeclaration { .. }
         | InstructionValue::FinishMemoize { .. } => {
             // No type equations for these
         }
@@ -1157,6 +1158,7 @@ fn apply_instruction_operands<'a>(
         | InstructionValue::DeclareContext { .. }
         | InstructionValue::RegExpLiteral { .. }
         | InstructionValue::MetaProperty { .. }
+        | InstructionValue::TSEnumDeclaration { .. }
         | InstructionValue::Debugger { .. } => {
             // No operand places
         }

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-block-scopes.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-block-scopes.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline-block-scopes.tsx
+---
+function Component() {
+	let first;
+	let second;
+	{
+		enum NumberValue {
+			Value = 1
+		}
+		first = NumberValue;
+	}
+	{
+		enum NumberValue {
+			Value = 2
+		}
+		second = NumberValue;
+	}
+	return <span>{first === second ? "same" : "different"}</span>;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: []
+};

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-captured-binding.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-captured-binding.snap
@@ -1,0 +1,19 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline-captured-binding.tsx
+---
+function Component(props: {
+	value: number;
+}) {
+	function Inner() {
+		enum NumberValue {
+			Value = props.value
+		}
+		return <span>{NumberValue.Value}</span>;
+	}
+	return <Inner />;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ value: 1 }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-member-mutation.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-member-mutation.snap
@@ -1,0 +1,36 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline-member-mutation.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+function Child(props) {
+	const $ = _c(2);
+	let t0;
+	if ($[0] !== props.items.length) {
+		t0 = <span>{props.items.length}</span>;
+		$[0] = props.items.length;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}
+function Component(props) {
+	const $ = _c(2);
+	enum Result {
+		Length = props.items.push(1)
+	}
+	let t0;
+	if ($[0] !== props.items) {
+		t0 = <Child items={props.items} />;
+		$[0] = props.items;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ items: [] }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-member-reference.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-member-reference.snap
@@ -1,0 +1,26 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline-member-reference.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+function Component(props) {
+	const $ = _c(2);
+	enum NumberValue {
+		First = 1,
+		Second = First
+	}
+	const t0 = NumberValue.Second + props.value;
+	let t1;
+	if ($[0] !== t0) {
+		t1 = <span>{t0}</span>;
+		$[0] = t0;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	return t1;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ value: 1 }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-merged.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-merged.snap
@@ -1,0 +1,26 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline-merged.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+function Component() {
+	const $ = _c(1);
+	enum NumberValue {
+		First = 1
+	}
+	enum NumberValue {
+		Second = 2
+	}
+	let t0;
+	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		t0 = <span>{NumberValue.First + NumberValue.Second}</span>;
+		$[0] = t0;
+	} else {
+		t0 = $[0];
+	}
+	return t0;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: []
+};

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-reactive-member.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-reactive-member.snap
@@ -1,0 +1,23 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline-reactive-member.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+function Component(props) {
+	const $ = _c(1);
+	enum NumberValue {
+		Value = props.value
+	}
+	let t0;
+	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		t0 = <span>{NumberValue.Value}</span>;
+		$[0] = t0;
+	} else {
+		t0 = $[0];
+	}
+	return t0;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ value: 1 }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-shadowed-local.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-shadowed-local.snap
@@ -1,0 +1,17 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline-shadowed-local.tsx
+---
+function Component(value: number) {
+	{
+		const value = 42;
+		enum NumberValue {
+			Value = value
+		}
+		return <span>{NumberValue.Value}</span>;
+	}
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [0]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-switch-case.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-switch-case.snap
@@ -1,0 +1,37 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline-switch-case.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+function Component(props) {
+	const $ = _c(2);
+	enum Action {
+		Select
+	}
+	switch (props.action) {
+		case String(Action.Select): {
+			let t0;
+			if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+				t0 = <span>selected</span>;
+				$[0] = t0;
+			} else {
+				t0 = $[0];
+			}
+			return t0;
+		}
+		default: {
+			let t0;
+			if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+				t0 = <span>unknown</span>;
+				$[1] = t0;
+			} else {
+				t0 = $[1];
+			}
+			return t0;
+		}
+	}
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ action: "0" }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-unused-side-effect.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-unused-side-effect.snap
@@ -1,0 +1,27 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline-unused-side-effect.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+function createValue(value: number): number {
+	return value;
+}
+function Component(props) {
+	const $ = _c(2);
+	enum Unused {
+		Value = createValue(props.value)
+	}
+	let t0;
+	if ($[0] !== props.value) {
+		t0 = <span>{props.value}</span>;
+		$[0] = props.value;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ value: 1 }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-write.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline-write.snap
@@ -1,0 +1,23 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline-write.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+function Component() {
+	const $ = _c(1);
+	enum Counter {
+		Value = count++
+	}
+	let t0;
+	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		t0 = <span>{0}</span>;
+		$[0] = t0;
+	} else {
+		t0 = $[0];
+	}
+	return t0;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: []
+};

--- a/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/ts-enum-inline.snap
@@ -2,16 +2,26 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/ts-enum-inline.tsx
 ---
+import { c as _c } from "react/compiler-runtime";
 function Component(props) {
+	const $ = _c(2);
 	enum Bool {
 		True = "true",
 		False = "false"
 	}
-	let bool: Bool = Bool.False;
+	let bool = Bool.False;
 	if (props.value) {
 		bool = Bool.True;
 	}
-	return <div>{bool}</div>;
+	let t0;
+	if ($[0] !== bool) {
+		t0 = <div>{bool}</div>;
+		$[0] = bool;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
 }
 export const FIXTURE_ENTRYPOINT = {
 	fn: Component,


### PR DESCRIPTION
Preserve inline TypeScript enums as opaque pass-through HIR nodes, matching upstream React Compiler behavior. Apply Oxc-specific raw AST reference renaming, and skip compilation when passthrough would hide nested captures or flatten block-local bindings.

AI-assisted: Codex was used to implement and validate this change.