### PR TITLE
feat(linter/unicorn): implement no-duplicate-logical-operands

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2978,6 +2978,13 @@ impl RuleRunner for crate::rules::react_perf::jsx_no_new_object_as_prop::JsxNoNe
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner
+    for crate::rules::unicorn::no_duplicate_logical_operands::NoDuplicateLogicalOperands
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::catch_error_name::CatchErrorName {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::CatchParameter]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -634,6 +634,7 @@ pub use crate::rules::unicorn::no_await_in_promise_methods::NoAwaitInPromiseMeth
 pub use crate::rules::unicorn::no_confusing_array_with::NoConfusingArrayWith as UnicornNoConfusingArrayWith;
 pub use crate::rules::unicorn::no_console_spaces::NoConsoleSpaces as UnicornNoConsoleSpaces;
 pub use crate::rules::unicorn::no_document_cookie::NoDocumentCookie as UnicornNoDocumentCookie;
+pub use crate::rules::unicorn::no_duplicate_logical_operands::NoDuplicateLogicalOperands as UnicornNoDuplicateLogicalOperands;
 pub use crate::rules::unicorn::no_empty_file::NoEmptyFile as UnicornNoEmptyFile;
 pub use crate::rules::unicorn::no_hex_escape::NoHexEscape as UnicornNoHexEscape;
 pub use crate::rules::unicorn::no_immediate_mutation::NoImmediateMutation as UnicornNoImmediateMutation;
@@ -1329,6 +1330,7 @@ pub enum RuleEnum {
     ReactPerfJsxNoNewArrayAsProp(ReactPerfJsxNoNewArrayAsProp),
     ReactPerfJsxNoNewFunctionAsProp(ReactPerfJsxNoNewFunctionAsProp),
     ReactPerfJsxNoNewObjectAsProp(ReactPerfJsxNoNewObjectAsProp),
+    UnicornNoDuplicateLogicalOperands(UnicornNoDuplicateLogicalOperands),
     UnicornCatchErrorName(UnicornCatchErrorName),
     UnicornConsistentAssert(UnicornConsistentAssert),
     UnicornConsistentDateClone(UnicornConsistentDateClone),
@@ -2237,7 +2239,9 @@ const REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID: usize =
     REACT_PERF_JSX_NO_NEW_ARRAY_AS_PROP_ID + 1usize;
 const REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID: usize =
     REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID + 1usize;
-const UNICORN_CATCH_ERROR_NAME_ID: usize = REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID + 1usize;
+const UNICORN_NO_DUPLICATE_LOGICAL_OPERANDS_ID: usize =
+    REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID + 1usize;
+const UNICORN_CATCH_ERROR_NAME_ID: usize = UNICORN_NO_DUPLICATE_LOGICAL_OPERANDS_ID + 1usize;
 const UNICORN_CONSISTENT_ASSERT_ID: usize = UNICORN_CATCH_ERROR_NAME_ID + 1usize;
 const UNICORN_CONSISTENT_DATE_CLONE_ID: usize = UNICORN_CONSISTENT_ASSERT_ID + 1usize;
 const UNICORN_CONSISTENT_EMPTY_ARRAY_SPREAD_ID: usize = UNICORN_CONSISTENT_DATE_CLONE_ID + 1usize;
@@ -2685,7 +2689,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 849usize] = [
+static RULE_NAMES: [&str; 850usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3144,6 +3148,7 @@ static RULE_NAMES: [&str; 849usize] = [
     ReactPerfJsxNoNewArrayAsProp::NAME,
     ReactPerfJsxNoNewFunctionAsProp::NAME,
     ReactPerfJsxNoNewObjectAsProp::NAME,
+    UnicornNoDuplicateLogicalOperands::NAME,
     UnicornCatchErrorName::NAME,
     UnicornConsistentAssert::NAME,
     UnicornConsistentDateClone::NAME,
@@ -4073,6 +4078,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => REACT_PERF_JSX_NO_NEW_ARRAY_AS_PROP_ID,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID,
+            Self::UnicornNoDuplicateLogicalOperands(_) => UNICORN_NO_DUPLICATE_LOGICAL_OPERANDS_ID,
             Self::UnicornCatchErrorName(_) => UNICORN_CATCH_ERROR_NAME_ID,
             Self::UnicornConsistentAssert(_) => UNICORN_CONSISTENT_ASSERT_ID,
             Self::UnicornConsistentDateClone(_) => UNICORN_CONSISTENT_DATE_CLONE_ID,
@@ -5079,6 +5085,9 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::CATEGORY,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::CATEGORY,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::CATEGORY,
+            Self::UnicornNoDuplicateLogicalOperands(_) => {
+                UnicornNoDuplicateLogicalOperands::CATEGORY
+            }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::CATEGORY,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::CATEGORY,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::CATEGORY,
@@ -6079,6 +6088,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::FIX,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::FIX,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::FIX,
+            Self::UnicornNoDuplicateLogicalOperands(_) => UnicornNoDuplicateLogicalOperands::FIX,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::FIX,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::FIX,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::FIX,
@@ -7166,6 +7176,9 @@ impl RuleEnum {
             }
             Self::ReactPerfJsxNoNewObjectAsProp(_) => {
                 ReactPerfJsxNoNewObjectAsProp::documentation()
+            }
+            Self::UnicornNoDuplicateLogicalOperands(_) => {
+                UnicornNoDuplicateLogicalOperands::documentation()
             }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::documentation(),
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::documentation(),
@@ -9051,6 +9064,10 @@ impl RuleEnum {
                 ReactPerfJsxNoNewObjectAsProp::config_schema(generator)
                     .or_else(|| ReactPerfJsxNoNewObjectAsProp::schema(generator))
             }
+            Self::UnicornNoDuplicateLogicalOperands(_) => {
+                UnicornNoDuplicateLogicalOperands::config_schema(generator)
+                    .or_else(|| UnicornNoDuplicateLogicalOperands::schema(generator))
+            }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::config_schema(generator)
                 .or_else(|| UnicornCatchErrorName::schema(generator)),
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::config_schema(generator)
@@ -10656,6 +10673,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => "react_perf",
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => "react_perf",
             Self::ReactPerfJsxNoNewObjectAsProp(_) => "react_perf",
+            Self::UnicornNoDuplicateLogicalOperands(_) => "unicorn",
             Self::UnicornCatchErrorName(_) => "unicorn",
             Self::UnicornConsistentAssert(_) => "unicorn",
             Self::UnicornConsistentDateClone(_) => "unicorn",
@@ -12606,6 +12624,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.to_configuration(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.to_configuration(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.to_configuration(),
+            Self::UnicornNoDuplicateLogicalOperands(rule) => rule.to_configuration(),
             Self::UnicornCatchErrorName(rule) => rule.to_configuration(),
             Self::UnicornConsistentAssert(rule) => rule.to_configuration(),
             Self::UnicornConsistentDateClone(rule) => rule.to_configuration(),
@@ -13462,6 +13481,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run(node, ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run(node, ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run(node, ctx),
+            Self::UnicornNoDuplicateLogicalOperands(rule) => rule.run(node, ctx),
             Self::UnicornCatchErrorName(rule) => rule.run(node, ctx),
             Self::UnicornConsistentAssert(rule) => rule.run(node, ctx),
             Self::UnicornConsistentDateClone(rule) => rule.run(node, ctx),
@@ -14328,6 +14348,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_once(ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_once(ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_once(ctx),
+            Self::UnicornNoDuplicateLogicalOperands(rule) => rule.run_once(ctx),
             Self::UnicornCatchErrorName(rule) => rule.run_once(ctx),
             Self::UnicornConsistentAssert(rule) => rule.run_once(ctx),
             Self::UnicornConsistentDateClone(rule) => rule.run_once(ctx),
@@ -15267,6 +15288,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoDuplicateLogicalOperands(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornCatchErrorName(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornConsistentAssert(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornConsistentDateClone(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16178,6 +16200,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.should_run(ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.should_run(ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.should_run(ctx),
+            Self::UnicornNoDuplicateLogicalOperands(rule) => rule.should_run(ctx),
             Self::UnicornCatchErrorName(rule) => rule.should_run(ctx),
             Self::UnicornConsistentAssert(rule) => rule.should_run(ctx),
             Self::UnicornConsistentDateClone(rule) => rule.should_run(ctx),
@@ -17220,6 +17243,9 @@ impl RuleEnum {
             }
             Self::ReactPerfJsxNoNewObjectAsProp(_) => {
                 ReactPerfJsxNoNewObjectAsProp::IS_TSGOLINT_RULE
+            }
+            Self::UnicornNoDuplicateLogicalOperands(_) => {
+                UnicornNoDuplicateLogicalOperands::IS_TSGOLINT_RULE
             }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::IS_TSGOLINT_RULE,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::IS_TSGOLINT_RULE,
@@ -18364,6 +18390,9 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::VERSION,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::VERSION,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::VERSION,
+            Self::UnicornNoDuplicateLogicalOperands(_) => {
+                UnicornNoDuplicateLogicalOperands::VERSION
+            }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::VERSION,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::VERSION,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::VERSION,
@@ -19408,6 +19437,9 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::HAS_CONFIG,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::HAS_CONFIG,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::HAS_CONFIG,
+            Self::UnicornNoDuplicateLogicalOperands(_) => {
+                UnicornNoDuplicateLogicalOperands::HAS_CONFIG
+            }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::HAS_CONFIG,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::HAS_CONFIG,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::HAS_CONFIG,
@@ -20431,6 +20463,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::INFO,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::INFO,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::INFO,
+            Self::UnicornNoDuplicateLogicalOperands(_) => UnicornNoDuplicateLogicalOperands::INFO,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::INFO,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::INFO,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::INFO,
@@ -21333,6 +21366,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.types_info(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.types_info(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.types_info(),
+            Self::UnicornNoDuplicateLogicalOperands(rule) => rule.types_info(),
             Self::UnicornCatchErrorName(rule) => rule.types_info(),
             Self::UnicornConsistentAssert(rule) => rule.types_info(),
             Self::UnicornConsistentDateClone(rule) => rule.types_info(),
@@ -22186,6 +22220,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_info(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_info(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_info(),
+            Self::UnicornNoDuplicateLogicalOperands(rule) => rule.run_info(),
             Self::UnicornCatchErrorName(rule) => rule.run_info(),
             Self::UnicornConsistentAssert(rule) => rule.run_info(),
             Self::UnicornConsistentDateClone(rule) => rule.run_info(),
@@ -23131,6 +23166,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactPerfJsxNoNewArrayAsProp(ReactPerfJsxNoNewArrayAsProp::default()),
         RuleEnum::ReactPerfJsxNoNewFunctionAsProp(ReactPerfJsxNoNewFunctionAsProp::default()),
         RuleEnum::ReactPerfJsxNoNewObjectAsProp(ReactPerfJsxNoNewObjectAsProp::default()),
+        RuleEnum::UnicornNoDuplicateLogicalOperands(UnicornNoDuplicateLogicalOperands::default()),
         RuleEnum::UnicornCatchErrorName(UnicornCatchErrorName::default()),
         RuleEnum::UnicornConsistentAssert(UnicornConsistentAssert::default()),
         RuleEnum::UnicornConsistentDateClone(UnicornConsistentDateClone::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -519,6 +519,7 @@ pub(crate) mod unicorn {
     pub mod no_confusing_array_with;
     pub mod no_console_spaces;
     pub mod no_document_cookie;
+    pub mod no_duplicate_logical_operands;
     pub mod no_empty_file;
     pub mod no_hex_escape;
     pub mod no_immediate_mutation;

--- a/crates/oxc_linter/src/rules/unicorn/no_duplicate_logical_operands.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_duplicate_logical_operands.rs
@@ -1,0 +1,239 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use oxc_syntax::operator::LogicalOperator;
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::is_same_expression};
+
+fn no_duplicate_logical_operands_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("This operand duplicates the left operand.")
+        .with_help("Remove the duplicate operand.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDuplicateLogicalOperands;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow adjacent duplicate operands in `&&` and `||` expressions.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Repeating an operand next to itself has no effect on the result, so the
+    /// duplicate is either dead code or a typo hiding the operand that was meant
+    /// to be there.
+    ///
+    /// Only side-effect-free references are compared, because repeating an
+    /// expression that can have side effects, such as `getValue() && getValue()`,
+    /// is not necessarily redundant.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// foo && foo
+    /// foo || bar || bar
+    /// foo.bar && foo.bar
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// foo && bar
+    /// foo && bar && foo
+    /// getValue() && getValue()
+    /// foo ?? foo
+    /// ```
+    NoDuplicateLogicalOperands,
+    unicorn,
+    suspicious,
+    fix_conditional,
+    version = "next",
+    short_description = "Disallow adjacent duplicate operands in logical expressions.",
+);
+
+/// A computed property that is stable enough to compare, e.g. the `bar` in `foo[bar]`.
+fn is_simple_computed_property(expr: &Expression) -> bool {
+    matches!(
+        expr.get_inner_expression(),
+        Expression::Identifier(_)
+            | Expression::ThisExpression(_)
+            | Expression::StringLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_)
+            | Expression::BigIntLiteral(_)
+            | Expression::RegExpLiteral(_)
+    )
+}
+
+/// A reference that can be repeated without side effects, e.g. `foo`, `this.foo`, `foo[bar].baz`.
+///
+/// Optional chains are excluded: `foo?.bar` short-circuits, so the second operand is not
+/// guaranteed to evaluate the same way as the first.
+fn is_simple_reference(expr: &Expression) -> bool {
+    match expr.get_inner_expression() {
+        Expression::Identifier(_) | Expression::ThisExpression(_) | Expression::Super(_) => true,
+        Expression::StaticMemberExpression(member) => {
+            !member.optional && is_simple_reference(&member.object)
+        }
+        Expression::ComputedMemberExpression(member) => {
+            !member.optional
+                && is_simple_reference(&member.object)
+                && is_simple_computed_property(&member.expression)
+        }
+        Expression::PrivateFieldExpression(member) => {
+            !member.optional && is_simple_reference(&member.object)
+        }
+        _ => false,
+    }
+}
+
+/// Replacing the whole expression with its left operand is only safe when it cannot change
+/// what a bare identifier resolves to, so bail out inside `with`.
+fn is_inside_with_statement(node: &AstNode, ctx: &LintContext) -> bool {
+    ctx.nodes()
+        .ancestors(node.id())
+        .any(|ancestor| matches!(ancestor.kind(), AstKind::WithStatement(_)))
+}
+
+impl Rule for NoDuplicateLogicalOperands {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::LogicalExpression(logical_expr) = node.kind() else {
+            return;
+        };
+
+        if !matches!(logical_expr.operator, LogicalOperator::And | LogicalOperator::Or) {
+            return;
+        }
+
+        // `a && b && c` parses as `(a && b) && c`, so the operand adjacent to `c` is `b`.
+        // Only the adjacent pair is compared, which is why `foo && bar && foo` is allowed.
+        let adjacent_left_operand = match logical_expr.left.without_parentheses() {
+            Expression::LogicalExpression(left_logical_expr)
+                if left_logical_expr.operator == logical_expr.operator =>
+            {
+                &left_logical_expr.right
+            }
+            _ => &logical_expr.left,
+        };
+
+        if !is_simple_reference(adjacent_left_operand)
+            || !is_simple_reference(&logical_expr.right)
+            || !is_same_expression(
+                adjacent_left_operand.get_inner_expression(),
+                logical_expr.right.get_inner_expression(),
+                ctx,
+            )
+            || is_inside_with_statement(node, ctx)
+        {
+            return;
+        }
+
+        let diagnostic = no_duplicate_logical_operands_diagnostic(logical_expr.right.span());
+
+        // The fix drops everything but the left operand, so every comment in the expression
+        // has to already live inside that operand or it would be deleted with the duplicate.
+        let comments_in_expression =
+            ctx.comments_range(logical_expr.span.start..logical_expr.span.end).count();
+        let comments_in_left_operand = ctx
+            .comments_range(logical_expr.left.span().start..logical_expr.left.span().end)
+            .count();
+
+        if comments_in_expression != comments_in_left_operand
+            || !is_safely_autofixable(adjacent_left_operand)
+            || !is_safely_autofixable(&logical_expr.right)
+        {
+            ctx.diagnostic(diagnostic);
+            return;
+        }
+
+        ctx.diagnostic_with_fix(diagnostic, |fixer| {
+            fixer.replace_with(&logical_expr.span, &logical_expr.left.span())
+        });
+    }
+}
+
+/// Member expressions are left alone because a getter can make `foo.bar` observable, so
+/// deleting the second read is a behaviour change rather than a cleanup.
+fn is_safely_autofixable(expr: &Expression) -> bool {
+    matches!(expr.without_parentheses(), Expression::Identifier(_) | Expression::ThisExpression(_))
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "foo && bar",
+        "foo || bar",
+        "foo && bar && foo",
+        "foo && (foo && bar)",
+        "foo ?? foo",
+        "getValue() && getValue()",
+        "getValue() || getValue()",
+        "foo.bar() && foo.bar()",
+        "foo + bar && foo + bar",
+        "await foo && await foo",
+        "foo++ && foo++",
+        "(foo = bar) && (foo = bar)",
+        "foo[bar()] && foo[bar()]",
+        "foo[bar + baz] || foo[bar + baz]",
+        "foo?.bar && foo?.bar",
+        "foo?.[bar] || foo?.[bar]",
+        "true && true",
+        "0 || 0",
+        "with (scope) {foo && foo;}", // {"sourceType": "script"}
+    ];
+
+    let fail = vec![
+        "foo && foo",
+        "foo || foo",
+        "foo && bar && bar",
+        "foo || bar || bar",
+        "(foo) && (foo)",
+        "this && this",
+        "foo.bar && foo.bar",
+        "foo.bar || foo.bar",
+        "foo.bar.baz && foo.bar.baz",
+        "foo && bar.baz && bar.baz",
+        "this.foo && this.foo",
+        "class Foo {#foo; method() {return this.#foo && this.#foo;}}",
+        "class Foo extends Bar {method() {return super.foo && super.foo;}}",
+        "foo[bar] && foo[bar]",
+        r#"foo["bar"] || foo.bar"#,
+        "(foo as boolean) && (foo as boolean)", // {"parser": parsers.typescript},
+        "(foo as Foo) && (foo as Bar)",         // {"parser": parsers.typescript},
+        "foo && (foo as Foo)",                  // {"parser": parsers.typescript},
+        "(<boolean>foo) && (<boolean>foo)",     // {"parser": parsers.typescript},
+        "foo! || foo!",                         // {"parser": parsers.typescript},
+        "foo! && foo",                          // {"parser": parsers.typescript},
+        "foo && foo!",                          // {"parser": parsers.typescript},
+        "(foo satisfies boolean) && (foo satisfies boolean)", // {"parser": parsers.typescript},
+        "foo && (foo satisfies Foo)",           // {"parser": parsers.typescript},
+        "foo /* keep */ && foo",
+        "foo && /* keep */ foo",
+        "foo && bar /* keep */ && bar",
+        "foo && (foo /* keep */)",
+        "(foo /* keep */) && foo",
+    ];
+
+    let fix = vec![
+        ("foo && foo", "foo"),
+        ("foo || foo", "foo"),
+        ("foo && bar && bar", "foo && bar"),
+        ("(foo) && (foo)", "(foo)"),
+        ("this && this", "this"),
+        // Member expressions are reported but not fixed, a getter could be observable.
+        ("foo.bar && foo.bar", "foo.bar && foo.bar"),
+        // Comments outside the left operand would be dropped by the fix.
+        ("foo && /* keep */ foo", "foo && /* keep */ foo"),
+        ("foo /* keep */ && foo", "foo /* keep */ && foo"),
+    ];
+
+    Tester::new(NoDuplicateLogicalOperands::NAME, NoDuplicateLogicalOperands::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_no_duplicate_logical_operands.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_duplicate_logical_operands.snap
@@ -1,0 +1,205 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:8]
+ 1 │ foo && foo
+   ·        ───
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:8]
+ 1 │ foo || foo
+   ·        ───
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:15]
+ 1 │ foo && bar && bar
+   ·               ───
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:15]
+ 1 │ foo || bar || bar
+   ·               ───
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:10]
+ 1 │ (foo) && (foo)
+   ·          ─────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:9]
+ 1 │ this && this
+   ·         ────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:12]
+ 1 │ foo.bar && foo.bar
+   ·            ───────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:12]
+ 1 │ foo.bar || foo.bar
+   ·            ───────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:16]
+ 1 │ foo.bar.baz && foo.bar.baz
+   ·                ───────────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:19]
+ 1 │ foo && bar.baz && bar.baz
+   ·                   ───────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:13]
+ 1 │ this.foo && this.foo
+   ·             ────────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:48]
+ 1 │ class Foo {#foo; method() {return this.#foo && this.#foo;}}
+   ·                                                ─────────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:54]
+ 1 │ class Foo extends Bar {method() {return super.foo && super.foo;}}
+   ·                                                      ─────────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:13]
+ 1 │ foo[bar] && foo[bar]
+   ·             ────────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:15]
+ 1 │ foo["bar"] || foo.bar
+   ·               ───────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:21]
+ 1 │ (foo as boolean) && (foo as boolean)
+   ·                     ────────────────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:17]
+ 1 │ (foo as Foo) && (foo as Bar)
+   ·                 ────────────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:8]
+ 1 │ foo && (foo as Foo)
+   ·        ────────────
+   ╰────
+  help: Remove the duplicate operand.
+
+  × Unexpected token
+   ╭─[no_duplicate_logical_operands.tsx:1:29]
+ 1 │ (<boolean>foo) && (<boolean>foo)
+   ·                             ────
+   ╰────
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:9]
+ 1 │ foo! || foo!
+   ·         ────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:9]
+ 1 │ foo! && foo
+   ·         ───
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:8]
+ 1 │ foo && foo!
+   ·        ────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:28]
+ 1 │ (foo satisfies boolean) && (foo satisfies boolean)
+   ·                            ───────────────────────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:8]
+ 1 │ foo && (foo satisfies Foo)
+   ·        ───────────────────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:19]
+ 1 │ foo /* keep */ && foo
+   ·                   ───
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:19]
+ 1 │ foo && /* keep */ foo
+   ·                   ───
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:26]
+ 1 │ foo && bar /* keep */ && bar
+   ·                          ───
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:8]
+ 1 │ foo && (foo /* keep */)
+   ·        ────────────────
+   ╰────
+  help: Remove the duplicate operand.
+
+  ⚠ unicorn(no-duplicate-logical-operands): This operand duplicates the left operand.
+   ╭─[no_duplicate_logical_operands.tsx:1:21]
+ 1 │ (foo /* keep */) && foo
+   ·                     ───
+   ╰────
+  help: Remove the duplicate operand.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9049,6 +9049,9 @@
         "unicorn/no-document-cookie": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/no-duplicate-logical-operands": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "unicorn/no-empty-file": {
           "$ref": "#/definitions/RuleNoConfig"
         },


### PR DESCRIPTION
Implements `unicorn/no-duplicate-logical-operands`, tracked in #684.

The rule flags an operand of `&&` or `||` that duplicates the operand immediately to its left, e.g. `foo && foo` or `foo || bar || bar`.

Only adjacent operands are compared, so `foo && bar && foo` is allowed, and only side-effect-free references are considered, so `getValue() && getValue()` and `foo?.bar && foo?.bar` are not reported. `??` is out of scope, matching upstream.

The fix replaces the expression with its left operand. It is applied only when both operands are a bare identifier or `this`, and only when every comment in the expression already sits inside that left operand; otherwise the duplicate is reported without a fix. Member expressions are reported but not fixed, since a getter can make the second read observable. Upstream offers a suggestion in that case, which this implementation does not.

Pass and fail cases are the upstream test corpus imported by `just new-unicorn-rule` — 19 pass, 29 fail.

### Test

```
cargo test -p oxc_linter no_duplicate_logical_operands   # 1 passed
cargo clippy -p oxc_linter --all-targets -- -D warnings  # clean
```

---

AI assistance was used to write this change (Claude Code). I have reviewed the diff and the upstream rule semantics it is based on.
