### PR TITLE
fix(linter): allow spread rule options in config types

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -925,7 +925,7 @@ export interface DummyRuleMap {
   "grouped-accessor-pairs"?:
     RuleNoConfig | [AllowWarnDeny, PairOrder] | [AllowWarnDeny, PairOrder, GroupedAccessorPairsConfig];
   "guard-for-in"?: RuleNoConfig;
-  "id-denylist"?: RuleNoConfig | [AllowWarnDeny, string, ...string[]];
+  "id-denylist"?: RuleNoConfig | [AllowWarnDeny, ...string[]];
   "id-length"?: RuleNoConfig | [AllowWarnDeny, IdLengthConfig];
   "id-match"?: RuleNoConfig | [AllowWarnDeny, string] | [AllowWarnDeny, string, IdMatchOptions];
   "import/consistent-type-specifier-style"?: RuleNoConfig | [AllowWarnDeny, Mode];
@@ -1203,11 +1203,9 @@ export interface DummyRuleMap {
   "no-redeclare"?: RuleNoConfig | [AllowWarnDeny, NoRedeclare];
   "no-regex-spaces"?: RuleNoConfig;
   "no-restricted-exports"?: RuleNoConfig | [AllowWarnDeny, NoRestrictedExportsConfig];
-  "no-restricted-globals"?:
-    RuleNoConfig | [AllowWarnDeny, NoRestrictedGlobalsConfigEnum, ...NoRestrictedGlobalsConfigEnum[]];
-  "no-restricted-imports"?:
-    RuleNoConfig | [AllowWarnDeny, NoRestrictedImportsConfigEnum, ...NoRestrictedImportsConfigEnum[]];
-  "no-restricted-properties"?: RuleNoConfig | [AllowWarnDeny, PropertyDetails, ...PropertyDetails[]];
+  "no-restricted-globals"?: RuleNoConfig | [AllowWarnDeny, ...NoRestrictedGlobalsConfigEnum[]];
+  "no-restricted-imports"?: RuleNoConfig | [AllowWarnDeny, ...NoRestrictedImportsConfigEnum[]];
+  "no-restricted-properties"?: RuleNoConfig | [AllowWarnDeny, ...PropertyDetails[]];
   "no-return-assign"?: RuleNoConfig | [AllowWarnDeny, NoReturnAssignMode];
   "no-script-url"?: RuleNoConfig;
   "no-self-assign"?: RuleNoConfig | [AllowWarnDeny, NoSelfAssign];

--- a/apps/oxlint/test/config.test-d.ts
+++ b/apps/oxlint/test/config.test-d.ts
@@ -13,3 +13,9 @@ defineConfig({
     ],
   },
 });
+
+defineConfig({
+  rules: {
+    "no-restricted-globals": ["warn", ...restrictedGlobals],
+  },
+});

--- a/apps/oxlint/test/config.test-d.ts
+++ b/apps/oxlint/test/config.test-d.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "../src-js/package/config.ts";
+
+const restrictedGlobals = ["addEventListener", "blur", "screen"];
+
+defineConfig({
+  rules: {
+    "no-restricted-globals": [
+      "warn",
+      ...restrictedGlobals.map((name) => ({
+        name,
+        message: `Use globalThis.${name} if intentional.`,
+      })),
+    ],
+  },
+});

--- a/apps/oxlint/test/fixtures/js_config_config_options_spread_valid/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_config_options_spread_valid/output.snap.md
@@ -1,0 +1,12 @@
+# Exit code
+1
+
+# stdout
+```
+No files found to lint. Please check your paths and ignore patterns.
+Finished in Xms on 0 files with 97 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/js_config_config_options_spread_valid/oxlint.config.mts
+++ b/apps/oxlint/test/fixtures/js_config_config_options_spread_valid/oxlint.config.mts
@@ -1,8 +1,8 @@
-import { defineConfig } from "../src-js/package/config.ts";
+import { defineConfig } from "#oxlint";
 
 const restrictedGlobals = ["addEventListener", "blur", "screen"];
 
-defineConfig({
+export default defineConfig({
   rules: {
     "no-restricted-globals": [
       "warn",

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -445,8 +445,6 @@ impl JsonSchema for OxlintRules {
                                 "Expected rule to not contain items and additionalItems at the same time"
                             );
                             if array.additional_items.is_some() {
-                                // Options may come from an empty spread, while the severity-only
-                                // form is already valid through `RuleNoConfig`.
                                 array.items = Some(SingleOrVec::Vec(vec![
                                     r#gen.subschema_for::<AllowWarnDeny>(),
                                 ]));

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -444,12 +444,13 @@ impl JsonSchema for OxlintRules {
                                 array.items.is_none() || array.additional_items.is_none(),
                                 "Expected rule to not contain items and additionalItems at the same time"
                             );
-                            if let Some(ref additional_items) = array.additional_items {
+                            if array.additional_items.is_some() {
+                                // Options may come from an empty spread, while the severity-only
+                                // form is already valid through `RuleNoConfig`.
                                 array.items = Some(SingleOrVec::Vec(vec![
                                     r#gen.subschema_for::<AllowWarnDeny>(),
-                                    *additional_items.clone(),
                                 ]));
-                                array.min_items = Some(2);
+                                array.min_items = Some(1);
                                 array.max_items = None;
                                 return Schema::Object(obj);
                             }

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2563,15 +2563,12 @@
               "items": [
                 {
                   "$ref": "#/definitions/AllowWarnDeny"
-                },
-                {
-                  "type": "string"
                 }
               ],
               "additionalItems": {
                 "type": "string"
               },
-              "minItems": 2,
+              "minItems": 1,
               "uniqueItems": true
             }
           ]
@@ -5218,15 +5215,12 @@
               "items": [
                 {
                   "$ref": "#/definitions/AllowWarnDeny"
-                },
-                {
-                  "$ref": "#/definitions/NoRestrictedGlobalsConfigEnum"
                 }
               ],
               "additionalItems": {
                 "$ref": "#/definitions/NoRestrictedGlobalsConfigEnum"
               },
-              "minItems": 2
+              "minItems": 1
             }
           ]
         },
@@ -5239,15 +5233,12 @@
               "items": [
                 {
                   "$ref": "#/definitions/AllowWarnDeny"
-                },
-                {
-                  "$ref": "#/definitions/NoRestrictedImportsConfigEnum"
                 }
               ],
               "additionalItems": {
                 "$ref": "#/definitions/NoRestrictedImportsConfigEnum"
               },
-              "minItems": 2
+              "minItems": 1
             }
           ]
         },
@@ -5260,15 +5251,12 @@
               "items": [
                 {
                   "$ref": "#/definitions/AllowWarnDeny"
-                },
-                {
-                  "$ref": "#/definitions/PropertyDetails"
                 }
               ],
               "additionalItems": {
                 "$ref": "#/definitions/PropertyDetails"
               },
-              "minItems": 2
+              "minItems": 1
             }
           ]
         },


### PR DESCRIPTION
## Summary

- represent variadic rule options as a severity followed by zero or more option values
- regenerate the Oxlint configuration schema and TypeScript declarations
- add a type-level regression for mapped options spread into `no-restricted-globals`

## Root cause

The schema wrapper materialized the first `additionalItems` entry as a required tuple element and set `minItems` to 2. A dynamic TypeScript spread has type `T[]` and may be empty, so it cannot satisfy that required position even though the severity-only form is already valid through `RuleNoConfig`.

Keeping severity as the only fixed tuple item and leaving the rule options in `additionalItems` generates `[severity, ...options]`, which accepts both an empty spread and populated spreads without changing runtime rule behavior.

Closes #25666

## Validation

- `node node_modules/.pnpm/typescript@6.0.3/node_modules/typescript/bin/tsc --noEmit --strict --skipLibCheck --target ESNext --module Preserve --moduleResolution Bundler --allowImportingTsExtensions apps/oxlint/test/config.test-d.ts --pretty false`
- `cargo test -p website_linter test_schema_json`
- `cargo test -p oxc_linter --features ruledocs config::rules`
- `cargo clippy -p oxc_linter --features ruledocs -- -D warnings`
- `cargo fmt --all -- --check`
- `pnpm exec oxfmt -c oxfmtrc.jsonc --check apps/oxlint/test/config.test-d.ts apps/oxlint/src-js/package/config.generated.ts`

## AI assistance

Implemented with assistance from OpenAI Codex. The contributor remains responsible for reviewing, understanding, and submitting the change under the repository AI usage policy.