### PR TITLE
fix(transform-react): match Babel v1 source filtering

### DIFF
--- a/napi/transform-react/src/options.rs
+++ b/napi/transform-react/src/options.rs
@@ -271,7 +271,9 @@ impl TransformOptions {
         filename: &str,
     ) -> Result<(Option<PluginOptions>, oxc::transformer::TransformOptions), OxcDiagnostic> {
         let react_compiler = match self.react_compiler {
-            None | Some(Either::A(true)) => Some(PluginOptions::default()),
+            None | Some(Either::A(true)) => {
+                (!filename.contains("node_modules")).then(PluginOptions::default)
+            }
             Some(Either::A(false)) => None,
             Some(Either::B(options)) => options.resolve(filename)?,
         };
@@ -297,10 +299,10 @@ impl TransformOptions {
 
 impl ReactCompilerOptions {
     fn resolve(self, filename: &str) -> Result<Option<PluginOptions>, OxcDiagnostic> {
-        let enabled = self
-            .sources
-            .as_ref()
-            .is_none_or(|sources| sources.iter().any(|source| filename.contains(source.as_str())));
+        let enabled = self.sources.as_ref().map_or_else(
+            || !filename.contains("node_modules"),
+            |sources| sources.iter().any(|source| filename.contains(source.as_str())),
+        );
         enabled.then(|| self.into_plugin_options()).transpose()
     }
 

--- a/napi/transform-react/test/fixtures/source-filter-component.tsx
+++ b/napi/transform-react/test/fixtures/source-filter-component.tsx
@@ -1,0 +1,6 @@
+import { useState } from "react";
+
+export function SourceFilterComponent({ label }: { label: string }) {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount(count + 1)}>{label}: {count}</button>;
+}

--- a/napi/transform-react/test/transform.test.ts
+++ b/napi/transform-react/test/transform.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import { transform, transformSync } from "../index";
@@ -14,6 +16,11 @@ export function Component(props: Props) {
   return <button onClick={() => setCount(count + 1)}>{props.text}: {count}</button>;
 }
 `;
+
+const sourceFilterFixture = readFileSync(
+  new URL("./fixtures/source-filter-component.tsx", import.meta.url),
+  "utf8",
+);
 
 describe("transformSync", () => {
   it("runs React Compiler before TypeScript and JSX transforms", () => {
@@ -166,6 +173,26 @@ export function Component({ value }: { value: string }) {
     expect(result.code).not.toContain("react/compiler-runtime");
     expect(result.code).not.toContain("interface Props");
     expect(result.code).not.toContain("<button");
+  });
+
+  it.each([
+    ["omitted options", undefined],
+    ["boolean shorthand", { reactCompiler: true }],
+    ["empty options", { reactCompiler: {} }],
+  ] as const)("skips node_modules with %s", (_, options) => {
+    const filename = "node_modules/example/Component.tsx";
+    const skipped = transformSync(filename, sourceFilterFixture, options);
+    expect(skipped.errors).toEqual([]);
+    expect(skipped.code).not.toContain("react/compiler-runtime");
+  });
+
+  it("allows node_modules through an explicit source", () => {
+    const filename = "node_modules/example/Component.tsx";
+    const compiled = transformSync(filename, sourceFilterFixture, {
+      reactCompiler: { sources: ["node_modules/example/"] },
+    });
+    expect(compiled.errors).toEqual([]);
+    expect(compiled.code).toContain("react/compiler-runtime");
   });
 
   it("keeps imports used by compiled computed keys", () => {


### PR DESCRIPTION
Skip `node_modules` by default across the public React Compiler option forms, while preserving explicit `sources` opt-in behavior from babel-plugin-react-compiler 1.0.

Validated with a file-backed NAPI fixture, native package tests, Clippy, and `just ready`.

AI-assisted investigation and implementation; reviewed and understood by the contributor.