### PR TITLE
fix(react-compiler): preserve tagged template runtime semantics

### DIFF
--- a/crates/oxc_react_compiler/fixtures/memoize-tagged-template-before-consumer.tsx
+++ b/crates/oxc_react_compiler/fixtures/memoize-tagged-template-before-consumer.tsx
@@ -1,0 +1,4 @@
+// @compilationMode:"infer" @panicThreshold:"none"
+export function Component({tag, consume}) {
+  return consume(tag`value`);
+}

--- a/crates/oxc_react_compiler/fixtures/tagged-template-mutable-result.js
+++ b/crates/oxc_react_compiler/fixtures/tagged-template-mutable-result.js
@@ -1,17 +1,23 @@
 // @compilationMode:annotation
-function tag(strings, value) {
-  return {value};
+const shared = {
+  value: 0,
+  toString() {
+    return this.value;
+  },
+};
+function tag() {
+  return shared;
 }
 
-function Component({value}) {
+function Component({tag}) {
   'use memo';
-  const result = tag`${value}`;
+  const result = tag`value`;
   result.value++;
-  return result.value;
+  return result + '';
 }
 
 export const FIXTURE_ENTRYPOINT = {
   fn: Component,
-  params: [{value: 1}],
-  sequentialRenders: [{value: 1}, {value: 1}],
+  params: [{tag}],
+  sequentialRenders: [{tag}, {tag}],
 };

--- a/crates/oxc_react_compiler/fixtures/tagged-template-primitive-result-mutation.js
+++ b/crates/oxc_react_compiler/fixtures/tagged-template-primitive-result-mutation.js
@@ -1,0 +1,17 @@
+// @compilationMode:annotation
+function Component({initial}) {
+  'use memo';
+  const object = {value: initial};
+  function tag() {
+    object.value++;
+    return 0;
+  }
+  tag`value`;
+  return object.value;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{initial: 0}],
+  sequentialRenders: [{initial: 0}, {initial: 0}],
+};

--- a/crates/oxc_react_compiler/fixtures/type-provider-tagged-template-expression.js
+++ b/crates/oxc_react_compiler/fixtures/type-provider-tagged-template-expression.js
@@ -1,24 +1,5 @@
-import {graphql} from 'shared-runtime';
+import {tag} from 'ReactCompilerPureTagTest';
 
-export function Component({a, b}) {
-  const fragment = graphql`
-    fragment Foo on User {
-      name
-    }
-  `;
-  return <div>{fragment}</div>;
+export function Component() {
+  return tag`value`;
 }
-
-export const FIXTURE_ENTRYPOINT = {
-  fn: Component,
-  params: [{a: 0, b: 0}],
-  sequentialRenders: [
-    {a: 0, b: 0},
-    {a: 1, b: 0},
-    {a: 1, b: 1},
-    {a: 1, b: 2},
-    {a: 2, b: 2},
-    {a: 3, b: 2},
-    {a: 0, b: 0},
-  ],
-};

--- a/crates/oxc_react_compiler/src/react_compiler_inference/flatten_scopes_with_hooks_or_use_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/flatten_scopes_with_hooks_or_use_hir.rs
@@ -19,10 +19,16 @@
 //! reasoning is slightly different for each, the result is that we can't memoize scopes that call
 //! hooks or use since this would make them called conditionally in the output.
 //!
-//! The pass finds and removes any scopes that transitively contain a hook or use call. By running all
-//! the reactive scope inference first, agnostic of hooks, we know that the reactive scopes accurately
+//! Opaque tagged templates also have to execute unconditionally. A tag is an arbitrary function
+//! call that may have side effects or return a fresh value or stable alias. Inferred result types
+//! cannot prove otherwise because consumers such as coercive binary operators may constrain an
+//! opaque result to `Primitive`. A configured read-only, pure signature with a known safe return is
+//! sufficient evidence to retain memoization.
+//!
+//! The pass finds and removes any scopes that transitively contain one of these instructions. By
+//! running all the reactive scope inference first, we know that the reactive scopes accurately
 //! describe the set of values which "construct together", and remove _all_ that memoization in order
-//! to ensure the hook call does not inadvertently become conditional.
+//! to ensure the instruction does not inadvertently become conditional.
 //!
 //! Analogous to TS `ReactiveScopes/FlattenScopesWithHooksOrUseHIR.ts`.
 
@@ -33,11 +39,14 @@ use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
     BlockId, HirFunction, InstructionValue, Terminal, Type, is_use_operator_type,
 };
+use crate::react_compiler_inference::is_known_pure_tagged_template;
 
-/// Flattens reactive scopes that contain hook calls or `use()` calls.
+/// Flattens reactive scopes that contain hook calls, `use()` calls, or tagged templates.
 ///
-/// Hooks and `use` must be called unconditionally, so any reactive scope containing
-/// such a call must be flattened to avoid making the call conditional.
+/// Hooks and `use` must be called unconditionally. Tagged templates without a known pure signature
+/// must also be recomputed because their inferred result type cannot establish that the call is pure
+/// or that its result is stable. Any reactive scope containing such an instruction must therefore
+/// be flattened to avoid making its evaluation conditional.
 pub fn flatten_scopes_with_hooks_or_use_hir(
     func: &mut HirFunction,
     env: &Environment,
@@ -54,15 +63,20 @@ pub fn flatten_scopes_with_hooks_or_use_hir(
 
         let block = &func.body.blocks[block_id];
 
-        // Check instructions for hook or use calls
+        // Check instructions that must execute unconditionally.
         for instr_id in &block.instructions {
             let instr = &func.instructions[instr_id.index()];
             match &instr.value {
-                InstructionValue::CallExpression { callee, .. }
-                | InstructionValue::TaggedTemplateExpression { tag: callee, .. } => {
+                InstructionValue::CallExpression { callee, .. } => {
                     let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                     if is_hook_or_use(env, callee_ty)? {
                         // All active scopes must be pruned
+                        prune.extend(active_scopes.iter().map(|s| s.block));
+                        active_scopes.clear();
+                    }
+                }
+                InstructionValue::TaggedTemplateExpression { tag, subexprs, .. } => {
+                    if !is_known_pure_tagged_template(env, tag, subexprs.len()) {
                         prune.extend(active_scopes.iter().map(|s| s.block));
                         active_scopes.clear();
                     }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -2081,10 +2081,10 @@ fn compute_signature_for_instruction<'a>(
             effects.push(AliasingEffect::Capture { from: *await_value, into: *lvalue });
         }
         InstructionValue::TaggedTemplateExpression { tag, subexprs, span, .. } => {
-            // A tagged template is a function call whose first argument is the
-            // call-site's frozen template object, followed by the interpolated
-            // expressions. There is no HIR place for the implicit template object,
-            // so preserve its parameter position with a hole.
+            // A primitive return type does not imply that invoking the tag is pure. Always retain
+            // call/aliasing effects so mutations of captured values remain in the same scope. A
+            // later pass flattens the containing scope unless the configured function signature
+            // independently proves the call safe to memoize.
             let mut args = ArenaVec::new_in(&alloc);
             args.push(PlaceOrSpreadOrHole::Hole);
             args.extend(subexprs.iter().copied().map(PlaceOrSpreadOrHole::Place));

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
@@ -11,8 +11,9 @@
 //! 1. Props (component parameters may change between renders)
 //! 2. Hooks (can access state or context)
 //! 3. `use` operator (can access context)
-//! 4. Mutation with reactive operands
-//! 5. Conditional assignment based on reactive control flow
+//! 4. Tagged templates (calls may produce a new result with stable operands)
+//! 5. Mutation with reactive operands
+//! 6. Conditional assignment based on reactive control flow
 
 use oxc_diagnostics::OxcDiagnostic;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -141,14 +142,19 @@ pub fn infer_reactive_places(
 
                 // Hooks and `use` operator are sources of reactivity
                 match value {
-                    InstructionValue::CallExpression { callee, .. }
-                    | InstructionValue::TaggedTemplateExpression { tag: callee, .. } => {
+                    InstructionValue::CallExpression { callee, .. } => {
                         let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                         if get_hook_kind_for_type(env, callee_ty)?.is_some()
                             || is_use_operator_type(callee_ty)
                         {
                             has_reactive_input = true;
                         }
+                    }
+                    InstructionValue::TaggedTemplateExpression { .. } => {
+                        // A tag may produce a new result even when its explicit operands are
+                        // stable. Proven-pure tags retain the resulting scope; other tags have it
+                        // flattened later so the call remains unconditional.
+                        has_reactive_input = true;
                     }
                     InstructionValue::MethodCall { property, .. } => {
                         let property_ty = &env.types[env.identifiers[property.identifier].type_];
@@ -585,14 +591,17 @@ fn apply_reactive_flags_replay(
 
             // Check hooks/use
             match &instr.value {
-                InstructionValue::CallExpression { callee, .. }
-                | InstructionValue::TaggedTemplateExpression { tag: callee, .. } => {
+                InstructionValue::CallExpression { callee, .. } => {
                     let callee_ty = &env.types[env.identifiers[callee.identifier].type_];
                     if get_hook_kind_for_type(env, callee_ty).ok().flatten().is_some()
                         || is_use_operator_type(callee_ty)
                     {
                         has_reactive_input = true;
                     }
+                }
+                InstructionValue::TaggedTemplateExpression { .. } => {
+                    // Mirror the fixpoint rule above when writing the final reactive flags.
+                    has_reactive_input = true;
                 }
                 InstructionValue::MethodCall { property, .. } => {
                     let property_ty = &env.types[env.identifiers[property.identifier].type_];

--- a/crates/oxc_react_compiler/src/react_compiler_inference/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/mod.rs
@@ -27,3 +27,42 @@ pub use infer_reactive_scope_variables::infer_reactive_scope_variables;
 pub use memoize_fbt_and_macro_operands_in_same_scope::memoize_fbt_and_macro_operands_in_same_scope;
 pub use merge_overlapping_reactive_scopes_hir::merge_overlapping_reactive_scopes_hir;
 pub use propagate_scope_dependencies_hir::propagate_scope_dependencies_hir;
+
+use crate::react_compiler_hir::environment::Environment;
+use crate::react_compiler_hir::type_config::ValueKind;
+use crate::react_compiler_hir::{Effect, Place};
+
+/// Whether a tagged-template call has enough configured effect information to be memoized.
+///
+/// A tagged template passes the frozen template object as its first argument, followed by its
+/// substitutions. Inferred result types are not evidence here: a consumer can constrain an opaque
+/// result to `Primitive`. Only the tag's function signature can prove the call and result safe.
+fn is_known_pure_tagged_template(
+    env: &Environment,
+    tag: &Place,
+    substitution_count: usize,
+) -> bool {
+    let tag_type = &env.types[env.identifiers[tag.identifier].type_];
+    let Some(signature) = env.get_function_signature(tag_type).ok().flatten() else {
+        return false;
+    };
+
+    if signature.hook_kind.is_some()
+        || signature.impure
+        || signature.known_incompatible.is_some()
+        || signature.aliasing.is_some()
+        || signature.callee_effect != Effect::Read
+        || !matches!(
+            signature.return_value_kind,
+            ValueKind::Primitive | ValueKind::Frozen | ValueKind::Mutable
+        )
+    {
+        return false;
+    }
+
+    // Include the implicit template object at parameter index zero.
+    (0..=substitution_count).all(|index| {
+        signature.positional_params.get(index).copied().or(signature.rest_param)
+            == Some(Effect::Read)
+    })
+}

--- a/crates/oxc_react_compiler/tests/snapshot.rs
+++ b/crates/oxc_react_compiler/tests/snapshot.rs
@@ -416,6 +416,27 @@ fn test_module_type_provider() -> FxIndexMap<String, TypeConfig> {
                 ("notAhookTypedAsHook", hook(type_ref(), None, None)),
             ]),
         ),
+        (
+            "ReactCompilerPureTagTest".to_string(),
+            object([(
+                "tag",
+                TypeConfig::Function(FunctionTypeConfig {
+                    positional_params: Vec::new(),
+                    rest_param: Some(Effect::Read),
+                    callee_effect: Effect::Read,
+                    return_type: Box::new(TypeConfig::TypeReference(TypeReferenceConfig {
+                        name: BuiltInTypeRef::Any,
+                    })),
+                    return_value_kind: ValueKind::Mutable,
+                    no_alias: None,
+                    mutable_only_if_operands_are_mutable: None,
+                    impure: Some(false),
+                    canonical_name: None,
+                    aliasing: None,
+                    known_incompatible: None,
+                }),
+            )]),
+        ),
         ("useDefaultExportNotTypedAsHook".to_string(), object([("default", type_ref())])),
     ])
 }

--- a/crates/oxc_react_compiler/tests/snapshots/destructuring-mixed-scope-and-local-variables-with-default.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/destructuring-mixed-scope-and-local-variables-with-default.snap
@@ -16,64 +16,57 @@ function useFragment(_arg1, _arg2) {
 	};
 }
 function Component(props) {
-	const $ = _c(9);
-	let t0;
-	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = graphql`
+	const $ = _c(8);
+	const post = useFragment(graphql`
       fragment F on T {
         id
       }
-    `;
-		$[0] = t0;
-	} else {
-		t0 = $[0];
-	}
-	const post = useFragment(t0, props.post);
-	let t1;
-	if ($[1] !== post) {
+    `, props.post);
+	let t0;
+	if ($[0] !== post) {
 		const allUrls = [];
-		const { media: t2, comments: t3, urls: t4 } = post;
-		const media = t2 === undefined ? null : t2;
+		const { media: t1, comments: t2, urls: t3 } = post;
+		const media = t1 === undefined ? null : t1;
+		let t4;
+		if ($[2] !== t2) {
+			t4 = t2 === undefined ? [] : t2;
+			$[2] = t2;
+			$[3] = t4;
+		} else {
+			t4 = $[3];
+		}
+		const comments = t4;
 		let t5;
-		if ($[3] !== t3) {
+		if ($[4] !== t3) {
 			t5 = t3 === undefined ? [] : t3;
-			$[3] = t3;
-			$[4] = t5;
+			$[4] = t3;
+			$[5] = t5;
 		} else {
-			t5 = $[4];
+			t5 = $[5];
 		}
-		const comments = t5;
+		const urls = t5;
 		let t6;
-		if ($[5] !== t4) {
-			t6 = t4 === undefined ? [] : t4;
-			$[5] = t4;
-			$[6] = t6;
-		} else {
-			t6 = $[6];
-		}
-		const urls = t6;
-		let t7;
-		if ($[7] !== comments.length) {
-			t7 = (e) => {
+		if ($[6] !== comments.length) {
+			t6 = (e) => {
 				if (!comments.length) {
 					return;
 				}
 				console.log(comments.length);
 			};
-			$[7] = comments.length;
-			$[8] = t7;
+			$[6] = comments.length;
+			$[7] = t6;
 		} else {
-			t7 = $[8];
+			t6 = $[7];
 		}
-		const onClick = t7;
+		const onClick = t6;
 		allUrls.push(...urls);
-		t1 = <Stringify media={media} allUrls={allUrls} onClick={onClick} />;
-		$[1] = post;
-		$[2] = t1;
+		t0 = <Stringify media={media} allUrls={allUrls} onClick={onClick} />;
+		$[0] = post;
+		$[1] = t0;
 	} else {
-		t1 = $[2];
+		t0 = $[1];
 	}
-	return t1;
+	return t0;
 }
 export const FIXTURE_ENTRYPOINT = {
 	fn: Component,

--- a/crates/oxc_react_compiler/tests/snapshots/destructuring-mixed-scope-declarations-and-locals.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/destructuring-mixed-scope-declarations-and-locals.snap
@@ -5,43 +5,36 @@ input_file: crates/oxc_react_compiler/fixtures/destructuring-mixed-scope-declara
 import { c as _c } from "react/compiler-runtime";
 import { useFragment } from "shared-runtime";
 function Component(props) {
-	const $ = _c(5);
-	let t0;
-	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = graphql`
+	const $ = _c(4);
+	const post = useFragment(graphql`
       fragment F on T {
         id
       }
-    `;
-		$[0] = t0;
-	} else {
-		t0 = $[0];
-	}
-	const post = useFragment(t0, props.post);
-	let t1;
-	if ($[1] !== post) {
+    `, props.post);
+	let t0;
+	if ($[0] !== post) {
 		const allUrls = [];
 		const { media, comments, urls } = post;
-		let t2;
-		if ($[3] !== comments.length) {
-			t2 = (e) => {
+		let t1;
+		if ($[2] !== comments.length) {
+			t1 = (e) => {
 				if (!comments.length) {
 					return;
 				}
 				console.log(comments.length);
 			};
-			$[3] = comments.length;
-			$[4] = t2;
+			$[2] = comments.length;
+			$[3] = t1;
 		} else {
-			t2 = $[4];
+			t1 = $[3];
 		}
-		const onClick = t2;
+		const onClick = t1;
 		allUrls.push(...urls);
-		t1 = <Media media={media} onClick={onClick} />;
-		$[1] = post;
-		$[2] = t1;
+		t0 = <Media media={media} onClick={onClick} />;
+		$[0] = post;
+		$[1] = t0;
 	} else {
-		t1 = $[2];
+		t0 = $[1];
 	}
-	return t1;
+	return t0;
 }

--- a/crates/oxc_react_compiler/tests/snapshots/memoize-tagged-template-before-consumer.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/memoize-tagged-template-before-consumer.snap
@@ -1,0 +1,8 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/memoize-tagged-template-before-consumer.tsx
+---
+// @compilationMode:"infer" @panicThreshold:"none"
+export function Component({ tag, consume }) {
+	return consume(tag`value`);
+}

--- a/crates/oxc_react_compiler/tests/snapshots/optional-call-logical.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/optional-call-logical.snap
@@ -5,28 +5,21 @@ input_file: crates/oxc_react_compiler/fixtures/optional-call-logical.js
 import { c as _c } from "react/compiler-runtime";
 import { useFragment } from "shared-runtime";
 function Component(props) {
-	const $ = _c(3);
-	let t0;
-	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = graphql`
+	const $ = _c(2);
+	const item = useFragment(graphql`
       fragment F on T {
         id
       }
-    `;
-		$[0] = t0;
+    `, props.item);
+	let t0;
+	if ($[0] !== item.items) {
+		t0 = item.items?.map(_temp) ?? [];
+		$[0] = item.items;
+		$[1] = t0;
 	} else {
-		t0 = $[0];
+		t0 = $[1];
 	}
-	const item = useFragment(t0, props.item);
-	let t1;
-	if ($[1] !== item.items) {
-		t1 = item.items?.map(_temp) ?? [];
-		$[1] = item.items;
-		$[2] = t1;
-	} else {
-		t1 = $[2];
-	}
-	return t1;
+	return t0;
 }
 function _temp(item_0) {
 	return renderItem(item_0);

--- a/crates/oxc_react_compiler/tests/snapshots/readonly-object-method-calls-mutable-lambda.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/readonly-object-method-calls-mutable-lambda.snap
@@ -5,20 +5,13 @@ input_file: crates/oxc_react_compiler/fixtures/readonly-object-method-calls-muta
 import { c as _c } from "react/compiler-runtime";
 import { useFragment } from "shared-runtime";
 function Component(props) {
-	const $ = _c(3);
+	const $ = _c(2);
 	const x = makeObject();
-	let t0;
-	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = graphql`
+	const user = useFragment(graphql`
       fragment Component_user on User {
         name
       }
-    `;
-		$[0] = t0;
-	} else {
-		t0 = $[0];
-	}
-	const user = useFragment(t0, props.user);
+    `, props.user);
 	const posts = user.timeline.posts.edges.nodes.map((node) => {
 		x.y = true;
 		return <Post post={node} />;
@@ -26,13 +19,13 @@ function Component(props) {
 	posts.push({});
 	const count = posts.length;
 	foo(count);
-	let t1;
-	if ($[1] !== posts) {
-		t1 = <>{posts}</>;
-		$[1] = posts;
-		$[2] = t1;
+	let t0;
+	if ($[0] !== posts) {
+		t0 = <>{posts}</>;
+		$[0] = posts;
+		$[1] = t0;
 	} else {
-		t1 = $[2];
+		t0 = $[1];
 	}
-	return t1;
+	return t0;
 }

--- a/crates/oxc_react_compiler/tests/snapshots/readonly-object-method-calls.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/readonly-object-method-calls.snap
@@ -5,39 +5,32 @@ input_file: crates/oxc_react_compiler/fixtures/readonly-object-method-calls.js
 import { c as _c } from "react/compiler-runtime";
 import { useFragment } from "shared-runtime";
 function Component(props) {
-	const $ = _c(5);
-	let t0;
-	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = graphql`
+	const $ = _c(4);
+	const user = useFragment(graphql`
       fragment Component_user on User {
         name
       }
-    `;
-		$[0] = t0;
-	} else {
-		t0 = $[0];
-	}
-	const user = useFragment(t0, props.user);
+    `, props.user);
 	let posts;
-	if ($[1] !== user.timeline.posts.edges.nodes) {
+	if ($[0] !== user.timeline.posts.edges.nodes) {
 		posts = user.timeline.posts.edges.nodes.map(_temp);
 		posts.push({});
 		const count = posts.length;
 		foo(count);
-		$[1] = user.timeline.posts.edges.nodes;
+		$[0] = user.timeline.posts.edges.nodes;
+		$[1] = posts;
+	} else {
+		posts = $[1];
+	}
+	let t0;
+	if ($[2] !== posts) {
+		t0 = <>{posts}</>;
 		$[2] = posts;
+		$[3] = t0;
 	} else {
-		posts = $[2];
+		t0 = $[3];
 	}
-	let t1;
-	if ($[3] !== posts) {
-		t1 = <>{posts}</>;
-		$[3] = posts;
-		$[4] = t1;
-	} else {
-		t1 = $[4];
-	}
-	return t1;
+	return t0;
 }
 function _temp(node) {
 	return <Post post={node} />;

--- a/crates/oxc_react_compiler/tests/snapshots/tagged-template-in-hook.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/tagged-template-in-hook.snap
@@ -2,21 +2,12 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/tagged-template-in-hook.js
 ---
-import { c as _c } from "react/compiler-runtime";
 import { useFragment } from "shared-runtime";
 function Component(props) {
-	const $ = _c(1);
-	let t0;
-	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = graphql`
+	const user = useFragment(graphql`
       fragment F on User {
         name
       }
-    `;
-		$[0] = t0;
-	} else {
-		t0 = $[0];
-	}
-	const user = useFragment(t0, props.user);
+    `, props.user);
 	return user.name;
 }

--- a/crates/oxc_react_compiler/tests/snapshots/tagged-template-literal.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/tagged-template-literal.snap
@@ -2,20 +2,11 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/tagged-template-literal.js
 ---
-import { c as _c } from "react/compiler-runtime";
 function component() {
-	const $ = _c(1);
-	let t0;
-	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = graphql`
+	const t = graphql`
     fragment F on T {
       id
     }
   `;
-		$[0] = t0;
-	} else {
-		t0 = $[0];
-	}
-	const t = t0;
 	return t;
 }

--- a/crates/oxc_react_compiler/tests/snapshots/tagged-template-mutable-result.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/tagged-template-mutable-result.snap
@@ -2,28 +2,25 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/tagged-template-mutable-result.js
 ---
-import { c as _c } from "react/compiler-runtime";
 // @compilationMode:annotation
-function tag(strings, value) {
-	return { value };
+const shared = {
+	value: 0,
+	toString() {
+		return this.value;
+	}
+};
+function tag() {
+	return shared;
 }
 function Component(t0) {
 	"use memo";
-	const $ = _c(2);
-	const { value } = t0;
-	let result;
-	if ($[0] !== value) {
-		result = tag`${value}`;
-		result.value = result.value + 1;
-		$[0] = value;
-		$[1] = result;
-	} else {
-		result = $[1];
-	}
-	return result.value;
+	const { tag } = t0;
+	const result = tag`value`;
+	result.value = result.value + 1;
+	return result + "";
 }
 export const FIXTURE_ENTRYPOINT = {
 	fn: Component,
-	params: [{ value: 1 }],
-	sequentialRenders: [{ value: 1 }, { value: 1 }]
+	params: [{ tag }],
+	sequentialRenders: [{ tag }, { tag }]
 };

--- a/crates/oxc_react_compiler/tests/snapshots/tagged-template-primitive-result-mutation.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/tagged-template-primitive-result-mutation.snap
@@ -1,0 +1,21 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/tagged-template-primitive-result-mutation.js
+---
+// @compilationMode:annotation
+function Component(t0) {
+	"use memo";
+	const { initial } = t0;
+	const object = { value: initial };
+	const tag = function tag() {
+		object.value = object.value + 1;
+		return 0;
+	};
+	tag`value`;
+	return object.value;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ initial: 0 }],
+	sequentialRenders: [{ initial: 0 }, { initial: 0 }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/type-provider-tagged-template-expression.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/type-provider-tagged-template-expression.snap
@@ -3,57 +3,15 @@ source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/type-provider-tagged-template-expression.js
 ---
 import { c as _c } from "react/compiler-runtime";
-import { graphql } from "shared-runtime";
-export function Component(t0) {
+import { tag } from "ReactCompilerPureTagTest";
+export function Component() {
 	const $ = _c(1);
-	let t1;
+	let t0;
 	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		const fragment = graphql`
-    fragment Foo on User {
-      name
-    }
-  `;
-		t1 = <div>{fragment}</div>;
-		$[0] = t1;
+		t0 = tag`value`;
+		$[0] = t0;
 	} else {
-		t1 = $[0];
+		t0 = $[0];
 	}
-	return t1;
+	return t0;
 }
-export const FIXTURE_ENTRYPOINT = {
-	fn: Component,
-	params: [{
-		a: 0,
-		b: 0
-	}],
-	sequentialRenders: [
-		{
-			a: 0,
-			b: 0
-		},
-		{
-			a: 1,
-			b: 0
-		},
-		{
-			a: 1,
-			b: 1
-		},
-		{
-			a: 1,
-			b: 2
-		},
-		{
-			a: 2,
-			b: 2
-		},
-		{
-			a: 3,
-			b: 2
-		},
-		{
-			a: 0,
-			b: 0
-		}
-	]
-};


### PR DESCRIPTION
Preserve tagged-template call, aliasing, and mutation effects instead of assuming no-substitution tags are primitive or pure.

Execute opaque or effectful tags unconditionally while retaining memoization only when a configured signature proves a read-only pure call and safe return.

AI-assisted investigation and implementation; reviewed and understood by the contributor.