### PR TITLE
fix(react-compiler): match BigInt value inference

### DIFF
--- a/crates/oxc_linter/src/rules/react/react_compiler.rs
+++ b/crates/oxc_linter/src/rules/react/react_compiler.rs
@@ -362,10 +362,9 @@ function Component(props) {
             }",
             None,
         ),
-        // Capitalized built-in globals are not components.
+        // Typed capitalized built-in globals are not components.
         (
             "function Component(value) {
-                const bigInt = BigInt(value);
                 const boolean = Boolean(value);
                 const number = Number(value);
                 const string = String(value);
@@ -374,7 +373,6 @@ function Component(props) {
                 const object = Object(value);
                 const date = Date();
                 return <div>{String([
-                    bigInt,
                     boolean,
                     number,
                     string,

--- a/crates/oxc_react_compiler/fixtures/memoize-bigint-global-calls.tsx
+++ b/crates/oxc_react_compiler/fixtures/memoize-bigint-global-calls.tsx
@@ -1,0 +1,7 @@
+// @compilationMode:"infer" @panicThreshold:"none"
+import {useState} from 'react';
+
+export function Component() {
+  const [value, setValue] = useState(BigInt('123'));
+  return <input value={value} onChange={setValue} step={BigInt(10)} />;
+}

--- a/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
@@ -1720,7 +1720,6 @@ const TYPED_GLOBAL_OBJECTS: &[GlobalObjectDef] = &[
 
 /// Simple global functions returning Primitive.
 const PRIMITIVE_GLOBAL_FNS: &[&str] = &[
-    "BigInt",
     "Boolean",
     "Number",
     "String",

--- a/crates/oxc_react_compiler/tests/snapshots/memoize-bigint-global-calls.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/memoize-bigint-global-calls.snap
@@ -1,0 +1,34 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/memoize-bigint-global-calls.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+// @compilationMode:"infer" @panicThreshold:"none"
+import { useState } from "react";
+export function Component() {
+	const $ = _c(4);
+	let t0;
+	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		t0 = BigInt("123");
+		$[0] = t0;
+	} else {
+		t0 = $[0];
+	}
+	const [value, setValue] = useState(t0);
+	let t1;
+	if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+		t1 = BigInt(10);
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== value) {
+		t2 = <input value={value} onChange={setValue} step={t1} />;
+		$[2] = value;
+		$[3] = t2;
+	} else {
+		t2 = $[3];
+	}
+	return t2;
+}


### PR DESCRIPTION
Treat `BigInt` as an untyped global, matching the latest React Compiler memoization and capitalized-call behavior.

Validated against the latest local React Compiler output, compiler fixtures, the affected linter case, Clippy, and `just ready`.

AI-assisted investigation and implementation; reviewed and understood by the contributor.