### PR TITLE
fix(react-compiler): include TypeScript bindings in hoisting

### DIFF
--- a/crates/oxc_react_compiler/fixtures/hoist-type-function-parameter-binding.tsx
+++ b/crates/oxc_react_compiler/fixtures/hoist-type-function-parameter-binding.tsx
@@ -1,0 +1,9 @@
+// @compilationMode:"infer" @panicThreshold:"none"
+import {useEffect, useState} from 'react';
+
+export function Component({source}) {
+  const callback = (setData: (data: string) => void) => setData(source);
+  const data = useState(source)[0];
+  useEffect(() => callback(() => data), [data]);
+  return data;
+}

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -365,6 +365,14 @@ fn lower_block_statement_inner<'a>(
                     Some(entry.span)
                 })
                 .collect();
+            refs_in_stmt.extend(builder.identifier_spans().type_binding_spans().iter().filter_map(
+                |&(type_binding_id, span)| {
+                    (scope.symbol_ident(type_binding_id) == *name
+                        && span.start >= stmt_start
+                        && span.start < stmt_end)
+                        .then_some(span)
+                },
+            ));
             // For hoisted bindings (function declarations) outside their own
             // declaration statement, the declaration site itself counts as a
             // reference (Babel's binding references include the declaration).

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
@@ -73,6 +73,11 @@ pub struct IdentifierLocIndex {
     /// Declaration (binding) identifier spans, keyed by their `symbol_id` cell.
     /// First declaration wins for redeclared symbols.
     decl_spans: FxHashMap<SymbolId, Span>,
+    /// Binding identifiers inside TS type subtrees. Babel's hoisting traversal
+    /// can treat function-type parameter names as references to a same-named
+    /// runtime binding, so retain their semantic identity and location for the
+    /// hoisting pass without exposing them to the other identifier analyses.
+    type_binding_spans: Vec<(SymbolId, Span)>,
 }
 
 impl IdentifierLocIndex {
@@ -82,6 +87,10 @@ impl IdentifierLocIndex {
 
     pub fn declaration_span(&self, symbol_id: SymbolId) -> Option<Span> {
         self.decl_spans.get(&symbol_id).copied()
+    }
+
+    pub fn type_binding_spans(&self) -> &[(SymbolId, Span)] {
+        &self.type_binding_spans
     }
 }
 
@@ -149,6 +158,9 @@ impl<'a> Visit<'a> for IdentifierLocVisitor {
         // never BindingIdentifier, so type-parameter declaration names (`<T>`) and
         // other binding positions inside type subtrees must not be recorded.
         if self.type_depth > 0 {
+            if let Some(symbol_id) = it.symbol_id.get() {
+                self.index.type_binding_spans.push((symbol_id, it.span));
+            }
             return;
         }
         self.record_declaration(it);

--- a/crates/oxc_react_compiler/tests/snapshots/hoist-type-function-parameter-binding.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/hoist-type-function-parameter-binding.snap
@@ -1,0 +1,40 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/hoist-type-function-parameter-binding.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+// @compilationMode:"infer" @panicThreshold:"none"
+import { useEffect, useState } from "react";
+export function Component(t0) {
+	const $ = _c(7);
+	const { source } = t0;
+	let t1;
+	if ($[0] !== source) {
+		t1 = (setData) => setData(source);
+		$[0] = source;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	const callback = t1;
+	const data = useState(source)[0];
+	let t2;
+	if ($[2] !== callback || $[3] !== data) {
+		t2 = () => callback(() => data);
+		$[2] = callback;
+		$[3] = data;
+		$[4] = t2;
+	} else {
+		t2 = $[4];
+	}
+	let t3;
+	if ($[5] !== data) {
+		t3 = [data];
+		$[5] = data;
+		$[6] = t3;
+	} else {
+		t3 = $[6];
+	}
+	useEffect(t2, t3);
+	return data;
+}


### PR DESCRIPTION
Include binding identifiers from TypeScript type subtrees in the hoisting analysis, matching the latest React Compiler dependency placement.

Validated against the latest local React Compiler output, fixture snapshots, Clippy, and `just ready`.

AI-assisted investigation and implementation; reviewed and understood by the contributor.