### PR TITLE
fix(react-compiler): bail on interpolated tagged templates

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -3800,14 +3800,16 @@ fn lower_expression<'a>(
         oxc::Expression::TaggedTemplateExpression(tagged) => {
             let span = Some(tagged.span);
             let quasi_span = Some(tagged.quasi.span);
-            // Upstream React Compiler bails on any interpolation here; the oxc port
-            // instead lowers the tag plus every quasi and every `${...}`
-            // subexpression (mirroring `TemplateLiteral`). This is a deliberate
-            // divergence from the TS reference.
-            //
-            // We still bail when any quasi's cooked value differs from its raw value
-            // (e.g. escape sequences or graphql templates), matching upstream's
-            // single-quasi behavior — the HIR only round-trips raw==cooked quasis.
+            if !tagged.quasi.expressions.is_empty() {
+                builder.record_error(
+                    ErrorCategory::Todo
+                        .diagnostic("(BuildHIR::lowerExpression) Handle tagged template with interpolations")
+                        .with_labels(span),
+                )?;
+                return Ok(InstructionValue::Primitive { value: PrimitiveValue::Undefined, span });
+            }
+            // Bail when the quasi's cooked value differs from its raw value (e.g.
+            // escape sequences or graphql templates), matching upstream behavior.
             if tagged.quasi.quasis.iter().any(|q| {
                 q.value.raw.as_str() != q.value.cooked.map(|c| c.to_string()).unwrap_or_default()
             }) {

--- a/crates/oxc_react_compiler/tests/snapshots/error.invalid-hook-reference-in-tagged-template-interpolation.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.invalid-hook-reference-in-tagged-template-interpolation.snap
@@ -4,6 +4,6 @@ input_file: crates/oxc_react_compiler/fixtures/error.invalid-hook-reference-in-t
 ---
 Diagnostics:
 
-OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Hooks: Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values", labels: [LabeledSpan { label: None, span: Span { start: 121, end: 129 }, primary: false }], help: None, note: None, severity: Error, code: OxcCode { scope: None, number: None }, url: None } }
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Todo: (BuildHIR::lowerExpression) Handle tagged template with interpolations", labels: [LabeledSpan { label: None, span: Span { start: 115, end: 131 }, primary: false }], help: None, note: None, severity: Warning, code: OxcCode { scope: None, number: None }, url: None } }
 
 No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/tagged-template-hook.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/tagged-template-hook.snap
@@ -2,28 +2,8 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/tagged-template-hook.jsx
 ---
-import { c as _c } from "react/compiler-runtime";
-import { useState } from "react";
-function useTagged(strings, value) {
-	useState(0);
-	return `${strings[0]}${value}${strings[1]}`;
-}
-function Component(t0) {
-	const $ = _c(2);
-	const { value } = t0;
-	const text = useTagged`value: ${value}`;
-	let t1;
-	if ($[0] !== text) {
-		t1 = <div>{text}</div>;
-		$[0] = text;
-		$[1] = t1;
-	} else {
-		t1 = $[1];
-	}
-	return t1;
-}
-export const FIXTURE_ENTRYPOINT = {
-	fn: Component,
-	params: [{ value: 0 }],
-	sequentialRenders: [{ value: 0 }, { value: 0 }]
-};
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Todo: (BuildHIR::lowerExpression) Handle tagged template with interpolations", labels: [LabeledSpan { label: None, span: Span { start: 180, end: 206 }, primary: false }], help: None, note: None, severity: Warning, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/tagged-template-mutable-result.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/tagged-template-mutable-result.snap
@@ -2,28 +2,8 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/tagged-template-mutable-result.js
 ---
-import { c as _c } from "react/compiler-runtime";
-// @compilationMode:annotation
-function tag(strings, value) {
-	return { value };
-}
-function Component(t0) {
-	"use memo";
-	const $ = _c(2);
-	const { value } = t0;
-	let result;
-	if ($[0] !== value) {
-		result = tag`${value}`;
-		result.value = result.value + 1;
-		$[0] = value;
-		$[1] = result;
-	} else {
-		result = $[1];
-	}
-	return result.value;
-}
-export const FIXTURE_ENTRYPOINT = {
-	fn: Component,
-	params: [{ value: 1 }],
-	sequentialRenders: [{ value: 1 }, { value: 1 }]
-};
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "[ReactCompiler] Todo: (BuildHIR::lowerExpression) Handle tagged template with interpolations", labels: [LabeledSpan { label: None, span: Span { start: 144, end: 157 }, primary: false }], help: None, note: None, severity: Warning, code: OxcCode { scope: None, number: None }, url: None } }
+
+No changes.


### PR DESCRIPTION
Match the latest React Compiler BuildHIR bailout for tagged templates with interpolations, removing the largest Oxc-ahead runtime-output class.

Validated against current React diagnostics, existing compiler fixtures, Clippy, and `just ready`.

AI-assisted investigation and implementation; reviewed and understood by the contributor.