### PR TITLE
fix(linter/jest/padding-around-after-all-blocks): report the missing padding after the block

### DIFF
--- a/crates/oxc_linter/src/rules/jest/padding_around_after_all_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_after_all_blocks.rs
@@ -38,11 +38,24 @@ fn test() {
         "const thing = 123;\n\nafterAll(() => {});",
         "describe('foo', () => {\nafterAll(() => {});\n});",
         "const thing = 123;\n\n/* one */\n/* two */\nafterAll(() => {});",
+        // Issue: <https://github.com/oxc-project/oxc/issues/25590>
+        "afterAll(() => {});
+
+describe('suite', () => {});",
+        "afterAll(() => {}); // trailing
+
+describe('suite', () => {});",
     ];
 
     let fail = vec![
         "const thing = 123;\nafterAll(() => {});",
         "const thing = 123;\n/* one */\n/* two */\nafterAll(() => {});",
+        // Issue: <https://github.com/oxc-project/oxc/issues/25590>
+        "afterAll(() => {});
+describe('suite', () => {});",
+        "afterAll(() => {});
+/* one */
+describe('suite', () => {});",
     ];
 
     let fix = vec![
@@ -50,6 +63,22 @@ fn test() {
         (
             "const thing = 123;\n/* one */\n/* two */\nafterAll(() => {});",
             "const thing = 123;\n\n/* one */\n/* two */\nafterAll(() => {});",
+        ),
+        (
+            "afterAll(() => {});
+describe('suite', () => {});",
+            "afterAll(() => {});
+
+describe('suite', () => {});",
+        ),
+        (
+            "afterAll(() => {});
+/* one */
+describe('suite', () => {});",
+            "afterAll(() => {});
+
+/* one */
+describe('suite', () => {});",
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_after_all_blocks.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_after_all_blocks.rs
@@ -4,7 +4,7 @@ use crate::{
     context::LintContext,
     utils::{
         JestGeneralFnKind, ParsedGeneralJestFnCall, PossibleJestNode, parse_general_jest_fn_call,
-        report_missing_padding_before_jest_block,
+        report_missing_padding_after_jest_block, report_missing_padding_before_jest_block,
     },
 };
 
@@ -55,4 +55,5 @@ pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<
         return;
     }
     report_missing_padding_before_jest_block(node, ctx, name);
+    report_missing_padding_after_jest_block(node, ctx, name);
 }

--- a/crates/oxc_linter/src/rules/vitest/padding_around_after_all_blocks.rs
+++ b/crates/oxc_linter/src/rules/vitest/padding_around_after_all_blocks.rs
@@ -47,6 +47,13 @@ fn test() {
         "const thing = 123;\n\n/**\n * JSDoc attached to afterAll\n */\nafterAll(() => {});",
         "const thing = 123; /* trailing on prev */\n\nafterAll(() => {});",
         "describe('foo', () => {\nafterAll(() => {});\n\nafterAll(() => {});\n});",
+        // Issue: <https://github.com/oxc-project/oxc/issues/25590>
+        "afterAll(() => {});
+
+describe('suite', () => {});",
+        "afterAll(() => {}); // trailing
+
+describe('suite', () => {});",
     ];
 
     let fail = vec![
@@ -59,6 +66,12 @@ fn test() {
         "const thing = 123;\n/**\n * JSDoc comment\n */\nafterAll(() => {});",
         "describe('foo', () => {\nafterAll(() => {});\nafterAll(() => {});\n});",
         "import { afterAll } from 'vitest';\n/* setup notes */\nafterAll(() => {});",
+        // Issue: <https://github.com/oxc-project/oxc/issues/25590>
+        "afterAll(() => {});
+describe('suite', () => {});",
+        "afterAll(() => {});
+/* one */
+describe('suite', () => {});",
     ];
 
     let fix = vec![
@@ -83,6 +96,22 @@ fn test() {
         (
             "describe('foo', () => {\nafterAll(() => {});\nafterAll(() => {});\n});",
             "describe('foo', () => {\nafterAll(() => {});\n\nafterAll(() => {});\n});",
+        ),
+        (
+            "afterAll(() => {});
+describe('suite', () => {});",
+            "afterAll(() => {});
+
+describe('suite', () => {});",
+        ),
+        (
+            "afterAll(() => {});
+/* one */
+describe('suite', () => {});",
+            "afterAll(() => {});
+
+/* one */
+describe('suite', () => {});",
         ),
     ];
 

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_after_all_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_after_all_blocks.snap
@@ -17,3 +17,19 @@ source: crates/oxc_linter/src/tester.rs
    · ▲
    ╰────
   help: Make sure there is an empty new line before the afterAll block
+
+  ⚠ jest(padding-around-after-all-blocks): Missing padding after afterAll block
+   ╭─[padding_around_after_all_blocks.tsx:1:20]
+ 1 │ afterAll(() => {});
+   ·                    ▲
+ 2 │ describe('suite', () => {});
+   ╰────
+  help: Make sure there is an empty new line after the afterAll block
+
+  ⚠ jest(padding-around-after-all-blocks): Missing padding after afterAll block
+   ╭─[padding_around_after_all_blocks.tsx:1:20]
+ 1 │ afterAll(() => {});
+   ·                    ▲
+ 2 │ /* one */
+   ╰────
+  help: Make sure there is an empty new line after the afterAll block

--- a/crates/oxc_linter/src/snapshots/vitest_padding_around_after_all_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_padding_around_after_all_blocks.snap
@@ -74,3 +74,19 @@ source: crates/oxc_linter/src/tester.rs
    · ▲
    ╰────
   help: Make sure there is an empty new line before the afterAll block
+
+  ⚠ vitest(padding-around-after-all-blocks): Missing padding after afterAll block
+   ╭─[padding_around_after_all_blocks.tsx:1:20]
+ 1 │ afterAll(() => {});
+   ·                    ▲
+ 2 │ describe('suite', () => {});
+   ╰────
+  help: Make sure there is an empty new line after the afterAll block
+
+  ⚠ vitest(padding-around-after-all-blocks): Missing padding after afterAll block
+   ╭─[padding_around_after_all_blocks.tsx:1:20]
+ 1 │ afterAll(() => {});
+   ·                    ▲
+ 2 │ /* one */
+   ╰────
+  help: Make sure there is an empty new line after the afterAll block

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -20,7 +20,9 @@ pub use crate::utils::jest::parse_jest_fn::{
     MemberExpressionElement, ParsedExpectFnCall, ParsedGeneralJestFnCall,
     ParsedJestFnCall as ParsedJestFnCallNew, parse_jest_fn_call,
 };
-pub use padding_around_block::report_missing_padding_before_jest_block;
+pub use padding_around_block::{
+    report_missing_padding_after_jest_block, report_missing_padding_before_jest_block,
+};
 
 mod padding_around_block;
 mod parse_jest_fn;

--- a/crates/oxc_linter/src/utils/jest/padding_around_block.rs
+++ b/crates/oxc_linter/src/utils/jest/padding_around_block.rs
@@ -1,4 +1,7 @@
-use oxc_ast::{AstKind, ast::Statement};
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, Statement},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::AstNode;
 use oxc_span::{GetSpan, Span};
@@ -8,6 +11,12 @@ use crate::context::LintContext;
 fn padding_around_jest_block_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Missing padding before {name} block"))
         .with_help(format!("Make sure there is an empty new line before the {name} block"))
+        .with_label(span)
+}
+
+fn padding_after_jest_block_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Missing padding after {name} block"))
+        .with_help(format!("Make sure there is an empty new line after the {name} block"))
         .with_label(span)
 }
 
@@ -71,6 +80,81 @@ pub fn report_missing_padding_before_jest_block<'a>(
     }
 }
 
+/// Counterpart of [`report_missing_padding_before_jest_block`] for the other side of the block.
+///
+/// The rules that use these enforce padding *around* a block, so a block that opens a scope — with
+/// nothing before it but a statement after it — still needs a blank line separating it from what
+/// follows.
+pub fn report_missing_padding_after_jest_block<'a>(
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+    name: &str,
+) {
+    let scope_node = ctx.nodes().get_node(ctx.scoping().get_node_id(node.scope_id()));
+    let spans = match scope_node.kind() {
+        AstKind::Program(program) => get_statement_spans_after_node(node, program.body.as_slice()),
+        AstKind::ArrowFunctionExpression(arrow_func_expr) => {
+            let Some(body) = arrow_func_expr.get_function_body() else { return };
+            get_statement_spans_after_node(node, body.statements.as_slice())
+        }
+        AstKind::Function(function) => {
+            let Some(body) = &function.body else {
+                return;
+            };
+            get_statement_spans_after_node(node, body.statements.as_slice())
+        }
+        _ => None,
+    };
+    let Some((own_statement_span, next_statement_span, next_statement)) = spans else {
+        return;
+    };
+
+    // When the next statement is another block of the same kind, it reports this very gap through
+    // its own "before" check. Reporting from both sides would flag one missing blank line twice.
+    if is_call_to(next_statement, name) {
+        return;
+    }
+
+    let comments_range = ctx.comments_range(own_statement_span.end..next_statement_span.start);
+    let mut span_between_start = own_statement_span.end;
+    let mut span_between_end = next_statement_span.start;
+    let mut prev_attached_end = own_statement_span.end;
+    for comment in comments_range {
+        let comment_span = comment.span;
+        // A comment on the same line as the block trails the block itself, so the blank line
+        // belongs after it rather than before.
+        let space_before = ctx.source_range(Span::new(prev_attached_end, comment_span.start));
+        if space_before.matches('\n').count() == 0 {
+            span_between_start = comment_span.end;
+            prev_attached_end = comment_span.end;
+            continue;
+        }
+        // Otherwise the comment leads the next statement, so the blank line belongs before it.
+        let space_after = ctx.source_range(Span::new(comment_span.end, span_between_end));
+        if space_after.matches('\n').count() > 1 {
+            break;
+        }
+        span_between_end = comment_span.start;
+        break;
+    }
+
+    let span_between = Span::new(span_between_start, span_between_end);
+    let content = ctx.source_range(span_between);
+    if content.matches('\n').count() < 2 {
+        ctx.diagnostic_with_fix(
+            padding_after_jest_block_diagnostic(
+                Span::new(own_statement_span.end, own_statement_span.end),
+                name,
+            ),
+            |fixer| {
+                let whitespace_after_last_line =
+                    content.rfind('\n').map_or("", |index| content.split_at(index + 1).1);
+                fixer.replace(span_between, format!("\n\n{whitespace_after_last_line}"))
+            },
+        );
+    }
+}
+
 fn get_statement_span_before_node(node: &AstNode, statements: &[Statement]) -> Option<Span> {
     statements
         .iter()
@@ -78,4 +162,29 @@ fn get_statement_span_before_node(node: &AstNode, statements: &[Statement]) -> O
             if statement.span().end <= node.span().start { Some(statement.span()) } else { None }
         })
         .next_back()
+}
+
+/// The span of the statement containing `node`, paired with the span of the statement that follows
+/// it in the same block. `None` when the block is the last statement — nothing to pad against.
+fn get_statement_spans_after_node<'a, 'b>(
+    node: &AstNode,
+    statements: &'b [Statement<'a>],
+) -> Option<(Span, Span, &'b Statement<'a>)> {
+    let index = statements.iter().position(|statement| {
+        let span = statement.span();
+        span.start <= node.span().start && node.span().end <= span.end
+    })?;
+    let next = statements.get(index + 1)?;
+    Some((statements[index].span(), next.span(), next))
+}
+
+/// Whether `statement` is a bare call to `name`, i.e. another block of the same kind.
+fn is_call_to(statement: &Statement, name: &str) -> bool {
+    let Statement::ExpressionStatement(expr_statement) = statement else {
+        return false;
+    };
+    let Expression::CallExpression(call_expr) = &expr_statement.expression else {
+        return false;
+    };
+    call_expr.callee.get_identifier_reference().is_some_and(|ident| ident.name == name)
 }


### PR DESCRIPTION
Closes #25590.

## The problem

The rule's own documentation says it "enforces a line of padding **before and after** 1 or more `afterAll` statements", but the implementation only ever called `report_missing_padding_before_jest_block`. There was no "after" side at all.

That is invisible while an `afterAll` sits below something, because the *next* block's own "before" check happens to cover the gap. It becomes visible the moment the `afterAll` is the first statement in its scope — the reproduction from the issue:

```js
afterAll(() => {});
describe("suite", () => {});
```

Nothing before it, so the "before" check returns early, and nothing after it, so oxlint exits clean. `eslint-plugin-jest` reports the missing blank line.

## The change

`report_missing_padding_after_jest_block`, mirroring the existing helper: it pairs the block's own statement with the statement that follows it in the same block, walks the comments between them, and offers the same blank-line fix.

Comment attribution is the reverse of the "before" side. A comment on the same line as the block trails the block, so the blank line goes after it; a comment on a later line leads the next statement, so the blank line goes before it:

```js
afterAll(() => {}); // trailing        →  blank line goes here, after the comment

afterAll(() => {});
/* leads describe */                   →  blank line goes before the comment
describe("suite", () => {});
```

**One case needed deciding, so it is worth calling out.** With both sides active, two adjacent blocks of the same kind would be reported twice for one missing blank line — once by the first block's "after" check and once by the second's "before" check. The "after" check returns early when the next statement is another call to the same block name, so `afterAll(); afterAll();` still reports exactly once, from the side that already did. The existing vitest test for that case (`describe('foo', () => {\nafterAll(() => {});\nafterAll(() => {});\n});`) keeps its current single diagnostic — its snapshot is unchanged.

## Tests

Added to both the jest and vitest rule files:

- **pass** — `afterAll(() => {});\n\ndescribe(...)`, and the trailing-comment form.
- **fail** — the issue's reproduction, and the leading-comment form.
- **fix** — both failures, asserting the blank line lands on the correct side of the comment.

Both snapshots change by addition only; no existing expectation moved.

## Scope

`padding-around-test-blocks` shares the same one-sided implementation and has the same gap. I left it out to keep this change to the reported issue — happy to follow up with it, or to widen this PR if you would rather have both at once.

## Verification

`cargo test -p oxc_linter --lib` — 1222 passed, 0 failed. `cargo clippy -p oxc_linter --lib` clean.

> AI disclosure, per the contributing policy: I used an AI assistant while investigating and writing this. I have read and understand the change, ran the tests myself, and stand behind it.
