### PR TITLE
fix(napi/parser): stop retaining visitor callbacks for the process lifetime

### DIFF
--- a/napi/parser/src-js/visit/visitor.js
+++ b/napi/parser/src-js/visit/visitor.js
@@ -49,28 +49,26 @@
 // ]
 // ```
 //
-// # Object reuse
+// # Compilation
 //
-// No more than 1 compiled visitor exists at any time, so we reuse a single array `compiledVisitor`,
-// rather than creating a new array for each file being linted.
-//
-// To compile visitors, call:
-// * `initCompiledVisitor` once.
+// To compile a visitor, call:
+// * `createCompiledVisitor` once.
 // * `addVisitorToCompiled` with each visitor object.
 // * `finalizeCompiledVisitor` once.
 //
-// After this sequence of calls, `compiledVisitor` is ready to be used to walk the AST.
+// After this sequence of calls, the array returned by `createCompiledVisitor` is ready to be used
+// to walk the AST. Each `Visitor` (see `index.js`) keeps the array it compiled, so a compiled
+// visitor outlives its compilation and nothing in it can be recycled into a later one.
 //
-// We also recycle:
+// # Object reuse
 //
-// * `{ enter, exit }` objects which are stored in compiled visitor.
-// * Temporary arrays used to store multiple visit functions, which are merged into a single function
-//   in `finalizeCompiledVisitor`.
+// The temporary arrays used to hold multiple visit functions for the same AST type *are* recycled:
+// `finalizeCompiledVisitor` merges each into a single function and empties it, so they hold nothing
+// afterwards. Reusing them reduces pressure on the garbage collector: they are long-lived and
+// graduate to "old space", leaving as much capacity as possible in "new space" for objects created
+// by user code in visitors.
 //
-// The aim is to reduce pressure on the garbage collector. All these recycled objects are long-lived
-// and will graduate to "old space", which leaves as much capacity as possible in "new space"
-// for objects created by user code in visitors. If ephemeral user-created objects all fit in new space,
-// it will avoid full GC runs, which should greatly improve performance.
+// The `{ enter, exit }` objects are not pooled, because a compiled visitor keeps them alive.
 
 import {
   LEAF_NODE_TYPES_COUNT,
@@ -121,25 +119,18 @@ mergedExitVisitorTypeIds.length = 0;
 // `true` if `addVisitor` has been called with a visitor which visits at least one AST type
 let hasActiveVisitors = false;
 
-// Enter+exit object cache.
+// Enter+exit objects.
 //
 // `compiledVisitor` may contain many `{ enter, exit }` objects.
-// Use this cache to reuse those objects across all visitor compilations.
 //
-// `enterExitObjectCacheNextIndex` is the index of first object in cache which is currently unused.
-// It may point to the end of the cache array.
-const enterExitObjectCache = [];
-let enterExitObjectCacheNextIndex = 0;
+// These are deliberately *not* pooled. Each compiled visitor is retained by the `Visitor` that
+// created it (see `index.js`), so its `{ enter, exit }` objects stay reachable for as long as that
+// `Visitor` lives, and cannot be handed out to a later compilation. Holding them in a module-level
+// cache instead kept every visitor callback -- and everything its closure captured -- alive for the
+// lifetime of the process.
 
 function getEnterExitObject() {
-  if (enterExitObjectCacheNextIndex < enterExitObjectCache.length) {
-    return enterExitObjectCache[enterExitObjectCacheNextIndex++];
-  }
-
-  const enterExit = { enter: null, exit: null };
-  enterExitObjectCache.push(enterExit);
-  enterExitObjectCacheNextIndex++;
-  return enterExit;
+  return { enter: null, exit: null };
 }
 
 // Visit function arrays cache.
@@ -166,24 +157,6 @@ function createVisitFnArray(visit1, visit2) {
   visitFnArrayCache.push(arr);
   visitFnArrayCacheNextIndex++;
   return arr;
-}
-
-/**
- * Initialize compiled visitor, ready for calls to `addVisitor`.
- */
-export function initCompiledVisitor() {
-  // Reset `compiledVisitor` array after previous compilation
-  for (let i = 0; i < NODE_TYPES_COUNT; i++) {
-    compiledVisitor[i] = null;
-  }
-
-  // Reset enter+exit objects which were used in previous compilation
-  for (let i = 0; i < enterExitObjectCacheNextIndex; i++) {
-    const enterExit = enterExitObjectCache[i];
-    enterExit.enter = null;
-    enterExit.exit = null;
-  }
-  enterExitObjectCacheNextIndex = 0;
 }
 
 /**


### PR DESCRIPTION
Closes #25510.

## The problem

`getEnterExitObject()` handed out `{ enter, exit }` objects from a module-level pool, and `enterExitObjectCacheNextIndex` was reset in exactly one place — `initCompiledVisitor()`.

Nothing calls `initCompiledVisitor()`. This module's only consumer is the public `Visitor` in `index.js`, which calls `createCompiledVisitor()`; the similarly-named machinery in `apps/oxlint/src-js/plugins/visitor.ts` is a separate implementation. So the index never reset, the pool grew by one object per non-leaf visited type per `Visitor`, and each object kept the user's callbacks — and everything their closures captured — alive for the lifetime of the process. That is the growth @Rambuto measured in Angular's i18n inliner, where each callback captures a whole `MagicString`.

## Why the pool can't work here rather than just needs resetting

Resetting the index would be worse than the leak: a `Visitor` **keeps** the array it compiled, and that array points at those `{ enter, exit }` objects. Handing the same objects to a later compilation would mutate a live `Visitor`'s callbacks out from under it.

The pool's own header comment says "No more than 1 compiled visitor exists at any time" — true for the recycled, compile-use-discard flow it was written for, and not true for the public `Visitor`, which is what this module actually serves.

So: allocate the objects fresh, and drop the pool. `initCompiledVisitor()` goes with it — it was dead, and its "reuse one shared `compiledVisitor`" contract is the one the only consumer does not follow. The header comment is updated to describe what the module really does.

The visit-function arrays stay pooled: `finalizeCompiledVisitor()` merges each into a single function and empties it (`visitFns.length = 0`), then resets `visitFnArrayCacheNextIndex`, so those arrays hold nothing between compilations. That pool is safe and unchanged.

## Measurement

`napi/parser` needs a native build I can't produce on this machine, so I exercised the module directly with plain Node instead of running the test suite. Two things, both against the unmodified module first:

**The pool grows and never resets** — 25 compilations, two non-leaf types each:

```
BEFORE cache state: {"cacheLen":50,"nextIndex":50}
```

**The captured state stays reachable** — 30 compilations whose callbacks capture an object, `WeakRef` on each captured object, then a turn of the event loop and `global.gc()`:

```
before: captured objects still reachable after GC: 30/30
after:  captured objects still reachable after GC: 1/30
```

The remaining 1 is the compilation the module-global `compiledVisitor` still points at, which is bounded and expected.

## On tests

I have not added one. The check that would prove this needs `WeakRef` + `--expose-gc`, and I could not run `napi/parser`'s vitest suite here to see how such a test behaves in your setup — I would rather not hand you a test I have never executed. Happy to add it if you want it, with the `--expose-gc` requirement made explicit, or to leave the module as its own witness.

> AI disclosure, per the contributing policy: I used an AI assistant while investigating and writing this. I have read and understand the change, ran the measurements myself, and stand behind it.
