### PR TITLE
fix(linter/jest/padding-around-test-blocks): report the missing padding after the block

### DIFF
--- a/crates/oxc_linter/src/rules/jest/padding_around_after_all_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_after_all_blocks.rs
@@ -38,11 +38,24 @@ fn test() {
         "const thing = 123;\n\nafterAll(() => {});",
         "describe('foo', () => {\nafterAll(() => {});\n});",
         "const thing = 123;\n\n/* one */\n/* two */\nafterAll(() => {});",
+        // Issue: <https://github.com/oxc-project/oxc/issues/25590>
+        "afterAll(() => {});
+
+describe('suite', () => {});",
+        "afterAll(() => {}); // trailing
+
+describe('suite', () => {});",
     ];
 
     let fail = vec![
         "const thing = 123;\nafterAll(() => {});",
         "const thing = 123;\n/* one */\n/* two */\nafterAll(() => {});",
+        // Issue: <https://github.com/oxc-project/oxc/issues/25590>
+        "afterAll(() => {});
+describe('suite', () => {});",
+        "afterAll(() => {});
+/* one */
+describe('suite', () => {});",
     ];
 
     let fix = vec![
@@ -50,6 +63,22 @@ fn test() {
         (
             "const thing = 123;\n/* one */\n/* two */\nafterAll(() => {});",
             "const thing = 123;\n\n/* one */\n/* two */\nafterAll(() => {});",
+        ),
+        (
+            "afterAll(() => {});
+describe('suite', () => {});",
+            "afterAll(() => {});
+
+describe('suite', () => {});",
+        ),
+        (
+            "afterAll(() => {});
+/* one */
+describe('suite', () => {});",
+            "afterAll(() => {});
+
+/* one */
+describe('suite', () => {});",
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
@@ -42,6 +42,13 @@ fn test() {
         "{ test('foo', () => {}); }",
         "describe('foo', () => {\ntest('bar', () => {});\n});",
         "const thing = 123;\n\n/* one */\n/* two */\ntest('foo', () => {});",
+        // Issue: <https://github.com/oxc-project/oxc/issues/25590>
+        "test('foo', () => {});
+
+const thing = 123;",
+        "test('foo', () => {});
+
+it('bar', () => {});",
     ];
 
     let fail = vec![
@@ -84,6 +91,11 @@ describe('other bar', function() {
     });
 });
             ",
+        // Issue: <https://github.com/oxc-project/oxc/issues/25590>
+        "test('foo', () => {});
+const thing = 123;",
+        "it('foo', () => {});
+describe('bar', () => {});",
     ];
 
     let fix = vec![
@@ -189,6 +201,13 @@ describe('other bar', function() {
     });
 });
             ",
+        ),
+        (
+            "test('foo', () => {});
+const thing = 123;",
+            "test('foo', () => {});
+
+const thing = 123;",
         ),
     ];
     Tester::new(PaddingAroundTestBlocks::NAME, PaddingAroundTestBlocks::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_after_all_blocks.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_after_all_blocks.rs
@@ -4,7 +4,7 @@ use crate::{
     context::LintContext,
     utils::{
         JestGeneralFnKind, ParsedGeneralJestFnCall, PossibleJestNode, parse_general_jest_fn_call,
-        report_missing_padding_before_jest_block,
+        report_missing_padding_after_jest_block, report_missing_padding_before_jest_block,
     },
 };
 
@@ -55,4 +55,5 @@ pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<
         return;
     }
     report_missing_padding_before_jest_block(node, ctx, name);
+    report_missing_padding_after_jest_block(node, ctx, name);
 }

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_after_all_blocks.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_after_all_blocks.rs
@@ -55,5 +55,5 @@ pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<
         return;
     }
     report_missing_padding_before_jest_block(node, ctx, name);
-    report_missing_padding_after_jest_block(node, ctx, name);
+    report_missing_padding_after_jest_block(node, ctx, name, |next| next == "afterAll");
 }

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_test_blocks.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_test_blocks.rs
@@ -3,7 +3,8 @@ use oxc_ast::AstKind;
 use crate::{
     context::LintContext,
     utils::{
-        JestGeneralFnKind, ParsedGeneralJestFnCall, PossibleJestNode, parse_general_jest_fn_call,
+        JestFnKind, JestGeneralFnKind, ParsedGeneralJestFnCall, PossibleJestNode,
+        parse_general_jest_fn_call, report_missing_padding_after_jest_block,
         report_missing_padding_before_jest_block,
     },
 };
@@ -69,4 +70,9 @@ pub fn run<'a>(jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
         return;
     }
     report_missing_padding_before_jest_block(node, ctx, name);
+    // Any test block covers the gap after this one through its own "before" check, and `test` /
+    // `it` and their variants are interchangeable, so match on the kind rather than the name.
+    report_missing_padding_after_jest_block(node, ctx, name, |next| {
+        JestFnKind::from(next) == JestFnKind::General(JestGeneralFnKind::Test)
+    });
 }

--- a/crates/oxc_linter/src/rules/vitest/padding_around_after_all_blocks.rs
+++ b/crates/oxc_linter/src/rules/vitest/padding_around_after_all_blocks.rs
@@ -47,6 +47,13 @@ fn test() {
         "const thing = 123;\n\n/**\n * JSDoc attached to afterAll\n */\nafterAll(() => {});",
         "const thing = 123; /* trailing on prev */\n\nafterAll(() => {});",
         "describe('foo', () => {\nafterAll(() => {});\n\nafterAll(() => {});\n});",
+        // Issue: <https://github.com/oxc-project/oxc/issues/25590>
+        "afterAll(() => {});
+
+describe('suite', () => {});",
+        "afterAll(() => {}); // trailing
+
+describe('suite', () => {});",
     ];
 
     let fail = vec![
@@ -59,6 +66,12 @@ fn test() {
         "const thing = 123;\n/**\n * JSDoc comment\n */\nafterAll(() => {});",
         "describe('foo', () => {\nafterAll(() => {});\nafterAll(() => {});\n});",
         "import { afterAll } from 'vitest';\n/* setup notes */\nafterAll(() => {});",
+        // Issue: <https://github.com/oxc-project/oxc/issues/25590>
+        "afterAll(() => {});
+describe('suite', () => {});",
+        "afterAll(() => {});
+/* one */
+describe('suite', () => {});",
     ];
 
     let fix = vec![
@@ -83,6 +96,22 @@ fn test() {
         (
             "describe('foo', () => {\nafterAll(() => {});\nafterAll(() => {});\n});",
             "describe('foo', () => {\nafterAll(() => {});\n\nafterAll(() => {});\n});",
+        ),
+        (
+            "afterAll(() => {});
+describe('suite', () => {});",
+            "afterAll(() => {});
+
+describe('suite', () => {});",
+        ),
+        (
+            "afterAll(() => {});
+/* one */
+describe('suite', () => {});",
+            "afterAll(() => {});
+
+/* one */
+describe('suite', () => {});",
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/vitest/padding_around_test_blocks.rs
+++ b/crates/oxc_linter/src/rules/vitest/padding_around_test_blocks.rs
@@ -42,6 +42,13 @@ fn test() {
         "{ test('foo', () => {}); }",
         "describe('foo', () => {\ntest('bar', () => {});\n});",
         "const thing = 123;\n\n/* one */\n/* two */\ntest('foo', () => {});",
+        // Issue: <https://github.com/oxc-project/oxc/issues/25590>
+        "test('foo', () => {});
+
+const thing = 123;",
+        "test('foo', () => {});
+
+it('bar', () => {});",
     ];
 
     let fail = vec![
@@ -79,6 +86,11 @@ describe('other bar', function() {
     });
 });
             ",
+        // Issue: <https://github.com/oxc-project/oxc/issues/25590>
+        "test('foo', () => {});
+const thing = 123;",
+        "it('foo', () => {});
+describe('bar', () => {});",
     ];
 
     let fix = vec![
@@ -168,6 +180,13 @@ describe('other bar', function() {
     });
 });
             ",
+        ),
+        (
+            "test('foo', () => {});
+const thing = 123;",
+            "test('foo', () => {});
+
+const thing = 123;",
         ),
     ];
     Tester::new(PaddingAroundTestBlocks::NAME, PaddingAroundTestBlocks::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_after_all_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_after_all_blocks.snap
@@ -17,3 +17,19 @@ source: crates/oxc_linter/src/tester.rs
    · ▲
    ╰────
   help: Make sure there is an empty new line before the afterAll block
+
+  ⚠ jest(padding-around-after-all-blocks): Missing padding after afterAll block
+   ╭─[padding_around_after_all_blocks.tsx:1:20]
+ 1 │ afterAll(() => {});
+   ·                    ▲
+ 2 │ describe('suite', () => {});
+   ╰────
+  help: Make sure there is an empty new line after the afterAll block
+
+  ⚠ jest(padding-around-after-all-blocks): Missing padding after afterAll block
+   ╭─[padding_around_after_all_blocks.tsx:1:20]
+ 1 │ afterAll(() => {});
+   ·                    ▲
+ 2 │ /* one */
+   ╰────
+  help: Make sure there is an empty new line after the afterAll block

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
@@ -60,6 +60,15 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Make sure there is an empty new line before the it block
 
+  ⚠ jest(padding-around-test-blocks): Missing padding after it block
+    ╭─[padding_around_test_blocks.tsx:20:9]
+ 19 │      it('is another bar w/ it', () => {
+ 20 │      });
+    ·         ▲
+ 21 │      test.skip('skipping', () => {}); // Another comment
+    ╰────
+  help: Make sure there is an empty new line after the it block
+
   ⚠ jest(padding-around-test-blocks): Missing padding before it block
     ╭─[padding_around_test_blocks.tsx:22:6]
  21 │      test.skip('skipping', () => {}); // Another comment
@@ -114,6 +123,15 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Make sure there is an empty new line before the test block
 
+  ⚠ jest(padding-around-test-blocks): Missing padding after test block
+    ╭─[padding_around_test_blocks.tsx:21:38]
+ 20 │      });
+ 21 │      test.skip('skipping', () => {}); // Another comment
+    ·                                      ▲
+ 22 │      it.skip('skipping too', () => {});
+    ╰────
+  help: Make sure there is an empty new line after the test block
+
   ⚠ jest(padding-around-test-blocks): Missing padding before test block
     ╭─[padding_around_test_blocks.tsx:24:2]
  23 │  });xtest('weird', () => {});
@@ -132,6 +150,15 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Make sure there is an empty new line before the xtest block
 
+  ⚠ jest(padding-around-test-blocks): Missing padding after xtest block
+    ╭─[padding_around_test_blocks.tsx:23:30]
+ 22 │      it.skip('skipping too', () => {});
+ 23 │  });xtest('weird', () => {});
+    ·                              ▲
+ 24 │  test
+    ╰────
+  help: Make sure there is an empty new line after the xtest block
+
   ⚠ jest(padding-around-test-blocks): Missing padding before xit block
     ╭─[padding_around_test_blocks.tsx:26:2]
  25 │    .skip('skippy skip', () => {});
@@ -149,3 +176,19 @@ source: crates/oxc_linter/src/tester.rs
  6 │     });
    ╰────
   help: Make sure there is an empty new line before the it block
+
+  ⚠ jest(padding-around-test-blocks): Missing padding after test block
+   ╭─[padding_around_test_blocks.tsx:1:23]
+ 1 │ test('foo', () => {});
+   ·                       ▲
+ 2 │ const thing = 123;
+   ╰────
+  help: Make sure there is an empty new line after the test block
+
+  ⚠ jest(padding-around-test-blocks): Missing padding after it block
+   ╭─[padding_around_test_blocks.tsx:1:21]
+ 1 │ it('foo', () => {});
+   ·                     ▲
+ 2 │ describe('bar', () => {});
+   ╰────
+  help: Make sure there is an empty new line after the it block

--- a/crates/oxc_linter/src/snapshots/vitest_padding_around_after_all_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_padding_around_after_all_blocks.snap
@@ -74,3 +74,19 @@ source: crates/oxc_linter/src/tester.rs
    · ▲
    ╰────
   help: Make sure there is an empty new line before the afterAll block
+
+  ⚠ vitest(padding-around-after-all-blocks): Missing padding after afterAll block
+   ╭─[padding_around_after_all_blocks.tsx:1:20]
+ 1 │ afterAll(() => {});
+   ·                    ▲
+ 2 │ describe('suite', () => {});
+   ╰────
+  help: Make sure there is an empty new line after the afterAll block
+
+  ⚠ vitest(padding-around-after-all-blocks): Missing padding after afterAll block
+   ╭─[padding_around_after_all_blocks.tsx:1:20]
+ 1 │ afterAll(() => {});
+   ·                    ▲
+ 2 │ /* one */
+   ╰────
+  help: Make sure there is an empty new line after the afterAll block

--- a/crates/oxc_linter/src/snapshots/vitest_padding_around_test_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_padding_around_test_blocks.snap
@@ -43,6 +43,15 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Make sure there is an empty new line before the it block
 
+  ⚠ vitest(padding-around-test-blocks): Missing padding after it block
+    ╭─[padding_around_test_blocks.tsx:17:9]
+ 16 │      it('is another bar w/ it', () => {
+ 17 │      });
+    ·         ▲
+ 18 │      test.skip('skipping', () => {}); // Another comment
+    ╰────
+  help: Make sure there is an empty new line after the it block
+
   ⚠ vitest(padding-around-test-blocks): Missing padding before it block
     ╭─[padding_around_test_blocks.tsx:19:6]
  18 │      test.skip('skipping', () => {}); // Another comment
@@ -88,6 +97,15 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Make sure there is an empty new line before the test block
 
+  ⚠ vitest(padding-around-test-blocks): Missing padding after test block
+    ╭─[padding_around_test_blocks.tsx:18:38]
+ 17 │      });
+ 18 │      test.skip('skipping', () => {}); // Another comment
+    ·                                      ▲
+ 19 │      it.skip('skipping too', () => {});
+    ╰────
+  help: Make sure there is an empty new line after the test block
+
   ⚠ vitest(padding-around-test-blocks): Missing padding before test block
     ╭─[padding_around_test_blocks.tsx:21:2]
  20 │  });
@@ -105,3 +123,19 @@ source: crates/oxc_linter/src/tester.rs
  6 │     });
    ╰────
   help: Make sure there is an empty new line before the it block
+
+  ⚠ vitest(padding-around-test-blocks): Missing padding after test block
+   ╭─[padding_around_test_blocks.tsx:1:23]
+ 1 │ test('foo', () => {});
+   ·                       ▲
+ 2 │ const thing = 123;
+   ╰────
+  help: Make sure there is an empty new line after the test block
+
+  ⚠ vitest(padding-around-test-blocks): Missing padding after it block
+   ╭─[padding_around_test_blocks.tsx:1:21]
+ 1 │ it('foo', () => {});
+   ·                     ▲
+ 2 │ describe('bar', () => {});
+   ╰────
+  help: Make sure there is an empty new line after the it block

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -20,7 +20,9 @@ pub use crate::utils::jest::parse_jest_fn::{
     MemberExpressionElement, ParsedExpectFnCall, ParsedGeneralJestFnCall,
     ParsedJestFnCall as ParsedJestFnCallNew, parse_jest_fn_call,
 };
-pub use padding_around_block::report_missing_padding_before_jest_block;
+pub use padding_around_block::{
+    report_missing_padding_after_jest_block, report_missing_padding_before_jest_block,
+};
 
 mod padding_around_block;
 mod parse_jest_fn;

--- a/crates/oxc_linter/src/utils/jest/padding_around_block.rs
+++ b/crates/oxc_linter/src/utils/jest/padding_around_block.rs
@@ -1,4 +1,7 @@
-use oxc_ast::{AstKind, ast::Statement};
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, Statement},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::AstNode;
 use oxc_span::{GetSpan, Span};
@@ -8,6 +11,12 @@ use crate::context::LintContext;
 fn padding_around_jest_block_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Missing padding before {name} block"))
         .with_help(format!("Make sure there is an empty new line before the {name} block"))
+        .with_label(span)
+}
+
+fn padding_after_jest_block_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Missing padding after {name} block"))
+        .with_help(format!("Make sure there is an empty new line after the {name} block"))
         .with_label(span)
 }
 
@@ -71,6 +80,81 @@ pub fn report_missing_padding_before_jest_block<'a>(
     }
 }
 
+/// Counterpart of [`report_missing_padding_before_jest_block`] for the other side of the block.
+///
+/// The rules that use these enforce padding *around* a block, so a block that opens a scope — with
+/// nothing before it but a statement after it — still needs a blank line separating it from what
+/// follows.
+pub fn report_missing_padding_after_jest_block<'a>(
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+    name: &str,
+) {
+    let scope_node = ctx.nodes().get_node(ctx.scoping().get_node_id(node.scope_id()));
+    let spans = match scope_node.kind() {
+        AstKind::Program(program) => get_statement_spans_after_node(node, program.body.as_slice()),
+        AstKind::ArrowFunctionExpression(arrow_func_expr) => {
+            let Some(body) = arrow_func_expr.get_function_body() else { return };
+            get_statement_spans_after_node(node, body.statements.as_slice())
+        }
+        AstKind::Function(function) => {
+            let Some(body) = &function.body else {
+                return;
+            };
+            get_statement_spans_after_node(node, body.statements.as_slice())
+        }
+        _ => None,
+    };
+    let Some((own_statement_span, next_statement_span, next_statement)) = spans else {
+        return;
+    };
+
+    // When the next statement is another block of the same kind, it reports this very gap through
+    // its own "before" check. Reporting from both sides would flag one missing blank line twice.
+    if is_call_to(next_statement, name) {
+        return;
+    }
+
+    let comments_range = ctx.comments_range(own_statement_span.end..next_statement_span.start);
+    let mut span_between_start = own_statement_span.end;
+    let mut span_between_end = next_statement_span.start;
+    let mut prev_attached_end = own_statement_span.end;
+    for comment in comments_range {
+        let comment_span = comment.span;
+        // A comment on the same line as the block trails the block itself, so the blank line
+        // belongs after it rather than before.
+        let space_before = ctx.source_range(Span::new(prev_attached_end, comment_span.start));
+        if space_before.matches('\n').count() == 0 {
+            span_between_start = comment_span.end;
+            prev_attached_end = comment_span.end;
+            continue;
+        }
+        // Otherwise the comment leads the next statement, so the blank line belongs before it.
+        let space_after = ctx.source_range(Span::new(comment_span.end, span_between_end));
+        if space_after.matches('\n').count() > 1 {
+            break;
+        }
+        span_between_end = comment_span.start;
+        break;
+    }
+
+    let span_between = Span::new(span_between_start, span_between_end);
+    let content = ctx.source_range(span_between);
+    if content.matches('\n').count() < 2 {
+        ctx.diagnostic_with_fix(
+            padding_after_jest_block_diagnostic(
+                Span::new(own_statement_span.end, own_statement_span.end),
+                name,
+            ),
+            |fixer| {
+                let whitespace_after_last_line =
+                    content.rfind('\n').map_or("", |index| content.split_at(index + 1).1);
+                fixer.replace(span_between, format!("\n\n{whitespace_after_last_line}"))
+            },
+        );
+    }
+}
+
 fn get_statement_span_before_node(node: &AstNode, statements: &[Statement]) -> Option<Span> {
     statements
         .iter()
@@ -78,4 +162,29 @@ fn get_statement_span_before_node(node: &AstNode, statements: &[Statement]) -> O
             if statement.span().end <= node.span().start { Some(statement.span()) } else { None }
         })
         .next_back()
+}
+
+/// The span of the statement containing `node`, paired with the span of the statement that follows
+/// it in the same block. `None` when the block is the last statement — nothing to pad against.
+fn get_statement_spans_after_node<'a, 'b>(
+    node: &AstNode,
+    statements: &'b [Statement<'a>],
+) -> Option<(Span, Span, &'b Statement<'a>)> {
+    let index = statements.iter().position(|statement| {
+        let span = statement.span();
+        span.start <= node.span().start && node.span().end <= span.end
+    })?;
+    let next = statements.get(index + 1)?;
+    Some((statements[index].span(), next.span(), next))
+}
+
+/// Whether `statement` is a bare call to `name`, i.e. another block of the same kind.
+fn is_call_to(statement: &Statement, name: &str) -> bool {
+    let Statement::ExpressionStatement(expr_statement) = statement else {
+        return false;
+    };
+    let Expression::CallExpression(call_expr) = &expr_statement.expression else {
+        return false;
+    };
+    call_expr.callee.get_identifier_reference().is_some_and(|ident| ident.name == name)
 }

--- a/crates/oxc_linter/src/utils/jest/padding_around_block.rs
+++ b/crates/oxc_linter/src/utils/jest/padding_around_block.rs
@@ -89,6 +89,7 @@ pub fn report_missing_padding_after_jest_block<'a>(
     node: &AstNode<'a>,
     ctx: &LintContext<'a>,
     name: &str,
+    reports_own_padding_before: impl Fn(&str) -> bool,
 ) {
     let scope_node = ctx.nodes().get_node(ctx.scoping().get_node_id(node.scope_id()));
     let spans = match scope_node.kind() {
@@ -109,9 +110,11 @@ pub fn report_missing_padding_after_jest_block<'a>(
         return;
     };
 
-    // When the next statement is another block of the same kind, it reports this very gap through
-    // its own "before" check. Reporting from both sides would flag one missing blank line twice.
-    if is_call_to(next_statement, name) {
+    // When the next statement is another block this same rule covers, it reports this very gap
+    // through its own "before" check. Reporting from both sides would flag one missing blank line
+    // twice. The caller decides what "same block" means: `afterAll` matches only itself, while the
+    // test rule covers `test`, `it` and their variants, which are interchangeable here.
+    if is_covered_call(next_statement, &reports_own_padding_before) {
         return;
     }
 
@@ -178,13 +181,13 @@ fn get_statement_spans_after_node<'a, 'b>(
     Some((statements[index].span(), next.span(), next))
 }
 
-/// Whether `statement` is a bare call to `name`, i.e. another block of the same kind.
-fn is_call_to(statement: &Statement, name: &str) -> bool {
+/// Whether `statement` is a bare call to a block the caller's rule reports padding for.
+fn is_covered_call(statement: &Statement, is_covered: &impl Fn(&str) -> bool) -> bool {
     let Statement::ExpressionStatement(expr_statement) = statement else {
         return false;
     };
     let Expression::CallExpression(call_expr) = &expr_statement.expression else {
         return false;
     };
-    call_expr.callee.get_identifier_reference().is_some_and(|ident| ident.name == name)
+    call_expr.callee.get_identifier_reference().is_some_and(|ident| is_covered(&ident.name))
 }


### PR DESCRIPTION
Also closes #25590. **Stacked on #25693** — that PR is the first commit here; review or merge it first and this rebases to a single commit.

I said in #25693 that `padding-around-test-blocks` had the same one-sided implementation and offered to follow up. This is that follow-up, kept separate so you can take the two independently.

## The problem

Identical shape to the `afterAll` case: the rule documents padding "before and after" a test block, but only called `report_missing_padding_before_jest_block`. So a test block followed by anything that is not itself a test block goes unreported:

```js
test('foo', () => {});
const thing = 123;
```

## The part that needed more than a copy

The guard I added in #25693 stops one missing blank line being reported twice — once by a block's "after" check and once by the next block's "before" check. It compared the next statement's callee to the block's own name, which is correct for `afterAll` and **wrong here**: `test('a'); it('b');` are two blocks this same rule covers under different names, so both sides would have reported the same gap.

So the helper now takes a predicate instead of a name. `afterAll` passes `|next| next == "afterAll"`; the test rule passes a check against the whole `JestGeneralFnKind::Test` family, reusing `JestFnKind::from` rather than hardcoding `test`/`it`/`fit`/`xit`/`xtest`.

The `afterAll` snapshots come out **unchanged**, which is the evidence that generalising the guard left that rule's behaviour exactly as #25693 leaves it.

## Tests

Added to both the jest and vitest rule files:

- **pass** — `test('foo', …);\n\nconst thing = 123;` and `test('foo', …);\n\nit('bar', …);`
- **fail** — the same two without the blank line, the second using different block names (`it` then `describe`) so the predicate is actually exercised
- **fix** — the blank line is inserted between the block and the following statement

Both new snapshots are additions only (`+43/-0` and `+34/-0`); nothing existing moved.

## Verification

`cargo test -p oxc_linter --lib` — 1222 passed, 0 failed. `cargo clippy -p oxc_linter --lib` clean.

> AI disclosure, per the contributing policy: I used an AI assistant while investigating and writing this. I have read and understand the change, ran the tests myself, and stand behind it.
