### PR TITLE
test(transformer): cover baseline browserslist targets

### DIFF
--- a/crates/oxc_transformer/tests/integrations/targets.rs
+++ b/crates/oxc_transformer/tests/integrations/targets.rs
@@ -4,6 +4,28 @@ use oxc_transformer::{ESTarget, EnvOptions, TransformOptions};
 use crate::{codegen, test};
 
 #[test]
+fn baseline_targets() {
+    // Use fixed dates and years for feature boundaries that change over time.
+    for (query, target, source_text) in [
+        ("baseline newly available", ESTarget::ES2026, "using x = acquire();"),
+        ("baseline widely available on 2026-08-15", ESTarget::ES2025, "using x = acquire();"),
+        ("baseline 2020", ESTarget::ES2021, "class C { static { foo(); } }"),
+        ("baseline widely available on 2022-07-01", ESTarget::ES2020, "a ||= b;"),
+        ("baseline widely available on 2022-07-01", ESTarget::ES2017, "({ ...x });"),
+    ] {
+        let options = TransformOptions {
+            env: EnvOptions::from_browserslist_query(query).unwrap(),
+            ..TransformOptions::default()
+        };
+        assert_eq!(
+            test(source_text, &TransformOptions::from(target)),
+            test(source_text, &options),
+            "{query} should match {target} for {source_text}",
+        );
+    }
+}
+
+#[test]
 fn targets() {
     let cases = [
         ("() => {}"),
@@ -16,13 +38,26 @@ fn targets() {
         "1n ** 2n",
     ];
 
-    // Test no transformation for default targets.
-    let options = TransformOptions {
-        env: EnvOptions::from_browserslist_query("defaults").unwrap(),
-        ..TransformOptions::default()
-    };
-    for case in cases {
-        assert_eq!(Ok(codegen(case, SourceType::mjs())), test(case, &options));
+    // Test no transformation for modern targets.
+    for query in [
+        "defaults",
+        "baseline widely available",
+        "baseline newly available",
+        "baseline 2020",
+        "baseline widely available with downstream",
+        "baseline widely available including kaios",
+    ] {
+        let options = TransformOptions {
+            env: EnvOptions::from_browserslist_query(query).unwrap(),
+            ..TransformOptions::default()
+        };
+        for case in cases {
+            assert_eq!(
+                Ok(codegen(case, SourceType::mjs())),
+                test(case, &options),
+                "{query}: {case}",
+            );
+        }
     }
 
     // Test transformation for very low targets.


### PR DESCRIPTION
Adds transformer integration coverage for Baseline Browserslist queries and verifies feature-specific lowering across dated and year-based targets.

Created with AI assistance.