### PR TITLE
ci(miri): allow host clock access

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -64,7 +64,7 @@ jobs:
         if: steps.filter.outputs.changed == 'true'
         # Enable strict provenance checks
         env:
-          MIRIFLAGS: -Zmiri-strict-provenance
+          MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-disable-isolation
         run: |
           cargo +"${MIRI_TOOLCHAIN}" miri test --all-features -p oxc_allocator -p oxc_ast -p oxc_data_structures
           cargo +"${MIRI_TOOLCHAIN}" miri test -p oxc_parser -p oxc_transformer


### PR DESCRIPTION
Allows Miri's transformer checks to access the host clock required by `oxc-browserslist` while preserving strict provenance checks.

This fixes the `baseline_targets` failure caused by isolated `clock_gettime`. The failing target passes with the pinned Miri toolchain.