### PR TITLE
fix(react-compiler): isolate typeof branch inference

### DIFF
--- a/crates/oxc_react_compiler/fixtures/bug-type-inference-control-flow.ts
+++ b/crates/oxc_react_compiler/fixtures/bug-type-inference-control-flow.ts
@@ -1,21 +1,15 @@
 import {arrayPush, CONST_NUMBER0, mutate} from 'shared-runtime';
 
 /**
- * Repro for bug in our type inference system. We currently propagate inferred
- * types through control flow / potential type guards. Note that this is
- * inconsistent with both Flow and Typescript.
+ * Regression test for flow-insensitive type inference through a potential
+ * type guard. A primitive use in one branch must not constrain sibling uses.
  * https://flow.org/try/#1N4Igxg9gdgZglgcxALlAIwIZoKYBsD6uEEAztvhgE6UYCe+JADpdhgCYowa5kA0I2KAFcAtiRQAXSkOz9sADwxgJ+NPTbYuQ3BMnTZA+Y2yU4IwRO4A6SFBIrGVDGM7c+h46fNRLuKxJIGWh8MeT0ZfhYlCStpHzNsFBAMIQkIEQwJODAQfiEyfBE4eWw2fDgofDBMsAALfAA3KjgsXGxxZC4eAw0G-GhcWn9aY3wWZldu-g1mbGqJUoBaCRHEzrcDEgBrbAk62kXhXFxJ923d-cPRHEpTgyEoMDaqZdW7vKgoOfaSKgOKpqmDA+d4gB5fMA-P6LCCMLLQbiLOoYCqgh6-GDYRYIXYLSgkRZkCR4jpddwPfJLZjpOBkO4AX34kA0SRWxgABAAxYjsgC87OAAB0oOzReythU2Mh2YKQNyILLeMKxeymrgZNLhCIbsL6QBuYVs7DsgBCVD5AuVYolUClMpAZsoiqtorVGvZWpuSqg9OFMAeyjg0HZdTmW3lAAp5NKAPJoABWcwkAEppWZGLg4O12fJ2bSuTyhSKxSwJEJKCKAOQ2tiVvMi3MAMkbOasNb5vP5svlsoNPuFfoD8JFGQqUel8vZAB9TVReCHoHa0MRnlBUwWIJbi6K4DB2RHbGxk1uVSrd-uAIShsDh4hR5PHoun5-siS1SgQADuHuw34AotQECUBGsqysmfYvuyvrbqepblg2EFitBKpwRWOZ9vSuQgA0JgkEGUBJBk9gmCA9JAA
  * https://www.typescriptlang.org/play/?#code/C4TwDgpgBAYg9nKBeKBvAUFLUDWBLAOwBMAuKAInjnIBpNsA3AQwBsBXCMgtgWwCMIAJ3QBfANzpQkKACEmg5GnpZ8xMuTmDayqM3aco3fkLoj0AMzYEAxsDxwCUawAsI1nFQAUADzJw+AFZuwACUZEwAzhFCwBFQ3lB4cVRK2InmUJ4AhJ4A5KpEuYmOCQBkpfEAdAXISCiUCOQhIalp2MDOgnAA7oYQvQCigl2CnuRWEN6QthBETTpmZhZWtvaOPEyEPmQpAD6y8jRODqRQfAgsEEwEYbAIrVh4GZ7WJy0Ybdgubh4IPiEST5YQQQYBsQQlQHYMxpEFgiHxCQiIA
  *
- * Found differences in evaluator results
- * Non-forget (expected):
+ * Expected evaluator results:
  *   (kind: ok)
  *   [2]
  *   [3]
- * Forget:
- *   (kind: ok)
- *   [2]
- *   [2,3]
  */
 function useFoo({cond, value}: {cond: boolean; value: number}) {
   const x = {value: cond ? CONST_NUMBER0 : []};
@@ -24,9 +18,9 @@ function useFoo({cond, value}: {cond: boolean; value: number}) {
   const xValue = x.value;
   let result;
   if (typeof xValue === 'number') {
-    result = xValue + 1; //               (1) here we infer xValue is a primitive
+    result = xValue + 1; //               (1) this use is guarded by typeof
   } else {
-    result = arrayPush(xValue, value); // (2) and propagate it to all other xValue references
+    result = arrayPush(xValue, value); // (2) xValue can still be an array here
   }
 
   return result;

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -10,7 +10,7 @@
 
 use std::mem::replace;
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::Allocator;
 use oxc_diagnostics::OxcDiagnostic;
@@ -29,7 +29,7 @@ use crate::react_compiler_hir::{
     IdentifierName, Instruction, InstructionId, InstructionKind, InstructionValue, JsxAttribute,
     JsxTag, LoweredFunction, ManualMemoDependencyRoot, NonLocalBinding, ObjectPropertyKey,
     ObjectPropertyOrSpread, ParamPattern, Pattern, PlaceOrSpread, PropertyLiteral,
-    PropertyNameKind, ReactFunctionType, Terminal, Type, TypeId,
+    PropertyNameKind, ReactFunctionType, Terminal, Type, TypeId, UnaryOperator,
 };
 use crate::react_compiler_ssa::enter_ssa::placeholder_function;
 use oxc_ast::ast::BinaryOperator;
@@ -474,17 +474,26 @@ fn generate_instruction_types<'a>(
             unifier.unify(left, Type::Primitive, shapes)?;
         }
 
-        InstructionValue::UnaryExpression { .. } => {
+        InstructionValue::UnaryExpression { operator, value, .. } => {
+            if *operator == UnaryOperator::TypeOf {
+                unifier.mark_typeof_operand(value.identifier);
+            }
             unifier.unify(left, Type::Primitive, shapes)?;
         }
 
         InstructionValue::LoadLocal { place, .. } => {
+            unifier.record_load_alias(instr.lvalue.identifier, place.identifier);
             set_name(names, instr.lvalue.identifier, &identifiers[place.identifier]);
             let place_type = get_type(place.identifier, identifiers);
             unifier.unify(left, place_type, shapes)?;
         }
 
-        InstructionValue::DeclareContext { .. } | InstructionValue::LoadContext { .. } => {
+        InstructionValue::LoadContext { place, .. } => {
+            unifier.record_load_alias(instr.lvalue.identifier, place.identifier);
+            // Intentionally skip type inference for most context variables
+        }
+
+        InstructionValue::DeclareContext { .. } => {
             // Intentionally skip type inference for most context variables
         }
 
@@ -512,10 +521,15 @@ fn generate_instruction_types<'a>(
             operator, left: bin_left, right: bin_right, ..
         } => {
             if is_primitive_binary_op(operator) {
-                let left_operand_type = get_type(bin_left.identifier, identifiers);
-                unifier.unify(left_operand_type, Type::Primitive, shapes)?;
-                let right_operand_type = get_type(bin_right.identifier, identifiers);
-                unifier.unify(right_operand_type, Type::Primitive, shapes)?;
+                // A `typeof` use can act as a control-flow type guard. Our type
+                // inference is flow-insensitive, so constraints learned from a
+                // guarded branch must not propagate to sibling branches.
+                for operand in [bin_left, bin_right] {
+                    if !unifier.is_typeof_operand(operand.identifier) {
+                        let operand_type = get_type(operand.identifier, identifiers);
+                        unifier.unify(operand_type, Type::Primitive, shapes)?;
+                    }
+                }
             }
             unifier.unify(left, Type::Primitive, shapes)?;
         }
@@ -1171,6 +1185,8 @@ fn apply_instruction_operands<'a>(
 
 struct Unifier<'a> {
     substitutions: FxHashMap<TypeId, Type<'a>>,
+    load_aliases: FxHashMap<IdentifierId, IdentifierId>,
+    typeof_operands: FxHashSet<IdentifierId>,
     enable_treat_ref_like_identifiers_as_refs: bool,
     enable_treat_set_identifiers_as_state_setters: bool,
     custom_hook_type: Option<Type<'a>>,
@@ -1184,10 +1200,34 @@ impl<'a> Unifier<'a> {
     ) -> Self {
         Unifier {
             substitutions: FxHashMap::default(),
+            load_aliases: FxHashMap::default(),
+            typeof_operands: FxHashSet::default(),
             enable_treat_ref_like_identifiers_as_refs,
             enable_treat_set_identifiers_as_state_setters,
             custom_hook_type,
         }
+    }
+
+    fn record_load_alias(&mut self, lvalue: IdentifierId, value: IdentifierId) {
+        self.load_aliases.insert(lvalue, value);
+    }
+
+    fn resolve_load_root(&self, mut identifier: IdentifierId) -> IdentifierId {
+        while let Some(&next) = self.load_aliases.get(&identifier) {
+            if next == identifier {
+                break;
+            }
+            identifier = next;
+        }
+        identifier
+    }
+
+    fn mark_typeof_operand(&mut self, identifier: IdentifierId) {
+        self.typeof_operands.insert(self.resolve_load_root(identifier));
+    }
+
+    fn is_typeof_operand(&self, identifier: IdentifierId) -> bool {
+        self.typeof_operands.contains(&self.resolve_load_root(identifier))
     }
 
     fn unify(

--- a/crates/oxc_react_compiler/tests/snapshots/bug-type-inference-control-flow.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/bug-type-inference-control-flow.snap
@@ -5,49 +5,34 @@ input_file: crates/oxc_react_compiler/fixtures/bug-type-inference-control-flow.t
 import { c as _c } from "react/compiler-runtime";
 import { arrayPush, CONST_NUMBER0, mutate } from "shared-runtime";
 /**
-* Repro for bug in our type inference system. We currently propagate inferred
-* types through control flow / potential type guards. Note that this is
-* inconsistent with both Flow and Typescript.
+* Regression test for flow-insensitive type inference through a potential
+* type guard. A primitive use in one branch must not constrain sibling uses.
 * https://flow.org/try/#1N4Igxg9gdgZglgcxALlAIwIZoKYBsD6uEEAztvhgE6UYCe+JADpdhgCYowa5kA0I2KAFcAtiRQAXSkOz9sADwxgJ+NPTbYuQ3BMnTZA+Y2yU4IwRO4A6SFBIrGVDGM7c+h46fNRLuKxJIGWh8MeT0ZfhYlCStpHzNsFBAMIQkIEQwJODAQfiEyfBE4eWw2fDgofDBMsAALfAA3KjgsXGxxZC4eAw0G-GhcWn9aY3wWZldu-g1mbGqJUoBaCRHEzrcDEgBrbAk62kXhXFxJ923d-cPRHEpTgyEoMDaqZdW7vKgoOfaSKgOKpqmDA+d4gB5fMA-P6LCCMLLQbiLOoYCqgh6-GDYRYIXYLSgkRZkCR4jpddwPfJLZjpOBkO4AX34kA0SRWxgABAAxYjsgC87OAAB0oOzReythU2Mh2YKQNyILLeMKxeymrgZNLhCIbsL6QBuYVs7DsgBCVD5AuVYolUClMpAZsoiqtorVGvZWpuSqg9OFMAeyjg0HZdTmW3lAAp5NKAPJoABWcwkAEppWZGLg4O12fJ2bSuTyhSKxSwJEJKCKAOQ2tiVvMi3MAMkbOasNb5vP5svlsoNPuFfoD8JFGQqUel8vZAB9TVReCHoHa0MRnlBUwWIJbi6K4DB2RHbGxk1uVSrd-uAIShsDh4hR5PHoun5-siS1SgQADuHuw34AotQECUBGsqysmfYvuyvrbqepblg2EFitBKpwRWOZ9vSuQgA0JgkEGUBJBk9gmCA9JAA
 * https://www.typescriptlang.org/play/?#code/C4TwDgpgBAYg9nKBeKBvAUFLUDWBLAOwBMAuKAInjnIBpNsA3AQwBsBXCMgtgWwCMIAJ3QBfANzpQkKACEmg5GnpZ8xMuTmDayqM3aco3fkLoj0AMzYEAxsDxwCUawAsI1nFQAUADzJw+AFZuwACUZEwAzhFCwBFQ3lB4cVRK2InmUJ4AhJ4A5KpEuYmOCQBkpfEAdAXISCiUCOQhIalp2MDOgnAA7oYQvQCigl2CnuRWEN6QthBETTpmZhZWtvaOPEyEPmQpAD6y8jRODqRQfAgsEEwEYbAIrVh4GZ7WJy0Ybdgubh4IPiEST5YQQQYBsQQlQHYMxpEFgiHxCQiIA
 *
-* Found differences in evaluator results
-* Non-forget (expected):
+* Expected evaluator results:
 *   (kind: ok)
 *   [2]
 *   [3]
-* Forget:
-*   (kind: ok)
-*   [2]
-*   [2,3]
 */
 function useFoo(t0) {
-	const $ = _c(5);
+	const $ = _c(3);
 	const { cond, value } = t0;
-	let x;
-	if ($[0] !== cond) {
-		x = { value: cond ? CONST_NUMBER0 : [] };
-		mutate(x);
-		$[0] = cond;
-		$[1] = x;
-	} else {
-		x = $[1];
-	}
-	const xValue = x.value;
 	let result;
-	if (typeof xValue === "number") {
-		result = xValue + 1;
-	} else {
-		let t1;
-		if ($[2] !== value || $[3] !== xValue) {
-			t1 = arrayPush(xValue, value);
-			$[2] = value;
-			$[3] = xValue;
-			$[4] = t1;
+	if ($[0] !== cond || $[1] !== value) {
+		const x = { value: cond ? CONST_NUMBER0 : [] };
+		mutate(x);
+		const xValue = x.value;
+		if (typeof xValue === "number") {
+			result = xValue + 1;
 		} else {
-			t1 = $[4];
+			result = arrayPush(xValue, value);
 		}
-		result = t1;
+		$[0] = cond;
+		$[1] = value;
+		$[2] = result;
+	} else {
+		result = $[2];
 	}
 	return result;
 }


### PR DESCRIPTION
Prevents a `typeof` use in one control-flow branch from constraining sibling uses of the same loaded value, avoiding incorrect memoization.

Validated with the React compiler suite, a runtime regression assertion, Clippy, and repository checks; Oxlint ANSI cases were rerun with color enabled.

AI-assisted: Codex was used for runtime differential analysis and implementation support.