### PR TITLE
refactor(packages/codegen): move debug asserts for non-empty `code` into `write*` functions

### DIFF
--- a/packages/codegen/src-js/print/write.ts
+++ b/packages/codegen/src-js/print/write.ts
@@ -217,6 +217,7 @@ if (DEBUG) {
  * @param last - Category of the last character of `code`
  */
 export function write(state: State, code: string, last: Category): void {
+  debugAssert(code.length > 0, "`code` should not be an empty string");
   debugAssertCategoryMatches(state, code, last);
 
   state.last = last;
@@ -263,6 +264,7 @@ export function writeNoLast(state: State, code: string): void {
  * @param node - Node this text came from
  */
 export function writeWithMap(state: State, code: string, last: Category, node: MappableNode): void {
+  debugAssert(code.length > 0, "`code` should not be an empty string");
   debugAssertCategoryMatches(state, code, last);
 
   if (SOURCEMAPS && node.loc != null) {
@@ -344,8 +346,6 @@ const IDENT_CONTINUE_REGEX = /[\p{ID_Continue}$\u200C\u200D]/u;
  */
 function debugAssertCategoryMatches(state: State, code: string, last: Category): void {
   if (!DEBUG) return;
-
-  debugAssert(code.length > 0, "`code` should not be an empty string");
 
   const ch = code.at(-1)!;
 


### PR DESCRIPTION
Pure refactor.

Move debug asserts that `code` cannot be an empty string into the body of `write` and `writeWithMap`. This makes it clearer what the invariants of these functions are.