### PR TITLE
docs(packages/codegen): fix JSDoc comments for `printSync`

### DIFF
--- a/packages/codegen/src-js/index.ts
+++ b/packages/codegen/src-js/index.ts
@@ -55,7 +55,7 @@ const PRINTER_PATHS = [
 const printers: (PrintModule["printSync"] | null)[] = [null, null, null, null];
 
 /**
- * Print `node`, returning the generated code.
+ * Print `node`, returning an object including the generated code.
  *
  * @param node - AST node to print, a `Program` or a single statement
  * @param options - Printing options (optional)

--- a/packages/codegen/src-js/print/index.ts
+++ b/packages/codegen/src-js/print/index.ts
@@ -18,7 +18,7 @@ import type { State } from "../state.ts";
 import type * as ESTree from "../../../../npm/oxc-types/types.d.ts";
 
 /**
- * Print `node`, returning the generated code.
+ * Print `node`, returning an object including the generated code.
  *
  * One of these exists per build. The package entry point picks the build and calls it -
  * callers of the package never reach this directly.


### PR DESCRIPTION
Follow-on after #25720. Fix inaccuracies in JSDoc comments, as pointed out by AI review https://github.com/oxc-project/oxc/pull/25720#pullrequestreview-4944174621. For some reason, it got merged before my change to that PR was integrated.