### PR TITLE
refactor(parser): remove dead match options in `get_modifier`

### DIFF
--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -514,9 +514,7 @@ impl<C: Config> ParserImpl<'_, C> {
         let is_modifier = match cur_kind {
             Kind::Const => next_kind == Kind::Enum,
             // These modifiers can cross line.
-            Kind::Accessor | Kind::Static | Kind::Get | Kind::Set => {
-                Self::can_follow_modifier(next_kind)
-            }
+            Kind::Accessor | Kind::Static => Self::can_follow_modifier(next_kind),
             // Rest modifiers cannot cross line
             _ => Self::can_follow_modifier(next_kind) && !next.is_on_new_line(),
         };


### PR DESCRIPTION
`cur_kind` can never be `Kind::Get` or `Kind::Set` because then the `ModifierKind::try_from(cur_kind).ok()?` line above would have returned earlier.