### PR TITLE
feat(react-compiler): validate terminal successors

### DIFF
--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -274,6 +274,18 @@ pub fn invariant_unexpected_error() -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn terminal_successor_references_unknown_block(
+    successor: impl Display,
+    terminal: impl Debug,
+    span: Option<Span>,
+) -> OxcDiagnostic {
+    const REASON: &str = "Terminal successor references unknown block";
+    diagnostic(ErrorCategory::Invariant, REASON)
+        .with_help(format!("Block bb{successor} does not exist for terminal '{terminal:?}'"))
+        .with_labels(span.map(|span| span.primary_label(REASON)))
+}
+
+#[cold]
 pub fn invariant_analyze_functions_expected_apply_effects_replaced_more_precise_effects()
 -> OxcDiagnostic {
     diagnostic(

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -12,10 +12,10 @@ use oxc_allocator::GetAllocator;
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 
 use crate::diagnostics;
-use crate::react_compiler_hir::ReactFunctionType;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::environment::OutputMode;
 use crate::react_compiler_hir::environment_config::{EnvironmentConfig, ExhaustiveEffectDepsMode};
+use crate::react_compiler_hir::{ReactFunctionType, assert_terminal_successors_exist};
 use crate::react_compiler_inference::align_method_call_scopes;
 use crate::react_compiler_inference::align_object_method_scopes;
 use crate::react_compiler_inference::align_reactive_scopes_to_block_scopes_hir;
@@ -166,7 +166,7 @@ fn run_pipeline<'a>(
     merge_consecutive_blocks(&mut hir, &mut env.functions, env.allocator);
 
     // TODO: port assertConsistentIdentifiers
-    // TODO: port assertTerminalSuccessorsExist
+    assert_terminal_successors_exist(&hir)?;
 
     enter_ssa(&mut hir, &mut env)?;
 
@@ -174,7 +174,7 @@ fn run_pipeline<'a>(
 
     // TODO: port assertConsistentIdentifiers
 
-    constant_propagation(&mut hir, &mut env);
+    constant_propagation(&mut hir, &mut env)?;
 
     infer_types(&mut hir, &mut env)?;
 
@@ -298,7 +298,7 @@ fn run_pipeline<'a>(
 
     flatten_scopes_with_hooks_or_use_hir(&mut hir, &env)?;
 
-    // TODO: port assertTerminalSuccessorsExist
+    assert_terminal_successors_exist(&hir)?;
     // TODO: port assertTerminalPredsExist
 
     propagate_scope_dependencies_hir(&mut hir, &mut env);

--- a/crates/oxc_react_compiler/src/react_compiler_hir/assert_terminal_blocks_exist.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/assert_terminal_blocks_exist.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+//! Assert that terminal block references point to blocks that exist.
+//!
+//! Corresponds to `src/HIR/AssertTerminalBlocksExist.ts`.
+
+use oxc_diagnostics::OxcDiagnostic;
+
+use crate::diagnostics;
+
+use super::{HIR, HirFunction, visitors::each_terminal_all_successors};
+
+pub fn assert_terminal_successors_exist(func: &HirFunction<'_>) -> Result<(), OxcDiagnostic> {
+    assert_terminal_successors_exist_in_body(&func.body)
+}
+
+fn assert_terminal_successors_exist_in_body(body: &HIR<'_>) -> Result<(), OxcDiagnostic> {
+    for block in body.blocks.values() {
+        for successor in each_terminal_all_successors(&block.terminal) {
+            if !body.blocks.contains_key(&successor) {
+                return Err(diagnostics::terminal_successor_references_unknown_block(
+                    successor.index(),
+                    &block.terminal,
+                    block.terminal.span().copied(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -1,3 +1,4 @@
+mod assert_terminal_blocks_exist;
 pub mod default_module_type_provider;
 pub mod dominator;
 pub mod environment;
@@ -11,6 +12,7 @@ pub mod visitors;
 
 use crate::react_compiler_utils::OrderedMap;
 use crate::react_compiler_utils::ordered_map::{ArenaOrderedMap, ArenaOrderedSet};
+pub use assert_terminal_blocks_exist::assert_terminal_successors_exist;
 use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds, Vec as ArenaVec};
 use oxc_ast::ast::*;
 use oxc_index::define_nonmax_u32_index_type;

--- a/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
@@ -24,6 +24,9 @@ use crate::react_compiler_hir::{
 /// of heap-allocating a `Vec` for every instruction visited.
 pub type PlaceList = SmallVec<[Place; 4]>;
 
+/// Non-switch terminals reference at most five blocks; keep those block IDs inline.
+pub type TerminalBlockList = SmallVec<[BlockId; 5]>;
+
 /// Yields `instr.lvalue` plus the value's lvalues.
 /// Equivalent to TS `eachInstructionLValue`.
 pub fn each_instruction_lvalue(instr: &Instruction) -> PlaceList {
@@ -606,8 +609,8 @@ pub fn map_terminal_successors(terminal: &mut Terminal, f: &mut impl FnMut(Block
 /// Yields ALL block IDs referenced by a terminal (successors + fallthroughs + internal blocks).
 /// Unlike `each_terminal_successor` which yields only standard control flow successors,
 /// this function yields every block ID that `map_terminal_successors` would visit.
-pub fn each_terminal_all_successors(terminal: &Terminal) -> Vec<BlockId> {
-    let mut result = Vec::new();
+pub fn each_terminal_all_successors(terminal: &Terminal) -> TerminalBlockList {
+    let mut result = TerminalBlockList::new();
     match terminal {
         Terminal::Goto { block, .. } => {
             result.push(*block);

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
@@ -55,7 +55,7 @@ struct ValueBlockNode {
 
 /// Returns all block IDs referenced by a terminal, including both direct
 /// successors and fallthrough.
-fn all_terminal_block_ids(terminal: &Terminal) -> Vec<BlockId> {
+fn all_terminal_block_ids(terminal: &Terminal) -> visitors::TerminalBlockList {
     visitors::each_terminal_all_successors(terminal)
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -29,6 +29,7 @@ use std::mem::replace;
 use rustc_hash::FxHashMap;
 
 use oxc_allocator::Allocator;
+use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::{StringToNumber, ToInt32, ToUint32};
 use oxc_str::{Ident, Str};
 use oxc_syntax::identifier::is_identifier_name;
@@ -39,7 +40,7 @@ use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
     BlockKind, FloatValue, FunctionId, GotoVariant, HirFunction, IdentifierId, InstructionId,
     InstructionValue, ManualMemoDependencyRoot, NonLocalBinding, Phi, Place, PrimitiveValue,
-    PropertyLiteral, Terminal, UnaryOperator,
+    PropertyLiteral, Terminal, UnaryOperator, assert_terminal_successors_exist,
 };
 use crate::react_compiler_lowering::{
     get_reverse_postordered_blocks, mark_instruction_ids, mark_predecessors,
@@ -83,18 +84,21 @@ type Constants<'a> = FxHashMap<IdentifierId, Constant<'a>>;
 // Public entry point
 // =============================================================================
 
-pub fn constant_propagation<'a>(func: &mut HirFunction<'a>, env: &mut Environment<'a>) {
+pub fn constant_propagation<'a>(
+    func: &mut HirFunction<'a>,
+    env: &mut Environment<'a>,
+) -> Result<(), OxcDiagnostic> {
     let mut constants: Constants<'a> = FxHashMap::default();
-    constant_propagation_impl(func, env, &mut constants);
+    constant_propagation_impl(func, env, &mut constants)
 }
 
 fn constant_propagation_impl<'a>(
     func: &mut HirFunction<'a>,
     env: &mut Environment<'a>,
     constants: &mut Constants<'a>,
-) {
+) -> Result<(), OxcDiagnostic> {
     loop {
-        let have_terminals_changed = apply_constant_propagation(func, env, constants);
+        let have_terminals_changed = apply_constant_propagation(func, env, constants)?;
         if !have_terminals_changed {
             break;
         }
@@ -128,17 +132,17 @@ fn constant_propagation_impl<'a>(
          */
         merge_consecutive_blocks(func, &mut env.functions, env.allocator);
 
-        // TODO: port assertConsistentIdentifiers(fn) and assertTerminalSuccessorsExist(fn)
-        // from TS HIR validation. These are debug assertions that verify structural
-        // invariants after the CFG cleanup helpers run.
+        // TODO: port assertConsistentIdentifiers(fn)
+        assert_terminal_successors_exist(func)?;
     }
+    Ok(())
 }
 
 fn apply_constant_propagation<'a>(
     func: &mut HirFunction<'a>,
     env: &mut Environment<'a>,
     constants: &mut Constants<'a>,
-) -> bool {
+) -> Result<bool, OxcDiagnostic> {
     let mut has_changes = false;
 
     let block_ids: Vec<_> = func.body.blocks.keys().copied().collect();
@@ -171,6 +175,15 @@ fn apply_constant_propagation<'a>(
                  */
                 continue;
             }
+            let inner_func = match &func.instructions[instr_id.index()].value {
+                InstructionValue::FunctionExpression { lowered_func, .. }
+                | InstructionValue::ObjectMethod { lowered_func, .. } => Some(lowered_func.func),
+                _ => None,
+            };
+            if let Some(inner_func) = inner_func {
+                process_inner_function(inner_func, env, constants)?;
+            }
+
             let result = evaluate_instruction(constants, func, env, *instr_id);
             if let Some(value) = result {
                 let lvalue_id = func.instructions[instr_id.index()].lvalue.identifier;
@@ -219,7 +232,7 @@ fn apply_constant_propagation<'a>(
         }
     }
 
-    has_changes
+    Ok(has_changes)
 }
 
 // =============================================================================
@@ -562,16 +575,6 @@ fn evaluate_instruction<'a>(
             }
             place_value
         }
-        InstructionValue::FunctionExpression { lowered_func, .. } => {
-            let func_id = lowered_func.func;
-            process_inner_function(func_id, env, constants);
-            None
-        }
-        InstructionValue::ObjectMethod { lowered_func, .. } => {
-            let func_id = lowered_func.func;
-            process_inner_function(func_id, env, constants);
-            None
-        }
         InstructionValue::StartMemoize { deps, .. } => {
             if let Some(deps) = deps {
                 // Two-phase: collect which deps are constant, then mutate
@@ -621,6 +624,8 @@ fn evaluate_instruction<'a>(
         | InstructionValue::PropertyDelete { .. }
         | InstructionValue::ComputedDelete { .. }
         | InstructionValue::StoreGlobal { .. }
+        | InstructionValue::FunctionExpression { .. }
+        | InstructionValue::ObjectMethod { .. }
         | InstructionValue::TaggedTemplateExpression { .. }
         | InstructionValue::Await { .. }
         | InstructionValue::GetIterator { .. }
@@ -640,10 +645,11 @@ fn process_inner_function<'a>(
     func_id: FunctionId,
     env: &mut Environment<'a>,
     constants: &mut Constants<'a>,
-) {
+) -> Result<(), OxcDiagnostic> {
     let mut inner = replace(&mut env.functions[func_id], placeholder_function(env.allocator));
-    constant_propagation_impl(&mut inner, env, constants);
+    let result = constant_propagation_impl(&mut inner, env, constants);
     env.functions[func_id] = inner;
+    result
 }
 
 // =============================================================================

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
@@ -18,7 +18,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use crate::diagnostics;
 use crate::react_compiler_hir::{
     ArrayElement, BlockId, FunctionId, HirFunction, InstructionValue, ObjectPropertyKey,
-    ObjectPropertyOrSpread, Terminal,
+    ObjectPropertyOrSpread, Terminal, assert_terminal_successors_exist,
 };
 use crate::react_compiler_lowering::{
     get_reverse_postordered_blocks, mark_instruction_ids, remove_dead_do_while_statements,
@@ -77,6 +77,8 @@ pub fn prune_maybe_throws<'a>(
                 }
             }
         }
+
+        assert_terminal_successors_exist(func)?;
     }
     Ok(())
 }


### PR DESCRIPTION
Ports React Compiler's terminal-successor invariant and runs it after CFG-rewriting passes. Uses the existing upstream `for-return.js` fixture for regression coverage.

AI-assisted: Codex was used to implement and verify this change.