### PR TITLE
fix(react-compiler): preserve unreferenced function expression names

### DIFF
--- a/crates/oxc_react_compiler/fixtures/duplicate-named-function-expression-names.tsx
+++ b/crates/oxc_react_compiler/fixtures/duplicate-named-function-expression-names.tsx
@@ -1,0 +1,17 @@
+export function Component({ value }) {
+  const columns = [
+    {
+      render: function Render(input) {
+        const copy = input;
+        return copy + value;
+      },
+    },
+    {
+      render: function Render(input) {
+        const copy = input;
+        return copy + value;
+      },
+    },
+  ];
+  return <div>{columns}</div>;
+}

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -661,6 +661,7 @@ fn lower_inner<'a>(
     let self_binding = if let Some(name) = id
         && let Some(symbol_id) = scope.get_binding(function_scope, name.as_str())
         && scope.decl_kind(symbol_id) == DeclKind::FunctionExpression
+        && !scope.reference_ids(symbol_id).is_empty()
     {
         let identifier = builder.resolve_binding_with_span(name, symbol_id, id_span)?;
         Some(Place { identifier, effect: Effect::Unknown, reactive: false, span: id_span })

--- a/crates/oxc_react_compiler/tests/snapshots/duplicate-named-function-expression-names.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/duplicate-named-function-expression-names.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/duplicate-named-function-expression-names.tsx
+---
+import { c as _c } from "react/compiler-runtime";
+export function Component(t0) {
+	const $ = _c(2);
+	const { value } = t0;
+	let t1;
+	if ($[0] !== value) {
+		const columns = [{ render: function Render(input) {
+			const copy = input;
+			return copy + value;
+		} }, { render: function Render(input_0) {
+			const copy_0 = input_0;
+			return copy_0 + value;
+		} }];
+		t1 = <div>{columns}</div>;
+		$[0] = value;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	return t1;
+}


### PR DESCRIPTION
Preserve named function expression names when the private name is unreferenced. This matches React Compiler lowering and avoids changing observable `Function.name` values.

Validated with `just ready`.

AI-assisted.
