### PR TITLE
feat(react-compiler): validate terminal predecessors

### DIFF
--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -286,6 +286,29 @@ pub fn terminal_successor_references_unknown_block(
 }
 
 #[cold]
+pub fn expected_predecessor_block_to_exist(
+    block: impl Display,
+    predecessor: impl Display,
+) -> OxcDiagnostic {
+    diagnostic(ErrorCategory::Invariant, "Expected predecessor block to exist")
+        .with_help(format!("Block {block} references non-existent {predecessor}"))
+}
+
+#[cold]
+pub fn terminal_successor_does_not_reference_correct_predecessor(
+    block: impl Display,
+    predecessor: impl Display,
+) -> OxcDiagnostic {
+    diagnostic(
+        ErrorCategory::Invariant,
+        "Terminal successor does not reference correct predecessor",
+    )
+    .with_help(format!(
+        "Block bb{block} has bb{predecessor} as a predecessor, but bb{predecessor}'s successors do not include bb{block}"
+    ))
+}
+
+#[cold]
 pub fn invariant_analyze_functions_expected_apply_effects_replaced_more_precise_effects()
 -> OxcDiagnostic {
     diagnostic(

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -15,7 +15,9 @@ use crate::diagnostics;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::environment::OutputMode;
 use crate::react_compiler_hir::environment_config::{EnvironmentConfig, ExhaustiveEffectDepsMode};
-use crate::react_compiler_hir::{ReactFunctionType, assert_terminal_successors_exist};
+use crate::react_compiler_hir::{
+    ReactFunctionType, assert_terminal_preds_exist, assert_terminal_successors_exist,
+};
 use crate::react_compiler_inference::align_method_call_scopes;
 use crate::react_compiler_inference::align_object_method_scopes;
 use crate::react_compiler_inference::align_reactive_scopes_to_block_scopes_hir;
@@ -299,7 +301,7 @@ fn run_pipeline<'a>(
     flatten_scopes_with_hooks_or_use_hir(&mut hir, &env)?;
 
     assert_terminal_successors_exist(&hir)?;
-    // TODO: port assertTerminalPredsExist
+    assert_terminal_preds_exist(&hir)?;
 
     propagate_scope_dependencies_hir(&mut hir, &mut env);
 

--- a/crates/oxc_react_compiler/src/react_compiler_hir/assert_terminal_blocks_exist.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/assert_terminal_blocks_exist.rs
@@ -11,7 +11,10 @@ use oxc_diagnostics::OxcDiagnostic;
 
 use crate::diagnostics;
 
-use super::{HIR, HirFunction, visitors::each_terminal_all_successors};
+use super::{
+    HIR, HirFunction,
+    visitors::{each_terminal_all_successors, each_terminal_successor},
+};
 
 pub fn assert_terminal_successors_exist(func: &HirFunction<'_>) -> Result<(), OxcDiagnostic> {
     assert_terminal_successors_exist_in_body(&func.body)
@@ -26,6 +29,28 @@ fn assert_terminal_successors_exist_in_body(body: &HIR<'_>) -> Result<(), OxcDia
                     &block.terminal,
                     block.terminal.span().copied(),
                 ));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn assert_terminal_preds_exist(func: &HirFunction<'_>) -> Result<(), OxcDiagnostic> {
+    for block in func.body.blocks.values() {
+        for predecessor in block.preds.iter().copied() {
+            let Some(predecessor_block) = func.body.blocks.get(&predecessor) else {
+                return Err(diagnostics::expected_predecessor_block_to_exist(
+                    block.id.index(),
+                    predecessor.index(),
+                ));
+            };
+            if !each_terminal_successor(&predecessor_block.terminal).contains(&block.id) {
+                return Err(
+                    diagnostics::terminal_successor_does_not_reference_correct_predecessor(
+                        block.id.index(),
+                        predecessor_block.id.index(),
+                    ),
+                );
             }
         }
     }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -12,7 +12,9 @@ pub mod visitors;
 
 use crate::react_compiler_utils::OrderedMap;
 use crate::react_compiler_utils::ordered_map::{ArenaOrderedMap, ArenaOrderedSet};
-pub use assert_terminal_blocks_exist::assert_terminal_successors_exist;
+pub use assert_terminal_blocks_exist::{
+    assert_terminal_preds_exist, assert_terminal_successors_exist,
+};
 use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds, Vec as ArenaVec};
 use oxc_ast::ast::*;
 use oxc_index::define_nonmax_u32_index_type;

--- a/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/visitors.rs
@@ -365,8 +365,8 @@ pub fn does_pattern_contain_spread_element(pattern: &Pattern) -> bool {
 
 /// Yields successor block IDs (NOT fallthroughs, this is intentional).
 /// Equivalent to TS `eachTerminalSuccessor`.
-pub fn each_terminal_successor(terminal: &Terminal) -> Vec<BlockId> {
-    let mut result = Vec::new();
+pub fn each_terminal_successor(terminal: &Terminal) -> TerminalBlockList {
+    let mut result = TerminalBlockList::new();
     match terminal {
         Terminal::Goto { block, .. } => {
             result.push(*block);


### PR DESCRIPTION
Ports Babel's terminal-predecessor invariant and runs it before HIR scope dependency propagation. Keeps terminal successor traversal inline to avoid per-edge heap allocations.

AI-assisted: Codex was used to implement and verify this change.