### PR TITLE
feat(react-compiler): validate identifier consistency

### DIFF
--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -309,6 +309,25 @@ pub fn terminal_successor_does_not_reference_correct_predecessor(
 }
 
 #[cold]
+pub fn expected_all_lvalues_to_be_temporaries(name: &str, span: Option<Span>) -> OxcDiagnostic {
+    const REASON: &str = "Expected all lvalues to be temporaries";
+    diagnostic(ErrorCategory::Invariant, REASON)
+        .with_help(format!("Found named lvalue `{name}`"))
+        .with_labels(span.map(|span| span.primary_label(REASON)))
+}
+
+#[cold]
+pub fn expected_lvalues_to_be_assigned_exactly_once(
+    place: impl Display,
+    span: Option<Span>,
+) -> OxcDiagnostic {
+    const REASON: &str = "Expected lvalues to be assigned exactly once";
+    diagnostic(ErrorCategory::Invariant, REASON)
+        .with_help(format!("Found duplicate assignment of '{place}'"))
+        .with_labels(span.map(|span| span.primary_label(REASON)))
+}
+
+#[cold]
 pub fn invariant_analyze_functions_expected_apply_effects_replaced_more_precise_effects()
 -> OxcDiagnostic {
     diagnostic(

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -16,7 +16,8 @@ use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::environment::OutputMode;
 use crate::react_compiler_hir::environment_config::{EnvironmentConfig, ExhaustiveEffectDepsMode};
 use crate::react_compiler_hir::{
-    ReactFunctionType, assert_terminal_preds_exist, assert_terminal_successors_exist,
+    ReactFunctionType, assert_consistent_identifiers, assert_terminal_preds_exist,
+    assert_terminal_successors_exist,
 };
 use crate::react_compiler_inference::align_method_call_scopes;
 use crate::react_compiler_inference::align_object_method_scopes;
@@ -154,7 +155,7 @@ fn run_pipeline<'a>(
         return Ok(Ok(None));
     }
 
-    prune_maybe_throws(&mut hir, &mut env.functions, env.allocator)?;
+    prune_maybe_throws(&mut hir, &mut env.functions, &env.identifiers, env.allocator)?;
 
     validate_context_variable_lvalues(&hir, &mut env)?;
 
@@ -167,14 +168,14 @@ fn run_pipeline<'a>(
 
     merge_consecutive_blocks(&mut hir, &mut env.functions, env.allocator);
 
-    // TODO: port assertConsistentIdentifiers
+    assert_consistent_identifiers(&hir, &env.identifiers)?;
     assert_terminal_successors_exist(&hir)?;
 
     enter_ssa(&mut hir, &mut env)?;
 
     eliminate_redundant_phi(&mut hir, &mut env);
 
-    // TODO: port assertConsistentIdentifiers
+    assert_consistent_identifiers(&hir, &env.identifiers)?;
 
     constant_propagation(&mut hir, &mut env)?;
 
@@ -206,7 +207,7 @@ fn run_pipeline<'a>(
 
     dead_code_elimination(&mut hir, &env);
 
-    prune_maybe_throws(&mut hir, &mut env.functions, env.allocator)?;
+    prune_maybe_throws(&mut hir, &mut env.functions, &env.identifiers, env.allocator)?;
 
     infer_mutation_aliasing_ranges(&mut hir, &mut env, false)?;
 

--- a/crates/oxc_react_compiler/src/react_compiler_hir/assert_consistent_identifiers.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/assert_consistent_identifiers.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+//! Assert that instruction lvalues use identifiers consistently.
+//!
+//! Corresponds to `src/HIR/AssertConsistentIdentifiers.ts`.
+
+use rustc_hash::FxHashSet;
+
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_index::IndexSlice;
+
+use crate::diagnostics;
+
+use super::{HirFunction, Identifier, IdentifierId, Place};
+
+pub fn assert_consistent_identifiers<'a>(
+    func: &HirFunction<'a>,
+    identifiers: &IndexSlice<IdentifierId, [Identifier<'a>]>,
+) -> Result<(), OxcDiagnostic> {
+    let mut assignments = FxHashSet::default();
+
+    /*
+     * Babel also walks every place to assert that a given IdentifierId always
+     * refers to the same Identifier object. Oxc represents places with an
+     * IdentifierId and stores the corresponding Identifier exactly once in this
+     * indexed slice, so that object-identity invariant holds by construction.
+     */
+    for block in func.body.blocks.values() {
+        for &instr_id in &block.instructions {
+            let instr = &func.instructions[instr_id.index()];
+            let identifier = &identifiers[instr.lvalue.identifier];
+
+            if let Some(name) = &identifier.name {
+                return Err(diagnostics::expected_all_lvalues_to_be_temporaries(
+                    name.value(),
+                    instr.lvalue.span,
+                ));
+            }
+
+            if !assignments.insert(instr.lvalue.identifier) {
+                return Err(diagnostics::expected_lvalues_to_be_assigned_exactly_once(
+                    format_place(&instr.lvalue, identifiers),
+                    instr.lvalue.span,
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Format a place like Babel's `printPlace()`, retaining the fields relevant to
+/// identifying a duplicate assignment.
+fn format_place(place: &Place, identifiers: &IndexSlice<IdentifierId, [Identifier<'_>]>) -> String {
+    let identifier = &identifiers[place.identifier];
+    let name = identifier.name.as_ref().map_or("", |name| name.value());
+    format!("{} {}${}", place.effect, name, place.identifier.index())
+}

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -1,3 +1,4 @@
+mod assert_consistent_identifiers;
 mod assert_terminal_blocks_exist;
 pub mod default_module_type_provider;
 pub mod dominator;
@@ -12,6 +13,7 @@ pub mod visitors;
 
 use crate::react_compiler_utils::OrderedMap;
 use crate::react_compiler_utils::ordered_map::{ArenaOrderedMap, ArenaOrderedSet};
+pub use assert_consistent_identifiers::assert_consistent_identifiers;
 pub use assert_terminal_blocks_exist::{
     assert_terminal_preds_exist, assert_terminal_successors_exist,
 };

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -40,7 +40,8 @@ use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
     BlockKind, FloatValue, FunctionId, GotoVariant, HirFunction, IdentifierId, InstructionId,
     InstructionValue, ManualMemoDependencyRoot, NonLocalBinding, Phi, Place, PrimitiveValue,
-    PropertyLiteral, Terminal, UnaryOperator, assert_terminal_successors_exist,
+    PropertyLiteral, Terminal, UnaryOperator, assert_consistent_identifiers,
+    assert_terminal_successors_exist,
 };
 use crate::react_compiler_lowering::{
     get_reverse_postordered_blocks, mark_instruction_ids, mark_predecessors,
@@ -132,7 +133,7 @@ fn constant_propagation_impl<'a>(
          */
         merge_consecutive_blocks(func, &mut env.functions, env.allocator);
 
-        // TODO: port assertConsistentIdentifiers(fn)
+        assert_consistent_identifiers(func, &env.identifiers)?;
         assert_terminal_successors_exist(func)?;
     }
     Ok(())

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/prune_maybe_throws.rs
@@ -17,8 +17,9 @@ use oxc_diagnostics::OxcDiagnostic;
 
 use crate::diagnostics;
 use crate::react_compiler_hir::{
-    ArrayElement, BlockId, FunctionId, HirFunction, InstructionValue, ObjectPropertyKey,
-    ObjectPropertyOrSpread, Terminal, assert_terminal_successors_exist,
+    ArrayElement, BlockId, FunctionId, HirFunction, Identifier, IdentifierId, InstructionValue,
+    ObjectPropertyKey, ObjectPropertyOrSpread, Terminal, assert_consistent_identifiers,
+    assert_terminal_successors_exist,
 };
 use crate::react_compiler_lowering::{
     get_reverse_postordered_blocks, mark_instruction_ids, remove_dead_do_while_statements,
@@ -31,6 +32,7 @@ use crate::react_compiler_optimization::merge_consecutive_blocks::merge_consecut
 pub fn prune_maybe_throws<'a>(
     func: &mut HirFunction<'a>,
     functions: &mut IndexSlice<FunctionId, [HirFunction<'a>]>,
+    identifiers: &IndexSlice<IdentifierId, [Identifier<'a>]>,
     alloc: &'a Allocator,
 ) -> Result<(), OxcDiagnostic> {
     let terminal_mapping = prune_maybe_throws_impl(func);
@@ -78,6 +80,7 @@ pub fn prune_maybe_throws<'a>(
             }
         }
 
+        assert_consistent_identifiers(func, identifiers)?;
         assert_terminal_successors_exist(func)?;
     }
     Ok(())


### PR DESCRIPTION
Ports Babel's identifier consistency invariant using Oxc's canonical identifier arena and runs it at every equivalent pipeline point.

Validated with the React compiler fixture corpus and clippy.

AI-assisted: Codex was used to implement and verify this change.