### PR TITLE
fix(react-compiler): recompile outlined JSX components

### DIFF
--- a/crates/oxc_react_compiler/fixtures/jsx-outlining-recompiles-outlined-component.js
+++ b/crates/oxc_react_compiler/fixtures/jsx-outlining-recompiles-outlined-component.js
@@ -1,0 +1,36 @@
+// @enableJsxOutlining
+function Component({items, label}) {
+  return [
+    items.map(item => (
+      <Item label={label}>
+        <Value item={item} />
+      </Item>
+    )),
+    items.map(item => (
+      <Item label={label}>
+        <StrongValue item={item} />
+      </Item>
+    )),
+  ];
+}
+
+function Item({label, children}) {
+  return (
+    <div>
+      {label}: {children}
+    </div>
+  );
+}
+
+function Value({item}) {
+  return item;
+}
+
+function StrongValue({item}) {
+  return <strong>{item}</strong>;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{items: ['one', 'two'], label: 'item'}],
+};

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -86,7 +86,6 @@ use crate::react_compiler_validation::validate_use_memo;
 use crate::scope::*;
 
 use super::compile_result::CodegenFunction;
-use super::compile_result::OutlinedFunction;
 use super::imports::ProgramContext;
 use crate::options::CompilerOutputMode;
 
@@ -382,41 +381,6 @@ fn run_pipeline<'a>(
         return Ok(Err(env.take_errors()));
     }
 
-    // Re-compile outlined functions through the full pipeline.
-    // This mirrors TS behavior where outlined functions from JSX outlining
-    // are pushed back onto the compilation queue and compiled as components.
-    let mut compiled_outlined: Vec<OutlinedFunction<'a>> = Vec::new();
-    for o in codegen_result.outlined {
-        let outlined_codegen = CodegenFunction {
-            span: o.func.span,
-            id: o.func.id,
-            name_hint: o.func.name_hint,
-            params: o.func.params,
-            body: o.func.body,
-            generator: o.func.generator,
-            is_async: o.func.is_async,
-            memo_slots_used: o.func.memo_slots_used,
-            memo_blocks: o.func.memo_blocks,
-            memo_values: o.func.memo_values,
-            pruned_memo_blocks: o.func.pruned_memo_blocks,
-            pruned_memo_values: o.func.pruned_memo_values,
-            outlined: Vec::new(),
-        };
-        if let Some(fn_type) = o.fn_type {
-            match compile_outlined_fn(outlined_codegen) {
-                Ok(compiled) => {
-                    compiled_outlined
-                        .push(OutlinedFunction { func: compiled, fn_type: Some(fn_type) });
-                }
-                Err(_err) => {
-                    // If re-compilation fails, skip the outlined function
-                }
-            }
-        } else {
-            compiled_outlined.push(OutlinedFunction { func: outlined_codegen, fn_type: o.fn_type });
-        }
-    }
-
     if let Some(uid_names) = env.take_uid_known_names() {
         context.merge_uid_known_names(&uid_names);
     }
@@ -434,20 +398,8 @@ fn run_pipeline<'a>(
         memo_values: codegen_result.memo_values,
         pruned_memo_blocks: codegen_result.pruned_memo_blocks,
         pruned_memo_values: codegen_result.pruned_memo_values,
-        outlined: compiled_outlined,
+        outlined: codegen_result.outlined,
     })))
-}
-
-/// Compile an outlined function's codegen AST through the full pipeline.
-///
-/// Creates a fresh Environment, builds a synthetic ScopeInfo with unique fake
-/// positions for identifier resolution, lowers from AST to HIR, then runs
-/// the full compilation pipeline. This mirrors the TS behavior where outlined
-/// functions are inserted into the program AST and re-compiled from scratch.
-pub fn compile_outlined_fn<'a>(
-    codegen_fn: CodegenFunction<'a>,
-) -> Result<CodegenFunction<'a>, OxcDiagnostic> {
-    Ok(codegen_fn)
 }
 
 /// Push a pass's diagnostics (validation / lint / telemetry path),

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -17,7 +17,7 @@ use oxc_ast::AstKind;
 use oxc_ast::ast::*;
 use oxc_ast::builder::AstBuilder;
 use oxc_diagnostics::Diagnostics;
-use oxc_span::{GetSpan, SPAN, Span};
+use oxc_span::{GetSpan, SPAN, SourceType, Span};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::diagnostics::{self, should_panic, with_fallback_label};
@@ -26,14 +26,13 @@ use crate::react_compiler_hir::environment_config::EnvironmentConfig;
 use crate::react_compiler_lowering::FunctionNode;
 use crate::scope::ScopeResolver;
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, CloneIn, GetAddress, GetAllocator};
-use oxc_semantic::{AstNodes, NodeId, Scoping, Semantic};
+use oxc_semantic::{AstNodes, NodeId, Scoping, Semantic, SemanticBuilder};
 use oxc_syntax::identifier::is_identifier_name;
 use oxc_syntax::keyword::is_reserved_keyword;
 use oxc_syntax::scope::ScopeId;
 use oxc_syntax::symbol::SymbolId;
 
-use super::compile_result::CodegenFunction;
-use super::compile_result::CompileResult;
+use super::compile_result::{CodegenFunction, CompileResult, OutlinedFunction};
 use super::imports::ProgramContext;
 use super::pipeline;
 use super::suppression::filter_suppressions_that_affect_function;
@@ -86,6 +85,7 @@ struct BodyDirective<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CompileSourceKind {
     Original,
+    Outlined,
 }
 
 // -----------------------------------------------------------------------
@@ -1062,6 +1062,159 @@ fn try_compile_function<'a>(
         env_config,
         context,
     )
+}
+
+/// Build the function declaration used to analyse an outlined component. Outlined functions are
+/// emitted as declarations regardless of the kind of the original function, matching Babel's
+/// `insertNewOutlinedFunctionNode`.
+fn outlined_function_declaration<'a>(
+    ast: &AstBuilder<'a>,
+    codegen_fn: &CodegenFunction<'a>,
+) -> Statement<'a> {
+    let allocator = ast.allocator();
+    let function = Function::boxed(
+        codegen_fn.span.unwrap_or_default(),
+        FunctionType::FunctionDeclaration,
+        codegen_fn.id.clone_in(allocator),
+        codegen_fn.generator,
+        codegen_fn.is_async,
+        false,
+        None,
+        None,
+        codegen_fn.params.clone_in(allocator),
+        None,
+        Some(codegen_fn.body.clone_in(allocator)),
+        ast,
+    );
+    Statement::FunctionDeclaration(function)
+}
+
+struct OutlinedNode<'a> {
+    outlined: Option<OutlinedFunction<'a>>,
+    children: Vec<usize>,
+}
+
+fn outlined_compile_source<'b, 'a>(
+    function: &'b Function<'a>,
+    fn_type: ReactFunctionType,
+) -> CompileSource<'b, 'a> {
+    let span = function.span;
+    CompileSource {
+        kind: CompileSourceKind::Outlined,
+        original_kind: OriginalFnKind::FunctionDeclaration,
+        fn_start: Some(span.start),
+        fn_end: Some(span.end),
+        fn_scope_id: function.scope_id.get().expect("outlined function should have a scope"),
+        fn_type,
+        fn_node: FunctionNode::Function(function),
+        body_directives: function.body.as_deref().map(body_directive_values).unwrap_or_default(),
+    }
+}
+
+/// Queue outlined functions back through [`process_fn`], as in `Program.ts`.
+///
+/// Babel updates scopes as it inserts a `NodePath`. Oxc semantics are immutable, so each FIFO
+/// generation is represented by one temporary program and one shared semantic build. The small
+/// node forest records where newly outlined functions were inserted so it can be flattened back
+/// into the codegen results after the queue is empty.
+#[allow(clippy::result_large_err)]
+fn compile_outlined_functions<'a, 'b, 'p, 's>(
+    ast: &AstBuilder<'a>,
+    compiled_fns: &mut [CompiledFunction<'a, 'b, 'p, 's>],
+    source_type: SourceType,
+    output_mode: CompilerOutputMode,
+    env_config: &EnvironmentConfig,
+    context: &mut ProgramContext<'a>,
+) -> Result<(), CompileResult<'a>> {
+    let mut nodes = Vec::new();
+    let mut roots = vec![Vec::new(); compiled_fns.len()];
+    let mut queue = Vec::new();
+    for (compiled, roots) in compiled_fns.iter_mut().zip(&mut roots) {
+        for outlined in std::mem::take(&mut compiled.codegen_fn.outlined) {
+            let should_compile = outlined.fn_type.is_some();
+            let index = nodes.len();
+            nodes.push(OutlinedNode { outlined: Some(outlined), children: Vec::new() });
+            roots.push(index);
+            if should_compile {
+                queue.push(index);
+            }
+        }
+    }
+
+    'queue: while !queue.is_empty() {
+        let mut body = ArenaVec::with_capacity_in(queue.len(), ast);
+        for &index in &queue {
+            let outlined = nodes[index].outlined.as_ref().unwrap();
+            body.push(outlined_function_declaration(ast, &outlined.func));
+        }
+        let program = Program::new(SPAN, source_type, context.source_text, [], None, [], body, ast);
+        let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(&program);
+        if !semantic_ret.diagnostics.is_empty() {
+            if let Some(result) = handle_error(
+                &semantic_ret.diagnostics,
+                None,
+                context.opts.panic_threshold,
+                &mut context.diagnostics,
+            ) {
+                return Err(result);
+            }
+            break 'queue;
+        }
+        let semantic = semantic_ret.semantic;
+        let scope = ScopeResolver::new(&semantic, ast.allocator());
+        let sources = program
+            .body
+            .iter()
+            .zip(&queue)
+            .map(|(statement, &index)| {
+                let Statement::FunctionDeclaration(function) = statement else { unreachable!() };
+                let fn_type = nodes[index].outlined.as_ref().unwrap().fn_type.unwrap();
+                outlined_compile_source(function, fn_type)
+            })
+            .collect::<Vec<_>>();
+        let mut results = Vec::with_capacity(sources.len());
+        for source in &sources {
+            results.push(process_fn(ast, source, &scope, output_mode, env_config, context));
+        }
+
+        let mut next_queue = Vec::new();
+        for (index, result) in queue.into_iter().zip(results) {
+            let nested = match result {
+                Ok(Some(mut compiled)) => {
+                    let nested = std::mem::take(&mut compiled.outlined);
+                    let outlined = nodes[index].outlined.as_mut().unwrap();
+                    outlined.fn_type = None;
+                    outlined.func = compiled;
+                    nested
+                }
+                Ok(None) => {
+                    nodes[index].outlined.as_mut().unwrap().fn_type = None;
+                    Vec::new()
+                }
+                Err(result) => return Err(result),
+            };
+            for outlined in nested {
+                let should_compile = outlined.fn_type.is_some();
+                let child = nodes.len();
+                nodes.push(OutlinedNode { outlined: Some(outlined), children: Vec::new() });
+                nodes[index].children.push(child);
+                if should_compile {
+                    next_queue.push(child);
+                }
+            }
+        }
+        queue = next_queue;
+    }
+
+    for (compiled, roots) in compiled_fns.iter_mut().zip(roots) {
+        let mut stack = roots.into_iter().rev().collect::<Vec<_>>();
+        while let Some(index) = stack.pop() {
+            let node = &mut nodes[index];
+            stack.extend(std::mem::take(&mut node.children).into_iter().rev());
+            compiled.codegen_fn.outlined.push(node.outlined.take().unwrap());
+        }
+    }
+    Ok(())
 }
 
 /// Process a single function: check directives, attempt compilation, handle results.
@@ -2751,11 +2904,16 @@ fn ox_transform_program<'a>(
     program.body.extend(appended_outlined_decls);
 
     // Register the memo cache import; codegen emitted its pre-reserved local name.
-    if replacements.iter().any(|r| r.codegen_fn.memo_slots_used > 0) {
+    if replacements.iter().any(|r| codegen_uses_memo_cache(&r.codegen_fn)) {
         context.add_memo_cache_import();
     }
 
     ox_add_imports_to_program(ast, program, context, import_span);
+}
+
+fn codegen_uses_memo_cache(codegen_fn: &CodegenFunction<'_>) -> bool {
+    codegen_fn.memo_slots_used > 0
+        || codegen_fn.outlined.iter().any(|outlined| codegen_uses_memo_cache(&outlined.func))
 }
 
 /// Insert outlined function declarations immediately after the statement that
@@ -3073,6 +3231,17 @@ pub fn compile_program<'a>(
                 return fatal_result;
             }
         }
+    }
+
+    if let Err(fatal_result) = compile_outlined_functions(
+        &ast,
+        &mut compiled_fns,
+        program.source_type,
+        output_mode,
+        &options.environment,
+        &mut context,
+    ) {
+        return fatal_result;
     }
 
     // TS invariant: if there's a module scope opt-out, no functions should have been compiled

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-child-stored-in-id.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-child-stored-in-id.snap
@@ -27,8 +27,26 @@ function Component(t0) {
 	return t1;
 }
 function _temp(t0) {
-	let { "i": i, "x": x } = t0;
-	return <Bar x={x}><Baz i={i} /></Bar>;
+	const $ = _c(5);
+	const { "i": i, "x": x } = t0;
+	let t1;
+	if ($[0] !== i) {
+		t1 = <Baz i={i} />;
+		$[0] = i;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== t1 || $[3] !== x) {
+		t2 = <Bar x={x}>{t1}</Bar>;
+		$[2] = t1;
+		$[3] = x;
+		$[4] = t2;
+	} else {
+		t2 = $[4];
+	}
+	return t2;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-dup-key-diff-value.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-dup-key-diff-value.snap
@@ -39,8 +39,35 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "i": i, "k": k, "x": x } = t0;
-	return <Bar x={x}><Baz i={i} /><Foo k={k} /></Bar>;
+	const $ = _c(8);
+	const { "i": i, "k": k, "x": x } = t0;
+	let t1;
+	if ($[0] !== i) {
+		t1 = <Baz i={i} />;
+		$[0] = i;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== k) {
+		t2 = <Foo k={k} />;
+		$[2] = k;
+		$[3] = t2;
+	} else {
+		t2 = $[3];
+	}
+	let t3;
+	if ($[4] !== t1 || $[5] !== t2 || $[6] !== x) {
+		t3 = <Bar x={x}>{t1}{t2}</Bar>;
+		$[4] = t1;
+		$[5] = t2;
+		$[6] = x;
+		$[7] = t3;
+	} else {
+		t3 = $[7];
+	}
+	return t3;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-dupe-attr-after-rename.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-dupe-attr-after-rename.snap
@@ -39,8 +39,44 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "k": k, "k1": k1, "k12": k12, "x": x } = t0;
-	return <Bar x={x}><Foo k={k} /><Foo k={k1} /><Baz k1={k12} /></Bar>;
+	const $ = _c(11);
+	const { "k": k, "k1": k1, "k12": k12, "x": x } = t0;
+	let t1;
+	if ($[0] !== k) {
+		t1 = <Foo k={k} />;
+		$[0] = k;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== k1) {
+		t2 = <Foo k={k1} />;
+		$[2] = k1;
+		$[3] = t2;
+	} else {
+		t2 = $[3];
+	}
+	let t3;
+	if ($[4] !== k12) {
+		t3 = <Baz k1={k12} />;
+		$[4] = k12;
+		$[5] = t3;
+	} else {
+		t3 = $[5];
+	}
+	let t4;
+	if ($[6] !== t1 || $[7] !== t2 || $[8] !== t3 || $[9] !== x) {
+		t4 = <Bar x={x}>{t1}{t2}{t3}</Bar>;
+		$[6] = t1;
+		$[7] = t2;
+		$[8] = t3;
+		$[9] = x;
+		$[10] = t4;
+	} else {
+		t4 = $[10];
+	}
+	return t4;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-dupe-key-dupe-component.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-dupe-key-dupe-component.snap
@@ -39,8 +39,35 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "k": k, "k1": k1, "x": x } = t0;
-	return <Bar x={x}><Foo k={k} /><Foo k={k1} /></Bar>;
+	const $ = _c(8);
+	const { "k": k, "k1": k1, "x": x } = t0;
+	let t1;
+	if ($[0] !== k) {
+		t1 = <Foo k={k} />;
+		$[0] = k;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== k1) {
+		t2 = <Foo k={k1} />;
+		$[2] = k1;
+		$[3] = t2;
+	} else {
+		t2 = $[3];
+	}
+	let t3;
+	if ($[4] !== t1 || $[5] !== t2 || $[6] !== x) {
+		t3 = <Bar x={x}>{t1}{t2}</Bar>;
+		$[4] = t1;
+		$[5] = t2;
+		$[6] = x;
+		$[7] = t3;
+	} else {
+		t3 = $[7];
+	}
+	return t3;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-duplicate-prop.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-duplicate-prop.snap
@@ -39,8 +39,35 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "i": i, "i1": i1, "x": x } = t0;
-	return <Bar x={x}><Baz i={i} /><Foo i={i1} /></Bar>;
+	const $ = _c(8);
+	const { "i": i, "i1": i1, "x": x } = t0;
+	let t1;
+	if ($[0] !== i) {
+		t1 = <Baz i={i} />;
+		$[0] = i;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== i1) {
+		t2 = <Foo i={i1} />;
+		$[2] = i1;
+		$[3] = t2;
+	} else {
+		t2 = $[3];
+	}
+	let t3;
+	if ($[4] !== t1 || $[5] !== t2 || $[6] !== x) {
+		t3 = <Bar x={x}>{t1}{t2}</Bar>;
+		$[4] = t1;
+		$[5] = t2;
+		$[6] = x;
+		$[7] = t3;
+	} else {
+		t3 = $[7];
+	}
+	return t3;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-jsx-stored-in-id.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-jsx-stored-in-id.snap
@@ -40,8 +40,26 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "i": i, "x": x } = t0;
-	return <Bar x={x}><Baz i={i} /></Bar>;
+	const $ = _c(5);
+	const { "i": i, "x": x } = t0;
+	let t1;
+	if ($[0] !== i) {
+		t1 = <Baz i={i} />;
+		$[0] = i;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== t1 || $[3] !== x) {
+		t2 = <Bar x={x}>{t1}</Bar>;
+		$[2] = t1;
+		$[3] = x;
+		$[4] = t2;
+	} else {
+		t2 = $[4];
+	}
+	return t2;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-recompiles-outlined-component.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-recompiles-outlined-component.snap
@@ -1,0 +1,142 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/jsx-outlining-recompiles-outlined-component.js
+---
+import { c as _c } from "react/compiler-runtime";
+// @enableJsxOutlining
+function Component(t0) {
+	const $ = _c(13);
+	const { items, label } = t0;
+	let t1;
+	if ($[0] !== items || $[1] !== label) {
+		let t2;
+		if ($[3] !== label) {
+			t2 = (item) => {
+				const T0 = _temp2;
+				return <T0 item={item} label={label} />;
+			};
+			$[3] = label;
+			$[4] = t2;
+		} else {
+			t2 = $[4];
+		}
+		t1 = items.map(t2);
+		$[0] = items;
+		$[1] = label;
+		$[2] = t1;
+	} else {
+		t1 = $[2];
+	}
+	let t2;
+	if ($[5] !== items || $[6] !== label) {
+		let t3;
+		if ($[8] !== label) {
+			t3 = (item_0) => {
+				const T0 = _temp;
+				return <T0 item={item_0} label={label} />;
+			};
+			$[8] = label;
+			$[9] = t3;
+		} else {
+			t3 = $[9];
+		}
+		t2 = items.map(t3);
+		$[5] = items;
+		$[6] = label;
+		$[7] = t2;
+	} else {
+		t2 = $[7];
+	}
+	let t3;
+	if ($[10] !== t1 || $[11] !== t2) {
+		t3 = [t1, t2];
+		$[10] = t1;
+		$[11] = t2;
+		$[12] = t3;
+	} else {
+		t3 = $[12];
+	}
+	return t3;
+}
+function _temp2(t0) {
+	const $ = _c(5);
+	const { "item": item, "label": label } = t0;
+	let t1;
+	if ($[0] !== item) {
+		t1 = <Value item={item} />;
+		$[0] = item;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== label || $[3] !== t1) {
+		t2 = <Item label={label}>{t1}</Item>;
+		$[2] = label;
+		$[3] = t1;
+		$[4] = t2;
+	} else {
+		t2 = $[4];
+	}
+	return t2;
+}
+function _temp(t0) {
+	const $ = _c(5);
+	const { "item": item, "label": label } = t0;
+	let t1;
+	if ($[0] !== item) {
+		t1 = <StrongValue item={item} />;
+		$[0] = item;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== label || $[3] !== t1) {
+		t2 = <Item label={label}>{t1}</Item>;
+		$[2] = label;
+		$[3] = t1;
+		$[4] = t2;
+	} else {
+		t2 = $[4];
+	}
+	return t2;
+}
+function Item(t0) {
+	const $ = _c(3);
+	const { label, children } = t0;
+	let t1;
+	if ($[0] !== children || $[1] !== label) {
+		t1 = <div>{label}: {children}</div>;
+		$[0] = children;
+		$[1] = label;
+		$[2] = t1;
+	} else {
+		t1 = $[2];
+	}
+	return t1;
+}
+function Value(t0) {
+	const { item } = t0;
+	return item;
+}
+function StrongValue(t0) {
+	const $ = _c(2);
+	const { item } = t0;
+	let t1;
+	if ($[0] !== item) {
+		t1 = <strong>{item}</strong>;
+		$[0] = item;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	return t1;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{
+		items: ["one", "two"],
+		label: "item"
+	}]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-separate-nested.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-separate-nested.snap
@@ -39,8 +39,44 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "i": i, "j": j, "k": k, "x": x } = t0;
-	return <Bar x={x}><Baz i={i} /><Joe j={j} /><Foo k={k} /></Bar>;
+	const $ = _c(11);
+	const { "i": i, "j": j, "k": k, "x": x } = t0;
+	let t1;
+	if ($[0] !== i) {
+		t1 = <Baz i={i} />;
+		$[0] = i;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== j) {
+		t2 = <Joe j={j} />;
+		$[2] = j;
+		$[3] = t2;
+	} else {
+		t2 = $[3];
+	}
+	let t3;
+	if ($[4] !== k) {
+		t3 = <Foo k={k} />;
+		$[4] = k;
+		$[5] = t3;
+	} else {
+		t3 = $[5];
+	}
+	let t4;
+	if ($[6] !== t1 || $[7] !== t2 || $[8] !== t3 || $[9] !== x) {
+		t4 = <Bar x={x}>{t1}{t2}{t3}</Bar>;
+		$[6] = t1;
+		$[7] = t2;
+		$[8] = t3;
+		$[9] = x;
+		$[10] = t4;
+	} else {
+		t4 = $[10];
+	}
+	return t4;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-simple.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-simple.snap
@@ -39,8 +39,26 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "i": i, "x": x } = t0;
-	return <Bar x={x}><Baz i={i} /></Bar>;
+	const $ = _c(5);
+	const { "i": i, "x": x } = t0;
+	let t1;
+	if ($[0] !== i) {
+		t1 = <Baz i={i} />;
+		$[0] = i;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	let t2;
+	if ($[2] !== t1 || $[3] !== x) {
+		t2 = <Bar x={x}>{t1}</Bar>;
+		$[2] = t1;
+		$[3] = x;
+		$[4] = t2;
+	} else {
+		t2 = $[4];
+	}
+	return t2;
 }
 function Bar(t0) {
 	const $ = _c(3);

--- a/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-with-non-jsx-children.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/jsx-outlining-with-non-jsx-children.snap
@@ -40,8 +40,36 @@ function Component(t0) {
 	return t2;
 }
 function _temp(t0) {
-	let { "i": i, "t": t, "k": k, "x": x } = t0;
-	return <Bar x={x}><Baz i={i}>{t}</Baz><Foo k={k} /></Bar>;
+	const $ = _c(9);
+	const { "i": i, "t": t, "k": k, "x": x } = t0;
+	let t1;
+	if ($[0] !== i || $[1] !== t) {
+		t1 = <Baz i={i}>{t}</Baz>;
+		$[0] = i;
+		$[1] = t;
+		$[2] = t1;
+	} else {
+		t1 = $[2];
+	}
+	let t2;
+	if ($[3] !== k) {
+		t2 = <Foo k={k} />;
+		$[3] = k;
+		$[4] = t2;
+	} else {
+		t2 = $[4];
+	}
+	let t3;
+	if ($[5] !== t1 || $[6] !== t2 || $[7] !== x) {
+		t3 = <Bar x={x}>{t1}{t2}</Bar>;
+		$[5] = t1;
+		$[6] = t2;
+		$[7] = x;
+		$[8] = t3;
+	} else {
+		t3 = $[8];
+	}
+	return t3;
 }
 function Bar(t0) {
 	const $ = _c(3);


### PR DESCRIPTION
Queue JSX-outlined components back through the normal `process_fn` pipeline, matching Babel's `Program.ts`. Oxc rebuilds immutable semantics once per FIFO generation and preserves Babel's outlined declaration order.

Validated against the React Compiler fixture suite, Babel output, and `just ready`.

AI-assisted; reviewed and validated by the contributor.