### PR TITLE
feat(linter/react): implement jsx-no-bind rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1363,6 +1363,7 @@ export interface DummyRuleMap {
   "react/jsx-handler-names"?: RuleNoConfig | [AllowWarnDeny, JsxHandlerNamesConfig];
   "react/jsx-key"?: RuleNoConfig | [AllowWarnDeny, JsxKeyConfig];
   "react/jsx-max-depth"?: RuleNoConfig | [AllowWarnDeny, JsxMaxDepthConfig];
+  "react/jsx-no-bind"?: RuleNoConfig | [AllowWarnDeny, JsxNoBindConfig];
   "react/jsx-no-comment-textnodes"?: RuleNoConfig;
   "react/jsx-no-constructed-context-values"?: RuleNoConfig;
   "react/jsx-no-duplicate-props"?: RuleNoConfig;
@@ -4891,6 +4892,13 @@ export interface JsxMaxDepthConfig {
    * The maximum allowed depth of nested JSX elements and fragments.
    */
   max?: number;
+}
+export interface JsxNoBindConfig {
+  allowArrowFunctions?: boolean;
+  allowBind?: boolean;
+  allowFunctions?: boolean;
+  ignoreDOMComponents?: boolean;
+  ignoreRefs?: boolean;
 }
 /**
  * The options shared between the top-level config and each `elementOverrides` entry.

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2712,6 +2712,12 @@ impl RuleRunner for crate::rules::react::jsx_max_depth::JsxMaxDepth {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::react::jsx_no_bind::JsxNoBind {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::JSXAttribute]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::jsx_no_comment_textnodes::JsxNoCommentTextnodes {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::JSXText]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -451,6 +451,7 @@ pub use crate::rules::react::jsx_fragments::JsxFragments as ReactJsxFragments;
 pub use crate::rules::react::jsx_handler_names::JsxHandlerNames as ReactJsxHandlerNames;
 pub use crate::rules::react::jsx_key::JsxKey as ReactJsxKey;
 pub use crate::rules::react::jsx_max_depth::JsxMaxDepth as ReactJsxMaxDepth;
+pub use crate::rules::react::jsx_no_bind::JsxNoBind as ReactJsxNoBind;
 pub use crate::rules::react::jsx_no_comment_textnodes::JsxNoCommentTextnodes as ReactJsxNoCommentTextnodes;
 pub use crate::rules::react::jsx_no_constructed_context_values::JsxNoConstructedContextValues as ReactJsxNoConstructedContextValues;
 pub use crate::rules::react::jsx_no_duplicate_props::JsxNoDuplicateProps as ReactJsxNoDuplicateProps;
@@ -1310,6 +1311,7 @@ pub enum RuleEnum {
     ReactJsxHandlerNames(ReactJsxHandlerNames),
     ReactJsxKey(ReactJsxKey),
     ReactJsxMaxDepth(ReactJsxMaxDepth),
+    ReactJsxNoBind(ReactJsxNoBind),
     ReactJsxNoCommentTextnodes(ReactJsxNoCommentTextnodes),
     ReactJsxNoConstructedContextValues(ReactJsxNoConstructedContextValues),
     ReactJsxNoDuplicateProps(ReactJsxNoDuplicateProps),
@@ -2236,7 +2238,8 @@ const REACT_JSX_FRAGMENTS_ID: usize = REACT_JSX_FILENAME_EXTENSION_ID + 1usize;
 const REACT_JSX_HANDLER_NAMES_ID: usize = REACT_JSX_FRAGMENTS_ID + 1usize;
 const REACT_JSX_KEY_ID: usize = REACT_JSX_HANDLER_NAMES_ID + 1usize;
 const REACT_JSX_MAX_DEPTH_ID: usize = REACT_JSX_KEY_ID + 1usize;
-const REACT_JSX_NO_COMMENT_TEXTNODES_ID: usize = REACT_JSX_MAX_DEPTH_ID + 1usize;
+const REACT_JSX_NO_BIND_ID: usize = REACT_JSX_MAX_DEPTH_ID + 1usize;
+const REACT_JSX_NO_COMMENT_TEXTNODES_ID: usize = REACT_JSX_NO_BIND_ID + 1usize;
 const REACT_JSX_NO_CONSTRUCTED_CONTEXT_VALUES_ID: usize =
     REACT_JSX_NO_COMMENT_TEXTNODES_ID + 1usize;
 const REACT_JSX_NO_DUPLICATE_PROPS_ID: usize = REACT_JSX_NO_CONSTRUCTED_CONTEXT_VALUES_ID + 1usize;
@@ -2751,7 +2754,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 871usize] = [
+static RULE_NAMES: [&str; 872usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3169,6 +3172,7 @@ static RULE_NAMES: [&str; 871usize] = [
     ReactJsxHandlerNames::NAME,
     ReactJsxKey::NAME,
     ReactJsxMaxDepth::NAME,
+    ReactJsxNoBind::NAME,
     ReactJsxNoCommentTextnodes::NAME,
     ReactJsxNoConstructedContextValues::NAME,
     ReactJsxNoDuplicateProps::NAME,
@@ -4116,6 +4120,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(_) => REACT_JSX_HANDLER_NAMES_ID,
             Self::ReactJsxKey(_) => REACT_JSX_KEY_ID,
             Self::ReactJsxMaxDepth(_) => REACT_JSX_MAX_DEPTH_ID,
+            Self::ReactJsxNoBind(_) => REACT_JSX_NO_BIND_ID,
             Self::ReactJsxNoCommentTextnodes(_) => REACT_JSX_NO_COMMENT_TEXTNODES_ID,
             Self::ReactJsxNoConstructedContextValues(_) => {
                 REACT_JSX_NO_CONSTRUCTED_CONTEXT_VALUES_ID
@@ -5146,6 +5151,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(_) => ReactJsxHandlerNames::CATEGORY,
             Self::ReactJsxKey(_) => ReactJsxKey::CATEGORY,
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::CATEGORY,
+            Self::ReactJsxNoBind(_) => ReactJsxNoBind::CATEGORY,
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::CATEGORY,
             Self::ReactJsxNoConstructedContextValues(_) => {
                 ReactJsxNoConstructedContextValues::CATEGORY
@@ -6170,6 +6176,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(_) => ReactJsxHandlerNames::FIX,
             Self::ReactJsxKey(_) => ReactJsxKey::FIX,
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::FIX,
+            Self::ReactJsxNoBind(_) => ReactJsxNoBind::FIX,
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::FIX,
             Self::ReactJsxNoConstructedContextValues(_) => ReactJsxNoConstructedContextValues::FIX,
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::FIX,
@@ -7270,6 +7277,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(_) => ReactJsxHandlerNames::documentation(),
             Self::ReactJsxKey(_) => ReactJsxKey::documentation(),
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::documentation(),
+            Self::ReactJsxNoBind(_) => ReactJsxNoBind::documentation(),
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::documentation(),
             Self::ReactJsxNoConstructedContextValues(_) => {
                 ReactJsxNoConstructedContextValues::documentation()
@@ -9124,6 +9132,8 @@ impl RuleEnum {
             }
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::config_schema(generator)
                 .or_else(|| ReactJsxMaxDepth::schema(generator)),
+            Self::ReactJsxNoBind(_) => ReactJsxNoBind::config_schema(generator)
+                .or_else(|| ReactJsxNoBind::schema(generator)),
             Self::ReactJsxNoCommentTextnodes(_) => {
                 ReactJsxNoCommentTextnodes::config_schema(generator)
                     .or_else(|| ReactJsxNoCommentTextnodes::schema(generator))
@@ -10857,6 +10867,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(_) => "react",
             Self::ReactJsxKey(_) => "react",
             Self::ReactJsxMaxDepth(_) => "react",
+            Self::ReactJsxNoBind(_) => "react",
             Self::ReactJsxNoCommentTextnodes(_) => "react",
             Self::ReactJsxNoConstructedContextValues(_) => "react",
             Self::ReactJsxNoDuplicateProps(_) => "react",
@@ -11978,6 +11989,9 @@ impl RuleEnum {
             Self::ReactJsxMaxDepth(_) => {
                 Ok(Self::ReactJsxMaxDepth(ReactJsxMaxDepth::from_configuration(value)?))
             }
+            Self::ReactJsxNoBind(_) => {
+                Ok(Self::ReactJsxNoBind(ReactJsxNoBind::from_configuration(value)?))
+            }
             Self::ReactJsxNoLiterals(_) => {
                 Ok(Self::ReactJsxNoLiterals(ReactJsxNoLiterals::from_configuration(value)?))
             }
@@ -12826,6 +12840,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(rule) => rule.to_configuration(),
             Self::ReactJsxKey(rule) => rule.to_configuration(),
             Self::ReactJsxMaxDepth(rule) => rule.to_configuration(),
+            Self::ReactJsxNoBind(rule) => rule.to_configuration(),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.to_configuration(),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.to_configuration(),
             Self::ReactJsxNoDuplicateProps(rule) => rule.to_configuration(),
@@ -13704,6 +13719,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(rule) => rule.run(node, ctx),
             Self::ReactJsxKey(rule) => rule.run(node, ctx),
             Self::ReactJsxMaxDepth(rule) => rule.run(node, ctx),
+            Self::ReactJsxNoBind(rule) => rule.run(node, ctx),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.run(node, ctx),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.run(node, ctx),
             Self::ReactJsxNoDuplicateProps(rule) => rule.run(node, ctx),
@@ -14592,6 +14608,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(rule) => rule.run_once(ctx),
             Self::ReactJsxKey(rule) => rule.run_once(ctx),
             Self::ReactJsxMaxDepth(rule) => rule.run_once(ctx),
+            Self::ReactJsxNoBind(rule) => rule.run_once(ctx),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.run_once(ctx),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.run_once(ctx),
             Self::ReactJsxNoDuplicateProps(rule) => rule.run_once(ctx),
@@ -15551,6 +15568,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxKey(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxMaxDepth(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactJsxNoBind(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactJsxNoDuplicateProps(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16486,6 +16504,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(rule) => rule.should_run(ctx),
             Self::ReactJsxKey(rule) => rule.should_run(ctx),
             Self::ReactJsxMaxDepth(rule) => rule.should_run(ctx),
+            Self::ReactJsxNoBind(rule) => rule.should_run(ctx),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.should_run(ctx),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.should_run(ctx),
             Self::ReactJsxNoDuplicateProps(rule) => rule.should_run(ctx),
@@ -17539,6 +17558,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(_) => ReactJsxHandlerNames::IS_TSGOLINT_RULE,
             Self::ReactJsxKey(_) => ReactJsxKey::IS_TSGOLINT_RULE,
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::IS_TSGOLINT_RULE,
+            Self::ReactJsxNoBind(_) => ReactJsxNoBind::IS_TSGOLINT_RULE,
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::IS_TSGOLINT_RULE,
             Self::ReactJsxNoConstructedContextValues(_) => {
                 ReactJsxNoConstructedContextValues::IS_TSGOLINT_RULE
@@ -18720,6 +18740,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(_) => ReactJsxHandlerNames::VERSION,
             Self::ReactJsxKey(_) => ReactJsxKey::VERSION,
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::VERSION,
+            Self::ReactJsxNoBind(_) => ReactJsxNoBind::VERSION,
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::VERSION,
             Self::ReactJsxNoConstructedContextValues(_) => {
                 ReactJsxNoConstructedContextValues::VERSION
@@ -19788,6 +19809,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(_) => ReactJsxHandlerNames::HAS_CONFIG,
             Self::ReactJsxKey(_) => ReactJsxKey::HAS_CONFIG,
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::HAS_CONFIG,
+            Self::ReactJsxNoBind(_) => ReactJsxNoBind::HAS_CONFIG,
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::HAS_CONFIG,
             Self::ReactJsxNoConstructedContextValues(_) => {
                 ReactJsxNoConstructedContextValues::HAS_CONFIG
@@ -20835,6 +20857,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(_) => ReactJsxHandlerNames::INFO,
             Self::ReactJsxKey(_) => ReactJsxKey::INFO,
             Self::ReactJsxMaxDepth(_) => ReactJsxMaxDepth::INFO,
+            Self::ReactJsxNoBind(_) => ReactJsxNoBind::INFO,
             Self::ReactJsxNoCommentTextnodes(_) => ReactJsxNoCommentTextnodes::INFO,
             Self::ReactJsxNoConstructedContextValues(_) => ReactJsxNoConstructedContextValues::INFO,
             Self::ReactJsxNoDuplicateProps(_) => ReactJsxNoDuplicateProps::INFO,
@@ -21761,6 +21784,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(rule) => rule.types_info(),
             Self::ReactJsxKey(rule) => rule.types_info(),
             Self::ReactJsxMaxDepth(rule) => rule.types_info(),
+            Self::ReactJsxNoBind(rule) => rule.types_info(),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.types_info(),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.types_info(),
             Self::ReactJsxNoDuplicateProps(rule) => rule.types_info(),
@@ -22636,6 +22660,7 @@ impl RuleEnum {
             Self::ReactJsxHandlerNames(rule) => rule.run_info(),
             Self::ReactJsxKey(rule) => rule.run_info(),
             Self::ReactJsxMaxDepth(rule) => rule.run_info(),
+            Self::ReactJsxNoBind(rule) => rule.run_info(),
             Self::ReactJsxNoCommentTextnodes(rule) => rule.run_info(),
             Self::ReactJsxNoConstructedContextValues(rule) => rule.run_info(),
             Self::ReactJsxNoDuplicateProps(rule) => rule.run_info(),
@@ -23601,6 +23626,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactJsxHandlerNames(ReactJsxHandlerNames::default()),
         RuleEnum::ReactJsxKey(ReactJsxKey::default()),
         RuleEnum::ReactJsxMaxDepth(ReactJsxMaxDepth::default()),
+        RuleEnum::ReactJsxNoBind(ReactJsxNoBind::default()),
         RuleEnum::ReactJsxNoCommentTextnodes(ReactJsxNoCommentTextnodes::default()),
         RuleEnum::ReactJsxNoConstructedContextValues(ReactJsxNoConstructedContextValues::default()),
         RuleEnum::ReactJsxNoDuplicateProps(ReactJsxNoDuplicateProps::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -468,6 +468,7 @@ pub(crate) mod react {
     pub mod jsx_handler_names;
     pub mod jsx_key;
     pub mod jsx_max_depth;
+    pub mod jsx_no_bind;
     pub mod jsx_no_comment_textnodes;
     pub mod jsx_no_constructed_context_values;
     pub mod jsx_no_duplicate_props;

--- a/crates/oxc_linter/src/rules/react/jsx_no_bind.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_bind.rs
@@ -1,0 +1,698 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, JSXAttributeValue, JSXOpeningElement},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+    utils::is_react_component_name,
+};
+
+fn bind_call_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("JSX props should not use `.bind()`")
+        .with_help(
+            "Bind the handler outside of render, e.g. in the constructor or with a class property.",
+        )
+        .with_label(span)
+}
+
+fn arrow_func_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("JSX props should not use arrow functions")
+        .with_help("Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.")
+        .with_label(span)
+}
+
+fn func_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("JSX props should not use functions")
+        .with_help("Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct ConfigElement0 {
+    #[serde(rename = "ignoreDOMComponents")]
+    ignore_dom_components: bool,
+    allow_bind: bool,
+    allow_functions: bool,
+    ignore_refs: bool,
+    allow_arrow_functions: bool,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct JsxNoBind(ConfigElement0);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows `.bind()` calls, arrow functions, and function expressions in
+    /// JSX props, including when they are assigned to a local `const` or
+    /// declared as a local function and then passed as a prop.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A `.bind()` call or a function created during render produces a brand
+    /// new function on every render. Child components receiving it as a prop
+    /// see a changed reference each time, which defeats memoization
+    /// (`React.memo`, `shouldComponentUpdate`, `PureComponent`) and causes
+    /// unnecessary re-renders.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <Foo onClick={this._handleClick.bind(this)} />
+    /// <Foo onClick={() => console.log('Hello!')} />
+    /// <Foo onClick={function () { console.log('Hello!'); }} />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <Foo onClick={this._handleClick} />
+    /// ```
+    JsxNoBind,
+    react,
+    perf,
+    config = JsxNoBind,
+    version = "next",
+    short_description = "Disallow `.bind()` or arrow functions in JSX props.",
+);
+
+#[derive(Debug, Clone, Copy)]
+enum ViolationType {
+    BindCall,
+    ArrowFunc,
+    Func,
+}
+
+impl ConfigElement0 {
+    fn get_violation_type(&self, expr: &Expression) -> Option<ViolationType> {
+        match expr.get_inner_expression() {
+            Expression::CallExpression(call) if !self.allow_bind => {
+                if let Expression::StaticMemberExpression(member) = &call.callee
+                    && member.property.name == "bind"
+                {
+                    Some(ViolationType::BindCall)
+                } else {
+                    None
+                }
+            }
+            Expression::ConditionalExpression(cond) => self
+                .get_violation_type(&cond.test)
+                .or_else(|| self.get_violation_type(&cond.consequent))
+                .or_else(|| self.get_violation_type(&cond.alternate)),
+            Expression::ArrowFunctionExpression(_) if !self.allow_arrow_functions => {
+                Some(ViolationType::ArrowFunc)
+            }
+            Expression::FunctionExpression(_) if !self.allow_functions => Some(ViolationType::Func),
+            _ => None,
+        }
+    }
+}
+
+fn is_dom_component(element: &JSXOpeningElement) -> bool {
+    element.name.get_identifier_name().is_some_and(|name| !is_react_component_name(&name))
+}
+
+impl Rule for JsxNoBind {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXAttribute(attr) = node.kind() else {
+            return;
+        };
+        let config = &self.0;
+
+        if config.ignore_refs && attr.name.as_identifier().is_some_and(|name| name.name == "ref") {
+            return;
+        }
+        let Some(JSXAttributeValue::ExpressionContainer(container)) = &attr.value else {
+            return;
+        };
+        let Some(expr) = container.expression.as_expression() else {
+            return;
+        };
+
+        if config.ignore_dom_components
+            && let AstKind::JSXOpeningElement(opening) = ctx.nodes().parent_kind(node.id())
+            && is_dom_component(opening)
+        {
+            return;
+        }
+
+        let expr = expr.get_inner_expression();
+
+        // A function created during render may be assigned to a `const` (or
+        // declared as a local function) and then passed as a prop, so resolve
+        // identifiers to their declaration.
+        if let Expression::Identifier(ident) = expr {
+            let Some(symbol_id) = ctx.scoping().get_reference(ident.reference_id()).symbol_id()
+            else {
+                return;
+            };
+            // Functions created at the root scope are not re-created on each
+            // render; the original rule likewise only tracks declarations
+            // inside a block.
+            if ctx.scoping().symbol_scope_id(symbol_id) == ctx.scoping().root_scope_id() {
+                return;
+            }
+            let decl_node = ctx.nodes().get_node(ctx.scoping().symbol_declaration(symbol_id));
+            let violation_type = match decl_node.kind() {
+                AstKind::VariableDeclarator(decl) => {
+                    let AstKind::VariableDeclaration(parent_decl) =
+                        ctx.nodes().parent_kind(decl_node.id())
+                    else {
+                        return;
+                    };
+                    // Only `const` is supported, matching the original rule.
+                    if !parent_decl.kind.is_const() {
+                        return;
+                    }
+                    decl.init.as_ref().and_then(|init| config.get_violation_type(init))
+                }
+                AstKind::Function(func) if func.is_declaration() && !config.allow_functions => {
+                    Some(ViolationType::Func)
+                }
+                _ => None,
+            };
+            if let Some(violation_type) = violation_type {
+                report(violation_type, attr.span, ctx);
+            }
+            return;
+        }
+
+        if let Some(violation_type) = config.get_violation_type(expr) {
+            report(violation_type, attr.span, ctx);
+        }
+    }
+}
+
+fn report(violation_type: ViolationType, span: Span, ctx: &LintContext<'_>) {
+    let diagnostic = match violation_type {
+        ViolationType::BindCall => bind_call_diagnostic(span),
+        ViolationType::ArrowFunc => arrow_func_diagnostic(span),
+        ViolationType::Func => func_diagnostic(span),
+    };
+    ctx.diagnostic(diagnostic);
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("<div onClick={this._handleClick}></div>", None),
+        ("<div onClick={this._handleClick}></div>", Some(serde_json::json!([{}]))),
+        ("<Foo onClick={this._handleClick} />", None),
+        ("<Foo onClick={this._handleClick} />", Some(serde_json::json!([{}]))),
+        ("<div meaningOfLife={42}></div>", None),
+        ("<div onClick={getHandler()}></div>", None),
+        (
+            "<div ref={c => this._input = c}></div>",
+            Some(serde_json::json!([{ "ignoreRefs": true }])),
+        ),
+        (
+            "<div ref={this._refCallback.bind(this)}></div>",
+            Some(serde_json::json!([{ "ignoreRefs": true }])),
+        ),
+        (
+            "<div ref={function (c) {this._input = c}}></div>",
+            Some(serde_json::json!([{ "ignoreRefs": true }])),
+        ),
+        (
+            "<div onClick={this._handleClick.bind(this)}></div>",
+            Some(serde_json::json!([{ "allowBind": true }])),
+        ),
+        (
+            r#"<div onClick={() => alert("1337")}></div>"#,
+            Some(serde_json::json!([{ "allowArrowFunctions": true }])),
+        ),
+        (
+            r#"<div onClick={async () => alert("1337")}></div>"#,
+            Some(serde_json::json!([{ "allowArrowFunctions": true }])),
+        ),
+        (
+            r#"<div onClick={function () { alert("1337") }}></div>"#,
+            Some(serde_json::json!([{ "allowFunctions": true }])),
+        ),
+        (
+            r#"<div onClick={function * () { alert("1337") }}></div>"#,
+            Some(serde_json::json!([{ "allowFunctions": true }])),
+        ),
+        (
+            r#"<div onClick={async function () { alert("1337") }}></div>"#,
+            Some(serde_json::json!([{ "allowFunctions": true }])),
+        ),
+        (
+            "
+                    class Hello extends Component {
+                      render() {
+                        return <div>Hello</div>;
+                      }
+                    }
+                    export default connect()(Hello);
+                  ",
+            Some(serde_json::json!([{ "allowBind": true }])),
+        ),
+        (
+            r#"
+                    var DocumentRow = Backbone.View.extend({
+                      tagName: "li",
+                      render: function() {
+                        this.onTap.bind(this);
+                      }
+                    });
+                  "#,
+            None,
+        ),
+        (
+            "
+                    const foo = {
+                      render: function() {
+                        this.onTap.bind(this);
+                        return true;
+                      }
+                    };
+                  ",
+            None,
+        ),
+        (
+            "
+                    const foo = {
+                      render() {
+                        this.onTap.bind(this);
+                        return true;
+                      }
+                    };
+                  ",
+            None,
+        ),
+        (
+            "
+                    class Hello extends Component {
+                      render() {
+                        const click = this.onTap.bind(this);
+                        return <div onClick={onClick}>Hello</div>;
+                      }
+                    };
+                  ",
+            None,
+        ),
+        (
+            "
+                    class Hello extends Component {
+                      render() {
+                        foo.onClick = this.onTap.bind(this);
+                        return <div onClick={onClick}>Hello</div>;
+                      }
+                    };
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    class Hello extends Component {
+                      render() {
+                        return (<div>{
+                          this.props.list.map(this.wrap.bind(this, "span"))
+                        }</div>);
+                      }
+                    };
+                  "#,
+            None,
+        ),
+        (
+            "
+                    class Hello extends Component {
+                      render() {
+                        const click = () => true;
+                        return <div onClick={onClick}>Hello</div>;
+                      }
+                    };
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    class Hello extends Component {
+                      render() {
+                        return (<div>{
+                          this.props.list.map(item => <item hello="true"/>)
+                        }</div>);
+                      }
+                    };
+                  "#,
+            None,
+        ),
+        (
+            r#"
+                    var Hello = React.createClass({
+                      render: function() {
+                        return (<div>{
+                          this.props.list.map(this.wrap.bind(this, "span"))
+                        }</div>);
+                      }
+                    });
+                  "#,
+            None,
+        ),
+        (
+            "
+                    var Hello = React.createClass({
+                      render: function() {
+                        const click = () => true
+                        return <div onClick={onClick}>Hello</div>;
+                      }
+                    });
+                  ",
+            None,
+        ),
+        (
+            r#"
+                    class Hello23 extends React.Component {
+                      renderDiv = () => {
+                        const onClick = this.doSomething.bind(this, "no")
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  "#,
+            None,
+        ),
+        (
+            r#"
+                    class Hello23 extends React.Component {
+                      renderDiv = async () => {
+                        return (<div>{
+                          this.props.list.map(this.wrap.bind(this, "span"))
+                        }</div>);
+                      }
+                    };
+                  "#,
+            None,
+        ),
+        (
+            "
+                    class Hello extends Component {
+                      render() {
+                        let click;
+                        return <div onClick={onClick}>Hello</div>;
+                      }
+                    }
+                  ",
+            None,
+        ),
+        (
+            "<div onClick={this._handleClick.bind(this)}></div>",
+            Some(serde_json::json!([{ "ignoreDOMComponents": true }])),
+        ),
+        (
+            r#"<div onClick={() => alert("1337")}></div>"#,
+            Some(serde_json::json!([{ "ignoreDOMComponents": true }])),
+        ),
+        (
+            r#"<div onClick={function () { alert("1337") }}></div>"#,
+            Some(serde_json::json!([{ "ignoreDOMComponents": true }])),
+        ),
+        (
+            "
+                    function click() { return true; }
+                    class Hello23 extends React.Component {
+                      renderDiv() {
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  ",
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        ("<div onClick={this._handleClick.bind(this)}></div>", None),
+("<div onClick={someGlobalFunction.bind(this)}></div>", None),
+("<div onClick={window.lol.bind(this)}></div>", None),
+("<div ref={this._refCallback.bind(this)}></div>", None),
+("
+                    var Hello = createReactClass({
+                      render: function() {
+                        const click = this.someMethod.bind(this);
+                        return <div onClick={click}>Hello {this.state.name}</div>;
+                      }
+                    });
+                  ", None),
+("
+                    class Hello23 extends React.Component {
+                      render() {
+                        const click = this.someMethod.bind(this);
+                        return <div onClick={click}>Hello {this.state.name}</div>;
+                      }
+                    };
+                  ", None),
+(r#"
+                    class Hello23 extends React.Component {
+                      renderDiv() {
+                        const click = this.doSomething.bind(this, "no")
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  "#, None),
+(r#"
+                    class Hello23 extends React.Component {
+                      renderDiv = () => {
+                        const click = this.doSomething.bind(this, "no")
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  "#, None),
+(r#"
+                    class Hello23 extends React.Component {
+                      renderDiv = async () => {
+                        const click = this.doSomething.bind(this, "no")
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  "#, None),
+("
+                    const foo = {
+                      render: ({onClick}) => (
+                        <div onClick={onClick.bind(this)}>Hello</div>
+                      )
+                    };
+                  ", None),
+(r#"
+                    var Hello = React.createClass({
+                      render: function() {
+                      return <div onClick={this.doSomething.bind(this, "hey")} />
+                      }
+                    });
+                  "#, None),
+(r#"
+                    var Hello = React.createClass({
+                      render: function() {
+                        const doThing = this.doSomething.bind(this, "hey")
+                        return <div onClick={doThing} />
+                      }
+                    });
+                  "#, None),
+(r#"
+                    class Hello23 extends React.Component {
+                      renderDiv = () => {
+                        const click = () => true
+                        const renderStuff = () => {
+                          const click = this.doSomething.bind(this, "hey")
+                          return <div onClick={click} />
+                        }
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  "#, None),
+("
+                    const foo = {
+                      render: ({onClick}) => (
+                        <div onClick={(returningBoolean()) ? onClick.bind(this) : onClick.bind(this)}>Hello</div>
+                      )
+                    };
+                  ", None),
+("
+                    const foo = {
+                      render: ({onClick}) => (
+                        <div onClick={(returningBoolean()) ? onClick.bind(this) : handleClick()}>Hello</div>
+                      )
+                    };
+                  ", None),
+("
+                    const foo = {
+                      render: ({onClick}) => (
+                        <div onClick={(returningBoolean()) ? handleClick() : this.onClick.bind(this)}>Hello</div>
+                      )
+                    };
+                  ", None),
+("
+                    const foo = {
+                      render: ({onClick}) => (
+                        <div onClick={returningBoolean.bind(this) ? handleClick() : onClick()}>Hello</div>
+                      )
+                    };
+                  ", None),
+(r#"<div onClick={() => alert("1337")}></div>"#, None),
+(r#"<div onClick={async () => alert("1337")}></div>"#, None),
+("<div onClick={() => 42}></div>", None),
+("<div onClick={param => { first(); second(); }}></div>", None),
+("<div ref={c => this._input = c}></div>", None),
+("
+                    class Hello23 extends React.Component {
+                      renderDiv = () => {
+                        const click = () => true
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  ", None),
+("
+                    class Hello23 extends React.Component {
+                      renderDiv = async () => {
+                        const click = () => true
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  ", None),
+("
+                    class Hello23 extends React.Component {
+                      renderDiv = async () => {
+                        const click = async () => true
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  ", None),
+("
+                    var Hello = React.createClass({
+                      render: function() {
+                      return <div onClick={() => true} />
+                      }
+                    });
+                  ", None),
+("
+                    var Hello = React.createClass({
+                      render: function() {
+                      return <div onClick={async () => true} />
+                      }
+                    });
+                  ", None),
+("
+                    var Hello = React.createClass({
+                      render: function() {
+                        const doThing = () => true
+                        return <div onClick={doThing} />
+                      }
+                    });
+                  ", None),
+("
+                    var Hello = React.createClass({
+                      render: function() {
+                        const doThing = async () => true
+                        return <div onClick={doThing} />
+                      }
+                    });
+                  ", None),
+(r#"<div onClick={function () { alert("1337") }}></div>"#, None),
+(r#"<div onClick={function * () { alert("1337") }}></div>"#, None),
+(r#"<div onClick={async function () { alert("1337") }}></div>"#, None),
+("<div ref={function (c) { this._input = c }}></div>", None),
+("
+                    class Hello23 extends React.Component {
+                      renderDiv = () => {
+                        const click = function () { return true }
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  ", None),
+("
+                    class Hello23 extends React.Component {
+                      renderDiv = () => {
+                        const click = function * () { return true }
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  ", None),
+("
+                    class Hello23 extends React.Component {
+                      renderDiv = async () => {
+                        const click = function () { return true }
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  ", None),
+("
+                    class Hello23 extends React.Component {
+                      renderDiv = async () => {
+                        const click = async function () { return true }
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  ", None),
+("
+                    var Hello = React.createClass({
+                      render: function() {
+                      return <div onClick={function () { return true }} />
+                      }
+                    });
+                  ", None),
+("
+                    var Hello = React.createClass({
+                      render: function() {
+                      return <div onClick={function * () { return true }} />
+                      }
+                    });
+                  ", None),
+("
+                    var Hello = React.createClass({
+                      render: function() {
+                      return <div onClick={async function () { return true }} />
+                      }
+                    });
+                  ", None),
+("
+                    var Hello = React.createClass({
+                      render: function() {
+                        const doThing = function () { return true }
+                        return <div onClick={doThing} />
+                      }
+                    });
+                  ", None),
+("
+                    var Hello = React.createClass({
+                      render: function() {
+                        const doThing = async function () { return true }
+                        return <div onClick={doThing} />
+                      }
+                    });
+                  ", None),
+("
+                    var Hello = React.createClass({
+                      render: function() {
+                        const doThing = function * () { return true }
+                        return <div onClick={doThing} />
+                      }
+                    });
+                  ", None),
+("
+                    class Hello23 extends React.Component {
+                      renderDiv() {
+                        function click() { return true; }
+                        return <div onClick={click}>Hello</div>;
+                      }
+                    };
+                  ", None),
+("<Foo onClick={this._handleClick.bind(this)} />", Some(serde_json::json!([{ "ignoreDOMComponents": true }])))
+    ];
+
+    Tester::new(JsxNoBind::NAME, JsxNoBind::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/react/jsx_no_bind.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_bind.rs
@@ -38,7 +38,7 @@ fn func_diagnostic(span: Span) -> OxcDiagnostic {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-struct ConfigElement0 {
+struct JsxNoBindConfig {
     #[serde(rename = "ignoreDOMComponents")]
     ignore_dom_components: bool,
     allow_bind: bool,
@@ -48,7 +48,7 @@ struct ConfigElement0 {
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
-pub struct JsxNoBind(ConfigElement0);
+pub struct JsxNoBind(JsxNoBindConfig);
 
 declare_oxc_lint!(
     /// ### What it does
@@ -93,7 +93,7 @@ enum ViolationType {
     Func,
 }
 
-impl ConfigElement0 {
+impl JsxNoBindConfig {
     fn get_violation_type(&self, expr: &Expression) -> Option<ViolationType> {
         match expr.get_inner_expression() {
             Expression::CallExpression(call) if !self.allow_bind => {

--- a/crates/oxc_linter/src/snapshots/react_jsx_no_bind.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_no_bind.snap
@@ -1,0 +1,389 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <div onClick={this._handleClick.bind(this)}></div>
+   ·      ──────────────────────────────────────
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <div onClick={someGlobalFunction.bind(this)}></div>
+   ·      ───────────────────────────────────────
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <div onClick={window.lol.bind(this)}></div>
+   ·      ───────────────────────────────
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <div ref={this._refCallback.bind(this)}></div>
+   ·      ──────────────────────────────────
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const click = this.someMethod.bind(this);
+ 5 │                         return <div onClick={click}>Hello {this.state.name}</div>;
+   ·                                     ───────────────
+ 6 │                       }
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const click = this.someMethod.bind(this);
+ 5 │                         return <div onClick={click}>Hello {this.state.name}</div>;
+   ·                                     ───────────────
+ 6 │                       }
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const click = this.doSomething.bind(this, "no")
+ 5 │                         return <div onClick={click}>Hello</div>;
+   ·                                     ───────────────
+ 6 │                       }
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const click = this.doSomething.bind(this, "no")
+ 5 │                         return <div onClick={click}>Hello</div>;
+   ·                                     ───────────────
+ 6 │                       }
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const click = this.doSomething.bind(this, "no")
+ 5 │                         return <div onClick={click}>Hello</div>;
+   ·                                     ───────────────
+ 6 │                       }
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:4:30]
+ 3 │                       render: ({onClick}) => (
+ 4 │                         <div onClick={onClick.bind(this)}>Hello</div>
+   ·                              ────────────────────────────
+ 5 │                       )
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:4:35]
+ 3 │                       render: function() {
+ 4 │                       return <div onClick={this.doSomething.bind(this, "hey")} />
+   ·                                   ────────────────────────────────────────────
+ 5 │                       }
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const doThing = this.doSomething.bind(this, "hey")
+ 5 │                         return <div onClick={doThing} />
+   ·                                     ─────────────────
+ 6 │                       }
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:7:39]
+ 6 │                           const click = this.doSomething.bind(this, "hey")
+ 7 │                           return <div onClick={click} />
+   ·                                       ───────────────
+ 8 │                         }
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use arrow functions
+    ╭─[jsx_no_bind.tsx:9:37]
+  8 │                         }
+  9 │                         return <div onClick={click}>Hello</div>;
+    ·                                     ───────────────
+ 10 │                       }
+    ╰────
+  help: Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:4:30]
+ 3 │                       render: ({onClick}) => (
+ 4 │                         <div onClick={(returningBoolean()) ? onClick.bind(this) : onClick.bind(this)}>Hello</div>
+   ·                              ────────────────────────────────────────────────────────────────────────
+ 5 │                       )
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:4:30]
+ 3 │                       render: ({onClick}) => (
+ 4 │                         <div onClick={(returningBoolean()) ? onClick.bind(this) : handleClick()}>Hello</div>
+   ·                              ───────────────────────────────────────────────────────────────────
+ 5 │                       )
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:4:30]
+ 3 │                       render: ({onClick}) => (
+ 4 │                         <div onClick={(returningBoolean()) ? handleClick() : this.onClick.bind(this)}>Hello</div>
+   ·                              ────────────────────────────────────────────────────────────────────────
+ 5 │                       )
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:4:30]
+ 3 │                       render: ({onClick}) => (
+ 4 │                         <div onClick={returningBoolean.bind(this) ? handleClick() : onClick()}>Hello</div>
+   ·                              ─────────────────────────────────────────────────────────────────
+ 5 │                       )
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.
+
+  ⚠ react(jsx-no-bind): JSX props should not use arrow functions
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <div onClick={() => alert("1337")}></div>
+   ·      ─────────────────────────────
+   ╰────
+  help: Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use arrow functions
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <div onClick={async () => alert("1337")}></div>
+   ·      ───────────────────────────────────
+   ╰────
+  help: Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use arrow functions
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <div onClick={() => 42}></div>
+   ·      ──────────────────
+   ╰────
+  help: Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use arrow functions
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <div onClick={param => { first(); second(); }}></div>
+   ·      ─────────────────────────────────────────
+   ╰────
+  help: Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use arrow functions
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <div ref={c => this._input = c}></div>
+   ·      ──────────────────────────
+   ╰────
+  help: Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use arrow functions
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const click = () => true
+ 5 │                         return <div onClick={click}>Hello</div>;
+   ·                                     ───────────────
+ 6 │                       }
+   ╰────
+  help: Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use arrow functions
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const click = () => true
+ 5 │                         return <div onClick={click}>Hello</div>;
+   ·                                     ───────────────
+ 6 │                       }
+   ╰────
+  help: Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use arrow functions
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const click = async () => true
+ 5 │                         return <div onClick={click}>Hello</div>;
+   ·                                     ───────────────
+ 6 │                       }
+   ╰────
+  help: Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use arrow functions
+   ╭─[jsx_no_bind.tsx:4:35]
+ 3 │                       render: function() {
+ 4 │                       return <div onClick={() => true} />
+   ·                                   ────────────────────
+ 5 │                       }
+   ╰────
+  help: Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use arrow functions
+   ╭─[jsx_no_bind.tsx:4:35]
+ 3 │                       render: function() {
+ 4 │                       return <div onClick={async () => true} />
+   ·                                   ──────────────────────────
+ 5 │                       }
+   ╰────
+  help: Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use arrow functions
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const doThing = () => true
+ 5 │                         return <div onClick={doThing} />
+   ·                                     ─────────────────
+ 6 │                       }
+   ╰────
+  help: Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use arrow functions
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const doThing = async () => true
+ 5 │                         return <div onClick={doThing} />
+   ·                                     ─────────────────
+ 6 │                       }
+   ╰────
+  help: Extract the arrow function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <div onClick={function () { alert("1337") }}></div>
+   ·      ───────────────────────────────────────
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <div onClick={function * () { alert("1337") }}></div>
+   ·      ─────────────────────────────────────────
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <div onClick={async function () { alert("1337") }}></div>
+   ·      ─────────────────────────────────────────────
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <div ref={function (c) { this._input = c }}></div>
+   ·      ──────────────────────────────────────
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const click = function () { return true }
+ 5 │                         return <div onClick={click}>Hello</div>;
+   ·                                     ───────────────
+ 6 │                       }
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const click = function * () { return true }
+ 5 │                         return <div onClick={click}>Hello</div>;
+   ·                                     ───────────────
+ 6 │                       }
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const click = function () { return true }
+ 5 │                         return <div onClick={click}>Hello</div>;
+   ·                                     ───────────────
+ 6 │                       }
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const click = async function () { return true }
+ 5 │                         return <div onClick={click}>Hello</div>;
+   ·                                     ───────────────
+ 6 │                       }
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:4:35]
+ 3 │                       render: function() {
+ 4 │                       return <div onClick={function () { return true }} />
+   ·                                   ─────────────────────────────────────
+ 5 │                       }
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:4:35]
+ 3 │                       render: function() {
+ 4 │                       return <div onClick={function * () { return true }} />
+   ·                                   ───────────────────────────────────────
+ 5 │                       }
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:4:35]
+ 3 │                       render: function() {
+ 4 │                       return <div onClick={async function () { return true }} />
+   ·                                   ───────────────────────────────────────────
+ 5 │                       }
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const doThing = function () { return true }
+ 5 │                         return <div onClick={doThing} />
+   ·                                     ─────────────────
+ 6 │                       }
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const doThing = async function () { return true }
+ 5 │                         return <div onClick={doThing} />
+   ·                                     ─────────────────
+ 6 │                       }
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         const doThing = function * () { return true }
+ 5 │                         return <div onClick={doThing} />
+   ·                                     ─────────────────
+ 6 │                       }
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use functions
+   ╭─[jsx_no_bind.tsx:5:37]
+ 4 │                         function click() { return true; }
+ 5 │                         return <div onClick={click}>Hello</div>;
+   ·                                     ───────────────
+ 6 │                       }
+   ╰────
+  help: Extract the function into a stable reference, e.g. a class method or a `useCallback` hook.
+
+  ⚠ react(jsx-no-bind): JSX props should not use `.bind()`
+   ╭─[jsx_no_bind.tsx:1:6]
+ 1 │ <Foo onClick={this._handleClick.bind(this)} />
+   ·      ──────────────────────────────────────
+   ╰────
+  help: Bind the handler outside of render, e.g. in the constructor or with a class property.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1528,6 +1528,32 @@
       "maxItems": 2,
       "minItems": 2
     },
+    "ConfigElement0": {
+      "type": "object",
+      "properties": {
+        "allowArrowFunctions": {
+          "default": false,
+          "type": "boolean"
+        },
+        "allowBind": {
+          "default": false,
+          "type": "boolean"
+        },
+        "allowFunctions": {
+          "default": false,
+          "type": "boolean"
+        },
+        "ignoreDOMComponents": {
+          "default": false,
+          "type": "boolean"
+        },
+        "ignoreRefs": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "ConsistentEachForJson": {
       "type": "object",
       "properties": {
@@ -6891,6 +6917,26 @@
                 },
                 {
                   "$ref": "#/definitions/JsxMaxDepthConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
+        "react/jsx-no-bind": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/JsxNoBind"
                 }
               ],
               "maxItems": 2,
@@ -12460,6 +12506,9 @@
         }
       },
       "additionalProperties": false
+    },
+    "JsxNoBind": {
+      "$ref": "#/definitions/ConfigElement0"
     },
     "JsxNoLiteralsConfig": {
       "description": "The options shared between the top-level config and each `elementOverrides` entry.",

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1528,32 +1528,6 @@
       "maxItems": 2,
       "minItems": 2
     },
-    "ConfigElement0": {
-      "type": "object",
-      "properties": {
-        "allowArrowFunctions": {
-          "default": false,
-          "type": "boolean"
-        },
-        "allowBind": {
-          "default": false,
-          "type": "boolean"
-        },
-        "allowFunctions": {
-          "default": false,
-          "type": "boolean"
-        },
-        "ignoreDOMComponents": {
-          "default": false,
-          "type": "boolean"
-        },
-        "ignoreRefs": {
-          "default": false,
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    },
     "ConsistentEachForJson": {
       "type": "object",
       "properties": {
@@ -12508,7 +12482,33 @@
       "additionalProperties": false
     },
     "JsxNoBind": {
-      "$ref": "#/definitions/ConfigElement0"
+      "$ref": "#/definitions/JsxNoBindConfig"
+    },
+    "JsxNoBindConfig": {
+      "type": "object",
+      "properties": {
+        "allowArrowFunctions": {
+          "default": false,
+          "type": "boolean"
+        },
+        "allowBind": {
+          "default": false,
+          "type": "boolean"
+        },
+        "allowFunctions": {
+          "default": false,
+          "type": "boolean"
+        },
+        "ignoreDOMComponents": {
+          "default": false,
+          "type": "boolean"
+        },
+        "ignoreRefs": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
     },
     "JsxNoLiteralsConfig": {
       "description": "The options shared between the top-level config and each `elementOverrides` entry.",

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -434,6 +434,7 @@ react/jsx-fragments                                        |    459
 react/jsx-handler-names                                    |    804
 react/jsx-key                                              |   1088
 react/jsx-max-depth                                        |    459
+react/jsx-no-bind                                          |    804
 react/jsx-no-comment-textnodes                             |    672
 react/jsx-no-constructed-context-values                    |    452
 react/jsx-no-duplicate-props                               |    452


### PR DESCRIPTION
## Summary

Adds a native Oxlint implementation of the [`eslint-plugin-react` `jsx-no-bind` rule](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md). This implementation is a port of the [rule source](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-no-bind.js) and test suite.

Implementation notes:

- Instead of the upstream per-block variable-name tracking, identifiers passed as props are resolved to their declarations (`const` initializers and local function declarations) via `oxc_semantic`, which also handles shadowing correctly.
- Declarations at the root scope are ignored, matching the upstream behavior of only tracking declarations inside a block.
- The `bindExpression` (`::`) detection is omitted because oxc does not parse the stage-0 bind operator proposal; the corresponding test cases were dropped.
- All options are supported: `allowBind`, `allowArrowFunctions`, `allowFunctions`, `ignoreRefs`, `ignoreDOMComponents`.

Related #1022

## AI Disclosure

Claude Code (Claude Fable 5) was used to assist with the implementation of this rule. The code and tests have been reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
