### PR TITLE
fix(react-compiler): preserve binary operand types

### DIFF
--- a/crates/oxc_react_compiler/fixtures/bug-binary-operand-type-inference.js
+++ b/crates/oxc_react_compiler/fixtures/bug-binary-operand-type-inference.js
@@ -1,0 +1,26 @@
+import {arrayPush, mutate} from 'shared-runtime';
+
+/**
+ * A binary expression may coerce an object operand to a primitive without making
+ * every use of that value primitive. Reusing the array across renders would return
+ * [2] and then [2, 3], instead of [2] and [3].
+ */
+function useFoo({value}) {
+  const x = {value: []};
+  mutate(x);
+
+  const xValue = x.value;
+  let result;
+  if (typeof xValue === 'number') {
+    result = xValue + 1;
+  } else {
+    result = arrayPush(xValue, value);
+  }
+  return result;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: useFoo,
+  params: [{value: 1}],
+  sequentialRenders: [{value: 2}, {value: 3}],
+};

--- a/crates/oxc_react_compiler/fixtures/bug-type-inference-control-flow.ts
+++ b/crates/oxc_react_compiler/fixtures/bug-type-inference-control-flow.ts
@@ -1,21 +1,15 @@
 import {arrayPush, CONST_NUMBER0, mutate} from 'shared-runtime';
 
 /**
- * Repro for bug in our type inference system. We currently propagate inferred
- * types through control flow / potential type guards. Note that this is
- * inconsistent with both Flow and Typescript.
+ * Regression test for flow-insensitive type inference through a potential
+ * type guard. A primitive use in one branch must not constrain sibling uses.
  * https://flow.org/try/#1N4Igxg9gdgZglgcxALlAIwIZoKYBsD6uEEAztvhgE6UYCe+JADpdhgCYowa5kA0I2KAFcAtiRQAXSkOz9sADwxgJ+NPTbYuQ3BMnTZA+Y2yU4IwRO4A6SFBIrGVDGM7c+h46fNRLuKxJIGWh8MeT0ZfhYlCStpHzNsFBAMIQkIEQwJODAQfiEyfBE4eWw2fDgofDBMsAALfAA3KjgsXGxxZC4eAw0G-GhcWn9aY3wWZldu-g1mbGqJUoBaCRHEzrcDEgBrbAk62kXhXFxJ923d-cPRHEpTgyEoMDaqZdW7vKgoOfaSKgOKpqmDA+d4gB5fMA-P6LCCMLLQbiLOoYCqgh6-GDYRYIXYLSgkRZkCR4jpddwPfJLZjpOBkO4AX34kA0SRWxgABAAxYjsgC87OAAB0oOzReythU2Mh2YKQNyILLeMKxeymrgZNLhCIbsL6QBuYVs7DsgBCVD5AuVYolUClMpAZsoiqtorVGvZWpuSqg9OFMAeyjg0HZdTmW3lAAp5NKAPJoABWcwkAEppWZGLg4O12fJ2bSuTyhSKxSwJEJKCKAOQ2tiVvMi3MAMkbOasNb5vP5svlsoNPuFfoD8JFGQqUel8vZAB9TVReCHoHa0MRnlBUwWIJbi6K4DB2RHbGxk1uVSrd-uAIShsDh4hR5PHoun5-siS1SgQADuHuw34AotQECUBGsqysmfYvuyvrbqepblg2EFitBKpwRWOZ9vSuQgA0JgkEGUBJBk9gmCA9JAA
  * https://www.typescriptlang.org/play/?#code/C4TwDgpgBAYg9nKBeKBvAUFLUDWBLAOwBMAuKAInjnIBpNsA3AQwBsBXCMgtgWwCMIAJ3QBfANzpQkKACEmg5GnpZ8xMuTmDayqM3aco3fkLoj0AMzYEAxsDxwCUawAsI1nFQAUADzJw+AFZuwACUZEwAzhFCwBFQ3lB4cVRK2InmUJ4AhJ4A5KpEuYmOCQBkpfEAdAXISCiUCOQhIalp2MDOgnAA7oYQvQCigl2CnuRWEN6QthBETTpmZhZWtvaOPEyEPmQpAD6y8jRODqRQfAgsEEwEYbAIrVh4GZ7WJy0Ybdgubh4IPiEST5YQQQYBsQQlQHYMxpEFgiHxCQiIA
  *
- * Found differences in evaluator results
- * Non-forget (expected):
+ * Expected evaluator results:
  *   (kind: ok)
  *   [2]
  *   [3]
- * Forget:
- *   (kind: ok)
- *   [2]
- *   [2,3]
  */
 function useFoo({cond, value}: {cond: boolean; value: number}) {
   const x = {value: cond ? CONST_NUMBER0 : []};
@@ -24,9 +18,9 @@ function useFoo({cond, value}: {cond: boolean; value: number}) {
   const xValue = x.value;
   let result;
   if (typeof xValue === 'number') {
-    result = xValue + 1; //               (1) here we infer xValue is a primitive
+    result = xValue + 1; //               (1) this use is guarded by typeof
   } else {
-    result = arrayPush(xValue, value); // (2) and propagate it to all other xValue references
+    result = arrayPush(xValue, value); // (2) xValue can still be an array here
   }
 
   return result;

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -32,7 +32,6 @@ use crate::react_compiler_hir::{
     PropertyNameKind, ReactFunctionType, Terminal, Type, TypeId,
 };
 use crate::react_compiler_ssa::enter_ssa::placeholder_function;
-use oxc_ast::ast::BinaryOperator;
 use oxc_span::Span;
 
 // =============================================================================
@@ -143,27 +142,6 @@ fn pre_resolve_globals_recursive<'a>(
     for child_id in child_func_ids {
         pre_resolve_globals_recursive(child_id, env, global_types);
     }
-}
-
-fn is_primitive_binary_op(op: &BinaryOperator) -> bool {
-    matches!(
-        op,
-        BinaryOperator::Addition
-            | BinaryOperator::Subtraction
-            | BinaryOperator::Division
-            | BinaryOperator::Remainder
-            | BinaryOperator::Multiplication
-            | BinaryOperator::Exponential
-            | BinaryOperator::BitwiseAnd
-            | BinaryOperator::BitwiseOR
-            | BinaryOperator::ShiftRight
-            | BinaryOperator::ShiftLeft
-            | BinaryOperator::BitwiseXOR
-            | BinaryOperator::GreaterThan
-            | BinaryOperator::LessThan
-            | BinaryOperator::GreaterEqualThan
-            | BinaryOperator::LessEqualThan
-    )
 }
 
 /// Resolve a property type from the shapes registry.
@@ -508,15 +486,10 @@ fn generate_instruction_types<'a>(
             unifier.unify(left, value_type, shapes)?;
         }
 
-        InstructionValue::BinaryExpression {
-            operator, left: bin_left, right: bin_right, ..
-        } => {
-            if is_primitive_binary_op(operator) {
-                let left_operand_type = get_type(bin_left.identifier, identifiers);
-                unifier.unify(left_operand_type, Type::Primitive, shapes)?;
-                let right_operand_type = get_type(bin_right.identifier, identifiers);
-                unifier.unify(right_operand_type, Type::Primitive, shapes)?;
-            }
+        InstructionValue::BinaryExpression { .. } => {
+            // Binary operators coerce their operands, so an operand may still be an object.
+            // Inferring it as primitive is also flow-insensitive and can leak a constraint
+            // learned in one control-flow branch into sibling branches.
             unifier.unify(left, Type::Primitive, shapes)?;
         }
 

--- a/crates/oxc_react_compiler/tests/snapshots/allocating-primitive-as-dep-nested-scope.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/allocating-primitive-as-dep-nested-scope.snap
@@ -9,21 +9,29 @@ import { c as _c } from "react/compiler-runtime";
 import { identity, mutate, setProperty } from "shared-runtime";
 //   - y depends on either bar(props.b) or bar(props.b) + 1
 function AllocatingPrimitiveAsDepNested(props) {
-	const $ = _c(5);
+	const $ = _c(7);
 	let t0;
 	if ($[0] !== props.a || $[1] !== props.b) {
 		const x = {};
 		mutate(x);
-		const t1 = identity(props.b) + 1;
-		let t2;
-		if ($[3] !== t1) {
-			t2 = identity(t1);
-			$[3] = t1;
-			$[4] = t2;
+		let t1;
+		if ($[3] !== props.b) {
+			t1 = identity(props.b);
+			$[3] = props.b;
+			$[4] = t1;
 		} else {
-			t2 = $[4];
+			t1 = $[4];
 		}
-		const y = t2;
+		const t2 = t1 + 1;
+		let t3;
+		if ($[5] !== t2) {
+			t3 = identity(t2);
+			$[5] = t2;
+			$[6] = t3;
+		} else {
+			t3 = $[6];
+		}
+		const y = t3;
 		setProperty(x, props.a);
 		t0 = [x, y];
 		$[0] = props.a;

--- a/crates/oxc_react_compiler/tests/snapshots/bug-binary-operand-type-inference.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/bug-binary-operand-type-inference.snap
@@ -1,0 +1,36 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/bug-binary-operand-type-inference.js
+---
+import { c as _c } from "react/compiler-runtime";
+import { arrayPush, mutate } from "shared-runtime";
+/**
+* A binary expression may coerce an object operand to a primitive without making
+* every use of that value primitive. Reusing the array across renders would return
+* [2] and then [2, 3], instead of [2] and [3].
+*/
+function useFoo(t0) {
+	const $ = _c(2);
+	const { value } = t0;
+	let result;
+	if ($[0] !== value) {
+		const x = { value: [] };
+		mutate(x);
+		const xValue = x.value;
+		if (typeof xValue === "number") {
+			result = xValue + 1;
+		} else {
+			result = arrayPush(xValue, value);
+		}
+		$[0] = value;
+		$[1] = result;
+	} else {
+		result = $[1];
+	}
+	return result;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: useFoo,
+	params: [{ value: 1 }],
+	sequentialRenders: [{ value: 2 }, { value: 3 }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/bug-type-inference-control-flow.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/bug-type-inference-control-flow.snap
@@ -5,49 +5,34 @@ input_file: crates/oxc_react_compiler/fixtures/bug-type-inference-control-flow.t
 import { c as _c } from "react/compiler-runtime";
 import { arrayPush, CONST_NUMBER0, mutate } from "shared-runtime";
 /**
-* Repro for bug in our type inference system. We currently propagate inferred
-* types through control flow / potential type guards. Note that this is
-* inconsistent with both Flow and Typescript.
+* Regression test for flow-insensitive type inference through a potential
+* type guard. A primitive use in one branch must not constrain sibling uses.
 * https://flow.org/try/#1N4Igxg9gdgZglgcxALlAIwIZoKYBsD6uEEAztvhgE6UYCe+JADpdhgCYowa5kA0I2KAFcAtiRQAXSkOz9sADwxgJ+NPTbYuQ3BMnTZA+Y2yU4IwRO4A6SFBIrGVDGM7c+h46fNRLuKxJIGWh8MeT0ZfhYlCStpHzNsFBAMIQkIEQwJODAQfiEyfBE4eWw2fDgofDBMsAALfAA3KjgsXGxxZC4eAw0G-GhcWn9aY3wWZldu-g1mbGqJUoBaCRHEzrcDEgBrbAk62kXhXFxJ923d-cPRHEpTgyEoMDaqZdW7vKgoOfaSKgOKpqmDA+d4gB5fMA-P6LCCMLLQbiLOoYCqgh6-GDYRYIXYLSgkRZkCR4jpddwPfJLZjpOBkO4AX34kA0SRWxgABAAxYjsgC87OAAB0oOzReythU2Mh2YKQNyILLeMKxeymrgZNLhCIbsL6QBuYVs7DsgBCVD5AuVYolUClMpAZsoiqtorVGvZWpuSqg9OFMAeyjg0HZdTmW3lAAp5NKAPJoABWcwkAEppWZGLg4O12fJ2bSuTyhSKxSwJEJKCKAOQ2tiVvMi3MAMkbOasNb5vP5svlsoNPuFfoD8JFGQqUel8vZAB9TVReCHoHa0MRnlBUwWIJbi6K4DB2RHbGxk1uVSrd-uAIShsDh4hR5PHoun5-siS1SgQADuHuw34AotQECUBGsqysmfYvuyvrbqepblg2EFitBKpwRWOZ9vSuQgA0JgkEGUBJBk9gmCA9JAA
 * https://www.typescriptlang.org/play/?#code/C4TwDgpgBAYg9nKBeKBvAUFLUDWBLAOwBMAuKAInjnIBpNsA3AQwBsBXCMgtgWwCMIAJ3QBfANzpQkKACEmg5GnpZ8xMuTmDayqM3aco3fkLoj0AMzYEAxsDxwCUawAsI1nFQAUADzJw+AFZuwACUZEwAzhFCwBFQ3lB4cVRK2InmUJ4AhJ4A5KpEuYmOCQBkpfEAdAXISCiUCOQhIalp2MDOgnAA7oYQvQCigl2CnuRWEN6QthBETTpmZhZWtvaOPEyEPmQpAD6y8jRODqRQfAgsEEwEYbAIrVh4GZ7WJy0Ybdgubh4IPiEST5YQQQYBsQQlQHYMxpEFgiHxCQiIA
 *
-* Found differences in evaluator results
-* Non-forget (expected):
+* Expected evaluator results:
 *   (kind: ok)
 *   [2]
 *   [3]
-* Forget:
-*   (kind: ok)
-*   [2]
-*   [2,3]
 */
 function useFoo(t0) {
-	const $ = _c(5);
+	const $ = _c(3);
 	const { cond, value } = t0;
-	let x;
-	if ($[0] !== cond) {
-		x = { value: cond ? CONST_NUMBER0 : [] };
-		mutate(x);
-		$[0] = cond;
-		$[1] = x;
-	} else {
-		x = $[1];
-	}
-	const xValue = x.value;
 	let result;
-	if (typeof xValue === "number") {
-		result = xValue + 1;
-	} else {
-		let t1;
-		if ($[2] !== value || $[3] !== xValue) {
-			t1 = arrayPush(xValue, value);
-			$[2] = value;
-			$[3] = xValue;
-			$[4] = t1;
+	if ($[0] !== cond || $[1] !== value) {
+		const x = { value: cond ? CONST_NUMBER0 : [] };
+		mutate(x);
+		const xValue = x.value;
+		if (typeof xValue === "number") {
+			result = xValue + 1;
 		} else {
-			t1 = $[4];
+			result = arrayPush(xValue, value);
 		}
-		result = t1;
+		$[0] = cond;
+		$[1] = value;
+		$[2] = result;
+	} else {
+		result = $[2];
 	}
 	return result;
 }

--- a/crates/oxc_react_compiler/tests/snapshots/recursive-function.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/recursive-function.snap
@@ -2,11 +2,31 @@
 source: crates/oxc_react_compiler/tests/snapshot.rs
 input_file: crates/oxc_react_compiler/fixtures/recursive-function.js
 ---
+import { c as _c } from "react/compiler-runtime";
 function foo(x) {
+	const $ = _c(4);
 	if (x <= 0) {
 		return 0;
 	}
-	return x + foo(x - 1) + foo(x - 2);
+	const t0 = x - 1;
+	let t1;
+	if ($[0] !== t0) {
+		t1 = foo(t0);
+		$[0] = t0;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	const t2 = x - 2;
+	let t3;
+	if ($[2] !== t2) {
+		t3 = foo(t2);
+		$[2] = t2;
+		$[3] = t3;
+	} else {
+		t3 = $[3];
+	}
+	return x + t1 + t3;
 }
 export const FIXTURE_ENTRYPOINT = {
 	fn: foo,

--- a/crates/oxc_react_compiler/tests/snapshots/rules-of-hooks__allow-locals-named-like-hooks.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/rules-of-hooks__allow-locals-named-like-hooks.snap
@@ -5,29 +5,36 @@ input_file: crates/oxc_react_compiler/fixtures/rules-of-hooks/allow-locals-named
 import { c as _c } from "react/compiler-runtime";
 import { makeObject_Primitives, Stringify } from "shared-runtime";
 function Component(props) {
-	const $ = _c(2);
-	const useFeature = makeObject_Primitives();
+	const $ = _c(3);
+	let t0;
+	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		t0 = makeObject_Primitives();
+		$[0] = t0;
+	} else {
+		t0 = $[0];
+	}
+	const useFeature = t0;
 	let x;
 	if (useFeature) {
-		let t0;
-		if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-			t0 = [useFeature + useFeature].push(-useFeature);
-			$[0] = t0;
+		let t1;
+		if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+			t1 = [useFeature + useFeature].push(-useFeature);
+			$[1] = t1;
 		} else {
-			t0 = $[0];
+			t1 = $[1];
 		}
-		x = t0;
+		x = t1;
 	}
 	const y = useFeature;
 	const z = useFeature.useProperty;
-	let t0;
-	if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = <Stringify val={useFeature}>{x}{y}{z}</Stringify>;
-		$[1] = t0;
+	let t1;
+	if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
+		t1 = <Stringify val={useFeature}>{x}{y}{z}</Stringify>;
+		$[2] = t1;
 	} else {
-		t0 = $[1];
+		t1 = $[2];
 	}
-	return t0;
+	return t1;
 }
 export const FIXTURE_ENTRYPOINT = {
 	fn: Component,

--- a/crates/oxc_react_compiler/tests/snapshots/timers.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/timers.snap
@@ -4,23 +4,30 @@ input_file: crates/oxc_react_compiler/fixtures/timers.js
 ---
 import { c as _c } from "react/compiler-runtime";
 function Component(props) {
-	const $ = _c(2);
-	const start = performance.now();
+	const $ = _c(3);
 	let t0;
 	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = Date.now();
+		t0 = performance.now();
 		$[0] = t0;
 	} else {
 		t0 = $[0];
 	}
-	const now = t0;
-	const time = performance.now() - start;
+	const start = t0;
 	let t1;
 	if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-		t1 = <div>rendering took {time} at {now}</div>;
+		t1 = Date.now();
 		$[1] = t1;
 	} else {
 		t1 = $[1];
 	}
-	return t1;
+	const now = t1;
+	let t2;
+	if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
+		const time = performance.now() - start;
+		t2 = <div>rendering took {time} at {now}</div>;
+		$[2] = t2;
+	} else {
+		t2 = $[2];
+	}
+	return t2;
 }

--- a/crates/oxc_react_compiler/tests/snapshots/type-test-polymorphic.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/type-test-polymorphic.snap
@@ -4,17 +4,24 @@ input_file: crates/oxc_react_compiler/fixtures/type-test-polymorphic.js
 ---
 import { c as _c } from "react/compiler-runtime";
 function component() {
-	const $ = _c(1);
-	const p = makePrimitive();
-	let x;
+	const $ = _c(2);
+	let t0;
 	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		t0 = makePrimitive();
+		$[0] = t0;
+	} else {
+		t0 = $[0];
+	}
+	const p = t0;
+	let x;
+	if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
 		const o = {};
 		x = {};
 		x.t = p;
 		x.t = o;
-		$[0] = x;
+		$[1] = x;
 	} else {
-		x = $[0];
+		x = $[1];
 	}
 	const y = x.t;
 	return y;


### PR DESCRIPTION
Stops binary operators from globally inferring their operands as primitive, preventing mutable values from being reused across renders. Binary expression results remain primitive.

Validated with the React compiler suite, a two-render runtime repro, and `just ready`.

AI-assisted: Codex was used for runtime differential analysis and implementation support.
