### PR TITLE
fix(react-compiler): cover incompatible aliasing signatures

### DIFF
--- a/crates/oxc_react_compiler/fixtures/error.invalid-known-incompatible-aliasing-function.js
+++ b/crates/oxc_react_compiler/fixtures/error.invalid-known-incompatible-aliasing-function.js
@@ -1,0 +1,6 @@
+import {knownIncompatibleAliasing} from 'ReactCompilerKnownIncompatibleTest';
+
+function Component() {
+  const data = knownIncompatibleAliasing();
+  return <div>{data}</div>;
+}

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -35,8 +35,9 @@ pub use crate::react_compiler_hir::environment_config::{
     InstrumentationConfig,
 };
 pub use crate::react_compiler_hir::type_config::{
-    BuiltInTypeRef, FunctionTypeConfig, HookTypeConfig, ObjectTypeConfig, TypeConfig,
-    TypeReferenceConfig, ValueKind,
+    AliasingEffectConfig, AliasingSignatureConfig, ApplyArgConfig, BuiltInTypeRef,
+    FunctionTypeConfig, HookTypeConfig, ObjectTypeConfig, TypeConfig, TypeReferenceConfig,
+    ValueKind, ValueReason,
 };
 pub use crate::react_compiler_utils::FxIndexMap;
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -2429,9 +2429,6 @@ fn compute_effects_for_legacy_signature<'a>(
         effects.push(AliasingEffect::Impure { place: *receiver, error });
     }
 
-    // TODO: check signature.known_incompatible and throw (TS line 2351-2370)
-    // This requires threading Result through apply_effect/apply_signature.
-
     // If the function is mutable only if operands are mutable, and all
     // arguments are immutable/non-mutating, short-circuit with simple aliasing.
     if signature.mutable_only_if_operands_are_mutable

--- a/crates/oxc_react_compiler/tests/snapshot.rs
+++ b/crates/oxc_react_compiler/tests/snapshot.rs
@@ -26,11 +26,11 @@ use oxc_allocator::Allocator;
 use oxc_codegen::Codegen;
 use oxc_parser::Parser;
 use oxc_react_compiler::{
-    BuiltInTypeRef, CompilationMode, CompileResult, CompilerOutputMode, DynamicGatingConfig,
-    Effect, EnvironmentConfig, ExhaustiveEffectDepsMode, ExternalFunctionConfig,
-    FunctionTypeConfig, FxIndexMap, GatingConfig, HookTypeConfig, InstrumentationConfig,
-    ObjectTypeConfig, PanicThreshold, PluginOptions, TypeConfig, TypeReferenceConfig, ValueKind,
-    compile, lint,
+    AliasingEffectConfig, AliasingSignatureConfig, BuiltInTypeRef, CompilationMode, CompileResult,
+    CompilerOutputMode, DynamicGatingConfig, Effect, EnvironmentConfig, ExhaustiveEffectDepsMode,
+    ExternalFunctionConfig, FunctionTypeConfig, FxIndexMap, GatingConfig, HookTypeConfig,
+    InstrumentationConfig, ObjectTypeConfig, PanicThreshold, PluginOptions, TypeConfig,
+    TypeReferenceConfig, ValueKind, ValueReason, compile, lint,
 };
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -414,6 +414,12 @@ fn test_module_type_provider() -> FxIndexMap<String, TypeConfig> {
                     "knownIncompatible",
                     incompatible_fn("useKnownIncompatible is known to be incompatible"),
                 ),
+                (
+                    "knownIncompatibleAliasing",
+                    incompatible_aliasing_fn(
+                        "knownIncompatibleAliasing is known to be incompatible",
+                    ),
+                ),
             ]),
         ),
         (
@@ -486,6 +492,33 @@ fn incompatible_fn(message: &str) -> TypeConfig {
         impure: None,
         canonical_name: None,
         aliasing: None,
+        known_incompatible: Some(message.to_string()),
+    })
+}
+
+fn incompatible_aliasing_fn(message: &str) -> TypeConfig {
+    TypeConfig::Function(FunctionTypeConfig {
+        positional_params: Vec::new(),
+        rest_param: Some(Effect::Read),
+        callee_effect: Effect::Read,
+        return_type: Box::new(type_ref()),
+        return_value_kind: ValueKind::Mutable,
+        no_alias: None,
+        mutable_only_if_operands_are_mutable: None,
+        impure: None,
+        canonical_name: None,
+        aliasing: Some(AliasingSignatureConfig {
+            receiver: "@receiver",
+            params: &[],
+            rest: Some("@rest"),
+            returns: "@returns",
+            temporaries: &[],
+            effects: &[AliasingEffectConfig::Create {
+                into: "@returns",
+                value: ValueKind::Mutable,
+                reason: ValueReason::KnownReturnSignature,
+            }],
+        }),
         known_incompatible: Some(message.to_string()),
     })
 }

--- a/crates/oxc_react_compiler/tests/snapshots/error.invalid-known-incompatible-aliasing-function.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.invalid-known-incompatible-aliasing-function.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/error.invalid-known-incompatible-aliasing-function.js
+---
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "Use of incompatible library", labels: [LabeledSpan { label: Some("knownIncompatibleAliasing is known to be incompatible"), span: Span { start: 117, end: 142 }, primary: true }], help: Some("This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized"), note: Some("React Compiler skipped optimizing this component or hook"), severity: Warning, code: OxcCode { scope: Some("react-compiler"), number: Some("IncompatibleLibrary") }, url: Some("https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library") } }
+
+No changes.


### PR DESCRIPTION
`known_incompatible` is already checked before both aliasing and legacy signature handling, making the legacy-path TODO stale. Add aliasing-signature coverage to guard the shared behavior.

Validated with `just ready`.

AI-assisted.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>