### PR TITLE
fix(react-compiler): validate block nesting

### DIFF
--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -286,6 +286,20 @@ pub fn terminal_successor_references_unknown_block(
 }
 
 #[cold]
+pub fn invalid_block_nesting(
+    parent_start: impl Display,
+    parent_end: impl Display,
+    current_start: impl Display,
+    current_end: impl Display,
+) -> OxcDiagnostic {
+    diagnostic(ErrorCategory::Invariant, "Invalid nesting in program blocks or scopes").with_help(
+        format!(
+            "Items overlap but are not nested: {parent_start}:{parent_end}({current_start}:{current_end})"
+        ),
+    )
+}
+
+#[cold]
 pub fn expected_predecessor_block_to_exist(
     block: impl Display,
     predecessor: impl Display,

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -17,7 +17,7 @@ use crate::react_compiler_hir::environment::OutputMode;
 use crate::react_compiler_hir::environment_config::{EnvironmentConfig, ExhaustiveEffectDepsMode};
 use crate::react_compiler_hir::{
     ReactFunctionType, assert_consistent_identifiers, assert_terminal_preds_exist,
-    assert_terminal_successors_exist,
+    assert_terminal_successors_exist, assert_valid_block_nesting,
 };
 use crate::react_compiler_inference::align_method_call_scopes;
 use crate::react_compiler_inference::align_object_method_scopes;
@@ -290,11 +290,11 @@ fn run_pipeline<'a>(
 
     merge_overlapping_reactive_scopes_hir(&mut hir, &mut env);
 
-    // TODO: port assertValidBlockNesting
+    assert_valid_block_nesting(&hir, &env)?;
 
-    build_reactive_scope_terminals_hir(&mut hir, &mut env);
+    build_reactive_scope_terminals_hir(&mut hir, &mut env)?;
 
-    // TODO: port assertValidBlockNesting
+    assert_valid_block_nesting(&hir, &env)?;
 
     flatten_reactive_loops_hir(&mut hir);
 

--- a/crates/oxc_react_compiler/src/react_compiler_hir/assert_valid_block_nesting.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/assert_valid_block_nesting.rs
@@ -1,0 +1,190 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+//! Assert that program blocks and reactive scopes form a properly nested tree.
+//!
+//! Corresponds to `src/HIR/AssertValidBlockNesting.ts`.
+
+use std::cmp::Ordering;
+
+use oxc_diagnostics::OxcDiagnostic;
+use rustc_hash::FxHashSet;
+
+use crate::diagnostics;
+
+use super::environment::Environment;
+use super::visitors::{
+    each_instruction_lvalue_ids, each_instruction_operand_ids, each_terminal_operand_ids,
+    terminal_fallthrough,
+};
+use super::{EvaluationOrder, HirFunction, IdentifierId, ScopeId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BlockRange {
+    start: EvaluationOrder,
+    end: EvaluationOrder,
+}
+
+/// Collect all unique scopes from places in the function that have non-empty ranges.
+/// Corresponds to TS `getScopes(fn)`.
+pub(crate) fn get_scopes(func: &HirFunction<'_>, env: &Environment<'_>) -> Vec<ScopeId> {
+    let mut scope_ids: FxHashSet<ScopeId> = FxHashSet::default();
+
+    let mut visit_place = |identifier_id: IdentifierId| {
+        if let Some(scope_id) = env.identifiers[identifier_id].scope {
+            let range = &env.scopes[scope_id].range;
+            if range.start != range.end {
+                scope_ids.insert(scope_id);
+            }
+        }
+    };
+
+    for block in func.body.blocks.values() {
+        for &instr_id in &block.instructions {
+            let instr = &func.instructions[instr_id.index()];
+            for id in each_instruction_lvalue_ids(instr) {
+                visit_place(id);
+            }
+            for id in each_instruction_operand_ids(instr, env) {
+                visit_place(id);
+            }
+        }
+        for id in each_terminal_operand_ids(&block.terminal) {
+            visit_place(id);
+        }
+    }
+
+    scope_ids.into_iter().collect()
+}
+
+/// Assert that program-block subtrees and reactive scopes are disjoint or nested.
+pub fn assert_valid_block_nesting(
+    func: &HirFunction<'_>,
+    env: &Environment<'_>,
+) -> Result<(), OxcDiagnostic> {
+    let mut ranges: Vec<BlockRange> = get_scopes(func, env)
+        .into_iter()
+        .map(|scope_id| {
+            let range = env.scopes[scope_id].range;
+            BlockRange { start: range.start, end: range.end }
+        })
+        .collect();
+
+    for block in func.body.blocks.values() {
+        let Some(fallthrough_id) = terminal_fallthrough(&block.terminal) else {
+            continue;
+        };
+        let Some(fallthrough) = func.body.blocks.get(&fallthrough_id) else {
+            return Err(diagnostics::terminal_successor_references_unknown_block(
+                fallthrough_id.index(),
+                &block.terminal,
+                block.terminal.span().copied(),
+            ));
+        };
+        let end = fallthrough.instructions.first().map_or_else(
+            || fallthrough.terminal.evaluation_order(),
+            |instr_id| func.instructions[instr_id.index()].id,
+        );
+        ranges.push(BlockRange { start: block.terminal.evaluation_order(), end });
+    }
+
+    assert_valid_ranges(ranges)
+}
+
+/// Sort ranges into tree pre-order, then reject partial overlaps.
+fn assert_valid_ranges(ranges: Vec<BlockRange>) -> Result<(), OxcDiagnostic> {
+    let mut context = ();
+    recursively_traverse_items(
+        ranges,
+        |range, ()| (range.start, range.end),
+        &mut context,
+        |_, ()| {},
+        |_, ()| {},
+    )
+}
+
+/// Traverse nested ranges in tree pre-order, calling `enter` and `exit` at range boundaries.
+/// Corresponds to TS `recursivelyTraverseItems`.
+pub(crate) fn recursively_traverse_items<T: Copy, Context>(
+    mut items: Vec<T>,
+    get_range: impl Fn(&T, &Context) -> (EvaluationOrder, EvaluationOrder),
+    context: &mut Context,
+    mut enter: impl FnMut(T, &mut Context),
+    mut exit: impl FnMut(T, &mut Context),
+) -> Result<(), OxcDiagnostic> {
+    items.sort_unstable_by(|a, b| {
+        let (a_start, a_end) = get_range(a, context);
+        let (b_start, b_end) = get_range(b, context);
+        let start_order = a_start.cmp(&b_start);
+        if start_order != Ordering::Equal {
+            return start_order;
+        }
+        b_end.cmp(&a_end)
+    });
+    let ranges: Vec<(EvaluationOrder, EvaluationOrder)> =
+        items.iter().map(|item| get_range(item, context)).collect();
+
+    let mut active_items: Vec<(T, EvaluationOrder, EvaluationOrder)> = Vec::new();
+    for (current, (current_start, current_end)) in items.into_iter().zip(ranges) {
+        while let Some(&(_, parent_start, parent_end)) = active_items.last() {
+            let disjoint = current_start >= parent_end;
+            let nested = current_end <= parent_end;
+            if !disjoint && !nested {
+                return Err(diagnostics::invalid_block_nesting(
+                    parent_start.index(),
+                    parent_end.index(),
+                    current_start.index(),
+                    current_end.index(),
+                ));
+            }
+            if !disjoint {
+                break;
+            }
+            let (parent, _, _) = active_items.pop().unwrap();
+            exit(parent, context);
+        }
+
+        enter(current, context);
+        active_items.push((current, current_start, current_end));
+    }
+
+    while let Some((item, _, _)) = active_items.pop() {
+        exit(item, context);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn range(start: usize, end: usize) -> BlockRange {
+        BlockRange {
+            start: EvaluationOrder::from_usize(start),
+            end: EvaluationOrder::from_usize(end),
+        }
+    }
+
+    #[test]
+    fn accepts_nested_ranges() {
+        assert!(
+            assert_valid_ranges(vec![range(2, 4), range(1, 8), range(5, 8), range(1, 5)]).is_ok()
+        );
+    }
+
+    #[test]
+    fn accepts_disjoint_ranges() {
+        assert!(assert_valid_ranges(vec![range(8, 9), range(1, 3), range(3, 5)]).is_ok());
+    }
+
+    #[test]
+    fn rejects_partially_overlapping_ranges() {
+        let diagnostic = assert_valid_ranges(vec![range(1, 5), range(3, 7)]).unwrap_err();
+
+        assert_eq!(diagnostic.message, "Invalid nesting in program blocks or scopes");
+        assert_eq!(diagnostic.help.as_deref(), Some("Items overlap but are not nested: 1:5(3:7)"));
+    }
+}

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -1,5 +1,6 @@
 mod assert_consistent_identifiers;
 mod assert_terminal_blocks_exist;
+mod assert_valid_block_nesting;
 pub mod default_module_type_provider;
 pub mod dominator;
 pub mod environment;
@@ -17,6 +18,8 @@ pub use assert_consistent_identifiers::assert_consistent_identifiers;
 pub use assert_terminal_blocks_exist::{
     assert_terminal_preds_exist, assert_terminal_successors_exist,
 };
+pub use assert_valid_block_nesting::assert_valid_block_nesting;
+pub(crate) use assert_valid_block_nesting::{get_scopes, recursively_traverse_items};
 use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds, Vec as ArenaVec};
 use oxc_ast::ast::*;
 use oxc_index::define_nonmax_u32_index_type;

--- a/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
@@ -11,70 +11,26 @@
 //!
 //! Ported from TypeScript `src/HIR/BuildReactiveScopeTerminalsHIR.ts`.
 
-use std::cmp::Ordering;
-
 use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
+use oxc_diagnostics::OxcDiagnostic;
 
 use crate::react_compiler_utils::ordered_map::ArenaOrderedSet;
 use rustc_hash::FxHashMap;
-use rustc_hash::FxHashSet;
 
 use crate::react_compiler_hir::BasicBlock;
 use crate::react_compiler_hir::BlockId;
 use crate::react_compiler_hir::EvaluationOrder;
 use crate::react_compiler_hir::GotoVariant;
 use crate::react_compiler_hir::HirFunction;
-use crate::react_compiler_hir::IdentifierId;
 use crate::react_compiler_hir::MutableRange;
 use crate::react_compiler_hir::ScopeId;
 use crate::react_compiler_hir::Terminal;
 use crate::react_compiler_hir::environment::Environment;
-use crate::react_compiler_hir::visitors::each_instruction_lvalue_ids;
-use crate::react_compiler_hir::visitors::each_instruction_operand_ids;
-use crate::react_compiler_hir::visitors::each_terminal_operand_ids;
+use crate::react_compiler_hir::{get_scopes, recursively_traverse_items};
 use crate::react_compiler_lowering::get_reverse_postordered_blocks;
 use crate::react_compiler_lowering::mark_instruction_ids;
 use crate::react_compiler_lowering::mark_predecessors;
 use crate::react_compiler_utils::OrderedMap;
-
-// =============================================================================
-// getScopes
-// =============================================================================
-
-/// Collect all unique scopes from places in the function that have non-empty ranges.
-/// Corresponds to TS `getScopes(fn)`.
-fn get_scopes(func: &HirFunction, env: &Environment) -> Vec<ScopeId> {
-    let mut scope_ids: FxHashSet<ScopeId> = FxHashSet::default();
-
-    let mut visit_place = |identifier_id: IdentifierId| {
-        if let Some(scope_id) = env.identifiers[identifier_id].scope {
-            let range = &env.scopes[scope_id].range;
-            if range.start != range.end {
-                scope_ids.insert(scope_id);
-            }
-        }
-    };
-
-    for (_block_id, block) in &func.body.blocks {
-        for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.index()];
-            // lvalues
-            for id in each_instruction_lvalue_ids(instr) {
-                visit_place(id);
-            }
-            // operands
-            for id in each_instruction_operand_ids(instr, env) {
-                visit_place(id);
-            }
-        }
-        // terminal operands
-        for id in each_terminal_operand_ids(&block.terminal) {
-            visit_place(id);
-        }
-    }
-
-    scope_ids.into_iter().collect()
-}
 
 // =============================================================================
 // TerminalRewriteInfo
@@ -107,73 +63,49 @@ impl TerminalRewriteInfo {
 // =============================================================================
 
 /// Collect all scope rewrites by traversing scopes in pre-order.
-fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<TerminalRewriteInfo> {
+fn collect_scope_rewrites(
+    func: &HirFunction,
+    env: &mut Environment,
+) -> Result<Vec<TerminalRewriteInfo>, OxcDiagnostic> {
     let scope_ids = get_scopes(func, env);
+    let mut context =
+        ScopeTraversalContext { fallthroughs: FxHashMap::default(), rewrites: Vec::new(), env };
+    recursively_traverse_items(
+        scope_ids,
+        |scope_id, context| {
+            let range = context.env.scopes[*scope_id].range;
+            (range.start, range.end)
+        },
+        &mut context,
+        push_start_scope_terminal,
+        push_end_scope_terminal,
+    )?;
+    Ok(context.rewrites)
+}
 
-    // Sort: ascending by start, descending by end for ties
-    let mut items: Vec<ScopeId> = scope_ids;
-    items.sort_unstable_by(|a, b| {
-        let a_range = &env.scopes[*a].range;
-        let b_range = &env.scopes[*b].range;
-        let start_diff = a_range.start.cmp(&b_range.start);
-        if start_diff != Ordering::Equal {
-            return start_diff;
-        }
-        b_range.end.cmp(&a_range.end)
+struct ScopeTraversalContext<'env, 'alloc> {
+    fallthroughs: FxHashMap<ScopeId, BlockId>,
+    rewrites: Vec<TerminalRewriteInfo>,
+    env: &'env mut Environment<'alloc>,
+}
+
+fn push_start_scope_terminal(scope_id: ScopeId, context: &mut ScopeTraversalContext<'_, '_>) {
+    let block_id = context.env.next_block_id();
+    let fallthrough_id = context.env.next_block_id();
+    let instr_id = context.env.scopes[scope_id].range.start;
+    context.rewrites.push(TerminalRewriteInfo::StartScope {
+        block_id,
+        fallthrough_id,
+        instr_id,
+        scope_id,
     });
+    context.fallthroughs.insert(scope_id, fallthrough_id);
+}
 
-    let mut rewrites: Vec<TerminalRewriteInfo> = Vec::new();
-    let mut fallthroughs: FxHashMap<ScopeId, BlockId> = FxHashMap::default();
-    let mut active_items: Vec<ScopeId> = Vec::new();
-
-    for &curr in &items {
-        let curr_start = env.scopes[curr].range.start;
-        let curr_end = env.scopes[curr].range.end;
-
-        // Pop active items that are disjoint with current
-        let mut j = active_items.len();
-        while j > 0 {
-            j -= 1;
-            let maybe_parent = active_items[j];
-            let parent_end = env.scopes[maybe_parent].range.end;
-            let disjoint = curr_start >= parent_end;
-            let nested = curr_end <= parent_end;
-            assert!(disjoint || nested, "Invalid nesting in program blocks or scopes");
-            if disjoint {
-                // Exit this scope
-                let fallthrough_id =
-                    *fallthroughs.get(&maybe_parent).expect("Expected scope to exist");
-                let end_instr_id = env.scopes[maybe_parent].range.end;
-                rewrites
-                    .push(TerminalRewriteInfo::EndScope { instr_id: end_instr_id, fallthrough_id });
-                active_items.truncate(j);
-            } else {
-                break;
-            }
-        }
-
-        // Enter scope
-        let block_id = env.next_block_id();
-        let fallthrough_id = env.next_block_id();
-        let start_instr_id = env.scopes[curr].range.start;
-        rewrites.push(TerminalRewriteInfo::StartScope {
-            block_id,
-            fallthrough_id,
-            instr_id: start_instr_id,
-            scope_id: curr,
-        });
-        fallthroughs.insert(curr, fallthrough_id);
-        active_items.push(curr);
-    }
-
-    // Exit remaining active items
-    while let Some(curr) = active_items.pop() {
-        let fallthrough_id = *fallthroughs.get(&curr).expect("Expected scope to exist");
-        let end_instr_id = env.scopes[curr].range.end;
-        rewrites.push(TerminalRewriteInfo::EndScope { instr_id: end_instr_id, fallthrough_id });
-    }
-
-    rewrites
+fn push_end_scope_terminal(scope_id: ScopeId, context: &mut ScopeTraversalContext<'_, '_>) {
+    let fallthrough_id = *context.fallthroughs.get(&scope_id).expect("Expected scope to exist");
+    let instr_id = context.env.scopes[scope_id].range.end;
+    context.rewrites.push(TerminalRewriteInfo::EndScope { instr_id, fallthrough_id });
 }
 
 // =============================================================================
@@ -259,9 +191,9 @@ fn handle_rewrite<'a>(
 pub fn build_reactive_scope_terminals_hir<'a>(
     func: &mut HirFunction<'a>,
     env: &mut Environment<'a>,
-) {
+) -> Result<(), OxcDiagnostic> {
     // Step 1: Collect rewrites
-    let mut queued_rewrites = collect_scope_rewrites(func, env);
+    let mut queued_rewrites = collect_scope_rewrites(func, env)?;
 
     // Step 2: Apply rewrites by splitting blocks
     let mut rewritten_final_blocks: FxHashMap<BlockId, BlockId> = FxHashMap::default();
@@ -354,6 +286,8 @@ pub fn build_reactive_scope_terminals_hir<'a>(
 
     // Step 5: Fix scope and identifier ranges to account for renumbered instructions
     fix_scope_and_identifier_ranges(func, env);
+
+    Ok(())
 }
 
 /// Fix scope ranges after instruction renumbering.


### PR DESCRIPTION
Port `assertValidBlockNesting` to reject partially overlapping program-block and reactive-scope ranges before and after scope-terminal rewriting. Reuse the traversal when constructing scope terminals.

Validated with `just ready`.

AI-assisted.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>