### PR TITLE
perf(linter): compact RuleEnum debug output

### DIFF
--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -472,6 +472,20 @@ mod test {
         (RuleEnum::TypescriptNoExplicitAny(Default::default()), AllowWarnDeny::Warn)
     }
 
+    fn no_unused_vars_is_local(rule: &RuleEnum) -> bool {
+        let RuleEnum::EslintNoUnusedVars(rule) = rule else {
+            panic!("expected eslint/no-unused-vars")
+        };
+        rule.vars.is_local()
+    }
+
+    #[cfg(not(feature = "ruledocs"))]
+    #[test]
+    fn rule_enum_debug_uses_qualified_name() {
+        let rule = RuleEnum::EslintNoUnusedVars(EslintNoUnusedVars::default());
+        assert_eq!(format!("{rule:?}"), "eslint/no-unused-vars");
+    }
+
     /// an empty ruleset is a no-op
     #[test]
     fn test_no_rules() {
@@ -1156,31 +1170,25 @@ mod test {
             ExternalPluginStore::default(),
         );
 
-        assert_eq!(
-            format!("{:?}", base_rules[0].0),
-            format!(
-                "{:?}",
-                store
-                    .resolve("app.ts".as_ref())
-                    .rules
-                    .iter()
-                    .find(|(rule, _)| matches!(rule, RuleEnum::EslintNoUnusedVars(_)))
-                    .unwrap()
-                    .0
-            )
-        );
+        let app_rules = store.resolve("app.ts".as_ref());
+        let app_rule = &app_rules
+            .rules
+            .iter()
+            .find(|(rule, _)| matches!(rule, RuleEnum::EslintNoUnusedVars(_)))
+            .unwrap()
+            .0;
+        assert_eq!(no_unused_vars_is_local(&base_rules[0].0), no_unused_vars_is_local(app_rule));
+
+        let app_tsx_rules = store.resolve("app.tsx".as_ref());
+        let app_tsx_rule = &app_tsx_rules
+            .rules
+            .iter()
+            .find(|(rule, _)| matches!(rule, RuleEnum::EslintNoUnusedVars(_)))
+            .unwrap()
+            .0;
         assert_ne!(
-            format!("{:?}", base_rules[0].0),
-            format!(
-                "{:?}",
-                store
-                    .resolve("app.tsx".as_ref())
-                    .rules
-                    .iter()
-                    .find(|(rule, _)| matches!(rule, RuleEnum::EslintNoUnusedVars(_)))
-                    .unwrap()
-                    .0
-            )
+            no_unused_vars_is_local(&base_rules[0].0),
+            no_unused_vars_is_local(app_tsx_rule)
         );
     }
 

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -889,7 +889,8 @@ use crate::{
     utils::PossibleJestNode,
 };
 use oxc_semantic::AstTypesBitset;
-#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ruledocs", derive(Debug))]
+#[derive(Clone)]
 pub enum RuleEnum {
     ImportConsistentTypeSpecifierStyle(ImportConsistentTypeSpecifierStyle),
     ImportDefault(ImportDefault),
@@ -23091,6 +23092,14 @@ impl RuleEnum {
             Self::VueValidDefineProps(rule) => rule.run_info(),
             Self::VueValidNextTick(rule) => rule.run_info(),
         }
+    }
+}
+#[cfg(not(feature = "ruledocs"))]
+impl std::fmt::Debug for RuleEnum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.plugin_name())?;
+        f.write_str("/")?;
+        f.write_str(self.name())
     }
 }
 impl std::hash::Hash for RuleEnum {

--- a/tasks/linter_codegen/src/rules_enum.rs
+++ b/tasks/linter_codegen/src/rules_enum.rs
@@ -132,7 +132,8 @@ fn generate_rule_enum(rule_entries: &[RuleEntry<'_>]) -> TokenStream {
         .collect();
 
     quote! {
-        #[derive(Debug, Clone)]
+        #[cfg_attr(feature = "ruledocs", derive(Debug))]
+        #[derive(Clone)]
         pub enum RuleEnum {
             #(#variants),*
         }
@@ -486,6 +487,15 @@ fn generate_rule_enum_impl(rule_entries: &[RuleEntry<'_>]) -> TokenStream {
 
 fn generate_trait_impls() -> TokenStream {
     quote! {
+        #[cfg(not(feature = "ruledocs"))]
+        impl std::fmt::Debug for RuleEnum {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.plugin_name())?;
+                f.write_str("/")?;
+                f.write_str(self.name())
+            }
+        }
+
         impl std::hash::Hash for RuleEnum {
             fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
                 self.id().hash(state);


### PR DESCRIPTION
Use a compact `RuleEnum` `Debug` implementation in normal builds while retaining detailed derived output for `ruledocs`. Update config-store coverage to inspect the underlying rule option directly.

Measured macOS release `__text` reduction: 2.2 KiB (16 bytes on disk due to Mach-O alignment).

Validated with `just ready`, `cargo lintgen`, and `cargo lint-timings`.

AI-assisted.