### PR TITLE
fix(react-compiler): support escaped tagged templates

### DIFF
--- a/crates/oxc_react_compiler/fixtures/tagged-template-escaped.js
+++ b/crates/oxc_react_compiler/fixtures/tagged-template-escaped.js
@@ -1,0 +1,3 @@
+function component(value) {
+  return tag`line one\nline two: ${value}\t`;
+}

--- a/crates/oxc_react_compiler/fixtures/tagged-template-invalid-escape.js
+++ b/crates/oxc_react_compiler/fixtures/tagged-template-invalid-escape.js
@@ -1,0 +1,3 @@
+function component() {
+  return tag`\unicode`;
+}

--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -882,20 +882,6 @@ where
 }
 
 #[cold]
-pub fn todo_build_hir_lower_expression_handle_tagged_template_where_cooked_value_different_from_raw_value<
-    L,
-    T,
->(
-    labels: T,
-) -> OxcDiagnostic
-where
-    L: Into<oxc_diagnostics::LabeledSpan>,
-    T: IntoIterator<Item = L>,
-{
-    diagnostic(ErrorCategory::Todo, "(BuildHIR::lowerExpression) Handle tagged template where cooked value is different from raw value").with_labels(labels)
-}
-
-#[cold]
 pub fn todo_build_hir_lower_expression_handle_yield_expression_expressions<L, T>(
     labels: T,
 ) -> OxcDiagnostic

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -3806,18 +3806,6 @@ fn lower_expression<'a>(
             // instead lowers the tag plus every quasi and every `${...}`
             // subexpression (mirroring `TemplateLiteral`). This is a deliberate
             // divergence from the TS reference.
-            //
-            // We still bail when any quasi's cooked value differs from its raw value
-            // (e.g. escape sequences or graphql templates), matching upstream's
-            // single-quasi behavior — the HIR only round-trips raw==cooked quasis.
-            if tagged.quasi.quasis.iter().any(|q| {
-                q.value.raw.as_str() != q.value.cooked.map(|c| c.to_string()).unwrap_or_default()
-            }) {
-                builder.record_error(
-                    diagnostics::todo_build_hir_lower_expression_handle_tagged_template_where_cooked_value_different_from_raw_value(span),
-                )?;
-                return Ok(InstructionValue::Primitive { value: PrimitiveValue::Undefined, span });
-            }
             // Evaluation order: the tag is evaluated first, then each interpolated
             // subexpression left-to-right.
             let tag = lower_expression_to_temporary(builder, &tagged.tag)?;

--- a/crates/oxc_react_compiler/tests/snapshots/tagged-template-escaped.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/tagged-template-escaped.snap
@@ -1,0 +1,7 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/tagged-template-escaped.js
+---
+function component(value) {
+	return tag`line one\nline two: ${value}\t`;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/tagged-template-invalid-escape.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/tagged-template-invalid-escape.snap
@@ -1,0 +1,7 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/tagged-template-invalid-escape.js
+---
+function component() {
+	return tag`\unicode`;
+}


### PR DESCRIPTION
React Compiler HIR already preserves both raw and cooked tagged-template values, but lowering rejected templates whenever they differed. Remove the stale bailout and cover escaped and invalid escape sequences.

Validated with `just ready`.

AI-assisted.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>