### PR TITLE
fix(react-compiler): support bigint object keys

### DIFF
--- a/crates/oxc_react_compiler/fixtures/bigint-object-keys.js
+++ b/crates/oxc_react_compiler/fixtures/bigint-object-keys.js
@@ -1,0 +1,9 @@
+function component(value) {
+  return {
+    1n: value,
+    0x10n: value,
+    0o10n: value,
+    0b10n: value,
+    9007199254740993n: value,
+  };
+}

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -5496,6 +5496,13 @@ fn lower_object_property_key<'a>(
                 span: Some(lit.span),
             }))
         }
+        // BigInt property keys are coerced to their canonical decimal string at
+        // runtime. Preserve that value rather than the source spelling so keys
+        // such as `0x10n` and `16n` remain equivalent.
+        oxc::PropertyKey::BigIntLiteral(lit) if !computed => Ok(Some(ObjectPropertyKey::String {
+            name: Ident::from(lit.value.as_str()),
+            span: Some(lit.span),
+        })),
         _ if computed => {
             let place = lower_expression_to_temporary(builder, key.to_expression())?;
             Ok(Some(ObjectPropertyKey::Computed { name: place, span: Some(key.span()) }))

--- a/crates/oxc_react_compiler/tests/snapshots/bigint-object-keys.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/bigint-object-keys.snap
@@ -1,0 +1,23 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/bigint-object-keys.js
+---
+import { c as _c } from "react/compiler-runtime";
+function component(value) {
+	const $ = _c(2);
+	let t0;
+	if ($[0] !== value) {
+		t0 = {
+			"1": value,
+			"16": value,
+			"8": value,
+			"2": value,
+			"9007199254740993": value
+		};
+		$[0] = value;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}


### PR DESCRIPTION
BigInt object keys fell through generic unsupported-key handling. Lower them through the exact parser-provided decimal string, preserving alternate bases and values beyond Number precision.

Validated with `just ready`.

AI-assisted.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>