### PR TITLE
feat(minifier): improve negation of expressions in boolean context

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
@@ -417,13 +417,13 @@ impl<'a> PeepholeOptimizations {
         ) {
             (Some(true), Some(false)) => {
                 let test = expr.test.take_in(ctx);
-                let test = Self::minimize_not(expr.span, test, ctx);
-                let test = Self::minimize_not(expr.span, test, ctx);
+                let test = Self::minimize_not(expr.span, test, ctx, false);
+                let test = Self::minimize_not(expr.span, test, ctx, false);
                 return Some(test);
             }
             (Some(false), Some(true)) => {
                 let test = expr.test.take_in(ctx);
-                let test = Self::minimize_not(expr.span, test, ctx);
+                let test = Self::minimize_not(expr.span, test, ctx, false);
                 return Some(test);
             }
             // "c ? false : x" => "!c && x" (exact for any `c`)
@@ -436,7 +436,7 @@ impl<'a> PeepholeOptimizations {
                     ) =>
             {
                 let test = expr.test.take_in(ctx);
-                let test = Self::minimize_not(expr.span, test, ctx);
+                let test = Self::minimize_not(expr.span, test, ctx, false);
                 let right = expr.alternate.take_in(ctx);
                 return Some(Self::join_with_left_associative_op(
                     expr.span,
@@ -456,7 +456,7 @@ impl<'a> PeepholeOptimizations {
                     ) =>
             {
                 let test = expr.test.take_in(ctx);
-                let test = Self::minimize_not(expr.span, test, ctx);
+                let test = Self::minimize_not(expr.span, test, ctx, false);
                 let right = expr.consequent.take_in(ctx);
                 return Some(Self::join_with_left_associative_op(
                     expr.span,
@@ -546,8 +546,8 @@ impl<'a> PeepholeOptimizations {
                 // But skip if parens would be needed (e.g., "a+b?1:0" => "+!!(a+b)" is longer)
                 if !needs_parens {
                     let test = expr.test.take_in(ctx);
-                    let test = Self::minimize_not(expr.span, test, ctx);
-                    let test = Self::minimize_not(expr.span, test, ctx);
+                    let test = Self::minimize_not(expr.span, test, ctx, false);
+                    let test = Self::minimize_not(expr.span, test, ctx, false);
                     return Some(Expression::new_unary_expression(expr.span,
                     UnaryOperator::UnaryPlus,
                     test, ctx));
@@ -559,7 +559,7 @@ impl<'a> PeepholeOptimizations {
                 // The `0` must be `+0`: `a ? -0 : 1` would become `+!a`, yielding `+0`, not `-0`.
                 if !consequent.is_sign_negative() && !Self::test_needs_parens(&expr.test) => {
                     let test = expr.test.take_in(ctx);
-                    let test = Self::minimize_not(expr.span, test, ctx);
+                    let test = Self::minimize_not(expr.span, test, ctx, false);
                     return Some(Expression::new_unary_expression(expr.span,
                     UnaryOperator::UnaryPlus,
                     test, ctx));

--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -8,24 +8,6 @@ use crate::TraverseCtx;
 use super::PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
-    /// Negate and simplify expression when we know it's used inside a boolean context, e.g. `if (boolean_context) {}`.
-    pub fn negate_expression_in_boolean_context(
-        expr: &mut Expression<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        if Self::try_negate_expression(expr, ctx, true) {
-            Self::minimize_expression_in_boolean_context(expr, ctx);
-        } else {
-            let new_expr = Expression::new_unary_expression(
-                expr.span(),
-                UnaryOperator::LogicalNot,
-                expr.take_in(ctx),
-                ctx,
-            );
-            ctx.replace_expression(expr, new_expr);
-        }
-    }
-
     /// Simplify syntax when we know it's used inside a boolean context, e.g. `if (boolean_context) {}`.
     ///
     /// `SimplifyBooleanExpr`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_ast_helpers.go#L2059>
@@ -99,32 +81,30 @@ impl<'a> PeepholeOptimizations {
                 Self::minimize_expression_in_boolean_context(&mut e.alternate, ctx);
                 if let Some(boolean) = e.consequent.get_side_free_boolean_value(ctx) {
                     let right = e.alternate.take_in(ctx);
+                    let left = e.test.take_in(ctx);
                     let span = e.span;
-                    let op = if boolean {
+                    let (op, left) = if boolean {
                         // "if (anything1 ? truthyNoSideEffects : anything2)" => "if (anything1 || anything2)"
-                        LogicalOperator::Or
+                        (LogicalOperator::Or, left)
                     } else {
                         // "if (anything1 ? falsyNoSideEffects : anything2)" => "if (!anything1 && anything2)"
-                        Self::negate_expression_in_boolean_context(&mut e.test, ctx);
-                        LogicalOperator::And
+                        (LogicalOperator::And, Self::minimize_not(left.span(), left, ctx, true))
                     };
-                    let left = e.test.take_in(ctx);
                     let new_expr = Self::join_with_left_associative_op(span, op, left, right, ctx);
                     ctx.replace_expression(expr, new_expr);
                     return;
                 }
                 if let Some(boolean) = e.alternate.get_side_free_boolean_value(ctx) {
+                    let left = e.test.take_in(ctx);
                     let right = e.consequent.take_in(ctx);
                     let span = e.span;
-                    let op = if boolean {
+                    let (op, left) = if boolean {
                         // "if (anything1 ? anything2 : truthyNoSideEffects)" => "if (!anything1 || anything2)"
-                        Self::negate_expression_in_boolean_context(&mut e.test, ctx);
-                        LogicalOperator::Or
+                        (LogicalOperator::Or, Self::minimize_not(left.span(), left, ctx, true))
                     } else {
                         // "if (anything1 ? anything2 : falsyNoSideEffects)" => "if (anything1 && anything2)"
-                        LogicalOperator::And
+                        (LogicalOperator::And, left)
                     };
-                    let left = e.test.take_in(ctx);
                     let new_expr = Self::join_with_left_associative_op(span, op, left, right, ctx);
                     ctx.replace_expression(expr, new_expr);
                 }

--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -82,13 +82,11 @@ impl<'a> PeepholeOptimizations {
                     let mut e = u2.argument.take_in(ctx);
                     Self::minimize_expression_in_boolean_context(&mut e, ctx);
                     ctx.replace_expression(expr, e);
+                } else if Self::try_negate_expression_in_boolean_context(&mut u1.argument, ctx) {
+                    let e = u1.argument.take_in(ctx);
+                    ctx.replace_expression(expr, e);
                 } else {
-                    if Self::try_negate_expression_in_boolean_context(&mut u1.argument, ctx) {
-                        let e = u1.argument.take_in(ctx);
-                        ctx.replace_expression(expr, e);
-                    } else {
-                        Self::minimize_expression_in_boolean_context(&mut u1.argument, ctx);
-                    }
+                    Self::minimize_expression_in_boolean_context(&mut u1.argument, ctx);
                 }
             }
             Expression::BinaryExpression(e)

--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -13,7 +13,9 @@ impl<'a> PeepholeOptimizations {
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if !Self::try_negate_expression_in_boolean_context(expr, ctx) {
+        if Self::try_negate_expression(expr, ctx, true) {
+            Self::minimize_expression_in_boolean_context(expr, ctx);
+        } else {
             let new_expr = Expression::new_unary_expression(
                 expr.span(),
                 UnaryOperator::LogicalNot,
@@ -21,48 +23,6 @@ impl<'a> PeepholeOptimizations {
                 ctx,
             );
             ctx.replace_expression(expr, new_expr);
-        }
-    }
-
-    fn try_negate_expression_in_boolean_context(
-        expr: &mut Expression<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) -> bool {
-        match expr {
-            Expression::UnaryExpression(unary_expr) if unary_expr.operator.is_not() => {
-                let mut e = unary_expr.argument.take_in(ctx);
-                Self::minimize_expression_in_boolean_context(&mut e, ctx);
-                ctx.replace_expression(expr, e);
-                true
-            }
-            // `!(a == b)` => `a != b`
-            // `!(a != b)` => `a == b`
-            // `!(a === b)` => `a !== b`
-            // `!(a !== b)` => `a === b`
-            Expression::BinaryExpression(binary_expr) if binary_expr.operator.is_equality() => {
-                binary_expr.operator = binary_expr.operator.equality_inverse_operator().unwrap();
-                Self::minimize_expression_in_boolean_context(expr, ctx);
-                true
-            }
-            // De Morgan's law for logical expressions
-            // `!(a == b || c == d)` => `a != b && c != d`
-            // `!(a == b && c == d)` => `a != b || c != d`
-            Expression::LogicalExpression(logical_expr)
-                if Self::de_morgan_paren_delta(logical_expr).is_some_and(|delta| delta <= 0) =>
-            {
-                Self::de_morgan_invert_logical(logical_expr);
-                Self::minimize_expression_in_boolean_context(expr, ctx);
-                true
-            }
-            // "!(a, b)" => "a, !b"
-            Expression::SequenceExpression(sequence_expr) => {
-                if let Some(last_expr) = sequence_expr.expressions.last_mut() {
-                    Self::negate_expression_in_boolean_context(last_expr, ctx);
-                    return true;
-                }
-                false
-            }
-            _ => false,
         }
     }
 
@@ -82,8 +42,9 @@ impl<'a> PeepholeOptimizations {
                     let mut e = u2.argument.take_in(ctx);
                     Self::minimize_expression_in_boolean_context(&mut e, ctx);
                     ctx.replace_expression(expr, e);
-                } else if Self::try_negate_expression_in_boolean_context(&mut u1.argument, ctx) {
-                    let e = u1.argument.take_in(ctx);
+                } else if Self::try_negate_expression(&mut u1.argument, ctx, true) {
+                    let mut e = u1.argument.take_in(ctx);
+                    Self::minimize_expression_in_boolean_context(&mut e, ctx);
                     ctx.replace_expression(expr, e);
                 } else {
                     Self::minimize_expression_in_boolean_context(&mut u1.argument, ctx);

--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -8,6 +8,64 @@ use crate::TraverseCtx;
 use super::PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
+    /// Negate and simplify expression when we know it's used inside a boolean context, e.g. `if (boolean_context) {}`.
+    pub fn negate_expression_in_boolean_context(
+        expr: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        if !Self::try_negate_expression_in_boolean_context(expr, ctx) {
+            let new_expr = Expression::new_unary_expression(
+                expr.span(),
+                UnaryOperator::LogicalNot,
+                expr.take_in(ctx),
+                ctx,
+            );
+            ctx.replace_expression(expr, new_expr);
+        }
+    }
+
+    fn try_negate_expression_in_boolean_context(
+        expr: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> bool {
+        match expr {
+            Expression::UnaryExpression(unary_expr) if unary_expr.operator.is_not() => {
+                let mut e = unary_expr.argument.take_in(ctx);
+                Self::minimize_expression_in_boolean_context(&mut e, ctx);
+                ctx.replace_expression(expr, e);
+                true
+            }
+            // `!(a == b)` => `a != b`
+            // `!(a != b)` => `a == b`
+            // `!(a === b)` => `a !== b`
+            // `!(a !== b)` => `a === b`
+            Expression::BinaryExpression(binary_expr) if binary_expr.operator.is_equality() => {
+                binary_expr.operator = binary_expr.operator.equality_inverse_operator().unwrap();
+                Self::minimize_expression_in_boolean_context(expr, ctx);
+                true
+            }
+            // De Morgan's law for logical expressions
+            // `!(a == b || c == d)` => `a != b && c != d`
+            // `!(a == b && c == d)` => `a != b || c != d`
+            Expression::LogicalExpression(logical_expr)
+                if Self::de_morgan_paren_delta(logical_expr).is_some_and(|delta| delta <= 0) =>
+            {
+                Self::de_morgan_invert_logical(logical_expr);
+                Self::minimize_expression_in_boolean_context(expr, ctx);
+                true
+            }
+            // "!(a, b)" => "a, !b"
+            Expression::SequenceExpression(sequence_expr) => {
+                if let Some(last_expr) = sequence_expr.expressions.last_mut() {
+                    Self::negate_expression_in_boolean_context(last_expr, ctx);
+                    return true;
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+
     /// Simplify syntax when we know it's used inside a boolean context, e.g. `if (boolean_context) {}`.
     ///
     /// `SimplifyBooleanExpr`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_ast_helpers.go#L2059>
@@ -16,14 +74,21 @@ impl<'a> PeepholeOptimizations {
         ctx: &mut TraverseCtx<'a>,
     ) {
         match expr {
-            // "!!a" => "a"
             Expression::UnaryExpression(u1) if u1.operator.is_not() => {
+                // "!!a" => "a"
                 if let Expression::UnaryExpression(u2) = &mut u1.argument
                     && u2.operator.is_not()
                 {
                     let mut e = u2.argument.take_in(ctx);
                     Self::minimize_expression_in_boolean_context(&mut e, ctx);
                     ctx.replace_expression(expr, e);
+                } else {
+                    if Self::try_negate_expression_in_boolean_context(&mut u1.argument, ctx) {
+                        let e = u1.argument.take_in(ctx);
+                        ctx.replace_expression(expr, e);
+                    } else {
+                        Self::minimize_expression_in_boolean_context(&mut u1.argument, ctx);
+                    }
                 }
             }
             Expression::BinaryExpression(e)
@@ -60,7 +125,7 @@ impl<'a> PeepholeOptimizations {
                 }
             }
             // "if (!!a ||!!b)" => "if (a || b)"
-            Expression::LogicalExpression(e) if e.operator == LogicalOperator::Or => {
+            Expression::LogicalExpression(e) if e.operator.is_or() => {
                 Self::minimize_expression_in_boolean_context(&mut e.left, ctx);
                 Self::minimize_expression_in_boolean_context(&mut e.right, ctx);
                 // "if (anything || falsyNoSideEffects)" => "if (anything)"
@@ -75,30 +140,32 @@ impl<'a> PeepholeOptimizations {
                 Self::minimize_expression_in_boolean_context(&mut e.alternate, ctx);
                 if let Some(boolean) = e.consequent.get_side_free_boolean_value(ctx) {
                     let right = e.alternate.take_in(ctx);
-                    let left = e.test.take_in(ctx);
                     let span = e.span;
-                    let (op, left) = if boolean {
+                    let op = if boolean {
                         // "if (anything1 ? truthyNoSideEffects : anything2)" => "if (anything1 || anything2)"
-                        (LogicalOperator::Or, left)
+                        LogicalOperator::Or
                     } else {
                         // "if (anything1 ? falsyNoSideEffects : anything2)" => "if (!anything1 && anything2)"
-                        (LogicalOperator::And, Self::minimize_not(left.span(), left, ctx))
+                        Self::negate_expression_in_boolean_context(&mut e.test, ctx);
+                        LogicalOperator::And
                     };
+                    let left = e.test.take_in(ctx);
                     let new_expr = Self::join_with_left_associative_op(span, op, left, right, ctx);
                     ctx.replace_expression(expr, new_expr);
                     return;
                 }
                 if let Some(boolean) = e.alternate.get_side_free_boolean_value(ctx) {
-                    let left = e.test.take_in(ctx);
                     let right = e.consequent.take_in(ctx);
                     let span = e.span;
-                    let (op, left) = if boolean {
+                    let op = if boolean {
                         // "if (anything1 ? anything2 : truthyNoSideEffects)" => "if (!anything1 || anything2)"
-                        (LogicalOperator::Or, Self::minimize_not(left.span(), left, ctx))
+                        Self::negate_expression_in_boolean_context(&mut e.test, ctx);
+                        LogicalOperator::Or
                     } else {
                         // "if (anything1 ? anything2 : falsyNoSideEffects)" => "if (anything1 && anything2)"
-                        (LogicalOperator::And, left)
+                        LogicalOperator::And
                     };
+                    let left = e.test.take_in(ctx);
                     let new_expr = Self::join_with_left_associative_op(span, op, left, right, ctx);
                     ctx.replace_expression(expr, new_expr);
                 }

--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -17,17 +17,9 @@ impl<'a> PeepholeOptimizations {
     ) {
         match expr {
             Expression::UnaryExpression(u1) if u1.operator.is_not() => {
-                // "!!a" => "a"
-                if let Expression::UnaryExpression(u2) = &mut u1.argument
-                    && u2.operator.is_not()
-                {
-                    let mut e = u2.argument.take_in(ctx);
-                    Self::minimize_expression_in_boolean_context(&mut e, ctx);
-                    ctx.replace_expression(expr, e);
-                } else if Self::try_negate_expression(&mut u1.argument, ctx, true) {
-                    let mut e = u1.argument.take_in(ctx);
-                    Self::minimize_expression_in_boolean_context(&mut e, ctx);
-                    ctx.replace_expression(expr, e);
+                if Self::try_negate_expression(&mut u1.argument, ctx, true) {
+                    Self::minimize_expression_in_boolean_context(&mut u1.argument, ctx);
+                    ctx.replace_expression_with(expr, Self::unwrap_unary);
                 } else {
                     Self::minimize_expression_in_boolean_context(&mut u1.argument, ctx);
                 }

--- a/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
@@ -41,9 +41,8 @@ impl<'a> PeepholeOptimizations {
             };
 
             let Statement::IfStatement(if_stmt) = first else { unreachable!() };
-            let IfStatement { mut test, alternate, .. } = if_stmt.unbox();
-            Self::negate_expression_in_boolean_context(&mut test, ctx);
-            let expr = test;
+            let IfStatement { test, alternate, .. } = if_stmt.unbox();
+            let expr = Self::minimize_not(test.span(), test, ctx, true);
 
             if let Some(test) = &mut for_stmt.test {
                 let left = test.take_in(ctx);

--- a/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
@@ -41,14 +41,9 @@ impl<'a> PeepholeOptimizations {
             };
 
             let Statement::IfStatement(if_stmt) = first else { unreachable!() };
-            let IfStatement { test, alternate, .. } = if_stmt.unbox();
-
-            let expr = match test {
-                Expression::UnaryExpression(unary_expr) if unary_expr.operator.is_not() => {
-                    unary_expr.unbox().argument
-                }
-                e => Self::minimize_not(e.span(), e, ctx),
-            };
+            let IfStatement { mut test, alternate, .. } = if_stmt.unbox();
+            Self::negate_expression_in_boolean_context(&mut test, ctx);
+            let expr = test;
 
             if let Some(test) = &mut for_stmt.test {
                 let left = test.take_in(ctx);

--- a/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
@@ -67,8 +67,7 @@ impl<'a> PeepholeOptimizations {
                     && let Expression::UnaryExpression(unary_expr) = &mut if_stmt.test
                     && unary_expr.operator.is_not()
                 {
-                    let new_test = unary_expr.argument.take_in(ctx);
-                    ctx.replace_expression(&mut if_stmt.test, new_test);
+                    ctx.replace_expression_with(&mut if_stmt.test, Self::unwrap_unary);
                     std::mem::swap(&mut if_stmt.consequent, alternate);
                 }
             }

--- a/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
@@ -40,13 +40,7 @@ impl<'a> PeepholeOptimizations {
 
             // `if (!a) {} else x;` => `if (a) x;`
             // `if (a)  {} else x;` => `if (!a) x;`
-            let new_test = match &mut if_stmt.test {
-                Expression::UnaryExpression(unary_expr) if unary_expr.operator.is_not() => {
-                    unary_expr.argument.take_in(ctx)
-                }
-                _ => Self::minimize_not(if_stmt.test.span(), if_stmt.test.take_in(ctx), ctx),
-            };
-            ctx.replace_expression(&mut if_stmt.test, new_test);
+            Self::negate_expression_in_boolean_context(&mut if_stmt.test, ctx);
             ctx.replace_statement(&mut if_stmt.consequent, new_consequent);
         }
 

--- a/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
@@ -40,7 +40,9 @@ impl<'a> PeepholeOptimizations {
 
             // `if (!a) {} else x;` => `if (a) x;`
             // `if (a)  {} else x;` => `if (!a) x;`
-            Self::negate_expression_in_boolean_context(&mut if_stmt.test, ctx);
+            ctx.replace_expression_with(&mut if_stmt.test, |old, ctx| {
+                Self::minimize_not(old.span(), old, ctx, true)
+            });
             ctx.replace_statement(&mut if_stmt.consequent, new_consequent);
         }
 

--- a/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
@@ -9,36 +9,30 @@ use super::PeepholeOptimizations;
 impl<'a> PeepholeOptimizations {
     pub fn minimize_not(
         span: Span,
-        expr: Expression<'a>,
+        mut expr: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
+        boolean_context: bool,
     ) -> Expression<'a> {
-        let mut unary =
-            Expression::new_unary_expression(span, UnaryOperator::LogicalNot, expr, ctx);
-        Self::minimize_unary(&mut unary, ctx);
-        unary
+        if !Self::try_negate_expression(&mut expr, ctx, boolean_context) {
+            return Expression::new_unary_expression(span, UnaryOperator::LogicalNot, expr, ctx);
+        }
+        expr
     }
 
-    /// `MaybeSimplifyNot`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_ast_helpers.go#L73>
-    pub fn minimize_unary(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
-        let Expression::UnaryExpression(e) = expr else { return };
-        if !e.operator.is_not() {
-            return;
-        }
-        Self::minimize_expression_in_boolean_context(&mut e.argument, ctx);
-        match &mut e.argument {
+    pub fn try_negate_expression(
+        expr: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+        boolean_context: bool,
+    ) -> bool {
+        match expr {
             // `!!true` -> `true`
             // `!!false` -> `false`
             Expression::UnaryExpression(e)
-                if e.operator.is_not() && e.argument.value_type(ctx).is_boolean() =>
+                if e.operator.is_not()
+                    && (boolean_context || e.argument.value_type(ctx).is_boolean()) =>
             {
-                // Both discarded `!` wrappers contain no references.
-                ctx.replace_expression_with(expr, |old, _| {
-                    let Expression::UnaryExpression(outer) = old else { unreachable!() };
-                    let Expression::UnaryExpression(inner) = outer.unbox().argument else {
-                        unreachable!()
-                    };
-                    inner.unbox().argument
-                });
+                ctx.replace_expression_with(expr, Self::unwrap_unary);
+                true
             }
             // `!(a == b)` => `a != b`
             // `!(a != b)` => `a == b`
@@ -46,7 +40,7 @@ impl<'a> PeepholeOptimizations {
             // `!(a !== b)` => `a === b`
             Expression::BinaryExpression(binary_expr) if binary_expr.operator.is_equality() => {
                 binary_expr.operator = binary_expr.operator.equality_inverse_operator().unwrap();
-                ctx.replace_expression_with(expr, Self::unwrap_unary);
+                true
             }
             // `!(a == b || c == d)` => `a != b && c != d`
             // `!(a == b && c == d)` => `a != b || c != d`
@@ -60,18 +54,33 @@ impl<'a> PeepholeOptimizations {
                 if Self::de_morgan_paren_delta(logical_expr).is_some_and(|delta| delta <= 0) =>
             {
                 Self::de_morgan_invert_logical(logical_expr);
-                ctx.replace_expression_with(expr, Self::unwrap_unary);
+                true
             }
             // "!(a, b)" => "a, !b"
             Expression::SequenceExpression(sequence_expr) => {
                 if let Some(last_expr) = sequence_expr.expressions.last_mut() {
                     ctx.replace_expression_with(last_expr, |old, ctx| {
-                        Self::minimize_not(old.span(), old, ctx)
+                        Self::minimize_not(old.span(), old, ctx, false)
                     });
-                    ctx.replace_expression_with(expr, Self::unwrap_unary);
+                    return true;
                 }
+                false
             }
-            _ => {}
+            _ => false,
+        }
+    }
+
+    /// `MaybeSimplifyNot`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_ast_helpers.go#L73>
+    pub fn minimize_unary(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
+        let Expression::UnaryExpression(e) = expr else { return };
+        if !e.operator.is_not() {
+            return;
+        }
+        Self::minimize_expression_in_boolean_context(&mut e.argument, ctx);
+
+        if Self::try_negate_expression(&mut e.argument, ctx, false) {
+            let new_expr = e.argument.take_in(ctx);
+            ctx.replace_expression(expr, new_expr);
         }
     }
 
@@ -85,7 +94,7 @@ impl<'a> PeepholeOptimizations {
     /// Character delta from parentheses added or removed by De Morgan's law
     /// (flipping `&&` <-> `||` changes which nested operands need parens), or
     /// `None` if some operand cannot invert its operator in place.
-    pub fn de_morgan_paren_delta(e: &LogicalExpression<'a>) -> Option<i32> {
+    fn de_morgan_paren_delta(e: &LogicalExpression<'a>) -> Option<i32> {
         if !matches!(e.operator, LogicalOperator::And | LogicalOperator::Or) {
             return None;
         }
@@ -111,7 +120,7 @@ impl<'a> PeepholeOptimizations {
 
     /// Apply De Morgan's law in place. Only called on chains approved by
     /// [`Self::de_morgan_paren_delta`].
-    pub fn de_morgan_invert_logical(e: &mut LogicalExpression<'a>) {
+    fn de_morgan_invert_logical(e: &mut LogicalExpression<'a>) {
         e.operator = if e.operator == LogicalOperator::And {
             LogicalOperator::Or
         } else {

--- a/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
@@ -13,7 +13,11 @@ impl<'a> PeepholeOptimizations {
         ctx: &mut TraverseCtx<'a>,
         boolean_context: bool,
     ) -> Expression<'a> {
-        if !Self::try_negate_expression(&mut expr, ctx, boolean_context) {
+        if Self::try_negate_expression(&mut expr, ctx, boolean_context) {
+            if boolean_context {
+                Self::minimize_expression_in_boolean_context(&mut expr, ctx);
+            }
+        } else {
             return Expression::new_unary_expression(span, UnaryOperator::LogicalNot, expr, ctx);
         }
         expr

--- a/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
@@ -85,7 +85,7 @@ impl<'a> PeepholeOptimizations {
     /// Character delta from parentheses added or removed by De Morgan's law
     /// (flipping `&&` <-> `||` changes which nested operands need parens), or
     /// `None` if some operand cannot invert its operator in place.
-    fn de_morgan_paren_delta(e: &LogicalExpression<'a>) -> Option<i32> {
+    pub fn de_morgan_paren_delta(e: &LogicalExpression<'a>) -> Option<i32> {
         if !matches!(e.operator, LogicalOperator::And | LogicalOperator::Or) {
             return None;
         }
@@ -111,7 +111,7 @@ impl<'a> PeepholeOptimizations {
 
     /// Apply De Morgan's law in place. Only called on chains approved by
     /// [`Self::de_morgan_paren_delta`].
-    fn de_morgan_invert_logical(e: &mut LogicalExpression<'a>) {
+    pub fn de_morgan_invert_logical(e: &mut LogicalExpression<'a>) {
         e.operator = if e.operator == LogicalOperator::And {
             LogicalOperator::Or
         } else {

--- a/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
@@ -60,7 +60,7 @@ impl<'a> PeepholeOptimizations {
             Expression::SequenceExpression(sequence_expr) => {
                 if let Some(last_expr) = sequence_expr.expressions.last_mut() {
                     ctx.replace_expression_with(last_expr, |old, ctx| {
-                        Self::minimize_not(old.span(), old, ctx, false)
+                        Self::minimize_not(old.span(), old, ctx, boolean_context)
                     });
                     return true;
                 }

--- a/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
@@ -83,8 +83,7 @@ impl<'a> PeepholeOptimizations {
         Self::minimize_expression_in_boolean_context(&mut e.argument, ctx);
 
         if Self::try_negate_expression(&mut e.argument, ctx, false) {
-            let new_expr = e.argument.take_in(ctx);
-            ctx.replace_expression(expr, new_expr);
+            ctx.replace_expression_with(expr, Self::unwrap_unary);
         }
     }
 

--- a/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
@@ -17,10 +17,10 @@ impl<'a> PeepholeOptimizations {
             if boolean_context {
                 Self::minimize_expression_in_boolean_context(&mut expr, ctx);
             }
+            expr
         } else {
-            return Expression::new_unary_expression(span, UnaryOperator::LogicalNot, expr, ctx);
+            Expression::new_unary_expression(span, UnaryOperator::LogicalNot, expr, ctx)
         }
-        expr
     }
 
     pub fn try_negate_expression(

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -859,9 +859,8 @@ impl<'a> PeepholeOptimizations {
                         } else {
                             body[0].span()
                         };
-                        let test = if_stmt.unbox().test;
-                        let mut test = Self::minimize_not(test.span(), test, ctx);
-                        Self::minimize_expression_in_boolean_context(&mut test, ctx);
+                        let mut test = if_stmt.unbox().test;
+                        Self::negate_expression_in_boolean_context(&mut test, ctx);
                         let consequent = if body.len() == 1 {
                             body.remove(0)
                         } else {

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -859,8 +859,8 @@ impl<'a> PeepholeOptimizations {
                         } else {
                             body[0].span()
                         };
-                        let mut test = if_stmt.unbox().test;
-                        Self::negate_expression_in_boolean_context(&mut test, ctx);
+                        let test = if_stmt.unbox().test;
+                        let test = Self::minimize_not(test.span(), test, ctx, true);
                         let consequent = if body.len() == 1 {
                             body.remove(0)
                         } else {

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1107,7 +1107,7 @@ impl<'a> PeepholeOptimizations {
                     Self::minimize_expression_in_boolean_context(&mut arg, ctx);
                     let arg =
                         Expression::new_unary_expression(span, UnaryOperator::LogicalNot, arg, ctx);
-                    Some(Self::minimize_not(span, arg, ctx))
+                    Some(Self::minimize_not(span, arg, ctx, false))
                 }
             },
             "String" => {

--- a/crates/oxc_minifier/tests/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_expression_in_boolean_context.rs
@@ -1,5 +1,29 @@
 use crate::test;
 
+fn test_boolean(source_text: &str, expected: &str) {
+    test(format!("for(;{source_text};);").as_str(), format!("for(;{expected};);").as_str());
+}
+
+#[test]
+fn test_minimize_expression_in_boolean_context() {
+    test_boolean("!!a", "a");
+    test_boolean("!!a ? b : c", "a ? b : c");
+    test_boolean("!!!a", "!a");
+    test_boolean("Boolean(!!a)", "a");
+    test_boolean("((a | +b) !== 0)", "a | +b");
+    test_boolean("(a | +b) === 0", "!(a | +b)");
+    test_boolean("!!a && !!b", "a && b");
+    test_boolean("!!a || !!b", "a || b");
+    test_boolean("anything || (0, false)", "anything");
+    test_boolean("a ? !!b : !!c", "a ? b : c");
+    test_boolean("foo, !!bar", "foo, bar");
+    test_boolean("anything1 ? (0, true) : anything2", "anything1 || anything2");
+    test_boolean("anything1 ? (0, false) : anything2", "!anything1 && anything2");
+    test_boolean("anything1 ? anything2 : (0, true)", "!anything1 || anything2");
+    test_boolean("anything1 ? anything2 : (0, false)", "anything1 && anything2");
+    test_boolean("+a === 0", "+a == 0");
+}
+
 #[test]
 fn test_try_fold_in_boolean_context() {
     test("if (!!a);", "a");

--- a/crates/oxc_minifier/tests/peephole/oxc.rs
+++ b/crates/oxc_minifier/tests/peephole/oxc.rs
@@ -51,7 +51,7 @@ fn integration() {
          }
          console.log(c, d);
         ",
-        "if (console.log('effect'), !1) var c, c, d;
+        "if (console.log('effect'), 0) var c, c, d;
         console.log(c, d);
         ",
     );

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 150
   sys alloc bytes: 14996600 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 144626
+  arena allocs: 144524
   arena reallocs: 28468
-  arena size: 19144184 # 19.14 MB
+  arena size: 19141528 # 19.14 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,7 +16,7 @@ App.tsx:
   sys deallocs: 61
   sys alloc bytes: 2128555 # 2.13 MB
   sys peak growth: 1612427 # 1.61 MB
-  arena allocs: 15730
+  arena allocs: 15718
   arena reallocs: 2721
   arena size: 2882416 # 2.88 MB
 
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 2427
   sys alloc bytes: 5334247 # 5.33 MB
   sys peak growth: 3693355 # 3.69 MB
-  arena allocs: 44970
+  arena allocs: 44854
   arena reallocs: 7718
-  arena size: 6311296 # 6.31 MB
+  arena size: 6308176 # 6.31 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 1038
   sys alloc bytes: 29976031 # 29.98 MB
   sys peak growth: 19934725 # 19.93 MB
-  arena allocs: 352722
+  arena allocs: 352497
   arena reallocs: 76289
-  arena size: 48806072 # 48.81 MB
+  arena size: 48799784 # 48.80 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,7 +60,7 @@ binder.ts:
   sys deallocs: 33
   sys alloc bytes: 963008 # 963.01 kB
   sys peak growth: 657404 # 657.40 kB
-  arena allocs: 6847
+  arena allocs: 6841
   arena reallocs: 842
   arena size: 1164432 # 1.16 MB
 
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 1854
   sys alloc bytes: 5307512 # 5.31 MB
   sys peak growth: 3707425 # 3.71 MB
-  arena allocs: 65134
+  arena allocs: 65050
   arena reallocs: 12252
-  arena size: 9397712 # 9.40 MB
+  arena size: 9395480 # 9.40 MB


### PR DESCRIPTION
add `boolean_context` to `minimize_not` so negation folding can happen in-place when possible, reducing extra AST rebuilds and allocations and `!0` / `!1` can now collapse directly to `1` / `0` in boolean context

```js
if (!a); else throw x;
//  ^~ this now is consistently negated by removal of `!` instead of `!!` as we are in boolean context
if (a) throw x;
```
```js
if ((a, !1)) throw x;
//      ^~ can now be collapsed to 0
if ((a, 0)) throw x;
```