### PR TITLE
fix(react-compiler): support typed assignment targets

### DIFF
--- a/crates/oxc_react_compiler/fixtures/error.todo-rust-as-expression-assignment-target.tsx
+++ b/crates/oxc_react_compiler/fixtures/error.todo-rust-as-expression-assignment-target.tsx
@@ -1,9 +1,0 @@
-function Component(props: {obj: {x: unknown}}) {
-  (props.obj.x as unknown as number) = 1;
-  return <div>{props.obj.x as number}</div>;
-}
-
-export const FIXTURE_ENTRYPOINT = {
-  fn: Component,
-  params: [{obj: {x: 0}}],
-};

--- a/crates/oxc_react_compiler/fixtures/typescript-assignment-targets.ts
+++ b/crates/oxc_react_compiler/fixtures/typescript-assignment-targets.ts
@@ -1,0 +1,36 @@
+function Component(props: {value: number}) {
+  let local = 0;
+  let updated = 0;
+  const obj = {x: props.value};
+  const read = () => local;
+
+  (local as unknown as number) = obj.x;
+  ((local) as number) = obj.x;
+  (local satisfies number) = local + 1;
+  (local!) = local + 1;
+
+  (obj.x as number) = local;
+  (((obj.x)) as number) = local;
+  (obj.x satisfies number) = local;
+  (obj.x!) = local;
+
+  (getObject()[getKey()] as number) = getValue();
+
+  (local as number) += 1;
+  (local satisfies number) -= 1;
+  (local!) *= 2;
+
+  (obj.x as number) += local;
+  (obj.x satisfies number) -= local;
+  (obj.x!) *= local;
+
+  (updated as number)++;
+  ++(obj.x!);
+
+  return read() + obj.x + updated;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{value: 0}],
+};

--- a/crates/oxc_react_compiler/fixtures/typescript-captured-update-target.ts
+++ b/crates/oxc_react_compiler/fixtures/typescript-captured-update-target.ts
@@ -1,0 +1,13 @@
+function Component() {
+  let value = 0;
+  const read = () => value;
+
+  (value as number)++;
+
+  return read();
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [],
+};

--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -1814,22 +1814,6 @@ pub fn enter_ssa_cycle(block: impl Display) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn unsupported_object_destructuring_assignment_target(
-    type_name: &str,
-    span: Option<Span>,
-) -> OxcDiagnostic {
-    diagnostic(
-        ErrorCategory::Todo,
-        format!(
-            "[FindContextIdentifiers] Cannot handle Object destructuring assignment target {type_name}"
-        ),
-    )
-    .with_labels(span.map(|span| {
-        span.primary_label(format!("Unsupported destructuring assignment target `{type_name}`"))
-    }))
-}
-
-#[cold]
 pub fn expected_scope_terminal(block: impl Display) -> OxcDiagnostic {
     diagnostic(
         ErrorCategory::Invariant,

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -1108,15 +1108,14 @@ fn lower_type_cast_expression<'a>(
     Ok(InstructionValue::TypeCastExpression { value, cast: cast(type_annotation), span })
 }
 
-/// Lower a member-expression update target (oxc's member variants of
-/// `SimpleAssignmentTarget`) into a receiver place + property + load value,
-/// mirroring `lower_member_expression_impl`.
-fn lower_member_expression_from_simple_target<'a>(
+/// Lower a member-expression update target into a receiver place + property +
+/// load value, mirroring `lower_member_expression_impl`.
+fn lower_member_expression_for_update<'a>(
     builder: &mut HirBuilder<'a, '_>,
-    target: &oxc::SimpleAssignmentTarget<'a>,
+    target: &oxc::MemberExpression<'a>,
 ) -> Result<LoweredMemberExpression<'a>, OxcDiagnostic> {
     match target {
-        oxc::SimpleAssignmentTarget::StaticMemberExpression(m) => {
+        oxc::MemberExpression::StaticMemberExpression(m) => {
             let span = Some(m.span);
             let property_span = Some(m.property.span);
             let object = lower_expression_to_temporary(builder, &m.object)?;
@@ -1134,7 +1133,7 @@ fn lower_member_expression_from_simple_target<'a>(
                 value,
             })
         }
-        oxc::SimpleAssignmentTarget::ComputedMemberExpression(m) => {
+        oxc::MemberExpression::ComputedMemberExpression(m) => {
             let span = Some(m.span);
             let object = lower_expression_to_temporary(builder, &m.object)?;
             if let oxc::Expression::NumericLiteral(lit) = &m.expression {
@@ -1162,7 +1161,7 @@ fn lower_member_expression_from_simple_target<'a>(
                 value,
             })
         }
-        oxc::SimpleAssignmentTarget::PrivateFieldExpression(m) => {
+        oxc::MemberExpression::PrivateFieldExpression(m) => {
             let span = Some(m.span);
             let object = lower_expression_to_temporary(builder, &m.object)?;
             builder.record_error(
@@ -1176,9 +1175,6 @@ fn lower_member_expression_from_simple_target<'a>(
                 property_span: None,
                 value: InstructionValue::Primitive { value: PrimitiveValue::Undefined, span },
             })
-        }
-        _ => {
-            unreachable!("lower_member_expression_from_simple_target called on a non-member target")
         }
     }
 }
@@ -1767,15 +1763,74 @@ fn lower_default_to_temp<'a>(
     Ok(temp)
 }
 
-/// Resolve a member-expression assignment target (oxc's member variants of
-/// `SimpleAssignmentTarget`) and store `value` into it, returning the store
-/// temporary. Mirrors the `PatternLike::MemberExpression` arm of the original
-/// `lower_assignment`.
+fn lower_identifier_assignment_target<'a>(
+    builder: &mut HirBuilder<'a, '_>,
+    span: Span,
+    kind: InstructionKind,
+    id: &oxc::IdentifierReference<'a>,
+    value: Place,
+) -> Result<Option<Place>, OxcDiagnostic> {
+    let result = lower_identifier_for_assignment(
+        builder,
+        span,
+        id.span,
+        kind,
+        id.name,
+        builder.scope().resolve_reference(id),
+    )?;
+    match result {
+        None => Ok(None),
+        Some(IdentifierForAssignment::Global { name }) => {
+            let temp = lower_value_to_temporary(
+                builder,
+                InstructionValue::StoreGlobal { name, value, span: Some(span) },
+            )?;
+            Ok(Some(temp))
+        }
+        Some(IdentifierForAssignment::Place(place)) => {
+            if builder.is_context_identifier(builder.scope().resolve_reference(id)) {
+                let is_hoisted = builder
+                    .scope()
+                    .resolve_reference(id)
+                    .map(|s| builder.environment().is_hoisted_identifier(s))
+                    .unwrap_or(false);
+                if kind == InstructionKind::Const && !is_hoisted {
+                    builder.record_error(
+                        diagnostics::syntax_expected_const_declaration_not_reassigned_2(span),
+                    )?;
+                }
+                let temp = lower_value_to_temporary(
+                    builder,
+                    InstructionValue::StoreContext {
+                        lvalue: LValue { place, kind },
+                        value,
+                        span: Some(span),
+                    },
+                )?;
+                Ok(Some(temp))
+            } else {
+                let temp = lower_value_to_temporary(
+                    builder,
+                    InstructionValue::StoreLocal {
+                        lvalue: LValue { place, kind },
+                        value,
+                        span: Some(span),
+                    },
+                )?;
+                Ok(Some(temp))
+            }
+        }
+    }
+}
+
+/// Resolve a member-expression assignment target and store `value` into it,
+/// returning the store temporary. Mirrors the `PatternLike::MemberExpression`
+/// arm of the original `lower_assignment`.
 fn lower_member_assignment_target<'a>(
     builder: &mut HirBuilder<'a, '_>,
     span: Span,
     kind: InstructionKind,
-    target: &oxc::SimpleAssignmentTarget<'a>,
+    target: &oxc::MemberExpression<'a>,
     value: Place,
 ) -> Result<Option<Place>, OxcDiagnostic> {
     // MemberExpression may only appear in an assignment expression (Reassign).
@@ -1786,7 +1841,7 @@ fn lower_member_assignment_target<'a>(
         return Ok(None);
     }
     match target {
-        oxc::SimpleAssignmentTarget::StaticMemberExpression(member) => {
+        oxc::MemberExpression::StaticMemberExpression(member) => {
             let object = lower_expression_to_temporary(builder, &member.object)?;
             let temp = lower_value_to_temporary(
                 builder,
@@ -1800,7 +1855,7 @@ fn lower_member_assignment_target<'a>(
             )?;
             Ok(Some(temp))
         }
-        oxc::SimpleAssignmentTarget::ComputedMemberExpression(member) => {
+        oxc::MemberExpression::ComputedMemberExpression(member) => {
             let object = lower_expression_to_temporary(builder, &member.object)?;
             // A numeric computed index is treated as a PropertyStore (matches the
             // original `member.computed && NumericLiteral` branch).
@@ -1829,7 +1884,7 @@ fn lower_member_assignment_target<'a>(
             )?;
             Ok(Some(temp))
         }
-        oxc::SimpleAssignmentTarget::PrivateFieldExpression(member) => {
+        oxc::MemberExpression::PrivateFieldExpression(member) => {
             // Babel modeled `a.#b = v` as a non-computed MemberExpression with a
             // PrivateName property; the original `lower_assignment` member arm hit
             // the generic property `_` branch and bailed with this Todo.
@@ -1843,7 +1898,6 @@ fn lower_member_assignment_target<'a>(
             )?;
             Ok(Some(temp))
         }
-        _ => unreachable!("lower_member_assignment_target called on a non-member target"),
     }
 }
 
@@ -1868,6 +1922,76 @@ fn assignment_target_is_local_identifier<'a>(
     }
 }
 
+fn lower_typed_assignment_target_expression<'a>(
+    builder: &mut HirBuilder<'a, '_>,
+    span: Span,
+    kind: InstructionKind,
+    expression: &oxc::Expression<'a>,
+    value: Place,
+) -> Result<Option<Place>, OxcDiagnostic> {
+    let expression = expression.get_inner_expression();
+    if let Some(member) = expression.as_member_expression() {
+        return lower_member_assignment_target(builder, span, kind, member, value);
+    }
+
+    match expression {
+        oxc::Expression::Identifier(id) => {
+            lower_identifier_assignment_target(builder, span, kind, id, value)
+        }
+        _ => unreachable!("TypeScript wrapper contains a non-assignable expression"),
+    }
+}
+
+enum SimpleAssignmentTargetRef<'b, 'a> {
+    Identifier(&'b oxc::IdentifierReference<'a>),
+    Member(&'b oxc::MemberExpression<'a>),
+}
+
+/// Unwrap TypeScript-only assignment-target wrappers while retaining the
+/// underlying identifier or member reference used at runtime.
+fn simple_assignment_target_ref<'b, 'a>(
+    target: &'b oxc::AssignmentTarget<'a>,
+) -> Option<SimpleAssignmentTargetRef<'b, 'a>> {
+    target.as_simple_assignment_target().and_then(simple_assignment_target_ref_from_simple)
+}
+
+fn simple_assignment_target_ref_from_simple<'b, 'a>(
+    target: &'b oxc::SimpleAssignmentTarget<'a>,
+) -> Option<SimpleAssignmentTargetRef<'b, 'a>> {
+    match target {
+        oxc::SimpleAssignmentTarget::AssignmentTargetIdentifier(id) => {
+            Some(SimpleAssignmentTargetRef::Identifier(id))
+        }
+        oxc::SimpleAssignmentTarget::StaticMemberExpression(_)
+        | oxc::SimpleAssignmentTarget::ComputedMemberExpression(_)
+        | oxc::SimpleAssignmentTarget::PrivateFieldExpression(_) => {
+            Some(SimpleAssignmentTargetRef::Member(target.to_member_expression()))
+        }
+        oxc::SimpleAssignmentTarget::TSAsExpression(node) => {
+            simple_assignment_target_expression_ref(&node.expression)
+        }
+        oxc::SimpleAssignmentTarget::TSSatisfiesExpression(node) => {
+            simple_assignment_target_expression_ref(&node.expression)
+        }
+        oxc::SimpleAssignmentTarget::TSNonNullExpression(node) => {
+            simple_assignment_target_expression_ref(&node.expression)
+        }
+        oxc::SimpleAssignmentTarget::TSTypeAssertion(node) => {
+            simple_assignment_target_expression_ref(&node.expression)
+        }
+    }
+}
+
+fn simple_assignment_target_expression_ref<'b, 'a>(
+    expression: &'b oxc::Expression<'a>,
+) -> Option<SimpleAssignmentTargetRef<'b, 'a>> {
+    let expression = expression.get_inner_expression();
+    match expression {
+        oxc::Expression::Identifier(id) => Some(SimpleAssignmentTargetRef::Identifier(id)),
+        _ => expression.as_member_expression().map(SimpleAssignmentTargetRef::Member),
+    }
+}
+
 /// Assign `value` to an assignment-expression target (`x`, `a.b`, `[a, b]`,
 /// `{a, b}`). Faithful translation of the original `lower_assignment` for the
 /// `PatternLike` cases that came from `AssignmentExpression.left` / destructuring
@@ -1882,65 +2006,19 @@ fn lower_assignment_target<'a>(
 ) -> Result<Option<Place>, OxcDiagnostic> {
     match target {
         oxc::AssignmentTarget::AssignmentTargetIdentifier(id) => {
-            let result = lower_identifier_for_assignment(
-                builder,
-                span,
-                id.span,
-                kind,
-                id.name,
-                builder.scope().resolve_reference(id),
-            )?;
-            match result {
-                None => Ok(None),
-                Some(IdentifierForAssignment::Global { name }) => {
-                    let temp = lower_value_to_temporary(
-                        builder,
-                        InstructionValue::StoreGlobal { name, value, span: Some(span) },
-                    )?;
-                    Ok(Some(temp))
-                }
-                Some(IdentifierForAssignment::Place(place)) => {
-                    if builder.is_context_identifier(builder.scope().resolve_reference(id)) {
-                        let is_hoisted = builder
-                            .scope()
-                            .resolve_reference(id)
-                            .map(|s| builder.environment().is_hoisted_identifier(s))
-                            .unwrap_or(false);
-                        if kind == InstructionKind::Const && !is_hoisted {
-                            builder.record_error(
-                                diagnostics::syntax_expected_const_declaration_not_reassigned_2(
-                                    span,
-                                ),
-                            )?;
-                        }
-                        let temp = lower_value_to_temporary(
-                            builder,
-                            InstructionValue::StoreContext {
-                                lvalue: LValue { place, kind },
-                                value,
-                                span: Some(span),
-                            },
-                        )?;
-                        Ok(Some(temp))
-                    } else {
-                        let temp = lower_value_to_temporary(
-                            builder,
-                            InstructionValue::StoreLocal {
-                                lvalue: LValue { place, kind },
-                                value,
-                                span: Some(span),
-                            },
-                        )?;
-                        Ok(Some(temp))
-                    }
-                }
-            }
+            lower_identifier_assignment_target(builder, span, kind, id, value)
         }
         oxc::AssignmentTarget::StaticMemberExpression(_)
         | oxc::AssignmentTarget::ComputedMemberExpression(_)
         | oxc::AssignmentTarget::PrivateFieldExpression(_) => {
             let simple = target.as_simple_assignment_target().unwrap();
-            lower_member_assignment_target(builder, span, kind, simple, value)
+            lower_member_assignment_target(
+                builder,
+                span,
+                kind,
+                simple.to_member_expression(),
+                value,
+            )
         }
         oxc::AssignmentTarget::ArrayAssignmentTarget(pattern) => {
             let alloc = builder.environment().allocator;
@@ -2374,13 +2452,18 @@ fn lower_assignment_target<'a>(
             }
             Ok(Some(temporary))
         }
-        // TS assignment-target wrappers (e.g. `(x as T) = ...`). The original
-        // recorded the TS-faithful Todo once in find_context_identifiers and
-        // returned None here.
-        oxc::AssignmentTarget::TSAsExpression(_)
-        | oxc::AssignmentTarget::TSSatisfiesExpression(_)
-        | oxc::AssignmentTarget::TSNonNullExpression(_)
-        | oxc::AssignmentTarget::TSTypeAssertion(_) => Ok(None),
+        oxc::AssignmentTarget::TSAsExpression(node) => {
+            lower_typed_assignment_target_expression(builder, span, kind, &node.expression, value)
+        }
+        oxc::AssignmentTarget::TSSatisfiesExpression(node) => {
+            lower_typed_assignment_target_expression(builder, span, kind, &node.expression, value)
+        }
+        oxc::AssignmentTarget::TSNonNullExpression(node) => {
+            lower_typed_assignment_target_expression(builder, span, kind, &node.expression, value)
+        }
+        oxc::AssignmentTarget::TSTypeAssertion(node) => {
+            lower_typed_assignment_target_expression(builder, span, kind, &node.expression, value)
+        }
     }
 }
 
@@ -3921,19 +4004,16 @@ fn lower_expression<'a>(
         }
         oxc::Expression::UpdateExpression(update) => {
             let span = Some(update.span);
-            match &update.argument {
-                oxc::SimpleAssignmentTarget::StaticMemberExpression(_)
-                | oxc::SimpleAssignmentTarget::ComputedMemberExpression(_)
-                | oxc::SimpleAssignmentTarget::PrivateFieldExpression(_) => {
+            match simple_assignment_target_ref_from_simple(&update.argument) {
+                Some(SimpleAssignmentTargetRef::Member(member)) => {
                     let binary_op = match update.operator {
                         oxc::UpdateOperator::Increment => BinaryOperator::Addition,
                         oxc::UpdateOperator::Decrement => BinaryOperator::Subtraction,
                     };
                     // Use the member expression's span (not the update expression's)
                     // to match TS behavior where the inner operations use leftExpr.node.span
-                    let member_span = Some(update.argument.span());
-                    let lowered =
-                        lower_member_expression_from_simple_target(builder, &update.argument)?;
+                    let member_span = Some(member.span());
+                    let lowered = lower_member_expression_for_update(builder, member)?;
                     let object = lowered.object;
                     let lowered_property = lowered.property;
                     let property_span = lowered.property_span;
@@ -3985,7 +4065,7 @@ fn lower_expression<'a>(
                     let result_place = if update.prefix { new_value_place } else { prev_value };
                     Ok(InstructionValue::LoadLocal { place: result_place, span: result_place.span })
                 }
-                oxc::SimpleAssignmentTarget::AssignmentTargetIdentifier(ident) => {
+                Some(SimpleAssignmentTargetRef::Identifier(ident)) => {
                     let symbol = builder.scope().resolve_reference(ident);
                     if builder.is_context_identifier(symbol) {
                         builder.record_error(
@@ -4053,7 +4133,7 @@ fn lower_expression<'a>(
                         })
                     }
                 }
-                _ => {
+                None => {
                     builder.record_error(
                         diagnostics::todo_update_expression_unsupported_argument_type(span),
                     )?;
@@ -4194,6 +4274,70 @@ fn lower_expression<'a>(
     }
 }
 
+/// Lower a member assignment while preserving JavaScript's evaluation order:
+/// receiver, computed key, then right-hand side.
+fn lower_member_assignment_expression<'a>(
+    builder: &mut HirBuilder<'a, '_>,
+    member: &oxc::MemberExpression<'a>,
+    right: &oxc::Expression<'a>,
+) -> Result<InstructionValue<'a>, OxcDiagnostic> {
+    let member_span = Some(member.span());
+    let temp = match member {
+        oxc::MemberExpression::StaticMemberExpression(member) => {
+            let object = lower_expression_to_temporary(builder, &member.object)?;
+            let value = lower_expression_to_temporary(builder, right)?;
+            lower_value_to_temporary(
+                builder,
+                InstructionValue::PropertyStore {
+                    object,
+                    property: PropertyLiteral::String(member.property.name),
+                    property_span: Some(member.property.span),
+                    value,
+                    span: member_span,
+                },
+            )?
+        }
+        oxc::MemberExpression::ComputedMemberExpression(member) => {
+            let object = lower_expression_to_temporary(builder, &member.object)?;
+            let property = match &member.expression {
+                oxc::Expression::NumericLiteral(num) => {
+                    MemberProperty::Literal(PropertyLiteral::Number(FloatValue::new(num.value)))
+                }
+                expression => {
+                    MemberProperty::Computed(lower_expression_to_temporary(builder, expression)?)
+                }
+            };
+            let value = lower_expression_to_temporary(builder, right)?;
+            match property {
+                MemberProperty::Literal(property) => lower_value_to_temporary(
+                    builder,
+                    InstructionValue::PropertyStore {
+                        object,
+                        property,
+                        property_span: Some(member.expression.span()),
+                        value,
+                        span: member_span,
+                    },
+                )?,
+                MemberProperty::Computed(property) => lower_value_to_temporary(
+                    builder,
+                    InstructionValue::ComputedStore { object, property, value, span: member_span },
+                )?,
+            }
+        }
+        oxc::MemberExpression::PrivateFieldExpression(member) => {
+            let object = lower_expression_to_temporary(builder, &member.object)?;
+            let property = lower_private_name_to_temporary(builder, member.field.span)?;
+            let value = lower_expression_to_temporary(builder, right)?;
+            lower_value_to_temporary(
+                builder,
+                InstructionValue::ComputedStore { object, property, value, span: member_span },
+            )?
+        }
+    };
+    Ok(InstructionValue::LoadLocal { place: temp, span: temp.span })
+}
+
 /// Lower an `AssignmentExpression`. Faithful translation of the original
 /// `Expression::AssignmentExpression` arm, adapted to oxc's `AssignmentTarget`
 /// split. `=` handles identifier / member / destructuring targets; compound
@@ -4205,6 +4349,11 @@ fn lower_assignment_expression<'a>(
     let span = Some(assign.span);
 
     if matches!(assign.operator, oxc::AssignmentOperator::Assign) {
+        if let Some(SimpleAssignmentTargetRef::Member(member)) =
+            simple_assignment_target_ref(&assign.left)
+        {
+            return lower_member_assignment_expression(builder, member, &assign.right);
+        }
         match &assign.left {
             oxc::AssignmentTarget::AssignmentTargetIdentifier(ident) => {
                 let symbol = builder.scope().resolve_reference(ident);
@@ -4266,73 +4415,6 @@ fn lower_assignment_expression<'a>(
                     }
                 }
             }
-            oxc::AssignmentTarget::StaticMemberExpression(_)
-            | oxc::AssignmentTarget::ComputedMemberExpression(_)
-            | oxc::AssignmentTarget::PrivateFieldExpression(_) => {
-                let simple = assign.left.as_simple_assignment_target().unwrap();
-                let right = lower_expression_to_temporary(builder, &assign.right)?;
-                let left_span = Some(simple.span());
-                let temp = match simple {
-                    oxc::SimpleAssignmentTarget::StaticMemberExpression(member) => {
-                        let object = lower_expression_to_temporary(builder, &member.object)?;
-                        lower_value_to_temporary(
-                            builder,
-                            InstructionValue::PropertyStore {
-                                object,
-                                property: PropertyLiteral::String(member.property.name),
-                                property_span: Some(member.property.span),
-                                value: right,
-                                span: left_span,
-                            },
-                        )?
-                    }
-                    oxc::SimpleAssignmentTarget::ComputedMemberExpression(member) => {
-                        let object = lower_expression_to_temporary(builder, &member.object)?;
-                        if let oxc::Expression::NumericLiteral(num) = &member.expression {
-                            lower_value_to_temporary(
-                                builder,
-                                InstructionValue::PropertyStore {
-                                    object,
-                                    property: PropertyLiteral::Number(FloatValue::new(num.value)),
-                                    property_span: Some(num.span),
-                                    value: right,
-                                    span: left_span,
-                                },
-                            )?
-                        } else {
-                            let prop = lower_expression_to_temporary(builder, &member.expression)?;
-                            lower_value_to_temporary(
-                                builder,
-                                InstructionValue::ComputedStore {
-                                    object,
-                                    property: prop,
-                                    value: right,
-                                    span: left_span,
-                                },
-                            )?
-                        }
-                    }
-                    oxc::SimpleAssignmentTarget::PrivateFieldExpression(member) => {
-                        // Babel modeled `a.#b = x` as a non-computed MemberExpression
-                        // whose property is a PrivateName; the original fell to the
-                        // generic property arm, lowering the PrivateName (which bails
-                        // to an undefined temp) and emitting a ComputedStore.
-                        let object = lower_expression_to_temporary(builder, &member.object)?;
-                        let prop = lower_private_name_to_temporary(builder, member.field.span)?;
-                        lower_value_to_temporary(
-                            builder,
-                            InstructionValue::ComputedStore {
-                                object,
-                                property: prop,
-                                value: right,
-                                span: left_span,
-                            },
-                        )?
-                    }
-                    _ => unreachable!(),
-                };
-                Ok(InstructionValue::LoadLocal { place: temp, span: temp.span })
-            }
             _ => {
                 // Destructuring assignment
                 let right = lower_expression_to_temporary(builder, &assign.right)?;
@@ -4382,8 +4464,8 @@ fn lower_assignment_expression<'a>(
             }
         };
 
-        match &assign.left {
-            oxc::AssignmentTarget::AssignmentTargetIdentifier(ident) => {
+        match simple_assignment_target_ref(&assign.left) {
+            Some(SimpleAssignmentTargetRef::Identifier(ident)) => {
                 let ident_span = ident.span;
                 let symbol = builder.scope().resolve_reference(ident);
                 let left_place = lower_identifier(builder, ident.name, ident_span, symbol)?;
@@ -4455,12 +4537,9 @@ fn lower_assignment_expression<'a>(
                     }
                 }
             }
-            oxc::AssignmentTarget::StaticMemberExpression(_)
-            | oxc::AssignmentTarget::ComputedMemberExpression(_)
-            | oxc::AssignmentTarget::PrivateFieldExpression(_) => {
-                let simple = assign.left.as_simple_assignment_target().unwrap();
-                let member_span = Some(simple.span());
-                let lowered = lower_member_expression_from_simple_target(builder, simple)?;
+            Some(SimpleAssignmentTargetRef::Member(member)) => {
+                let member_span = Some(member.span());
+                let lowered = lower_member_expression(builder, member)?;
                 let object = lowered.object;
                 let lowered_property = lowered.property;
                 let property_span = lowered.property_span;
@@ -4491,7 +4570,7 @@ fn lower_assignment_expression<'a>(
                     }),
                 }
             }
-            _ => {
+            None => {
                 builder.record_error(
                     diagnostics::todo_compound_assignment_complex_pattern_not_yet_supported(span),
                 )?;

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
@@ -35,10 +35,8 @@ use oxc_ast::ast::*;
 use oxc_ast::match_assignment_target;
 use oxc_ast_visit::VisitJs;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_span::Span;
 use oxc_syntax::scope::ScopeFlags;
 
-use crate::diagnostics;
 use crate::scope::ScopeId;
 use crate::scope::ScopeResolver;
 use crate::scope::SymbolId;
@@ -62,7 +60,6 @@ struct ContextIdentifierVisitor<'a> {
     /// Empty when at the top level of the function being compiled.
     function_stack: Vec<ScopeId>,
     binding_info: FxHashMap<SymbolId, BindingInfo>,
-    error: Option<OxcDiagnostic>,
 }
 
 impl<'a> ContextIdentifierVisitor<'a> {
@@ -127,18 +124,6 @@ impl<'a> ContextIdentifierVisitor<'a> {
                 info.reassigned_by_inner_fn = true;
             }
         }
-    }
-
-    /// Record the TS-faithful Todo for an unsupported assignment-target wrapper
-    /// node, recording the error once (the first time it is hit).
-    fn record_unsupported_lval(&mut self, type_name: &str, span: Span) {
-        if self.error.is_some() {
-            return;
-        }
-        self.error = Some(diagnostics::unsupported_object_destructuring_assignment_target(
-            type_name,
-            Some(span),
-        ));
     }
 }
 
@@ -253,17 +238,13 @@ impl<'a> VisitJs<'a> for ContextIdentifierVisitor<'a> {
 
     fn visit_assignment_expression(&mut self, it: &AssignmentExpression<'a>) {
         let current_scope = self.current_scope();
-        if self.error.is_none() {
-            self.walk_assignment_target_for_reassignment(&it.left, current_scope);
-        }
+        self.walk_assignment_target_for_reassignment(&it.left, current_scope);
         oxc_ast_visit::walk_js::walk_assignment_expression(self, it);
     }
 
     fn visit_update_expression(&mut self, it: &UpdateExpression<'a>) {
-        if let SimpleAssignmentTarget::AssignmentTargetIdentifier(ident) = &it.argument {
-            let current_scope = self.current_scope();
-            self.handle_reassignment_identifier(&ident.name, current_scope);
-        }
+        let current_scope = self.current_scope();
+        self.walk_simple_assignment_target_for_reassignment(&it.argument, current_scope);
         oxc_ast_visit::walk_js::walk_update_expression(self, it);
     }
 
@@ -340,19 +321,85 @@ impl<'a> ContextIdentifierVisitor<'a> {
             AssignmentTarget::StaticMemberExpression(_)
             | AssignmentTarget::ComputedMemberExpression(_)
             | AssignmentTarget::PrivateFieldExpression(_) => {}
-            // Unsupported TS assignment-target wrappers throw a TS-faithful Todo.
             AssignmentTarget::TSAsExpression(node) => {
-                self.record_unsupported_lval("TSAsExpression", node.span);
+                self.walk_assignment_target_expression_for_reassignment(
+                    &node.expression,
+                    current_scope,
+                );
             }
             AssignmentTarget::TSSatisfiesExpression(node) => {
-                self.record_unsupported_lval("TSSatisfiesExpression", node.span);
+                self.walk_assignment_target_expression_for_reassignment(
+                    &node.expression,
+                    current_scope,
+                );
             }
             AssignmentTarget::TSNonNullExpression(node) => {
-                self.record_unsupported_lval("TSNonNullExpression", node.span);
+                self.walk_assignment_target_expression_for_reassignment(
+                    &node.expression,
+                    current_scope,
+                );
             }
             AssignmentTarget::TSTypeAssertion(node) => {
-                self.record_unsupported_lval("TSTypeAssertion", node.span);
+                self.walk_assignment_target_expression_for_reassignment(
+                    &node.expression,
+                    current_scope,
+                );
             }
+        }
+    }
+
+    fn walk_assignment_target_expression_for_reassignment(
+        &mut self,
+        expression: &Expression<'a>,
+        current_scope: ScopeId,
+    ) {
+        match expression.get_inner_expression() {
+            Expression::Identifier(ident) => {
+                self.handle_reassignment_identifier(&ident.name, current_scope);
+            }
+            Expression::StaticMemberExpression(_)
+            | Expression::ComputedMemberExpression(_)
+            | Expression::PrivateFieldExpression(_) => {}
+            _ => unreachable!("TypeScript wrapper contains a non-assignable expression"),
+        }
+    }
+
+    fn walk_simple_assignment_target_for_reassignment(
+        &mut self,
+        target: &SimpleAssignmentTarget<'a>,
+        current_scope: ScopeId,
+    ) {
+        match target {
+            SimpleAssignmentTarget::AssignmentTargetIdentifier(ident) => {
+                self.handle_reassignment_identifier(&ident.name, current_scope);
+            }
+            SimpleAssignmentTarget::TSAsExpression(node) => {
+                self.walk_assignment_target_expression_for_reassignment(
+                    &node.expression,
+                    current_scope,
+                );
+            }
+            SimpleAssignmentTarget::TSSatisfiesExpression(node) => {
+                self.walk_assignment_target_expression_for_reassignment(
+                    &node.expression,
+                    current_scope,
+                );
+            }
+            SimpleAssignmentTarget::TSNonNullExpression(node) => {
+                self.walk_assignment_target_expression_for_reassignment(
+                    &node.expression,
+                    current_scope,
+                );
+            }
+            SimpleAssignmentTarget::TSTypeAssertion(node) => {
+                self.walk_assignment_target_expression_for_reassignment(
+                    &node.expression,
+                    current_scope,
+                );
+            }
+            SimpleAssignmentTarget::StaticMemberExpression(_)
+            | SimpleAssignmentTarget::ComputedMemberExpression(_)
+            | SimpleAssignmentTarget::PrivateFieldExpression(_) => {}
         }
     }
 
@@ -408,7 +455,6 @@ pub fn find_context_identifiers(
         scope_stack: vec![func_scope],
         function_stack: Vec::new(),
         binding_info: FxHashMap::default(),
-        error: None,
     };
 
     // Walk params and body (like Babel's func.traverse()): the function node
@@ -424,10 +470,6 @@ pub fn find_context_identifiers(
             visitor.visit_formal_parameters(&arrow.params);
             visitor.visit_arrow_function_body(&arrow.body);
         }
-    }
-
-    if let Some(error) = visitor.error {
-        return Err(error);
     }
 
     // Supplement the walker-based analysis with resolved-reference data.

--- a/crates/oxc_react_compiler/tests/snapshots/error.todo-rust-as-expression-assignment-target.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.todo-rust-as-expression-assignment-target.snap
@@ -1,9 +1,0 @@
----
-source: crates/oxc_react_compiler/tests/snapshot.rs
-input_file: crates/oxc_react_compiler/fixtures/error.todo-rust-as-expression-assignment-target.tsx
----
-Diagnostics:
-
-OxcDiagnostic { inner: OxcDiagnosticInner { message: "[FindContextIdentifiers] Cannot handle Object destructuring assignment target TSAsExpression", labels: [LabeledSpan { label: Some("Unsupported destructuring assignment target `TSAsExpression`"), span: Span { start: 52, end: 84 }, primary: true }], help: Some("Rewrite the highlighted code using syntax supported by React Compiler"), note: Some("React Compiler skipped optimizing this component or hook"), severity: Warning, code: OxcCode { scope: Some("react-compiler"), number: Some("Todo") }, url: Some("https://react.dev/reference/eslint-plugin-react-hooks/lints/unsupported-syntax") } }
-
-No changes.

--- a/crates/oxc_react_compiler/tests/snapshots/typescript-assignment-targets.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/typescript-assignment-targets.snap
@@ -1,0 +1,43 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/typescript-assignment-targets.ts
+---
+import { c as _c } from "react/compiler-runtime";
+function Component(props) {
+	const $ = _c(3);
+	let obj;
+	let t0;
+	if ($[0] !== props.value) {
+		let local = 0;
+		obj = { x: props.value };
+		const read = () => local;
+		local = obj.x;
+		local = obj.x;
+		local = local + 1;
+		local = local + 1;
+		obj.x = local;
+		obj.x = local;
+		obj.x = local;
+		obj.x = local;
+		getObject()[getKey()] = getValue();
+		local = local + 1;
+		local = local - 1;
+		local = local * 2;
+		obj.x = obj.x + local;
+		obj.x = obj.x - local;
+		obj.x = obj.x * local;
+		obj.x = obj.x + 1;
+		t0 = read();
+		$[0] = props.value;
+		$[1] = obj;
+		$[2] = t0;
+	} else {
+		obj = $[1];
+		t0 = $[2];
+	}
+	return t0 + obj.x + 1;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{ value: 0 }]
+};

--- a/crates/oxc_react_compiler/tests/snapshots/typescript-captured-update-target.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/typescript-captured-update-target.snap
@@ -1,0 +1,9 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/typescript-captured-update-target.ts
+---
+Diagnostics:
+
+OxcDiagnostic { inner: OxcDiagnosticInner { message: "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas.", labels: [LabeledSpan { label: None, span: Span { start: 71, end: 90 }, primary: true }], help: Some("Rewrite the highlighted code using syntax supported by React Compiler"), note: Some("React Compiler skipped optimizing this component or hook"), severity: Warning, code: OxcCode { scope: Some("react-compiler"), number: Some("Todo") }, url: Some("https://react.dev/reference/eslint-plugin-react-hooks/lints/unsupported-syntax") } }
+
+No changes.

--- a/crates/oxc_react_compiler/tests/transform.rs
+++ b/crates/oxc_react_compiler/tests/transform.rs
@@ -9,7 +9,9 @@ use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 
-use oxc_react_compiler::{CompileResult, ErrorCategory, PanicThreshold, PluginOptions, compile};
+use oxc_react_compiler::{
+    CompilationMode, CompileResult, ErrorCategory, PanicThreshold, PluginOptions, compile,
+};
 
 fn options() -> PluginOptions {
     PluginOptions::default()
@@ -338,6 +340,25 @@ fn ts_wrapped_assignment_targets_do_not_panic() {
         let allocator = Allocator::default();
         let _ = transform_source(source, SourceType::tsx(), &allocator, opts.clone());
     }
+}
+
+#[test]
+fn ts_type_assertion_assignment_target_compiles() {
+    let source = "function Component(props: {x: number}) {\n  let x = 0;\n  const obj = {x: 1};\n  (<number>x) = props.x;\n  (<number>x) += 1;\n  (<number>obj.x) *= x;\n  return x + obj.x;\n}\n";
+    let allocator = Allocator::default();
+    let mut opts = options();
+    opts.compilation_mode = CompilationMode::All;
+    let (program, result) = transform_source(source, SourceType::ts(), &allocator, opts);
+
+    assert!(result.changed, "component should compile; diagnostics: {:?}", result.diagnostics);
+    assert!(result.diagnostics.is_empty(), "unexpected diagnostics: {:?}", result.diagnostics);
+    let output = Codegen::new().build(&program).code;
+    assert!(output.contains("x = props.x"), "type assertion assignment was lost:\n{output}");
+    assert!(output.contains("x = x + 1"), "type assertion compound assignment was lost:\n{output}");
+    assert!(
+        output.contains("obj.x = obj.x * x"),
+        "type assertion member compound assignment was lost:\n{output}"
+    );
 }
 
 /// Class bodies are stubbed by the converter and re-parsed from source on the


### PR DESCRIPTION
Support TypeScript-wrapped assignment targets in context analysis and HIR lowering.

AI-assisted; reviewed and validated by the contributor.