### PR TITLE
fix(react-compiler): support dynamic imports

### DIFF
--- a/crates/oxc_react_compiler/fixtures/dynamic-import-options.js
+++ b/crates/oxc_react_compiler/fixtures/dynamic-import-options.js
@@ -1,0 +1,19 @@
+function loadModule(name, options) {
+  return import(name, options);
+}
+
+function loadSource(name) {
+  return import.source(name);
+}
+
+function loadDeferred(name) {
+  return import.defer(name);
+}
+
+function loadWebpackChunk() {
+  return import(/* webpackChunkName: "settings" */ './settings');
+}
+
+function loadViteUrl(url) {
+  return import(/* @vite-ignore */ url);
+}

--- a/crates/oxc_react_compiler/fixtures/dynamic-import.js
+++ b/crates/oxc_react_compiler/fixtures/dynamic-import.js
@@ -1,7 +1,3 @@
-// HIR Pattern: UNSUPPORTED_NODE_FORMAT (186 files, 56%)
-// UnsupportedNode: TS includes type:"Import", Rust omits it
-// Also: error reason text differs
-
 const ConfirmationCodeInput = React.lazy(
   () => import('ConfirmationCodeInput.react')
 ) as React.ComponentType<React.ElementConfig<ConfirmationCodeInputType>>;

--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -821,16 +821,6 @@ where
 }
 
 #[cold]
-pub fn todo_build_hir_lower_expression_handle_import_expressions<L, T>(labels: T) -> OxcDiagnostic
-where
-    L: Into<oxc_diagnostics::LabeledSpan>,
-    T: IntoIterator<Item = L>,
-{
-    diagnostic(ErrorCategory::Todo, "(BuildHIR::lowerExpression) Handle Import expressions")
-        .with_labels(labels)
-}
-
-#[cold]
 pub fn todo_build_hir_lower_expression_handle_private_name_expressions<L, T>(
     labels: T,
 ) -> OxcDiagnostic

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/compile_result.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/compile_result.rs
@@ -43,6 +43,8 @@ pub struct CodegenFunction<'a> {
     pub memo_values: u32,
     pub pruned_memo_blocks: u32,
     pub pruned_memo_values: u32,
+    /// Spans of dynamic imports emitted directly by this function.
+    pub dynamic_import_spans: Vec<Span>,
     pub outlined: Vec<OutlinedFunction<'a>>,
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -398,6 +398,7 @@ fn run_pipeline<'a>(
         memo_values: codegen_result.memo_values,
         pruned_memo_blocks: codegen_result.pruned_memo_blocks,
         pruned_memo_values: codegen_result.pruned_memo_values,
+        dynamic_import_spans: codegen_result.dynamic_import_spans,
         outlined: codegen_result.outlined,
     })))
 }

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -2233,6 +2233,13 @@ struct OxcReplacement<'a> {
     gating: Option<GatingConfig>,
 }
 
+fn collect_dynamic_import_spans(codegen_fn: &CodegenFunction<'_>, spans: &mut Vec<Span>) {
+    spans.extend_from_slice(&codegen_fn.dynamic_import_spans);
+    for outlined in &codegen_fn.outlined {
+        collect_dynamic_import_spans(&outlined.func, spans);
+    }
+}
+
 /// The owned output of a [`compile`](crate::compile) that produced changes:
 /// everything the transform phase needs, carrying only the arena lifetime — no
 /// borrows of the input `Program` or `Semantic` — so the caller can drop its
@@ -2240,6 +2247,7 @@ struct OxcReplacement<'a> {
 pub struct CompileOutput<'a> {
     replacements: Vec<OxcReplacement<'a>>,
     context: ProgramContext<'a>,
+    dynamic_import_spans: Vec<Span>,
 }
 
 impl<'a> CompileOutput<'a> {
@@ -2251,23 +2259,35 @@ impl<'a> CompileOutput<'a> {
     /// `program` must be the same, unmodified program [`compile`](crate::compile)
     /// saw. Afterwards any previously computed `Semantic`/`Scoping` is stale.
     pub fn transform(self, program: &mut Program<'a>) {
-        let CompileOutput { replacements, mut context } = self;
+        let CompileOutput { replacements, mut context, dynamic_import_spans } = self;
         let ast = AstBuilder::new(context.allocator());
         ox_transform_program(&ast, program, &replacements, &mut context);
         // Diagnostics were extracted at the end of compilation; nothing in the
         // transform phase may add more.
         debug_assert!(context.diagnostics.is_empty());
-        prune_inner_comments(program);
+        prune_inner_comments(program, dynamic_import_spans);
     }
 }
 
-/// Drop comments left dangling by compilation.
-///
-/// Rewritten functions may no longer contain the statements comments were attached to.
-fn prune_inner_comments(program: &mut Program<'_>) {
+/// Drop comments left dangling by compilation while retaining comments inside
+/// rebuilt dynamic imports. Bundlers use those comments for directives such as
+/// chunk names and ignored runtime URLs.
+fn prune_inner_comments(program: &mut Program<'_>, mut import_spans: Vec<Span>) {
     if program.comments.is_empty() {
         return;
     }
+    import_spans.sort_unstable_by_key(|span| span.start);
+    let mut merged_import_spans: Vec<Span> = Vec::with_capacity(import_spans.len());
+    for span in import_spans {
+        if let Some(previous) = merged_import_spans.last_mut()
+            && span.start <= previous.end
+        {
+            previous.end = previous.end.max(span.end);
+        } else {
+            merged_import_spans.push(span);
+        }
+    }
+
     let mut top_level_starts = FxHashSet::default();
     top_level_starts.insert(0u32);
     for stmt in &program.body {
@@ -2276,7 +2296,13 @@ fn prune_inner_comments(program: &mut Program<'_>) {
             top_level_starts.insert(start);
         }
     }
-    program.comments.retain(|comment| top_level_starts.contains(&comment.attached_to));
+    program.comments.retain(|comment| {
+        if top_level_starts.contains(&comment.attached_to) {
+            return true;
+        }
+        let index = merged_import_spans.partition_point(|span| span.start <= comment.span.start);
+        index > 0 && comment.span.end <= merged_import_spans[index - 1].end
+    });
 }
 
 /// Copy the TS metadata (type annotation, decorators, optional/modifier flags)
@@ -3263,9 +3289,11 @@ pub fn compile_program<'a>(
     // (`use memo if(identifier)`) takes precedence over plugin-level gating; gating
     // only applies to 'original' (not 'outlined') functions. Mirrors the Babel path.
     let function_gating_config = options.gating.clone();
+    let mut dynamic_import_spans = Vec::new();
     let replacements: Vec<OxcReplacement<'a>> = compiled_fns
         .into_iter()
         .map(|cf| {
+            collect_dynamic_import_spans(&cf.codegen_fn, &mut dynamic_import_spans);
             let gating = if cf.kind == CompileSourceKind::Original {
                 let dynamic_gating =
                     find_directives_dynamic_gating(&cf.source.body_directives, &options)
@@ -3297,7 +3325,7 @@ pub fn compile_program<'a>(
     let output = if replacements.is_empty() {
         None
     } else {
-        Some(Box::new(CompileOutput { replacements, context }))
+        Some(Box::new(CompileOutput { replacements, context, dynamic_import_spans }))
     };
     CompileResult::Success { output, diagnostics }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -1017,19 +1017,24 @@ fn template_quasi_from_oxc<'a>(q: &oxc::TemplateElement<'a>) -> TemplateQuasi<'a
     TemplateQuasi { raw: q.value.raw, cooked: q.value.cooked, span: q.span }
 }
 
-/// Lower the `import` keyword callee of an `ImportExpression`. The original Babel
-/// path treats this as the `Import` node, which bails (records an error) and
-/// returns an undefined primitive that is then loaded to a temporary.
+/// Lower the `import` keyword callee of an `ImportExpression` as a special global
+/// function reference. Keeping the call in the existing `CallExpression` HIR path
+/// preserves argument ordering and unknown-call effects, while codegen emits the
+/// identifier as the dynamic import keyword.
 fn lower_import_keyword_to_temporary(
     builder: &mut HirBuilder<'_, '_>,
     span: &Option<Span>,
+    name: &'static str,
 ) -> Result<Place, OxcDiagnostic> {
-    builder.record_error(
-        diagnostics::todo_build_hir_lower_expression_handle_import_expressions(*span),
-    )?;
     lower_value_to_temporary(
         builder,
-        InstructionValue::Primitive { value: PrimitiveValue::Undefined, span: *span },
+        InstructionValue::LoadGlobal {
+            // The synthetic dotted names preserve import phases until codegen.
+            // They cannot collide with source bindings because `.` is not valid
+            // in an identifier and the marker is never emitted as an identifier.
+            binding: NonLocalBinding::Global { name: Ident::from(name) },
+            span: *span,
+        },
     )
 }
 
@@ -4010,14 +4015,19 @@ fn lower_expression<'a>(
         oxc::Expression::ImportExpression(imp) => {
             // oxc's `import(source, options?)` maps to Babel's
             // `CallExpression { callee: Import, arguments: [source] + options? }`.
-            // The `Import` keyword callee bails (records an error), then the source
-            // and options arguments are lowered left-to-right.
+            // The source and options arguments are lowered left-to-right.
             let span = Some(imp.span);
             // The `import` keyword has no standalone node in oxc; synthesize its
-            // span ([start, start+6)) so the callee bail error and temporary carry
-            // the keyword span, matching Babel's `Import` node span.
+            // span ([start, start+6)) so the callee temporary carries the keyword
+            // span, matching Babel's `Import` node span.
             let import_keyword_span = Some(oxc_span::Span::new(imp.span.start, imp.span.start + 6));
-            let callee = lower_import_keyword_to_temporary(builder, &import_keyword_span)?;
+            let callee_name = match imp.phase {
+                None => "import",
+                Some(oxc::ImportPhase::Source) => "import.source",
+                Some(oxc::ImportPhase::Defer) => "import.defer",
+            };
+            let callee =
+                lower_import_keyword_to_temporary(builder, &import_keyword_span, callee_name)?;
             let alloc = builder.environment().allocator;
             let mut args = ArenaVec::new_in(&alloc);
             let source = lower_expression_to_temporary(builder, &imp.source)?;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -160,6 +160,8 @@ pub fn codegen_function<'a>(
         )
     });
 
+    let dynamic_import_spans = std::mem::take(&mut cx.dynamic_import_spans);
+
     // Release the borrow of `env` held by `cx` so the outlined functions can be
     // compiled with fresh contexts (mirrors TS `codegenFunction`).
     drop(cx);
@@ -179,6 +181,7 @@ pub fn codegen_function<'a>(
         memo_values: compiled.memo_values,
         pruned_memo_blocks: compiled.pruned_memo_blocks,
         pruned_memo_values: compiled.pruned_memo_values,
+        dynamic_import_spans,
         outlined,
     })
 }
@@ -275,6 +278,7 @@ struct OxcContext<'a, 'env> {
     unique_identifiers: IdentHashSet<'a>,
     fbt_operands: FxHashSet<IdentifierId>,
     synthesized_names: IdentHashMap<'a, Ident<'a>>,
+    dynamic_import_spans: Vec<Span>,
 }
 
 impl<'a, 'env> OxcContext<'a, 'env> {
@@ -294,6 +298,7 @@ impl<'a, 'env> OxcContext<'a, 'env> {
             unique_identifiers,
             fbt_operands,
             synthesized_names: IdentHashMap::default(),
+            dynamic_import_spans: Vec::new(),
         }
     }
 
@@ -1950,6 +1955,37 @@ fn ox_codegen_base_instruction_value<'a>(
         )),
         InstructionValue::CallExpression { callee, args, .. } => {
             let callee_expr = ox_codegen_place_to_expression(cx, callee)?;
+            let import_phase = match &callee_expr {
+                oxc::Expression::Identifier(identifier) => match identifier.name.as_str() {
+                    "import" => Some(None),
+                    "import.source" => Some(Some(oxc::ImportPhase::Source)),
+                    "import.defer" => Some(Some(oxc::ImportPhase::Defer)),
+                    _ => None,
+                },
+                _ => None,
+            };
+            if let Some(phase) = import_phase {
+                cx.dynamic_import_spans.push(span);
+                let source = match args.first() {
+                    Some(PlaceOrSpread::Place(source)) => {
+                        ox_codegen_place_to_expression(cx, source)?
+                    }
+                    _ => unreachable!("dynamic import always has a source expression"),
+                };
+                let options = match args.get(1) {
+                    Some(PlaceOrSpread::Place(options)) => {
+                        Some(ox_codegen_place_to_expression(cx, options)?)
+                    }
+                    Some(PlaceOrSpread::Spread(_)) => {
+                        unreachable!("dynamic import options cannot be spread")
+                    }
+                    None => None,
+                };
+                assert!(args.len() <= 2, "dynamic import has at most two arguments");
+                return Ok(OxValue::Expression(oxc::Expression::new_import_expression(
+                    span, source, options, phase, &cx.ast,
+                )));
+            }
             let arguments = ox_codegen_arguments(cx, args)?;
             let call =
                 ox_create_call_expression(cx, callee_expr, arguments, callee.identifier, span);

--- a/crates/oxc_react_compiler/tests/snapshots/dynamic-import-options.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/dynamic-import-options.snap
@@ -1,0 +1,71 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/dynamic-import-options.js
+---
+import { c as _c } from "react/compiler-runtime";
+function loadModule(name, options) {
+	const $ = _c(3);
+	let t0;
+	if ($[0] !== name || $[1] !== options) {
+		t0 = import(name, options);
+		$[0] = name;
+		$[1] = options;
+		$[2] = t0;
+	} else {
+		t0 = $[2];
+	}
+	return t0;
+}
+function loadSource(name) {
+	const $ = _c(2);
+	let t0;
+	if ($[0] !== name) {
+		t0 = import.source(name);
+		$[0] = name;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}
+function loadDeferred(name) {
+	const $ = _c(2);
+	let t0;
+	if ($[0] !== name) {
+		t0 = import.defer(name);
+		$[0] = name;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}
+function loadWebpackChunk() {
+	const $ = _c(1);
+	let t0;
+	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		t0 = import(
+			/* webpackChunkName: "settings" */
+			"./settings"
+);
+		$[0] = t0;
+	} else {
+		t0 = $[0];
+	}
+	return t0;
+}
+function loadViteUrl(url) {
+	const $ = _c(2);
+	let t0;
+	if ($[0] !== url) {
+		t0 = import(
+			/* @vite-ignore */
+			url
+);
+		$[0] = url;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}

--- a/crates/oxc_react_compiler/tests/snapshots/dynamic-import.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/dynamic-import.snap
@@ -1,0 +1,19 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/dynamic-import.js
+---
+import { c as _c } from "react/compiler-runtime";
+const ConfirmationCodeInput = React.lazy(() => {
+	const $ = _c(1);
+	let t0;
+	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+		t0 = import("ConfirmationCodeInput.react");
+		$[0] = t0;
+	} else {
+		t0 = $[0];
+	}
+	return t0;
+}) as React.ComponentType<React.ElementConfig<ConfirmationCodeInputType>>;
+export const examples = [{ render(): React.MixedElement {
+	return <ConfirmationCodeInput helperText={isCompleted && `Your code entry is completed: ${value}`} label={fbt()} />;
+} }];

--- a/crates/oxc_react_compiler/tests/snapshots/error.todo-hir_unsupported_node_format.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/error.todo-hir_unsupported_node_format.snap
@@ -1,9 +1,0 @@
----
-source: crates/oxc_react_compiler/tests/snapshot.rs
-input_file: crates/oxc_react_compiler/fixtures/error.todo-hir_unsupported_node_format.js
----
-Diagnostics:
-
-OxcDiagnostic { inner: OxcDiagnosticInner { message: "(BuildHIR::lowerExpression) Handle Import expressions", labels: [LabeledSpan { label: None, span: Span { start: 204, end: 210 }, primary: true }], help: Some("Rewrite the highlighted code using syntax supported by React Compiler"), note: Some("React Compiler skipped optimizing this component or hook"), severity: Warning, code: OxcCode { scope: Some("react-compiler"), number: Some("Todo") }, url: Some("https://react.dev/reference/eslint-plugin-react-hooks/lints/unsupported-syntax") } }
-
-No changes.


### PR DESCRIPTION
Support dynamic import expressions, including options and source/defer phases.

AI-assisted; reviewed and validated by the contributor.