### PR TITLE
perf(linter): outline diagnostic construction

### DIFF
--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -291,11 +291,15 @@ impl Diagnostic for OxcDiagnostic {
 
 impl OxcDiagnostic {
     /// Create new an error-level [`OxcDiagnostic`].
+    #[cold]
+    #[inline(never)]
     pub fn error<T: Into<Cow<'static, str>>>(message: T) -> Self {
         Self::new(Severity::Error, message.into())
     }
 
     /// Create new a warning-level [`OxcDiagnostic`].
+    #[cold]
+    #[inline(never)]
     pub fn warn<T: Into<Cow<'static, str>>>(message: T) -> Self {
         Self::new(Severity::Warning, message.into())
     }
@@ -307,6 +311,7 @@ impl OxcDiagnostic {
 
     // Outlined so the `Box` allocation + field initialization exists once in the binary
     // instead of being inlined into every diagnostic construction site.
+    #[cold]
     #[inline(never)]
     fn new(severity: Severity, message: Cow<'static, str>) -> Self {
         Self {
@@ -384,6 +389,8 @@ impl OxcDiagnostic {
     ///         .with_help("Run my_tool --init to set up a new config file"));
     /// }
     /// ```
+    #[cold]
+    #[inline(never)]
     pub fn with_help<T: Into<Cow<'static, str>>>(mut self, help: T) -> Self {
         self.inner.help = Some(help.into());
         self
@@ -403,6 +410,8 @@ impl OxcDiagnostic {
     ///         .with_note("Some useful information or suggestion"));
     /// }
     /// ```
+    #[cold]
+    #[inline(never)]
     pub fn with_note<T: Into<Cow<'static, str>>>(mut self, note: T) -> Self {
         self.inner.note = Some(note.into());
         self

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -284,7 +284,8 @@ impl<'a> LintContext<'a> {
     /// Report a lint rule violation.
     ///
     /// Use [`LintContext::diagnostic_with_fix`] to provide an automatic fix.
-    #[inline]
+    #[cold]
+    #[inline(never)]
     pub fn diagnostic(&self, diagnostic: OxcDiagnostic) {
         self.add_diagnostic(Message::new(diagnostic, PossibleFixes::None));
     }

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -255,6 +255,8 @@ pub struct Message {
 }
 
 impl Message {
+    #[cold]
+    #[inline(never)]
     pub fn new(error: OxcDiagnostic, fixes: PossibleFixes) -> Self {
         let span = error
             .labels


### PR DESCRIPTION
Diagnostic reporting is a cold path, but `LintContext::diagnostic` was explicitly inlined into hundreds of rule bodies. This also duplicated `Message::new`, its primary-label search, and generic diagnostic builders.

Mark these paths `#[cold]` and `#[inline(never)]` so call sites share a few outlined implementations instead of embedding the construction code.

This reduces the stripped aarch64 macOS `oxlint` binary by 224.9 KiB (1.66%; `__text` by 224.3 KiB).

Validated with `just ready` and a release fat-LTO size comparison.

AI assistance: Codex was used to implement and validate this change.