### PR TITLE
perf(lsp): deduplicate server future

### DIFF
--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use futures::future::BoxFuture;
 use rustc_hash::FxBuildHasher;
 use tower_lsp_server::ls_types::Uri;
 use tower_lsp_server::{LspService, Server, ls_types::ServerInfo};
@@ -43,8 +44,19 @@ impl<'a> TextDocument<'a> {
     }
 }
 
-/// Run the language server
-pub async fn run_server(
+/// Run the language server.
+///
+/// The future is type-erased to reduce binary size by preventing CLI and NAPI execution paths from
+/// each generating a copy of the LSP server state machine.
+pub fn run_server(
+    server_name: String,
+    server_version: String,
+    worker_manager: WorkerManager,
+) -> BoxFuture<'static, ()> {
+    Box::pin(run_server_impl(server_name, server_version, worker_manager))
+}
+
+async fn run_server_impl(
     server_name: String,
     server_version: String,
     worker_manager: WorkerManager,


### PR DESCRIPTION
Type-erase the shared LSP server future so CLI and NAPI reuse one async state machine. This removes duplicate LSP machinery and reduced the measured release binary by about 1.3 MiB.

AI assistance was used to implement this change.