### PR TITLE
test(package/codegen): add benchmark with sourcemaps

### DIFF
--- a/packages/codegen/bench.bench.ts
+++ b/packages/codegen/bench.bench.ts
@@ -1,11 +1,27 @@
 // Benchmarks. Run with `pnpm run bench`.
 //
-// Source maps are not measured. `printSync` is given no `sourcemap`, so it selects the builds
-// compiled without source map support, which is what most callers use.
+// Each fixture is printed three ways:
 //
-// Imports from `dist`, which must hold a RELEASE build. `pnpm run build-dev` replaces `dist` with a debug build,
-// which keeps `debugAssert` calls live and does not represent shipped performance.
-// `pnpm run bench` builds a release build first, so benchmarking that way is always correct.
+// 1. Without source maps:
+//    No `sourcemap` option is given, so `printSync` selects the builds compiled without source map support,
+//    which is what most callers use.
+//
+// 2. With source maps:
+//    `sourcemap: true` selects the source-map build, and `sourceText` is provided, so every mapped write
+//    records a mapping and `generateSourceMap` encodes them all into a Source Map v3 object at the end.
+//    This is the end-to-end cost of printing with a source map.
+//
+// 3. With source maps, without generating the map:
+//    Same as 2, except it skips the final `generateSourceMap` pass, measuring the print pass with its pushes
+//    to the mapping arrays alone - the difference from 2 is the cost of encoding the map.
+//
+// All 3 print the same AST. Mappings come from the `start` / `end` offsets every node already carries,
+// so the source-map build sees exactly the node shapes the plain build does.
+//
+// Imports from `dist`, which must hold a RELEASE build with `BENCHMARKS` enabled.
+// `pnpm run build-dev` replaces `dist` with a debug build, which keeps `debugAssert` calls live
+// and does not represent shipped performance.
+// `pnpm run bench` builds the right build first, so benchmarking that way is always correct.
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join as pathJoin } from "node:path";
@@ -92,14 +108,48 @@ for (const { filename, code } of fixtures) {
   // `.tsx`/`.jsx` fixtures need JSX-safe printing of type parameter lists (`<T,>`)
   const options = { jsx: filename.endsWith("x"), ts: /\.tsx?$/.test(filename) };
 
-  // Print once before timing, so a benchmark can never measure the printer bailing out.
+  // Options for the 2 source-map variants. `sourceText` is what mapped writes read to record
+  // an original name, and what `generateSourceMap` scans for line breaks at the end.
+  //
+  // `skipSourcemapGeneration` is spelled out in both, so the 2 objects share one shape -
+  // `printSync` and the `State` constructor read these options on every call.
+  // It is benchmarks-only, so it is absent from `Options`, which is why neither object is passed
+  // as a literal - an excess property is an error on a literal, but not on a variable.
+  const mapOptions = {
+    ...options,
+    sourcemap: true,
+    sourceText: code,
+    sourceFilename: filename,
+    skipSourcemapGeneration: false,
+  };
+  const mapNoGenerationOptions = { ...mapOptions, skipSourcemapGeneration: true };
+
+  // Print once before timing, so a benchmark can never measure the printer bailing out
   oxcPrintSync(program, options);
+  oxcPrintSync(program, mapOptions);
+  oxcPrintSync(program, mapNoGenerationOptions);
 
   describe(`${filename} (${code.length} bytes)`, () => {
     bench(
       "oxc-codegen",
       () => {
         oxcPrintSync(program, options);
+      },
+      BENCH_OPTIONS,
+    );
+
+    bench(
+      "oxc-codegen sourcemaps",
+      () => {
+        oxcPrintSync(program, mapOptions);
+      },
+      BENCH_OPTIONS,
+    );
+
+    bench(
+      "oxc-codegen sourcemaps no generation",
+      () => {
+        oxcPrintSync(program, mapNoGenerationOptions);
       },
       BENCH_OPTIONS,
     );

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -39,7 +39,9 @@
     "build": "node scripts/build.ts",
     "build-dev": "cross-env DEBUG=true node scripts/build.ts",
     "build-test": "pnpm run build-dev && pnpm --filter oxc-parser run build-test && pnpm --filter oxc-codegen-conformance run build",
-    "test": "vitest run --dir ./test"
+    "build-bench": "cross-env BENCHMARKS=true node scripts/build.ts",
+    "test": "vitest run --dir ./test",
+    "bench": "pnpm run build-bench && vitest bench --run bench.bench.ts"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/codegen/src-js/globals.d.ts
+++ b/packages/codegen/src-js/globals.d.ts
@@ -12,3 +12,9 @@ declare const TS: boolean;
 // Built with `pnpm run build-dev`, which sets `DEBUG=true`. Debug builds keep `debugAssert` calls
 // (see `src/asserts.ts`). Release builds strip them in `tsdown_plugins/remove_asserts.ts`.
 declare const DEBUG: boolean;
+
+// `true` if is benchmark build.
+// Built with `pnpm run bench`, which sets `BENCHMARKS=true`. Benchmark builds honor the
+// `skipSourcemapGeneration` option, so a benchmark can measure the print pass without the final
+// source map generation. In normal builds the option does nothing and the check folds away.
+declare const BENCHMARKS: boolean;

--- a/packages/codegen/src-js/print/index.ts
+++ b/packages/codegen/src-js/print/index.ts
@@ -37,8 +37,13 @@ export function printSync(node: ESTree.Node, state: State, options: Options): Co
     printStatement(node, state);
   }
 
-  // This is removed by minifier in non-sourcemap builds
-  if (SOURCEMAPS) {
+  // This is removed by minifier in non-sourcemap builds.
+  //
+  // The `skipSourcemapGeneration` check exists only in benchmark builds -
+  // everywhere else `BENCHMARKS` is `false` and the condition folds back to `SOURCEMAPS` alone.
+  // The option is deliberately not in `Options` - types are documentation, and it is not public API.
+  // @ts-expect-error `skipSourcemapGeneration` is benchmarks-only, so is not in `Options`
+  if (SOURCEMAPS && (!BENCHMARKS || !options.skipSourcemapGeneration)) {
     debugAssert(options.sourcemap === true, "`options.sourcemap` should be true in a maps build");
     return { code: state.output, map: generateSourceMap(state, options) };
   }

--- a/packages/codegen/tsdown.config.ts
+++ b/packages/codegen/tsdown.config.ts
@@ -16,12 +16,19 @@ const isEnabled = (env: string | undefined) => env === "true" || env === "1";
 // It replaces the release build in `dist`, so rebuild with `pnpm run build` before benchmarking.
 const DEBUG = isEnabled(process.env.DEBUG);
 
+// When run with `pnpm run bench`, generate a build which honors the `skipSourcemapGeneration` option,
+// so the benchmarks can measure the print pass without source map generation.
+const BENCHMARKS = isEnabled(process.env.BENCHMARKS);
+
 // Only remove assertions in release build. Debug builds keep `debugAssert` calls live.
 const assertPlugins = DEBUG ? [] : [removeAssertsPlugin];
 
 // Global constants defined at build time. See `src-js/globals.d.ts`.
 // `DEBUG: false` lets the minifier remove the body of `debugAssert` and any other debug-only code.
-const definedGlobals = { DEBUG: DEBUG ? "true" : "false" };
+const definedGlobals = {
+  DEBUG: DEBUG ? "true" : "false",
+  BENCHMARKS: BENCHMARKS ? "true" : "false",
+};
 
 // Base config.
 // `platform: "node"` because the entry point loads the printer with `createRequire`.


### PR DESCRIPTION
Add benchmarks for source maps in `oxc-codegen`.

2 benchmarks:

1. Full end-to-end.
2. Without the actual sourcemap generation at the end.

The 2nd is to measure the overhead that pushing to the sourcemap arrays adds while printing in isolation.