### PR TITLE
perf(linter): use unstable sorts for unique keys

### DIFF
--- a/apps/oxlint/src/output_formatter/json.rs
+++ b/apps/oxlint/src/output_formatter/json.rs
@@ -64,7 +64,7 @@ impl InternalFormatter for JsonOutputFormatter {
             })
             .collect();
 
-        rules_info.sort_by_key(|rule| (rule.scope, rule.value));
+        rules_info.sort_unstable_by_key(|rule| (rule.scope, rule.value));
 
         Some(serde_json::to_string_pretty(&rules_info).expect("Failed to serialize"))
     }

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -227,7 +227,7 @@ impl OxlintRules {
 
         if !errors.is_empty() {
             // Sort by the error message so output is stable
-            errors.sort_by_key(std::string::ToString::to_string);
+            errors.sort_unstable_by_key(std::string::ToString::to_string);
             return Err(errors);
         }
 

--- a/crates/oxc_linter/src/rules/eslint/constructor_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/constructor_super.rs
@@ -276,7 +276,7 @@ impl Rule for ConstructorSuper {
                     // Treat as single path
                     if super_call_spans.len() > 1 {
                         let mut sorted_spans = super_call_spans;
-                        sorted_spans.sort_by_key(|s| s.start);
+                        sorted_spans.sort_unstable_by_key(|s| s.start);
                         let first_super_span = sorted_spans[0];
 
                         for &span in sorted_spans.iter().skip(1) {
@@ -311,7 +311,7 @@ impl Rule for ConstructorSuper {
 
                     if has_duplicate && super_call_spans.len() > 1 {
                         let mut sorted_spans = super_call_spans;
-                        sorted_spans.sort_by_key(|s| s.start);
+                        sorted_spans.sort_unstable_by_key(|s| s.start);
                         let first_super_span = sorted_spans[0];
 
                         for &span in sorted_spans.iter().skip(1) {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_export_from.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_export_from.rs
@@ -679,7 +679,7 @@ impl PreferExportFrom {
 
         let mut parent_nodes: Vec<&AstNode> =
             violations.iter().map(|v| ctx.nodes().get_node(v.export_node_id)).collect();
-        parent_nodes.sort_by_key(|node| node.span().start);
+        parent_nodes.sort_unstable_by_key(|node| node.span().start);
 
         let replace_export_spans: Vec<Span> = parent_nodes
             .iter()

--- a/crates/oxc_linter/src/table.rs
+++ b/crates/oxc_linter/src/table.rs
@@ -78,7 +78,7 @@ impl RuleTable {
 
         let total = rows.len();
 
-        rows.sort_by_key(|row| (row.plugin.clone(), row.name));
+        rows.sort_unstable_by(|a, b| a.plugin.cmp(&b.plugin).then(a.name.cmp(b.name)));
 
         let rules_with_fixes = rows.iter().filter(|r| r.autofix.has_fix()).count();
 


### PR DESCRIPTION
Switches order-independent sorts to unstable sorting and avoids cloning rule-table plugin names.

Reduces the stripped `oxlint` release binary from 12,773,568 to 12,757,040 bytes: 16,528 bytes (0.13%).

Validated with `cargo test -p oxc_linter` and focused oxlint JSON checks.

AI assistance was used for analysis and implementation.