### PR TITLE
fix(linter/typescript/explicit-module-boundary-types): anchor diagnostics on arrows

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -310,12 +310,19 @@ impl Fn<'_> {
 /// Name and span of the symbol an anonymous function or arrow is assigned to - a variable binding,
 /// class property, or object property key.
 ///
-/// Used so that diagnostics point at, and refer to, that name rather than the anonymous function
-/// expression itself, and so the name can be checked against the `allowedNames` option.
+/// Used so that diagnostics can point at, and refer to, that name rather than the anonymous
+/// function expression itself, and so the name can be checked against the `allowedNames` option.
 #[derive(Clone, Copy)]
 struct TargetSymbol<'a> {
     span: Span,
     name: &'a str,
+    kind: TargetSymbolKind,
+}
+
+#[derive(Clone, Copy)]
+enum TargetSymbolKind {
+    Binding,
+    Property,
 }
 
 struct ExplicitTypesChecker<'a, 'c> {
@@ -355,7 +362,11 @@ impl<'a, 'c> ExplicitTypesChecker<'a, 'c> {
 
     fn with_target_binding(&mut self, binding: Option<&BindingIdentifier<'a>>) -> bool {
         if let Some(id) = binding {
-            self.target_symbol = Some(TargetSymbol { span: id.span, name: id.name.as_str() });
+            self.target_symbol = Some(TargetSymbol {
+                span: id.span,
+                name: id.name.as_str(),
+                kind: TargetSymbolKind::Binding,
+            });
             true
         } else {
             false
@@ -367,7 +378,8 @@ impl<'a, 'c> ExplicitTypesChecker<'a, 'c> {
             return false;
         };
         if let Some(Cow::Borrowed(name)) = id.static_name() {
-            self.target_symbol = Some(TargetSymbol { span: id.span(), name });
+            self.target_symbol =
+                Some(TargetSymbol { span: id.span(), name, kind: TargetSymbolKind::Property });
             true
         } else {
             false
@@ -494,7 +506,23 @@ impl<'a, 'c> ExplicitTypesChecker<'a, 'c> {
         debug_assert!(arrow.return_type.is_none());
         let target = self.target_symbol.as_ref();
         let target_name = target.map(|t| t.name);
-        let span = target.map_or(arrow.params.span, |t| t.span);
+        let span = match target {
+            Some(TargetSymbol { span, kind: TargetSymbolKind::Property, .. }) => *span,
+            // Match typescript-eslint's function-head location for the exported arrow itself.
+            _ if self.fns.len() == 1 => {
+                let arrow_token_start = self
+                    .ctx
+                    .find_prev_token_within(arrow.params.span.end, arrow.body.span().start, "=>")
+                    .map(|offset| arrow.params.span.end + offset);
+                debug_assert!(
+                    arrow_token_start.is_some(),
+                    "arrow function is missing an arrow token"
+                );
+                arrow_token_start.map_or(arrow.params.span, |start| Span::sized(start, 2))
+            }
+            Some(target) => target.span,
+            None => arrow.params.span,
+        };
         let is_allowed = || self.rule.is_some_allowed_name(target_name);
 
         if !self.rule.allow_higher_order_functions {
@@ -877,6 +905,18 @@ mod test {
             ("export function test(): void { return; }", None),
             ("export var fn = function (): number { return 1; };", None),
             ("export var arrowFn = (): string => 'test';", None),
+            (
+                "
+            export const showLastActiveUsersWarningDialog = async (
+              users: string[],
+              organization: { id: string }
+              // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+            ) => {
+              return { users, organization };
+            };
+            ",
+                None,
+            ),
             (
                 "
             class Test {
@@ -1696,6 +1736,17 @@ mod test {
             ("export function test() { return; }", None),
             ("export var fn = function () { return 1; };", None),
             ("export var arrowFn = () => 'test';", None),
+            (
+                "
+            export const showLastActiveUsersWarningDialog = async (
+              users: string[],
+              organization: { id: string }
+            ) => {
+              return { users, organization };
+            };
+            ",
+                None,
+            ),
             (
                 "
             export class Test {

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
@@ -24,9 +24,18 @@ source: crates/oxc_linter/src/tester.rs
   help: Define an explicit return type for the function.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:1:12]
+   ╭─[explicit_module_boundary_types.tsx:1:25]
  1 │ export var arrowFn = () => 'test';
-   ·            ───────
+   ·                         ──
+   ╰────
+  help: Define an explicit return type for the function.
+
+  ⚠ typescript(explicit-module-boundary-types): Missing return type on function
+   ╭─[explicit_module_boundary_types.tsx:5:15]
+ 4 │               organization: { id: string }
+ 5 │             ) => {
+   ·               ──
+ 6 │               return { users, organization };
    ╰────
   help: Define an explicit return type for the function.
 
@@ -148,16 +157,16 @@ source: crates/oxc_linter/src/tester.rs
   help: Define an explicit return type for the function.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:1:16]
+   ╭─[explicit_module_boundary_types.tsx:1:19]
  1 │ export default () => (true ? () => {} : (): void => {});
-   ·                ──
+   ·                   ──
    ╰────
   help: Define an explicit return type for the function.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:1:12]
+   ╭─[explicit_module_boundary_types.tsx:1:25]
  1 │ export var arrowFn = () => 'test';
-   ·            ───────
+   ·                         ──
    ╰────
   help: Define an explicit return type for the function.
 
@@ -240,37 +249,37 @@ source: crates/oxc_linter/src/tester.rs
   help: Define an explicit return type for the function.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:2:26]
+   ╭─[explicit_module_boundary_types.tsx:2:50]
  1 │ 
  2 │             export const func1 = (value: number) => ({ type: 'X', value }) as any;
-   ·                          ─────
+   ·                                                  ──
  3 │             export const func2 = (value: number) => ({ type: 'X', value }) as Action;
    ╰────
   help: Define an explicit return type for the function.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:3:26]
+   ╭─[explicit_module_boundary_types.tsx:3:50]
  2 │             export const func1 = (value: number) => ({ type: 'X', value }) as any;
  3 │             export const func2 = (value: number) => ({ type: 'X', value }) as Action;
-   ·                          ─────
+   ·                                                  ──
  4 │             
    ╰────
   help: Define an explicit return type for the function.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:2:26]
+   ╭─[explicit_module_boundary_types.tsx:2:49]
  1 │ 
  2 │             export const func = (value: number) => ({ type: 'X', value }) as const;
-   ·                          ────
+   ·                                                 ──
  3 │             
    ╰────
   help: Define an explicit return type for the function.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:7:26]
+   ╭─[explicit_module_boundary_types.tsx:7:49]
  6 │ 
  7 │             export const func = (value: number) =>
-   ·                          ────
+   ·                                                 ──
  8 │               ({ type: 'X', value }) as const satisfies R;
    ╰────
   help: Define an explicit return type for the function.
@@ -302,10 +311,10 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:2:26]
+   ╭─[explicit_module_boundary_types.tsx:2:50]
  1 │ 
  2 │             export const func1 = (value: number) => value;
-   ·                          ─────
+   ·                                                  ──
  3 │             export const func2 = (value: number) => value;
    ╰────
   help: Define an explicit return type for the function.
@@ -370,10 +379,10 @@ source: crates/oxc_linter/src/tester.rs
   help: Define an explicit argument type for each argument.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:2:19]
+   ╭─[explicit_module_boundary_types.tsx:2:29]
  1 │ 
  2 │             const foo = arg => arg;
-   ·                   ───
+   ·                             ──
  3 │             export default foo;
    ╰────
   help: Define an explicit return type for the function.
@@ -388,10 +397,10 @@ source: crates/oxc_linter/src/tester.rs
   help: Define an explicit argument type for each argument.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:2:19]
+   ╭─[explicit_module_boundary_types.tsx:2:29]
  1 │ 
  2 │             const foo = arg => arg;
-   ·                   ───
+   ·                             ──
  3 │             export = foo;
    ╰────
   help: Define an explicit return type for the function.
@@ -406,10 +415,10 @@ source: crates/oxc_linter/src/tester.rs
   help: Define an explicit argument type for each argument.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:2:19]
+   ╭─[explicit_module_boundary_types.tsx:2:29]
  1 │ 
  2 │             const foo = arg => arg;
-   ·                   ───
+   ·                             ──
  3 │             export default [foo];
    ╰────
   help: Define an explicit return type for the function.
@@ -424,10 +433,10 @@ source: crates/oxc_linter/src/tester.rs
   help: Define an explicit argument type for each argument.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:2:19]
+   ╭─[explicit_module_boundary_types.tsx:2:29]
  1 │ 
  2 │             const foo = arg => arg;
-   ·                   ───
+   ·                             ──
  3 │             export default { foo };
    ╰────
   help: Define an explicit return type for the function.
@@ -622,10 +631,10 @@ source: crates/oxc_linter/src/tester.rs
   help: Define an explicit argument type for each argument.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:2:17]
+   ╭─[explicit_module_boundary_types.tsx:2:28]
  1 │ 
  2 │             let test = arg => argl;
-   ·                 ────
+   ·                            ──
  3 │             test = (): void => {
    ╰────
   help: Define an explicit return type for the function.
@@ -640,20 +649,20 @@ source: crates/oxc_linter/src/tester.rs
   help: Define an explicit argument type for each argument.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:2:17]
+   ╭─[explicit_module_boundary_types.tsx:2:28]
  1 │ 
  2 │             let test = arg => argl;
-   ·                 ────
+   ·                            ──
  3 │             test = (): void => {
    ╰────
   help: Define an explicit return type for the function.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:2:26]
- 1 │ 
+   ╭─[explicit_module_boundary_types.tsx:3:18]
  2 │             export const foo =
-   ·                          ───
  3 │               () =>
+   ·                  ──
+ 4 │               (a: string): ((n: number) => string) => {
    ╰────
   help: Define an explicit return type for the function.
 
@@ -841,18 +850,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Define an explicit return type for the function.
 
   ⚠ typescript(explicit-module-boundary-types): Missing return type on function
-    ╭─[explicit_module_boundary_types.tsx:2:28]
-  1 │     
-  2 │ ╭─▶             export default ({
-  3 │ │                   a,
-  4 │ │                   b,
-  5 │ │                   c,
-  6 │ │               }: {
-  7 │ │                   a: string;
-  8 │ │                   b: string;
-  9 │ │                   c: string;
- 10 │ ╰─▶             }) => {
- 11 │                     return `${a} ${b} ${c}`;
+    ╭─[explicit_module_boundary_types.tsx:10:16]
+  9 │                 c: string;
+ 10 │             }) => {
+    ·                ──
+ 11 │                 return `${a} ${b} ${c}`;
     ╰────
   help: Define an explicit return type for the function.
 


### PR DESCRIPTION
## Summary

- anchor exported arrow return-type diagnostics on the arrow token, matching typescript-eslint
- preserve existing property and nested-function diagnostic anchors
- add focused multiline and disable-directive regression coverage

Closes #25627.
