### PR TITLE
fix(linter/eslint/array-callback-return): anchor diagnostic on callback

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -45,14 +45,27 @@ fn guess_missing_return_hint(
     }
 }
 
+fn get_function_head_span(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Span {
+    match node.kind() {
+        AstKind::ArrowFunctionExpression(arrow) => ctx
+            .find_prev_token_within(arrow.span.start, arrow.body.span().start, "=>")
+            .map_or(arrow.span, |offset| Span::sized(arrow.span.start + offset, 2)),
+        AstKind::Function(function) => Span::new(function.span.start, function.params.span.start),
+        _ => unreachable!(),
+    }
+}
+
 fn expect_return(
     method_name: &str,
     array_method_span: Span,
+    function_node: &AstNode<'_>,
     function_body: &FunctionBody<'_>,
     allow_implicit: bool,
+    ctx: &LintContext<'_>,
 ) -> OxcDiagnostic {
-    let (span, hint) = guess_missing_return_hint(function_body)
-        .map_or((function_body.span, None), |(span, hint)| (span, Some(hint)));
+    let hint = guess_missing_return_hint(function_body);
+    let diagnostic_span =
+        hint.map_or(function_body.span, |_| get_function_head_span(function_node, ctx));
 
     let value_requirement = if allow_implicit {
         ""
@@ -60,7 +73,7 @@ fn expect_return(
         "\nReturn a value on each path (or enable `allowImplicit` to allow `return;`)."
     };
 
-    let (message, help) = match hint {
+    let (message, help) = match hint.map(|(_, hint)| hint) {
         Some(MissingReturnHint::SwitchWithoutDefault) => (
             format!(
                 "Callback for array method {method_name:?} may fall through a `switch` without returning"
@@ -85,12 +98,13 @@ fn expect_return(
         ),
     };
 
-    let mut diagnostic = OxcDiagnostic::warn(message).with_help(help).with_label(span);
+    let mut diagnostic = OxcDiagnostic::warn(message).with_help(help).with_label(diagnostic_span);
     if allow_implicit {
         diagnostic = diagnostic.with_note("With `allowImplicit`, callbacks that don't explicitly return a value are considered to return `undefined`.");
     }
-    if hint.is_some() {
+    if let Some((hint_span, _)) = hint {
         diagnostic = diagnostic
+            .and_label(hint_span.label("This path may reach the end of the callback."))
             .and_label(array_method_span.label(format!("{method_name:?} is called here.")));
     }
 
@@ -277,8 +291,10 @@ impl Rule for ArrayCallbackReturn {
                         ctx.diagnostic(expect_return(
                             &full_array_method_name(array_method),
                             array_method_span,
+                            node,
                             function_body.unwrap(),
                             self.allow_implicit,
+                            ctx,
                         ));
                     }
                 }
@@ -287,8 +303,10 @@ impl Rule for ArrayCallbackReturn {
                         ctx.diagnostic(expect_return(
                             &full_array_method_name(array_method),
                             array_method_span,
+                            node,
                             function_body.unwrap(),
                             self.allow_implicit,
+                            ctx,
                         ));
                     }
                 }
@@ -297,8 +315,10 @@ impl Rule for ArrayCallbackReturn {
                         ctx.diagnostic(expect_return(
                             &full_array_method_name(array_method),
                             array_method_span,
+                            node,
                             function_body.unwrap(),
                             self.allow_implicit,
+                            ctx,
                         ));
                     }
                 }
@@ -650,6 +670,17 @@ fn test() {
 }",
             None,
         ),
+        (
+            r#"const out = parts
+  // eslint-disable-next-line array-callback-return
+  .map(p => {
+    switch (p.type) {
+      case "a":
+        return p.value;
+    }
+  });"#,
+            Some(serde_json::json!([{"allowImplicit": true}])),
+        ),
     ];
 
     let fail = vec![
@@ -688,6 +719,15 @@ const _test = fruits.map((fruit) => {
   }
 });"#,
             None,
+        ),
+        (
+            r#"const out = parts.map(p => {
+  switch (p.type) {
+    case "a":
+      return p.value;
+  }
+});"#,
+            Some(serde_json::json!([{"allowImplicit": true}])),
         ),
         ("foo.reduce(function() {})", None),
         ("foo.reduce(function foo() {})", None),

--- a/crates/oxc_linter/src/snapshots/eslint_array_callback_return.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_array_callback_return.snap
@@ -150,7 +150,7 @@ source: crates/oxc_linter/src/tester.rs
     ╭─[array_callback_return.tsx:3:22]
   2 │     
   3 │     const _test = fruits.map((fruit) => {
-    ·                          ─┬─
+    ·                          ─┬─         ──
     ·                           ╰── "Array.prototype.map" is called here.
   4 │ ╭─▶   switch (fruit.name) {
   5 │ │       case "apple": {
@@ -160,11 +160,27 @@ source: crates/oxc_linter/src/tester.rs
   9 │ │       case "banana": {
  10 │ │         return "b"
  11 │ │       }
- 12 │ ╰─▶   }
+ 12 │ ├─▶   }
+    · ╰──── This path may reach the end of the callback.
  13 │     });
     ╰────
   help: This `switch` has no `default` case, so the callback may reach the end without a `return`. Add a `default` that returns/throws, or add a final `return` after the `switch`.
         Return a value on each path (or enable `allowImplicit` to allow `return;`).
+
+  ⚠ eslint(array-callback-return): Callback for array method "Array.prototype.map" may fall through a `switch` without returning
+   ╭─[array_callback_return.tsx:1:19]
+ 1 │     const out = parts.map(p => {
+   ·                       ─┬─   ──
+   ·                        ╰── "Array.prototype.map" is called here.
+ 2 │ ╭─▶   switch (p.type) {
+ 3 │ │       case "a":
+ 4 │ │         return p.value;
+ 5 │ ├─▶   }
+   · ╰──── This path may reach the end of the callback.
+ 6 │     });
+   ╰────
+  help: This `switch` has no `default` case, so the callback may reach the end without a `return`. Add a `default` that returns/throws, or add a final `return` after the `switch`.
+  note: With `allowImplicit`, callbacks that don't explicitly return a value are considered to return `undefined`.
 
   ⚠ eslint(array-callback-return): Callback for array method "Array.prototype.reduce" does not return on all code paths
    ╭─[array_callback_return.tsx:1:23]
@@ -305,7 +321,8 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint(array-callback-return): Callback for array method "Array.prototype.every" may reach the end of an `if` without returning
    ╭─[array_callback_return.tsx:1:5]
  1 │ foo.every(function() { if (a) return true; })
-   ·     ──┬──              ───────────────────
+   ·     ──┬── ────────     ─────────┬─────────
+   ·       │       │                 ╰── This path may reach the end of the callback.
    ·       ╰── "Array.prototype.every" is called here.
    ╰────
   help: This `if` has no `else` branch, so the callback may reach the end without a `return`. Add an `else`, or add a final `return`/`throw` after the `if`.
@@ -314,7 +331,8 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint(array-callback-return): Callback for array method "Array.prototype.every" may reach the end of an `if` without returning
    ╭─[array_callback_return.tsx:1:5]
  1 │ foo.every(function cb() { if (a) return true; })
-   ·     ──┬──                 ───────────────────
+   ·     ──┬── ───────────     ─────────┬─────────
+   ·       │        │                   ╰── This path may reach the end of the callback.
    ·       ╰── "Array.prototype.every" is called here.
    ╰────
   help: This `if` has no `else` branch, so the callback may reach the end without a `return`. Add an `else`, or add a final `return`/`throw` after the `if`.
@@ -379,7 +397,8 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint(array-callback-return): Callback for array method "Array.prototype.every" may reach the end of an `if` without returning
    ╭─[array_callback_return.tsx:1:5]
  1 │ foo.every(function() { if (a) return; })
-   ·     ──┬──              ──────────────
+   ·     ──┬── ────────     ───────┬──────
+   ·       │       │               ╰── This path may reach the end of the callback.
    ·       ╰── "Array.prototype.every" is called here.
    ╰────
   help: This `if` has no `else` branch, so the callback may reach the end without a `return`. Add an `else`, or add a final `return`/`throw` after the `if`.
@@ -388,7 +407,8 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint(array-callback-return): Callback for array method "Array.prototype.every" may reach the end of an `if` without returning
    ╭─[array_callback_return.tsx:1:5]
  1 │ foo.every(function foo() { if (a) return; })
-   ·     ──┬──                  ──────────────
+   ·     ──┬── ────────────     ───────┬──────
+   ·       │         │                 ╰── This path may reach the end of the callback.
    ·       ╰── "Array.prototype.every" is called here.
    ╰────
   help: This `if` has no `else` branch, so the callback may reach the end without a `return`. Add an `else`, or add a final `return`/`throw` after the `if`.


### PR DESCRIPTION
## Summary

- anchor switch/if missing-return diagnostics on the array callback function head, matching ESLint
- preserve the inner control-flow statement as a secondary diagnostic label
- add regression coverage for diagnostic location and eslint-disable-next-line behavior

Fixes #25632