### PR TITLE
ci(labeler): label codegen package PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -73,7 +73,7 @@ A-parser:
 
 A-codegen:
   - changed-files:
-      - any-glob-to-any-file: ["crates/oxc_codegen/**"]
+      - any-glob-to-any-file: ["crates/oxc_codegen/**", "packages/codegen/**"]
 
 A-semantic:
   - changed-files:


### PR DESCRIPTION
## Summary

- automatically apply A-codegen to changes under packages/codegen
- keep the Rust and TypeScript code generators in the same functional area

## Naming

Reuse A-codegen because recent packages/codegen PRs already receive it manually. A-printer is stale, while names such as A-codegen-js or P-codegen would introduce a distinction or label prefix the repository does not currently use.
