### PR TITLE
fix(linter/typescript/no-unnecessary-type-conversion): mark fixer as `suggestion`

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_conversion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_conversion.rs
@@ -29,7 +29,7 @@ declare_oxc_lint!(
     NoUnnecessaryTypeConversion(tsgolint),
     typescript,
     suspicious,
-    pending,
+    suggestion,
     version = "1.49.0",
     short_description = "Disallow unnecessary type conversion expressions.",
 );


### PR DESCRIPTION
## Summary

- classify typescript/no-unnecessary-type-conversion as suggestion-only
- prevent its runtime-changing removal from being advertised as a normal autofix
- keep TSGolint RuleSuggestion edits available through suggestion handling

Related to #25549.
