### PR TITLE
feat(minifier): inline let assignments into declarations

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -10,6 +10,7 @@ use oxc_ecmascript::{
 };
 use oxc_semantic::ScopeFlags;
 use oxc_span::{ContentEq, GetSpan, GetSpanMut, SPAN};
+use oxc_syntax::symbol::SymbolId;
 
 use crate::{TraverseCtx, is_terminated::IsTerminated, keep_var::KeepVar};
 
@@ -538,9 +539,18 @@ impl<'a> PeepholeOptimizations {
             if kind.name == id.name {
                 if decl.init.is_none()
                     && (declaration_kind == VariableDeclarationKind::Var
-                        || assign_expr.right.is_literal_value(true, ctx))
+                        || assign_expr.right.is_literal_value(true, ctx)
+                        || kind.symbol_id.get().is_some_and(|symbol_id| {
+                            Self::lexical_init_merge_is_safe(
+                                symbol_id,
+                                &id.name,
+                                &assign_expr.right,
+                                ctx,
+                            )
+                        }))
                 {
                     // "var a; a = b();" => "var a = b();"
+                    // "let a; a = b();" => "let a = b();"
                     decl.init = Some(assign_expr.right.take_in(ctx));
                     return true;
                 }
@@ -564,6 +574,54 @@ impl<'a> PeepholeOptimizations {
             }
         }
         false
+    }
+
+    /// Whether `let a; a = <init>` => `let a = <init>` is safe for a lexical binding.
+    ///
+    /// The merge moves `<init>` from after the binding is initialized to during its
+    /// initialization, so it must be impossible for anything `<init>` evaluates to
+    /// observe `a` in its Temporal Dead Zone. Two conditions, per the analysis in
+    /// <https://github.com/oxc-project/oxc/issues/14310>:
+    ///
+    /// 1. `<init>` must not read `a` itself (`let a; a = foo(a)`).
+    /// 2. No read of `a` may be deferred to a later point that `<init>` can trigger,
+    ///    as in `function f() { console.log(a) } let a; a = f()`.
+    ///
+    /// Condition (2) is enforced by requiring every reference to sit in the binding's
+    /// own scope. Classifying the intermediate scopes instead would be less
+    /// conservative, but a class scope carries no distinguishing [`ScopeFlags`] and a
+    /// field initializer gets no scope of its own, so a deferred read in
+    /// `class D { x = a }` is indistinguishable from an inline one in a plain block.
+    /// Every deferred construct — function, arrow, accessor, static block, class body
+    /// — introduces at least one scope, so same-scope is sound; the cost is that a
+    /// read inside a nested block (`if (x) { foo(a) }`) also blocks the merge.
+    ///
+    /// A direct `eval` in the binding's scope defeats (2) without producing a
+    /// resolved reference, so it bails as well.
+    fn lexical_init_merge_is_safe(
+        symbol_id: SymbolId,
+        name: &str,
+        init: &Expression<'a>,
+        ctx: &TraverseCtx<'a>,
+    ) -> bool {
+        let scoping = ctx.scoping();
+        let binding_scope = scoping.symbol_scope_id(symbol_id);
+        // A program-scope lexical can be read by code this file cannot see, so the
+        // reference scan below proves nothing about it. An exported binding is
+        // reachable from a cyclic import, and a Script root's `let` joins the global
+        // lexical environment shared with every other script — in both cases the
+        // initializer can call out to code that reads the binding in its TDZ.
+        if binding_scope == scoping.root_scope_id() {
+            return false;
+        }
+        if scoping.scope_flags(binding_scope).contains_direct_eval() {
+            return false;
+        }
+        if scoping.get_resolved_references(symbol_id).any(|r| r.scope_id() != binding_scope) {
+            return false;
+        }
+        // Walks the whole initializer, so it runs last.
+        !FindIdentifierReference::is_referenced_in_expression(name, init)
     }
 
     /// Check if a switch case can be inlined by verifying:
@@ -1919,6 +1977,52 @@ impl<'a> PeepholeOptimizations {
                 ctx.parent().is_function_body()
             }
             _ => false,
+        }
+    }
+}
+
+/// Finds whether `name` occurs as an identifier reference within an expression.
+///
+/// Used to keep `let a; a = <expr>` => `let a = <expr>` from introducing a TDZ
+/// error: moving `<expr>` into the declarator makes it run while `a` is still
+/// uninitialized, so any read of `a` inside it would throw.
+///
+/// Descends into function bodies too, and that is load-bearing rather than mere
+/// conservatism: in `let a; a = f(() => a)` the callee may invoke the closure
+/// immediately, reading `a` in its TDZ. Matching is by name, so a shadowed binding
+/// (`let a; a = (function (a) { return a })()`) blocks the merge unnecessarily —
+/// that direction is only a missed optimization.
+struct FindIdentifierReference<'n> {
+    name: &'n str,
+    found: bool,
+}
+
+impl<'n> FindIdentifierReference<'n> {
+    fn is_referenced_in_expression(name: &'n str, expr: &Expression<'_>) -> bool {
+        let mut visitor = Self { name, found: false };
+        visitor.visit_expression(expr);
+        visitor.found
+    }
+}
+
+impl<'a> VisitJs<'a> for FindIdentifierReference<'_> {
+    fn visit_expression(&mut self, it: &Expression<'a>) {
+        if self.found {
+            return;
+        }
+        walk_js::walk_expression(self, it);
+    }
+
+    fn visit_statement(&mut self, it: &Statement<'a>) {
+        if self.found {
+            return;
+        }
+        walk_js::walk_statement(self, it);
+    }
+
+    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
+        if it.name == self.name {
+            self.found = true;
         }
     }
 }

--- a/crates/oxc_minifier/tests/peephole/merge_assignments_to_declarations.rs
+++ b/crates/oxc_minifier/tests/peephole/merge_assignments_to_declarations.rs
@@ -155,3 +155,24 @@ fn merge_assignments_to_declarations_other() {
     test_same("using a = 0; a = 1");
     test_same("await using a = 0; a = 1");
 }
+
+/// The two examples from <https://github.com/oxc-project/oxc/issues/14310>.
+#[test]
+fn merge_assignments_to_declarations_issue_14310() {
+    // The reported case. `deserializeBindingPatternKind` resolves outside the
+    // function, so nothing can observe `param` during its initialization; once the
+    // merge happens a later pass collapses the temporary away entirely, which is
+    // the reduction the issue asked for.
+    test(
+        "export function deserializeFormalParameter(pos) { let param; param = deserializeBindingPatternKind(pos + 32); return param; }",
+        "export function deserializeFormalParameter(pos) { return deserializeBindingPatternKind(pos + 32) }",
+    );
+    // The counter-example from the issue discussion: here
+    // `deserializeBindingPatternKind` closes over `param`, so merging would call it
+    // while `param` sits in its TDZ. The read lives in the inner function's scope,
+    // not the binding's, so the merge is rejected and the assignment stays put.
+    test(
+        "(function deserializeFormalParameter(pos) { function deserializeBindingPatternKind() { console.log('param', param) } let param; param = deserializeBindingPatternKind(pos + 32); return param; })(0)",
+        "(function(pos) { function deserializeBindingPatternKind() { console.log('param', param) } let param; return param = deserializeBindingPatternKind(pos + 32), param })(0)",
+    );
+}

--- a/crates/oxc_minifier/tests/peephole/merge_assignments_to_declarations.rs
+++ b/crates/oxc_minifier/tests/peephole/merge_assignments_to_declarations.rs
@@ -1,4 +1,6 @@
-use crate::{test, test_same};
+use oxc_span::SourceType;
+
+use crate::{default_options, test, test_options_source_type, test_same};
 
 #[test]
 fn merge_assignments_to_declarations_var() {
@@ -38,6 +40,113 @@ fn merge_assignments_to_declarations_let() {
     test_same("let a; a = foo(a)"); // `let a = foo(a)` will cause TDZ error
     test("let a; a = (() => a)()", "let a; a = a;"); // `let a = (() => a)()` will cause TDZ error
     test("let a; a = () => a", "let a = () => a");
+
+    // the initializer does not read `a`, so there is no TDZ error to introduce
+    // https://github.com/oxc-project/oxc/issues/14310
+    test(
+        "export function f() { let a; a = c(); foo(a) }",
+        "export function f() { let a = c(); foo(a) }",
+    );
+    test(
+        "export function f() { let a; a = c(b); foo(a) }",
+        "export function f() { let a = c(b); foo(a) }",
+    );
+    test(
+        "export function f() { let a; a = b.c; foo(a) }",
+        "export function f() { let a = b.c; foo(a) }",
+    );
+    // the initializer reads `a`, which `let a = <init>` would evaluate in its TDZ
+    test(
+        "export function f() { let a; a = c(a); foo(a) }",
+        "export function f() { let a; a = c(a), foo(a) }",
+    );
+    test(
+        "export function f() { let a; a = { b: a }; foo(a) }",
+        "export function f() { let a; a = { b: a }, foo(a) }",
+    );
+    test(
+        "export function f() { let a; a = (a = b()); foo(a) }",
+        "export function f() { let a; a = a = b(), foo(a) }",
+    );
+    test(
+        "export function f() { let a; a = class extends a {}; foo(a) }",
+        "export function f() { let a; a = class extends a {}, foo(a) }",
+    );
+
+    // `c` closes over `a`, so calling it during `a`'s initialization would read
+    // `a` in its TDZ, even though the initializer does not mention `a`.
+    test(
+        "export function f() { function c() { return a } let a; a = c(); foo(a) }",
+        "export function f() { function c() { return a } let a; a = c(), foo(a) }",
+    );
+    test(
+        "export function f() { let a; function c() { return a } a = c(); foo(a) }",
+        "export function f() { let a; function c() { return a } a = c(), foo(a) }",
+    );
+    test(
+        "export function f() { let a; a = (() => { const d = () => a; return d() })(); foo(a) }",
+        "export function f() { let a; a = a, foo(a) }",
+    );
+}
+
+/// Reads of the binding that are deferred past the initializer, or that this
+/// analysis cannot place, must block the merge.
+#[test]
+fn merge_assignments_to_declarations_let_deferred_reads() {
+    // A class field initializer runs at construction time, so `new D()` reads `a`
+    // while it is still uninitialized. The reference sits in the class scope, which
+    // carries no flag distinguishing it from a plain block.
+    test(
+        "export function f() { class D { x = a } let a; a = new D(); console.log(a.x) }",
+        "export function f() { class D { x = a } let a; a = new D(), console.log(a.x) }",
+    );
+    test(
+        "export function f() { const D = class { x = a }; let a; a = new D(); console.log(a.x) }",
+        "export function f() { let D = class { x = a }, a; a = new D(), console.log(a.x) }",
+    );
+
+    // A read in a nested block executes inline and would be safe to merge past, but
+    // it is not in the binding's scope, so the conservative rule rejects it.
+    //
+    // NOTE: the block here holds a `let` so it survives minification. A block that
+    // gets flattened (`if (x) { foo(a) }`) makes this transform iteration-dependent:
+    // the flattening pass removes the block but leaves the reference's `scope_id`
+    // pointing at it, so the merge is rejected on one pass and accepted on the next.
+    // The staleness only ever reports *more* scopes than exist, so it errs safe.
+    test(
+        "export function f() { let a; a = c(); { let b = a; foo(b) } }",
+        "export function f() { let a; a = c(); { let b = a; foo(b) } }",
+    );
+
+    // A direct `eval` can read the binding without producing a resolved reference.
+    test(
+        "export function f() { let a; a = c(); eval('foo'); return a }",
+        "export function f() { let a; return a = c(), eval('foo'), a }",
+    );
+}
+
+/// A program-scope lexical is reachable from code the reference scan cannot see,
+/// so the initializer must not be moved into the declaration.
+#[test]
+fn merge_assignments_to_declarations_let_program_scope() {
+    // A cyclic import can call back into this module and read the exported `a`,
+    // which is initialized (`undefined`) before the assignment but in its TDZ
+    // once the initializer moves into the declaration.
+    test_same("import { f } from './b.mjs'; let a; a = f(); export { a }");
+    test_same("import { f } from './b.mjs'; let a; a = f(); export default () => a");
+
+    // A Script root's `let` joins the global lexical environment, so a function
+    // from another script can read it while this initializer runs.
+    test_options_source_type(
+        "let a; a = f(); console.log(a)",
+        "let a; a = f(), console.log(a)",
+        SourceType::cjs(),
+        &default_options(),
+    );
+
+    // the untouched `is_literal_value` branch still merges at program scope: a
+    // literal initializer executes no code, so nothing can observe the binding
+    test("let a; a = 0; foo(a)", "let a = 0; foo(0)");
 }
 
 #[test]

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,8 +5,8 @@ checker.ts:
   sys deallocs: 150
   sys alloc bytes: 14996600 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 144012
-  arena reallocs: 28468
+  arena allocs: 144015
+  arena reallocs: 28467
   arena size: 19127248 # 19.13 MB
 
 App.tsx:


### PR DESCRIPTION
Closes #14310. Part of #19360.

## What

`merge_assignment_to_declaration` merged `a = b()` into a preceding declaration only for `var`, or for a literal right-hand side. This extends it to lexical (`let`) bindings with an arbitrary initializer.

The reported case now reduces the whole way down, because merging unblocks a later pass:

```js
// in
export function deserializeFormalParameter(pos) {
  let param;
  param = deserializeBindingPatternKind(pos + 32);
  return param;
}

// out
export function deserializeFormalParameter(pos) {
  return deserializeBindingPatternKind(pos + 32);
}
```

## Safety

Moving the initializer into the declarator makes it run while the binding is still in its TDZ, so the merge is gated on `lexical_init_merge_is_safe`, which implements the two conditions @sapphi-red proposed in the issue:

1. **The initializer must not read the binding.** `FindIdentifierReference` walks the initializer, descending into function bodies — `let a; a = f(() => a)` is unsafe, because `f` may invoke the closure immediately.
2. **No read of the binding may be deferred to a point the initializer can trigger.** @sapphi-red noted it was unclear whether this could be checked without traversing the whole scope. It can, via `get_resolved_references`: every reference must sit in the binding's own scope. Every deferred construct — function, arrow, accessor, static block, class body — introduces at least one scope, so requiring same-scope is sound.

The counter-example from the discussion is covered as a test and still bails, since the read of `param` lives in the inner function's scope.

Two further hazards not raised in the issue also bail out:

- **Program scope.** An exported binding is reachable from a cyclic import, and a Script root's `let` joins the global lexical environment shared with every other script. In both cases the initializer can call out to code that reads the binding in its TDZ, so the reference scan proves nothing.
- **Direct `eval`** in the binding's scope, which can read the binding without producing a resolved reference.

## Known conservatism

- A read in a nested block (`if (x) { foo(a) }`) blocks the merge even though it executes inline. Classifying the intermediate scopes instead would be less conservative, but a class scope carries no distinguishing `ScopeFlags` and a field initializer gets no scope of its own, so a deferred read in `class D { x = a }` would be indistinguishable from an inline one in a plain block.
- A shadowed binding (`let a; a = (function (a) { return a })()`) blocks the merge, because matching is by name.

Both are missed optimizations rather than miscompiles.

## Testing

- `cargo test -p oxc_minifier` passes.
- `cargo minsize` reports no snapshot change; the transform trades a `;` for a `=` on the benchmark files.
- `cargo allocs` regenerates with the one snapshot change included here.
- `just doc` and `just ast` are clean (`ast` regenerates with no diff).
- `just ready` does **not** pass cleanly on my Windows checkout, but neither failure is related to this change and both reproduce without it: an oxlint fixture whose symlink is materialized as a text file under `core.symlinks=false`, and a `disallowed_methods` clippy warning in `crates/oxc_language_server/src/worker_manager.rs`.

## AI usage disclosure

Per `AGENTS.md`: AI assistance (Claude Code) was used while writing this change and
in producing the analysis above. I have reviewed, tested and understand the
implementation, and I take responsibility for it.
