### PR TITLE
feat(allocator): stamp process-wide buffer ids on fixed-size arenas

### DIFF
--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -590,6 +590,13 @@ impl Allocator {
         &self.arena
     }
 
+    /// `true` if this [`Allocator`] is a fixed-size raw-transfer arena.
+    ///
+    /// Empty allocators (no chunks) are not fixed-size.
+    pub fn is_fixed_size(&self) -> bool {
+        self.arena.is_fixed_size()
+    }
+
     /// Create [`Allocator`] from an [`Arena`].
     ///
     /// This method is not public. Only used by [`Allocator::from_raw_parts`].

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -251,6 +251,17 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     pub const fn min_align(&self) -> usize {
         Self::MIN_ALIGN
     }
+
+    /// `true` if the current chunk was created as a fixed-size raw-transfer arena.
+    ///
+    /// Empty arenas (no chunks) are not fixed-size.
+    pub fn is_fixed_size(&self) -> bool {
+        match self.current_chunk_footer_ptr.get() {
+            // SAFETY: `current_chunk_footer_ptr` always points to a valid `ChunkFooter` when `Some`.
+            Some(footer_ptr) => unsafe { footer_ptr.as_ref().is_fixed_size },
+            None => false,
+        }
+    }
 }
 
 // SAFETY:

--- a/crates/oxc_allocator/src/pool/fixed_size.rs
+++ b/crates/oxc_allocator/src/pool/fixed_size.rs
@@ -3,9 +3,30 @@ use std::{
     ptr::NonNull,
     sync::{
         Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
     },
 };
+
+/// Process-wide id stamped into each fixed-size arena's `metadata.id`.
+///
+/// Two pools in one process (LSP folders) must not share ids, so this is not a pool slot index.
+static NEXT_BUFFER_ID: AtomicU32 = AtomicU32::new(0);
+
+fn next_buffer_id() -> u32 {
+    loop {
+        let id = NEXT_BUFFER_ID.load(Ordering::Relaxed);
+        #[expect(clippy::manual_assert)]
+        if id == u32::MAX {
+            panic!("fixed-size allocator buffer_id overflow");
+        }
+        if NEXT_BUFFER_ID
+            .compare_exchange_weak(id, id + 1, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            return id;
+        }
+    }
+}
 
 #[cfg(target_os = "windows")]
 use std::sync::Condvar;
@@ -82,6 +103,12 @@ pub struct FixedSizeAllocatorPool {
     /// Only used on Windows. On *nix systems, we don't need this synchronization.
     #[cfg(target_os = "windows")]
     available: Condvar,
+
+    /// Number of allocators actually created. On Windows this can be less than `thread_count`.
+    len: usize,
+
+    /// Buffer ids of every allocator in this pool, in creation order.
+    buffer_ids: Box<[u32]>,
 }
 
 impl FixedSizeAllocatorPool {
@@ -102,18 +129,23 @@ impl FixedSizeAllocatorPool {
     #[cfg(not(target_os = "windows"))]
     pub fn new(thread_count: usize) -> Self {
         let mut allocators = Stack::with_capacity(thread_count);
+        let mut buffer_ids = Vec::with_capacity(thread_count);
 
         // Create `thread_count` allocators
-        for i in 0..thread_count {
+        for _ in 0..thread_count {
             // It's impossible to create more than `u32::MAX` allocators, as `u32::MAX` x 4 GiB allocations would
             // consume almost the entirety of a 64-bit address space. No platform has such a large address space.
             // Typically they use 48 bit address space, or 53 bit at most.
-            #[expect(clippy::cast_possible_truncation)]
-            let allocator = FixedSizeAllocator::try_new(i as u32).unwrap();
+            let allocator = FixedSizeAllocator::try_new().unwrap();
+            buffer_ids.push(allocator.buffer_id());
             allocators.push(allocator);
         }
 
-        Self { allocators: Mutex::new(allocators) }
+        Self {
+            allocators: Mutex::new(allocators),
+            len: thread_count,
+            buffer_ids: buffer_ids.into_boxed_slice(),
+        }
     }
 
     /// Create a new [`FixedSizeAllocatorPool`] containing *up to* `thread_count` allocators.
@@ -151,15 +183,16 @@ impl FixedSizeAllocatorPool {
         let capacity = thread_count + 1;
 
         let mut allocators = Stack::with_capacity(capacity);
+        let mut buffer_ids = Vec::with_capacity(capacity);
 
         // Get as many allocators as possible, up to `capacity`
-        for i in 0..capacity {
+        for _ in 0..capacity {
             // It's impossible to create more than `u32::MAX` allocators, as `u32::MAX` x 4 GiB allocations would
             // consume almost the entirety of a 64-bit address space. No platform has such a large address space.
             // Typically they use 48 bit address space, or 53 bit at most.
-            #[expect(clippy::cast_possible_truncation)]
-            let allocator = FixedSizeAllocator::try_new(i as u32);
+            let allocator = FixedSizeAllocator::try_new();
             let Ok(allocator) = allocator else { break };
+            buffer_ids.push(allocator.buffer_id());
             allocators.push(allocator);
         }
 
@@ -175,10 +208,17 @@ impl FixedSizeAllocatorPool {
             // Otherwise, discard the last allocator we got, to leave memory free for other allocations
             _ => {
                 allocators.pop();
+                buffer_ids.pop();
             }
         }
 
-        Self { allocators: Mutex::new(allocators), available: Condvar::new() }
+        let len = allocators.len();
+        Self {
+            allocators: Mutex::new(allocators),
+            available: Condvar::new(),
+            len,
+            buffer_ids: buffer_ids.into_boxed_slice(),
+        }
     }
 
     /// Retrieve an [`Allocator`] from the pool.
@@ -252,6 +292,16 @@ impl FixedSizeAllocatorPool {
         // On Windows, notify waiting threads that an allocator is available (see Windows impl of `get`)
         #[cfg(target_os = "windows")]
         self.available.notify_one();
+    }
+
+    /// Number of allocators actually created for this pool.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Buffer ids of every allocator in this pool.
+    pub fn buffer_ids(&self) -> &[u32] {
+        &self.buffer_ids
     }
 }
 
@@ -363,7 +413,7 @@ impl FixedSizeAllocator {
     /// Try to create a new [`FixedSizeAllocator`].
     ///
     /// Returns `Err` if memory allocation fails.
-    fn try_new(id: u32) -> Result<Self, ()> {
+    fn try_new() -> Result<Self, ()> {
         // Only support little-endian systems. `Allocator::from_raw_parts` includes this same assertion.
         // This module is only compiled on 64-bit little-endian systems, so it should be impossible for
         // this panic to occur. But we want to make absolutely sure that if there's a mistake elsewhere,
@@ -378,6 +428,7 @@ impl FixedSizeAllocator {
         // Wrap `Allocator` in `ManuallyDrop` so that we can control whether it's dropped in `FixedSizeAllocator`'s
         // `Drop` impl, depending on whether the buffer is currently shared with JS.
         let allocator = Allocator::new_fixed_size().ok_or(())?;
+        let id = next_buffer_id();
         let allocator = ManuallyDrop::new(allocator);
 
         // Pointer to the start of the chunk. `data_end_ptr` is the start of the `ChunkFooter`,
@@ -425,6 +476,14 @@ impl FixedSizeAllocator {
             debug_assert!(cursor_ptr.addr().get().is_multiple_of(CURSOR_MIN_ALIGN));
             self.allocator.set_cursor_ptr(cursor_ptr);
         }
+    }
+
+    /// Process-wide buffer id stamped into this allocator by [`try_new`].
+    ///
+    /// [`try_new`]: Self::try_new
+    fn buffer_id(&self) -> u32 {
+        // SAFETY: `try_new` wrote a `FixedSizeAllocatorMetadata` for this `Allocator`.
+        unsafe { self.allocator.fixed_size_buffer_id() }
     }
 
     /// Unwrap a [`FixedSizeAllocator`] into the [`Allocator`] it contains.
@@ -505,6 +564,16 @@ pub unsafe fn free_fixed_size_allocator(metadata_ptr: NonNull<FixedSizeAllocator
 }
 
 impl Allocator {
+    /// Process-wide id stamped into this fixed-size arena.
+    ///
+    /// # SAFETY
+    /// This `Allocator` must have been created by a `FixedSizeAllocator`.
+    pub unsafe fn fixed_size_buffer_id(&self) -> u32 {
+        debug_assert!(self.is_fixed_size());
+        // SAFETY: Caller guarantees this `Allocator` was created by a `FixedSizeAllocator`.
+        unsafe { self.fixed_size_metadata_ptr().as_ref().id }
+    }
+
     /// Get pointer to the `FixedSizeAllocatorMetadata` for this [`Allocator`].
     ///
     /// # SAFETY

--- a/crates/oxc_allocator/src/pool/mod.rs
+++ b/crates/oxc_allocator/src/pool/mod.rs
@@ -82,6 +82,57 @@ impl AllocatorPool {
         AllocatorGuard { allocator: ManuallyDrop::new(allocator), pool: self }
     }
 
+    /// Number of allocators this pool was constructed with.
+    ///
+    /// For a fixed-size pool this is the number of arenas that were actually created
+    /// (on Windows this can be less than the requested `thread_count`).
+    pub fn len(&self) -> usize {
+        match &self.0 {
+            AllocatorPoolInner::Standard(pool) => pool.len(),
+            #[cfg(all(
+                feature = "fixed_size",
+                target_pointer_width = "64",
+                target_endian = "little"
+            ))]
+            AllocatorPoolInner::FixedSize(pool) => pool.len(),
+        }
+    }
+
+    /// `true` if this pool was constructed with no allocators.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Buffer ids of every allocator in this pool.
+    ///
+    /// Empty for a standard pool, which does not stamp buffer ids.
+    ///
+    /// Callers use this to tell JS to drop its cached raw-transfer views before the pool is dropped.
+    pub fn buffer_ids(&self) -> &[u32] {
+        match &self.0 {
+            AllocatorPoolInner::Standard(_) => &[],
+            #[cfg(all(
+                feature = "fixed_size",
+                target_pointer_width = "64",
+                target_endian = "little"
+            ))]
+            AllocatorPoolInner::FixedSize(pool) => pool.buffer_ids(),
+        }
+    }
+
+    /// `true` if this pool uses fixed-size raw-transfer allocators.
+    pub fn is_fixed_size(&self) -> bool {
+        match &self.0 {
+            AllocatorPoolInner::Standard(_) => false,
+            #[cfg(all(
+                feature = "fixed_size",
+                target_pointer_width = "64",
+                target_endian = "little"
+            ))]
+            AllocatorPoolInner::FixedSize(_) => true,
+        }
+    }
+
     /// Add an [`Allocator`] to the pool.
     ///
     /// The `Allocator` is reset by this method, so it's ready to be re-used.
@@ -129,5 +180,76 @@ impl Drop for AllocatorGuard<'_> {
         // SAFETY: After taking ownership of the `Allocator`, we do not touch the `ManuallyDrop` again
         let allocator = unsafe { ManuallyDrop::take(&mut self.allocator) };
         self.pool.add(allocator);
+    }
+}
+
+#[cfg(all(test, feature = "fixed_size", target_pointer_width = "64", target_endian = "little"))]
+mod buffer_id_tests {
+    use std::mem::size_of;
+
+    use rustc_hash::FxHashSet;
+
+    use super::*;
+
+    #[test]
+    fn buffer_id_two_pools_are_distinct() {
+        let pool_a = AllocatorPool::new_fixed_size(2);
+        let pool_b = AllocatorPool::new_fixed_size(2);
+        assert_eq!(pool_a.len(), 2);
+        assert_eq!(pool_b.len(), 2);
+        assert!(pool_a.is_fixed_size());
+        assert!(pool_b.is_fixed_size());
+
+        let a0 = pool_a.get();
+        let a1 = pool_a.get();
+        let b0 = pool_b.get();
+        let b1 = pool_b.get();
+
+        assert!(a0.is_fixed_size());
+        assert!(a1.is_fixed_size());
+        assert!(b0.is_fixed_size());
+        assert!(b1.is_fixed_size());
+
+        // SAFETY: these allocators came from `new_fixed_size` pools.
+        let ids = unsafe {
+            [
+                a0.fixed_size_buffer_id(),
+                a1.fixed_size_buffer_id(),
+                b0.fixed_size_buffer_id(),
+                b1.fixed_size_buffer_id(),
+            ]
+        };
+        assert_eq!(FxHashSet::from_iter(ids).len(), 4);
+        assert_eq!(size_of::<FixedSizeAllocatorMetadata>(), 8);
+    }
+
+    #[test]
+    fn buffer_id_new_fixed_size_len() {
+        assert_eq!(AllocatorPool::new_fixed_size(2).len(), 2);
+    }
+
+    #[test]
+    fn buffer_id_standard_pool_is_not_fixed_size() {
+        let pool = AllocatorPool::new(2);
+        assert_eq!(pool.len(), 2);
+        assert!(!pool.is_fixed_size());
+        assert!(!pool.get().is_fixed_size());
+        assert!(pool.buffer_ids().is_empty());
+    }
+
+    /// The language server forgets a folder's buffers by id, so `buffer_ids` has to list exactly
+    /// the ids of the arenas the pool hands out — no more, no fewer.
+    #[test]
+    fn buffer_ids_match_the_arenas_the_pool_hands_out() {
+        let pool = AllocatorPool::new_fixed_size(3);
+        let expected = pool.buffer_ids().iter().copied().collect::<FxHashSet<_>>();
+        assert_eq!(expected.len(), pool.len());
+
+        let guards = [pool.get(), pool.get(), pool.get()];
+        // SAFETY: these allocators came from a `new_fixed_size` pool.
+        let actual = unsafe {
+            guards.iter().map(|guard| guard.fixed_size_buffer_id()).collect::<FxHashSet<_>>()
+        };
+        assert_eq!(actual, expected);
     }
 }

--- a/crates/oxc_allocator/src/pool/standard.rs
+++ b/crates/oxc_allocator/src/pool/standard.rs
@@ -14,13 +14,23 @@ pub struct StandardAllocatorPool {
     /// and those are the operations we do while `Mutex` lock is held.
     /// The shorter the time lock is held, the less contention there is.
     allocators: Mutex<Stack<Allocator>>,
+    /// Number of allocators created when the pool was constructed.
+    /// The pool can grow past this if [`get`] creates extras.
+    ///
+    /// [`get`]: Self::get
+    len: usize,
 }
 
 impl StandardAllocatorPool {
     /// Create a new [`StandardAllocatorPool`] for use across the specified number of threads.
     pub fn new(thread_count: usize) -> StandardAllocatorPool {
         let allocators = iter::repeat_with(Allocator::new).take(thread_count).collect();
-        StandardAllocatorPool { allocators: Mutex::new(allocators) }
+        StandardAllocatorPool { allocators: Mutex::new(allocators), len: thread_count }
+    }
+
+    /// Number of allocators created when the pool was constructed.
+    pub fn len(&self) -> usize {
+        self.len
     }
 
     /// Retrieve an [`Allocator`] from the pool, or create a new one if the pool is empty.


### PR DESCRIPTION
## Summary

- Stamp a process-wide `buffer_id` into the existing 8-byte `FixedSizeAllocatorMetadata.id` when a fixed-size arena is minted
- Two pools in one process (for example two LSP folders) get distinct ids
- Overflow panics in release rather than wrapping
- Expose `AllocatorPool::len`, `is_fixed_size`, and `buffer_ids`

No behavior change for current callers. This is the allocator half of JS-plugin buffer routing.

## Test plan

- [x] `cargo test -p oxc_allocator --features fixed_size buffer_id` (4 passed)


Made with [Cursor](https://cursor.com)