### PR TITLE
feat(linter)!: route JS plugin callbacks by buffer id

### DIFF
--- a/apps/oxlint/src-js/bindings.d.ts
+++ b/apps/oxlint/src-js/bindings.d.ts
@@ -59,6 +59,10 @@ export type JsCreateWorkspaceCb =
 export type JsDestroyWorkspaceCb =
   ((arg: string) => void)
 
+/** JS callback to drop a cached raw-transfer buffer. */
+export type JsForgetBufferCb =
+  ((arg: number) => void)
+
 /** JS callback to lint a file. */
 export type JsLintFileCb =
   ((arg0: string, arg1: number, arg2: Uint8Array | undefined | null, arg3: Array<number>, arg4: Array<number>, arg5: string, arg6: string, arg7?: string | undefined | null) => string | null)
@@ -83,13 +87,14 @@ export type JsSetupRuleConfigsCb =
  * 2. `load_plugin`: Load a JS plugin from a file path.
  * 3. `setup_rule_configs`: Setup configuration options.
  * 4. `lint_file`: Lint a file.
- * 5. `create_workspace`: Create a workspace.
- * 6. `destroy_workspace`: Destroy a workspace.
- * 7. `load_js_configs`: Load JavaScript config files.
+ * 5. `forget_buffer`: Drop a cached raw-transfer buffer.
+ * 6. `create_workspace`: Create a workspace.
+ * 7. `destroy_workspace`: Destroy a workspace.
+ * 8. `load_js_configs`: Load JavaScript config files.
  *
  * Returns `true` if linting succeeded without errors, `false` otherwise.
  */
-export declare function lint(args: Array<string>, loadPlugin: JsLoadPluginCb, setupRuleConfigs: JsSetupRuleConfigsCb, lintFile: JsLintFileCb, createWorkspace: JsCreateWorkspaceCb, destroyWorkspace: JsDestroyWorkspaceCb, loadJsConfigs: JsLoadJsConfigsCb): Promise<boolean>
+export declare function lint(args: Array<string>, loadPlugin: JsLoadPluginCb, setupRuleConfigs: JsSetupRuleConfigsCb, lintFile: JsLintFileCb, forgetBuffer: JsForgetBufferCb, createWorkspace: JsCreateWorkspaceCb, destroyWorkspace: JsDestroyWorkspaceCb, loadJsConfigs: JsLoadJsConfigsCb): Promise<boolean>
 
 /**
  * Parse AST into provided `Uint8Array` buffer, synchronously.

--- a/apps/oxlint/src-js/cli.ts
+++ b/apps/oxlint/src-js/cli.ts
@@ -7,6 +7,7 @@ import { debugAssertIsNonNull, debugAssertIsNotUndefined } from "./utils/asserts
 let loadPlugin: typeof import("./plugins/index.ts").loadPlugin | null = null;
 let setupRuleConfigs: typeof import("./plugins/index.ts").setupRuleConfigs | null = null;
 let lintFile: typeof import("./plugins/index.ts").lintFile | null = null;
+let forgetBuffer: typeof import("./plugins/index.ts").forgetBuffer | null = null;
 let createWorkspace: typeof import("./workspace/index.ts").createWorkspace | null = null;
 let destroyWorkspace: typeof import("./workspace/index.ts").destroyWorkspace | null = null;
 // Lazy-loaded JS/TS config loader (experimental)
@@ -38,7 +39,7 @@ function loadPluginWrapper(
     // Use promises here instead of making `loadPluginWrapper` an async function,
     // to avoid a micro-tick and extra wrapper `Promise` in all later calls to `loadPluginWrapper`
     return import("./plugins/index.ts").then((mod) => {
-      ({ loadPlugin, lintFile, setupRuleConfigs } = mod);
+      ({ loadPlugin, lintFile, setupRuleConfigs, forgetBuffer } = mod);
       return loadPlugin(path, pluginName, pluginNameIsAlias, workspaceUri);
     });
   }
@@ -101,6 +102,19 @@ function lintFileWrapper(
     globalsJSON,
     workspaceUri,
   );
+}
+
+/**
+ * Drop the cached buffer with this ID.
+ *
+ * Delegates to `forgetBuffer`, which was lazy-loaded by `loadPluginWrapper`. Rust only asks to
+ * forget buffers it previously sent to JS, so the plugins module is always loaded by then.
+ *
+ * @param bufferId - ID of buffer to forget
+ */
+function forgetBufferWrapper(bufferId: number): undefined {
+  debugAssertIsNonNull(forgetBuffer);
+  forgetBuffer(bufferId);
 }
 
 /**
@@ -187,6 +201,7 @@ const success = await lint(
   loadPluginWrapper,
   setupRuleConfigsWrapper,
   lintFileWrapper,
+  forgetBufferWrapper,
   createWorkspaceWrapper,
   destroyWorkspaceWrapper,
   loadJsConfigsWrapper,

--- a/apps/oxlint/src-js/plugins/index.ts
+++ b/apps/oxlint/src-js/plugins/index.ts
@@ -1,6 +1,6 @@
 // Patch `WeakMap` before any plugins are loaded
 import "./weak_map.ts";
 
-export { lintFile } from "./lint.ts";
+export { lintFile, forgetBuffer } from "./lint.ts";
 export { loadPlugin } from "./load.ts";
 export { setupRuleConfigs } from "./config.ts";

--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -28,9 +28,28 @@ import type { AfterHook, BufferWithArrays } from "./types.ts";
 // Buffers cache.
 //
 // All buffers sent from Rust are stored in this array, indexed by `bufferId` (also sent from Rust).
-// Buffers are only added to this array, never removed, so no buffers will be garbage collected
-// until the process exits.
+// `forgetBuffer` nulls a slot so the `Uint8Array` can be garbage collected.
 export const buffers: (BufferWithArrays | null)[] = [];
+
+/**
+ * Drop the cached buffer for `id` so the `Uint8Array` can be garbage collected.
+ *
+ * Called from Rust when the owning allocator is freed.
+ */
+export function forgetBuffer(id: number): void {
+  if (id < buffers.length) buffers[id] = null;
+}
+
+/**
+ * Number of cached buffers that have not been forgotten.
+ */
+export function occupiedBufferCount(): number {
+  let count = 0;
+  for (let i = 0, len = buffers.length; i < len; i++) {
+    if (buffers[i] != null) count++;
+  }
+  return count;
+}
 
 // Array of `after` hooks to run after traversal. This array reused for every file.
 const afterHooks: AfterHook[] = [];

--- a/apps/oxlint/src/js_plugins/external_linter.rs
+++ b/apps/oxlint/src/js_plugins/external_linter.rs
@@ -13,38 +13,43 @@ use serde::Deserialize;
 use oxc_allocator::{Allocator, free_fixed_size_allocator};
 use oxc_linter::{
     ExternalLinter, ExternalLinterCreateWorkspaceCb, ExternalLinterDestroyWorkspaceCb,
-    ExternalLinterLintFileCb, ExternalLinterLoadPluginCb, ExternalLinterSetupRuleConfigsCb,
-    LintFileResult, LoadPluginResult,
+    ExternalLinterForgetBufferCb, ExternalLinterLintFileCb, ExternalLinterLoadPluginCb,
+    ExternalLinterSetupRuleConfigsCb, LintFileResult, LoadPluginResult,
 };
 
 use crate::{
     generated::raw_transfer_constants::{BLOCK_ALIGN, BUFFER_SIZE},
     run::{
-        JsCreateWorkspaceCb, JsDestroyWorkspaceCb, JsLintFileCb, JsLoadPluginCb,
+        JsCreateWorkspaceCb, JsDestroyWorkspaceCb, JsForgetBufferCb, JsLintFileCb, JsLoadPluginCb,
         JsSetupRuleConfigsCb,
     },
 };
 
 /// Wrap JS callbacks as normal Rust functions, and create [`ExternalLinter`].
+///
+/// This is the single-isolate (`K == 1`) path, where JS plugins run on the main JS thread.
 pub fn create_external_linter(
     load_plugin: JsLoadPluginCb,
     setup_rule_configs: JsSetupRuleConfigsCb,
     lint_file: JsLintFileCb,
+    forget_buffer: JsForgetBufferCb,
     create_workspace: JsCreateWorkspaceCb,
     destroy_workspace: JsDestroyWorkspaceCb,
 ) -> ExternalLinter {
     let rust_load_plugin = wrap_load_plugin(load_plugin);
     let rust_setup_rule_configs = wrap_setup_rule_configs(setup_rule_configs);
     let rust_lint_file = wrap_lint_file(lint_file);
+    let rust_forget_buffer = wrap_forget_buffer(forget_buffer);
     let rust_create_workspace = wrap_create_workspace(create_workspace);
     let rust_destroy_workspace = wrap_destroy_workspace(destroy_workspace);
 
     ExternalLinter::new(
-        rust_load_plugin,
-        rust_setup_rule_configs,
-        rust_lint_file,
-        rust_create_workspace,
-        rust_destroy_workspace,
+        Box::new([rust_load_plugin]),
+        Box::new([rust_setup_rule_configs]),
+        Box::new([rust_lint_file]),
+        Box::new([rust_forget_buffer]),
+        Box::new([rust_create_workspace]),
+        Box::new([rust_destroy_workspace]),
     )
 }
 
@@ -226,6 +231,22 @@ fn wrap_lint_file(cb: JsLintFileCb) -> ExternalLinterLintFileCb {
             }
         },
     ))
+}
+
+/// Wrap `forgetBuffer` JS callback as a normal Rust function.
+///
+/// The JS side just nulls a slot in its buffer cache, so there's no return value to wait for.
+/// Dispatch it non-blocking and don't block the calling thread: the buffer's memory is freed by the
+/// `Uint8Array` finalizer once JS garbage collects the view, which cannot happen synchronously.
+fn wrap_forget_buffer(cb: JsForgetBufferCb) -> ExternalLinterForgetBufferCb {
+    Arc::new(Box::new(move |buffer_id: u32| {
+        let status = cb.call(buffer_id, ThreadsafeFunctionCallMode::NonBlocking);
+        if status == Status::Ok {
+            Ok(())
+        } else {
+            Err(format!("Failed to schedule `forgetBuffer` callback: {status:?}"))
+        }
+    }))
 }
 
 /// Get buffer ID of the `Allocator` and, if it hasn't already been sent to JS,

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -234,7 +234,7 @@ impl CliRunner {
 
         // Setup JS workspace before loading any configs (config parsing can load JS plugins).
         if let Some(external_linter) = &external_linter {
-            let res = (external_linter.create_workspace)(self.cwd.to_string_lossy().into_owned());
+            let res = external_linter.create_workspace(self.cwd.to_string_lossy().into_owned());
 
             if let Err(err) = res {
                 print_and_flush_stdout(stdout, &format!("Failed to setup JS workspace:\n{err}\n"));

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -99,7 +99,7 @@ impl ServerLinterBuilder {
 
         // Setup JS workspace. This must be done before loading any configs
         if let Some(external_linter) = external_linter {
-            let res = (external_linter.create_workspace)(root_uri.as_str().to_string());
+            let res = external_linter.create_workspace(root_uri.as_str().to_string());
 
             if let Err(err) = res {
                 error!("Failed to setup JS workspace:\n{err}\n");
@@ -221,10 +221,25 @@ impl ServerLinterBuilder {
             }
         }
 
+        // This folder gets its own pool of arenas. Building a pool here mints buffer ids
+        // that `ExternalLinter` routes by `buffer_id % K` (K is 1 on the main-thread path).
+        let mut buffer_ids = Vec::new();
+        let mut new_allocator_pools = || {
+            // `external_linter` was already cleared above if no JS plugins were loaded.
+            let pools =
+                crate::utils::create_allocator_pools(external_linter.is_some(), use_cross_module);
+            buffer_ids.extend_from_slice(pools.parse.buffer_ids());
+            if let Some(js_pool) = pools.js.as_ref() {
+                buffer_ids.extend_from_slice(js_pool.buffer_ids());
+            }
+            pools
+        };
+
         let runner = match LintRunnerBuilder::new(lint_service_options.clone(), linter)
             .with_type_aware(type_aware)
             .with_fix_kind(fix_kind)
             .with_ignore_fixes(true)
+            .with_allocator_pools(new_allocator_pools())
             .build()
         {
             Ok(runner) => runner,
@@ -237,10 +252,18 @@ impl ServerLinterBuilder {
                     .with_type_aware(false)
                     .with_fix_kind(fix_kind)
                     .with_ignore_fixes(true)
+                    .with_allocator_pools(new_allocator_pools())
                     .build()
                     .expect("Failed to build LintRunner without type-aware linting")
             }
         };
+
+        // The failed builder above drops its pool, but JS still holds those buffers, so the guard
+        // has to forget every id minted during this build, not just the surviving pool's.
+        let js_buffers =
+            external_linter.filter(|_| !buffer_ids.is_empty()).map(|external_linter| {
+                JsBufferGuard { buffer_ids, external_linter: external_linter.clone() }
+            });
 
         (
             ServerLinter::new(
@@ -253,7 +276,8 @@ impl ServerLinterBuilder {
                 fix_kind,
                 lint_options.report_unused_directive,
                 options.rules_customization,
-            ),
+            )
+            .with_js_buffers(js_buffers),
             None,
         )
     }
@@ -313,7 +337,7 @@ impl ToolBuilder for ServerLinterBuilder {
 
         // Destroy JS workspace
         if let Some(external_linter) = &self.external_linter {
-            let res = (external_linter.destroy_workspace)(root_uri.as_str().to_string());
+            let res = external_linter.destroy_workspace(root_uri.as_str().to_string());
 
             if let Err(err) = res {
                 error!("Failed to destroy JS workspace:\n{err}\n");
@@ -412,6 +436,29 @@ pub struct ServerLinter {
     fix_kind: FixKind,
     unused_directives_severity: Option<AllowWarnDeny>,
     rules_customization: Option<RulesCustomization>,
+    /// Drops this folder's raw-transfer buffers on the JS side. Only the field's `Drop` matters.
+    js_buffers: Option<JsBufferGuard>,
+}
+
+/// Releases the JS-side references to a folder's fixed-size arenas when it is dropped.
+///
+/// Each fixed-size arena is exposed to JS as a `Uint8Array` that `lint.ts` caches, so the
+/// arena's finalizer never runs while that cache entry lives. Since the language server builds a
+/// fresh pool per folder and rebuilds on every config change, the buffers would otherwise pile up
+/// at 2 GiB of address space each. `forgetBuffer` clears the cache entry so the arena can be freed.
+struct JsBufferGuard {
+    buffer_ids: Vec<u32>,
+    external_linter: ExternalLinter,
+}
+
+impl Drop for JsBufferGuard {
+    fn drop(&mut self) {
+        for &buffer_id in &self.buffer_ids {
+            if let Err(err) = self.external_linter.forget_buffer(buffer_id) {
+                error!("Failed to drop JS buffer {buffer_id}:\n{err}\n");
+            }
+        }
+    }
 }
 
 impl Tool for ServerLinter {
@@ -721,7 +768,14 @@ impl ServerLinter {
             fix_kind,
             unused_directives_severity,
             rules_customization,
+            js_buffers: None,
         }
+    }
+
+    #[must_use]
+    fn with_js_buffers(mut self, js_buffers: Option<JsBufferGuard>) -> Self {
+        self.js_buffers = js_buffers;
+        self
     }
 
     fn get_code_actions_for_uri(

--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -38,6 +38,21 @@ pub type JsLoadPluginCb = ThreadsafeFunction<
     false,
 >;
 
+/// JS callback to drop a cached raw-transfer buffer.
+#[napi]
+pub type JsForgetBufferCb = ThreadsafeFunction<
+    // Arguments
+    u32, // Buffer ID
+    // Return value
+    (),
+    // Arguments (repeated)
+    u32,
+    // Error status
+    Status,
+    // CalleeHandled
+    false,
+>;
+
 /// JS callback to lint a file.
 #[napi]
 pub type JsLintFileCb = ThreadsafeFunction<
@@ -129,9 +144,10 @@ pub type JsLoadJsConfigsCb = ThreadsafeFunction<
 /// 2. `load_plugin`: Load a JS plugin from a file path.
 /// 3. `setup_rule_configs`: Setup configuration options.
 /// 4. `lint_file`: Lint a file.
-/// 5. `create_workspace`: Create a workspace.
-/// 6. `destroy_workspace`: Destroy a workspace.
-/// 7. `load_js_configs`: Load JavaScript config files.
+/// 5. `forget_buffer`: Drop a cached raw-transfer buffer.
+/// 6. `create_workspace`: Create a workspace.
+/// 7. `destroy_workspace`: Destroy a workspace.
+/// 8. `load_js_configs`: Load JavaScript config files.
 ///
 /// Returns `true` if linting succeeded without errors, `false` otherwise.
 #[expect(clippy::allow_attributes)]
@@ -142,6 +158,7 @@ pub async fn lint(
     load_plugin: JsLoadPluginCb,
     setup_rule_configs: JsSetupRuleConfigsCb,
     lint_file: JsLintFileCb,
+    forget_buffer: JsForgetBufferCb,
     create_workspace: JsCreateWorkspaceCb,
     destroy_workspace: JsDestroyWorkspaceCb,
     load_js_configs: JsLoadJsConfigsCb,
@@ -151,6 +168,7 @@ pub async fn lint(
         load_plugin,
         setup_rule_configs,
         lint_file,
+        forget_buffer,
         create_workspace,
         destroy_workspace,
         load_js_configs,
@@ -166,6 +184,7 @@ async fn lint_impl(
     load_plugin: JsLoadPluginCb,
     setup_rule_configs: JsSetupRuleConfigsCb,
     lint_file: JsLintFileCb,
+    forget_buffer: JsForgetBufferCb,
     create_workspace: JsCreateWorkspaceCb,
     destroy_workspace: JsDestroyWorkspaceCb,
     load_js_configs: JsLoadJsConfigsCb,
@@ -199,6 +218,7 @@ async fn lint_impl(
             load_plugin,
             setup_rule_configs,
             lint_file,
+            forget_buffer,
             create_workspace,
             destroy_workspace,
         ));
@@ -206,10 +226,11 @@ async fn lint_impl(
     };
     #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
     let (external_linter, js_config_loader) = {
-        let (_, _, _, _, _, _) = (
+        let (_, _, _, _, _, _, _) = (
             load_plugin,
             setup_rule_configs,
             lint_file,
+            forget_buffer,
             create_workspace,
             destroy_workspace,
             load_js_configs,

--- a/apps/oxlint/src/utils.rs
+++ b/apps/oxlint/src/utils.rs
@@ -1,5 +1,43 @@
 use std::path::{Component, Path, PathBuf};
 
+use oxc_allocator::AllocatorPool;
+use oxc_linter::AllocatorPools;
+
+/// Create the allocator pools for a lint run.
+///
+/// JS plugins need fixed-size arenas, because those are the only arenas that can be shared with JS
+/// via raw transfer. Which pool is fixed-size depends on whether multi-file analysis is enabled:
+///
+/// * JS plugins, no `import` plugin: parse straight into fixed-size arenas. At most `thread_count`
+///   ASTs are live at once, so `thread_count` arenas suffice.
+/// * JS plugins and `import` plugin: parse into standard arenas (many ASTs stay live at once), and
+///   copy into a fixed-size arena only when handing a file to JS.
+/// * No JS plugins: standard arenas throughout.
+///
+/// Each fixed-size arena carries a buffer id that `ExternalLinter` uses to route a file
+/// to the isolate that owns that arena.
+pub fn create_allocator_pools(has_js_plugins: bool, cross_module: bool) -> AllocatorPools {
+    let thread_count = rayon::current_num_threads();
+
+    #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+    if has_js_plugins {
+        return if cross_module {
+            AllocatorPools {
+                parse: AllocatorPool::new(thread_count),
+                js: Some(AllocatorPool::new_fixed_size(thread_count)),
+            }
+        } else {
+            AllocatorPools { parse: AllocatorPool::new_fixed_size(thread_count), js: None }
+        };
+    }
+
+    // JS plugins are unsupported on these platforms, so fixed-size arenas are never needed.
+    #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
+    let _ = (has_js_plugins, cross_module);
+
+    AllocatorPools { parse: AllocatorPool::new(thread_count), js: None }
+}
+
 /// Normalize a path by removing `.` and resolving `..` components,
 /// without touching the filesystem.
 pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {

--- a/apps/oxlint/test/forget_buffer.test.ts
+++ b/apps/oxlint/test/forget_buffer.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buffers, forgetBuffer, occupiedBufferCount } from "../src-js/plugins/lint.ts";
+
+import type { BufferWithArrays } from "../src-js/plugins/types.ts";
+
+function fakeBuffer(): BufferWithArrays {
+  return new Uint8Array(8) as BufferWithArrays;
+}
+
+describe("forgetBuffer", () => {
+  afterEach(() => {
+    buffers.length = 0;
+  });
+
+  it("nulls the cached buffer at the given id", () => {
+    const first = fakeBuffer();
+    const second = fakeBuffer();
+    buffers[0] = first;
+    buffers[1] = second;
+
+    forgetBuffer(0);
+
+    expect(buffers[0]).toBeNull();
+    expect(buffers[1]).toBe(second);
+  });
+
+  it("does not grow the cache for an unknown id", () => {
+    forgetBuffer(99);
+    expect(buffers).toHaveLength(0);
+  });
+
+  it("is a no-op when the slot is already empty", () => {
+    buffers.push(null);
+    forgetBuffer(0);
+    expect(buffers[0]).toBeNull();
+    expect(buffers).toHaveLength(1);
+  });
+});
+
+describe("occupiedBufferCount", () => {
+  afterEach(() => {
+    buffers.length = 0;
+  });
+
+  it("counts only non-null entries", () => {
+    buffers.push(fakeBuffer(), null, fakeBuffer());
+    expect(occupiedBufferCount()).toBe(2);
+    forgetBuffer(0);
+    expect(occupiedBufferCount()).toBe(1);
+    forgetBuffer(2);
+    expect(occupiedBufferCount()).toBe(0);
+  });
+});

--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -590,6 +590,13 @@ impl Allocator {
         &self.arena
     }
 
+    /// `true` if this [`Allocator`] is a fixed-size raw-transfer arena.
+    ///
+    /// Empty allocators (no chunks) are not fixed-size.
+    pub fn is_fixed_size(&self) -> bool {
+        self.arena.is_fixed_size()
+    }
+
     /// Create [`Allocator`] from an [`Arena`].
     ///
     /// This method is not public. Only used by [`Allocator::from_raw_parts`].

--- a/crates/oxc_allocator/src/arena/mod.rs
+++ b/crates/oxc_allocator/src/arena/mod.rs
@@ -251,6 +251,17 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     pub const fn min_align(&self) -> usize {
         Self::MIN_ALIGN
     }
+
+    /// `true` if the current chunk was created as a fixed-size raw-transfer arena.
+    ///
+    /// Empty arenas (no chunks) are not fixed-size.
+    pub fn is_fixed_size(&self) -> bool {
+        match self.current_chunk_footer_ptr.get() {
+            // SAFETY: `current_chunk_footer_ptr` always points to a valid `ChunkFooter` when `Some`.
+            Some(footer_ptr) => unsafe { footer_ptr.as_ref().is_fixed_size },
+            None => false,
+        }
+    }
 }
 
 // SAFETY:

--- a/crates/oxc_allocator/src/pool/fixed_size.rs
+++ b/crates/oxc_allocator/src/pool/fixed_size.rs
@@ -3,9 +3,30 @@ use std::{
     ptr::NonNull,
     sync::{
         Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
     },
 };
+
+/// Process-wide id stamped into each fixed-size arena's `metadata.id`.
+///
+/// Two pools in one process (LSP folders) must not share ids, so this is not a pool slot index.
+static NEXT_BUFFER_ID: AtomicU32 = AtomicU32::new(0);
+
+fn next_buffer_id() -> u32 {
+    loop {
+        let id = NEXT_BUFFER_ID.load(Ordering::Relaxed);
+        #[expect(clippy::manual_assert)]
+        if id == u32::MAX {
+            panic!("fixed-size allocator buffer_id overflow");
+        }
+        if NEXT_BUFFER_ID
+            .compare_exchange_weak(id, id + 1, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            return id;
+        }
+    }
+}
 
 #[cfg(target_os = "windows")]
 use std::sync::Condvar;
@@ -82,6 +103,12 @@ pub struct FixedSizeAllocatorPool {
     /// Only used on Windows. On *nix systems, we don't need this synchronization.
     #[cfg(target_os = "windows")]
     available: Condvar,
+
+    /// Number of allocators actually created. On Windows this can be less than `thread_count`.
+    len: usize,
+
+    /// Buffer ids of every allocator in this pool, in creation order.
+    buffer_ids: Box<[u32]>,
 }
 
 impl FixedSizeAllocatorPool {
@@ -102,18 +129,23 @@ impl FixedSizeAllocatorPool {
     #[cfg(not(target_os = "windows"))]
     pub fn new(thread_count: usize) -> Self {
         let mut allocators = Stack::with_capacity(thread_count);
+        let mut buffer_ids = Vec::with_capacity(thread_count);
 
         // Create `thread_count` allocators
-        for i in 0..thread_count {
+        for _ in 0..thread_count {
             // It's impossible to create more than `u32::MAX` allocators, as `u32::MAX` x 4 GiB allocations would
             // consume almost the entirety of a 64-bit address space. No platform has such a large address space.
             // Typically they use 48 bit address space, or 53 bit at most.
-            #[expect(clippy::cast_possible_truncation)]
-            let allocator = FixedSizeAllocator::try_new(i as u32).unwrap();
+            let allocator = FixedSizeAllocator::try_new().unwrap();
+            buffer_ids.push(allocator.buffer_id());
             allocators.push(allocator);
         }
 
-        Self { allocators: Mutex::new(allocators) }
+        Self {
+            allocators: Mutex::new(allocators),
+            len: thread_count,
+            buffer_ids: buffer_ids.into_boxed_slice(),
+        }
     }
 
     /// Create a new [`FixedSizeAllocatorPool`] containing *up to* `thread_count` allocators.
@@ -151,15 +183,16 @@ impl FixedSizeAllocatorPool {
         let capacity = thread_count + 1;
 
         let mut allocators = Stack::with_capacity(capacity);
+        let mut buffer_ids = Vec::with_capacity(capacity);
 
         // Get as many allocators as possible, up to `capacity`
-        for i in 0..capacity {
+        for _ in 0..capacity {
             // It's impossible to create more than `u32::MAX` allocators, as `u32::MAX` x 4 GiB allocations would
             // consume almost the entirety of a 64-bit address space. No platform has such a large address space.
             // Typically they use 48 bit address space, or 53 bit at most.
-            #[expect(clippy::cast_possible_truncation)]
-            let allocator = FixedSizeAllocator::try_new(i as u32);
+            let allocator = FixedSizeAllocator::try_new();
             let Ok(allocator) = allocator else { break };
+            buffer_ids.push(allocator.buffer_id());
             allocators.push(allocator);
         }
 
@@ -175,10 +208,17 @@ impl FixedSizeAllocatorPool {
             // Otherwise, discard the last allocator we got, to leave memory free for other allocations
             _ => {
                 allocators.pop();
+                buffer_ids.pop();
             }
         }
 
-        Self { allocators: Mutex::new(allocators), available: Condvar::new() }
+        let len = allocators.len();
+        Self {
+            allocators: Mutex::new(allocators),
+            available: Condvar::new(),
+            len,
+            buffer_ids: buffer_ids.into_boxed_slice(),
+        }
     }
 
     /// Retrieve an [`Allocator`] from the pool.
@@ -252,6 +292,16 @@ impl FixedSizeAllocatorPool {
         // On Windows, notify waiting threads that an allocator is available (see Windows impl of `get`)
         #[cfg(target_os = "windows")]
         self.available.notify_one();
+    }
+
+    /// Number of allocators actually created for this pool.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Buffer ids of every allocator in this pool.
+    pub fn buffer_ids(&self) -> &[u32] {
+        &self.buffer_ids
     }
 }
 
@@ -363,7 +413,7 @@ impl FixedSizeAllocator {
     /// Try to create a new [`FixedSizeAllocator`].
     ///
     /// Returns `Err` if memory allocation fails.
-    fn try_new(id: u32) -> Result<Self, ()> {
+    fn try_new() -> Result<Self, ()> {
         // Only support little-endian systems. `Allocator::from_raw_parts` includes this same assertion.
         // This module is only compiled on 64-bit little-endian systems, so it should be impossible for
         // this panic to occur. But we want to make absolutely sure that if there's a mistake elsewhere,
@@ -378,6 +428,7 @@ impl FixedSizeAllocator {
         // Wrap `Allocator` in `ManuallyDrop` so that we can control whether it's dropped in `FixedSizeAllocator`'s
         // `Drop` impl, depending on whether the buffer is currently shared with JS.
         let allocator = Allocator::new_fixed_size().ok_or(())?;
+        let id = next_buffer_id();
         let allocator = ManuallyDrop::new(allocator);
 
         // Pointer to the start of the chunk. `data_end_ptr` is the start of the `ChunkFooter`,
@@ -425,6 +476,14 @@ impl FixedSizeAllocator {
             debug_assert!(cursor_ptr.addr().get().is_multiple_of(CURSOR_MIN_ALIGN));
             self.allocator.set_cursor_ptr(cursor_ptr);
         }
+    }
+
+    /// Process-wide buffer id stamped into this allocator by [`try_new`].
+    ///
+    /// [`try_new`]: Self::try_new
+    fn buffer_id(&self) -> u32 {
+        // SAFETY: `try_new` wrote a `FixedSizeAllocatorMetadata` for this `Allocator`.
+        unsafe { self.allocator.fixed_size_buffer_id() }
     }
 
     /// Unwrap a [`FixedSizeAllocator`] into the [`Allocator`] it contains.
@@ -505,6 +564,16 @@ pub unsafe fn free_fixed_size_allocator(metadata_ptr: NonNull<FixedSizeAllocator
 }
 
 impl Allocator {
+    /// Process-wide id stamped into this fixed-size arena.
+    ///
+    /// # SAFETY
+    /// This `Allocator` must have been created by a `FixedSizeAllocator`.
+    pub unsafe fn fixed_size_buffer_id(&self) -> u32 {
+        debug_assert!(self.is_fixed_size());
+        // SAFETY: Caller guarantees this `Allocator` was created by a `FixedSizeAllocator`.
+        unsafe { self.fixed_size_metadata_ptr().as_ref().id }
+    }
+
     /// Get pointer to the `FixedSizeAllocatorMetadata` for this [`Allocator`].
     ///
     /// # SAFETY

--- a/crates/oxc_allocator/src/pool/mod.rs
+++ b/crates/oxc_allocator/src/pool/mod.rs
@@ -82,6 +82,57 @@ impl AllocatorPool {
         AllocatorGuard { allocator: ManuallyDrop::new(allocator), pool: self }
     }
 
+    /// Number of allocators this pool was constructed with.
+    ///
+    /// For a fixed-size pool this is the number of arenas that were actually created
+    /// (on Windows this can be less than the requested `thread_count`).
+    pub fn len(&self) -> usize {
+        match &self.0 {
+            AllocatorPoolInner::Standard(pool) => pool.len(),
+            #[cfg(all(
+                feature = "fixed_size",
+                target_pointer_width = "64",
+                target_endian = "little"
+            ))]
+            AllocatorPoolInner::FixedSize(pool) => pool.len(),
+        }
+    }
+
+    /// `true` if this pool was constructed with no allocators.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Buffer ids of every allocator in this pool.
+    ///
+    /// Empty for a standard pool, which does not stamp buffer ids.
+    ///
+    /// Callers use this to tell JS to drop its cached raw-transfer views before the pool is dropped.
+    pub fn buffer_ids(&self) -> &[u32] {
+        match &self.0 {
+            AllocatorPoolInner::Standard(_) => &[],
+            #[cfg(all(
+                feature = "fixed_size",
+                target_pointer_width = "64",
+                target_endian = "little"
+            ))]
+            AllocatorPoolInner::FixedSize(pool) => pool.buffer_ids(),
+        }
+    }
+
+    /// `true` if this pool uses fixed-size raw-transfer allocators.
+    pub fn is_fixed_size(&self) -> bool {
+        match &self.0 {
+            AllocatorPoolInner::Standard(_) => false,
+            #[cfg(all(
+                feature = "fixed_size",
+                target_pointer_width = "64",
+                target_endian = "little"
+            ))]
+            AllocatorPoolInner::FixedSize(_) => true,
+        }
+    }
+
     /// Add an [`Allocator`] to the pool.
     ///
     /// The `Allocator` is reset by this method, so it's ready to be re-used.
@@ -129,5 +180,76 @@ impl Drop for AllocatorGuard<'_> {
         // SAFETY: After taking ownership of the `Allocator`, we do not touch the `ManuallyDrop` again
         let allocator = unsafe { ManuallyDrop::take(&mut self.allocator) };
         self.pool.add(allocator);
+    }
+}
+
+#[cfg(all(test, feature = "fixed_size", target_pointer_width = "64", target_endian = "little"))]
+mod buffer_id_tests {
+    use std::mem::size_of;
+
+    use rustc_hash::FxHashSet;
+
+    use super::*;
+
+    #[test]
+    fn buffer_id_two_pools_are_distinct() {
+        let pool_a = AllocatorPool::new_fixed_size(2);
+        let pool_b = AllocatorPool::new_fixed_size(2);
+        assert_eq!(pool_a.len(), 2);
+        assert_eq!(pool_b.len(), 2);
+        assert!(pool_a.is_fixed_size());
+        assert!(pool_b.is_fixed_size());
+
+        let a0 = pool_a.get();
+        let a1 = pool_a.get();
+        let b0 = pool_b.get();
+        let b1 = pool_b.get();
+
+        assert!(a0.is_fixed_size());
+        assert!(a1.is_fixed_size());
+        assert!(b0.is_fixed_size());
+        assert!(b1.is_fixed_size());
+
+        // SAFETY: these allocators came from `new_fixed_size` pools.
+        let ids = unsafe {
+            [
+                a0.fixed_size_buffer_id(),
+                a1.fixed_size_buffer_id(),
+                b0.fixed_size_buffer_id(),
+                b1.fixed_size_buffer_id(),
+            ]
+        };
+        assert_eq!(FxHashSet::from_iter(ids).len(), 4);
+        assert_eq!(size_of::<FixedSizeAllocatorMetadata>(), 8);
+    }
+
+    #[test]
+    fn buffer_id_new_fixed_size_len() {
+        assert_eq!(AllocatorPool::new_fixed_size(2).len(), 2);
+    }
+
+    #[test]
+    fn buffer_id_standard_pool_is_not_fixed_size() {
+        let pool = AllocatorPool::new(2);
+        assert_eq!(pool.len(), 2);
+        assert!(!pool.is_fixed_size());
+        assert!(!pool.get().is_fixed_size());
+        assert!(pool.buffer_ids().is_empty());
+    }
+
+    /// The language server forgets a folder's buffers by id, so `buffer_ids` has to list exactly
+    /// the ids of the arenas the pool hands out — no more, no fewer.
+    #[test]
+    fn buffer_ids_match_the_arenas_the_pool_hands_out() {
+        let pool = AllocatorPool::new_fixed_size(3);
+        let expected = pool.buffer_ids().iter().copied().collect::<FxHashSet<_>>();
+        assert_eq!(expected.len(), pool.len());
+
+        let guards = [pool.get(), pool.get(), pool.get()];
+        // SAFETY: these allocators came from a `new_fixed_size` pool.
+        let actual = unsafe {
+            guards.iter().map(|guard| guard.fixed_size_buffer_id()).collect::<FxHashSet<_>>()
+        };
+        assert_eq!(actual, expected);
     }
 }

--- a/crates/oxc_allocator/src/pool/standard.rs
+++ b/crates/oxc_allocator/src/pool/standard.rs
@@ -14,13 +14,23 @@ pub struct StandardAllocatorPool {
     /// and those are the operations we do while `Mutex` lock is held.
     /// The shorter the time lock is held, the less contention there is.
     allocators: Mutex<Stack<Allocator>>,
+    /// Number of allocators created when the pool was constructed.
+    /// The pool can grow past this if [`get`] creates extras.
+    ///
+    /// [`get`]: Self::get
+    len: usize,
 }
 
 impl StandardAllocatorPool {
     /// Create a new [`StandardAllocatorPool`] for use across the specified number of threads.
     pub fn new(thread_count: usize) -> StandardAllocatorPool {
         let allocators = iter::repeat_with(Allocator::new).take(thread_count).collect();
-        StandardAllocatorPool { allocators: Mutex::new(allocators) }
+        StandardAllocatorPool { allocators: Mutex::new(allocators), len: thread_count }
+    }
+
+    /// Number of allocators created when the pool was constructed.
+    pub fn len(&self) -> usize {
+        self.len
     }
 
     /// Retrieve an [`Allocator`] from the pool, or create a new one if the pool is empty.

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -679,16 +679,12 @@ impl ConfigStoreBuilder {
         // Note: `unwrap()` here is infallible as `plugin_path` is an absolute path.
         let plugin_url = String::from(Url::from_file_path(&plugin_path).unwrap());
 
-        let result = (external_linter.load_plugin)(
-            plugin_url,
-            plugin_name,
-            alias.is_some(),
-            workspace_uri.map(String::from),
-        )
-        .map_err(|error| ConfigBuilderError::PluginLoadFailed {
-            plugin_specifier: plugin_specifier.to_string(),
-            error,
-        })?;
+        let result = external_linter
+            .load_plugin(plugin_url, plugin_name, alias.is_some(), workspace_uri.map(String::from))
+            .map_err(|error| ConfigBuilderError::PluginLoadFailed {
+                plugin_specifier: plugin_specifier.to_string(),
+                error,
+            })?;
         let plugin_name = result.name;
 
         if LintPlugins::try_from(plugin_name.as_str()).is_err() {

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -359,13 +359,10 @@ impl ExternalLinter {
     ///
     /// # Errors
     ///
-    /// Returns the first worker error, if any.
+    /// Returns every worker error, joined. Every slot is still called so a failure
+    /// on one isolate cannot leave the others unconfigured.
     pub fn setup_rule_configs(&self, options_json: String) -> Result<(), String> {
-        let last = self.k - 1;
-        for cb in &self.setup_rule_configs_on_workers[..last] {
-            cb(options_json.clone())?;
-        }
-        (self.setup_rule_configs_on_workers[last])(options_json)
+        call_every_worker(&self.setup_rule_configs_on_workers, options_json)
     }
 
     /// Route `lint_file` to the worker that owns `allocator`'s buffer (`buffer_id % K`).
@@ -436,26 +433,41 @@ impl ExternalLinter {
     ///
     /// # Errors
     ///
-    /// Returns the first worker error, if any.
+    /// Returns every worker error, joined. Every slot is still called.
     pub fn create_workspace(&self, workspace_uri: String) -> Result<(), String> {
-        let last = self.k - 1;
-        for cb in &self.create_workspace_on_workers[..last] {
-            cb(workspace_uri.clone())?;
-        }
-        (self.create_workspace_on_workers[last])(workspace_uri)
+        call_every_worker(&self.create_workspace_on_workers, workspace_uri)
     }
 
     /// Destroy a JS workspace on every worker.
     ///
     /// # Errors
     ///
-    /// Returns the first worker error, if any.
+    /// Returns every worker error, joined. Every slot is still called.
     pub fn destroy_workspace(&self, workspace_uri: String) -> Result<(), String> {
-        let last = self.k - 1;
-        for cb in &self.destroy_workspace_on_workers[..last] {
-            cb(workspace_uri.clone())?;
+        call_every_worker(&self.destroy_workspace_on_workers, workspace_uri)
+    }
+}
+
+/// Call every callback with `arg`. Collect errors instead of returning on the first failure,
+/// so a broken isolate cannot skip configuration of the rest.
+fn call_every_worker(
+    callbacks: &[Arc<Box<dyn Fn(String) -> Result<(), String> + Send + Sync>>],
+    arg: String,
+) -> Result<(), String> {
+    let last = callbacks.len() - 1;
+    let mut errors = Vec::new();
+    for cb in &callbacks[..last] {
+        if let Err(err) = cb(arg.clone()) {
+            errors.push(err);
         }
-        (self.destroy_workspace_on_workers[last])(workspace_uri)
+    }
+    if let Err(err) = callbacks[last](arg) {
+        errors.push(err);
+    }
+    match errors.len() {
+        0 => Ok(()),
+        1 => Err(errors.pop().unwrap()),
+        _ => Err(errors.join("; ")),
     }
 }
 
@@ -695,6 +707,28 @@ mod tests {
             vec![
                 setup_stub(Arc::clone(&calls0), None),
                 setup_stub(Arc::clone(&calls1), Some("bad options".into())),
+            ],
+            vec![unused_lint(), unused_lint()],
+            vec![unused_forget(), unused_forget()],
+            vec![unused_create(), unused_create()],
+            vec![unused_destroy(), unused_destroy()],
+        );
+
+        let err = linter.setup_rule_configs("{}".into()).unwrap_err();
+        assert_eq!(err, "bad options");
+        assert_eq!(calls0.load(Ordering::SeqCst), 1);
+        assert_eq!(calls1.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn setup_rule_configs_still_calls_later_workers_when_one_fails() {
+        let calls0 = Arc::new(AtomicUsize::new(0));
+        let calls1 = Arc::new(AtomicUsize::new(0));
+        let linter = linter_from_slots(
+            vec![unused_load(), unused_load()],
+            vec![
+                setup_stub(Arc::clone(&calls0), Some("bad options".into())),
+                setup_stub(Arc::clone(&calls1), None),
             ],
             vec![unused_lint(), unused_lint()],
             vec![unused_forget(), unused_forget()],

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -40,6 +40,8 @@ pub type ExternalLinterLoadPluginCb = Arc<
 pub type ExternalLinterSetupRuleConfigsCb =
     Arc<Box<dyn Fn(String) -> Result<(), String> + Send + Sync>>;
 
+pub type ExternalLinterForgetBufferCb = Arc<Box<dyn Fn(u32) -> Result<(), String> + Send + Sync>>;
+
 pub type ExternalLinterLintFileCb = Arc<
     Box<
         dyn Fn(
@@ -247,23 +249,218 @@ fn create_invalid_offset_error(span: Span) -> Result<Fix, MergeFixesError> {
 
 #[derive(Clone)]
 pub struct ExternalLinter {
-    pub(crate) load_plugin: ExternalLinterLoadPluginCb,
-    pub(crate) setup_rule_configs: ExternalLinterSetupRuleConfigsCb,
-    pub(crate) lint_file: ExternalLinterLintFileCb,
-    pub create_workspace: ExternalLinterCreateWorkspaceCb,
-    pub destroy_workspace: ExternalLinterDestroyWorkspaceCb,
+    k: usize,
+    load_plugin_on_workers: Box<[ExternalLinterLoadPluginCb]>,
+    setup_rule_configs_on_workers: Box<[ExternalLinterSetupRuleConfigsCb]>,
+    lint_file_on_workers: Box<[ExternalLinterLintFileCb]>,
+    forget_buffer_on_workers: Box<[ExternalLinterForgetBufferCb]>,
+    create_workspace_on_workers: Box<[ExternalLinterCreateWorkspaceCb]>,
+    destroy_workspace_on_workers: Box<[ExternalLinterDestroyWorkspaceCb]>,
 }
 
 impl ExternalLinter {
+    /// Create an [`ExternalLinter`] with `K` callback slots (one per JS isolate).
+    ///
+    /// All slices must have the same non-zero length `K`. `K == 1` is today's
+    /// main-thread callback path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any slice is empty or the slice lengths do not match.
     pub fn new(
-        load_plugin: ExternalLinterLoadPluginCb,
-        setup_rule_configs: ExternalLinterSetupRuleConfigsCb,
-        lint_file: ExternalLinterLintFileCb,
-        create_workspace: ExternalLinterCreateWorkspaceCb,
-        destroy_workspace: ExternalLinterDestroyWorkspaceCb,
+        load_plugin_on_workers: Box<[ExternalLinterLoadPluginCb]>,
+        setup_rule_configs_on_workers: Box<[ExternalLinterSetupRuleConfigsCb]>,
+        lint_file_on_workers: Box<[ExternalLinterLintFileCb]>,
+        forget_buffer_on_workers: Box<[ExternalLinterForgetBufferCb]>,
+        create_workspace_on_workers: Box<[ExternalLinterCreateWorkspaceCb]>,
+        destroy_workspace_on_workers: Box<[ExternalLinterDestroyWorkspaceCb]>,
     ) -> Self {
-        Self { load_plugin, setup_rule_configs, lint_file, create_workspace, destroy_workspace }
+        let k = load_plugin_on_workers.len();
+        assert!(k >= 1, "ExternalLinter requires at least one worker");
+        assert_eq!(
+            setup_rule_configs_on_workers.len(),
+            k,
+            "setup_rule_configs callback count must equal K"
+        );
+        assert_eq!(lint_file_on_workers.len(), k, "lint_file callback count must equal K");
+        assert_eq!(forget_buffer_on_workers.len(), k, "forget_buffer callback count must equal K");
+        assert_eq!(
+            create_workspace_on_workers.len(),
+            k,
+            "create_workspace callback count must equal K"
+        );
+        assert_eq!(
+            destroy_workspace_on_workers.len(),
+            k,
+            "destroy_workspace callback count must equal K"
+        );
+        Self {
+            k,
+            load_plugin_on_workers,
+            setup_rule_configs_on_workers,
+            lint_file_on_workers,
+            forget_buffer_on_workers,
+            create_workspace_on_workers,
+            destroy_workspace_on_workers,
+        }
     }
+
+    /// Load a JS plugin on every worker and return the first worker's result.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any worker fails to load the plugin, or if workers
+    /// register different `name` / `offset` / `rule_names`.
+    pub fn load_plugin(
+        &self,
+        plugin_url: String,
+        plugin_name: Option<String>,
+        plugin_name_is_alias: bool,
+        workspace_uri: Option<String>,
+    ) -> Result<LoadPluginResult, String> {
+        if self.k == 1 {
+            return (self.load_plugin_on_workers[0])(
+                plugin_url,
+                plugin_name,
+                plugin_name_is_alias,
+                workspace_uri,
+            );
+        }
+        let first = (self.load_plugin_on_workers[0])(
+            plugin_url.clone(),
+            plugin_name.clone(),
+            plugin_name_is_alias,
+            workspace_uri.clone(),
+        )?;
+        for cb in &self.load_plugin_on_workers[1..self.k - 1] {
+            let other = cb(
+                plugin_url.clone(),
+                plugin_name.clone(),
+                plugin_name_is_alias,
+                workspace_uri.clone(),
+            )?;
+            if load_plugin_mismatch(&first, &other) {
+                return Err("JS worker rule registration mismatch".to_string());
+            }
+        }
+        let other = (self.load_plugin_on_workers[self.k - 1])(
+            plugin_url,
+            plugin_name,
+            plugin_name_is_alias,
+            workspace_uri,
+        )?;
+        if load_plugin_mismatch(&first, &other) {
+            return Err("JS worker rule registration mismatch".to_string());
+        }
+        Ok(first)
+    }
+
+    /// Send rule options JSON to every worker.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first worker error, if any.
+    pub fn setup_rule_configs(&self, options_json: String) -> Result<(), String> {
+        let last = self.k - 1;
+        for cb in &self.setup_rule_configs_on_workers[..last] {
+            cb(options_json.clone())?;
+        }
+        (self.setup_rule_configs_on_workers[last])(options_json)
+    }
+
+    /// Route `lint_file` to the worker that owns `allocator`'s buffer (`buffer_id % K`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the owning worker's callback fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `allocator` is not a fixed-size arena.
+    pub fn lint_file(
+        &self,
+        file_path: String,
+        rule_ids: Vec<u32>,
+        options_ids: Vec<u32>,
+        settings_json: String,
+        globals_json: String,
+        workspace_uri: Option<String>,
+        allocator: &Allocator,
+    ) -> Result<Vec<LintFileResult>, String> {
+        assert!(
+            allocator.is_fixed_size(),
+            "ExternalLinter::lint_file requires a fixed-size allocator"
+        );
+
+        #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+        {
+            // SAFETY: `is_fixed_size` was checked above.
+            let buffer_id = unsafe { allocator.fixed_size_buffer_id() };
+            let owner = (buffer_id as usize) % self.k;
+            (self.lint_file_on_workers[owner])(
+                file_path,
+                rule_ids,
+                options_ids,
+                settings_json,
+                globals_json,
+                workspace_uri,
+                allocator,
+            )
+        }
+
+        #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
+        {
+            (self.lint_file_on_workers[0])(
+                file_path,
+                rule_ids,
+                options_ids,
+                settings_json,
+                globals_json,
+                workspace_uri,
+                allocator,
+            )
+        }
+    }
+
+    /// Drop a cached raw-transfer buffer on the worker that owns `buffer_id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the owning worker's callback fails.
+    pub fn forget_buffer(&self, buffer_id: u32) -> Result<(), String> {
+        let owner = (buffer_id as usize) % self.k;
+        (self.forget_buffer_on_workers[owner])(buffer_id)
+    }
+
+    /// Create a JS workspace on every worker.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first worker error, if any.
+    pub fn create_workspace(&self, workspace_uri: String) -> Result<(), String> {
+        let last = self.k - 1;
+        for cb in &self.create_workspace_on_workers[..last] {
+            cb(workspace_uri.clone())?;
+        }
+        (self.create_workspace_on_workers[last])(workspace_uri)
+    }
+
+    /// Destroy a JS workspace on every worker.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first worker error, if any.
+    pub fn destroy_workspace(&self, workspace_uri: String) -> Result<(), String> {
+        let last = self.k - 1;
+        for cb in &self.destroy_workspace_on_workers[..last] {
+            cb(workspace_uri.clone())?;
+        }
+        (self.destroy_workspace_on_workers[last])(workspace_uri)
+    }
+}
+
+fn load_plugin_mismatch(first: &LoadPluginResult, other: &LoadPluginResult) -> bool {
+    other.rule_names != first.rule_names || other.offset != first.offset || other.name != first.name
 }
 
 impl Debug for ExternalLinter {
@@ -299,5 +496,313 @@ impl Serialize for EnabledEnvs<'_> {
         }
 
         map.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use oxc_allocator::Allocator;
+
+    use super::*;
+
+    fn unused_load() -> ExternalLinterLoadPluginCb {
+        Arc::new(Box::new(|_, _, _, _| panic!("load_plugin should not be called")))
+    }
+
+    fn unused_setup() -> ExternalLinterSetupRuleConfigsCb {
+        Arc::new(Box::new(|_| panic!("setup_rule_configs should not be called")))
+    }
+
+    fn unused_lint() -> ExternalLinterLintFileCb {
+        Arc::new(Box::new(|_, _, _, _, _, _, _| panic!("lint_file should not be called")))
+    }
+
+    fn unused_forget() -> ExternalLinterForgetBufferCb {
+        Arc::new(Box::new(|_| panic!("forget_buffer should not be called")))
+    }
+
+    fn unused_create() -> ExternalLinterCreateWorkspaceCb {
+        Arc::new(Box::new(|_| panic!("create_workspace should not be called")))
+    }
+
+    fn unused_destroy() -> ExternalLinterDestroyWorkspaceCb {
+        Arc::new(Box::new(|_| panic!("destroy_workspace should not be called")))
+    }
+
+    fn plugin_ok(name: &str, offset: usize, rules: &[&str]) -> LoadPluginResult {
+        LoadPluginResult {
+            name: name.to_string(),
+            offset,
+            rule_names: rules.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    fn load_stub(result: LoadPluginResult, calls: Arc<AtomicUsize>) -> ExternalLinterLoadPluginCb {
+        Arc::new(Box::new(move |_, _, _, _| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(result.clone())
+        }))
+    }
+
+    fn setup_stub(
+        calls: Arc<AtomicUsize>,
+        err: Option<String>,
+    ) -> ExternalLinterSetupRuleConfigsCb {
+        Arc::new(Box::new(move |_| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            match &err {
+                Some(message) => Err(message.clone()),
+                None => Ok(()),
+            }
+        }))
+    }
+
+    fn lint_stub(called: Arc<Mutex<Vec<u32>>>) -> ExternalLinterLintFileCb {
+        Arc::new(Box::new(move |_, _, _, _, _, _, allocator| {
+            #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+            {
+                // SAFETY: routing tests only pass fixed-size allocators.
+                let buffer_id = unsafe { allocator.fixed_size_buffer_id() };
+                called.lock().expect("lint_file stub mutex poisoned").push(buffer_id);
+            }
+            #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
+            {
+                let _ = allocator;
+                called.lock().expect("lint_file stub mutex poisoned").push(0);
+            }
+            Ok(Vec::new())
+        }))
+    }
+
+    fn forget_stub(called: Arc<Mutex<Vec<u32>>>) -> ExternalLinterForgetBufferCb {
+        Arc::new(Box::new(move |buffer_id| {
+            called.lock().expect("forget_buffer stub mutex poisoned").push(buffer_id);
+            Ok(())
+        }))
+    }
+
+    fn linter_from_slots(
+        load: Vec<ExternalLinterLoadPluginCb>,
+        setup: Vec<ExternalLinterSetupRuleConfigsCb>,
+        lint: Vec<ExternalLinterLintFileCb>,
+        forget: Vec<ExternalLinterForgetBufferCb>,
+        create: Vec<ExternalLinterCreateWorkspaceCb>,
+        destroy: Vec<ExternalLinterDestroyWorkspaceCb>,
+    ) -> ExternalLinter {
+        ExternalLinter::new(
+            load.into_boxed_slice(),
+            setup.into_boxed_slice(),
+            lint.into_boxed_slice(),
+            forget.into_boxed_slice(),
+            create.into_boxed_slice(),
+            destroy.into_boxed_slice(),
+        )
+    }
+
+    fn call_lint_file(
+        linter: &ExternalLinter,
+        allocator: &Allocator,
+    ) -> Result<Vec<LintFileResult>, String> {
+        linter.lint_file(
+            "file.js".to_string(),
+            Vec::new(),
+            Vec::new(),
+            "{}".to_string(),
+            "{}".to_string(),
+            None,
+            allocator,
+        )
+    }
+
+    #[test]
+    fn load_plugin_calls_all_k_and_returns_first() {
+        let calls0 = Arc::new(AtomicUsize::new(0));
+        let calls1 = Arc::new(AtomicUsize::new(0));
+        let first = plugin_ok("demo", 3, &["a", "b"]);
+        let linter = linter_from_slots(
+            vec![
+                load_stub(first.clone(), Arc::clone(&calls0)),
+                load_stub(first.clone(), Arc::clone(&calls1)),
+            ],
+            vec![unused_setup(), unused_setup()],
+            vec![unused_lint(), unused_lint()],
+            vec![unused_forget(), unused_forget()],
+            vec![unused_create(), unused_create()],
+            vec![unused_destroy(), unused_destroy()],
+        );
+
+        let result = linter
+            .load_plugin("file:///plugin.js".into(), Some("demo".into()), false, None)
+            .unwrap();
+        assert_eq!(calls0.load(Ordering::SeqCst), 1);
+        assert_eq!(calls1.load(Ordering::SeqCst), 1);
+        assert_eq!(result.name, first.name);
+        assert_eq!(result.offset, first.offset);
+        assert_eq!(result.rule_names, first.rule_names);
+    }
+
+    #[test]
+    fn load_plugin_mismatch_is_error() {
+        let first = plugin_ok("demo", 3, &["a"]);
+        let other = plugin_ok("demo", 3, &["b"]);
+        let linter = linter_from_slots(
+            vec![
+                load_stub(first, Arc::new(AtomicUsize::new(0))),
+                load_stub(other, Arc::new(AtomicUsize::new(0))),
+            ],
+            vec![unused_setup(), unused_setup()],
+            vec![unused_lint(), unused_lint()],
+            vec![unused_forget(), unused_forget()],
+            vec![unused_create(), unused_create()],
+            vec![unused_destroy(), unused_destroy()],
+        );
+
+        let err = linter
+            .load_plugin("file:///plugin.js".into(), Some("demo".into()), false, None)
+            .unwrap_err();
+        assert_eq!(err, "JS worker rule registration mismatch");
+    }
+
+    #[test]
+    fn setup_rule_configs_calls_all_k() {
+        let calls0 = Arc::new(AtomicUsize::new(0));
+        let calls1 = Arc::new(AtomicUsize::new(0));
+        let linter = linter_from_slots(
+            vec![unused_load(), unused_load()],
+            vec![setup_stub(Arc::clone(&calls0), None), setup_stub(Arc::clone(&calls1), None)],
+            vec![unused_lint(), unused_lint()],
+            vec![unused_forget(), unused_forget()],
+            vec![unused_create(), unused_create()],
+            vec![unused_destroy(), unused_destroy()],
+        );
+
+        linter.setup_rule_configs("{}".into()).unwrap();
+        assert_eq!(calls0.load(Ordering::SeqCst), 1);
+        assert_eq!(calls1.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn setup_rule_configs_worker_error_is_error() {
+        let calls0 = Arc::new(AtomicUsize::new(0));
+        let calls1 = Arc::new(AtomicUsize::new(0));
+        let linter = linter_from_slots(
+            vec![unused_load(), unused_load()],
+            vec![
+                setup_stub(Arc::clone(&calls0), None),
+                setup_stub(Arc::clone(&calls1), Some("bad options".into())),
+            ],
+            vec![unused_lint(), unused_lint()],
+            vec![unused_forget(), unused_forget()],
+            vec![unused_create(), unused_create()],
+            vec![unused_destroy(), unused_destroy()],
+        );
+
+        let err = linter.setup_rule_configs("{}".into()).unwrap_err();
+        assert_eq!(err, "bad options");
+        assert_eq!(calls0.load(Ordering::SeqCst), 1);
+        assert_eq!(calls1.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "ExternalLinter::lint_file requires a fixed-size allocator")]
+    fn lint_file_panics_on_non_fixed_size_allocator() {
+        let linter = linter_from_slots(
+            vec![unused_load()],
+            vec![unused_setup()],
+            vec![unused_lint()],
+            vec![unused_forget()],
+            vec![unused_create()],
+            vec![unused_destroy()],
+        );
+        let allocator = Allocator::new();
+        let _ = call_lint_file(&linter, &allocator);
+    }
+
+    #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+    #[test]
+    fn lint_file_routes_by_buffer_id_mod_k() {
+        use oxc_allocator::AllocatorPool;
+
+        let called0 = Arc::new(Mutex::new(Vec::new()));
+        let called1 = Arc::new(Mutex::new(Vec::new()));
+        let linter = linter_from_slots(
+            vec![unused_load(), unused_load()],
+            vec![unused_setup(), unused_setup()],
+            vec![lint_stub(Arc::clone(&called0)), lint_stub(Arc::clone(&called1))],
+            vec![unused_forget(), unused_forget()],
+            vec![unused_create(), unused_create()],
+            vec![unused_destroy(), unused_destroy()],
+        );
+
+        let pool = AllocatorPool::new_fixed_size(2);
+        let a0 = pool.get();
+        let a1 = pool.get();
+        // SAFETY: allocators came from `new_fixed_size`.
+        let id0 = unsafe { a0.fixed_size_buffer_id() };
+        // SAFETY: allocators came from `new_fixed_size`.
+        let id1 = unsafe { a1.fixed_size_buffer_id() };
+
+        call_lint_file(&linter, &a0).unwrap();
+        call_lint_file(&linter, &a1).unwrap();
+
+        let got0 = called0.lock().expect("mutex").clone();
+        let got1 = called1.lock().expect("mutex").clone();
+        for id in [id0, id1] {
+            let owner = (id as usize) % 2;
+            if owner == 0 {
+                assert!(got0.contains(&id), "buffer {id} should route to worker 0");
+                assert!(!got1.contains(&id), "buffer {id} should not route to worker 1");
+            } else {
+                assert!(got1.contains(&id), "buffer {id} should route to worker 1");
+                assert!(!got0.contains(&id), "buffer {id} should not route to worker 0");
+            }
+        }
+    }
+
+    #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+    #[test]
+    fn lint_file_k1_uses_the_only_callback() {
+        use oxc_allocator::AllocatorPool;
+
+        let called = Arc::new(Mutex::new(Vec::new()));
+        let linter = linter_from_slots(
+            vec![unused_load()],
+            vec![unused_setup()],
+            vec![lint_stub(Arc::clone(&called))],
+            vec![unused_forget()],
+            vec![unused_create()],
+            vec![unused_destroy()],
+        );
+
+        let pool = AllocatorPool::new_fixed_size(1);
+        let allocator = pool.get();
+        // SAFETY: allocator came from `new_fixed_size`.
+        let id = unsafe { allocator.fixed_size_buffer_id() };
+        call_lint_file(&linter, &allocator).unwrap();
+        assert_eq!(*called.lock().expect("mutex"), vec![id]);
+    }
+
+    #[test]
+    fn forget_buffer_routes_by_buffer_id_mod_k() {
+        let called0 = Arc::new(Mutex::new(Vec::new()));
+        let called1 = Arc::new(Mutex::new(Vec::new()));
+        let linter = linter_from_slots(
+            vec![unused_load(), unused_load()],
+            vec![unused_setup(), unused_setup()],
+            vec![unused_lint(), unused_lint()],
+            vec![forget_stub(Arc::clone(&called0)), forget_stub(Arc::clone(&called1))],
+            vec![unused_create(), unused_create()],
+            vec![unused_destroy(), unused_destroy()],
+        );
+
+        linter.forget_buffer(4).unwrap();
+        linter.forget_buffer(5).unwrap();
+        assert_eq!(*called0.lock().expect("mutex"), vec![4]);
+        assert_eq!(*called1.lock().expect("mutex"), vec![5]);
     }
 }

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -170,7 +170,7 @@ impl ExternalPluginStore {
     ) -> Result<(), String> {
         let json = serde_json::to_string(&ConfigSer::new(cwd, workspace_uri, self));
         match json {
-            Ok(options_json) => (external_linter.setup_rule_configs)(options_json),
+            Ok(options_json) => external_linter.setup_rule_configs(options_json),
             Err(err) => Err(format!("Failed to serialize external plugin options: {err}")),
         }
     }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -76,8 +76,9 @@ pub use crate::{
     context::{ContextSubHost, ContextSubHostOptions, LintContext},
     external_linter::{
         ExternalLinter, ExternalLinterCreateWorkspaceCb, ExternalLinterDestroyWorkspaceCb,
-        ExternalLinterLintFileCb, ExternalLinterLoadPluginCb, ExternalLinterSetupRuleConfigsCb,
-        JsFix, LintFileResult, LoadPluginResult, convert_and_merge_js_fixes,
+        ExternalLinterForgetBufferCb, ExternalLinterLintFileCb, ExternalLinterLoadPluginCb,
+        ExternalLinterSetupRuleConfigsCb, JsFix, LintFileResult, LoadPluginResult,
+        convert_and_merge_js_fixes,
     },
     external_plugin_store::{ExternalOptionsId, ExternalPluginStore, ExternalRuleId},
     fixer::{Fix, FixKind, Fixer, Message, PossibleFixes, oxc_code_short_canonical_name},
@@ -88,7 +89,7 @@ pub use crate::{
     options::LintOptions,
     options::{AllowWarnDeny, InvalidFilterKind, LintFilter, LintFilterKind},
     rule::{RuleCategory, RuleFixMeta, RuleMeta, RuleRunFunctionsImplemented, RuleRunner},
-    service::{LintService, LintServiceOptions, OsFileSystem, RuntimeFileSystem},
+    service::{AllocatorPools, LintService, LintServiceOptions, OsFileSystem, RuntimeFileSystem},
     suppression::{OxlintSuppressionFileAction, SuppressionManager},
     timing::{RuleTimingRecord, RuleTimingSource, RuleTimingStore},
     tsgolint::TsGoLintState,
@@ -801,7 +802,7 @@ impl Linter {
         let external_linter = self.external_linter.as_ref().unwrap();
 
         // Pass AST and rule IDs + options IDs to JS
-        let result = (external_linter.lint_file)(
+        let result = external_linter.lint_file(
             path_string.to_owned(),
             external_rules.iter().map(|(rule_id, _, _)| rule_id.raw()).collect(),
             external_rules.iter().map(|(_, options_id, _)| options_id.raw()).collect(),

--- a/crates/oxc_linter/src/lint_runner.rs
+++ b/crates/oxc_linter/src/lint_runner.rs
@@ -10,8 +10,8 @@ use oxc_diagnostics::{DiagnosticSender, DiagnosticService};
 use oxc_span::Span;
 
 use crate::{
-    AllowWarnDeny, DisableDirectives, FixKind, LintService, LintServiceOptions, Linter, Message,
-    OsFileSystem, RuleTimingStore, TsGoLintState, suppression::DiffManager,
+    AllocatorPools, AllowWarnDeny, DisableDirectives, FixKind, LintService, LintServiceOptions,
+    Linter, Message, OsFileSystem, RuleTimingStore, TsGoLintState, suppression::DiffManager,
 };
 
 /// Unified runner that orchestrates both regular (oxc) and type-aware (tsgolint) linting
@@ -154,6 +154,7 @@ pub struct LintRunnerBuilder {
     type_check_only: bool,
     timings: bool,
     with_ignore_fixes: bool,
+    allocator_pools: Option<AllocatorPools>,
 }
 
 impl LintRunnerBuilder {
@@ -168,6 +169,7 @@ impl LintRunnerBuilder {
             type_check_only: false,
             timings: false,
             with_ignore_fixes: false,
+            allocator_pools: None,
         }
     }
 
@@ -213,6 +215,16 @@ impl LintRunnerBuilder {
         self
     }
 
+    /// Use prebuilt allocator pools instead of letting the runtime create its own.
+    ///
+    /// Required when the caller already minted buffer ids (for example the language server,
+    /// which must forget those ids when a folder is dropped).
+    #[must_use]
+    pub fn with_allocator_pools(mut self, pools: AllocatorPools) -> Self {
+        self.allocator_pools = Some(pools);
+        self
+    }
+
     /// # Errors
     /// Returns an error if the type-aware linter fails to initialize.
     pub fn build(self) -> Result<LintRunner, String> {
@@ -238,7 +250,14 @@ impl LintRunnerBuilder {
         };
 
         let cwd = self.lint_service_options.cwd().to_path_buf();
-        let mut lint_service = LintService::new(self.regular_linter, self.lint_service_options);
+        let mut lint_service = match self.allocator_pools {
+            Some(pools) => LintService::new_with_allocator_pools(
+                self.regular_linter,
+                self.lint_service_options,
+                pools,
+            ),
+            None => LintService::new(self.regular_linter, self.lint_service_options),
+        };
         lint_service.set_disable_directives_map(directives_coordinator.map());
 
         Ok(LintRunner {

--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -6,6 +6,7 @@ use std::{
 
 use rustc_hash::FxHashMap;
 
+use oxc_allocator::AllocatorPool;
 use oxc_diagnostics::DiagnosticSender;
 
 use crate::{Linter, RuleTimingStore, suppression::DiffManager};
@@ -60,6 +61,18 @@ impl LintServiceOptions {
     }
 }
 
+/// Allocator pools for a lint run.
+///
+/// Callers that need to track buffer ids (the language server) build these themselves.
+/// Rust-only callers let [`Runtime`] pick pools for them.
+pub struct AllocatorPools {
+    /// Pool used for parsing and linting.
+    pub parse: AllocatorPool,
+    /// Pool used only to copy ASTs into fixed-size arenas before handing them to JS plugins.
+    /// `None` unless both JS plugins and the `import` plugin are enabled.
+    pub js: Option<AllocatorPool>,
+}
+
 pub struct LintService {
     runtime: Runtime,
 }
@@ -67,6 +80,16 @@ pub struct LintService {
 impl LintService {
     pub fn new(linter: Linter, options: LintServiceOptions) -> Self {
         let runtime = Runtime::new(linter, options);
+        Self { runtime }
+    }
+
+    /// Create a [`LintService`] which uses `pools` instead of creating its own.
+    pub fn new_with_allocator_pools(
+        linter: Linter,
+        options: LintServiceOptions,
+        pools: AllocatorPools,
+    ) -> Self {
+        let runtime = Runtime::new_with_allocator_pools(linter, options, pools);
         Self { runtime }
     }
 

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -37,7 +37,7 @@ use crate::{
     utils::read_to_arena_str,
 };
 
-use super::LintServiceOptions;
+use super::{AllocatorPools, LintServiceOptions};
 
 type ModulesByPath =
     papaya::HashMap<Arc<OsStr>, SmallVec<[Arc<ModuleRecord>; 1]>, BuildHasherDefault<FxHasher>>;
@@ -254,7 +254,31 @@ impl Runtime {
         };
 
         #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
-        let allocator_pool = AllocatorPool::new(thread_count);
+        let (allocator_pool, js_allocator_pool) = (AllocatorPool::new(thread_count), None);
+
+        Self::new_with_allocator_pools(
+            linter,
+            options,
+            AllocatorPools { parse: allocator_pool, js: js_allocator_pool },
+        )
+    }
+
+    /// Create a [`Runtime`] which uses `pools` instead of creating its own.
+    ///
+    /// Used by callers which must create the pools themselves so they can record the
+    /// buffer ids minted for those arenas.
+    pub(super) fn new_with_allocator_pools(
+        linter: Linter,
+        options: LintServiceOptions,
+        pools: AllocatorPools,
+    ) -> Self {
+        // See `Runtime::new` for why the thread pool is initialized here too. Callers passing
+        // prebuilt pools have already locked the thread count, so this is a no-op for them.
+        let _ = rayon::ThreadPoolBuilder::new().build_global();
+
+        let AllocatorPools { parse: allocator_pool, js: js_allocator_pool } = pools;
+        #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
+        drop(js_allocator_pool);
 
         let resolver = options.cross_module.then(|| Self::get_resolver(options.tsconfig));
 


### PR DESCRIPTION
## Summary

Stacked on #25793. Review the latest commits for this change; the allocator commit is that PR.

- `ExternalLinter` holds `K` callback slots and exposes methods instead of public fields
- `lint_file` / `forget_buffer` route with `buffer_id % K`
- `load_plugin` / `setup_rule_configs` / workspace hooks fan out to every slot (and still call the rest if one fails)
- JS caches raw-transfer views by `buffer_id` and `forgetBuffer` drops a slot
- LSP folder teardown forgets that folder's buffer ids so views can be GC'd

Production still constructs `K = 1` (main-thread JS). No worker isolates in this PR.

**BREAKING CHANGE:** `ExternalLinter::new` takes `K` callback slices, and `load_plugin` / `setup_rule_configs` / `lint_file` / `create_workspace` / `destroy_workspace` are methods instead of public fields.

## Test plan

- [x] `cargo test -p oxc_linter --lib external_linter::` (9 passed)
- [x] `cargo test -p oxc_allocator --features fixed_size buffer_id` (4 passed)
- [x] `pnpm exec vitest --dir ./test run forget_buffer` (4 passed)
- [x] `cargo check -p oxlint --features napi`