### PR TITLE
perf(oxlint): reduce debug formatting code size

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -743,7 +743,7 @@ impl Debug for ConfigStoreBuilder {
 }
 
 /// An error that can occur while building a [`Config`] from an [`Oxlintrc`].
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Clone)]
 pub enum ConfigBuilderError {
     /// There were unknown rules that could not be matched to any known plugins/rules.
     UnknownRules {
@@ -784,6 +784,12 @@ pub enum ConfigBuilderError {
         cycle: Vec<PathBuf>,
         referenced_from: Vec<PathBuf>,
     },
+}
+
+impl Debug for ConfigBuilderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(self, f)
+    }
 }
 
 impl Display for ConfigBuilderError {

--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -276,12 +276,12 @@ pub fn invariant_unexpected_error() -> OxcDiagnostic {
 #[cold]
 pub fn terminal_successor_references_unknown_block(
     successor: impl Display,
-    terminal: impl Debug,
+    terminal: impl Display,
     span: Option<Span>,
 ) -> OxcDiagnostic {
     const REASON: &str = "Terminal successor references unknown block";
     diagnostic(ErrorCategory::Invariant, REASON)
-        .with_help(format!("Block bb{successor} does not exist for terminal '{terminal:?}'"))
+        .with_help(format!("Block bb{successor} does not exist for terminal '{terminal}'"))
         .with_labels(span.map(|span| span.primary_label(REASON)))
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -12,6 +12,8 @@ pub mod reactive;
 pub mod type_config;
 pub mod visitors;
 
+use std::fmt;
+
 use crate::react_compiler_utils::OrderedMap;
 use crate::react_compiler_utils::ordered_map::{ArenaOrderedMap, ArenaOrderedSet};
 pub use assert_consistent_identifiers::assert_consistent_identifiers;
@@ -304,7 +306,6 @@ pub struct Phi<'a> {
 // Terminal enum
 // =============================================================================
 
-#[derive(Debug)]
 pub enum Terminal<'a> {
     Unreachable {
         id: EvaluationOrder,
@@ -462,6 +463,40 @@ pub enum Terminal<'a> {
         id: EvaluationOrder,
         span: Option<Span>,
     },
+}
+
+impl fmt::Display for Terminal<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Unreachable { .. } => "Unreachable",
+            Self::Throw { .. } => "Throw",
+            Self::Return { .. } => "Return",
+            Self::Goto { .. } => "Goto",
+            Self::If { .. } => "If",
+            Self::Branch { .. } => "Branch",
+            Self::Switch { .. } => "Switch",
+            Self::DoWhile { .. } => "DoWhile",
+            Self::While { .. } => "While",
+            Self::For { .. } => "For",
+            Self::ForOf { .. } => "ForOf",
+            Self::ForIn { .. } => "ForIn",
+            Self::Logical { .. } => "Logical",
+            Self::Ternary { .. } => "Ternary",
+            Self::Optional { .. } => "Optional",
+            Self::Label { .. } => "Label",
+            Self::Sequence { .. } => "Sequence",
+            Self::MaybeThrow { .. } => "MaybeThrow",
+            Self::Try { .. } => "Try",
+            Self::Scope { .. } => "Scope",
+            Self::PrunedScope { .. } => "PrunedScope",
+        })
+    }
+}
+
+impl fmt::Debug for Terminal<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
 }
 
 impl<'a> Terminal<'a> {


### PR DESCRIPTION
Use compact `Display` formatting for React Compiler terminals and reuse `ConfigBuilderError`'s existing `Display` implementation for `Debug`.

This reduces the release `oxlint` binary from 12,773,552 to 12,740,432 bytes: **-33,120 bytes (-0.26%)**, with `__text` reduced by 24,452 bytes.

Validated with the affected crate tests, workspace checks, and oxlint snapshot tests.

AI assistance was used for implementation and measurement.
