### PR TITLE
fix(linter/jest/prefer-mock-return-shorthand): preserve implementations using this

### DIFF
--- a/crates/oxc_linter/src/rules/jest/prefer_mock_return_shorthand.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_mock_return_shorthand.rs
@@ -323,6 +323,23 @@ fn test() {
                 return 0;
               }
             });",
+        "jest.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(
+              function (this: HTMLElement) {
+                return this.dataset.testId === 'ai-assistant-messages' ? 400 : 68;
+              },
+            );",
+        "aVariable.mockImplementation(function () {
+              return () => this.value;
+            });",
+        "aVariable.mockImplementation(function () {
+              return class { [this.key] = 1; };
+            });",
+        "aVariable.mockImplementation(function () {
+              return class { @this.decorator field = 1; };
+            });",
+        "aVariable.mockImplementation(function () {
+              return class { method(@this.decorator x) {} };
+            });",
     ];
 
     let fail = vec![
@@ -544,6 +561,12 @@ fn test() {
             aVariable.mockImplementation(() => true ? true : true ? value : false);
             aVariable.mockImplementation(() => true ? true : true ? x : false);
             aVariable.mockImplementation(() => true ? true : true ? true : false);",
+        "aVariable.mockImplementationOnce(() => this.value);",
+        "aVariable.mockImplementation(() => ({ get value() { return this.x; } }));",
+        "aVariable.mockImplementation(function () { return class { field = this.x; } });",
+        "aVariable.mockImplementation(function () { return class { accessor field = this.x; } });",
+        "aVariable.mockImplementation(function () { return class { static { this.x; } } });",
+        "aVariable.mockImplementation(function () { return class { method(x = this.x) {} } });",
     ];
 
     let fix = vec![
@@ -913,6 +936,30 @@ fn test() {
             aVariable.mockImplementation(() => true ? true : true ? value : false);
             aVariable.mockReturnValue(true ? true : true ? x : false);
             aVariable.mockReturnValue(true ? true : true ? true : false);",
+        ),
+        (
+            "aVariable.mockImplementationOnce(() => this.value);",
+            "aVariable.mockReturnValueOnce(this.value);",
+        ),
+        (
+            "aVariable.mockImplementation(() => ({ get value() { return this.x; } }));",
+            "aVariable.mockReturnValue({ get value() { return this.x; } });",
+        ),
+        (
+            "aVariable.mockImplementation(function () { return class { field = this.x; } });",
+            "aVariable.mockReturnValue(class { field = this.x; });",
+        ),
+        (
+            "aVariable.mockImplementation(function () { return class { accessor field = this.x; } });",
+            "aVariable.mockReturnValue(class { accessor field = this.x; });",
+        ),
+        (
+            "aVariable.mockImplementation(function () { return class { static { this.x; } } });",
+            "aVariable.mockReturnValue(class { static { this.x; } });",
+        ),
+        (
+            "aVariable.mockImplementation(function () { return class { method(x = this.x) {} } });",
+            "aVariable.mockReturnValue(class { method(x = this.x) {} });",
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_mock_return_shorthand.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_mock_return_shorthand.rs
@@ -1,13 +1,15 @@
 use oxc_ast::{
     AstKind,
     ast::{
-        Argument, CallExpression, Expression, IdentifierReference, ImportExpression, NewExpression,
-        Statement, TaggedTemplateExpression, VariableDeclarationKind,
+        AccessorProperty, Argument, CallExpression, Expression, FormalParameter,
+        FormalParameterRest, Function, IdentifierReference, ImportExpression, NewExpression,
+        PropertyDefinition, Statement, StaticBlock, TaggedTemplateExpression, ThisExpression,
+        VariableDeclarationKind,
     },
 };
-use oxc_ast_visit::VisitJs;
+use oxc_ast_visit::{VisitJs, walk_js};
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_semantic::{ReferenceId, SymbolId};
+use oxc_semantic::{ReferenceId, ScopeFlags, SymbolId};
 use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashSet;
 
@@ -110,6 +112,10 @@ pub fn run<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) {
     let mut visitor = IdentifierCollectorVisitor::new();
 
     visitor.visit_expression(return_expression);
+
+    if matches!(expr, Expression::FunctionExpression(_)) && visitor.has_this_expression {
+        return;
+    }
 
     for reference_id in visitor.references {
         if let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id()
@@ -249,16 +255,83 @@ impl<'a> VisitJs<'a> for CallLikeExpressionVisitor {
 
 struct IdentifierCollectorVisitor {
     references: FxHashSet<ReferenceId>,
+    has_this_expression: bool,
+    this_binding_depth: u32,
 }
 
 impl IdentifierCollectorVisitor {
     fn new() -> Self {
-        Self { references: FxHashSet::default() }
+        Self { references: FxHashSet::default(), has_this_expression: false, this_binding_depth: 0 }
     }
 }
 
 impl<'a> VisitJs<'a> for IdentifierCollectorVisitor {
     fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
         self.references.insert(ident.reference_id());
+    }
+
+    fn visit_this_expression(&mut self, _this_expr: &ThisExpression) {
+        if self.this_binding_depth == 0 {
+            self.has_this_expression = true;
+        }
+    }
+
+    fn visit_function(&mut self, function: &Function<'a>, flags: ScopeFlags) {
+        self.this_binding_depth += 1;
+        walk_js::walk_function(self, function, flags);
+        self.this_binding_depth -= 1;
+    }
+
+    fn visit_formal_parameter(&mut self, parameter: &FormalParameter<'a>) {
+        if parameter.decorators.is_empty() || self.this_binding_depth == 0 {
+            walk_js::walk_formal_parameter(self, parameter);
+            return;
+        }
+
+        self.this_binding_depth -= 1;
+        self.visit_decorators(&parameter.decorators);
+        self.this_binding_depth += 1;
+        self.visit_binding_pattern(&parameter.pattern);
+        if let Some(initializer) = &parameter.initializer {
+            self.visit_expression(initializer);
+        }
+    }
+
+    fn visit_formal_parameter_rest(&mut self, parameter: &FormalParameterRest<'a>) {
+        if parameter.decorators.is_empty() || self.this_binding_depth == 0 {
+            walk_js::walk_formal_parameter_rest(self, parameter);
+            return;
+        }
+
+        self.this_binding_depth -= 1;
+        self.visit_decorators(&parameter.decorators);
+        self.this_binding_depth += 1;
+        self.visit_binding_rest_element(&parameter.rest);
+    }
+
+    fn visit_property_definition(&mut self, property: &PropertyDefinition<'a>) {
+        self.visit_decorators(&property.decorators);
+        self.visit_property_key(&property.key);
+        if let Some(value) = &property.value {
+            self.this_binding_depth += 1;
+            self.visit_expression(value);
+            self.this_binding_depth -= 1;
+        }
+    }
+
+    fn visit_accessor_property(&mut self, property: &AccessorProperty<'a>) {
+        self.visit_decorators(&property.decorators);
+        self.visit_property_key(&property.key);
+        if let Some(value) = &property.value {
+            self.this_binding_depth += 1;
+            self.visit_expression(value);
+            self.this_binding_depth -= 1;
+        }
+    }
+
+    fn visit_static_block(&mut self, block: &StaticBlock<'a>) {
+        self.this_binding_depth += 1;
+        walk_js::walk_static_block(self, block);
+        self.this_binding_depth -= 1;
     }
 }

--- a/crates/oxc_linter/src/snapshots/jest_prefer_mock_return_shorthand.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_mock_return_shorthand.snap
@@ -693,3 +693,45 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ──────────────────
    ╰────
   help: Replace `mockImplementation` with `mockReturnValue`.
+
+  ⚠ jest(prefer-mock-return-shorthand): Mock functions that return simple values should use `mockReturnValue/mockReturnValueOnce`.
+   ╭─[prefer_mock_return_shorthand.tsx:1:11]
+ 1 │ aVariable.mockImplementationOnce(() => this.value);
+   ·           ──────────────────────
+   ╰────
+  help: Replace `mockImplementationOnce` with `mockReturnValueOnce`.
+
+  ⚠ jest(prefer-mock-return-shorthand): Mock functions that return simple values should use `mockReturnValue/mockReturnValueOnce`.
+   ╭─[prefer_mock_return_shorthand.tsx:1:11]
+ 1 │ aVariable.mockImplementation(() => ({ get value() { return this.x; } }));
+   ·           ──────────────────
+   ╰────
+  help: Replace `mockImplementation` with `mockReturnValue`.
+
+  ⚠ jest(prefer-mock-return-shorthand): Mock functions that return simple values should use `mockReturnValue/mockReturnValueOnce`.
+   ╭─[prefer_mock_return_shorthand.tsx:1:11]
+ 1 │ aVariable.mockImplementation(function () { return class { field = this.x; } });
+   ·           ──────────────────
+   ╰────
+  help: Replace `mockImplementation` with `mockReturnValue`.
+
+  ⚠ jest(prefer-mock-return-shorthand): Mock functions that return simple values should use `mockReturnValue/mockReturnValueOnce`.
+   ╭─[prefer_mock_return_shorthand.tsx:1:11]
+ 1 │ aVariable.mockImplementation(function () { return class { accessor field = this.x; } });
+   ·           ──────────────────
+   ╰────
+  help: Replace `mockImplementation` with `mockReturnValue`.
+
+  ⚠ jest(prefer-mock-return-shorthand): Mock functions that return simple values should use `mockReturnValue/mockReturnValueOnce`.
+   ╭─[prefer_mock_return_shorthand.tsx:1:11]
+ 1 │ aVariable.mockImplementation(function () { return class { static { this.x; } } });
+   ·           ──────────────────
+   ╰────
+  help: Replace `mockImplementation` with `mockReturnValue`.
+
+  ⚠ jest(prefer-mock-return-shorthand): Mock functions that return simple values should use `mockReturnValue/mockReturnValueOnce`.
+   ╭─[prefer_mock_return_shorthand.tsx:1:11]
+ 1 │ aVariable.mockImplementation(function () { return class { method(x = this.x) {} } });
+   ·           ──────────────────
+   ╰────
+  help: Replace `mockImplementation` with `mockReturnValue`.


### PR DESCRIPTION
## Summary

- skip prefer-mock-return-shorthand when the returned expression references this
- reuse the existing return-expression traversal without adding another AST pass
- cover the reported typed this parameter and mockImplementationOnce arrow callback cases

Closes #25796