### PR TITLE
fix(linter/eslint/no-return-assign): anchor diagnostic on return stmt

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_return_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_return_assign.rs
@@ -12,10 +12,10 @@ use crate::{
     rule::{DefaultRuleConfig, Rule},
 };
 
-fn no_return_assign_diagnostic(span: Span, message: &'static str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(message)
+fn no_return_assign_diagnostic(span: Span, help: &'static str) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Returned expression contains an assignment.")
         .with_label(span)
-        .with_help("Did you mean to use `==` instead of `=`?")
+        .with_help(help)
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -79,7 +79,7 @@ impl Rule for NoReturnAssign {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::AssignmentExpression(assign) = node.kind() else {
+        let AstKind::AssignmentExpression(_) = node.kind() else {
             return;
         };
 
@@ -98,20 +98,24 @@ impl Rule for NoReturnAssign {
             parent_node = ctx.nodes().parent_node(parent_node.id());
         }
 
-        match parent_node.kind() {
-            AstKind::ReturnStatement(_) => {
-                ctx.diagnostic(no_return_assign_diagnostic(
-                    assign.span(),
-                    "Return statements should not contain an assignment.",
-                ));
+        let return_span = match parent_node.kind() {
+            AstKind::ReturnStatement(stmt) => stmt.span(),
+            AstKind::ArrowFunctionExpression(arrow) if arrow.is_expression() => arrow.span(),
+            _ => return,
+        };
+        ctx.diagnostic(no_return_assign_diagnostic(return_span, self.help_message()));
+    }
+}
+
+impl NoReturnAssign {
+    fn help_message(&self) -> &'static str {
+        match self.0 {
+            NoReturnAssignMode::Always => {
+                "Compute the value in a separate statement before returning it."
             }
-            AstKind::ArrowFunctionExpression(arrow) if arrow.is_expression() => {
-                ctx.diagnostic(no_return_assign_diagnostic(
-                    assign.span(),
-                    "Arrow functions should not return an assignment.",
-                ));
+            NoReturnAssignMode::ExceptParens => {
+                "Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit."
             }
-            _ => (),
         }
     }
 }
@@ -157,6 +161,27 @@ fn test() {
             None,
         ),
         ("const foo = (a) => (b) => (a = b)", None), // { "ecmaVersion": 6 }
+        (
+            r"const cache = {};
+const o = {
+    get x() {
+        // eslint-disable-next-line no-return-assign
+        return (
+            cache.x ??
+            (cache.x = build())
+        );
+    },
+};",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            r"// eslint-disable-next-line no-return-assign
+const get = () => (
+    cache.x ??
+    (cache.x = build())
+);",
+            Some(serde_json::json!(["always"])),
+        ),
     ];
 
     let fail = vec![
@@ -216,6 +241,25 @@ fn test() {
             None,
         ),
         ("const foo = (a) => (b) => a = b", None), // { "ecmaVersion": 6 }
+        (
+            r"const cache = {};
+const o = {
+    get x() {
+        return (
+            cache.x ??
+            (cache.x = build())
+        );
+    },
+};",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            r"const get = () => (
+    cache.x ??
+    (cache.x = build())
+);",
+            Some(serde_json::json!(["always"])),
+        ),
     ];
 
     Tester::new(NoReturnAssign::NAME, NoReturnAssign::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/eslint_no_return_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_return_assign.snap
@@ -2,127 +2,147 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
-  ⚠ eslint(no-return-assign): Return statements should not contain an assignment.
-   ╭─[no_return_assign.tsx:1:23]
- 1 │ function x() { return result = a * b; };
-   ·                       ──────────────
-   ╰────
-  help: Did you mean to use `==` instead of `=`?
-
-  ⚠ eslint(no-return-assign): Return statements should not contain an assignment.
-   ╭─[no_return_assign.tsx:1:23]
- 1 │ function x() { return (result) = (a * b); };
-   ·                       ──────────────────
-   ╰────
-  help: Did you mean to use `==` instead of `=`?
-
-  ⚠ eslint(no-return-assign): Return statements should not contain an assignment.
-   ╭─[no_return_assign.tsx:1:23]
- 1 │ function x() { return result = a * b; };
-   ·                       ──────────────
-   ╰────
-  help: Did you mean to use `==` instead of `=`?
-
-  ⚠ eslint(no-return-assign): Return statements should not contain an assignment.
-   ╭─[no_return_assign.tsx:1:23]
- 1 │ function x() { return (result) = (a * b); };
-   ·                       ──────────────────
-   ╰────
-  help: Did you mean to use `==` instead of `=`?
-
-  ⚠ eslint(no-return-assign): Return statements should not contain an assignment.
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
    ╭─[no_return_assign.tsx:1:16]
- 1 │ () => { return result = a * b; }
-   ·                ──────────────
-   ╰────
-  help: Did you mean to use `==` instead of `=`?
-
-  ⚠ eslint(no-return-assign): Arrow functions should not return an assignment.
-   ╭─[no_return_assign.tsx:1:7]
- 1 │ () => result = a * b
-   ·       ──────────────
-   ╰────
-  help: Did you mean to use `==` instead of `=`?
-
-  ⚠ eslint(no-return-assign): Return statements should not contain an assignment.
-   ╭─[no_return_assign.tsx:1:23]
  1 │ function x() { return result = a * b; };
-   ·                       ──────────────
+   ·                ──────────────────────
    ╰────
-  help: Did you mean to use `==` instead of `=`?
+  help: Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit.
 
-  ⚠ eslint(no-return-assign): Return statements should not contain an assignment.
-   ╭─[no_return_assign.tsx:1:24]
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:1:16]
+ 1 │ function x() { return (result) = (a * b); };
+   ·                ──────────────────────────
+   ╰────
+  help: Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit.
+
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:1:16]
+ 1 │ function x() { return result = a * b; };
+   ·                ──────────────────────
+   ╰────
+  help: Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit.
+
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:1:16]
+ 1 │ function x() { return (result) = (a * b); };
+   ·                ──────────────────────────
+   ╰────
+  help: Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit.
+
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:1:9]
+ 1 │ () => { return result = a * b; }
+   ·         ──────────────────────
+   ╰────
+  help: Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit.
+
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:1:1]
+ 1 │ () => result = a * b
+   · ────────────────────
+   ╰────
+  help: Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit.
+
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:1:16]
+ 1 │ function x() { return result = a * b; };
+   ·                ──────────────────────
+   ╰────
+  help: Compute the value in a separate statement before returning it.
+
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:1:16]
  1 │ function x() { return (result = a * b); };
-   ·                        ──────────────
+   ·                ────────────────────────
    ╰────
-  help: Did you mean to use `==` instead of `=`?
+  help: Compute the value in a separate statement before returning it.
 
-  ⚠ eslint(no-return-assign): Return statements should not contain an assignment.
-   ╭─[no_return_assign.tsx:1:34]
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:1:16]
  1 │ function x() { return result || (result = a * b); };
-   ·                                  ──────────────
+   ·                ──────────────────────────────────
    ╰────
-  help: Did you mean to use `==` instead of `=`?
+  help: Compute the value in a separate statement before returning it.
 
-  ⚠ eslint(no-return-assign): Return statements should not contain an assignment.
-   ╭─[no_return_assign.tsx:2:36]
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:2:29]
  1 │ function foo(){
  2 │                             return a = b
-   ·                                    ─────
+   ·                             ────────────
  3 │                         }
    ╰────
-  help: Did you mean to use `==` instead of `=`?
+  help: Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit.
 
-  ⚠ eslint(no-return-assign): Return statements should not contain an assignment.
-   ╭─[no_return_assign.tsx:2:36]
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:2:29]
  1 │ function doSomething() {
  2 │                             return foo = bar && foo > 0;
-   ·                                    ────────────────────
+   ·                             ────────────────────────────
  3 │                         }
    ╰────
-  help: Did you mean to use `==` instead of `=`?
+  help: Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit.
 
-  ⚠ eslint(no-return-assign): Return statements should not contain an assignment.
-   ╭─[no_return_assign.tsx:2:36]
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:2:29]
  1 │     function doSomething() {
  2 │ ╭─▶                             return foo = function(){
  3 │ │                                   return (bar = bar1)
  4 │ ╰─▶                             }
  5 │                             }
    ╰────
-  help: Did you mean to use `==` instead of `=`?
+  help: Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit.
 
-  ⚠ eslint(no-return-assign): Return statements should not contain an assignment.
-   ╭─[no_return_assign.tsx:2:36]
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:2:29]
  1 │ function doSomething() {
  2 │                             return foo = () => a
-   ·                                    ─────────────
+   ·                             ────────────────────
  3 │                         }
    ╰────
-  help: Did you mean to use `==` instead of `=`?
+  help: Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit.
 
-  ⚠ eslint(no-return-assign): Arrow functions should not return an assignment.
-   ╭─[no_return_assign.tsx:2:42]
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:2:36]
  1 │ function doSomething() {
  2 │                             return () => a = () => b
-   ·                                          ───────────
+   ·                                    ─────────────────
  3 │                         }
    ╰────
-  help: Did you mean to use `==` instead of `=`?
+  help: Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit.
 
-  ⚠ eslint(no-return-assign): Return statements should not contain an assignment.
-   ╭─[no_return_assign.tsx:3:40]
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:3:33]
  2 │                             return function bar(b){
  3 │                                 return a = b
-   ·                                        ─────
+   ·                                 ────────────
  4 │                             }
    ╰────
-  help: Did you mean to use `==` instead of `=`?
+  help: Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit.
 
-  ⚠ eslint(no-return-assign): Arrow functions should not return an assignment.
-   ╭─[no_return_assign.tsx:1:27]
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:1:20]
  1 │ const foo = (a) => (b) => a = b
-   ·                           ─────
+   ·                    ────────────
    ╰────
-  help: Did you mean to use `==` instead of `=`?
+  help: Compute the value before returning it, or wrap the assignment in parentheses to make the intent explicit.
+
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:4:9]
+ 3 │         get x() {
+ 4 │ ╭─▶         return (
+ 5 │ │               cache.x ??
+ 6 │ │               (cache.x = build())
+ 7 │ ╰─▶         );
+ 8 │         },
+   ╰────
+  help: Compute the value in a separate statement before returning it.
+
+  ⚠ eslint(no-return-assign): Returned expression contains an assignment.
+   ╭─[no_return_assign.tsx:1:13]
+ 1 │ ╭─▶ const get = () => (
+ 2 │ │       cache.x ??
+ 3 │ │       (cache.x = build())
+ 4 │ ╰─▶ );
+   ╰────
+  help: Compute the value in a separate statement before returning it.


### PR DESCRIPTION
## Summary

 - align with ESLint and anchor the diagnostic on the full return stmt


closes #25628