### PR TITLE
ci(actions): use high-memory Linux test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   test-ubuntu:
     name: Test Linux
-    runs-on: namespace-profile-linux-x64-default
+    runs-on: nscloud-ubuntu-22.04-amd64-4x16-with-cache
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - uses: oxc-project/setup-node@d59b270414aa7d0eed947eed4eb5b0b8a675f01d # v1.4.0


### PR DESCRIPTION
Moves the Linux test job from the shared 4x8 profile to a cache-enabled 4x16 Namespace runner after `rustc` was killed under memory pressure. Other Linux jobs remain on the shared default profile.

Validated with `env -u NO_COLOR just ready`.

AI-assisted.