### PR TITLE
refactor(react_compiler): remove unreachable JSX colon check

### DIFF
--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -2030,15 +2030,6 @@ pub fn missing_function_declaration_binding(name: &str, span: Span) -> OxcDiagno
 }
 
 #[cold]
-pub fn jsx_attribute_colon(name: &str, span: Span) -> OxcDiagnostic {
-    diagnostic(
-        ErrorCategory::Todo,
-        format!("(BuildHIR::lowerExpression) Unexpected colon in attribute name `{name}`"),
-    )
-    .with_label(span.primary_label(format!("`{name}` contains an unsupported colon")))
-}
-
-#[cold]
 pub fn local_fbt_tag(tag_name: &str, span: Option<Span>) -> OxcDiagnostic {
     let reason = format!("<{tag_name}> tags should be module-level imports");
     diagnostic(ErrorCategory::Invariant, &reason)

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -4612,14 +4612,7 @@ fn lower_jsx_element_expr<'a>(
             oxc::JSXAttributeItem::Attribute(attr) => {
                 // Get the attribute name
                 let prop_name = match &attr.name {
-                    oxc::JSXAttributeName::Identifier(id) => {
-                        let name = id.name.as_str();
-                        if name.contains(':') {
-                            builder
-                                .record_error(diagnostics::jsx_attribute_colon(name, id.span))?;
-                        }
-                        Ident::from(name)
-                    }
+                    oxc::JSXAttributeName::Identifier(id) => Ident::from(id.name.as_str()),
                     oxc::JSXAttributeName::NamespacedName(ns) => format_ident!(
                         builder.environment().allocator,
                         "{}:{}",


### PR DESCRIPTION
Remove an unreachable React Compiler diagnostic for colons in JSX attribute identifiers. Oxc's parser represents namespaced attributes with `JSXNamespacedName`, so parser-produced identifiers cannot contain colons.

Validated with `cargo test -p oxc_react_compiler`. `just ready` passed formatting and workspace checks, but its full suite hit environment-sensitive ANSI snapshot mismatches in unrelated Oxlint CLI tests.

AI-assisted; reviewed and validated by the contributor.