### PR TITLE
fix(react-compiler): format numeric object keys like JavaScript

### DIFF
--- a/crates/oxc_react_compiler/fixtures/numeric-object-keys.js
+++ b/crates/oxc_react_compiler/fixtures/numeric-object-keys.js
@@ -1,0 +1,9 @@
+function component(value) {
+  return {
+    1e21: value,
+    1e-7: value,
+    1e20: value,
+    1e-6: value,
+    0x10: value,
+  };
+}

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -22,6 +22,7 @@ use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
 use oxc_str::{Ident, Str, format_ident, static_ident};
+use oxc_syntax::number::ToJsString;
 
 use crate::react_compiler_lowering::FunctionNode;
 use crate::react_compiler_lowering::find_context_identifiers::find_context_identifiers;
@@ -5571,7 +5572,10 @@ fn lower_object_property_key<'a>(
         }
         oxc::PropertyKey::NumericLiteral(lit) if !computed => {
             Ok(Some(ObjectPropertyKey::Identifier {
-                name: format_ident!(builder.environment().allocator, "{}", lit.value),
+                name: Ident::from_str_in(
+                    &lit.value.to_js_string(),
+                    &builder.environment().allocator,
+                ),
                 span: Some(lit.span),
             }))
         }

--- a/crates/oxc_react_compiler/tests/snapshots/numeric-object-keys.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/numeric-object-keys.snap
@@ -1,0 +1,23 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/numeric-object-keys.js
+---
+import { c as _c } from "react/compiler-runtime";
+function component(value) {
+	const $ = _c(2);
+	let t0;
+	if ($[0] !== value) {
+		t0 = {
+			1e+21: value,
+			1e-7: value,
+			100000000000000000000: value,
+			0.000001: value,
+			16: value
+		};
+		$[0] = value;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}


### PR DESCRIPTION
Format numeric object keys with ECMAScript `Number::toString` semantics so exponent-form keys retain upstream spellings.

AI-assisted.
