### PR TITLE
perf(linter): share config deserialization entry point

### DIFF
--- a/apps/oxlint/src/js_config.rs
+++ b/apps/oxlint/src/js_config.rs
@@ -100,8 +100,8 @@ fn parse_js_oxlintrc(mut value: serde_json::Value) -> Result<Oxlintrc, OxcDiagno
         Vec::new()
     };
 
-    let mut oxlintrc: Oxlintrc =
-        serde_json::from_value(value).map_err(|err| OxcDiagnostic::error(err.to_string()))?;
+    let mut oxlintrc =
+        Oxlintrc::from_json_value(&value).map_err(|err| OxcDiagnostic::error(err.to_string()))?;
     oxlintrc.extends_configs = extends_configs;
     Ok(oxlintrc)
 }

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -354,7 +354,7 @@ impl Oxlintrc {
             )));
         }
 
-        let mut config = Self::deserialize(&json).map_err(|err| {
+        let mut config = Self::from_json_value(&json).map_err(|err| {
             OxcDiagnostic::error(format!("Failed to parse config with error {err:?}"))
         })?;
 
@@ -389,9 +389,26 @@ impl Oxlintrc {
             ));
         }
 
-        Self::deserialize(&json).map_err(|err| {
+        Self::from_json_value(&json).map_err(|err| {
             OxcDiagnostic::error(format!("Failed to parse config with error {err:?}"))
         })
+    }
+
+    /// Deserialize a configuration from an already parsed JSON value.
+    ///
+    /// This is the single entry point for turning JSON into an [`Oxlintrc`]; every caller
+    /// (config files, JS configs in `oxlint`, ...) should go through it rather than calling
+    /// `Oxlintrc::deserialize` with a deserializer of their own. `Deserialize::deserialize` is
+    /// generic, so each crate that calls it compiles its own copy of the whole configuration
+    /// type tree; this non-generic function is compiled once and shared. It is `#[inline(never)]`
+    /// so that it is not inlined across crates, which would re-instantiate the tree in the caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns the deserialization error if `json` does not describe a valid configuration.
+    #[inline(never)]
+    pub fn from_json_value(json: &serde_json::Value) -> Result<Self, serde_json::Error> {
+        Self::deserialize(json)
     }
 
     /// Merges two [Oxlintrc] files together.

--- a/crates/oxc_linter/src/config/settings/mod.rs
+++ b/crates/oxc_linter/src/config/settings/mod.rs
@@ -98,8 +98,8 @@ impl<'de> Deserialize<'de> for OxlintSettings {
     {
         let raw_value = serde_json::Value::deserialize(deserializer)?;
 
-        let well_known_settings: WellKnownOxlintSettings =
-            serde_json::from_value(raw_value.clone()).map_err(serde::de::Error::custom)?;
+        let well_known_settings =
+            WellKnownOxlintSettings::deserialize(&raw_value).map_err(serde::de::Error::custom)?;
 
         let arbitrary_settings =
             if let serde_json::Value::Object(json) = raw_value { Some(json) } else { None };


### PR DESCRIPTION
Share a non-generic JSON deserialization entry point across `oxc_linter` and `oxlint`, avoiding duplicate monomorphizations. Also deserialize well-known settings without deep-cloning the raw JSON value.

On `aarch64-apple-darwin`, `cargo build -p oxlint --release --features allocator` reduces the `oxlint` binary by 115,712 bytes (113 KiB, 0.91%), from 12,756,960 to 12,641,248 bytes.

Validated with `just ready`.

AI assistance was used for implementation and measurement.