### PR TITLE
perf(linter): compute sort keys once with sort_by_cached_key

### DIFF
--- a/crates/oxc_linter/src/config/ignore_matcher.rs
+++ b/crates/oxc_linter/src/config/ignore_matcher.rs
@@ -29,11 +29,7 @@ impl LintIgnoreMatcher {
         };
 
         // Sort nested configs deepest-to-shallowest for correct precedence
-        nested.sort_unstable_by(|a, b| {
-            let a_len = a.1.components().count();
-            let b_len = b.1.components().count();
-            b_len.cmp(&a_len)
-        });
+        nested.sort_by_cached_key(|(_, root)| std::cmp::Reverse(root.components().count()));
         let nested = nested
             .into_iter()
             .map(|(patterns, root)| {

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -226,8 +226,9 @@ impl OxlintRules {
         }
 
         if !errors.is_empty() {
-            // Sort by the error message so output is stable
-            errors.sort_unstable_by_key(std::string::ToString::to_string);
+            // Sort by the error message so output is stable. The key is computed once per error
+            // rather than once per comparison, which also keeps the `Display` impl out of the sort.
+            errors.sort_by_cached_key(std::string::ToString::to_string);
             return Err(errors);
         }
 

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -1,4 +1,7 @@
-use std::fmt::{Display, Write};
+use std::{
+    borrow::Cow,
+    fmt::{Display, Write},
+};
 
 use cow_utils::CowUtils;
 use itertools::Itertools;
@@ -286,14 +289,13 @@ impl SortImports {
                     // add a empty string for zip with specifiers
                     paddings.push("");
 
-                    let specifiers = specifiers.iter().sorted_by(|a, b| {
-                        let a = a.local.name.as_str();
-                        let b = b.local.name.as_str();
-
+                    // Compute each sort key once instead of once per comparison.
+                    let specifiers = specifiers.iter().sorted_by_cached_key(|specifier| {
+                        let name = specifier.local.name.as_str();
                         if self.ignore_case {
-                            a.cow_to_ascii_lowercase().cmp(&b.cow_to_ascii_lowercase())
+                            name.cow_to_ascii_lowercase()
                         } else {
-                            a.cmp(b)
+                            Cow::Borrowed(name)
                         }
                     });
 


### PR DESCRIPTION
Three sorts pass a comparator that recomputes a derived key on every comparison. A sort instantiation expands to about eight functions — `quicksort`, `heapsort`, `small_sort_general`, `median3_rec`, `bidirectional_merge`, … — and the comparator is inlined into each of them, so an expensive key is duplicated eight times over and costs several KiB per call site:

- `OxlintRules::override_rules` sorted errors by `ToString::to_string`, which allocates a `String` and pulls the whole `Display` impl into the sort.
- `LintIgnoreMatcher::new` sorted nested configs by `Path::components().count()`.
- The `sort_imports` member fixer sorted specifiers by `cow_to_ascii_lowercase()`.

`sort_by_cached_key` computes each key once, up front, and sorts those.

For `sort_imports` the resulting order is identical: itertools' `sorted_by` and `sorted_by_cached_key` are both stable sorts (`Vec::sort_by` / `Vec::sort_by_cached_key`). The other two go from an unstable sort to a stable one, so entries with an equal key keep their input order instead of an arbitrary one. Both of those sort for deterministic output in the first place, so that is a small improvement rather than a change in behavior.

### Size

Release `oxlint`, `__text`: 10,582,632 → 10,553,076 bytes — **-29,556 bytes (-0.28%)**; stripped binary -33,024 bytes.

Where it comes from:

| call site | before | after | delta |
| --- | ---: | ---: | ---: |
| `override_rules` (`OverrideRulesError`) | 14,656 B / 11 symbols | 656 B / 4 symbols | -14,000 |
| `sort_imports` member fixer | 28,896 B / 18 symbols | 9,108 B / 11 symbols | -19,788 |
| `LintIgnoreMatcher::new` | 11,648 B / 10 symbols | 2,700 B / 3 symbols | -8,948 |

(The per-call-site figures cover each site's whole symbol group, so they overlap where a sort shares a monomorphization; `core::slice::sort::*` overall goes from 379,100 to 348,136 bytes.)

Validated with `cargo test -p oxc_linter -p oxlint` and `cargo clippy` with warnings denied.

AI assistance was used for implementation and measurement.
