### PR TITLE
refactor(linter): route two config parses through the shared path

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/consistent_test_it.rs
@@ -112,8 +112,7 @@ impl ConsistentTestItConfig {
 
         let config_value = value.get(0).unwrap_or(value);
 
-        let mut config: ConsistentTestItConfig =
-            serde_json::from_value(config_value.clone()).unwrap_or_default();
+        let mut config = ConsistentTestItConfig::deserialize(config_value).unwrap_or_default();
 
         // If withinDescribe wasn't provided, default it to the value of `fn` only if fn was explicitly provided
         if config_value.get("withinDescribe").is_none() && config_value.get("fn").is_some() {

--- a/crates/oxc_linter/src/utils/react_perf.rs
+++ b/crates/oxc_linter/src/utils/react_perf.rs
@@ -74,7 +74,7 @@ pub fn react_perf_from_configuration<T>(value: serde_json::Value) -> Result<T, s
 where
     T: Default + serde::de::DeserializeOwned,
 {
-    serde_json::from_value::<DefaultRuleConfig<T>>(value).map(DefaultRuleConfig::into_inner)
+    DefaultRuleConfig::<T>::from_value(value).map(DefaultRuleConfig::into_inner)
 }
 
 pub fn run_react_perf_rule<'a>(


### PR DESCRIPTION
#25765 routed rule configuration parsing through `DefaultRuleConfig::from_value`, which deserializes from `&serde_json::Value`. Two call sites were missed and still went through `serde_json::from_value`, which instantiates the owned-`Value` deserializer for those configuration types on top of the borrowed-`Value` one every other rule uses:

- `react_perf_from_configuration`, shared by the `react_perf` rules.
- `ConsistentTestItConfig::from_configuration`, shared by the jest and vitest `consistent-test-it` rules. This one also cloned the configuration value before parsing it; deserializing by reference drops the clone.

### Size

Release `oxlint`, `__text`: **-2,072 bytes** — `consistent_test_it` 5,784 → 3,760 bytes (its `TestCaseName` owned-`Value` deserializer goes away entirely) and `react_perf` 10,004 → 9,956 bytes. The stripped binary comes out the same size, as a saving this small falls inside existing padding.

Mostly a consistency fix, then, rather than a size win on its own.

Validated with `cargo test -p oxc_linter` and `cargo clippy` with warnings denied.

AI assistance was used for implementation and measurement.
