### PR TITLE
perf(estree_tokens): share JS token update entry point

### DIFF
--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -10,7 +10,7 @@ use napi_derive::napi;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{Comment, CommentContent, CommentKind};
 use oxc_ast_visit::utf8_to_utf16::Utf8ToUtf16;
-use oxc_estree_tokens::{ESTreeTokenOptionsJS, update_tokens};
+use oxc_estree_tokens::update_tokens_as_js;
 use oxc_linter::RawTransferMetadata2 as RawTransferMetadata;
 use oxc_napi::get_source_type;
 use oxc_parser::{ParseOptions, Parser, ParserReturn, config::RuntimeParserConfig};
@@ -252,7 +252,7 @@ unsafe fn parse_raw_impl(
             };
 
             // Convert token spans to UTF-16 and update token kinds
-            update_tokens(&mut tokens, program, &span_converter, ESTreeTokenOptionsJS);
+            update_tokens_as_js(&mut tokens, program, &span_converter);
 
             // Convert AST spans to UTF-16
             span_converter.convert_program(program);

--- a/crates/oxc_estree_tokens/src/lib.rs
+++ b/crates/oxc_estree_tokens/src/lib.rs
@@ -23,4 +23,4 @@ pub use jsx_state::{JSXState, JSXStateJS, JSXStateTS};
 pub use options::{
     ESTreeTokenConfig, ESTreeTokenOptions, ESTreeTokenOptionsJS, ESTreeTokenOptionsTS,
 };
-pub use raw_transfer::update_tokens;
+pub use raw_transfer::{update_tokens, update_tokens_as_js};

--- a/crates/oxc_estree_tokens/src/raw_transfer/mod.rs
+++ b/crates/oxc_estree_tokens/src/raw_transfer/mod.rs
@@ -11,7 +11,11 @@ use oxc_ast_visit::{
 };
 use oxc_parser::{Kind, Token};
 
-use crate::{context::Context, options::ESTreeTokenConfig, visitor::Visitor};
+use crate::{
+    context::Context,
+    options::{ESTreeTokenConfig, ESTreeTokenOptionsJS},
+    visitor::Visitor,
+};
 
 mod estree_kind;
 use estree_kind::ESTreeKind;
@@ -37,6 +41,22 @@ pub fn update_tokens<O: ESTreeTokenConfig>(
     });
     visitor.visit_program(program);
     visitor.into_ctx().finish();
+}
+
+/// [`update_tokens`] for JS-style tokens ([`ESTreeTokenOptionsJS`]).
+///
+/// Prefer this over `update_tokens(.., ESTreeTokenOptionsJS)` when JS-style tokens are all that is
+/// needed. `update_tokens` is generic, so every crate that calls it compiles its own copy of the
+/// whole token visitor; this non-generic entry point is compiled once and shared. It is
+/// `#[inline(never)]` so that it is not inlined across crates, which would re-instantiate the
+/// visitor in the caller.
+#[inline(never)]
+pub fn update_tokens_as_js(
+    tokens: &mut [Token],
+    program: &Program<'_>,
+    span_converter: &Utf8ToUtf16,
+) {
+    update_tokens(tokens, program, span_converter, ESTreeTokenOptionsJS);
 }
 
 /// Raw transfer context.

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -23,7 +23,7 @@ use oxc_ast_macros::ast;
 use oxc_ast_visit::utf8_to_utf16::Utf8ToUtf16;
 use oxc_data_structures::box_macros::boxed_array;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_estree_tokens::{ESTreeTokenOptionsJS, update_tokens};
+use oxc_estree_tokens::update_tokens_as_js;
 use oxc_parser::Token;
 use oxc_semantic::{AstNode, Semantic};
 use oxc_span::Span;
@@ -721,7 +721,7 @@ impl Linter {
         // Convert token spans to UTF-16 and update token kinds
         #[expect(clippy::if_not_else, clippy::cast_possible_truncation)]
         let (tokens_offset, tokens_len) = if !tokens.is_empty() {
-            update_tokens(tokens, program, &span_converter, ESTreeTokenOptionsJS);
+            update_tokens_as_js(tokens, program, &span_converter);
             (tokens.as_ptr() as u32, tokens.len() as u32)
         } else {
             (0, 0)


### PR DESCRIPTION
Add a shared non-generic JS-style token update entry point so `oxc_linter` and `oxlint` do not each instantiate the ESTree token visitor.

On `aarch64-apple-darwin`, `cargo build -p oxlint --release --features allocator` reduces the `oxlint` binary by 49,616 bytes (48.5 KiB, 0.39%), from 12,756,960 to 12,707,344 bytes.

Validated with `just ready`.

AI assistance was used for implementation and measurement.