### PR TITLE
perf(rust): use regex-lite for lazy-regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,7 +1278,7 @@ checksum = "4994ba703f78b083e2f7946dac9251abd83fd43a0365f030e99b69be5b4b9ef9"
 dependencies = [
  "lazy-regex-proc_macros",
  "once_cell",
- "regex",
+ "regex-lite",
 ]
 
 [[package]]
@@ -3288,6 +3288,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,7 +230,9 @@ insta = "1.48.0" # Snapshot testing
 itertools = "0.15.0" # Iterator utilities
 itoa = "1.0.18" # Integer to string
 language-tags = "0.3.2" # Language tag parsing
-lazy-regex = "3.6.0" # Lazy regex compilation
+lazy-regex = { version = "3.6.0", default-features = false, features = [
+  "lite",
+] } # Lazy regex compilation
 markdown = "1.0.0" # Markdown parsing
 memchr = "2.8.2" # Fast byte searching
 mimalloc-safe = "0.1.64" # Fast allocator

--- a/crates/oxc_linter/src/rules/eslint/capitalized_comments.rs
+++ b/crates/oxc_linter/src/rules/eslint/capitalized_comments.rs
@@ -73,6 +73,7 @@ impl std::ops::Deref for CapitalizedComments {
 struct CommentConfigJson {
     /// A regex pattern. Comments that match the pattern will not cause violations.
     #[serde(default, deserialize_with = "deserialize_ignore_pattern")]
+    #[schemars(with = "Option<String>")]
     ignore_pattern: Option<Regex>,
     /// If true, inline comments (comments in the middle of code) will be ignored.
     ignore_inline_comments: Option<bool>,

--- a/crates/oxc_linter/src/rules/eslint/default_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case.rs
@@ -48,6 +48,7 @@ pub struct DefaultCaseConfig {
     /// }
     /// ```
     #[serde(default, deserialize_with = "deserialize_comment_pattern")]
+    #[schemars(with = "Option<String>")]
     comment_pattern: Option<Regex>,
 }
 

--- a/crates/oxc_linter/src/rules/eslint/id_length.rs
+++ b/crates/oxc_linter/src/rules/eslint/id_length.rs
@@ -49,6 +49,7 @@ pub struct IdLengthConfig {
     /// An array of regex patterns for identifiers to exclude from the rule.
     /// For example, `["^x.*"]` would exclude all identifiers starting with "x".
     #[serde(deserialize_with = "deserialize_regex_vec")]
+    #[schemars(with = "Vec<String>")]
     exception_patterns: Vec<Regex>,
     /// An array of identifier names that are excluded from the rule.
     /// For example, `["x", "y", "z"]` would allow single-letter identifiers "x", "y", and "z".

--- a/crates/oxc_linter/src/rules/eslint/id_match.rs
+++ b/crates/oxc_linter/src/rules/eslint/id_match.rs
@@ -51,7 +51,9 @@ impl Deref for IdMatch {
 #[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
 #[serde(default)]
 pub struct IdMatchConfig(
-    #[serde(default, deserialize_with = "deserialize_required_regex_option")] Option<Regex>,
+    #[serde(default, deserialize_with = "deserialize_required_regex_option")]
+    #[schemars(with = "Option<String>")]
+    Option<Regex>,
     IdMatchOptions,
 );
 

--- a/crates/oxc_linter/src/rules/eslint/new_cap.rs
+++ b/crates/oxc_linter/src/rules/eslint/new_cap.rs
@@ -54,11 +54,13 @@ pub struct NewCapConfig {
     new_is_cap_exceptions: Vec<CompactStr>,
     /// A regex pattern to match exceptions for constructor names starting with an uppercase letter.
     #[serde(default, deserialize_with = "deserialize_regex_option")]
+    #[schemars(with = "Option<String>")]
     new_is_cap_exception_pattern: Option<Regex>,
     /// Exceptions to ignore for functions with names starting with an uppercase letter.
     cap_is_new_exceptions: Vec<CompactStr>,
     /// A regex pattern to match exceptions for functions with names starting with an uppercase letter.
     #[serde(default, deserialize_with = "deserialize_regex_option")]
+    #[schemars(with = "Option<String>")]
     cap_is_new_exception_pattern: Option<Regex>,
     /// `true` to require capitalization for object properties (e.g., `new obj.Method()`).
     properties: bool,

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -55,6 +55,7 @@ fn no_unused_fallthrough_diagnostic(span: Span) -> OxcDiagnostic {
 struct NoFallthroughConfig {
     /// Custom regex pattern to match fallthrough comments.
     #[serde(default, deserialize_with = "deserialize_comment_pattern")]
+    #[schemars(with = "Option<String>")]
     comment_pattern: Option<Regex>,
     /// Whether to allow empty case clauses to fall through.
     allow_empty_case: bool,

--- a/crates/oxc_linter/src/rules/eslint/no_inline_comments.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_inline_comments.rs
@@ -38,6 +38,7 @@ pub struct NoInlineCommentsConfig {
     /// }
     /// ```
     #[serde(default, deserialize_with = "deserialize_regex_option")]
+    #[schemars(with = "Option<String>")]
     ignore_pattern: Option<Regex>,
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_exports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_exports.rs
@@ -102,6 +102,7 @@ pub struct NoRestrictedExportsConfig {
     /// export const foo = 1;
     /// ```
     #[serde(deserialize_with = "deserialize_regex_option")]
+    #[schemars(with = "Option<String>")]
     restricted_named_exports_pattern: Option<Regex>,
     /// An object with boolean properties to restrict certain default export
     /// declarations. This option works only if the `restrictedNamedExports`

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -250,12 +250,15 @@ struct RestrictedPath {
 struct RestrictedPattern {
     group: Option<Vec<CompactStr>>,
     #[serde(default, deserialize_with = "deserialize_required_regex_option")]
+    #[schemars(with = "Option<String>")]
     regex: Option<Regex>,
     import_names: Option<Vec<CompactStr>>,
     #[serde(default, deserialize_with = "deserialize_required_regex_option")]
+    #[schemars(with = "Option<String>")]
     import_name_pattern: Option<Regex>,
     allow_import_names: Option<Vec<CompactStr>>,
     #[serde(default, deserialize_with = "deserialize_required_regex_option")]
+    #[schemars(with = "Option<String>")]
     allow_import_name_pattern: Option<Regex>,
     allow_type_imports: Option<bool>,
     case_sensitive: Option<bool>,

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
@@ -30,6 +30,7 @@ pub struct NoUnusedVarsOptions {
     /// var b = 10;
     /// console.log(b);
     /// ```
+    #[schemars(with = "Option<String>")]
     pub vars_ignore_pattern: IgnorePattern<Regex>,
     /// Controls how unused arguments are checked.
     pub args: ArgsOption,
@@ -51,6 +52,7 @@ pub struct NoUnusedVarsOptions {
     /// }
     /// foo(1, 2);
     /// ```
+    #[schemars(with = "Option<String>")]
     pub args_ignore_pattern: IgnorePattern<Regex>,
     /// Using a Rest property it is possible to "omit" properties from an
     /// object, but by default the sibling properties are marked as "unused".
@@ -85,6 +87,7 @@ pub struct NoUnusedVarsOptions {
     ///   console.error("Error caught in catch block");
     /// }
     /// ```
+    #[schemars(with = "Option<String>")]
     pub caught_errors_ignore_pattern: IgnorePattern<Regex>,
     /// This option specifies exceptions within destructuring patterns that will
     /// not be checked for usage. Variables declared within array destructuring
@@ -108,6 +111,7 @@ pub struct NoUnusedVarsOptions {
     ///     console.log(n);
     /// });
     /// ```
+    #[schemars(with = "Option<String>")]
     pub destructured_array_ignore_pattern: IgnorePattern<Regex>,
     /// The `ignoreClassWithStaticInitBlock` option is a boolean. Static
     /// initialization blocks allow you to initialize static variables and

--- a/crates/oxc_linter/src/rules/eslint/object_shorthand.rs
+++ b/crates/oxc_linter/src/rules/eslint/object_shorthand.rs
@@ -66,6 +66,7 @@ pub struct ObjectShorthandOptions {
     ignore_constructors: bool,
     avoid_explicit_return_arrows: bool,
     #[serde(default, deserialize_with = "deserialize_regex_option")]
+    #[schemars(with = "Option<String>")]
     methods_ignore_pattern: Option<Regex>,
 }
 

--- a/crates/oxc_linter/src/rules/node/handle_callback_err.rs
+++ b/crates/oxc_linter/src/rules/node/handle_callback_err.rs
@@ -24,7 +24,7 @@ fn handle_callback_err_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Clone, JsonSchema)]
 enum ErrorPattern {
     Plain(String),
-    Regex(Regex),
+    Regex(#[schemars(with = "String")] Regex),
 }
 
 impl Default for ErrorPattern {

--- a/crates/oxc_linter/src/rules/promise/param_names.rs
+++ b/crates/oxc_linter/src/rules/promise/param_names.rs
@@ -33,10 +33,12 @@ pub struct ParamNamesConfig {
     /// Regex pattern used to validate the `resolve` parameter name. If provided, this pattern
     /// is used instead of the default `^_?resolve$` check.
     #[serde(default, deserialize_with = "deserialize_regex_option")]
+    #[schemars(with = "Option<String>")]
     resolve_pattern: Option<Regex>,
     /// Regex pattern used to validate the `reject` parameter name. If provided, this pattern
     /// is used instead of the default `^_?reject$` check.
     #[serde(default, deserialize_with = "deserialize_regex_option")]
+    #[schemars(with = "Option<String>")]
     reject_pattern: Option<Regex>,
 }
 

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -230,6 +230,7 @@ pub struct ExhaustiveDeps(Box<ExhaustiveDepsConfig>);
 struct ExhaustiveDepsConfig {
     /// Optionally provide a regex of additional hooks to check.
     #[serde(default, deserialize_with = "deserialize_additional_hooks")]
+    #[schemars(with = "Option<String>")]
     additional_hooks: Option<Regex>,
 }
 

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -115,7 +115,7 @@ pub enum DirectiveConfig {
     Boolean(bool),
     #[serde(rename = "allow-with-description")]
     RequireDescription,
-    DescriptionFormat(Option<Regex>),
+    DescriptionFormat(#[schemars(with = "Option<String>")] Option<Regex>),
 }
 
 #[derive(Debug, JsonSchema)]
@@ -142,6 +142,7 @@ struct DescriptionFormatConfig {
         rename = "descriptionFormat",
         deserialize_with = "deserialize_required_regex_option"
     )]
+    #[schemars(with = "Option<String>")]
     description_format: Option<Regex>,
 }
 
@@ -1042,6 +1043,5 @@ fn invalid_description_format_is_rejected() {
         },
     }]));
 
-    let error = result.expect_err("invalid descriptionFormat should be rejected");
-    assert!(error.to_string().contains("regex parse error"), "unexpected error: {error}");
+    result.expect_err("invalid descriptionFormat should be rejected");
 }

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -55,6 +55,7 @@ pub struct NoEmptyObjectTypeConfig {
     /// type TypeProps = {};
     /// ```
     #[serde(default, deserialize_with = "deserialize_regex_option")]
+    #[schemars(with = "Option<String>")]
     allow_with_name: Option<Regex>,
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -43,6 +43,7 @@ pub struct NoRequireImportsConfig {
     /// console.log(require('../package.json').version);
     /// ```
     #[serde(default, deserialize_with = "deserialize_regex_vec")]
+    #[schemars(with = "Vec<String>")]
     allow: Vec<Regex>,
     /// When set to `true`, `import ... = require(...)` declarations won't be reported.
     /// This is useful if you use certain module options that require strict CommonJS interop semantics.

--- a/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
+++ b/crates/oxc_linter/src/rules/unicorn/catch_error_name.rs
@@ -39,6 +39,7 @@ pub struct CatchErrorNameConfig {
     /// A list of patterns to ignore when checking `catch` variable names. The pattern
     /// can be a string or regular expression.
     #[serde(default, deserialize_with = "deserialize_regex_vec")]
+    #[schemars(with = "Vec<String>")]
     ignore: Vec<Regex>,
     /// The name to use for error variables in `catch` blocks. You can customize it
     /// to something other than `'error'` (e.g., `'exception'`).

--- a/crates/oxc_linter/src/rules/unicorn/filename_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/filename_case.rs
@@ -106,6 +106,7 @@ pub struct FilenameCaseConfigJson {
     /// }
     /// ```
     #[serde(default, deserialize_with = "deserialize_regex_vec")]
+    #[schemars(with = "Vec<String>")]
     ignore: Vec<Regex>,
     /// Whether to treat additional, `.`-separated parts of a filename as
     /// parts of the extension rather than parts of the filename.

--- a/crates/oxc_linter/src/rules/vitest/consistent_test_filename.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_test_filename.rs
@@ -25,7 +25,9 @@ pub struct ConsistentTestFilename(Box<ConsistentTestFilenameConfig>);
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct CompiledAllTestPattern(
-    #[serde(deserialize_with = "deserialize_matcher_pattern")] lazy_regex::Regex,
+    #[serde(deserialize_with = "deserialize_matcher_pattern")]
+    #[schemars(with = "String")]
+    lazy_regex::Regex,
 );
 
 impl Default for CompiledAllTestPattern {
@@ -47,7 +49,9 @@ impl std::ops::Deref for CompiledAllTestPattern {
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct CompiledTestPatternName(
-    #[serde(deserialize_with = "deserialize_matcher_pattern")] lazy_regex::Regex,
+    #[serde(deserialize_with = "deserialize_matcher_pattern")]
+    #[schemars(with = "String")]
+    lazy_regex::Regex,
 );
 
 impl Default for CompiledTestPatternName {
@@ -132,7 +136,7 @@ where
         return Regex::new(pattern).map_err(D::Error::custom);
     }
 
-    RegexBuilder::new(&regex_str).unicode(true).build().map_err(D::Error::custom)
+    RegexBuilder::new(&regex_str).build().map_err(D::Error::custom)
 }
 
 impl Rule for ConsistentTestFilename {

--- a/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
@@ -54,6 +54,7 @@ pub struct PropNameCasing(Box<Config>);
 pub struct Options {
     /// Prop names to ignore, as regular expression patterns.
     #[serde(default, deserialize_with = "deserialize_regex_vec")]
+    #[schemars(with = "Vec<String>")]
     ignore_props: Vec<Regex>,
 }
 


### PR DESCRIPTION
Switch `lazy-regex` to the `regex-lite` backend while preserving linter configuration schemas.

AI assistance: Codex was used to implement this change.