### PR TITLE
fix(linter): report exhaustive effect dependencies

### DIFF
--- a/crates/oxc_linter/src/rules/react/exhaustive_effect_dependencies.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_effect_dependencies.rs
@@ -17,14 +17,6 @@ declare_react_compiler_lint!(
     ///
     upstream = "exhaustive-effect-dependencies",
     ///
-    /// ::: warning
-    /// This rule is currently inactive: the underlying validation
-    /// (`validateExhaustiveEffectDependencies`) is disabled in the fixed
-    /// options oxlint compiles with, matching the upstream ESLint plugin's
-    /// defaults. It will activate once React Compiler options become
-    /// configurable in oxlint.
-    /// :::
-    ///
     /// ### Why is this bad?
     ///
     /// Missing effect dependencies capture stale values from a previous
@@ -56,9 +48,36 @@ function Component(props) {
   return <div>{props.text}</div>;
 }
 ",
+        "
+import {useEffect} from 'react';
+function Component({value}) {
+  useEffect(() => {
+    log(value);
+  }, [value]);
+}
+",
     ];
 
-    let fail = vec![];
+    let fail = vec![
+        // Missing dependency.
+        "
+import {useEffect} from 'react';
+function Component({value}) {
+  useEffect(() => {
+    log(value);
+  }, []);
+}
+",
+        // Extraneous dependency.
+        "
+import {useEffect} from 'react';
+function Component({value, extra}) {
+  useEffect(() => {
+    log(value);
+  }, [value, extra]);
+}
+",
+    ];
 
     Tester::new(
         ExhaustiveEffectDependencies::NAME,

--- a/crates/oxc_linter/src/snapshots/react_exhaustive_effect_dependencies.snap
+++ b/crates/oxc_linter/src/snapshots/react_exhaustive_effect_dependencies.snap
@@ -2,3 +2,27 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
+  ⚠ react(exhaustive-effect-dependencies): Found missing effect dependencies
+   ╭─[exhaustive_effect_dependencies.tsx:6:6]
+ 4 │   useEffect(() => {
+ 5 │     log(value);
+   ·         ──┬──
+   ·           ╰── Missing dependency `value`
+ 6 │   }, []);
+   ·      ─┬
+   ·       ╰── This dependency list is missing values used by the callback
+ 7 │ }
+   ╰────
+  help: Missing dependencies can cause an effect to fire less often than it should
+  note: React Compiler skipped optimizing this component or hook. Additional guidance: https://react.dev/reference/eslint-plugin-react-hooks/lints/exhaustive-deps
+
+  ⚠ react(exhaustive-effect-dependencies): Found extra effect dependencies
+   ╭─[exhaustive_effect_dependencies.tsx:6:14]
+ 5 │     log(value);
+ 6 │   }, [value, extra]);
+   ·              ──┬──
+   ·                ╰── Unnecessary dependency `extra`
+ 7 │ }
+   ╰────
+  help: Extra dependencies can cause an effect to fire more often than it should, resulting in performance problems such as excessive renders and side effects
+  note: React Compiler skipped optimizing this component or hook. Additional guidance: https://react.dev/reference/eslint-plugin-react-hooks/lints/exhaustive-deps

--- a/crates/oxc_linter/src/utils/react_compiler.rs
+++ b/crates/oxc_linter/src/utils/react_compiler.rs
@@ -2,7 +2,8 @@ use std::borrow::Cow;
 
 use oxc_diagnostics::OxcCode;
 use oxc_react_compiler::{
-    CompilerOutputMode, EnvironmentConfig, ErrorCategory, LintDiagnostic, PluginOptions,
+    CompilerOutputMode, EnvironmentConfig, ErrorCategory, ExhaustiveEffectDepsMode, LintDiagnostic,
+    PluginOptions,
 };
 
 use crate::{
@@ -46,6 +47,7 @@ fn react_compiler_plugin_options() -> PluginOptions {
             validate_no_capitalized_calls: Some(vec![]),
             validate_hooks_usage: true,
             validate_no_derived_computations_in_effects: true,
+            validate_exhaustive_effect_dependencies: ExhaustiveEffectDepsMode::All,
             ..EnvironmentConfig::default()
         },
         ..PluginOptions::default()


### PR DESCRIPTION
Enable React Compiler exhaustive effect dependency validation in Oxlint so the rule reports missing and extra dependencies instead of remaining inert.

Validated with `just ready`.

AI-assisted.