### PR TITLE
fix(semantic): keep an ambient computed class key a value reference

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -1588,6 +1588,37 @@ export class Foo extends Bar {}
 ",
             None,
         ),
+        // A computed key is evaluated as a value even when the field is `declare`,
+        // so the import backing it is not type-only. `tsc` needs the binding to stay
+        // a value import here, and typescript-eslint does not report these either.
+        (
+            "
+              import { StateKey } from './keys';
+              import type { State } from './types';
+              export class Example {
+                declare protected [StateKey]: State;
+              }
+            ",
+            None,
+        ),
+        (
+            "
+              import { StateKey } from './keys';
+              export abstract class Example {
+                abstract [StateKey]: string;
+              }
+            ",
+            None,
+        ),
+        (
+            "
+              import { MethodKey } from './keys';
+              declare class Example {
+                [MethodKey](): string;
+              }
+            ",
+            None,
+        ),
     ];
 
     let fail = vec![

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2454,8 +2454,11 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.visit_decorators(&method.decorators);
         if method.computed && (method.r#type.is_abstract() || self.in_ambient_context()) {
             // declare class A { [prop](): string }
-            //                    ^^^^  The property can reference value or [`SymbolFlags::TypeImport`] symbol
-            self.current_reference_flags = ReferenceFlags::ValueAsType;
+            //                    ^^^^  The key is evaluated as a value, but it may also be
+            // backed by a type-only import. `ValueAsType` lets it bind a
+            // [`SymbolFlags::TypeImport`] symbol; `Read` keeps the reference a value one
+            // when it resolves to a real value, instead of collapsing it to `Type`.
+            self.current_reference_flags = ReferenceFlags::ValueAsType | ReferenceFlags::Read;
         }
         self.visit_property_key(&method.key);
         self.current_reference_flags = ReferenceFlags::empty();
@@ -2477,8 +2480,11 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.enter_ambient_context(prop.declare);
         if prop.computed && (prop.r#type.is_abstract() || self.in_ambient_context()) {
             // class A { declare [prop]: string }
-            //                   ^^^^^ The property can reference value or [`SymbolFlags::TypeImport`] symbol
-            self.current_reference_flags = ReferenceFlags::ValueAsType;
+            //                   ^^^^^ The key is evaluated as a value, but it may also be
+            // backed by a type-only import. `ValueAsType` lets it bind a
+            // [`SymbolFlags::TypeImport`] symbol; `Read` keeps the reference a value one
+            // when it resolves to a real value, instead of collapsing it to `Type`.
+            self.current_reference_flags = ReferenceFlags::ValueAsType | ReferenceFlags::Read;
         }
         self.visit_property_key(&prop.key);
         self.current_reference_flags = ReferenceFlags::empty();

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-fields.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-fields.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_semantic/tests/main.rs
+assertion_line: 151
 input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-fields.ts
 ---
 [
@@ -67,7 +68,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-fie
         "node": "VariableDeclarator(declaredKey)",
         "references": [
           {
-            "flags": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Read | ValueAsType)",
             "id": 0,
             "name": "declaredKey",
             "node_id": 25,
@@ -82,7 +83,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-fie
         "node": "VariableDeclarator(ambientKey)",
         "references": [
           {
-            "flags": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Read | ValueAsType)",
             "id": 3,
             "name": "ambientKey",
             "node_id": 40,
@@ -97,7 +98,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-fie
         "node": "VariableDeclarator(abstractKey)",
         "references": [
           {
-            "flags": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Read | ValueAsType)",
             "id": 5,
             "name": "abstractKey",
             "node_id": 51,

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-methods.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-methods.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_semantic/tests/main.rs
+assertion_line: 151
 input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-methods.ts
 ---
 [
@@ -112,7 +113,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-met
         "node": "VariableDeclarator(declaredMethodKey)",
         "references": [
           {
-            "flags": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Read | ValueAsType)",
             "id": 5,
             "name": "declaredMethodKey",
             "node_id": 34,
@@ -127,7 +128,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-met
         "node": "VariableDeclarator(declaredGetterKey)",
         "references": [
           {
-            "flags": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Read | ValueAsType)",
             "id": 6,
             "name": "declaredGetterKey",
             "node_id": 40,
@@ -142,7 +143,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-met
         "node": "VariableDeclarator(abstractMethodKey)",
         "references": [
           {
-            "flags": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Read | ValueAsType)",
             "id": 8,
             "name": "abstractMethodKey",
             "node_id": 55,
@@ -157,7 +158,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-met
         "node": "VariableDeclarator(abstractSetterKey)",
         "references": [
           {
-            "flags": "ReferenceFlags(Type)",
+            "flags": "ReferenceFlags(Read | ValueAsType)",
             "id": 9,
             "name": "abstractSetterKey",
             "node_id": 61,


### PR DESCRIPTION
Closes #25805.

### The problem

The reporter's case is a computed key on a `declare` field:

```ts
import { StateKey } from './keys';       // ← reported as type-only
import type { State } from './types';

export class Example {
  declare protected [StateKey]: State;
}
```

`typescript/consistent-type-imports` asks for the whole `import { StateKey }` declaration to become `import type`. typescript-eslint never asks for this — and as the issue documents, the conversion can break real builds, because transforms that keep the computed key emit it at runtime while `import type` erases the binding.

### Root cause

Not in the rule. The rule just asks semantic whether every reference is a type reference (`is_only_has_type_references` → `Reference::is_type`), and semantic was answering yes.

`SemanticBuilder::visit_property_definition` / `visit_method_definition` flag an ambient or abstract computed key as `ReferenceFlags::ValueAsType`:

https://github.com/oxc-project/oxc/blob/main/crates/oxc_semantic/src/builder.rs#L2478-L2482

`ValueAsType` is documented as *"resolve to value symbols initially, but will ultimately be treated as type references"* — it exists for `typeof x`. Resolution therefore collapses it to `ReferenceFlags::Type`, and the binding looks type-only.

A computed key is not that case. It is evaluated as a value, and only *may* additionally be backed by a type-only import — which is what the original comment was getting at.

### The fix

Add `Read` alongside `ValueAsType` at both sites. No new flag and no change to resolution: `try_resolve_reference` already separates the two cases.

- key resolves to a real value (`const StateKey = Symbol()`) → `symbol_flags.is_value() && flags.is_value()` now holds, the `Type` flag is dropped, and the reference stays a value one.
- key resolves to a type-only import → `symbol_flags.is_value()` is still false, so it falls through to `*flags = ReferenceFlags::Type` **exactly as before**.

### Verification

`crates/oxc_semantic/tests/fixtures/oxc/ts/declare-computed-class-{fields,methods}.ts` already covered both shapes, which makes the snapshots a direct proof rather than churn — the only lines that move are the value-backed keys:

| key | before | after |
|---|---|---|
| `declaredKey`, `ambientKey`, `abstractKey`, `declaredMethodKey`, `declaredGetterKey`, `abstractMethodKey`, `abstractSetterKey` | `Type` | `Read \| ValueAsType` |
| **`importedKey`** (type-only import, ×5) | `Type` | **`Type` — unchanged** |
| `runtimeKey`, `runtimeMethodKey` (non-ambient) | `Read` | `Read` — unchanged |

- **Revert-checked.** The three new `pass` cases in `consistent_type_imports.rs` — the issue's own `declare protected [StateKey]`, plus the `abstract` field and ambient-method siblings — all fail on `main` with `All imports in the declaration are only used as types`, and pass with this change.
- `cargo test -p oxc_linter --lib` → **1252 passed, 0 failed**.
- `cargo test -p oxc_semantic` → green after the two snapshot updates.
- `cargo test -p oxc_transformer -p oxc_isolated_declarations -p oxc_minifier` → **760 passed, 0 failed**.
- `cargo clippy -p oxc_semantic --lib` and `cargo fmt --check` clean.

I also traced the only two places outside semantic that read these flags:

- `no_unused_vars/fixers/fix_conflicts.rs` — `reference_can_be_captured` already returned `true` via `is_value_as_type()`; it now returns `true` via `is_value()`. Same answer.
- `oxc_minifier/src/symbol_liveness/mod.rs:517` — only inspects `export { … }` specifiers, which this change never touches.

### Scope

Both the method and property sites are the same expression with the same semantics, so fixing one and leaving the other would be arbitrary. `abstract` members are included for that reason; the issue only reports `declare`, so please say if you would rather I narrow it.

**Disclosure:** written with AI assistance (Claude). I have reviewed and tested the change myself — the root-cause trace, the flag reasoning and the revert-check above are the parts I would ask you to check hardest.

One limitation I did not resolve: `cargo test -p oxc_codegen` has one pre-existing failure here, `sourcemap::stacktrace_is_correct`. It fails identically on a pristine checkout with my changes stashed, so it is unrelated, but I would rather state it than let it look green.
