### PR TITLE
fix(formatter): keep a comment inside a parenthesised if/while test

### DIFF
--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -842,13 +842,33 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatCommentForEmptyStatement<'a, 
     }
 }
 
-struct FormatTestOfIfAndWhileStatement<'a, 'b>(&'b AstNode<'a, Expression<'a>>);
+struct FormatTestOfIfAndWhileStatement<'a, 'b> {
+    test: &'b AstNode<'a, Expression<'a>>,
+    /// Start of the statement body. Bounds the scan for the statement's own `)` so it
+    /// never reaches code where a `)` could sit inside a string literal; between the
+    /// test and the body there is only trivia and punctuation.
+    body_start: u32,
+}
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatTestOfIfAndWhileStatement<'a, '_> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         // FormatNodeWithoutTrailingComments already handles suppression comments internally,
         // so no separate has_trailing_suppression_comment check is needed here.
-        write!(f, FormatNodeWithoutTrailingComments(self.0));
-        let comments = f.context().comments().comments_before_character(self.0.span().end, b')');
+        write!(f, FormatNodeWithoutTrailingComments(self.test));
+
+        // Same rule as `do...while` above: comments inside the parens belong to the test.
+        // Redundant parens are not AST nodes, so when the test is itself parenthesised
+        // (`if ((a, b) /* c */)`) the expression's span ends *before* its own `)`. Scanning
+        // for a trailing comment from there stops at that paren and misses the comment,
+        // which then leaks out of the condition -- and escapes one paren per reformat until
+        // it lands outside the test entirely. Bound the range by the statement's own `)`.
+        let test_end = self.test.span().end;
+        let all_comments = f.context().comments();
+        let comments: &[Comment] = if all_comments.has_comment_in_range(test_end, self.body_start) {
+            let rparen_end = all_comments.end_including_source_parens(test_end, self.body_start);
+            all_comments.comments_in_range(test_end, rparen_end)
+        } else {
+            &[]
+        };
         if !comments.is_empty() {
             write!(f, [space(), FormatTrailingComments::Comments(comments)]);
         }
@@ -869,7 +889,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
                 space(),
                 "(",
                 group(&soft_block_indent(&format_args!(
-                    FormatTestOfIfAndWhileStatement(self.test()),
+                    FormatTestOfIfAndWhileStatement {
+                        test: self.test(),
+                        body_start: body.span().start
+                    },
                     FormatCommentForEmptyStatement(self.body())
                 ))),
                 ")",
@@ -1024,7 +1047,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
                 "if",
                 space(),
                 "(",
-                group(&soft_block_indent(&FormatTestOfIfAndWhileStatement(test))),
+                group(&soft_block_indent(&FormatTestOfIfAndWhileStatement {
+                    test,
+                    body_start: consequent.span().start
+                })),
                 ")",
                 FormatStatementBody::new(consequent),
             ))

--- a/crates/oxc_formatter/tests/fixtures/js/if/parenthesized-test-comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/if/parenthesized-test-comment.js
@@ -1,0 +1,20 @@
+// The test is parenthesised, so its own `)` sits between the expression and the
+// statement's `)`. The comment belongs to the condition and must stay inside it
+// on every pass -- it used to escape one paren per reformat.
+if ((0, 0/* comment */)) {}
+
+while ((0, 0/* comment */)) {}
+
+if ((a, b) /* comment */) {}
+
+while ((a, b) /* comment */) {}
+
+if (((x)) /* comment */) {}
+
+// Unparenthesised tests, and comments that really do sit after the `)`,
+// must keep their existing placement.
+if (x /* comment */) {}
+
+while (x /* comment */) {}
+
+if (x) /* comment */ {}

--- a/crates/oxc_formatter/tests/fixtures/js/if/parenthesized-test-comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/if/parenthesized-test-comment.js.snap
@@ -1,0 +1,85 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// The test is parenthesised, so its own `)` sits between the expression and the
+// statement's `)`. The comment belongs to the condition and must stay inside it
+// on every pass -- it used to escape one paren per reformat.
+if ((0, 0/* comment */)) {}
+
+while ((0, 0/* comment */)) {}
+
+if ((a, b) /* comment */) {}
+
+while ((a, b) /* comment */) {}
+
+if (((x)) /* comment */) {}
+
+// Unparenthesised tests, and comments that really do sit after the `)`,
+// must keep their existing placement.
+if (x /* comment */) {}
+
+while (x /* comment */) {}
+
+if (x) /* comment */ {}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// The test is parenthesised, so its own `)` sits between the expression and the
+// statement's `)`. The comment belongs to the condition and must stay inside it
+// on every pass -- it used to escape one paren per reformat.
+if ((0, 0) /* comment */) {
+}
+
+while ((0, 0) /* comment */) {}
+
+if ((a, b) /* comment */) {
+}
+
+while ((a, b) /* comment */) {}
+
+if (x /* comment */) {
+}
+
+// Unparenthesised tests, and comments that really do sit after the `)`,
+// must keep their existing placement.
+if (x /* comment */) {
+}
+
+while (x /* comment */) {}
+
+if (x) /* comment */ {
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// The test is parenthesised, so its own `)` sits between the expression and the
+// statement's `)`. The comment belongs to the condition and must stay inside it
+// on every pass -- it used to escape one paren per reformat.
+if ((0, 0) /* comment */) {
+}
+
+while ((0, 0) /* comment */) {}
+
+if ((a, b) /* comment */) {
+}
+
+while ((a, b) /* comment */) {}
+
+if (x /* comment */) {
+}
+
+// Unparenthesised tests, and comments that really do sit after the `)`,
+// must keep their existing placement.
+if (x /* comment */) {
+}
+
+while (x /* comment */) {}
+
+if (x) /* comment */ {
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_formatter/tests/conformance.rs
+assertion_line: 172
 expression: report
 ---
 js compatibility: 773/810 (95.43%), 23 files skipped
@@ -81,8 +82,6 @@ js compatibility: 773/810 (95.43%), 23 files skipped
 - js/comments/between-head-and-body/between-head-and-body.js
 - js/comments/between-head-and-body/empty-statement.js
 - js/comments/first-argument/first-argument.js
-- js/comments/while-like/if.js
-- js/comments/while-like/while.js
 - js/comments/while-like/with.js
 - js/for/9812-2.js
 - js/for/continue-and-break-comment-without-blocks.js


### PR DESCRIPTION
### A comment escapes the condition, one parenthesis per reformat

```js
// input
if ((0, 0/* comment */)) {}

// pass 1
if ((0, 0) /* comment */) {}

// pass 2  <- fixpoint
if ((0, 0)) /* comment */ {}
```

The comment starts inside the condition and ends up outside it. `while` is worse — the second pass moves the comment **into the loop body**, attaching it to a different statement:

```js
// while, pass 2
while ((0, 0)) {
  /* comment */
}
```

So `oxfmt` on an already-formatted file both changes it again (`--check` fails on its own output) and silently re-parents a comment.

### Root cause

`FormatTestOfIfAndWhileStatement` collected the test's trailing comments with:

```rust
comments_before_character(self.0.span().end, b')')
```

That helper stops at the first `)` it meets. Redundant parentheses are not AST nodes, so for `if ((a, b) /* c */)` the test expression's span ends *before its own* `)` — the helper stops at that paren and returns nothing. The comment is then left for whatever prints next, which is how it ends up past the condition.

Each pass leaves the comment one paren further out, so it keeps moving until no parenthesis remains between it and the statement — a fixpoint, but the wrong one.

### The fix

`do...while`, ~40 lines above in the same file, already gets this right and states the rule outright:

> `// Comments inside the parens belong to the test and stay there;`
> `// only comments between ) and ; move behind the semicolon.`

It uses `end_including_source_parens`, which skips source parens and ignores `)` inside comments. This PR adopts the same approach for `if`/`while`: take the comments between the test end and the statement's own `)`.

The scan needs an upper bound that contains only trivia and punctuation (a `)` inside a string literal would false-match — the constraint `end_including_source_parens` documents), so the statement body's start is threaded in for that. Nothing else about the helper changes, and the 15 other callers of `comments_before_character` are untouched.

### Verification

**The conformance suite already tracked this.** `crates/oxc_formatter_tests` re-formats every Prettier fixture and records violations in a `# Not idempotent` section, so the evidence was sitting in the repo. The complete snapshot diff is two deletions:

```diff
 # Not idempotent
-- js/comments/while-like/if.js
-- js/comments/while-like/while.js
```

Nothing added, no Prettier-compatibility result changed, and `prettier-ts` is byte-identical.

- New fixture `js/if/parenthesized-test-comment.js` covers both statements, several paren depths, and the cases that must **not** move (unparenthesised test; a comment genuinely after the `)`).
- **Revert-checked:** with the fix reverted, that fixture's snapshot gains two `Not idempotent (second pass)` sections and the test fails.
- `cargo test -p oxc_formatter` → **396 passed, 0 failed** (54 + 2 + conformance + 339 fixtures).
- `cargo clippy -p oxc_formatter --lib` and `cargo fmt --check` clean.

### Scope

`js/comments/while-like/with.js` stays on the list. It is a different bug — a trailing comment after `{` (`with (foo) { // 2`) moves to the next line — and I left it out rather than widen this PR. Happy to follow up.

One observation while doing this, entirely your call: the harness *computes* idempotency but only records it, so a regression can silently join that list. The new fixture is asserted, but the Prettier corpus is not. If you would like a follow-up that fails on additions to `# Not idempotent` while keeping the current entries as a known-issues allowlist, I am glad to write it.

**Disclosure:** written with AI assistance (Claude). I found the bug by reading the conformance snapshot, reduced it to the cases above, and verified the reasoning and the revert-check myself.
