### PR TITLE
refactor(napi): share JavaScript RegExp conversion

### DIFF
--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -33,6 +33,3 @@ napi-derive = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
-
-[package.metadata.cargo-shear]
-ignored = ["napi"]

--- a/crates/oxc_napi/src/js_reg_exp.rs
+++ b/crates/oxc_napi/src/js_reg_exp.rs
@@ -1,0 +1,71 @@
+use napi::{
+    Env, Error, Status, Unknown,
+    bindgen_prelude::{
+        FnArgs, FromNapiValue, Function, JsObjectValue, JsValue, Object, ToNapiValue, TypeName,
+        ValidateNapiValue,
+    },
+    sys,
+};
+
+/// Owned data copied from a JavaScript `RegExp`.
+#[derive(Debug, Default, Clone)]
+pub struct JsRegExp {
+    /// Pattern source without delimiters.
+    pub source: String,
+    /// JavaScript regular expression flags.
+    pub flags: String,
+    /// Current match position used by global and sticky regular expressions.
+    pub last_index: u32,
+}
+
+impl JsRegExp {
+    /// Creates a regular expression with `lastIndex` set to zero.
+    pub fn new(source: String, flags: String) -> Self {
+        Self { source, flags, last_index: 0 }
+    }
+}
+
+impl TypeName for JsRegExp {
+    fn type_name() -> &'static str {
+        "RegExp"
+    }
+
+    fn value_type() -> napi::ValueType {
+        napi::ValueType::Object
+    }
+}
+
+impl ValidateNapiValue for JsRegExp {}
+
+impl FromNapiValue for JsRegExp {
+    unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
+        let object = Object::from_raw(env, napi_val);
+        let env = Env::from(env);
+        let global = env.get_global()?;
+        let constructor = global.get_named_property::<Function<Unknown, ()>>("RegExp")?;
+
+        if !object.instanceof(constructor)? {
+            return Err(Error::new(Status::ObjectExpected, "Expected a RegExp object"));
+        }
+
+        Ok(Self {
+            source: object.get_named_property::<String>("source")?,
+            flags: object.get_named_property::<String>("flags")?,
+            last_index: object.get_named_property::<u32>("lastIndex").unwrap_or_default(),
+        })
+    }
+}
+
+impl ToNapiValue for JsRegExp {
+    unsafe fn to_napi_value(env: sys::napi_env, value: Self) -> napi::Result<sys::napi_value> {
+        let global = Env::from(env).get_global()?;
+        let constructor =
+            global.get_named_property::<Function<FnArgs<(String, String)>, Unknown>>("RegExp")?;
+        let object = constructor.new_instance(FnArgs::from((value.source, value.flags)))?;
+        let mut object = Object::from_raw(env, object.raw());
+        if value.last_index != 0 {
+            object.set_named_property("lastIndex", value.last_index)?;
+        }
+        Ok(object.raw())
+    }
+}

--- a/crates/oxc_napi/src/lib.rs
+++ b/crates/oxc_napi/src/lib.rs
@@ -1,8 +1,10 @@
 mod comment;
 mod error;
+mod js_reg_exp;
 
 pub use comment::*;
 pub use error::*;
+pub use js_reg_exp::*;
 
 use oxc_ast::{CommentKind, ast::Program};
 use oxc_ast_visit::utf8_to_utf16::Utf8ToUtf16;

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -1,15 +1,9 @@
-use napi::{
-    Either, Env, Error, Status, Unknown,
-    bindgen_prelude::{
-        FnArgs, FromNapiValue, Function, JsObjectValue, JsValue, Object, ToNapiValue, TypeName,
-        ValidateNapiValue,
-    },
-    sys,
-};
+use napi::Either;
 use napi_derive::napi;
 use rustc_hash::FxHashMap;
 
 use oxc_compat::EngineTargets;
+pub use oxc_napi::JsRegExp;
 use oxc_str::CompactStr;
 
 #[napi(object)]
@@ -282,62 +276,12 @@ impl From<&MangleOptionsKeepNames> for oxc_minifier::MangleOptionsKeepNames {
     }
 }
 
-/// Owned source and flags from a JavaScript `RegExp`.
-pub struct JsRegExp {
-    /// Pattern source without delimiters.
-    pub source: String,
-    /// JavaScript regular expression flags.
-    pub flags: String,
-}
-
-impl TypeName for JsRegExp {
-    fn type_name() -> &'static str {
-        "RegExp"
-    }
-
-    fn value_type() -> napi::ValueType {
-        napi::ValueType::Object
-    }
-}
-
-impl ValidateNapiValue for JsRegExp {}
-
-impl FromNapiValue for JsRegExp {
-    unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
-        let object = Object::from_raw(env, napi_val);
-        let env = Env::from(env);
-        let global = env.get_global()?;
-        let constructor = global.get_named_property::<Function<Unknown, ()>>("RegExp")?;
-
-        if !object.instanceof(constructor)? {
-            return Err(Error::new(Status::ObjectExpected, "Expected a RegExp object"));
-        }
-
-        Ok(Self {
-            source: object.get_named_property::<String>("source")?,
-            flags: object.get_named_property::<String>("flags")?,
-        })
-    }
-}
-
-impl ToNapiValue for JsRegExp {
-    unsafe fn to_napi_value(env: sys::napi_env, value: Self) -> napi::Result<sys::napi_value> {
-        let global = Env::from(env).get_global()?;
-        let constructor =
-            global.get_named_property::<Function<FnArgs<(String, String)>, Unknown>>("RegExp")?;
-        let object = constructor.new_instance(FnArgs::from((value.source, value.flags)))?;
-        Ok(object.raw())
-    }
-}
-
-impl JsRegExp {
-    fn compile(&self, option_name: &str) -> Result<lazy_regex::Regex, String> {
-        let error = |error| format!("Invalid mangleProps.{option_name} regex: {error}");
-        if self.flags.is_empty() {
-            lazy_regex::Regex::new(&self.source).map_err(error)
-        } else {
-            lazy_regex::Regex::new(&format!("(?{}){}", self.flags, self.source)).map_err(error)
-        }
+fn compile_js_reg_exp(regex: &JsRegExp, option_name: &str) -> Result<lazy_regex::Regex, String> {
+    let error = |error| format!("Invalid mangleProps.{option_name} regex: {error}");
+    if regex.flags.is_empty() {
+        lazy_regex::Regex::new(&regex.source).map_err(error)
+    } else {
+        lazy_regex::Regex::new(&format!("(?{}){}", regex.flags, regex.source)).map_err(error)
     }
 }
 
@@ -378,8 +322,12 @@ impl TryFrom<&ManglePropertiesOptions> for oxc_minifier::ManglePropertiesOptions
     type Error = String;
 
     fn try_from(options: &ManglePropertiesOptions) -> Result<Self, Self::Error> {
-        let include = options.include.compile("include")?;
-        let exclude = options.exclude.as_ref().map(|regex| regex.compile("exclude")).transpose()?;
+        let include = compile_js_reg_exp(&options.include, "include")?;
+        let exclude = options
+            .exclude
+            .as_ref()
+            .map(|regex| compile_js_reg_exp(regex, "exclude"))
+            .transpose()?;
         let mut cache = oxc_minifier::ManglePropertyCache::default();
         if let Some(entries) = &options.cache {
             for (original, value) in entries {


### PR DESCRIPTION
Oxc and Rolldown currently duplicate the N-API conversion between a JavaScript `RegExp` and owned Rust data.

This moves that conversion to `oxc_napi::JsRegExp`. It copies `source`, `flags`, and `lastIndex`, supports converting back to a JavaScript `RegExp`, and keeps regex compilation in each consumer. `oxc_minify_napi::JsRegExp` remains available as a re-export.

This is a good place to put since Rolldown already used `oxc_napi` and crate is exactly for napi related struct