### PR TITLE
perf(minifier): move owned statements directly

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -165,7 +165,7 @@ impl<'a> PeepholeOptimizations {
                             };
                             let prev_stmt = stmts.pop().unwrap();
                             let Statement::IfStatement(prev_if) = prev_stmt else { unreachable!() };
-                            let mut prev_if = prev_if.unbox();
+                            let prev_if = prev_if.unbox();
                             let Statement::ReturnStatement(prev_return) = prev_if.consequent else {
                                 unreachable!()
                             };
@@ -173,47 +173,23 @@ impl<'a> PeepholeOptimizations {
                             let left_span = prev_return.span;
                             let right_span = last_return.span;
                             // "if (a) return; return b;" => "return a ? void 0 : b;"
-                            let mut left = prev_return
+                            let left = prev_return
                                 .unbox()
                                 .argument
                                 .unwrap_or_else(|| Expression::new_void_0(left_span, ctx));
                             // "if (a) return a; return;" => "return a ? b : void 0;"
-                            let mut right = last_return
+                            let right = last_return
                                 .unbox()
                                 .argument
                                 .unwrap_or_else(|| Expression::new_void_0(right_span, ctx));
 
-                            // "if (!a) return b; return c;" => "return a ? c : b;"
-                            if let Expression::UnaryExpression(unary_expr) = &mut prev_if.test
-                                && unary_expr.operator.is_not()
-                            {
-                                prev_if.test = unary_expr.argument.take_in(ctx);
-                                std::mem::swap(&mut left, &mut right);
-                            }
-
-                            let argument = if let Expression::SequenceExpression(sequence_expr) =
-                                &mut prev_if.test
-                            {
-                                // "if (a, b) return c; return d;" => "return a, b ? c : d;"
-                                let test = sequence_expr.expressions.pop().unwrap();
-                                let mut b = Self::minimize_conditional(
-                                    prev_if.span,
-                                    test,
-                                    left,
-                                    right,
-                                    ctx,
-                                );
-                                Self::join_sequence(&mut prev_if.test, &mut b, ctx)
-                            } else {
-                                // "if (a) return b; return c;" => "return a ? b : c;"
-                                Self::minimize_conditional(
-                                    prev_if.span,
-                                    prev_if.test.take_in(ctx),
-                                    left,
-                                    right,
-                                    ctx,
-                                )
-                            };
+                            let argument = Self::minimize_conditional_after_if(
+                                prev_if.span,
+                                prev_if.test,
+                                left,
+                                right,
+                                ctx,
+                            );
                             let last_return_stmt =
                                 Statement::new_return_statement(right_span, Some(argument), ctx);
                             stmts.push(last_return_stmt);
@@ -270,46 +246,19 @@ impl<'a> PeepholeOptimizations {
                             };
                             let prev_stmt = stmts.pop().unwrap();
                             let Statement::IfStatement(prev_if) = prev_stmt else { unreachable!() };
-                            let mut prev_if = prev_if.unbox();
+                            let prev_if = prev_if.unbox();
                             let Statement::ThrowStatement(prev_throw) = prev_if.consequent else {
                                 unreachable!()
                             };
 
                             let right_span = last_throw.span;
-                            let mut left = prev_throw.unbox().argument;
-                            let mut right = last_throw.unbox().argument;
-
-                            // "if (!a) throw b; throw c;" => "throw a ? c : b;"
-                            if let Expression::UnaryExpression(unary_expr) = &mut prev_if.test
-                                && unary_expr.operator.is_not()
-                            {
-                                prev_if.test = unary_expr.argument.take_in(ctx);
-                                std::mem::swap(&mut left, &mut right);
-                            }
-
-                            let argument = if let Expression::SequenceExpression(sequence_expr) =
-                                &mut prev_if.test
-                            {
-                                // "if (a, b) throw c; throw d;" => "throw a, b ? c : d;"
-                                let test = sequence_expr.expressions.pop().unwrap();
-                                let mut b = Self::minimize_conditional(
-                                    prev_if.span,
-                                    test,
-                                    left,
-                                    right,
-                                    ctx,
-                                );
-                                Self::join_sequence(&mut prev_if.test, &mut b, ctx)
-                            } else {
-                                // "if (a) throw b; throw c;" => "throw a ? b : c;"
-                                Self::minimize_conditional(
-                                    prev_if.span,
-                                    prev_if.test.take_in(ctx),
-                                    left,
-                                    right,
-                                    ctx,
-                                )
-                            };
+                            let argument = Self::minimize_conditional_after_if(
+                                prev_if.span,
+                                prev_if.test,
+                                prev_throw.unbox().argument,
+                                last_throw.unbox().argument,
+                                ctx,
+                            );
                             let last_throw_stmt =
                                 Statement::new_throw_statement(right_span, argument, ctx);
                             stmts.push(last_throw_stmt);
@@ -334,6 +283,36 @@ impl<'a> PeepholeOptimizations {
             current = &c.alternate;
         }
         false
+    }
+
+    fn minimize_conditional_after_if(
+        span: Span,
+        test: Expression<'a>,
+        consequent: Expression<'a>,
+        alternate: Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        match test {
+            // "if (!a) return/throw b; return/throw c;" => "return/throw a ? c : b;"
+            Expression::UnaryExpression(unary_expr) if unary_expr.operator.is_not() => {
+                Self::minimize_conditional(
+                    span,
+                    unary_expr.unbox().argument,
+                    alternate,
+                    consequent,
+                    ctx,
+                )
+            }
+            // "if (a, b) return/throw c; return/throw d;" => "return/throw a, b ? c : d;"
+            Expression::SequenceExpression(mut sequence_expr) => {
+                let test = sequence_expr.expressions.pop().unwrap();
+                let conditional =
+                    Self::minimize_conditional(span, test, consequent, alternate, ctx);
+                sequence_expr.expressions.push(conditional);
+                Expression::SequenceExpression(sequence_expr)
+            }
+            test => Self::minimize_conditional(span, test, consequent, alternate, ctx),
+        }
     }
 
     fn minimize_statement(
@@ -735,11 +714,8 @@ impl<'a> PeepholeOptimizations {
         }
 
         if switch_stmt.cases.is_empty() {
-            result.push(Statement::new_expression_statement(
-                switch_stmt.span,
-                switch_stmt.discriminant.take_in(ctx),
-                ctx,
-            ));
+            let SwitchStatement { span, discriminant, .. } = switch_stmt.unbox();
+            result.push(Statement::new_expression_statement(span, discriminant, ctx));
             return;
         } else if let Some(last_case) = switch_stmt.cases.last_mut()
             && let Some(Statement::BreakStatement(last_break)) = last_case.consequent.last()
@@ -752,29 +728,31 @@ impl<'a> PeepholeOptimizations {
         if !ctx.is_tree_shake_only()
             && switch_stmt.cases.len() == 1
             && Self::can_switch_case_be_inlined(&switch_stmt.cases[0])
-            && let Some(mut case) = switch_stmt.cases.pop()
+            && let Some(case) = switch_stmt.cases.pop()
         {
             ctx.notice_change();
+            let switch_scope_id = switch_stmt.scope_id();
+            let SwitchStatement { span: switch_span, discriminant, .. } = switch_stmt.unbox();
+            let SwitchCase { span: case_span, test, mut consequent, .. } = case;
 
-            let block_stmt = if case.consequent.len() == 1
-                && matches!(case.consequent[0], Statement::BlockStatement(_))
-            {
-                case.consequent.pop().unwrap()
-            } else {
-                Statement::new_block_statement_with_scope_id(
-                    case.span,
-                    case.consequent.take_in(ctx),
-                    switch_stmt.scope_id(),
-                    ctx,
-                )
-            };
+            let block_stmt =
+                if consequent.len() == 1 && matches!(consequent[0], Statement::BlockStatement(_)) {
+                    consequent.pop().unwrap()
+                } else {
+                    Statement::new_block_statement_with_scope_id(
+                        case_span,
+                        consequent,
+                        switch_scope_id,
+                        ctx,
+                    )
+                };
 
-            if let Some(test) = case.test {
+            if let Some(test) = test {
                 result.push(Statement::new_if_statement(
-                    switch_stmt.span,
+                    switch_span,
                     Expression::new_binary_expression(
                         SPAN,
-                        switch_stmt.discriminant.take_in(ctx),
+                        discriminant,
                         BinaryOperator::StrictEquality,
                         test,
                         ctx,
@@ -786,10 +764,10 @@ impl<'a> PeepholeOptimizations {
                 return;
             }
 
-            if !switch_stmt.discriminant.is_literal() {
+            if !discriminant.is_literal() {
                 result.push(Statement::new_expression_statement(
-                    switch_stmt.discriminant.span(),
-                    switch_stmt.discriminant.take_in(ctx),
+                    discriminant.span(),
+                    discriminant,
                     ctx,
                 ));
             }
@@ -831,15 +809,20 @@ impl<'a> PeepholeOptimizations {
                     // "if (a) continue c; if (b) continue c;" => "if (a || b) continue c;"
                     // "if (a) return c; if (b) return c;" => "if (a || b) return c;"
                     // "if (a) throw c; if (b) throw c;" => "if (a || b) throw c;"
-                    if_stmt.test = Self::join_with_left_associative_op(
-                        if_stmt.test.span(),
-                        LogicalOperator::Or,
-                        prev_if_stmt.test.take_in(ctx),
-                        if_stmt.test.take_in(ctx),
-                        ctx,
-                    );
-                    let dropped = result.pop().unwrap();
-                    ctx.drop_statement(&dropped);
+                    let previous = result.pop().unwrap();
+                    let Statement::IfStatement(previous) = previous else { unreachable!() };
+                    let previous = previous.unbox();
+                    let span = if_stmt.test.span();
+                    ctx.replace_expression_with(&mut if_stmt.test, |test, ctx| {
+                        Self::join_with_left_associative_op(
+                            span,
+                            LogicalOperator::Or,
+                            previous.test,
+                            test,
+                            ctx,
+                        )
+                    });
+                    ctx.drop_statement(&previous.consequent);
                 }
 
                 if Self::can_remove_termination_statement(&if_stmt.consequent, ctx) {
@@ -876,7 +859,7 @@ impl<'a> PeepholeOptimizations {
                         } else {
                             body[0].span()
                         };
-                        let test = if_stmt.test.take_in(ctx);
+                        let test = if_stmt.unbox().test;
                         let mut test = Self::minimize_not(test.span(), test, ctx);
                         Self::minimize_expression_in_boolean_context(&mut test, ctx);
                         let consequent = if body.len() == 1 {
@@ -949,11 +932,10 @@ impl<'a> PeepholeOptimizations {
                     let a = &mut prev_expr_stmt.expression;
                     prev_expr_stmt.expression = Self::join_sequence(a, argument, ctx);
                 } else {
-                    result.push(Statement::new_expression_statement(
-                        argument.span(),
-                        argument.take_in(ctx),
-                        ctx,
-                    ));
+                    let span = argument.span();
+                    let argument = ret_stmt.argument.take().unwrap();
+                    result.push(Statement::new_expression_statement(span, argument, ctx));
+                    ctx.notice_change();
                 }
             }
             if let Some(old) = ret_stmt.argument.take() {
@@ -1072,10 +1054,12 @@ impl<'a> PeepholeOptimizations {
                             ctx.drop_statement(&dropped);
                         }
                     } else {
-                        for_stmt.init =
-                            Some(ForStatementInit::from(prev_expr_stmt.expression.take_in(ctx)));
-                        let dropped = result.pop().unwrap();
-                        ctx.drop_statement(&dropped);
+                        let previous = result.pop().unwrap();
+                        let Statement::ExpressionStatement(previous) = previous else {
+                            unreachable!()
+                        };
+                        for_stmt.init = Some(ForStatementInit::from(previous.unbox().expression));
+                        ctx.notice_change();
                     }
                 }
                 Some(Statement::VariableDeclaration(prev_var_decl)) => {

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -202,15 +202,25 @@ impl<'a> PeepholeOptimizations {
                     let mut keep_var = KeepVar::new();
                     keep_var.visit_statement(&for_stmt.body);
                     let mut var_decl = keep_var.get_variable_declaration(&ctx.ast);
-                    let Some(ForStatementInit::VariableDeclaration(var_init)) = &mut for_stmt.init
-                    else {
-                        return;
-                    };
-                    if var_init.kind.is_var() {
+                    let init_is_var = matches!(
+                        &for_stmt.init,
+                        Some(ForStatementInit::VariableDeclaration(var_init)) if var_init.kind.is_var()
+                    );
+                    if init_is_var {
                         if let Some(var_decl) = &mut var_decl {
+                            let Some(ForStatementInit::VariableDeclaration(var_init)) =
+                                &mut for_stmt.init
+                            else {
+                                unreachable!()
+                            };
                             var_decl.declarations.splice(0..0, var_init.declarations.take_in(ctx));
                         } else {
-                            var_decl = Some(var_init.take_in_box(ctx));
+                            let Some(ForStatementInit::VariableDeclaration(var_init)) =
+                                for_stmt.init.take()
+                            else {
+                                unreachable!()
+                            };
+                            var_decl = Some(var_init);
                         }
                     }
                     let new_stmt = var_decl.map_or_else(

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 150
   sys alloc bytes: 14996600 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 145315
+  arena allocs: 144629
   arena reallocs: 28468
-  arena size: 19154792 # 19.15 MB
+  arena size: 19144184 # 19.14 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,9 +16,9 @@ App.tsx:
   sys deallocs: 61
   sys alloc bytes: 2128555 # 2.13 MB
   sys peak growth: 1612427 # 1.61 MB
-  arena allocs: 15795
+  arena allocs: 15730
   arena reallocs: 2721
-  arena size: 2883328 # 2.88 MB
+  arena size: 2882416 # 2.88 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 2427
   sys alloc bytes: 5334247 # 5.33 MB
   sys peak growth: 3693355 # 3.69 MB
-  arena allocs: 45153
+  arena allocs: 44972
   arena reallocs: 7718
-  arena size: 6314208 # 6.31 MB
+  arena size: 6312336 # 6.31 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 1038
   sys alloc bytes: 29976031 # 29.98 MB
   sys peak growth: 19934725 # 19.93 MB
-  arena allocs: 353569
+  arena allocs: 352732
   arena reallocs: 76289
-  arena size: 48820232 # 48.82 MB
+  arena size: 48806072 # 48.81 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,9 +60,9 @@ binder.ts:
   sys deallocs: 33
   sys alloc bytes: 963008 # 963.01 kB
   sys peak growth: 657404 # 657.40 kB
-  arena allocs: 6877
+  arena allocs: 6847
   arena reallocs: 842
-  arena size: 1164880 # 1.16 MB
+  arena size: 1164432 # 1.16 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 1854
   sys alloc bytes: 5307512 # 5.31 MB
   sys peak growth: 3707425 # 3.71 MB
-  arena allocs: 65970
+  arena allocs: 65730
   arena reallocs: 12252
-  arena size: 9410968 # 9.41 MB
+  arena size: 9407416 # 9.41 MB


### PR DESCRIPTION
Statement transforms still use `take_in` after popping or consuming their parent nodes. Removing those dummies is less mechanical because references from discarded branches and pass mutations must remain accounted for.

Move the owned statement fields directly, centralize the shared return/throw conditional rewrite, and use explicit dropped-subtree or mutation reporting at each ownership boundary. The adjacent-`if` rewrite also uses the closure-based replacement API introduced at the bottom of this stack.

Relative to its parent, the tracked allocation fixtures record 2,039 fewer arena allocations and 31,552 fewer arena bytes. Across the complete stack, the improvement is 25,252 arena allocations and 404,352 arena bytes. Minsize output is unchanged.

Validated with `cargo test -p oxc_minifier`, `just minsize`, `cargo clippy -p oxc_minifier -- -D warnings`, `just fmt`, and `git diff --check`.

AI assistance was used for research, implementation, review, and testing. I reviewed and take responsibility for the changes.