### PR TITLE
feat(linter/vue): implement no-deprecated-dollar-scopedslots-api rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1770,6 +1770,7 @@ export interface DummyRuleMap {
   "vue/no-deprecated-data-object-declaration"?: RuleNoConfig;
   "vue/no-deprecated-delete-set"?: RuleNoConfig;
   "vue/no-deprecated-destroyed-lifecycle"?: RuleNoConfig;
+  "vue/no-deprecated-dollar-scopedslots-api"?: RuleNoConfig;
   "vue/no-deprecated-events-api"?: RuleNoConfig;
   "vue/no-deprecated-model-definition"?: RuleNoConfig | [AllowWarnDeny, NoDeprecatedModelDefinitionConfig];
   "vue/no-deprecated-props-default-this"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5240,13 +5240,6 @@ impl RuleRunner for crate::rules::node::no_top_level_await::NoTopLevelAwait {
 }
 
 impl RuleRunner
-    for crate::rules::vue::no_deprecated_dollar_scopedslots_api::NoDeprecatedDollarScopedslotsApi
-{
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
-}
-
-impl RuleRunner
     for crate::rules::vue::component_definition_name_casing::ComponentDefinitionNameCasing
 {
     const NODE_TYPES: Option<&AstTypesBitset> =
@@ -5334,6 +5327,14 @@ impl RuleRunner
 {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::ExportDefaultDeclaration]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
+    for crate::rules::vue::no_deprecated_dollar_scopedslots_api::NoDeprecatedDollarScopedslotsApi
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::StaticMemberExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5240,6 +5240,13 @@ impl RuleRunner for crate::rules::node::no_top_level_await::NoTopLevelAwait {
 }
 
 impl RuleRunner
+    for crate::rules::vue::no_deprecated_dollar_scopedslots_api::NoDeprecatedDollarScopedslotsApi
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
     for crate::rules::vue::component_definition_name_casing::ComponentDefinitionNameCasing
 {
     const NODE_TYPES: Option<&AstTypesBitset> =

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -846,6 +846,7 @@ pub use crate::rules::vue::no_computed_properties_in_data::NoComputedPropertiesI
 pub use crate::rules::vue::no_deprecated_data_object_declaration::NoDeprecatedDataObjectDeclaration as VueNoDeprecatedDataObjectDeclaration;
 pub use crate::rules::vue::no_deprecated_delete_set::NoDeprecatedDeleteSet as VueNoDeprecatedDeleteSet;
 pub use crate::rules::vue::no_deprecated_destroyed_lifecycle::NoDeprecatedDestroyedLifecycle as VueNoDeprecatedDestroyedLifecycle;
+pub use crate::rules::vue::no_deprecated_dollar_scopedslots_api::NoDeprecatedDollarScopedslotsApi as VueNoDeprecatedDollarScopedslotsApi;
 pub use crate::rules::vue::no_deprecated_events_api::NoDeprecatedEventsApi as VueNoDeprecatedEventsApi;
 pub use crate::rules::vue::no_deprecated_model_definition::NoDeprecatedModelDefinition as VueNoDeprecatedModelDefinition;
 pub use crate::rules::vue::no_deprecated_props_default_this::NoDeprecatedPropsDefaultThis as VueNoDeprecatedPropsDefaultThis;
@@ -1722,6 +1723,7 @@ pub enum RuleEnum {
     NodeNoProcessEnv(NodeNoProcessEnv),
     NodeNoSync(NodeNoSync),
     NodeNoTopLevelAwait(NodeNoTopLevelAwait),
+    VueNoDeprecatedDollarScopedslotsApi(VueNoDeprecatedDollarScopedslotsApi),
     VueComponentDefinitionNameCasing(VueComponentDefinitionNameCasing),
     VueDefineEmitsDeclaration(VueDefineEmitsDeclaration),
     VueDefinePropsDeclaration(VueDefinePropsDeclaration),
@@ -2695,7 +2697,9 @@ const NODE_NO_PATH_CONCAT_ID: usize = NODE_NO_NEW_REQUIRE_ID + 1usize;
 const NODE_NO_PROCESS_ENV_ID: usize = NODE_NO_PATH_CONCAT_ID + 1usize;
 const NODE_NO_SYNC_ID: usize = NODE_NO_PROCESS_ENV_ID + 1usize;
 const NODE_NO_TOP_LEVEL_AWAIT_ID: usize = NODE_NO_SYNC_ID + 1usize;
-const VUE_COMPONENT_DEFINITION_NAME_CASING_ID: usize = NODE_NO_TOP_LEVEL_AWAIT_ID + 1usize;
+const VUE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API_ID: usize = NODE_NO_TOP_LEVEL_AWAIT_ID + 1usize;
+const VUE_COMPONENT_DEFINITION_NAME_CASING_ID: usize =
+    VUE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API_ID + 1usize;
 const VUE_DEFINE_EMITS_DECLARATION_ID: usize = VUE_COMPONENT_DEFINITION_NAME_CASING_ID + 1usize;
 const VUE_DEFINE_PROPS_DECLARATION_ID: usize = VUE_DEFINE_EMITS_DECLARATION_ID + 1usize;
 const VUE_DEFINE_PROPS_DESTRUCTURING_ID: usize = VUE_DEFINE_PROPS_DECLARATION_ID + 1usize;
@@ -2748,7 +2752,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 870usize] = [
+static RULE_NAMES: [&str; 871usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3573,6 +3577,7 @@ static RULE_NAMES: [&str; 870usize] = [
     NodeNoProcessEnv::NAME,
     NodeNoSync::NAME,
     NodeNoTopLevelAwait::NAME,
+    VueNoDeprecatedDollarScopedslotsApi::NAME,
     VueComponentDefinitionNameCasing::NAME,
     VueDefineEmitsDeclaration::NAME,
     VueDefinePropsDeclaration::NAME,
@@ -4573,6 +4578,9 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NODE_NO_PROCESS_ENV_ID,
             Self::NodeNoSync(_) => NODE_NO_SYNC_ID,
             Self::NodeNoTopLevelAwait(_) => NODE_NO_TOP_LEVEL_AWAIT_ID,
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VUE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API_ID
+            }
             Self::VueComponentDefinitionNameCasing(_) => VUE_COMPONENT_DEFINITION_NAME_CASING_ID,
             Self::VueDefineEmitsDeclaration(_) => VUE_DEFINE_EMITS_DECLARATION_ID,
             Self::VueDefinePropsDeclaration(_) => VUE_DEFINE_PROPS_DECLARATION_ID,
@@ -5622,6 +5630,9 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::CATEGORY,
             Self::NodeNoSync(_) => NodeNoSync::CATEGORY,
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::CATEGORY,
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::CATEGORY
+            }
             Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::CATEGORY,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::CATEGORY,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::CATEGORY,
@@ -6613,6 +6624,9 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::FIX,
             Self::NodeNoSync(_) => NodeNoSync::FIX,
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::FIX,
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::FIX
+            }
             Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::FIX,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::FIX,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::FIX,
@@ -7860,6 +7874,9 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::documentation(),
             Self::NodeNoSync(_) => NodeNoSync::documentation(),
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::documentation(),
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::documentation()
+            }
             Self::VueComponentDefinitionNameCasing(_) => {
                 VueComponentDefinitionNameCasing::documentation()
             }
@@ -10289,6 +10306,10 @@ impl RuleEnum {
             }
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::config_schema(generator)
                 .or_else(|| NodeNoTopLevelAwait::schema(generator)),
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::config_schema(generator)
+                    .or_else(|| VueNoDeprecatedDollarScopedslotsApi::schema(generator))
+            }
             Self::VueComponentDefinitionNameCasing(_) => {
                 VueComponentDefinitionNameCasing::config_schema(generator)
                     .or_else(|| VueComponentDefinitionNameCasing::schema(generator))
@@ -11253,6 +11274,7 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => "node",
             Self::NodeNoSync(_) => "node",
             Self::NodeNoTopLevelAwait(_) => "node",
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => "vue",
             Self::VueComponentDefinitionNameCasing(_) => "vue",
             Self::VueDefineEmitsDeclaration(_) => "vue",
             Self::VueDefinePropsDeclaration(_) => "vue",
@@ -13258,6 +13280,7 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(rule) => rule.run(node, ctx),
             Self::NodeNoSync(rule) => rule.run(node, ctx),
             Self::NodeNoTopLevelAwait(rule) => rule.run(node, ctx),
+            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.run(node, ctx),
             Self::VueComponentDefinitionNameCasing(rule) => rule.run(node, ctx),
             Self::VueDefineEmitsDeclaration(rule) => rule.run(node, ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.run(node, ctx),
@@ -14145,6 +14168,7 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(rule) => rule.run_once(ctx),
             Self::NodeNoSync(rule) => rule.run_once(ctx),
             Self::NodeNoTopLevelAwait(rule) => rule.run_once(ctx),
+            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.run_once(ctx),
             Self::VueComponentDefinitionNameCasing(rule) => rule.run_once(ctx),
             Self::VueDefineEmitsDeclaration(rule) => rule.run_once(ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.run_once(ctx),
@@ -15145,6 +15169,9 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeNoSync(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeNoTopLevelAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
             Self::VueComponentDefinitionNameCasing(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueDefineEmitsDeclaration(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16037,6 +16064,7 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(rule) => rule.should_run(ctx),
             Self::NodeNoSync(rule) => rule.should_run(ctx),
             Self::NodeNoTopLevelAwait(rule) => rule.should_run(ctx),
+            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.should_run(ctx),
             Self::VueComponentDefinitionNameCasing(rule) => rule.should_run(ctx),
             Self::VueDefineEmitsDeclaration(rule) => rule.should_run(ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.should_run(ctx),
@@ -17279,6 +17307,9 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::IS_TSGOLINT_RULE,
             Self::NodeNoSync(_) => NodeNoSync::IS_TSGOLINT_RULE,
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::IS_TSGOLINT_RULE,
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::IS_TSGOLINT_RULE
+            }
             Self::VueComponentDefinitionNameCasing(_) => {
                 VueComponentDefinitionNameCasing::IS_TSGOLINT_RULE
             }
@@ -18343,6 +18374,9 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::VERSION,
             Self::NodeNoSync(_) => NodeNoSync::VERSION,
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::VERSION,
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::VERSION
+            }
             Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::VERSION,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::VERSION,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::VERSION,
@@ -19428,6 +19462,9 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::HAS_CONFIG,
             Self::NodeNoSync(_) => NodeNoSync::HAS_CONFIG,
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::HAS_CONFIG,
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::HAS_CONFIG
+            }
             Self::VueComponentDefinitionNameCasing(_) => {
                 VueComponentDefinitionNameCasing::HAS_CONFIG
             }
@@ -20424,6 +20461,9 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::INFO,
             Self::NodeNoSync(_) => NodeNoSync::INFO,
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::INFO,
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::INFO
+            }
             Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::INFO,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::INFO,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::INFO,
@@ -21307,6 +21347,7 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(rule) => rule.types_info(),
             Self::NodeNoSync(rule) => rule.types_info(),
             Self::NodeNoTopLevelAwait(rule) => rule.types_info(),
+            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.types_info(),
             Self::VueComponentDefinitionNameCasing(rule) => rule.types_info(),
             Self::VueDefineEmitsDeclaration(rule) => rule.types_info(),
             Self::VueDefinePropsDeclaration(rule) => rule.types_info(),
@@ -22181,6 +22222,7 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(rule) => rule.run_info(),
             Self::NodeNoSync(rule) => rule.run_info(),
             Self::NodeNoTopLevelAwait(rule) => rule.run_info(),
+            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.run_info(),
             Self::VueComponentDefinitionNameCasing(rule) => rule.run_info(),
             Self::VueDefineEmitsDeclaration(rule) => rule.run_info(),
             Self::VueDefinePropsDeclaration(rule) => rule.run_info(),
@@ -23187,6 +23229,9 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::NodeNoProcessEnv(NodeNoProcessEnv::default()),
         RuleEnum::NodeNoSync(NodeNoSync::default()),
         RuleEnum::NodeNoTopLevelAwait(NodeNoTopLevelAwait::default()),
+        RuleEnum::VueNoDeprecatedDollarScopedslotsApi(
+            VueNoDeprecatedDollarScopedslotsApi::default(),
+        ),
         RuleEnum::VueComponentDefinitionNameCasing(VueComponentDefinitionNameCasing::default()),
         RuleEnum::VueDefineEmitsDeclaration(VueDefineEmitsDeclaration::default()),
         RuleEnum::VueDefinePropsDeclaration(VueDefinePropsDeclaration::default()),

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -1723,7 +1723,6 @@ pub enum RuleEnum {
     NodeNoProcessEnv(NodeNoProcessEnv),
     NodeNoSync(NodeNoSync),
     NodeNoTopLevelAwait(NodeNoTopLevelAwait),
-    VueNoDeprecatedDollarScopedslotsApi(VueNoDeprecatedDollarScopedslotsApi),
     VueComponentDefinitionNameCasing(VueComponentDefinitionNameCasing),
     VueDefineEmitsDeclaration(VueDefineEmitsDeclaration),
     VueDefinePropsDeclaration(VueDefinePropsDeclaration),
@@ -1736,6 +1735,7 @@ pub enum RuleEnum {
     VueNoDeprecatedDataObjectDeclaration(VueNoDeprecatedDataObjectDeclaration),
     VueNoDeprecatedDeleteSet(VueNoDeprecatedDeleteSet),
     VueNoDeprecatedDestroyedLifecycle(VueNoDeprecatedDestroyedLifecycle),
+    VueNoDeprecatedDollarScopedslotsApi(VueNoDeprecatedDollarScopedslotsApi),
     VueNoDeprecatedEventsApi(VueNoDeprecatedEventsApi),
     VueNoDeprecatedModelDefinition(VueNoDeprecatedModelDefinition),
     VueNoDeprecatedPropsDefaultThis(VueNoDeprecatedPropsDefaultThis),
@@ -2697,9 +2697,7 @@ const NODE_NO_PATH_CONCAT_ID: usize = NODE_NO_NEW_REQUIRE_ID + 1usize;
 const NODE_NO_PROCESS_ENV_ID: usize = NODE_NO_PATH_CONCAT_ID + 1usize;
 const NODE_NO_SYNC_ID: usize = NODE_NO_PROCESS_ENV_ID + 1usize;
 const NODE_NO_TOP_LEVEL_AWAIT_ID: usize = NODE_NO_SYNC_ID + 1usize;
-const VUE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API_ID: usize = NODE_NO_TOP_LEVEL_AWAIT_ID + 1usize;
-const VUE_COMPONENT_DEFINITION_NAME_CASING_ID: usize =
-    VUE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API_ID + 1usize;
+const VUE_COMPONENT_DEFINITION_NAME_CASING_ID: usize = NODE_NO_TOP_LEVEL_AWAIT_ID + 1usize;
 const VUE_DEFINE_EMITS_DECLARATION_ID: usize = VUE_COMPONENT_DEFINITION_NAME_CASING_ID + 1usize;
 const VUE_DEFINE_PROPS_DECLARATION_ID: usize = VUE_DEFINE_EMITS_DECLARATION_ID + 1usize;
 const VUE_DEFINE_PROPS_DESTRUCTURING_ID: usize = VUE_DEFINE_PROPS_DECLARATION_ID + 1usize;
@@ -2714,7 +2712,9 @@ const VUE_NO_DEPRECATED_DATA_OBJECT_DECLARATION_ID: usize =
 const VUE_NO_DEPRECATED_DELETE_SET_ID: usize =
     VUE_NO_DEPRECATED_DATA_OBJECT_DECLARATION_ID + 1usize;
 const VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID: usize = VUE_NO_DEPRECATED_DELETE_SET_ID + 1usize;
-const VUE_NO_DEPRECATED_EVENTS_API_ID: usize = VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID + 1usize;
+const VUE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API_ID: usize =
+    VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID + 1usize;
+const VUE_NO_DEPRECATED_EVENTS_API_ID: usize = VUE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API_ID + 1usize;
 const VUE_NO_DEPRECATED_MODEL_DEFINITION_ID: usize = VUE_NO_DEPRECATED_EVENTS_API_ID + 1usize;
 const VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID: usize =
     VUE_NO_DEPRECATED_MODEL_DEFINITION_ID + 1usize;
@@ -3577,7 +3577,6 @@ static RULE_NAMES: [&str; 871usize] = [
     NodeNoProcessEnv::NAME,
     NodeNoSync::NAME,
     NodeNoTopLevelAwait::NAME,
-    VueNoDeprecatedDollarScopedslotsApi::NAME,
     VueComponentDefinitionNameCasing::NAME,
     VueDefineEmitsDeclaration::NAME,
     VueDefinePropsDeclaration::NAME,
@@ -3590,6 +3589,7 @@ static RULE_NAMES: [&str; 871usize] = [
     VueNoDeprecatedDataObjectDeclaration::NAME,
     VueNoDeprecatedDeleteSet::NAME,
     VueNoDeprecatedDestroyedLifecycle::NAME,
+    VueNoDeprecatedDollarScopedslotsApi::NAME,
     VueNoDeprecatedEventsApi::NAME,
     VueNoDeprecatedModelDefinition::NAME,
     VueNoDeprecatedPropsDefaultThis::NAME,
@@ -4578,9 +4578,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NODE_NO_PROCESS_ENV_ID,
             Self::NodeNoSync(_) => NODE_NO_SYNC_ID,
             Self::NodeNoTopLevelAwait(_) => NODE_NO_TOP_LEVEL_AWAIT_ID,
-            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
-                VUE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API_ID
-            }
             Self::VueComponentDefinitionNameCasing(_) => VUE_COMPONENT_DEFINITION_NAME_CASING_ID,
             Self::VueDefineEmitsDeclaration(_) => VUE_DEFINE_EMITS_DECLARATION_ID,
             Self::VueDefinePropsDeclaration(_) => VUE_DEFINE_PROPS_DECLARATION_ID,
@@ -4595,6 +4592,9 @@ impl RuleEnum {
             }
             Self::VueNoDeprecatedDeleteSet(_) => VUE_NO_DEPRECATED_DELETE_SET_ID,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => VUE_NO_DEPRECATED_DESTROYED_LIFECYCLE_ID,
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VUE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API_ID
+            }
             Self::VueNoDeprecatedEventsApi(_) => VUE_NO_DEPRECATED_EVENTS_API_ID,
             Self::VueNoDeprecatedModelDefinition(_) => VUE_NO_DEPRECATED_MODEL_DEFINITION_ID,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID,
@@ -5630,9 +5630,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::CATEGORY,
             Self::NodeNoSync(_) => NodeNoSync::CATEGORY,
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::CATEGORY,
-            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
-                VueNoDeprecatedDollarScopedslotsApi::CATEGORY
-            }
             Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::CATEGORY,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::CATEGORY,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::CATEGORY,
@@ -5648,6 +5645,9 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(_) => VueNoDeprecatedDeleteSet::CATEGORY,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => {
                 VueNoDeprecatedDestroyedLifecycle::CATEGORY
+            }
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::CATEGORY
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::CATEGORY,
             Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::CATEGORY,
@@ -6624,9 +6624,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::FIX,
             Self::NodeNoSync(_) => NodeNoSync::FIX,
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::FIX,
-            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
-                VueNoDeprecatedDollarScopedslotsApi::FIX
-            }
             Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::FIX,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::FIX,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::FIX,
@@ -6641,6 +6638,9 @@ impl RuleEnum {
             }
             Self::VueNoDeprecatedDeleteSet(_) => VueNoDeprecatedDeleteSet::FIX,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => VueNoDeprecatedDestroyedLifecycle::FIX,
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::FIX
+            }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::FIX,
             Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::FIX,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::FIX,
@@ -7874,9 +7874,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::documentation(),
             Self::NodeNoSync(_) => NodeNoSync::documentation(),
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::documentation(),
-            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
-                VueNoDeprecatedDollarScopedslotsApi::documentation()
-            }
             Self::VueComponentDefinitionNameCasing(_) => {
                 VueComponentDefinitionNameCasing::documentation()
             }
@@ -7898,6 +7895,9 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(_) => VueNoDeprecatedDeleteSet::documentation(),
             Self::VueNoDeprecatedDestroyedLifecycle(_) => {
                 VueNoDeprecatedDestroyedLifecycle::documentation()
+            }
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::documentation()
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::documentation(),
             Self::VueNoDeprecatedModelDefinition(_) => {
@@ -10306,10 +10306,6 @@ impl RuleEnum {
             }
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::config_schema(generator)
                 .or_else(|| NodeNoTopLevelAwait::schema(generator)),
-            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
-                VueNoDeprecatedDollarScopedslotsApi::config_schema(generator)
-                    .or_else(|| VueNoDeprecatedDollarScopedslotsApi::schema(generator))
-            }
             Self::VueComponentDefinitionNameCasing(_) => {
                 VueComponentDefinitionNameCasing::config_schema(generator)
                     .or_else(|| VueComponentDefinitionNameCasing::schema(generator))
@@ -10352,6 +10348,10 @@ impl RuleEnum {
             Self::VueNoDeprecatedDestroyedLifecycle(_) => {
                 VueNoDeprecatedDestroyedLifecycle::config_schema(generator)
                     .or_else(|| VueNoDeprecatedDestroyedLifecycle::schema(generator))
+            }
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::config_schema(generator)
+                    .or_else(|| VueNoDeprecatedDollarScopedslotsApi::schema(generator))
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::config_schema(generator)
                 .or_else(|| VueNoDeprecatedEventsApi::schema(generator)),
@@ -11274,7 +11274,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => "node",
             Self::NodeNoSync(_) => "node",
             Self::NodeNoTopLevelAwait(_) => "node",
-            Self::VueNoDeprecatedDollarScopedslotsApi(_) => "vue",
             Self::VueComponentDefinitionNameCasing(_) => "vue",
             Self::VueDefineEmitsDeclaration(_) => "vue",
             Self::VueDefinePropsDeclaration(_) => "vue",
@@ -11287,6 +11286,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDataObjectDeclaration(_) => "vue",
             Self::VueNoDeprecatedDeleteSet(_) => "vue",
             Self::VueNoDeprecatedDestroyedLifecycle(_) => "vue",
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => "vue",
             Self::VueNoDeprecatedEventsApi(_) => "vue",
             Self::VueNoDeprecatedModelDefinition(_) => "vue",
             Self::VueNoDeprecatedPropsDefaultThis(_) => "vue",
@@ -13280,7 +13280,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(rule) => rule.run(node, ctx),
             Self::NodeNoSync(rule) => rule.run(node, ctx),
             Self::NodeNoTopLevelAwait(rule) => rule.run(node, ctx),
-            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.run(node, ctx),
             Self::VueComponentDefinitionNameCasing(rule) => rule.run(node, ctx),
             Self::VueDefineEmitsDeclaration(rule) => rule.run(node, ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.run(node, ctx),
@@ -13293,6 +13292,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.run(node, ctx),
             Self::VueNoDeprecatedDeleteSet(rule) => rule.run(node, ctx),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run(node, ctx),
+            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.run(node, ctx),
             Self::VueNoDeprecatedEventsApi(rule) => rule.run(node, ctx),
             Self::VueNoDeprecatedModelDefinition(rule) => rule.run(node, ctx),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run(node, ctx),
@@ -14168,7 +14168,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(rule) => rule.run_once(ctx),
             Self::NodeNoSync(rule) => rule.run_once(ctx),
             Self::NodeNoTopLevelAwait(rule) => rule.run_once(ctx),
-            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.run_once(ctx),
             Self::VueComponentDefinitionNameCasing(rule) => rule.run_once(ctx),
             Self::VueDefineEmitsDeclaration(rule) => rule.run_once(ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.run_once(ctx),
@@ -14181,6 +14180,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.run_once(ctx),
             Self::VueNoDeprecatedDeleteSet(rule) => rule.run_once(ctx),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_once(ctx),
+            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.run_once(ctx),
             Self::VueNoDeprecatedEventsApi(rule) => rule.run_once(ctx),
             Self::VueNoDeprecatedModelDefinition(rule) => rule.run_once(ctx),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_once(ctx),
@@ -15169,9 +15169,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeNoSync(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::NodeNoTopLevelAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
-            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => {
-                rule.run_on_jest_node(jest_node, ctx)
-            }
             Self::VueComponentDefinitionNameCasing(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueDefineEmitsDeclaration(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15186,6 +15183,9 @@ impl RuleEnum {
             }
             Self::VueNoDeprecatedDeleteSet(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
             Self::VueNoDeprecatedEventsApi(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoDeprecatedModelDefinition(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16064,7 +16064,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(rule) => rule.should_run(ctx),
             Self::NodeNoSync(rule) => rule.should_run(ctx),
             Self::NodeNoTopLevelAwait(rule) => rule.should_run(ctx),
-            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.should_run(ctx),
             Self::VueComponentDefinitionNameCasing(rule) => rule.should_run(ctx),
             Self::VueDefineEmitsDeclaration(rule) => rule.should_run(ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.should_run(ctx),
@@ -16077,6 +16076,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedDeleteSet(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.should_run(ctx),
+            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedEventsApi(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedModelDefinition(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.should_run(ctx),
@@ -17307,9 +17307,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::IS_TSGOLINT_RULE,
             Self::NodeNoSync(_) => NodeNoSync::IS_TSGOLINT_RULE,
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::IS_TSGOLINT_RULE,
-            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
-                VueNoDeprecatedDollarScopedslotsApi::IS_TSGOLINT_RULE
-            }
             Self::VueComponentDefinitionNameCasing(_) => {
                 VueComponentDefinitionNameCasing::IS_TSGOLINT_RULE
             }
@@ -17331,6 +17328,9 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(_) => VueNoDeprecatedDeleteSet::IS_TSGOLINT_RULE,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => {
                 VueNoDeprecatedDestroyedLifecycle::IS_TSGOLINT_RULE
+            }
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::IS_TSGOLINT_RULE
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::IS_TSGOLINT_RULE,
             Self::VueNoDeprecatedModelDefinition(_) => {
@@ -18374,9 +18374,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::VERSION,
             Self::NodeNoSync(_) => NodeNoSync::VERSION,
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::VERSION,
-            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
-                VueNoDeprecatedDollarScopedslotsApi::VERSION
-            }
             Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::VERSION,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::VERSION,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::VERSION,
@@ -18392,6 +18389,9 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(_) => VueNoDeprecatedDeleteSet::VERSION,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => {
                 VueNoDeprecatedDestroyedLifecycle::VERSION
+            }
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::VERSION
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::VERSION,
             Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::VERSION,
@@ -19462,9 +19462,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::HAS_CONFIG,
             Self::NodeNoSync(_) => NodeNoSync::HAS_CONFIG,
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::HAS_CONFIG,
-            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
-                VueNoDeprecatedDollarScopedslotsApi::HAS_CONFIG
-            }
             Self::VueComponentDefinitionNameCasing(_) => {
                 VueComponentDefinitionNameCasing::HAS_CONFIG
             }
@@ -19482,6 +19479,9 @@ impl RuleEnum {
             Self::VueNoDeprecatedDeleteSet(_) => VueNoDeprecatedDeleteSet::HAS_CONFIG,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => {
                 VueNoDeprecatedDestroyedLifecycle::HAS_CONFIG
+            }
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::HAS_CONFIG
             }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::HAS_CONFIG,
             Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::HAS_CONFIG,
@@ -20461,9 +20461,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::INFO,
             Self::NodeNoSync(_) => NodeNoSync::INFO,
             Self::NodeNoTopLevelAwait(_) => NodeNoTopLevelAwait::INFO,
-            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
-                VueNoDeprecatedDollarScopedslotsApi::INFO
-            }
             Self::VueComponentDefinitionNameCasing(_) => VueComponentDefinitionNameCasing::INFO,
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::INFO,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::INFO,
@@ -20478,6 +20475,9 @@ impl RuleEnum {
             }
             Self::VueNoDeprecatedDeleteSet(_) => VueNoDeprecatedDeleteSet::INFO,
             Self::VueNoDeprecatedDestroyedLifecycle(_) => VueNoDeprecatedDestroyedLifecycle::INFO,
+            Self::VueNoDeprecatedDollarScopedslotsApi(_) => {
+                VueNoDeprecatedDollarScopedslotsApi::INFO
+            }
             Self::VueNoDeprecatedEventsApi(_) => VueNoDeprecatedEventsApi::INFO,
             Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::INFO,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::INFO,
@@ -21347,7 +21347,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(rule) => rule.types_info(),
             Self::NodeNoSync(rule) => rule.types_info(),
             Self::NodeNoTopLevelAwait(rule) => rule.types_info(),
-            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.types_info(),
             Self::VueComponentDefinitionNameCasing(rule) => rule.types_info(),
             Self::VueDefineEmitsDeclaration(rule) => rule.types_info(),
             Self::VueDefinePropsDeclaration(rule) => rule.types_info(),
@@ -21360,6 +21359,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.types_info(),
             Self::VueNoDeprecatedDeleteSet(rule) => rule.types_info(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.types_info(),
+            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.types_info(),
             Self::VueNoDeprecatedEventsApi(rule) => rule.types_info(),
             Self::VueNoDeprecatedModelDefinition(rule) => rule.types_info(),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.types_info(),
@@ -22222,7 +22222,6 @@ impl RuleEnum {
             Self::NodeNoProcessEnv(rule) => rule.run_info(),
             Self::NodeNoSync(rule) => rule.run_info(),
             Self::NodeNoTopLevelAwait(rule) => rule.run_info(),
-            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.run_info(),
             Self::VueComponentDefinitionNameCasing(rule) => rule.run_info(),
             Self::VueDefineEmitsDeclaration(rule) => rule.run_info(),
             Self::VueDefinePropsDeclaration(rule) => rule.run_info(),
@@ -22235,6 +22234,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.run_info(),
             Self::VueNoDeprecatedDeleteSet(rule) => rule.run_info(),
             Self::VueNoDeprecatedDestroyedLifecycle(rule) => rule.run_info(),
+            Self::VueNoDeprecatedDollarScopedslotsApi(rule) => rule.run_info(),
             Self::VueNoDeprecatedEventsApi(rule) => rule.run_info(),
             Self::VueNoDeprecatedModelDefinition(rule) => rule.run_info(),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_info(),
@@ -23229,9 +23229,6 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::NodeNoProcessEnv(NodeNoProcessEnv::default()),
         RuleEnum::NodeNoSync(NodeNoSync::default()),
         RuleEnum::NodeNoTopLevelAwait(NodeNoTopLevelAwait::default()),
-        RuleEnum::VueNoDeprecatedDollarScopedslotsApi(
-            VueNoDeprecatedDollarScopedslotsApi::default(),
-        ),
         RuleEnum::VueComponentDefinitionNameCasing(VueComponentDefinitionNameCasing::default()),
         RuleEnum::VueDefineEmitsDeclaration(VueDefineEmitsDeclaration::default()),
         RuleEnum::VueDefinePropsDeclaration(VueDefinePropsDeclaration::default()),
@@ -23246,6 +23243,9 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         ),
         RuleEnum::VueNoDeprecatedDeleteSet(VueNoDeprecatedDeleteSet::default()),
         RuleEnum::VueNoDeprecatedDestroyedLifecycle(VueNoDeprecatedDestroyedLifecycle::default()),
+        RuleEnum::VueNoDeprecatedDollarScopedslotsApi(
+            VueNoDeprecatedDollarScopedslotsApi::default(),
+        ),
         RuleEnum::VueNoDeprecatedEventsApi(VueNoDeprecatedEventsApi::default()),
         RuleEnum::VueNoDeprecatedModelDefinition(VueNoDeprecatedModelDefinition::default()),
         RuleEnum::VueNoDeprecatedPropsDefaultThis(VueNoDeprecatedPropsDefaultThis::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -926,6 +926,7 @@ pub(crate) mod vue {
     pub mod no_deprecated_data_object_declaration;
     pub mod no_deprecated_delete_set;
     pub mod no_deprecated_destroyed_lifecycle;
+    pub mod no_deprecated_dollar_scopedslots_api;
     pub mod no_deprecated_events_api;
     pub mod no_deprecated_model_definition;
     pub mod no_deprecated_props_default_this;

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_dollar_scopedslots_api.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_dollar_scopedslots_api.rs
@@ -1,0 +1,462 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    ast_util::get_declaration_from_reference_id,
+    context::LintContext,
+    rule::Rule,
+    utils::{is_in_vue_component_instance_method, is_this_alias},
+};
+
+fn no_deprecated_dollar_scopedslots_api_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("`$scopedSlots` is deprecated.")
+        .with_help(
+            "Use `$slots` instead; in Vue 3, all slots are exposed as functions on `$slots`.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDeprecatedDollarScopedslotsApi;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow using deprecated `$scopedSlots` (in Vue.js 3.0.0+).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// In Vue 3, the `$scopedSlots` instance property was removed. Scoped
+    /// slots are unified with regular slots and exposed as functions on
+    /// `$slots`, so accessing `this.$scopedSlots` no longer works.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   render() {
+    ///     return this.$scopedSlots.default('data')
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   render() {
+    ///     return this.$slots.default('data')
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    NoDeprecatedDollarScopedslotsApi,
+    vue,
+    correctness,
+    suggestion,
+    version = "next",
+    short_description = "Disallow using deprecated `$scopedSlots` (in Vue.js 3.0.0+).",
+);
+
+impl Rule for NoDeprecatedDollarScopedslotsApi {
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::StaticMemberExpression(member) = node.kind() else { return };
+        if member.property.name != "$scopedSlots" {
+            return;
+        }
+
+        // The component context is anchored at the `this` usage itself, or at
+        // the `const vm = this` declaration when accessed through an alias, so
+        // an alias captured by a nested function still reports.
+        let in_component = match member.object.get_inner_expression() {
+            Expression::ThisExpression(_) => is_in_vue_component_instance_method(node, ctx),
+            Expression::Identifier(ident) => {
+                is_this_alias(ident, ctx)
+                    && get_declaration_from_reference_id(ident.reference_id(), ctx.semantic())
+                        .is_some_and(|decl| is_in_vue_component_instance_method(decl, ctx))
+            }
+            _ => false,
+        };
+
+        if in_component {
+            let span = member.property.span;
+            ctx.diagnostic_with_suggestion(
+                no_deprecated_dollar_scopedslots_api_diagnostic(span),
+                |fixer| fixer.replace(span, "$slots"),
+            );
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            r#"
+                    <template>
+                      <div v-bind="$attrs"/>
+                    </template>
+                    <script>
+                    export default {
+                      mounted () {
+                        this.$emit('start')
+                      }
+                    }
+                    </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      methods: {
+                        click () {
+                          this.$emit('click')
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                    }
+                    const another = function () {
+                      console.log(this.$scopedSlots)
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+                    <template>
+                      <div foo="$scopedSlots"/>
+                    </template>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+                    <template>
+                      <div v-on="() => {
+                        function click ($scopedSlots) {
+                          fn(foo.$scopedSlots)
+                          fn($scopedSlots)
+                        }
+                      }"/>
+                      <div v-for="$scopedSlots in list">
+                        <div v-on="$scopedSlots">
+                      </div>
+                      <VueComp>
+                        <template v-slot="{$scopedSlots}">
+                          <div v-on="$scopedSlots">
+                        </template>
+                      </VueComp>
+                    </template>
+                    <script>
+                    export default {
+                      methods: {
+                        click ($scopedSlots) {
+                          foo.$scopedSlots
+                        }
+                      }
+                    }
+                    </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      computed: {
+                        foo () {
+                          const {vm} = this
+                          return vm.$scopedSlots
+                        }
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            r#"
+                    <template>
+                      <div v-if="$scopedSlots.default"/>
+                    </template>
+                    <script>
+                    export default {
+                      render() {
+                        return this.$scopedSlots.foo('bar')
+                      }
+                    }
+                    </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+                    <template>
+                      <div v-for="slot in $scopedSlots"/>
+                      <div :foo="$scopedSlots"/>
+                    </template>
+                    <script>
+                    export default {
+                      computed: {
+                        foo () {
+                          fn(this.$scopedSlots)
+                        }
+                      }
+                    }
+                    </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      render() {
+                        const vm = this
+                        return vm.$scopedSlots.foo('bar')
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      render() {
+                        const vm = this
+                        function fn() {
+                          return vm.$scopedSlots
+                        }
+                        return fn().foo('bar')
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      render () {
+                        const vm = this
+                        const a = vm?.$scopedSlots
+                        const b = this?.$scopedSlots
+                        return a.foo('bar')
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fix = vec![
+        (
+            r#"
+                    <template>
+                      <div v-if="$scopedSlots.default"/>
+                    </template>
+                    <script>
+                    export default {
+                      render() {
+                        return this.$scopedSlots.foo('bar')
+                      }
+                    }
+                    </script>
+                  "#,
+            // Template is not parsed, so only the script usage is fixed.
+            r#"
+                    <template>
+                      <div v-if="$scopedSlots.default"/>
+                    </template>
+                    <script>
+                    export default {
+                      render() {
+                        return this.$slots.foo('bar')
+                      }
+                    }
+                    </script>
+                  "#,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+                    <template>
+                      <div v-for="slot in $scopedSlots"/>
+                      <div :foo="$scopedSlots"/>
+                    </template>
+                    <script>
+                    export default {
+                      computed: {
+                        foo () {
+                          fn(this.$scopedSlots)
+                        }
+                      }
+                    }
+                    </script>
+                  "#,
+            r#"
+                    <template>
+                      <div v-for="slot in $scopedSlots"/>
+                      <div :foo="$scopedSlots"/>
+                    </template>
+                    <script>
+                    export default {
+                      computed: {
+                        foo () {
+                          fn(this.$slots)
+                        }
+                      }
+                    }
+                    </script>
+                  "#,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      render() {
+                        const vm = this
+                        return vm.$scopedSlots.foo('bar')
+                      }
+                    }
+                    </script>
+                  ",
+            "
+                    <script>
+                    export default {
+                      render() {
+                        const vm = this
+                        return vm.$slots.foo('bar')
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      render() {
+                        const vm = this
+                        function fn() {
+                          return vm.$scopedSlots
+                        }
+                        return fn().foo('bar')
+                      }
+                    }
+                    </script>
+                  ",
+            "
+                    <script>
+                    export default {
+                      render() {
+                        const vm = this
+                        function fn() {
+                          return vm.$slots
+                        }
+                        return fn().foo('bar')
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                    export default {
+                      render () {
+                        const vm = this
+                        const a = vm?.$scopedSlots
+                        const b = this?.$scopedSlots
+                        return a.foo('bar')
+                      }
+                    }
+                    </script>
+                  ",
+            "
+                    <script>
+                    export default {
+                      render () {
+                        const vm = this
+                        const a = vm?.$slots
+                        const b = this?.$slots
+                        return a.foo('bar')
+                      }
+                    }
+                    </script>
+                  ",
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    Tester::new(
+        NoDeprecatedDollarScopedslotsApi::NAME,
+        NoDeprecatedDollarScopedslotsApi::PLUGIN,
+        pass,
+        fail,
+    )
+    .expect_fix(fix)
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_dollar_scopedslots_api.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_dollar_scopedslots_api.rs
@@ -103,6 +103,7 @@ fn test() {
     use std::path::PathBuf;
 
     use crate::tester::Tester;
+    // ref: https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-deprecated-dollar-scopedslots-api.test.ts
 
     let pass = vec![
         (

--- a/crates/oxc_linter/src/snapshots/vue_no_deprecated_dollar_scopedslots_api.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_deprecated_dollar_scopedslots_api.snap
@@ -1,0 +1,58 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 505
+---
+
+  ⚠ vue(no-deprecated-dollar-scopedslots-api): `$scopedSlots` is deprecated.
+   ╭─[no_deprecated_dollar_scopedslots_api.tsx:8:37]
+ 7 │                       render() {
+ 8 │                         return this.$scopedSlots.foo('bar')
+   ·                                     ────────────
+ 9 │                       }
+   ╰────
+  help: Use `$slots` instead; in Vue 3, all slots are exposed as functions on `$slots`.
+
+  ⚠ vue(no-deprecated-dollar-scopedslots-api): `$scopedSlots` is deprecated.
+    ╭─[no_deprecated_dollar_scopedslots_api.tsx:10:35]
+  9 │                         foo () {
+ 10 │                           fn(this.$scopedSlots)
+    ·                                   ────────────
+ 11 │                         }
+    ╰────
+  help: Use `$slots` instead; in Vue 3, all slots are exposed as functions on `$slots`.
+
+  ⚠ vue(no-deprecated-dollar-scopedslots-api): `$scopedSlots` is deprecated.
+   ╭─[no_deprecated_dollar_scopedslots_api.tsx:6:35]
+ 5 │                         const vm = this
+ 6 │                         return vm.$scopedSlots.foo('bar')
+   ·                                   ────────────
+ 7 │                       }
+   ╰────
+  help: Use `$slots` instead; in Vue 3, all slots are exposed as functions on `$slots`.
+
+  ⚠ vue(no-deprecated-dollar-scopedslots-api): `$scopedSlots` is deprecated.
+   ╭─[no_deprecated_dollar_scopedslots_api.tsx:7:37]
+ 6 │                         function fn() {
+ 7 │                           return vm.$scopedSlots
+   ·                                     ────────────
+ 8 │                         }
+   ╰────
+  help: Use `$slots` instead; in Vue 3, all slots are exposed as functions on `$slots`.
+
+  ⚠ vue(no-deprecated-dollar-scopedslots-api): `$scopedSlots` is deprecated.
+   ╭─[no_deprecated_dollar_scopedslots_api.tsx:6:39]
+ 5 │                         const vm = this
+ 6 │                         const a = vm?.$scopedSlots
+   ·                                       ────────────
+ 7 │                         const b = this?.$scopedSlots
+   ╰────
+  help: Use `$slots` instead; in Vue 3, all slots are exposed as functions on `$slots`.
+
+  ⚠ vue(no-deprecated-dollar-scopedslots-api): `$scopedSlots` is deprecated.
+   ╭─[no_deprecated_dollar_scopedslots_api.tsx:7:41]
+ 6 │                         const a = vm?.$scopedSlots
+ 7 │                         const b = this?.$scopedSlots
+   ·                                         ────────────
+ 8 │                         return a.foo('bar')
+   ╰────
+  help: Use `$slots` instead; in Vue 3, all slots are exposed as functions on `$slots`.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -10430,6 +10430,9 @@
         "vue/no-deprecated-destroyed-lifecycle": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "vue/no-deprecated-dollar-scopedslots-api": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "vue/no-deprecated-events-api": {
           "$ref": "#/definitions/RuleNoConfig"
         },


### PR DESCRIPTION
Part of #11440.

Implements `vue/no-deprecated-dollar-scopedslots-api`: reports `this.$scopedSlots` / `this?.$scopedSlots` and access through a `const vm = this` alias inside Vue component instance methods (including an alias captured by a nested function — the component context is anchored at the alias declaration, matching upstream semantics). Destructured aliases, `let` aliases, and `this` outside a component are not reported. Provides a suggestion fix replacing `$scopedSlots` with `$slots`.

Template usages are out of scope until Vue template parsing lands, same as the other implemented vue rules; the ported fixer expectations were adjusted accordingly (script-only).

- Tests ported from `eslint-plugin-vue` via `rulegen` (6 pass / 5 fail / 5 fix, snapshot included)
- `cargo test -p oxc_linter` and `cargo clippy -p oxc_linter --all-targets` pass
- Verified end-to-end with a local `oxlint` build: `--fix-suggestions` rewrites both direct and aliased access to `$slots` and leaves existing `$slots` usage untouched

Same shape as #25843 (`no-deprecated-dollar-listeners-api`); the branches are independent, generated files will need a trivial regen on whichever lands second.


AI assistance with Claude; reviewed and taken responsibility for per AGENTS.md.


### Known limitations (shared with the merged sibling rules)

- Like `no-deprecated-delete-set` and #25843, the rule runs only on `.vue` files (`should_run` gate); upstream also lints Vue components in plain `.js`/`.ts` (`defineComponent({...})`).
- The shared `is_in_vue_component_instance_method` helper recognizes top-level option methods and functions directly under `methods`/`computed`/`watch`, but not object-style `computed: { x: { get() {} } }` or `watch: { x: { handler() {} } }` (one nesting level deeper). Upstream flags `this.$scopedSlots` there too.

Happy to address either in a follow-up if maintainers prefer — both would touch the shared helper / gate used by already-merged rules, so I kept this PR at parity with its siblings.
