### PR TITLE
feat(linter/vue): implement no-mutating-props rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1780,6 +1780,7 @@ export interface DummyRuleMap {
   "vue/no-import-compiler-macros"?: RuleNoConfig;
   "vue/no-lifecycle-after-await"?: RuleNoConfig;
   "vue/no-multiple-slot-args"?: RuleNoConfig;
+  "vue/no-mutating-props"?: RuleNoConfig | [AllowWarnDeny, NoMutatingPropsConfig];
   "vue/no-required-prop-with-default"?: RuleNoConfig;
   "vue/no-reserved-component-names"?: RuleNoConfig | [AllowWarnDeny, NoReservedComponentNames];
   "vue/no-reserved-keys"?: RuleNoConfig | [AllowWarnDeny, NoReservedKeysConfig];
@@ -6734,6 +6735,14 @@ export interface NoDupeKeysConfig {
    * built-in `props`, `computed`, `data`, `methods` and `setup` groups.
    */
   groups?: string[];
+}
+export interface NoMutatingPropsConfig {
+  /**
+   * When `true`, only mutations that write directly to a prop itself
+   * (e.g. `props.a = 1`, `props.a++`) are reported; mutations of nested
+   * values (e.g. `props.a.b = 1`, `props.a.push(1)`) are allowed.
+   */
+  shallowOnly?: boolean;
 }
 export interface NoReservedComponentNames {
   /**

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5398,6 +5398,11 @@ impl RuleRunner for crate::rules::vue::no_multiple_slot_args::NoMultipleSlotArgs
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::vue::no_mutating_props::NoMutatingProps {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::vue::no_required_prop_with_default::NoRequiredPropWithDefault {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::CallExpression,

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -856,6 +856,7 @@ pub use crate::rules::vue::no_expose_after_await::NoExposeAfterAwait as VueNoExp
 pub use crate::rules::vue::no_import_compiler_macros::NoImportCompilerMacros as VueNoImportCompilerMacros;
 pub use crate::rules::vue::no_lifecycle_after_await::NoLifecycleAfterAwait as VueNoLifecycleAfterAwait;
 pub use crate::rules::vue::no_multiple_slot_args::NoMultipleSlotArgs as VueNoMultipleSlotArgs;
+pub use crate::rules::vue::no_mutating_props::NoMutatingProps as VueNoMutatingProps;
 pub use crate::rules::vue::no_required_prop_with_default::NoRequiredPropWithDefault as VueNoRequiredPropWithDefault;
 pub use crate::rules::vue::no_reserved_component_names::NoReservedComponentNames as VueNoReservedComponentNames;
 pub use crate::rules::vue::no_reserved_keys::NoReservedKeys as VueNoReservedKeys;
@@ -1744,6 +1745,7 @@ pub enum RuleEnum {
     VueNoImportCompilerMacros(VueNoImportCompilerMacros),
     VueNoLifecycleAfterAwait(VueNoLifecycleAfterAwait),
     VueNoMultipleSlotArgs(VueNoMultipleSlotArgs),
+    VueNoMutatingProps(VueNoMutatingProps),
     VueNoRequiredPropWithDefault(VueNoRequiredPropWithDefault),
     VueNoReservedComponentNames(VueNoReservedComponentNames),
     VueNoReservedKeys(VueNoReservedKeys),
@@ -2722,7 +2724,8 @@ const VUE_NO_EXPOSE_AFTER_AWAIT_ID: usize = VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID + 1
 const VUE_NO_IMPORT_COMPILER_MACROS_ID: usize = VUE_NO_EXPOSE_AFTER_AWAIT_ID + 1usize;
 const VUE_NO_LIFECYCLE_AFTER_AWAIT_ID: usize = VUE_NO_IMPORT_COMPILER_MACROS_ID + 1usize;
 const VUE_NO_MULTIPLE_SLOT_ARGS_ID: usize = VUE_NO_LIFECYCLE_AFTER_AWAIT_ID + 1usize;
-const VUE_NO_REQUIRED_PROP_WITH_DEFAULT_ID: usize = VUE_NO_MULTIPLE_SLOT_ARGS_ID + 1usize;
+const VUE_NO_MUTATING_PROPS_ID: usize = VUE_NO_MULTIPLE_SLOT_ARGS_ID + 1usize;
+const VUE_NO_REQUIRED_PROP_WITH_DEFAULT_ID: usize = VUE_NO_MUTATING_PROPS_ID + 1usize;
 const VUE_NO_RESERVED_COMPONENT_NAMES_ID: usize = VUE_NO_REQUIRED_PROP_WITH_DEFAULT_ID + 1usize;
 const VUE_NO_RESERVED_KEYS_ID: usize = VUE_NO_RESERVED_COMPONENT_NAMES_ID + 1usize;
 const VUE_NO_RESERVED_PROPS_ID: usize = VUE_NO_RESERVED_KEYS_ID + 1usize;
@@ -2748,7 +2751,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 870usize] = [
+static RULE_NAMES: [&str; 871usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3595,6 +3598,7 @@ static RULE_NAMES: [&str; 870usize] = [
     VueNoImportCompilerMacros::NAME,
     VueNoLifecycleAfterAwait::NAME,
     VueNoMultipleSlotArgs::NAME,
+    VueNoMutatingProps::NAME,
     VueNoRequiredPropWithDefault::NAME,
     VueNoReservedComponentNames::NAME,
     VueNoReservedKeys::NAME,
@@ -4597,6 +4601,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(_) => VUE_NO_IMPORT_COMPILER_MACROS_ID,
             Self::VueNoLifecycleAfterAwait(_) => VUE_NO_LIFECYCLE_AFTER_AWAIT_ID,
             Self::VueNoMultipleSlotArgs(_) => VUE_NO_MULTIPLE_SLOT_ARGS_ID,
+            Self::VueNoMutatingProps(_) => VUE_NO_MUTATING_PROPS_ID,
             Self::VueNoRequiredPropWithDefault(_) => VUE_NO_REQUIRED_PROP_WITH_DEFAULT_ID,
             Self::VueNoReservedComponentNames(_) => VUE_NO_RESERVED_COMPONENT_NAMES_ID,
             Self::VueNoReservedKeys(_) => VUE_NO_RESERVED_KEYS_ID,
@@ -5648,6 +5653,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::CATEGORY,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::CATEGORY,
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::CATEGORY,
+            Self::VueNoMutatingProps(_) => VueNoMutatingProps::CATEGORY,
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::CATEGORY,
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::CATEGORY,
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::CATEGORY,
@@ -6637,6 +6643,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::FIX,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::FIX,
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::FIX,
+            Self::VueNoMutatingProps(_) => VueNoMutatingProps::FIX,
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::FIX,
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::FIX,
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::FIX,
@@ -7898,6 +7905,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::documentation(),
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::documentation(),
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::documentation(),
+            Self::VueNoMutatingProps(_) => VueNoMutatingProps::documentation(),
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::documentation(),
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::documentation(),
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::documentation(),
@@ -10361,6 +10369,8 @@ impl RuleEnum {
                 .or_else(|| VueNoLifecycleAfterAwait::schema(generator)),
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::config_schema(generator)
                 .or_else(|| VueNoMultipleSlotArgs::schema(generator)),
+            Self::VueNoMutatingProps(_) => VueNoMutatingProps::config_schema(generator)
+                .or_else(|| VueNoMutatingProps::schema(generator)),
             Self::VueNoRequiredPropWithDefault(_) => {
                 VueNoRequiredPropWithDefault::config_schema(generator)
                     .or_else(|| VueNoRequiredPropWithDefault::schema(generator))
@@ -11275,6 +11285,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(_) => "vue",
             Self::VueNoLifecycleAfterAwait(_) => "vue",
             Self::VueNoMultipleSlotArgs(_) => "vue",
+            Self::VueNoMutatingProps(_) => "vue",
             Self::VueNoRequiredPropWithDefault(_) => "vue",
             Self::VueNoReservedComponentNames(_) => "vue",
             Self::VueNoReservedKeys(_) => "vue",
@@ -12372,6 +12383,9 @@ impl RuleEnum {
             Self::VueNoDupeKeys(_) => {
                 Ok(Self::VueNoDupeKeys(VueNoDupeKeys::from_configuration(value)?))
             }
+            Self::VueNoMutatingProps(_) => {
+                Ok(Self::VueNoMutatingProps(VueNoMutatingProps::from_configuration(value)?))
+            }
             Self::VueNoReservedComponentNames(_) => Ok(Self::VueNoReservedComponentNames(
                 VueNoReservedComponentNames::from_configuration(value)?,
             )),
@@ -13280,6 +13294,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(rule) => rule.run(node, ctx),
             Self::VueNoLifecycleAfterAwait(rule) => rule.run(node, ctx),
             Self::VueNoMultipleSlotArgs(rule) => rule.run(node, ctx),
+            Self::VueNoMutatingProps(rule) => rule.run(node, ctx),
             Self::VueNoRequiredPropWithDefault(rule) => rule.run(node, ctx),
             Self::VueNoReservedComponentNames(rule) => rule.run(node, ctx),
             Self::VueNoReservedKeys(rule) => rule.run(node, ctx),
@@ -14167,6 +14182,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(rule) => rule.run_once(ctx),
             Self::VueNoLifecycleAfterAwait(rule) => rule.run_once(ctx),
             Self::VueNoMultipleSlotArgs(rule) => rule.run_once(ctx),
+            Self::VueNoMutatingProps(rule) => rule.run_once(ctx),
             Self::VueNoRequiredPropWithDefault(rule) => rule.run_once(ctx),
             Self::VueNoReservedComponentNames(rule) => rule.run_once(ctx),
             Self::VueNoReservedKeys(rule) => rule.run_once(ctx),
@@ -15169,6 +15185,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoLifecycleAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoMultipleSlotArgs(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VueNoMutatingProps(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoRequiredPropWithDefault(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoReservedComponentNames(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoReservedKeys(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16059,6 +16076,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(rule) => rule.should_run(ctx),
             Self::VueNoLifecycleAfterAwait(rule) => rule.should_run(ctx),
             Self::VueNoMultipleSlotArgs(rule) => rule.should_run(ctx),
+            Self::VueNoMutatingProps(rule) => rule.should_run(ctx),
             Self::VueNoRequiredPropWithDefault(rule) => rule.should_run(ctx),
             Self::VueNoReservedComponentNames(rule) => rule.should_run(ctx),
             Self::VueNoReservedKeys(rule) => rule.should_run(ctx),
@@ -17317,6 +17335,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::IS_TSGOLINT_RULE,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::IS_TSGOLINT_RULE,
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::IS_TSGOLINT_RULE,
+            Self::VueNoMutatingProps(_) => VueNoMutatingProps::IS_TSGOLINT_RULE,
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::IS_TSGOLINT_RULE,
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::IS_TSGOLINT_RULE,
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::IS_TSGOLINT_RULE,
@@ -18369,6 +18388,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::VERSION,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::VERSION,
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::VERSION,
+            Self::VueNoMutatingProps(_) => VueNoMutatingProps::VERSION,
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::VERSION,
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::VERSION,
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::VERSION,
@@ -19458,6 +19478,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::HAS_CONFIG,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::HAS_CONFIG,
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::HAS_CONFIG,
+            Self::VueNoMutatingProps(_) => VueNoMutatingProps::HAS_CONFIG,
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::HAS_CONFIG,
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::HAS_CONFIG,
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::HAS_CONFIG,
@@ -20448,6 +20469,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::INFO,
             Self::VueNoLifecycleAfterAwait(_) => VueNoLifecycleAfterAwait::INFO,
             Self::VueNoMultipleSlotArgs(_) => VueNoMultipleSlotArgs::INFO,
+            Self::VueNoMutatingProps(_) => VueNoMutatingProps::INFO,
             Self::VueNoRequiredPropWithDefault(_) => VueNoRequiredPropWithDefault::INFO,
             Self::VueNoReservedComponentNames(_) => VueNoReservedComponentNames::INFO,
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::INFO,
@@ -21329,6 +21351,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(rule) => rule.types_info(),
             Self::VueNoLifecycleAfterAwait(rule) => rule.types_info(),
             Self::VueNoMultipleSlotArgs(rule) => rule.types_info(),
+            Self::VueNoMutatingProps(rule) => rule.types_info(),
             Self::VueNoRequiredPropWithDefault(rule) => rule.types_info(),
             Self::VueNoReservedComponentNames(rule) => rule.types_info(),
             Self::VueNoReservedKeys(rule) => rule.types_info(),
@@ -22203,6 +22226,7 @@ impl RuleEnum {
             Self::VueNoImportCompilerMacros(rule) => rule.run_info(),
             Self::VueNoLifecycleAfterAwait(rule) => rule.run_info(),
             Self::VueNoMultipleSlotArgs(rule) => rule.run_info(),
+            Self::VueNoMutatingProps(rule) => rule.run_info(),
             Self::VueNoRequiredPropWithDefault(rule) => rule.run_info(),
             Self::VueNoReservedComponentNames(rule) => rule.run_info(),
             Self::VueNoReservedKeys(rule) => rule.run_info(),
@@ -23211,6 +23235,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueNoImportCompilerMacros(VueNoImportCompilerMacros::default()),
         RuleEnum::VueNoLifecycleAfterAwait(VueNoLifecycleAfterAwait::default()),
         RuleEnum::VueNoMultipleSlotArgs(VueNoMultipleSlotArgs::default()),
+        RuleEnum::VueNoMutatingProps(VueNoMutatingProps::default()),
         RuleEnum::VueNoRequiredPropWithDefault(VueNoRequiredPropWithDefault::default()),
         RuleEnum::VueNoReservedComponentNames(VueNoReservedComponentNames::default()),
         RuleEnum::VueNoReservedKeys(VueNoReservedKeys::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -936,6 +936,7 @@ pub(crate) mod vue {
     pub mod no_import_compiler_macros;
     pub mod no_lifecycle_after_await;
     pub mod no_multiple_slot_args;
+    pub mod no_mutating_props;
     pub mod no_required_prop_with_default;
     pub mod no_reserved_component_names;
     pub mod no_reserved_keys;

--- a/crates/oxc_linter/src/rules/vue/no_mutating_props.rs
+++ b/crates/oxc_linter/src/rules/vue/no_mutating_props.rs
@@ -1,0 +1,1019 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use oxc_ast::{
+    AstKind,
+    ast::{
+        BindingIdentifier, BindingPattern, CallExpression, Expression, ObjectExpression,
+        ObjectPropertyKind, UnaryOperator,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use rustc_hash::FxHashSet;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    frameworks::FrameworkOptions,
+    rule::{DefaultRuleConfig, Rule},
+    utils::{find_property, is_vue_component_options_object},
+};
+
+fn no_mutating_props_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unexpected mutation of \"{name}\" prop."))
+        .with_help(
+            "Props are read-only. Emit an event and let the parent component perform the mutation.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct NoMutatingPropsConfig {
+    /// When `true`, only mutations that write directly to a prop itself
+    /// (e.g. `props.a = 1`, `props.a++`) are reported; mutations of nested
+    /// values (e.g. `props.a.b = 1`, `props.a.push(1)`) are allowed.
+    shallow_only: bool,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct NoMutatingProps(NoMutatingPropsConfig);
+
+// Ported from <https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-mutating-props.js>
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows mutating component props: assignments, update expressions,
+    /// `delete`, mutating array methods (`push`, `splice`, ...) and
+    /// `Object.assign` applied to props received via the `props` option,
+    /// `setup(props)`, or `defineProps()`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Vue props implement a one-way-down binding: when the parent component
+    /// updates, the new value overwrites any local mutation, and Vue warns at
+    /// runtime when a prop is reassigned. Mutating a prop makes the data flow
+    /// hard to reason about and couples the child to the parent's internal
+    /// state. The child should instead emit an event and let the owner of the
+    /// data perform the mutation.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script setup>
+    /// const props = defineProps(['todo', 'items'])
+    /// props.todo = 'error'
+    /// props.items.push('error')
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script setup>
+    /// import { computed } from 'vue'
+    /// const props = defineProps(['todo'])
+    /// const todoText = computed(() => props.todo.text)
+    /// </script>
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// ```json
+    /// { "vue/no-mutating-props": ["error", { "shallowOnly": false }] }
+    /// ```
+    ///
+    /// - `shallowOnly` (`boolean`, default `false`) — report only mutations
+    ///   that reassign the prop itself, allowing mutations of nested values.
+    NoMutatingProps,
+    vue,
+    correctness,
+    config = NoMutatingPropsConfig,
+    version = "next",
+    short_description = "Disallow mutation of component props.",
+);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MutationKind {
+    Assignment,
+    Update,
+    Call,
+}
+
+struct Mutation {
+    kind: MutationKind,
+    span: Span,
+    /// Member-access path from the checked expression to the mutated value,
+    /// e.g. for `props.a.b = 1` starting at `props` the path is `["a", "b"]`.
+    path: Vec<String>,
+}
+
+const MUTATING_METHODS: [&str; 9] =
+    ["push", "pop", "shift", "unshift", "reverse", "splice", "sort", "copyWithin", "fill"];
+
+fn is_object_assign_call(call: &CallExpression, arg_span: Span) -> bool {
+    if call.arguments.first().is_none_or(|arg| arg.span() != arg_span) {
+        return false;
+    }
+    let Some(member) = call.callee.get_inner_expression().as_member_expression() else {
+        return false;
+    };
+    member.static_property_name() == Some("assign")
+        && matches!(
+            member.object().get_inner_expression(),
+            Expression::Identifier(ident) if ident.name == "Object"
+        )
+}
+
+fn computed_key_text(expr: &Expression, ctx: &LintContext) -> String {
+    match expr.get_inner_expression() {
+        Expression::StringLiteral(lit) => lit.value.to_string(),
+        Expression::NumericLiteral(lit) => lit.value.to_string(),
+        _ => format!("[{}]", ctx.source_range(expr.span())),
+    }
+}
+
+/// Walks up from `start` and returns the mutation applied to it, if any.
+/// Port of `findMutating` from eslint-plugin-vue's `lib/utils/index.ts`.
+fn find_mutating<'a>(start: &AstNode<'a>, ctx: &LintContext<'a>) -> Option<Mutation> {
+    let mut path: Vec<String> = Vec::new();
+    let mut current_id = start.id();
+    let mut current_span = start.kind().span();
+    loop {
+        let parent = ctx.nodes().parent_node(current_id);
+        match parent.kind() {
+            AstKind::AssignmentExpression(assign) => {
+                return (assign.left.span() == current_span).then_some(Mutation {
+                    kind: MutationKind::Assignment,
+                    span: assign.span,
+                    path,
+                });
+            }
+            AstKind::UpdateExpression(update) => {
+                return Some(Mutation { kind: MutationKind::Update, span: update.span, path });
+            }
+            AstKind::UnaryExpression(unary) => {
+                return (unary.operator == UnaryOperator::Delete).then_some(Mutation {
+                    kind: MutationKind::Update,
+                    span: unary.span,
+                    path,
+                });
+            }
+            AstKind::CallExpression(call) => {
+                if call.callee.span() == current_span
+                    && path.last().is_some_and(|name| MUTATING_METHODS.contains(&name.as_str()))
+                {
+                    path.pop();
+                    return Some(Mutation { kind: MutationKind::Call, span: call.span, path });
+                }
+                if is_object_assign_call(call, current_span) {
+                    return Some(Mutation { kind: MutationKind::Call, span: call.span, path });
+                }
+                return None;
+            }
+            AstKind::StaticMemberExpression(member) => {
+                if member.object.span() != current_span {
+                    return None;
+                }
+                path.push(member.property.name.to_string());
+            }
+            AstKind::ComputedMemberExpression(member) => {
+                if member.object.span() != current_span {
+                    return None;
+                }
+                path.push(computed_key_text(&member.expression, ctx));
+            }
+            AstKind::ChainExpression(_)
+            | AstKind::ParenthesizedExpression(_)
+            | AstKind::TSAsExpression(_)
+            | AstKind::TSNonNullExpression(_)
+            | AstKind::TSSatisfiesExpression(_)
+            | AstKind::TSTypeAssertion(_) => {}
+            _ => return None,
+        }
+        current_id = parent.id();
+        current_span = parent.kind().span();
+    }
+}
+
+impl NoMutatingProps {
+    /// `shallowOnly` reports only direct writes to the prop itself.
+    fn should_report(&self, mutation: &Mutation, is_root_props: bool) -> bool {
+        if !self.0.shallow_only {
+            return true;
+        }
+        mutation.path.len() == usize::from(is_root_props)
+            && matches!(mutation.kind, MutationKind::Assignment | MutationKind::Update)
+    }
+
+    /// Checks all reads of a binding that holds the props object (empty
+    /// `path`) or a value destructured out of it (`path` = keys from the
+    /// props object down to the binding).
+    fn verify_prop_binding<'a>(
+        &self,
+        binding: &BindingIdentifier<'a>,
+        path: &[String],
+        ctx: &LintContext<'a>,
+    ) {
+        let is_root_props = path.is_empty();
+        for reference in ctx.scoping().get_resolved_references(binding.symbol_id()) {
+            if !reference.is_read() {
+                continue;
+            }
+            let ref_node = ctx.nodes().get_node(reference.node_id());
+            let Some(mutation) = find_mutating(ref_node, ctx) else { continue };
+            if !self.should_report(&mutation, is_root_props) {
+                continue;
+            }
+            let name = if is_root_props {
+                // Mutating the whole binding (`props = {}`) rebinds a local
+                // variable and does not touch the props object.
+                let Some(first) = mutation.path.first() else { continue };
+                first.clone()
+            } else {
+                // For a destructured prop, mutating the binding itself is
+                // only a prop mutation for calls (`arr.push(1)` where the
+                // path is already consumed); plain reassignment rebinds.
+                if mutation.path.is_empty() && mutation.kind != MutationKind::Call {
+                    continue;
+                }
+                path[0].clone()
+            };
+            ctx.diagnostic(no_mutating_props_diagnostic(mutation.span, &name));
+        }
+    }
+
+    /// Recursively visits a binding pattern, yielding every identifier with
+    /// its member path relative to the pattern root.
+    fn walk_pattern<'a>(
+        &self,
+        pattern: &BindingPattern<'a>,
+        path: &[String],
+        ctx: &LintContext<'a>,
+    ) {
+        match pattern {
+            BindingPattern::BindingIdentifier(ident) => {
+                self.verify_prop_binding(ident, path, ctx);
+            }
+            BindingPattern::AssignmentPattern(assignment) => {
+                self.walk_pattern(&assignment.left, path, ctx);
+            }
+            BindingPattern::ObjectPattern(object) => {
+                for property in &object.properties {
+                    let key = property.key.static_name().map_or_else(
+                        || format!("[{}]", ctx.source_range(property.key.span())),
+                        |name| name.to_string(),
+                    );
+                    let mut child_path = path.to_vec();
+                    child_path.push(key);
+                    self.walk_pattern(&property.value, &child_path, ctx);
+                }
+                if let Some(rest) = &object.rest {
+                    self.walk_pattern(&rest.argument, path, ctx);
+                }
+            }
+            BindingPattern::ArrayPattern(array) => {
+                for (index, element) in array.elements.iter().enumerate() {
+                    if let Some(element) = element {
+                        let mut child_path = path.to_vec();
+                        child_path.push(index.to_string());
+                        self.walk_pattern(element, &child_path, ctx);
+                    }
+                }
+                if let Some(rest) = &array.rest {
+                    let mut child_path = path.to_vec();
+                    child_path.push(array.elements.len().to_string());
+                    self.walk_pattern(&rest.argument, &child_path, ctx);
+                }
+            }
+        }
+    }
+
+    /// Handles `const props = defineProps(...)` and
+    /// `const props = withDefaults(defineProps(...), ...)`.
+    fn check_define_props<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let mut target = node;
+        let mut parent = ctx.nodes().parent_node(target.id());
+        if let AstKind::CallExpression(call) = parent.kind()
+            && matches!(
+                call.callee.get_inner_expression(),
+                Expression::Identifier(ident) if ident.name == "withDefaults"
+            )
+            && call.arguments.first().is_some_and(|arg| arg.span() == target.kind().span())
+        {
+            target = parent;
+            parent = ctx.nodes().parent_node(target.id());
+        }
+        let AstKind::VariableDeclarator(declarator) = parent.kind() else { return };
+        if declarator.init.as_ref().is_none_or(|init| init.span() != target.kind().span()) {
+            return;
+        }
+        self.walk_pattern(&declarator.id, &[], ctx);
+    }
+
+    /// Reports `this.<prop>` mutations inside the component's options object.
+    fn check_this_mutations<'a>(
+        &self,
+        options_node: &AstNode<'a>,
+        prop_names: &FxHashSet<String>,
+        ctx: &LintContext<'a>,
+    ) {
+        for node in ctx.nodes() {
+            let name = match node.kind() {
+                AstKind::StaticMemberExpression(member)
+                    if matches!(
+                        member.object.get_inner_expression(),
+                        Expression::ThisExpression(_)
+                    ) =>
+                {
+                    member.property.name.as_str()
+                }
+                AstKind::ComputedMemberExpression(member)
+                    if matches!(
+                        member.object.get_inner_expression(),
+                        Expression::ThisExpression(_)
+                    ) =>
+                {
+                    match member.expression.get_inner_expression() {
+                        Expression::StringLiteral(lit) => lit.value.as_str(),
+                        _ => continue,
+                    }
+                }
+                _ => continue,
+            };
+            if !prop_names.contains(name) {
+                continue;
+            }
+            if !ctx.nodes().ancestors(node.id()).any(|ancestor| ancestor.id() == options_node.id())
+            {
+                continue;
+            }
+            if let Some(mutation) = find_mutating(node, ctx)
+                && self.should_report(&mutation, false)
+            {
+                ctx.diagnostic(no_mutating_props_diagnostic(mutation.span, name));
+            }
+        }
+    }
+}
+
+fn collect_prop_names(obj: &ObjectExpression) -> FxHashSet<String> {
+    let mut names = FxHashSet::default();
+    let Some(props) = find_property(obj, "props") else { return names };
+    match props.value.get_inner_expression() {
+        Expression::ObjectExpression(object) => {
+            for property in &object.properties {
+                if let ObjectPropertyKind::ObjectProperty(property) = property
+                    && let Some(name) = property.key.static_name()
+                {
+                    names.insert(name.to_string());
+                }
+            }
+        }
+        Expression::ArrayExpression(array) => {
+            for element in &array.elements {
+                if let Some(Expression::StringLiteral(lit)) =
+                    element.as_expression().map(Expression::get_inner_expression)
+                {
+                    names.insert(lit.value.to_string());
+                }
+            }
+        }
+        _ => {}
+    }
+    names
+}
+
+fn setup_first_param<'a, 'b>(obj: &'b ObjectExpression<'a>) -> Option<&'b BindingPattern<'a>> {
+    let setup = find_property(obj, "setup")?;
+    let params = match setup.value.get_inner_expression() {
+        Expression::FunctionExpression(function) => &function.params,
+        Expression::ArrowFunctionExpression(function) => &function.params,
+        _ => return None,
+    };
+    params.items.first().map(|param| &param.pattern)
+}
+
+impl Rule for NoMutatingProps {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        DefaultRuleConfig::<Self>::from_value(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run_once(&self, ctx: &LintContext) {
+        if ctx.frameworks_options() == FrameworkOptions::VueSetup {
+            for node in ctx.nodes() {
+                if let AstKind::CallExpression(call) = node.kind()
+                    && matches!(
+                        call.callee.get_inner_expression(),
+                        Expression::Identifier(ident) if ident.name == "defineProps"
+                    )
+                {
+                    self.check_define_props(node, ctx);
+                }
+            }
+        }
+
+        for node in ctx.nodes() {
+            let AstKind::ObjectExpression(obj) = node.kind() else { continue };
+            if !is_vue_component_options_object(node, ctx) {
+                continue;
+            }
+            let prop_names = collect_prop_names(obj);
+            if !prop_names.is_empty() {
+                self.check_this_mutations(node, &prop_names, ctx);
+            }
+            if let Some(param) = setup_first_param(obj)
+                && !matches!(param, BindingPattern::ArrayPattern(_))
+            {
+                self.walk_pattern(param, &[], ctx);
+            }
+        }
+    }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
+    }
+}
+
+// Test cases ported from
+// <https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-mutating-props.js>
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"
+                    <template>
+                      <div>
+                        <div v-if="foo"></div>
+                        <div v-if="prop1 = [1, 2]"></div>
+                        <div v-if="prop2++"></div>
+                        <div v-text="prop3.shift()"></div>
+                        <div v-text="prop4.slice(0).shift()"></div>
+                        <div v-if="this.prop5 = [1, 2] && this.someProp"></div>
+                        <div v-if="this.prop6++ && this.someProp < 10"></div>
+                        <div v-text="this.prop7.shift()"></div>
+                        <div v-text="this.prop8.slice(0).shift()"></div>
+                      </div>
+                    </template>
+                    <script>
+                      export default {
+                        props: ['foo']
+                      }
+                    </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))),
+(r#"
+                    <template>
+                      <div>
+                        <input v-model="prop1.text">
+                        <input v-model="prop2">
+                        <input v-model="this.prop3.text">
+                        <input v-model="this.prop4">
+                        <input :value="prop5.text" @input="$emit('input', $event.target.value)">
+                        <div v-for="prop5 of data">
+                          <input v-model="prop5">
+                        </div>
+                        <div v-for="(prop6, index) of data">
+                          <input v-model="prop6">
+                        </div>
+                        <template v-for="(test, index) of data">
+                          <template v-for="(prop6, index) of data">
+                            <input v-model="prop6">
+                            <div v-text="prop6.shift()"></div>
+                          </template>
+                        </template>
+                      </div>
+                    </template>
+                    <script>
+                      export default {
+                        props: ['prop5', 'prop6', 'prop7', 'prop8']
+                      }
+                    </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))),
+(r#"
+                    <template>
+                      <div>
+                        <input v-model="prop1.text">
+                        <input v-model="prop2">
+                        <input v-model="this.prop3.text">
+                        <input v-model="this.prop4">
+                      </div>
+                    </template>
+                    <script>
+                      export default {
+                        props: ['prop5', 'prop6', 'prop7', 'prop8']
+                      }
+                    </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))),
+(r#"
+                    <template>
+                      <div>
+                        <input v-for="i in prop.slice()">
+                        <input v-for="i in prop.foo.slice()">
+                      </div>
+                    </template>
+                    <script>
+                      export default {
+                        props: ['prop']
+                      }
+                    </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                      export default {
+                        props: {
+                          todo: {
+                            type: Object,
+                            required: true
+                          },
+                          items: {
+                            type: Array,
+                            default: []
+                          }
+                        },
+                        methods: {
+                          openModal() {
+                            this.$emit('someEvent', this.todo)
+                            const a = this.items.slice(0).push('something') // no mutation because of `slice(0)`
+                          }
+                        }
+                      }
+                    </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+(r#"
+                    <template>
+                      <div v-if="prop">
+                        <div v-for="prop in data">
+                          <MyComp @click="prop.foo++"></MyComp>
+                          <input v-model="prop">
+                        </div>
+                        <input v-model="prop()">
+                        <input v-model="foo">
+                        <input @click="prop().foo++">
+                        <input v-model="foo[this]">
+                        <input v-model="foo[this.prop]">
+                        <input v-model="this">
+                        <MyComp @click="bar = {prop: foo++}"></MyComp>
+                      </div>
+                    </template>
+                    <script>
+                      export default {
+                        props: ['prop'],
+                        methods: {
+                          onKeydown() {
+                            const vm = this
+                            foo.prop = 1
+                            vm()()()
+                            vm.prop()()
+                            prop++
+                            prop = 1
+                            const bar = {prop: foo}
+                            prop[this] ++
+                          }
+                        }
+                      }
+                    </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))),
+(r#"
+                    <template>
+                      <div>
+                        <button @click="foo++"></button>
+                        <button @click="foo+=1"></button>
+                        <button @click="foo.push($event)"></button>
+                        <input v-model="foo">
+                        <input v-model="this.foo">
+                      </div>
+                    </template>
+                  "#, None, None, Some(PathBuf::from("test.vue"))),
+(r#"
+                    <template>
+                      <div>
+                        <input v-model="prop1.text">
+                        <input v-model="this.prop2.text">
+                        <button @click="prop3.text = '1'"></button>
+                        <button @click="prop3.count++"></button>
+                        <button @click="prop3.list.push(1)"></button>
+                        <button @click="prop3.parent.text = '2'"></button>
+                        <button @click="delete prop3.parent.text"></button>
+                      </div>
+                    </template>
+                    <script>
+                      export default {
+                        props: ['prop1', 'prop2', 'prop3'],
+                        methods: {
+                            onKeydown() {
+                              this.prop3.text = '2'
+                              this.prop3.count ++
+                              this.prop3.list.push(1)
+                              this.prop3.parent.text = '2'
+                              delete this.prop3.parent.text
+                            }
+                        }
+                      }
+                    </script>
+                  "#, Some(serde_json::json!([{ "shallowOnly": true }])), None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                      export default {
+                        setup(props) {
+                          props ++
+                          props = 1
+                          props.push(1)
+                        }
+                      }
+                    </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                      export default {
+                        setup({a}) {
+                          a ++
+                          a = 1
+                        }
+                      }
+                    </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                      export default {
+                        setup({...props}) {
+                          props ++
+                          props = 1
+                          props.push(1)
+                        }
+                      }
+                    </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                      export default {
+                        ssss(props) {
+                          props.a ++
+                        }
+                      }
+                    </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                      export default {
+                        setup(props) {
+                          const a = props.a
+                        }
+                      }
+                    </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                      export default {
+                        setup() {
+                          props.a++
+                        }
+                      }
+                    </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                      export default {
+                        setup(...props) {
+                          props.a++
+                        }
+                      }
+                    </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                      export default {
+                        setup([props]) {
+                          props.a++
+                        }
+                      }
+                    </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                    // not <script setup>
+                    const {value} = defineProps({
+                      value: Object,
+                    })
+                    value.value++
+                    </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                    // not <script setup>
+                    const {value} = defineProps({
+                      value: Object,
+                    })
+                    value.value++
+                    </script>
+                    <script setup>
+                    value.value++
+                    </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+("
+                  <script>
+                    export default {
+                      props: ['prop'],
+                      setup(props) {
+                        props.prop.sortAscending()
+                      }
+                    }
+                  </script>", None, None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                      export default {
+                        setup(props) {
+                            props.prop1.text = '2'
+                            props.prop1.count ++
+                            props.prop1.list.push(1)
+                            props.prop1.parent.text = '2'
+                        }
+                      }
+                    </script>
+                  ", Some(serde_json::json!([{ "shallowOnly": true }])), None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                      export default {
+                        setup({a,b,c, d: [e, , f]}) {
+                          a.foo ++
+                          b.foo = 1
+                          c.push(1)
+            
+                          c.x.push(1)
+                          delete c.y
+                          e.foo++
+                          f.foo++
+                        }
+                      }
+                    </script>
+                  ", Some(serde_json::json!([{ "shallowOnly": true }])), None, Some(PathBuf::from("test.vue"))),
+(r#"
+                    <template>
+                      <input v-model="foo">
+                      <input v-model="bar">
+                      <input v-model="Infinity">
+                    </template>
+                    <script setup>
+                    import { ref } from 'vue'
+                    import { bar } from './my-script'
+                    defineProps({
+                      foo: String,
+                      bar: String,
+                      Infinity: Number
+                    })
+                    const foo = ref('')
+                    </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))),
+("
+                    <script>
+                      export default {
+                        props: ['data'],
+                        methods: {
+                          update() {
+                            return Object.assign({}, this.data, { extra: 'value' })
+                          }
+                        }
+                      }
+                    </script>
+                  ", None, None, Some(PathBuf::from("test.vue")))
+    ];
+
+    // Upstream fail cases that mutate props from within the <template> block are
+    // not ported: oxlint lints only the <script> part of SFCs.
+    // Upstream fail cases that mutate props only from within the <template>
+    // block are not ported: oxlint lints the <script> part of SFCs.
+    let fail = vec![
+        (
+            "
+                    <script>
+                      export default {
+                        props: {
+                          todo: {
+                            type: Object,
+                            required: true
+                          },
+                          items: {
+                            type: Array,
+                            default: []
+                          }
+                        },
+                        methods: {
+                          openModal() {
+                            ++this.items
+                            this.todo.type = 'completed'
+                            this.items.push('something')
+                            delete this.todo.type
+                          }
+                        }
+                      }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                      export default {
+                        props: ['foo', 'bar', 'baz'],
+                        methods: {
+                          openModal() {
+                            this?.foo?.push?.('something')
+                            ;(this?.bar)?.push?.('something')
+                            ;(this?.baz?.push)?.('something')
+                          }
+                        }
+                      }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                      export default {
+                        setup(props) {
+                          props.a ++
+                          props.b = 1
+                          props.c.push(1)
+                          delete props.d
+                        }
+                      }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                      export default {
+                        setup({a,b,c, d: [e, , f]}) {
+                          a.foo ++
+                          b.foo = 1
+                          c.push(1)
+            
+                          c.x.push(1)
+                          delete c.y
+                          e.foo++
+                          f.foo++
+                        }
+                      }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                      export default {
+                        setup({a: foo, b: [...bar], c: baz = 1}) {
+                          foo.x ++
+                          delete foo.y
+                          bar.x = 1
+                          baz.push(1)
+                        }
+                      }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                      export default {
+                        setup({...props}) {
+                          props.a ++
+                          props.b = 1
+                          props.c.push(1)
+                          delete props.d
+                        }
+                      }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                      export default {
+                        setup(props) {
+                          props[a] ++
+                        }
+                      }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                      export default {
+                        setup({[a]: c}) {
+                          c.foo ++
+                        }
+                      }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script setup>
+                    const props = defineProps({
+                      value: String,
+                    })
+                    props.value++
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script setup>
+                    const {value} = defineProps({
+                      value: Object,
+                    })
+                    value.value++
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+                    <script setup lang="ts">
+                    const props = withDefaults(defineProps<Props>(), {
+                      msg: 'hello'
+                    })
+                    props.value++
+                    </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                      export default {
+                        setup(props) {
+                          props.a ++
+                          props.b = 1
+                          props.c.push(1)
+                          delete props.d
+            
+                          function foo() {
+                            props.a ++
+                          }
+                        }
+                      }
+                    </script>
+            
+                  ",
+            Some(serde_json::json!([{ "shallowOnly": true }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                    <script>
+                      export default {
+                        props: ['data'],
+                        methods: {
+                          update() {
+                            return Object.assign(this.data, { extra: 'value' })
+                          }
+                        }
+                      }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    Tester::new(NoMutatingProps::NAME, NoMutatingProps::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/no_mutating_props.rs
+++ b/crates/oxc_linter/src/rules/vue/no_mutating_props.rs
@@ -18,7 +18,7 @@ use crate::{
     context::LintContext,
     frameworks::FrameworkOptions,
     rule::{DefaultRuleConfig, Rule},
-    utils::{find_property, is_vue_component_options_object},
+    utils::{find_property, is_this_object, is_vue_component_options_object},
 };
 
 fn no_mutating_props_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
@@ -321,20 +321,14 @@ impl NoMutatingProps {
         ctx: &LintContext<'a>,
     ) {
         for node in ctx.nodes() {
+            // Like upstream `isThis`, the object may be `this` itself or a
+            // `const` alias of it (`const vm = this`).
             let name = match node.kind() {
-                AstKind::StaticMemberExpression(member)
-                    if matches!(
-                        member.object.get_inner_expression(),
-                        Expression::ThisExpression(_)
-                    ) =>
-                {
+                AstKind::StaticMemberExpression(member) if is_this_object(&member.object, ctx) => {
                     member.property.name.as_str()
                 }
                 AstKind::ComputedMemberExpression(member)
-                    if matches!(
-                        member.object.get_inner_expression(),
-                        Expression::ThisExpression(_)
-                    ) =>
+                    if is_this_object(&member.object, ctx) =>
                 {
                     match member.expression.get_inner_expression() {
                         Expression::StringLiteral(lit) => lit.value.as_str(),
@@ -779,11 +773,29 @@ fn test() {
                         }
                       }
                     </script>
-                  ", None, None, Some(PathBuf::from("test.vue")))
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+        // additional case (not in upstream tests): a non-const alias is not a
+        // safe `this` alias, matching upstream `isThis`
+        (
+            "
+                    <script>
+                      export default {
+                        props: ['count'],
+                        methods: {
+                          bump() {
+                            let vm = this
+                            vm.count++
+                          }
+                        }
+                      }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
-    // Upstream fail cases that mutate props from within the <template> block are
-    // not ported: oxlint lints only the <script> part of SFCs.
     // Upstream fail cases that mutate props only from within the <template>
     // block are not ported: oxlint lints the <script> part of SFCs.
     let fail = vec![
@@ -1004,6 +1016,26 @@ fn test() {
                         methods: {
                           update() {
                             return Object.assign(this.data, { extra: 'value' })
+                          }
+                        }
+                      }
+                    </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // additional case (not in upstream tests): mutation through a const
+        // `this` alias, matching upstream `isThis`
+        (
+            "
+                    <script>
+                      export default {
+                        props: ['count'],
+                        methods: {
+                          bump() {
+                            const vm = this
+                            vm.count++
                           }
                         }
                       }

--- a/crates/oxc_linter/src/snapshots/vue_no_mutating_props.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_mutating_props.snap
@@ -1,0 +1,328 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 505
+---
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "items" prop.
+    ╭─[no_mutating_props.tsx:16:29]
+ 15 │                           openModal() {
+ 16 │                             ++this.items
+    ·                             ────────────
+ 17 │                             this.todo.type = 'completed'
+    ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "todo" prop.
+    ╭─[no_mutating_props.tsx:17:29]
+ 16 │                             ++this.items
+ 17 │                             this.todo.type = 'completed'
+    ·                             ────────────────────────────
+ 18 │                             this.items.push('something')
+    ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "items" prop.
+    ╭─[no_mutating_props.tsx:18:29]
+ 17 │                             this.todo.type = 'completed'
+ 18 │                             this.items.push('something')
+    ·                             ────────────────────────────
+ 19 │                             delete this.todo.type
+    ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "todo" prop.
+    ╭─[no_mutating_props.tsx:19:29]
+ 18 │                             this.items.push('something')
+ 19 │                             delete this.todo.type
+    ·                             ─────────────────────
+ 20 │                           }
+    ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "foo" prop.
+   ╭─[no_mutating_props.tsx:7:29]
+ 6 │                           openModal() {
+ 7 │                             this?.foo?.push?.('something')
+   ·                             ──────────────────────────────
+ 8 │                             ;(this?.bar)?.push?.('something')
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "bar" prop.
+   ╭─[no_mutating_props.tsx:8:30]
+ 7 │                             this?.foo?.push?.('something')
+ 8 │                             ;(this?.bar)?.push?.('something')
+   ·                              ────────────────────────────────
+ 9 │                             ;(this?.baz?.push)?.('something')
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "baz" prop.
+    ╭─[no_mutating_props.tsx:9:30]
+  8 │                             ;(this?.bar)?.push?.('something')
+  9 │                             ;(this?.baz?.push)?.('something')
+    ·                              ────────────────────────────────
+ 10 │                           }
+    ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "a" prop.
+   ╭─[no_mutating_props.tsx:5:27]
+ 4 │                         setup(props) {
+ 5 │                           props.a ++
+   ·                           ──────────
+ 6 │                           props.b = 1
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "b" prop.
+   ╭─[no_mutating_props.tsx:6:27]
+ 5 │                           props.a ++
+ 6 │                           props.b = 1
+   ·                           ───────────
+ 7 │                           props.c.push(1)
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "c" prop.
+   ╭─[no_mutating_props.tsx:7:27]
+ 6 │                           props.b = 1
+ 7 │                           props.c.push(1)
+   ·                           ───────────────
+ 8 │                           delete props.d
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "d" prop.
+   ╭─[no_mutating_props.tsx:8:27]
+ 7 │                           props.c.push(1)
+ 8 │                           delete props.d
+   ·                           ──────────────
+ 9 │                         }
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "a" prop.
+   ╭─[no_mutating_props.tsx:5:27]
+ 4 │                         setup({a,b,c, d: [e, , f]}) {
+ 5 │                           a.foo ++
+   ·                           ────────
+ 6 │                           b.foo = 1
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "b" prop.
+   ╭─[no_mutating_props.tsx:6:27]
+ 5 │                           a.foo ++
+ 6 │                           b.foo = 1
+   ·                           ─────────
+ 7 │                           c.push(1)
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "c" prop.
+   ╭─[no_mutating_props.tsx:7:27]
+ 6 │                           b.foo = 1
+ 7 │                           c.push(1)
+   ·                           ─────────
+ 8 │             
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "c" prop.
+    ╭─[no_mutating_props.tsx:9:27]
+  8 │             
+  9 │                           c.x.push(1)
+    ·                           ───────────
+ 10 │                           delete c.y
+    ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "c" prop.
+    ╭─[no_mutating_props.tsx:10:27]
+  9 │                           c.x.push(1)
+ 10 │                           delete c.y
+    ·                           ──────────
+ 11 │                           e.foo++
+    ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "d" prop.
+    ╭─[no_mutating_props.tsx:11:27]
+ 10 │                           delete c.y
+ 11 │                           e.foo++
+    ·                           ───────
+ 12 │                           f.foo++
+    ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "d" prop.
+    ╭─[no_mutating_props.tsx:12:27]
+ 11 │                           e.foo++
+ 12 │                           f.foo++
+    ·                           ───────
+ 13 │                         }
+    ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "a" prop.
+   ╭─[no_mutating_props.tsx:5:27]
+ 4 │                         setup({a: foo, b: [...bar], c: baz = 1}) {
+ 5 │                           foo.x ++
+   ·                           ────────
+ 6 │                           delete foo.y
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "a" prop.
+   ╭─[no_mutating_props.tsx:6:27]
+ 5 │                           foo.x ++
+ 6 │                           delete foo.y
+   ·                           ────────────
+ 7 │                           bar.x = 1
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "b" prop.
+   ╭─[no_mutating_props.tsx:7:27]
+ 6 │                           delete foo.y
+ 7 │                           bar.x = 1
+   ·                           ─────────
+ 8 │                           baz.push(1)
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "c" prop.
+   ╭─[no_mutating_props.tsx:8:27]
+ 7 │                           bar.x = 1
+ 8 │                           baz.push(1)
+   ·                           ───────────
+ 9 │                         }
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "a" prop.
+   ╭─[no_mutating_props.tsx:5:27]
+ 4 │                         setup({...props}) {
+ 5 │                           props.a ++
+   ·                           ──────────
+ 6 │                           props.b = 1
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "b" prop.
+   ╭─[no_mutating_props.tsx:6:27]
+ 5 │                           props.a ++
+ 6 │                           props.b = 1
+   ·                           ───────────
+ 7 │                           props.c.push(1)
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "c" prop.
+   ╭─[no_mutating_props.tsx:7:27]
+ 6 │                           props.b = 1
+ 7 │                           props.c.push(1)
+   ·                           ───────────────
+ 8 │                           delete props.d
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "d" prop.
+   ╭─[no_mutating_props.tsx:8:27]
+ 7 │                           props.c.push(1)
+ 8 │                           delete props.d
+   ·                           ──────────────
+ 9 │                         }
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "[a]" prop.
+   ╭─[no_mutating_props.tsx:5:27]
+ 4 │                         setup(props) {
+ 5 │                           props[a] ++
+   ·                           ───────────
+ 6 │                         }
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "[a]" prop.
+   ╭─[no_mutating_props.tsx:5:27]
+ 4 │                         setup({[a]: c}) {
+ 5 │                           c.foo ++
+   ·                           ────────
+ 6 │                         }
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "value" prop.
+   ╭─[no_mutating_props.tsx:6:21]
+ 5 │                     })
+ 6 │                     props.value++
+   ·                     ─────────────
+ 7 │                     </script>
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "value" prop.
+   ╭─[no_mutating_props.tsx:6:21]
+ 5 │                     })
+ 6 │                     value.value++
+   ·                     ─────────────
+ 7 │                     </script>
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "value" prop.
+   ╭─[no_mutating_props.tsx:6:21]
+ 5 │                     })
+ 6 │                     props.value++
+   ·                     ─────────────
+ 7 │                     </script>
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "a" prop.
+   ╭─[no_mutating_props.tsx:5:27]
+ 4 │                         setup(props) {
+ 5 │                           props.a ++
+   ·                           ──────────
+ 6 │                           props.b = 1
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "b" prop.
+   ╭─[no_mutating_props.tsx:6:27]
+ 5 │                           props.a ++
+ 6 │                           props.b = 1
+   ·                           ───────────
+ 7 │                           props.c.push(1)
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "d" prop.
+   ╭─[no_mutating_props.tsx:8:27]
+ 7 │                           props.c.push(1)
+ 8 │                           delete props.d
+   ·                           ──────────────
+ 9 │             
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "a" prop.
+    ╭─[no_mutating_props.tsx:11:29]
+ 10 │                           function foo() {
+ 11 │                             props.a ++
+    ·                             ──────────
+ 12 │                           }
+    ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "data" prop.
+   ╭─[no_mutating_props.tsx:7:36]
+ 6 │                           update() {
+ 7 │                             return Object.assign(this.data, { extra: 'value' })
+   ·                                    ────────────────────────────────────────────
+ 8 │                           }
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.

--- a/crates/oxc_linter/src/snapshots/vue_no_mutating_props.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_mutating_props.snap
@@ -326,3 +326,12 @@ assertion_line: 505
  8 │                           }
    ╰────
   help: Props are read-only. Emit an event and let the parent component perform the mutation.
+
+  ⚠ vue(no-mutating-props): Unexpected mutation of "count" prop.
+   ╭─[no_mutating_props.tsx:8:29]
+ 7 │                             const vm = this
+ 8 │                             vm.count++
+   ·                             ──────────
+ 9 │                           }
+   ╰────
+  help: Props are read-only. Emit an event and let the parent component perform the mutation.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -10494,6 +10494,26 @@
         "vue/no-multiple-slot-args": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "vue/no-mutating-props": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/NoMutatingPropsConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "vue/no-required-prop-with-default": {
           "$ref": "#/definitions/RuleNoConfig"
         },
@@ -14977,6 +14997,18 @@
           "default": false,
           "type": "boolean",
           "markdownDescription": "When `true`, the rule will ignore stateless components and will allow you to have multiple\nstateless components in the same file. Or one stateful component and one-or-more stateless\ncomponents in the same file.\n\nStateless basically just means function components, including those created via\n`memo` and `forwardRef`."
+        }
+      },
+      "additionalProperties": false
+    },
+    "NoMutatingPropsConfig": {
+      "type": "object",
+      "properties": {
+        "shallowOnly": {
+          "description": "When `true`, only mutations that write directly to a prop itself\n(e.g. `props.a = 1`, `props.a++`) are reported; mutations of nested\nvalues (e.g. `props.a.b = 1`, `props.a.push(1)`) are allowed.",
+          "default": false,
+          "type": "boolean",
+          "markdownDescription": "When `true`, only mutations that write directly to a prop itself\n(e.g. `props.a = 1`, `props.a++`) are reported; mutations of nested\nvalues (e.g. `props.a.b = 1`, `props.a.push(1)`) are allowed."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Part of #11440.

Implements `vue/no-mutating-props`, ported from [eslint-plugin-vue/lib/rules/no-mutating-props.js](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-mutating-props.js).

### What it does

Reports mutations of component props in the `<script>` part of `.vue` files, across all three component styles:

- `<script setup>`: `const props = defineProps(...)` (including `withDefaults(defineProps<T>(), ...)` and destructured props with member paths, e.g. `const { a: { b } } = defineProps(...)`)
- Options API: `this.<prop>` mutations inside the component options object (props collected from the `props` option — array or object form), including mutations through `const` aliases of `this` (`const vm = this; vm.count++`), matching upstream `isThis`
- `setup(props)`: mutations through the `props` parameter or its destructured bindings

Detected mutation kinds are a full port of upstream `findMutating`: assignments, update expressions, `delete`, mutating array methods (`push`, `pop`, `shift`, `unshift`, `reverse`, `splice`, `sort`, `copyWithin`, `fill`), and `Object.assign(<prop>, ...)`, reached through chain/parenthesized/TS-assertion wrappers.

The `shallowOnly` option is supported: only direct writes to the prop itself are reported; nested-value mutations are allowed.

### Divergence from upstream

Upstream test cases that mutate props from within the `<template>` block (e.g. `v-model="prop"`, `v-on` assignment expressions) are not ported — oxlint lints the `<script>` part of SFCs. Script-side coverage matches upstream (14 fail cases, all pass cases kept).

### Testing

- Ported upstream unit tests via `rulegen` + snapshot (`vue_no_mutating_props.snap`)
- `just ready` green locally
- E2E with a locally built `oxlint` on demo `.vue` files: all three component styles report correctly, plain reads are untouched

> [!NOTE]
> AI assisted: this PR was implemented with the help of an AI assistant (Claude); I have reviewed and tested the code.
