### PR TITLE
refactor(packages/codegen): add line breaks

### DIFF
--- a/packages/codegen/src-js/print/class.ts
+++ b/packages/codegen/src-js/print/class.ts
@@ -221,6 +221,7 @@ function printClassBody(node: ClassBodyNode, state: State): void {
  */
 function printMethodDefinition(node: MethodDefinitionNode, state: State): void {
   markWithMap(state, node);
+
   const { decorators } = node;
   if (decorators != null && decorators.length > 0) printDecorators(decorators, state);
 
@@ -292,6 +293,7 @@ function printMethodDefinition(node: MethodDefinitionNode, state: State): void {
  */
 function printPropertyDefinition(node: PropertyDefinitionNode, state: State): void {
   markWithMap(state, node);
+
   const { decorators } = node;
   if (decorators != null && decorators.length > 0) printDecorators(decorators, state);
 
@@ -382,6 +384,7 @@ function printStaticBlock(node: ESTree.StaticBlock, state: State): void {
  */
 function printAccessorProperty(node: AccessorPropertyNode, state: State): void {
   markWithMap(state, node);
+
   const { decorators } = node;
   if (decorators != null && decorators.length > 0) printDecorators(decorators, state);
 

--- a/packages/codegen/src-js/print/expression.ts
+++ b/packages/codegen/src-js/print/expression.ts
@@ -459,6 +459,7 @@ function printObjectProperty(node: ESTree.ObjectPropertyKind, state: State): voi
     (TS && value.type === "TSEmptyBodyFunctionExpression")
   ) {
     markWithMap(state, node);
+
     const { kind } = node;
     const isGetter = kind === "get";
     const isAccessor = isGetter || kind === "set";
@@ -621,6 +622,7 @@ function printAssignmentExpression(
   if (wrap) write(state, "(", CAT_OTHER);
 
   markWithMap(state, node);
+
   printAssignmentTarget(left, state);
   write(state, PADDED_ASSIGN_OPERATORS[node.operator], CAT_OTHER);
   printExpression(node.right, state, PREC_COMMA, ctx);

--- a/packages/codegen/src-js/print/source_map.ts
+++ b/packages/codegen/src-js/print/source_map.ts
@@ -53,12 +53,14 @@ export function generateSourceMap(state: State, options: Options): SourceMap {
   let sourceLineStart = 0;
   let replayedSourceScanTotal = 0;
   let lineStart = 0;
+
   // Proving an output contains only `\n` takes a full scan. Amortize it only when enough mappings will benefit.
   // Sparse maps and huge one-line literals stay on the single-pass regexp path.
   const useOutputLineFeedFastPath =
     mappingCount >= MIN_LF_FAST_PATH_MAPPINGS &&
     output.length <= mappingCount * MAX_LF_FAST_PATH_CHARS_PER_MAPPING &&
     !hasUncommonLineTerminator(output);
+
   // Require mappings to cover a substantial part of the source, so looking for the first line break
   // cannot scan a huge unmapped suffix. Reordered inputs conservatively take the slow path.
   const useSourceLineBoundaryCache =
@@ -91,9 +93,10 @@ export function generateSourceMap(state: State, options: Options): SourceMap {
     }
 
     const generatedColumn = offset - lineStart;
-    let sourceOffset = mapPositions[positionIndex + 1];
+
     // Rust end mappings use `span.end - 1`, which may land inside a multi-byte code point.
     // The JS equivalent can land on a low surrogate - normalize it back to the code point's start.
+    let sourceOffset = mapPositions[positionIndex + 1];
     if (sourceOffset > 0) {
       const char = sourceText.charCodeAt(sourceOffset);
       if (
@@ -105,6 +108,7 @@ export function generateSourceMap(state: State, options: Options): SourceMap {
         sourceOffset--;
       }
     }
+
     let originalLine: number;
     let originalColumn: number;
     if (sourceLineStarts === undefined) {
@@ -155,6 +159,7 @@ export function generateSourceMap(state: State, options: Options): SourceMap {
         // Once replaying costs as much as building a line table, the fallback below becomes cheaper.
         if (sourceOffset < sourceLineStart) {
           replayedSourceScanTotal += sourceScanOffset - sourceOffset;
+
           while (sourceOffset < sourceLineStart) {
             let index = sourceLineStart - 1;
             if (sourceText.charCodeAt(index) === 10 && sourceText.charCodeAt(index - 1) === 13) {
@@ -162,15 +167,19 @@ export function generateSourceMap(state: State, options: Options): SourceMap {
             } else {
               index--;
             }
+
             while (index >= 0) {
               const char = sourceText.charCodeAt(index);
               if (char === 10 || char === 13 || char === 0x2028 || char === 0x2029) break;
               index--;
             }
+
             sourceLineStart = index + 1;
             sourceLine--;
           }
+
           sourceScanOffset = sourceOffset;
+
           if (useSourceLineBoundaryCache) {
             nextSourceLineStart = findNextLineStart(
               sourceText,
@@ -202,26 +211,31 @@ export function generateSourceMap(state: State, options: Options): SourceMap {
         mappingLength + MAX_MAPPING_SEGMENT_LENGTH,
       );
     }
+
     if (hasSegmentOnLine) mappingBuffer[mappingLength++] = 44; // `,`
+
     mappingLength = writeVlq(
       mappingBuffer,
       mappingLength,
       generatedColumn - previousGeneratedColumn,
     );
+
     // All mappings point into the one source file, so the source-index delta is always zero (`A`)
     mappingBuffer[mappingLength++] = 65;
     mappingLength = writeVlq(mappingBuffer, mappingLength, originalLine - previousOriginalLine);
     mappingLength = writeVlq(mappingBuffer, mappingLength, originalColumn - previousOriginalColumn);
 
     if (index === nextNamedMappingIndex) {
-      const name = mapNames![mapNameEntryIndex + 1] as string;
       nameIds ??= new Map<string, number>();
+
+      const name = mapNames![mapNameEntryIndex + 1] as string;
       let nameId = nameIds.get(name);
       if (nameId === undefined) {
         nameId = names.length;
         names.push(name);
         nameIds.set(name, nameId);
       }
+
       mappingLength = writeVlq(mappingBuffer, mappingLength, nameId - previousNameId);
       previousNameId = nameId;
       mapNameEntryIndex += 2;
@@ -300,6 +314,7 @@ function writeVlq(buffer: Buffer, index: number, value: number): number {
       if (vlq > 0) digit |= 32;
       buffer[index++] = BASE64_CODES[digit];
     } while (vlq > 0);
+
     return index;
   }
 
@@ -309,6 +324,7 @@ function writeVlq(buffer: Buffer, index: number, value: number): number {
     if (vlq > 0) digit += 32;
     buffer[index++] = BASE64_CODES[digit];
   } while (vlq > 0);
+
   return index;
 }
 
@@ -363,6 +379,7 @@ function hasOnlyLineFeedsAndCrLf(sourceText: string): boolean {
     if (sourceText.charCodeAt(carriageReturn + 1) !== 10) return false;
     carriageReturn = sourceText.indexOf("\r", carriageReturn + 1);
   }
+
   return true;
 }
 

--- a/packages/codegen/src-js/print/write.ts
+++ b/packages/codegen/src-js/print/write.ts
@@ -360,6 +360,7 @@ export function markWithMapAtStartOffset(
   columnOffset: number,
 ): void {
   if (!SOURCEMAPS) return;
+
   const { sourceText } = state;
   if (sourceText === undefined) return;
 
@@ -380,6 +381,7 @@ export function markWithMapAtStartOffset(
     state.mapPositions !== null,
     "Source map positions should exist when source maps are enabled",
   );
+
   const sourceOffset = start + columnOffset;
   if (!(sourceOffset >= 0 && sourceOffset <= sourceText.length)) return;
   if (state.mapPositions[state.mapPositions.length - 1] === sourceOffset) return;
@@ -392,6 +394,7 @@ export function markWithMapAtStartOffset(
  */
 function recordSourceMapping(state: State, node: MappableNode, location: false | 1 | 2 | 3): void {
   if (!SOURCEMAPS) return;
+
   const { sourceText } = state;
   if (sourceText === undefined) return;
 
@@ -421,6 +424,7 @@ function recordSourceMapping(state: State, node: MappableNode, location: false |
   } else {
     sourceOffset = start;
   }
+
   if (!(sourceOffset >= 0 && sourceOffset <= sourceText.length)) return;
 
   // `oxc_codegen` suppresses consecutive source positions as it records them. Do this before
@@ -442,6 +446,7 @@ function recordSourceMapping(state: State, node: MappableNode, location: false |
         (nameEnd === end || isDefinitelyIdentifierBoundary(sourceText.charCodeAt(nameEnd)))
           ? printedName
           : originalNameFromSource(sourceText, node, start, end);
+
       // A transformed or hand-authored AST can carry ranges unrelated to `sourceText`.
       // Preserve the existing fallback in that case instead of recording an arbitrary source substring.
       name =
@@ -457,6 +462,7 @@ function recordSourceMapping(state: State, node: MappableNode, location: false |
 
   const mappingIndex = state.mapPositions.length >> 1;
   state.mapPositions.push(state.output.length, sourceOffset);
+
   if (name !== undefined) {
     (state.mapNames ??= []).push(mappingIndex, name);
   }

--- a/packages/codegen/test/utils/common.ts
+++ b/packages/codegen/test/utils/common.ts
@@ -67,6 +67,7 @@ export function getEcmaScriptLineTable(sourceText: string): {
   }
 
   lines.push(sourceText.slice(lineStart));
+
   return { lines, lineStarts };
 }
 


### PR DESCRIPTION
Follow-on after #25585.

Pure style change. Similar to #25848 - just remove the worst excesses of LLM coding style where it produces dense blocks of code with no line breaks, which makes code hard to read.

No substantive changes, just adds line breaks.