### PR TITLE
refactor(packages/codegen): remove redundant types export

### DIFF
--- a/packages/codegen/src-js/print/index.ts
+++ b/packages/codegen/src-js/print/index.ts
@@ -45,5 +45,3 @@ export function printSync(node: ESTree.Node, state: State, options: Options): Co
 
   return { code: state.output };
 }
-
-export type { CodegenResult, Options, SourceMap } from "./options.ts";


### PR DESCRIPTION
Remove a redundant type export. Nothing reads it.