### PR TITLE
refactor(packages/codegen): re-order options

### DIFF
--- a/packages/codegen/src-js/print/options.ts
+++ b/packages/codegen/src-js/print/options.ts
@@ -44,14 +44,14 @@ export interface Options {
   ts?: boolean;
 
   /**
-   * Original source text. Required for source-map mappings.
-   */
-  sourceText?: string;
-
-  /**
    * Generate and return a source map in `CodegenResult.map`.
    */
   sourcemap?: boolean;
+
+  /**
+   * Original source text. Required for source-map mappings.
+   */
+  sourceText?: string;
 
   /**
    * Original source filename recorded in the returned source map.


### PR DESCRIPTION
Follow-on after #25585.

Pure refactor. Re-order options so `sourcemap` is first. The other 2 are sourcemap-related, so it makes sense to have them after.