### PR TITLE
refactor(packages/codegen): `printSync` return consistent object shape

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -79,7 +79,7 @@ const { code } = printSync(program, {
 ### `printSync(node, options?)`
 
 ```ts
-function printSync(node: Node, options?: Options): { code: string; map?: SourceMap };
+function printSync(node: Node, options?: Options): { code: string; map: SourceMap | null };
 ```
 
 Prints a complete `Program` or a single statement and returns the generated source code,

--- a/packages/codegen/src-js/print/index.ts
+++ b/packages/codegen/src-js/print/index.ts
@@ -43,5 +43,5 @@ export function printSync(node: ESTree.Node, state: State, options: Options): Co
     return { code: state.output, map: generateSourceMap(state, options) };
   }
 
-  return { code: state.output };
+  return { code: state.output, map: null };
 }

--- a/packages/codegen/src-js/print/options.ts
+++ b/packages/codegen/src-js/print/options.ts
@@ -12,7 +12,7 @@ export interface SourceMap {
 /** Result returned by `printSync`. */
 export interface CodegenResult {
   code: string;
-  map?: SourceMap;
+  map: SourceMap | null;
 }
 
 /**

--- a/packages/codegen/test/source-maps.test.ts
+++ b/packages/codegen/test/source-maps.test.ts
@@ -186,7 +186,7 @@ describe("Rust conformance", () => {
   test("returns a source map only when requested", () => {
     const code = "const value = 1;";
     const program = parseProgram("return-map.js", code);
-    expect(printSync(program).map).toBeUndefined();
+    expect(printSync(program).map).toBeNull();
 
     const { map } = printSync(program, {
       sourcemap: true,


### PR DESCRIPTION
Follow-on after #25585.

Nit. Make `printSync` return an object with consistent shape. With `sourcemap: false` it now returns `{ code: string, map: null }` instead of just `{ code: string }`.

Co-authored-by: Cameron <cameron.clark@hey.com>