### PR TITLE
feat(packages/codegen): alter capitalization of `sourceFilename` option

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -93,7 +93,7 @@ const sourceText = "const answer=6*7";
 const { program } = parseSync("input.js", sourceText);
 const { code, map } = printSync(program, {
   sourcemap: true,
-  sourceFileName: "input.js",
+  sourceFilename: "input.js",
   sourceText,
 });
 ```
@@ -111,7 +111,7 @@ an empty `mappings` string.
 | `jsx`                 | `boolean` | `false` | Enable TSX-safe printing for ambiguous TypeScript syntax         |
 | `ts`                  | `boolean` | `false` | Select the printer that supports TypeScript nodes                |
 | `sourcemap`           | `boolean` | `false` | Return a Source Map v3 object in `map`                           |
-| `sourceFileName`      | `string`  | `""`    | Original source filename recorded in the source map              |
+| `sourceFilename`      | `string`  | `""`    | Original source filename recorded in the source map              |
 | `sourceText`          | `string`  | -       | Original text required for source-map mappings and content       |
 
 ## Why pure JavaScript?

--- a/packages/codegen/src-js/print/options.ts
+++ b/packages/codegen/src-js/print/options.ts
@@ -56,5 +56,5 @@ export interface Options {
   /**
    * Original source filename recorded in the returned source map.
    */
-  sourceFileName?: string;
+  sourceFilename?: string;
 }

--- a/packages/codegen/src-js/print/source_map.ts
+++ b/packages/codegen/src-js/print/source_map.ts
@@ -48,7 +48,7 @@ export function generateSourceMap(state: State, options: Options): SourceMap {
       version: 3,
       mappings: "",
       names: [],
-      sources: [options.sourceFileName ?? ""],
+      sources: [options.sourceFilename ?? ""],
     };
     if (sourceText !== undefined) map.sourcesContent = [sourceText];
     return map;
@@ -268,7 +268,7 @@ export function generateSourceMap(state: State, options: Options): SourceMap {
     version: 3,
     mappings: mappingBuffer.toString("ascii", 0, mappingLength),
     names,
-    sources: [options.sourceFileName ?? ""],
+    sources: [options.sourceFilename ?? ""],
   };
   if (sourceText !== undefined) map.sourcesContent = [sourceText];
   return map;

--- a/packages/codegen/test/source-maps.test.ts
+++ b/packages/codegen/test/source-maps.test.ts
@@ -123,7 +123,7 @@ describe("Rust conformance", () => {
 
     const { map } = printSync(program, {
       sourcemap: true,
-      sourceFileName: "invalid-offset.js",
+      sourceFilename: "invalid-offset.js",
       sourceText: code,
     });
     expect(decodeSourceMap(map!)).toContainEqual(expect.objectContaining({ name: "name" }));
@@ -143,7 +143,7 @@ describe("Rust conformance", () => {
 
     const { map } = printSync(program, {
       sourcemap: true,
-      sourceFileName: "stale-offset.js",
+      sourceFilename: "stale-offset.js",
       sourceText: code,
     });
     const mappings = decodeSourceMap(map!);
@@ -162,7 +162,7 @@ describe("Rust conformance", () => {
 
     const { map } = printSync(program, {
       sourcemap: true,
-      sourceFileName: "renamed.js",
+      sourceFilename: "renamed.js",
       sourceText: code,
     });
     expect(map?.names).toEqual(["ab"]);
@@ -175,7 +175,7 @@ describe("Rust conformance", () => {
 
     const { map } = printSync(program, {
       sourcemap: true,
-      sourceFileName: "reordered.js",
+      sourceFilename: "reordered.js",
       sourceText: code,
     });
     const mappings = decodeSourceMap(map!);
@@ -190,7 +190,7 @@ describe("Rust conformance", () => {
 
     const { map } = printSync(program, {
       sourcemap: true,
-      sourceFileName: "return-map.js",
+      sourceFilename: "return-map.js",
       sourceText: code,
     });
     expect(map).toMatchObject({
@@ -355,7 +355,7 @@ for (const fixture of FIXTURES) {
         jsx,
         ts,
         sourcemap: true,
-        sourceFileName: fixture.name,
+        sourceFilename: fixture.name,
         sourceText: code,
       });
       const { code: withoutMaps } = printSync(program, { jsx, ts });
@@ -461,7 +461,7 @@ describe("indent option", () => {
     const { code: out, map } = printSync(program, {
       indent: indent as string | undefined,
       sourcemap: true,
-      sourceFileName: "indent.js",
+      sourceFilename: "indent.js",
       sourceText: INLINE_JS,
     });
 

--- a/packages/codegen/test/utils/common.ts
+++ b/packages/codegen/test/utils/common.ts
@@ -133,7 +133,7 @@ export function checkFixture(
       ts,
       jsx,
       sourcemap: true,
-      sourceFileName: filename,
+      sourceFilename: filename,
       sourceText,
     });
     expect(actualWithSourceMap, `preserveParens: ${preserveParens}, sourceMap: code`).toBe(

--- a/packages/codegen/test/utils/typescript-make-units-from-test.ts
+++ b/packages/codegen/test/utils/typescript-make-units-from-test.ts
@@ -98,7 +98,7 @@ function getSourceType(filePath: string, jsxOption: boolean): SourceType | null 
  */
 export function makeUnitsFromTest(filePath: string, code: string): TestCaseContent {
   const currentFileOptions = new Map<string, string>();
-  let currentFileName: string | null = null;
+  let currentFilename: string | null = null;
   const testUnitData: Omit<TestUnitData, "sourceType">[] = [];
   let currentFileContent = "";
 
@@ -116,14 +116,14 @@ export function makeUnitsFromTest(filePath: string, code: string): TestCaseConte
       const metaValue = match[2].trim();
 
       if (metaName === "filename") {
-        if (currentFileName !== null) {
+        if (currentFilename !== null) {
           testUnitData.push({
-            name: currentFileName,
+            name: currentFilename,
             content: currentFileContent,
           });
           currentFileContent = "";
         }
-        currentFileName = metaValue;
+        currentFilename = metaValue;
       } else {
         currentFileOptions.set(metaName, metaValue);
       }
@@ -136,9 +136,9 @@ export function makeUnitsFromTest(filePath: string, code: string): TestCaseConte
   }
 
   // Handle the last file (or the only file if no @filename is used)
-  const fileName = currentFileName || path.basename(filePath);
+  const filename = currentFilename || path.basename(filePath);
   testUnitData.push({
-    name: fileName,
+    name: filename,
     content: currentFileContent,
   });
 


### PR DESCRIPTION
Follow-on after #25585.

Rename `options.sourceFileName` to `sourceFilename`. We use both capitalizations internal Rust code, but always `filename` in external JS APIs (Oxlint plugins etc).

NOTE: this is not marked as a breaking change as it was merged before the feature was released.