### PR TITLE
refactor(codegen): remove legacy mapped type support

### DIFF
--- a/packages/codegen/DESIGN.md
+++ b/packages/codegen/DESIGN.md
@@ -576,7 +576,7 @@ See `Normalize` in `tasks/codegen_conformance/src/lib.rs`.
 - **Oxc offsets only.** `start` / `end` offsets are converted to UTF-16 line/column once at the end.
   Source maps require `sourceText`; `loc` and `range` are not supported inputs.
 - **TS-ESLint ASTs are accepted**, and differ from Oxc's in a handful of places
-  (`TSMappedType`, `TSImportType`, `TSEnumDeclaration`, `TSModuleDeclaration`).
+  (`TSImportType`, `TSEnumDeclaration`, `TSModuleDeclaration`).
   [`print/types.ts`] holds the widened node types and documents each difference.
 
 ## How it is tested

--- a/packages/codegen/src-js/print/types.ts
+++ b/packages/codegen/src-js/print/types.ts
@@ -68,20 +68,6 @@ export type TSModuleDeclarationNode = Omit<
 };
 
 /**
- * Oxc puts a mapped type's parameter in `key` and `constraint`, where TS-ESLint < 6 used `typeParameter`.
- */
-export type TSMappedTypeNode = Omit<ESTree.TSMappedType, "key"> & {
-  key?: ESTree.BindingIdentifier | null;
-};
-
-/**
- * The pre-TS-ESLint-6 shape `TSMappedTypeNode` falls back to reading.
- */
-export interface TSMappedTypeLegacyParameter {
-  typeParameter: Omit<ESTree.TSTypeParameter, "constraint"> & { constraint: ESTree.TSType };
-}
-
-/**
  * Oxc's `TSImportType` names the module in `source`, where TS-ESLint < 8 used `argument`.
  */
 export type TSImportTypeNode = Omit<ESTree.TSImportType, "source"> & {

--- a/packages/codegen/src-js/print/typescript.ts
+++ b/packages/codegen/src-js/print/typescript.ts
@@ -38,8 +38,6 @@ import type {
   TSEnumDeclarationNode,
   TSImportTypeLegacyArgument,
   TSImportTypeNode,
-  TSMappedTypeLegacyParameter,
-  TSMappedTypeNode,
   TSModuleDeclarationNode,
   UnknownNode,
 } from "./types.ts";
@@ -748,7 +746,7 @@ function printTSConditionalType(node: ESTree.TSConditionalType, state: State): v
  *
  * The braces are padded with spaces and the whole type stays on one line, however large it is.
  */
-function printTSMappedType(node: TSMappedTypeNode, state: State): void {
+function printTSMappedType(node: ESTree.TSMappedType, state: State): void {
   writeNoLast(state, "{ ");
 
   const { readonly } = node;
@@ -762,17 +760,9 @@ function printTSMappedType(node: TSMappedTypeNode, state: State): void {
 
   writeNoLast(state, "[");
 
-  // TS-ESLint >= 6: `key` + `constraint`; older: `typeParameter`
-  if (node.key != null) {
-    writeWithMapNoLast(state, node.key.name, node.key);
-    write(state, " in ", CAT_OTHER);
-    printTSType(node.constraint, state);
-  } else {
-    typeAssertIs<TSMappedTypeLegacyParameter>(node);
-    writeNoLast(state, node.typeParameter.name.name);
-    write(state, " in ", CAT_OTHER);
-    printTSType(node.typeParameter.constraint, state);
-  }
+  writeWithMapNoLast(state, node.key.name, node.key);
+  write(state, " in ", CAT_OTHER);
+  printTSType(node.constraint, state);
 
   if (node.nameType != null) {
     write(state, " as ", CAT_OTHER);


### PR DESCRIPTION
## Summary
- remove the pre-v6 TS-ESLint TSMappedType.typeParameter fallback
- require Oxc's key / constraint mapped-type AST shape
- update compatibility documentation