### PR TITLE
refactor(codegen): remove legacy import type support

### DIFF
--- a/packages/codegen/DESIGN.md
+++ b/packages/codegen/DESIGN.md
@@ -576,7 +576,7 @@ See `Normalize` in `tasks/codegen_conformance/src/lib.rs`.
 - **Oxc offsets only.** `start` / `end` offsets are converted to UTF-16 line/column once at the end.
   Source maps require `sourceText`; `loc` and `range` are not supported inputs.
 - **TS-ESLint ASTs are accepted**, and differ from Oxc's in a handful of places
-  (`TSImportType`, `TSEnumDeclaration`, `TSModuleDeclaration`).
+  (`TSEnumDeclaration`, `TSModuleDeclaration`).
   [`print/types.ts`] holds the widened node types and documents each difference.
 
 ## How it is tested

--- a/packages/codegen/src-js/print/types.ts
+++ b/packages/codegen/src-js/print/types.ts
@@ -68,20 +68,6 @@ export type TSModuleDeclarationNode = Omit<
 };
 
 /**
- * Oxc's `TSImportType` names the module in `source`, where TS-ESLint < 8 used `argument`.
- */
-export type TSImportTypeNode = Omit<ESTree.TSImportType, "source"> & {
-  source?: ESTree.StringLiteral | null;
-};
-
-/**
- * The pre-TS-ESLint-8 shape `TSImportTypeNode` falls back to reading.
- */
-export interface TSImportTypeLegacyArgument {
-  argument: ESTree.StringLiteral | ESTree.TSLiteralType | ESTree.TSType;
-}
-
-/**
  * Oxc wraps enum members in a `TSEnumBody`, where TS-ESLint < 8 put them on the declaration itself.
  */
 export type TSEnumDeclarationNode = Omit<ESTree.TSEnumDeclaration, "body"> & {

--- a/packages/codegen/src-js/print/typescript.ts
+++ b/packages/codegen/src-js/print/typescript.ts
@@ -36,8 +36,6 @@ import type {
   LiteralExtras,
   TSEnumDeclarationLegacyMembers,
   TSEnumDeclarationNode,
-  TSImportTypeLegacyArgument,
-  TSImportTypeNode,
   TSModuleDeclarationNode,
   UnknownNode,
 } from "./types.ts";
@@ -854,20 +852,10 @@ function printTSTypeQueryExprName(node: ESTree.TSTypeQueryExprName, state: State
  * The options argument prints at `PREC_LOWEST` through the expression printer,
  * and both the qualifier and the type arguments are optional.
  */
-function printTSImportType(node: TSImportTypeNode, state: State): void {
+function printTSImportType(node: ESTree.TSImportType, state: State): void {
   write(state, "import(", CAT_OTHER);
 
-  // TS-ESLint v8: `source` is the string literal, older versions used `argument` (a `TSLiteralType`)
-  typeAssertIs<TSImportTypeLegacyArgument>(node);
-  const argument = node.source != null ? node.source : node.argument;
-  if (argument.type === "Literal") {
-    printString(state, argument.value, argument);
-  } else if (argument.type === "TSLiteralType") {
-    typeAssertIs<ESTree.StringLiteral>(argument.literal);
-    printString(state, argument.literal.value, argument.literal);
-  } else {
-    printTSType(argument, state);
-  }
+  printString(state, node.source.value, node.source);
 
   if (node.options != null) {
     write(state, ", ", CAT_OTHER);


### PR DESCRIPTION
## Summary
- remove the legacy TSImportType argument fallback
- require Oxc's source AST shape
- update compatibility documentation
