### PR TITLE
refactor(codegen): remove legacy enum declaration support

### DIFF
--- a/packages/codegen/DESIGN.md
+++ b/packages/codegen/DESIGN.md
@@ -576,7 +576,7 @@ See `Normalize` in `tasks/codegen_conformance/src/lib.rs`.
 - **Oxc offsets only.** `start` / `end` offsets are converted to UTF-16 line/column once at the end.
   Source maps require `sourceText`; `loc` and `range` are not supported inputs.
 - **TS-ESLint ASTs are accepted**, and differ from Oxc's in a handful of places
-  (`TSEnumDeclaration`, `TSModuleDeclaration`).
+  (`TSModuleDeclaration`).
   [`print/types.ts`] holds the widened node types and documents each difference.
 
 ## How it is tested

--- a/packages/codegen/src-js/print/types.ts
+++ b/packages/codegen/src-js/print/types.ts
@@ -68,20 +68,6 @@ export type TSModuleDeclarationNode = Omit<
 };
 
 /**
- * Oxc wraps enum members in a `TSEnumBody`, where TS-ESLint < 8 put them on the declaration itself.
- */
-export type TSEnumDeclarationNode = Omit<ESTree.TSEnumDeclaration, "body"> & {
-  body?: ESTree.TSEnumBody | null;
-};
-
-/**
- * The pre-TS-ESLint-8 shape `TSEnumDeclarationNode` falls back to reading.
- */
-export interface TSEnumDeclarationLegacyMembers {
-  members: ESTree.TSEnumMember[];
-}
-
-/**
  * A node carrying the offsets needed for source mappings.
  */
 export interface MappableNode {

--- a/packages/codegen/src-js/print/typescript.ts
+++ b/packages/codegen/src-js/print/typescript.ts
@@ -32,13 +32,7 @@ import { printDirectivesAndStatements } from "./statement.ts";
 import { printString } from "./string.ts";
 
 import type { State } from "../state.ts";
-import type {
-  LiteralExtras,
-  TSEnumDeclarationLegacyMembers,
-  TSEnumDeclarationNode,
-  TSModuleDeclarationNode,
-  UnknownNode,
-} from "./types.ts";
+import type { LiteralExtras, TSModuleDeclarationNode, UnknownNode } from "./types.ts";
 import type * as ESTree from "../../../../npm/oxc-types/types.d.ts";
 
 /**
@@ -1102,10 +1096,8 @@ function isLeftmostIntrinsicReference(ty: ESTree.TSType): boolean {
  * Members print one per indented line with a comma after all but the last, and an enum with no members
  * collapses to `{}`.
  *
- * Oxc wraps the members in a `TSEnumBody` while older producers put them on the declaration itself,
- * so both shapes are read.
  */
-export function printTSEnumDeclaration(node: TSEnumDeclarationNode, state: State): void {
+export function printTSEnumDeclaration(node: ESTree.TSEnumDeclaration, state: State): void {
   printSpaceBeforeIdentifier(state);
 
   if (node.declare) write(state, "declare ", CAT_OTHER);
@@ -1117,9 +1109,8 @@ export function printTSEnumDeclaration(node: TSEnumDeclarationNode, state: State
 
   write(state, " ", CAT_OTHER);
 
-  typeAssertIs<TSEnumDeclarationLegacyMembers>(node);
-  const body = node.body != null ? node.body : node;
-  const members = node.body != null ? node.body.members : node.members;
+  const { body } = node;
+  const { members } = body;
   const { length } = members;
   if (length === 0) {
     writeWithMapNoLast(state, "{", body);


### PR DESCRIPTION
## Summary
- remove the legacy TSEnumDeclaration members fallback
- require Oxc's enum body AST shape
- update compatibility documentation