### PR TITLE
refactor(codegen): remove legacy module declaration support

### DIFF
--- a/packages/codegen/DESIGN.md
+++ b/packages/codegen/DESIGN.md
@@ -575,9 +575,6 @@ See `Normalize` in `tasks/codegen_conformance/src/lib.rs`.
 
 - **Oxc offsets only.** `start` / `end` offsets are converted to UTF-16 line/column once at the end.
   Source maps require `sourceText`; `loc` and `range` are not supported inputs.
-- **TS-ESLint ASTs are accepted**, and differ from Oxc's in a handful of places
-  (`TSModuleDeclaration`).
-  [`print/types.ts`] holds the widened node types and documents each difference.
 
 ## How it is tested
 

--- a/packages/codegen/src-js/print/types.ts
+++ b/packages/codegen/src-js/print/types.ts
@@ -57,17 +57,6 @@ export type ExportNamedDeclarationNode = Omit<ESTree.ExportNamedDeclaration, "de
 };
 
 /**
- * Oxc keeps a module's kind in `kind`, using `global: true` for `declare global`.
- * Older producers have no `kind`, and only the `global` flag distinguishes the two.
- */
-export type TSModuleDeclarationNode = Omit<
-  ESTree.TSModuleDeclaration | ESTree.TSGlobalDeclaration,
-  "kind"
-> & {
-  kind?: ESTree.TSModuleDeclarationKind | "global" | null;
-};
-
-/**
  * A node carrying the offsets needed for source mappings.
  */
 export interface MappableNode {

--- a/packages/codegen/src-js/print/typescript.ts
+++ b/packages/codegen/src-js/print/typescript.ts
@@ -32,7 +32,7 @@ import { printDirectivesAndStatements } from "./statement.ts";
 import { printString } from "./string.ts";
 
 import type { State } from "../state.ts";
-import type { LiteralExtras, TSModuleDeclarationNode, UnknownNode } from "./types.ts";
+import type { LiteralExtras, UnknownNode } from "./types.ts";
 import type * as ESTree from "../../../../npm/oxc-types/types.d.ts";
 
 /**
@@ -917,12 +917,14 @@ export function printTSTypeAssertion(
  * `global` is the one kind with no name of its own, so nothing is printed where the id would go.
  *
  * A missing body is the declaration form and ends in `;` instead of a block.
- * Producers which have no `kind` field are read off the `global` flag instead.
  */
-export function printTSModuleDeclaration(node: TSModuleDeclarationNode, state: State): void {
+export function printTSModuleDeclaration(
+  node: ESTree.TSModuleDeclaration | ESTree.TSGlobalDeclaration,
+  state: State,
+): void {
   if (node.declare) write(state, "declare ", CAT_OTHER);
 
-  const kind = node.kind != null ? node.kind : node.global ? "global" : "module";
+  const { kind } = node;
   write(state, kind, CAT_IDENT);
 
   if (kind !== "global") {


### PR DESCRIPTION
## Summary
- remove the legacy TSModuleDeclaration kind fallback
- require Oxc's explicit kind AST shape
- remove the completed compatibility documentation section
