### PR TITLE
refactor(codegen): use `magicString` to preserve mappings in strip-ts

### DIFF
--- a/packages/codegen/tsdown_plugins/strip_ts.ts
+++ b/packages/codegen/tsdown_plugins/strip_ts.ts
@@ -43,19 +43,23 @@ const stripTsPlugin = (): Plugin => {
       // Only process TS files in `src-js/print` directory
       filter: { id: /\/src-js\/print\/.+\.ts$/ },
 
-      handler(code) {
-        code = code.replace(REGION, () => {
+      handler(code, _path, meta) {
+        const magicString = meta.magicString!;
+        for (const match of code.matchAll(REGION)) {
           strippedRegions++;
-          return "";
-        });
+          const start = match.index!;
+          magicString.remove(start, start + match[0].length);
+        }
+
+        const transformed = magicString.toString();
 
         // Unbalanced or nested fences leave a marker behind.
         // Most files have no fences at all, so the "did this plugin do anything" check is per build, in `buildEnd`.
-        if (code.includes("IF TS") || code.includes("END_IF")) {
+        if (transformed.includes("IF TS") || transformed.includes("END_IF")) {
           throw new Error("strip-ts: unbalanced or nested `/* IF TS */` / `/* END_IF */` fences");
         }
 
-        return code;
+        return { code: magicString };
       },
     },
 


### PR DESCRIPTION
## Summary

Preserve source maps when `strip-ts` removes TypeScript-only printer regions from JS builds.

The plugin now uses Rolldown’s `magicString` transform context instead of a plain string replacement, so removed `/* IF TS */` regions retain correct mappings back to the original printer source. 