### PR TITLE
fix(codegen): narrow printSync input type

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -79,7 +79,13 @@ const { code } = printSync(program, {
 ### `printSync(node, options?)`
 
 ```ts
-function printSync(node: Node, options?: Options): { code: string; map: SourceMap | null };
+function printSync(
+  node: ESTree.Program | ESTree.Statement,
+  options?: Options,
+): {
+  code: string;
+  map: SourceMap | null;
+};
 ```
 
 Prints a complete `Program` or a single statement and returns the generated source code,

--- a/packages/codegen/src-js/index.ts
+++ b/packages/codegen/src-js/index.ts
@@ -61,7 +61,10 @@ const printers: (PrintModule["printSync"] | null)[] = [null, null, null, null];
  * @param options - Printing options (optional)
  * @returns Object holding the generated code
  */
-export function printSync(node: ESTree.Node, options?: Options): CodegenResult {
+export function printSync(
+  node: ESTree.Program | ESTree.Statement,
+  options?: Options,
+): CodegenResult {
   // The printer is built 4 times, over whether the AST may contain TypeScript and whether
   // source mappings are wanted. This picks the build the options call for and loads it on first use,
   // so a caller printing only JavaScript never pays for the TypeScript printers.

--- a/packages/codegen/test/print.test.ts
+++ b/packages/codegen/test/print.test.ts
@@ -92,7 +92,7 @@ const e = (expression: ESTree.Expression) => program(stmt(expression));
 // --- Runner ---------------------------------------------------------------------------------
 
 /** A case: its name, the AST to print, and the output the printer must produce for it. */
-type Case = [name: string, ast: ESTree.Node, output: string];
+type Case = [name: string, ast: ESTree.Program | ESTree.Statement, output: string];
 
 /**
  * Define one test per case, checking the printer's output is exactly the expected string.


### PR DESCRIPTION
## Summary
- narrow the public `printSync` input type to `ESTree.Program | ESTree.Statement`
- document the supported input type in the package README