### PR TITLE
refactor(codegen): use `it.for` for generated tests

### DIFF
--- a/packages/codegen/test/jsx.test.ts
+++ b/packages/codegen/test/jsx.test.ts
@@ -15,11 +15,9 @@ const fixturePaths = (await readdir(JSX_DIR_PATH, { recursive: true }))
   .sort();
 
 describe.concurrent("JSX", () => {
-  for (const path of fixturePaths) {
-    // oxlint-disable-next-line vitest/valid-title, vitest/expect-expect
-    it(path, async (ctx) => {
-      const sourceText = await readFile(pathJoin(JSX_DIR_PATH, path), "utf8");
-      if (!checkFixture(path, sourceText, "jsx", "unambiguous")) ctx.skip();
-    });
-  }
+  // oxlint-disable-next-line vitest/expect-expect
+  it.for(fixturePaths)("%s", async (path, ctx) => {
+    const sourceText = await readFile(pathJoin(JSX_DIR_PATH, path), "utf8");
+    if (!checkFixture(path, sourceText, "jsx", "unambiguous")) ctx.skip();
+  });
 });

--- a/packages/codegen/test/leftmost.test.ts
+++ b/packages/codegen/test/leftmost.test.ts
@@ -379,28 +379,17 @@ const CONTEXTS: Context[] = [
 // --- Tests ------------------------------------------------------------------------------------
 
 describe.concurrent("leftmost position", () => {
-  for (const context of CONTEXTS) {
-    // oxlint-disable-next-line vitest/valid-title
-    describe(context.name, () => {
-      for (const testCase of CASES) {
-        const built = context.build(testCase);
+  describe.for(CONTEXTS)("$name", (context) => {
+    it.for(CASES)("$name", (testCase, ctx) => {
+      const built = context.build(testCase);
 
-        // Reported as skipped, carrying the reason, rather than left out of the run
-        // oxlint-disable-next-line vitest/no-conditional-tests
-        if ("skip" in built) {
-          // oxlint-disable-next-line vitest/valid-title, vitest/expect-expect
-          it(testCase.name, (ctx) => ctx.skip(built.skip));
-          continue;
-        }
+      // Reported as skipped, carrying the reason, rather than left out of the run
+      if ("skip" in built) return ctx.skip(built.skip);
 
-        // oxlint-disable-next-line vitest/valid-title
-        it(testCase.name, () => {
-          const lang = testCase.lang ?? "js";
-          const sourceType = context.module || testCase.module ? "module" : "script";
-          const checked = checkFixture(`leftmost.${lang}`, built.source, lang, sourceType);
-          expect(checked, `snippet does not parse:\n${built.source}`).toBe(true);
-        });
-      }
+      const lang = testCase.lang ?? "js";
+      const sourceType = context.module || testCase.module ? "module" : "script";
+      const checked = checkFixture(`leftmost.${lang}`, built.source, lang, sourceType);
+      expect(checked, `snippet does not parse:\n${built.source}`).toBe(true);
     });
-  }
+  });
 });

--- a/packages/codegen/test/source-maps.test.ts
+++ b/packages/codegen/test/source-maps.test.ts
@@ -377,115 +377,123 @@ interface Printed {
   srcLines: string[];
 }
 
-for (const fixture of FIXTURES) {
-  // A cached fixture which has not been downloaded is reported as skipped rather than passing quietly.
-  // `pnpm run bench` downloads them.
-  const describeFixture = fixture.code === null ? describe.skip : describe;
+function addFixtureTests(fixture: Fixture) {
+  let printed!: Printed;
 
-  describeFixture(fixture.name, () => {
-    let printed!: Printed;
+  beforeAll(() => {
+    const { code } = fixture;
+    if (code === null) return;
 
-    beforeAll(() => {
-      const code = fixture.code as string;
-      const program = parseProgram(fixture.name, code);
-      const { jsx, ts } = fixture;
+    const program = parseProgram(fixture.name, code);
+    const { jsx, ts } = fixture;
 
-      // Both builds through the public API.
-      // `printSync` picks the maps build when `sourcemap` is true, and the no-maps build when it is not.
-      const { code: withMaps, map } = printSync(program, {
-        jsx,
-        ts,
-        sourcemap: true,
-        sourceFilename: fixture.name,
-        sourceText: code,
-      });
-      const { code: withoutMaps } = printSync(program, { jsx, ts });
-
-      printed = {
-        withMaps,
-        withoutMaps,
-        mappings: decodeSourceMap(map!),
-        outLines: getEcmaScriptLineTable(withMaps).lines,
-        srcLines: getEcmaScriptLineTable(code).lines,
-      };
+    // Both builds through the public API.
+    // `printSync` picks the maps build when `sourcemap` is true, and the no-maps build when it is not.
+    const { code: withMaps, map } = printSync(program, {
+      jsx,
+      ts,
+      sourcemap: true,
+      sourceFilename: fixture.name,
+      sourceText: code,
     });
+    const { code: withoutMaps } = printSync(program, { jsx, ts });
 
-    test("source maps do not change the printed code", () => {
-      expect(printed.withMaps).toBe(printed.withoutMaps);
-    });
+    printed = {
+      withMaps,
+      withoutMaps,
+      mappings: decodeSourceMap(map!),
+      outLines: getEcmaScriptLineTable(withMaps).lines,
+      srcLines: getEcmaScriptLineTable(code).lines,
+    };
+  });
 
-    test("emits mappings", () => {
-      expect(printed.mappings.length).toBeGreaterThan(0);
-    });
+  test("source maps do not change the printed code", () => {
+    expect(printed.withMaps).toBe(printed.withoutMaps);
+  });
 
-    test("generated positions never go backwards", () => {
-      let prevLine = 0,
-        prevCol = 0;
-      let outOfOrder = null;
-      for (const mapping of printed.mappings) {
-        const { generatedLine: line, generatedColumn: col } = mapping;
-        if (line < prevLine || (line === prevLine && col < prevCol)) {
-          outOfOrder = `${line}:${col} follows ${prevLine}:${prevCol}`;
-          break;
-        }
-        prevLine = line;
-        prevCol = col;
+  test("emits mappings", () => {
+    expect(printed.mappings.length).toBeGreaterThan(0);
+  });
+
+  test("generated positions never go backwards", () => {
+    let prevLine = 0,
+      prevCol = 0;
+    let outOfOrder = null;
+    for (const mapping of printed.mappings) {
+      const { generatedLine: line, generatedColumn: col } = mapping;
+      if (line < prevLine || (line === prevLine && col < prevCol)) {
+        outOfOrder = `${line}:${col} follows ${prevLine}:${prevCol}`;
+        break;
       }
-      expect(outOfOrder).toBeNull();
-    });
+      prevLine = line;
+      prevCol = col;
+    }
+    expect(outOfOrder).toBeNull();
+  });
 
-    test("generated positions are within the printed output", () => {
-      let outOfRange = null;
-      for (const { generatedLine, generatedColumn } of printed.mappings) {
-        const line = printed.outLines[generatedLine - 1];
-        if (line === undefined || generatedColumn > line.length) {
-          outOfRange = `${generatedLine}:${generatedColumn}`;
-          break;
-        }
+  test("generated positions are within the printed output", () => {
+    let outOfRange = null;
+    for (const { generatedLine, generatedColumn } of printed.mappings) {
+      const line = printed.outLines[generatedLine - 1];
+      if (line === undefined || generatedColumn > line.length) {
+        outOfRange = `${generatedLine}:${generatedColumn}`;
+        break;
       }
-      expect(outOfRange).toBeNull();
-    });
+    }
+    expect(outOfRange).toBeNull();
+  });
 
-    test("original positions are within the source", () => {
-      let outOfRange = null;
-      for (const { originalLine, originalColumn } of printed.mappings) {
-        const line = printed.srcLines[originalLine - 1];
-        if (line === undefined || originalColumn > line.length) {
-          outOfRange = `${originalLine}:${originalColumn}`;
-          break;
-        }
+  test("original positions are within the source", () => {
+    let outOfRange = null;
+    for (const { originalLine, originalColumn } of printed.mappings) {
+      const line = printed.srcLines[originalLine - 1];
+      if (line === undefined || originalColumn > line.length) {
+        outOfRange = `${originalLine}:${originalColumn}`;
+        break;
       }
-      expect(outOfRange).toBeNull();
-    });
+    }
+    expect(outOfRange).toBeNull();
+  });
 
-    test("every mapping names the source file", () => {
-      const wrong = printed.mappings.find((mapping) => mapping.source !== fixture.name);
-      expect(wrong).toBeUndefined();
-    });
+  test("every mapping names the source file", () => {
+    const wrong = printed.mappings.find((mapping) => mapping.source !== fixture.name);
+    expect(wrong).toBeUndefined();
+  });
 
-    // Where a mapping lands on an identifier in the output, the source position it points at
-    // should hold the same identifier. A handful disagree legitimately - a printed name can come
-    // from a node whose span starts at a keyword - so this is a ratio rather than an absolute.
-    test("identifier text agrees at mapped positions", () => {
-      let checked = 0,
-        mismatched = 0;
-      for (const mapping of printed.mappings) {
-        const outLine = printed.outLines[mapping.generatedLine - 1];
-        const srcLine = printed.srcLines[mapping.originalLine - 1];
-        if (outLine === undefined || srcLine === undefined) continue;
-        const generatedIdent = IDENT_RE.exec(outLine.slice(mapping.generatedColumn));
-        const originalIdent = IDENT_RE.exec(srcLine.slice(mapping.originalColumn));
-        if (generatedIdent !== null && originalIdent !== null) {
-          checked++;
-          if (generatedIdent[0] !== originalIdent[0]) mismatched++;
-        }
+  // Where a mapping lands on an identifier in the output, the source position it points at
+  // should hold the same identifier. A handful disagree legitimately - a printed name can come
+  // from a node whose span starts at a keyword - so this is a ratio rather than an absolute.
+  test("identifier text agrees at mapped positions", () => {
+    let checked = 0,
+      mismatched = 0;
+    for (const mapping of printed.mappings) {
+      const outLine = printed.outLines[mapping.generatedLine - 1];
+      const srcLine = printed.srcLines[mapping.originalLine - 1];
+      if (outLine === undefined || srcLine === undefined) continue;
+      const generatedIdent = IDENT_RE.exec(outLine.slice(mapping.generatedColumn));
+      const originalIdent = IDENT_RE.exec(srcLine.slice(mapping.originalColumn));
+      if (generatedIdent !== null && originalIdent !== null) {
+        checked++;
+        if (generatedIdent[0] !== originalIdent[0]) mismatched++;
       }
-      // Guard against the ratio passing because nothing was compared
-      expect(checked).toBeGreaterThan(0);
-      expect(1 - mismatched / checked).toBeGreaterThan(0.97);
-    });
+    }
+    // Guard against the ratio passing because nothing was compared
+    expect(checked).toBeGreaterThan(0);
+    expect(1 - mismatched / checked).toBeGreaterThan(0.97);
   });
 }
+
+// A cached fixture which has not been downloaded is reported as skipped rather than passing quietly.
+// `pnpm run bench` downloads them.
+const CACHED_FIXTURES = FIXTURES.filter((fixture) => fixture.code !== null);
+const MISSING_FIXTURES = FIXTURES.filter((fixture) => fixture.code === null);
+
+describe.for(CACHED_FIXTURES)("$name", (fixture) => {
+  addFixtureTests(fixture);
+});
+describe.for(MISSING_FIXTURES)("$name", { skip: true }, (fixture) => {
+  addFixtureTests(fixture);
+});
 
 // --- Indentation ----------------------------------------------------------------------------
 

--- a/packages/codegen/test/test262.test.ts
+++ b/packages/codegen/test/test262.test.ts
@@ -14,11 +14,9 @@ const fixturePaths = (await readdir(TEST262_DIR_PATH, { recursive: true }))
   .sort();
 
 describe.concurrent("test262", () => {
-  for (const path of fixturePaths) {
-    // oxlint-disable-next-line vitest/valid-title, vitest/expect-expect
-    it(path, async (ctx) => {
-      const sourceText = await readFile(pathJoin(TEST262_DIR_PATH, path), "utf8");
-      if (!checkFixture(path, sourceText, "js", test262SourceType(sourceText))) ctx.skip();
-    });
-  }
+  // oxlint-disable-next-line vitest/expect-expect
+  it.for(fixturePaths)("%s", async (path, ctx) => {
+    const sourceText = await readFile(pathJoin(TEST262_DIR_PATH, path), "utf8");
+    if (!checkFixture(path, sourceText, "js", test262SourceType(sourceText))) ctx.skip();
+  });
 });

--- a/packages/codegen/test/typescript.test.ts
+++ b/packages/codegen/test/typescript.test.ts
@@ -45,35 +45,34 @@ const SKIPPED_PATHS = new Set([
 ]);
 
 describe.concurrent("TypeScript", () => {
-  for (const path of fixturePaths) {
-    const itFixture = SKIPPED_PATHS.has(path) ? it.skip : it;
+  // oxlint-disable-next-line vitest/expect-expect
+  it.for(fixturePaths)("%s", async (path, ctx) => {
+    if (SKIPPED_PATHS.has(path)) ctx.skip();
 
-    itFixture(path, async (ctx) => {
-      let sourceText = await readFile(pathJoin(TS_CASES_DIR_PATH, path), "utf8");
-      // Trim off UTF-8 BOM
-      if (sourceText.charCodeAt(0) === 0xfeff) sourceText = sourceText.slice(1);
+    let sourceText = await readFile(pathJoin(TS_CASES_DIR_PATH, path), "utf8");
+    // Trim off UTF-8 BOM
+    if (sourceText.charCodeAt(0) === 0xfeff) sourceText = sourceText.slice(1);
 
-      const { tests } = makeUnitsFromTest(path, sourceText);
+    const { tests } = makeUnitsFromTest(path, sourceText);
 
-      let checked = 0;
-      for (const { name, content, sourceType } of tests) {
-        const lang = langOf(sourceType.typescript, sourceType.jsx);
+    let checked = 0;
+    for (const { name, content, sourceType } of tests) {
+      const lang = langOf(sourceType.typescript, sourceType.jsx);
 
-        // Always a TS-shaped AST, even for the `.js` units. The TypeScript suite has fixtures
-        // which put TS syntax in a `.js` file on purpose, and Oxc's Rust parser keeps and prints it,
-        // so the JS side has to be able to see it too.
-        const checkedUnit = checkFixture(
-          name,
-          content,
-          lang,
-          sourceType.module ? "module" : "unambiguous",
-          "ts",
-        );
-        if (checkedUnit) checked++;
-      }
+      // Always a TS-shaped AST, even for the `.js` units. The TypeScript suite has fixtures
+      // which put TS syntax in a `.js` file on purpose, and Oxc's Rust parser keeps and prints it,
+      // so the JS side has to be able to see it too.
+      const checkedUnit = checkFixture(
+        name,
+        content,
+        lang,
+        sourceType.module ? "module" : "unambiguous",
+        "ts",
+      );
+      if (checkedUnit) checked++;
+    }
 
-      // Every unit failed to parse, so the fixture contributed nothing to check
-      if (checked === 0) ctx.skip();
-    });
-  }
+    // Every unit failed to parse, so the fixture contributed nothing to check
+    if (checked === 0) ctx.skip();
+  });
 });


### PR DESCRIPTION
## Summary
- replace manual test-registration loops with Vitest parameterized APIs
- preserve per-fixture skip behavior with `.for` and parameterized suite options
- retain imperative loops that exercise fixture contents rather than register tests
