### PR TITLE
docs(packages/codegen): reformat comments

### DIFF
--- a/packages/codegen/src-js/print/expression.ts
+++ b/packages/codegen/src-js/print/expression.ts
@@ -240,9 +240,9 @@ export function printExpression(
       throw new Error(`Unknown expression type: ${node.type}`);
   }
 
-  // Rust adds an exclusive-end mapping after a postfix operand which ended in `)` or `]`, so the
-  // punctuation of a following call/member/tag chain resolves to the operand rather than one
-  // character to its left.
+  // Rust adds an exclusive-end mapping after a postfix operand which ended in `)` or `]`,
+  // so the punctuation of a following call/member/tag chain resolves to the operand,
+  // rather than one character to its left
   if (SOURCEMAPS && precedence === PREC_POSTFIX && state.lastWasPostfixClose) {
     markWithMapAfter(state, node);
   }

--- a/packages/codegen/src-js/state.ts
+++ b/packages/codegen/src-js/state.ts
@@ -142,7 +142,7 @@ export class State {
     }
 
     // `writeWithMap` records the output offset and original position of every mapped node,
-    // and `generateSourceMap` encodes them in one pass at the end.
+    // and `generateSourceMap` encodes them in one pass at the end
     if (options.sourcemap !== true) {
       this.mapPositions = null;
       this.mapNames = null;


### PR DESCRIPTION
Continuation of #25848. Pure style change. Reformat a couple of comments I missed previously.