### PR TITLE
test(codegen): add source-level coverage

### DIFF
--- a/packages/codegen/test/fixtures.test.ts
+++ b/packages/codegen/test/fixtures.test.ts
@@ -1,0 +1,47 @@
+// Local fixture conformance.
+//
+// Put a JavaScript or TypeScript reproduction anywhere under `test/fixtures/`.
+// This suite infers its language from the extension and checks the normal and source-map printer
+// builds against Rust `oxc_codegen`, in both `preserveParens` modes.
+
+import { readdir, readFile } from "node:fs/promises";
+import { join as pathJoin, relative as pathRelative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { checkFixture } from "./utils/common.ts";
+
+import type { Lang } from "./utils/common.ts";
+
+const FIXTURES_DIR_PATH = pathJoin(import.meta.dirname, "fixtures");
+
+const LANG_BY_EXTENSION: Record<string, Lang | undefined> = {
+  ".cjs": "js",
+  ".cts": "ts",
+  ".js": "js",
+  ".jsx": "jsx",
+  ".mjs": "js",
+  ".mts": "ts",
+  ".ts": "ts",
+  ".tsx": "tsx",
+};
+
+const fixturePaths = (await readdir(FIXTURES_DIR_PATH, { recursive: true, withFileTypes: true }))
+  .filter((entry) => entry.isFile() && entry.name !== "README.md")
+  .map((entry) => pathJoin(pathRelative(FIXTURES_DIR_PATH, entry.parentPath), entry.name))
+  .sort();
+
+describe.concurrent("local fixtures", () => {
+  it.each(fixturePaths)("%s", async (path) => {
+    const sourceText = await readFile(pathJoin(FIXTURES_DIR_PATH, path), "utf8");
+    const lang = langOfPath(path);
+    if (lang === undefined) throw new Error(`Unsupported fixture extension: ${path}`);
+
+    // Local fixtures are ordinary source files rather than test cases with frontmatter. Let the
+    // parser recognize imports and exports while still accepting scripts.
+    expect(checkFixture(path, sourceText, lang, "unambiguous")).toBe(true);
+  });
+});
+
+function langOfPath(path: string): Lang | undefined {
+  return LANG_BY_EXTENSION[path.slice(path.lastIndexOf("."))];
+}

--- a/packages/codegen/test/fixtures/README.md
+++ b/packages/codegen/test/fixtures/README.md
@@ -1,0 +1,8 @@
+# Local codegen fixtures
+
+Put a `.js`, `.cjs`, `.mjs`, `.jsx`, `.ts`, `.cts`, `.mts`, or `.tsx` reproduction in this directory
+(subdirectories are supported). `fixtures.test.ts` parses each file in unambiguous mode and checks both
+the normal and source-map printers against Rust `oxc_codegen`.
+
+Use a hand-built AST test for input shapes a parser cannot produce, such as historical TS-ESLint AST
+layouts. See `test/print.test.ts` for that style of test.

--- a/packages/codegen/test/fixtures/coverage.js
+++ b/packages/codegen/test/fixtures/coverage.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+"use strict";
+"directive with 'quote";
+("ordinary string statement");
+
+debugger;
+
+const value = 1e21;
+const tiny = 0.000000001;
+const regex = /script/gi;
+const bigint = 123n;
+const template = `value: ${value}`;
+const object = {
+  value,
+  __proto__,
+  __proto__: value,
+  get answer() { return 42; },
+  set answer(next) { value = next; },
+  async *[key](item) { yield item; },
+  ...source,
+};
+const [first, , ...rest] = list;
+const { value: renamed = 0, ...remaining } = object;
+[first, ...rest] = list;
+({ value: renamed = 0, ...remaining } = object);
+
+label: for (let index = 0; index < 3; index++) {
+  if (index === 1) continue label;
+  if (index === 2) break label;
+}
+for (const item of list) item;
+for (let async of list) async;
+for (const key in object) object[key];
+while (false) break;
+do { value; } while (false);
+
+if (value) {
+  value;
+} else if (tiny) {
+  tiny;
+} else value;
+
+switch (value) {
+  case 1:
+    break;
+  default:
+    value;
+}
+
+try {
+  throw regex;
+} catch (error) {
+  error;
+} finally {
+  value;
+}
+with (object) value;
+
+class Example extends Base {
+  static {}
+  #private = 1;
+  static #staticPrivate;
+  get answer() { return this.#private; }
+  set answer(next) { this.#private = next; }
+  static get shared() { return this.#staticPrivate; }
+  [key](item) { return (#private in item) && true; }
+}
+
+const member = (let)[0];
+const chained = new Factory()(arg)?.field;
+const dynamic = import("module", { with: { type: "json" } });
+function rest(...args) { return args; }
+if (value)
+  if (tiny) value;
+for ((let) of list) {}
+for ((let)[0] of list) {}
+import Default, * as Namespace from "module";
+import { value as importedValue, "named" as importedNamed } from "module";
+import data from "data" with { type: "json" };
+export {};
+export const exported = value;
+export function exportedFunction() {}
+export class Exported {}
+export default class DefaultExport {}
+export { member, chained, dynamic };
+export * from "other";
+
+const \u{61} = 1;
+
+class PrivateFields {
+  #field = \u{61};
+
+  read() {
+    return this.#field;
+  }
+}
+
+const integerWithoutTrailingZero = 1234;
+const fractionWithoutLeadingZeros = 0.5;
+const fractionWithTooFewLeadingZerosForExponent = 0.001;
+const exponentWithoutFraction = 1e21;
+const exponentFoldedWhenItStaysShort = 1.5e21;
+const exponentLeftUnfoldedWhenItWouldGrow = 1.5e-9;

--- a/packages/codegen/test/fixtures/coverage.jsx
+++ b/packages/codegen/test/fixtures/coverage.jsx
@@ -1,0 +1,22 @@
+const value = 1;
+const props = { value };
+const tree = (
+  <Ns.Component
+    title="plain"
+    quote={'contains " a quote'}
+    enabled
+    {...props}
+  >
+    text {value}
+    <span>{/* comment */}child</span>
+    <>
+      <Leaf />
+      {value + 1}
+    </>
+    {...items}
+  </Ns.Component>
+);
+const namespaced = <svg:path xml:lang="en" />;
+const attributeChildren = <Comp child={<span />} fragment={<><Leaf /></>} />;
+const unicodeText = <span>😀</span>;
+const customElement = <x-card data-id="card" />;

--- a/packages/codegen/test/fixtures/coverage.ts
+++ b/packages/codegen/test/fixtures/coverage.ts
@@ -1,0 +1,83 @@
+declare const value: boolean;
+declare const tiny: boolean;
+
+if (value)
+  if (tiny) debugger;
+  else debugger;
+else if (tiny) debugger;
+else debugger;
+
+do {} while (false);
+do; while (false);
+do debugger; while (false);
+
+switch (value) {}
+switch (value) {
+  case true:
+    debugger;
+    break;
+  default:
+    debugger;
+}
+
+try {
+  debugger;
+} catch {
+  debugger;
+} finally {
+  debugger;
+}
+
+enum TemplateKeys {
+  [`key`] = 1,
+}
+
+type PrefixNullable = ?number;
+type PrefixNonNullable = !string;
+type TupleForms = [required: string, optional?: number, ...rest: boolean[]];
+
+type Source = { a: string };
+type MappedPlus = { +readonly [K in keyof Source]+?: Source[K] };
+type MappedMinus = { -readonly [K in keyof Source]-?: Source[K] };
+type Imported = import("mod").Foo<Bar>;
+type ImportedOptions = import("mod", { with: { type: "json" } }).Foo;
+type Queried = typeof import("mod").Foo;
+type IntrinsicArray = (intrinsic)[];
+type IntrinsicIndex = (intrinsic)["x"];
+type IntrinsicUnion = (intrinsic | string);
+type IntrinsicConditional<T> = (intrinsic extends T ? string : number);
+
+declare module "foo";
+declare module "bar" {}
+export {};
+declare global {}
+namespace N {
+  interface I {}
+}
+
+type Keyed = {
+  key: string;
+  "quoted": number;
+  [computed]: boolean;
+  get value(): string;
+  set value(value: string);
+  (arg: number): string;
+  new (arg: string): Date;
+  readonly [index: string]: number;
+};
+
+interface Empty {}
+interface Full<in T, out U> extends A<T>, B {
+  readonly foo?: string;
+  [key: string]: number;
+  get value(): string;
+  set value(value: string);
+  <X>(value: X): X;
+  new (value: string): Date;
+}
+
+const enum EmptyEnum {}
+declare enum DeclaredEnum {
+  A = 1,
+  "B" = 2,
+}

--- a/packages/codegen/test/fixtures/coverage.tsx
+++ b/packages/codegen/test/fixtures/coverage.tsx
@@ -1,0 +1,49 @@
+import type { ComponentType as Widget } from "widgets";
+
+type Qualified = Namespace.Inner;
+type Parenthesized = (string | number);
+type Tuple = [first: string, second?: number, ...rest: boolean[]];
+type Imported = import("widgets").Thing;
+type ImportedWithOptions = import("widgets", { with: { "resolution-mode": "import" } }).Thing;
+type Mapped = {
+  +readonly [Key in keyof Imported as `${Key}`]?: Imported[Key];
+};
+
+declare module "widgets" {
+  interface Thing {
+    readonly [key: string]: unknown;
+  }
+}
+
+interface Props<T extends object = object> extends Base<T> {
+  readonly [key: string]: unknown;
+  render?<U>(value: U): T;
+}
+
+class Registry {
+  [key: string]: unknown;
+}
+
+const value = 1;
+const props = { value };
+const children = [<span key="one" />, <span key="two" />];
+
+const view = (
+  <>
+    text
+    {value}
+    <Widget data={<span />} ns:label="namespaced" {...props}>
+      <Namespace.Inner>{...children}</Namespace.Inner>
+      <svg:path />
+    </Widget>
+  </>
+);
+
+const instantiated = identity<string>("value");
+const template = `prefix ${value} suffix`;
+const tagged = tag<number>`item ${value}`;
+const loaded = import(`./${value}`);
+const escaped = "line\n\r\t\\\"\u2028\u2029\u00a0";
+const numeric = [-0, Infinity, -Infinity, 1n];
+
+export { view, instantiated, template, tagged, loaded, escaped, numeric };


### PR DESCRIPTION
## Summary

- add a recursive local fixture runner with consolidated JS, JSX, TS, and TSX coverage cases to address missing test coverage
