### PR TITLE
perf(packages/codegen): remove redundant mapping from `printParams`

### DIFF
--- a/packages/codegen/src-js/print/function.ts
+++ b/packages/codegen/src-js/print/function.ts
@@ -110,8 +110,11 @@ function printParams(params: ESTree.ParamPattern[], state: State): void {
     }
 
     const { decorators } = param;
-    markWithMapNoName(state, decorators != null && decorators.length > 0 ? decorators[0] : param);
-    if (decorators != null && decorators.length > 0) printDecorators(decorators, state);
+    if (decorators != null && decorators.length > 0) {
+      printDecorators(decorators, state);
+    } else {
+      markWithMapNoName(state, param);
+    }
 
     if (TS && param.type === "TSParameterProperty") {
       if (param.accessibility != null) {


### PR DESCRIPTION
Follow-on after #25585. Small optimization.

It's redundant to call `markWithMapNoName` with `decorators[0]` as `printDecorators` marks the same mapping immediately after.