### PR TITLE
perf(packages/codegen): combine 2 writes in `printJSXElement`

### DIFF
--- a/packages/codegen/src-js/print/jsx.ts
+++ b/packages/codegen/src-js/print/jsx.ts
@@ -38,8 +38,7 @@ export function printJSXElement(node: ESTree.JSXElement, state: State): void {
     writeNoLast(state, " ");
     const attribute = attributes[i];
     if (attribute.type === "JSXSpreadAttribute") {
-      writeWithMapNoLast(state, "{", attribute);
-      write(state, "...", CAT_OTHER);
+      writeWithMap(state, "{...", CAT_OTHER, attribute);
       printExpression(attribute.argument, state, PREC_COMMA, CTX_NONE);
       writeWithMapEnd(state, "}", CAT_OTHER, attribute);
     } else {


### PR DESCRIPTION
Follow-on after #25585. Small optimization.

These 2 write calls can be combined into 1 without any behavior difference.