### PR TITLE
perf(packages/codegen): remove redundant setting of `last` in `printImportAttributes` and `printIf`

### DIFF
--- a/packages/codegen/src-js/print/module.ts
+++ b/packages/codegen/src-js/print/module.ts
@@ -142,7 +142,7 @@ function printImportAttributes(
 
   // ESTree omits the `WithClause` wrapper. The Rust reference normalizes its mapping anchor
   // to the first attribute, which is the first location both representations carry.
-  write(state, " ", CAT_OTHER);
+  writeNoLast(state, " ");
   markWithMapAtStartOffset(state, attributes[0], 0);
   write(state, "with { ", CAT_OTHER);
 

--- a/packages/codegen/src-js/print/statement.ts
+++ b/packages/codegen/src-js/print/statement.ts
@@ -424,7 +424,7 @@ function printIf(node: ESTree.IfStatement, state: State): void {
     printBlockStatement(consequent, state);
     write(state, alternate != null ? " " : "\n", CAT_OTHER);
   } else if (wrapToAvoidAmbiguousElse(consequent)) {
-    write(state, ") ", CAT_OTHER);
+    writeNoLast(state, ") ");
     writeWithMap(state, "{\n", CAT_OTHER, consequent);
     state.indentLevel++;
     printStatement(consequent, state);


### PR DESCRIPTION
Follow-on after #25585. Small optimization.

No point setting `last` here, since in both cases its immediately overwritten before anything else can read it.