### PR TITLE
perf(packages/codegen): remove redundant branch

### DIFF
--- a/packages/codegen/src-js/print/source_map.ts
+++ b/packages/codegen/src-js/print/source_map.ts
@@ -264,14 +264,13 @@ export function generateSourceMap(state: State, options: Options): SourceMap {
     previousOriginalColumn = originalColumn;
   }
 
-  const map: SourceMap = {
+  return {
     version: 3,
     mappings: mappingBuffer.toString("ascii", 0, mappingLength),
     names,
     sources: [options.sourceFilename ?? ""],
+    sourcesContent: [sourceText],
   };
-  if (sourceText !== undefined) map.sourcesContent = [sourceText];
-  return map;
 }
 
 /**


### PR DESCRIPTION
Follow-on after #25585. Small optimization.

The function exits early if `sourceText === undefined`, so no need to check this again later.