### PR TITLE
perf(packages/codegen): check `sourceText` only once

### DIFF
--- a/packages/codegen/src-js/print/source_map.ts
+++ b/packages/codegen/src-js/print/source_map.ts
@@ -43,22 +43,19 @@ export function generateSourceMap(state: State, options: Options): SourceMap {
     "Source map positions should exist when sourcemap generation is enabled",
   );
 
-  const { output, mapPositions, mapNames } = state;
+  const { output, mapPositions, mapNames, sourceText } = state;
   const mappingCount = mapPositions.length >> 1;
-  const { sourceText } = options;
-  debugAssert(
-    sourceText !== undefined || mappingCount === 0,
-    "Mappings should only be recorded when sourceText is available",
-  );
-  if (sourceText === undefined || mappingCount === 0) {
-    const map: SourceMap = {
+
+  debugAssert(sourceText !== null, "`sourceText` should be defined when producing a source map");
+
+  if (mappingCount === 0) {
+    return {
       version: 3,
       mappings: "",
       names: [],
       sources: [options.sourceFilename ?? ""],
+      sourcesContent: [sourceText],
     };
-    if (sourceText !== undefined) map.sourcesContent = [sourceText];
-    return map;
   }
 
   let mappingBuffer: Buffer = Buffer.allocUnsafe(

--- a/packages/codegen/src-js/print/write.ts
+++ b/packages/codegen/src-js/print/write.ts
@@ -375,9 +375,6 @@ export function markWithMapAtStartOffset(
 ): void {
   if (!SOURCEMAPS) return;
 
-  const { sourceText } = state;
-  if (sourceText === undefined) return;
-
   const { start, end } = node;
   if (
     typeof start !== "number" ||
@@ -392,12 +389,12 @@ export function markWithMapAtStartOffset(
   }
 
   debugAssert(
-    state.mapPositions !== null,
-    "Source map positions should exist when source maps are enabled",
+    state.mapPositions !== null && state.sourceText !== null,
+    "`mapPositions` and `sourceText` should be defined when source maps are enabled",
   );
 
   const sourceOffset = start + columnOffset;
-  if (!(sourceOffset >= 0 && sourceOffset <= sourceText.length)) return;
+  if (!(sourceOffset >= 0 && sourceOffset <= state.sourceText.length)) return;
   if (state.mapPositions[state.mapPositions.length - 1] === sourceOffset) return;
 
   state.mapPositions.push(state.output.length, sourceOffset);
@@ -409,9 +406,6 @@ export function markWithMapAtStartOffset(
 function recordSourceMapping(state: State, node: MappableNode, location: Location): void {
   if (!SOURCEMAPS) return;
 
-  const { sourceText } = state;
-  if (sourceText === undefined) return;
-
   const { start, end } = node;
   if (
     typeof start !== "number" ||
@@ -426,8 +420,8 @@ function recordSourceMapping(state: State, node: MappableNode, location: Locatio
   }
 
   debugAssert(
-    state.mapPositions !== null,
-    "Source map positions should exist when source maps are enabled",
+    state.mapPositions !== null && state.sourceText !== null,
+    "`mapPositions` and `sourceText` should be defined when source maps are enabled",
   );
 
   let sourceOffset: number;
@@ -440,6 +434,7 @@ function recordSourceMapping(state: State, node: MappableNode, location: Locatio
     sourceOffset = start;
   }
 
+  const { sourceText } = state;
   if (!(sourceOffset >= 0 && sourceOffset <= sourceText.length)) return;
 
   // `oxc_codegen` suppresses consecutive source positions as it records them. Do this before

--- a/packages/codegen/src-js/state.ts
+++ b/packages/codegen/src-js/state.ts
@@ -9,6 +9,7 @@
 // Nothing in `print/` constructs one, and none of the 4 printer builds bundles this file.
 
 import { CAT_OTHER } from "./print/write.ts";
+import { debugAssert } from "./asserts.ts";
 
 import type { Category } from "./print/write.ts";
 import type { Options } from "./print/options.ts";
@@ -86,7 +87,7 @@ export class State {
   declare mapNames: (number | string)[] | null;
 
   // Original source text, used to preserve names in source maps when the caller provides it.
-  declare sourceText: string | undefined;
+  declare sourceText: string | null;
 
   constructor(options: Options) {
     this.output = "";
@@ -133,7 +134,6 @@ export class State {
     // which is why the category is tracked rather than derived.
     this.last = CAT_OTHER;
     this.lastWasPostfixClose = false;
-    this.sourceText = options.sourceText;
 
     // Debug-only fields for checking `last` is correct on both writes and reads
     if (DEBUG) {
@@ -144,9 +144,12 @@ export class State {
     // `writeWithMap` records the output offset and original position of every mapped node,
     // and `generateSourceMap` encodes them in one pass at the end
     if (options.sourcemap !== true) {
+      this.sourceText = null;
       this.mapPositions = null;
       this.mapNames = null;
     } else {
+      debugAssert(options.sourceText != null);
+      this.sourceText = options.sourceText;
       this.mapPositions = [];
       this.mapNames = null;
     }


### PR DESCRIPTION
Follow-on after #25585. Small optimization.

Sourcemaps can't be generated unless `options.sourceText` is provided. This is already checked at the start. So everywhere else can then rely on `state.sourceText != null`, rather than re-checking it on each write.