### PR TITLE
fix(codegen): remove deprecated test APIs

### DIFF
--- a/oxlintrc.json
+++ b/oxlintrc.json
@@ -34,6 +34,12 @@
   },
   "overrides": [
     {
+      "files": ["packages/codegen/**"],
+      "rules": {
+        "typescript/no-deprecated": "error"
+      }
+    },
+    {
       "files": ["tasks/e2e/test/*.test.ts"],
       "rules": {
         "vitest/valid-describe-callback": ["off"],

--- a/packages/codegen/test/print.test.ts
+++ b/packages/codegen/test/print.test.ts
@@ -111,13 +111,13 @@ describe("indent", () => {
   const ast = e(id("x"));
 
   test.each(["", "x", "\n", "\r\n", " x "])("rejects %j", (indent) => {
-    expect(() => printSync(ast, { indent })).toThrowError(
+    expect(() => printSync(ast, { indent })).toThrow(
       new TypeError("`indent` must be a non-empty string containing only spaces and tabs"),
     );
   });
 
   test.each([4, null, {}])("rejects non-string value %j", (indent) => {
-    expect(() => printSync(ast, { indent: indent as unknown as string })).toThrowError(
+    expect(() => printSync(ast, { indent: indent as unknown as string })).toThrow(
       new TypeError("`indent` must be a non-empty string containing only spaces and tabs"),
     );
   });

--- a/packages/codegen/test/source-maps.test.ts
+++ b/packages/codegen/test/source-maps.test.ts
@@ -212,7 +212,7 @@ describe("source map options", () => {
   ])("rejects %s sourceText", (_name, sourceText) => {
     expect(() =>
       printSync(program, { sourcemap: true, sourceText: sourceText as unknown as string }),
-    ).toThrowError(new TypeError("`sourceText` must be a string when `sourcemap` is true"));
+    ).toThrow(new TypeError("`sourceText` must be a string when `sourcemap` is true"));
   });
 
   test.each([
@@ -225,7 +225,7 @@ describe("source map options", () => {
         sourceText: code,
         sourceFilename: sourceFilename as unknown as string,
       }),
-    ).toThrowError(new TypeError("`sourceFilename` must be a string when supplied"));
+    ).toThrow(new TypeError("`sourceFilename` must be a string when supplied"));
   });
 
   test("accepts valid source map options", () => {


### PR DESCRIPTION
## Summary
- replace deprecated Vitest `toThrowError` assertions with `toThrow`
- enable `typescript/no-deprecated` for `packages/codegen`