### PR TITLE
feat(linter/vue): Implement `vue/match-component-import-name`

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1762,6 +1762,7 @@ export interface DummyRuleMap {
   "vue/define-emits-declaration"?: RuleNoConfig | [AllowWarnDeny, DeclarationStyle];
   "vue/define-props-declaration"?: RuleNoConfig | [AllowWarnDeny, DeclarationStyle2];
   "vue/define-props-destructuring"?: RuleNoConfig | [AllowWarnDeny, DefinePropsDestructuring];
+  "vue/match-component-import-name"?: RuleNoConfig;
   "vue/max-props"?: RuleNoConfig | [AllowWarnDeny, MaxProps];
   "vue/next-tick-style"?: RuleNoConfig | [AllowWarnDeny, NextTickOption];
   "vue/no-arrow-functions-in-watch"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5265,6 +5265,12 @@ impl RuleRunner for crate::rules::vue::define_props_destructuring::DefinePropsDe
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::vue::match_component_import_name::MatchComponentImportName {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ObjectExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::max_props::MaxProps {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::CallExpression,

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -838,6 +838,7 @@ pub use crate::rules::vue::component_definition_name_casing::ComponentDefinition
 pub use crate::rules::vue::define_emits_declaration::DefineEmitsDeclaration as VueDefineEmitsDeclaration;
 pub use crate::rules::vue::define_props_declaration::DefinePropsDeclaration as VueDefinePropsDeclaration;
 pub use crate::rules::vue::define_props_destructuring::DefinePropsDestructuring as VueDefinePropsDestructuring;
+pub use crate::rules::vue::match_component_import_name::MatchComponentImportName as VueMatchComponentImportName;
 pub use crate::rules::vue::max_props::MaxProps as VueMaxProps;
 pub use crate::rules::vue::next_tick_style::NextTickStyle as VueNextTickStyle;
 pub use crate::rules::vue::no_arrow_functions_in_watch::NoArrowFunctionsInWatch as VueNoArrowFunctionsInWatch;
@@ -1726,6 +1727,7 @@ pub enum RuleEnum {
     VueDefineEmitsDeclaration(VueDefineEmitsDeclaration),
     VueDefinePropsDeclaration(VueDefinePropsDeclaration),
     VueDefinePropsDestructuring(VueDefinePropsDestructuring),
+    VueMatchComponentImportName(VueMatchComponentImportName),
     VueMaxProps(VueMaxProps),
     VueNextTickStyle(VueNextTickStyle),
     VueNoArrowFunctionsInWatch(VueNoArrowFunctionsInWatch),
@@ -2699,7 +2701,8 @@ const VUE_COMPONENT_DEFINITION_NAME_CASING_ID: usize = NODE_NO_TOP_LEVEL_AWAIT_I
 const VUE_DEFINE_EMITS_DECLARATION_ID: usize = VUE_COMPONENT_DEFINITION_NAME_CASING_ID + 1usize;
 const VUE_DEFINE_PROPS_DECLARATION_ID: usize = VUE_DEFINE_EMITS_DECLARATION_ID + 1usize;
 const VUE_DEFINE_PROPS_DESTRUCTURING_ID: usize = VUE_DEFINE_PROPS_DECLARATION_ID + 1usize;
-const VUE_MAX_PROPS_ID: usize = VUE_DEFINE_PROPS_DESTRUCTURING_ID + 1usize;
+const VUE_MATCH_COMPONENT_IMPORT_NAME_ID: usize = VUE_DEFINE_PROPS_DESTRUCTURING_ID + 1usize;
+const VUE_MAX_PROPS_ID: usize = VUE_MATCH_COMPONENT_IMPORT_NAME_ID + 1usize;
 const VUE_NEXT_TICK_STYLE_ID: usize = VUE_MAX_PROPS_ID + 1usize;
 const VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID: usize = VUE_NEXT_TICK_STYLE_ID + 1usize;
 const VUE_NO_ASYNC_IN_COMPUTED_PROPERTIES_ID: usize = VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID + 1usize;
@@ -2748,7 +2751,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 870usize] = [
+static RULE_NAMES: [&str; 871usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3577,6 +3580,7 @@ static RULE_NAMES: [&str; 870usize] = [
     VueDefineEmitsDeclaration::NAME,
     VueDefinePropsDeclaration::NAME,
     VueDefinePropsDestructuring::NAME,
+    VueMatchComponentImportName::NAME,
     VueMaxProps::NAME,
     VueNextTickStyle::NAME,
     VueNoArrowFunctionsInWatch::NAME,
@@ -4577,6 +4581,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(_) => VUE_DEFINE_EMITS_DECLARATION_ID,
             Self::VueDefinePropsDeclaration(_) => VUE_DEFINE_PROPS_DECLARATION_ID,
             Self::VueDefinePropsDestructuring(_) => VUE_DEFINE_PROPS_DESTRUCTURING_ID,
+            Self::VueMatchComponentImportName(_) => VUE_MATCH_COMPONENT_IMPORT_NAME_ID,
             Self::VueMaxProps(_) => VUE_MAX_PROPS_ID,
             Self::VueNextTickStyle(_) => VUE_NEXT_TICK_STYLE_ID,
             Self::VueNoArrowFunctionsInWatch(_) => VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID,
@@ -5626,6 +5631,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::CATEGORY,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::CATEGORY,
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::CATEGORY,
+            Self::VueMatchComponentImportName(_) => VueMatchComponentImportName::CATEGORY,
             Self::VueMaxProps(_) => VueMaxProps::CATEGORY,
             Self::VueNextTickStyle(_) => VueNextTickStyle::CATEGORY,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::CATEGORY,
@@ -6617,6 +6623,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::FIX,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::FIX,
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::FIX,
+            Self::VueMatchComponentImportName(_) => VueMatchComponentImportName::FIX,
             Self::VueMaxProps(_) => VueMaxProps::FIX,
             Self::VueNextTickStyle(_) => VueNextTickStyle::FIX,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::FIX,
@@ -7866,6 +7873,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::documentation(),
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::documentation(),
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::documentation(),
+            Self::VueMatchComponentImportName(_) => VueMatchComponentImportName::documentation(),
             Self::VueMaxProps(_) => VueMaxProps::documentation(),
             Self::VueNextTickStyle(_) => VueNextTickStyle::documentation(),
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::documentation(),
@@ -10305,6 +10313,10 @@ impl RuleEnum {
                 VueDefinePropsDestructuring::config_schema(generator)
                     .or_else(|| VueDefinePropsDestructuring::schema(generator))
             }
+            Self::VueMatchComponentImportName(_) => {
+                VueMatchComponentImportName::config_schema(generator)
+                    .or_else(|| VueMatchComponentImportName::schema(generator))
+            }
             Self::VueMaxProps(_) => {
                 VueMaxProps::config_schema(generator).or_else(|| VueMaxProps::schema(generator))
             }
@@ -11257,6 +11269,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(_) => "vue",
             Self::VueDefinePropsDeclaration(_) => "vue",
             Self::VueDefinePropsDestructuring(_) => "vue",
+            Self::VueMatchComponentImportName(_) => "vue",
             Self::VueMaxProps(_) => "vue",
             Self::VueNextTickStyle(_) => "vue",
             Self::VueNoArrowFunctionsInWatch(_) => "vue",
@@ -13262,6 +13275,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(rule) => rule.run(node, ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.run(node, ctx),
             Self::VueDefinePropsDestructuring(rule) => rule.run(node, ctx),
+            Self::VueMatchComponentImportName(rule) => rule.run(node, ctx),
             Self::VueMaxProps(rule) => rule.run(node, ctx),
             Self::VueNextTickStyle(rule) => rule.run(node, ctx),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.run(node, ctx),
@@ -14149,6 +14163,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(rule) => rule.run_once(ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.run_once(ctx),
             Self::VueDefinePropsDestructuring(rule) => rule.run_once(ctx),
+            Self::VueMatchComponentImportName(rule) => rule.run_once(ctx),
             Self::VueMaxProps(rule) => rule.run_once(ctx),
             Self::VueNextTickStyle(rule) => rule.run_once(ctx),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.run_once(ctx),
@@ -15149,6 +15164,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueDefinePropsDestructuring(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VueMatchComponentImportName(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueMaxProps(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNextTickStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -16041,6 +16057,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(rule) => rule.should_run(ctx),
             Self::VueDefinePropsDeclaration(rule) => rule.should_run(ctx),
             Self::VueDefinePropsDestructuring(rule) => rule.should_run(ctx),
+            Self::VueMatchComponentImportName(rule) => rule.should_run(ctx),
             Self::VueMaxProps(rule) => rule.should_run(ctx),
             Self::VueNextTickStyle(rule) => rule.should_run(ctx),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.should_run(ctx),
@@ -17285,6 +17302,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::IS_TSGOLINT_RULE,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::IS_TSGOLINT_RULE,
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::IS_TSGOLINT_RULE,
+            Self::VueMatchComponentImportName(_) => VueMatchComponentImportName::IS_TSGOLINT_RULE,
             Self::VueMaxProps(_) => VueMaxProps::IS_TSGOLINT_RULE,
             Self::VueNextTickStyle(_) => VueNextTickStyle::IS_TSGOLINT_RULE,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::IS_TSGOLINT_RULE,
@@ -18347,6 +18365,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::VERSION,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::VERSION,
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::VERSION,
+            Self::VueMatchComponentImportName(_) => VueMatchComponentImportName::VERSION,
             Self::VueMaxProps(_) => VueMaxProps::VERSION,
             Self::VueNextTickStyle(_) => VueNextTickStyle::VERSION,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::VERSION,
@@ -19434,6 +19453,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::HAS_CONFIG,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::HAS_CONFIG,
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::HAS_CONFIG,
+            Self::VueMatchComponentImportName(_) => VueMatchComponentImportName::HAS_CONFIG,
             Self::VueMaxProps(_) => VueMaxProps::HAS_CONFIG,
             Self::VueNextTickStyle(_) => VueNextTickStyle::HAS_CONFIG,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::HAS_CONFIG,
@@ -20428,6 +20448,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(_) => VueDefineEmitsDeclaration::INFO,
             Self::VueDefinePropsDeclaration(_) => VueDefinePropsDeclaration::INFO,
             Self::VueDefinePropsDestructuring(_) => VueDefinePropsDestructuring::INFO,
+            Self::VueMatchComponentImportName(_) => VueMatchComponentImportName::INFO,
             Self::VueMaxProps(_) => VueMaxProps::INFO,
             Self::VueNextTickStyle(_) => VueNextTickStyle::INFO,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::INFO,
@@ -21311,6 +21332,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(rule) => rule.types_info(),
             Self::VueDefinePropsDeclaration(rule) => rule.types_info(),
             Self::VueDefinePropsDestructuring(rule) => rule.types_info(),
+            Self::VueMatchComponentImportName(rule) => rule.types_info(),
             Self::VueMaxProps(rule) => rule.types_info(),
             Self::VueNextTickStyle(rule) => rule.types_info(),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.types_info(),
@@ -22185,6 +22207,7 @@ impl RuleEnum {
             Self::VueDefineEmitsDeclaration(rule) => rule.run_info(),
             Self::VueDefinePropsDeclaration(rule) => rule.run_info(),
             Self::VueDefinePropsDestructuring(rule) => rule.run_info(),
+            Self::VueMatchComponentImportName(rule) => rule.run_info(),
             Self::VueMaxProps(rule) => rule.run_info(),
             Self::VueNextTickStyle(rule) => rule.run_info(),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.run_info(),
@@ -23191,6 +23214,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueDefineEmitsDeclaration(VueDefineEmitsDeclaration::default()),
         RuleEnum::VueDefinePropsDeclaration(VueDefinePropsDeclaration::default()),
         RuleEnum::VueDefinePropsDestructuring(VueDefinePropsDestructuring::default()),
+        RuleEnum::VueMatchComponentImportName(VueMatchComponentImportName::default()),
         RuleEnum::VueMaxProps(VueMaxProps::default()),
         RuleEnum::VueNextTickStyle(VueNextTickStyle::default()),
         RuleEnum::VueNoArrowFunctionsInWatch(VueNoArrowFunctionsInWatch::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -918,6 +918,7 @@ pub(crate) mod vue {
     pub mod define_emits_declaration;
     pub mod define_props_declaration;
     pub mod define_props_destructuring;
+    pub mod match_component_import_name;
     pub mod max_props;
     pub mod next_tick_style;
     pub mod no_arrow_functions_in_watch;

--- a/crates/oxc_linter/src/rules/vue/match_component_import_name.rs
+++ b/crates/oxc_linter/src/rules/vue/match_component_import_name.rs
@@ -1,0 +1,216 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, ObjectPropertyKind},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{find_property, is_vue_component_options_object_excluding_instance, vue_casing},
+};
+
+fn match_component_import_name_diagnostic(
+    span: Span,
+    alias: &str,
+    expected: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Component alias {alias} should be one of: {expected}."))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct MatchComponentImportName;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Requires the key a component is registered under in the `components`
+    /// option to match the name of the imported binding, either in
+    /// `PascalCase` or in `kebab-case`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Registering a component under an unrelated alias hides which import a
+    /// tag in the template actually resolves to, so a reader has to jump
+    /// between the template, the `components` option and the import list to
+    /// follow it. Keeping the two names in sync also means renaming the
+    /// import is enough to find every usage.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// import SomeRandomName from './SomeRandomName.vue';
+    ///
+    /// export default {
+    ///   components: { InvalidName: SomeRandomName }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// import ValidImport from './ValidImport.vue';
+    ///
+    /// export default {
+    ///   components: { ValidImport, 'valid-import': ValidImport }
+    /// }
+    /// </script>
+    /// ```
+    MatchComponentImportName,
+    vue,
+    style,
+    version = "1.79.0",
+    short_description = "Require the registered component name to match the imported component name.",
+);
+
+impl Rule for MatchComponentImportName {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ObjectExpression(obj) = node.kind() else {
+            return;
+        };
+        if !is_vue_component_options_object_excluding_instance(node, ctx) {
+            return;
+        }
+        let Some(components) = find_property(obj, "components") else {
+            return;
+        };
+        let Expression::ObjectExpression(components) = &components.value else {
+            return;
+        };
+
+        for prop in &components.properties {
+            let ObjectPropertyKind::ObjectProperty(prop) = prop else {
+                continue;
+            };
+            if prop.computed {
+                continue;
+            }
+            let Expression::Identifier(imported) = &prop.value else {
+                continue;
+            };
+
+            let alias = prop.key.static_name().unwrap_or_default();
+            let pascal = vue_casing::pascal_case(&imported.name);
+            let kebab = vue_casing::kebab_case(&imported.name);
+            if alias == pascal.as_str() || alias == kebab.as_str() {
+                continue;
+            }
+
+            ctx.diagnostic(match_component_import_name_diagnostic(
+                prop.span,
+                &alias,
+                &format!("{pascal}, {kebab}"),
+            ));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+    use std::path::PathBuf;
+
+    let vue = || Some(PathBuf::from("test.vue"));
+    let js = || Some(PathBuf::from("test.js"));
+
+    let pass = vec![
+        ("<script> export default { components: { ValidImport } } </script>", None, None, vue()),
+        (
+            "<script> export default { components: { ValidImport: ValidImport } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script> export default { components: { 'valid-import': ValidImport } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script> export default { components: { ValidImport, ...SpreadImport } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script> export default { components: { 'valid-import': ValidImport, [computedImport]: ComputedImport } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script> export default { components: { ValidImport, [differentComputedImport]: ComputedImport } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        // `components` that is not an object literal is ignored.
+        ("<script> export default { components } </script>", None, None, vue()),
+        ("<script> export default { components: [SomeRandomName] } </script>", None, None, vue()),
+        // Values that are not plain identifiers are ignored.
+        (
+            "<script> export default { components: { InvalidExport: () => import('./Foo.vue') } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        // Not a component options object.
+        (
+            "<script> export default { foo: { components: { InvalidExport: SomeRandomName } } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        // `export default` in a non-vue file is not a component.
+        ("export default { components: { InvalidExport: SomeRandomName } }", None, None, js()),
+        // `new Vue({...})` is an instance, not a component definition.
+        ("new Vue({ components: { InvalidExport: SomeRandomName } })", None, None, js()),
+        // Component definition calls are checked in plain JS too.
+        ("defineComponent({ components: { ValidImport } })", None, None, js()),
+    ];
+
+    let fail = vec![
+        (
+            "<script> export default { components: { InvalidExport: SomeRandomName } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script> export default { components: { 'invalid-export': SomeRandomName } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script> export default { components: { validImport: ValidImport } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script> export default { components: { ValidImport, InvalidExport: SomeRandomName } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        ("defineComponent({ components: { InvalidExport: SomeRandomName } })", None, None, js()),
+        (
+            "<script> Vue.component('Foo', { components: { InvalidExport: SomeRandomName } }) </script>",
+            None,
+            None,
+            vue(),
+        ),
+    ];
+
+    Tester::new(MatchComponentImportName::NAME, MatchComponentImportName::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/match_component_import_name.rs
+++ b/crates/oxc_linter/src/rules/vue/match_component_import_name.rs
@@ -79,7 +79,11 @@ impl Rule for MatchComponentImportName {
         let Some(components) = find_property(obj, "components") else {
             return;
         };
-        let Expression::ObjectExpression(components) = &components.value else {
+        // `without_parentheses`, not `get_inner_expression`: ESTree has no
+        // parenthesized-expression node, so upstream sees through parens, but
+        // it does *not* see through `as` casts.
+        let Expression::ObjectExpression(components) = components.value.without_parentheses()
+        else {
             return;
         };
         // Checked last: it walks the ancestor chain, so only objects that
@@ -95,7 +99,7 @@ impl Rule for MatchComponentImportName {
             if prop.computed {
                 continue;
             }
-            let Expression::Identifier(imported) = &prop.value else {
+            let Expression::Identifier(imported) = prop.value.without_parentheses() else {
                 continue;
             };
 
@@ -166,6 +170,29 @@ fn test() {
             None,
             vue(),
         ),
+        // Upstream compares `property.value.type` without unwrapping `as`
+        // casts, so a cast value is skipped rather than reported.
+        (
+            "<script lang=\"ts\"> export default { components: { InvalidExport: SomeRandomName as any } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        // A quoted key is compared the same as a bare one.
+        (
+            "<script> export default { components: { 'ValidImport': ValidImport } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        // Parens around the value are invisible to upstream, so a name that
+        // matches through them still passes.
+        (
+            "<script> export default { components: { ValidImport: (ValidImport) } } </script>",
+            None,
+            None,
+            vue(),
+        ),
         // Not a component options object.
         (
             "<script> export default { foo: { components: { InvalidExport: SomeRandomName } } } </script>",
@@ -209,6 +236,21 @@ fn test() {
         ("defineComponent({ components: { InvalidExport: SomeRandomName } })", None, None, js()),
         (
             "<script> Vue.component('Foo', { components: { InvalidExport: SomeRandomName } }) </script>",
+            None,
+            None,
+            vue(),
+        ),
+        // A camelCase shorthand matches neither expected casing.
+        ("<script> export default { components: { someRandomName } } </script>", None, None, vue()),
+        // Parens are invisible to upstream, so these are still reported.
+        (
+            "<script> export default { components: { InvalidExport: (SomeRandomName) } } </script>",
+            None,
+            None,
+            vue(),
+        ),
+        (
+            "<script> export default { components: ({ InvalidExport: SomeRandomName }) } </script>",
             None,
             None,
             vue(),

--- a/crates/oxc_linter/src/rules/vue/match_component_import_name.rs
+++ b/crates/oxc_linter/src/rules/vue/match_component_import_name.rs
@@ -16,9 +16,10 @@ use crate::{
 fn match_component_import_name_diagnostic(
     span: Span,
     alias: &str,
-    expected: &str,
+    pascal: &str,
+    kebab: &str,
 ) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Component alias {alias} should be one of: {expected}."))
+    OxcDiagnostic::warn(format!("Component alias {alias} should be one of: {pascal}, {kebab}."))
         .with_label(span)
 }
 
@@ -75,15 +76,17 @@ impl Rule for MatchComponentImportName {
         let AstKind::ObjectExpression(obj) = node.kind() else {
             return;
         };
-        if !is_vue_component_options_object_excluding_instance(node, ctx) {
-            return;
-        }
         let Some(components) = find_property(obj, "components") else {
             return;
         };
         let Expression::ObjectExpression(components) = &components.value else {
             return;
         };
+        // Checked last: it walks the ancestor chain, so only objects that
+        // actually carry a `components: { ... }` option pay for it.
+        if !is_vue_component_options_object_excluding_instance(node, ctx) {
+            return;
+        }
 
         for prop in &components.properties {
             let ObjectPropertyKind::ObjectProperty(prop) = prop else {
@@ -98,15 +101,16 @@ impl Rule for MatchComponentImportName {
 
             let alias = prop.key.static_name().unwrap_or_default();
             let pascal = vue_casing::pascal_case(&imported.name);
+            if alias == pascal.as_str() {
+                continue;
+            }
             let kebab = vue_casing::kebab_case(&imported.name);
-            if alias == pascal.as_str() || alias == kebab.as_str() {
+            if alias == kebab.as_str() {
                 continue;
             }
 
             ctx.diagnostic(match_component_import_name_diagnostic(
-                prop.span,
-                &alias,
-                &format!("{pascal}, {kebab}"),
+                prop.span, &alias, &pascal, &kebab,
             ));
         }
     }

--- a/crates/oxc_linter/src/rules/vue/match_component_import_name.rs
+++ b/crates/oxc_linter/src/rules/vue/match_component_import_name.rs
@@ -67,7 +67,7 @@ declare_oxc_lint!(
     MatchComponentImportName,
     vue,
     style,
-    version = "1.79.0",
+    version = "next",
     short_description = "Require the registered component name to match the imported component name.",
 );
 

--- a/crates/oxc_linter/src/rules/vue/match_component_import_name.rs
+++ b/crates/oxc_linter/src/rules/vue/match_component_import_name.rs
@@ -100,7 +100,9 @@ impl Rule for MatchComponentImportName {
                 continue;
             };
 
-            let alias = prop.key.static_name().unwrap_or_default();
+            let Some(alias) = prop.key.static_name() else {
+                continue;
+            };
             let pascal = vue_casing::pascal_case(&imported.name);
             if alias == pascal.as_str() {
                 continue;

--- a/crates/oxc_linter/src/rules/vue/match_component_import_name.rs
+++ b/crates/oxc_linter/src/rules/vue/match_component_import_name.rs
@@ -29,17 +29,14 @@ pub struct MatchComponentImportName;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Requires the key a component is registered under in the `components`
-    /// option to match the name of the imported binding, either in
-    /// `PascalCase` or in `kebab-case`.
+    /// Requires the key used in the `components` option to match the name of the
+    /// imported component, either in `PascalCase` or in `kebab-case`.
     ///
     /// ### Why is this bad?
     ///
     /// Registering a component under an unrelated alias hides which import a
-    /// tag in the template actually resolves to, so a reader has to jump
-    /// between the template, the `components` option and the import list to
-    /// follow it. Keeping the two names in sync also means renaming the
-    /// import is enough to find every usage.
+    /// tag in the template actually resolves to, which makes the code more
+    /// difficult to follow for the reader.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/snapshots/vue_match_component_import_name.snap
+++ b/crates/oxc_linter/src/snapshots/vue_match_component_import_name.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vue(match-component-import-name): Component alias InvalidExport should be one of: SomeRandomName, some-random-name.
+   ╭─[match_component_import_name.tsx:1:41]
+ 1 │ <script> export default { components: { InvalidExport: SomeRandomName } } </script>
+   ·                                         ─────────────────────────────
+   ╰────
+
+  ⚠ vue(match-component-import-name): Component alias invalid-export should be one of: SomeRandomName, some-random-name.
+   ╭─[match_component_import_name.tsx:1:41]
+ 1 │ <script> export default { components: { 'invalid-export': SomeRandomName } } </script>
+   ·                                         ────────────────────────────────
+   ╰────
+
+  ⚠ vue(match-component-import-name): Component alias validImport should be one of: ValidImport, valid-import.
+   ╭─[match_component_import_name.tsx:1:41]
+ 1 │ <script> export default { components: { validImport: ValidImport } } </script>
+   ·                                         ────────────────────────
+   ╰────
+
+  ⚠ vue(match-component-import-name): Component alias InvalidExport should be one of: SomeRandomName, some-random-name.
+   ╭─[match_component_import_name.tsx:1:54]
+ 1 │ <script> export default { components: { ValidImport, InvalidExport: SomeRandomName } } </script>
+   ·                                                      ─────────────────────────────
+   ╰────
+
+  ⚠ vue(match-component-import-name): Component alias InvalidExport should be one of: SomeRandomName, some-random-name.
+   ╭─[match_component_import_name.tsx:1:33]
+ 1 │ defineComponent({ components: { InvalidExport: SomeRandomName } })
+   ·                                 ─────────────────────────────
+   ╰────
+
+  ⚠ vue(match-component-import-name): Component alias InvalidExport should be one of: SomeRandomName, some-random-name.
+   ╭─[match_component_import_name.tsx:1:47]
+ 1 │ <script> Vue.component('Foo', { components: { InvalidExport: SomeRandomName } }) </script>
+   ·                                               ─────────────────────────────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/vue_match_component_import_name.snap
+++ b/crates/oxc_linter/src/snapshots/vue_match_component_import_name.snap
@@ -37,3 +37,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <script> Vue.component('Foo', { components: { InvalidExport: SomeRandomName } }) </script>
    ·                                               ─────────────────────────────
    ╰────
+
+  ⚠ vue(match-component-import-name): Component alias someRandomName should be one of: SomeRandomName, some-random-name.
+   ╭─[match_component_import_name.tsx:1:41]
+ 1 │ <script> export default { components: { someRandomName } } </script>
+   ·                                         ──────────────
+   ╰────
+
+  ⚠ vue(match-component-import-name): Component alias InvalidExport should be one of: SomeRandomName, some-random-name.
+   ╭─[match_component_import_name.tsx:1:41]
+ 1 │ <script> export default { components: { InvalidExport: (SomeRandomName) } } </script>
+   ·                                         ───────────────────────────────
+   ╰────
+
+  ⚠ vue(match-component-import-name): Component alias InvalidExport should be one of: SomeRandomName, some-random-name.
+   ╭─[match_component_import_name.tsx:1:42]
+ 1 │ <script> export default { components: ({ InvalidExport: SomeRandomName }) } </script>
+   ·                                          ─────────────────────────────
+   ╰────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -10355,6 +10355,9 @@
             }
           ]
         },
+        "vue/match-component-import-name": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "vue/max-props": {
           "anyOf": [
             {

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -758,6 +758,7 @@ vitest/valid-expect-in-promise                             |      0
 vitest/valid-title                                         |      0
 vitest/warn-todo                                           |      0
 vue/component-definition-name-casing                       |  76731
+vue/match-component-import-name                            |  14125
 vue/no-arrow-functions-in-watch                            |  62608
 vue/no-deprecated-destroyed-lifecycle                      |      2
 vue/no-deprecated-events-api                               |  62606


### PR DESCRIPTION
- Upstream rule docs: https://eslint.vuejs.org/rules/match-component-import-name
- Tests: https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/match-component-import-name.test.ts
- Source: https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/match-component-import-name.ts

AI Disclosure: Generated with Claude Code, Opus 5. Reviewed and tested by me, all tests were ported and a few were added on top to ensure that we persisted any behavioral quirks from the original rule.

Part of https://github.com/oxc-project/oxc/issues/11440

This could be moved to `restriction` instead of `style`, I don't have a strong preference on that. A fix can potentially be implemented so we can mark it as pending if desired, but the upstream didn't have an autofix so I left it alone for now.

The goal of the rule is to simply enforce that - if you use `components` and no `<script setup>` - you don't alias the component names to something else.

```vue
<script>
export default {
  components: {
    /* ✓ GOOD */
    AppButton,
    AppButton: AppButton,
    'app-button': AppButton,

    /* ✗ BAD */
    SomeOtherName: AppButton,
    'some-other-name': AppButton
  }
}
</script>
```