### PR TITLE
chore(linter): Mark vue/prefer-single-event-payload as unsupported.

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -357,6 +357,7 @@
     "vue/padding-line-between-tags": "Stylistic rule.",
     "vue/padding-lines-in-component-definition": "Stylistic rule.",
     "vue/prefer-separate-static-class": "Not currently possible, as it requires Vue template parsing.",
+    "vue/prefer-single-event-payload": "Not currently possible, as it requires Vue template parsing.",
     "vue/prefer-template": "Not currently possible, as it requires Vue template parsing.",
     "vue/prefer-true-attribute-shorthand": "Not currently possible, as it requires Vue template parsing.",
     "vue/prefer-v-model": "Not currently possible, as it requires Vue template parsing.",


### PR DESCRIPTION
It requires template parsing. https://eslint.vuejs.org/rules/prefer-single-event-payload.html