### PR TITLE
perf(linter/vue): look up vue component options object from the parent node

### DIFF
--- a/crates/oxc_linter/src/utils/vue.rs
+++ b/crates/oxc_linter/src/utils/vue.rs
@@ -247,7 +247,7 @@ pub fn vue_component_options_kind(
         return None;
     };
 
-    ctx.nodes().ancestors(object_node.id()).find_map(|ancestor| match ancestor.kind() {
+    match ctx.nodes().parent_kind(object_node.id()) {
         AstKind::ExportDefaultDeclaration(export_default_decl) => {
             if ctx.file_extension().is_none_or(|ext| ext != "vue") {
                 return None;
@@ -269,7 +269,7 @@ pub fn vue_component_options_kind(
             && new_expr.callee.get_identifier_reference().is_some_and(|ident| ident.name == "Vue"))
         .then_some(VueComponentObjectKind::Instance),
         _ => None,
-    })
+    }
 }
 
 /// Whether the given `ObjectExpression` is *any* Vue options object — the


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, Opus 5. Tested and reviewed by me. This is a micro-optimization, but it saves time and reduces the work needed when calling this method.

`vue_component_options_kind` walked every ancestor up to `Program` for each `ObjectExpression` it was asked about. It never needed to: all three recognized forms require the object expression's span to match a *direct child slot* of the matched node —

- `export default {...}` — `export_default_decl.declaration.span() == object_expr.span`
- a definition call's last argument — `is_last_argument_span(call_expr, object_expr.span)`
- `new Vue({...})`'s first argument — `new_expr.arguments.first()...span() == object_expr.span`

Span equality with a child slot means the object *is* that child, so its parent is the matched node. Arguments and default-export declarations are not themselves AST nodes in oxc, so nothing sits in between. No ancestor above the parent could ever match, and checking the parent alone is equivalent.

This matters beyond the single call: `is_vue_component_options_object` is called by 17 vue rules on object nodes, and `require_slots_as_functions` calls it from inside its own `ancestors()` loop, which made that path quadratic in nesting depth.

## Testing

Diagnostics are byte-identical before and after on both corpora below (`sort`ed full output diffed; 1,910 and 3,050 diagnostics respectively).

## Benchmark

Single-threaded, `--silent`, all 46 vue rules enabled, interleaved paired samples (n=40 or n=30) so thermal drift cancels. Negative = faster.

| Corpus | Files / lines | Paired diff | 95% CI |
| --- | --- | --- | --- |
| n8n | 1,254 / 287K | **-1.50ms** | [-2.61, -0.39] |
| GitLab | 4,566 / 629K | **-2.63ms** | [-3.25, -2.01] |

For scale, all 46 vue rules together cost ~20ms on the n8n corpus and ~49ms on the GitLab one, measured against a parse-only config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
