### PR TITLE
fix(linter): remove invalid React compiler doc links

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -412,6 +412,27 @@ pub(crate) mod jest {
 macro_rules! declare_react_compiler_lint {
     (
         $(#[$intro:meta])*
+        unlinked_upstream = $upstream_rule:literal,
+        $(#[$rest:meta])*
+        $name:ident,
+        react,
+        $category:ident,
+        $($options:tt)*
+    ) => {
+        oxc_macros::declare_oxc_lint!(
+            $(#[$intro])*
+            #[doc = "Powered by the React Compiler, which runs once per file and is shared"]
+            #[doc = "with the other React Compiler rules. Port of"]
+            #[doc = concat!("`react-hooks/", $upstream_rule, "`.")]
+            $(#[$rest])*
+            $name,
+            react,
+            $category,
+            $($options)*
+        );
+    };
+    (
+        $(#[$intro:meta])*
         upstream = $upstream_rule:literal,
         $(#[$rest:meta])*
         $name:ident,

--- a/crates/oxc_linter/src/rules/react/capitalized_calls.rs
+++ b/crates/oxc_linter/src/rules/react/capitalized_calls.rs
@@ -16,7 +16,7 @@ declare_react_compiler_lint!(
     /// render instead of rendering them with JSX, since capitalized names are
     /// reserved for components.
     ///
-    upstream = "capitalized-calls",
+    unlinked_upstream = "capitalized-calls",
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/react/exhaustive_effect_dependencies.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_effect_dependencies.rs
@@ -15,7 +15,7 @@ declare_react_compiler_lint!(
     /// Validates that effect dependency arrays are exhaustive and contain no
     /// extraneous values.
     ///
-    upstream = "exhaustive-effect-dependencies",
+    unlinked_upstream = "exhaustive-effect-dependencies",
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/react/hooks.rs
+++ b/crates/oxc_linter/src/rules/react/hooks.rs
@@ -16,7 +16,7 @@ declare_react_compiler_lint!(
     /// called unconditionally, in a consistent order, at the top level of a
     /// component or hook, and not be used as first-class values.
     ///
-    upstream = "hooks",
+    unlinked_upstream = "hooks",
     ///
     /// This rule overlaps with `react/rules-of-hooks`; upstream ships it
     /// disabled for that reason.

--- a/crates/oxc_linter/src/rules/react/invariant.rs
+++ b/crates/oxc_linter/src/rules/react/invariant.rs
@@ -16,7 +16,7 @@ declare_react_compiler_lint!(
     /// bug in the compiler itself, not in your code — consider reporting them
     /// to the oxc or React teams.
     ///
-    upstream = "invariant",
+    unlinked_upstream = "invariant",
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/react/memo_dependencies.rs
+++ b/crates/oxc_linter/src/rules/react/memo_dependencies.rs
@@ -15,7 +15,7 @@ declare_react_compiler_lint!(
     /// Validates that `useMemo()` and `useCallback()` declare comprehensive
     /// dependency lists without extraneous values.
     ///
-    upstream = "memo-dependencies",
+    unlinked_upstream = "memo-dependencies",
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/react/no_deriving_state_in_effects.rs
+++ b/crates/oxc_linter/src/rules/react/no_deriving_state_in_effects.rs
@@ -16,7 +16,7 @@ declare_react_compiler_lint!(
     /// back into state; derived values should be computed during render
     /// instead.
     ///
-    upstream = "no-deriving-state-in-effects",
+    unlinked_upstream = "no-deriving-state-in-effects",
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/react/rule_suppression.rs
+++ b/crates/oxc_linter/src/rules/react/rule_suppression.rs
@@ -18,7 +18,7 @@ declare_react_compiler_lint!(
     /// suppressions, since the suppressed violation may make compilation
     /// unsafe.
     ///
-    upstream = "rule-suppression",
+    unlinked_upstream = "rule-suppression",
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/react/syntax.rs
+++ b/crates/oxc_linter/src/rules/react/syntax.rs
@@ -15,7 +15,7 @@ declare_react_compiler_lint!(
     /// Reports invalid JavaScript encountered by React Compiler while
     /// analyzing a component or hook, such as reassigning a `const` binding.
     ///
-    upstream = "syntax",
+    unlinked_upstream = "syntax",
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/react/todo.rs
+++ b/crates/oxc_linter/src/rules/react/todo.rs
@@ -16,7 +16,7 @@ declare_react_compiler_lint!(
     /// features the compiler has not implemented. These are skipped
     /// optimizations (bail-outs), not rule violations.
     ///
-    upstream = "todo",
+    unlinked_upstream = "todo",
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/react/void_use_memo.rs
+++ b/crates/oxc_linter/src/rules/react/void_use_memo.rs
@@ -15,7 +15,7 @@ declare_react_compiler_lint!(
     /// Validates that `useMemo()` callbacks return a value and that the
     /// memoized result is actually used by the component or hook.
     ///
-    upstream = "void-use-memo",
+    unlinked_upstream = "void-use-memo",
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/tests/integration_test.rs
+++ b/crates/oxc_linter/tests/integration_test.rs
@@ -68,47 +68,52 @@ fn test_declare_oxc_lint() {
 
 #[test]
 fn test_react_compiler_rule_categories() {
-    const EXPECTED: [(&str, RuleCategory); 22] = [
-        ("capitalized-calls", RuleCategory::Suspicious),
-        ("error-boundaries", RuleCategory::Correctness),
-        ("exhaustive-effect-dependencies", RuleCategory::Suspicious),
-        ("globals", RuleCategory::Correctness),
-        ("hooks", RuleCategory::Suspicious),
-        ("immutability", RuleCategory::Correctness),
-        ("incompatible-library", RuleCategory::Correctness),
-        ("invariant", RuleCategory::Restriction),
-        ("memo-dependencies", RuleCategory::Suspicious),
-        ("no-deriving-state-in-effects", RuleCategory::Perf),
-        ("preserve-manual-memoization", RuleCategory::Correctness),
-        ("purity", RuleCategory::Correctness),
-        ("refs", RuleCategory::Correctness),
-        ("rule-suppression", RuleCategory::Restriction),
-        ("set-state-in-effect", RuleCategory::Correctness),
-        ("set-state-in-render", RuleCategory::Correctness),
-        ("static-components", RuleCategory::Correctness),
-        ("syntax", RuleCategory::Restriction),
-        ("todo", RuleCategory::Restriction),
-        ("unsupported-syntax", RuleCategory::Restriction),
-        ("use-memo", RuleCategory::Correctness),
-        ("void-use-memo", RuleCategory::Correctness),
+    const EXPECTED: [(&str, RuleCategory, bool); 22] = [
+        ("capitalized-calls", RuleCategory::Suspicious, false),
+        ("error-boundaries", RuleCategory::Correctness, true),
+        ("exhaustive-effect-dependencies", RuleCategory::Suspicious, false),
+        ("globals", RuleCategory::Correctness, true),
+        ("hooks", RuleCategory::Suspicious, false),
+        ("immutability", RuleCategory::Correctness, true),
+        ("incompatible-library", RuleCategory::Correctness, true),
+        ("invariant", RuleCategory::Restriction, false),
+        ("memo-dependencies", RuleCategory::Suspicious, false),
+        ("no-deriving-state-in-effects", RuleCategory::Perf, false),
+        ("preserve-manual-memoization", RuleCategory::Correctness, true),
+        ("purity", RuleCategory::Correctness, true),
+        ("refs", RuleCategory::Correctness, true),
+        ("rule-suppression", RuleCategory::Restriction, false),
+        ("set-state-in-effect", RuleCategory::Correctness, true),
+        ("set-state-in-render", RuleCategory::Correctness, true),
+        ("static-components", RuleCategory::Correctness, true),
+        ("syntax", RuleCategory::Restriction, false),
+        ("todo", RuleCategory::Restriction, false),
+        ("unsupported-syntax", RuleCategory::Restriction, true),
+        ("use-memo", RuleCategory::Correctness, true),
+        ("void-use-memo", RuleCategory::Correctness, false),
     ];
 
-    let names = EXPECTED.iter().map(|(name, _)| *name).collect::<std::collections::BTreeSet<_>>();
+    let names =
+        EXPECTED.iter().map(|(name, _, _)| *name).collect::<std::collections::BTreeSet<_>>();
     assert_eq!(names.len(), EXPECTED.len(), "React Compiler rule names must be unique");
 
-    for (name, expected_category) in EXPECTED {
+    for (name, expected_category, has_upstream_docs) in EXPECTED {
         let rule = RULES
             .iter()
             .find(|rule| rule.plugin_name() == "react" && rule.name() == name)
             .unwrap_or_else(|| panic!("React Compiler rule react/{name} must be registered"));
         assert_eq!(rule.category(), expected_category, "unexpected category for react/{name}");
 
+        #[cfg(not(feature = "ruledocs"))]
+        let _ = has_upstream_docs;
+
         #[cfg(feature = "ruledocs")]
-        assert!(
+        assert_eq!(
             rule.documentation().is_some_and(|docs| docs.contains(&format!(
                 "https://react.dev/reference/eslint-plugin-react-hooks/lints/{name}"
             ))),
-            "missing upstream documentation link for react/{name}"
+            has_upstream_docs,
+            "unexpected upstream documentation link state for react/{name}"
         );
     }
 }


### PR DESCRIPTION
The shared React Compiler rule macro generated `react.dev` links for internal categories without public lint pages. Render those attributions without links and verify linked versus unlinked rule documentation.

Validated with `just ready`.

AI-assisted.