### PR TITLE
fix(linter/react/no-react-children): resolve `react` imports by symbol

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_react_children.rs
+++ b/crates/oxc_linter/src/rules/react/no_react_children.rs
@@ -3,7 +3,12 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{is_import_from_module, is_import_symbol},
+};
 
 fn no_react_children_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`React.Children` should not be used.")
@@ -106,31 +111,24 @@ impl Rule for NoReactChildren {
 
         let object = member_expr.object().get_inner_expression();
 
-        // Pattern 1: Children.method() where Children is imported from 'react'
+        // Pattern 1: Children.method(), where `Children` is the named `react` import
         if let Some(ident) = object.get_identifier_reference()
-            && ident.name == "Children"
-            && is_imported_from_react(ident.name.as_str(), ctx)
+            && is_import_symbol(ident, "react", "Children", ctx)
         {
             ctx.diagnostic(no_react_children_diagnostic(member_expr.span()));
             return;
         }
 
-        // Pattern 2: React.Children.method() where React is imported from 'react'
+        // Pattern 2: React.Children.method(), where `React` is any `react` import
         if let Some(inner_member) = object.as_member_expression()
             && inner_member.static_property_name() == Some("Children")
             && let Some(ident) =
                 inner_member.object().get_inner_expression().get_identifier_reference()
-            && is_imported_from_react(ident.name.as_str(), ctx)
+            && is_import_from_module(ident, "react", ctx)
         {
             ctx.diagnostic(no_react_children_diagnostic(member_expr.span()));
         }
     }
-}
-
-fn is_imported_from_react(local_name: &str, ctx: &LintContext) -> bool {
-    ctx.module_record().import_entries.iter().any(|entry| {
-        entry.module_request.name() == "react" && entry.local_name.name() == local_name
-    })
 }
 
 #[test]
@@ -164,6 +162,12 @@ fn test() {
                </div>
              );
            }"#,
+        // A local binding shadowing the import is not `React.Children`.
+        "import { Children } from 'react'; function f(x) { const Children = { count: () => 0 }; return Children.count(x); }",
+        "import React from 'react'; function f(x) { const React = { Children: { map: () => {} } }; return React.Children.map(x); }",
+        "import { Children } from 'react'; export function f(Children) { return Children.count(1); }",
+        // `Children` here is a local alias of an unrelated `react` export.
+        "import { count as Children } from 'react'; Children.toArray(x)",
     ];
 
     let fail = vec![
@@ -226,6 +230,8 @@ fn test() {
            });
            // ...
          }",
+        // Aliased named import of `Children`.
+        "import { Children as C } from 'react'; C.toArray(x)",
         // Optional chaining
         "import React from 'react'; React.Children?.map(children, child => child)",
         // Parenthesized expressions

--- a/crates/oxc_linter/src/rules/react/no_react_children.rs
+++ b/crates/oxc_linter/src/rules/react/no_react_children.rs
@@ -119,7 +119,7 @@ impl Rule for NoReactChildren {
             return;
         }
 
-        // Pattern 2: React.Children.method(), where `React` is any `react` import
+        // Pattern 2: *.Children.method(), where `*` is any `react` import
         if let Some(inner_member) = object.as_member_expression()
             && inner_member.static_property_name() == Some("Children")
             && let Some(ident) =
@@ -162,11 +162,9 @@ fn test() {
                </div>
              );
            }"#,
-        // A local binding shadowing the import is not `React.Children`.
         "import { Children } from 'react'; function f(x) { const Children = { count: () => 0 }; return Children.count(x); }",
         "import React from 'react'; function f(x) { const React = { Children: { map: () => {} } }; return React.Children.map(x); }",
         "import { Children } from 'react'; export function f(Children) { return Children.count(1); }",
-        // `Children` here is a local alias of an unrelated `react` export.
         "import { count as Children } from 'react'; Children.toArray(x)",
     ];
 
@@ -230,14 +228,13 @@ fn test() {
            });
            // ...
          }",
-        // Aliased named import of `Children`.
-        "import { Children as C } from 'react'; C.toArray(x)",
         // Optional chaining
         "import React from 'react'; React.Children?.map(children, child => child)",
         // Parenthesized expressions
         "import { Children } from 'react'; (Children).map(children, child => child)",
         "import React from 'react'; (React.Children).map(children, child => child)",
         "import React from 'react'; (React.Children as any).map(children, child => child)",
+        "import { Children as C } from 'react'; C.toArray(x)",
     ];
 
     Tester::new(NoReactChildren::NAME, NoReactChildren::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/react_no_react_children.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_react_children.snap
@@ -149,14 +149,6 @@ source: crates/oxc_linter/src/tester.rs
   note: https://react.dev/reference/react/Children#alternatives
 
   ⚠ react(no-react-children): `React.Children` should not be used.
-   ╭─[no_react_children.tsx:1:40]
- 1 │ import { Children as C } from 'react'; C.toArray(x)
-   ·                                        ─────────
-   ╰────
-  help: `React.Children` is uncommon and leads to fragile React components.
-  note: https://react.dev/reference/react/Children#alternatives
-
-  ⚠ react(no-react-children): `React.Children` should not be used.
    ╭─[no_react_children.tsx:1:28]
  1 │ import React from 'react'; React.Children?.map(children, child => child)
    ·                            ───────────────────
@@ -184,6 +176,14 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_react_children.tsx:1:28]
  1 │ import React from 'react'; (React.Children as any).map(children, child => child)
    ·                            ───────────────────────────
+   ╰────
+  help: `React.Children` is uncommon and leads to fragile React components.
+  note: https://react.dev/reference/react/Children#alternatives
+
+  ⚠ react(no-react-children): `React.Children` should not be used.
+   ╭─[no_react_children.tsx:1:40]
+ 1 │ import { Children as C } from 'react'; C.toArray(x)
+   ·                                        ─────────
    ╰────
   help: `React.Children` is uncommon and leads to fragile React components.
   note: https://react.dev/reference/react/Children#alternatives

--- a/crates/oxc_linter/src/snapshots/react_no_react_children.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_react_children.snap
@@ -149,6 +149,14 @@ source: crates/oxc_linter/src/tester.rs
   note: https://react.dev/reference/react/Children#alternatives
 
   ⚠ react(no-react-children): `React.Children` should not be used.
+   ╭─[no_react_children.tsx:1:40]
+ 1 │ import { Children as C } from 'react'; C.toArray(x)
+   ·                                        ─────────
+   ╰────
+  help: `React.Children` is uncommon and leads to fragile React components.
+  note: https://react.dev/reference/react/Children#alternatives
+
+  ⚠ react(no-react-children): `React.Children` should not be used.
    ╭─[no_react_children.tsx:1:28]
  1 │ import React from 'react'; React.Children?.map(children, child => child)
    ·                            ───────────────────


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, Opus 5. Tested and reviewed by me.

`no-react-children` decided whether an identifier came from `react` with a hand-rolled helper that matched by **name**:

```rust
fn is_imported_from_react(local_name: &str, ctx: &LintContext) -> bool {
    ctx.module_record().import_entries.iter().any(|entry| {
        entry.module_request.name() == "react" && entry.local_name.name() == local_name
    })
}
```

This replaces it with the existing shared helpers, `is_import_symbol` and `is_import_from_module`.

### Bugs fixed

Four false positives, where a local binding shadowed the import:

```js
import { Children } from 'react';
function f(x) { const Children = { count: () => 0 }; return Children.count(x); }

import React from 'react';
function f(x) { const React = { Children: { map: () => {} } }; return React.Children.map(x); }

import { Children } from 'react';
export function f(Children) { return Children.count(1); }

import { count as Children } from 'react'; Children.toArray(x)
```

One false negative, an aliased import the local-name check couldn't see:

```js
import { Children as C } from 'react'; C.toArray(x)
```

All five are covered by new test cases.

### Performance

This has a minor downside in perf, but it's significantly less than a millisecond difference and is probably worth the downside. We had originally decided not to care about aliases when implementing this rule, but this change allows us to reuse the existing util code for checking where the import comes from, and fixes the aforementioned edge cases, so I think this is a worthwhile change.

Measured with two `--features allocator` builds, paired and interleaved, using `--debug=timings --threads=1` to isolate the rule's own time from parse/semantic noise.

| corpus | base | new | change |
| --- | --- | --- | --- |
| sentry | 4.416ms | 4.589ms | +3.9% slower |
| material-ui | 3.111ms | 3.217ms | +3.4% slower |
| bluesky | 0.503ms | 0.540ms | +7.2% slower |
| actualbudget | 2.012ms | 2.105ms | +4.6% slower |
| synthetic, `Children` used heavily | 19.112ms | 15.443ms | 19.2% faster |

There is a small, consistent regression on real code, and it's deliberate. Dropping the `ident.name == "Children"` gate means every `obj.method()` call in a file importing `react` now does two array lookups instead of one string compare; removing the `O(imports)` scan only pays off where `Children` is actually used, which is 27 files out of 8.8K in sentry. The absolute cost is ≤0.17ms, and `no-react-children` isn't a default rule anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)