### PR TITLE
docs(linter): set `version` to 1.79.0 for rules shipped in 1.79.0

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unreachable_loop.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable_loop.rs
@@ -85,7 +85,7 @@ declare_oxc_lint!(
     eslint,
     nursery,
     config = NoUnreachableLoop,
-    version = "next",
+    version = "1.79.0",
     short_description = "Disallow loops whose body allows only one iteration.",
 );
 

--- a/crates/oxc_linter/src/rules/react/capitalized_calls.rs
+++ b/crates/oxc_linter/src/rules/react/capitalized_calls.rs
@@ -44,7 +44,7 @@ declare_react_compiler_lint!(
     CapitalizedCalls,
     react,
     suspicious,
-    version = "next",
+    version = "1.79.0",
     short_description = "Disallow calling capitalized functions and methods instead of using JSX.",
 );
 

--- a/crates/oxc_linter/src/rules/react/error_boundaries.rs
+++ b/crates/oxc_linter/src/rules/react/error_boundaries.rs
@@ -51,7 +51,7 @@ declare_react_compiler_lint!(
     ErrorBoundaries,
     react,
     correctness,
-    version = "next",
+    version = "1.79.0",
     short_description = "Validates using error boundaries instead of try/catch for child errors.",
 );
 

--- a/crates/oxc_linter/src/rules/react/exhaustive_effect_dependencies.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_effect_dependencies.rs
@@ -24,7 +24,7 @@ declare_react_compiler_lint!(
     ExhaustiveEffectDependencies,
     react,
     suspicious,
-    version = "next",
+    version = "1.79.0",
     short_description = "Validates that effect dependencies are exhaustive, without extraneous values.",
 );
 

--- a/crates/oxc_linter/src/rules/react/globals.rs
+++ b/crates/oxc_linter/src/rules/react/globals.rs
@@ -50,7 +50,7 @@ declare_react_compiler_lint!(
     Globals,
     react,
     correctness,
-    version = "next",
+    version = "1.79.0",
     short_description = "Disallow assigning to or mutating globals during render.",
 );
 

--- a/crates/oxc_linter/src/rules/react/hooks.rs
+++ b/crates/oxc_linter/src/rules/react/hooks.rs
@@ -50,7 +50,7 @@ declare_react_compiler_lint!(
     Hooks,
     react,
     suspicious,
-    version = "next",
+    version = "1.79.0",
     short_description = "Validates the Rules of Hooks with the React Compiler's analysis.",
 );
 

--- a/crates/oxc_linter/src/rules/react/immutability.rs
+++ b/crates/oxc_linter/src/rules/react/immutability.rs
@@ -45,7 +45,7 @@ declare_react_compiler_lint!(
     Immutability,
     react,
     correctness,
-    version = "next",
+    version = "1.79.0",
     short_description = "Disallow mutating props, state, and other values that are immutable by the Rules of React.",
 );
 

--- a/crates/oxc_linter/src/rules/react/incompatible_library.rs
+++ b/crates/oxc_linter/src/rules/react/incompatible_library.rs
@@ -45,7 +45,7 @@ declare_react_compiler_lint!(
     IncompatibleLibrary,
     react,
     correctness,
-    version = "next",
+    version = "1.79.0",
     short_description = "Warns on usage of libraries that are incompatible with memoization.",
 );
 

--- a/crates/oxc_linter/src/rules/react/invariant.rs
+++ b/crates/oxc_linter/src/rules/react/invariant.rs
@@ -25,7 +25,7 @@ declare_react_compiler_lint!(
     Invariant,
     react,
     restriction,
-    version = "next",
+    version = "1.79.0",
     short_description = "Reports internal React Compiler invariant violations, which indicate a compiler bug.",
 );
 

--- a/crates/oxc_linter/src/rules/react/memo_dependencies.rs
+++ b/crates/oxc_linter/src/rules/react/memo_dependencies.rs
@@ -24,7 +24,7 @@ declare_react_compiler_lint!(
     MemoDependencies,
     react,
     suspicious,
-    version = "next",
+    version = "1.79.0",
     short_description = "Validates that `useMemo()` and `useCallback()` dependencies are comprehensive, without extraneous values.",
 );
 

--- a/crates/oxc_linter/src/rules/react/no_deriving_state_in_effects.rs
+++ b/crates/oxc_linter/src/rules/react/no_deriving_state_in_effects.rs
@@ -49,7 +49,7 @@ declare_react_compiler_lint!(
     NoDerivingStateInEffects,
     react,
     perf,
-    version = "next",
+    version = "1.79.0",
     short_description = "Disallow deriving values from state in an effect instead of computing them during render.",
 );
 

--- a/crates/oxc_linter/src/rules/react/preserve_manual_memoization.rs
+++ b/crates/oxc_linter/src/rules/react/preserve_manual_memoization.rs
@@ -46,7 +46,7 @@ declare_react_compiler_lint!(
     PreserveManualMemoization,
     react,
     correctness,
-    version = "next",
+    version = "1.79.0",
     short_description = "Validates that existing manual memoization is preserved by the React Compiler.",
 );
 

--- a/crates/oxc_linter/src/rules/react/purity.rs
+++ b/crates/oxc_linter/src/rules/react/purity.rs
@@ -44,7 +44,7 @@ declare_react_compiler_lint!(
     Purity,
     react,
     correctness,
-    version = "next",
+    version = "1.79.0",
     short_description = "Validates that components and hooks do not call known-impure functions.",
 );
 

--- a/crates/oxc_linter/src/rules/react/refs.rs
+++ b/crates/oxc_linter/src/rules/react/refs.rs
@@ -49,7 +49,7 @@ declare_react_compiler_lint!(
     Refs,
     react,
     correctness,
-    version = "next",
+    version = "1.79.0",
     short_description = "Validates correct usage of refs: not reading or writing `ref.current` during render.",
 );
 

--- a/crates/oxc_linter/src/rules/react/rule_suppression.rs
+++ b/crates/oxc_linter/src/rules/react/rule_suppression.rs
@@ -47,7 +47,7 @@ declare_react_compiler_lint!(
     RuleSuppression,
     react,
     restriction,
-    version = "next",
+    version = "1.79.0",
     short_description = "Reports suppressions of React rules, which make the React Compiler skip the affected function.",
 );
 

--- a/crates/oxc_linter/src/rules/react/set_state_in_effect.rs
+++ b/crates/oxc_linter/src/rules/react/set_state_in_effect.rs
@@ -48,7 +48,7 @@ declare_react_compiler_lint!(
     SetStateInEffect,
     react,
     correctness,
-    version = "next",
+    version = "1.79.0",
     short_description = "Disallow calling `setState` synchronously inside an effect.",
 );
 

--- a/crates/oxc_linter/src/rules/react/set_state_in_render.rs
+++ b/crates/oxc_linter/src/rules/react/set_state_in_render.rs
@@ -46,7 +46,7 @@ declare_react_compiler_lint!(
     SetStateInRender,
     react,
     correctness,
-    version = "next",
+    version = "1.79.0",
     short_description = "Disallow setting state during render, which can trigger additional renders and infinite render loops.",
 );
 

--- a/crates/oxc_linter/src/rules/react/static_components.rs
+++ b/crates/oxc_linter/src/rules/react/static_components.rs
@@ -46,7 +46,7 @@ declare_react_compiler_lint!(
     StaticComponents,
     react,
     correctness,
-    version = "next",
+    version = "1.79.0",
     short_description = "Validates that components are static, not recreated on every render.",
 );
 

--- a/crates/oxc_linter/src/rules/react/syntax.rs
+++ b/crates/oxc_linter/src/rules/react/syntax.rs
@@ -24,7 +24,7 @@ declare_react_compiler_lint!(
     Syntax,
     react,
     restriction,
-    version = "next",
+    version = "1.79.0",
     short_description = "Reports invalid JavaScript syntax encountered by the React Compiler.",
 );
 

--- a/crates/oxc_linter/src/rules/react/todo.rs
+++ b/crates/oxc_linter/src/rules/react/todo.rs
@@ -26,7 +26,7 @@ declare_react_compiler_lint!(
     Todo,
     react,
     restriction,
-    version = "next",
+    version = "1.79.0",
     short_description = "Reports code using features the React Compiler has not implemented yet.",
 );
 

--- a/crates/oxc_linter/src/rules/react/unsupported_syntax.rs
+++ b/crates/oxc_linter/src/rules/react/unsupported_syntax.rs
@@ -41,7 +41,7 @@ declare_react_compiler_lint!(
     UnsupportedSyntax,
     react,
     restriction,
-    version = "next",
+    version = "1.79.0",
     short_description = "Warns on syntax that the React Compiler does not plan to support, such as `eval`.",
 );
 

--- a/crates/oxc_linter/src/rules/react/use_memo.rs
+++ b/crates/oxc_linter/src/rules/react/use_memo.rs
@@ -47,7 +47,7 @@ declare_react_compiler_lint!(
     UseMemo,
     react,
     correctness,
-    version = "next",
+    version = "1.79.0",
     short_description = "Validates usage of the `useMemo()` hook against common mistakes.",
 );
 

--- a/crates/oxc_linter/src/rules/react/void_use_memo.rs
+++ b/crates/oxc_linter/src/rules/react/void_use_memo.rs
@@ -47,7 +47,7 @@ declare_react_compiler_lint!(
     VoidUseMemo,
     react,
     correctness,
-    version = "next",
+    version = "1.79.0",
     short_description = "Validates that `useMemo()` callbacks return a value and the result is used.",
 );
 


### PR DESCRIPTION
The 22 React Compiler rules split out by #25500, plus `eslint/no-unreachable-loop`, all first shipped in oxlint 1.79.0 but were still marked `version = "next"`. I think the release PR must've failed to run this part of the release task?

🤖 Generated with [Claude Code](https://claude.com/claude-code)