### PR TITLE
fix(linter/vue): resolve `vue` imports via shared import helpers

### DIFF
--- a/crates/oxc_linter/src/rules/vue/no_deprecated_delete_set.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_delete_set.rs
@@ -6,8 +6,12 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::module_record::ImportImportName;
-use crate::{AstNode, context::LintContext, rule::Rule, utils::is_this_object};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{is_import_symbol, is_this_object},
+};
 
 fn no_deprecated_delete_set_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`$delete` and `$set` are deprecated.").with_label(span)
@@ -105,25 +109,7 @@ fn is_imported_set_or_del_from_vue<'a>(
     ident: &IdentifierReference<'a>,
     ctx: &LintContext<'a>,
 ) -> bool {
-    let scoping = ctx.scoping();
-    let Some(ref_symbol) = scoping.get_reference(ident.reference_id()).symbol_id() else {
-        return false;
-    };
-    for import_entry in &ctx.module_record().import_entries {
-        if import_entry.module_request.name() != "vue" {
-            continue;
-        }
-        let ImportImportName::Name(name_span) = &import_entry.import_name else {
-            continue;
-        };
-        if !matches!(name_span.name(), "set" | "del") {
-            continue;
-        }
-        if scoping.get_root_binding(import_entry.local_name.name().into()) == Some(ref_symbol) {
-            return true;
-        }
-    }
-    false
+    is_import_symbol(ident, "vue", "set", ctx) || is_import_symbol(ident, "vue", "del", ctx)
 }
 
 /// Returns the callee as a `StaticMemberExpression`, peeling parens and an
@@ -148,31 +134,8 @@ fn is_in_vue_component<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
         AstKind::CallExpression(call) => call
             .callee
             .get_identifier_reference()
-            .is_some_and(|ident| is_vue_define_component_reference(ident, ctx)),
+            .is_some_and(|ident| is_import_symbol(ident, "vue", "defineComponent", ctx)),
         _ => false,
-    })
-}
-
-fn is_vue_define_component_reference<'a>(
-    ident: &IdentifierReference<'a>,
-    ctx: &LintContext<'a>,
-) -> bool {
-    if ident.name != "defineComponent" {
-        return false;
-    }
-    let scoping = ctx.scoping();
-    let Some(symbol_id) = scoping.get_reference(ident.reference_id()).symbol_id() else {
-        return false;
-    };
-    let declaration = ctx.symbol_declaration(symbol_id);
-    if !matches!(declaration.kind(), AstKind::ImportSpecifier(_)) {
-        return false;
-    }
-    ctx.nodes().ancestors(declaration.id()).any(|ancestor| {
-        matches!(
-            ancestor.kind(),
-            AstKind::ImportDeclaration(import_decl) if import_decl.source.value == "vue"
-        )
     })
 }
 
@@ -355,6 +318,23 @@ fn test() {
                     this.$delete(obj, key)
                   }
                 }
+                </script>
+            ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // Phase 2: aliased `defineComponent` import
+        (
+            "
+                <script>
+                import { defineComponent as dc } from 'vue'
+                dc({
+                  mounted () {
+                    this.$set(obj, key, value)
+                    this.$delete(obj, key)
+                  }
+                })
                 </script>
             ",
             None,

--- a/crates/oxc_linter/src/snapshots/vue_no_deprecated_delete_set.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_deprecated_delete_set.snap
@@ -19,6 +19,22 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ vue(no-deprecated-delete-set): `$delete` and `$set` are deprecated.
+   ╭─[no_deprecated_delete_set.tsx:6:26]
+ 5 │                   mounted () {
+ 6 │                     this.$set(obj, key, value)
+   ·                          ────
+ 7 │                     this.$delete(obj, key)
+   ╰────
+
+  ⚠ vue(no-deprecated-delete-set): `$delete` and `$set` are deprecated.
+   ╭─[no_deprecated_delete_set.tsx:7:26]
+ 6 │                     this.$set(obj, key, value)
+ 7 │                     this.$delete(obj, key)
+   ·                          ───────
+ 8 │                   }
+   ╰────
+
+  ⚠ vue(no-deprecated-delete-set): `$delete` and `$set` are deprecated.
    ╭─[no_deprecated_delete_set.tsx:7:24]
  6 │                     const vm = this
  7 │                     vm.$set(obj, key, value)

--- a/crates/oxc_linter/src/utils/vue.rs
+++ b/crates/oxc_linter/src/utils/vue.rs
@@ -11,7 +11,7 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{
     AstNode, ContextSubHost, LintContext, ast_util::get_declaration_from_reference_id,
-    frameworks::FrameworkOptions, module_record::ImportImportName,
+    frameworks::FrameworkOptions, module_record::ImportImportName, utils::is_import_symbol,
 };
 
 // These sets mirror eslint-plugin-vue's `vue/no-reserved-component-names`.
@@ -333,25 +333,7 @@ pub fn is_vue_component_options_call(call_expr: &CallExpression<'_>) -> bool {
 
 /// Check whether the identifier is imported as `nextTick` or aliased from `'vue'`.
 pub fn is_vue_next_tick_import(ident: &IdentifierReference, ctx: &LintContext<'_>) -> bool {
-    let scoping = ctx.scoping();
-    let Some(symbol_id) = scoping.get_reference(ident.reference_id()).symbol_id() else {
-        return false;
-    };
-    for entry in &ctx.module_record().import_entries {
-        if entry.module_request.name() != "vue" {
-            continue;
-        }
-        let ImportImportName::Name(name_span) = &entry.import_name else {
-            continue;
-        };
-        if name_span.name() != "nextTick" {
-            continue;
-        }
-        if scoping.get_root_binding(entry.local_name.name().into()) == Some(symbol_id) {
-            return true;
-        }
-    }
-    false
+    is_import_symbol(ident, "vue", "nextTick", ctx)
 }
 
 /// Finds the first `ObjectProperty` whose static key matches `name` in the given object.


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, Opus 5. Tested and reviewed by me. 

Why do many code when few do trick?

Follow-up to #25901. Hand-rolled import checks can simply be replaced with the shared `is_import_symbol` helper, this also helps improve the accuracy of the code to catch aliased imports for one of them.

### Bug fixed

`is_vue_define_component_reference` (used by `vue/no-deprecated-delete-set` to decide whether a `this.$set` / `this.$delete` call sits inside a Vue component) gated on the **local** name being `defineComponent` before walking up to the `ImportDeclaration`, so an aliased import was never recognised:

```vue
<script>
import { defineComponent as dc } from 'vue'
dc({
  mounted () {
    this.$set(obj, key, value)
    this.$delete(obj, key)
  }
})
</script>
```

Neither call was reported before; both are now. Covered by a new test case.

### Pure simplifications

- `is_imported_set_or_del_from_vue` (`no-deprecated-delete-set`) — 20 lines → two `is_import_symbol` calls.
- `is_vue_next_tick_import` (`utils/vue.rs`, used by `vue/next-tick-style` and `vue/valid-next-tick`) — 18 lines → one call.

Both already matched by symbol id, so behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)