### PR TITLE
fix(transformer): handle multiple object rest declarators

### DIFF
--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -820,7 +820,7 @@ impl<'a> ObjectRestSpread<'a> {
                 new_decls.push((i, decls));
             }
         }
-        for (i, decls) in new_decls {
+        for (i, decls) in new_decls.into_iter().rev() {
             decl.declarations.splice(i..=i, decls);
         }
     }

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1eac4481
 
-Passed: 270/398
+Passed: 271/399
 
 # All Passed:
 * babel-plugin-transform-class-static-block

--- a/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/oxc/multiple-object-rest-declarators/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/oxc/multiple-object-rest-declarators/input.js
@@ -1,0 +1,5 @@
+function merge(e, t) {
+  const { ariaAttributes: s, style: r, ...n } = e,
+    { ariaAttributes: i, style: l, ...f } = t;
+  return [s, r, n, i, l, f];
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/oxc/multiple-object-rest-declarators/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/oxc/multiple-object-rest-declarators/output.js
@@ -1,0 +1,5 @@
+const _excluded = ["ariaAttributes", "style"], _excluded2 = ["ariaAttributes", "style"];
+function merge(e, t) {
+	const { ariaAttributes: s, style: r } = e, n = babelHelpers.objectWithoutProperties(e, _excluded), { ariaAttributes: i, style: l } = t, f = babelHelpers.objectWithoutProperties(t, _excluded2);
+	return [s, r, n, i, l, f];
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/oxc/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/oxc/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-object-rest-spread"]
+}


### PR DESCRIPTION
## Summary

- Apply object-rest declarator replacements from right to left so their original indices remain valid.
- Add a regression fixture for multiple object-rest declarators in one variable declaration.

`transform_variable_declaration` collects the original declarator indices before expanding each matching object-rest declarator. Replacing them from left to right can shift the remaining indices. With two object-rest declarators in one declaration, the second splice removes the first generated rest binding and leaves the moved-from `{}` / `null` node behind.

Applying the queued replacements in reverse preserves source order while keeping every original index valid.

Fixes #25907.
Related to vitejs/vite#23298.

## Test

- `cargo run -p oxc_transform_conformance -- --filter babel-plugin-transform-object-rest-spread/test/fixtures/oxc/multiple-object-rest-declarators`
- `cargo run -p oxc_transform_conformance -- --filter babel-plugin-transform-object-rest-spread`
- `cargo test -p oxc_transformer`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI assistance

Codex was used to assist with root-cause analysis, implementation, and test execution. The change is limited to reversing the queued splices and includes a targeted regression fixture.