### PR TITLE
fix(linter): resolve globals by reference, not by name

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -1,6 +1,7 @@
 use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
+use oxc_semantic::IsGlobalReference;
 use oxc_span::{GetSpan, Span};
 use oxc_str::CompactStr;
 use schemars::JsonSchema;
@@ -107,9 +108,8 @@ impl Rule for NoConsole {
             return;
         };
 
-        if ident.name != "console"
-            || !ctx.scoping().root_unresolved_references().contains_key("console")
-        {
+        // Not `ctx.is_reference_to_global_variable`: `globals: { console: "off" }` still reports.
+        if ident.name != "console" || !ident.is_global_reference(ctx.scoping()) {
             return;
         }
 
@@ -190,6 +190,12 @@ fn test() {
 
     let pass = vec![
         ("Console.info(foo)", None, None),
+        // `console` is shadowed here; the global is only referenced on the first line
+        (
+            "var c = console; function f(myLogger) { const console = myLogger; console.log(foo); }",
+            None,
+            None,
+        ),
         ("console.info(foo)", Some(serde_json::json!([{ "allow": ["info"] }])), None),
         (
             "console.info(foo)",

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -190,7 +190,6 @@ fn test() {
 
     let pass = vec![
         ("Console.info(foo)", None, None),
-        // `console` is shadowed here; the global is only referenced on the first line
         (
             "var c = console; function f(myLogger) { const console = myLogger; console.log(foo); }",
             None,

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -1,11 +1,12 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+
 use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
 use oxc_span::{GetSpan, Span};
 use oxc_str::CompactStr;
-use schemars::JsonSchema;
-use serde::Deserialize;
 
 use crate::{
     AstNode,
@@ -190,11 +191,6 @@ fn test() {
 
     let pass = vec![
         ("Console.info(foo)", None, None),
-        (
-            "var c = console; function f(myLogger) { const console = myLogger; console.log(foo); }",
-            None,
-            None,
-        ),
         ("console.info(foo)", Some(serde_json::json!([{ "allow": ["info"] }])), None),
         (
             "console.info(foo)",
@@ -215,6 +211,11 @@ fn test() {
         ("console.log(foo)", Some(serde_json::json!([{ "allow": ["info", "log", "warn"] }])), None),
         ("var console = require('myconsole'); console.log(foo)", None, None),
         ("import console from 'myconsole'; console.log(foo)", None, None),
+        (
+            "var c = console; function f(myLogger) { const console = myLogger; console.log(foo); }",
+            None,
+            None,
+        ),
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -235,7 +235,7 @@ impl NoConstantBinaryExpression {
             Expression::CallExpression(call_expr) => {
                 if let Expression::Identifier(ident) = &call_expr.callee {
                     return ["Boolean", "String", "Number"].contains(&ident.name.as_str())
-                        && ctx.scoping().root_unresolved_references().contains_key(&ident.name);
+                        && ctx.is_reference_to_global_variable(ident);
                 }
                 false
             }
@@ -358,14 +358,13 @@ impl NoConstantBinaryExpression {
             },
             Expression::CallExpression(call_expr) => {
                 if let Expression::Identifier(ident) = &call_expr.callee {
-                    let unresolved_references = ctx.scoping().root_unresolved_references();
                     if (ident.name == "String" || ident.name == "Number")
-                        && unresolved_references.contains_key(&ident.name)
+                        && ctx.is_reference_to_global_variable(ident)
                     {
                         return true;
                     }
 
-                    if ident.name == "Boolean" && unresolved_references.contains_key(&ident.name) {
+                    if ident.name == "Boolean" && ctx.is_reference_to_global_variable(ident) {
                         return call_expr
                             .arguments
                             .iter()
@@ -463,14 +462,18 @@ fn test() {
         "[n] == true",
         "delete bar.baz === true",
         "foo.Boolean(true) && foo",
-        // "function Boolean(n) { return n; }; Boolean(x) ?? foo",
-        // "function String(n) { return n; }; String(x) ?? foo",
-        // "function Number(n) { return n; }; Number(x) ?? foo",
-        // "function Boolean(n) { return Math.random(); }; Boolean(x) === 1",
-        // "function Boolean(n) { return Math.random(); }; Boolean(1) == true",
+        "function Boolean(n) { return n; }; Boolean(x) ?? foo",
+        "function String(n) { return n; }; String(x) ?? foo",
+        "function Number(n) { return n; }; Number(x) ?? foo",
+        // shadowed in the function, global only referenced on the next statement
+        "function f(MyString, x, y) { const String = MyString; return String(x) ?? y; }; String(1)",
+        "function Boolean(n) { return Math.random(); }; Boolean(x) === 1",
+        "function Boolean(n) { return Math.random(); }; Boolean(1) == true",
         "new Foo() === x",
         "x === new someObj.Promise()",
         "Boolean(foo) === true",
+        // TODO: `undefined` is matched by name, so a shadowed binding is still treated as
+        // the global. See `Expression::is_undefined` usage in this rule.
         // "function foo(undefined) { undefined ?? bar;}",
         // "function foo(undefined) { undefined == true;}",
         // "function foo(undefined) { undefined === true;}",

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -465,7 +465,6 @@ fn test() {
         "function Boolean(n) { return n; }; Boolean(x) ?? foo",
         "function String(n) { return n; }; String(x) ?? foo",
         "function Number(n) { return n; }; Number(x) ?? foo",
-        // shadowed in the function, global only referenced on the next statement
         "function f(MyString, x, y) { const String = MyString; return String(x) ?? y; }; String(1)",
         "function Boolean(n) { return Math.random(); }; Boolean(x) === 1",
         "function Boolean(n) { return Math.random(); }; Boolean(1) == true",

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -79,8 +79,6 @@ fn test() {
 
     let pass = vec![
         "var foo = Symbol('foo');",
-        // `Symbol` is shadowed here; the global is only referenced on the next line
-        "function f(FakeSymbol) { const Symbol = FakeSymbol; new Symbol(); }; Symbol('foo');",
         "function bar(Symbol) { var baz = new Symbol('baz');}",
         "function Symbol() {} new Symbol();",
         "new foo(Symbol);",
@@ -90,6 +88,7 @@ fn test() {
         "function BigInt() {} new BigInt();",
         "new foo(BigInt);",
         "new foo(bar, BigInt);",
+        "function f(FakeSymbol) { const Symbol = FakeSymbol; new Symbol(); }; Symbol('foo');",
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -61,7 +61,7 @@ impl Rule for NoNewNativeNonconstructor {
             return;
         };
         if matches!(ident.name.as_str(), "Symbol" | "BigInt")
-            && ctx.scoping().root_unresolved_references().contains_key(&ident.name)
+            && ctx.is_reference_to_global_variable(ident)
         {
             let start = expr.span.start;
             let end = start + 3;
@@ -79,6 +79,8 @@ fn test() {
 
     let pass = vec![
         "var foo = Symbol('foo');",
+        // `Symbol` is shadowed here; the global is only referenced on the next line
+        "function f(FakeSymbol) { const Symbol = FakeSymbol; new Symbol(); }; Symbol('foo');",
         "function bar(Symbol) { var baz = new Symbol('baz');}",
         "function Symbol() {} new Symbol();",
         "new foo(Symbol);",

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
@@ -89,19 +89,15 @@ impl Rule for PreferObjectSpread {
             return;
         };
 
-        let unresolved_references = ctx.scoping().root_unresolved_references();
-
         match callee.object().get_inner_expression() {
             Expression::Identifier(ident) => {
-                if ident.name != "Object" || !unresolved_references.contains_key(&ident.name) {
+                if ident.name != "Object" || !ctx.is_reference_to_global_variable(ident) {
                     return;
                 }
             }
             Expression::StaticMemberExpression(member_expr) => {
                 if let Expression::Identifier(ident) = member_expr.object.get_inner_expression() {
-                    if ident.name != "globalThis"
-                        || !unresolved_references.contains_key(&ident.name)
-                    {
+                    if ident.name != "globalThis" || !ctx.is_reference_to_global_variable(ident) {
                         return;
                     }
                 } else {
@@ -368,6 +364,8 @@ fn test() {
 
     let pass = vec![
         "Object.assign()",
+        // `Object` is shadowed here; the global is only referenced on the next line
+        "function f(MyObject, a) { const Object = MyObject; return Object.assign({}, a) }; Object.keys(x)",
         "let a = Object.assign(a, b)",
         "Object.assign(a, b)",
         "let a = Object.assign(b, { c: 1 })",

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
@@ -364,8 +364,6 @@ fn test() {
 
     let pass = vec![
         "Object.assign()",
-        // `Object` is shadowed here; the global is only referenced on the next line
-        "function f(MyObject, a) { const Object = MyObject; return Object.assign({}, a) }; Object.keys(x)",
         "let a = Object.assign(a, b)",
         "Object.assign(a, b)",
         "let a = Object.assign(b, { c: 1 })",
@@ -422,6 +420,7 @@ fn test() {
         "Object.assign({}, { set a(val) {} })",
         "Object.assign({}, { foo: 'bar', get a() {} }, {})",
         "Object.assign({ foo }, bar, {}, { baz: 'quux', set a(val) {}, quuux }, {})",
+        "function f(MyObject, a) { const Object = MyObject; return Object.assign({}, a) }; Object.keys(x)",
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -81,13 +81,12 @@ fn test() {
 
     let pass = vec![
         r#"Symbol("Foo");"#,
-        // `Symbol` is shadowed here; the global is only referenced on the next line
-        r#"function f(FakeSymbol) { const Symbol = FakeSymbol; Symbol(); }; Symbol("Foo");"#,
         r#"var foo = "foo"; Symbol(foo);"#,
         "var Symbol = function () {}; Symbol();",
         "Symbol(); var Symbol = function () {};",
         "function bar() { var Symbol = function () {}; Symbol(); }",
         "function bar(Symbol) { Symbol(); }",
+        r#"function f(FakeSymbol) { const Symbol = FakeSymbol; Symbol(); }; Symbol("Foo");"#,
     ];
 
     let fail = vec!["Symbol();", "Symbol(); Symbol = function () {};"];

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -68,7 +68,7 @@ impl Rule for SymbolDescription {
 
         if ident.name == "Symbol"
             && call_expr.arguments.is_empty()
-            && ctx.scoping().root_unresolved_references().contains_key(&ident.name)
+            && ctx.is_reference_to_global_variable(ident)
         {
             ctx.diagnostic(symbol_description_diagnostic(call_expr.span));
         }
@@ -81,6 +81,8 @@ fn test() {
 
     let pass = vec![
         r#"Symbol("Foo");"#,
+        // `Symbol` is shadowed here; the global is only referenced on the next line
+        r#"function f(FakeSymbol) { const Symbol = FakeSymbol; Symbol(); }; Symbol("Foo");"#,
         r#"var foo = "foo"; Symbol(foo);"#,
         "var Symbol = function () {}; Symbol();",
         "Symbol(); var Symbol = function () {};",

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -1,9 +1,10 @@
+use schemars::JsonSchema;
+
 use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span, best_match};
 use oxc_syntax::operator::UnaryOperator;
-use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::{
@@ -184,11 +185,6 @@ fn test() {
 
     let pass = vec![
         ("typeof foo === 'string'", None),
-        // `undefined` is shadowed here; the global is only referenced on the next line
-        (
-            "function f(x, u) { const undefined = u; return typeof x === undefined; }; var y = undefined;",
-            None,
-        ),
         ("typeof foo === 'object'", None),
         ("typeof foo === 'function'", None),
         ("typeof foo === 'undefined'", None),
@@ -224,6 +220,10 @@ fn test() {
         ("typeof foo === `string`", Some(serde_json::json!([{ "requireStringLiterals": true }]))),
         ("`object` === typeof foo", Some(serde_json::json!([{ "requireStringLiterals": true }]))),
         ("typeof foo === `str${somethingElse}`", None), // { "ecmaVersion": 6 }
+        (
+            "function f(x, u) { const undefined = u; return typeof x === undefined; }; var y = undefined;",
+            None,
+        ),
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -145,7 +145,7 @@ impl Rule for ValidTypeof {
 
         if let Expression::Identifier(ident) = sibling
             && ident.name == "undefined"
-            && ctx.scoping().root_unresolved_references().contains_key(&ident.name)
+            && ctx.is_reference_to_global_variable(ident)
         {
             ctx.diagnostic_with_fix(
                 if self.require_string_literals {
@@ -184,6 +184,11 @@ fn test() {
 
     let pass = vec![
         ("typeof foo === 'string'", None),
+        // `undefined` is shadowed here; the global is only referenced on the next line
+        (
+            "function f(x, u) { const undefined = u; return typeof x === undefined; }; var y = undefined;",
+            None,
+        ),
         ("typeof foo === 'object'", None),
         ("typeof foo === 'function'", None),
         ("typeof foo === 'undefined'", None),

--- a/crates/oxc_linter/src/rules/promise/avoid_new.rs
+++ b/crates/oxc_linter/src/rules/promise/avoid_new.rs
@@ -71,14 +71,13 @@ fn test() {
 
     let pass = vec![
         "Promise.resolve()",
-        // `Promise` is shadowed here; the global is only referenced on the next line
-        "function f(FakePromise) { const Promise = FakePromise; new Promise(function (r) { r() }) }; Promise.resolve()",
         "Promise.reject()",
         "Promise.all()",
         "new Horse()",
         "new PromiseLikeThing()",
         "new Promise.resolve()",
         "var Promise = a; new Promise()",
+        "function f(FakePromise) { const Promise = FakePromise; new Promise(function (r) { r() }) }; Promise.resolve()",
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/promise/avoid_new.rs
+++ b/crates/oxc_linter/src/rules/promise/avoid_new.rs
@@ -59,9 +59,7 @@ impl Rule for AvoidNew {
             return;
         };
 
-        if ident.name == "Promise"
-            && ctx.scoping().root_unresolved_references().contains_key(&ident.name)
-        {
+        if ident.name == "Promise" && ctx.is_reference_to_global_variable(ident) {
             ctx.diagnostic(avoid_new_promise_diagnostic(expr.span));
         }
     }
@@ -73,6 +71,8 @@ fn test() {
 
     let pass = vec![
         "Promise.resolve()",
+        // `Promise` is shadowed here; the global is only referenced on the next line
+        "function f(FakePromise) { const Promise = FakePromise; new Promise(function (r) { r() }) }; Promise.resolve()",
         "Promise.reject()",
         "Promise.all()",
         "new Horse()",

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -177,8 +177,6 @@ fn test() {
 
     let pass = vec![
         "const foo = new Object()",
-        // `String` is shadowed here; the global is only referenced on the next line
-        "function f(MyString) { const String = MyString; return new String('x') }; String(1)",
         "const foo = new Array()",
         "const foo = Array?.()",
         "const foo = Map?.()",
@@ -235,6 +233,7 @@ fn test() {
         "(x) !== Object(x)",
         // r#"new Symbol("")"#, // {"globals": {"Symbol": "off"}},
         "const foo = new Date();",
+        "function f(MyString) { const String = MyString; return new String('x') }; String(1)",
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -117,12 +117,11 @@ fn is_expr_global_builtin<'a, 'b>(
 ) -> Option<&'b str> {
     let expr = expr.without_parentheses();
     if let Expression::Identifier(ident) = expr {
-        let name = ident.name.as_str();
-        if !ctx.scoping().root_unresolved_references().contains_key(name) {
+        if !ctx.is_reference_to_global_variable(ident) {
             return None;
         }
 
-        Some(name)
+        Some(ident.name.as_str())
     } else {
         let member_expr = expr.as_member_expression()?;
 
@@ -178,6 +177,8 @@ fn test() {
 
     let pass = vec![
         "const foo = new Object()",
+        // `String` is shadowed here; the global is only referenced on the next line
+        "function f(MyString) { const String = MyString; return new String('x') }; String(1)",
         "const foo = new Array()",
         "const foo = Array?.()",
         "const foo = Map?.()",

--- a/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
@@ -303,7 +303,6 @@ fn test() {
         "window[foo]",
         "window[title]",
         r#"window["foo"]"#,
-        // `window` is shadowed here; the global is only referenced on the next line
         "function f(fake) { const window = fake; return window.foo }; window[key]",
     ];
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
@@ -70,7 +70,7 @@ impl Rule for PreferGlobalThis {
 
         if !matches!(ident.name.as_str(), "window" | "self" | "global")
             || is_computed_member_expression_object(node, ctx)
-            || !ctx.scoping().root_unresolved_references().contains_key(&ident.name)
+            || !ctx.is_reference_to_global_variable(ident)
         {
             return;
         }
@@ -259,6 +259,8 @@ fn test() {
 
     let pass = vec![
         "globalThis",
+        // `window` is shadowed here; the global is only referenced on the next line
+        "function f(fake) { const window = fake; return window.foo }; window[key]",
         "globalThis.foo",
         "globalThis[foo]",
         "globalThis.foo()",

--- a/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
@@ -259,8 +259,6 @@ fn test() {
 
     let pass = vec![
         "globalThis",
-        // `window` is shadowed here; the global is only referenced on the next line
-        "function f(fake) { const window = fake; return window.foo }; window[key]",
         "globalThis.foo",
         "globalThis[foo]",
         "globalThis.foo()",
@@ -305,6 +303,8 @@ fn test() {
         "window[foo]",
         "window[title]",
         r#"window["foo"]"#,
+        // `window` is shadowed here; the global is only referenced on the next line
+        "function f(fake) { const window = fake; return window.foo }; window[key]",
     ];
 
     let fail = vec![


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, Opus 5. Tested and reviewed by me.

Ten call sites across nine rules checked whether an identifier is a specific global with:

```rust
ctx.scoping().root_unresolved_references().contains_key(&ident.name)
```

That asks whether the **name** is unresolved **somewhere in the file**, not whether **this reference** is global. Any file that shadows the global in one scope and uses the real global in another gets a false positive on the shadowed use:

```js
function f(myLogger) {
  const console = myLogger;
  console.log(1);        // reported by `no-console` — this is the bug
}
console.log(2);          // the real global, elsewhere in the file
```

`ctx.is_reference_to_global_variable(ident)` already exists for this and is used at ~50 other call sites. It is `reference.symbol_id().is_none()` — one field read instead of hashing the name into the unresolved-references map — and it honours the user's `globals: { X: "off" }` config.

### Rules fixed

| rule | shadowed code that was wrongly reported |
| --- | --- |
| `eslint/no-console` | `const console = myLogger; console.log(foo)` |
| `eslint/no-constant-binary-expression` | `const String = MyString; String(x) ?? y` |
| `eslint/no-new-native-nonconstructor` | `const Symbol = FakeSymbol; new Symbol()` |
| `eslint/prefer-object-spread` | `const Object = MyObject; Object.assign({}, a)` |
| `eslint/symbol-description` | `const Symbol = FakeSymbol; Symbol()` |
| `eslint/valid-typeof` | `const undefined = u; typeof x === undefined` |
| `promise/avoid-new` | `const Promise = FakePromise; new Promise(fn)` |
| `unicorn/new-for-builtins` | `const String = MyString; new String('x')` |
| `unicorn/prefer-global-this` | `const window = fake; window.foo` |

Each rule gets a pass test in that shape. Both halves matter — without a second, genuine use of the global the name lookup already returns false, so a single-scope test would pass before the fix too.

Three of these ship a fix or suggestion (`prefer-global-this`, `valid-typeof`, `no-console`), so the false positive was rewriting or deleting code the user owns.

### Real-world impact

Base vs. branch over four corpora (vscode, sentry, material-ui, actual), each rule isolated with `-A all -A nursery -D <rule> --format=json --no-ignore --disable-nested-config`, diagnostics normalised to `(file, span, code, message)`:

**0 added, 23 removed.** Every removal is `prefer-global-this` on a genuinely shadowed `window`:

- `vscode/src/vs/base/browser/dompurify/dompurify.js` (16) — `let window = arguments.length > 0 ? arguments[0] : getGlobal()`
- `material-ui/packages-internal/core-docs/src/Demo/DemoSandbox.tsx` (5) — `function IsolatedDemo({ children, cssVarPrefix, colorSchemeNode, window })`, a destructured prop
- `sentry/src/sentry/templates/sentry/error-page-embed.js` (2) — `(function (window, document, JSON) { ... })(window, document, JSON)`, the classic IIFE parameter

In each file the real global references outside the shadowing scope are still reported.

### Notes

- `no-console` uses `ident.is_global_reference(ctx.scoping())` rather than the context helper. An existing fail case pins that `globals: { console: "off" }` must still report, and the context helper treats `"off"` as "not a global". The other eight sites use the context helper, so they now respect that config, but this one doesn't.
- Five upstream ESLint pass cases that were commented out in `no-constant-binary-expression` now pass and are re-enabled (`function Boolean(n) { return n; }; Boolean(x) ?? foo` and friends). Two others in that list stay commented — they are `function foo(undefined) { ... }`, which is a separate problem: the rule matches `undefined` by name via `Expression::is_undefined()`. Left a TODO pointing at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)