### PR TITLE
feat(linter): add jest/vitest padding-around-describe-blocks rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -999,6 +999,7 @@ export interface DummyRuleMap {
   "jest/no-unneeded-async-expect-function"?: RuleNoConfig;
   "jest/no-untyped-mock-factory"?: RuleNoConfig;
   "jest/padding-around-after-all-blocks"?: RuleNoConfig;
+  "jest/padding-around-describe-blocks"?: RuleNoConfig;
   "jest/padding-around-test-blocks"?: RuleNoConfig;
   "jest/prefer-called-with"?: RuleNoConfig;
   "jest/prefer-comparison-matcher"?: RuleNoConfig;
@@ -1715,6 +1716,7 @@ export interface DummyRuleMap {
   "vitest/no-test-return-statement"?: RuleNoConfig;
   "vitest/no-unneeded-async-expect-function"?: RuleNoConfig;
   "vitest/padding-around-after-all-blocks"?: RuleNoConfig;
+  "vitest/padding-around-describe-blocks"?: RuleNoConfig;
   "vitest/padding-around-test-blocks"?: RuleNoConfig;
   "vitest/prefer-called-exactly-once-with"?: RuleNoConfig;
   "vitest/prefer-called-once"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2393,6 +2393,13 @@ impl RuleRunner
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner
+    for crate::rules::jest::padding_around_describe_blocks::PaddingAroundDescribeBlocks
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::jest::padding_around_test_blocks::PaddingAroundTestBlocks {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
@@ -4932,6 +4939,13 @@ impl RuleRunner
 
 impl RuleRunner
     for crate::rules::vitest::padding_around_after_all_blocks::PaddingAroundAfterAllBlocks
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
+impl RuleRunner
+    for crate::rules::vitest::padding_around_describe_blocks::PaddingAroundDescribeBlocks
 {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -259,6 +259,7 @@ pub use crate::rules::jest::no_test_return_statement::NoTestReturnStatement as J
 pub use crate::rules::jest::no_unneeded_async_expect_function::NoUnneededAsyncExpectFunction as JestNoUnneededAsyncExpectFunction;
 pub use crate::rules::jest::no_untyped_mock_factory::NoUntypedMockFactory as JestNoUntypedMockFactory;
 pub use crate::rules::jest::padding_around_after_all_blocks::PaddingAroundAfterAllBlocks as JestPaddingAroundAfterAllBlocks;
+pub use crate::rules::jest::padding_around_describe_blocks::PaddingAroundDescribeBlocks as JestPaddingAroundDescribeBlocks;
 pub use crate::rules::jest::padding_around_test_blocks::PaddingAroundTestBlocks as JestPaddingAroundTestBlocks;
 pub use crate::rules::jest::prefer_called_with::PreferCalledWith as JestPreferCalledWith;
 pub use crate::rules::jest::prefer_comparison_matcher::PreferComparisonMatcher as JestPreferComparisonMatcher;
@@ -791,6 +792,7 @@ pub use crate::rules::vitest::no_test_prefixes::NoTestPrefixes as VitestNoTestPr
 pub use crate::rules::vitest::no_test_return_statement::NoTestReturnStatement as VitestNoTestReturnStatement;
 pub use crate::rules::vitest::no_unneeded_async_expect_function::NoUnneededAsyncExpectFunction as VitestNoUnneededAsyncExpectFunction;
 pub use crate::rules::vitest::padding_around_after_all_blocks::PaddingAroundAfterAllBlocks as VitestPaddingAroundAfterAllBlocks;
+pub use crate::rules::vitest::padding_around_describe_blocks::PaddingAroundDescribeBlocks as VitestPaddingAroundDescribeBlocks;
 pub use crate::rules::vitest::padding_around_test_blocks::PaddingAroundTestBlocks as VitestPaddingAroundTestBlocks;
 pub use crate::rules::vitest::prefer_called_exactly_once_with::PreferCalledExactlyOnceWith as VitestPreferCalledExactlyOnceWith;
 pub use crate::rules::vitest::prefer_called_once::PreferCalledOnce as VitestPreferCalledOnce;
@@ -1251,6 +1253,7 @@ pub enum RuleEnum {
     JestNoUnneededAsyncExpectFunction(JestNoUnneededAsyncExpectFunction),
     JestNoUntypedMockFactory(JestNoUntypedMockFactory),
     JestPaddingAroundAfterAllBlocks(JestPaddingAroundAfterAllBlocks),
+    JestPaddingAroundDescribeBlocks(JestPaddingAroundDescribeBlocks),
     JestPaddingAroundTestBlocks(JestPaddingAroundTestBlocks),
     JestPreferCalledWith(JestPreferCalledWith),
     JestPreferComparisonMatcher(JestPreferComparisonMatcher),
@@ -1666,6 +1669,7 @@ pub enum RuleEnum {
     VitestNoTestReturnStatement(VitestNoTestReturnStatement),
     VitestNoUnneededAsyncExpectFunction(VitestNoUnneededAsyncExpectFunction),
     VitestPaddingAroundAfterAllBlocks(VitestPaddingAroundAfterAllBlocks),
+    VitestPaddingAroundDescribeBlocks(VitestPaddingAroundDescribeBlocks),
     VitestPaddingAroundTestBlocks(VitestPaddingAroundTestBlocks),
     VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith),
     VitestPreferCalledOnce(VitestPreferCalledOnce),
@@ -2176,7 +2180,9 @@ const JEST_NO_TEST_RETURN_STATEMENT_ID: usize = JEST_NO_TEST_PREFIXES_ID + 1usiz
 const JEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID: usize = JEST_NO_TEST_RETURN_STATEMENT_ID + 1usize;
 const JEST_NO_UNTYPED_MOCK_FACTORY_ID: usize = JEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID + 1usize;
 const JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID: usize = JEST_NO_UNTYPED_MOCK_FACTORY_ID + 1usize;
-const JEST_PADDING_AROUND_TEST_BLOCKS_ID: usize = JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID + 1usize;
+const JEST_PADDING_AROUND_DESCRIBE_BLOCKS_ID: usize =
+    JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID + 1usize;
+const JEST_PADDING_AROUND_TEST_BLOCKS_ID: usize = JEST_PADDING_AROUND_DESCRIBE_BLOCKS_ID + 1usize;
 const JEST_PREFER_CALLED_WITH_ID: usize = JEST_PADDING_AROUND_TEST_BLOCKS_ID + 1usize;
 const JEST_PREFER_COMPARISON_MATCHER_ID: usize = JEST_PREFER_CALLED_WITH_ID + 1usize;
 const JEST_PREFER_EACH_ID: usize = JEST_PREFER_COMPARISON_MATCHER_ID + 1usize;
@@ -2635,8 +2641,10 @@ const VITEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID: usize =
     VITEST_NO_TEST_RETURN_STATEMENT_ID + 1usize;
 const VITEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID: usize =
     VITEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID + 1usize;
-const VITEST_PADDING_AROUND_TEST_BLOCKS_ID: usize =
+const VITEST_PADDING_AROUND_DESCRIBE_BLOCKS_ID: usize =
     VITEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID + 1usize;
+const VITEST_PADDING_AROUND_TEST_BLOCKS_ID: usize =
+    VITEST_PADDING_AROUND_DESCRIBE_BLOCKS_ID + 1usize;
 const VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID: usize =
     VITEST_PADDING_AROUND_TEST_BLOCKS_ID + 1usize;
 const VITEST_PREFER_CALLED_ONCE_ID: usize = VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID + 1usize;
@@ -2748,7 +2756,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 870usize] = [
+static RULE_NAMES: [&str; 872usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3108,6 +3116,7 @@ static RULE_NAMES: [&str; 870usize] = [
     JestNoUnneededAsyncExpectFunction::NAME,
     JestNoUntypedMockFactory::NAME,
     JestPaddingAroundAfterAllBlocks::NAME,
+    JestPaddingAroundDescribeBlocks::NAME,
     JestPaddingAroundTestBlocks::NAME,
     JestPreferCalledWith::NAME,
     JestPreferComparisonMatcher::NAME,
@@ -3519,6 +3528,7 @@ static RULE_NAMES: [&str; 870usize] = [
     VitestNoTestReturnStatement::NAME,
     VitestNoUnneededAsyncExpectFunction::NAME,
     VitestPaddingAroundAfterAllBlocks::NAME,
+    VitestPaddingAroundDescribeBlocks::NAME,
     VitestPaddingAroundTestBlocks::NAME,
     VitestPreferCalledExactlyOnceWith::NAME,
     VitestPreferCalledOnce::NAME,
@@ -4052,6 +4062,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(_) => JEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID,
             Self::JestNoUntypedMockFactory(_) => JEST_NO_UNTYPED_MOCK_FACTORY_ID,
             Self::JestPaddingAroundAfterAllBlocks(_) => JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID,
+            Self::JestPaddingAroundDescribeBlocks(_) => JEST_PADDING_AROUND_DESCRIBE_BLOCKS_ID,
             Self::JestPaddingAroundTestBlocks(_) => JEST_PADDING_AROUND_TEST_BLOCKS_ID,
             Self::JestPreferCalledWith(_) => JEST_PREFER_CALLED_WITH_ID,
             Self::JestPreferComparisonMatcher(_) => JEST_PREFER_COMPARISON_MATCHER_ID,
@@ -4513,6 +4524,7 @@ impl RuleEnum {
                 VITEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID
             }
             Self::VitestPaddingAroundAfterAllBlocks(_) => VITEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID,
+            Self::VitestPaddingAroundDescribeBlocks(_) => VITEST_PADDING_AROUND_DESCRIBE_BLOCKS_ID,
             Self::VitestPaddingAroundTestBlocks(_) => VITEST_PADDING_AROUND_TEST_BLOCKS_ID,
             Self::VitestPreferCalledExactlyOnceWith(_) => VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID,
             Self::VitestPreferCalledOnce(_) => VITEST_PREFER_CALLED_ONCE_ID,
@@ -5079,6 +5091,7 @@ impl RuleEnum {
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::CATEGORY,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::CATEGORY,
+            Self::JestPaddingAroundDescribeBlocks(_) => JestPaddingAroundDescribeBlocks::CATEGORY,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::CATEGORY,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::CATEGORY,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::CATEGORY,
@@ -5555,6 +5568,9 @@ impl RuleEnum {
             }
             Self::VitestPaddingAroundAfterAllBlocks(_) => {
                 VitestPaddingAroundAfterAllBlocks::CATEGORY
+            }
+            Self::VitestPaddingAroundDescribeBlocks(_) => {
+                VitestPaddingAroundDescribeBlocks::CATEGORY
             }
             Self::VitestPaddingAroundTestBlocks(_) => VitestPaddingAroundTestBlocks::CATEGORY,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
@@ -6104,6 +6120,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(_) => JestNoUnneededAsyncExpectFunction::FIX,
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::FIX,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::FIX,
+            Self::JestPaddingAroundDescribeBlocks(_) => JestPaddingAroundDescribeBlocks::FIX,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::FIX,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::FIX,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::FIX,
@@ -6557,6 +6574,7 @@ impl RuleEnum {
                 VitestNoUnneededAsyncExpectFunction::FIX
             }
             Self::VitestPaddingAroundAfterAllBlocks(_) => VitestPaddingAroundAfterAllBlocks::FIX,
+            Self::VitestPaddingAroundDescribeBlocks(_) => VitestPaddingAroundDescribeBlocks::FIX,
             Self::VitestPaddingAroundTestBlocks(_) => VitestPaddingAroundTestBlocks::FIX,
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::FIX,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::FIX,
@@ -7191,6 +7209,9 @@ impl RuleEnum {
             Self::JestPaddingAroundAfterAllBlocks(_) => {
                 JestPaddingAroundAfterAllBlocks::documentation()
             }
+            Self::JestPaddingAroundDescribeBlocks(_) => {
+                JestPaddingAroundDescribeBlocks::documentation()
+            }
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::documentation(),
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::documentation(),
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::documentation(),
@@ -7779,6 +7800,9 @@ impl RuleEnum {
             }
             Self::VitestPaddingAroundAfterAllBlocks(_) => {
                 VitestPaddingAroundAfterAllBlocks::documentation()
+            }
+            Self::VitestPaddingAroundDescribeBlocks(_) => {
+                VitestPaddingAroundDescribeBlocks::documentation()
             }
             Self::VitestPaddingAroundTestBlocks(_) => {
                 VitestPaddingAroundTestBlocks::documentation()
@@ -8955,6 +8979,10 @@ impl RuleEnum {
             Self::JestPaddingAroundAfterAllBlocks(_) => {
                 JestPaddingAroundAfterAllBlocks::config_schema(generator)
                     .or_else(|| JestPaddingAroundAfterAllBlocks::schema(generator))
+            }
+            Self::JestPaddingAroundDescribeBlocks(_) => {
+                JestPaddingAroundDescribeBlocks::config_schema(generator)
+                    .or_else(|| JestPaddingAroundDescribeBlocks::schema(generator))
             }
             Self::JestPaddingAroundTestBlocks(_) => {
                 JestPaddingAroundTestBlocks::config_schema(generator)
@@ -10138,6 +10166,10 @@ impl RuleEnum {
                 VitestPaddingAroundAfterAllBlocks::config_schema(generator)
                     .or_else(|| VitestPaddingAroundAfterAllBlocks::schema(generator))
             }
+            Self::VitestPaddingAroundDescribeBlocks(_) => {
+                VitestPaddingAroundDescribeBlocks::config_schema(generator)
+                    .or_else(|| VitestPaddingAroundDescribeBlocks::schema(generator))
+            }
             Self::VitestPaddingAroundTestBlocks(_) => {
                 VitestPaddingAroundTestBlocks::config_schema(generator)
                     .or_else(|| VitestPaddingAroundTestBlocks::schema(generator))
@@ -10788,6 +10820,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(_) => "jest",
             Self::JestNoUntypedMockFactory(_) => "jest",
             Self::JestPaddingAroundAfterAllBlocks(_) => "jest",
+            Self::JestPaddingAroundDescribeBlocks(_) => "jest",
             Self::JestPaddingAroundTestBlocks(_) => "jest",
             Self::JestPreferCalledWith(_) => "jest",
             Self::JestPreferComparisonMatcher(_) => "jest",
@@ -11199,6 +11232,7 @@ impl RuleEnum {
             Self::VitestNoTestReturnStatement(_) => "vitest",
             Self::VitestNoUnneededAsyncExpectFunction(_) => "vitest",
             Self::VitestPaddingAroundAfterAllBlocks(_) => "vitest",
+            Self::VitestPaddingAroundDescribeBlocks(_) => "vitest",
             Self::VitestPaddingAroundTestBlocks(_) => "vitest",
             Self::VitestPreferCalledExactlyOnceWith(_) => "vitest",
             Self::VitestPreferCalledOnce(_) => "vitest",
@@ -12793,6 +12827,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run(node, ctx),
             Self::JestNoUntypedMockFactory(rule) => rule.run(node, ctx),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run(node, ctx),
+            Self::JestPaddingAroundDescribeBlocks(rule) => rule.run(node, ctx),
             Self::JestPaddingAroundTestBlocks(rule) => rule.run(node, ctx),
             Self::JestPreferCalledWith(rule) => rule.run(node, ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.run(node, ctx),
@@ -13204,6 +13239,7 @@ impl RuleEnum {
             Self::VitestNoTestReturnStatement(rule) => rule.run(node, ctx),
             Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.run(node, ctx),
             Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.run(node, ctx),
+            Self::VitestPaddingAroundDescribeBlocks(rule) => rule.run(node, ctx),
             Self::VitestPaddingAroundTestBlocks(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run(node, ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run(node, ctx),
@@ -13680,6 +13716,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run_once(ctx),
             Self::JestNoUntypedMockFactory(rule) => rule.run_once(ctx),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run_once(ctx),
+            Self::JestPaddingAroundDescribeBlocks(rule) => rule.run_once(ctx),
             Self::JestPaddingAroundTestBlocks(rule) => rule.run_once(ctx),
             Self::JestPreferCalledWith(rule) => rule.run_once(ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.run_once(ctx),
@@ -14091,6 +14128,7 @@ impl RuleEnum {
             Self::VitestNoTestReturnStatement(rule) => rule.run_once(ctx),
             Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.run_once(ctx),
             Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.run_once(ctx),
+            Self::VitestPaddingAroundDescribeBlocks(rule) => rule.run_once(ctx),
             Self::VitestPaddingAroundTestBlocks(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_once(ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run_once(ctx),
@@ -14636,6 +14674,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestNoUntypedMockFactory(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::JestPaddingAroundDescribeBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPaddingAroundTestBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPreferCalledWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15089,6 +15128,7 @@ impl RuleEnum {
                 rule.run_on_jest_node(jest_node, ctx)
             }
             Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestPaddingAroundDescribeBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPaddingAroundTestBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferCalledOnce(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15572,6 +15612,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.should_run(ctx),
             Self::JestNoUntypedMockFactory(rule) => rule.should_run(ctx),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.should_run(ctx),
+            Self::JestPaddingAroundDescribeBlocks(rule) => rule.should_run(ctx),
             Self::JestPaddingAroundTestBlocks(rule) => rule.should_run(ctx),
             Self::JestPreferCalledWith(rule) => rule.should_run(ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.should_run(ctx),
@@ -15983,6 +16024,7 @@ impl RuleEnum {
             Self::VitestNoTestReturnStatement(rule) => rule.should_run(ctx),
             Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.should_run(ctx),
             Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.should_run(ctx),
+            Self::VitestPaddingAroundDescribeBlocks(rule) => rule.should_run(ctx),
             Self::VitestPaddingAroundTestBlocks(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledOnce(rule) => rule.should_run(ctx),
@@ -16610,6 +16652,9 @@ impl RuleEnum {
             Self::JestPaddingAroundAfterAllBlocks(_) => {
                 JestPaddingAroundAfterAllBlocks::IS_TSGOLINT_RULE
             }
+            Self::JestPaddingAroundDescribeBlocks(_) => {
+                JestPaddingAroundDescribeBlocks::IS_TSGOLINT_RULE
+            }
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::IS_TSGOLINT_RULE,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::IS_TSGOLINT_RULE,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::IS_TSGOLINT_RULE,
@@ -17198,6 +17243,9 @@ impl RuleEnum {
             }
             Self::VitestPaddingAroundAfterAllBlocks(_) => {
                 VitestPaddingAroundAfterAllBlocks::IS_TSGOLINT_RULE
+            }
+            Self::VitestPaddingAroundDescribeBlocks(_) => {
+                VitestPaddingAroundDescribeBlocks::IS_TSGOLINT_RULE
             }
             Self::VitestPaddingAroundTestBlocks(_) => {
                 VitestPaddingAroundTestBlocks::IS_TSGOLINT_RULE
@@ -17800,6 +17848,7 @@ impl RuleEnum {
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::VERSION,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::VERSION,
+            Self::JestPaddingAroundDescribeBlocks(_) => JestPaddingAroundDescribeBlocks::VERSION,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::VERSION,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::VERSION,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::VERSION,
@@ -18276,6 +18325,9 @@ impl RuleEnum {
             }
             Self::VitestPaddingAroundAfterAllBlocks(_) => {
                 VitestPaddingAroundAfterAllBlocks::VERSION
+            }
+            Self::VitestPaddingAroundDescribeBlocks(_) => {
+                VitestPaddingAroundDescribeBlocks::VERSION
             }
             Self::VitestPaddingAroundTestBlocks(_) => VitestPaddingAroundTestBlocks::VERSION,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
@@ -18865,6 +18917,7 @@ impl RuleEnum {
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::HAS_CONFIG,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::HAS_CONFIG,
+            Self::JestPaddingAroundDescribeBlocks(_) => JestPaddingAroundDescribeBlocks::HAS_CONFIG,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::HAS_CONFIG,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::HAS_CONFIG,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::HAS_CONFIG,
@@ -19359,6 +19412,9 @@ impl RuleEnum {
             }
             Self::VitestPaddingAroundAfterAllBlocks(_) => {
                 VitestPaddingAroundAfterAllBlocks::HAS_CONFIG
+            }
+            Self::VitestPaddingAroundDescribeBlocks(_) => {
+                VitestPaddingAroundDescribeBlocks::HAS_CONFIG
             }
             Self::VitestPaddingAroundTestBlocks(_) => VitestPaddingAroundTestBlocks::HAS_CONFIG,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
@@ -19915,6 +19971,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(_) => JestNoUnneededAsyncExpectFunction::INFO,
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::INFO,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::INFO,
+            Self::JestPaddingAroundDescribeBlocks(_) => JestPaddingAroundDescribeBlocks::INFO,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::INFO,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::INFO,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::INFO,
@@ -20368,6 +20425,7 @@ impl RuleEnum {
                 VitestNoUnneededAsyncExpectFunction::INFO
             }
             Self::VitestPaddingAroundAfterAllBlocks(_) => VitestPaddingAroundAfterAllBlocks::INFO,
+            Self::VitestPaddingAroundDescribeBlocks(_) => VitestPaddingAroundDescribeBlocks::INFO,
             Self::VitestPaddingAroundTestBlocks(_) => VitestPaddingAroundTestBlocks::INFO,
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::INFO,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::INFO,
@@ -20842,6 +20900,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.types_info(),
             Self::JestNoUntypedMockFactory(rule) => rule.types_info(),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.types_info(),
+            Self::JestPaddingAroundDescribeBlocks(rule) => rule.types_info(),
             Self::JestPaddingAroundTestBlocks(rule) => rule.types_info(),
             Self::JestPreferCalledWith(rule) => rule.types_info(),
             Self::JestPreferComparisonMatcher(rule) => rule.types_info(),
@@ -21253,6 +21312,7 @@ impl RuleEnum {
             Self::VitestNoTestReturnStatement(rule) => rule.types_info(),
             Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.types_info(),
             Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.types_info(),
+            Self::VitestPaddingAroundDescribeBlocks(rule) => rule.types_info(),
             Self::VitestPaddingAroundTestBlocks(rule) => rule.types_info(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.types_info(),
             Self::VitestPreferCalledOnce(rule) => rule.types_info(),
@@ -21716,6 +21776,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run_info(),
             Self::JestNoUntypedMockFactory(rule) => rule.run_info(),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run_info(),
+            Self::JestPaddingAroundDescribeBlocks(rule) => rule.run_info(),
             Self::JestPaddingAroundTestBlocks(rule) => rule.run_info(),
             Self::JestPreferCalledWith(rule) => rule.run_info(),
             Self::JestPreferComparisonMatcher(rule) => rule.run_info(),
@@ -22127,6 +22188,7 @@ impl RuleEnum {
             Self::VitestNoTestReturnStatement(rule) => rule.run_info(),
             Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.run_info(),
             Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.run_info(),
+            Self::VitestPaddingAroundDescribeBlocks(rule) => rule.run_info(),
             Self::VitestPaddingAroundTestBlocks(rule) => rule.run_info(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_info(),
             Self::VitestPreferCalledOnce(rule) => rule.run_info(),
@@ -22678,6 +22740,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JestNoUnneededAsyncExpectFunction(JestNoUnneededAsyncExpectFunction::default()),
         RuleEnum::JestNoUntypedMockFactory(JestNoUntypedMockFactory::default()),
         RuleEnum::JestPaddingAroundAfterAllBlocks(JestPaddingAroundAfterAllBlocks::default()),
+        RuleEnum::JestPaddingAroundDescribeBlocks(JestPaddingAroundDescribeBlocks::default()),
         RuleEnum::JestPaddingAroundTestBlocks(JestPaddingAroundTestBlocks::default()),
         RuleEnum::JestPreferCalledWith(JestPreferCalledWith::default()),
         RuleEnum::JestPreferComparisonMatcher(JestPreferComparisonMatcher::default()),
@@ -23131,6 +23194,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
             VitestNoUnneededAsyncExpectFunction::default(),
         ),
         RuleEnum::VitestPaddingAroundAfterAllBlocks(VitestPaddingAroundAfterAllBlocks::default()),
+        RuleEnum::VitestPaddingAroundDescribeBlocks(VitestPaddingAroundDescribeBlocks::default()),
         RuleEnum::VitestPaddingAroundTestBlocks(VitestPaddingAroundTestBlocks::default()),
         RuleEnum::VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith::default()),
         RuleEnum::VitestPreferCalledOnce(VitestPreferCalledOnce::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -376,6 +376,7 @@ pub(crate) mod jest {
     pub mod no_unneeded_async_expect_function;
     pub mod no_untyped_mock_factory;
     pub mod padding_around_after_all_blocks;
+    pub mod padding_around_describe_blocks;
     pub mod padding_around_test_blocks;
     pub mod prefer_called_with;
     pub mod prefer_comparison_matcher;
@@ -852,6 +853,7 @@ pub(crate) mod vitest {
     pub mod no_test_return_statement;
     pub mod no_unneeded_async_expect_function;
     pub mod padding_around_after_all_blocks;
+    pub mod padding_around_describe_blocks;
     pub mod padding_around_test_blocks;
     pub mod prefer_called_exactly_once_with;
     pub mod prefer_called_once;

--- a/crates/oxc_linter/src/rules/jest/padding_around_describe_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_describe_blocks.rs
@@ -1,0 +1,81 @@
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    rules::shared::padding_around_describe_blocks::{DOCUMENTATION, run},
+    utils::PossibleJestNode,
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct PaddingAroundDescribeBlocks;
+
+declare_oxc_lint!(
+    PaddingAroundDescribeBlocks,
+    jest,
+    style,
+    fix,
+    docs = DOCUMENTATION,
+    // TODO: confirm this matches the actual next-unreleased crate version at build time
+    // (crates/oxc_linter/Cargo.toml was at 1.79.0 in this checkout).
+    version = "1.80.0",
+);
+
+impl Rule for PaddingAroundDescribeBlocks {
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        run(jest_node, ctx);
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "describe('foo', () => {});",
+        "const thing = 123;\n\ndescribe('foo', () => {});",
+        "describe('foo', () => {\ndescribe('bar', () => {});\n});",
+        "const thing = 123;\n\n/* one */\n/* two */\ndescribe('foo', () => {});",
+        "const thing = 123;\n\nfdescribe('foo', () => {});",
+        "const thing = 123;\n\nxdescribe('foo', () => {});",
+        "const thing = 123;\n\ndescribe.each([1, 2])('foo %i', () => {});",
+        "const thing = 123;\n\ndescribe.only('foo', () => {});",
+        "const thing = 123;\n\ndescribe.skip('foo', () => {});",
+        "describe('foo', () => {});\n\ndescribe('bar', () => {});",
+    ];
+
+    let fail = vec![
+        "const thing = 123;\ndescribe('foo', () => {});",
+        "const thing = 123;\n/* one */\n/* two */\ndescribe('foo', () => {});",
+        "const thing = 123;\nfdescribe('foo', () => {});",
+        "const thing = 123;\nxdescribe('foo', () => {});",
+        "const thing = 123;\ndescribe.each([1, 2])('foo %i', () => {});",
+        "const thing = 123;\ndescribe.only('foo', () => {});",
+        "const thing = 123;\ndescribe.skip('foo', () => {});",
+        "describe('foo', () => {});\ndescribe('bar', () => {});",
+    ];
+
+    let fix = vec![
+        (
+            "const thing = 123;\ndescribe('foo', () => {});",
+            "const thing = 123;\n\ndescribe('foo', () => {});",
+        ),
+        (
+            "const thing = 123;\n/* one */\n/* two */\ndescribe('foo', () => {});",
+            "const thing = 123;\n\n/* one */\n/* two */\ndescribe('foo', () => {});",
+        ),
+        (
+            "describe('foo', () => {});\ndescribe('bar', () => {});",
+            "describe('foo', () => {});\n\ndescribe('bar', () => {});",
+        ),
+    ];
+
+    Tester::new(PaddingAroundDescribeBlocks::NAME, PaddingAroundDescribeBlocks::PLUGIN, pass, fail)
+        .with_jest_plugin(true)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
@@ -21,6 +21,7 @@ pub mod no_test_prefixes;
 pub mod no_test_return_statement;
 pub mod no_unneeded_async_expect_function;
 pub mod padding_around_after_all_blocks;
+pub mod padding_around_describe_blocks;
 pub mod padding_around_test_blocks;
 pub mod prefer_called_with;
 pub mod prefer_comparison_matcher;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_describe_blocks.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_describe_blocks.rs
@@ -1,0 +1,67 @@
+use oxc_ast::AstKind;
+
+use crate::{
+    context::LintContext,
+    utils::{
+        JestGeneralFnKind, ParsedGeneralJestFnCall, PossibleJestNode, parse_general_jest_fn_call,
+        report_missing_padding_before_jest_block,
+    },
+};
+
+pub const DOCUMENTATION: &str = r"### What it does
+
+This rule enforces a line of padding before and after 1 or more
+`describe` statements, including its `fdescribe`/`xdescribe`/`suite`
+aliases and `.each`/`.only`/`.skip` variants.
+
+### Why is this bad?
+
+Inconsistent formatting of code can make the code more difficult to read
+and follow. This rule helps ensure that `describe` blocks are visually
+separated from the rest of the code, making them easier to identify while
+looking through test files.
+
+### Examples
+
+Examples of **incorrect** code for this rule:
+```js
+const thing = 123;
+describe('foo', () => {});
+```
+
+```js
+describe('foo', () => {});
+describe('bar', () => {});
+```
+
+Examples of **correct** code for this rule:
+```js
+const thing = 123;
+
+describe('foo', () => {});
+```
+
+```js
+describe('foo', () => {});
+
+describe('bar', () => {});
+```
+";
+
+pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    let node = possible_jest_node.node;
+    let AstKind::CallExpression(call_expr) = node.kind() else {
+        return;
+    };
+    let Some(jest_fn_call) = parse_general_jest_fn_call(call_expr, possible_jest_node, ctx) else {
+        return;
+    };
+    let ParsedGeneralJestFnCall { kind, name, .. } = &jest_fn_call;
+    let Some(kind) = kind.to_general() else {
+        return;
+    };
+    if kind != JestGeneralFnKind::Describe {
+        return;
+    }
+    report_missing_padding_before_jest_block(node, ctx, name);
+}

--- a/crates/oxc_linter/src/rules/vitest/padding_around_describe_blocks.rs
+++ b/crates/oxc_linter/src/rules/vitest/padding_around_describe_blocks.rs
@@ -1,0 +1,122 @@
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    rules::shared::padding_around_describe_blocks::{DOCUMENTATION, run},
+    utils::PossibleJestNode,
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct PaddingAroundDescribeBlocks;
+
+declare_oxc_lint!(
+    PaddingAroundDescribeBlocks,
+    vitest,
+    style,
+    fix,
+    docs = DOCUMENTATION,
+    // TODO: confirm this matches the actual next-unreleased crate version at build time
+    // (crates/oxc_linter/Cargo.toml was at 1.79.0 in this checkout).
+    version = "1.80.0",
+);
+
+impl Rule for PaddingAroundDescribeBlocks {
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        run(jest_node, ctx);
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "describe('foo', () => {});",
+        "const thing = 123;\n\ndescribe('foo', () => {});",
+        "describe('foo', () => {\ndescribe('bar', () => {});\n});",
+        "// This is a comment\ndescribe('foo', () => {});",
+        "import { describe } from 'vitest';\n\ndescribe('foo', () => {});",
+        "import { describe } from 'vitest';\nimport { helper } from './helper';\n\ndescribe('foo', () => {});",
+        "import './setup';\n\ndescribe('foo', () => {});",
+        "/* leading block comment */\ndescribe('foo', () => {});",
+        "/**\n * JSDoc-style comment\n */\ndescribe('foo', () => {});",
+        "const thing = 123;\n\n/* attached to describe */\ndescribe('foo', () => {});",
+        "const thing = 123;\n\n/**\n * JSDoc attached to describe\n */\ndescribe('foo', () => {});",
+        "const thing = 123; /* trailing on prev */\n\ndescribe('foo', () => {});",
+        "describe('foo', () => {\ndescribe('bar', () => {});\n\ndescribe('baz', () => {});\n});",
+        // `fdescribe`/`xdescribe` are Jest-only globals, not part of Vitest's API,
+        // so Vitest-mode parsing doesn't recognize them as describe blocks at all
+        // (see the jest wrapper's test for coverage of those aliases).
+        "const thing = 123;\nfdescribe('foo', () => {});",
+        "const thing = 123;\nxdescribe('foo', () => {});",
+        "const thing = 123;\n\ndescribe.each([1, 2])('foo %i', () => {});",
+        "const thing = 123;\n\ndescribe.only('foo', () => {});",
+        "const thing = 123;\n\ndescribe.skip('foo', () => {});",
+        "const thing = 123;\n\nsuite('foo', () => {});",
+        "const thing = 123;\n\nsuite.each([1, 2])('foo %i', () => {});",
+        "describe('foo', () => {});\n\ndescribe('bar', () => {});",
+    ];
+
+    let fail = vec![
+        "const thing = 123;\ndescribe('foo', () => {});",
+        "const thing = 123;\n//My comment\ndescribe('foo', () => {});",
+        "import { describe } from 'vitest';\ndescribe('foo', () => {});",
+        "import { describe } from 'vitest';\nimport { helper } from './helper';\ndescribe('foo', () => {});",
+        "import './setup';\ndescribe('foo', () => {});",
+        "const thing = 123;\n/* block comment */\ndescribe('foo', () => {});",
+        "const thing = 123;\n/**\n * JSDoc comment\n */\ndescribe('foo', () => {});",
+        "describe('foo', () => {\ndescribe('bar', () => {});\ndescribe('baz', () => {});\n});",
+        "import { describe } from 'vitest';\n/* setup notes */\ndescribe('foo', () => {});",
+        "const thing = 123;\ndescribe.each([1, 2])('foo %i', () => {});",
+        "const thing = 123;\ndescribe.only('foo', () => {});",
+        "const thing = 123;\ndescribe.skip('foo', () => {});",
+        "const thing = 123;\nsuite('foo', () => {});",
+        "const thing = 123;\nsuite.each([1, 2])('foo %i', () => {});",
+        "describe('foo', () => {});\ndescribe('bar', () => {});",
+    ];
+
+    let fix = vec![
+        (
+            "const thing = 123;\ndescribe('foo', () => {});",
+            "const thing = 123;\n\ndescribe('foo', () => {});",
+        ),
+        (
+            "const thing = 123;\n// This is a comment\ndescribe('foo', () => {});",
+            "const thing = 123;\n\n// This is a comment\ndescribe('foo', () => {});",
+        ),
+        (
+            "import { describe } from 'vitest';\ndescribe('foo', () => {});",
+            "import { describe } from 'vitest';\n\ndescribe('foo', () => {});",
+        ),
+        (
+            "import './setup';\ndescribe('foo', () => {});",
+            "import './setup';\n\ndescribe('foo', () => {});",
+        ),
+        (
+            "const thing = 123;\n/* block comment */\ndescribe('foo', () => {});",
+            "const thing = 123;\n\n/* block comment */\ndescribe('foo', () => {});",
+        ),
+        (
+            "const thing = 123;\n/**\n * JSDoc comment\n */\ndescribe('foo', () => {});",
+            "const thing = 123;\n\n/**\n * JSDoc comment\n */\ndescribe('foo', () => {});",
+        ),
+        (
+            "describe('foo', () => {\ndescribe('bar', () => {});\ndescribe('baz', () => {});\n});",
+            "describe('foo', () => {\ndescribe('bar', () => {});\n\ndescribe('baz', () => {});\n});",
+        ),
+        (
+            "const thing = 123;\nsuite('foo', () => {});",
+            "const thing = 123;\n\nsuite('foo', () => {});",
+        ),
+    ];
+
+    Tester::new(PaddingAroundDescribeBlocks::NAME, PaddingAroundDescribeBlocks::PLUGIN, pass, fail)
+        .with_vitest_plugin(true)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_describe_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_describe_blocks.snap
@@ -1,0 +1,67 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ jest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ describe('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ jest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:4:1]
+ 3 │ /* two */
+ 4 │ describe('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ jest(padding-around-describe-blocks): Missing padding before fdescribe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ fdescribe('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the fdescribe block
+
+  ⚠ jest(padding-around-describe-blocks): Missing padding before xdescribe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ xdescribe('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the xdescribe block
+
+  ⚠ jest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ describe.each([1, 2])('foo %i', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ jest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ describe.only('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ jest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ describe.skip('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ jest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ describe('foo', () => {});
+ 2 │ describe('bar', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block

--- a/crates/oxc_linter/src/snapshots/vitest_padding_around_describe_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_padding_around_describe_blocks.snap
@@ -1,0 +1,124 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ describe('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:3:1]
+ 2 │ //My comment
+ 3 │ describe('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ import { describe } from 'vitest';
+ 2 │ describe('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:3:1]
+ 2 │ import { helper } from './helper';
+ 3 │ describe('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ import './setup';
+ 2 │ describe('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:3:1]
+ 2 │ /* block comment */
+ 3 │ describe('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:5:1]
+ 4 │  */
+ 5 │ describe('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:3:1]
+ 2 │ describe('bar', () => {});
+ 3 │ describe('baz', () => {});
+   · ▲
+ 4 │ });
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:3:1]
+ 2 │ /* setup notes */
+ 3 │ describe('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ describe.each([1, 2])('foo %i', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ describe.only('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ describe.skip('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before suite block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ suite('foo', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the suite block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before suite block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ suite.each([1, 2])('foo %i', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the suite block
+
+  ⚠ vitest(padding-around-describe-blocks): Missing padding before describe block
+   ╭─[padding_around_describe_blocks.tsx:2:1]
+ 1 │ describe('foo', () => {});
+ 2 │ describe('bar', () => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the describe block

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -3300,6 +3300,9 @@
         "jest/padding-around-after-all-blocks": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "jest/padding-around-describe-blocks": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "jest/padding-around-test-blocks": {
           "$ref": "#/definitions/RuleNoConfig"
         },
@@ -10008,6 +10011,9 @@
           "$ref": "#/definitions/RuleNoConfig"
         },
         "vitest/padding-around-after-all-blocks": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
+        "vitest/padding-around-describe-blocks": {
           "$ref": "#/definitions/RuleNoConfig"
         },
         "vitest/padding-around-test-blocks": {

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -246,6 +246,7 @@ jest/no-test-return-statement                              |  14199
 jest/no-unneeded-async-expect-function                     |      0
 jest/no-untyped-mock-factory                               |      0
 jest/padding-around-after-all-blocks                       |      0
+jest/padding-around-describe-blocks                        |      0
 jest/padding-around-test-blocks                            |      0
 jest/prefer-called-with                                    |      0
 jest/prefer-comparison-matcher                             |      0
@@ -714,6 +715,7 @@ vitest/no-test-prefixes                                    |      0
 vitest/no-test-return-statement                            |  14199
 vitest/no-unneeded-async-expect-function                   |      0
 vitest/padding-around-after-all-blocks                     |      0
+vitest/padding-around-describe-blocks                      |      0
 vitest/padding-around-test-blocks                          |      0
 vitest/prefer-called-exactly-once-with                     |  14953
 vitest/prefer-called-once                                  |      0


### PR DESCRIPTION
## Summary
- Implement `jest/padding-around-describe-blocks` and `vitest/padding-around-describe-blocks`
- Enforces a blank line before `describe` blocks (including `fdescribe`/`xdescribe`/`suite` aliases and `.each`/`.only`/`.skip` variants), mirroring the existing `padding-around-test-blocks` / `padding-around-after-all-blocks` rules
- Auto-fixable

Part of #492.

## Test plan
- [x] `cargo test -p oxc_linter padding_around_describe_blocks`
- [x] `cargo fmt -p oxc_linter -- --check`
- [x] `cargo clippy -p oxc_linter --lib -- -D warnings`
- [x] `cargo lintgen`, `pnpm --filter oxlint-app generate-config-types`, `cargo lint-timings` (no diff beyond the committed timing snapshot update)
QwQ