### PR TITLE
refactor(codegen): use `Uint8Array` for base64 lookup table

### DIFF
--- a/packages/codegen/src-js/print/source_map.ts
+++ b/packages/codegen/src-js/print/source_map.ts
@@ -12,7 +12,7 @@ import type { Options, SourceMap } from "./options.ts";
 import type { State } from "../state.ts";
 
 const BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-const BASE64_CODES = /* @__PURE__ */ Buffer.from(BASE64_CHARS, "ascii");
+const BASE64_CODES = Uint8Array.from(BASE64_CHARS, (char) => char.charCodeAt(0));
 const LINE_SEARCH_ITERATIONS = 16;
 const MIN_LF_FAST_PATH_MAPPINGS = 64;
 const MAX_LF_FAST_PATH_CHARS_PER_MAPPING = 256;


### PR DESCRIPTION
## Summary

Replace the `Buffer`-backed base64 character-code table with a `Uint8Array`.

`BASE64_CODES` is only used as a lookup table mapping VLQ digits from `0–63` to ASCII byte values. It does not require any `Buffer`-specific APIs, and `Uint8Array` provides the same indexed byte semantics in both Node.js and browsers.

This reduces unnecessary Node-specific usage and is a small step toward making `oxc-codegen` browser-compatible. The hot encoding loop remains unchanged; only the one-time lookup-table initialization differs.

This does not remove the remaining `Buffer` dependency used for the source-map output buffer.
