### PR TITLE
refactor(codegen): remove Buffer dependency from source maps

### DIFF
--- a/packages/codegen/src-js/print/source_map.ts
+++ b/packages/codegen/src-js/print/source_map.ts
@@ -4,8 +4,6 @@
 // `generateSourceMap` defined here converts them to generated positions
 // and encodes a standard Source Map v3 in one pass at the end.
 
-import { Buffer } from "node:buffer";
-
 import { debugAssert } from "../asserts.ts";
 
 import type { Options, SourceMap } from "./options.ts";
@@ -34,6 +32,8 @@ debugAssert(
 // `\r\n` must be one line terminator, rather than two.
 const NEXT_LINE_TERMINATOR_REGEX = /\r\n|[\r\n\u2028\u2029]/g;
 
+const ASCII_DECODER = /* @__PURE__ */ new TextDecoder();
+
 /**
  * Convert deferred mapping data into a standard Source Map v3 object.
  */
@@ -58,7 +58,7 @@ export function generateSourceMap(state: State, options: Options): SourceMap {
     };
   }
 
-  let mappingBuffer: Buffer = Buffer.allocUnsafe(
+  let mappingBuffer: Uint8Array = new Uint8Array(
     Math.max(MIN_MAPPING_BUFFER_LENGTH, mappingCount * ESTIMATED_BYTES_PER_MAPPING),
   );
   let mappingLength = 0;
@@ -266,7 +266,7 @@ export function generateSourceMap(state: State, options: Options): SourceMap {
 
   return {
     version: 3,
-    mappings: mappingBuffer.toString("ascii", 0, mappingLength),
+    mappings: ASCII_DECODER.decode(mappingBuffer.subarray(0, mappingLength)),
     names,
     sources: [options.sourceFilename ?? ""],
     sourcesContent: [sourceText],
@@ -320,7 +320,7 @@ function findSourceLine(lineStarts: number[], sourceOffset: number, previousLine
 /**
  * Write one signed source-map delta as base64 VLQ, returning the next buffer position.
  */
-function writeVlq(buffer: Buffer, index: number, value: number): number {
+function writeVlq(buffer: Uint8Array, index: number, value: number): number {
   let vlq = value < 0 ? -value * 2 + 1 : value * 2;
   if (vlq <= MAX_BITWISE_VLQ) {
     do {
@@ -348,12 +348,12 @@ function writeVlq(buffer: Buffer, index: number, value: number): number {
  *
  * The returned buffer is guaranteed to have at least `MAX_MAPPING_SEGMENT_LENGTH` spare capacity.
  */
-function growMappingBuffer(buffer: Buffer, writtenLength: number): Buffer {
+function growMappingBuffer(buffer: Uint8Array, writtenLength: number): Uint8Array {
   // Buffer starts with at least `MIN_MAPPING_BUFFER_LENGTH` bytes capacity.
   // Maximum extra capacity required is `MAX_MAPPING_SEGMENT_LENGTH`, which is <= `MIN_MAPPING_BUFFER_LENGTH`,
   // so doubling capacity is always enough.
-  const newBuffer = Buffer.allocUnsafe(buffer.length * 2);
-  buffer.copy(newBuffer, 0, 0, writtenLength);
+  const newBuffer = new Uint8Array(buffer.length * 2);
+  newBuffer.set(buffer.subarray(0, writtenLength));
   return newBuffer;
 }
 


### PR DESCRIPTION
## Summary

- replace Node.js `Buffer` storage with `Uint8Array` in the source-map encoder
- use `TextDecoder` to create the final mappings string
- use `Uint8Array#set` when growing the mappings buffer
- remove the `node:buffer` runtime dependency

This makes source-map generation runtime-neutral and removes a blocker for browser support for the codegen package.

## Performance

Indexed access, copying, and ASCII decoding have comparable performance. `Uint8Array` allocation requires zero-initialization, unlike `Buffer.allocUnsafe`, but the expected end-to-end impact is small.