### PR TITLE
refactor(packages/codegen): move options validation into `State` constructor

### DIFF
--- a/packages/codegen/src-js/index.ts
+++ b/packages/codegen/src-js/index.ts
@@ -73,15 +73,7 @@ export function printSync(
     options = EMPTY_OPTIONS;
   } else {
     if (options.ts === true) index = 1;
-    if (options.sourcemap === true) {
-      if (typeof options.sourceText !== "string") {
-        throw new TypeError("`sourceText` must be a string when `sourcemap` is true");
-      }
-      if (options.sourceFilename !== undefined && typeof options.sourceFilename !== "string") {
-        throw new TypeError("`sourceFilename` must be a string when supplied");
-      }
-      index |= 2;
-    }
+    if (options.sourcemap === true) index |= 2;
   }
 
   let print = printers[index];

--- a/packages/codegen/src-js/state.ts
+++ b/packages/codegen/src-js/state.ts
@@ -9,7 +9,6 @@
 // Nothing in `print/` constructs one, and none of the 4 printer builds bundles this file.
 
 import { CAT_OTHER } from "./print/write.ts";
-import { debugAssert } from "./asserts.ts";
 
 import type { Category } from "./print/write.ts";
 import type { Options } from "./print/options.ts";
@@ -143,8 +142,15 @@ export class State {
       this.mapPositions = null;
       this.mapNames = null;
     } else {
-      debugAssert(options.sourceText != null);
-      this.sourceText = options.sourceText;
+      const { sourceText } = options;
+      if (typeof sourceText !== "string") {
+        throw new TypeError("`sourceText` must be a string when `sourcemap` is true");
+      }
+      if (options.sourceFilename !== undefined && typeof options.sourceFilename !== "string") {
+        throw new TypeError("`sourceFilename` must be a string when supplied");
+      }
+
+      this.sourceText = sourceText;
       this.mapPositions = [];
       this.mapNames = null;
     }


### PR DESCRIPTION
Move sourcemap-related options validation into `State` constructor. This removes an assumption we had to make there (a `debugAssert`) that the validity check had already been done earlier.

(addressing https://github.com/oxc-project/oxc/pull/25887#issuecomment-5339337349)