### PR TITLE
docs(linter): correct export/import mismatch in bar and foo example

### DIFF
--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// // ./bar.js
-    /// export default function bar() { return null }
+    /// export function bar() { return null }
     ///
     /// // ./foo.js
     /// import { bar } from './bar' // correct usage of named import


### PR DESCRIPTION
The example incorrectly used a named import for a default export. Changed `export default function bar()` to `export function bar()` to align with the `import { bar }` statement.