### PR TITLE
feat(linter/jsdoc): implement `no-blank-block-descriptions` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1035,6 +1035,7 @@ export interface DummyRuleMap {
   "jsdoc/check-tag-names"?: RuleNoConfig | [AllowWarnDeny, CheckTagNamesConfig];
   "jsdoc/empty-tags"?: RuleNoConfig | [AllowWarnDeny, EmptyTagsConfig];
   "jsdoc/implements-on-classes"?: RuleNoConfig;
+  "jsdoc/no-blank-block-descriptions"?: RuleNoConfig;
   "jsdoc/no-blank-blocks"?: RuleNoConfig | [AllowWarnDeny, NoBlankBlocks];
   "jsdoc/no-defaults"?: RuleNoConfig | [AllowWarnDeny, NoDefaultsConfig];
   "jsdoc/require-param"?: RuleNoConfig | [AllowWarnDeny, RequireParamConfig];

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4571,6 +4571,11 @@ impl RuleRunner for crate::rules::jsdoc::implements_on_classes::ImplementsOnClas
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::jsdoc::no_blank_block_descriptions::NoBlankBlockDescriptions {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
+}
+
 impl RuleRunner for crate::rules::jsdoc::no_blank_blocks::NoBlankBlocks {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -295,6 +295,7 @@ pub use crate::rules::jsdoc::check_property_names::CheckPropertyNames as JsdocCh
 pub use crate::rules::jsdoc::check_tag_names::CheckTagNames as JsdocCheckTagNames;
 pub use crate::rules::jsdoc::empty_tags::EmptyTags as JsdocEmptyTags;
 pub use crate::rules::jsdoc::implements_on_classes::ImplementsOnClasses as JsdocImplementsOnClasses;
+pub use crate::rules::jsdoc::no_blank_block_descriptions::NoBlankBlockDescriptions as JsdocNoBlankBlockDescriptions;
 pub use crate::rules::jsdoc::no_blank_blocks::NoBlankBlocks as JsdocNoBlankBlocks;
 pub use crate::rules::jsdoc::no_defaults::NoDefaults as JsdocNoDefaults;
 pub use crate::rules::jsdoc::require_param::RequireParam as JsdocRequireParam;
@@ -1602,6 +1603,7 @@ pub enum RuleEnum {
     JsdocCheckTagNames(JsdocCheckTagNames),
     JsdocEmptyTags(JsdocEmptyTags),
     JsdocImplementsOnClasses(JsdocImplementsOnClasses),
+    JsdocNoBlankBlockDescriptions(JsdocNoBlankBlockDescriptions),
     JsdocNoBlankBlocks(JsdocNoBlankBlocks),
     JsdocNoDefaults(JsdocNoDefaults),
     JsdocRequireParam(JsdocRequireParam),
@@ -2568,7 +2570,8 @@ const JSDOC_CHECK_PROPERTY_NAMES_ID: usize = JSDOC_CHECK_ACCESS_ID + 1usize;
 const JSDOC_CHECK_TAG_NAMES_ID: usize = JSDOC_CHECK_PROPERTY_NAMES_ID + 1usize;
 const JSDOC_EMPTY_TAGS_ID: usize = JSDOC_CHECK_TAG_NAMES_ID + 1usize;
 const JSDOC_IMPLEMENTS_ON_CLASSES_ID: usize = JSDOC_EMPTY_TAGS_ID + 1usize;
-const JSDOC_NO_BLANK_BLOCKS_ID: usize = JSDOC_IMPLEMENTS_ON_CLASSES_ID + 1usize;
+const JSDOC_NO_BLANK_BLOCK_DESCRIPTIONS_ID: usize = JSDOC_IMPLEMENTS_ON_CLASSES_ID + 1usize;
+const JSDOC_NO_BLANK_BLOCKS_ID: usize = JSDOC_NO_BLANK_BLOCK_DESCRIPTIONS_ID + 1usize;
 const JSDOC_NO_DEFAULTS_ID: usize = JSDOC_NO_BLANK_BLOCKS_ID + 1usize;
 const JSDOC_REQUIRE_PARAM_ID: usize = JSDOC_NO_DEFAULTS_ID + 1usize;
 const JSDOC_REQUIRE_PARAM_DESCRIPTION_ID: usize = JSDOC_REQUIRE_PARAM_ID + 1usize;
@@ -2748,7 +2751,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 870usize] = [
+static RULE_NAMES: [&str; 871usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3455,6 +3458,7 @@ static RULE_NAMES: [&str; 870usize] = [
     JsdocCheckTagNames::NAME,
     JsdocEmptyTags::NAME,
     JsdocImplementsOnClasses::NAME,
+    JsdocNoBlankBlockDescriptions::NAME,
     JsdocNoBlankBlocks::NAME,
     JsdocNoDefaults::NAME,
     JsdocRequireParam::NAME,
@@ -4447,6 +4451,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JSDOC_CHECK_TAG_NAMES_ID,
             Self::JsdocEmptyTags(_) => JSDOC_EMPTY_TAGS_ID,
             Self::JsdocImplementsOnClasses(_) => JSDOC_IMPLEMENTS_ON_CLASSES_ID,
+            Self::JsdocNoBlankBlockDescriptions(_) => JSDOC_NO_BLANK_BLOCK_DESCRIPTIONS_ID,
             Self::JsdocNoBlankBlocks(_) => JSDOC_NO_BLANK_BLOCKS_ID,
             Self::JsdocNoDefaults(_) => JSDOC_NO_DEFAULTS_ID,
             Self::JsdocRequireParam(_) => JSDOC_REQUIRE_PARAM_ID,
@@ -5488,6 +5493,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::CATEGORY,
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::CATEGORY,
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::CATEGORY,
+            Self::JsdocNoBlankBlockDescriptions(_) => JsdocNoBlankBlockDescriptions::CATEGORY,
             Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::CATEGORY,
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::CATEGORY,
             Self::JsdocRequireParam(_) => JsdocRequireParam::CATEGORY,
@@ -6491,6 +6497,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::FIX,
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::FIX,
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::FIX,
+            Self::JsdocNoBlankBlockDescriptions(_) => JsdocNoBlankBlockDescriptions::FIX,
             Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::FIX,
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::FIX,
             Self::JsdocRequireParam(_) => JsdocRequireParam::FIX,
@@ -7698,6 +7705,9 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::documentation(),
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::documentation(),
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::documentation(),
+            Self::JsdocNoBlankBlockDescriptions(_) => {
+                JsdocNoBlankBlockDescriptions::documentation()
+            }
             Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::documentation(),
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::documentation(),
             Self::JsdocRequireParam(_) => JsdocRequireParam::documentation(),
@@ -9969,6 +9979,10 @@ impl RuleEnum {
                 .or_else(|| JsdocEmptyTags::schema(generator)),
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::config_schema(generator)
                 .or_else(|| JsdocImplementsOnClasses::schema(generator)),
+            Self::JsdocNoBlankBlockDescriptions(_) => {
+                JsdocNoBlankBlockDescriptions::config_schema(generator)
+                    .or_else(|| JsdocNoBlankBlockDescriptions::schema(generator))
+            }
             Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::config_schema(generator)
                 .or_else(|| JsdocNoBlankBlocks::schema(generator)),
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::config_schema(generator)
@@ -11135,6 +11149,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => "jsdoc",
             Self::JsdocEmptyTags(_) => "jsdoc",
             Self::JsdocImplementsOnClasses(_) => "jsdoc",
+            Self::JsdocNoBlankBlockDescriptions(_) => "jsdoc",
             Self::JsdocNoBlankBlocks(_) => "jsdoc",
             Self::JsdocNoDefaults(_) => "jsdoc",
             Self::JsdocRequireParam(_) => "jsdoc",
@@ -13140,6 +13155,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(rule) => rule.run(node, ctx),
             Self::JsdocEmptyTags(rule) => rule.run(node, ctx),
             Self::JsdocImplementsOnClasses(rule) => rule.run(node, ctx),
+            Self::JsdocNoBlankBlockDescriptions(rule) => rule.run(node, ctx),
             Self::JsdocNoBlankBlocks(rule) => rule.run(node, ctx),
             Self::JsdocNoDefaults(rule) => rule.run(node, ctx),
             Self::JsdocRequireParam(rule) => rule.run(node, ctx),
@@ -14027,6 +14043,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(rule) => rule.run_once(ctx),
             Self::JsdocEmptyTags(rule) => rule.run_once(ctx),
             Self::JsdocImplementsOnClasses(rule) => rule.run_once(ctx),
+            Self::JsdocNoBlankBlockDescriptions(rule) => rule.run_once(ctx),
             Self::JsdocNoBlankBlocks(rule) => rule.run_once(ctx),
             Self::JsdocNoDefaults(rule) => rule.run_once(ctx),
             Self::JsdocRequireParam(rule) => rule.run_once(ctx),
@@ -15023,6 +15040,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsdocEmptyTags(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsdocImplementsOnClasses(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::JsdocNoBlankBlockDescriptions(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsdocNoBlankBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsdocNoDefaults(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JsdocRequireParam(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -15919,6 +15937,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(rule) => rule.should_run(ctx),
             Self::JsdocEmptyTags(rule) => rule.should_run(ctx),
             Self::JsdocImplementsOnClasses(rule) => rule.should_run(ctx),
+            Self::JsdocNoBlankBlockDescriptions(rule) => rule.should_run(ctx),
             Self::JsdocNoBlankBlocks(rule) => rule.should_run(ctx),
             Self::JsdocNoDefaults(rule) => rule.should_run(ctx),
             Self::JsdocRequireParam(rule) => rule.should_run(ctx),
@@ -17117,6 +17136,9 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::IS_TSGOLINT_RULE,
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::IS_TSGOLINT_RULE,
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::IS_TSGOLINT_RULE,
+            Self::JsdocNoBlankBlockDescriptions(_) => {
+                JsdocNoBlankBlockDescriptions::IS_TSGOLINT_RULE
+            }
             Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::IS_TSGOLINT_RULE,
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::IS_TSGOLINT_RULE,
             Self::JsdocRequireParam(_) => JsdocRequireParam::IS_TSGOLINT_RULE,
@@ -18209,6 +18231,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::VERSION,
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::VERSION,
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::VERSION,
+            Self::JsdocNoBlankBlockDescriptions(_) => JsdocNoBlankBlockDescriptions::VERSION,
             Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::VERSION,
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::VERSION,
             Self::JsdocRequireParam(_) => JsdocRequireParam::VERSION,
@@ -19290,6 +19313,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::HAS_CONFIG,
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::HAS_CONFIG,
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::HAS_CONFIG,
+            Self::JsdocNoBlankBlockDescriptions(_) => JsdocNoBlankBlockDescriptions::HAS_CONFIG,
             Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::HAS_CONFIG,
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::HAS_CONFIG,
             Self::JsdocRequireParam(_) => JsdocRequireParam::HAS_CONFIG,
@@ -20302,6 +20326,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(_) => JsdocCheckTagNames::INFO,
             Self::JsdocEmptyTags(_) => JsdocEmptyTags::INFO,
             Self::JsdocImplementsOnClasses(_) => JsdocImplementsOnClasses::INFO,
+            Self::JsdocNoBlankBlockDescriptions(_) => JsdocNoBlankBlockDescriptions::INFO,
             Self::JsdocNoBlankBlocks(_) => JsdocNoBlankBlocks::INFO,
             Self::JsdocNoDefaults(_) => JsdocNoDefaults::INFO,
             Self::JsdocRequireParam(_) => JsdocRequireParam::INFO,
@@ -21189,6 +21214,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(rule) => rule.types_info(),
             Self::JsdocEmptyTags(rule) => rule.types_info(),
             Self::JsdocImplementsOnClasses(rule) => rule.types_info(),
+            Self::JsdocNoBlankBlockDescriptions(rule) => rule.types_info(),
             Self::JsdocNoBlankBlocks(rule) => rule.types_info(),
             Self::JsdocNoDefaults(rule) => rule.types_info(),
             Self::JsdocRequireParam(rule) => rule.types_info(),
@@ -22063,6 +22089,7 @@ impl RuleEnum {
             Self::JsdocCheckTagNames(rule) => rule.run_info(),
             Self::JsdocEmptyTags(rule) => rule.run_info(),
             Self::JsdocImplementsOnClasses(rule) => rule.run_info(),
+            Self::JsdocNoBlankBlockDescriptions(rule) => rule.run_info(),
             Self::JsdocNoBlankBlocks(rule) => rule.run_info(),
             Self::JsdocNoDefaults(rule) => rule.run_info(),
             Self::JsdocRequireParam(rule) => rule.run_info(),
@@ -23065,6 +23092,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JsdocCheckTagNames(JsdocCheckTagNames::default()),
         RuleEnum::JsdocEmptyTags(JsdocEmptyTags::default()),
         RuleEnum::JsdocImplementsOnClasses(JsdocImplementsOnClasses::default()),
+        RuleEnum::JsdocNoBlankBlockDescriptions(JsdocNoBlankBlockDescriptions::default()),
         RuleEnum::JsdocNoBlankBlocks(JsdocNoBlankBlocks::default()),
         RuleEnum::JsdocNoDefaults(JsdocNoDefaults::default()),
         RuleEnum::JsdocRequireParam(JsdocRequireParam::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -801,6 +801,7 @@ pub(crate) mod jsdoc {
     pub mod check_tag_names;
     pub mod empty_tags;
     pub mod implements_on_classes;
+    pub mod no_blank_block_descriptions;
     pub mod no_blank_blocks;
     pub mod no_defaults;
     pub mod require_param;

--- a/crates/oxc_linter/src/rules/jsdoc/no_blank_block_descriptions.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_blank_block_descriptions.rs
@@ -1,0 +1,134 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule};
+
+fn no_blank_block_descriptions_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("No blank block descriptions").with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoBlankBlockDescriptions;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Prevents empty lines in JSDoc block descriptions when tags are present.
+    /// When no tags are present, it prevents extra empty lines in the block
+    /// description.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unnecessary empty lines make JSDoc blocks inconsistent and add visual
+    /// noise without improving readability.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// /**
+    ///  *
+    ///  * @param {number} x
+    ///  */
+    ///
+    /// /**
+    ///  *
+    ///  *
+    ///  */
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// /**
+    ///  * Non-empty description
+    ///  * @param {number} x
+    ///  */
+    ///
+    /// /**
+    ///  * @param {number} x
+    ///  */
+    ///
+    /// /**
+    ///  *
+    ///  */
+    ///
+    /// /** */
+    ///
+    /// /** Some description. */
+    ///
+    /// /** @someTag */
+    /// ```
+    NoBlankBlockDescriptions,
+    jsdoc,
+    style,
+    pending,
+    version = "next",
+    short_description = "Prevents empty lines in JSDoc block descriptions.",
+);
+
+impl Rule for NoBlankBlockDescriptions {
+    fn run_once(&self, ctx: &LintContext) {
+        for jsdoc in ctx.jsdoc().iter_all() {
+            let comment = jsdoc.comment();
+            let content = comment.parsed_preserving_whitespace();
+
+            if !content.trim().is_empty() {
+                continue;
+            }
+
+            let description_line_count = count_description_lines(&content);
+            if description_line_count == 0 {
+                continue;
+            }
+
+            if jsdoc.tags().is_empty() && description_line_count < 2 {
+                continue;
+            }
+
+            ctx.diagnostic(no_blank_block_descriptions_diagnostic(jsdoc.span));
+        }
+    }
+}
+
+/// Count block-description lines, excluding the structural newlines immediately after `/**`
+/// and before either the first tag or `*/`.
+fn count_description_lines(content: &str) -> usize {
+    if content.is_empty() {
+        return 0;
+    }
+
+    // `split` preserves the trailing empty item needed to distinguish a structural newline.
+    let mut count = content.split('\n').count();
+
+    if content.starts_with('\n') {
+        count -= 1;
+    }
+
+    if content.ends_with('\n') {
+        count -= 1;
+    }
+
+    count
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "/**\n * Non-empty description\n * @param {number} x\n */",
+        "/**\n * Non-empty description\n *\n */",
+        "/**\n * @param {number} x\n */",
+        "/**\n *\n */",
+        "/**\n */",
+        "/** */",
+        "/** Some desc. */",
+        "/** @someTag */",
+    ];
+
+    let fail = vec!["/**\n *\n * @param {number} x\n */", "/**\n *\n *\n */"];
+
+    Tester::new(NoBlankBlockDescriptions::NAME, NoBlankBlockDescriptions::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/jsdoc_no_blank_block_descriptions.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_no_blank_block_descriptions.snap
@@ -1,0 +1,19 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ jsdoc(no-blank-block-descriptions): No blank block descriptions
+   ╭─[no_blank_block_descriptions.tsx:1:4]
+ 1 │ ╭─▶ /**
+ 2 │ │    *
+ 3 │ │    * @param {number} x
+ 4 │ ╰─▶  */
+   ╰────
+
+  ⚠ jsdoc(no-blank-block-descriptions): No blank block descriptions
+   ╭─[no_blank_block_descriptions.tsx:1:4]
+ 1 │ ╭─▶ /**
+ 2 │ │    *
+ 3 │ │    *
+ 4 │ ╰─▶  */
+   ╰────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -3578,6 +3578,9 @@
         "jsdoc/implements-on-classes": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "jsdoc/no-blank-block-descriptions": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "jsdoc/no-blank-blocks": {
           "anyOf": [
             {

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -282,6 +282,7 @@ jsdoc/check-property-names                                 |      7
 jsdoc/check-tag-names                                      |      7
 jsdoc/empty-tags                                           |      7
 jsdoc/implements-on-classes                                |  16812
+jsdoc/no-blank-block-descriptions                          |      7
 jsdoc/no-blank-blocks                                      |      7
 jsdoc/no-defaults                                          |  16812
 jsdoc/require-param                                        |  16812


### PR DESCRIPTION
This PR adds diagnostic support for `jsdoc/no-blank-block-descriptions`, related to #1170.

  ## Summary

  - Reports whitespace-only block descriptions when tags are present.
  - Reports block descriptions containing two or more blank lines when no tags are present.
  - Registers the rule and updates generated configuration and timing metadata.
  - Adds pass/fail snapshot coverage based on the upstream test cases.
  - Autofix support is not included in this PR.

  Upstream reference: [eslint-plugin-jsdoc implementation](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/src/rules/noBlankBlockDescriptions.js)

  ## Testing

  - `cargo test -p oxc_linter -- no_blank_block_descriptions`
  - `cargo test -p oxc_linter --quiet`
  - `cargo clippy -p oxc_linter --lib --tests -- -D warnings`

  ## AI usage disclosure

  I used Codex to help implement and refactor the rule, port and review the upstream test cases, regenerate metadata, rebase onto upstream/main, run tests, and
  draft this PR description. I reviewed and understand the changes and take full responsibility for this contribution.
