### PR TITLE
perf(minifier): avoid creation of unnecessary conditional expressions

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
@@ -62,12 +62,9 @@ impl<'a> PeepholeOptimizations {
             }
             // "!a ? b : c" => "a ? c : b"
             Expression::UnaryExpression(test_expr) if test_expr.operator.is_not() => {
-                let test = test_expr.argument.take_in(ctx);
-                let consequent = expr.alternate.take_in(ctx);
-                let alternate = expr.consequent.take_in(ctx);
-                return Some(Self::minimize_conditional(
-                    expr.span, test, consequent, alternate, ctx,
-                ));
+                std::mem::swap(&mut expr.consequent, &mut expr.alternate);
+                ctx.replace_expression_with(&mut expr.test, Self::unwrap_unary);
+                return Self::minimize_conditional_expression(expr, ctx);
             }
             Expression::Identifier(id) => {
                 // "a ? a : b" => "a || b"
@@ -96,19 +93,15 @@ impl<'a> PeepholeOptimizations {
                 }
             }
             // `x != y ? b : c` -> `x == y ? c : b`
-            Expression::BinaryExpression(test_expr) => {
+            Expression::BinaryExpression(test_expr)
                 if matches!(
                     test_expr.operator,
                     BinaryOperator::Inequality | BinaryOperator::StrictInequality
-                ) {
-                    test_expr.operator = test_expr.operator.equality_inverse_operator().unwrap();
-                    let test = expr.test.take_in(ctx);
-                    let consequent = expr.consequent.take_in(ctx);
-                    let alternate = expr.alternate.take_in(ctx);
-                    return Some(Self::minimize_conditional(
-                        expr.span, test, alternate, consequent, ctx,
-                    ));
-                }
+                ) =>
+            {
+                test_expr.operator = test_expr.operator.equality_inverse_operator().unwrap();
+                std::mem::swap(&mut expr.consequent, &mut expr.alternate);
+                return Self::minimize_conditional_expression(expr, ctx);
             }
             _ => {}
         }

--- a/tasks/track_memory_allocations/allocs_minifier.yaml
+++ b/tasks/track_memory_allocations/allocs_minifier.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 150
   sys alloc bytes: 14996600 # 15.00 MB
   sys peak growth: 10169560 # 10.17 MB
-  arena allocs: 144524
+  arena allocs: 144012
   arena reallocs: 28468
-  arena size: 19141528 # 19.14 MB
+  arena size: 19127248 # 19.13 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,9 +16,9 @@ App.tsx:
   sys deallocs: 61
   sys alloc bytes: 2128555 # 2.13 MB
   sys peak growth: 1612427 # 1.61 MB
-  arena allocs: 15718
+  arena allocs: 15670
   arena reallocs: 2721
-  arena size: 2882416 # 2.88 MB
+  arena size: 2880752 # 2.88 MB
 
 RadixUIAdoptionSection.jsx:
   file size: 2520 # 2.52 kB
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 2427
   sys alloc bytes: 5334247 # 5.33 MB
   sys peak growth: 3693355 # 3.69 MB
-  arena allocs: 44854
+  arena allocs: 44802
   arena reallocs: 7718
-  arena size: 6308176 # 6.31 MB
+  arena size: 6306768 # 6.31 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 1038
   sys alloc bytes: 29976031 # 29.98 MB
   sys peak growth: 19934725 # 19.93 MB
-  arena allocs: 352497
+  arena allocs: 351769
   arena reallocs: 76289
-  arena size: 48799784 # 48.80 MB
+  arena size: 48779400 # 48.78 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,7 +60,7 @@ binder.ts:
   sys deallocs: 33
   sys alloc bytes: 963008 # 963.01 kB
   sys peak growth: 657404 # 657.40 kB
-  arena allocs: 6841
+  arena allocs: 6809
   arena reallocs: 842
   arena size: 1164432 # 1.16 MB
 
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 1854
   sys alloc bytes: 5307512 # 5.31 MB
   sys peak growth: 3707425 # 3.71 MB
-  arena allocs: 65050
+  arena allocs: 64966
   arena reallocs: 12252
-  arena size: 9395480 # 9.40 MB
+  arena size: 9394240 # 9.39 MB


### PR DESCRIPTION
I started reviewing `minimize_conditional_expression` and looks like there is alot of wasted effort there, esp, when we are re-creating `ConditionalExpression` recursively by calling `minimize_conditional`, for now i decided to only optimize `!==` and `!`, but folding of `SequenceExpression` and creation of all new `Expression::new_conditional_expression` could be removed as we should just mutate current expression