### PR TITLE
fix(react-compiler): preserve computed property access

### DIFF
--- a/crates/oxc_react_compiler/fixtures/preserve-computed-property-access.js
+++ b/crates/oxc_react_compiler/fixtures/preserve-computed-property-access.js
@@ -1,0 +1,17 @@
+function Component() {
+  const namespace = useParams()['namespace'];
+  return <div>{namespace}</div>;
+}
+
+function OtherComponent(props) {
+  return <div>{props['external']}</div>;
+}
+
+function ConstantKeyComponent(props) {
+  const key = 'external';
+  return <div>{props[key]}</div>;
+}
+
+function OptionalComponent(props) {
+  return <div>{props?.['external']}</div>;
+}

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -767,6 +767,7 @@ pub enum InstructionValue<'a> {
     PropertyStore {
         object: Place,
         property: PropertyLiteral<'a>,
+        computed: bool,
         property_span: Option<Span>,
         value: Place,
         span: Option<Span>,
@@ -774,6 +775,7 @@ pub enum InstructionValue<'a> {
     PropertyLoad {
         object: Place,
         property: PropertyLiteral<'a>,
+        computed: bool,
         property_span: Option<Span>,
         span: Option<Span>,
     },
@@ -1016,6 +1018,7 @@ pub enum ManualMemoDependencyRoot<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DependencyPathEntry<'a> {
     pub property: PropertyLiteral<'a>,
+    pub computed: bool,
     pub optional: bool,
     pub span: Option<Span>,
 }
@@ -1888,19 +1891,26 @@ impl<'a> CloneIn<'a> for InstructionValue<'a> {
             InstructionValue::MetaProperty { meta, property, span } => {
                 InstructionValue::MetaProperty { meta: *meta, property: *property, span: *span }
             }
-            InstructionValue::PropertyStore { object, property, property_span, value, span } => {
-                InstructionValue::PropertyStore {
-                    object: *object,
-                    property: *property,
-                    property_span: *property_span,
-                    value: *value,
-                    span: *span,
-                }
-            }
-            InstructionValue::PropertyLoad { object, property, property_span, span } => {
+            InstructionValue::PropertyStore {
+                object,
+                property,
+                computed,
+                property_span,
+                value,
+                span,
+            } => InstructionValue::PropertyStore {
+                object: *object,
+                property: *property,
+                computed: *computed,
+                property_span: *property_span,
+                value: *value,
+                span: *span,
+            },
+            InstructionValue::PropertyLoad { object, property, computed, property_span, span } => {
                 InstructionValue::PropertyLoad {
                     object: *object,
                     property: *property,
+                    computed: *computed,
                     property_span: *property_span,
                     span: *span,
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -279,16 +279,23 @@ fn collect_temporaries_sidemap_impl<'a>(
             let used_outside = used_outside_declaring_scope.contains(&lvalue_decl_id);
 
             match &instr.value {
-                InstructionValue::PropertyLoad { object, property, property_span, span }
-                    if !used_outside =>
-                {
+                InstructionValue::PropertyLoad {
+                    object,
+                    property,
+                    computed,
+                    property_span,
+                    span,
+                } if !used_outside => {
                     if inner_fn_context.is_none() || temporaries[object.identifier].is_some() {
                         let prop = get_property(
                             object,
-                            property,
-                            false,
-                            *span,
-                            *property_span,
+                            PropertyAccess {
+                                property: *property,
+                                computed: *computed,
+                                optional: false,
+                                span: *span,
+                                property_span: *property_span,
+                            },
                             temporaries,
                             env.allocator,
                         );
@@ -347,35 +354,51 @@ fn collect_temporaries_sidemap_impl<'a>(
 }
 
 /// Corresponds to TS `getProperty`.
-fn get_property<'a>(
-    object: &Place,
-    property_name: &PropertyLiteral<'a>,
+#[derive(Clone, Copy)]
+struct PropertyAccess<'a> {
+    property: PropertyLiteral<'a>,
+    computed: bool,
     optional: bool,
     span: Option<Span>,
     property_span: Option<Span>,
+}
+
+fn get_property<'a>(
+    object: &Place,
+    access: PropertyAccess<'a>,
     temporaries: &TemporariesMap<'a>,
     alloc: &'a Allocator,
 ) -> ReactiveScopeDependency<'a> {
-    let property_span = property_span.or(span);
+    let property_span = access.property_span.or(access.span);
     let resolved = temporaries[object.identifier].as_ref();
     if let Some(resolved) = resolved {
         let mut path = resolved.path.clone_in(alloc);
-        path.push(DependencyPathEntry { property: *property_name, optional, span: property_span });
+        path.push(DependencyPathEntry {
+            property: access.property,
+            computed: access.computed,
+            optional: access.optional,
+            span: property_span,
+        });
         ReactiveScopeDependency {
             identifier: resolved.identifier,
             reactive: resolved.reactive,
             path,
-            span,
+            span: access.span,
         }
     } else {
         ReactiveScopeDependency {
             identifier: object.identifier,
             reactive: object.reactive,
             path: ArenaVec::from_array_in(
-                [DependencyPathEntry { property: *property_name, optional, span: property_span }],
+                [DependencyPathEntry {
+                    property: access.property,
+                    computed: access.computed,
+                    optional: access.optional,
+                    span: property_span,
+                }],
                 &alloc,
             ),
-            span,
+            span: access.span,
         }
     }
 }
@@ -460,6 +483,7 @@ fn traverse_function_optional<'a>(
 struct MatchConsequentResult<'a> {
     consequent_id: IdentifierId,
     property: PropertyLiteral<'a>,
+    computed: bool,
     property_id: IdentifierId,
     store_local_lvalue_id: IdentifierId,
     consequent_goto: BlockId,
@@ -484,12 +508,13 @@ fn match_optional_test_block<'a>(
     let instr0 = &func.instructions[consequent_block.instructions[0].index()];
     let instr1 = &func.instructions[consequent_block.instructions[1].index()];
 
-    let (property_load_object, property, property_load_span, property_span) = match &instr0.value {
-        InstructionValue::PropertyLoad { object, property, property_span, span } => {
-            (object, property, span, property_span)
-        }
-        _ => return None,
-    };
+    let (property_load_object, property, computed, property_load_span, property_span) =
+        match &instr0.value {
+            InstructionValue::PropertyLoad { object, property, computed, property_span, span } => {
+                (object, property, computed, span, property_span)
+            }
+            _ => return None,
+        };
 
     let store_local_value = match &instr1.value {
         InstructionValue::StoreLocal { value, lvalue, .. } => {
@@ -525,6 +550,7 @@ fn match_optional_test_block<'a>(
             Some(MatchConsequentResult {
                 consequent_id: store_local_value.identifier,
                 property: *property,
+                computed: *computed,
                 property_id: instr0.lvalue.identifier,
                 store_local_lvalue_id: instr1.lvalue.identifier,
                 consequent_goto: *goto_block,
@@ -571,11 +597,16 @@ fn traverse_optional_block<'a>(
                 let curr_instr = &func.instructions[maybe_test_block.instructions[i].index()];
                 let prev_instr = &func.instructions[maybe_test_block.instructions[i - 1].index()];
                 match &curr_instr.value {
-                    InstructionValue::PropertyLoad { object, property, property_span, span }
-                        if object.identifier == prev_instr.lvalue.identifier =>
-                    {
+                    InstructionValue::PropertyLoad {
+                        object,
+                        property,
+                        computed,
+                        property_span,
+                        span,
+                    } if object.identifier == prev_instr.lvalue.identifier => {
                         path.push(DependencyPathEntry {
                             property: *property,
+                            computed: *computed,
                             optional: false,
                             span: property_span.or(*span),
                         });
@@ -678,6 +709,7 @@ fn traverse_optional_block<'a>(
             let mut p = base_object.path;
             p.push(DependencyPathEntry {
                 property: match_result.property,
+                computed: match_result.computed,
                 optional: is_optional,
                 span: match_result.property_span.or(match_result.property_load_span),
             });
@@ -876,6 +908,7 @@ fn reduce_maybe_optional_chains(nodes: &mut BTreeSet<usize>, registry: &mut Prop
                 let next_entry = if entry.optional && nodes.contains(&curr_node) {
                     DependencyPathEntry {
                         property: entry.property,
+                        computed: entry.computed,
                         optional: false,
                         span: entry.span,
                     }
@@ -1456,6 +1489,7 @@ struct HoistableNodeEntry<'a> {
 struct DependencyNode<'a> {
     properties: FxIndexMap<PropertyLiteral<'a>, Box<DependencyNodeEntry<'a>>>,
     access_type: PropertyAccessType,
+    computed: bool,
     span: Option<Span>,
 }
 
@@ -1523,6 +1557,7 @@ impl<'a> ReactiveScopeDependencyTreeHIR<'a> {
                 DependencyNode {
                     properties: FxIndexMap::default(),
                     access_type: PropertyAccessType::UnconditionalAccess,
+                    computed: false,
                     span: dep.span,
                 },
                 dep.reactive,
@@ -1551,11 +1586,13 @@ impl<'a> ReactiveScopeDependencyTreeHIR<'a> {
                     node: DependencyNode {
                         properties: FxIndexMap::default(),
                         access_type,
+                        computed: entry.computed,
                         span: entry.span,
                     },
                 })
             });
             child.node.access_type = merge_access(child.node.access_type, access_type);
+            child.node.computed |= entry.computed;
 
             dep_cursor = &mut child.node;
             hoistable_ptr = next_hoistable;
@@ -1605,6 +1642,7 @@ fn collect_minimal_deps_in_subtree<'a>(
             let mut new_path = path.to_vec();
             new_path.push(DependencyPathEntry {
                 property: *child_name,
+                computed: child_entry.node.computed,
                 optional: is_optional_access(child_entry.node.access_type),
                 span: child_entry.node.span,
             });
@@ -1768,21 +1806,10 @@ impl<'a, 'e> DependencyCollectionContext<'a, 'e> {
     fn visit_property(
         &mut self,
         object: &Place,
-        property: &PropertyLiteral<'a>,
-        optional: bool,
-        span: Option<Span>,
-        property_span: Option<Span>,
+        access: PropertyAccess<'a>,
         env: &mut Environment<'a>,
     ) {
-        let dep = get_property(
-            object,
-            property,
-            optional,
-            span,
-            property_span,
-            self.temporaries,
-            env.allocator,
-        );
+        let dep = get_property(object, access, self.temporaries, env.allocator);
         self.visit_dependency(dep, env);
     }
 
@@ -1971,8 +1998,18 @@ fn handle_instruction<'a>(
     }
 
     match &instr.value {
-        InstructionValue::PropertyLoad { object, property, property_span, span } => {
-            ctx.visit_property(object, property, false, *span, *property_span, env);
+        InstructionValue::PropertyLoad { object, property, computed, property_span, span } => {
+            ctx.visit_property(
+                object,
+                PropertyAccess {
+                    property: *property,
+                    computed: *computed,
+                    optional: false,
+                    span: *span,
+                    property_span: *property_span,
+                },
+                env,
+            );
         }
         InstructionValue::StoreLocal { value: val, lvalue, .. } => {
             ctx.visit_operand(val, env);

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -916,6 +916,7 @@ enum MemberProperty<'a> {
 struct LoweredMemberExpression<'a> {
     object: Place,
     property: MemberProperty<'a>,
+    computed: bool,
     property_span: Option<Span>,
     value: InstructionValue<'a>,
 }
@@ -946,12 +947,14 @@ fn lower_member_expression_impl<'a>(
             let value = InstructionValue::PropertyLoad {
                 object,
                 property: prop_literal,
+                computed: false,
                 property_span,
                 span,
             };
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Literal(prop_literal),
+                computed: false,
                 property_span,
                 value,
             })
@@ -969,12 +972,14 @@ fn lower_member_expression_impl<'a>(
                 let value = InstructionValue::PropertyLoad {
                     object,
                     property: prop_literal,
+                    computed: true,
                     property_span,
                     span,
                 };
                 return Ok(LoweredMemberExpression {
                     object,
                     property: MemberProperty::Literal(prop_literal),
+                    computed: true,
                     property_span,
                     value,
                 });
@@ -984,6 +989,7 @@ fn lower_member_expression_impl<'a>(
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Computed(property),
+                computed: true,
                 property_span: property.span,
                 value,
             })
@@ -1004,6 +1010,7 @@ fn lower_member_expression_impl<'a>(
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Literal(PropertyLiteral::String(Ident::empty())),
+                computed: false,
                 property_span: None,
                 value: InstructionValue::Primitive { value: PrimitiveValue::Undefined, span },
             })
@@ -1123,12 +1130,14 @@ fn lower_member_expression_for_update<'a>(
             let value = InstructionValue::PropertyLoad {
                 object,
                 property: prop_literal,
+                computed: false,
                 property_span,
                 span,
             };
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Literal(prop_literal),
+                computed: false,
                 property_span,
                 value,
             })
@@ -1142,12 +1151,14 @@ fn lower_member_expression_for_update<'a>(
                 let value = InstructionValue::PropertyLoad {
                     object,
                     property: prop_literal,
+                    computed: true,
                     property_span,
                     span,
                 };
                 return Ok(LoweredMemberExpression {
                     object,
                     property: MemberProperty::Literal(prop_literal),
+                    computed: true,
                     property_span,
                     value,
                 });
@@ -1157,6 +1168,7 @@ fn lower_member_expression_for_update<'a>(
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Computed(property),
+                computed: true,
                 property_span: property.span,
                 value,
             })
@@ -1172,6 +1184,7 @@ fn lower_member_expression_for_update<'a>(
             Ok(LoweredMemberExpression {
                 object,
                 property: MemberProperty::Literal(PropertyLiteral::String(Ident::empty())),
+                computed: false,
                 property_span: None,
                 value: InstructionValue::Primitive { value: PrimitiveValue::Undefined, span },
             })
@@ -1848,6 +1861,7 @@ fn lower_member_assignment_target<'a>(
                 InstructionValue::PropertyStore {
                     object,
                     property: PropertyLiteral::String(member.property.name),
+                    computed: false,
                     property_span: Some(member.property.span),
                     value,
                     span: Some(span),
@@ -1865,6 +1879,7 @@ fn lower_member_assignment_target<'a>(
                     InstructionValue::PropertyStore {
                         object,
                         property: PropertyLiteral::Number(FloatValue::new(num.value)),
+                        computed: true,
                         property_span: Some(num.span),
                         value,
                         span: Some(span),
@@ -4016,6 +4031,7 @@ fn lower_expression<'a>(
                     let lowered = lower_member_expression_for_update(builder, member)?;
                     let object = lowered.object;
                     let lowered_property = lowered.property;
+                    let computed = lowered.computed;
                     let property_span = lowered.property_span;
                     let prev_value = lower_value_to_temporary(builder, lowered.value)?;
 
@@ -4045,6 +4061,7 @@ fn lower_expression<'a>(
                             InstructionValue::PropertyStore {
                                 object,
                                 property: prop_literal,
+                                computed,
                                 property_span,
                                 value: updated,
                                 span: member_span,
@@ -4291,6 +4308,7 @@ fn lower_member_assignment_expression<'a>(
                 InstructionValue::PropertyStore {
                     object,
                     property: PropertyLiteral::String(member.property.name),
+                    computed: false,
                     property_span: Some(member.property.span),
                     value,
                     span: member_span,
@@ -4314,6 +4332,7 @@ fn lower_member_assignment_expression<'a>(
                     InstructionValue::PropertyStore {
                         object,
                         property,
+                        computed: true,
                         property_span: Some(member.expression.span()),
                         value,
                         span: member_span,
@@ -4542,6 +4561,7 @@ fn lower_assignment_expression<'a>(
                 let lowered = lower_member_expression(builder, member)?;
                 let object = lowered.object;
                 let lowered_property = lowered.property;
+                let computed = lowered.computed;
                 let property_span = lowered.property_span;
                 let current_value = lower_value_to_temporary(builder, lowered.value)?;
                 let right = lower_expression_to_temporary(builder, &assign.right)?;
@@ -4558,6 +4578,7 @@ fn lower_assignment_expression<'a>(
                     MemberProperty::Literal(prop_literal) => Ok(InstructionValue::PropertyStore {
                         object,
                         property: prop_literal,
+                        computed,
                         property_span,
                         value: result,
                         span: member_span,
@@ -4910,6 +4931,7 @@ fn lower_jsx_member_expression<'a>(
     let value = InstructionValue::PropertyLoad {
         object,
         property: PropertyLiteral::String(Ident::from(prop_name)),
+        computed: false,
         property_span: Some(expr.property.span),
         span: expr_span,
     };

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -309,6 +309,7 @@ fn evaluate_instruction<'a>(
                             InstructionValue::PropertyLoad {
                                 object,
                                 property: new_property,
+                                computed: true,
                                 property_span,
                                 span,
                             };
@@ -322,6 +323,7 @@ fn evaluate_instruction<'a>(
                             InstructionValue::PropertyLoad {
                                 object,
                                 property: new_property,
+                                computed: true,
                                 property_span,
                                 span,
                             };
@@ -348,6 +350,7 @@ fn evaluate_instruction<'a>(
                             InstructionValue::PropertyStore {
                                 object,
                                 property: new_property,
+                                computed: true,
                                 property_span,
                                 value: store_value,
                                 span,
@@ -363,6 +366,7 @@ fn evaluate_instruction<'a>(
                             InstructionValue::PropertyStore {
                                 object,
                                 property: new_property,
+                                computed: true,
                                 property_span,
                                 value: store_value,
                                 span,

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
@@ -376,13 +376,14 @@ fn collect_maybe_memo_dependencies<'a>(
             path: ArenaVec::new_in(&env.allocator),
             span: *span,
         }),
-        InstructionValue::PropertyLoad { object, property, property_span, span } => {
+        InstructionValue::PropertyLoad { object, property, computed, property_span, span } => {
             maybe_deps.get(&object.identifier).map(|object_dep| ManualMemoDependency {
                 root: object_dep.root,
                 path: {
                     let mut path = object_dep.path.clone_in(env.allocator);
                     path.push(DependencyPathEntry {
                         property: *property,
+                        computed: *computed,
                         optional,
                         span: property_span.or(*span),
                     });

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -2011,14 +2011,21 @@ fn ox_codegen_base_instruction_value<'a>(
         InstructionValue::ObjectExpression { properties, .. } => {
             ox_codegen_object_expression(cx, properties, span)
         }
-        InstructionValue::PropertyLoad { object, property, property_span, .. } => {
+        InstructionValue::PropertyLoad { object, property, computed, property_span, .. } => {
             let obj = ox_codegen_place_to_expression(cx, object)?;
-            let member = ox_property_member(cx, obj, property, span, *property_span);
+            let member = ox_property_member(cx, obj, property, *computed, span, *property_span);
             Ok(OxValue::Expression(oxc::Expression::from(member)))
         }
-        InstructionValue::PropertyStore { object, property, property_span, value, .. } => {
+        InstructionValue::PropertyStore {
+            object,
+            property,
+            computed,
+            property_span,
+            value,
+            ..
+        } => {
             let obj = ox_codegen_place_to_expression(cx, object)?;
-            let member = ox_property_member(cx, obj, property, span, *property_span);
+            let member = ox_property_member(cx, obj, property, *computed, span, *property_span);
             let val = ox_codegen_place_to_expression(cx, value)?;
             let target = oxc::AssignmentTarget::from(oxc::SimpleAssignmentTarget::from(member));
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_assignment_expression(
@@ -2031,7 +2038,7 @@ fn ox_codegen_base_instruction_value<'a>(
         }
         InstructionValue::PropertyDelete { object, property, property_span, .. } => {
             let obj = ox_codegen_place_to_expression(cx, object)?;
-            let member = ox_property_member(cx, obj, property, span, *property_span);
+            let member = ox_property_member(cx, obj, property, false, span, *property_span);
             Ok(OxValue::Expression(oxc_ast::ast::Expression::new_unary_expression(
                 span,
                 oxc::UnaryOperator::Delete,
@@ -2281,11 +2288,26 @@ fn ox_property_member<'a>(
     cx: &OxcContext<'a, '_>,
     object: oxc::Expression<'a>,
     property: &PropertyLiteral,
+    computed: bool,
     span: Span,
     property_span: Option<Span>,
 ) -> oxc::MemberExpression<'a> {
     let property_span = property_span.unwrap_or(span);
     match property {
+        PropertyLiteral::String(s) if computed => {
+            oxc_ast::ast::MemberExpression::new_computed_member_expression(
+                span,
+                object,
+                oxc_ast::ast::Expression::new_string_literal(
+                    property_span,
+                    ox_str(&cx.ast, s),
+                    None,
+                    &cx.ast,
+                ),
+                false,
+                &cx.ast,
+            )
+        }
         PropertyLiteral::String(s) => oxc_ast::ast::MemberExpression::new_static_member_expression(
             span,
             object,
@@ -2614,8 +2636,14 @@ fn ox_codegen_dependency<'a>(
         // plain members whose `optional` flags are preserved. Wrapping each step in
         // its own `ChainExpression` would force spurious parens such as `(((a.b)?.c).d)?.e`.
         for path_entry in &dep.path {
-            let member =
-                ox_property_member(cx, object, &path_entry.property, span, path_entry.span);
+            let member = ox_property_member(
+                cx,
+                object,
+                &path_entry.property,
+                path_entry.computed,
+                span,
+                path_entry.span,
+            );
             object = match member {
                 oxc::MemberExpression::StaticMemberExpression(m) => {
                     let m = m.unbox();

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
@@ -244,6 +244,7 @@ fn apply_early_return_to_scope<'a>(
                         span: None, // GeneratedSource
                     },
                     property: PropertyLiteral::String(Ident::from("for")),
+                    computed: false,
                     property_span: None,
                     span: None,
                 }),

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -665,7 +665,13 @@ fn collect_dependencies<'a>(
                         }
                     }
                 }
-                InstructionValue::PropertyLoad { object, property, property_span, .. } => {
+                InstructionValue::PropertyLoad {
+                    object,
+                    property,
+                    computed,
+                    property_span,
+                    ..
+                } => {
                     // Number properties or ref.current: visit the object directly
                     let is_numeric = matches!(property, PropertyLiteral::Number(_));
                     let is_ref_current =
@@ -690,6 +696,7 @@ fn collect_dependencies<'a>(
                             new_path.push(DependencyPathEntry {
                                 optional,
                                 property: *property,
+                                computed: *computed,
                                 span: property_span.or_else(|| instr.value.span().copied()),
                             });
                             temporaries.insert(

--- a/crates/oxc_react_compiler/tests/snapshots/alias-computed-load.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/alias-computed-load.snap
@@ -9,7 +9,7 @@ function component(a) {
 	if ($[0] !== a) {
 		x = { a };
 		const y = {};
-		y.x = x.a;
+		y.x = x["a"];
 		mutate(y);
 		$[0] = a;
 		$[1] = x;

--- a/crates/oxc_react_compiler/tests/snapshots/capturing-func-alias-computed-mutate-iife.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/capturing-func-alias-computed-mutate-iife.snap
@@ -10,7 +10,7 @@ function component(a) {
 	if ($[0] !== a) {
 		const x = { a };
 		y = {};
-		y.x = x;
+		y["x"] = x;
 		mutate(y);
 		$[0] = a;
 		$[1] = y;

--- a/crates/oxc_react_compiler/tests/snapshots/capturing-func-alias-computed-mutate.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/capturing-func-alias-computed-mutate.snap
@@ -12,7 +12,7 @@ function Component(t0) {
 		const x = { a };
 		y = {};
 		const f0 = function() {
-			y.x = x;
+			y["x"] = x;
 		};
 		f0();
 		mutate(y);

--- a/crates/oxc_react_compiler/tests/snapshots/capturing-func-alias-receiver-computed-mutate-iife.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/capturing-func-alias-receiver-computed-mutate-iife.snap
@@ -11,7 +11,7 @@ function component(a) {
 		const x = { a };
 		y = {};
 		const a_0 = y;
-		a_0.x = x;
+		a_0["x"] = x;
 		mutate(y);
 		$[0] = a;
 		$[1] = y;

--- a/crates/oxc_react_compiler/tests/snapshots/capturing-func-alias-receiver-computed-mutate.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/capturing-func-alias-receiver-computed-mutate.snap
@@ -13,7 +13,7 @@ function Component(t0) {
 		y = {};
 		const f0 = function() {
 			const a_0 = y;
-			a_0.x = x;
+			a_0["x"] = x;
 		};
 		f0();
 		mutate(y);

--- a/crates/oxc_react_compiler/tests/snapshots/computed-store-alias.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/computed-store-alias.snap
@@ -11,7 +11,7 @@ function useHook(t0) {
 	if ($[0] !== a || $[1] !== b) {
 		const y = { a };
 		x = { b };
-		x.y = y;
+		x["y"] = y;
 		mutate(x);
 		$[0] = a;
 		$[1] = b;

--- a/crates/oxc_react_compiler/tests/snapshots/constant-computed.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/constant-computed.snap
@@ -8,8 +8,8 @@ function Component(props) {
 	let x;
 	if ($[0] !== props.foo) {
 		x = {};
-		x.foo = x.foo + x.bar;
-		x.foo(props.foo);
+		x["foo"] = x["foo"] + x["bar"];
+		x["foo"](props.foo);
 		$[0] = props.foo;
 		$[1] = x;
 	} else {

--- a/crates/oxc_react_compiler/tests/snapshots/hoisting-computed-member-expression.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/hoisting-computed-member-expression.snap
@@ -9,7 +9,7 @@ function hoisting() {
 	let t0;
 	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
 		const onClick = function onClick() {
-			return bar.baz;
+			return bar["baz"];
 		};
 		const onClick2 = function onClick2() {
 			return bar[baz];

--- a/crates/oxc_react_compiler/tests/snapshots/preserve-computed-property-access.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/preserve-computed-property-access.snap
@@ -1,0 +1,55 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/preserve-computed-property-access.js
+---
+import { c as _c } from "react/compiler-runtime";
+function Component() {
+	const $ = _c(2);
+	const namespace = useParams()["namespace"];
+	let t0;
+	if ($[0] !== namespace) {
+		t0 = <div>{namespace}</div>;
+		$[0] = namespace;
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}
+function OtherComponent(props) {
+	const $ = _c(2);
+	let t0;
+	if ($[0] !== props["external"]) {
+		t0 = <div>{props["external"]}</div>;
+		$[0] = props["external"];
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}
+function ConstantKeyComponent(props) {
+	const $ = _c(2);
+	let t0;
+	if ($[0] !== props["external"]) {
+		t0 = <div>{props["external"]}</div>;
+		$[0] = props["external"];
+		$[1] = t0;
+	} else {
+		t0 = $[1];
+	}
+	return t0;
+}
+function OptionalComponent(props) {
+	const $ = _c(2);
+	const t0 = props?.["external"];
+	let t1;
+	if ($[0] !== t0) {
+		t1 = <div>{t0}</div>;
+		$[0] = t0;
+		$[1] = t1;
+	} else {
+		t1 = $[1];
+	}
+	return t1;
+}


### PR DESCRIPTION
Closes #25918.

Supersedes #25919.
References react/react#37234.

AI-assisted.