### PR TITLE
fix(codegen): print `#` before private identifier in TS signature key

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3802,7 +3802,7 @@ impl Gen for TSSignature<'_> {
                             key.print(p, ctx);
                         }
                         PropertyKey::PrivateIdentifier(key) => {
-                            p.print_str(key.name.as_str());
+                            key.print(p, ctx);
                         }
                         PropertyKey::StringLiteral(key) => {
                             p.print_string_literal(key, false);
@@ -3853,7 +3853,7 @@ impl Gen for TSPropertySignature<'_> {
                     key.print(p, ctx);
                 }
                 PropertyKey::PrivateIdentifier(key) => {
-                    p.print_str(key.name.as_str());
+                    key.print(p, ctx);
                 }
                 PropertyKey::StringLiteral(key) => {
                     p.print_string_literal(key, false);

--- a/packages/codegen/src-js/print/typescript.ts
+++ b/packages/codegen/src-js/print/typescript.ts
@@ -525,6 +525,7 @@ function printSignatureKey(key: ESTree.PropertyKey, state: State, ctx: number): 
       writeWithMap(state, key.name, CAT_IDENT, key);
       break;
     case "PrivateIdentifier":
+      writeWithMapNoLast(state, "#", key);
       write(state, key.name, CAT_IDENT);
       break;
     case "Literal":


### PR DESCRIPTION
`TSPropertySignature` and `TSMethodSignature` were printing a `PrivateIdentifier` key as `key.name`, dropping the `#`, so `interface I { #x: number }` was printed as `interface I { x: number }`.

This PR switches `oxc_codegen` to delegating to the `PrivateIdentifier` printer, as every other property key site already does. It also applies the same thing to JS printer `oxc-codegen`.

This is not legal syntax anyway - TS rejects it with TS18016, and Oxc parser with "Private identifier '#x' is not allowed in property names" - so this is only reachable from a recovered parse or a hand-built AST. But, since we have this code, it might as well do what you'd expect it to.