### PR TITLE
fix(codegen): do not include `#` for private identifiers in source maps names

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3066,18 +3066,18 @@ impl Gen for AccessorProperty<'_> {
 
 impl Gen for PrivateIdentifier<'_> {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
-        p.add_source_mapping_for_name(self.span, &self.name);
-        p.print_ascii_byte(b'#');
-
-        if let Some(mangled) = p.private_member_mappings.as_ref().and_then(|mappings| {
+        let mangled = p.private_member_mappings.as_ref().and_then(|mappings| {
             p.current_class_ids()
                 .find_map(|class_id| mappings.get(class_id).and_then(|m| m.get(self.name.as_str())))
                 .cloned()
-        }) {
-            p.print_str(mangled.as_str());
-        } else {
-            p.print_str(self.name.as_str());
-        }
+        });
+        // Name the mapping after what is printed, so a mangled name is recorded as a rename
+        // and an unmangled one as no rename at all
+        let name = mangled.as_ref().map_or(self.name.as_str(), |mangled| mangled.as_str());
+
+        p.add_source_mapping_for_private_name(self.span, name);
+        p.print_ascii_byte(b'#');
+        p.print_str(name);
     }
 }
 

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -984,4 +984,20 @@ impl<'a> Codegen<'a> {
     #[inline]
     #[expect(clippy::needless_pass_by_ref_mut, clippy::unused_self)]
     fn add_source_mapping_for_name(&mut self, _span: Span, _name: &str) {}
+
+    /// As `add_source_mapping_for_name`, for a private identifier - `#foo`.
+    /// `span` covers the `#`, which is no part of `name`.
+    #[cfg(feature = "sourcemap")]
+    fn add_source_mapping_for_private_name(&mut self, span: Span, name: &str) {
+        if let Some(sourcemap_builder) = self.sourcemap_builder.as_mut()
+            && !span.is_empty()
+        {
+            sourcemap_builder.add_source_mapping_for_private_name(self.code.as_bytes(), span, name);
+        }
+    }
+
+    #[cfg(not(feature = "sourcemap"))]
+    #[inline]
+    #[expect(clippy::needless_pass_by_ref_mut, clippy::unused_self)]
+    fn add_source_mapping_for_private_name(&mut self, _span: Span, _name: &str) {}
 }

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -99,6 +99,25 @@ impl<'a> SourcemapBuilder<'a> {
     }
 
     pub fn add_source_mapping_for_name(&mut self, output: &[u8], span: Span, name: &str) {
+        self.add_source_mapping_for_name_at(output, span, span.start, name);
+    }
+
+    /// Add a mapping for a private identifier, whose span covers the leading `#`.
+    ///
+    /// The mapping stays on the `#`, where the printed token starts, but the name is read from
+    /// after it, so what the map records is the name the AST holds. Babel does the same.
+    pub fn add_source_mapping_for_private_name(&mut self, output: &[u8], span: Span, name: &str) {
+        self.add_source_mapping_for_name_at(output, span, span.start + 1, name);
+    }
+
+    /// Add a mapping at `span.start`, naming it after the source between `name_start` and `span.end`.
+    fn add_source_mapping_for_name_at(
+        &mut self,
+        output: &[u8],
+        span: Span,
+        name_start: u32,
+        name: &str,
+    ) {
         debug_assert!(
             (span.end as usize) <= self.original_source.len(),
             "violated {}:{} <= {} for {name}",
@@ -106,7 +125,7 @@ impl<'a> SourcemapBuilder<'a> {
             span.end,
             self.original_source.len()
         );
-        let original_name = self.original_source.get(span.start as usize..span.end as usize);
+        let original_name = self.original_source.get(name_start as usize..span.end as usize);
         // The token name should be original name.
         // If it hasn't change, name should be `None` to reduce `SourceMap` size.
         let token_name = if original_name == Some(name) { None } else { original_name };
@@ -630,6 +649,29 @@ mod test {
             None
         );
         // The name `b` -> `c`, save `b` to token.
+        assert_eq!(
+            sm.get_source_view_token(1_u32)
+                .as_ref()
+                .and_then(oxc_sourcemap::SourceViewToken::get_name),
+            Some("b")
+        );
+    }
+
+    #[test]
+    fn add_source_mapping_for_private_name() {
+        let output = b"#a#c";
+        let mut builder = SourcemapBuilder::new(Path::new("x.js"), "#a#b");
+        builder.add_source_mapping_for_private_name(output, Span::new(0, 2), "a");
+        builder.add_source_mapping_for_private_name(output, Span::new(2, 4), "c");
+        let sm = builder.into_sourcemap();
+        // The name `a` not change.
+        assert_eq!(
+            sm.get_source_view_token(0_u32)
+                .as_ref()
+                .and_then(oxc_sourcemap::SourceViewToken::get_name),
+            None
+        );
+        // The name `b` -> `c`, save `b` to token, without the `#`.
         assert_eq!(
             sm.get_source_view_token(1_u32)
                 .as_ref()

--- a/packages/codegen/src-js/print/write.ts
+++ b/packages/codegen/src-js/print/write.ts
@@ -490,6 +490,9 @@ function recordSourceMapping(state: State, node: MappableNode, location: Locatio
 
 /**
  * Recover the original identifier spelling from validated source offsets.
+ *
+ * A private identifier's span covers the leading `#`, which is no part of the name the AST holds
+ * or a source map consumer looks up, so the name is read from after it.
  */
 function originalNameFromSource(
   sourceText: string,
@@ -527,7 +530,7 @@ function originalNameFromSource(
     index += char.length;
   }
 
-  return index === identifierStart ? undefined : sourceText.slice(start, index);
+  return index === identifierStart ? undefined : sourceText.slice(identifierStart, index);
 }
 
 /**

--- a/packages/codegen/test/source-maps.test.ts
+++ b/packages/codegen/test/source-maps.test.ts
@@ -168,6 +168,34 @@ describe("Rust conformance", () => {
     expect(map?.names).toEqual(["ab"]);
   });
 
+  test("a private identifier is named without its `#`", () => {
+    const code = "class C {\n  #foo = 1;\n  m() { return this.#foo; }\n}";
+    const program = parseProgram("private.js", code);
+
+    const classDeclaration = program.body[0];
+    if (classDeclaration.type !== "ClassDeclaration") throw new Error("Expected class declaration");
+    const [property, method] = classDeclaration.body.body;
+    if (property.type !== "PropertyDefinition") throw new Error("Expected property definition");
+    if (property.key.type !== "PrivateIdentifier") throw new Error("Expected private identifier");
+    if (method.type !== "MethodDefinition") throw new Error("Expected method definition");
+    const statement = method.value.body?.body[0];
+    if (statement?.type !== "ReturnStatement") throw new Error("Expected return statement");
+    const access = statement.argument;
+    if (access?.type !== "MemberExpression") throw new Error("Expected member expression");
+    const accessedKey = access.property;
+    if (accessedKey.type !== "PrivateIdentifier") throw new Error("Expected private identifier");
+
+    const options = { sourcemap: true, sourceFilename: "private.js", sourceText: code };
+
+    // Printed as it was written, so nothing is renamed and no mapping carries a name
+    expect(printSync(program, options).map?.names).toEqual([]);
+
+    // The `#` is no part of the name, so only what follows it is recorded
+    property.key.name = "a";
+    accessedKey.name = "a";
+    expect(printSync(program, options).map?.names).toEqual(["foo"]);
+  });
+
   test("handles transformed ASTs whose source locations move backwards", () => {
     const code = `const first = 1;\n${"\n".repeat(5000)}const second = 2;`;
     const program = parseProgram("reordered.js", code);


### PR DESCRIPTION
This is partly an unambiguous bug fix, and partly a behavior change which is more arguable, but which I believe is likely desirable. Both stem from the same source.

A `PrivateIdentifier`'s span includes the leading `#`, but the `name` the AST holds does not. The source map name was read from the whole span, so two things went wrong:

1. The recorded name was `#foo` rather than `foo`.
2. The check which omits the `name` field when it wasn't renamed compared `#foo` against `foo`. It never matched, so a name was recorded for *every* private identifier, renamed or not.

This PR fixes both by reading the name from after the `#`. The mapping itself stays on the `#`, where the printed token starts. `PrivateIdentifier`'s `Gen` impl now also names the mapping after what it prints, so a mangled name is recorded as a rename and an unmangled one as no rename at all. The fix applies to both Rust `oxc_codegen` and JS `oxc-codegen`.

It's the first change which is arguable. The new behavior (no `#` in the name in sourcemap) follows Babel and Terser. But ESBuild does something different - it includes `#` in the name, same as our behavior prior to this PR. So there isn't complete consensus on what's "right".

Personally I think Babel is a more reliable model to follow - it's battle-tested over years and its output is more likely to be considered "industry standard". One of Babel's maintainers is on TC39, and is leading the charge on the sourcemaps spec - so I'd assume Babel is doing what it's meant to in this regard. The sourcemap spec itself (according to Claude's reading of it) is ambiguous.