### PR TITLE
chore(deps): bump MSRV to 1.96.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Avoid editing `generated` subdirectories.
 
 ## Development Commands
 
-Prerequisites: Rust (MSRV: 1.95), Node.js, pnpm, just
+Prerequisites: Rust (MSRV: 1.96), Node.js, pnpm, just
 
 **Setup Notes:**
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "A collection of JavaScript tools written in Rust."
 edition = "2024"
 # MSRV Policy N-2 (12 weeks).
 # Balance between the core contributors enjoying the latest version of rustc, while waiting for dependents to catch up.
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 
 # <https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html>
 [workspace.lints.rust]

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -225,7 +225,10 @@ impl<'s> StructState<'s> {
             layout.size = next_offset;
 
             // Get highest alignment next field can have
-            *current_align = next_offset.isolate_lowest_one();
+            #[expect(clippy::manual_isolate_lowest_one, reason = "MSRV is 1.96")]
+            {
+                *current_align = next_offset & next_offset.wrapping_neg();
+            }
         }
 
         // Return offset of this field


### PR DESCRIPTION
## Summary

- bump the workspace MSRV from 1.95.0 to 1.96.0 under the N-2 policy after #25945
- retain an MSRV-compatible layout calculation while suppressing the Rust 1.98 Clippy suggestion