### PR TITLE
fix(parser): track irregular line terminators in trivia

### DIFF
--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -544,6 +544,24 @@ token /* Trailing 1 */
     }
 
     #[test]
+    fn html_close_comments_after_irregular_line_terminators_are_leading() {
+        for line_terminator in ['\u{2028}', '\u{2029}'] {
+            let allocator = Allocator::default();
+            let source_text = format!("foo();{line_terminator}--> comment\nbar();");
+            let source_type = SourceType::default().with_script(true);
+            let ret = Parser::new(&allocator, &source_text, source_type).parse();
+            assert!(ret.diagnostics.is_empty());
+
+            let comments = &ret.program.comments;
+            assert_eq!(comments.len(), 1);
+            assert!(comments[0].is_leading());
+            assert!(comments[0].preceded_by_newline());
+            let bar_start = u32::try_from(source_text.find("bar").unwrap()).unwrap();
+            assert_eq!(comments[0].attached_to, bar_start);
+        }
+    }
+
+    #[test]
     fn comment_attachments3() {
         let source_text = "
 /*

--- a/crates/oxc_parser/src/lexer/unicode.rs
+++ b/crates/oxc_parser/src/lexer/unicode.rs
@@ -67,6 +67,7 @@ impl<'a, C: Config> Lexer<'a, C> {
     fn handle_irregular_line_terminator(&mut self, _c: char) -> Kind {
         self.consume_char();
         self.token.set_is_on_new_line(true);
+        self.trivia_builder.handle_newline();
         self.trivia_builder.add_irregular_whitespace(self.token.start(), self.offset());
         Kind::Skip
     }


### PR DESCRIPTION
## Summary

- notify `TriviaBuilder` when the lexer consumes U+2028 or U+2029
- keep Annex B HTML-close comments after irregular line terminators attached as leading trivia
- add a script-mode regression test covering both Unicode separators