### PR TITLE
fix(semantic): resolve nested parameter references correctly

### DIFF
--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -278,6 +278,35 @@ fn dce_var_hoisting() {
     );
 }
 
+// https://github.com/rolldown/rolldown/issues/10722
+#[test]
+fn preserves_function_scoped_binding_in_default_parameter() {
+    test_same(
+        "let n = 1;
+        function bump() { n += 1 }
+        function factory(get) {
+            const read = function(a = n.IS_BLOCK) { return a };
+            var n = get(81937);
+            return read;
+        }
+        globalThis.__keep = [n, bump, factory];",
+    );
+}
+
+#[test]
+fn preserves_function_scoped_binding_declared_before_default_parameter() {
+    test_same(
+        "let n = 1;
+        function bump() { n += 1 }
+        function factory(get) {
+            var n = get(81937);
+            const read = function(a = n.IS_BLOCK) { return a };
+            return read;
+        }
+        globalThis.__keep = [n, bump, factory];",
+    );
+}
+
 // Dropping a dead-after-throw statement (`module.exports = x`) removes the
 // only reference to `x`. Without recording that as a mutation, the peephole
 // loop terminates before `flush_pass_changes` prunes the dropped reference,

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -641,8 +641,12 @@ impl<'a> SemanticBuilder<'a> {
     /// and reference creation is a simple Vec push instead of a hashmap insert.
     fn resolve_all_references(&mut self) {
         let refs = self.unresolved_references.take();
-        for (name, reference_id) in refs {
-            if !self.walk_up_resolve_reference(name, reference_id) {
+        for (name, reference_id, start_scope_id) in refs {
+            let resolved = match start_scope_id {
+                Some(scope_id) => self.walk_up_resolve_reference_from(name, reference_id, scope_id),
+                None => self.walk_up_resolve_reference(name, reference_id),
+            };
+            if !resolved {
                 self.scoping.add_root_unresolved_reference(name, reference_id);
             }
         }
@@ -653,7 +657,19 @@ impl<'a> SemanticBuilder<'a> {
     #[expect(clippy::inline_always, reason = "Hot path — called for every reference resolution")]
     #[inline(always)]
     fn walk_up_resolve_reference(&mut self, name: Ident<'a>, reference_id: ReferenceId) -> bool {
-        let mut scope_id = Some(self.scoping.references[reference_id].scope_id());
+        let scope_id = self.scoping.references[reference_id].scope_id();
+        self.walk_up_resolve_reference_from(name, reference_id, scope_id)
+    }
+
+    #[expect(clippy::inline_always, reason = "Hot path — called for every reference resolution")]
+    #[inline(always)]
+    fn walk_up_resolve_reference_from(
+        &mut self,
+        name: Ident<'a>,
+        reference_id: ReferenceId,
+        start_scope_id: ScopeId,
+    ) -> bool {
+        let mut scope_id = Some(start_scope_id);
         while let Some(sid) = scope_id {
             if let Some(symbol_id) = self.scoping.get_binding(sid, name)
                 && self.try_resolve_reference(reference_id, symbol_id)
@@ -715,19 +731,21 @@ impl<'a> SemanticBuilder<'a> {
         true
     }
 
-    /// Early-resolve references collected since the checkpoint by walking up the
-    /// full scope chain. Used for function parameters and catch parameters where
-    /// references must be resolved before entering the function body, to avoid
-    /// binding to variables declared inside the body (which share the same scope).
+    /// Early-resolve references collected since the checkpoint within the
+    /// current function parameter scope. References which do not resolve there
+    /// are deferred until all enclosing declarations have been visited, then
+    /// resolved starting from the parent scope. This avoids binding to variables
+    /// declared inside the function body (which shares the parameter scope),
+    /// while still seeing forward declarations in enclosing function bodies.
     ///
     /// Resolved references are removed. Unresolved references stay in the flat
     /// list for later resolution by `resolve_all_references` (which handles
     /// forward references to declarations not yet visited).
     fn resolve_references_for_current_scope(&mut self) {
         // Process in-place using a retain-style write-cursor — no temporary
-        // `Vec`. Reads each `(name, reference_id)` by value out of the flat
-        // list (both fields are `Copy`), so calling `walk_up_resolve_reference`
-        // (which takes `&mut self`) doesn't conflict with the index read.
+        // `Vec`. Reads each entry by value out of the flat list (all fields are
+        // `Copy`), so calling `try_resolve_reference` (which takes `&mut self`)
+        // doesn't conflict with the index read.
         let checkpoint = self.unresolved_references_checkpoint;
         let end = self.unresolved_references.len();
         if end <= checkpoint {
@@ -735,11 +753,53 @@ impl<'a> SemanticBuilder<'a> {
         }
         let mut write_idx = checkpoint;
         for read_idx in checkpoint..end {
-            let (name, reference_id) = self.unresolved_references.get(read_idx);
-            if !self.walk_up_resolve_reference(name, reference_id) {
-                // Keep in the flat list — may resolve later via forward declarations.
+            let (name, reference_id, start_scope_id) = self.unresolved_references.get(read_idx);
+            // An inner parameter scope may already have deferred this reference.
+            // Resume from its override so declarations in that inner function body
+            // stay excluded, then let each enclosing parameter scope either resolve
+            // the reference or advance the override past its own function body.
+            let resolution_scope_id =
+                start_scope_id.unwrap_or_else(|| self.scoping.references[reference_id].scope_id());
+            let is_inside_current_scope = self
+                .scoping
+                .scope_ancestors(resolution_scope_id)
+                .any(|scope_id| scope_id == self.current_scope_id);
+
+            if is_inside_current_scope {
+                let mut scope_id = Some(resolution_scope_id);
+                let mut resolved = false;
+                while let Some(sid) = scope_id {
+                    if let Some(symbol_id) = self.scoping.get_binding(sid, name)
+                        && self.try_resolve_reference(reference_id, symbol_id)
+                    {
+                        resolved = true;
+                        break;
+                    }
+                    if sid == self.current_scope_id {
+                        break;
+                    }
+                    scope_id = self.scoping.scope_parent_id(sid);
+                }
+
+                if !resolved {
+                    let parent_scope_id = self
+                        .scoping
+                        .scope_parent_id(self.current_scope_id)
+                        .expect("parameter scopes always have a parent");
+                    self.unresolved_references.set(
+                        write_idx,
+                        name,
+                        reference_id,
+                        Some(parent_scope_id),
+                    );
+                    write_idx += 1;
+                }
+            } else {
+                // Parameter decorators are intentionally visited in an outer
+                // class scope. Their recorded scope already excludes the
+                // function body, so normal end-of-program resolution is safe.
                 if write_idx != read_idx {
-                    self.unresolved_references.set(write_idx, name, reference_id);
+                    self.unresolved_references.set(write_idx, name, reference_id, start_scope_id);
                 }
                 write_idx += 1;
             }

--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -1,5 +1,5 @@
 use oxc_str::Ident;
-use oxc_syntax::reference::ReferenceId;
+use oxc_syntax::{reference::ReferenceId, scope::ScopeId};
 
 /// Flat list of unresolved references collected during AST traversal.
 ///
@@ -7,8 +7,11 @@ use oxc_syntax::reference::ReferenceId;
 /// references are collected flat and resolved in a single pass after traversal (walk-up).
 /// This eliminates all hashmap drain+insert operations during scope exit.
 pub struct UnresolvedReferences<'a> {
-    /// Flat list of (name, reference_id) pairs collected during traversal.
-    references: Vec<(Ident<'a>, ReferenceId)>,
+    /// Flat list of `(name, reference_id, resolution_start_scope)` entries
+    /// collected during traversal. Most references use their recorded scope;
+    /// the override is only set for unresolved function-parameter references
+    /// which must skip declarations in their own function body.
+    references: Vec<(Ident<'a>, ReferenceId, Option<ScopeId>)>,
 }
 
 impl<'a> UnresolvedReferences<'a> {
@@ -27,7 +30,7 @@ impl<'a> UnresolvedReferences<'a> {
     /// Push an unresolved reference to the flat list.
     #[inline]
     pub(crate) fn push(&mut self, name: Ident<'a>, reference_id: ReferenceId) {
-        self.references.push((name, reference_id));
+        self.references.push((name, reference_id, None));
     }
 
     /// Get the current length, used as a checkpoint for early resolution.
@@ -38,7 +41,7 @@ impl<'a> UnresolvedReferences<'a> {
 
     /// Take all collected references, leaving the list empty. O(1) pointer swap.
     #[inline]
-    pub(crate) fn take(&mut self) -> Vec<(Ident<'a>, ReferenceId)> {
+    pub(crate) fn take(&mut self) -> Vec<(Ident<'a>, ReferenceId, Option<ScopeId>)> {
         std::mem::take(&mut self.references)
     }
 
@@ -51,14 +54,14 @@ impl<'a> UnresolvedReferences<'a> {
     /// Read a reference by index, by value.
     ///
     /// Used by [`crate::SemanticBuilder::resolve_references_for_current_scope`]
-    /// to process the list in-place without allocating a temporary `Vec`. Both
-    /// `Ident<'a>` and `ReferenceId` are `Copy`, so this hands the caller an
-    /// owned pair that's detached from the underlying borrow.
+    /// to process the list in-place without allocating a temporary `Vec`. All
+    /// entry fields are `Copy`, so this hands the caller an owned tuple that's
+    /// detached from the underlying borrow.
     ///
     /// # Panics
     /// Panics if `idx >= self.len()`.
     #[inline]
-    pub(crate) fn get(&self, idx: usize) -> (Ident<'a>, ReferenceId) {
+    pub(crate) fn get(&self, idx: usize) -> (Ident<'a>, ReferenceId, Option<ScopeId>) {
         self.references[idx]
     }
 
@@ -68,8 +71,14 @@ impl<'a> UnresolvedReferences<'a> {
     /// # Panics
     /// Panics if `idx >= self.len()`.
     #[inline]
-    pub(crate) fn set(&mut self, idx: usize, name: Ident<'a>, reference_id: ReferenceId) {
-        self.references[idx] = (name, reference_id);
+    pub(crate) fn set(
+        &mut self,
+        idx: usize,
+        name: Ident<'a>,
+        reference_id: ReferenceId,
+        resolution_start_scope_id: Option<ScopeId>,
+    ) {
+        self.references[idx] = (name, reference_id, resolution_start_scope_id);
     }
 
     /// Truncate the list to `len`, removing references at the end.

--- a/crates/oxc_semantic/tests/integration/symbols.rs
+++ b/crates/oxc_semantic/tests/integration/symbols.rs
@@ -85,6 +85,109 @@ fn test_var_read_write() {
     .test();
 }
 
+// https://github.com/rolldown/rolldown/issues/10722
+#[test]
+fn test_forward_outer_binding_in_nested_default_parameter() {
+    let tester = SemanticTester::js(
+        "let var_n = 0, let_n = 0, fn_n = 0;
+        function outer() {
+            const read_var = function(a = var_n) { return a };
+            const read_let = function(a = let_n) { return a };
+            const read_fn = function(a = fn_n) { return a };
+            var var_n = 1;
+            let let_n = 1;
+            function fn_n() {}
+            return [read_var, read_let, read_fn];
+        }
+        use(var_n, let_n, fn_n, outer);",
+    );
+    let semantic = tester.build();
+    let scoping = semantic.scoping();
+    let root_scope_id = scoping.root_scope_id();
+
+    for name in ["var_n", "let_n", "fn_n"] {
+        let root_symbol = scoping.get_binding(root_scope_id, name.into()).unwrap();
+        let local_symbol = scoping
+            .symbol_ids()
+            .find(|&symbol_id| {
+                scoping.symbol_name(symbol_id) == name
+                    && scoping.symbol_scope_id(symbol_id) != root_scope_id
+            })
+            .unwrap();
+
+        assert_eq!(scoping.get_resolved_references(root_symbol).count(), 1, "{name}");
+        assert_eq!(scoping.get_resolved_references(local_symbol).count(), 1, "{name}");
+    }
+}
+
+#[test]
+fn test_nested_default_parameter_does_not_see_own_function_body() {
+    let tester = SemanticTester::js(
+        "let n = 0;
+        function outer() {
+            const read = function(a = n) {
+                var n = 1;
+                return a;
+            };
+            return read;
+        }
+        use(n, outer);",
+    );
+    let semantic = tester.build();
+    let scoping = semantic.scoping();
+    let root_scope_id = scoping.root_scope_id();
+    let root_n = scoping.get_binding(root_scope_id, "n".into()).unwrap();
+    let local_n = scoping
+        .symbol_ids()
+        .find(|&symbol_id| {
+            scoping.symbol_name(symbol_id) == "n"
+                && scoping.symbol_scope_id(symbol_id) != root_scope_id
+        })
+        .unwrap();
+
+    assert_eq!(scoping.get_resolved_references(root_n).count(), 2);
+    assert_eq!(scoping.get_resolved_references(local_n).count(), 0);
+}
+
+#[test]
+fn test_nested_default_parameter_in_outer_parameter_skips_outer_function_body() {
+    let tester = SemanticTester::js(
+        "let n = 0;
+        function outer(read = function(a = n) { return a }) {
+            var n = 1;
+            return read;
+        }
+        use(n, outer);",
+    );
+    let semantic = tester.build();
+    let scoping = semantic.scoping();
+    let root_scope_id = scoping.root_scope_id();
+    let root_n = scoping.get_binding(root_scope_id, "n".into()).unwrap();
+    let local_n = scoping
+        .symbol_ids()
+        .find(|&symbol_id| {
+            scoping.symbol_name(symbol_id) == "n"
+                && scoping.symbol_scope_id(symbol_id) != root_scope_id
+        })
+        .unwrap();
+
+    assert_eq!(scoping.get_resolved_references(root_n).count(), 2);
+    assert_eq!(scoping.get_resolved_references(local_n).count(), 0);
+}
+
+#[test]
+fn test_nested_default_parameter_sees_later_outer_parameter() {
+    SemanticTester::js(
+        "function outer(read = function(a = n) { return a }, n) {
+            return read;
+        }
+        use(outer);",
+    )
+    .has_some_symbol("n")
+    .has_number_of_references(1)
+    .test();
+}
+
 #[test]
 fn test_types_simple() {
     let test = SemanticTester::ts(

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: b465fdbf
 
 semantic_typescript Summary:
 AST Parsed     : 4720/4720 (100.00%)
-Positive Passed: 3490/4720 (73.94%)
+Positive Passed: 3489/4720 (73.92%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
@@ -17576,6 +17576,17 @@ rebuilt        : SymbolId(0): Span { start: 38, end: 39 }
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 38, end: 39 }]
 rebuilt        : SymbolId(0): []
+
+semantic Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionParameterObjectRestAndInitializers.ts
+Symbol reference IDs mismatch for "a":
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(6): []
+Reference symbol mismatch for "a":
+after transform: SymbolId(1) "a"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["require"]
+rebuilt        : ["a", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorYieldContextualType.ts
 Bindings mismatch:


### PR DESCRIPTION
Rolldown's DCE-only minification can remove a function-local `var` that is read by a nested function's default parameter. In rolldown/rolldown#10722, the nested `n` reference was incorrectly bound to a top-level `n`, leaving the local declaration with no references and allowing DCE to delete it.

```js
function factory(get) {
  const read = function (a = n.IS_BLOCK) {
    return a;
  };
  var n = get(81937);
  return read;
}
```

Function parameter initializers must not see declarations from their own function body, but they can see forward declarations in enclosing bodies. The semantic builder previously early-resolved parameter references by walking the entire currently available chain, which could bind a nested default parameter to the wrong outer symbol before an enclosing forward declaration had been visited.

This change attaches an optional resolution-start scope to deferred references. Each parameter scope resolves only within the visible portion of that scope; unresolved references advance past that function body and are reconsidered by enclosing parameter scopes or the final resolution pass. This preserves the flat in-place resolution path while handling own-body exclusion, nested parameter scopes, later outer parameters, and forward `var`, `let`, and function declarations.

Regression coverage includes the Rolldown DCE case, a declared-before near miss, forward binding categories, own- and outer-body shadowing, and later outer parameters.

The TypeScript semantic snapshot gains one expected mismatch for `functionParameterObjectRestAndInitializers.ts`. Correct reference rebuilding now exposes an existing transform issue where an object-rest parameter binding is moved into the body even though a later default parameter still reads it; the former resolver incorrectly masked that mismatch.

Validated with `cargo test -p oxc_semantic -p oxc_minifier`, `cargo coverage -- semantic`, strict Clippy, `just minsize`, and the standalone DCE reproduction with a second pass. Minifier size snapshots were unchanged, and the allocation delta reproduced on clean `main`, so it is excluded. `just ready` completed formatting, generated-code checks, and workspace checking, then stopped in the all-features test suite only because `stacktrace_is_correct` records Node.js v26.5.0 while this machine runs v25.8.1.

Related: https://github.com/rolldown/rolldown/issues/10722

Disclosure: this change was prepared and verified with AI assistance (Codex).
