### PR TITLE
fix(isolated-declarations): reject interpolated enum templates

### DIFF
--- a/crates/oxc_isolated_declarations/src/declaration.rs
+++ b/crates/oxc_isolated_declarations/src/declaration.rs
@@ -17,6 +17,28 @@ use crate::{
 };
 
 impl<'a> IsolatedDeclarations<'a> {
+    pub(crate) fn collect_constant_bindings(&mut self, stmts: &ArenaVec<'a, Statement<'a>>) {
+        for stmt in stmts {
+            let decl = match stmt {
+                Statement::VariableDeclaration(decl) => Some(decl),
+                Statement::ExportDeclaration(decl) => match &decl.declaration {
+                    Declaration::VariableDeclaration(decl) => Some(decl),
+                    _ => None,
+                },
+                _ => None,
+            };
+
+            let Some(decl) = decl.filter(|decl| decl.kind.is_const()) else { continue };
+            for declarator in &decl.declarations {
+                if let (Some(name), Some(init)) =
+                    (declarator.id.get_identifier_name(), declarator.init.as_ref())
+                {
+                    self.scope.add_constant_binding(name.into(), init.clone_in(self.allocator()));
+                }
+            }
+        }
+    }
+
     pub(crate) fn transform_variable_declaration(
         &self,
         decl: &VariableDeclaration<'a>,

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -164,7 +164,7 @@ impl<'a> IsolatedDeclarations<'a> {
             }
             Expression::NumericLiteral(lit) => Some(ConstantValue::Number(lit.value)),
             Expression::StringLiteral(lit) => Some(ConstantValue::String(lit.value.to_string())),
-            Expression::TemplateLiteral(lit) => {
+            Expression::TemplateLiteral(lit) if lit.expressions.is_empty() => {
                 let mut value = String::new();
                 for part in &lit.quasis {
                     value.push_str(&part.value.raw);

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -1,4 +1,4 @@
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::{ArenaVec, CloneIn, GetAllocator};
 use oxc_ast::ast::*;
@@ -107,13 +107,15 @@ impl<'a> IsolatedDeclarations<'a> {
         enum_name: &str,
         prev_members: &FxHashMap<Str<'a>, ConstantValue>,
     ) -> Option<ConstantValue> {
-        self.evaluate(expr, enum_name, prev_members)
+        self.evaluate(expr, enum_name, prev_members, &mut FxHashSet::default())
     }
 
     fn evaluate_ref(
+        &self,
         expr: &Expression<'a>,
         enum_name: &str,
         prev_members: &FxHashMap<Str<'a>, ConstantValue>,
+        evaluating_bindings: &mut FxHashSet<Str<'a>>,
     ) -> Option<ConstantValue> {
         match expr {
             match_member_expression!(Expression) => {
@@ -137,7 +139,14 @@ impl<'a> IsolatedDeclarations<'a> {
                     return Some(value.clone());
                 }
 
-                None
+                let name: Str<'a> = ident.name.into();
+                let expr = self.scope.get_constant_binding(name.as_str())?;
+                if !evaluating_bindings.insert(name) {
+                    return None;
+                }
+                let value = self.evaluate(expr, enum_name, prev_members, evaluating_bindings);
+                evaluating_bindings.remove(name.as_str());
+                value
             }
             _ => None,
         }
@@ -148,31 +157,43 @@ impl<'a> IsolatedDeclarations<'a> {
         expr: &Expression<'a>,
         enum_name: &str,
         prev_members: &FxHashMap<Str<'a>, ConstantValue>,
+        evaluating_bindings: &mut FxHashSet<Str<'a>>,
     ) -> Option<ConstantValue> {
         match expr {
             Expression::Identifier(_)
             | Expression::ComputedMemberExpression(_)
             | Expression::StaticMemberExpression(_)
             | Expression::PrivateFieldExpression(_) => {
-                Self::evaluate_ref(expr, enum_name, prev_members)
+                self.evaluate_ref(expr, enum_name, prev_members, evaluating_bindings)
             }
             Expression::BinaryExpression(expr) => {
-                self.eval_binary_expression(expr, enum_name, prev_members)
+                self.eval_binary_expression(expr, enum_name, prev_members, evaluating_bindings)
             }
             Expression::UnaryExpression(expr) => {
-                self.eval_unary_expression(expr, enum_name, prev_members)
+                self.eval_unary_expression(expr, enum_name, prev_members, evaluating_bindings)
             }
             Expression::NumericLiteral(lit) => Some(ConstantValue::Number(lit.value)),
             Expression::StringLiteral(lit) => Some(ConstantValue::String(lit.value.to_string())),
-            Expression::TemplateLiteral(lit) if lit.expressions.is_empty() => {
+            Expression::TemplateLiteral(lit) => {
                 let mut value = String::new();
-                for part in &lit.quasis {
+                for (index, part) in lit.quasis.iter().enumerate() {
                     value.push_str(&part.value.raw);
+                    if let Some(expression) = lit.expressions.get(index) {
+                        match self.evaluate(
+                            expression,
+                            enum_name,
+                            prev_members,
+                            evaluating_bindings,
+                        )? {
+                            ConstantValue::Number(number) => value.push_str(&number.to_js_string()),
+                            ConstantValue::String(string) => value.push_str(&string),
+                        }
+                    }
                 }
                 Some(ConstantValue::String(value))
             }
             Expression::ParenthesizedExpression(expr) => {
-                self.evaluate(&expr.expression, enum_name, prev_members)
+                self.evaluate(&expr.expression, enum_name, prev_members, evaluating_bindings)
             }
             _ => None,
         }
@@ -183,9 +204,10 @@ impl<'a> IsolatedDeclarations<'a> {
         expr: &BinaryExpression<'a>,
         enum_name: &str,
         prev_members: &FxHashMap<Str<'a>, ConstantValue>,
+        evaluating_bindings: &mut FxHashSet<Str<'a>>,
     ) -> Option<ConstantValue> {
-        let left = self.evaluate(&expr.left, enum_name, prev_members)?;
-        let right = self.evaluate(&expr.right, enum_name, prev_members)?;
+        let left = self.evaluate(&expr.left, enum_name, prev_members, evaluating_bindings)?;
+        let right = self.evaluate(&expr.right, enum_name, prev_members, evaluating_bindings)?;
 
         if matches!(expr.operator, BinaryOperator::Addition)
             && (matches!(left, ConstantValue::String(_))
@@ -248,8 +270,9 @@ impl<'a> IsolatedDeclarations<'a> {
         expr: &UnaryExpression<'a>,
         enum_name: &str,
         prev_members: &FxHashMap<Str<'a>, ConstantValue>,
+        evaluating_bindings: &mut FxHashSet<Str<'a>>,
     ) -> Option<ConstantValue> {
-        let value = self.evaluate(&expr.argument, enum_name, prev_members)?;
+        let value = self.evaluate(&expr.argument, enum_name, prev_members, evaluating_bindings)?;
 
         let value = match value {
             ConstantValue::Number(value) => value,

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -189,6 +189,7 @@ impl<'a> IsolatedDeclarations<'a> {
         stmts: &ArenaVec<'a, Statement<'a>>,
     ) -> ArenaVec<'a, Statement<'a>> {
         self.report_error_for_expando_function(stmts, false);
+        self.collect_constant_bindings(stmts);
 
         let mut stmts = stmts
             .iter()

--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -21,13 +21,19 @@ bitflags! {
 #[derive(Debug)]
 struct Scope<'a> {
     bindings: FxHashMap<Str<'a>, KindFlags>,
+    constant_bindings: FxHashMap<Str<'a>, Expression<'a>>,
     references: FxHashMap<Str<'a>, KindFlags>,
     flags: ScopeFlags,
 }
 
 impl Scope<'_> {
     fn new(flags: ScopeFlags) -> Self {
-        Self { bindings: FxHashMap::default(), references: FxHashMap::default(), flags }
+        Self {
+            bindings: FxHashMap::default(),
+            constant_bindings: FxHashMap::default(),
+            references: FxHashMap::default(),
+            flags,
+        }
     }
 }
 
@@ -36,7 +42,7 @@ impl Scope<'_> {
 pub struct ScopeTree<'a> {
     levels: Vec<Scope<'a>>,
     /// Pool of scopes whose maps have been emptied. Scopes are entered and left in a stack
-    /// pattern, so rather than dropping a left scope's two `FxHashMap`s (and allocating +
+    /// pattern, so rather than dropping a left scope's `FxHashMap`s (and allocating +
     /// re-growing fresh ones on the next `enter_scope`), keep them here to reuse their heap
     /// allocations and retained capacity.
     free_scopes: Vec<Scope<'a>>,
@@ -64,9 +70,18 @@ impl<'a> ScopeTree<'a> {
         scope.references.get(name).iter().any(|flags| flags.contains(KindFlags::Value))
     }
 
+    pub fn get_constant_binding(&self, name: &str) -> Option<&Expression<'a>> {
+        self.levels.iter().rev().find_map(|scope| scope.constant_bindings.get(name))
+    }
+
     fn add_binding(&mut self, name: Str<'a>, flags: KindFlags) {
         let scope = self.levels.last_mut().unwrap();
         scope.bindings.insert(name, flags);
+    }
+
+    pub fn add_constant_binding(&mut self, name: Str<'a>, initializer: Expression<'a>) {
+        let scope = self.levels.last_mut().unwrap();
+        scope.constant_bindings.insert(name, initializer);
     }
 
     fn add_reference(&mut self, name: Str<'a>, flags: KindFlags) {
@@ -79,7 +94,8 @@ impl<'a> ScopeTree<'a> {
         debug_assert!(self.levels.len() >= 2);
 
         // Remove the current scope, taking ownership of its maps so they can be recycled.
-        let Scope { mut bindings, mut references, .. } = self.levels.pop().unwrap();
+        let Scope { mut bindings, mut constant_bindings, mut references, .. } =
+            self.levels.pop().unwrap();
 
         // Resolve references in the current scope against its own bindings.
         references.retain(|name, reference_flags| {
@@ -93,10 +109,16 @@ impl<'a> ScopeTree<'a> {
             parent_scope.references.entry(name).and_modify(|f| *f |= flags).or_insert(flags);
         }
 
-        // Recycle both now-empty maps (capacity retained) to avoid re-allocating + re-growing
+        // Recycle the now-empty maps (capacity retained) to avoid re-allocating + re-growing
         // them for the next scope. `flags` is a placeholder; `enter_scope` overwrites it.
         bindings.clear();
-        self.free_scopes.push(Scope { bindings, references, flags: ScopeFlags::empty() });
+        constant_bindings.clear();
+        self.free_scopes.push(Scope {
+            bindings,
+            constant_bindings,
+            references,
+            flags: ScopeFlags::empty(),
+        });
     }
 }
 

--- a/crates/oxc_isolated_declarations/tests/fixtures/enum-runtime-initializer.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/enum-runtime-initializer.ts
@@ -8,7 +8,11 @@ export const enum BadConstEnum {
   B = A + 1,
 }
 
+const foo = "123";
+
 export const enum TemplateEnum {
   NoSubstitution = `constant`,
-  WithSubstitution = `prefix${Math.random()}`,
+  WithConstantSubstitution = `prefix${"foo"}`,
+  WithConstantIdentifierSubstitution = `prefix${foo}`,
+  WithRuntimeSubstitution = `prefix${Math.random()}`,
 }

--- a/crates/oxc_isolated_declarations/tests/fixtures/enum-runtime-initializer.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/enum-runtime-initializer.ts
@@ -7,3 +7,8 @@ export const enum BadConstEnum {
   A = Math.random(),
   B = A + 1,
 }
+
+export const enum TemplateEnum {
+  NoSubstitution = `constant`,
+  WithSubstitution = `prefix${Math.random()}`,
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/enum-runtime-initializer.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/enum-runtime-initializer.snap
@@ -13,6 +13,10 @@ export declare const enum BadConstEnum {
 	A,
 	B
 }
+export declare const enum TemplateEnum {
+	NoSubstitution = "constant",
+	WithSubstitution
+}
 
 
 ==================== Errors ====================
@@ -32,6 +36,14 @@ export declare const enum BadConstEnum {
    :       ^^^^^
  9 | }
    `----
+
+  x TS2474: const enum member initializers must be constant expressions.
+    ,-[13:22]
+ 12 |   NoSubstitution = `constant`,
+ 13 |   WithSubstitution = `prefix${Math.random()}`,
+    :                      ^^^^^^^^^^^^^^^^^^^^^^^^
+ 14 | }
+    `----
 
 
 ```

--- a/crates/oxc_isolated_declarations/tests/snapshots/enum-runtime-initializer.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/enum-runtime-initializer.snap
@@ -15,7 +15,9 @@ export declare const enum BadConstEnum {
 }
 export declare const enum TemplateEnum {
 	NoSubstitution = "constant",
-	WithSubstitution
+	WithConstantSubstitution = "prefixfoo",
+	WithConstantIdentifierSubstitution = "prefix123",
+	WithRuntimeSubstitution
 }
 
 
@@ -38,11 +40,11 @@ export declare const enum TemplateEnum {
    `----
 
   x TS2474: const enum member initializers must be constant expressions.
-    ,-[13:22]
- 12 |   NoSubstitution = `constant`,
- 13 |   WithSubstitution = `prefix${Math.random()}`,
-    :                      ^^^^^^^^^^^^^^^^^^^^^^^^
- 14 | }
+    ,-[17:29]
+ 16 |   WithConstantIdentifierSubstitution = `prefix${foo}`,
+ 17 |   WithRuntimeSubstitution = `prefix${Math.random()}`,
+    :                             ^^^^^^^^^^^^^^^^^^^^^^^^
+ 18 | }
     `----
 
 


### PR DESCRIPTION
## Summary
- evaluate const-enum template literals when every substitution is constant
- resolve constant identifiers through the existing declaration-scope stack
- diagnose runtime substitutions, such as Math.random(), with TS2474

## Testing
- cargo test -p oxc_isolated_declarations

AI-assisted change; reviewed and tested before submission.