### PR TITLE
fix(linter): support TypeScript extension aliases

### DIFF
--- a/crates/oxc_linter/fixtures/import/extension-alias/extension-alias-cjs.cts
+++ b/crates/oxc_linter/fixtures/import/extension-alias/extension-alias-cjs.cts
@@ -1,0 +1,1 @@
+export const cjs = 1;

--- a/crates/oxc_linter/fixtures/import/extension-alias/extension-alias-js-ts.ts
+++ b/crates/oxc_linter/fixtures/import/extension-alias/extension-alias-js-ts.ts
@@ -1,0 +1,1 @@
+export const jsTs = 1;

--- a/crates/oxc_linter/fixtures/import/extension-alias/extension-alias-js-tsx.tsx
+++ b/crates/oxc_linter/fixtures/import/extension-alias/extension-alias-js-tsx.tsx
@@ -1,0 +1,1 @@
+export const jsTsx = () => <button />;

--- a/crates/oxc_linter/fixtures/import/extension-alias/extension-alias-jsx-tsx.tsx
+++ b/crates/oxc_linter/fixtures/import/extension-alias/extension-alias-jsx-tsx.tsx
@@ -1,0 +1,1 @@
+export const jsxTsx = () => <button />;

--- a/crates/oxc_linter/fixtures/import/extension-alias/extension-alias-mjs.mts
+++ b/crates/oxc_linter/fixtures/import/extension-alias/extension-alias-mjs.mts
@@ -1,0 +1,1 @@
+export const mjs = 1;

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -430,4 +430,19 @@ fn test() {
             .change_rule_path("export-star-4/index.js")
             .test();
     }
+
+    {
+        let pass = vec![
+            r#"export * from "./extension-alias-js-ts.js""#,
+            r#"export * from "./extension-alias-js-tsx.js""#,
+            r#"export * from "./extension-alias-jsx-tsx.jsx""#,
+            r#"export * from "./extension-alias-mjs.mjs""#,
+            r#"export * from "./extension-alias-cjs.cjs""#,
+        ];
+
+        Tester::new(Export::NAME, Export::PLUGIN, pass, vec![])
+            .with_import_plugin(true)
+            .change_rule_path("extension-alias/index.ts")
+            .test();
+    }
 }

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -303,11 +303,14 @@ impl Runtime {
             Some(_) => None, // Path provided but file doesn't exist
             None => Some(TsconfigDiscovery::Auto),
         };
+        // Keep TypeScript's extension substitution in sync with the type checker.
         let extension_alias = tsconfig.as_ref().map_or_else(Vec::new, |_| {
+            let alias = |extensions: &[&str]| extensions.iter().map(ToString::to_string).collect();
             vec![
-                (".js".into(), vec![".js".into(), ".ts".into()]),
-                (".mjs".into(), vec![".mjs".into(), ".mts".into()]),
-                (".cjs".into(), vec![".cjs".into(), ".cts".into()]),
+                (".js".to_string(), alias(&[".ts", ".tsx", ".d.ts", ".js", ".jsx"])),
+                (".jsx".to_string(), alias(&[".tsx", ".ts", ".d.ts", ".jsx", ".js"])),
+                (".mjs".to_string(), alias(&[".mts", ".d.mts", ".mjs"])),
+                (".cjs".to_string(), alias(&[".cts", ".d.cts", ".cjs"])),
             ]
         });
         Resolver::new(ResolveOptions {


### PR DESCRIPTION
## Summary

When a tsconfig is present, align the linter resolver with the type checker's TypeScript extension substitution order. This fixes false positives for JS/JSX specifiers that resolve to TS/TSX modules, and also covers MTS/CTS declaration aliases.

## Validation

- focused import/export regression test
- cargo check for oxc_linter
- cargo fmt check
- cargo clippy for oxc_linter (allowing an existing main-branch lint)

Fixes #25951.

AI tools assisted with code exploration and test drafting. The final patch was reviewed against the existing type-checker resolver behavior and validated with the checks above.