### PR TITLE
feat(linter): add allow and allowPattern options to react/capitalized-calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,6 +2498,7 @@ dependencies = [
  "cow-utils",
  "indexmap",
  "insta",
+ "lazy-regex",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1332,7 +1332,7 @@ export interface DummyRuleMap {
   "react-perf/jsx-no-new-function-as-prop"?: RuleNoConfig | [AllowWarnDeny, ReactPerfConfig];
   "react-perf/jsx-no-new-object-as-prop"?: RuleNoConfig | [AllowWarnDeny, ReactPerfConfig];
   "react/button-has-type"?: RuleNoConfig | [AllowWarnDeny, ButtonHasType];
-  "react/capitalized-calls"?: RuleNoConfig;
+  "react/capitalized-calls"?: RuleNoConfig | [AllowWarnDeny, CapitalizedCallsConfig];
   "react/checked-requires-onchange-or-readonly"?: RuleNoConfig | [AllowWarnDeny, CheckedRequiresOnchangeOrReadonly];
   "react/display-name"?: RuleNoConfig | [AllowWarnDeny, DisplayNameConfig];
   "react/error-boundaries"?: RuleNoConfig;
@@ -4622,6 +4622,13 @@ export interface ButtonHasType {
    * If true, allow `type="submit"`.
    */
   submit?: boolean;
+}
+export interface CapitalizedCallsConfig {
+  /**
+   * A regex pattern; capitalized functions and methods whose name matches
+   * may be called directly.
+   */
+  allowPattern?: string;
 }
 export interface CheckedRequiresOnchangeOrReadonly {
   /**

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -4626,7 +4626,8 @@ export interface ButtonHasType {
 export interface CapitalizedCallsConfig {
   /**
    * A regex pattern; capitalized functions and methods whose name matches
-   * may be called directly.
+   * may be called directly. Anchor the pattern to allow exact names, e.g.
+   * `"^(StyleSheet|Schema)$"`.
    */
   allowPattern?: string;
 }

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -4625,9 +4625,16 @@ export interface ButtonHasType {
 }
 export interface CapitalizedCallsConfig {
   /**
-   * A regex pattern; capitalized functions and methods whose name matches
-   * may be called directly. Anchor the pattern to allow exact names, e.g.
-   * `"^(StyleSheet|Schema)$"`.
+   * Exact names of capitalized functions that may be called directly.
+   * Forwarded to the React Compiler's `validateNoCapitalizedCalls`
+   * environment option.
+   */
+  allow?: string[];
+  /**
+   * A regex pattern; capitalized functions whose name matches may be called
+   * directly, checked alongside `allow`. Useful when a codebase has a
+   * naming convention for capitalized non-component factories, such as
+   * generated event or schema builders (e.g. `"Event$"`).
    */
   allowPattern?: string;
 }

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -25,7 +25,7 @@ use crate::{
     module_record::ModuleRecord,
     options::LintOptions,
     rules::RuleEnum,
-    utils::ReactCompilerResults,
+    utils::{ReactCompilerEnvOptions, ReactCompilerResults},
 };
 
 #[cfg(not(test))]
@@ -190,6 +190,9 @@ pub struct ContextHost<'a> {
     /// every rule in the React Compiler family (`react/hooks`, `react/refs`, …).
     /// Stays empty until the first such rule runs on this file.
     pub(super) react_compiler_results: OnceCell<ReactCompilerResults>,
+    /// Config-derived environment additions for that shared run (from the
+    /// `react/capitalized-calls` rule's options).
+    react_compiler_env_options: ReactCompilerEnvOptions,
 }
 
 impl std::fmt::Debug for ContextHost<'_> {
@@ -230,8 +233,22 @@ impl<'a> ContextHost<'a> {
             frameworks: options.framework_hints,
             with_ignore_fixes: options.with_ignore_fixes,
             react_compiler_results: OnceCell::new(),
+            react_compiler_env_options: ReactCompilerEnvOptions::default(),
         }
         .sniff_for_frameworks()
+    }
+
+    /// Set the config-derived environment additions for the shared React
+    /// Compiler run. Must happen before the first React Compiler family rule
+    /// runs on this file.
+    pub fn with_react_compiler_env_options(mut self, env_options: ReactCompilerEnvOptions) -> Self {
+        self.react_compiler_env_options = env_options;
+        self
+    }
+
+    /// Config-derived environment additions for the shared React Compiler run.
+    pub(crate) fn react_compiler_env_options(&self) -> &ReactCompilerEnvOptions {
+        &self.react_compiler_env_options
     }
 
     /// The current [`ContextSubHost`]

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -11919,6 +11919,9 @@ impl RuleEnum {
             Self::ReactButtonHasType(_) => {
                 Ok(Self::ReactButtonHasType(ReactButtonHasType::from_configuration(value)?))
             }
+            Self::ReactCapitalizedCalls(_) => {
+                Ok(Self::ReactCapitalizedCalls(ReactCapitalizedCalls::from_configuration(value)?))
+            }
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 Ok(Self::ReactCheckedRequiresOnchangeOrReadonly(
                     ReactCheckedRequiresOnchangeOrReadonly::from_configuration(value)?,

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -357,8 +357,20 @@ impl Linter {
         let ResolvedLinterState { rules, config, external_rules } = self.config.resolve(path);
         let mut timing_recorder = TIMINGS.then(|| RuleTimingRecorder::with_capacity(rules.len()));
 
-        let mut ctx_host =
-            Rc::new(ContextHost::new(path, context_sub_hosts, allocator, self.options, config));
+        // The shared React Compiler run takes its environment additions from the
+        // `react/capitalized-calls` rule's resolved options.
+        let react_compiler_env_options = rules
+            .iter()
+            .find_map(|(rule, _)| match rule {
+                RuleEnum::ReactCapitalizedCalls(rule) => Some(rule.react_compiler_env_options()),
+                _ => None,
+            })
+            .unwrap_or_default();
+
+        let mut ctx_host = Rc::new(
+            ContextHost::new(path, context_sub_hosts, allocator, self.options, config)
+                .with_react_compiler_env_options(react_compiler_env_options),
+        );
 
         #[cfg(debug_assertions)]
         let mut current_diagnostic_index = 0;

--- a/crates/oxc_linter/src/rules/react/capitalized_calls.rs
+++ b/crates/oxc_linter/src/rules/react/capitalized_calls.rs
@@ -1,5 +1,5 @@
 use lazy_regex::Regex;
-use oxc_react_compiler::{ErrorCategory, LintDiagnostic};
+use oxc_react_compiler::ErrorCategory;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -7,16 +7,22 @@ use crate::{
     context::{ContextHost, LintContext},
     rule::{DefaultRuleConfig, Rule},
     utils::{
-        deserialize_regex_option, run_react_compiler_rule_filtered, should_run_react_compiler,
+        ReactCompilerEnvOptions, deserialize_regex_option, run_react_compiler_rule,
+        should_run_react_compiler,
     },
 };
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct CapitalizedCallsConfig {
-    /// A regex pattern; capitalized functions and methods whose name matches
-    /// may be called directly. Anchor the pattern to allow exact names, e.g.
-    /// `"^(StyleSheet|Schema)$"`.
+    /// Exact names of capitalized functions that may be called directly.
+    /// Forwarded to the React Compiler's `validateNoCapitalizedCalls`
+    /// environment option.
+    allow: Vec<String>,
+    /// A regex pattern; capitalized functions whose name matches may be called
+    /// directly, checked alongside `allow`. Useful when a codebase has a
+    /// naming convention for capitalized non-component factories, such as
+    /// generated event or schema builders (e.g. `"Event$"`).
     #[serde(deserialize_with = "deserialize_regex_option")]
     allow_pattern: Option<Regex>,
 }
@@ -71,9 +77,7 @@ impl Rule for CapitalizedCalls {
     }
 
     fn run_once(&self, ctx: &LintContext) {
-        run_react_compiler_rule_filtered(ctx, ErrorCategory::CapitalizedCalls, |finding| {
-            !self.is_allowed(finding, ctx)
-        });
+        run_react_compiler_rule(ctx, ErrorCategory::CapitalizedCalls);
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
@@ -82,16 +86,13 @@ impl Rule for CapitalizedCalls {
 }
 
 impl CapitalizedCalls {
-    fn is_allowed(&self, finding: &LintDiagnostic, ctx: &LintContext) -> bool {
-        let Some(pattern) = self.0.allow_pattern.as_ref() else {
-            return false;
-        };
-        // The finding's label covers exactly the offending function or method
-        // name (see `diagnostics::capitalized_call`).
-        let Some(label) = finding.diagnostic.labels.first() else {
-            return false;
-        };
-        pattern.is_match(ctx.source_range(label.span()))
+    /// The environment additions this rule's options contribute to the shared
+    /// React Compiler run.
+    pub(crate) fn react_compiler_env_options(&self) -> ReactCompilerEnvOptions {
+        ReactCompilerEnvOptions {
+            capitalized_calls_allow: self.0.allow.clone(),
+            capitalized_calls_allow_pattern: self.0.allow_pattern.clone(),
+        }
     }
 }
 
@@ -110,7 +111,7 @@ function Component(props) {
 ",
             None,
         ),
-        // Anchored pattern allows an exact name
+        // Exact name allowed
         (
             "
 import Child from './Child';
@@ -120,19 +121,7 @@ function Component() {
   </>;
 }
 ",
-            Some(json!([{ "allowPattern": "^Child$" }])),
-        ),
-        // The pattern applies to method calls too
-        (
-            "
-import myModule from './MyModule';
-function Component() {
-  return <>
-    {myModule.Child()}
-  </>;
-}
-",
-            Some(json!([{ "allowPattern": "^Child$" }])),
+            Some(json!([{ "allow": ["Child"] }])),
         ),
         // Pattern allowed
         (
@@ -144,6 +133,18 @@ function Component() {
 }
 ",
             Some(json!([{ "allowPattern": "Event$" }])),
+        ),
+        // Anchored pattern allows an exact name
+        (
+            "
+import Child from './Child';
+function Component() {
+  return <>
+    {Child()}
+  </>;
+}
+",
+            Some(json!([{ "allowPattern": "^Child$" }])),
         ),
     ];
 
@@ -197,6 +198,19 @@ function Component() {
 ",
             None,
         ),
+        // Like the compiler's validateNoCapitalizedCalls, the allowlist only
+        // applies to global loads, not to method calls
+        (
+            "
+import myModule from './MyModule';
+function Component() {
+  return <>
+    {myModule.Child()}
+  </>;
+}
+",
+            Some(json!([{ "allow": ["Child"], "allowPattern": "^Child$" }])),
+        ),
         // Allowing one name does not allow others
         (
             "
@@ -208,7 +222,7 @@ function Component() {
     {Child2()}
   </>;
 }",
-            Some(json!([{ "allowPattern": "^Child1$" }])),
+            Some(json!([{ "allow": ["Child1"] }])),
         ),
         // Pattern matches the whole name, not the suffix convention
         (

--- a/crates/oxc_linter/src/rules/react/capitalized_calls.rs
+++ b/crates/oxc_linter/src/rules/react/capitalized_calls.rs
@@ -1,13 +1,37 @@
-use oxc_react_compiler::ErrorCategory;
+use lazy_regex::{Regex, RegexBuilder};
+use oxc_react_compiler::{ErrorCategory, LintDiagnostic};
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     context::{ContextHost, LintContext},
-    rule::Rule,
-    utils::{run_react_compiler_rule, should_run_react_compiler},
+    rule::{DefaultRuleConfig, Rule},
+    utils::{run_react_compiler_rule_filtered, should_run_react_compiler},
 };
 
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct CapitalizedCallsConfig {
+    /// A regex pattern; capitalized functions and methods whose name matches
+    /// may be called directly.
+    #[serde(deserialize_with = "deserialize_allow_pattern")]
+    allow_pattern: Option<Regex>,
+}
+
+fn deserialize_allow_pattern<'de, D>(deserializer: D) -> Result<Option<Regex>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    Option::<String>::deserialize(deserializer)?
+        .map(|pattern| RegexBuilder::new(&pattern).build())
+        .transpose()
+        .map_err(D::Error::custom)
+}
+
 #[derive(Debug, Default, Clone)]
-pub struct CapitalizedCalls;
+pub struct CapitalizedCalls(Box<CapitalizedCallsConfig>);
 
 declare_react_compiler_lint!(
     /// ### What it does
@@ -41,16 +65,46 @@ declare_react_compiler_lint!(
     ///   return <div><Child /></div>;
     /// }
     /// ```
+    ///
+    /// ### Options
+    ///
+    /// #### allowPattern
+    ///
+    /// `{ type: string, default: undefined }`
+    ///
+    /// A regex pattern; capitalized functions and methods whose name matches
+    /// may be called directly — the rule-level counterpart of the React
+    /// Compiler's `validateNoCapitalizedCalls` environment option. Useful when
+    /// a codebase has a naming convention for capitalized non-component
+    /// factories, such as generated event or schema builders. Anchor the
+    /// pattern to allow exact names, e.g. `"^(StyleSheet|Schema)$"`.
+    ///
+    /// Example of **correct** code for this rule with `{ "allowPattern": "Event$" }`:
+    /// ```jsx
+    /// import { ButtonClickEvent } from './events';
+    /// function Component() {
+    ///   const event = ButtonClickEvent();
+    ///   return <button onClick={() => log(event)} />;
+    /// }
+    /// ```
     CapitalizedCalls,
     react,
     suspicious,
+    config = CapitalizedCallsConfig,
     version = "1.79.0",
     short_description = "Disallow calling capitalized functions and methods instead of using JSX.",
 );
 
 impl Rule for CapitalizedCalls {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        DefaultRuleConfig::<CapitalizedCallsConfig>::from_value(value)
+            .map(|config| Self(Box::new(config.into_inner())))
+    }
+
     fn run_once(&self, ctx: &LintContext) {
-        run_react_compiler_rule(ctx, ErrorCategory::CapitalizedCalls);
+        run_react_compiler_rule_filtered(ctx, ErrorCategory::CapitalizedCalls, |finding| {
+            !self.is_allowed(finding, ctx)
+        });
     }
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
@@ -58,22 +112,38 @@ impl Rule for CapitalizedCalls {
     }
 }
 
+impl CapitalizedCalls {
+    fn is_allowed(&self, finding: &LintDiagnostic, ctx: &LintContext) -> bool {
+        let Some(pattern) = self.0.allow_pattern.as_ref() else {
+            return false;
+        };
+        // The finding's label covers exactly the offending function or method
+        // name (see `diagnostics::capitalized_call`).
+        let Some(label) = finding.diagnostic.labels.first() else {
+            return false;
+        };
+        pattern.is_match(ctx.source_range(label.span()))
+    }
+}
+
 #[test]
 fn test() {
+    use serde_json::json;
+
     use crate::tester::Tester;
 
     let pass = vec![
-        "
+        (
+            "
 function Component(props) {
   return <div>{props.text}</div>;
 }
 ",
-    ];
-
-    let fail = vec![
-        // ---- NoCapitalizedCallsRule-test.ts ----
-        // Simple violation
-        "
+            None,
+        ),
+        // Anchored pattern allows an exact name
+        (
+            "
 import Child from './Child';
 function Component() {
   return <>
@@ -81,8 +151,11 @@ function Component() {
   </>;
 }
 ",
-        // Method call violation
-        "
+            Some(json!([{ "allowPattern": "^Child$" }])),
+        ),
+        // The pattern applies to method calls too
+        (
+            "
 import myModule from './MyModule';
 function Component() {
   return <>
@@ -90,8 +163,50 @@ function Component() {
   </>;
 }
 ",
+            Some(json!([{ "allowPattern": "^Child$" }])),
+        ),
+        // Pattern allowed
+        (
+            "
+import { ButtonClickEvent } from './events';
+function Component() {
+  const event = ButtonClickEvent();
+  return <button onClick={() => log(event)} />;
+}
+",
+            Some(json!([{ "allowPattern": "Event$" }])),
+        ),
+    ];
+
+    let fail = vec![
+        // ---- NoCapitalizedCallsRule-test.ts ----
+        // Simple violation
+        (
+            "
+import Child from './Child';
+function Component() {
+  return <>
+    {Child()}
+  </>;
+}
+",
+            None,
+        ),
+        // Method call violation
+        (
+            "
+import myModule from './MyModule';
+function Component() {
+  return <>
+    {myModule.Child()}
+  </>;
+}
+",
+            None,
+        ),
         // Multiple diagnostics within the same function are surfaced
-        "
+        (
+            "
 import Child1 from './Child1';
 import MyModule from './MyModule';
 function Component() {
@@ -100,6 +215,43 @@ function Component() {
     {MyModule.Child2()}
   </>;
 }",
+            None,
+        ),
+        // The pattern-allowed pass case above is a violation without config
+        (
+            "
+import { ButtonClickEvent } from './events';
+function Component() {
+  const event = ButtonClickEvent();
+  return <button onClick={() => log(event)} />;
+}
+",
+            None,
+        ),
+        // Allowing one name does not allow others
+        (
+            "
+import Child1 from './Child1';
+import Child2 from './Child2';
+function Component() {
+  return <>
+    {Child1()}
+    {Child2()}
+  </>;
+}",
+            Some(json!([{ "allowPattern": "^Child1$" }])),
+        ),
+        // Pattern matches the whole name, not the suffix convention
+        (
+            "
+import { EventChild } from './EventChild';
+function Component() {
+  return <>
+    {EventChild()}
+  </>;
+}",
+            Some(json!([{ "allowPattern": "Event$" }])),
+        ),
     ];
 
     Tester::new(CapitalizedCalls::NAME, CapitalizedCalls::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/react/capitalized_calls.rs
+++ b/crates/oxc_linter/src/rules/react/capitalized_calls.rs
@@ -1,4 +1,4 @@
-use lazy_regex::{Regex, RegexBuilder};
+use lazy_regex::Regex;
 use oxc_react_compiler::{ErrorCategory, LintDiagnostic};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -6,28 +6,19 @@ use serde::Deserialize;
 use crate::{
     context::{ContextHost, LintContext},
     rule::{DefaultRuleConfig, Rule},
-    utils::{run_react_compiler_rule_filtered, should_run_react_compiler},
+    utils::{
+        deserialize_regex_option, run_react_compiler_rule_filtered, should_run_react_compiler,
+    },
 };
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct CapitalizedCallsConfig {
     /// A regex pattern; capitalized functions and methods whose name matches
-    /// may be called directly.
-    #[serde(deserialize_with = "deserialize_allow_pattern")]
+    /// may be called directly. Anchor the pattern to allow exact names, e.g.
+    /// `"^(StyleSheet|Schema)$"`.
+    #[serde(deserialize_with = "deserialize_regex_option")]
     allow_pattern: Option<Regex>,
-}
-
-fn deserialize_allow_pattern<'de, D>(deserializer: D) -> Result<Option<Regex>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::de::Error;
-
-    Option::<String>::deserialize(deserializer)?
-        .map(|pattern| RegexBuilder::new(&pattern).build())
-        .transpose()
-        .map_err(D::Error::custom)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -63,28 +54,6 @@ declare_react_compiler_lint!(
     /// import Child from './Child';
     /// function Component() {
     ///   return <div><Child /></div>;
-    /// }
-    /// ```
-    ///
-    /// ### Options
-    ///
-    /// #### allowPattern
-    ///
-    /// `{ type: string, default: undefined }`
-    ///
-    /// A regex pattern; capitalized functions and methods whose name matches
-    /// may be called directly — the rule-level counterpart of the React
-    /// Compiler's `validateNoCapitalizedCalls` environment option. Useful when
-    /// a codebase has a naming convention for capitalized non-component
-    /// factories, such as generated event or schema builders. Anchor the
-    /// pattern to allow exact names, e.g. `"^(StyleSheet|Schema)$"`.
-    ///
-    /// Example of **correct** code for this rule with `{ "allowPattern": "Event$" }`:
-    /// ```jsx
-    /// import { ButtonClickEvent } from './events';
-    /// function Component() {
-    ///   const event = ButtonClickEvent();
-    ///   return <button onClick={() => log(event)} />;
     /// }
     /// ```
     CapitalizedCalls,

--- a/crates/oxc_linter/src/snapshots/react_capitalized_calls.snap
+++ b/crates/oxc_linter/src/snapshots/react_capitalized_calls.snap
@@ -58,6 +58,17 @@ source: crates/oxc_linter/src/tester.rs
   note: `ButtonClickEvent` is treated as a component because it begins with an uppercase letter; React Compiler skipped optimizing this component or hook. Additional guidance: https://react.dev/reference/eslint-plugin-react-hooks/lints/static-components
 
   ⚠ react(capitalized-calls): Capitalized function called without JSX
+   ╭─[capitalized_calls.tsx:5:15]
+ 4 │   return <>
+ 5 │     {myModule.Child()}
+   ·               ──┬──
+   ·                 ╰── `Child` may be a component
+ 6 │   </>;
+   ╰────
+  help: Render `Child` with JSX if it is a component; otherwise rename it to start with a lowercase letter or allowlist it in the compiler configuration
+  note: `Child` is treated as a component because it begins with an uppercase letter; React Compiler skipped optimizing this component or hook. Additional guidance: https://react.dev/reference/eslint-plugin-react-hooks/lints/static-components
+
+  ⚠ react(capitalized-calls): Capitalized function called without JSX
    ╭─[capitalized_calls.tsx:7:6]
  6 │     {Child1()}
  7 │     {Child2()}

--- a/crates/oxc_linter/src/snapshots/react_capitalized_calls.snap
+++ b/crates/oxc_linter/src/snapshots/react_capitalized_calls.snap
@@ -45,3 +45,36 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Render `Child2` with JSX if it is a component; otherwise rename it to start with a lowercase letter or allowlist it in the compiler configuration
   note: `Child2` is treated as a component because it begins with an uppercase letter; React Compiler skipped optimizing this component or hook. Additional guidance: https://react.dev/reference/eslint-plugin-react-hooks/lints/static-components
+
+  ⚠ react(capitalized-calls): Capitalized function called without JSX
+   ╭─[capitalized_calls.tsx:4:17]
+ 3 │ function Component() {
+ 4 │   const event = ButtonClickEvent();
+   ·                 ────────┬───────
+   ·                         ╰── `ButtonClickEvent` may be a component
+ 5 │   return <button onClick={() => log(event)} />;
+   ╰────
+  help: Render `ButtonClickEvent` with JSX if it is a component; otherwise rename it to start with a lowercase letter or allowlist it in the compiler configuration
+  note: `ButtonClickEvent` is treated as a component because it begins with an uppercase letter; React Compiler skipped optimizing this component or hook. Additional guidance: https://react.dev/reference/eslint-plugin-react-hooks/lints/static-components
+
+  ⚠ react(capitalized-calls): Capitalized function called without JSX
+   ╭─[capitalized_calls.tsx:7:6]
+ 6 │     {Child1()}
+ 7 │     {Child2()}
+   ·      ───┬──
+   ·         ╰── `Child2` may be a component
+ 8 │   </>;
+   ╰────
+  help: Render `Child2` with JSX if it is a component; otherwise rename it to start with a lowercase letter or allowlist it in the compiler configuration
+  note: `Child2` is treated as a component because it begins with an uppercase letter; React Compiler skipped optimizing this component or hook. Additional guidance: https://react.dev/reference/eslint-plugin-react-hooks/lints/static-components
+
+  ⚠ react(capitalized-calls): Capitalized function called without JSX
+   ╭─[capitalized_calls.tsx:5:6]
+ 4 │   return <>
+ 5 │     {EventChild()}
+   ·      ─────┬────
+   ·           ╰── `EventChild` may be a component
+ 6 │   </>;
+   ╰────
+  help: Render `EventChild` with JSX if it is a component; otherwise rename it to start with a lowercase letter or allowlist it in the compiler configuration
+  note: `EventChild` is treated as a component because it begins with an uppercase letter; React Compiler skipped optimizing this component or hook. Additional guidance: https://react.dev/reference/eslint-plugin-react-hooks/lints/static-components

--- a/crates/oxc_linter/src/utils/react_compiler.rs
+++ b/crates/oxc_linter/src/utils/react_compiler.rs
@@ -103,7 +103,23 @@ pub fn should_run_react_compiler(ctx: &ContextHost) -> bool {
 /// Shared `run_once` body for the React Compiler family of rules: report the
 /// shared run's findings for `category` under the calling rule's name.
 pub fn run_react_compiler_rule(ctx: &LintContext, category: ErrorCategory) {
+    run_react_compiler_rule_filtered(ctx, category, |_| true);
+}
+
+/// [`run_react_compiler_rule`] with per-finding filtering for rules with
+/// allowlist options: findings for which `should_report` returns `false` are
+/// skipped. Filtering happens at report time only — the shared compiler run is
+/// unaffected, exactly as if the finding were suppressed with a disable
+/// comment.
+pub fn run_react_compiler_rule_filtered(
+    ctx: &LintContext,
+    category: ErrorCategory,
+    mut should_report: impl FnMut(&LintDiagnostic) -> bool,
+) {
     for finding in ctx.react_compiler_results().diagnostics_for(category) {
+        if !should_report(finding) {
+            continue;
+        }
         let mut diagnostic = finding.diagnostic.clone();
 
         // `LintContext` supplies the per-category Oxlint rule code and primary

--- a/crates/oxc_linter/src/utils/react_compiler.rs
+++ b/crates/oxc_linter/src/utils/react_compiler.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use lazy_regex::Regex;
 use oxc_diagnostics::OxcCode;
 use oxc_react_compiler::{
     CompilerOutputMode, EnvironmentConfig, ErrorCategory, ExhaustiveEffectDepsMode, LintDiagnostic,
@@ -11,16 +12,29 @@ use crate::{
     loader::LINT_PARTIAL_LOADER_EXTENSIONS,
 };
 
+/// Environment additions to the shared React Compiler run that come from rule
+/// configuration, extracted once per resolved config in `Linter::run` (from the
+/// `react/capitalized-calls` rule's options). Config-derived rather than
+/// per-run rule state, so the single shared run stays valid for any
+/// combination of enabled rules.
+#[derive(Debug, Default, Clone)]
+pub struct ReactCompilerEnvOptions {
+    /// Extra allowed names for `validateNoCapitalizedCalls`.
+    pub capitalized_calls_allow: Vec<String>,
+    /// Allowed-name pattern for `validateNoCapitalizedCalls`.
+    pub capitalized_calls_allow_pattern: Option<Regex>,
+}
+
 /// The compiler options the React Compiler family of rules lints with — `lint`
 /// output mode plus validations that are off by default in the compiler.
 /// Mirrors `COMPILER_OPTIONS` in `eslint-plugin-react-hooks`'s
 /// `src/shared/RunReactCompiler.ts`.
 ///
-/// The options are a fixed superset shared by every rule in the family: which
-/// rules are enabled only routes categories to reporters, it never changes
-/// what the compiler analyzes. That keeps the single shared run valid for any
-/// combination of enabled rules.
-fn react_compiler_plugin_options() -> PluginOptions {
+/// The options are a superset shared by every rule in the family: which rules
+/// are enabled only routes categories to reporters, and the only per-config
+/// variation is [`ReactCompilerEnvOptions`]. That keeps the single shared run
+/// valid for any combination of enabled rules.
+fn react_compiler_plugin_options(env_options: &ReactCompilerEnvOptions) -> PluginOptions {
     PluginOptions {
         output_mode: Some(CompilerOutputMode::Lint),
         // Oxlint does not parse Flow files.
@@ -44,7 +58,10 @@ fn react_compiler_plugin_options() -> PluginOptions {
             validate_static_components: true,
             validate_no_freezing_known_mutable_functions: true,
             validate_no_void_use_memo: true,
-            validate_no_capitalized_calls: Some(vec![]),
+            validate_no_capitalized_calls: Some(env_options.capitalized_calls_allow.clone()),
+            validate_no_capitalized_calls_pattern: env_options
+                .capitalized_calls_allow_pattern
+                .clone(),
             validate_hooks_usage: true,
             validate_no_derived_computations_in_effects: true,
             validate_exhaustive_memoization_dependencies: true,
@@ -82,7 +99,7 @@ pub fn build_react_compiler_results(host: &ContextHost) -> ReactCompilerResults 
         program,
         semantic,
         host.allocator(),
-        react_compiler_plugin_options(),
+        react_compiler_plugin_options(host.react_compiler_env_options()),
     );
 
     ReactCompilerResults { diagnostics: result.diagnostics }
@@ -103,23 +120,7 @@ pub fn should_run_react_compiler(ctx: &ContextHost) -> bool {
 /// Shared `run_once` body for the React Compiler family of rules: report the
 /// shared run's findings for `category` under the calling rule's name.
 pub fn run_react_compiler_rule(ctx: &LintContext, category: ErrorCategory) {
-    run_react_compiler_rule_filtered(ctx, category, |_| true);
-}
-
-/// [`run_react_compiler_rule`] with per-finding filtering for rules with
-/// allowlist options: findings for which `should_report` returns `false` are
-/// skipped. Filtering happens at report time only — the shared compiler run is
-/// unaffected, exactly as if the finding were suppressed with a disable
-/// comment.
-pub fn run_react_compiler_rule_filtered(
-    ctx: &LintContext,
-    category: ErrorCategory,
-    mut should_report: impl FnMut(&LintDiagnostic) -> bool,
-) {
     for finding in ctx.react_compiler_results().diagnostics_for(category) {
-        if !should_report(finding) {
-            continue;
-        }
         let mut diagnostic = finding.diagnostic.clone();
 
         // `LintContext` supplies the per-category Oxlint rule code and primary

--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -28,6 +28,7 @@ include = ["src/**/*", "examples/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 doctest = false
 
 [dependencies]
+lazy-regex = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment_config.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment_config.rs
@@ -8,6 +8,7 @@
 //! Contains feature flags and custom hook definitions that control compiler behavior.
 
 use crate::react_compiler_utils::FxIndexMap;
+use lazy_regex::Regex;
 use rustc_hash::FxHashMap;
 
 use crate::react_compiler_hir::Effect;
@@ -89,6 +90,9 @@ pub struct EnvironmentConfig {
     pub validate_no_jsx_in_try_statements: bool,
     pub validate_static_components: bool,
     pub validate_no_capitalized_calls: Option<Vec<String>>,
+    /// Oxlint extension to `validate_no_capitalized_calls`: names matching the
+    /// pattern are allowed, in addition to the exact entries above.
+    pub validate_no_capitalized_calls_pattern: Option<Regex>,
     pub validate_blocklisted_imports: Option<Vec<String>>,
     pub validate_source_locations: bool,
     pub validate_no_impure_functions_in_render: bool,
@@ -141,6 +145,7 @@ impl Default for EnvironmentConfig {
             validate_no_jsx_in_try_statements: false,
             validate_static_components: false,
             validate_no_capitalized_calls: None,
+            validate_no_capitalized_calls_pattern: None,
             validate_blocklisted_imports: None,
             validate_source_locations: false,
             validate_no_impure_functions_in_render: false,

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_capitalized_calls.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_capitalized_calls.rs
@@ -23,6 +23,7 @@ pub fn validate_no_capitalized_calls(
             allow_list.insert(entry.clone());
         }
     }
+    let allow_pattern = env.config.validate_no_capitalized_calls_pattern.clone();
 
     let mut capital_load_globals: FxHashMap<IdentifierId, Ident> = FxHashMap::default();
     let mut capitalized_properties: FxHashMap<IdentifierId, (Ident, Option<Span>)> =
@@ -42,6 +43,7 @@ pub fn validate_no_capitalized_calls(
                         // We don't want to flag CONSTANTS()
                         && name.as_str() != name.cow_to_uppercase()
                         && !allow_list.contains(name.as_str())
+                        && !allow_pattern.as_ref().is_some_and(|pattern| pattern.is_match(name.as_str()))
                     {
                         capital_load_globals.insert(lvalue_id, name);
                     }

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1164,10 +1164,19 @@
     "CapitalizedCallsConfig": {
       "type": "object",
       "properties": {
+        "allow": {
+          "description": "Exact names of capitalized functions that may be called directly.\nForwarded to the React Compiler's `validateNoCapitalizedCalls`\nenvironment option.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Exact names of capitalized functions that may be called directly.\nForwarded to the React Compiler's `validateNoCapitalizedCalls`\nenvironment option."
+        },
         "allowPattern": {
-          "description": "A regex pattern; capitalized functions and methods whose name matches\nmay be called directly. Anchor the pattern to allow exact names, e.g.\n`\"^(StyleSheet|Schema)$\"`.",
+          "description": "A regex pattern; capitalized functions whose name matches may be called\ndirectly, checked alongside `allow`. Useful when a codebase has a\nnaming convention for capitalized non-component factories, such as\ngenerated event or schema builders (e.g. `\"Event$\"`).",
           "type": "string",
-          "markdownDescription": "A regex pattern; capitalized functions and methods whose name matches\nmay be called directly. Anchor the pattern to allow exact names, e.g.\n`\"^(StyleSheet|Schema)$\"`."
+          "markdownDescription": "A regex pattern; capitalized functions whose name matches may be called\ndirectly, checked alongside `allow`. Useful when a codebase has a\nnaming convention for capitalized non-component factories, such as\ngenerated event or schema builders (e.g. `\"Event$\"`)."
         }
       },
       "additionalProperties": false

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1165,9 +1165,9 @@
       "type": "object",
       "properties": {
         "allowPattern": {
-          "description": "A regex pattern; capitalized functions and methods whose name matches\nmay be called directly.",
+          "description": "A regex pattern; capitalized functions and methods whose name matches\nmay be called directly. Anchor the pattern to allow exact names, e.g.\n`\"^(StyleSheet|Schema)$\"`.",
           "type": "string",
-          "markdownDescription": "A regex pattern; capitalized functions and methods whose name matches\nmay be called directly."
+          "markdownDescription": "A regex pattern; capitalized functions and methods whose name matches\nmay be called directly. Anchor the pattern to allow exact names, e.g.\n`\"^(StyleSheet|Schema)$\"`."
         }
       },
       "additionalProperties": false

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1161,6 +1161,17 @@
       },
       "markdownDescription": "The rule takes a single option - an array of possible callback names - which may include object methods. The default callback names are `callback`, `cb`, `next`."
     },
+    "CapitalizedCallsConfig": {
+      "type": "object",
+      "properties": {
+        "allowPattern": {
+          "description": "A regex pattern; capitalized functions and methods whose name matches\nmay be called directly.",
+          "type": "string",
+          "markdownDescription": "A regex pattern; capitalized functions and methods whose name matches\nmay be called directly."
+        }
+      },
+      "additionalProperties": false
+    },
     "CapitalizedCommentsOptions": {
       "description": "Configuration for the capitalized-comments rule.\n\nThe first element specifies whether comments should `\"always\"` or `\"never\"`\nbegin with a capital letter. The second element is an optional object\ncontaining additional options.",
       "type": "array",
@@ -6551,7 +6562,24 @@
           ]
         },
         "react/capitalized-calls": {
-          "$ref": "#/definitions/RuleNoConfig"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/CapitalizedCallsConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
         },
         "react/checked-requires-onchange-or-readonly": {
           "anyOf": [


### PR DESCRIPTION
## What this PR does

Adds two options to `react/capitalized-calls` that feed the React Compiler's `validateNoCapitalizedCalls` environment option:

- `allow: string[]`: exact names of capitalized functions that may be called directly, forwarded as the `validateNoCapitalizedCalls` entries.
- `allowPattern: string`: a regex checked next to the allowlist inside the validation, for codebases where the allowed factories follow a naming convention.

```jsonc
"react/capitalized-calls": ["error", { "allowPattern": "Event$" }]
```

## Why

The rule currently has no way to allowlist anything. The upstream ESLint plugin accepts per-rule options and merges them into the compiler options, so `validateNoCapitalizedCalls` is reachable there, but Oxlint's shared compiler run uses fixed options and nothing gets through.

That hurts codebases with naming conventions for capitalized non-component factories. Concretely: our company's monorepo has ~2,900 inline `oxlint-disable-next-line react/capitalized-calls` comments across ~1,600 files, almost all of them on generated analytics-event builders (`...FooClickedEvent()` spreads). Exact names don't scale to thousands of generated factories, which is what `allowPattern` is for.

## How

The linter extracts the rule's resolved options in `Linter::run` and hands them to `ContextHost`, where the shared React Compiler run picks them up when it is built. The run still varies only with resolved config, never with which rules execute, so the single shared run stays valid for every rule in the family. `allowPattern` is a small oxc-side extension to `EnvironmentConfig`, checked in `validate_no_capitalized_calls` in the same place as the names allowlist.

One behavior note: same as the upstream compiler, the allowlist only applies to global loads. Method calls like `obj.Child()` are flagged from `PropertyLoad`/`MethodCall`, which has no allowlist, so they cannot be exempted. A test pins that.

## Testing

- `cargo test -p oxc_linter capitalized_calls` covers both options (exact name, anchored pattern, suffix pattern, one name does not allow others, method calls stay flagged under an allowlist), snapshot updated.
- `cargo test -p oxc_react_compiler` passes.
- `cargo lintgen`, schema and TS config types regenerated (`just linter-schema-json`, `just linter-config-ts`), `cargo lint-timings` unchanged.

## Disclosure

This PR was implemented with Claude Code (AI assistance) and has been reviewed, tested, and is understood by the submitting contributor.
