### PR TITLE
refactor(lsp): allow tools to send multiple ClientMessages

### DIFF
--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -42,8 +42,8 @@ impl ServerFormatterBuilder {
     }
 
     /// Creates a new `ServerFormatter` instance based on the provided root URI and options.
-    /// Returns a tuple containing the `ServerFormatter` instance and an optional message to be sent to the client.
-    /// This message will be used to inform about misconfiguration.
+    /// Returns a tuple containing the `ServerFormatter` instance and optional messages to be sent to the client.
+    /// These messages will be used to inform about misconfiguration.
     ///
     /// # Panics
     /// Panics if the root URI cannot be converted to a file path.
@@ -51,7 +51,7 @@ impl ServerFormatterBuilder {
         &self,
         root_uri: &Uri,
         options: serde_json::Value,
-    ) -> (ServerFormatter, Option<ClientMessage>) {
+    ) -> (ServerFormatter, Vec<ClientMessage>) {
         let options = deserialize_lsp_options(options);
 
         let root_path = root_uri.to_file_path().unwrap();
@@ -91,7 +91,7 @@ impl ServerFormatterBuilder {
                 explicit_config_path,
                 use_nested_config,
             ),
-            None,
+            Vec::new(),
         )
     }
 }
@@ -107,8 +107,8 @@ impl ToolBuilder for ServerFormatterBuilder {
     }
 
     fn build(&self, root_uri: &Uri, options: serde_json::Value) -> ToolBuildResult {
-        let (tool, client_message) = self.build(root_uri, options);
-        ToolBuildResult { tool: Box::new(tool), client_message }
+        let (tool, client_messages) = self.build(root_uri, options);
+        ToolBuildResult { tool: Box::new(tool), client_messages }
     }
 }
 
@@ -172,17 +172,21 @@ impl Tool for ServerFormatter {
         let new_option = deserialize_lsp_options(new_options_json.clone());
 
         if old_option == new_option {
-            return ToolRestartChanges { tool: None, watch_patterns: None, client_message: None };
+            return ToolRestartChanges {
+                tool: None,
+                watch_patterns: None,
+                client_messages: Vec::new(),
+            };
         }
 
         builder.shutdown(root_uri);
-        let ToolBuildResult { tool, client_message } =
+        let ToolBuildResult { tool, client_messages } =
             builder.build(root_uri, new_options_json.clone());
         let watch_patterns = tool.get_watcher_patterns(new_options_json);
         ToolRestartChanges {
             tool: Some(tool),
             watch_patterns: Some(watch_patterns),
-            client_message,
+            client_messages,
         }
     }
 
@@ -227,7 +231,7 @@ impl Tool for ServerFormatter {
         );
         *self.state.write().expect("state rwlock poisoned") = Arc::new(new_state);
 
-        ToolRestartChanges { tool: None, watch_patterns: None, client_message: None }
+        ToolRestartChanges { tool: None, watch_patterns: None, client_messages: Vec::new() }
     }
 
     fn run_format(&self, document: &TextDocument) -> Result<Vec<TextEdit>, String> {

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -74,8 +74,8 @@ impl ServerLinterBuilder {
     }
 
     /// Creates a new `ServerLinter` instance based on the provided root URI and options.
-    /// Returns a tuple containing the `ServerLinter` instance and an optional message to be sent to the client.
-    /// This message will be used to inform about misconfiguration.
+    /// Returns a tuple containing the `ServerLinter` instance and optional messages to be sent to the client.
+    /// These messages will be used to inform about misconfiguration.
     ///
     /// # Panics
     /// Panics if the root URI cannot be converted to a file path.
@@ -83,7 +83,7 @@ impl ServerLinterBuilder {
         &self,
         root_uri: &Uri,
         options: serde_json::Value,
-    ) -> (ServerLinter, Option<ClientMessage>) {
+    ) -> (ServerLinter, Vec<ClientMessage>) {
         let options = match serde_json::from_value::<LSPLintOptions>(options) {
             Ok(opts) => opts,
             Err(e) => {
@@ -254,7 +254,7 @@ impl ServerLinterBuilder {
                 lint_options.report_unused_directive,
                 options.rules_customization,
             ),
-            None,
+            Vec::new(),
         )
     }
 }
@@ -301,8 +301,8 @@ impl ToolBuilder for ServerLinterBuilder {
     }
 
     fn build(&self, root_uri: &Uri, options: serde_json::Value) -> ToolBuildResult {
-        let (tool, client_message) = self.build(root_uri, options);
-        ToolBuildResult { tool: Box::new(tool), client_message }
+        let (tool, client_messages) = self.build(root_uri, options);
+        ToolBuildResult { tool: Box::new(tool), client_messages }
     }
 
     #[expect(unused)]
@@ -445,12 +445,16 @@ impl Tool for ServerLinter {
         };
 
         if !Self::needs_restart(&old_option, &new_options) {
-            return ToolRestartChanges { tool: None, watch_patterns: None, client_message: None };
+            return ToolRestartChanges {
+                tool: None,
+                watch_patterns: None,
+                client_messages: Vec::new(),
+            };
         }
 
         // get the cached files before refreshing the linter, and revalidate them after
         builder.shutdown(root_uri);
-        let ToolBuildResult { tool, client_message } =
+        let ToolBuildResult { tool, client_messages } =
             builder.build(root_uri, new_options_json.clone());
 
         let patterns = {
@@ -464,7 +468,7 @@ impl Tool for ServerLinter {
             }
         };
 
-        ToolRestartChanges { tool: Some(tool), watch_patterns: patterns, client_message }
+        ToolRestartChanges { tool: Some(tool), watch_patterns: patterns, client_messages }
     }
 
     fn get_watcher_patterns(&self, options: serde_json::Value) -> Vec<Pattern> {
@@ -513,13 +517,13 @@ impl Tool for ServerLinter {
     ) -> ToolRestartChanges {
         // TODO: Check if the changed file is actually a config file (including extended paths)
         builder.shutdown(root_uri);
-        let ToolBuildResult { tool, client_message } = builder.build(root_uri, options);
+        let ToolBuildResult { tool, client_messages } = builder.build(root_uri, options);
 
         ToolRestartChanges {
             tool: Some(tool),
             // TODO: update watch patterns if config_path changed, or the extended paths changed
             watch_patterns: None,
-            client_message,
+            client_messages,
         }
     }
 

--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -163,17 +163,14 @@ impl LanguageServer for Backend {
                     .unwrap_or_default();
 
                 debug!("starting worker in initialize with options: {option:?}");
-                if let Some(message) = worker.start_worker(option).await {
-                    client_messages.push(message);
-                }
+
+                client_messages.extend(worker.start_worker(option).await);
             }
         }
 
-        if let Some(client_message) =
-            self.worker_manager.start_manager(workers, capabilities.diagnostic_mode.clone()).await
-        {
-            client_messages.push(client_message);
-        }
+        client_messages.extend(
+            self.worker_manager.start_manager(workers, capabilities.diagnostic_mode.clone()).await,
+        );
 
         if !client_messages.is_empty() {
             let _ = self.pending_initialization_messages.set(client_messages);
@@ -239,9 +236,7 @@ impl LanguageServer for Backend {
                 // get the configuration from the response and start the worker
                 let configuration = configurations.get(index).unwrap_or(&serde_json::Value::Null);
                 debug!("starting worker in initialize with options: {configuration:?}");
-                if let Some(message) = worker.start_worker(configuration.clone()).await {
-                    client_messages.push(message);
-                }
+                client_messages.extend(worker.start_worker(configuration.clone()).await);
 
                 // run diagnostics for all known files in the workspace of the worker.
                 // This is necessary because the worker was not started before.
@@ -427,9 +422,7 @@ impl LanguageServer for Backend {
 
             removing_registrations.extend(result.removed_watchers);
             adding_registrations.extend(result.new_watchers);
-            if let Some(client_message) = result.client_message {
-                client_messages.push(client_message);
-            }
+            client_messages.extend(result.client_messages);
         }
 
         if diagnostic_mode == DiagnosticMode::Push && !new_diagnostics.is_empty() {
@@ -496,9 +489,7 @@ impl LanguageServer for Backend {
                 }
                 removing_registrations.extend(result.removed_watchers);
                 adding_registrations.extend(result.new_watchers);
-                if let Some(client_message) = result.client_message {
-                    client_messages.push(client_message);
-                }
+                client_messages.extend(result.client_messages);
             }
         }
 
@@ -580,9 +571,7 @@ impl LanguageServer for Backend {
             let worker = self.worker_manager.create_worker(folder.uri, diagnostic_mode.clone());
             let options = configurations.get(index).unwrap_or(&serde_json::Value::Null);
 
-            if let Some(message) = worker.start_worker(options.clone()).await {
-                client_messages.push(message);
-            }
+            client_messages.extend(worker.start_worker(options.clone()).await);
             added_registrations.extend(worker.init_watchers().await);
             new_workers.push(worker);
         }
@@ -706,7 +695,7 @@ impl LanguageServer for Backend {
             let diagnostic_mode =
                 capabilities.map(|c| c.diagnostic_mode.clone()).unwrap_or_default();
             let dynamic_watchers = capabilities.is_some_and(|c| c.dynamic_watchers);
-            let (registrations, client_message) = self
+            let (registrations, client_messages) = self
                 .worker_manager
                 .ensure_worker_for_file_uri(&uri, diagnostic_mode, dynamic_watchers)
                 .await;
@@ -717,8 +706,8 @@ impl LanguageServer for Backend {
                 warn!("registering file watchers for single-file workspace failed: {err}");
             }
 
-            if let Some(client_message) = client_message {
-                self.client.show_message(client_message.r#type, client_message.message).await;
+            for message in client_messages {
+                self.client.show_message(message.r#type, message.message).await;
             }
         }
 

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -22,12 +22,12 @@ use crate::{
 pub struct FakeToolBuilder {
     diagnostic_mode: DiagnosticMode,
     cache_uris: Option<Arc<Mutex<Vec<Uri>>>>,
-    pub build_client_message: Option<ClientMessage>,
+    pub build_client_message: Vec<ClientMessage>,
 }
 
 impl FakeToolBuilder {
     pub fn new(diagnostic_mode: DiagnosticMode) -> Self {
-        Self { diagnostic_mode, cache_uris: None, build_client_message: None }
+        Self { diagnostic_mode, cache_uris: None, build_client_message: Vec::new() }
     }
 
     pub fn with_cache_tracking(self, cache_uris: Arc<Mutex<Vec<Uri>>>) -> Self {
@@ -39,7 +39,7 @@ impl ToolBuilder for FakeToolBuilder {
     fn build(&self, _root_uri: &Uri, _options: serde_json::Value) -> ToolBuildResult {
         ToolBuildResult {
             tool: Box::new(FakeTool { cache_uris: self.cache_uris.clone() }),
-            client_message: self.build_client_message.clone(),
+            client_messages: self.build_client_message.clone(),
         }
     }
 
@@ -99,27 +99,27 @@ impl Tool for FakeTool {
             return ToolRestartChanges {
                 tool: Some(result.tool),
                 watch_patterns: None,
-                client_message: result.client_message,
+                client_messages: result.client_messages,
             };
         }
         if new_options_json.as_u64() == Some(2) {
             return ToolRestartChanges {
                 tool: None,
                 watch_patterns: Some(vec!["**/new_watcher.config".to_string()]),
-                client_message: None,
+                client_messages: Vec::new(),
             };
         }
         if new_options_json.as_u64() == Some(4) {
             return ToolRestartChanges {
                 tool: None,
                 watch_patterns: None,
-                client_message: Some(ClientMessage {
+                client_messages: vec![ClientMessage {
                     message: "Fake misconfiguration message".to_string(),
                     r#type: MessageType::WARNING,
-                }),
+                }],
             };
         }
-        ToolRestartChanges { tool: None, watch_patterns: None, client_message: None }
+        ToolRestartChanges { tool: None, watch_patterns: None, client_messages: Vec::new() }
     }
 
     fn get_watcher_patterns(
@@ -144,28 +144,28 @@ impl Tool for FakeTool {
             return ToolRestartChanges {
                 tool: Some(result.tool),
                 watch_patterns: None,
-                client_message: result.client_message,
+                client_messages: result.client_messages,
             };
         }
         if changed_uri.as_str().ends_with("watcher.config") {
             return ToolRestartChanges {
                 tool: None,
                 watch_patterns: Some(vec!["**/new_watcher.config".to_string()]),
-                client_message: None,
+                client_messages: Vec::new(),
             };
         }
         if changed_uri.as_str().ends_with("misconfiguration.config") {
             return ToolRestartChanges {
                 tool: None,
                 watch_patterns: None,
-                client_message: Some(ClientMessage {
+                client_messages: vec![ClientMessage {
                     message: "Fake misconfiguration message".to_string(),
                     r#type: MessageType::WARNING,
-                }),
+                }],
             };
         }
 
-        ToolRestartChanges { tool: None, watch_patterns: None, client_message: None }
+        ToolRestartChanges { tool: None, watch_patterns: None, client_messages: Vec::new() }
     }
 
     fn get_code_actions_or_commands(
@@ -663,10 +663,10 @@ mod test_suite {
     #[tokio::test]
     async fn test_client_message_deferred_until_initialized() {
         let builder = FakeToolBuilder {
-            build_client_message: Some(ClientMessage {
+            build_client_message: vec![ClientMessage {
                 message: "Fake misconfiguration message".to_string(),
                 r#type: MessageType::WARNING,
-            }),
+            }],
             ..Default::default()
         };
         let mut server = TestServer::new(|client| {
@@ -1107,10 +1107,10 @@ mod test_suite {
         );
 
         let builder = FakeToolBuilder {
-            build_client_message: Some(ClientMessage {
+            build_client_message: vec![ClientMessage {
                 message: "Fake misconfiguration message".to_string(),
                 r#type: MessageType::WARNING,
-            }),
+            }],
             ..Default::default()
         };
 
@@ -2028,10 +2028,10 @@ mod test_suite {
         #[tokio::test]
         async fn test_dynamic_workers_show_client_message_in_single_file_mode() {
             let builder = FakeToolBuilder {
-                build_client_message: Some(ClientMessage {
+                build_client_message: vec![ClientMessage {
                     message: "Fake misconfiguration message".to_string(),
                     r#type: MessageType::WARNING,
-                }),
+                }],
                 ..Default::default()
             };
 

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -152,8 +152,8 @@ pub struct ToolBuildResult {
     /// It should always be started and on internal errors, fallback to the default configuration of the tool.
     pub tool: Box<dyn Tool>,
     /// Even if the tool started successfully, it may have encountered issues during initialization.
-    /// The `client_message` field can be used to communicate any warnings or errors to the client.
-    pub client_message: Option<ClientMessage>,
+    /// The `client_messages` field can be used to communicate any warnings or errors to the client.
+    pub client_messages: Vec<ClientMessage>,
 }
 
 pub struct ToolRestartChanges {
@@ -164,6 +164,6 @@ pub struct ToolRestartChanges {
     /// Old patterns will be automatically unregistered
     pub watch_patterns: Option<Vec<Pattern>>,
     /// Even if the tool restarted successfully, it may have encountered issues during initialization.
-    /// The `client_message` field can be used to communicate any warnings or errors to the client.
-    pub client_message: Option<ClientMessage>,
+    /// The `client_messages` field can be used to communicate any warnings or errors to the client.
+    pub client_messages: Vec<ClientMessage>,
 }

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -27,8 +27,8 @@ pub struct WorkerToolChangeResult {
     pub new_watchers: Vec<Registration>,
     /// Watchers that need to be unregistered
     pub removed_watchers: Vec<Unregistration>,
-    /// Optional message to be sent to the client, e.g., for misconfiguration
-    pub client_message: Option<ClientMessage>,
+    /// Optional messages to be sent to the client, e.g., for misconfiguration
+    pub client_messages: Vec<ClientMessage>,
 }
 
 /// A worker that manages the individual tool for a specific workspace
@@ -77,14 +77,14 @@ impl WorkspaceWorker {
     /// Start all programs (linter, formatter) for the worker.
     /// This should be called after the client has sent the workspace configuration.
     ///
-    /// Returns an optional message to be sent to the client.
-    pub async fn start_worker(&self, options: serde_json::Value) -> Option<ClientMessage> {
+    /// Returns messages to be sent to the client.
+    pub async fn start_worker(&self, options: serde_json::Value) -> Vec<ClientMessage> {
         let result = self.builder.build(&self.root_uri, options.clone());
         *self.tool.write().await = Some(result.tool);
 
         *self.options.lock().await = Some(options);
 
-        result.client_message
+        result.client_messages
     }
 
     /// Initialize file system watchers for the workspace.
@@ -332,7 +332,7 @@ impl WorkspaceWorker {
                 diagnostics: None,
                 new_watchers: registrations,
                 removed_watchers: unregistrations,
-                client_message: None, // TODO: Should we return a message to the client if the tool is not initialized?
+                client_messages: Vec::new(), // TODO: Should we return a message to the client if the tool is not initialized?
             };
         };
         let change = change_handler(tool, self.builder.as_ref());
@@ -352,7 +352,7 @@ impl WorkspaceWorker {
                     diagnostics: None,
                     new_watchers: registrations,
                     removed_watchers: unregistrations,
-                    client_message: change.client_message,
+                    client_messages: change.client_messages,
                 };
             };
 
@@ -377,7 +377,7 @@ impl WorkspaceWorker {
             diagnostics,
             new_watchers: registrations,
             removed_watchers: unregistrations,
-            client_message: change.client_message,
+            client_messages: change.client_messages,
         }
     }
 
@@ -724,11 +724,11 @@ mod tests {
         assert_eq!(result.removed_watchers.len(), 0);
         assert!(!needs_diagnostic_refresh);
         assert_eq!(
-            result.client_message,
-            Some(ClientMessage {
+            result.client_messages,
+            vec![ClientMessage {
                 message: "Fake misconfiguration message".to_string(),
                 r#type: MessageType::WARNING,
-            })
+            }]
         );
     }
 
@@ -758,11 +758,11 @@ mod tests {
         assert_eq!(result.removed_watchers.len(), 0);
         assert!(!needs_diagnostic_refresh);
         assert_eq!(
-            result.client_message,
-            Some(ClientMessage {
+            result.client_messages,
+            vec![ClientMessage {
                 message: "Fake misconfiguration message".to_string(),
                 r#type: MessageType::WARNING,
-            })
+            }]
         );
     }
 

--- a/crates/oxc_language_server/src/worker_manager.rs
+++ b/crates/oxc_language_server/src/worker_manager.rs
@@ -100,7 +100,7 @@ impl WorkerManager {
     /// Start the manager with the given workers and diagnostic mode.
     ///
     /// On dynamic workspaces, this will also start a worker for the root URI `file:///` with the given diagnostic mode.
-    /// It can return an optional [`ClientMessage`] that should be sent to the client.
+    /// It can return a list of [`ClientMessage`] that should be sent to the client.
     ///
     /// # Panics
     /// If `file:///` cannot be converted to `Uri`, which should never happen.
@@ -108,7 +108,7 @@ impl WorkerManager {
         &self,
         workers: Vec<WorkspaceWorker>,
         diagnostic_mode: DiagnosticMode,
-    ) -> Option<ClientMessage> {
+    ) -> Vec<ClientMessage> {
         *self.workers.write().await = workers;
 
         // for dynamic workspaces we need to start them manually
@@ -123,14 +123,14 @@ impl WorkerManager {
                 Arc::clone(&self.tool_builder),
                 diagnostic_mode,
             );
-            let client_message = worker.start_worker(serde_json::Value::Null).await;
+            let client_messages = worker.start_worker(serde_json::Value::Null).await;
 
             let _ = cell.set(worker);
 
-            return client_message;
+            return client_messages;
         }
 
-        None
+        vec![]
     }
 
     /// Shut down all workers and clear the worker list.
@@ -368,28 +368,28 @@ impl WorkerManager {
         uri: &Uri,
         diagnostic_mode: DiagnosticMode,
         dynamic_watchers: bool,
-    ) -> (Option<Registration>, Option<ClientMessage>) {
+    ) -> (Option<Registration>, Vec<ClientMessage>) {
         // Bail out immediately if we are not in single-file mode.
         if !self.is_single_file_mode() {
-            return (None, None);
+            return (None, vec![]);
         }
 
         let Some(parent_uri) = Self::get_parent_dir_uri(uri) else {
-            return (None, None);
+            return (None, vec![]);
         };
 
         // Fast path: avoid a write lock when a suitable worker already exists.
         {
             let workers = self.workers.read().await;
             if Self::find_worker_for_uri(&workers, uri).is_some() {
-                return (None, None);
+                return (None, vec![]);
             }
         }
 
         debug!("single file mode: creating workspace worker for {}", parent_uri.as_str());
         let worker =
             WorkspaceWorker::new(parent_uri, Arc::clone(&self.tool_builder), diagnostic_mode);
-        let client_message = worker.start_worker(Value::Null).await;
+        let client_messages = worker.start_worker(Value::Null).await;
         let registration = if dynamic_watchers { worker.init_watchers().await } else { None };
 
         // Acquire the write lock to insert the worker.  Re-check both the mode
@@ -411,10 +411,10 @@ impl WorkerManager {
         // the caller that no new registrations are needed.
         if let Some(discarded) = worker {
             discarded.shutdown().await;
-            return (None, None);
+            return (None, vec![]);
         }
 
-        (registration, client_message)
+        (registration, client_messages)
     }
 
     /// In single-file mode, shut down and remove the [`WorkspaceWorker`] whose


### PR DESCRIPTION
> ## Pull request overview
> 
> Refactors the language-server tool initialization/restart plumbing to support emitting multiple `ClientMessage`s (instead of a single optional message), so tools can surface more than one warning/error to the client during startup and config changes.
> 