### PR TITLE
refactor(lsp): reduce client messages to the client to a max of 5

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -258,7 +258,8 @@ impl LanguageServer for Backend {
                                 "running diagnostics for {} failed: {err}",
                                 document.uri.as_str()
                             );
-                            self.client.show_message(MessageType::ERROR, err).await;
+                            client_messages
+                                .push(ClientMessage { r#type: MessageType::ERROR, message: err });
                         }
                         Ok(diagnostics) => new_diagnostics.extend(diagnostics),
                     }
@@ -282,9 +283,7 @@ impl LanguageServer for Backend {
             }
         }
 
-        for message in client_messages {
-            self.client.show_message(message.r#type, message.message).await;
-        }
+        self.send_client_messages(client_messages).await;
 
         let mut registrations = vec![];
 
@@ -447,9 +446,7 @@ impl LanguageServer for Backend {
             warn!("sending registerCapability.didChangeWatchedFiles failed: {err}");
         }
 
-        for message in client_messages {
-            self.client.show_message(message.r#type, message.message).await;
-        }
+        self.send_client_messages(client_messages).await;
     }
 
     /// This notification is sent when a configuration file of a tool changes (example: `.oxlintrc.json`).
@@ -518,9 +515,7 @@ impl LanguageServer for Backend {
             }
         }
 
-        for message in client_messages {
-            self.client.show_message(message.r#type, message.message).await;
-        }
+        self.send_client_messages(client_messages).await;
     }
 
     /// The server will start new [WorkspaceWorker]s for added workspace folders
@@ -599,9 +594,7 @@ impl LanguageServer for Backend {
         }
 
         // === Phase 6: Show messages to the client ===
-        for message in client_messages {
-            self.client.show_message(message.r#type, message.message).await;
-        }
+        self.send_client_messages(client_messages).await;
     }
 
     /// It will save the in-memory file content, because non file-system files needs to be keep tracked too, and can not be accessed by the OS file system.
@@ -706,9 +699,7 @@ impl LanguageServer for Backend {
                 warn!("registering file watchers for single-file workspace failed: {err}");
             }
 
-            for message in client_messages {
-                self.client.show_message(message.r#type, message.message).await;
-            }
+            self.send_client_messages(client_messages).await;
         }
 
         let content = params.text_document.text;
@@ -1026,6 +1017,34 @@ impl Backend {
             let version = version_map.pin().get(&uri).copied();
             self.client.publish_diagnostics(uri, diagnostics, version)
         }))
+        .await;
+    }
+
+    /// Send multiple messages to the client, if any.
+    /// Will cap the number of messages to 5, to avoid flooding the client.
+    async fn send_client_messages(&self, messages: Vec<ClientMessage>) {
+        let max_messages = 5;
+        let messages_to_send = if messages.len() > max_messages {
+            let extra_message = ClientMessage {
+                r#type: MessageType::WARNING,
+                message: format!(
+                    "{} more messages not shown. See LSP logs for details.",
+                    messages.len() - max_messages + 1
+                ),
+            };
+            let mut messages_to_send =
+                messages.into_iter().take(max_messages - 1).collect::<Vec<_>>();
+            messages_to_send.push(extra_message);
+            messages_to_send
+        } else {
+            messages
+        };
+
+        join_all(
+            messages_to_send
+                .into_iter()
+                .map(|message| self.client.show_message(message.r#type, message.message)),
+        )
         .await;
     }
 }

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -689,6 +689,46 @@ mod test_suite {
     }
 
     #[tokio::test]
+    async fn test_client_message_cap_max_messages() {
+        let builder = FakeToolBuilder {
+            build_client_message: (1..=6)
+                .map(|index| ClientMessage {
+                    message: format!("Fake misconfiguration message {index}"),
+                    r#type: MessageType::WARNING,
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let mut server = TestServer::new(|client| {
+            Backend::new(client, server_info(), create_workspace_manager_with_builder(builder))
+        });
+
+        // initialize: worker starts here (no workspace_configuration), messages must NOT be sent yet
+        server.send_request(initialize_request(InitializeRequestOptions::default())).await;
+        let initialize_result = server.recv_response().await;
+        assert!(initialize_result.is_ok());
+
+        // initialized: messages are capped to 5 with the last one being an overflow warning
+        server.send_request(initialized_notification()).await;
+
+        for index in 1..=4 {
+            let show_message = server.recv_notification().await;
+            assert_eq!(show_message.method(), "window/showMessage");
+            let params = show_message.params().unwrap();
+            assert_eq!(params["message"], format!("Fake misconfiguration message {index}"));
+            assert_eq!(params["type"], json!(MessageType::WARNING));
+        }
+
+        let show_message = server.recv_notification().await;
+        assert_eq!(show_message.method(), "window/showMessage");
+        let params = show_message.params().unwrap();
+        assert_eq!(params["message"], "2 more messages not shown. See LSP logs for details.");
+        assert_eq!(params["type"], json!(MessageType::WARNING));
+
+        server.shutdown(2).await;
+    }
+
+    #[tokio::test]
     async fn test_basic_start_and_shutdown_flow() {
         let mut server = TestServer::new(|client| {
             Backend::new(client, server_info(), create_workspace_manager())


### PR DESCRIPTION
> ## Pull request overview
> 
> This PR refactors the language server’s client-notification flow to avoid flooding editors with too many `window/showMessage` notifications by capping the number of messages sent in a batch to 5.
> 

Test generated with GPT-5.3-Codex 🤖 