### PR TITLE
perf(packages/codegen): remove `node` param from `printString` and `printNonNegativeFloat`

### DIFF
--- a/packages/codegen/DESIGN.md
+++ b/packages/codegen/DESIGN.md
@@ -366,6 +366,10 @@ A plugin silently doing nothing is a failure mode worth guarding against.
 Rewrites `writeWithMap(state, code, cat, node)` into `write(state, code, cat)` in non-sourcemap builds,
 drops the `node` argument, and rewrites the import to match.
 
+`printString` and `printNonNegativeFloat` take a node only to hand on to a mapped write. They keep their names,
+but the argument comes off every call, and the parameter off their declarations - which, unlike the mapped writes,
+survive into the build.
+
 Without it, the node argument would still be evaluated and held live across a call which ignores it.
 
 The three `markMap*` calls write nothing, so they have no plain form to become, and keep their names -

--- a/packages/codegen/tsdown_plugins/unmap_writes.ts
+++ b/packages/codegen/tsdown_plugins/unmap_writes.ts
@@ -23,6 +23,10 @@ import type { Plugin } from "rolldown";
  * The import is rewritten to match, which both keeps the plain name in scope and leaves the mapped functions
  * unreferenced for the minifier to remove.
  *
+ * `printString` and `printNonNegativeFloat` take a node only to hand it on to their mapped writes.
+ * So they are rewritten the same way, but keep their names - the argument comes off every call.
+ * The parameter also comes off their declarations which, unlike the mapped writes, survive into the build.
+ *
  * Only valid where `SOURCEMAPS` is `false`, which is where the config includes it.
  *
  * The checks afterwards fail the build rather than let a mismatch through. A rewrite which dropped
@@ -39,6 +43,9 @@ const REWRITES = {
   markWithMapNoName: { arity: 2, remove: 1, rename: null },
   markWithMapAfter: { arity: 2, remove: 1, rename: null },
   markWithMapAtStartOffset: { arity: 3, remove: 2, rename: null },
+  // `rename: null` to transform the function declarations, removing the `node` param
+  printString: { arity: 3, remove: 1, rename: null },
+  printNonNegativeFloat: { arity: 3, remove: 1, rename: null },
 } as const;
 
 const WRITE_MODULE = "./write.ts";


### PR DESCRIPTION
Small optimization to no-sourcemap builds.

`printString` and `printNonNegativeFloat` receive `node` as their last param, but in no-sourcemap builds, all the code which uses `node` is removed anyway.

Use the mechanism added in #25970 to remove the `node` param from the function declarations, and the corresponding argument from all call sites. This avoids passing data into these functions pointlessly, freeing a register.