### PR TITLE
refactor(packages/codegen): rename `write*` and `mark*` functions

### DIFF
--- a/packages/codegen/DESIGN.md
+++ b/packages/codegen/DESIGN.md
@@ -255,16 +255,17 @@ No operator merges with a plain `!`, so storing it must not cost `printSpaceBefo
 Not every write needs to update `last`.
 
 When one token is written in pieces - a string's opening quote, its contents, its closing quote -
-only the last piece's category can possibly be read. Hence four write primitives in [`print/write.ts`]:
+only the last piece's category can possibly be read. Hence five write primitives in [`print/write.ts`]:
 
-| Function             | Updates `last` | Records a source mapping |
-| :------------------- | :------------- | :----------------------- |
-| `write`              | Yes            | No                       |
-| `writeWithMap`       | Yes            | Yes                      |
-| `writeNoLast`        | No             | No                       |
-| `writeWithMapNoLast` | No             | Yes                      |
+| Function                  | Updates `last` | Records a source mapping     |
+| :------------------------ | :------------- | :--------------------------- |
+| `write`                   | Yes            | No                           |
+| `writeWithMapNamed`       | Yes            | At the node's start          |
+| `writeWithMapEnd`         | Yes            | At the node's last character |
+| `writeNoLast`             | No             | No                           |
+| `writeWithMapNamedNoLast` | No             | At the node's start          |
 
-- The `*NoLast` pair is used at 89 sites, against 596 for the other two.
+- The four `markMap*` functions record a mapping without writing anything, so `last` is not theirs to update.
 - The rule is exact: **only sound where the value of `last` is provably dead**.
   Another real write must follow before anything reads it.
 - JSX carries the longest runs. Printing `<a.b x="1">hi</a.b>` updates `last` exactly once, on the final `>`.
@@ -363,8 +364,9 @@ A plugin silently doing nothing is a failure mode worth guarding against.
 
 #### `unmap_writes`
 
-Rewrites `writeWithMap(state, code, cat, node)` into `write(state, code, cat)` in non-sourcemap builds,
-drops the `node` argument, and rewrites the import to match.
+Rewrites every mapped write into the plain one it becomes with no mapping to record - so
+`writeWithMapNamed(state, code, cat, node)` turns into `write(state, code, cat)` - and rewrites the import
+to match. `writeWithMapEnd` becomes `write` too, and `writeWithMapNamedNoLast` becomes `writeNoLast`.
 
 `printString` and `printNonNegativeFloat` take a node only to hand on to a mapped write. They keep their names,
 but the argument comes off every call, and the parameter off their declarations - which, unlike the mapped writes,

--- a/packages/codegen/src-js/print/assignment_target.ts
+++ b/packages/codegen/src-js/print/assignment_target.ts
@@ -2,7 +2,7 @@
 
 import { typeAssertIs } from "../asserts.ts";
 import { printPropertyKey } from "./binding_pattern.ts";
-import { CAT_CLOSE_BRACKET, CAT_IDENT, CAT_OTHER, write, writeWithMap } from "./write.ts";
+import { CAT_CLOSE_BRACKET, CAT_IDENT, CAT_OTHER, write, writeWithMapNamed } from "./write.ts";
 import { printExpression, printMemberExpression } from "./expression.ts";
 import { printSpaceBeforeIdentifier } from "./space.ts";
 import { CTX_NONE } from "./operators.ts";
@@ -23,7 +23,7 @@ export function printAssignmentTarget(node: ESTree.AssignmentTarget, state: Stat
     // For speed, the two common ones are printed here instead of through the expression printer's own dispatch.
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, node.name, CAT_IDENT, node);
+      writeWithMapNamed(state, node.name, CAT_IDENT, node);
       break;
     case "MemberExpression":
       printMemberExpression(node, state, CTX_NONE);
@@ -53,7 +53,7 @@ export function printAssignmentTarget(node: ESTree.AssignmentTarget, state: Stat
  * Print an object destructuring target, as in `({ a, b: c } = obj)`.
  */
 function printObjectAssignmentTarget(node: ESTree.ObjectAssignmentTarget, state: State): void {
-  writeWithMap(state, "{", CAT_OTHER, node);
+  writeWithMapNamed(state, "{", CAT_OTHER, node);
 
   const { properties } = node;
   const { length } = properties;
@@ -62,7 +62,7 @@ function printObjectAssignmentTarget(node: ESTree.ObjectAssignmentTarget, state:
 
     const property = properties[i];
     if (property.type === "RestElement") {
-      writeWithMap(state, "...", CAT_OTHER, property);
+      writeWithMapNamed(state, "...", CAT_OTHER, property);
       printAssignmentTarget(property.argument, state);
     } else {
       printAssignmentTargetProperty(property, state);
@@ -83,12 +83,12 @@ function printAssignmentTargetProperty(node: ESTree.AssignmentTargetProperty, st
     if (value.type === "AssignmentPattern") {
       typeAssertIs<ESTree.IdentifierReference>(value.left);
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, value.left.name, CAT_IDENT, value.left);
+      writeWithMapNamed(state, value.left.name, CAT_IDENT, value.left);
       write(state, " = ", CAT_OTHER);
       printExpression(value.right, state, PREC_COMMA, CTX_NONE);
     } else {
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, value.name, CAT_IDENT, value);
+      writeWithMapNamed(state, value.name, CAT_IDENT, value);
     }
   } else {
     const { key } = node;
@@ -139,7 +139,7 @@ function printArrayAssignmentTarget(node: ESTree.ArrayAssignmentTarget, state: S
     }
   }
 
-  writeWithMap(state, "[", CAT_OTHER, node);
+  writeWithMapNamed(state, "[", CAT_OTHER, node);
 
   for (let i = 0; i < length; i++) {
     if (i !== 0) write(state, ", ", CAT_OTHER);
@@ -155,7 +155,7 @@ function printArrayAssignmentTarget(node: ESTree.ArrayAssignmentTarget, state: S
 
   if (rest !== null) {
     if (length > 0) write(state, " ", CAT_OTHER);
-    writeWithMap(state, "...", CAT_OTHER, rest);
+    writeWithMapNamed(state, "...", CAT_OTHER, rest);
     printAssignmentTarget(rest.argument, state);
   }
 

--- a/packages/codegen/src-js/print/binding_pattern.ts
+++ b/packages/codegen/src-js/print/binding_pattern.ts
@@ -7,8 +7,8 @@ import {
   CAT_OTHER,
   CAT_QUESTION,
   write,
-  writeWithMap,
-  writeWithMapNoLast,
+  writeWithMapNamed,
+  writeWithMapNamedNoLast,
 } from "./write.ts";
 import { printExpression } from "./expression.ts";
 import { printSpaceBeforeIdentifier } from "./space.ts";
@@ -39,7 +39,7 @@ export function printBindingPattern(node: BindingPatternNode | UnknownNode, stat
   switch (node.type) {
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, node.name, CAT_IDENT, node);
+      writeWithMapNamed(state, node.name, CAT_IDENT, node);
       if (TS && node.optional) write(state, "?", CAT_QUESTION);
       if (TS && node.typeAnnotation != null) printTypeAnnotation(node.typeAnnotation, state);
       break;
@@ -59,7 +59,7 @@ export function printBindingPattern(node: BindingPatternNode | UnknownNode, stat
       printExpression(node.right, state, PREC_COMMA, CTX_NONE);
       break;
     case "RestElement":
-      writeWithMap(state, "...", CAT_OTHER, node);
+      writeWithMapNamed(state, "...", CAT_OTHER, node);
       printBindingPattern(node.argument, state);
       if (TS && node.typeAnnotation != null) printTypeAnnotation(node.typeAnnotation, state);
       break;
@@ -76,17 +76,17 @@ function printObjectBindingPattern(node: ESTree.ObjectPattern, state: State): vo
   const { length } = properties;
 
   if (length === 0) {
-    writeWithMap(state, "{}", CAT_OTHER, node);
+    writeWithMapNamed(state, "{}", CAT_OTHER, node);
     return;
   }
 
-  writeWithMap(state, "{ ", CAT_OTHER, node);
+  writeWithMapNamed(state, "{ ", CAT_OTHER, node);
 
   for (let i = 0; i < length; i++) {
     if (i > 0) write(state, ", ", CAT_OTHER);
     const property = properties[i];
     if (property.type === "RestElement") {
-      writeWithMap(state, "...", CAT_OTHER, property);
+      writeWithMapNamed(state, "...", CAT_OTHER, property);
       printBindingPattern(property.argument, state);
     } else {
       printBindingProperty(property, state);
@@ -141,10 +141,10 @@ export function printPropertyKey(key: ESTree.PropertyKey, state: State): void {
   switch (key.type) {
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, key.name, CAT_IDENT, key);
+      writeWithMapNamed(state, key.name, CAT_IDENT, key);
       break;
     case "PrivateIdentifier":
-      writeWithMapNoLast(state, "#", key);
+      writeWithMapNamedNoLast(state, "#", key);
       write(state, key.name, CAT_IDENT);
       break;
     case "Literal":
@@ -177,7 +177,7 @@ function printArrayBindingPattern(node: ESTree.ArrayPattern, state: State): void
     }
   }
 
-  writeWithMap(state, "[", CAT_OTHER, node);
+  writeWithMapNamed(state, "[", CAT_OTHER, node);
 
   for (let i = 0; i < length; i++) {
     if (i !== 0) write(state, ", ", CAT_OTHER);

--- a/packages/codegen/src-js/print/class.ts
+++ b/packages/codegen/src-js/print/class.ts
@@ -10,12 +10,12 @@ import {
   CAT_QUESTION,
   CAT_START_OF_STMT,
   debugAssertLastFresh,
-  markWithMap,
+  markMapNamed,
   write,
   writeNoLast,
-  writeWithMap,
+  writeWithMapNamed,
   writeWithMapEnd,
-  writeWithMapNoLast,
+  writeWithMapNamedNoLast,
 } from "./write.ts";
 import { printExpression } from "./expression.ts";
 import { printFunctionBody, printParenParams } from "./function.ts";
@@ -64,23 +64,23 @@ export function printClass(node: ESTree.Class, state: State): void {
   const abstract = TS && node.abstract;
 
   // The node's mapping goes on whichever of these is written first
-  if (declare) writeWithMap(state, "declare ", CAT_OTHER, node);
+  if (declare) writeWithMapNamed(state, "declare ", CAT_OTHER, node);
   if (abstract) {
     if (declare) {
       write(state, "abstract ", CAT_OTHER);
     } else {
-      writeWithMap(state, "abstract ", CAT_OTHER, node);
+      writeWithMapNamed(state, "abstract ", CAT_OTHER, node);
     }
   }
   if (declare || abstract) {
     write(state, "class", CAT_IDENT);
   } else {
-    writeWithMap(state, "class", CAT_IDENT, node);
+    writeWithMapNamed(state, "class", CAT_IDENT, node);
   }
 
   if (node.id != null) {
     write(state, " ", CAT_OTHER);
-    writeWithMap(state, node.id.name, CAT_IDENT, node.id);
+    writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
   }
 
   if (TS) printTypeParameters(node.typeParameters, state);
@@ -119,7 +119,7 @@ export function printDecorators(decorators: ESTree.Decorator[], state: State): v
   for (let i = 0; i < length; i++) {
     const decorator = decorators[i];
 
-    writeWithMap(state, "@", CAT_OTHER, decorator);
+    writeWithMapNamed(state, "@", CAT_OTHER, decorator);
 
     const { expression } = decorator;
     const wrap = decoratorNeedsWrap(expression);
@@ -161,12 +161,12 @@ function printClassBody(node: ClassBodyNode, state: State): void {
   const { body } = node;
   const { length } = body;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", node);
+    writeWithMapNamedNoLast(state, "{", node);
     writeWithMapEnd(state, "}", CAT_OTHER, node);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, node);
+  writeWithMapNamed(state, "{\n", CAT_OTHER, node);
 
   state.indentLevel++;
 
@@ -221,7 +221,7 @@ function printClassBody(node: ClassBodyNode, state: State): void {
  * Print a method, including getters, setters, constructors and their modifiers.
  */
 function printMethodDefinition(node: MethodDefinitionNode, state: State): void {
-  markWithMap(state, node);
+  markMapNamed(state, node);
 
   const { decorators } = node;
   if (decorators != null && decorators.length > 0) printDecorators(decorators, state);
@@ -293,7 +293,7 @@ function printMethodDefinition(node: MethodDefinitionNode, state: State): void {
  * Print a class field, with its modifiers and initializer.
  */
 function printPropertyDefinition(node: PropertyDefinitionNode, state: State): void {
-  markWithMap(state, node);
+  markMapNamed(state, node);
 
   const { decorators } = node;
   if (decorators != null && decorators.length > 0) printDecorators(decorators, state);
@@ -356,17 +356,17 @@ function printPropertyDefinition(node: PropertyDefinitionNode, state: State): vo
 function printStaticBlock(node: ESTree.StaticBlock, state: State): void {
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "static ", CAT_OTHER, node);
+  writeWithMapNamed(state, "static ", CAT_OTHER, node);
 
   const { body } = node;
   const { length } = body;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", node);
+    writeWithMapNamedNoLast(state, "{", node);
     writeWithMapEnd(state, "}", CAT_OTHER, node);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, node);
+  writeWithMapNamed(state, "{\n", CAT_OTHER, node);
 
   state.indentLevel++;
 
@@ -384,7 +384,7 @@ function printStaticBlock(node: ESTree.StaticBlock, state: State): void {
  * Print an `accessor` field.
  */
 function printAccessorProperty(node: AccessorPropertyNode, state: State): void {
-  markWithMap(state, node);
+  markMapNamed(state, node);
 
   const { decorators } = node;
   if (decorators != null && decorators.length > 0) printDecorators(decorators, state);

--- a/packages/codegen/src-js/print/expression.ts
+++ b/packages/codegen/src-js/print/expression.ts
@@ -16,14 +16,14 @@ import {
   CAT_START_OF_ARROW_EXPR,
   CAT_START_OF_STMT,
   debugAssertLastFresh,
-  markWithMap,
-  markWithMapAfter,
-  markWithMapAtStartOffset,
+  markMapNamed,
+  markMapAfter,
+  markMapAtStartOffset,
   write,
   writeNoLast,
-  writeWithMap,
+  writeWithMapNamed,
   writeWithMapEnd,
-  writeWithMapNoLast,
+  writeWithMapNamedNoLast,
 } from "./write.ts";
 import { printClass } from "./class.ts";
 import {
@@ -96,7 +96,7 @@ export function printExpression(
   switch (node.type) {
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, node.name, CAT_IDENT, node);
+      writeWithMapNamed(state, node.name, CAT_IDENT, node);
       break;
     case "MemberExpression":
       printMemberExpression(node, state, ctx);
@@ -148,11 +148,11 @@ export function printExpression(
       break;
     case "ThisExpression":
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "this", CAT_IDENT, node);
+      writeWithMapNamed(state, "this", CAT_IDENT, node);
       break;
     case "Super":
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "super", CAT_IDENT, node);
+      writeWithMapNamed(state, "super", CAT_IDENT, node);
       break;
     case "NewExpression":
       printNewExpression(node, state, precedence);
@@ -161,7 +161,7 @@ export function printExpression(
       printTemplateLiteral(node, state);
       break;
     case "TaggedTemplateExpression":
-      markWithMap(state, node);
+      markMapNamed(state, node);
       printExpression(node.tag, state, PREC_POSTFIX, ctx & CTX_FORBID_CALL);
       if (TS) printTypeArguments(node.typeArguments, state);
       printTemplateLiteral(node.quasi, state);
@@ -180,7 +180,7 @@ export function printExpression(
       break;
     case "MetaProperty":
       printSpaceBeforeIdentifier(state);
-      writeWithMapNoLast(state, node.meta.name, node);
+      writeWithMapNamedNoLast(state, node.meta.name, node);
       writeNoLast(state, ".");
       write(state, node.property.name, CAT_IDENT);
       break;
@@ -196,7 +196,7 @@ export function printExpression(
         printExpression(inner, state, PREC_LOWEST, CTX_NONE);
         write(state, ")", CAT_CLOSE_BRACKET);
         if (SOURCEMAPS && precedence === PREC_POSTFIX) {
-          markWithMapAfter(state, inner);
+          markMapAfter(state, inner);
           const wrappers: ESTree.ParenthesizedExpression[] = [];
           let wrapper = expression;
           while (wrapper.type === "ParenthesizedExpression") {
@@ -204,7 +204,7 @@ export function printExpression(
             wrapper = wrapper.expression;
           }
           for (let index = wrappers.length - 1; index >= 0; index--) {
-            markWithMapAfter(state, wrappers[index]);
+            markMapAfter(state, wrappers[index]);
           }
         }
       } else {
@@ -244,7 +244,7 @@ export function printExpression(
   // rather than one character to its left
   debugAssertLastFresh(state);
   if (SOURCEMAPS && precedence === PREC_POSTFIX && state.last === CAT_CLOSE_BRACKET) {
-    markWithMapAfter(state, node);
+    markMapAfter(state, node);
   }
 }
 
@@ -291,10 +291,10 @@ export function printMemberExpression(
 
     const { property } = node;
     if (property.type === "PrivateIdentifier") {
-      writeWithMapNoLast(state, "#", property);
+      writeWithMapNamedNoLast(state, "#", property);
       write(state, property.name, CAT_IDENT);
     } else {
-      writeWithMap(state, property.name, CAT_IDENT, property);
+      writeWithMapNamed(state, property.name, CAT_IDENT, property);
     }
   }
 }
@@ -363,7 +363,7 @@ function printArguments(
 
     const arg = args[i];
     if (arg.type === "SpreadElement") {
-      writeWithMap(state, "...", CAT_OTHER, arg);
+      writeWithMapNamed(state, "...", CAT_OTHER, arg);
       printExpression(arg.argument, state, PREC_COMMA, CTX_NONE);
     } else {
       printExpression(arg, state, PREC_COMMA, CTX_NONE);
@@ -388,8 +388,8 @@ export function printPrivateInExpression(
   const wrap = precedence >= PREC_COMPARE;
   if (wrap) write(state, "(", CAT_OTHER);
 
-  markWithMap(state, node);
-  writeWithMapNoLast(state, "#", node.left);
+  markMapNamed(state, node);
+  writeWithMapNamedNoLast(state, "#", node.left);
   write(state, node.left.name, CAT_IDENT);
   write(state, " in ", CAT_OTHER);
   printExpression(node.right, state, PREC_EQUALS, CTX_FORBID_IN);
@@ -415,7 +415,7 @@ function printObjectExpression(node: ESTree.ObjectExpression, state: State): voi
   const { length } = properties;
   const isMultiLine = length > 1;
 
-  writeWithMap(state, "{", CAT_OTHER, node);
+  writeWithMapNamed(state, "{", CAT_OTHER, node);
 
   if (isMultiLine) {
     state.indentLevel++;
@@ -448,7 +448,7 @@ function printObjectExpression(node: ESTree.ObjectExpression, state: State): voi
  */
 function printObjectProperty(node: ESTree.ObjectPropertyKind, state: State): void {
   if (node.type === "SpreadElement") {
-    writeWithMap(state, "...", CAT_OTHER, node);
+    writeWithMapNamed(state, "...", CAT_OTHER, node);
     printExpression(node.argument, state, PREC_COMMA, CTX_NONE);
     return;
   }
@@ -458,7 +458,7 @@ function printObjectProperty(node: ESTree.ObjectPropertyKind, state: State): voi
     value.type === "FunctionExpression"
     || (TS && value.type === "TSEmptyBodyFunctionExpression")
   ) {
-    markWithMap(state, node);
+    markMapNamed(state, node);
 
     const { kind } = node;
     const isGetter = kind === "get";
@@ -529,7 +529,7 @@ function printObjectProperty(node: ESTree.ObjectPropertyKind, state: State): voi
   if (shorthand) {
     if (shorthandIdentifier !== null) {
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, shorthandIdentifier.name, CAT_IDENT, shorthandIdentifier);
+      writeWithMapNamed(state, shorthandIdentifier.name, CAT_IDENT, shorthandIdentifier);
     } else {
       // `__proto__` shorthand, whose value can be anything. Print through any parens around it.
       printExpression(withoutParens(value), state, PREC_COMMA, CTX_NONE);
@@ -561,7 +561,7 @@ function printArrayExpression(node: ESTree.ArrayExpression, state: State): void 
   const { length } = elements;
   const isMultiLine = length > 2;
 
-  writeWithMap(state, "[", CAT_OTHER, node);
+  writeWithMapNamed(state, "[", CAT_OTHER, node);
 
   if (isMultiLine) state.indentLevel++;
 
@@ -576,7 +576,7 @@ function printArrayExpression(node: ESTree.ArrayExpression, state: State): void 
     const element = elements[i];
     if (element != null) {
       if (element.type === "SpreadElement") {
-        writeWithMap(state, "...", CAT_OTHER, element);
+        writeWithMapNamed(state, "...", CAT_OTHER, element);
         printExpression(element.argument, state, PREC_COMMA, CTX_NONE);
       } else {
         printExpression(element, state, PREC_COMMA, CTX_NONE);
@@ -621,7 +621,7 @@ function printAssignmentExpression(
 
   if (wrap) write(state, "(", CAT_OTHER);
 
-  markWithMap(state, node);
+  markMapNamed(state, node);
 
   printAssignmentTarget(left, state);
   write(state, PADDED_ASSIGN_OPERATORS[node.operator], CAT_OTHER);
@@ -651,10 +651,10 @@ function printUpdateExpression(
 
   if (node.prefix) {
     printSpaceBeforeOperator(state, operatorCode);
-    writeWithMap(state, node.operator, operatorCode, node);
+    writeWithMapNamed(state, node.operator, operatorCode, node);
     printExpression(node.argument, state, PREC_PREFIX, ctx);
   } else {
-    markWithMap(state, node);
+    markMapNamed(state, node);
     printExpression(node.argument, state, PREC_POSTFIX, ctx);
     printSpaceBeforeOperator(state, operatorCode);
     write(state, node.operator, operatorCode);
@@ -684,7 +684,7 @@ function printUnaryExpression(
   if (operator.length > 1) {
     // typeof, void, delete
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, operator, CAT_IDENT, node);
+    writeWithMapNamed(state, operator, CAT_IDENT, node);
     write(state, " ", CAT_OTHER);
     // `delete Infinity` is a syntax error in strict mode
     isDeleteInfinity =
@@ -696,7 +696,7 @@ function printUnaryExpression(
     if (operatorCode === CAT_OP_UN_NOT && state.last === CAT_LT) {
       operatorCode = CAT_OP_UN_NOT_AFTER_LT;
     }
-    writeWithMap(state, operator, operatorCode, node);
+    writeWithMapNamed(state, operator, operatorCode, node);
   }
 
   if (isDeleteInfinity) write(state, "(0, ", CAT_OTHER);
@@ -796,7 +796,7 @@ function printArrowFunctionExpression(
 
   if (node.async) {
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, "async ", CAT_OTHER, node);
+    writeWithMapNamed(state, "async ", CAT_OTHER, node);
   }
 
   if (TS) printTypeParameters(node.typeParameters, state);
@@ -832,7 +832,7 @@ function printNewExpression(node: ESTree.NewExpression, state: State, precedence
   if (wrap) write(state, "(", CAT_OTHER);
 
   printSpaceBeforeIdentifier(state);
-  writeWithMap(state, "new ", CAT_OTHER, node);
+  writeWithMapNamed(state, "new ", CAT_OTHER, node);
   printExpression(node.callee, state, PREC_NEW, CTX_FORBID_CALL);
   if (TS) printTypeArguments(node.typeArguments, state);
   printArguments(node, node.arguments, state);
@@ -847,7 +847,7 @@ function printNewExpression(node: ESTree.NewExpression, state: State, precedence
  * Substitutions print from `PREC_LOWEST` with no context flags, since `${` and `}` fence them from everything around.
  */
 function printTemplateLiteral(node: ESTree.TemplateLiteral, state: State): void {
-  writeWithMapNoLast(state, "`", node);
+  writeWithMapNamedNoLast(state, "`", node);
 
   const { quasis, expressions } = node;
   const { length } = expressions;
@@ -863,7 +863,7 @@ function printTemplateLiteral(node: ESTree.TemplateLiteral, state: State): void 
     const raw = templateQuasiRaw(quasi);
     // A TS-shaped Oxc ESTree quasi includes the substitution's closing `}` in its span.
     // The JS-shaped ESTree quasi and Oxc's Rust AST both start at the raw template text.
-    if (raw.length > 0) markWithMapAtStartOffset(state, quasi, TS ? 1 : 0);
+    if (raw.length > 0) markMapAtStartOffset(state, quasi, TS ? 1 : 0);
     writeNoLast(state, raw);
   }
 
@@ -898,7 +898,7 @@ function printAwaitExpression(
   if (wrap) write(state, "(", CAT_OTHER);
 
   printSpaceBeforeIdentifier(state);
-  writeWithMap(state, "await ", CAT_OTHER, node);
+  writeWithMapNamed(state, "await ", CAT_OTHER, node);
   printExpression(node.argument, state, PREC_EXPONENTIATION, ctx);
 
   if (wrap) write(state, ")", CAT_CLOSE_BRACKET);
@@ -917,7 +917,7 @@ function printYieldExpression(
   if (wrap) write(state, "(", CAT_OTHER);
 
   printSpaceBeforeIdentifier(state);
-  writeWithMap(state, "yield", CAT_IDENT, node);
+  writeWithMapNamed(state, "yield", CAT_IDENT, node);
 
   if (node.delegate) write(state, "*", CAT_OTHER);
 
@@ -945,7 +945,7 @@ function printImportExpression(
   if (wrap) write(state, "(", CAT_OTHER);
 
   printSpaceBeforeIdentifier(state);
-  writeWithMap(state, "import", CAT_IDENT, node);
+  writeWithMapNamed(state, "import", CAT_IDENT, node);
 
   if (node.phase != null) {
     writeNoLast(state, ".");

--- a/packages/codegen/src-js/print/function.ts
+++ b/packages/codegen/src-js/print/function.ts
@@ -8,12 +8,12 @@ import {
   CAT_OTHER,
   CAT_START_OF_STMT,
   debugAssertLastFresh,
-  markWithMapNoName,
+  markMapStart,
   write,
   writeNoLast,
-  writeWithMap,
+  writeWithMapNamed,
   writeWithMapEnd,
-  writeWithMapNoLast,
+  writeWithMapNamedNoLast,
 } from "./write.ts";
 import { printDecorators } from "./class.ts";
 import { printSpaceBeforeIdentifier } from "./space.ts";
@@ -45,17 +45,17 @@ export function printFunction(node: ESTree.Function, state: State): void {
   // The node's mapping goes on whichever of these is written first
   const declare = TS && node.declare;
   if (declare) {
-    writeWithMap(state, "declare ", CAT_OTHER, node);
+    writeWithMapNamed(state, "declare ", CAT_OTHER, node);
     write(state, node.async ? "async function" : "function", CAT_IDENT);
   } else {
-    writeWithMap(state, node.async ? "async function" : "function", CAT_IDENT, node);
+    writeWithMapNamed(state, node.async ? "async function" : "function", CAT_IDENT, node);
   }
 
   if (node.generator) write(state, "* ", CAT_OTHER);
 
   if (node.id != null) {
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, node.id.name, CAT_IDENT, node.id);
+    writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
   }
 
   if (TS) printTypeParameters(node.typeParameters, state);
@@ -114,7 +114,7 @@ function printParams(params: ESTree.ParamPattern[], state: State): void {
     if (decorators != null && decorators.length > 0) {
       printDecorators(decorators, state);
     } else {
-      markWithMapNoName(state, param);
+      markMapStart(state, param);
     }
 
     if (TS && param.type === "TSParameterProperty") {
@@ -152,12 +152,12 @@ export function printFunctionBody(body: ESTree.FunctionBody, state: State): void
   // `body` is a BlockStatement holding directives + statements.
   const statements = body.body;
   if (statements.length === 0) {
-    writeWithMapNoLast(state, "{", body);
+    writeWithMapNamedNoLast(state, "{", body);
     writeWithMapEnd(state, "}", CAT_OTHER, body);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, body);
+  writeWithMapNamed(state, "{\n", CAT_OTHER, body);
   state.indentLevel++;
   printDirectivesAndStatements(statements, state);
   state.indentLevel--;

--- a/packages/codegen/src-js/print/jsx.ts
+++ b/packages/codegen/src-js/print/jsx.ts
@@ -5,9 +5,9 @@ import {
   CAT_OTHER,
   write,
   writeNoLast,
-  writeWithMap,
+  writeWithMapNamed,
   writeWithMapEnd,
-  writeWithMapNoLast,
+  writeWithMapNamedNoLast,
 } from "./write.ts";
 import { printExpression } from "./expression.ts";
 import { CTX_NONE } from "./operators.ts";
@@ -27,7 +27,7 @@ import type * as ESTree from "../../../../npm/oxc-types/types.d.ts";
 export function printJSXElement(node: ESTree.JSXElement, state: State): void {
   const { openingElement } = node;
 
-  writeWithMapNoLast(state, "<", openingElement);
+  writeWithMapNamedNoLast(state, "<", openingElement);
   printJSXElementName(openingElement.name, state);
 
   if (TS) printTypeArguments(openingElement.typeArguments, state);
@@ -38,7 +38,7 @@ export function printJSXElement(node: ESTree.JSXElement, state: State): void {
     writeNoLast(state, " ");
     const attribute = attributes[i];
     if (attribute.type === "JSXSpreadAttribute") {
-      writeWithMap(state, "{...", CAT_OTHER, attribute);
+      writeWithMapNamed(state, "{...", CAT_OTHER, attribute);
       printExpression(attribute.argument, state, PREC_COMMA, CTX_NONE);
       writeWithMapEnd(state, "}", CAT_OTHER, attribute);
     } else {
@@ -60,7 +60,7 @@ export function printJSXElement(node: ESTree.JSXElement, state: State): void {
     printJSXChild(children[i], state);
   }
 
-  writeWithMapNoLast(state, "</", closingElement);
+  writeWithMapNamedNoLast(state, "</", closingElement);
   printJSXElementName(closingElement.name, state);
   write(state, ">", CAT_OTHER);
 }
@@ -74,7 +74,7 @@ function printJSXElementName(
 ): void {
   switch (node.type) {
     case "JSXIdentifier":
-      writeWithMapNoLast(state, node.name, node);
+      writeWithMapNamedNoLast(state, node.name, node);
       break;
     case "JSXMemberExpression":
       printJSXElementName(node.object, state);
@@ -82,12 +82,12 @@ function printJSXElementName(
       printJSXElementName(node.property, state);
       break;
     case "JSXNamespacedName":
-      writeWithMapNoLast(state, node.namespace.name, node.namespace);
+      writeWithMapNamedNoLast(state, node.namespace.name, node.namespace);
       writeNoLast(state, ":");
-      writeWithMapNoLast(state, node.name.name, node.name);
+      writeWithMapNamedNoLast(state, node.name.name, node.name);
       break;
     case "ThisExpression":
-      writeWithMapNoLast(state, "this", node);
+      writeWithMapNamedNoLast(state, "this", node);
       break;
     default:
       throw new Error(`Unknown JSX name type: ${node.type}`);
@@ -104,11 +104,11 @@ function printJSXAttribute(node: ESTree.JSXAttribute, state: State): void {
   // and the next real write reads `last`.
   const { name } = node;
   if (name.type === "JSXNamespacedName") {
-    writeWithMapNoLast(state, name.namespace.name, name.namespace);
+    writeWithMapNamedNoLast(state, name.namespace.name, name.namespace);
     writeNoLast(state, ":");
-    writeWithMapNoLast(state, name.name.name, name.name);
+    writeWithMapNamedNoLast(state, name.name.name, name.name);
   } else {
-    writeWithMapNoLast(state, name.name, name);
+    writeWithMapNamedNoLast(state, name.name, name);
   }
 
   const { value } = node;
@@ -178,7 +178,7 @@ function printJSXExpressionContainer(node: ESTree.JSXExpressionContainer, state:
  * Print a `<>...</>` fragment.
  */
 export function printJSXFragment(node: ESTree.JSXFragment, state: State): void {
-  writeWithMapNoLast(state, "<>", node.openingFragment);
+  writeWithMapNamedNoLast(state, "<>", node.openingFragment);
 
   const { children } = node;
   const { length } = children;
@@ -186,7 +186,7 @@ export function printJSXFragment(node: ESTree.JSXFragment, state: State): void {
     printJSXChild(children[i], state);
   }
 
-  writeWithMap(state, "</>", CAT_OTHER, node.closingFragment);
+  writeWithMapNamed(state, "</>", CAT_OTHER, node.closingFragment);
 }
 
 /**
@@ -198,7 +198,7 @@ export function printJSXFragment(node: ESTree.JSXFragment, state: State): void {
 function printJSXChild(node: ESTree.JSXChild | UnknownNode, state: State): void {
   switch (node.type) {
     case "JSXText":
-      writeWithMapNoLast(state, node.raw != null ? node.raw : node.value, node);
+      writeWithMapNamedNoLast(state, node.raw != null ? node.raw : node.value, node);
       break;
     case "JSXExpressionContainer":
       printJSXExpressionContainer(node, state);

--- a/packages/codegen/src-js/print/literal.ts
+++ b/packages/codegen/src-js/print/literal.ts
@@ -10,8 +10,8 @@ import {
   CAT_REGEX_SLASH,
   write,
   writeNoLast,
-  writeWithMap,
-  writeWithMapNoLast,
+  writeWithMapNamed,
+  writeWithMapNamedNoLast,
 } from "./write.ts";
 import { printSpaceBeforeIdentifier, printSpaceBeforeOperator } from "./space.ts";
 import { printNonNegativeFloat } from "./number.ts";
@@ -60,7 +60,7 @@ export function printLiteral(
       break;
     case "boolean":
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, value ? "true" : "false", CAT_IDENT, node);
+      writeWithMapNamed(state, value ? "true" : "false", CAT_IDENT, node);
       break;
     default:
       typeAssertIs<LiteralExtras>(node);
@@ -73,7 +73,7 @@ export function printLiteral(
       } else {
         // `null`
         printSpaceBeforeIdentifier(state);
-        writeWithMap(state, "null", CAT_IDENT, node);
+        writeWithMapNamed(state, "null", CAT_IDENT, node);
       }
       break;
   }
@@ -102,7 +102,7 @@ function printNumericLiteral(
     // `CAT_IDENT` rather than `CAT_INT_DIGIT` - raw text only prints inside a TS type,
     // where no member `.` can follow, so there is no `0 .toExponential()` hazard to separate.
     const { raw } = node;
-    writeWithMap(state, raw, raw[raw.length - 1] === "." ? CAT_OTHER : CAT_IDENT, node);
+    writeWithMapNamed(state, raw, raw[raw.length - 1] === "." ? CAT_OTHER : CAT_IDENT, node);
     return;
   }
 
@@ -113,7 +113,7 @@ function printNumericLiteral(
     printNonNegativeFloat(state, value, node);
   } else if (Number.isNaN(value)) {
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, "NaN", CAT_IDENT, node);
+    writeWithMapNamed(state, "NaN", CAT_IDENT, node);
   } else if (!Number.isFinite(value)) {
     const negative = value < 0;
     const wrap = negative && precedence >= PREC_PREFIX;
@@ -125,13 +125,13 @@ function printNumericLiteral(
     } else {
       printSpaceBeforeIdentifier(state);
     }
-    writeWithMap(state, "Infinity", CAT_IDENT, node);
+    writeWithMapNamed(state, "Infinity", CAT_IDENT, node);
 
     if (wrap) write(state, ")", CAT_CLOSE_BRACKET);
   } else if (Object.is(value, 0)) {
     // +0 exactly - `Object.is` rejects `-0`, which the negative paths below print as `-0`
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, "0", CAT_INT_DIGIT, node);
+    writeWithMapNamed(state, "0", CAT_INT_DIGIT, node);
   } else if (precedence >= PREC_PREFIX) {
     writeNoLast(state, "(-");
     printNonNegativeFloat(state, -value, node);
@@ -169,7 +169,7 @@ function printRegExpLiteral(node: ESTree.RegExpLiteral, state: State): void {
   // * `last === CAT_REGEX_SLASH` keeps `/a//b/` from lexing as a line comment
   // * `CAT_LT` arm keeps `<` followed by `/script...` from closing a host `<script>` element.
 
-  writeWithMapNoLast(state, "/", node);
+  writeWithMapNamedNoLast(state, "/", node);
   writeNoLast(state, node.regex.pattern);
 
   // `CAT_REGEX_SLASH` rather than `CAT_OTHER`. It means "a regex just closed", which is what the
@@ -192,11 +192,11 @@ function printBigIntLiteral(node: ESTree.BigIntLiteral, state: State, precedence
 
   const value = node.bigint;
   if (value.startsWith("-") && precedence >= PREC_PREFIX) {
-    writeWithMapNoLast(state, "(", node);
+    writeWithMapNamedNoLast(state, "(", node);
     writeNoLast(state, value);
     write(state, "n)", CAT_CLOSE_BRACKET);
   } else {
-    writeWithMapNoLast(state, value, node);
+    writeWithMapNamedNoLast(state, value, node);
     write(state, "n", CAT_IDENT);
   }
 }

--- a/packages/codegen/src-js/print/module.ts
+++ b/packages/codegen/src-js/print/module.ts
@@ -6,7 +6,7 @@ import {
   CAT_START_OF_DEFAULT_EXPORT,
   write,
   writeNoLast,
-  writeWithMap,
+  writeWithMapNamed,
 } from "./write.ts";
 import { printClass } from "./class.ts";
 import { printExpression } from "./expression.ts";
@@ -39,7 +39,7 @@ export function printImportDeclaration(node: ESTree.ImportDeclaration, state: St
   printIndent(state);
 
   printSpaceBeforeIdentifier(state);
-  writeWithMap(state, "import", CAT_IDENT, node);
+  writeWithMapNamed(state, "import", CAT_IDENT, node);
 
   if (TS && node.importKind === "type") write(state, " type", CAT_IDENT);
 
@@ -74,7 +74,7 @@ export function printImportDeclaration(node: ESTree.ImportDeclaration, state: St
         }
 
         printSpaceBeforeIdentifier(state);
-        writeWithMap(state, specifier.local.name, CAT_IDENT, specifier);
+        writeWithMapNamed(state, specifier.local.name, CAT_IDENT, specifier);
 
         if (i === length - 1) write(state, " ", CAT_OTHER);
 
@@ -90,7 +90,7 @@ export function printImportDeclaration(node: ESTree.ImportDeclaration, state: St
         }
 
         write(state, "* as ", CAT_OTHER);
-        writeWithMap(state, specifier.local.name, CAT_IDENT, specifier.local);
+        writeWithMapNamed(state, specifier.local.name, CAT_IDENT, specifier.local);
         write(state, " ", CAT_OTHER);
         break;
       default: {
@@ -111,7 +111,7 @@ export function printImportDeclaration(node: ESTree.ImportDeclaration, state: St
         const { local } = specifier;
         if (importedName !== local.name) {
           write(state, " as ", CAT_OTHER);
-          writeWithMap(state, local.name, CAT_IDENT, local);
+          writeWithMapNamed(state, local.name, CAT_IDENT, local);
         }
         break;
       }
@@ -142,7 +142,7 @@ function printImportAttributes(
   // ESTree omits the `WithClause` wrapper. The Rust reference normalizes its mapping anchor
   // to the first attribute, which is the first location both representations carry.
   writeNoLast(state, " ");
-  writeWithMap(state, "with { ", CAT_OTHER, attributes[0]);
+  writeWithMapNamed(state, "with { ", CAT_OTHER, attributes[0]);
 
   for (let i = 0; i < length; i++) {
     if (i > 0) write(state, ", ", CAT_OTHER);
@@ -174,7 +174,7 @@ function printImportAttributes(
 function moduleExportName(node: ESTree.ModuleExportName, state: State): string {
   if (node.type === "Identifier") {
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, node.name, CAT_IDENT, node);
+    writeWithMapNamed(state, node.name, CAT_IDENT, node);
     return node.name;
   }
 
@@ -189,7 +189,7 @@ function moduleExportName(node: ESTree.ModuleExportName, state: State): string {
 export function printExportNamedDeclaration(node: ExportNamedDeclarationNode, state: State): void {
   printIndent(state);
 
-  writeWithMap(state, "export ", CAT_OTHER, node);
+  writeWithMapNamed(state, "export ", CAT_OTHER, node);
 
   const { declaration } = node;
   if (declaration != null) {
@@ -281,7 +281,7 @@ export function printExportNamedDeclaration(node: ExportNamedDeclarationNode, st
 export function printExportAllDeclaration(node: ESTree.ExportAllDeclaration, state: State): void {
   printIndent(state);
 
-  writeWithMap(
+  writeWithMapNamed(
     state,
     TS && node.exportKind === "type" ? "export type *" : "export *",
     CAT_OTHER,
@@ -311,7 +311,7 @@ export function printExportDefaultDeclaration(
 ): void {
   printIndent(state);
 
-  writeWithMap(state, "export default ", CAT_OTHER, node);
+  writeWithMapNamed(state, "export default ", CAT_OTHER, node);
 
   const { declaration } = node;
   switch (declaration.type) {

--- a/packages/codegen/src-js/print/number.ts
+++ b/packages/codegen/src-js/print/number.ts
@@ -9,7 +9,7 @@
 // Each form is written to the output in pieces, so no candidate string is ever built.
 
 import { debugAssert } from "../asserts.ts";
-import { CAT_IDENT, CAT_INT_DIGIT, markWithMapNoName, write, writeNoLast } from "./write.ts";
+import { CAT_IDENT, CAT_INT_DIGIT, markMapStart, write, writeNoLast } from "./write.ts";
 
 import type { State } from "../state.ts";
 import type * as ESTree from "../../../../npm/oxc-types/types.d.ts";
@@ -25,7 +25,7 @@ import type * as ESTree from "../../../../npm/oxc-types/types.d.ts";
  * from a following `.` already.
  */
 export function printNonNegativeFloat(state: State, value: number, node: ESTree.Node): void {
-  markWithMapNoName(state, node);
+  markMapStart(state, node);
 
   if (Number.isInteger(value)) {
     if (value < 1000) {

--- a/packages/codegen/src-js/print/statement.ts
+++ b/packages/codegen/src-js/print/statement.ts
@@ -9,12 +9,12 @@ import {
   CAT_OP_UN_NOT,
   CAT_OTHER,
   CAT_START_OF_STMT,
-  markWithMap,
+  markMapNamed,
   write,
   writeNoLast,
-  writeWithMap,
+  writeWithMapNamed,
   writeWithMapEnd,
-  writeWithMapNoLast,
+  writeWithMapNamedNoLast,
 } from "./write.ts";
 import { printClass } from "./class.ts";
 import { printExpression } from "./expression.ts";
@@ -87,7 +87,7 @@ export function printDirectivesAndStatements(
       if (inner.type === "Literal" && typeof inner.value === "string") {
         const mapsIndent = state.indentLevel > 0 || state.pendingIndentAsSpace;
         printIndent(state);
-        if (mapsIndent) markWithMap(state, stmt);
+        if (mapsIndent) markMapNamed(state, stmt);
         writeNoLast(state, "(");
         printString(state, inner.value, inner);
         write(state, ");\n", CAT_OTHER);
@@ -128,7 +128,7 @@ function printDirective(stmt: ESTree.Directive, state: State): void {
     }
   }
 
-  writeWithMapNoLast(state, quote, stmt);
+  writeWithMapNamedNoLast(state, quote, stmt);
   writeNoLast(state, directive);
   writeNoLast(state, quote);
   write(state, ";\n", CAT_OTHER);
@@ -185,20 +185,20 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
     case "BreakStatement":
       printIndent(state);
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "break", CAT_IDENT, node);
+      writeWithMapNamed(state, "break", CAT_IDENT, node);
       if (node.label != null) {
         write(state, " ", CAT_OTHER);
-        writeWithMap(state, node.label.name, CAT_IDENT, node.label);
+        writeWithMapNamed(state, node.label.name, CAT_IDENT, node.label);
       }
       write(state, ";\n", CAT_OTHER);
       break;
     case "ContinueStatement":
       printIndent(state);
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "continue", CAT_IDENT, node);
+      writeWithMapNamed(state, "continue", CAT_IDENT, node);
       if (node.label != null) {
         write(state, " ", CAT_OTHER);
-        writeWithMap(state, node.label.name, CAT_IDENT, node.label);
+        writeWithMapNamed(state, node.label.name, CAT_IDENT, node.label);
       }
       write(state, ";\n", CAT_OTHER);
       break;
@@ -208,7 +208,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
     case "ThrowStatement":
       printIndent(state);
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "throw ", CAT_OTHER, node);
+      writeWithMapNamed(state, "throw ", CAT_OTHER, node);
       printExpression(node.argument, state, PREC_LOWEST, CTX_NONE);
       write(state, ";\n", CAT_OTHER);
       break;
@@ -226,14 +226,14 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
     case "LabeledStatement":
       printIndent(state);
       printSpaceBeforeIdentifier(state);
-      markWithMap(state, node);
-      writeWithMap(state, node.label.name, CAT_IDENT, node.label);
+      markMapNamed(state, node);
+      writeWithMapNamed(state, node.label.name, CAT_IDENT, node.label);
       write(state, ":", CAT_OTHER);
       printBody(node.body, state);
       break;
     case "EmptyStatement":
       printIndent(state);
-      writeWithMap(state, ";\n", CAT_OTHER, node);
+      writeWithMapNamed(state, ";\n", CAT_OTHER, node);
       break;
     case "ImportDeclaration":
       printImportDeclaration(node, state);
@@ -250,7 +250,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
     case "WithStatement":
       printIndent(state);
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "with(", CAT_OTHER, node);
+      writeWithMapNamed(state, "with(", CAT_OTHER, node);
       printExpression(node.object, state, PREC_LOWEST, CTX_NONE);
       write(state, ")", CAT_CLOSE_BRACKET);
       printBody(node.body, state);
@@ -258,7 +258,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
     case "DebuggerStatement":
       printIndent(state);
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "debugger;\n", CAT_OTHER, node);
+      writeWithMapNamed(state, "debugger;\n", CAT_OTHER, node);
       break;
     /* IF TS */
     case "TSModuleDeclaration":
@@ -300,7 +300,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
     case "TSNamespaceExportDeclaration":
       printIndent(state);
       write(state, "export as namespace ", CAT_OTHER);
-      writeWithMap(state, node.id.name, CAT_IDENT, node.id);
+      writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
       write(state, ";\n", CAT_OTHER);
       break;
     /* END_IF */
@@ -318,7 +318,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
 function printExpressionStatement(node: ESTree.ExpressionStatement, state: State): void {
   const mapsIndent = state.indentLevel > 0 || state.pendingIndentAsSpace;
   printIndent(state);
-  if (mapsIndent) markWithMap(state, node);
+  if (mapsIndent) markMapNamed(state, node);
   state.last = CAT_START_OF_STMT;
   printExpression(node.expression, state, PREC_LOWEST, CTX_NONE);
   write(state, ";\n", CAT_OTHER);
@@ -341,10 +341,10 @@ export function printVariableDeclaration(
   // The node's mapping goes on whichever of these is written first
   const declare = TS && node.declare;
   if (declare) {
-    writeWithMap(state, "declare ", CAT_OTHER, node);
+    writeWithMapNamed(state, "declare ", CAT_OTHER, node);
     write(state, node.kind, CAT_IDENT);
   } else {
-    writeWithMap(state, node.kind, CAT_IDENT, node);
+    writeWithMapNamed(state, node.kind, CAT_IDENT, node);
   }
 
   const { declarations } = node;
@@ -360,7 +360,7 @@ export function printVariableDeclaration(
       // `let x!: T` - the `!` sits between the name and its annotation
       typeAssertIs<ESTree.BindingIdentifier>(id);
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, id.name, CAT_IDENT, id);
+      writeWithMapNamed(state, id.name, CAT_IDENT, id);
       write(state, "!", CAT_OP_UN_NOT);
       if (id.typeAnnotation != null) {
         printTypeAnnotation(id.typeAnnotation, state);
@@ -387,12 +387,12 @@ function printBlockStatement(block: ESTree.BlockStatement, state: State): void {
   const { body } = block;
   const { length } = body;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", block);
+    writeWithMapNamedNoLast(state, "{", block);
     writeWithMapEnd(state, "}", CAT_OTHER, block);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, block);
+  writeWithMapNamed(state, "{\n", CAT_OTHER, block);
   state.indentLevel++;
 
   for (let i = 0; i < length; i++) {
@@ -414,7 +414,7 @@ function printBlockStatement(block: ESTree.BlockStatement, state: State): void {
 function printIf(node: ESTree.IfStatement, state: State): void {
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "if (", CAT_OTHER, node);
+  writeWithMapNamed(state, "if (", CAT_OTHER, node);
 
   printExpression(node.test, state, PREC_LOWEST, CTX_NONE);
 
@@ -425,7 +425,7 @@ function printIf(node: ESTree.IfStatement, state: State): void {
     write(state, alternate != null ? " " : "\n", CAT_OTHER);
   } else if (wrapToAvoidAmbiguousElse(consequent)) {
     writeNoLast(state, ") ");
-    writeWithMap(state, "{\n", CAT_OTHER, consequent);
+    writeWithMapNamed(state, "{\n", CAT_OTHER, consequent);
     state.indentLevel++;
     printStatement(consequent, state);
     state.indentLevel--;
@@ -493,10 +493,10 @@ function printReturnStatement(node: ESTree.ReturnStatement, state: State): void 
 
   const { argument } = node;
   if (argument != null) {
-    writeWithMap(state, "return ", CAT_OTHER, node);
+    writeWithMapNamed(state, "return ", CAT_OTHER, node);
     printExpression(argument, state, PREC_LOWEST, CTX_NONE);
   } else {
-    writeWithMap(state, "return", CAT_IDENT, node);
+    writeWithMapNamed(state, "return", CAT_IDENT, node);
   }
 
   write(state, ";\n", CAT_OTHER);
@@ -510,7 +510,7 @@ function printTryStatement(node: ESTree.TryStatement, state: State): void {
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "try ", CAT_OTHER, node);
+  writeWithMapNamed(state, "try ", CAT_OTHER, node);
 
   printBlockStatement(node.block, state);
 
@@ -544,19 +544,19 @@ function printSwitchStatement(node: ESTree.SwitchStatement, state: State): void 
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "switch (", CAT_OTHER, node);
+  writeWithMapNamed(state, "switch (", CAT_OTHER, node);
   printExpression(node.discriminant, state, PREC_LOWEST, CTX_NONE);
   write(state, ") ", CAT_OTHER);
 
   const { cases } = node;
   const { length } = cases;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", node);
+    writeWithMapNamedNoLast(state, "{", node);
     writeWithMapEnd(state, "}\n", CAT_OTHER, node);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, node);
+  writeWithMapNamed(state, "{\n", CAT_OTHER, node);
   state.indentLevel++;
 
   for (let i = 0; i < length; i++) {
@@ -576,10 +576,10 @@ function printSwitchCase(node: ESTree.SwitchCase, state: State): void {
   printIndent(state);
 
   if (node.test != null) {
-    writeWithMap(state, "case ", CAT_OTHER, node);
+    writeWithMapNamed(state, "case ", CAT_OTHER, node);
     printExpression(node.test, state, PREC_LOWEST, CTX_NONE);
   } else {
-    writeWithMap(state, "default", CAT_IDENT, node);
+    writeWithMapNamed(state, "default", CAT_IDENT, node);
   }
 
   write(state, ":", CAT_OTHER);
@@ -609,7 +609,7 @@ function printWhileStatement(node: ESTree.WhileStatement, state: State): void {
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "while (", CAT_OTHER, node);
+  writeWithMapNamed(state, "while (", CAT_OTHER, node);
   printExpression(node.test, state, PREC_LOWEST, CTX_NONE);
   write(state, ")", CAT_CLOSE_BRACKET);
 
@@ -627,7 +627,7 @@ function printDoWhileStatement(node: ESTree.DoWhileStatement, state: State): voi
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "do", CAT_IDENT, node);
+  writeWithMapNamed(state, "do", CAT_IDENT, node);
 
   const { body } = node;
   if (body.type === "BlockStatement") {
@@ -636,7 +636,7 @@ function printDoWhileStatement(node: ESTree.DoWhileStatement, state: State): voi
     write(state, " ", CAT_OTHER);
   } else if (body.type === "EmptyStatement") {
     printIndent(state);
-    writeWithMap(state, ";\n", CAT_OTHER, body);
+    writeWithMapNamed(state, ";\n", CAT_OTHER, body);
   } else {
     write(state, "\n", CAT_OTHER);
     state.indentLevel++;
@@ -661,7 +661,7 @@ function printForStatement(node: ESTree.ForStatement, state: State): void {
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "for (", CAT_OTHER, node);
+  writeWithMapNamed(state, "for (", CAT_OTHER, node);
 
   const { init } = node;
   if (init != null) {
@@ -699,7 +699,7 @@ function printForInStatement(node: ESTree.ForInStatement, state: State): void {
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "for (", CAT_OTHER, node);
+  writeWithMapNamed(state, "for (", CAT_OTHER, node);
 
   const { left } = node;
   if (left.type === "VariableDeclaration") {
@@ -727,7 +727,7 @@ function printForOfStatement(node: ESTree.ForOfStatement, state: State): void {
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "for", CAT_IDENT, node);
+  writeWithMapNamed(state, "for", CAT_IDENT, node);
 
   if (node.await) write(state, " await", CAT_IDENT);
 

--- a/packages/codegen/src-js/print/string.ts
+++ b/packages/codegen/src-js/print/string.ts
@@ -1,6 +1,6 @@
 // String literal printing (port of `str.rs`, pretty mode: fixed quote).
 
-import { CAT_OTHER, write, writeNoLast, writeWithMapNoLast } from "./write.ts";
+import { CAT_OTHER, write, writeNoLast, writeWithMapNamedNoLast } from "./write.ts";
 import { debugAssert } from "../asserts.ts";
 
 import type { State } from "../state.ts";
@@ -24,7 +24,7 @@ const STRING_ESCAPE_REGEX =
  */
 export function printString(state: State, value: string, node: ESTree.Node): void {
   // Quote is fixed - double, matching `oxc_codegen`'s default option
-  writeWithMapNoLast(state, '"', node);
+  writeWithMapNamedNoLast(state, '"', node);
 
   // Almost no string needs escaping, so the loop which performs escaping sits in its own function
   if (!STRING_ESCAPE_REGEX.test(value)) {

--- a/packages/codegen/src-js/print/typescript.ts
+++ b/packages/codegen/src-js/print/typescript.ts
@@ -9,12 +9,12 @@ import {
   CAT_OTHER,
   CAT_QUESTION,
   debugAssertLastFresh,
-  markWithMapAtStartOffset,
+  markMapAtStartOffset,
   write,
   writeNoLast,
-  writeWithMap,
+  writeWithMapNamed,
   writeWithMapEnd,
-  writeWithMapNoLast,
+  writeWithMapNamedNoLast,
 } from "./write.ts";
 import { printExpression } from "./expression.ts";
 import { printParenParams, printParenParamsArrow } from "./function.ts";
@@ -282,13 +282,13 @@ function printTSTypeName(
   if (node.type === "TSQualifiedName") {
     printTSTypeName(node.left, state);
     write(state, ".", CAT_OTHER);
-    writeWithMap(state, node.right.name, CAT_IDENT, node.right);
+    writeWithMapNamed(state, node.right.name, CAT_IDENT, node.right);
   } else if (node.type === "ThisExpression") {
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, "this", CAT_IDENT, node);
+    writeWithMapNamed(state, "this", CAT_IDENT, node);
   } else {
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, node.name, CAT_IDENT, node);
+    writeWithMapNamed(state, node.name, CAT_IDENT, node);
   }
 }
 
@@ -432,12 +432,12 @@ function printTSTypeLiteral(node: ESTree.TSTypeLiteral, state: State): void {
   const { members } = node;
   const { length } = members;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", node);
+    writeWithMapNamedNoLast(state, "{", node);
     writeWithMapEnd(state, "}", CAT_OTHER, node);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, node);
+  writeWithMapNamed(state, "{\n", CAT_OTHER, node);
   state.indentLevel++;
 
   for (let i = 0; i < length; i++) {
@@ -522,10 +522,10 @@ function printSignatureKey(key: ESTree.PropertyKey, state: State, ctx: number): 
   switch (key.type) {
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, key.name, CAT_IDENT, key);
+      writeWithMapNamed(state, key.name, CAT_IDENT, key);
       break;
     case "PrivateIdentifier":
-      writeWithMapNoLast(state, "#", key);
+      writeWithMapNamedNoLast(state, "#", key);
       write(state, key.name, CAT_IDENT);
       break;
     case "Literal":
@@ -647,7 +647,7 @@ function printTSTypeParameter(node: ESTree.TSTypeParameter, state: State): void 
   if (node.in) writeNoLast(state, "in ");
   if (node.out) writeNoLast(state, "out ");
 
-  writeWithMap(state, node.name.name, CAT_IDENT, node.name);
+  writeWithMapNamed(state, node.name.name, CAT_IDENT, node.name);
 
   if (node.constraint != null) {
     write(state, " extends ", CAT_OTHER);
@@ -692,7 +692,7 @@ function printTSTupleElement(node: ESTree.TSTupleElement, state: State): void {
       printTSType(node.typeAnnotation, state);
       break;
     case "TSNamedTupleMember":
-      writeWithMap(state, node.label.name, CAT_IDENT, node.label);
+      writeWithMapNamed(state, node.label.name, CAT_IDENT, node.label);
       if (node.optional) write(state, "?", CAT_QUESTION);
       write(state, ": ", CAT_OTHER);
       printTSType(node.elementType, state);
@@ -754,7 +754,7 @@ function printTSMappedType(node: ESTree.TSMappedType, state: State): void {
 
   writeNoLast(state, "[");
 
-  writeWithMapNoLast(state, node.key.name, node.key);
+  writeWithMapNamedNoLast(state, node.key.name, node.key);
   write(state, " in ", CAT_OTHER);
   printTSType(node.constraint, state);
 
@@ -818,7 +818,7 @@ function printTSTypePredicate(node: ESTree.TSTypePredicate, state: State): void 
     write(state, "this", CAT_IDENT);
   } else {
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, parameterName.name, CAT_IDENT, parameterName);
+    writeWithMapNamed(state, parameterName.name, CAT_IDENT, parameterName);
   }
 
   if (node.typeAnnotation != null) {
@@ -957,12 +957,12 @@ export function printTSModuleDeclaration(
 function printModuleBlock(body: ESTree.TSModuleBlock, state: State): void {
   const statements = body.body;
   if (statements.length === 0) {
-    writeWithMapNoLast(state, "{", body);
+    writeWithMapNamedNoLast(state, "{", body);
     writeWithMapEnd(state, "}", CAT_OTHER, body);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, body);
+  writeWithMapNamed(state, "{\n", CAT_OTHER, body);
 
   state.indentLevel++;
   printDirectivesAndStatements(statements, state);
@@ -990,7 +990,7 @@ export function printTSInterfaceDeclaration(
 
   write(state, "interface ", CAT_OTHER);
 
-  writeWithMap(state, node.id.name, CAT_IDENT, node.id);
+  writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
 
   printTypeParameters(node.typeParameters, state);
 
@@ -1012,12 +1012,12 @@ export function printTSInterfaceDeclaration(
   const members = node.body.body;
   const { length } = members;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", node.body);
+    writeWithMapNamedNoLast(state, "{", node.body);
     writeWithMapEnd(state, "}", CAT_OTHER, node.body);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, node.body);
+  writeWithMapNamed(state, "{\n", CAT_OTHER, node.body);
   state.indentLevel++;
 
   for (let i = 0; i < length; i++) {
@@ -1044,7 +1044,7 @@ export function printTSTypeAliasDeclaration(
 
   write(state, "type ", CAT_OTHER);
 
-  writeWithMap(state, node.id.name, CAT_IDENT, node.id);
+  writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
 
   printTypeParameters(node.typeParameters, state);
 
@@ -1109,7 +1109,7 @@ export function printTSEnumDeclaration(node: ESTree.TSEnumDeclaration, state: St
 
   write(state, "enum ", CAT_OTHER);
 
-  writeWithMap(state, node.id.name, CAT_IDENT, node.id);
+  writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
 
   write(state, " ", CAT_OTHER);
 
@@ -1117,12 +1117,12 @@ export function printTSEnumDeclaration(node: ESTree.TSEnumDeclaration, state: St
   const { members } = body;
   const { length } = members;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", body);
+    writeWithMapNamedNoLast(state, "{", body);
     writeWithMapEnd(state, "}", CAT_OTHER, body);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, body);
+  writeWithMapNamed(state, "{\n", CAT_OTHER, body);
   state.indentLevel++;
 
   const lastIndex = length - 1;
@@ -1146,13 +1146,13 @@ function printTSEnumMember(node: ESTree.TSEnumMember, state: State): void {
   const { id } = node;
   if (id.type === "Identifier") {
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, id.name, CAT_IDENT, id);
+    writeWithMapNamed(state, id.name, CAT_IDENT, id);
   } else if (id.type === "Literal") {
     printString(state, id.value, id);
   } else {
     // Computed string/template member name
     if (id.type === "TemplateLiteral") {
-      markWithMapAtStartOffset(state, id.quasis[0], 1);
+      markMapAtStartOffset(state, id.quasis[0], 1);
       writeNoLast(state, "[`");
       writeNoLast(state, id.quasis[0].value.raw);
       write(state, "`", CAT_OTHER);
@@ -1182,7 +1182,7 @@ export function printTSImportEqualsDeclaration(
 
   if (node.importKind === "type") write(state, "type ", CAT_OTHER);
 
-  writeWithMap(state, node.id.name, CAT_IDENT, node.id);
+  writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
 
   write(state, " = ", CAT_OTHER);
 

--- a/packages/codegen/src-js/print/write.ts
+++ b/packages/codegen/src-js/print/write.ts
@@ -272,7 +272,12 @@ export function write(state: State, code: string, last: Category): void {
  * @param last - Category of the last character of `code`
  * @param node - Node this text came from
  */
-export function writeWithMap(state: State, code: string, last: Category, node: MappableNode): void {
+export function writeWithMapNamed(
+  state: State,
+  code: string,
+  last: Category,
+  node: MappableNode,
+): void {
   debugAssert(code.length > 0, "`code` should not be an empty string");
   debugAssertCategoryMatches(state, code, last);
 
@@ -320,10 +325,10 @@ export function writeNoLast(state: State, code: string): void {
  * into `writeNoLast` and drops the `node` argument, leaving this unreferenced for the minifier to remove.
  *
  * @param state - Printer state
- * @param code - Text to append, which unlike `writeWithMap` may be empty
+ * @param code - Text to append, which unlike `writeWithMapNamed` may be empty
  * @param node - Node this text came from
  */
-export function writeWithMapNoLast(state: State, code: string, node: MappableNode): void {
+export function writeWithMapNamedNoLast(state: State, code: string, node: MappableNode): void {
   recordSourceMapping(state, node, LOCATION_NAMED);
 
   state.output += code;
@@ -381,7 +386,7 @@ export function writeWithMapEnd(
  * @param state - Printer state
  * @param node - Node the mapping points at
  */
-export function markWithMap(state: State, node: MappableNode): void {
+export function markMapNamed(state: State, node: MappableNode): void {
   if (SOURCEMAPS) recordSourceMapping(state, node, LOCATION_NAMED);
 }
 
@@ -394,7 +399,7 @@ export function markWithMap(state: State, node: MappableNode): void {
  * @param state - Printer state
  * @param node - Node the mapping points at
  */
-export function markWithMapNoName(state: State, node: MappableNode): void {
+export function markMapStart(state: State, node: MappableNode): void {
   if (SOURCEMAPS) recordSourceMapping(state, node, LOCATION_START);
 }
 
@@ -407,7 +412,7 @@ export function markWithMapNoName(state: State, node: MappableNode): void {
  * @param state - Printer state
  * @param node - Node whose end offset the mapping points at
  */
-export function markWithMapAfter(state: State, node: MappableNode): void {
+export function markMapAfter(state: State, node: MappableNode): void {
   if (SOURCEMAPS) recordSourceMapping(state, node, LOCATION_END);
 }
 
@@ -421,11 +426,7 @@ export function markWithMapAfter(state: State, node: MappableNode): void {
  * @param node - Node the mapping points into
  * @param columnOffset - Number of UTF-16 units to add to `node`'s start offset
  */
-export function markWithMapAtStartOffset(
-  state: State,
-  node: MappableNode,
-  columnOffset: number,
-): void {
+export function markMapAtStartOffset(state: State, node: MappableNode, columnOffset: number): void {
   if (!SOURCEMAPS) return;
 
   const { start, end } = node;

--- a/packages/codegen/src-js/state.ts
+++ b/packages/codegen/src-js/state.ts
@@ -136,7 +136,7 @@ export class State {
       this.lastCharWritten = "";
     }
 
-    // `writeWithMap` records the output offset and original position of every mapped node,
+    // `writeWithMap*` functions record the output offset and original position of every mapped node,
     // and `generateSourceMap` encodes them in one pass at the end
     if (options.sourcemap !== true) {
       this.sourceText = null;

--- a/packages/codegen/tsdown.config.ts
+++ b/packages/codegen/tsdown.config.ts
@@ -71,7 +71,7 @@ const minifyConfig = DEBUG
 // `src-js/index.ts` loads whichever build the caller's options call for.
 //
 // In builds without source maps, nothing reads the `node` argument the mapping writes take,
-// so `unmap_writes` rewrites every `writeWithMap` / `writeWithMapNoLast` call, and the imports
+// so `unmap_writes` rewrites every `writeWithMapNamed` / `writeWithMapNamedNoLast` call, and the imports
 // which bring them in, into the plain `write` / `writeNoLast` they become without it.
 const printerConfig = (name: string, { sourcemaps, ts }: { sourcemaps: boolean; ts: boolean }) => ({
   ...commonConfig,

--- a/packages/codegen/tsdown_plugins/unmap_writes.ts
+++ b/packages/codegen/tsdown_plugins/unmap_writes.ts
@@ -7,13 +7,13 @@ import type { Plugin } from "rolldown";
  *
  * ```ts
  * // Original code
- * writeWithMap(state, "declare ", CAT_OTHER, node);
+ * writeWithMapNamed(state, "declare ", CAT_OTHER, node);
  *
  * // After transform
  * write(state, "declare ", CAT_OTHER);
  * ```
  *
- * The mapped writes and `markWithMap*` exist to record a source mapping for the node they are given.
+ * The mapped writes and `markMap*` exist to record a source mapping for the node they are given.
  * A build without source map support has nothing to record, so the call becomes the plain write
  * it would otherwise be, and the node argument goes with it - it would still be evaluated,
  * and held live across the call, for a function which ignores it.
@@ -35,14 +35,14 @@ import type { Plugin } from "rolldown";
  */
 const REWRITES = {
   // `write` takes the `last` category between the code and the node, `writeNoLast` does not
-  writeWithMap: { arity: 4, remove: 1, rename: "write" },
-  writeWithMapNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },
+  writeWithMapNamed: { arity: 4, remove: 1, rename: "write" },
+  writeWithMapNamedNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },
   writeWithMapEnd: { arity: 4, remove: 1, rename: "write" },
   // `rename: null` because a standalone mark has no non-sourcemap equivalent
-  markWithMap: { arity: 2, remove: 1, rename: null },
-  markWithMapNoName: { arity: 2, remove: 1, rename: null },
-  markWithMapAfter: { arity: 2, remove: 1, rename: null },
-  markWithMapAtStartOffset: { arity: 3, remove: 2, rename: null },
+  markMapNamed: { arity: 2, remove: 1, rename: null },
+  markMapStart: { arity: 2, remove: 1, rename: null },
+  markMapAfter: { arity: 2, remove: 1, rename: null },
+  markMapAtStartOffset: { arity: 3, remove: 2, rename: null },
   // `rename: null` to transform the function declarations, removing the `node` param
   printString: { arity: 3, remove: 1, rename: null },
   printNonNegativeFloat: { arity: 3, remove: 1, rename: null },


### PR DESCRIPTION
Pure refactor. Just rename functions:

- `markWithMap` -> `markMap` for brevity.
- All functions which can produce a named mapping called `*Named`.

This mainly prepares the way for next PR #25975, which introduces separate `write` functions for where a mapping can never be named.