### PR TITLE
refactor(minifier): remove old code for folding expressions to throw/return

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -118,29 +118,6 @@ impl<'a> PeepholeOptimizations {
                     let prev_index = stmts.len() - 2;
                     let prev_stmt = &stmts[prev_index];
                     match prev_stmt {
-                        Statement::ExpressionStatement(_) => {
-                            if let Some(Statement::ReturnStatement(last_return)) = stmts.last()
-                                && last_return.argument.is_none()
-                            {
-                                break 'return_loop;
-                            }
-                            ctx.notice_change();
-                            // "a(); return b;" => "return a(), b;"
-                            let last_stmt = stmts.pop().unwrap();
-                            let Statement::ReturnStatement(mut last_return) = last_stmt else {
-                                unreachable!()
-                            };
-                            let prev_stmt = stmts.pop().unwrap();
-                            let Statement::ExpressionStatement(mut expr_stmt) = prev_stmt else {
-                                unreachable!()
-                            };
-                            let b = last_return.argument.as_mut().unwrap();
-                            let argument = Self::join_sequence(&mut expr_stmt.expression, b, ctx);
-                            let right_span = last_return.span;
-                            let last_return_stmt =
-                                Statement::new_return_statement(right_span, Some(argument), ctx);
-                            stmts.push(last_return_stmt);
-                        }
                         // Merge the last two statements
                         Statement::IfStatement(if_stmt) => {
                             // The previous statement must be an if statement with no else clause
@@ -202,27 +179,6 @@ impl<'a> PeepholeOptimizations {
                     let prev_index = stmts.len() - 2;
                     let prev_stmt = &stmts[prev_index];
                     match prev_stmt {
-                        Statement::ExpressionStatement(_) => {
-                            ctx.notice_change();
-                            // "a(); throw b;" => "throw a(), b;"
-                            let last_stmt = stmts.pop().unwrap();
-                            let Statement::ThrowStatement(mut last_throw) = last_stmt else {
-                                unreachable!()
-                            };
-                            let prev_stmt = stmts.pop().unwrap();
-                            let Statement::ExpressionStatement(mut expr_stmt) = prev_stmt else {
-                                unreachable!()
-                            };
-                            let argument = Self::join_sequence(
-                                &mut expr_stmt.expression,
-                                &mut last_throw.argument,
-                                ctx,
-                            );
-                            let right_span = last_throw.span;
-                            let last_throw_stmt =
-                                Statement::new_throw_statement(right_span, argument, ctx);
-                            stmts.push(last_throw_stmt);
-                        }
                         // Merge the last two statements
                         Statement::IfStatement(if_stmt) => {
                             // The previous statement must be an if statement with no else clause


### PR DESCRIPTION
drop dead code related to folding expressions to throw/return as is no longer can be executed

this code is no longer executed and its a duplication of `handle_throw_statement` and `handle_return_statement`

we process all stmts first, and after that we try to process them again, even if everything should be join't already, beside normal check, i'v tried to execute this code on bunch of codebases / all tests cases and its truly dead, we may want to move logic used for IF's also to `handle_return_statement` and `handle_throw_statement`

originally this was added before handle_throw_statement and handle_return_statement was a thing and its part of initial setup

https://github.com/oxc-project/oxc/blob/b016fd41101de5038a77484c11c0a19c1aa965a9/crates/oxc_minifier/src/peephole/minimize_statements.rs#L947-L956

https://github.com/oxc-project/oxc/blob/b016fd41101de5038a77484c11c0a19c1aa965a9/crates/oxc_minifier/src/peephole/minimize_statements.rs#L972-L981