### PR TITLE
perf(packages/codegen): combine condition checks

### DIFF
--- a/packages/codegen/src-js/print/write.ts
+++ b/packages/codegen/src-js/print/write.ts
@@ -481,8 +481,7 @@ export function markMapAtStartOffset(state: State, node: MappableNode, columnOff
     || !Number.isSafeInteger(start)
     || !Number.isSafeInteger(end)
     || start < 0
-    || end < start
-    || start === end
+    || end <= start
   ) {
     return;
   }
@@ -516,8 +515,7 @@ function recordSourceMapping(state: State, node: MappableNode, location: Locatio
     || !Number.isSafeInteger(start)
     || !Number.isSafeInteger(end)
     || start < 0
-    || end < start
-    || start === end
+    || end <= start
   ) {
     return;
   }


### PR DESCRIPTION
Small optimization to sourcemap builds.

- Before: `end < start || start === end`
- After: `end <= start`

The 2 are equivalent.