### PR TITLE
refactor(packages/codegen): add `writeWithMapNamedJSXNoLast`

### DIFF
--- a/packages/codegen/DESIGN.md
+++ b/packages/codegen/DESIGN.md
@@ -255,17 +255,18 @@ No operator merges with a plain `!`, so storing it must not cost `printSpaceBefo
 Not every write needs to update `last`.
 
 When one token is written in pieces - a string's opening quote, its contents, its closing quote -
-only the last piece's category can possibly be read. Hence seven write primitives in [`print/write.ts`]:
+only the last piece's category can possibly be read. Hence eight write primitives in [`print/write.ts`]:
 
-| Function                  | Updates `last` | Records a source mapping       |
-| :------------------------ | :------------- | :----------------------------- |
-| `write`                   | Yes            | No                             |
-| `writeWithMap`            | Yes            | At the node's start            |
-| `writeWithMapNamed`       | Yes            | At the node's start, with name |
-| `writeWithMapEnd`         | Yes            | At the node's last character   |
-| `writeNoLast`             | No             | No                             |
-| `writeWithMapNoLast`      | No             | At the node's start            |
-| `writeWithMapNamedNoLast` | No             | At the node's start, with name |
+| Function                     | Updates `last` | Records a source mapping       |
+| :--------------------------- | :------------- | :----------------------------- |
+| `write`                      | Yes            | No                             |
+| `writeWithMap`               | Yes            | At the node's start            |
+| `writeWithMapNamed`          | Yes            | At the node's start, with name |
+| `writeWithMapEnd`            | Yes            | At the node's last character   |
+| `writeNoLast`                | No             | No                             |
+| `writeWithMapNoLast`         | No             | At the node's start            |
+| `writeWithMapNamedNoLast`    | No             | At the node's start, with name |
+| `writeWithMapNamedJSXNoLast` | No             | At the node's start, with name |
 
 - The `*Named` functions record the name the node had in the source, and take a `NamedMappableNode`,
   which covers nodes with a string `name`.

--- a/packages/codegen/src-js/print/jsx.ts
+++ b/packages/codegen/src-js/print/jsx.ts
@@ -7,7 +7,7 @@ import {
   writeNoLast,
   writeWithMap,
   writeWithMapEnd,
-  writeWithMapNamedNoLast,
+  writeWithMapNamedJSXNoLast,
   writeWithMapNoLast,
 } from "./write.ts";
 import { printExpression } from "./expression.ts";
@@ -75,7 +75,7 @@ function printJSXElementName(
 ): void {
   switch (node.type) {
     case "JSXIdentifier":
-      writeWithMapNamedNoLast(state, node.name, node);
+      writeWithMapNamedJSXNoLast(state, node.name, node);
       break;
     case "JSXMemberExpression":
       printJSXElementName(node.object, state);
@@ -83,9 +83,9 @@ function printJSXElementName(
       printJSXElementName(node.property, state);
       break;
     case "JSXNamespacedName":
-      writeWithMapNamedNoLast(state, node.namespace.name, node.namespace);
+      writeWithMapNamedJSXNoLast(state, node.namespace.name, node.namespace);
       writeNoLast(state, ":");
-      writeWithMapNamedNoLast(state, node.name.name, node.name);
+      writeWithMapNamedJSXNoLast(state, node.name.name, node.name);
       break;
     case "ThisExpression":
       writeWithMapNoLast(state, "this", node);
@@ -105,11 +105,11 @@ function printJSXAttribute(node: ESTree.JSXAttribute, state: State): void {
   // and the next real write reads `last`.
   const { name } = node;
   if (name.type === "JSXNamespacedName") {
-    writeWithMapNamedNoLast(state, name.namespace.name, name.namespace);
+    writeWithMapNamedJSXNoLast(state, name.namespace.name, name.namespace);
     writeNoLast(state, ":");
-    writeWithMapNamedNoLast(state, name.name.name, name.name);
+    writeWithMapNamedJSXNoLast(state, name.name.name, name.name);
   } else {
-    writeWithMapNamedNoLast(state, name.name, name);
+    writeWithMapNamedJSXNoLast(state, name.name, name);
   }
 
   const { value } = node;

--- a/packages/codegen/src-js/print/types.ts
+++ b/packages/codegen/src-js/print/types.ts
@@ -80,6 +80,16 @@ export interface NamedMappableNode extends MappableNode {
 }
 
 /**
+ * A named node which is not a `JSXIdentifier`.
+ *
+ * A `JSXIdentifier`'s name is recovered from the source by a different scan,
+ * so it goes to a write function of its own.
+ */
+export interface IdentMappableNode extends NamedMappableNode {
+  type: "Identifier" | "PrivateIdentifier";
+}
+
+/**
  * A node whose mapping records no name, because it has no string `name` to record.
  *
  * `name?: object` is how a node which does have one is rejected - `string` is not assignable to it.

--- a/packages/codegen/src-js/print/write.ts
+++ b/packages/codegen/src-js/print/write.ts
@@ -5,8 +5,14 @@
 
 import { debugAssert } from "../asserts.ts";
 
-import type { MappableNode, NamedMappableNode, UnnamedMappableNode } from "./types.ts";
+import type {
+  MappableNode,
+  NamedMappableNode,
+  IdentMappableNode,
+  UnnamedMappableNode,
+} from "./types.ts";
 import type { State } from "../state.ts";
+import type * as ESTree from "../../../../npm/oxc-types/types.d.ts";
 
 // `state.last` records what was written last, by category, not the last character itself.
 //
@@ -295,12 +301,12 @@ export function writeWithMapNamed(
   state: State,
   code: string,
   last: Category,
-  node: NamedMappableNode,
+  node: IdentMappableNode,
 ): void {
   debugAssert(code.length > 0, "`code` should not be an empty string");
   debugAssertCategoryMatches(state, code, last);
 
-  markMapNamed(state, node);
+  markMapNamed(state, false, node);
 
   state.last = last;
   state.output += code;
@@ -374,14 +380,44 @@ export function writeWithMapNoLast(state: State, code: string, node: UnnamedMapp
  * @param code - Text to append, which unlike `writeWithMapNamed` may be empty
  * @param node - Node this text came from
  */
-export function writeWithMapNamedNoLast(state: State, code: string, node: NamedMappableNode): void {
-  markMapNamed(state, node);
+export function writeWithMapNamedNoLast(state: State, code: string, node: IdentMappableNode): void {
+  markMapNamed(state, false, node);
 
   state.output += code;
 
   if (DEBUG) {
     state.lastIsStale = true;
     if (code.length > 0) state.lastCharWritten = code[code.length - 1];
+  }
+}
+
+/**
+ * Append `name` and record a named source mapping for a JSX identifier, leaving `state.last` alone.
+ *
+ * The JSX form of `writeWithMapNamedNoLast`. A JSX identifier's name can hold a `-`,
+ * so recovering its original name takes a different scan of the source.
+ *
+ * Builds without source map support have no use for this. For those builds, TSDown plugin rewrites every call
+ * into `writeNoLast` and drops the `node` argument, leaving this unreferenced for the minifier to remove.
+ *
+ * @param state - Printer state
+ * @param name - The identifier's name, so never empty, unlike the other `NoLast` forms
+ * @param node - JSX identifier this text came from
+ */
+export function writeWithMapNamedJSXNoLast(
+  state: State,
+  name: string,
+  node: ESTree.JSXIdentifier,
+): void {
+  debugAssert(name.length > 0, "`name` should not be an empty string");
+
+  markMapNamed(state, true, node);
+
+  state.output += name;
+
+  if (DEBUG) {
+    state.lastIsStale = true;
+    if (name.length > 0) state.lastCharWritten = name[name.length - 1];
   }
 }
 
@@ -484,9 +520,10 @@ function markMapEnd(state: State, node: MappableNode): void {
  * The name is only recorded for the mapping where it differs from the text which is printed.
  *
  * @param state - Printer state
+ * @param isJSXIdentifier - `true` if the node is a `JSXIdentifier`
  * @param node - Node the mapping points at
  */
-function markMapNamed(state: State, node: NamedMappableNode): void {
+function markMapNamed(state: State, isJSXIdentifier: boolean, node: NamedMappableNode): void {
   if (!SOURCEMAPS || !hasMappableSpan(node)) return;
 
   debugAssert(
@@ -536,7 +573,9 @@ function markMapNamed(state: State, node: NamedMappableNode): void {
   if (!matchesSource) {
     // Read the name out of the source.
     // We can use it for a definitive comparison, which the quick check above couldn't.
-    const originalName = originalNameFromSource(sourceText, node, start, end);
+    const originalName = isJSXIdentifier
+      ? originalJSXNameFromSource(sourceText, start, end)
+      : originalNameFromSource(sourceText, start, end);
 
     // A transformed or hand-authored AST can carry ranges unrelated to `sourceText`.
     // Preserve the existing fallback in that case instead of recording an arbitrary source substring.
@@ -616,25 +655,16 @@ function isSameToken(originalName: string, printedName: string, hashLength: 0 | 
  * and the `#` is part of what is returned - the token is `#name`.
  *
  * @param sourceText - Original source text
- * @param node - Node the offsets came from
  * @param start - Start offset of `node`, already validated
  * @param end - End offset of `node`, already validated
  * @returns The identifier as it appears in the source, or `undefined` if the offsets do not span one
  */
 function originalNameFromSource(
   sourceText: string,
-  node: MappableNode,
   start: number,
   end: number,
 ): string | undefined {
   if (end > sourceText.length) return undefined;
-
-  // JSX identifiers admit `-`, which is not an ECMAScript identifier character. Their spans do
-  // not absorb TypeScript annotations, so the ESTree end offset is already exact.
-  if (node.type === "JSXIdentifier") {
-    const originalName = sourceText.slice(start, end);
-    return JSX_IDENTIFIER_REGEX.test(originalName) ? originalName : undefined;
-  }
 
   let index = start;
   if (index < end && sourceText.charCodeAt(index) === 35) index++; // `#` in a private identifier
@@ -658,6 +688,29 @@ function originalNameFromSource(
   }
 
   return index === identifierStart ? undefined : sourceText.slice(start, index);
+}
+
+/**
+ * Recover a JSX identifier's original spelling from validated source offsets.
+ *
+ * JSX identifiers admit `-`, which is not an ECMAScript identifier character, so the scan in
+ * `originalNameFromSource` would stop short of one. Their spans also do not absorb TypeScript
+ * annotations, so the ESTree end offset is already exact and the whole span is the name.
+ *
+ * @param sourceText - Original source text
+ * @param start - Start offset of the node, already validated
+ * @param end - End offset of the node, already validated
+ * @returns The identifier as it was spelled in the source, or `undefined` if the offsets do not span one
+ */
+function originalJSXNameFromSource(
+  sourceText: string,
+  start: number,
+  end: number,
+): string | undefined {
+  if (end > sourceText.length) return undefined;
+
+  const originalName = sourceText.slice(start, end);
+  return JSX_IDENTIFIER_REGEX.test(originalName) ? originalName : undefined;
 }
 
 /**

--- a/packages/codegen/test/source-maps.test.ts
+++ b/packages/codegen/test/source-maps.test.ts
@@ -169,6 +169,33 @@ describe("Rust conformance", () => {
     expect(map?.names).toEqual(["ab"]);
   });
 
+  test("stale JSX identifier offsets preserve a name holding a dash", () => {
+    const code = 'const el = <data-foo bar-baz="1" />;';
+    const program = parseProgram("renamed.jsx", code);
+    const statement = program.body[0];
+    if (statement.type !== "VariableDeclaration") throw new Error("Expected variable declaration");
+    const element = statement.declarations[0].init;
+    if (element?.type !== "JSXElement") throw new Error("Expected JSX element");
+
+    const { name, attributes } = element.openingElement;
+    if (name.type !== "JSXIdentifier") throw new Error("Expected JSX identifier");
+    const attribute = attributes[0];
+    if (attribute.type !== "JSXAttribute" || attribute.name.type !== "JSXIdentifier") {
+      throw new Error("Expected JSX attribute");
+    }
+
+    name.name = "X";
+    attribute.name.name = "y";
+
+    const { map } = printSync(program, {
+      jsx: true,
+      sourcemap: true,
+      sourceFilename: "renamed.jsx",
+      sourceText: code,
+    });
+    expect(map?.names).toEqual(["data-foo", "bar-baz"]);
+  });
+
   test("a private identifier is named only when it was renamed", () => {
     const code = "class C { #ab; m() { return this.#ab; } }";
     const program = parseProgram("private.js", code);

--- a/packages/codegen/tsdown_plugins/unmap_writes.ts
+++ b/packages/codegen/tsdown_plugins/unmap_writes.ts
@@ -39,6 +39,7 @@ const REWRITES = {
   writeWithMapNamed: { arity: 4, remove: 1, rename: "write" },
   writeWithMapNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },
   writeWithMapNamedNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },
+  writeWithMapNamedJSXNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },
   writeWithMapEnd: { arity: 4, remove: 1, rename: "write" },
   // `rename: null` because a standalone mark has no non-sourcemap equivalent
   markMapStart: { arity: 2, remove: 1, rename: null },


### PR DESCRIPTION
Writing mappings for JSX identifiers requires different logic than for normal `Identifiers`.

- Add specialized function `writeWithMapNamedJSXNoLast` for writing `JSXIdentifier`s.
- Move the logic for getting original name of a `JSXIdentifier` into a separate function.
- Branch on an `isJSXIdentifier` param passed in to `markMapNamed`, to decide which function to use to get original identifier name.

The main motivation is to avoid having to pass `node` into `originalNameFromSource`, where reading `node.type` is a polymorphic access (because `node` could be an `Identifier`, an `PrivateIdentifier` or `JSXIdentifier`). This is part of a broader move to remove the reliance of all `write` and `markMap` functions on receiving polymorphic/megamorphic `node` params (later PRs in this stack).