### PR TITLE
refactor(packages/codegen): add `writeWithMapNamedPrivate`

### DIFF
--- a/packages/codegen/DESIGN.md
+++ b/packages/codegen/DESIGN.md
@@ -255,13 +255,15 @@ No operator merges with a plain `!`, so storing it must not cost `printSpaceBefo
 Not every write needs to update `last`.
 
 When one token is written in pieces - a string's opening quote, its contents, its closing quote -
-only the last piece's category can possibly be read. Hence eight write primitives in [`print/write.ts`]:
+only the last piece's category can possibly be read. Hence ten write primitives in [`print/write.ts`]:
 
 | Function                     | Updates `last` | Records a source mapping       |
 | :--------------------------- | :------------- | :----------------------------- |
 | `write`                      | Yes            | No                             |
+| `writePrivate`               | Yes            | No                             |
 | `writeWithMap`               | Yes            | At the node's start            |
 | `writeWithMapNamed`          | Yes            | At the node's start, with name |
+| `writeWithMapNamedPrivate`   | Yes            | At the node's start, with name |
 | `writeWithMapEnd`            | Yes            | At the node's last character   |
 | `writeNoLast`                | No             | No                             |
 | `writeWithMapNoLast`         | No             | At the node's start            |
@@ -269,8 +271,15 @@ only the last piece's category can possibly be read. Hence eight write primitive
 | `writeWithMapNamedJSXNoLast` | No             | At the node's start, with name |
 
 - The `*Named` functions record the name the node had in the source, and take a `NamedMappableNode`,
-  which covers nodes with a string `name`.
+  which covers nodes with a string `name`. What they record is the text they print -
+  debug builds assert the two are the same string.
 - The other `writeWithMap*` functions take an `UnnamedMappableNode` which covers nodes without a string `name`.
+- There is a `*Named` function per way of recovering the original name from the source, because the scan differs -
+  a JSX identifier may hold a `-`, and a private identifier's span covers a `#` which is not part of its name.
+  Which one applies is settled at the call site, where the node's type is known statically, rather than read back
+  off a `node` which is megamorphic by the time it arrives.
+- The two `Private` forms write the `#` themselves, so the name they are given is what follows it,
+  and `last` is always `CAT_IDENT` - the caller passes neither.
 - The three `markMap*` functions record a mapping without writing anything, so `last` is not theirs to update.
 - The rule is exact: **only sound where the value of `last` is provably dead**.
   Another real write must follow before anything reads it.
@@ -372,7 +381,8 @@ A plugin silently doing nothing is a failure mode worth guarding against.
 
 Rewrites every mapped write into the plain one it becomes with no mapping to record - so
 `writeWithMap(state, code, cat, node)` turns into `write(state, code, cat)` - and rewrites the import to match.
-`writeWithMapNamed` and `writeWithMapEnd` become `write` too, and both `NoLast` forms become `writeNoLast`.
+`writeWithMapNamed` and `writeWithMapEnd` become `write` too, every `NoLast` form becomes `writeNoLast`,
+and `writeWithMapNamedPrivate` becomes `writePrivate`, the one plain form nothing calls directly.
 
 `printString` and `printNonNegativeFloat` take a node only to hand on to a mapped write. They keep their names,
 but the argument comes off every call, and the parameter off their declarations - which, unlike the mapped writes,

--- a/packages/codegen/src-js/print/binding_pattern.ts
+++ b/packages/codegen/src-js/print/binding_pattern.ts
@@ -9,7 +9,7 @@ import {
   write,
   writeWithMap,
   writeWithMapNamed,
-  writeWithMapNamedNoLast,
+  writeWithMapNamedPrivate,
 } from "./write.ts";
 import { printExpression } from "./expression.ts";
 import { printSpaceBeforeIdentifier } from "./space.ts";
@@ -145,8 +145,7 @@ export function printPropertyKey(key: ESTree.PropertyKey, state: State): void {
       writeWithMapNamed(state, key.name, CAT_IDENT, key);
       break;
     case "PrivateIdentifier":
-      writeWithMapNamedNoLast(state, "#", key);
-      write(state, key.name, CAT_IDENT);
+      writeWithMapNamedPrivate(state, key.name, key);
       break;
     case "Literal":
       if (typeof key.value === "string") {

--- a/packages/codegen/src-js/print/expression.ts
+++ b/packages/codegen/src-js/print/expression.ts
@@ -24,7 +24,7 @@ import {
   writeWithMap,
   writeWithMapEnd,
   writeWithMapNamed,
-  writeWithMapNamedNoLast,
+  writeWithMapNamedPrivate,
   writeWithMapNoLast,
 } from "./write.ts";
 import { printClass } from "./class.ts";
@@ -293,8 +293,7 @@ export function printMemberExpression(
 
     const { property } = node;
     if (property.type === "PrivateIdentifier") {
-      writeWithMapNamedNoLast(state, "#", property);
-      write(state, property.name, CAT_IDENT);
+      writeWithMapNamedPrivate(state, property.name, property);
     } else {
       writeWithMapNamed(state, property.name, CAT_IDENT, property);
     }
@@ -391,8 +390,7 @@ export function printPrivateInExpression(
   if (wrap) write(state, "(", CAT_OTHER);
 
   markMapStart(state, node);
-  writeWithMapNamedNoLast(state, "#", node.left);
-  write(state, node.left.name, CAT_IDENT);
+  writeWithMapNamedPrivate(state, node.left.name, node.left);
   write(state, " in ", CAT_OTHER);
   printExpression(node.right, state, PREC_EQUALS, CTX_FORBID_IN);
 

--- a/packages/codegen/src-js/print/types.ts
+++ b/packages/codegen/src-js/print/types.ts
@@ -80,13 +80,13 @@ export interface NamedMappableNode extends MappableNode {
 }
 
 /**
- * A named node which is not a `JSXIdentifier`.
+ * An `Identifier` node.
  *
- * A `JSXIdentifier`'s name is recovered from the source by a different scan,
- * so it goes to a write function of its own.
+ * This does not include `JSXIdentifier` or `PrivateIdentifier`. A `JSXIdentifier`'s or `PrivateIdentifier`'s name
+ * is recovered from the source by a different scan, so it goes to a write function of its own.
  */
 export interface IdentMappableNode extends NamedMappableNode {
-  type: "Identifier" | "PrivateIdentifier";
+  type: "Identifier";
 }
 
 /**

--- a/packages/codegen/src-js/print/typescript.ts
+++ b/packages/codegen/src-js/print/typescript.ts
@@ -16,6 +16,7 @@ import {
   writeWithMapEnd,
   writeWithMapNamed,
   writeWithMapNamedNoLast,
+  writeWithMapNamedPrivate,
   writeWithMapNoLast,
 } from "./write.ts";
 import { printExpression } from "./expression.ts";
@@ -527,8 +528,7 @@ function printSignatureKey(key: ESTree.PropertyKey, state: State, ctx: number): 
       writeWithMapNamed(state, key.name, CAT_IDENT, key);
       break;
     case "PrivateIdentifier":
-      writeWithMapNamedNoLast(state, "#", key);
-      write(state, key.name, CAT_IDENT);
+      writeWithMapNamedPrivate(state, key.name, key);
       break;
     case "Literal":
       if (typeof key.value === "string") {

--- a/packages/codegen/src-js/print/write.ts
+++ b/packages/codegen/src-js/print/write.ts
@@ -252,6 +252,31 @@ export function write(state: State, code: string, last: Category): void {
 }
 
 /**
+ * Append a private identifier - `#` and `name` - to the output, and record what it ends with.
+ *
+ * The plain form of `writeWithMapNamedPrivate`.
+ * Nothing calls it directly - the TSDown plugin rewrites the mapped calls to it for builds without source map support.
+ *
+ * `last` is always `CAT_IDENT`, since the name is what is written last, so the caller does not pass it.
+ *
+ * @param state - Printer state
+ * @param name - The identifier's name, which is what follows the `#`, so never empty
+ */
+export function writePrivate(state: State, name: string): void {
+  debugAssert(name.length > 0, "`name` should not be an empty string");
+  debugAssertCategoryMatches(state, name, CAT_IDENT);
+
+  state.last = CAT_IDENT;
+  state.output += "#";
+  state.output += name;
+
+  if (DEBUG) {
+    state.lastIsStale = false;
+    state.lastCharWritten = name[name.length - 1];
+  }
+}
+
+/**
  * Append `code` to the output, record what it ends with, and record an unnamed source mapping for `node`.
  *
  * The mapping is only recorded where the caller asked for source maps and `node` carries `start` / `end` offsets.
@@ -305,8 +330,9 @@ export function writeWithMapNamed(
 ): void {
   debugAssert(code.length > 0, "`code` should not be an empty string");
   debugAssertCategoryMatches(state, code, last);
+  debugAssertNameMatches(node, code);
 
-  markMapNamed(state, false, node);
+  markMapNamed(state, code, false, 0, node);
 
   state.last = last;
   state.output += code;
@@ -314,6 +340,42 @@ export function writeWithMapNamed(
   if (DEBUG) {
     state.lastIsStale = false;
     state.lastCharWritten = code[code.length - 1];
+  }
+}
+
+/**
+ * Append a private identifier - `#` and `name` - to the output, record what it ends with,
+ * and record a named source mapping for `node`.
+ *
+ * The mapping is only recorded where the caller asked for source maps and `node` carries `start` / `end` offsets.
+ *
+ * `last` is always `CAT_IDENT`, since the name is what is written last, so the caller does not pass it.
+ *
+ * Builds without source map support have no use for this. For those builds, TSDown plugin rewrites every call
+ * into `writePrivate` and drops the `node` argument, leaving this unreferenced for the minifier to remove.
+ *
+ * @param state - Printer state
+ * @param name - The identifier's name, which is what follows the `#`, so never empty
+ * @param node - Private identifier this text came from
+ */
+export function writeWithMapNamedPrivate(
+  state: State,
+  name: string,
+  node: ESTree.PrivateIdentifier,
+): void {
+  debugAssert(name.length > 0, "`name` should not be an empty string");
+  debugAssertCategoryMatches(state, name, CAT_IDENT);
+  debugAssertNameMatches(node, name);
+
+  markMapNamed(state, name, false, 1, node);
+
+  state.last = CAT_IDENT;
+  state.output += "#";
+  state.output += name;
+
+  if (DEBUG) {
+    state.lastIsStale = false;
+    state.lastCharWritten = name[name.length - 1];
   }
 }
 
@@ -377,11 +439,14 @@ export function writeWithMapNoLast(state: State, code: string, node: UnnamedMapp
  * into `writeNoLast` and drops the `node` argument, leaving this unreferenced for the minifier to remove.
  *
  * @param state - Printer state
- * @param code - Text to append, which unlike `writeWithMapNamed` may be empty
+ * @param code - The identifier's name, so never empty, unlike the plain `NoLast` forms
  * @param node - Node this text came from
  */
 export function writeWithMapNamedNoLast(state: State, code: string, node: IdentMappableNode): void {
-  markMapNamed(state, false, node);
+  debugAssert(code.length > 0, "`code` should not be an empty string");
+  debugAssertNameMatches(node, code);
+
+  markMapNamed(state, code, false, 0, node);
 
   state.output += code;
 
@@ -410,8 +475,9 @@ export function writeWithMapNamedJSXNoLast(
   node: ESTree.JSXIdentifier,
 ): void {
   debugAssert(name.length > 0, "`name` should not be an empty string");
+  debugAssertNameMatches(node, name);
 
-  markMapNamed(state, true, node);
+  markMapNamed(state, name, true, 0, node);
 
   state.output += name;
 
@@ -519,16 +585,33 @@ function markMapEnd(state: State, node: MappableNode): void {
  *
  * The name is only recorded for the mapping where it differs from the text which is printed.
  *
+ * A private identifier's mapping stays on the `#`, where the printed token starts, and the `#` is part
+ * of the name recorded - the token is `#name`, so a name of `name` alone would describe a region of
+ * the output which includes the `#`.
+ *
  * @param state - Printer state
+ * @param printedName - Name written to the output, which is the identifier's `name`
  * @param isJSXIdentifier - `true` if the node is a `JSXIdentifier`
+ * @param hashLength - Length of the `#` the token is printed behind.
+ *   1 if the node is a `PrivateIdentifier`, 0 otherwise.
  * @param node - Node the mapping points at
  */
-function markMapNamed(state: State, isJSXIdentifier: boolean, node: NamedMappableNode): void {
+function markMapNamed(
+  state: State,
+  printedName: string,
+  isJSXIdentifier: boolean,
+  hashLength: 0 | 1,
+  node: NamedMappableNode,
+): void {
   if (!SOURCEMAPS || !hasMappableSpan(node)) return;
 
   debugAssert(
     state.mapPositions !== null && state.mapNames !== null && state.sourceText !== null,
     "`mapPositions`, `mapNames` and `sourceText` should be defined when source maps are enabled",
+  );
+  debugAssert(
+    !(isJSXIdentifier && hashLength > 0),
+    "A node cannot be both a `JSXIdentifier` and a `PrivateIdentifier`",
   );
 
   const { start, end } = node;
@@ -559,8 +642,6 @@ function markMapNamed(state: State, isJSXIdentifier: boolean, node: NamedMappabl
   //
   // A private identifier prints as `#` followed by its name, and its span covers the `#`, so the token is `#name`.
   // That is what the source is compared against, and what gets recorded as the name.
-  const printedName = node.name;
-  const hashLength = node.type === "PrivateIdentifier" ? 1 : 0;
   const nameStart = start + hashLength;
   const nameEnd = nameStart + printedName.length;
   const matchesSource =
@@ -655,8 +736,8 @@ function isSameToken(originalName: string, printedName: string, hashLength: 0 | 
  * and the `#` is part of what is returned - the token is `#name`.
  *
  * @param sourceText - Original source text
- * @param start - Start offset of `node`, already validated
- * @param end - End offset of `node`, already validated
+ * @param start - Offset the identifier starts at, already validated
+ * @param end - Offset the scan stops at, already validated
  * @returns The identifier as it appears in the source, or `undefined` if the offsets do not span one
  */
 function originalNameFromSource(
@@ -782,6 +863,24 @@ function isDefinitelyIdentifierBoundary(code: number): boolean {
     && code !== 45 // `-` in JSX identifiers
     && code !== 92 // `\` starting a Unicode escape
     && code !== 95 // `_`
+  );
+}
+
+/**
+ * Assert that the name a mapping records is the text which was printed.
+ *
+ * The `Named` write functions record what they print, on the premise that an identifier's `name` and
+ * the text printed for it are one and the same string. This is what holds that premise up.
+ *
+ * Debug builds only. Removed by minifier in release builds.
+ *
+ * @param node - Node the mapping is for
+ * @param name - Name the mapping records, which is what was printed
+ */
+function debugAssertNameMatches(node: NamedMappableNode, name: string): void {
+  debugAssert(
+    node.name === name,
+    () => `\`${node.type}\` has name "${node.name}", but "${name}" was printed`,
   );
 }
 

--- a/packages/codegen/tsdown_plugins/unmap_writes.ts
+++ b/packages/codegen/tsdown_plugins/unmap_writes.ts
@@ -40,6 +40,8 @@ const REWRITES = {
   writeWithMapNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },
   writeWithMapNamedNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },
   writeWithMapNamedJSXNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },
+  // A private identifier writes its own `#`, so its plain form is not `write`
+  writeWithMapNamedPrivate: { arity: 3, remove: 1, rename: "writePrivate" },
   writeWithMapEnd: { arity: 4, remove: 1, rename: "write" },
   // `rename: null` because a standalone mark has no non-sourcemap equivalent
   markMapStart: { arity: 2, remove: 1, rename: null },


### PR DESCRIPTION
Continuation of #25980.

Add a specialized function `writeWithMapNamedPrivate` for writing a `PrivateIdentifier`. It feeds `hashLength: 1` to `markMapNamed`, which allows removing polymoprhic `node.type` access from `markMapNamed`.

The code being printed in paths that lead to `markMapNamed` is always the same as `node.name`, so just pass it in to `markMapNamed`, which removes a polymorphic `node.name` read there.

Additionally, `writeWithMapNamedNoLast` now only receives `Identifier` nodes, so becomes monomorphic.