### PR TITLE
perf(packages/codegen): remove `last` param from `writeWithMapNamed`

### DIFF
--- a/packages/codegen/DESIGN.md
+++ b/packages/codegen/DESIGN.md
@@ -255,11 +255,12 @@ No operator merges with a plain `!`, so storing it must not cost `printSpaceBefo
 Not every write needs to update `last`.
 
 When one token is written in pieces - a string's opening quote, its contents, its closing quote -
-only the last piece's category can possibly be read. Hence ten write primitives in [`print/write.ts`]:
+only the last piece's category can possibly be read. Hence eleven write primitives in [`print/write.ts`]:
 
 | Function                     | Updates `last` | Records a source mapping       |
 | :--------------------------- | :------------- | :----------------------------- |
 | `write`                      | Yes            | No                             |
+| `writeIdent`                 | Yes            | No                             |
 | `writePrivate`               | Yes            | No                             |
 | `writeWithMap`               | Yes            | At the node's start            |
 | `writeWithMapNamed`          | Yes            | At the node's start, with name |
@@ -278,6 +279,9 @@ only the last piece's category can possibly be read. Hence ten write primitives 
   a JSX identifier may hold a `-`, and a private identifier's span covers a `#` which is not part of its name.
   Which one applies is settled at the call site, where the node's type is known statically, rather than read back
   off a `node` which is megamorphic by the time it arrives.
+- `writeWithMapNamed` and `writeWithMapNamedPrivate` take no category, because a name ends in an identifier
+  character and so `last` is always `CAT_IDENT`. The private form writes its own `#`, so what it takes is
+  the name which follows it. That is why their plain forms are `writeIdent` and `writePrivate`, not `write`.
 - The two `Private` forms write the `#` themselves, so the name they are given is what follows it,
   and `last` is always `CAT_IDENT` - the caller passes neither.
 - The three `markMap*` functions record a mapping without writing anything, so `last` is not theirs to update.
@@ -381,8 +385,9 @@ A plugin silently doing nothing is a failure mode worth guarding against.
 
 Rewrites every mapped write into the plain one it becomes with no mapping to record - so
 `writeWithMap(state, code, cat, node)` turns into `write(state, code, cat)` - and rewrites the import to match.
-`writeWithMapNamed` and `writeWithMapEnd` become `write` too, every `NoLast` form becomes `writeNoLast`,
-and `writeWithMapNamedPrivate` becomes `writePrivate`, the one plain form nothing calls directly.
+`writeWithMapEnd` becomes `write` too, and every `NoLast` form becomes `writeNoLast`.
+`writeWithMapNamed` and `writeWithMapNamedPrivate` become `writeIdent` and `writePrivate` -
+the two plain forms nothing calls directly, which exist only for these rewrites to land on.
 
 `printString` and `printNonNegativeFloat` take a node only to hand on to a mapped write. They keep their names,
 but the argument comes off every call, and the parameter off their declarations - which, unlike the mapped writes,

--- a/packages/codegen/src-js/print/assignment_target.ts
+++ b/packages/codegen/src-js/print/assignment_target.ts
@@ -2,14 +2,7 @@
 
 import { typeAssertIs } from "../asserts.ts";
 import { printPropertyKey } from "./binding_pattern.ts";
-import {
-  CAT_CLOSE_BRACKET,
-  CAT_IDENT,
-  CAT_OTHER,
-  write,
-  writeWithMap,
-  writeWithMapNamed,
-} from "./write.ts";
+import { CAT_CLOSE_BRACKET, CAT_OTHER, write, writeWithMap, writeWithMapNamed } from "./write.ts";
 import { printExpression, printMemberExpression } from "./expression.ts";
 import { printSpaceBeforeIdentifier } from "./space.ts";
 import { CTX_NONE } from "./operators.ts";
@@ -30,7 +23,7 @@ export function printAssignmentTarget(node: ESTree.AssignmentTarget, state: Stat
     // For speed, the two common ones are printed here instead of through the expression printer's own dispatch.
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, node.name, CAT_IDENT, node);
+      writeWithMapNamed(state, node.name, node);
       break;
     case "MemberExpression":
       printMemberExpression(node, state, CTX_NONE);
@@ -90,12 +83,12 @@ function printAssignmentTargetProperty(node: ESTree.AssignmentTargetProperty, st
     if (value.type === "AssignmentPattern") {
       typeAssertIs<ESTree.IdentifierReference>(value.left);
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, value.left.name, CAT_IDENT, value.left);
+      writeWithMapNamed(state, value.left.name, value.left);
       write(state, " = ", CAT_OTHER);
       printExpression(value.right, state, PREC_COMMA, CTX_NONE);
     } else {
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, value.name, CAT_IDENT, value);
+      writeWithMapNamed(state, value.name, value);
     }
   } else {
     const { key } = node;

--- a/packages/codegen/src-js/print/binding_pattern.ts
+++ b/packages/codegen/src-js/print/binding_pattern.ts
@@ -3,7 +3,6 @@
 import { typeAssertIs } from "../asserts.ts";
 import {
   CAT_CLOSE_BRACKET,
-  CAT_IDENT,
   CAT_OTHER,
   CAT_QUESTION,
   write,
@@ -40,7 +39,7 @@ export function printBindingPattern(node: BindingPatternNode | UnknownNode, stat
   switch (node.type) {
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, node.name, CAT_IDENT, node);
+      writeWithMapNamed(state, node.name, node);
       if (TS && node.optional) write(state, "?", CAT_QUESTION);
       if (TS && node.typeAnnotation != null) printTypeAnnotation(node.typeAnnotation, state);
       break;
@@ -142,7 +141,7 @@ export function printPropertyKey(key: ESTree.PropertyKey, state: State): void {
   switch (key.type) {
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, key.name, CAT_IDENT, key);
+      writeWithMapNamed(state, key.name, key);
       break;
     case "PrivateIdentifier":
       writeWithMapNamedPrivate(state, key.name, key);

--- a/packages/codegen/src-js/print/class.ts
+++ b/packages/codegen/src-js/print/class.ts
@@ -81,7 +81,7 @@ export function printClass(node: ESTree.Class, state: State): void {
 
   if (node.id != null) {
     write(state, " ", CAT_OTHER);
-    writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
+    writeWithMapNamed(state, node.id.name, node.id);
   }
 
   if (TS) printTypeParameters(node.typeParameters, state);

--- a/packages/codegen/src-js/print/expression.ts
+++ b/packages/codegen/src-js/print/expression.ts
@@ -98,7 +98,7 @@ export function printExpression(
   switch (node.type) {
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, node.name, CAT_IDENT, node);
+      writeWithMapNamed(state, node.name, node);
       break;
     case "MemberExpression":
       printMemberExpression(node, state, ctx);
@@ -295,7 +295,7 @@ export function printMemberExpression(
     if (property.type === "PrivateIdentifier") {
       writeWithMapNamedPrivate(state, property.name, property);
     } else {
-      writeWithMapNamed(state, property.name, CAT_IDENT, property);
+      writeWithMapNamed(state, property.name, property);
     }
   }
 }
@@ -529,7 +529,7 @@ function printObjectProperty(node: ESTree.ObjectPropertyKind, state: State): voi
   if (shorthand) {
     if (shorthandIdentifier !== null) {
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, shorthandIdentifier.name, CAT_IDENT, shorthandIdentifier);
+      writeWithMapNamed(state, shorthandIdentifier.name, shorthandIdentifier);
     } else {
       // `__proto__` shorthand, whose value can be anything. Print through any parens around it.
       printExpression(withoutParens(value), state, PREC_COMMA, CTX_NONE);

--- a/packages/codegen/src-js/print/function.ts
+++ b/packages/codegen/src-js/print/function.ts
@@ -56,7 +56,7 @@ export function printFunction(node: ESTree.Function, state: State): void {
 
   if (node.id != null) {
     printSpaceBeforeIdentifier(state);
-    writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
+    writeWithMapNamed(state, node.id.name, node.id);
   }
 
   if (TS) printTypeParameters(node.typeParameters, state);

--- a/packages/codegen/src-js/print/module.ts
+++ b/packages/codegen/src-js/print/module.ts
@@ -91,7 +91,7 @@ export function printImportDeclaration(node: ESTree.ImportDeclaration, state: St
         }
 
         write(state, "* as ", CAT_OTHER);
-        writeWithMapNamed(state, specifier.local.name, CAT_IDENT, specifier.local);
+        writeWithMapNamed(state, specifier.local.name, specifier.local);
         write(state, " ", CAT_OTHER);
         break;
       default: {
@@ -112,7 +112,7 @@ export function printImportDeclaration(node: ESTree.ImportDeclaration, state: St
         const { local } = specifier;
         if (importedName !== local.name) {
           write(state, " as ", CAT_OTHER);
-          writeWithMapNamed(state, local.name, CAT_IDENT, local);
+          writeWithMapNamed(state, local.name, local);
         }
         break;
       }
@@ -175,7 +175,7 @@ function printImportAttributes(
 function moduleExportName(node: ESTree.ModuleExportName, state: State): string {
   if (node.type === "Identifier") {
     printSpaceBeforeIdentifier(state);
-    writeWithMapNamed(state, node.name, CAT_IDENT, node);
+    writeWithMapNamed(state, node.name, node);
     return node.name;
   }
 

--- a/packages/codegen/src-js/print/statement.ts
+++ b/packages/codegen/src-js/print/statement.ts
@@ -189,7 +189,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
       writeWithMap(state, "break", CAT_IDENT, node);
       if (node.label != null) {
         write(state, " ", CAT_OTHER);
-        writeWithMapNamed(state, node.label.name, CAT_IDENT, node.label);
+        writeWithMapNamed(state, node.label.name, node.label);
       }
       write(state, ";\n", CAT_OTHER);
       break;
@@ -199,7 +199,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
       writeWithMap(state, "continue", CAT_IDENT, node);
       if (node.label != null) {
         write(state, " ", CAT_OTHER);
-        writeWithMapNamed(state, node.label.name, CAT_IDENT, node.label);
+        writeWithMapNamed(state, node.label.name, node.label);
       }
       write(state, ";\n", CAT_OTHER);
       break;
@@ -228,7 +228,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
       printIndent(state);
       printSpaceBeforeIdentifier(state);
       markMapStart(state, node);
-      writeWithMapNamed(state, node.label.name, CAT_IDENT, node.label);
+      writeWithMapNamed(state, node.label.name, node.label);
       write(state, ":", CAT_OTHER);
       printBody(node.body, state);
       break;
@@ -301,7 +301,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
     case "TSNamespaceExportDeclaration":
       printIndent(state);
       write(state, "export as namespace ", CAT_OTHER);
-      writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
+      writeWithMapNamed(state, node.id.name, node.id);
       write(state, ";\n", CAT_OTHER);
       break;
     /* END_IF */
@@ -361,7 +361,7 @@ export function printVariableDeclaration(
       // `let x!: T` - the `!` sits between the name and its annotation
       typeAssertIs<ESTree.BindingIdentifier>(id);
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, id.name, CAT_IDENT, id);
+      writeWithMapNamed(state, id.name, id);
       write(state, "!", CAT_OP_UN_NOT);
       if (id.typeAnnotation != null) {
         printTypeAnnotation(id.typeAnnotation, state);

--- a/packages/codegen/src-js/print/typescript.ts
+++ b/packages/codegen/src-js/print/typescript.ts
@@ -285,13 +285,13 @@ function printTSTypeName(
   if (node.type === "TSQualifiedName") {
     printTSTypeName(node.left, state);
     write(state, ".", CAT_OTHER);
-    writeWithMapNamed(state, node.right.name, CAT_IDENT, node.right);
+    writeWithMapNamed(state, node.right.name, node.right);
   } else if (node.type === "ThisExpression") {
     printSpaceBeforeIdentifier(state);
     writeWithMap(state, "this", CAT_IDENT, node);
   } else {
     printSpaceBeforeIdentifier(state);
-    writeWithMapNamed(state, node.name, CAT_IDENT, node);
+    writeWithMapNamed(state, node.name, node);
   }
 }
 
@@ -525,7 +525,7 @@ function printSignatureKey(key: ESTree.PropertyKey, state: State, ctx: number): 
   switch (key.type) {
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, key.name, CAT_IDENT, key);
+      writeWithMapNamed(state, key.name, key);
       break;
     case "PrivateIdentifier":
       writeWithMapNamedPrivate(state, key.name, key);
@@ -649,7 +649,7 @@ function printTSTypeParameter(node: ESTree.TSTypeParameter, state: State): void 
   if (node.in) writeNoLast(state, "in ");
   if (node.out) writeNoLast(state, "out ");
 
-  writeWithMapNamed(state, node.name.name, CAT_IDENT, node.name);
+  writeWithMapNamed(state, node.name.name, node.name);
 
   if (node.constraint != null) {
     write(state, " extends ", CAT_OTHER);
@@ -694,7 +694,7 @@ function printTSTupleElement(node: ESTree.TSTupleElement, state: State): void {
       printTSType(node.typeAnnotation, state);
       break;
     case "TSNamedTupleMember":
-      writeWithMapNamed(state, node.label.name, CAT_IDENT, node.label);
+      writeWithMapNamed(state, node.label.name, node.label);
       if (node.optional) write(state, "?", CAT_QUESTION);
       write(state, ": ", CAT_OTHER);
       printTSType(node.elementType, state);
@@ -820,7 +820,7 @@ function printTSTypePredicate(node: ESTree.TSTypePredicate, state: State): void 
     write(state, "this", CAT_IDENT);
   } else {
     printSpaceBeforeIdentifier(state);
-    writeWithMapNamed(state, parameterName.name, CAT_IDENT, parameterName);
+    writeWithMapNamed(state, parameterName.name, parameterName);
   }
 
   if (node.typeAnnotation != null) {
@@ -992,7 +992,7 @@ export function printTSInterfaceDeclaration(
 
   write(state, "interface ", CAT_OTHER);
 
-  writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
+  writeWithMapNamed(state, node.id.name, node.id);
 
   printTypeParameters(node.typeParameters, state);
 
@@ -1046,7 +1046,7 @@ export function printTSTypeAliasDeclaration(
 
   write(state, "type ", CAT_OTHER);
 
-  writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
+  writeWithMapNamed(state, node.id.name, node.id);
 
   printTypeParameters(node.typeParameters, state);
 
@@ -1111,7 +1111,7 @@ export function printTSEnumDeclaration(node: ESTree.TSEnumDeclaration, state: St
 
   write(state, "enum ", CAT_OTHER);
 
-  writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
+  writeWithMapNamed(state, node.id.name, node.id);
 
   write(state, " ", CAT_OTHER);
 
@@ -1148,7 +1148,7 @@ function printTSEnumMember(node: ESTree.TSEnumMember, state: State): void {
   const { id } = node;
   if (id.type === "Identifier") {
     printSpaceBeforeIdentifier(state);
-    writeWithMapNamed(state, id.name, CAT_IDENT, id);
+    writeWithMapNamed(state, id.name, id);
   } else if (id.type === "Literal") {
     printString(state, id.value, id);
   } else {
@@ -1184,7 +1184,7 @@ export function printTSImportEqualsDeclaration(
 
   if (node.importKind === "type") write(state, "type ", CAT_OTHER);
 
-  writeWithMapNamed(state, node.id.name, CAT_IDENT, node.id);
+  writeWithMapNamed(state, node.id.name, node.id);
 
   write(state, " = ", CAT_OTHER);
 

--- a/packages/codegen/src-js/print/write.ts
+++ b/packages/codegen/src-js/print/write.ts
@@ -252,6 +252,28 @@ export function write(state: State, code: string, last: Category): void {
 }
 
 /**
+ * Append `name` to the output, and record what it ends with as `CAT_IDENT`.
+ *
+ * The plain form of `writeWithMapNamed`.
+ * Nothing calls it directly - the TSDown plugin rewrites the mapped calls to it for builds without source map support.
+ *
+ * @param state - Printer state
+ * @param name - The identifier's name, never empty
+ */
+export function writeIdent(state: State, name: string): void {
+  debugAssert(name.length > 0, "`name` should not be an empty string");
+  debugAssertCategoryMatches(state, name, CAT_IDENT);
+
+  state.last = CAT_IDENT;
+  state.output += name;
+
+  if (DEBUG) {
+    state.lastIsStale = false;
+    state.lastCharWritten = name[name.length - 1];
+  }
+}
+
+/**
  * Append a private identifier - `#` and `name` - to the output, and record what it ends with.
  *
  * The plain form of `writeWithMapNamedPrivate`.
@@ -314,27 +336,23 @@ export function writeWithMap(
  *
  * The mapping is only recorded where the caller asked for source maps and `node` carries `start` / `end` offsets.
  *
+ * `last` is always `CAT_IDENT`, since a name ends in an identifier character, so the caller does not pass it.
+ *
  * Builds without source map support have no use for this. For those builds, TSDown plugin rewrites every call
- * into `write` and drops the `node` argument, leaving this unreferenced for the minifier to remove.
+ * into `writeIdent` and drops the `node` argument, leaving this unreferenced for the minifier to remove.
  *
  * @param state - Printer state
  * @param name - Name to append, never empty
- * @param last - Category of the last character of `name`
  * @param node - Node this text came from
  */
-export function writeWithMapNamed(
-  state: State,
-  name: string,
-  last: Category,
-  node: IdentMappableNode,
-): void {
+export function writeWithMapNamed(state: State, name: string, node: IdentMappableNode): void {
   debugAssert(name.length > 0, "`name` should not be an empty string");
-  debugAssertCategoryMatches(state, name, last);
+  debugAssertCategoryMatches(state, name, CAT_IDENT);
   debugAssertNameMatches(node, name);
 
   markMapNamed(state, name, false, 0, node);
 
-  state.last = last;
+  state.last = CAT_IDENT;
   state.output += name;
 
   if (DEBUG) {

--- a/packages/codegen/tsdown_plugins/unmap_writes.ts
+++ b/packages/codegen/tsdown_plugins/unmap_writes.ts
@@ -36,7 +36,7 @@ import type { Plugin } from "rolldown";
 const REWRITES = {
   // `write` takes the `last` category between the code and the node, `writeNoLast` does not
   writeWithMap: { arity: 4, remove: 1, rename: "write" },
-  writeWithMapNamed: { arity: 4, remove: 1, rename: "write" },
+  writeWithMapNamed: { arity: 3, remove: 1, rename: "writeIdent" },
   writeWithMapNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },
   writeWithMapNamedNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },
   writeWithMapNamedJSXNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },


### PR DESCRIPTION
Optimization to sourcemap and no-sourcemap builds.

`writeWithMapNamed` now always receives an `Identifier`, so all call sites pass `last` as `CAT_IDENT`. Remove the param and just write `state.last = CAT_IDENT` directly. This avoids using a register to pass a value which is always the same, and makes setting `last` cheaper too.

Add a new `writeIdent` function which `writeWithMapNamed` is converted to in no-sourcemap builds, which also doesn't have a `last` param.