### PR TITLE
perf(packages/codegen): replace `write` calls with `writeIdent`

### DIFF
--- a/packages/codegen/DESIGN.md
+++ b/packages/codegen/DESIGN.md
@@ -279,9 +279,11 @@ only the last piece's category can possibly be read. Hence eleven write primitiv
   a JSX identifier may hold a `-`, and a private identifier's span covers a `#` which is not part of its name.
   Which one applies is settled at the call site, where the node's type is known statically, rather than read back
   off a `node` which is megamorphic by the time it arrives.
-- `writeWithMapNamed` and `writeWithMapNamedPrivate` take no category, because a name ends in an identifier
-  character and so `last` is always `CAT_IDENT`. The private form writes its own `#`, so what it takes is
-  the name which follows it. That is why their plain forms are `writeIdent` and `writePrivate`, not `write`.
+- `writeIdent` is `write` with the category fixed at `CAT_IDENT` - an identifier, a keyword, or the trailing digits
+  of a number. It is the commonest category by far, so every call which passed it was spending an argument
+  on a value which could never be anything else.
+- `writeWithMapNamed` and `writeWithMapNamedPrivate` take no category for the same reason, which is why their
+  plain forms are `writeIdent` and `writePrivate` rather than `write`.
 - The two `Private` forms write the `#` themselves, so the name they are given is what follows it,
   and `last` is always `CAT_IDENT` - the caller passes neither.
 - The three `markMap*` functions record a mapping without writing anything, so `last` is not theirs to update.
@@ -386,8 +388,8 @@ A plugin silently doing nothing is a failure mode worth guarding against.
 Rewrites every mapped write into the plain one it becomes with no mapping to record - so
 `writeWithMap(state, code, cat, node)` turns into `write(state, code, cat)` - and rewrites the import to match.
 `writeWithMapEnd` becomes `write` too, and every `NoLast` form becomes `writeNoLast`.
-`writeWithMapNamed` and `writeWithMapNamedPrivate` become `writeIdent` and `writePrivate` -
-the two plain forms nothing calls directly, which exist only for these rewrites to land on.
+`writeWithMapNamed` and `writeWithMapNamedPrivate` become `writeIdent` and `writePrivate`, which fix the category
+instead of taking it. `writePrivate` exists only for the rewrite to land on.
 
 `printString` and `printNonNegativeFloat` take a node only to hand on to a mapped write. They keep their names,
 but the argument comes off every call, and the parameter off their declarations - which, unlike the mapped writes,

--- a/packages/codegen/src-js/print/class.ts
+++ b/packages/codegen/src-js/print/class.ts
@@ -12,6 +12,7 @@ import {
   debugAssertLastFresh,
   markMapStart,
   write,
+  writeIdent,
   writeNoLast,
   writeWithMap,
   writeWithMapEnd,
@@ -74,7 +75,7 @@ export function printClass(node: ESTree.Class, state: State): void {
     }
   }
   if (declare || abstract) {
-    write(state, "class", CAT_IDENT);
+    writeIdent(state, "class");
   } else {
     writeWithMap(state, "class", CAT_IDENT, node);
   }
@@ -411,7 +412,7 @@ function printAccessorProperty(node: AccessorPropertyNode, state: State): void {
   }
 
   printSpaceBeforeIdentifier(state);
-  write(state, "accessor", CAT_IDENT);
+  writeIdent(state, "accessor");
 
   if (node.computed) {
     write(state, " [", CAT_OTHER);

--- a/packages/codegen/src-js/print/expression.ts
+++ b/packages/codegen/src-js/print/expression.ts
@@ -20,6 +20,7 @@ import {
   markMapAtStartOffset,
   markMapStart,
   write,
+  writeIdent,
   writeNoLast,
   writeWithMap,
   writeWithMapEnd,
@@ -184,7 +185,7 @@ export function printExpression(
       printSpaceBeforeIdentifier(state);
       writeWithMapNoLast(state, node.meta.name, node);
       writeNoLast(state, ".");
-      write(state, node.property.name, CAT_IDENT);
+      writeIdent(state, node.property.name);
       break;
     case "ChainExpression":
       printChainExpression(node, state, precedence, ctx);
@@ -949,7 +950,7 @@ function printImportExpression(
 
   if (node.phase != null) {
     writeNoLast(state, ".");
-    write(state, node.phase, CAT_IDENT);
+    writeIdent(state, node.phase);
   }
 
   write(state, "(", CAT_OTHER);

--- a/packages/codegen/src-js/print/function.ts
+++ b/packages/codegen/src-js/print/function.ts
@@ -10,6 +10,7 @@ import {
   debugAssertLastFresh,
   markMapStart,
   write,
+  writeIdent,
   writeNoLast,
   writeWithMap,
   writeWithMapEnd,
@@ -47,7 +48,7 @@ export function printFunction(node: ESTree.Function, state: State): void {
   const declare = TS && node.declare;
   if (declare) {
     writeWithMap(state, "declare ", CAT_OTHER, node);
-    write(state, node.async ? "async function" : "function", CAT_IDENT);
+    writeIdent(state, node.async ? "async function" : "function");
   } else {
     writeWithMap(state, node.async ? "async function" : "function", CAT_IDENT, node);
   }
@@ -106,7 +107,7 @@ function printParams(params: ESTree.ParamPattern[], state: State): void {
     // Oxc stores TypeScript's special `this` parameter separately from formal parameters
     // and prints it without a source mapping.
     if (TS && param.type === "Identifier" && param.name === "this") {
-      write(state, "this", CAT_IDENT);
+      writeIdent(state, "this");
       if (param.typeAnnotation != null) printTypeAnnotation(param.typeAnnotation, state);
       continue;
     }

--- a/packages/codegen/src-js/print/literal.ts
+++ b/packages/codegen/src-js/print/literal.ts
@@ -9,6 +9,7 @@ import {
   CAT_OTHER,
   CAT_REGEX_SLASH,
   write,
+  writeIdent,
   writeNoLast,
   writeWithMap,
   writeWithMapNoLast,
@@ -179,7 +180,7 @@ function printRegExpLiteral(node: ESTree.RegExpLiteral, state: State): void {
     write(state, "/", CAT_REGEX_SLASH);
   } else {
     writeNoLast(state, "/");
-    write(state, flags, CAT_IDENT);
+    writeIdent(state, flags);
   }
 }
 
@@ -197,6 +198,6 @@ function printBigIntLiteral(node: ESTree.BigIntLiteral, state: State, precedence
     write(state, "n)", CAT_CLOSE_BRACKET);
   } else {
     writeWithMapNoLast(state, value, node);
-    write(state, "n", CAT_IDENT);
+    writeIdent(state, "n");
   }
 }

--- a/packages/codegen/src-js/print/module.ts
+++ b/packages/codegen/src-js/print/module.ts
@@ -5,6 +5,7 @@ import {
   CAT_OTHER,
   CAT_START_OF_DEFAULT_EXPORT,
   write,
+  writeIdent,
   writeNoLast,
   writeWithMap,
   writeWithMapNamed,
@@ -42,11 +43,11 @@ export function printImportDeclaration(node: ESTree.ImportDeclaration, state: St
   printSpaceBeforeIdentifier(state);
   writeWithMap(state, "import", CAT_IDENT, node);
 
-  if (TS && node.importKind === "type") write(state, " type", CAT_IDENT);
+  if (TS && node.importKind === "type") writeIdent(state, " type");
 
   if (node.phase != null) {
     writeNoLast(state, " ");
-    write(state, node.phase, CAT_IDENT);
+    writeIdent(state, node.phase);
   }
 
   const { specifiers } = node;
@@ -151,7 +152,7 @@ function printImportAttributes(
     const attribute = attributes[i];
     const { key } = attribute;
     if (key.type === "Identifier") {
-      write(state, key.name, CAT_IDENT);
+      writeIdent(state, key.name);
     } else {
       printString(state, key.value, key);
     }

--- a/packages/codegen/src-js/print/number.ts
+++ b/packages/codegen/src-js/print/number.ts
@@ -9,7 +9,7 @@
 // Each form is written to the output in pieces, so no candidate string is ever built.
 
 import { debugAssert } from "../asserts.ts";
-import { CAT_IDENT, CAT_INT_DIGIT, markMapStart, write, writeNoLast } from "./write.ts";
+import { CAT_INT_DIGIT, markMapStart, write, writeIdent, writeNoLast } from "./write.ts";
 
 import type { State } from "../state.ts";
 import type * as ESTree from "../../../../npm/oxc-types/types.d.ts";
@@ -69,7 +69,7 @@ function printShortestInteger(state: State, value: number): void {
     if (exponent.length + 1 < zeros) {
       writeNoLast(state, formatted.slice(0, length - zeros));
       writeNoLast(state, "e");
-      write(state, exponent, CAT_IDENT);
+      writeIdent(state, exponent);
       return;
     }
   }
@@ -114,18 +114,18 @@ function printShortestFraction(state: State, value: number): void {
       if (exponent.length + 2 < start - 1) {
         writeNoLast(state, formatted.slice(start));
         writeNoLast(state, "e-");
-        write(state, exponent, CAT_IDENT);
+        writeIdent(state, exponent);
         return;
       }
     }
 
-    write(state, formatted.slice(1), CAT_IDENT);
+    writeIdent(state, formatted.slice(1));
     return;
   }
 
   const exponentIndex = formatted.indexOf("e");
   if (exponentIndex === -1) {
-    write(state, formatted, CAT_IDENT);
+    writeIdent(state, formatted);
     return;
   }
 
@@ -160,13 +160,13 @@ function printExponent(state: State, formatted: string, exponentIndex: number): 
       writeNoLast(state, formatted[0]);
       writeNoLast(state, formatted.slice(2, exponentIndex));
       writeNoLast(state, "e");
-      write(state, folded, CAT_IDENT);
+      writeIdent(state, folded);
       return;
     }
   }
 
   writeNoLast(state, formatted.slice(0, exponentIndex + 1));
-  write(state, exponent, CAT_IDENT);
+  writeIdent(state, exponent);
 }
 
 /**
@@ -191,7 +191,7 @@ function printHexIfShorter(state: State, value: number, length: number): boolean
   if (hex.length + 2 >= length) return false;
 
   writeNoLast(state, "0x");
-  write(state, hex, CAT_IDENT);
+  writeIdent(state, hex);
 
   return true;
 }

--- a/packages/codegen/src-js/print/statement.ts
+++ b/packages/codegen/src-js/print/statement.ts
@@ -11,6 +11,7 @@ import {
   CAT_START_OF_STMT,
   markMapStart,
   write,
+  writeIdent,
   writeNoLast,
   writeWithMap,
   writeWithMapEnd,
@@ -343,7 +344,7 @@ export function printVariableDeclaration(
   const declare = TS && node.declare;
   if (declare) {
     writeWithMap(state, "declare ", CAT_OTHER, node);
-    write(state, node.kind, CAT_IDENT);
+    writeIdent(state, node.kind);
   } else {
     writeWithMap(state, node.kind, CAT_IDENT, node);
   }
@@ -442,7 +443,7 @@ function printIf(node: ESTree.IfStatement, state: State): void {
   if (alternate != null) {
     printSpaceBeforeIdentifier(state);
 
-    write(state, "else", CAT_IDENT);
+    writeIdent(state, "else");
 
     if (alternate.type === "BlockStatement") {
       write(state, " ", CAT_OTHER);
@@ -517,7 +518,7 @@ function printTryStatement(node: ESTree.TryStatement, state: State): void {
 
   const { handler } = node;
   if (handler != null) {
-    write(state, " catch", CAT_IDENT);
+    writeIdent(state, " catch");
 
     if (handler.param != null) {
       write(state, " (", CAT_OTHER);
@@ -730,7 +731,7 @@ function printForOfStatement(node: ESTree.ForOfStatement, state: State): void {
 
   writeWithMap(state, "for", CAT_IDENT, node);
 
-  if (node.await) write(state, " await", CAT_IDENT);
+  if (node.await) writeIdent(state, " await");
 
   write(state, " (", CAT_OTHER);
 

--- a/packages/codegen/src-js/print/typescript.ts
+++ b/packages/codegen/src-js/print/typescript.ts
@@ -11,6 +11,7 @@ import {
   debugAssertLastFresh,
   markMapAtStartOffset,
   write,
+  writeIdent,
   writeNoLast,
   writeWithMap,
   writeWithMapEnd,
@@ -84,59 +85,59 @@ function printTSType(
       break;
     case "TSStringKeyword":
       printSpaceBeforeIdentifier(state);
-      write(state, "string", CAT_IDENT);
+      writeIdent(state, "string");
       break;
     case "TSNumberKeyword":
       printSpaceBeforeIdentifier(state);
-      write(state, "number", CAT_IDENT);
+      writeIdent(state, "number");
       break;
     case "TSBooleanKeyword":
       printSpaceBeforeIdentifier(state);
-      write(state, "boolean", CAT_IDENT);
+      writeIdent(state, "boolean");
       break;
     case "TSAnyKeyword":
       printSpaceBeforeIdentifier(state);
-      write(state, "any", CAT_IDENT);
+      writeIdent(state, "any");
       break;
     case "TSVoidKeyword":
       printSpaceBeforeIdentifier(state);
-      write(state, "void", CAT_IDENT);
+      writeIdent(state, "void");
       break;
     case "TSUnknownKeyword":
       printSpaceBeforeIdentifier(state);
-      write(state, "unknown", CAT_IDENT);
+      writeIdent(state, "unknown");
       break;
     case "TSNeverKeyword":
       printSpaceBeforeIdentifier(state);
-      write(state, "never", CAT_IDENT);
+      writeIdent(state, "never");
       break;
     case "TSUndefinedKeyword":
       printSpaceBeforeIdentifier(state);
-      write(state, "undefined", CAT_IDENT);
+      writeIdent(state, "undefined");
       break;
     case "TSNullKeyword":
       printSpaceBeforeIdentifier(state);
-      write(state, "null", CAT_IDENT);
+      writeIdent(state, "null");
       break;
     case "TSObjectKeyword":
       printSpaceBeforeIdentifier(state);
-      write(state, "object", CAT_IDENT);
+      writeIdent(state, "object");
       break;
     case "TSSymbolKeyword":
       printSpaceBeforeIdentifier(state);
-      write(state, "symbol", CAT_IDENT);
+      writeIdent(state, "symbol");
       break;
     case "TSBigIntKeyword":
       printSpaceBeforeIdentifier(state);
-      write(state, "bigint", CAT_IDENT);
+      writeIdent(state, "bigint");
       break;
     case "TSIntrinsicKeyword":
       printSpaceBeforeIdentifier(state);
-      write(state, "intrinsic", CAT_IDENT);
+      writeIdent(state, "intrinsic");
       break;
     case "TSThisType":
       printSpaceBeforeIdentifier(state);
-      write(state, "this", CAT_IDENT);
+      writeIdent(state, "this");
       break;
     case "TSLiteralType":
       printTSLiteral(node.literal, state);
@@ -245,7 +246,7 @@ function printTSType(
       break;
     case "TSJSDocUnknownType":
       printSpaceBeforeIdentifier(state);
-      write(state, "unknown", CAT_IDENT);
+      writeIdent(state, "unknown");
       break;
     case "TSJSDocNullableType":
       if (node.postfix) {
@@ -575,7 +576,7 @@ export function printTSIndexSignature(node: ESTree.TSIndexSignature, state: Stat
   write(state, "[", CAT_OTHER);
 
   const parameter = node.parameters[0];
-  write(state, parameter.name, CAT_IDENT);
+  writeIdent(state, parameter.name);
 
   write(state, ": ", CAT_OTHER);
 
@@ -790,7 +791,7 @@ function printTSMappedType(node: ESTree.TSMappedType, state: State): void {
  * bind to only part of it.
  */
 function printTSTypeOperator(node: ESTree.TSTypeOperator, state: State): void {
-  write(state, node.operator, CAT_IDENT);
+  writeIdent(state, node.operator);
 
   write(state, " ", CAT_OTHER);
 
@@ -817,7 +818,7 @@ function printTSTypePredicate(node: ESTree.TSTypePredicate, state: State): void 
 
   const { parameterName } = node;
   if (parameterName.type === "TSThisType") {
-    write(state, "this", CAT_IDENT);
+    writeIdent(state, "this");
   } else {
     printSpaceBeforeIdentifier(state);
     writeWithMapNamed(state, parameterName.name, parameterName);
@@ -879,9 +880,9 @@ function printTSImportTypeQualifier(node: ESTree.TSImportTypeQualifier, state: S
   if (node.type === "TSQualifiedName") {
     printTSImportTypeQualifier(node.left, state);
     write(state, ".", CAT_OTHER);
-    write(state, node.right.name, CAT_IDENT);
+    writeIdent(state, node.right.name);
   } else {
-    write(state, node.name, CAT_IDENT);
+    writeIdent(state, node.name);
   }
 }
 
@@ -929,7 +930,7 @@ export function printTSModuleDeclaration(
   if (node.declare) write(state, "declare ", CAT_OTHER);
 
   const { kind } = node;
-  write(state, kind, CAT_IDENT);
+  writeIdent(state, kind);
 
   if (kind !== "global") {
     write(state, " ", CAT_OTHER);

--- a/packages/codegen/src-js/print/write.ts
+++ b/packages/codegen/src-js/print/write.ts
@@ -252,24 +252,25 @@ export function write(state: State, code: string, last: Category): void {
 }
 
 /**
- * Append `name` to the output, and record what it ends with as `CAT_IDENT`.
+ * Append `name` to the output, and record what it ends with as `CAT_IDENT` -
+ * an identifier, a keyword, or the trailing digits of a number.
  *
- * The plain form of `writeWithMapNamed`.
- * Nothing calls it directly - the TSDown plugin rewrites the mapped calls to it for builds without source map support.
+ * This is `write` with the category fixed. `CAT_IDENT` one of the most common categories,
+ * so passing it at every call site is an argument spent on a value which is never anything else.
  *
  * @param state - Printer state
- * @param name - The identifier's name, never empty
+ * @param code - Text to append, never empty
  */
-export function writeIdent(state: State, name: string): void {
-  debugAssert(name.length > 0, "`name` should not be an empty string");
-  debugAssertCategoryMatches(state, name, CAT_IDENT);
+export function writeIdent(state: State, code: string): void {
+  debugAssert(code.length > 0, "`code` should not be an empty string");
+  debugAssertCategoryMatches(state, code, CAT_IDENT);
 
   state.last = CAT_IDENT;
-  state.output += name;
+  state.output += code;
 
   if (DEBUG) {
     state.lastIsStale = false;
-    state.lastCharWritten = name[name.length - 1];
+    state.lastCharWritten = code[code.length - 1];
   }
 }
 


### PR DESCRIPTION
Optimization to sourcemap and no-sourcemap builds.

#25983 introduced a `writeIdent` function. Use it everywhere which was previously calling `write` with `CAT_IDENT`. This has the same advantages as #25983 - avoids using a register just to pass a static value, and makes setting `last` cheaper in this hot path.