### PR TITLE
refactor(packages/codegen): re-order params of `markMapAtStartOffset`

### DIFF
--- a/packages/codegen/src-js/print/expression.ts
+++ b/packages/codegen/src-js/print/expression.ts
@@ -864,7 +864,7 @@ function printTemplateLiteral(node: ESTree.TemplateLiteral, state: State): void 
     const raw = templateQuasiRaw(quasi);
     // A TS-shaped Oxc ESTree quasi includes the substitution's closing `}` in its span.
     // The JS-shaped ESTree quasi and Oxc's Rust AST both start at the raw template text.
-    if (raw.length > 0) markMapAtStartOffset(state, quasi, TS ? 1 : 0);
+    if (raw.length > 0) markMapAtStartOffset(state, TS ? 1 : 0, quasi);
     writeNoLast(state, raw);
   }
 

--- a/packages/codegen/src-js/print/typescript.ts
+++ b/packages/codegen/src-js/print/typescript.ts
@@ -1155,7 +1155,7 @@ function printTSEnumMember(node: ESTree.TSEnumMember, state: State): void {
   } else {
     // Computed string/template member name
     if (id.type === "TemplateLiteral") {
-      markMapAtStartOffset(state, id.quasis[0], 1);
+      markMapAtStartOffset(state, 1, id.quasis[0]);
       writeNoLast(state, "[`");
       writeNoLast(state, id.quasis[0].value.raw);
       write(state, "`", CAT_OTHER);

--- a/packages/codegen/src-js/print/write.ts
+++ b/packages/codegen/src-js/print/write.ts
@@ -576,10 +576,10 @@ export function markMapAfter(state: State, node: MappableNode): void {
  * Builds without source map support have no use for this. In those builds, minifier removes it.
  *
  * @param state - Printer state
- * @param node - Node the mapping points into
  * @param columnOffset - Number of UTF-16 units to add to `node`'s start offset
+ * @param node - Node the mapping points into
  */
-export function markMapAtStartOffset(state: State, node: MappableNode, columnOffset: number): void {
+export function markMapAtStartOffset(state: State, columnOffset: number, node: MappableNode): void {
   if (SOURCEMAPS && hasMappableSpan(node)) recordMapping(state, node.start + columnOffset);
 }
 


### PR DESCRIPTION
Pure refactor. Just re-order `markMapAtStartOffset`'s params, so `node` is last, matching all the other functions.