### PR TITLE
perf(packages/codegen): pass `start` and `end` to `write` and `mark` functions

### DIFF
--- a/packages/codegen/DESIGN.md
+++ b/packages/codegen/DESIGN.md
@@ -271,6 +271,12 @@ only the last piece's category can possibly be read. Hence eleven write primitiv
 | `writeWithMapNamedNoLast`    | No             | At the node's start, with name |
 | `writeWithMapNamedJSXNoLast` | No             | At the node's start, with name |
 
+- Every `writeWithMap*` and `markMap*` function takes the node's `start` and `end` offsets, extracted by the caller.
+  The node itself is still passed, last, but only debug asserts read it - which is what checks the offsets
+  against the node they claim to describe. The point is where the read happens - in a caller the node's type is known,
+  so `node.start` is a monomorphic load, whereas inside the write functions the same read is megamorphic,
+  because the printer reaches them from every node type there is. Release builds have the parameter and every argument
+  removed by the TSDown plugin.
 - The `*Named` functions record the name the node had in the source, and take a `NamedMappableNode`,
   which covers nodes with a string `name`. What they record is the text they print -
   debug builds assert the two are the same string.
@@ -386,16 +392,17 @@ A plugin silently doing nothing is a failure mode worth guarding against.
 #### `unmap_writes`
 
 Rewrites every mapped write into the plain one it becomes with no mapping to record - so
-`writeWithMap(state, code, cat, node)` turns into `write(state, code, cat)` - and rewrites the import to match.
+`writeWithMap(state, code, cat, node.start, node.end, node)` turns into `write(state, code, cat)` -
+and rewrites the import to match.
 `writeWithMapEnd` becomes `write` too, and every `NoLast` form becomes `writeNoLast`.
 `writeWithMapNamed` and `writeWithMapNamedPrivate` become `writeIdent` and `writePrivate`, which fix the category
 instead of taking it. `writePrivate` exists only for the rewrite to land on.
 
-`printString` and `printNonNegativeFloat` take a node only to hand on to a mapped write. They keep their names,
-but the argument comes off every call, and the parameter off their declarations - which, unlike the mapped writes,
-survive into the build.
+`printString` and `printNonNegativeFloat` take the offsets and the node only to hand them on to a mapped write.
+They keep their names, but the arguments come off every call, and the parameters off their declarations -
+which, unlike the mapped writes, survive into the build.
 
-Without it, the node argument would still be evaluated and held live across a call which ignores it.
+Without it, the offsets would still be read and held live across a call which ignores them.
 
 The three `markMap*` calls write nothing, so they have no plain form to become, and keep their names -
 the arguments come off, and a body which opens `if (!SOURCEMAPS) return` lets the minifier remove what is left.

--- a/packages/codegen/src-js/print/assignment_target.ts
+++ b/packages/codegen/src-js/print/assignment_target.ts
@@ -23,7 +23,7 @@ export function printAssignmentTarget(node: ESTree.AssignmentTarget, state: Stat
     // For speed, the two common ones are printed here instead of through the expression printer's own dispatch.
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, node.name, node);
+      writeWithMapNamed(state, node.name, node.start, node.end, node);
       break;
     case "MemberExpression":
       printMemberExpression(node, state, CTX_NONE);
@@ -53,7 +53,7 @@ export function printAssignmentTarget(node: ESTree.AssignmentTarget, state: Stat
  * Print an object destructuring target, as in `({ a, b: c } = obj)`.
  */
 function printObjectAssignmentTarget(node: ESTree.ObjectAssignmentTarget, state: State): void {
-  writeWithMap(state, "{", CAT_OTHER, node);
+  writeWithMap(state, "{", CAT_OTHER, node.start, node.end, node);
 
   const { properties } = node;
   const { length } = properties;
@@ -62,7 +62,7 @@ function printObjectAssignmentTarget(node: ESTree.ObjectAssignmentTarget, state:
 
     const property = properties[i];
     if (property.type === "RestElement") {
-      writeWithMap(state, "...", CAT_OTHER, property);
+      writeWithMap(state, "...", CAT_OTHER, property.start, property.end, property);
       printAssignmentTarget(property.argument, state);
     } else {
       printAssignmentTargetProperty(property, state);
@@ -83,12 +83,12 @@ function printAssignmentTargetProperty(node: ESTree.AssignmentTargetProperty, st
     if (value.type === "AssignmentPattern") {
       typeAssertIs<ESTree.IdentifierReference>(value.left);
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, value.left.name, value.left);
+      writeWithMapNamed(state, value.left.name, value.left.start, value.left.end, value.left);
       write(state, " = ", CAT_OTHER);
       printExpression(value.right, state, PREC_COMMA, CTX_NONE);
     } else {
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, value.name, value);
+      writeWithMapNamed(state, value.name, value.start, value.end, value);
     }
   } else {
     const { key } = node;
@@ -139,7 +139,7 @@ function printArrayAssignmentTarget(node: ESTree.ArrayAssignmentTarget, state: S
     }
   }
 
-  writeWithMap(state, "[", CAT_OTHER, node);
+  writeWithMap(state, "[", CAT_OTHER, node.start, node.end, node);
 
   for (let i = 0; i < length; i++) {
     if (i !== 0) write(state, ", ", CAT_OTHER);
@@ -155,7 +155,7 @@ function printArrayAssignmentTarget(node: ESTree.ArrayAssignmentTarget, state: S
 
   if (rest !== null) {
     if (length > 0) write(state, " ", CAT_OTHER);
-    writeWithMap(state, "...", CAT_OTHER, rest);
+    writeWithMap(state, "...", CAT_OTHER, rest.start, rest.end, rest);
     printAssignmentTarget(rest.argument, state);
   }
 

--- a/packages/codegen/src-js/print/binding_pattern.ts
+++ b/packages/codegen/src-js/print/binding_pattern.ts
@@ -39,7 +39,7 @@ export function printBindingPattern(node: BindingPatternNode | UnknownNode, stat
   switch (node.type) {
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, node.name, node);
+      writeWithMapNamed(state, node.name, node.start, node.end, node);
       if (TS && node.optional) write(state, "?", CAT_QUESTION);
       if (TS && node.typeAnnotation != null) printTypeAnnotation(node.typeAnnotation, state);
       break;
@@ -59,7 +59,7 @@ export function printBindingPattern(node: BindingPatternNode | UnknownNode, stat
       printExpression(node.right, state, PREC_COMMA, CTX_NONE);
       break;
     case "RestElement":
-      writeWithMap(state, "...", CAT_OTHER, node);
+      writeWithMap(state, "...", CAT_OTHER, node.start, node.end, node);
       printBindingPattern(node.argument, state);
       if (TS && node.typeAnnotation != null) printTypeAnnotation(node.typeAnnotation, state);
       break;
@@ -76,17 +76,17 @@ function printObjectBindingPattern(node: ESTree.ObjectPattern, state: State): vo
   const { length } = properties;
 
   if (length === 0) {
-    writeWithMap(state, "{}", CAT_OTHER, node);
+    writeWithMap(state, "{}", CAT_OTHER, node.start, node.end, node);
     return;
   }
 
-  writeWithMap(state, "{ ", CAT_OTHER, node);
+  writeWithMap(state, "{ ", CAT_OTHER, node.start, node.end, node);
 
   for (let i = 0; i < length; i++) {
     if (i > 0) write(state, ", ", CAT_OTHER);
     const property = properties[i];
     if (property.type === "RestElement") {
-      writeWithMap(state, "...", CAT_OTHER, property);
+      writeWithMap(state, "...", CAT_OTHER, property.start, property.end, property);
       printBindingPattern(property.argument, state);
     } else {
       printBindingProperty(property, state);
@@ -141,14 +141,14 @@ export function printPropertyKey(key: ESTree.PropertyKey, state: State): void {
   switch (key.type) {
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, key.name, key);
+      writeWithMapNamed(state, key.name, key.start, key.end, key);
       break;
     case "PrivateIdentifier":
-      writeWithMapNamedPrivate(state, key.name, key);
+      writeWithMapNamedPrivate(state, key.name, key.start, key.end, key);
       break;
     case "Literal":
       if (typeof key.value === "string") {
-        printString(state, key.value, key);
+        printString(state, key.value, key.start, key.end, key);
       } else {
         printLiteral(key, state, PREC_COMMA, CTX_NONE);
       }
@@ -176,7 +176,7 @@ function printArrayBindingPattern(node: ESTree.ArrayPattern, state: State): void
     }
   }
 
-  writeWithMap(state, "[", CAT_OTHER, node);
+  writeWithMap(state, "[", CAT_OTHER, node.start, node.end, node);
 
   for (let i = 0; i < length; i++) {
     if (i !== 0) write(state, ", ", CAT_OTHER);

--- a/packages/codegen/src-js/print/class.ts
+++ b/packages/codegen/src-js/print/class.ts
@@ -66,23 +66,23 @@ export function printClass(node: ESTree.Class, state: State): void {
   const abstract = TS && node.abstract;
 
   // The node's mapping goes on whichever of these is written first
-  if (declare) writeWithMap(state, "declare ", CAT_OTHER, node);
+  if (declare) writeWithMap(state, "declare ", CAT_OTHER, node.start, node.end, node);
   if (abstract) {
     if (declare) {
       write(state, "abstract ", CAT_OTHER);
     } else {
-      writeWithMap(state, "abstract ", CAT_OTHER, node);
+      writeWithMap(state, "abstract ", CAT_OTHER, node.start, node.end, node);
     }
   }
   if (declare || abstract) {
     writeIdent(state, "class");
   } else {
-    writeWithMap(state, "class", CAT_IDENT, node);
+    writeWithMap(state, "class", CAT_IDENT, node.start, node.end, node);
   }
 
   if (node.id != null) {
     write(state, " ", CAT_OTHER);
-    writeWithMapNamed(state, node.id.name, node.id);
+    writeWithMapNamed(state, node.id.name, node.id.start, node.id.end, node.id);
   }
 
   if (TS) printTypeParameters(node.typeParameters, state);
@@ -121,7 +121,7 @@ export function printDecorators(decorators: ESTree.Decorator[], state: State): v
   for (let i = 0; i < length; i++) {
     const decorator = decorators[i];
 
-    writeWithMap(state, "@", CAT_OTHER, decorator);
+    writeWithMap(state, "@", CAT_OTHER, decorator.start, decorator.end, decorator);
 
     const { expression } = decorator;
     const wrap = decoratorNeedsWrap(expression);
@@ -163,12 +163,12 @@ function printClassBody(node: ClassBodyNode, state: State): void {
   const { body } = node;
   const { length } = body;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", node);
-    writeWithMapEnd(state, "}", CAT_OTHER, node);
+    writeWithMapNoLast(state, "{", node.start, node.end, node);
+    writeWithMapEnd(state, "}", CAT_OTHER, node.start, node.end, node);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, node);
+  writeWithMap(state, "{\n", CAT_OTHER, node.start, node.end, node);
 
   state.indentLevel++;
 
@@ -216,14 +216,14 @@ function printClassBody(node: ClassBodyNode, state: State): void {
   state.indentLevel--;
 
   printIndent(state);
-  writeWithMapEnd(state, "}", CAT_OTHER, node);
+  writeWithMapEnd(state, "}", CAT_OTHER, node.start, node.end, node);
 }
 
 /**
  * Print a method, including getters, setters, constructors and their modifiers.
  */
 function printMethodDefinition(node: MethodDefinitionNode, state: State): void {
-  markMapStart(state, node);
+  markMapStart(state, node.start, node.end, node);
 
   const { decorators } = node;
   if (decorators != null && decorators.length > 0) printDecorators(decorators, state);
@@ -295,7 +295,7 @@ function printMethodDefinition(node: MethodDefinitionNode, state: State): void {
  * Print a class field, with its modifiers and initializer.
  */
 function printPropertyDefinition(node: PropertyDefinitionNode, state: State): void {
-  markMapStart(state, node);
+  markMapStart(state, node.start, node.end, node);
 
   const { decorators } = node;
   if (decorators != null && decorators.length > 0) printDecorators(decorators, state);
@@ -358,17 +358,17 @@ function printPropertyDefinition(node: PropertyDefinitionNode, state: State): vo
 function printStaticBlock(node: ESTree.StaticBlock, state: State): void {
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "static ", CAT_OTHER, node);
+  writeWithMap(state, "static ", CAT_OTHER, node.start, node.end, node);
 
   const { body } = node;
   const { length } = body;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", node);
-    writeWithMapEnd(state, "}", CAT_OTHER, node);
+    writeWithMapNoLast(state, "{", node.start, node.end, node);
+    writeWithMapEnd(state, "}", CAT_OTHER, node.start, node.end, node);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, node);
+  writeWithMap(state, "{\n", CAT_OTHER, node.start, node.end, node);
 
   state.indentLevel++;
 
@@ -379,14 +379,14 @@ function printStaticBlock(node: ESTree.StaticBlock, state: State): void {
   state.indentLevel--;
 
   printIndent(state);
-  writeWithMapEnd(state, "}", CAT_OTHER, node);
+  writeWithMapEnd(state, "}", CAT_OTHER, node.start, node.end, node);
 }
 
 /**
  * Print an `accessor` field.
  */
 function printAccessorProperty(node: AccessorPropertyNode, state: State): void {
-  markMapStart(state, node);
+  markMapStart(state, node.start, node.end, node);
 
   const { decorators } = node;
   if (decorators != null && decorators.length > 0) printDecorators(decorators, state);

--- a/packages/codegen/src-js/print/expression.ts
+++ b/packages/codegen/src-js/print/expression.ts
@@ -99,7 +99,7 @@ export function printExpression(
   switch (node.type) {
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, node.name, node);
+      writeWithMapNamed(state, node.name, node.start, node.end, node);
       break;
     case "MemberExpression":
       printMemberExpression(node, state, ctx);
@@ -151,11 +151,11 @@ export function printExpression(
       break;
     case "ThisExpression":
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "this", CAT_IDENT, node);
+      writeWithMap(state, "this", CAT_IDENT, node.start, node.end, node);
       break;
     case "Super":
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "super", CAT_IDENT, node);
+      writeWithMap(state, "super", CAT_IDENT, node.start, node.end, node);
       break;
     case "NewExpression":
       printNewExpression(node, state, precedence);
@@ -164,7 +164,7 @@ export function printExpression(
       printTemplateLiteral(node, state);
       break;
     case "TaggedTemplateExpression":
-      markMapStart(state, node);
+      markMapStart(state, node.start, node.end, node);
       printExpression(node.tag, state, PREC_POSTFIX, ctx & CTX_FORBID_CALL);
       if (TS) printTypeArguments(node.typeArguments, state);
       printTemplateLiteral(node.quasi, state);
@@ -183,7 +183,7 @@ export function printExpression(
       break;
     case "MetaProperty":
       printSpaceBeforeIdentifier(state);
-      writeWithMapNoLast(state, node.meta.name, node);
+      writeWithMapNoLast(state, node.meta.name, node.start, node.end, node);
       writeNoLast(state, ".");
       writeIdent(state, node.property.name);
       break;
@@ -199,7 +199,7 @@ export function printExpression(
         printExpression(inner, state, PREC_LOWEST, CTX_NONE);
         write(state, ")", CAT_CLOSE_BRACKET);
         if (SOURCEMAPS && precedence === PREC_POSTFIX) {
-          markMapAfter(state, inner);
+          markMapAfter(state, inner.start, inner.end, inner);
           const wrappers: ESTree.ParenthesizedExpression[] = [];
           let wrapper = expression;
           while (wrapper.type === "ParenthesizedExpression") {
@@ -207,7 +207,8 @@ export function printExpression(
             wrapper = wrapper.expression;
           }
           for (let index = wrappers.length - 1; index >= 0; index--) {
-            markMapAfter(state, wrappers[index]);
+            const wrapper = wrappers[index];
+            markMapAfter(state, wrapper.start, wrapper.end, wrapper);
           }
         }
       } else {
@@ -247,7 +248,7 @@ export function printExpression(
   // rather than one character to its left
   debugAssertLastFresh(state);
   if (SOURCEMAPS && precedence === PREC_POSTFIX && state.last === CAT_CLOSE_BRACKET) {
-    markMapAfter(state, node);
+    markMapAfter(state, node.start, node.end, node);
   }
 }
 
@@ -294,9 +295,9 @@ export function printMemberExpression(
 
     const { property } = node;
     if (property.type === "PrivateIdentifier") {
-      writeWithMapNamedPrivate(state, property.name, property);
+      writeWithMapNamedPrivate(state, property.name, property.start, property.end, property);
     } else {
-      writeWithMapNamed(state, property.name, property);
+      writeWithMapNamed(state, property.name, property.start, property.end, property);
     }
   }
 }
@@ -354,7 +355,7 @@ function printArguments(
   const { length } = args;
   if (length === 0) {
     writeNoLast(state, "(");
-    writeWithMapEnd(state, ")", CAT_CLOSE_BRACKET, node);
+    writeWithMapEnd(state, ")", CAT_CLOSE_BRACKET, node.start, node.end, node);
     return;
   }
 
@@ -365,14 +366,14 @@ function printArguments(
 
     const arg = args[i];
     if (arg.type === "SpreadElement") {
-      writeWithMap(state, "...", CAT_OTHER, arg);
+      writeWithMap(state, "...", CAT_OTHER, arg.start, arg.end, arg);
       printExpression(arg.argument, state, PREC_COMMA, CTX_NONE);
     } else {
       printExpression(arg, state, PREC_COMMA, CTX_NONE);
     }
   }
 
-  writeWithMapEnd(state, ")", CAT_CLOSE_BRACKET, node);
+  writeWithMapEnd(state, ")", CAT_CLOSE_BRACKET, node.start, node.end, node);
 }
 
 /**
@@ -390,8 +391,8 @@ export function printPrivateInExpression(
   const wrap = precedence >= PREC_COMPARE;
   if (wrap) write(state, "(", CAT_OTHER);
 
-  markMapStart(state, node);
-  writeWithMapNamedPrivate(state, node.left.name, node.left);
+  markMapStart(state, node.start, node.end, node);
+  writeWithMapNamedPrivate(state, node.left.name, node.left.start, node.left.end, node.left);
   write(state, " in ", CAT_OTHER);
   printExpression(node.right, state, PREC_EQUALS, CTX_FORBID_IN);
 
@@ -416,7 +417,7 @@ function printObjectExpression(node: ESTree.ObjectExpression, state: State): voi
   const { length } = properties;
   const isMultiLine = length > 1;
 
-  writeWithMap(state, "{", CAT_OTHER, node);
+  writeWithMap(state, "{", CAT_OTHER, node.start, node.end, node);
 
   if (isMultiLine) {
     state.indentLevel++;
@@ -436,7 +437,7 @@ function printObjectExpression(node: ESTree.ObjectExpression, state: State): voi
     write(state, " ", CAT_OTHER);
   }
 
-  writeWithMapEnd(state, "}", CAT_OTHER, node);
+  writeWithMapEnd(state, "}", CAT_OTHER, node.start, node.end, node);
 
   if (wrap) write(state, ")", CAT_CLOSE_BRACKET);
 }
@@ -449,7 +450,7 @@ function printObjectExpression(node: ESTree.ObjectExpression, state: State): voi
  */
 function printObjectProperty(node: ESTree.ObjectPropertyKind, state: State): void {
   if (node.type === "SpreadElement") {
-    writeWithMap(state, "...", CAT_OTHER, node);
+    writeWithMap(state, "...", CAT_OTHER, node.start, node.end, node);
     printExpression(node.argument, state, PREC_COMMA, CTX_NONE);
     return;
   }
@@ -459,7 +460,7 @@ function printObjectProperty(node: ESTree.ObjectPropertyKind, state: State): voi
     value.type === "FunctionExpression"
     || (TS && value.type === "TSEmptyBodyFunctionExpression")
   ) {
-    markMapStart(state, node);
+    markMapStart(state, node.start, node.end, node);
 
     const { kind } = node;
     const isGetter = kind === "get";
@@ -530,7 +531,13 @@ function printObjectProperty(node: ESTree.ObjectPropertyKind, state: State): voi
   if (shorthand) {
     if (shorthandIdentifier !== null) {
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, shorthandIdentifier.name, shorthandIdentifier);
+      writeWithMapNamed(
+        state,
+        shorthandIdentifier.name,
+        shorthandIdentifier.start,
+        shorthandIdentifier.end,
+        shorthandIdentifier,
+      );
     } else {
       // `__proto__` shorthand, whose value can be anything. Print through any parens around it.
       printExpression(withoutParens(value), state, PREC_COMMA, CTX_NONE);
@@ -562,7 +569,7 @@ function printArrayExpression(node: ESTree.ArrayExpression, state: State): void 
   const { length } = elements;
   const isMultiLine = length > 2;
 
-  writeWithMap(state, "[", CAT_OTHER, node);
+  writeWithMap(state, "[", CAT_OTHER, node.start, node.end, node);
 
   if (isMultiLine) state.indentLevel++;
 
@@ -577,7 +584,7 @@ function printArrayExpression(node: ESTree.ArrayExpression, state: State): void 
     const element = elements[i];
     if (element != null) {
       if (element.type === "SpreadElement") {
-        writeWithMap(state, "...", CAT_OTHER, element);
+        writeWithMap(state, "...", CAT_OTHER, element.start, element.end, element);
         printExpression(element.argument, state, PREC_COMMA, CTX_NONE);
       } else {
         printExpression(element, state, PREC_COMMA, CTX_NONE);
@@ -595,7 +602,7 @@ function printArrayExpression(node: ESTree.ArrayExpression, state: State): void 
     printIndent(state);
   }
 
-  writeWithMapEnd(state, "]", CAT_CLOSE_BRACKET, node);
+  writeWithMapEnd(state, "]", CAT_CLOSE_BRACKET, node.start, node.end, node);
 }
 
 /**
@@ -622,7 +629,7 @@ function printAssignmentExpression(
 
   if (wrap) write(state, "(", CAT_OTHER);
 
-  markMapStart(state, node);
+  markMapStart(state, node.start, node.end, node);
 
   printAssignmentTarget(left, state);
   write(state, PADDED_ASSIGN_OPERATORS[node.operator], CAT_OTHER);
@@ -652,10 +659,10 @@ function printUpdateExpression(
 
   if (node.prefix) {
     printSpaceBeforeOperator(state, operatorCode);
-    writeWithMap(state, node.operator, operatorCode, node);
+    writeWithMap(state, node.operator, operatorCode, node.start, node.end, node);
     printExpression(node.argument, state, PREC_PREFIX, ctx);
   } else {
-    markMapStart(state, node);
+    markMapStart(state, node.start, node.end, node);
     printExpression(node.argument, state, PREC_POSTFIX, ctx);
     printSpaceBeforeOperator(state, operatorCode);
     write(state, node.operator, operatorCode);
@@ -685,7 +692,7 @@ function printUnaryExpression(
   if (operator.length > 1) {
     // typeof, void, delete
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, operator, CAT_IDENT, node);
+    writeWithMap(state, operator, CAT_IDENT, node.start, node.end, node);
     write(state, " ", CAT_OTHER);
     // `delete Infinity` is a syntax error in strict mode
     isDeleteInfinity =
@@ -697,7 +704,7 @@ function printUnaryExpression(
     if (operatorCode === CAT_OP_UN_NOT && state.last === CAT_LT) {
       operatorCode = CAT_OP_UN_NOT_AFTER_LT;
     }
-    writeWithMap(state, operator, operatorCode, node);
+    writeWithMap(state, operator, operatorCode, node.start, node.end, node);
   }
 
   if (isDeleteInfinity) write(state, "(0, ", CAT_OTHER);
@@ -797,7 +804,7 @@ function printArrowFunctionExpression(
 
   if (node.async) {
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, "async ", CAT_OTHER, node);
+    writeWithMap(state, "async ", CAT_OTHER, node.start, node.end, node);
   }
 
   if (TS) printTypeParameters(node.typeParameters, state);
@@ -833,7 +840,7 @@ function printNewExpression(node: ESTree.NewExpression, state: State, precedence
   if (wrap) write(state, "(", CAT_OTHER);
 
   printSpaceBeforeIdentifier(state);
-  writeWithMap(state, "new ", CAT_OTHER, node);
+  writeWithMap(state, "new ", CAT_OTHER, node.start, node.end, node);
   printExpression(node.callee, state, PREC_NEW, CTX_FORBID_CALL);
   if (TS) printTypeArguments(node.typeArguments, state);
   printArguments(node, node.arguments, state);
@@ -848,7 +855,7 @@ function printNewExpression(node: ESTree.NewExpression, state: State, precedence
  * Substitutions print from `PREC_LOWEST` with no context flags, since `${` and `}` fence them from everything around.
  */
 function printTemplateLiteral(node: ESTree.TemplateLiteral, state: State): void {
-  writeWithMapNoLast(state, "`", node);
+  writeWithMapNoLast(state, "`", node.start, node.end, node);
 
   const { quasis, expressions } = node;
   const { length } = expressions;
@@ -864,7 +871,7 @@ function printTemplateLiteral(node: ESTree.TemplateLiteral, state: State): void 
     const raw = templateQuasiRaw(quasi);
     // A TS-shaped Oxc ESTree quasi includes the substitution's closing `}` in its span.
     // The JS-shaped ESTree quasi and Oxc's Rust AST both start at the raw template text.
-    if (raw.length > 0) markMapAtStartOffset(state, TS ? 1 : 0, quasi);
+    if (raw.length > 0) markMapAtStartOffset(state, TS ? 1 : 0, quasi.start, quasi.end, quasi);
     writeNoLast(state, raw);
   }
 
@@ -899,7 +906,7 @@ function printAwaitExpression(
   if (wrap) write(state, "(", CAT_OTHER);
 
   printSpaceBeforeIdentifier(state);
-  writeWithMap(state, "await ", CAT_OTHER, node);
+  writeWithMap(state, "await ", CAT_OTHER, node.start, node.end, node);
   printExpression(node.argument, state, PREC_EXPONENTIATION, ctx);
 
   if (wrap) write(state, ")", CAT_CLOSE_BRACKET);
@@ -918,7 +925,7 @@ function printYieldExpression(
   if (wrap) write(state, "(", CAT_OTHER);
 
   printSpaceBeforeIdentifier(state);
-  writeWithMap(state, "yield", CAT_IDENT, node);
+  writeWithMap(state, "yield", CAT_IDENT, node.start, node.end, node);
 
   if (node.delegate) write(state, "*", CAT_OTHER);
 
@@ -946,7 +953,7 @@ function printImportExpression(
   if (wrap) write(state, "(", CAT_OTHER);
 
   printSpaceBeforeIdentifier(state);
-  writeWithMap(state, "import", CAT_IDENT, node);
+  writeWithMap(state, "import", CAT_IDENT, node.start, node.end, node);
 
   if (node.phase != null) {
     writeNoLast(state, ".");

--- a/packages/codegen/src-js/print/function.ts
+++ b/packages/codegen/src-js/print/function.ts
@@ -47,17 +47,25 @@ export function printFunction(node: ESTree.Function, state: State): void {
   // The node's mapping goes on whichever of these is written first
   const declare = TS && node.declare;
   if (declare) {
-    writeWithMap(state, "declare ", CAT_OTHER, node);
+    writeWithMap(state, "declare ", CAT_OTHER, node.start, node.end, node);
     writeIdent(state, node.async ? "async function" : "function");
   } else {
-    writeWithMap(state, node.async ? "async function" : "function", CAT_IDENT, node);
+    writeWithMap(
+      state,
+      node.async ? "async function" : "function",
+      CAT_IDENT,
+      node.start,
+      node.end,
+      node,
+    );
   }
 
   if (node.generator) write(state, "* ", CAT_OTHER);
 
-  if (node.id != null) {
+  const { id } = node;
+  if (id != null) {
     printSpaceBeforeIdentifier(state);
-    writeWithMapNamed(state, node.id.name, node.id);
+    writeWithMapNamed(state, id.name, id.start, id.end, id);
   }
 
   if (TS) printTypeParameters(node.typeParameters, state);
@@ -116,7 +124,7 @@ function printParams(params: ESTree.ParamPattern[], state: State): void {
     if (decorators != null && decorators.length > 0) {
       printDecorators(decorators, state);
     } else {
-      markMapStart(state, param);
+      markMapStart(state, param.start, param.end, param);
     }
 
     if (TS && param.type === "TSParameterProperty") {
@@ -154,18 +162,18 @@ export function printFunctionBody(body: ESTree.FunctionBody, state: State): void
   // `body` is a BlockStatement holding directives + statements.
   const statements = body.body;
   if (statements.length === 0) {
-    writeWithMapNoLast(state, "{", body);
-    writeWithMapEnd(state, "}", CAT_OTHER, body);
+    writeWithMapNoLast(state, "{", body.start, body.end, body);
+    writeWithMapEnd(state, "}", CAT_OTHER, body.start, body.end, body);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, body);
+  writeWithMap(state, "{\n", CAT_OTHER, body.start, body.end, body);
   state.indentLevel++;
   printDirectivesAndStatements(statements, state);
   state.indentLevel--;
   printIndent(state);
 
-  writeWithMapEnd(state, "}", CAT_OTHER, body);
+  writeWithMapEnd(state, "}", CAT_OTHER, body.start, body.end, body);
 }
 
 /**

--- a/packages/codegen/src-js/print/jsx.ts
+++ b/packages/codegen/src-js/print/jsx.ts
@@ -28,7 +28,7 @@ import type * as ESTree from "../../../../npm/oxc-types/types.d.ts";
 export function printJSXElement(node: ESTree.JSXElement, state: State): void {
   const { openingElement } = node;
 
-  writeWithMapNoLast(state, "<", openingElement);
+  writeWithMapNoLast(state, "<", openingElement.start, openingElement.end, openingElement);
   printJSXElementName(openingElement.name, state);
 
   if (TS) printTypeArguments(openingElement.typeArguments, state);
@@ -39,9 +39,9 @@ export function printJSXElement(node: ESTree.JSXElement, state: State): void {
     writeNoLast(state, " ");
     const attribute = attributes[i];
     if (attribute.type === "JSXSpreadAttribute") {
-      writeWithMap(state, "{...", CAT_OTHER, attribute);
+      writeWithMap(state, "{...", CAT_OTHER, attribute.start, attribute.end, attribute);
       printExpression(attribute.argument, state, PREC_COMMA, CTX_NONE);
-      writeWithMapEnd(state, "}", CAT_OTHER, attribute);
+      writeWithMapEnd(state, "}", CAT_OTHER, attribute.start, attribute.end, attribute);
     } else {
       printJSXAttribute(attribute, state);
     }
@@ -61,7 +61,7 @@ export function printJSXElement(node: ESTree.JSXElement, state: State): void {
     printJSXChild(children[i], state);
   }
 
-  writeWithMapNoLast(state, "</", closingElement);
+  writeWithMapNoLast(state, "</", closingElement.start, closingElement.end, closingElement);
   printJSXElementName(closingElement.name, state);
   write(state, ">", CAT_OTHER);
 }
@@ -75,7 +75,7 @@ function printJSXElementName(
 ): void {
   switch (node.type) {
     case "JSXIdentifier":
-      writeWithMapNamedJSXNoLast(state, node.name, node);
+      writeWithMapNamedJSXNoLast(state, node.name, node.start, node.end, node);
       break;
     case "JSXMemberExpression":
       printJSXElementName(node.object, state);
@@ -83,12 +83,18 @@ function printJSXElementName(
       printJSXElementName(node.property, state);
       break;
     case "JSXNamespacedName":
-      writeWithMapNamedJSXNoLast(state, node.namespace.name, node.namespace);
+      writeWithMapNamedJSXNoLast(
+        state,
+        node.namespace.name,
+        node.namespace.start,
+        node.namespace.end,
+        node.namespace,
+      );
       writeNoLast(state, ":");
-      writeWithMapNamedJSXNoLast(state, node.name.name, node.name);
+      writeWithMapNamedJSXNoLast(state, node.name.name, node.name.start, node.name.end, node.name);
       break;
     case "ThisExpression":
-      writeWithMapNoLast(state, "this", node);
+      writeWithMapNoLast(state, "this", node.start, node.end, node);
       break;
     default:
       throw new Error(`Unknown JSX name type: ${node.type}`);
@@ -105,11 +111,17 @@ function printJSXAttribute(node: ESTree.JSXAttribute, state: State): void {
   // and the next real write reads `last`.
   const { name } = node;
   if (name.type === "JSXNamespacedName") {
-    writeWithMapNamedJSXNoLast(state, name.namespace.name, name.namespace);
+    writeWithMapNamedJSXNoLast(
+      state,
+      name.namespace.name,
+      name.namespace.start,
+      name.namespace.end,
+      name.namespace,
+    );
     writeNoLast(state, ":");
-    writeWithMapNamedJSXNoLast(state, name.name.name, name.name);
+    writeWithMapNamedJSXNoLast(state, name.name.name, name.name.start, name.name.end, name.name);
   } else {
-    writeWithMapNamedJSXNoLast(state, name.name, name);
+    writeWithMapNamedJSXNoLast(state, name.name, name.start, name.end, name);
   }
 
   const { value } = node;
@@ -179,7 +191,13 @@ function printJSXExpressionContainer(node: ESTree.JSXExpressionContainer, state:
  * Print a `<>...</>` fragment.
  */
 export function printJSXFragment(node: ESTree.JSXFragment, state: State): void {
-  writeWithMapNoLast(state, "<>", node.openingFragment);
+  writeWithMapNoLast(
+    state,
+    "<>",
+    node.openingFragment.start,
+    node.openingFragment.end,
+    node.openingFragment,
+  );
 
   const { children } = node;
   const { length } = children;
@@ -187,7 +205,14 @@ export function printJSXFragment(node: ESTree.JSXFragment, state: State): void {
     printJSXChild(children[i], state);
   }
 
-  writeWithMap(state, "</>", CAT_OTHER, node.closingFragment);
+  writeWithMap(
+    state,
+    "</>",
+    CAT_OTHER,
+    node.closingFragment.start,
+    node.closingFragment.end,
+    node.closingFragment,
+  );
 }
 
 /**
@@ -199,7 +224,13 @@ export function printJSXFragment(node: ESTree.JSXFragment, state: State): void {
 function printJSXChild(node: ESTree.JSXChild | UnknownNode, state: State): void {
   switch (node.type) {
     case "JSXText":
-      writeWithMapNoLast(state, node.raw != null ? node.raw : node.value, node);
+      writeWithMapNoLast(
+        state,
+        node.raw != null ? node.raw : node.value,
+        node.start,
+        node.end,
+        node,
+      );
       break;
     case "JSXExpressionContainer":
       printJSXExpressionContainer(node, state);

--- a/packages/codegen/src-js/print/literal.ts
+++ b/packages/codegen/src-js/print/literal.ts
@@ -53,7 +53,7 @@ export function printLiteral(
   const { value } = node;
   switch (typeof value) {
     case "string":
-      printString(state, value, node);
+      printString(state, value, node.start, node.end, node);
       break;
     case "number":
       typeAssertIs<ESTree.NumericLiteral>(node);
@@ -61,7 +61,7 @@ export function printLiteral(
       break;
     case "boolean":
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, value ? "true" : "false", CAT_IDENT, node);
+      writeWithMap(state, value ? "true" : "false", CAT_IDENT, node.start, node.end, node);
       break;
     default:
       typeAssertIs<LiteralExtras>(node);
@@ -74,7 +74,7 @@ export function printLiteral(
       } else {
         // `null`
         printSpaceBeforeIdentifier(state);
-        writeWithMap(state, "null", CAT_IDENT, node);
+        writeWithMap(state, "null", CAT_IDENT, node.start, node.end, node);
       }
       break;
   }
@@ -103,7 +103,14 @@ function printNumericLiteral(
     // `CAT_IDENT` rather than `CAT_INT_DIGIT` - raw text only prints inside a TS type,
     // where no member `.` can follow, so there is no `0 .toExponential()` hazard to separate.
     const { raw } = node;
-    writeWithMap(state, raw, raw[raw.length - 1] === "." ? CAT_OTHER : CAT_IDENT, node);
+    writeWithMap(
+      state,
+      raw,
+      raw[raw.length - 1] === "." ? CAT_OTHER : CAT_IDENT,
+      node.start,
+      node.end,
+      node,
+    );
     return;
   }
 
@@ -111,10 +118,10 @@ function printNumericLiteral(
     // Finite and positive: the common case, and the same branch the chain
     // below would reach, without the two builtin calls.
     printSpaceBeforeIdentifier(state);
-    printNonNegativeFloat(state, value, node);
+    printNonNegativeFloat(state, value, node.start, node.end, node);
   } else if (Number.isNaN(value)) {
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, "NaN", CAT_IDENT, node);
+    writeWithMap(state, "NaN", CAT_IDENT, node.start, node.end, node);
   } else if (!Number.isFinite(value)) {
     const negative = value < 0;
     const wrap = negative && precedence >= PREC_PREFIX;
@@ -126,21 +133,21 @@ function printNumericLiteral(
     } else {
       printSpaceBeforeIdentifier(state);
     }
-    writeWithMap(state, "Infinity", CAT_IDENT, node);
+    writeWithMap(state, "Infinity", CAT_IDENT, node.start, node.end, node);
 
     if (wrap) write(state, ")", CAT_CLOSE_BRACKET);
   } else if (Object.is(value, 0)) {
     // +0 exactly - `Object.is` rejects `-0`, which the negative paths below print as `-0`
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, "0", CAT_INT_DIGIT, node);
+    writeWithMap(state, "0", CAT_INT_DIGIT, node.start, node.end, node);
   } else if (precedence >= PREC_PREFIX) {
     writeNoLast(state, "(-");
-    printNonNegativeFloat(state, -value, node);
+    printNonNegativeFloat(state, -value, node.start, node.end, node);
     write(state, ")", CAT_CLOSE_BRACKET);
   } else {
     printSpaceBeforeOperator(state, CAT_OP_UN_NEG);
     writeNoLast(state, "-");
-    printNonNegativeFloat(state, -value, node);
+    printNonNegativeFloat(state, -value, node.start, node.end, node);
   }
 }
 
@@ -170,7 +177,7 @@ function printRegExpLiteral(node: ESTree.RegExpLiteral, state: State): void {
   // * `last === CAT_REGEX_SLASH` keeps `/a//b/` from lexing as a line comment
   // * `CAT_LT` arm keeps `<` followed by `/script...` from closing a host `<script>` element.
 
-  writeWithMapNoLast(state, "/", node);
+  writeWithMapNoLast(state, "/", node.start, node.end, node);
   writeNoLast(state, node.regex.pattern);
 
   // `CAT_REGEX_SLASH` rather than `CAT_OTHER`. It means "a regex just closed", which is what the
@@ -193,11 +200,11 @@ function printBigIntLiteral(node: ESTree.BigIntLiteral, state: State, precedence
 
   const value = node.bigint;
   if (value.startsWith("-") && precedence >= PREC_PREFIX) {
-    writeWithMapNoLast(state, "(", node);
+    writeWithMapNoLast(state, "(", node.start, node.end, node);
     writeNoLast(state, value);
     write(state, "n)", CAT_CLOSE_BRACKET);
   } else {
-    writeWithMapNoLast(state, value, node);
+    writeWithMapNoLast(state, value, node.start, node.end, node);
     writeIdent(state, "n");
   }
 }

--- a/packages/codegen/src-js/print/module.ts
+++ b/packages/codegen/src-js/print/module.ts
@@ -41,7 +41,7 @@ export function printImportDeclaration(node: ESTree.ImportDeclaration, state: St
   printIndent(state);
 
   printSpaceBeforeIdentifier(state);
-  writeWithMap(state, "import", CAT_IDENT, node);
+  writeWithMap(state, "import", CAT_IDENT, node.start, node.end, node);
 
   if (TS && node.importKind === "type") writeIdent(state, " type");
 
@@ -55,7 +55,7 @@ export function printImportDeclaration(node: ESTree.ImportDeclaration, state: St
   if (length === 0) {
     // `import "source";`
     write(state, " ", CAT_OTHER);
-    printString(state, node.source.value, node.source);
+    printString(state, node.source.value, node.source.start, node.source.end, node.source);
     printImportAttributes(node.attributes, state);
     write(state, ";\n", CAT_OTHER);
     return;
@@ -76,7 +76,14 @@ export function printImportDeclaration(node: ESTree.ImportDeclaration, state: St
         }
 
         printSpaceBeforeIdentifier(state);
-        writeWithMap(state, specifier.local.name, CAT_IDENT, specifier);
+        writeWithMap(
+          state,
+          specifier.local.name,
+          CAT_IDENT,
+          specifier.start,
+          specifier.end,
+          specifier,
+        );
 
         if (i === length - 1) write(state, " ", CAT_OTHER);
 
@@ -92,7 +99,13 @@ export function printImportDeclaration(node: ESTree.ImportDeclaration, state: St
         }
 
         write(state, "* as ", CAT_OTHER);
-        writeWithMapNamed(state, specifier.local.name, specifier.local);
+        writeWithMapNamed(
+          state,
+          specifier.local.name,
+          specifier.local.start,
+          specifier.local.end,
+          specifier.local,
+        );
         write(state, " ", CAT_OTHER);
         break;
       default: {
@@ -113,7 +126,7 @@ export function printImportDeclaration(node: ESTree.ImportDeclaration, state: St
         const { local } = specifier;
         if (importedName !== local.name) {
           write(state, " as ", CAT_OTHER);
-          writeWithMapNamed(state, local.name, local);
+          writeWithMapNamed(state, local.name, local.start, local.end, local);
         }
         break;
       }
@@ -121,7 +134,7 @@ export function printImportDeclaration(node: ESTree.ImportDeclaration, state: St
   }
 
   write(state, inBlock ? " } from " : "from ", CAT_OTHER);
-  printString(state, node.source.value, node.source);
+  printString(state, node.source.value, node.source.start, node.source.end, node.source);
   printImportAttributes(node.attributes, state);
   write(state, ";\n", CAT_OTHER);
 }
@@ -144,7 +157,7 @@ function printImportAttributes(
   // ESTree omits the `WithClause` wrapper. The Rust reference normalizes its mapping anchor
   // to the first attribute, which is the first location both representations carry.
   writeNoLast(state, " ");
-  writeWithMap(state, "with { ", CAT_OTHER, attributes[0]);
+  writeWithMap(state, "with { ", CAT_OTHER, attributes[0].start, attributes[0].end, attributes[0]);
 
   for (let i = 0; i < length; i++) {
     if (i > 0) write(state, ", ", CAT_OTHER);
@@ -154,12 +167,18 @@ function printImportAttributes(
     if (key.type === "Identifier") {
       writeIdent(state, key.name);
     } else {
-      printString(state, key.value, key);
+      printString(state, key.value, key.start, key.end, key);
     }
 
     write(state, ": ", CAT_OTHER);
 
-    printString(state, attribute.value.value, attribute.value);
+    printString(
+      state,
+      attribute.value.value,
+      attribute.value.start,
+      attribute.value.end,
+      attribute.value,
+    );
   }
 
   write(state, " }", CAT_OTHER);
@@ -176,11 +195,11 @@ function printImportAttributes(
 function moduleExportName(node: ESTree.ModuleExportName, state: State): string {
   if (node.type === "Identifier") {
     printSpaceBeforeIdentifier(state);
-    writeWithMapNamed(state, node.name, node);
+    writeWithMapNamed(state, node.name, node.start, node.end, node);
     return node.name;
   }
 
-  printString(state, node.value, node);
+  printString(state, node.value, node.start, node.end, node);
   return node.value;
 }
 
@@ -191,7 +210,7 @@ function moduleExportName(node: ESTree.ModuleExportName, state: State): string {
 export function printExportNamedDeclaration(node: ExportNamedDeclarationNode, state: State): void {
   printIndent(state);
 
-  writeWithMap(state, "export ", CAT_OTHER, node);
+  writeWithMap(state, "export ", CAT_OTHER, node.start, node.end, node);
 
   const { declaration } = node;
   if (declaration != null) {
@@ -270,7 +289,7 @@ export function printExportNamedDeclaration(node: ExportNamedDeclarationNode, st
 
   if (node.source != null) {
     write(state, " from ", CAT_OTHER);
-    printString(state, node.source.value, node.source);
+    printString(state, node.source.value, node.source.start, node.source.end, node.source);
     printImportAttributes(node.attributes, state);
   }
 
@@ -287,6 +306,8 @@ export function printExportAllDeclaration(node: ESTree.ExportAllDeclaration, sta
     state,
     TS && node.exportKind === "type" ? "export type *" : "export *",
     CAT_OTHER,
+    node.start,
+    node.end,
     node,
   );
 
@@ -296,7 +317,7 @@ export function printExportAllDeclaration(node: ESTree.ExportAllDeclaration, sta
   }
 
   write(state, " from ", CAT_OTHER);
-  printString(state, node.source.value, node.source);
+  printString(state, node.source.value, node.source.start, node.source.end, node.source);
   printImportAttributes(node.attributes, state);
   write(state, ";\n", CAT_OTHER);
 }
@@ -313,7 +334,7 @@ export function printExportDefaultDeclaration(
 ): void {
   printIndent(state);
 
-  writeWithMap(state, "export default ", CAT_OTHER, node);
+  writeWithMap(state, "export default ", CAT_OTHER, node.start, node.end, node);
 
   const { declaration } = node;
   switch (declaration.type) {

--- a/packages/codegen/src-js/print/number.ts
+++ b/packages/codegen/src-js/print/number.ts
@@ -24,8 +24,14 @@ import type * as ESTree from "../../../../npm/oxc-types/types.d.ts";
  * and every other form ends in, or contains, a `.`, an `e` or an `x` which separates it
  * from a following `.` already.
  */
-export function printNonNegativeFloat(state: State, value: number, node: ESTree.Node): void {
-  markMapStart(state, node);
+export function printNonNegativeFloat(
+  state: State,
+  value: number,
+  start: number,
+  end: number,
+  node: ESTree.Node,
+): void {
+  markMapStart(state, start, end, node);
 
   if (Number.isInteger(value)) {
     if (value < 1000) {

--- a/packages/codegen/src-js/print/statement.ts
+++ b/packages/codegen/src-js/print/statement.ts
@@ -89,9 +89,9 @@ export function printDirectivesAndStatements(
       if (inner.type === "Literal" && typeof inner.value === "string") {
         const mapsIndent = state.indentLevel > 0 || state.pendingIndentAsSpace;
         printIndent(state);
-        if (mapsIndent) markMapStart(state, stmt);
+        if (mapsIndent) markMapStart(state, stmt.start, stmt.end, stmt);
         writeNoLast(state, "(");
-        printString(state, inner.value, inner);
+        printString(state, inner.value, inner.start, inner.end, inner);
         write(state, ");\n", CAT_OTHER);
         i++;
       }
@@ -130,7 +130,7 @@ function printDirective(stmt: ESTree.Directive, state: State): void {
     }
   }
 
-  writeWithMapNoLast(state, quote, stmt);
+  writeWithMapNoLast(state, quote, stmt.start, stmt.end, stmt);
   writeNoLast(state, directive);
   writeNoLast(state, quote);
   write(state, ";\n", CAT_OTHER);
@@ -187,20 +187,20 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
     case "BreakStatement":
       printIndent(state);
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "break", CAT_IDENT, node);
+      writeWithMap(state, "break", CAT_IDENT, node.start, node.end, node);
       if (node.label != null) {
         write(state, " ", CAT_OTHER);
-        writeWithMapNamed(state, node.label.name, node.label);
+        writeWithMapNamed(state, node.label.name, node.label.start, node.label.end, node.label);
       }
       write(state, ";\n", CAT_OTHER);
       break;
     case "ContinueStatement":
       printIndent(state);
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "continue", CAT_IDENT, node);
+      writeWithMap(state, "continue", CAT_IDENT, node.start, node.end, node);
       if (node.label != null) {
         write(state, " ", CAT_OTHER);
-        writeWithMapNamed(state, node.label.name, node.label);
+        writeWithMapNamed(state, node.label.name, node.label.start, node.label.end, node.label);
       }
       write(state, ";\n", CAT_OTHER);
       break;
@@ -210,7 +210,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
     case "ThrowStatement":
       printIndent(state);
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "throw ", CAT_OTHER, node);
+      writeWithMap(state, "throw ", CAT_OTHER, node.start, node.end, node);
       printExpression(node.argument, state, PREC_LOWEST, CTX_NONE);
       write(state, ";\n", CAT_OTHER);
       break;
@@ -228,14 +228,14 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
     case "LabeledStatement":
       printIndent(state);
       printSpaceBeforeIdentifier(state);
-      markMapStart(state, node);
-      writeWithMapNamed(state, node.label.name, node.label);
+      markMapStart(state, node.start, node.end, node);
+      writeWithMapNamed(state, node.label.name, node.label.start, node.label.end, node.label);
       write(state, ":", CAT_OTHER);
       printBody(node.body, state);
       break;
     case "EmptyStatement":
       printIndent(state);
-      writeWithMap(state, ";\n", CAT_OTHER, node);
+      writeWithMap(state, ";\n", CAT_OTHER, node.start, node.end, node);
       break;
     case "ImportDeclaration":
       printImportDeclaration(node, state);
@@ -252,7 +252,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
     case "WithStatement":
       printIndent(state);
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "with(", CAT_OTHER, node);
+      writeWithMap(state, "with(", CAT_OTHER, node.start, node.end, node);
       printExpression(node.object, state, PREC_LOWEST, CTX_NONE);
       write(state, ")", CAT_CLOSE_BRACKET);
       printBody(node.body, state);
@@ -260,7 +260,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
     case "DebuggerStatement":
       printIndent(state);
       printSpaceBeforeIdentifier(state);
-      writeWithMap(state, "debugger;\n", CAT_OTHER, node);
+      writeWithMap(state, "debugger;\n", CAT_OTHER, node.start, node.end, node);
       break;
     /* IF TS */
     case "TSModuleDeclaration":
@@ -302,7 +302,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
     case "TSNamespaceExportDeclaration":
       printIndent(state);
       write(state, "export as namespace ", CAT_OTHER);
-      writeWithMapNamed(state, node.id.name, node.id);
+      writeWithMapNamed(state, node.id.name, node.id.start, node.id.end, node.id);
       write(state, ";\n", CAT_OTHER);
       break;
     /* END_IF */
@@ -320,7 +320,7 @@ export function printStatement(node: ESTree.Statement | UnknownNode, state: Stat
 function printExpressionStatement(node: ESTree.ExpressionStatement, state: State): void {
   const mapsIndent = state.indentLevel > 0 || state.pendingIndentAsSpace;
   printIndent(state);
-  if (mapsIndent) markMapStart(state, node);
+  if (mapsIndent) markMapStart(state, node.start, node.end, node);
   state.last = CAT_START_OF_STMT;
   printExpression(node.expression, state, PREC_LOWEST, CTX_NONE);
   write(state, ";\n", CAT_OTHER);
@@ -343,10 +343,10 @@ export function printVariableDeclaration(
   // The node's mapping goes on whichever of these is written first
   const declare = TS && node.declare;
   if (declare) {
-    writeWithMap(state, "declare ", CAT_OTHER, node);
+    writeWithMap(state, "declare ", CAT_OTHER, node.start, node.end, node);
     writeIdent(state, node.kind);
   } else {
-    writeWithMap(state, node.kind, CAT_IDENT, node);
+    writeWithMap(state, node.kind, CAT_IDENT, node.start, node.end, node);
   }
 
   const { declarations } = node;
@@ -362,7 +362,7 @@ export function printVariableDeclaration(
       // `let x!: T` - the `!` sits between the name and its annotation
       typeAssertIs<ESTree.BindingIdentifier>(id);
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, id.name, id);
+      writeWithMapNamed(state, id.name, id.start, id.end, id);
       write(state, "!", CAT_OP_UN_NOT);
       if (id.typeAnnotation != null) {
         printTypeAnnotation(id.typeAnnotation, state);
@@ -389,12 +389,12 @@ function printBlockStatement(block: ESTree.BlockStatement, state: State): void {
   const { body } = block;
   const { length } = body;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", block);
-    writeWithMapEnd(state, "}", CAT_OTHER, block);
+    writeWithMapNoLast(state, "{", block.start, block.end, block);
+    writeWithMapEnd(state, "}", CAT_OTHER, block.start, block.end, block);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, block);
+  writeWithMap(state, "{\n", CAT_OTHER, block.start, block.end, block);
   state.indentLevel++;
 
   for (let i = 0; i < length; i++) {
@@ -403,7 +403,7 @@ function printBlockStatement(block: ESTree.BlockStatement, state: State): void {
 
   state.indentLevel--;
   printIndent(state);
-  writeWithMapEnd(state, "}", CAT_OTHER, block);
+  writeWithMapEnd(state, "}", CAT_OTHER, block.start, block.end, block);
 }
 
 /**
@@ -416,7 +416,7 @@ function printBlockStatement(block: ESTree.BlockStatement, state: State): void {
 function printIf(node: ESTree.IfStatement, state: State): void {
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "if (", CAT_OTHER, node);
+  writeWithMap(state, "if (", CAT_OTHER, node.start, node.end, node);
 
   printExpression(node.test, state, PREC_LOWEST, CTX_NONE);
 
@@ -427,12 +427,12 @@ function printIf(node: ESTree.IfStatement, state: State): void {
     write(state, alternate != null ? " " : "\n", CAT_OTHER);
   } else if (wrapToAvoidAmbiguousElse(consequent)) {
     writeNoLast(state, ") ");
-    writeWithMap(state, "{\n", CAT_OTHER, consequent);
+    writeWithMap(state, "{\n", CAT_OTHER, consequent.start, consequent.end, consequent);
     state.indentLevel++;
     printStatement(consequent, state);
     state.indentLevel--;
     printIndent(state);
-    writeWithMapEnd(state, "}", CAT_OTHER, consequent);
+    writeWithMapEnd(state, "}", CAT_OTHER, consequent.start, consequent.end, consequent);
     write(state, alternate != null ? " " : "\n", CAT_OTHER);
   } else {
     write(state, ")", CAT_CLOSE_BRACKET);
@@ -495,10 +495,10 @@ function printReturnStatement(node: ESTree.ReturnStatement, state: State): void 
 
   const { argument } = node;
   if (argument != null) {
-    writeWithMap(state, "return ", CAT_OTHER, node);
+    writeWithMap(state, "return ", CAT_OTHER, node.start, node.end, node);
     printExpression(argument, state, PREC_LOWEST, CTX_NONE);
   } else {
-    writeWithMap(state, "return", CAT_IDENT, node);
+    writeWithMap(state, "return", CAT_IDENT, node.start, node.end, node);
   }
 
   write(state, ";\n", CAT_OTHER);
@@ -512,7 +512,7 @@ function printTryStatement(node: ESTree.TryStatement, state: State): void {
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "try ", CAT_OTHER, node);
+  writeWithMap(state, "try ", CAT_OTHER, node.start, node.end, node);
 
   printBlockStatement(node.block, state);
 
@@ -546,19 +546,19 @@ function printSwitchStatement(node: ESTree.SwitchStatement, state: State): void 
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "switch (", CAT_OTHER, node);
+  writeWithMap(state, "switch (", CAT_OTHER, node.start, node.end, node);
   printExpression(node.discriminant, state, PREC_LOWEST, CTX_NONE);
   write(state, ") ", CAT_OTHER);
 
   const { cases } = node;
   const { length } = cases;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", node);
-    writeWithMapEnd(state, "}\n", CAT_OTHER, node);
+    writeWithMapNoLast(state, "{", node.start, node.end, node);
+    writeWithMapEnd(state, "}\n", CAT_OTHER, node.start, node.end, node);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, node);
+  writeWithMap(state, "{\n", CAT_OTHER, node.start, node.end, node);
   state.indentLevel++;
 
   for (let i = 0; i < length; i++) {
@@ -567,7 +567,7 @@ function printSwitchStatement(node: ESTree.SwitchStatement, state: State): void 
 
   state.indentLevel--;
   printIndent(state);
-  writeWithMapEnd(state, "}\n", CAT_OTHER, node);
+  writeWithMapEnd(state, "}\n", CAT_OTHER, node.start, node.end, node);
 }
 
 /**
@@ -578,10 +578,10 @@ function printSwitchCase(node: ESTree.SwitchCase, state: State): void {
   printIndent(state);
 
   if (node.test != null) {
-    writeWithMap(state, "case ", CAT_OTHER, node);
+    writeWithMap(state, "case ", CAT_OTHER, node.start, node.end, node);
     printExpression(node.test, state, PREC_LOWEST, CTX_NONE);
   } else {
-    writeWithMap(state, "default", CAT_IDENT, node);
+    writeWithMap(state, "default", CAT_IDENT, node.start, node.end, node);
   }
 
   write(state, ":", CAT_OTHER);
@@ -611,7 +611,7 @@ function printWhileStatement(node: ESTree.WhileStatement, state: State): void {
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "while (", CAT_OTHER, node);
+  writeWithMap(state, "while (", CAT_OTHER, node.start, node.end, node);
   printExpression(node.test, state, PREC_LOWEST, CTX_NONE);
   write(state, ")", CAT_CLOSE_BRACKET);
 
@@ -629,7 +629,7 @@ function printDoWhileStatement(node: ESTree.DoWhileStatement, state: State): voi
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "do", CAT_IDENT, node);
+  writeWithMap(state, "do", CAT_IDENT, node.start, node.end, node);
 
   const { body } = node;
   if (body.type === "BlockStatement") {
@@ -638,7 +638,7 @@ function printDoWhileStatement(node: ESTree.DoWhileStatement, state: State): voi
     write(state, " ", CAT_OTHER);
   } else if (body.type === "EmptyStatement") {
     printIndent(state);
-    writeWithMap(state, ";\n", CAT_OTHER, body);
+    writeWithMap(state, ";\n", CAT_OTHER, body.start, body.end, body);
   } else {
     write(state, "\n", CAT_OTHER);
     state.indentLevel++;
@@ -663,7 +663,7 @@ function printForStatement(node: ESTree.ForStatement, state: State): void {
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "for (", CAT_OTHER, node);
+  writeWithMap(state, "for (", CAT_OTHER, node.start, node.end, node);
 
   const { init } = node;
   if (init != null) {
@@ -701,7 +701,7 @@ function printForInStatement(node: ESTree.ForInStatement, state: State): void {
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "for (", CAT_OTHER, node);
+  writeWithMap(state, "for (", CAT_OTHER, node.start, node.end, node);
 
   const { left } = node;
   if (left.type === "VariableDeclaration") {
@@ -729,7 +729,7 @@ function printForOfStatement(node: ESTree.ForOfStatement, state: State): void {
   printIndent(state);
   printSpaceBeforeIdentifier(state);
 
-  writeWithMap(state, "for", CAT_IDENT, node);
+  writeWithMap(state, "for", CAT_IDENT, node.start, node.end, node);
 
   if (node.await) writeIdent(state, " await");
 

--- a/packages/codegen/src-js/print/string.ts
+++ b/packages/codegen/src-js/print/string.ts
@@ -22,9 +22,15 @@ const STRING_ESCAPE_REGEX =
  * Pretty mode always uses double quotes, matching Oxc's default options, so there is no quote to choose.
  * Almost no string needs escaping, so the scan for characters or sequences which do is all that happens on the common path.
  */
-export function printString(state: State, value: string, node: UnnamedMappableNode): void {
+export function printString(
+  state: State,
+  value: string,
+  start: number,
+  end: number,
+  node: UnnamedMappableNode,
+): void {
   // Quote is fixed - double, matching `oxc_codegen`'s default option
-  writeWithMapNoLast(state, '"', node);
+  writeWithMapNoLast(state, '"', start, end, node);
 
   // Almost no string needs escaping, so the loop which performs escaping sits in its own function
   if (!STRING_ESCAPE_REGEX.test(value)) {

--- a/packages/codegen/src-js/print/typescript.ts
+++ b/packages/codegen/src-js/print/typescript.ts
@@ -286,13 +286,13 @@ function printTSTypeName(
   if (node.type === "TSQualifiedName") {
     printTSTypeName(node.left, state);
     write(state, ".", CAT_OTHER);
-    writeWithMapNamed(state, node.right.name, node.right);
+    writeWithMapNamed(state, node.right.name, node.right.start, node.right.end, node.right);
   } else if (node.type === "ThisExpression") {
     printSpaceBeforeIdentifier(state);
-    writeWithMap(state, "this", CAT_IDENT, node);
+    writeWithMap(state, "this", CAT_IDENT, node.start, node.end, node);
   } else {
     printSpaceBeforeIdentifier(state);
-    writeWithMapNamed(state, node.name, node);
+    writeWithMapNamed(state, node.name, node.start, node.end, node);
   }
 }
 
@@ -436,12 +436,12 @@ function printTSTypeLiteral(node: ESTree.TSTypeLiteral, state: State): void {
   const { members } = node;
   const { length } = members;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", node);
-    writeWithMapEnd(state, "}", CAT_OTHER, node);
+    writeWithMapNoLast(state, "{", node.start, node.end, node);
+    writeWithMapEnd(state, "}", CAT_OTHER, node.start, node.end, node);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, node);
+  writeWithMap(state, "{\n", CAT_OTHER, node.start, node.end, node);
   state.indentLevel++;
 
   for (let i = 0; i < length; i++) {
@@ -452,7 +452,7 @@ function printTSTypeLiteral(node: ESTree.TSTypeLiteral, state: State): void {
 
   state.indentLevel--;
   printIndent(state);
-  writeWithMapEnd(state, "}", CAT_OTHER, node);
+  writeWithMapEnd(state, "}", CAT_OTHER, node.start, node.end, node);
 }
 
 /**
@@ -526,14 +526,14 @@ function printSignatureKey(key: ESTree.PropertyKey, state: State, ctx: number): 
   switch (key.type) {
     case "Identifier":
       printSpaceBeforeIdentifier(state);
-      writeWithMapNamed(state, key.name, key);
+      writeWithMapNamed(state, key.name, key.start, key.end, key);
       break;
     case "PrivateIdentifier":
-      writeWithMapNamedPrivate(state, key.name, key);
+      writeWithMapNamedPrivate(state, key.name, key.start, key.end, key);
       break;
     case "Literal":
       if (typeof key.value === "string") {
-        printString(state, key.value, key);
+        printString(state, key.value, key.start, key.end, key);
       } else {
         printLiteral(key, state, PREC_COMMA, ctx);
       }
@@ -650,7 +650,7 @@ function printTSTypeParameter(node: ESTree.TSTypeParameter, state: State): void 
   if (node.in) writeNoLast(state, "in ");
   if (node.out) writeNoLast(state, "out ");
 
-  writeWithMapNamed(state, node.name.name, node.name);
+  writeWithMapNamed(state, node.name.name, node.name.start, node.name.end, node.name);
 
   if (node.constraint != null) {
     write(state, " extends ", CAT_OTHER);
@@ -695,7 +695,7 @@ function printTSTupleElement(node: ESTree.TSTupleElement, state: State): void {
       printTSType(node.typeAnnotation, state);
       break;
     case "TSNamedTupleMember":
-      writeWithMapNamed(state, node.label.name, node.label);
+      writeWithMapNamed(state, node.label.name, node.label.start, node.label.end, node.label);
       if (node.optional) write(state, "?", CAT_QUESTION);
       write(state, ": ", CAT_OTHER);
       printTSType(node.elementType, state);
@@ -757,7 +757,7 @@ function printTSMappedType(node: ESTree.TSMappedType, state: State): void {
 
   writeNoLast(state, "[");
 
-  writeWithMapNamedNoLast(state, node.key.name, node.key);
+  writeWithMapNamedNoLast(state, node.key.name, node.key.start, node.key.end, node.key);
   write(state, " in ", CAT_OTHER);
   printTSType(node.constraint, state);
 
@@ -821,7 +821,13 @@ function printTSTypePredicate(node: ESTree.TSTypePredicate, state: State): void 
     writeIdent(state, "this");
   } else {
     printSpaceBeforeIdentifier(state);
-    writeWithMapNamed(state, parameterName.name, parameterName);
+    writeWithMapNamed(
+      state,
+      parameterName.name,
+      parameterName.start,
+      parameterName.end,
+      parameterName,
+    );
   }
 
   if (node.typeAnnotation != null) {
@@ -854,7 +860,7 @@ function printTSTypeQueryExprName(node: ESTree.TSTypeQueryExprName, state: State
 function printTSImportType(node: ESTree.TSImportType, state: State): void {
   write(state, "import(", CAT_OTHER);
 
-  printString(state, node.source.value, node.source);
+  printString(state, node.source.value, node.source.start, node.source.end, node.source);
 
   if (node.options != null) {
     write(state, ", ", CAT_OTHER);
@@ -936,7 +942,7 @@ export function printTSModuleDeclaration(
     write(state, " ", CAT_OTHER);
     const { id } = node;
     if (id.type === "Literal") {
-      printString(state, id.value, id);
+      printString(state, id.value, id.start, id.end, id);
     } else {
       printTSTypeName(id, state);
     }
@@ -960,19 +966,19 @@ export function printTSModuleDeclaration(
 function printModuleBlock(body: ESTree.TSModuleBlock, state: State): void {
   const statements = body.body;
   if (statements.length === 0) {
-    writeWithMapNoLast(state, "{", body);
-    writeWithMapEnd(state, "}", CAT_OTHER, body);
+    writeWithMapNoLast(state, "{", body.start, body.end, body);
+    writeWithMapEnd(state, "}", CAT_OTHER, body.start, body.end, body);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, body);
+  writeWithMap(state, "{\n", CAT_OTHER, body.start, body.end, body);
 
   state.indentLevel++;
   printDirectivesAndStatements(statements, state);
   state.indentLevel--;
 
   printIndent(state);
-  writeWithMapEnd(state, "}", CAT_OTHER, body);
+  writeWithMapEnd(state, "}", CAT_OTHER, body.start, body.end, body);
 }
 
 /**
@@ -993,7 +999,7 @@ export function printTSInterfaceDeclaration(
 
   write(state, "interface ", CAT_OTHER);
 
-  writeWithMapNamed(state, node.id.name, node.id);
+  writeWithMapNamed(state, node.id.name, node.id.start, node.id.end, node.id);
 
   printTypeParameters(node.typeParameters, state);
 
@@ -1015,12 +1021,12 @@ export function printTSInterfaceDeclaration(
   const members = node.body.body;
   const { length } = members;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", node.body);
-    writeWithMapEnd(state, "}", CAT_OTHER, node.body);
+    writeWithMapNoLast(state, "{", node.body.start, node.body.end, node.body);
+    writeWithMapEnd(state, "}", CAT_OTHER, node.body.start, node.body.end, node.body);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, node.body);
+  writeWithMap(state, "{\n", CAT_OTHER, node.body.start, node.body.end, node.body);
   state.indentLevel++;
 
   for (let i = 0; i < length; i++) {
@@ -1031,7 +1037,7 @@ export function printTSInterfaceDeclaration(
 
   state.indentLevel--;
   printIndent(state);
-  writeWithMapEnd(state, "}", CAT_OTHER, node.body);
+  writeWithMapEnd(state, "}", CAT_OTHER, node.body.start, node.body.end, node.body);
 }
 
 /**
@@ -1047,7 +1053,7 @@ export function printTSTypeAliasDeclaration(
 
   write(state, "type ", CAT_OTHER);
 
-  writeWithMapNamed(state, node.id.name, node.id);
+  writeWithMapNamed(state, node.id.name, node.id.start, node.id.end, node.id);
 
   printTypeParameters(node.typeParameters, state);
 
@@ -1112,7 +1118,7 @@ export function printTSEnumDeclaration(node: ESTree.TSEnumDeclaration, state: St
 
   write(state, "enum ", CAT_OTHER);
 
-  writeWithMapNamed(state, node.id.name, node.id);
+  writeWithMapNamed(state, node.id.name, node.id.start, node.id.end, node.id);
 
   write(state, " ", CAT_OTHER);
 
@@ -1120,12 +1126,12 @@ export function printTSEnumDeclaration(node: ESTree.TSEnumDeclaration, state: St
   const { members } = body;
   const { length } = members;
   if (length === 0) {
-    writeWithMapNoLast(state, "{", body);
-    writeWithMapEnd(state, "}", CAT_OTHER, body);
+    writeWithMapNoLast(state, "{", body.start, body.end, body);
+    writeWithMapEnd(state, "}", CAT_OTHER, body.start, body.end, body);
     return;
   }
 
-  writeWithMap(state, "{\n", CAT_OTHER, body);
+  writeWithMap(state, "{\n", CAT_OTHER, body.start, body.end, body);
   state.indentLevel++;
 
   const lastIndex = length - 1;
@@ -1137,7 +1143,7 @@ export function printTSEnumDeclaration(node: ESTree.TSEnumDeclaration, state: St
 
   state.indentLevel--;
   printIndent(state);
-  writeWithMapEnd(state, "}", CAT_OTHER, body);
+  writeWithMapEnd(state, "}", CAT_OTHER, body.start, body.end, body);
 }
 
 /**
@@ -1149,13 +1155,13 @@ function printTSEnumMember(node: ESTree.TSEnumMember, state: State): void {
   const { id } = node;
   if (id.type === "Identifier") {
     printSpaceBeforeIdentifier(state);
-    writeWithMapNamed(state, id.name, id);
+    writeWithMapNamed(state, id.name, id.start, id.end, id);
   } else if (id.type === "Literal") {
-    printString(state, id.value, id);
+    printString(state, id.value, id.start, id.end, id);
   } else {
     // Computed string/template member name
     if (id.type === "TemplateLiteral") {
-      markMapAtStartOffset(state, 1, id.quasis[0]);
+      markMapAtStartOffset(state, 1, id.quasis[0].start, id.quasis[0].end, id.quasis[0]);
       writeNoLast(state, "[`");
       writeNoLast(state, id.quasis[0].value.raw);
       write(state, "`", CAT_OTHER);
@@ -1185,14 +1191,20 @@ export function printTSImportEqualsDeclaration(
 
   if (node.importKind === "type") write(state, "type ", CAT_OTHER);
 
-  writeWithMapNamed(state, node.id.name, node.id);
+  writeWithMapNamed(state, node.id.name, node.id.start, node.id.end, node.id);
 
   write(state, " = ", CAT_OTHER);
 
   const ref = node.moduleReference;
   if (ref.type === "TSExternalModuleReference") {
     write(state, "require(", CAT_OTHER);
-    printString(state, ref.expression.value, ref.expression);
+    printString(
+      state,
+      ref.expression.value,
+      ref.expression.start,
+      ref.expression.end,
+      ref.expression,
+    );
     write(state, ")", CAT_CLOSE_BRACKET);
   } else {
     printTSTypeName(ref, state);

--- a/packages/codegen/src-js/print/write.ts
+++ b/packages/codegen/src-js/print/write.ts
@@ -305,23 +305,27 @@ export function writePrivate(state: State, name: string): void {
  * The mapping is only recorded where the caller asked for source maps and `node` carries `start` / `end` offsets.
  *
  * Builds without source map support have no use for this. For those builds, TSDown plugin rewrites every call
- * into `write` and drops the `node` argument, leaving this unreferenced for the minifier to remove.
+ * into `write` and drops the `start`, `end` and `node` arguments, leaving this unreferenced for the minifier to remove.
  *
  * @param state - Printer state
  * @param code - Text to append, never empty
  * @param last - Category of the last character of `code`
- * @param node - Node this text came from
+ * @param start - `node`'s start offset
+ * @param end - `node`'s end offset
+ * @param node - Node this text came from. Read only by debug asserts.
  */
 export function writeWithMap(
   state: State,
   code: string,
   last: Category,
+  start: number,
+  end: number,
   node: UnnamedMappableNode,
 ): void {
   debugAssert(code.length > 0, "`code` should not be an empty string");
   debugAssertCategoryMatches(state, code, last);
 
-  markMapStart(state, node);
+  markMapStart(state, start, end, node);
 
   state.last = last;
   state.output += code;
@@ -340,18 +344,27 @@ export function writeWithMap(
  * `last` is always `CAT_IDENT`, since a name ends in an identifier character, so the caller does not pass it.
  *
  * Builds without source map support have no use for this. For those builds, TSDown plugin rewrites every call
- * into `writeIdent` and drops the `node` argument, leaving this unreferenced for the minifier to remove.
+ * into `writeIdent` and drops the `start`, `end` and `node` arguments, leaving this unreferenced for
+ * the minifier to remove.
  *
  * @param state - Printer state
  * @param name - Name to append, never empty
- * @param node - Node this text came from
+ * @param start - `node`'s start offset
+ * @param end - `node`'s end offset
+ * @param node - Node this text came from. Read only by debug asserts.
  */
-export function writeWithMapNamed(state: State, name: string, node: IdentMappableNode): void {
+export function writeWithMapNamed(
+  state: State,
+  name: string,
+  start: number,
+  end: number,
+  node: IdentMappableNode,
+): void {
   debugAssert(name.length > 0, "`name` should not be an empty string");
   debugAssertCategoryMatches(state, name, CAT_IDENT);
   debugAssertNameMatches(node, name);
 
-  markMapNamed(state, name, false, 0, node);
+  markMapNamed(state, name, false, 0, start, end, node);
 
   state.last = CAT_IDENT;
   state.output += name;
@@ -371,22 +384,27 @@ export function writeWithMapNamed(state: State, name: string, node: IdentMappabl
  * `last` is always `CAT_IDENT`, since the name is what is written last, so the caller does not pass it.
  *
  * Builds without source map support have no use for this. For those builds, TSDown plugin rewrites every call
- * into `writePrivate` and drops the `node` argument, leaving this unreferenced for the minifier to remove.
+ * into `writePrivate` and drops the `start`, `end` and `node` arguments, leaving this unreferenced for
+ * the minifier to remove.
  *
  * @param state - Printer state
  * @param name - The identifier's name, which is what follows the `#`, so never empty
- * @param node - Private identifier this text came from
+ * @param start - `node`'s start offset
+ * @param end - `node`'s end offset
+ * @param node - Private identifier this text came from. Read only by debug asserts.
  */
 export function writeWithMapNamedPrivate(
   state: State,
   name: string,
+  start: number,
+  end: number,
   node: ESTree.PrivateIdentifier,
 ): void {
   debugAssert(name.length > 0, "`name` should not be an empty string");
   debugAssertCategoryMatches(state, name, CAT_IDENT);
   debugAssertNameMatches(node, name);
 
-  markMapNamed(state, name, false, 1, node);
+  markMapNamed(state, name, false, 1, start, end, node);
 
   state.last = CAT_IDENT;
   state.output += "#";
@@ -430,14 +448,23 @@ export function writeNoLast(state: State, code: string): void {
  * `writeNoLast`'s rule about `last` applies here too - another write must follow before anything reads it.
  *
  * Builds without source map support have no use for this. For those builds, TSDown plugin rewrites every call
- * into `writeNoLast` and drops the `node` argument, leaving this unreferenced for the minifier to remove.
+ * into `writeNoLast` and drops the `start`, `end` and `node` arguments, leaving this unreferenced for
+ * the minifier to remove.
  *
  * @param state - Printer state
  * @param code - Text to append, which unlike `writeWithMap` may be empty
- * @param node - Node this text came from
+ * @param start - `node`'s start offset
+ * @param end - `node`'s end offset
+ * @param node - Node this text came from. Read only by debug asserts.
  */
-export function writeWithMapNoLast(state: State, code: string, node: UnnamedMappableNode): void {
-  markMapStart(state, node);
+export function writeWithMapNoLast(
+  state: State,
+  code: string,
+  start: number,
+  end: number,
+  node: UnnamedMappableNode,
+): void {
+  markMapStart(state, start, end, node);
 
   state.output += code;
 
@@ -455,17 +482,26 @@ export function writeWithMapNoLast(state: State, code: string, node: UnnamedMapp
  * `writeNoLast`'s rule about `last` applies here too - another write must follow before anything reads it.
  *
  * Builds without source map support have no use for this. For those builds, TSDown plugin rewrites every call
- * into `writeNoLast` and drops the `node` argument, leaving this unreferenced for the minifier to remove.
+ * into `writeNoLast` and drops the `start`, `end` and `node` arguments, leaving this unreferenced for
+ * the minifier to remove.
  *
  * @param state - Printer state
  * @param name - The identifier's name, so never empty, unlike the plain `NoLast` forms
- * @param node - Node this text came from
+ * @param start - `node`'s start offset
+ * @param end - `node`'s end offset
+ * @param node - Node this text came from. Read only by debug asserts.
  */
-export function writeWithMapNamedNoLast(state: State, name: string, node: IdentMappableNode): void {
+export function writeWithMapNamedNoLast(
+  state: State,
+  name: string,
+  start: number,
+  end: number,
+  node: IdentMappableNode,
+): void {
   debugAssert(name.length > 0, "`name` should not be an empty string");
   debugAssertNameMatches(node, name);
 
-  markMapNamed(state, name, false, 0, node);
+  markMapNamed(state, name, false, 0, start, end, node);
 
   state.output += name;
 
@@ -482,21 +518,26 @@ export function writeWithMapNamedNoLast(state: State, name: string, node: IdentM
  * so recovering its original name takes a different scan of the source.
  *
  * Builds without source map support have no use for this. For those builds, TSDown plugin rewrites every call
- * into `writeNoLast` and drops the `node` argument, leaving this unreferenced for the minifier to remove.
+ * into `writeNoLast` and drops the `start`, `end` and `node` arguments, leaving this unreferenced for
+ * the minifier to remove.
  *
  * @param state - Printer state
  * @param name - The identifier's name, so never empty, unlike the other `NoLast` forms
- * @param node - JSX identifier this text came from
+ * @param start - `node`'s start offset
+ * @param end - `node`'s end offset
+ * @param node - JSX identifier this text came from. Read only by debug asserts.
  */
 export function writeWithMapNamedJSXNoLast(
   state: State,
   name: string,
+  start: number,
+  end: number,
   node: ESTree.JSXIdentifier,
 ): void {
   debugAssert(name.length > 0, "`name` should not be an empty string");
   debugAssertNameMatches(node, name);
 
-  markMapNamed(state, name, true, 0, node);
+  markMapNamed(state, name, true, 0, start, end, node);
 
   state.output += name;
 
@@ -516,23 +557,27 @@ export function writeWithMapNamedJSXNoLast(
  * The mapping is only recorded where the caller asked for source maps and `node` carries `start` / `end` offsets.
  *
  * Builds without source map support have no use for this. For those builds, TSDown plugin rewrites every call
- * into `write` and drops the `node` argument, leaving this unreferenced for the minifier to remove.
+ * into `write` and drops the `start`, `end` and `node` arguments, leaving this unreferenced for the minifier to remove.
  *
  * @param state - Printer state
  * @param code - Text to append, never empty
  * @param last - Category of the last character of `code`
- * @param node - Node whose last source character this text maps to
+ * @param start - `node`'s start offset
+ * @param end - `node`'s end offset
+ * @param node - Node whose last source character this text maps to. Read only by debug asserts.
  */
 export function writeWithMapEnd(
   state: State,
   code: string,
   last: Category,
+  start: number,
+  end: number,
   node: MappableNode,
 ): void {
   debugAssert(code.length > 0, "`code` should not be an empty string");
   debugAssertCategoryMatches(state, code, last);
 
-  markMapEnd(state, node);
+  markMapEnd(state, start, end, node);
 
   state.last = last;
   state.output += code;
@@ -550,10 +595,16 @@ export function writeWithMapEnd(
  * Builds without source map support have no use for this. In those builds, minifier removes it.
  *
  * @param state - Printer state
- * @param node - Node the mapping points at
+ * @param start - `node`'s start offset
+ * @param end - `node`'s end offset
+ * @param node - Node the mapping points at. Read only by debug asserts.
  */
-export function markMapStart(state: State, node: MappableNode): void {
-  if (SOURCEMAPS && hasMappableSpan(node)) recordMapping(state, node.start);
+export function markMapStart(state: State, start: number, end: number, node: MappableNode): void {
+  if (!SOURCEMAPS) return;
+
+  debugAssertSpanMatches(node, start, end);
+
+  if (hasMappableSpan(start, end)) recordMapping(state, start);
 }
 
 /**
@@ -563,10 +614,16 @@ export function markMapStart(state: State, node: MappableNode): void {
  * Builds without source map support have no use for this. In those builds, minifier removes it.
  *
  * @param state - Printer state
- * @param node - Node whose end offset the mapping points at
+ * @param start - `node`'s start offset
+ * @param end - `node`'s end offset
+ * @param node - Node whose end offset the mapping points at. Read only by debug asserts.
  */
-export function markMapAfter(state: State, node: MappableNode): void {
-  if (SOURCEMAPS && hasMappableSpan(node)) recordMapping(state, node.end);
+export function markMapAfter(state: State, start: number, end: number, node: MappableNode): void {
+  if (!SOURCEMAPS) return;
+
+  debugAssertSpanMatches(node, start, end);
+
+  if (hasMappableSpan(start, end)) recordMapping(state, end);
 }
 
 /**
@@ -577,10 +634,22 @@ export function markMapAfter(state: State, node: MappableNode): void {
  *
  * @param state - Printer state
  * @param columnOffset - Number of UTF-16 units to add to `node`'s start offset
- * @param node - Node the mapping points into
+ * @param start - `node`'s start offset
+ * @param end - `node`'s end offset
+ * @param node - Node the mapping points into. Read only by debug asserts.
  */
-export function markMapAtStartOffset(state: State, columnOffset: number, node: MappableNode): void {
-  if (SOURCEMAPS && hasMappableSpan(node)) recordMapping(state, node.start + columnOffset);
+export function markMapAtStartOffset(
+  state: State,
+  columnOffset: number,
+  start: number,
+  end: number,
+  node: MappableNode,
+): void {
+  if (!SOURCEMAPS) return;
+
+  debugAssertSpanMatches(node, start, end);
+
+  if (hasMappableSpan(start, end)) recordMapping(state, start + columnOffset);
 }
 
 /**
@@ -590,12 +659,18 @@ export function markMapAtStartOffset(state: State, columnOffset: number, node: M
  * `generateSourceMap` normalizes a landing on a low surrogate back to its code point.
  *
  * @param state - Printer state
- * @param node - Node whose last source character the mapping points at
+ * @param start - `node`'s start offset
+ * @param end - `node`'s end offset
+ * @param node - Node whose last source character the mapping points at. Read only by debug asserts.
  */
-function markMapEnd(state: State, node: MappableNode): void {
-  if (SOURCEMAPS && hasMappableSpan(node)) {
+function markMapEnd(state: State, start: number, end: number, node: MappableNode): void {
+  if (!SOURCEMAPS) return;
+
+  debugAssertSpanMatches(node, start, end);
+
+  if (hasMappableSpan(start, end)) {
     // `hasMappableSpan` ensured span is non-empty, so `end` is at least 1. `end - 1` cannot go negative.
-    recordMapping(state, node.end - 1);
+    recordMapping(state, end - 1);
   }
 }
 
@@ -613,16 +688,24 @@ function markMapEnd(state: State, node: MappableNode): void {
  * @param isJSXIdentifier - `true` if the node is a `JSXIdentifier`
  * @param hashLength - Length of the `#` the token is printed behind.
  *   1 if the node is a `PrivateIdentifier`, 0 otherwise.
- * @param node - Node the mapping points at
+ * @param start - `node`'s start offset
+ * @param end - `node`'s end offset
+ * @param node - Node the mapping points at. Read only by debug asserts.
  */
 function markMapNamed(
   state: State,
   printedName: string,
   isJSXIdentifier: boolean,
   hashLength: 0 | 1,
+  start: number,
+  end: number,
   node: NamedMappableNode,
 ): void {
-  if (!SOURCEMAPS || !hasMappableSpan(node)) return;
+  if (!SOURCEMAPS) return;
+
+  debugAssertSpanMatches(node, start, end);
+
+  if (!hasMappableSpan(start, end)) return;
 
   debugAssert(
     state.mapPositions !== null && state.mapNames !== null && state.sourceText !== null,
@@ -633,7 +716,6 @@ function markMapNamed(
     "A node cannot be both a `JSXIdentifier` and a `PrivateIdentifier`",
   );
 
-  const { start, end } = node;
   const { sourceText } = state;
   if (start > sourceText.length) return;
 
@@ -691,19 +773,18 @@ function markMapNamed(
 }
 
 /**
- * Whether `node` carries a span a mapping can be recorded for.
+ * Whether the offsets given describe a span a mapping can be recorded for.
  *
- * A transformed or hand-authored AST can carry anything at all, so the offsets are checked rather
- * than trusted. Proving `start` and `end` here is what lets each recorder below skip the lower half
- * of its own bounds check - `start` is not negative, and `end` is greater than it.
+ * A transformed or hand-authored AST can carry anything at all - including nodes with no offsets,
+ * which arrive here as `undefined` however the parameters are typed - so they are checked rather than trusted.
+ * Proving them here is what lets each recorder skip the lower half of its own bounds check -
+ * `start` is not negative, and `end` is greater than it.
  *
- * @param node - Node the mapping is for
- * @returns `true` if `node` has a non-empty span of safe integer offsets
+ * @param start - Start offset of the node the mapping is for
+ * @param end - End offset of that node
+ * @returns `true` if the offsets are a non-empty span of safe integers
  */
-function hasMappableSpan(
-  node: MappableNode,
-): node is MappableNode & { start: number; end: number } {
-  const { start, end } = node;
+function hasMappableSpan(start: number, end: number): boolean {
   return (
     typeof start === "number"
     && typeof end === "number"
@@ -882,6 +963,25 @@ function isDefinitelyIdentifierBoundary(code: number): boolean {
     && code !== 45 // `-` in JSX identifiers
     && code !== 92 // `\` starting a Unicode escape
     && code !== 95 // `_`
+  );
+}
+
+/**
+ * Assert that the offsets a mapping is recorded from are the node's own.
+ *
+ * Callers extract `start` and `end` themselves, where the node's type is known statically and the reads
+ * are monomorphic. This is what holds them to the node they claim to describe.
+ *
+ * Debug builds only. Removed by minifier in release builds.
+ *
+ * @param node - Node the mapping is for
+ * @param start - Start offset passed for it
+ * @param end - End offset passed for it
+ */
+function debugAssertSpanMatches(node: MappableNode, start: number, end: number): void {
+  debugAssert(
+    start === node.start && end === node.end,
+    () => `\`${node.type}\` spans ${node.start}-${node.end}, but ${start}-${end} was passed`,
   );
 }
 

--- a/packages/codegen/tsdown.config.ts
+++ b/packages/codegen/tsdown.config.ts
@@ -70,9 +70,9 @@ const minifyConfig = DEBUG
 //
 // `src-js/index.ts` loads whichever build the caller's options call for.
 //
-// In builds without source maps, nothing reads the `node` argument the mapping writes take,
+// In builds without source maps, nothing reads the mapping arguments the mapped writes take,
 // so `unmap_writes` rewrites every mapped write call, and the imports which bring them in,
-// into the plain `write` / `writeNoLast` they become without it.
+// into the plain `write` / `writeNoLast` they become without the mapping arguments.
 const printerConfig = (name: string, { sourcemaps, ts }: { sourcemaps: boolean; ts: boolean }) => ({
   ...commonConfig,
   minify: minifyConfig,

--- a/packages/codegen/tsdown_plugins/unmap_writes.ts
+++ b/packages/codegen/tsdown_plugins/unmap_writes.ts
@@ -7,25 +7,25 @@ import type { Plugin } from "rolldown";
  *
  * ```ts
  * // Original code
- * writeWithMap(state, "declare ", CAT_OTHER, node);
+ * writeWithMap(state, "declare ", CAT_OTHER, node.start, node.end, node);
  *
  * // After transform
  * write(state, "declare ", CAT_OTHER);
  * ```
  *
- * The mapped writes and `markMap*` exist to record a source mapping for the node they are given.
+ * The mapped writes and `markMap*` exist to record a source mapping at the offsets they are given.
  * A build without source map support has nothing to record, so the call becomes the plain write
- * it would otherwise be, and the node argument goes with it - it would still be evaluated,
- * and held live across the call, for a function which ignores it.
+ * it would otherwise be, and the offsets and the node go with it - they would still be read,
+ * for a function which ignores them.
  *
  * `remove` is how many trailing arguments are dropped from the call.
  *
  * The import is rewritten to match, which both keeps the plain name in scope and leaves the mapped functions
  * unreferenced for the minifier to remove.
  *
- * `printString` and `printNonNegativeFloat` take a node only to hand it on to their mapped writes.
- * So they are rewritten the same way, but keep their names - the argument comes off every call.
- * The parameter also comes off their declarations which, unlike the mapped writes, survive into the build.
+ * `printString` and `printNonNegativeFloat` take the offsets and the node only to hand them on to their
+ * mapped writes. So they are rewritten the same way, but keep their names - the arguments come off every call.
+ * The parameters also come off their declarations which, unlike the mapped writes, survive into the build.
  *
  * Only valid where `SOURCEMAPS` is `false`, which is where the config includes it.
  *
@@ -34,22 +34,24 @@ import type { Plugin } from "rolldown";
  * everywhere or subtly wrong everywhere, and nothing downstream names the plugin as the cause.
  */
 const REWRITES = {
-  // `write` takes the `last` category between the code and the node, `writeNoLast` does not
-  writeWithMap: { arity: 4, remove: 1, rename: "write" },
-  writeWithMapNamed: { arity: 3, remove: 1, rename: "writeIdent" },
-  writeWithMapNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },
-  writeWithMapNamedNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },
-  writeWithMapNamedJSXNoLast: { arity: 3, remove: 1, rename: "writeNoLast" },
+  // Every mapped write ends `..., start, end, node`, so 3 arguments come off.
+  // `write` takes the `last` category before them, `writeNoLast` does not.
+  writeWithMap: { arity: 6, remove: 3, rename: "write" },
+  writeWithMapNamed: { arity: 5, remove: 3, rename: "writeIdent" },
+  writeWithMapNoLast: { arity: 5, remove: 3, rename: "writeNoLast" },
+  writeWithMapNamedNoLast: { arity: 5, remove: 3, rename: "writeNoLast" },
+  writeWithMapNamedJSXNoLast: { arity: 5, remove: 3, rename: "writeNoLast" },
   // A private identifier writes its own `#`, so its plain form is not `write`
-  writeWithMapNamedPrivate: { arity: 3, remove: 1, rename: "writePrivate" },
-  writeWithMapEnd: { arity: 4, remove: 1, rename: "write" },
-  // `rename: null` because a standalone mark has no non-sourcemap equivalent
-  markMapStart: { arity: 2, remove: 1, rename: null },
-  markMapAfter: { arity: 2, remove: 1, rename: null },
-  markMapAtStartOffset: { arity: 3, remove: 2, rename: null },
-  // `rename: null` to transform the function declarations, removing the `node` param
-  printString: { arity: 3, remove: 1, rename: null },
-  printNonNegativeFloat: { arity: 3, remove: 1, rename: null },
+  writeWithMapNamedPrivate: { arity: 5, remove: 3, rename: "writePrivate" },
+  writeWithMapEnd: { arity: 6, remove: 3, rename: "write" },
+  // `rename: null` because a standalone mark has no non-sourcemap equivalent.
+  // Everything but `state` comes off - `markMapAtStartOffset`'s column offset included.
+  markMapStart: { arity: 4, remove: 3, rename: null },
+  markMapAfter: { arity: 4, remove: 3, rename: null },
+  markMapAtStartOffset: { arity: 5, remove: 4, rename: null },
+  // `rename: null` to transform the function declarations, removing the dropped params
+  printString: { arity: 5, remove: 3, rename: null },
+  printNonNegativeFloat: { arity: 5, remove: 3, rename: null },
 } as const;
 
 const WRITE_MODULE = "./write.ts";


### PR DESCRIPTION
Optimization to sourcemap builds. This is what the rest of this stack has been working towards.

All the `writeWithMap*` and `markMap*` functions received a `node` param which they're extract `start` and `end` from. The problem is that these functions receive a range of different node types, so accessing `node.start` / `node.end` are megamorphic, involving an expensive dispatch.

Instead, extract `start` and `end` at call sites, where the type of `node` is already known (monomorphic), and pass them in to `writeWithMap*` / `markMap*` functions.

These functions still keep their `node` param, as it's needed for debug asserts, but it's never touched in release builds. #25989 removes it entirely from release builds too.

This has quite a large effect on perf. The cumulative perf gain of this stack (#25968 onwards) in the "without generation" sourcemaps benchmark is:

<table>
<tr>
<th align="left">Fixture</th>
<th align="right">Bytes</th>
<th align="right">Before</th>
<th align="right">After</th>
<th align="right">Faster by</th>
</tr>
<tr>
<td align="left">

`RadixUIAdoptionSection.jsx`

</td>
<td align="right">2,518</td>
<td align="right">0.0077 ms</td>
<td align="right">0.0059 ms</td>
<td align="right">+31.5%</td>
</tr>
<tr>
<td align="left">

`react.development.js`

</td>
<td align="right">72,141</td>
<td align="right">0.2549 ms</td>
<td align="right">0.2015 ms</td>
<td align="right">+26.9%</td>
</tr>
<tr>
<td align="left">

`lodash.js`

</td>
<td align="right">544,096</td>
<td align="right">1.14 ms</td>
<td align="right">0.9289 ms</td>
<td align="right">+23.5%</td>
</tr>
<tr>
<td align="left">

`App.tsx`

</td>
<td align="right">415,340</td>
<td align="right">1.84 ms</td>
<td align="right">1.51 ms</td>
<td align="right">+21.2%</td>
</tr>
<tr>
<td align="left">

`binder.ts`

</td>
<td align="right">193,077</td>
<td align="right">0.6598 ms</td>
<td align="right">0.5483 ms</td>
<td align="right">+20.6%</td>
</tr>
<tr>
<td align="left">

`kitchen-sink.tsx`

</td>
<td align="right">732,222</td>
<td align="right">5.12 ms</td>
<td align="right">4.33 ms</td>
<td align="right">+17.7%</td>
</tr>
<tr>
<td align="left">

`antd.js`

</td>
<td align="right">6,683,633</td>
<td align="right">23.52 ms</td>
<td align="right">20.30 ms</td>
<td align="right">+15.7%</td>
</tr>
<tr>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
</tr>
</table>

The vast majority of that gain is down to this PR, and the ones preceding it which also remove polymorphic/megamorphic accesses.

---

Note: Actually this change is unnecessary for `writeWithMapNamed`, `writeWithMapNamedPrivate`, and `writeWithMapNamedJSXNoLast` - they only receive a single type of node so are already monomorphic. But it's easier to be consistent, and this uniformity enables the further optimization in #25989. We could pare this back in a later PR, so we only pass in `start` and `end` where it's beneficial to do so.