### PR TITLE
refactor(packages/codegen): TSDown plugin strip all `debugAssert*` calls

### DIFF
--- a/packages/codegen/tsdown.config.ts
+++ b/packages/codegen/tsdown.config.ts
@@ -85,11 +85,12 @@ const printerConfig = (name: string, { sourcemaps, ts }: { sourcemaps: boolean; 
     TS: ts ? "true" : "false",
   },
   plugins: [
-    // `strip_ts` is a text transform, so must run before the AST-based plugins
+    // `strip_ts` is a text transform, so must run before the AST-based plugins.
+    // `const_functions` runs last, so the plugins before it still see function declarations.
     ...(ts ? [] : [stripTsPlugin()]),
+    ...assertPlugins,
     ...(sourcemaps ? [] : [unmapWritesPlugin]),
     constFunctionsPlugin,
-    ...assertPlugins,
   ],
 });
 

--- a/packages/codegen/tsdown_plugins/remove_asserts.ts
+++ b/packages/codegen/tsdown_plugins/remove_asserts.ts
@@ -6,6 +6,9 @@ import type { Plugin } from "rolldown";
 // Path to file which defines assertion functions
 const ASSERTS_PATH = pathJoin(import.meta.dirname, "../src-js/asserts.ts");
 
+// Prefix naming an assertion function, wherever it is defined
+const DEBUG_ASSERT_PREFIX = "debugAssert";
+
 /**
  * Plugin to remove imports of `typeAssertIs` from `src-js/asserts.ts`, and all its call sites.
  *
@@ -25,6 +28,9 @@ const ASSERTS_PATH = pathJoin(import.meta.dirname, "../src-js/asserts.ts");
  *
  * This plugin removes the calls entirely, expressions included, which makes `typeAssertIs`
  * cost nothing at all. Adapted from `apps/oxlint/tsdown_plugins/replace_asserts.ts`.
+ *
+ * Calls to any function named `debugAssert*` go the same way, wherever it is defined and whether or not
+ * it is imported - the printer defines various `debugAssert*` functions.
  */
 const plugin: Plugin = {
   name: "remove-asserts",
@@ -66,25 +72,44 @@ const plugin: Plugin = {
         magicString.remove(stmt.start, stmt.end);
       }
 
-      if (assertFnNames.size === 0) return;
-
       // Visit AST and remove all calls to assertion functions
       const visitor = new Visitor({
         // Replace `typeAssertIs(...)` calls with `null`. Minifier will remove the `null`.
         CallExpression(node) {
           const { callee } = node;
           if (callee.type !== "Identifier") return;
-          if (assertFnNames.has(callee.name)) {
+
+          const { name } = callee;
+          if (assertFnNames.has(name) || name.startsWith(DEBUG_ASSERT_PREFIX)) {
             idents.add(callee);
             magicString.overwrite(node.start, node.end, "null");
           }
         },
+
+        // A `debugAssert*` function's own declaration is not a use of it
+        FunctionDeclaration(node) {
+          const { id } = node;
+          if (id !== null && id.name.startsWith(DEBUG_ASSERT_PREFIX)) idents.add(id);
+        },
+
+        // Nor is importing one. Every call it was imported for is being removed, so the binding
+        // is left unused for the minifier to drop, along with the function it names.
+        ImportSpecifier(node) {
+          const { local, imported } = node;
+          if (!local.name.startsWith(DEBUG_ASSERT_PREFIX)) return;
+          idents.add(local);
+          if (imported.type === "Identifier") idents.add(imported);
+        },
+
         // Error if assertion functions are used in any other way. We lack logic to deal with that.
         Identifier(node) {
           const { name } = node;
-          if (assertFnNames.has(name) && !idents.has(node)) {
+          if (
+            (assertFnNames.has(name) || name.startsWith(DEBUG_ASSERT_PREFIX))
+            && !idents.has(node)
+          ) {
             throw new Error(
-              `Do not use \`${name}\` imported from \`asserts.ts\` except in function calls: ${path}`,
+              `Do not use assertion function \`${name}\` except in function calls: ${path}`,
             );
           }
         },


### PR DESCRIPTION
Refactor in preparation for #25989.

`remove_asserts` TSDown plugin removes debug assertions in release builds, but only when the assertion functions are imported from `asserts.ts`.

We have various other `debugAssert*` functions which are defined elsewhere. Make the plugin remove them too in release builds.

The reason this is needed is that many of these `debugAssert` functions receive `node`. #25989 removes `node` param from functions containing these assertions, which means `node` becomes a global. Minifier has to assume accessing a global may have side-effects and therefore does not remove these debug assertions. We need the plugin to do it.