### PR TITLE
perf(react-compiler): reuse instruction operands

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
@@ -130,13 +130,9 @@ pub fn infer_reactive_places(
 
                 // Check if any operand is reactive
                 let mut has_reactive_input = false;
-                let operands: Vec<IdentifierId> =
-                    visitors::each_instruction_value_operand(value, env)
-                        .into_iter()
-                        .map(|p| p.identifier)
-                        .collect();
-                for &op_id in &operands {
-                    let reactive = reactive_map.is_reactive(op_id);
+                let operands = visitors::each_instruction_value_operand(value, env);
+                for op in &operands {
+                    let reactive = reactive_map.is_reactive(op.identifier);
                     has_reactive_input = has_reactive_input || reactive;
                 }
 
@@ -169,11 +165,8 @@ pub fn infer_reactive_places(
 
                 if has_reactive_input {
                     // Mark lvalues reactive (unless stable)
-                    let lvalue_ids: Vec<IdentifierId> = visitors::each_instruction_lvalue(instr)
-                        .into_iter()
-                        .map(|p| p.identifier)
-                        .collect();
-                    for lvalue_id in lvalue_ids {
+                    for lvalue in visitors::each_instruction_lvalue(instr) {
+                        let lvalue_id = lvalue.identifier;
                         if stable_sidemap.is_stable(lvalue_id) {
                             continue;
                         }
@@ -183,8 +176,7 @@ pub fn infer_reactive_places(
 
                 if has_reactive_input || has_reactive_control {
                     // Mark mutable operands reactive
-                    let operand_places = visitors::each_instruction_value_operand(value, env);
-                    for op_place in &operand_places {
+                    for op_place in &operands {
                         match op_place.effect {
                             Effect::Capture
                             | Effect::Store
@@ -323,11 +315,8 @@ impl StableSidemap {
             InstructionValue::Destructure { value: val, .. } => {
                 let source_id = val.identifier;
                 if self.map.contains_key(&source_id) {
-                    let lvalue_ids: Vec<IdentifierId> = visitors::each_instruction_lvalue(instr)
-                        .into_iter()
-                        .map(|p| p.identifier)
-                        .collect();
-                    for lid in lvalue_ids {
+                    for lvalue in visitors::each_instruction_lvalue(instr) {
+                        let lid = lvalue.identifier;
                         let lid_ty = &env.types[env.identifiers[lid].type_];
                         if is_stable_type_container(lid_ty) {
                             self.map.insert(lid, false);
@@ -574,15 +563,11 @@ fn apply_reactive_flags_replay(
             let instr = &func.instructions[instr_id.index()];
 
             // Compute hasReactiveInput by checking value operands
-            let value_operand_ids: Vec<IdentifierId> =
-                visitors::each_instruction_value_operand(&instr.value, env)
-                    .into_iter()
-                    .map(|p| p.identifier)
-                    .collect();
             let mut has_reactive_input = false;
-            for &op_id in &value_operand_ids {
-                if reactive_ids.contains(&op_id) {
+            for operand in visitors::each_instruction_value_operand(&instr.value, env) {
+                if reactive_ids.contains(&operand.identifier) {
                     has_reactive_input = true;
+                    break;
                 }
             }
 


### PR DESCRIPTION
Reuse operand visitor results in reactive-place inference to avoid repeated traversals and temporary `Vec` allocations.