### PR TITLE
fix(rust): address nightly deprecations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.96.0"
 [workspace.lints.rust]
 absolute_paths_not_starting_with_crate = "warn"
 non_ascii_idents = "warn"
-unit-bindings = "warn"
+unit_bindings = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)', 'cfg(coverage_nightly)'] }
 tail_expr_drop_order = "warn"
 unsafe_op_in_unsafe_fn = "warn"

--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -82,7 +82,6 @@
     clippy::needless_for_each,
     clippy::cloned_instead_of_copied,
     clippy::checked_conversions,
-    clippy::legacy_numeric_constants,
     clippy::cast_sign_loss,
     clippy::cast_possible_wrap,
     clippy::swap_ptr_to_ref,
@@ -220,7 +219,7 @@ where
     T: Sized,
 {
     let pointee_size = size_of::<T>();
-    assert!(0 < pointee_size && pointee_size <= isize::max_value() as usize);
+    assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);
 
     // This is the same sequence that Clang emits for pointer subtraction.
     // It can be neither `nsw` nor `nuw` because the input is treated as

--- a/crates/oxc_allocator/tests/arena/alloc_fill.rs
+++ b/crates/oxc_allocator/tests/arena/alloc_fill.rs
@@ -35,5 +35,5 @@ fn alloc_slice_fill_zero() {
 fn alloc_slice_overflow() {
     let b = Arena::new();
 
-    b.alloc_slice_fill_default::<u64>(usize::max_value());
+    b.alloc_slice_fill_default::<u64>(usize::MAX);
 }

--- a/crates/oxc_allocator/tests/arena/main.rs
+++ b/crates/oxc_allocator/tests/arena/main.rs
@@ -6,7 +6,6 @@
     clippy::items_after_statements,
     clippy::large_enum_variant,
     clippy::large_stack_arrays,
-    clippy::legacy_numeric_constants,
     clippy::match_like_matches_macro,
     clippy::match_same_arms,
     clippy::needless_pass_by_value,

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -13,10 +13,12 @@ use crate::ExternalLinter;
 
 define_index_type! {
     pub struct ExternalPluginId = u32;
+    MAX_INDEX = u32::MAX as usize;
 }
 
 define_index_type! {
     pub struct ExternalRuleId = u32;
+    MAX_INDEX = u32::MAX as usize;
 }
 
 impl ExternalRuleId {
@@ -26,6 +28,7 @@ impl ExternalRuleId {
 
 define_index_type! {
     pub struct ExternalOptionsId = u32;
+    MAX_INDEX = u32::MAX as usize;
 }
 
 impl ExternalOptionsId {

--- a/crates/oxc_semantic/src/multi_index_vec.rs
+++ b/crates/oxc_semantic/src/multi_index_vec.rs
@@ -326,6 +326,7 @@ pub(crate) use multi_index_vec;
 mod tests {
     oxc_index::define_index_type! {
         struct TestId = usize;
+        MAX_INDEX = usize::MAX;
     }
 
     multi_index_vec! {
@@ -347,6 +348,7 @@ mod tests {
 
     oxc_index::define_index_type! {
         struct StringId = usize;
+        MAX_INDEX = usize::MAX;
     }
 
     multi_index_vec! {

--- a/crates/oxc_syntax/src/class.rs
+++ b/crates/oxc_syntax/src/class.rs
@@ -4,9 +4,11 @@ use oxc_index::define_index_type;
 
 define_index_type! {
     pub struct ClassId = u32;
+    MAX_INDEX = u32::MAX as usize;
 }
 define_index_type! {
     pub struct ElementId = u32;
+    MAX_INDEX = u32::MAX as usize;
 }
 
 bitflags! {

--- a/tasks/ast_tools/src/generators/estree_visit.rs
+++ b/tasks/ast_tools/src/generators/estree_visit.rs
@@ -25,6 +25,7 @@ use super::define_generator;
 
 define_index_type! {
     pub struct NodeId = u32;
+    MAX_INDEX = u32::MAX as usize;
 }
 
 impl Display for NodeId {

--- a/tasks/ast_tools/src/parse/load.rs
+++ b/tasks/ast_tools/src/parse/load.rs
@@ -1,5 +1,6 @@
 use std::{fs, path::Path};
 
+use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
     Attribute, Ident, Item, ItemEnum, ItemMacro, ItemStruct, Meta, Token, Visibility,
@@ -78,6 +79,8 @@ fn parse_index_type_macro(
                 quote!(#ty_ident)
             };
             let _ = input.parse::<Token![;]>()?;
+            // Ignore optional macro configuration after the type declaration.
+            let _ = input.parse::<TokenStream>()?;
 
             let Some((name, is_foreign, is_meta)) = get_type_name(&attrs, &ident) else {
                 return Ok(None);

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -32,6 +32,7 @@ pub mod extensions {
 define_index_type! {
     /// ID of type in the AST
     pub struct TypeId = u32;
+    MAX_INDEX = u32::MAX as usize;
 }
 
 impl TypeId {
@@ -41,11 +42,13 @@ impl TypeId {
 define_index_type! {
     /// ID of source file
     pub struct FileId = u32;
+    MAX_INDEX = u32::MAX as usize;
 }
 
 define_index_type! {
     /// ID of meta type
     pub struct MetaId = u32;
+    MAX_INDEX = u32::MAX as usize;
 }
 
 /// Schema of all AST types.


### PR DESCRIPTION
Addresses deprecations reported by the latest Rust nightly while preserving Rust 1.98 compatibility.

- Rename `unit-bindings` to `unit_bindings`: hyphenated lint names are deprecated in favor of their canonical underscore spelling.
- Replace `isize::max_value()` and `usize::max_value()` with `isize::MAX` and `usize::MAX`: the legacy numeric methods are deprecated in favor of associated constants.
- Set explicit `MAX_INDEX` values on `define_index_type!`: `oxc_index` otherwise generates `<raw>::max_value() as usize`; the explicit modern constants avoid that deprecated expansion without changing the index limits.
- Remove obsolete `clippy::legacy_numeric_constants` expectations: the corrected code no longer triggers that lint, so the expectations would be unfulfilled.
- Allow the AST scanner to consume optional `define_index_type!` configuration: it previously parsed only the struct declaration and rejected the added `MAX_INDEX` option.

AI-assisted.