### PR TITLE
refactor(oxlint/lsp): send trace messages on backend side

### DIFF
--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -106,9 +106,10 @@ impl ServerLinterBuilder {
             let res = (external_linter.create_workspace)(root_uri.as_str().to_string());
 
             if let Err(err) = res {
-                let message = format!("Failed to setup JS workspace:\n{err}\n");
-                error!(message);
-                client_messages.insert(ClientMessage { message, r#type: MessageType::ERROR });
+                client_messages.insert(ClientMessage {
+                    message: format!("Failed to setup JS workspace:\n{err}\n"),
+                    r#type: MessageType::ERROR,
+                });
             }
         }
 
@@ -125,9 +126,7 @@ impl ServerLinterBuilder {
         let mut oxlintrc = match loader.load_root_config(&root_path, config_path.as_ref()) {
             Ok(config) => config,
             Err(e) => {
-                let message = oxc_diagnostic_to_client_message(&e);
-                error!(message.message);
-                client_messages.insert(message);
+                client_messages.insert(oxc_diagnostic_to_client_message(&e));
                 Oxlintrc::default()
             }
         };
@@ -164,11 +163,10 @@ impl ServerLinterBuilder {
         ) {
             Ok(builder) => builder,
             Err(e) => {
-                let message = format!("Failed to build config from oxlintrc:\n{e}");
-                // show message in LSP stderr
-                error!(message);
-
-                client_messages.insert(ClientMessage { message, r#type: MessageType::ERROR });
+                client_messages.insert(ClientMessage {
+                    message: format!("Failed to build config from oxlintrc:\n{e}"),
+                    r#type: MessageType::ERROR,
+                });
                 ConfigStoreBuilder::default()
             }
         };
@@ -183,9 +181,10 @@ impl ServerLinterBuilder {
 
         extended_paths.extend(config_builder.extended_paths.clone());
         let base_config = config_builder.build(&mut external_plugin_store).unwrap_or_else(|err| {
-            let message = format!("Failed to build config:\n{err}");
-            error!("{message}");
-            client_messages.insert(ClientMessage { message, r#type: MessageType::ERROR });
+            client_messages.insert(ClientMessage {
+                message: format!("Failed to build config:\n{err}"),
+                r#type: MessageType::ERROR,
+            });
             ConfigStoreBuilder::empty().build(&mut ExternalPluginStore::new(false)).unwrap()
         });
 
@@ -220,9 +219,10 @@ impl ServerLinterBuilder {
                 external_linter,
             );
             if let Err(err) = res {
-                let message = format!("Failed to setup JS plugins config:\n{err}");
-                error!("{message}");
-                client_messages.insert(ClientMessage { message, r#type: MessageType::ERROR });
+                client_messages.insert(ClientMessage {
+                    message: format!("Failed to setup JS plugins config:\n{err}"),
+                    r#type: MessageType::ERROR,
+                });
             }
         }
 
@@ -247,11 +247,10 @@ impl ServerLinterBuilder {
         {
             Ok(runner) => runner,
             Err(e) => {
-                let message = format!("Failed to initialize type-aware linting:\n{e}");
-
-                error!(message);
-
-                client_messages.insert(ClientMessage { message, r#type: MessageType::ERROR });
+                client_messages.insert(ClientMessage {
+                    message: format!("Failed to initialize type-aware linting:\n{e}"),
+                    r#type: MessageType::ERROR,
+                });
                 let linter =
                     Linter::new(lint_options, config_store_clone, external_linter.cloned())
                         .with_workspace_uri(Some(root_uri.as_str()));
@@ -375,13 +374,11 @@ impl ServerLinterBuilder {
 
         let mut client_messages = Vec::with_capacity(errors.len());
         for error in errors {
-            let message = config_loader_error_to_message(error);
-
-            // send message to LSP stderr
-            warn!(message);
-
-            // show message to the LSP client, if there is already a message, append to it
-            client_messages.push(ClientMessage { message, r#type: MessageType::ERROR });
+            // show message to the LSP client
+            client_messages.push(ClientMessage {
+                message: config_loader_error_to_message(error),
+                r#type: MessageType::ERROR,
+            });
         }
 
         (

--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -1036,6 +1036,18 @@ impl Backend {
     /// Send multiple messages to the client, if any.
     /// Will cap the number of messages to 5, to avoid flooding the client.
     async fn send_client_messages(&self, messages: Vec<ClientMessage>) {
+        // Log every message before limiting what is shown in the client. In particular, this
+        // ensures messages omitted by the client-facing cap remain available on LSP stderr.
+        for message in &messages {
+            match message.r#type {
+                MessageType::ERROR => error!("{}", message.message),
+                MessageType::WARNING => warn!("{}", message.message),
+                MessageType::INFO => info!("{}", message.message),
+                MessageType::LOG => debug!("{}", message.message),
+                message_type => warn!(?message_type, "{}", message.message),
+            }
+        }
+
         let max_messages = 5;
         let messages_to_send = if messages.len() > max_messages {
             let extra_message = ClientMessage {


### PR DESCRIPTION
It is always a good idea to send the message the `stderr` channel too, because the client can filter a stack of messages out (like VSCode does).
Instead of having the responsibility on `oxfmt` and `oxlint`, we can now move logic to the `Backend`.