### PR TITLE
feat(oxfmt): better detect angular .html template files 

### DIFF
--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -74,7 +74,7 @@ pub fn classify_file_kind(path: Arc<Path>) -> Option<FileKind> {
     // Prettier-delegated files are only supported with the `napi` feature
     #[cfg(feature = "napi")]
     {
-        if let Some(parser_name) = get_prettier_parser_name(file_name, extension) {
+        if let Some(parser_name) = get_prettier_parser_name(&path, file_name, extension) {
             let supports_tailwind = TAILWIND_PARSERS.contains(parser_name);
             let supports_oxfmt = OXFMT_PARSERS.contains(parser_name);
             let supports_svelte = SVELTE_PARSERS.contains(parser_name);
@@ -417,7 +417,11 @@ static YAML_EXTENSIONS: phf::Set<&'static str> = phf_set! {
 /// Returns the Prettier parser name for the file, if supported.
 /// See also `prettier --support-info | jq '.languages[]'`
 #[cfg(feature = "napi")]
-fn get_prettier_parser_name(file_name: &str, extension: Option<&str>) -> Option<&'static str> {
+fn get_prettier_parser_name(
+    path: &Path,
+    file_name: &str,
+    extension: Option<&str>,
+) -> Option<&'static str> {
     // Markdown and variants
     if MARKDOWN_FILENAMES.contains(file_name) {
         return Some("markdown");
@@ -434,6 +438,9 @@ fn get_prettier_parser_name(file_name: &str, extension: Option<&str>) -> Option<
     // HTML and variants
     // Must be checked before generic HTML
     if file_name.ends_with(".component.html") {
+        return Some("angular");
+    }
+    if extension == Some("html") && path.with_extension("ts").is_file() {
         return Some("angular");
     }
     if let Some(ext) = extension
@@ -629,7 +636,7 @@ mod tests {
         fn get_parser_name(file_name: &str) -> Option<&'static str> {
             let path = Path::new(file_name);
             let extension = path.extension().and_then(|ext| ext.to_str());
-            get_prettier_parser_name(file_name, extension)
+            get_prettier_parser_name(path, file_name, extension)
         }
 
         let test_cases = vec![
@@ -685,6 +692,43 @@ mod tests {
             let result = get_parser_name(file_name);
             assert_eq!(result, expected, "`{file_name}` should be parsed as {expected:?}");
         }
+
+        // Angular template detection via sibling `.ts` file
+        let temp_dir =
+            std::env::temp_dir().join(format!("oxfmt_test_angular_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&temp_dir);
+
+        let my_comp_ts = temp_dir.join("mycomponent.ts");
+        let my_comp_html = temp_dir.join("mycomponent.html");
+        let standalone_html = temp_dir.join("standalone.html");
+
+        std::fs::write(&my_comp_ts, "").unwrap();
+        std::fs::write(&my_comp_html, "").unwrap();
+        std::fs::write(&standalone_html, "").unwrap();
+
+        let ext = Some("html");
+        let parser_with_sibling = get_prettier_parser_name(&my_comp_html, "mycomponent.html", ext);
+        assert_eq!(
+            parser_with_sibling,
+            Some("angular"),
+            "mycomponent.html with sibling mycomponent.ts should be parsed as angular"
+        );
+
+        let parser_without_sibling =
+            get_prettier_parser_name(&standalone_html, "standalone.html", ext);
+        assert_eq!(
+            parser_without_sibling,
+            Some("html"),
+            "standalone.html without sibling .ts should be parsed as html"
+        );
+
+        let kind = classify_file_kind(Arc::from(my_comp_html.as_path())).unwrap();
+        assert!(
+            matches!(kind, FileKind::Prettier { parser_name: "angular", .. }),
+            "classify_file_kind should classify mycomponent.html as Prettier angular"
+        );
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
     #[test]

--- a/apps/oxfmt/test/api/basic.test.ts
+++ b/apps/oxfmt/test/api/basic.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { format } from "../../dist/index.js";
 
@@ -37,6 +40,58 @@ describe("Format non-js", () => {
 `.trimStart(),
     );
     expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should format angular component templates ending with .component.html", async () => {
+    const angularCode = `@if (  condition  ) {
+  <div *ngIf="  isOpen  ">{{   message   }}</div>
+}`;
+    const result = await format("my.component.html", angularCode, {});
+    expect(result.code).toBe(
+      `@if (condition) {
+  <div *ngIf="isOpen">{{ message }}</div>
+}
+`,
+    );
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should format .html with sibling .ts as angular template", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "oxfmt-angular-test-"));
+    const tsFile = path.join(tempDir, "mycomponent.ts");
+    const htmlFile = path.join(tempDir, "mycomponent.html");
+    const standaloneHtmlFile = path.join(tempDir, "standalone.html");
+
+    fs.writeFileSync(tsFile, "export class MyComponent {}");
+    fs.writeFileSync(htmlFile, "");
+    fs.writeFileSync(standaloneHtmlFile, "");
+
+    const angularCode = `@if (  condition  ) {
+  <div *ngIf="  isOpen  ">{{   message   }}</div>
+}`;
+
+    try {
+      const resultSibling = await format(htmlFile, angularCode, {});
+      expect(resultSibling.code).toBe(
+        `@if (condition) {
+  <div *ngIf="isOpen">{{ message }}</div>
+}
+`,
+      );
+      expect(resultSibling.errors).toStrictEqual([]);
+
+      const resultStandalone = await format(standaloneHtmlFile, angularCode, {});
+      // Formatted with HTML parser (does not format Angular bindings/control flow expressions)
+      expect(resultStandalone.code).toBe(
+        `@if ( condition ) {
+<div *ngIf="  isOpen  ">{{ message }}</div>
+}
+`,
+      );
+      expect(resultStandalone.errors).toStrictEqual([]);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("should surface Prettier parse errors as-is", async () => {


### PR DESCRIPTION
We do this by identifying siblings.

In case we have both `component-name.ts` and `component-name.html` in the same folder in an angular project, we can safely assume that `component-name.html` is an angular template.

If we have a `standalone.html` without a `standalone.ts` we parse and format  `standalone.html` as a html file and not an angular template.

With this solution we don't need extra configuration options for angular while keeping code changes minmal. 

NB this PR was created with the help of AI. I'm by no means a Rust programmer. However, the added code is minimal and is consistent with the code already present.