### PR TITLE
feat(ast, parser, codegen, linter): use WTF-8 for lone surrogates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,6 +1788,7 @@ dependencies = [
  "oxc_span",
  "oxc_str",
  "oxc_syntax",
+ "oxc_wtf8",
 ]
 
 [[package]]
@@ -1903,6 +1904,7 @@ dependencies = [
  "oxc_span",
  "oxc_str",
  "oxc_syntax",
+ "oxc_wtf8",
  "pico-args",
  "rustc-hash",
 ]
@@ -2148,6 +2150,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "oxc_tasks_common",
+ "oxc_wtf8",
  "pico-args",
 ]
 
@@ -2370,6 +2373,7 @@ dependencies = [
  "oxc_str",
  "oxc_syntax",
  "oxc_traverse",
+ "oxc_wtf8",
  "pico-args",
  "rustc-hash",
 ]
@@ -2449,6 +2453,7 @@ dependencies = [
  "oxc_span",
  "oxc_str",
  "oxc_syntax",
+ "oxc_wtf8",
  "pico-args",
  "rustc-hash",
  "seq-macro",
@@ -2644,11 +2649,13 @@ name = "oxc_str"
 version = "0.146.0"
 dependencies = [
  "compact_str 0.10.0",
+ "cow-utils",
  "hashbrown 0.17.1",
  "oxc-schemars",
  "oxc_allocator",
  "oxc_data_structures",
  "oxc_estree",
+ "oxc_wtf8",
  "serde",
 ]
 
@@ -2878,6 +2885,10 @@ dependencies = [
  "rustc-hash",
  "self_cell",
 ]
+
+[[package]]
+name = "oxc_wtf8"
+version = "0.146.0"
 
 [[package]]
 name = "oxfmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ oxc_relay = { version = "0.144.0", path = "crates/oxc_relay" } # Relay graphql t
 oxc_semantic = { version = "0.146.0", path = "crates/oxc_semantic" } # Semantic analysis
 oxc_span = { version = "0.146.0", path = "crates/oxc_span" } # Source positions
 oxc_str = { version = "0.146.0", path = "crates/oxc_str" } # String types
+oxc_wtf8 = { version = "0.146.0", path = "crates/oxc_wtf8" } # WTF-8 encoding
 oxc_syntax = { version = "0.146.0", path = "crates/oxc_syntax" } # Syntax utilities
 oxc_transform_napi = { version = "0.146.0", path = "napi/transform" } # Node.js transformer binding
 oxc_transform_react_napi = { version = "0.143.0", path = "napi/transform-react" } # Node.js React Compiler binding

--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -613,11 +613,6 @@ function deserializeTemplateElement(pos) {
     start = deserializeI32(pos) - 1,
     end = deserializeI32(pos + 4) + 2 - tail,
     value = deserializeTemplateElementValue(pos + 16);
-  value.cooked !== null
-    && deserializeBool(pos + 13)
-    && (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
   return {
     __proto__: NodeProto,
     type: "TemplateElement",
@@ -3455,13 +3450,8 @@ function deserializeStringLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    }),
-    value = deserializeStr(pos + 16);
-  deserializeBool(pos + 12)
-    && (value = value.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
-  node.value = value;
+    });
+  node.value = deserializeStr(pos + 16);
   parent = previousParent;
   return node;
 }

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -29,6 +29,7 @@ oxc_regular_expression = { workspace = true }
 oxc_span = { workspace = true }
 oxc_str = { workspace = true }
 oxc_syntax = { workspace = true }
+oxc_wtf8 = { workspace = true }
 
 bitflags = { workspace = true }
 

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -26,7 +26,7 @@ use oxc_allocator::{Box, CloneIn, Dummy, GetAddress, ReplaceWith, TakeIn, Unstab
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_span::{ContentEq, GetSpan, GetSpanMut, SourceType, Span};
-use oxc_str::{Ident, Str};
+use oxc_str::{Ident, Str, Wtf8Str};
 use oxc_syntax::{
     node::NodeId,
     operator::{
@@ -453,14 +453,6 @@ pub struct TemplateElement<'a> {
     pub span: Span,
     pub value: TemplateElementValue<'a>,
     pub tail: bool,
-    /// The template element contains lone surrogates.
-    ///
-    /// `value.cooked` is encoded using `\u{FFFD}` (the lossy replacement character) as an escape character.
-    /// Lone surrogates are encoded as `\u{FFFD}XXXX`, where `XXXX` is the code unit in hex.
-    /// The lossy escape character itself is encoded as `\u{FFFD}fffd`.
-    #[builder(default)]
-    #[estree(skip)]
-    pub lone_surrogates: bool,
 }
 
 /// See [template-strings-cooked-vs-raw](https://exploringjs.com/js/book/ch_template-literals.html#template-strings-cooked-vs-raw)
@@ -477,7 +469,8 @@ pub struct TemplateElementValue<'a> {
     /// For example, \t produces a tab character.
     /// This interpretation of the template strings is stored as an Array in the first argument.
     /// cooked = None when template literal has invalid escape sequence
-    pub cooked: Option<Str<'a>>,
+    /// Value is stored as WTF-8, which can contain lone surrogates.
+    pub cooked: Option<Wtf8Str<'a>>,
 }
 
 /// Represents a member access expression, which can include computed member access,

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -10,7 +10,7 @@ use oxc_allocator::{Box, CloneIn, Dummy, GetAddress, ReplaceWith, TakeIn, Unstab
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_span::{ContentEq, GetSpan, GetSpanMut, Span};
-use oxc_str::Str;
+use oxc_str::{Str, Wtf8Str};
 use oxc_syntax::node::NodeId;
 
 use super::{js::*, literal::*, ts::*};
@@ -532,7 +532,9 @@ pub struct JSXText<'a> {
     /// Node location in source code.
     pub span: Span,
     /// The text content.
-    pub value: Str<'a>,
+    ///
+    /// Value is stored as WTF-8, which can contain lone surrogates.
+    pub value: Wtf8Str<'a>,
 
     /// The raw string as it appears in source code.
     ///

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -12,7 +12,7 @@ use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_regular_expression::ast::Pattern;
 use oxc_span::{ContentEq, GetSpan, GetSpanMut, Span};
-use oxc_str::Str;
+use oxc_str::{Str, Wtf8Str};
 use oxc_syntax::{
     node::NodeId,
     number::{BigintBase, NumberBase},
@@ -93,8 +93,9 @@ pub struct StringLiteral<'a> {
     /// The value of the string.
     ///
     /// Any escape sequences in the raw code are unescaped.
+    /// Value is stored as WTF-8, which can contain lone surrogates.
     #[estree(via = StringLiteralValue)]
-    pub value: Str<'a>,
+    pub value: Wtf8Str<'a>,
 
     /// The raw string as it appears in source code.
     ///
@@ -102,15 +103,6 @@ pub struct StringLiteral<'a> {
     #[content_eq(skip)]
     #[estree(from_span)]
     pub raw: Option<Str<'a>>,
-
-    /// The string value contains lone surrogates.
-    ///
-    /// `value` is encoded using `\u{FFFD}` (the lossy replacement character) as an escape character.
-    /// Lone surrogates are encoded as `\u{FFFD}XXXX`, where `XXXX` is the code unit in hex.
-    /// The lossy escape character itself is encoded as `\u{FFFD}fffd`.
-    #[builder(default)]
-    #[estree(skip)]
-    pub lone_surrogates: bool,
 }
 
 /// BigInt literal

--- a/crates/oxc_ast/src/ast/mod.rs
+++ b/crates/oxc_ast/src/ast/mod.rs
@@ -172,7 +172,7 @@
 
 // Re-export AST types from other crates
 pub use oxc_span::{Language, LanguageVariant, ModuleKind, SourceType, Span};
-pub use oxc_str::{Ident, Str};
+pub use oxc_str::{Ident, Str, Wtf8Str};
 pub use oxc_syntax::{
     number::{BigintBase, NumberBase},
     operator::{

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -95,7 +95,7 @@ impl<'a> Expression<'a> {
     #[inline]
     pub fn is_specific_string_literal(&self, string: &str) -> bool {
         match self {
-            Self::StringLiteral(s) => s.value == string,
+            Self::StringLiteral(s) => s.value.as_str() == Some(string),
             _ => false,
         }
     }
@@ -465,12 +465,12 @@ impl<'a> PropertyKey<'a> {
     pub fn static_name(&self) -> Option<Cow<'a, str>> {
         match self {
             Self::StaticIdentifier(ident) => Some(Cow::Borrowed(ident.name.as_str())),
-            Self::StringLiteral(lit) => Some(Cow::Borrowed(lit.value.as_str())),
+            Self::StringLiteral(lit) => lit.value.as_str().map(Cow::Borrowed),
             Self::RegExpLiteral(lit) => Some(Cow::Owned(lit.regex.to_string())),
             Self::NumericLiteral(lit) => Some(Cow::Owned(lit.value.to_string())),
             Self::BigIntLiteral(lit) => Some(Cow::Borrowed(lit.value.as_str())),
             Self::NullLiteral(_) => Some(Cow::Borrowed("null")),
-            Self::TemplateLiteral(lit) => lit.single_quasi().map(Into::into),
+            Self::TemplateLiteral(lit) => lit.single_quasi().map(|s| Cow::Borrowed(s.as_str())),
             _ => None,
         }
     }
@@ -531,7 +531,7 @@ impl<'a> PropertyKey<'a> {
 
     /// Returns `true` if this property key is a string literal with the given value.
     pub fn is_specific_string_literal(&self, string: &str) -> bool {
-        matches!(self, Self::StringLiteral(s) if s.value == string)
+        matches!(self, Self::StringLiteral(s) if s.value.as_str() == Some(string))
     }
 }
 
@@ -558,7 +558,11 @@ impl<'a> TemplateLiteral<'a> {
 
     /// Get single quasi from `template`
     pub fn single_quasi(&self) -> Option<Str<'a>> {
-        if self.is_no_substitution_template() { self.quasis[0].value.cooked } else { None }
+        if self.is_no_substitution_template() {
+            self.quasis[0].value.cooked.and_then(|c| c.as_str().map(Str::from))
+        } else {
+            None
+        }
     }
 }
 
@@ -624,10 +628,13 @@ impl<'a> MemberExpression<'a> {
     pub fn static_property_info(&self) -> Option<(Span, &'a str)> {
         match self {
             MemberExpression::ComputedMemberExpression(expr) => match &expr.expression {
-                Expression::StringLiteral(lit) => Some((lit.span, lit.value.as_str())),
+                Expression::StringLiteral(lit) => lit.value.as_str().map(|s| (lit.span, s)),
                 Expression::TemplateLiteral(lit) => {
                     if lit.quasis.len() == 1 {
-                        lit.quasis[0].value.cooked.map(|cooked| (lit.span, cooked.as_str()))
+                        lit.quasis[0]
+                            .value
+                            .cooked
+                            .and_then(|cooked| cooked.as_str().map(|s| (lit.span, s)))
                     } else {
                         None
                     }
@@ -670,8 +677,10 @@ impl<'a> ComputedMemberExpression<'a> {
     /// Returns the static property name of this member expression, if it has one, or `None` otherwise.
     pub fn static_property_name(&self) -> Option<Str<'a>> {
         match &self.expression {
-            Expression::StringLiteral(lit) => Some(lit.value),
-            Expression::TemplateLiteral(lit) if lit.quasis.len() == 1 => lit.quasis[0].value.cooked,
+            Expression::StringLiteral(lit) => lit.value.as_str().map(Str::from),
+            Expression::TemplateLiteral(lit) if lit.quasis.len() == 1 => {
+                lit.quasis[0].value.cooked.and_then(|c| c.as_str().map(Str::from))
+            }
             Expression::RegExpLiteral(lit) => lit.raw,
             _ => None,
         }
@@ -682,9 +691,9 @@ impl<'a> ComputedMemberExpression<'a> {
     /// If you don't need the [`Span`], use [`ComputedMemberExpression::static_property_name`] instead.
     pub fn static_property_info(&self) -> Option<(Span, &'a str)> {
         match &self.expression {
-            Expression::StringLiteral(lit) => Some((lit.span, lit.value.as_str())),
+            Expression::StringLiteral(lit) => lit.value.as_str().map(|s| (lit.span, s)),
             Expression::TemplateLiteral(lit) if lit.quasis.len() == 1 => {
-                lit.quasis[0].value.cooked.map(|cooked| (lit.span, cooked.as_str()))
+                lit.quasis[0].value.cooked.and_then(|cooked| cooked.as_str().map(|s| (lit.span, s)))
             }
             Expression::RegExpLiteral(lit) => lit.raw.map(|raw| (lit.span, raw.as_str())),
             _ => None,
@@ -2041,7 +2050,9 @@ impl<'a> ImportAttributeKey<'a> {
     pub fn as_arena_str(&self) -> Str<'a> {
         match self {
             Self::Identifier(identifier) => identifier.name.into(),
-            Self::StringLiteral(literal) => literal.value,
+            Self::StringLiteral(literal) => {
+                literal.value.as_str().map_or_else(|| Str::from(""), Str::from)
+            }
         }
     }
 }
@@ -2126,7 +2137,9 @@ impl<'a> ModuleExportName<'a> {
         match self {
             Self::IdentifierName(identifier) => identifier.name.into(),
             Self::IdentifierReference(identifier) => identifier.name.into(),
-            Self::StringLiteral(literal) => literal.value,
+            Self::StringLiteral(literal) => {
+                literal.value.as_str().map_or_else(|| Str::from(""), Str::from)
+            }
         }
     }
 

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -83,25 +83,15 @@ impl StringLiteral<'_> {
     ///
     /// See: <https://tc39.es/ecma262/multipage/abstract-operations.html#sec-isstringwellformedunicode>
     pub fn is_string_well_formed_unicode(&self) -> bool {
-        let mut chars = self.value.chars();
-        while let Some(c) = chars.next() {
-            if c == '\\' && chars.next() == Some('u') {
-                let hex = &chars.as_str()[..4];
-                if let Ok(hex) = u32::from_str_radix(hex, 16)
-                    && (0xd800..=0xdfff).contains(&hex)
-                {
-                    return false;
-                }
-            }
-        }
-        true
+        // WTF-8 string is well-formed iff it's valid UTF-8 (i.e., contains no lone surrogates).
+        self.value.as_str().is_some()
     }
 }
 
-impl AsRef<str> for StringLiteral<'_> {
+impl AsRef<oxc_wtf8::Wtf8> for StringLiteral<'_> {
     #[inline]
-    fn as_ref(&self) -> &str {
-        self.value.as_ref()
+    fn as_ref(&self) -> &oxc_wtf8::Wtf8 {
+        self.value.as_wtf8()
     }
 }
 

--- a/crates/oxc_ast/src/ast_impl/ts.rs
+++ b/crates/oxc_ast/src/ast_impl/ts.rs
@@ -16,7 +16,9 @@ impl<'a> TSEnumMemberName<'a> {
     pub fn static_name(&self) -> Str<'a> {
         match self {
             Self::Identifier(ident) => ident.name.into(),
-            Self::String(lit) | Self::ComputedString(lit) => lit.value,
+            Self::String(lit) | Self::ComputedString(lit) => {
+                lit.value.as_str().map_or_else(|| Str::from(""), Str::from)
+            }
             Self::ComputedTemplateString(template) => template
                 .single_quasi()
                 .expect("`TSEnumMemberName::TemplateString` should have no substitution and at least one quasi"),

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -664,10 +664,13 @@ impl<'a> MemberExpressionKind<'a> {
     pub fn static_property_info(&self) -> Option<(Span, &'a str)> {
         match self {
             Self::Computed(expr) => match &expr.expression {
-                Expression::StringLiteral(lit) => Some((lit.span, lit.value.as_str())),
+                Expression::StringLiteral(lit) => lit.value.as_str().map(|s| (lit.span, s)),
                 Expression::TemplateLiteral(lit) => {
                     if lit.quasis.len() == 1 {
-                        lit.quasis[0].value.cooked.map(|cooked| (lit.span, cooked.as_str()))
+                        lit.quasis[0]
+                            .value
+                            .cooked
+                            .and_then(|cooked| cooked.as_str().map(|s| (lit.span, s)))
                     } else {
                         None
                     }

--- a/crates/oxc_ast/src/builder/custom.rs
+++ b/crates/oxc_ast/src/builder/custom.rs
@@ -13,7 +13,7 @@ use std::{alloc::Layout, mem::MaybeUninit, slice, str};
 
 use oxc_allocator::{Allocator, ArenaBox, GetAllocator};
 use oxc_span::{SPAN, Span};
-use oxc_str::Str;
+use oxc_str::{Str, Wtf8Str};
 use oxc_syntax::{number::NumberBase, operator::UnaryOperator, scope::ScopeId};
 
 use crate::ast::*;
@@ -56,9 +56,10 @@ impl<'a> Directive<'a> {
     pub fn new_use_strict(builder: &impl GetAstBuilder<'a>) -> Self {
         let builder = builder.builder();
         let use_strict = Str::from("use strict");
+        let use_strict_wtf8 = Wtf8Str::new_const("use strict");
         Directive::new(
             SPAN,
-            StringLiteral::new(SPAN, use_strict, None, builder),
+            StringLiteral::new(SPAN, use_strict_wtf8, None, builder),
             use_strict,
             builder,
         )
@@ -197,29 +198,6 @@ impl<'a> TemplateElement<'a> {
         let builder = builder.builder();
         value.raw = escape_template_element_raw(value.raw, builder.allocator());
         TemplateElement::new(span, value, tail, builder)
-    }
-
-    /// Build a [`TemplateElement`] with `lone_surrogates`, escaping special characters in the raw value.
-    ///
-    /// Like [`TemplateElement::new_with_lone_surrogates`], but escapes backticks, `${`,
-    /// backslashes, and carriage returns in `value.raw` first.
-    ///
-    /// ## Parameters
-    /// * `span`: The [`Span`] covering this node
-    /// * `value`
-    /// * `tail`
-    /// * `lone_surrogates`: The template element contains lone surrogates.
-    #[inline]
-    pub fn new_escape_raw_with_lone_surrogates(
-        span: Span,
-        mut value: TemplateElementValue<'a>,
-        tail: bool,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        let builder = builder.builder();
-        value.raw = escape_template_element_raw(value.raw, builder.allocator());
-        TemplateElement::new_with_lone_surrogates(span, value, tail, lone_surrogates, builder)
     }
 }
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -122,13 +122,12 @@ const _: () = {
     assert!(offset_of!(TaggedTemplateExpression, type_arguments) == 32);
     assert!(offset_of!(TaggedTemplateExpression, quasi) == 40);
 
-    // Padding: 2 bytes
+    // Padding: 3 bytes
     assert!(size_of::<TemplateElement>() == 48);
     assert!(align_of::<TemplateElement>() == 8);
     assert!(offset_of!(TemplateElement, span) == 0);
     assert!(offset_of!(TemplateElement, node_id) == 8);
     assert!(offset_of!(TemplateElement, tail) == 12);
-    assert!(offset_of!(TemplateElement, lone_surrogates) == 13);
     assert!(offset_of!(TemplateElement, value) == 16);
 
     // Padding: 0 bytes
@@ -1000,12 +999,11 @@ const _: () = {
     assert!(offset_of!(NumericLiteral, raw) == 16);
     assert!(offset_of!(NumericLiteral, value) == 32);
 
-    // Padding: 3 bytes
+    // Padding: 4 bytes
     assert!(size_of::<StringLiteral>() == 48);
     assert!(align_of::<StringLiteral>() == 8);
     assert!(offset_of!(StringLiteral, span) == 0);
     assert!(offset_of!(StringLiteral, node_id) == 8);
-    assert!(offset_of!(StringLiteral, lone_surrogates) == 12);
     assert!(offset_of!(StringLiteral, value) == 16);
     assert!(offset_of!(StringLiteral, raw) == 32);
 
@@ -1964,13 +1962,12 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TaggedTemplateExpression, type_arguments) == 20);
     assert!(offset_of!(TaggedTemplateExpression, quasi) == 24);
 
-    // Padding: 2 bytes
+    // Padding: 3 bytes
     assert!(size_of::<TemplateElement>() == 32);
     assert!(align_of::<TemplateElement>() == 4);
     assert!(offset_of!(TemplateElement, span) == 0);
     assert!(offset_of!(TemplateElement, node_id) == 8);
     assert!(offset_of!(TemplateElement, tail) == 12);
-    assert!(offset_of!(TemplateElement, lone_surrogates) == 13);
     assert!(offset_of!(TemplateElement, value) == 16);
 
     // Padding: 0 bytes
@@ -2217,12 +2214,12 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<Statement>() == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<Directive>() == 52);
+    assert!(size_of::<Directive>() == 48);
     assert!(align_of::<Directive>() == 4);
     assert!(offset_of!(Directive, span) == 0);
     assert!(offset_of!(Directive, node_id) == 8);
     assert!(offset_of!(Directive, expression) == 12);
-    assert!(offset_of!(Directive, directive) == 44);
+    assert!(offset_of!(Directive, directive) == 40);
 
     // Padding: 0 bytes
     assert!(size_of::<Hashbang>() == 20);
@@ -2694,7 +2691,7 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(ImportExpression, options) == 24);
 
     // Padding: 2 bytes
-    assert!(size_of::<ImportDeclaration>() == 68);
+    assert!(size_of::<ImportDeclaration>() == 64);
     assert!(align_of::<ImportDeclaration>() == 4);
     assert!(offset_of!(ImportDeclaration, span) == 0);
     assert!(offset_of!(ImportDeclaration, node_id) == 8);
@@ -2702,7 +2699,7 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(ImportDeclaration, import_kind) == 13);
     assert!(offset_of!(ImportDeclaration, specifiers) == 16);
     assert!(offset_of!(ImportDeclaration, source) == 32);
-    assert!(offset_of!(ImportDeclaration, with_clause) == 64);
+    assert!(offset_of!(ImportDeclaration, with_clause) == 60);
 
     assert!(size_of::<ImportPhase>() == 1);
     assert!(align_of::<ImportPhase>() == 1);
@@ -2711,13 +2708,13 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<ImportDeclarationSpecifier>() == 4);
 
     // Padding: 3 bytes
-    assert!(size_of::<ImportSpecifier>() == 80);
+    assert!(size_of::<ImportSpecifier>() == 76);
     assert!(align_of::<ImportSpecifier>() == 4);
     assert!(offset_of!(ImportSpecifier, span) == 0);
     assert!(offset_of!(ImportSpecifier, node_id) == 8);
     assert!(offset_of!(ImportSpecifier, import_kind) == 12);
     assert!(offset_of!(ImportSpecifier, imported) == 16);
-    assert!(offset_of!(ImportSpecifier, local) == 52);
+    assert!(offset_of!(ImportSpecifier, local) == 48);
 
     // Padding: 0 bytes
     assert!(size_of::<ImportDefaultSpecifier>() == 40);
@@ -2745,14 +2742,14 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<WithClauseKeyword>() == 1);
 
     // Padding: 0 bytes
-    assert!(size_of::<ImportAttribute>() == 80);
+    assert!(size_of::<ImportAttribute>() == 72);
     assert!(align_of::<ImportAttribute>() == 4);
     assert!(offset_of!(ImportAttribute, span) == 0);
     assert!(offset_of!(ImportAttribute, node_id) == 8);
     assert!(offset_of!(ImportAttribute, key) == 12);
-    assert!(offset_of!(ImportAttribute, value) == 48);
+    assert!(offset_of!(ImportAttribute, value) == 44);
 
-    assert!(size_of::<ImportAttributeKey>() == 36);
+    assert!(size_of::<ImportAttributeKey>() == 32);
     assert!(align_of::<ImportAttributeKey>() == 4);
 
     // Padding: 0 bytes
@@ -2771,14 +2768,14 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(ExportNamedDeclaration, specifiers) == 16);
 
     // Padding: 3 bytes
-    assert!(size_of::<ExportFromDeclaration>() == 68);
+    assert!(size_of::<ExportFromDeclaration>() == 64);
     assert!(align_of::<ExportFromDeclaration>() == 4);
     assert!(offset_of!(ExportFromDeclaration, span) == 0);
     assert!(offset_of!(ExportFromDeclaration, node_id) == 8);
     assert!(offset_of!(ExportFromDeclaration, export_kind) == 12);
     assert!(offset_of!(ExportFromDeclaration, specifiers) == 16);
     assert!(offset_of!(ExportFromDeclaration, source) == 32);
-    assert!(offset_of!(ExportFromDeclaration, with_clause) == 64);
+    assert!(offset_of!(ExportFromDeclaration, with_clause) == 60);
 
     // Padding: 0 bytes
     assert!(size_of::<ExportDefaultDeclaration>() == 20);
@@ -2788,28 +2785,28 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(ExportDefaultDeclaration, declaration) == 12);
 
     // Padding: 3 bytes
-    assert!(size_of::<ExportAllDeclaration>() == 88);
+    assert!(size_of::<ExportAllDeclaration>() == 80);
     assert!(align_of::<ExportAllDeclaration>() == 4);
     assert!(offset_of!(ExportAllDeclaration, span) == 0);
     assert!(offset_of!(ExportAllDeclaration, node_id) == 8);
     assert!(offset_of!(ExportAllDeclaration, export_kind) == 12);
     assert!(offset_of!(ExportAllDeclaration, exported) == 16);
-    assert!(offset_of!(ExportAllDeclaration, source) == 52);
-    assert!(offset_of!(ExportAllDeclaration, with_clause) == 84);
+    assert!(offset_of!(ExportAllDeclaration, source) == 48);
+    assert!(offset_of!(ExportAllDeclaration, with_clause) == 76);
 
     // Padding: 3 bytes
-    assert!(size_of::<ExportSpecifier>() == 88);
+    assert!(size_of::<ExportSpecifier>() == 80);
     assert!(align_of::<ExportSpecifier>() == 4);
     assert!(offset_of!(ExportSpecifier, span) == 0);
     assert!(offset_of!(ExportSpecifier, node_id) == 8);
     assert!(offset_of!(ExportSpecifier, export_kind) == 12);
     assert!(offset_of!(ExportSpecifier, local) == 16);
-    assert!(offset_of!(ExportSpecifier, exported) == 52);
+    assert!(offset_of!(ExportSpecifier, exported) == 48);
 
     assert!(size_of::<ExportDefaultDeclarationKind>() == 8);
     assert!(align_of::<ExportDefaultDeclarationKind>() == 4);
 
-    assert!(size_of::<ModuleExportName>() == 36);
+    assert!(size_of::<ModuleExportName>() == 32);
     assert!(align_of::<ModuleExportName>() == 4);
 
     // Padding: 0 bytes
@@ -2842,14 +2839,13 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(NumericLiteral, raw) == 16);
     assert!(offset_of!(NumericLiteral, value) == 24);
 
-    // Padding: 3 bytes
-    assert!(size_of::<StringLiteral>() == 32);
+    // Padding: 0 bytes
+    assert!(size_of::<StringLiteral>() == 28);
     assert!(align_of::<StringLiteral>() == 4);
     assert!(offset_of!(StringLiteral, span) == 0);
     assert!(offset_of!(StringLiteral, node_id) == 8);
-    assert!(offset_of!(StringLiteral, lone_surrogates) == 12);
-    assert!(offset_of!(StringLiteral, value) == 16);
-    assert!(offset_of!(StringLiteral, raw) == 24);
+    assert!(offset_of!(StringLiteral, value) == 12);
+    assert!(offset_of!(StringLiteral, raw) == 20);
 
     // Padding: 3 bytes
     assert!(size_of::<BigIntLiteral>() == 32);
@@ -3427,14 +3423,14 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<TSTypePredicateName>() == 4);
 
     // Padding: 3 bytes
-    assert!(size_of::<TSExternalModuleDeclaration>() == 56);
+    assert!(size_of::<TSExternalModuleDeclaration>() == 52);
     assert!(align_of::<TSExternalModuleDeclaration>() == 4);
     assert!(offset_of!(TSExternalModuleDeclaration, span) == 0);
     assert!(offset_of!(TSExternalModuleDeclaration, node_id) == 8);
     assert!(offset_of!(TSExternalModuleDeclaration, scope_id) == 12);
     assert!(offset_of!(TSExternalModuleDeclaration, id) == 16);
-    assert!(offset_of!(TSExternalModuleDeclaration, body) == 48);
-    assert!(offset_of!(TSExternalModuleDeclaration, declare) == 52);
+    assert!(offset_of!(TSExternalModuleDeclaration, body) == 44);
+    assert!(offset_of!(TSExternalModuleDeclaration, declare) == 48);
 
     // Padding: 2 bytes
     assert!(size_of::<TSNamespaceDeclaration>() == 56);
@@ -3497,14 +3493,14 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<TSTypeQueryExprName>() == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSImportType>() == 60);
+    assert!(size_of::<TSImportType>() == 56);
     assert!(align_of::<TSImportType>() == 4);
     assert!(offset_of!(TSImportType, span) == 0);
     assert!(offset_of!(TSImportType, node_id) == 8);
     assert!(offset_of!(TSImportType, source) == 12);
-    assert!(offset_of!(TSImportType, options) == 44);
-    assert!(offset_of!(TSImportType, qualifier) == 48);
-    assert!(offset_of!(TSImportType, type_arguments) == 56);
+    assert!(offset_of!(TSImportType, options) == 40);
+    assert!(offset_of!(TSImportType, qualifier) == 44);
+    assert!(offset_of!(TSImportType, type_arguments) == 52);
 
     assert!(size_of::<TSImportTypeQualifier>() == 8);
     assert!(align_of::<TSImportTypeQualifier>() == 4);
@@ -3600,7 +3596,7 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<TSModuleReference>() == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSExternalModuleReference>() == 44);
+    assert!(size_of::<TSExternalModuleReference>() == 40);
     assert!(align_of::<TSExternalModuleReference>() == 4);
     assert!(offset_of!(TSExternalModuleReference, span) == 0);
     assert!(offset_of!(TSExternalModuleReference, node_id) == 8);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -16,7 +16,7 @@
 use std::cell::Cell;
 
 use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator, IntoIn};
-use oxc_str::{Ident, Str};
+use oxc_str::{Ident, Str, Wtf8Str};
 use oxc_syntax::{reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
 
 use crate::{
@@ -191,37 +191,11 @@ impl<'a> Expression<'a> {
     #[inline]
     pub fn new_string_literal(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::StringLiteral(StringLiteral::boxed(span, value, raw, builder.builder()))
-    }
-
-    /// Build an [`Expression::StringLiteral`] with `lone_surrogates`.
-    ///
-    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_string_literal_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::StringLiteral(StringLiteral::boxed_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 
     /// Build an [`Expression::TemplateLiteral`].
@@ -1719,37 +1693,11 @@ impl<'a> ArrayExpressionElement<'a> {
     #[inline]
     pub fn new_string_literal(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::StringLiteral(StringLiteral::boxed(span, value, raw, builder.builder()))
-    }
-
-    /// Build an [`ArrayExpressionElement::StringLiteral`] with `lone_surrogates`.
-    ///
-    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_string_literal_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::StringLiteral(StringLiteral::boxed_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 
     /// Build an [`ArrayExpressionElement::TemplateLiteral`].
@@ -3154,37 +3102,11 @@ impl<'a> PropertyKey<'a> {
     #[inline]
     pub fn new_string_literal(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::StringLiteral(StringLiteral::boxed(span, value, raw, builder.builder()))
-    }
-
-    /// Build a [`PropertyKey::StringLiteral`] with `lone_surrogates`.
-    ///
-    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_string_literal_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::StringLiteral(StringLiteral::boxed_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 
     /// Build a [`PropertyKey::TemplateLiteral`].
@@ -4385,38 +4307,7 @@ impl<'a> TemplateElement<'a> {
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         let builder = builder.builder();
-        TemplateElement {
-            node_id: Cell::new(builder.node_id()),
-            span,
-            value,
-            tail,
-            lone_surrogates: Default::default(),
-        }
-    }
-
-    /// Build a [`TemplateElement`] with `lone_surrogates`.
-    ///
-    /// ## Parameters
-    /// * `span`: The [`Span`] covering this node
-    /// * `value`
-    /// * `tail`
-    /// * `lone_surrogates`: The template element contains lone surrogates.
-    #[inline]
-    pub fn new_with_lone_surrogates(
-        span: Span,
-        value: TemplateElementValue<'a>,
-        tail: bool,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        let builder = builder.builder();
-        TemplateElement {
-            node_id: Cell::new(builder.node_id()),
-            span,
-            value,
-            tail,
-            lone_surrogates,
-        }
+        TemplateElement { node_id: Cell::new(builder.node_id()), span, value, tail }
     }
 }
 
@@ -5096,37 +4987,11 @@ impl<'a> Argument<'a> {
     #[inline]
     pub fn new_string_literal(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::StringLiteral(StringLiteral::boxed(span, value, raw, builder.builder()))
-    }
-
-    /// Build an [`Argument::StringLiteral`] with `lone_surrogates`.
-    ///
-    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_string_literal_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::StringLiteral(StringLiteral::boxed_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 
     /// Build an [`Argument::TemplateLiteral`].
@@ -10432,37 +10297,11 @@ impl<'a> ForStatementInit<'a> {
     #[inline]
     pub fn new_string_literal(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::StringLiteral(StringLiteral::boxed(span, value, raw, builder.builder()))
-    }
-
-    /// Build a [`ForStatementInit::StringLiteral`] with `lone_surrogates`.
-    ///
-    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_string_literal_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::StringLiteral(StringLiteral::boxed_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 
     /// Build a [`ForStatementInit::TemplateLiteral`].
@@ -13494,37 +13333,11 @@ impl<'a> ArrowFunctionBody<'a> {
     #[inline]
     pub fn new_string_literal(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::StringLiteral(StringLiteral::boxed(span, value, raw, builder.builder()))
-    }
-
-    /// Build an [`ArrowFunctionBody::StringLiteral`] with `lone_surrogates`.
-    ///
-    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_string_literal_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::StringLiteral(StringLiteral::boxed_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 
     /// Build an [`ArrowFunctionBody::TemplateLiteral`].
@@ -16311,35 +16124,11 @@ impl<'a> ImportAttributeKey<'a> {
     #[inline]
     pub fn new_string_literal(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::StringLiteral(StringLiteral::new(span, value, raw, builder.builder()))
-    }
-
-    /// Build an [`ImportAttributeKey::StringLiteral`] with `lone_surrogates`.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_string_literal_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::StringLiteral(StringLiteral::new_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 }
 
@@ -16963,37 +16752,11 @@ impl<'a> ExportDefaultDeclarationKind<'a> {
     #[inline]
     pub fn new_string_literal(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::StringLiteral(StringLiteral::boxed(span, value, raw, builder.builder()))
-    }
-
-    /// Build an [`ExportDefaultDeclarationKind::StringLiteral`] with `lone_surrogates`.
-    ///
-    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_string_literal_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::StringLiteral(StringLiteral::boxed_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 
     /// Build an [`ExportDefaultDeclarationKind::TemplateLiteral`].
@@ -18139,35 +17902,11 @@ impl<'a> ModuleExportName<'a> {
     #[inline]
     pub fn new_string_literal(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::StringLiteral(StringLiteral::new(span, value, raw, builder.builder()))
-    }
-
-    /// Build a [`ModuleExportName::StringLiteral`] with `lone_surrogates`.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_string_literal_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::StringLiteral(StringLiteral::new_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 }
 
@@ -18339,18 +18078,12 @@ impl<'a> StringLiteral<'a> {
     #[inline]
     pub fn new(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         let builder = builder.builder();
-        StringLiteral {
-            node_id: Cell::new(builder.node_id()),
-            span,
-            value: value.into(),
-            raw,
-            lone_surrogates: Default::default(),
-        }
+        StringLiteral { node_id: Cell::new(builder.node_id()), span, value: value.into(), raw }
     }
 
     /// Build a [`StringLiteral`], and store it in the memory arena.
@@ -18365,65 +18098,12 @@ impl<'a> StringLiteral<'a> {
     #[inline]
     pub fn boxed(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> ArenaBox<'a, Self> {
         let builder = builder.builder();
         ArenaBox::new_in(Self::new(span, value, raw, builder), &builder.allocator())
-    }
-
-    /// Build a [`StringLiteral`] with `lone_surrogates`.
-    ///
-    /// If you want the built node to be allocated in the memory arena,
-    /// use [`StringLiteral::boxed_with_lone_surrogates`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        let builder = builder.builder();
-        StringLiteral {
-            node_id: Cell::new(builder.node_id()),
-            span,
-            value: value.into(),
-            raw,
-            lone_surrogates,
-        }
-    }
-
-    /// Build a [`StringLiteral`] with `lone_surrogates`, and store it in the memory arena.
-    ///
-    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
-    /// If you want a stack-allocated node, use [`StringLiteral::new_with_lone_surrogates`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn boxed_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> ArenaBox<'a, Self> {
-        let builder = builder.builder();
-        ArenaBox::new_in(
-            Self::new_with_lone_surrogates(span, value, raw, lone_surrogates, builder),
-            &builder.allocator(),
-        )
     }
 }
 
@@ -19154,37 +18834,11 @@ impl<'a> JSXExpression<'a> {
     #[inline]
     pub fn new_string_literal(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::StringLiteral(StringLiteral::boxed(span, value, raw, builder.builder()))
-    }
-
-    /// Build a [`JSXExpression::StringLiteral`] with `lone_surrogates`.
-    ///
-    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_string_literal_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::StringLiteral(StringLiteral::boxed_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 
     /// Build a [`JSXExpression::TemplateLiteral`].
@@ -20459,37 +20113,11 @@ impl<'a> JSXAttributeValue<'a> {
     #[inline]
     pub fn new_string_literal(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::StringLiteral(StringLiteral::boxed(span, value, raw, builder.builder()))
-    }
-
-    /// Build a [`JSXAttributeValue::StringLiteral`] with `lone_surrogates`.
-    ///
-    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_string_literal_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::StringLiteral(StringLiteral::boxed_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 
     /// Build a [`JSXAttributeValue::ExpressionContainer`].
@@ -20611,7 +20239,7 @@ impl<'a> JSXChild<'a> {
     #[inline]
     pub fn new_text(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
@@ -20754,7 +20382,7 @@ impl<'a> JSXText<'a> {
     #[inline]
     pub fn new(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
@@ -20774,7 +20402,7 @@ impl<'a> JSXText<'a> {
     #[inline]
     pub fn boxed(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> ArenaBox<'a, Self> {
@@ -20973,37 +20601,11 @@ impl<'a> TSEnumMemberName<'a> {
     #[inline]
     pub fn new_string(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::String(StringLiteral::boxed(span, value, raw, builder.builder()))
-    }
-
-    /// Build a [`TSEnumMemberName::String`] with `lone_surrogates`.
-    ///
-    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_string_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::String(StringLiteral::boxed_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 
     /// Build a [`TSEnumMemberName::ComputedString`].
@@ -21017,37 +20619,11 @@ impl<'a> TSEnumMemberName<'a> {
     #[inline]
     pub fn new_computed_string(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::ComputedString(StringLiteral::boxed(span, value, raw, builder.builder()))
-    }
-
-    /// Build a [`TSEnumMemberName::ComputedString`] with `lone_surrogates`.
-    ///
-    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_computed_string_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::ComputedString(StringLiteral::boxed_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 
     /// Build a [`TSEnumMemberName::ComputedTemplateString`].
@@ -21206,37 +20782,11 @@ impl<'a> TSLiteral<'a> {
     #[inline]
     pub fn new_string_literal(
         span: Span,
-        value: impl Into<Str<'a>>,
+        value: impl Into<Wtf8Str<'a>>,
         raw: Option<Str<'a>>,
         builder: &impl GetAstBuilder<'a>,
     ) -> Self {
         Self::StringLiteral(StringLiteral::boxed(span, value, raw, builder.builder()))
-    }
-
-    /// Build a [`TSLiteral::StringLiteral`] with `lone_surrogates`.
-    ///
-    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code.
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    /// * `lone_surrogates`: The string value contains lone surrogates.
-    #[inline]
-    pub fn new_string_literal_with_lone_surrogates(
-        span: Span,
-        value: impl Into<Str<'a>>,
-        raw: Option<Str<'a>>,
-        lone_surrogates: bool,
-        builder: &impl GetAstBuilder<'a>,
-    ) -> Self {
-        Self::StringLiteral(StringLiteral::boxed_with_lone_surrogates(
-            span,
-            value,
-            raw,
-            lone_surrogates,
-            builder.builder(),
-        ))
     }
 
     /// Build a [`TSLiteral::TemplateLiteral`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -592,11 +592,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for TemplateElement<'_> {
             span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
             value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
             tail: CloneIn::clone_in_impl(&self.tail, with_semantic_ids, allocator),
-            lone_surrogates: CloneIn::clone_in_impl(
-                &self.lone_surrogates,
-                with_semantic_ids,
-                allocator,
-            ),
         }
     }
 }
@@ -3239,11 +3234,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for StringLiteral<'_> {
             span: CloneIn::clone_in_impl(&self.span, with_semantic_ids, allocator),
             value: CloneIn::clone_in_impl(&self.value, with_semantic_ids, allocator),
             raw: CloneIn::clone_in_impl(&self.raw, with_semantic_ids, allocator),
-            lone_surrogates: CloneIn::clone_in_impl(
-                &self.lone_surrogates,
-                with_semantic_ids,
-                allocator,
-            ),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -292,7 +292,6 @@ impl ContentEq for TemplateElement<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.value, &other.value)
             && ContentEq::content_eq(&self.tail, &other.tail)
-            && ContentEq::content_eq(&self.lone_surrogates, &other.lone_surrogates)
     }
 }
 
@@ -1581,7 +1580,6 @@ impl ContentEq for NumericLiteral<'_> {
 impl ContentEq for StringLiteral<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.value, &other.value)
-            && ContentEq::content_eq(&self.lone_surrogates, &other.lone_surrogates)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -232,7 +232,6 @@ impl<'a> Dummy<'a> for TemplateElement<'a> {
             span: Dummy::dummy(allocator),
             value: Dummy::dummy(allocator),
             tail: Dummy::dummy(allocator),
-            lone_surrogates: Dummy::dummy(allocator),
         }
     }
 }
@@ -1816,7 +1815,6 @@ impl<'a> Dummy<'a> for StringLiteral<'a> {
             span: Dummy::dummy(allocator),
             value: Dummy::dummy(allocator),
             raw: Dummy::dummy(allocator),
-            lone_surrogates: Dummy::dummy(allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/serialize/literal.rs
+++ b/crates/oxc_ast/src/serialize/literal.rs
@@ -1,5 +1,5 @@
 use oxc_ast_macros::ast_meta;
-use oxc_estree::{ESTree, JsonSafeString, LoneSurrogatesString, Serializer, StructSerializer};
+use oxc_estree::{ESTree, JsonSafeString, Serializer, StructSerializer};
 
 use crate::ast::*;
 
@@ -51,38 +51,15 @@ impl ESTree for NullLiteralRaw<'_> {
 
 /// Serializer for `value` field of `StringLiteral`.
 ///
-/// Handle when `lone_surrogates` flag is set, indicating the string contains lone surrogates.
+/// Value is stored as WTF-8, which can contain lone surrogates.
+/// `Wtf8Str`'s `ESTree` impl handles surrogate escaping as `\uXXXX`.
 #[ast_meta]
-#[estree(
-    ts_type = "string",
-    raw_deser = r#"
-        let value = DESER[Str](POS_OFFSET.value);
-        if (DESER[bool](POS_OFFSET.lone_surrogates)) {
-            value = value.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)));
-        }
-        value
-    "#
-)]
+#[estree(ts_type = "string", raw_deser = "DESER[Wtf8Str](POS_OFFSET.value)")]
 pub struct StringLiteralValue<'a, 'b>(pub &'b StringLiteral<'a>);
 
 impl ESTree for StringLiteralValue<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let lit = self.0;
-        #[expect(clippy::if_not_else)]
-        if !lit.lone_surrogates {
-            lit.value.serialize(serializer);
-        } else {
-            // String contains lone surrogates. Very uncommon, so cold path.
-            self.serialize_lone_surrogates(serializer);
-        }
-    }
-}
-
-impl StringLiteralValue<'_, '_> {
-    #[cold]
-    #[inline(never)]
-    fn serialize_lone_surrogates<S: Serializer>(&self, serializer: S) {
-        LoneSurrogatesString(self.0.value.as_str()).serialize(serializer);
+        self.0.value.serialize(serializer);
     }
 }
 
@@ -200,10 +177,6 @@ impl ESTree for RegExpFlagsConverter<'_> {
         start = IS_TS ? DESER[i32](POS_OFFSET.span.start) - 1 : DESER[i32](POS_OFFSET.span.start),
         end = IS_TS ? DESER[i32](POS_OFFSET.span.end) + 2 - tail : DESER[i32](POS_OFFSET.span.end),
         value = DESER[TemplateElementValue](POS_OFFSET.value);
-    if (value.cooked !== null && DESER[bool](POS_OFFSET.lone_surrogates)) {
-        value.cooked = value.cooked
-            .replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)));
-    }
     { type: 'TemplateElement', value, tail, start, end, ...(RANGE && { range: [start, end] }), ...(PARENT && { parent }) }
 "#)]
 pub struct TemplateElementConverter<'a, 'b>(pub &'b TemplateElement<'a>);
@@ -230,42 +203,12 @@ impl ESTree for TemplateElementConverter<'_, '_> {
 }
 
 /// Serializer for `value` field of `TemplateElement`.
-///
-/// Handle when `lone_surrogates` flag is set, indicating the cooked string contains lone surrogates.
-///
-/// Implementation for `raw_deser` is included in `TemplateElementConverter` above.
 #[ast_meta]
-#[estree(
-    ts_type = "TemplateElementValue",
-    raw_deser = "(() => { throw new Error('Should not appear in deserializer code'); })()"
-)]
+#[estree(ts_type = "TemplateElementValue")]
 pub struct TemplateElementValue<'a, 'b>(pub &'b TemplateElement<'a>);
 
 impl ESTree for TemplateElementValue<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let element = self.0;
-        #[expect(clippy::if_not_else)]
-        if !element.lone_surrogates {
-            element.value.serialize(serializer);
-        } else {
-            // String contains lone surrogates. Very uncommon, so cold path.
-            self.serialize_lone_surrogates(serializer);
-        }
-    }
-}
-
-impl TemplateElementValue<'_, '_> {
-    #[cold]
-    #[inline(never)]
-    fn serialize_lone_surrogates<S: Serializer>(&self, serializer: S) {
-        let value = &self.0.value;
-
-        let mut state = serializer.serialize_struct();
-        state.serialize_field("raw", &value.raw);
-
-        let cooked = value.cooked.as_ref().map(|cooked| LoneSurrogatesString(cooked.as_str()));
-        state.serialize_field("cooked", &cooked);
-
-        state.end();
+        self.0.value.serialize(serializer);
     }
 }

--- a/crates/oxc_ast_macros/src/generated/structs.rs
+++ b/crates/oxc_ast_macros/src/generated/structs.rs
@@ -423,7 +423,7 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
         (
             "StringLiteral",
             StructDetails {
-                field_order: Some(&[1, 0, 3, 4, 2]),
+                field_order: Some(&[1, 0, 2, 3]),
                 is_node: true,
                 is_transparent: false,
             },
@@ -1270,7 +1270,7 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
         (
             "TemplateElement",
             StructDetails {
-                field_order: Some(&[1, 0, 4, 2, 3]),
+                field_order: Some(&[1, 0, 3, 2]),
                 is_node: true,
                 is_transparent: false,
             },

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -22,6 +22,7 @@ doctest = true
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
+oxc_wtf8 = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["code_buffer", "slice_iter", "stack"] }
 oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true }

--- a/crates/oxc_codegen/src/cjs_module_lexer.rs
+++ b/crates/oxc_codegen/src/cjs_module_lexer.rs
@@ -158,7 +158,7 @@ pub fn try_print_equality_string(
     let Expression::StringLiteral(str_lit) = operand else {
         return false;
     };
-    if !matches!(str_lit.value.as_str(), "default" | "__esModule") {
+    if !matches!(str_lit.value.as_str(), Some("default" | "__esModule")) {
         return false;
     }
     p.print_string_literal(str_lit, false);

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1170,7 +1170,7 @@ fn get_module_export_name<'a>(
     match module_export_name {
         ModuleExportName::IdentifierName(ident) => ident.name.as_str(),
         ModuleExportName::IdentifierReference(ident) => p.get_identifier_reference_name(ident),
-        ModuleExportName::StringLiteral(s) => s.value.as_str(),
+        ModuleExportName::StringLiteral(s) => s.value.as_str().unwrap_or(""),
     }
 }
 
@@ -2726,9 +2726,10 @@ impl Gen for JSXAttributeValue<'_> {
             Self::Fragment(fragment) => fragment.print(p, ctx),
             Self::Element(el) => el.print(p, ctx),
             Self::StringLiteral(lit) => {
-                let quote = if lit.value.contains('"') { b'\'' } else { b'"' };
+                let quote = if lit.value.as_bytes().contains(&b'"') { b'\'' } else { b'"' };
                 p.print_ascii_byte(quote);
-                p.print_str(&lit.value);
+                // For JSX attribute string, use WTF-8 aware printing via lossy fallback for now
+                p.print_str(&lit.value.to_string_lossy());
                 p.print_ascii_byte(quote);
             }
             Self::ExpressionContainer(expr_container) => expr_container.print(p, ctx),
@@ -2819,7 +2820,8 @@ impl Gen for JSXClosingFragment {
 impl Gen for JSXText<'_> {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
         p.add_source_mapping(self.span);
-        p.print_str(self.value.as_str());
+        // JSXText value is WTF-8; print lossily for now
+        p.print_str(&self.value.to_string_lossy());
     }
 }
 

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -423,7 +423,7 @@ impl<'a> Codegen<'a> {
 
     /// Print a string as a JavaScript string literal.
     pub fn print_string(&mut self, s: &str) {
-        self.print_string_impl(s, false, false);
+        self.print_string_impl(s, false);
     }
 }
 

--- a/crates/oxc_codegen/src/str.rs
+++ b/crates/oxc_codegen/src/str.rs
@@ -6,6 +6,7 @@ use oxc_syntax::{
     identifier::NBSP,
     line_terminator::{LS_LAST_2_BYTES, PS_LAST_2_BYTES},
 };
+use oxc_wtf8::Wtf8;
 
 use crate::Codegen;
 
@@ -31,7 +32,7 @@ impl Codegen<'_> {
     pub(crate) fn print_string_literal(&mut self, s: &StringLiteral<'_>, allow_backtick: bool) {
         self.print_property_key_annotation(s.span.start);
         self.add_source_mapping(s.span);
-        self.print_string_impl(s.value.as_str(), s.lone_surrogates, allow_backtick);
+        self.print_wtf8_string_impl(s.value.as_wtf8(), allow_backtick);
     }
 
     /// Print a [`StringLiteral`] as a template literal, whatever its contents.
@@ -42,15 +43,11 @@ impl Codegen<'_> {
         self.print_property_key_annotation(s.span.start);
         self.add_source_mapping(s.span);
         Quote::Backtick.print(self);
-        self.print_string_body(s.value.as_str(), s.lone_surrogates, Some(Quote::Backtick), true);
+        self.print_wtf8_string_body(s.value.as_wtf8(), Some(Quote::Backtick), true);
+        Quote::Backtick.print(self);
     }
 
-    pub(super) fn print_string_impl(
-        &mut self,
-        s: &str,
-        lone_surrogates: bool,
-        allow_backtick: bool,
-    ) {
+    pub(super) fn print_string_impl(&mut self, s: &str, allow_backtick: bool) {
         // If `minify` option enabled, quote will be chosen depending on what produces shortest output.
         // What is the best quote to use will be determined when first character needing escape is found.
         // This avoids iterating through the string twice if it contains no quotes (common case).
@@ -65,30 +62,18 @@ impl Codegen<'_> {
             Some(quote)
         };
 
-        self.print_string_body(s, lone_surrogates, quote, allow_backtick);
+        self.print_string_body(s, quote, allow_backtick);
     }
 
     /// Print the contents of a string, and its closing quote.
     ///
     /// `quote` is `None` where it has yet to be chosen - it is then calculated from the contents,
     /// and the opening quote printed, when the first character needing an escape is found.
-    fn print_string_body(
-        &mut self,
-        s: &str,
-        lone_surrogates: bool,
-        quote: Option<Quote>,
-        allow_backtick: bool,
-    ) {
+    fn print_string_body(&mut self, s: &str, quote: Option<Quote>, allow_backtick: bool) {
         // Loop through bytes, looking for any which need to be escaped.
         // String is written to buffer in chunks.
         let bytes = s.as_bytes().iter();
-        let mut state = PrintStringState {
-            chunk_start: bytes.ptr(),
-            bytes,
-            quote,
-            lone_surrogates,
-            allow_backtick,
-        };
+        let mut state = PrintStringState { chunk_start: bytes.ptr(), bytes, quote, allow_backtick };
 
         // Loop through bytes.
         while let Some(b) = state.peek() {
@@ -123,6 +108,195 @@ impl Codegen<'_> {
         let quote = unsafe { state.quote.unwrap_unchecked() };
         quote.print(self);
     }
+
+    pub(super) fn print_wtf8_string_impl(&mut self, s: &Wtf8, allow_backtick: bool) {
+        if let Some(s_str) = s.as_str() {
+            self.print_string_impl(s_str, allow_backtick);
+            return;
+        }
+        // Contains lone surrogates – need WTF-8 aware printing
+        let quote = if self.options.minify {
+            if allow_backtick {
+                // Replicate calculate_quote_maybe_backtick logic over CodePoints
+                let mut single_cost: isize = 0;
+                let mut double_cost: isize = 0;
+                let mut backtick_cost: isize = 0;
+                let mut iter = s.code_points().peekable();
+                while let Some(cp) = iter.next() {
+                    if let Some(c) = cp.to_char() {
+                        match c {
+                            '\n' => backtick_cost -= 1,
+                            '\'' => single_cost += 1,
+                            '"' => double_cost += 1,
+                            '`' => backtick_cost += 1,
+                            '$' => {
+                                if matches!(
+                                    iter.peek().and_then(|a: &oxc_wtf8::CodePoint| {
+                                        oxc_wtf8::CodePoint::to_char(*a)
+                                    }),
+                                    Some('{')
+                                ) {
+                                    backtick_cost += 1;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                if backtick_cost <= double_cost {
+                    if backtick_cost <= single_cost { Quote::Backtick } else { Quote::Single }
+                } else if double_cost <= single_cost {
+                    Quote::Double
+                } else {
+                    Quote::Single
+                }
+            } else {
+                // No backtick option – count single vs double
+                let mut single_cost: isize = 0;
+                for cp in s.code_points() {
+                    if let Some(c) = cp.to_char() {
+                        match c {
+                            '\'' => single_cost += 1,
+                            '"' => single_cost -= 1,
+                            _ => {}
+                        }
+                    }
+                }
+                if single_cost < 0 { Quote::Single } else { Quote::Double }
+            }
+        } else {
+            self.quote
+        };
+        quote.print(self);
+        self.print_wtf8_string_body(s, Some(quote), allow_backtick);
+        quote.print(self);
+    }
+
+    fn print_wtf8_string_body(&mut self, s: &Wtf8, quote: Option<Quote>, _allow_backtick: bool) {
+        // Iterate over code points; surrogates are emitted as \uXXXX, valid chars are escaped as needed
+        let mut iter = s.code_points().peekable();
+        while let Some(cp) = iter.next() {
+            if let Some(c) = cp.to_char() {
+                // Handle escapes for valid scalar values
+                match c {
+                    '"' => {
+                        if quote == Some(Quote::Double) {
+                            self.code.print_str("\\\"");
+                        } else {
+                            self.code.print_str("\"");
+                        }
+                    }
+                    '\'' => {
+                        if quote == Some(Quote::Single) {
+                            self.code.print_str("\\'");
+                        } else {
+                            self.code.print_str("'");
+                        }
+                    }
+                    '\\' => self.code.print_str("\\\\"),
+                    '\n' => {
+                        if quote == Some(Quote::Backtick) {
+                            self.code.print_str("\n");
+                        } else {
+                            self.code.print_str("\\n");
+                        }
+                    }
+                    '\r' => self.code.print_str("\\r"),
+                    '\t' => self.code.print_str("\\t"),
+                    '\x08' => self.code.print_str("\\b"),
+                    '\x0C' => self.code.print_str("\\f"),
+                    '\x0B' => self.code.print_str("\\v"),
+                    '\0' => {
+                        // Check if next char is digit (0-9) – if so, use \x00, else \0
+                        let next_is_digit = iter
+                            .peek()
+                            .and_then(|a: &oxc_wtf8::CodePoint| oxc_wtf8::CodePoint::to_char(*a))
+                            .is_some_and(|next_c| next_c.is_ascii_digit());
+                        if next_is_digit {
+                            self.code.print_str("\\x00");
+                        } else {
+                            self.code.print_str("\\0");
+                        }
+                    }
+                    '`' => {
+                        if quote == Some(Quote::Backtick) {
+                            self.code.print_str("\\`");
+                        } else {
+                            self.code.print_str("`");
+                        }
+                    }
+                    '$' => {
+                        if quote == Some(Quote::Backtick)
+                            && matches!(
+                                iter.peek().and_then(|a: &oxc_wtf8::CodePoint| {
+                                    oxc_wtf8::CodePoint::to_char(*a)
+                                }),
+                                Some('{')
+                            )
+                        {
+                            self.code.print_str("\\$");
+                        } else {
+                            self.code.print_str("$");
+                        }
+                    }
+                    '<' => {
+                        // Escape `</script` and `<!--` as \x3C
+                        // Check if following code points are "/script" or "!--"
+                        #[expect(clippy::unused_peekable)]
+                        // The lookahead clone only calls `next()`, never `peek()`
+                        let mut lookahead = iter.clone();
+                        let mut is_script = false;
+                        let mut is_comment = false;
+                        if let Some(cp1) = lookahead.next().and_then(oxc_wtf8::CodePoint::to_char) {
+                            if cp1 == '/' {
+                                let s: String = lookahead
+                                    .by_ref()
+                                    .take(6)
+                                    .filter_map(oxc_wtf8::CodePoint::to_char)
+                                    .collect();
+                                if s.eq_ignore_ascii_case("script") {
+                                    is_script = true;
+                                }
+                            } else if cp1 == '!' {
+                                let mut s = String::new();
+                                if let Some(cp2) =
+                                    lookahead.next().and_then(oxc_wtf8::CodePoint::to_char)
+                                {
+                                    s.push(cp2);
+                                    if let Some(cp3) =
+                                        lookahead.next().and_then(oxc_wtf8::CodePoint::to_char)
+                                    {
+                                        s.push(cp3);
+                                        if s == "--" {
+                                            is_comment = true;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        if is_script || is_comment {
+                            self.code.print_str("\\x3C");
+                        } else {
+                            self.code.print_str("<");
+                        }
+                    }
+                    '\u{2028}' => self.code.print_str("\\u2028"),
+                    '\u{2029}' => self.code.print_str("\\u2029"),
+                    c if c.is_control() => {
+                        self.code.print_str(format!("\\u{:04x}", c as u32));
+                    }
+                    _ => {
+                        let mut buf = [0u8; 4];
+                        let s = c.encode_utf8(&mut buf);
+                        self.code.print_str(s);
+                    }
+                }
+            } else {
+                // Lone surrogate – emit \uXXXX (lowercase per spec)
+                self.code.print_str(format!("\\u{:04x}", cp.to_u32()));
+            }
+        }
+    }
 }
 
 /// String printer state.
@@ -133,7 +307,6 @@ struct PrintStringState<'s> {
     chunk_start: *const u8,
     bytes: slice::Iter<'s, u8>,
     quote: Option<Quote>,
-    lone_surrogates: bool,
     allow_backtick: bool,
 }
 
@@ -333,12 +506,6 @@ const NBSP_BYTES: [u8; 2] = to_bytes(NBSP);
 const _: () = assert!(NBSP_BYTES[0] == 0xC2);
 const NBSP_LAST_BYTE: u8 = NBSP_BYTES[1];
 
-/// Lossy replacement character (U+FFFD) as UTF-8 bytes.
-const LOSSY_REPLACEMENT_CHAR_BYTES: [u8; 3] = to_bytes('\u{FFFD}');
-const _: () = assert!(LOSSY_REPLACEMENT_CHAR_BYTES[0] == 0xEF);
-const LOSSY_REPLACEMENT_CHAR_LAST_2_BYTES: [u8; 2] =
-    [LOSSY_REPLACEMENT_CHAR_BYTES[1], LOSSY_REPLACEMENT_CHAR_BYTES[2]];
-
 /// Escape codes.
 ///
 /// Discriminant - 1 is used as index into `BYTE_HANDLERS` (except for `__` variant).
@@ -362,7 +529,6 @@ enum Escape {
     LT = 14, // <     - Less-than sign
     LS = 15, // LS/PS - U+2028 LINE SEPARATOR or U+2029 PARAGRAPH SEPARATOR (first byte)
     NB = 16, // NBSP  - Non-breaking space (first byte)
-    LO = 17, // �     - U+FFFD lossy replacement character (first byte)
 }
 
 /// Struct which ensures content is aligned on 128.
@@ -393,7 +559,7 @@ static ESCAPES: Aligned128<[Escape; 256]> = {
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // B
         __, __, NB, __, __, __, __, __, __, __, __, __, __, __, __, __, // C
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // D
-        __, __, LS, __, __, __, __, __, __, __, __, __, __, __, __, LO, // E
+        __, __, LS, __, __, __, __, __, __, __, __, __, __, __, __, __, // E
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // F
     ])
 };
@@ -408,7 +574,7 @@ type ByteHandler = unsafe fn(&mut Codegen, &mut PrintStringState);
 /// Function pointers are 8 bytes each, so `BYTE_HANDLERS` is 136 bytes in total.
 /// Aligned on 128, so first 16 occupy a pair of L1 cache lines.
 /// The last will be in separate cache line, but it should be vanishingly rare that it's accessed.
-static BYTE_HANDLERS: Aligned128<[ByteHandler; 17]> = Aligned128([
+static BYTE_HANDLERS: Aligned128<[ByteHandler; 16]> = Aligned128([
     print_null,
     print_bell,
     print_backspace,
@@ -425,7 +591,6 @@ static BYTE_HANDLERS: Aligned128<[ByteHandler; 17]> = Aligned128([
     print_less_than,
     print_ls_or_ps,
     print_non_breaking_space,
-    print_lossy_replacement,
 ]);
 
 /// Call byte handler for byte which needs escaping.
@@ -668,69 +833,6 @@ unsafe fn print_non_breaking_space(codegen: &mut Codegen, state: &mut PrintStrin
         // SAFETY: 0xC2 is always the start of a 2-byte Unicode character.
         unsafe { state.consume_bytes_unchecked(2) };
     }
-}
-
-// 0xEF - first byte of lossy replacement character (U+FFFD)
-unsafe fn print_lossy_replacement(codegen: &mut Codegen, state: &mut PrintStringState) {
-    debug_assert_eq!(state.peek(), Some(0xEF));
-
-    if state.lone_surrogates {
-        // String contains lone surrogates which use the lossy replacement character (U+FFFD)
-        // as an escape marker.
-        // The lone surrogate is encoded as `\u{FFFD}XXXX` where `XXXX` is the code point as hex.
-        let next2: [u8; 2] = {
-            // SAFETY: 0xEF is always the start of a 3-byte Unicode character,
-            // so there must be 2 more bytes available to consume
-            let next2 = unsafe { state.bytes.as_slice().get_unchecked(1..3) };
-            next2.try_into().unwrap()
-        };
-
-        if next2 == LOSSY_REPLACEMENT_CHAR_LAST_2_BYTES {
-            // Get the 4 hex bytes
-            let bytes = &mut state.bytes;
-            let hex: [u8; 4] = bytes.as_slice()[3..7].try_into().unwrap();
-
-            if hex == *b"fffd" {
-                // Actual lossy replacement character.
-                // Flush up to and including the lossy replacement character, then skip the 4 hex bytes.
-                // SAFETY: 0xEF is always the start of a 3-byte Unicode character
-                unsafe { state.consume_bytes_unchecked(3) };
-                state.flush(codegen);
-                // SAFETY: 0xEF is always the start of a 3-byte Unicode character.
-                // `bytes.as_slice()[3..7]` would have panicked if there weren't 4 more bytes after it.
-                // All those bytes are ASCII, so this leaves `bytes` on a UTF-8 char boundary.
-                unsafe { state.consume_bytes_unchecked(4) };
-                // Start next chunk after the 4 hex bytes
-                state.start_chunk();
-                return;
-            }
-
-            // Flush text before the lossy replacement character
-            state.flush(codegen);
-
-            // Check all 4 hex bytes are ASCII
-            assert_eq!(u32::from_ne_bytes(hex) & 0x8080_8080, 0);
-
-            // SAFETY: `bytes.as_slice()[3..7]` would have panicked if there weren't at least 7 bytes
-            // remaining. First 3 bytes are lossy replacement character, and we just checked that
-            // next 4 bytes are ASCII, so this leaves `bytes` on a UTF-8 char boundary.
-            unsafe { state.consume_bytes_unchecked(7) };
-
-            // Start next chunk after the 4 hex bytes
-            state.start_chunk();
-
-            codegen.print_str("\\u");
-            // SAFETY: Just checked all 4 hex bytes are ASCII
-            unsafe { codegen.code.print_bytes_unchecked(&hex) };
-
-            return;
-        }
-    }
-
-    // `lone_surrogates` is `false` or character is some other character starting with 0xEF.
-    // Advance past the character.
-    // SAFETY: 0xEF is always the start of a 3-byte Unicode character
-    unsafe { state.consume_bytes_unchecked(3) };
 }
 
 /// Call a closure while hinting to compiler that this branch is rarely taken.

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -906,7 +906,7 @@ fn template_literal_escape_when_building_ast() {
     let cooked = "hello`world${foo}\\bar";
     let value = TemplateElementValue {
         raw: Str::from_str_in(cooked, &ast),
-        cooked: Some(Str::from_str_in(cooked, &ast)),
+        cooked: Some(oxc_str::Wtf8Str::from_str_in(cooked, &ast)),
     };
     let element = TemplateElement::new_escape_raw(SPAN, value, true, &ast);
     let template_literal = TemplateLiteral::new(SPAN, [element], [], &ast);

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -68,7 +68,7 @@ pub fn try_fold_known_global_methods<'a>(
         }
         Expression::ComputedMemberExpression(member) if !member.optional => {
             match &member.expression {
-                Expression::StringLiteral(s) => (s.value.as_str(), &member.object),
+                Expression::StringLiteral(s) => (s.value.as_str()?, &member.object),
                 _ => return None,
             }
         }
@@ -109,7 +109,7 @@ fn try_fold_string_casing<'a>(
     }
 
     let value = match object {
-        Expression::StringLiteral(s) => Cow::Borrowed(s.value.as_str()),
+        Expression::StringLiteral(s) => Cow::Borrowed(s.value.as_str()?),
         Expression::Identifier(ident) => ident
             .reference_id
             .get()
@@ -155,9 +155,9 @@ fn try_fold_string_index_of<'a>(
     };
 
     let result = match name {
-        "indexOf" => s.value.as_str().index_of(search_value.as_deref(), search_start_index),
+        "indexOf" => s.value.as_str()?.index_of(search_value.as_deref(), search_start_index),
         "lastIndexOf" => {
-            s.value.as_str().last_index_of(search_value.as_deref(), search_start_index)
+            s.value.as_str()?.last_index_of(search_value.as_deref(), search_start_index)
         }
         _ => unreachable!(),
     };
@@ -198,7 +198,7 @@ fn try_fold_string_substring_or_slice<'a>(
         return None;
     }
 
-    Some(ConstantValue::String(Cow::Owned(s.value.as_str().substring(start_idx, end_idx))))
+    Some(ConstantValue::String(Cow::Owned(s.value.as_str()?.substring(start_idx, end_idx))))
 }
 
 fn try_fold_string_char_at<'a>(
@@ -218,7 +218,7 @@ fn try_fold_string_char_at<'a>(
         None => None,
     };
 
-    let result = match s.value.as_str().char_at(char_at_index) {
+    let result = match s.value.as_str()?.char_at(char_at_index) {
         StringCharAtResult::Value(c) => c.to_string(),
         StringCharAtResult::InvalidChar(_) => return None,
         StringCharAtResult::OutOfRange => String::new(),
@@ -247,7 +247,7 @@ fn try_fold_string_char_code_at<'a>(
         None => None,
     };
 
-    let value = s.value.as_str().char_code_at(char_at_index).map_or(f64::NAN, |n| n as f64);
+    let value = s.value.as_str()?.char_code_at(char_at_index).map_or(f64::NAN, |n| n as f64);
     Some(ConstantValue::Number(value))
 }
 
@@ -261,7 +261,9 @@ fn try_fold_starts_with<'a>(
     }
     let Argument::StringLiteral(arg) = args.first().unwrap() else { return None };
     let Expression::StringLiteral(s) = object else { return None };
-    Some(ConstantValue::Boolean(s.value.starts_with(arg.value.as_str())))
+    let s_str = s.value.as_str()?;
+    let arg_str = arg.value.as_str()?;
+    Some(ConstantValue::Boolean(s_str.starts_with(arg_str)))
 }
 
 fn try_fold_string_replace<'a>(
@@ -295,9 +297,10 @@ fn try_fold_string_replace<'a>(
     if replace_value.contains('$') {
         return None;
     }
+    let s_str = s.value.as_str()?;
     let result = match name {
-        "replace" => s.value.as_str().cow_replacen(search_value.as_ref(), &replace_value, 1),
-        "replaceAll" => s.value.as_str().cow_replace(search_value.as_ref(), &replace_value),
+        "replace" => s_str.cow_replacen(search_value.as_ref(), &replace_value, 1),
+        "replaceAll" => s_str.cow_replace(search_value.as_ref(), &replace_value),
         _ => unreachable!(),
     };
     Some(ConstantValue::String(result))

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -162,14 +162,7 @@ impl<'a> ConstantEvaluation<'a> for Expression<'a> {
             Expression::BooleanLiteral(lit) => Some(ConstantValue::Boolean(lit.value)),
             Expression::BigIntLiteral(lit) => lit.to_big_int(ctx).map(ConstantValue::BigInt),
             Expression::StringLiteral(lit) => {
-                // The value of a string with lone surrogates encodes them with
-                // `\u{FFFD}` escapes. Consumers materialize the returned value
-                // into new string literals without the `lone_surrogates` flag,
-                // which would print the escape encoding as literal text.
-                if lit.lone_surrogates {
-                    return None;
-                }
-                Some(ConstantValue::String(Cow::Borrowed(lit.value.as_str())))
+                lit.value.as_str().map(|s| ConstantValue::String(Cow::Borrowed(s)))
             }
             Expression::StaticMemberExpression(e) => e.evaluate_value_to(ctx, target_ty),
             Expression::ComputedMemberExpression(e) => e.evaluate_value_to(ctx, target_ty),

--- a/crates/oxc_ecmascript/src/prop_name.rs
+++ b/crates/oxc_ecmascript/src/prop_name.rs
@@ -32,7 +32,7 @@ impl PropName for PropertyKey<'_> {
         match self {
             PropertyKey::StaticIdentifier(ident) => Some((&ident.name, ident.span)),
             PropertyKey::Identifier(ident) => Some((&ident.name, ident.span)),
-            PropertyKey::StringLiteral(lit) => Some((&lit.value, lit.span)),
+            PropertyKey::StringLiteral(lit) => lit.value.as_str().map(|s| (s, lit.span)),
             _ => None,
         }
     }

--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -431,10 +431,11 @@ impl<'a> MayHaveSideEffects<'a> for ComputedMemberExpression<'a> {
     fn may_have_side_effects(&self, ctx: &impl MayHaveSideEffectsContext<'a>) -> bool {
         match &self.expression {
             Expression::StringLiteral(s) => {
-                property_access_may_have_side_effects(&self.object, &s.value, ctx)
+                let prop = s.value.as_str().unwrap_or("");
+                property_access_may_have_side_effects(&self.object, prop, ctx)
             }
             Expression::TemplateLiteral(t) => t.single_quasi().is_none_or(|quasi| {
-                property_access_may_have_side_effects(&self.object, &quasi, ctx)
+                property_access_may_have_side_effects(&self.object, quasi.as_str(), ctx)
             }),
             Expression::NumericLiteral(n) => !n.value.to_integer_index().is_some_and(|n| {
                 !integer_index_property_access_may_have_side_effects(&self.object, n, ctx)
@@ -516,7 +517,9 @@ fn integer_index_property_access_may_have_side_effects<'a>(
         return false;
     }
     match object {
-        Expression::StringLiteral(s) => property as usize >= s.value.encode_utf16().count(),
+        Expression::StringLiteral(s) => {
+            property as usize >= s.value.as_wtf8().to_ill_formed_utf16().count()
+        }
         Expression::ArrayExpression(arr) => property as usize >= get_array_minimum_length(arr),
         _ => true,
     }
@@ -528,7 +531,7 @@ fn get_array_minimum_length(arr: &ArrayExpression) -> usize {
         .map(|e| match e {
             ArrayExpressionElement::SpreadElement(spread) => match &spread.argument {
                 Expression::ArrayExpression(arr) => get_array_minimum_length(arr),
-                Expression::StringLiteral(str) => str.value.chars().count(),
+                Expression::StringLiteral(str) => str.value.as_wtf8().code_points().count(),
                 _ => 0,
             },
             _ => 1,
@@ -657,7 +660,8 @@ impl<'a> MayHaveSideEffects<'a> for CallExpression<'a> {
             Expression::ComputedMemberExpression(member) if !member.optional => {
                 match &member.expression {
                     Expression::StringLiteral(s) => {
-                        (member.object.get_identifier_reference(), s.value.as_str())
+                        let Some(name) = s.value.as_str() else { return true };
+                        (member.object.get_identifier_reference(), name)
                     }
                     _ => return true,
                 }

--- a/crates/oxc_ecmascript/src/side_effects/known_globals.rs
+++ b/crates/oxc_ecmascript/src/side_effects/known_globals.rs
@@ -35,7 +35,10 @@ pub fn is_valid_regexp<'a>(
             // validated below because support for that constructor form varies by target.
             Some(Expression::RegExpLiteral(_)) => ("", true),
             // String literal: extract the pattern to validate
-            Some(Expression::StringLiteral(s)) if !s.lone_surrogates => (s.value.as_str(), false),
+            Some(Expression::StringLiteral(s)) => {
+                let Some(p) = s.value.as_str() else { return false };
+                (p, false)
+            }
             // Non-literal argument: can't statically determine, assume side effects
             _ => return false,
         },
@@ -45,7 +48,10 @@ pub fn is_valid_regexp<'a>(
     let flags = match args.get(1) {
         None => None,
         Some(arg) => match arg.as_expression() {
-            Some(Expression::StringLiteral(s)) => Some(s.value.as_str()),
+            Some(Expression::StringLiteral(s)) => {
+                let Some(f) = s.value.as_str() else { return false };
+                Some(f)
+            }
             // Non-literal flags: can't statically determine, assume side effects
             _ => return false,
         },

--- a/crates/oxc_ecmascript/src/side_effects/pure_function.rs
+++ b/crates/oxc_ecmascript/src/side_effects/pure_function.rs
@@ -46,7 +46,8 @@ fn extract_callee_path<'a>(callee: &'a Expression<'a>) -> Option<Vec<&'a str>> {
                 let Expression::StringLiteral(lit) = &member.expression else {
                     return None;
                 };
-                path_parts.push(lit.value.as_str());
+                let Some(s) = lit.value.as_str() else { return None };
+                path_parts.push(s);
                 current = &member.object;
             }
             Expression::CallExpression(call) => {
@@ -64,7 +65,8 @@ fn extract_callee_path<'a>(callee: &'a Expression<'a>) -> Option<Vec<&'a str>> {
                     let Expression::StringLiteral(lit) = &member.expression else {
                         return None;
                     };
-                    path_parts.push(lit.value.as_str());
+                    let Some(s) = lit.value.as_str() else { return None };
+                    path_parts.push(s);
                     current = &member.object;
                 }
                 ChainElement::CallExpression(call) => {

--- a/crates/oxc_ecmascript/src/to_big_int.rs
+++ b/crates/oxc_ecmascript/src/to_big_int.rs
@@ -47,7 +47,7 @@ impl<'a> ToBigInt<'a> for Expression<'a> {
                 _ => None,
             },
             Expression::StringLiteral(string_literal) => {
-                string_literal.value.as_str().string_to_big_int()
+                string_literal.value.as_str()?.string_to_big_int()
             }
             Expression::TemplateLiteral(_) => {
                 self.to_js_string(ctx).and_then(|value| value.as_ref().string_to_big_int())

--- a/crates/oxc_ecmascript/src/to_number.rs
+++ b/crates/oxc_ecmascript/src/to_number.rs
@@ -29,7 +29,7 @@ impl<'a> ToNumber<'a> for Expression<'a> {
                 "NaN" | "undefined" if ctx.is_global_reference(ident) => Some(f64::NAN),
                 _ => None,
             },
-            Expression::StringLiteral(lit) => Some(lit.value.as_str().string_to_number()),
+            Expression::StringLiteral(lit) => Some(lit.value.as_str()?.string_to_number()),
             Expression::UnaryExpression(unary) if unary.operator.is_not() => {
                 let boolean = unary.argument.to_boolean(ctx)?;
                 Some(if boolean { 0.0 } else { 1.0 })

--- a/crates/oxc_ecmascript/src/to_primitive.rs
+++ b/crates/oxc_ecmascript/src/to_primitive.rs
@@ -87,7 +87,7 @@ pub fn maybe_object_with_to_primitive_related_properties_overridden(
             }
             PropertyKey::PrivateIdentifier(_) => false,
             PropertyKey::StringLiteral(str) => {
-                matches!(str.value.as_str(), "toString" | "valueOf")
+                matches!(str.value.as_str(), Some("toString" | "valueOf"))
             }
             PropertyKey::TemplateLiteral(temp) => temp
                 .single_quasi()

--- a/crates/oxc_ecmascript/src/to_string.rs
+++ b/crates/oxc_ecmascript/src/to_string.rs
@@ -53,14 +53,10 @@ impl<'a> ToJsString<'a> for ArrayExpressionElement<'a> {
 
 impl<'a> ToJsString<'a> for StringLiteral<'a> {
     fn to_js_string(&self, _ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
-        // The value of a string with lone surrogates encodes them with
-        // `\u{FFFD}` escapes. Consumers build new string literals from the
-        // returned value without carrying the `lone_surrogates` flag over,
-        // which would print the escape encoding as literal text.
-        if self.lone_surrogates {
-            return None;
-        }
-        Some(Cow::Borrowed(self.value.as_str()))
+        // Lone surrogates make the string not representable as valid UTF-8 &str.
+        // Consumers build new string literals from the returned value, which would
+        // lose surrogate information if we returned lossy string.
+        Some(Cow::Borrowed(self.value.as_str()?))
     }
 }
 
@@ -68,12 +64,9 @@ impl<'a> ToJsString<'a> for TemplateLiteral<'a> {
     fn to_js_string(&self, ctx: &impl GlobalContext<'a>) -> Option<Cow<'a, str>> {
         let mut str = String::new();
         for (i, quasi) in self.quasis.iter().enumerate() {
-            // See the `StringLiteral` impl: the cooked value encodes lone
-            // surrogates with `\u{FFFD}` escapes.
-            if quasi.lone_surrogates {
-                return None;
-            }
-            str.push_str(quasi.value.cooked.as_ref()?);
+            // Lone surrogates make the cooked value invalid UTF-8.
+            let cooked = quasi.value.cooked.as_ref()?.as_str()?;
+            str.push_str(cooked);
 
             if i < self.expressions.len() {
                 let expr = &self.expressions[i];

--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -23,7 +23,7 @@ pub use concat::{Concat2, Concat3, ConcatElement};
 pub use config::{Config, ConfigFixes, ConfigNoFixes};
 pub use formatter::{CompactFormatter, Formatter, PrettyFormatter};
 pub use sequences::SequenceSerializer;
-pub use strings::{JsonSafeString, LoneSurrogatesString};
+pub use strings::JsonSafeString;
 pub use structs::{ESTreeSpan, FlatStructSerializer, StructSerializer};
 
 /// Trait for types which can be serialized to ESTree.

--- a/crates/oxc_estree/src/serialize/strings.rs
+++ b/crates/oxc_estree/src/serialize/strings.rs
@@ -4,17 +4,6 @@ use oxc_data_structures::{code_buffer::CodeBuffer, slice_iter::SliceIter};
 
 use super::{ESTree, Serializer};
 
-/// Convert `char` to UTF-8 bytes array.
-const fn char_to_bytes<const N: usize>(ch: char) -> [u8; N] {
-    let mut bytes = [0u8; N];
-    ch.encode_utf8(&mut bytes);
-    bytes
-}
-
-/// Lossy replacement character (U+FFFD) as UTF-8 bytes.
-const LOSSY_REPLACEMENT_CHAR_BYTES: [u8; 3] = char_to_bytes('\u{FFFD}');
-const LOSSY_REPLACEMENT_CHAR_FIRST_BYTE: u8 = LOSSY_REPLACEMENT_CHAR_BYTES[0]; // 0xEF
-
 /// A string which does not need any escaping in JSON.
 ///
 /// This provides better performance when you know that the string definitely contains no characters
@@ -27,21 +16,6 @@ impl ESTree for JsonSafeString<'_> {
     #[inline(always)]
     fn serialize<S: Serializer>(&self, mut serializer: S) {
         serializer.buffer_mut().print_strs_array(["\"", self.0, "\""]);
-    }
-}
-
-/// A string which contains lone surrogates escaped with lossy replacement character (U+FFFD).
-///
-/// Lone surrogates are encoded in the string as `\uFFFD1234` where `1234` is the code point in hex.
-/// These are converted to `\u1234` in JSON.
-/// An actual lossy replacement character is encoded in the string as `\uFFFDfffd`, and is converted
-/// to the actual character.
-pub struct LoneSurrogatesString<'s>(pub &'s str);
-
-impl ESTree for LoneSurrogatesString<'_> {
-    #[inline(always)]
-    fn serialize<S: Serializer>(&self, mut serializer: S) {
-        write_str::<LoneSurrogatesEscapeTable>(self.0, serializer.buffer_mut());
     }
 }
 
@@ -71,7 +45,6 @@ enum Escape {
     RR = b'r',  // \x0D
     QU = b'"',  // \x22
     BS = b'\\', // \x5C
-    LO = b'X',  // Lossy escape character first byte
     UU = b'u',  // \x00...\x1F except the ones above
 }
 
@@ -80,12 +53,9 @@ enum Escape {
 ///
 /// A value of `UU` means that byte is escaped as `\u00xx`, where `xx` is the hex code of the byte.
 /// e.g. `0x1F` is output as `\u001F`.
-static ESCAPE: [Escape; 256] = create_table(Escape::__);
+static ESCAPE: [Escape; 256] = create_table();
 
-/// Same as `ESCAPE` but with `Escape::LO` for byte 0xEF.
-static ESCAPE_LONE_SURROGATES: [Escape; 256] = create_table(Escape::LO);
-
-const fn create_table(lo: Escape) -> [Escape; 256] {
+const fn create_table() -> [Escape; 256] {
     #[allow(clippy::enum_glob_use, clippy::allow_attributes)]
     use Escape::*;
 
@@ -105,16 +75,13 @@ const fn create_table(lo: Escape) -> [Escape; 256] {
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // B
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // C
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // D
-        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, lo, // E
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // E
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // F
     ]
 }
 
 /// Trait for tables determining whether bytes need escaping.
 trait EscapeTable {
-    /// `true` if need to escape lone surrogate escape sequences.
-    const LONE_SURROGATES: bool;
-
     /// Get `Escape` for a byte.
     /// If byte does not require escaping, returns `Escape::__`.
     fn get_escape_for_byte(b: u8) -> Escape;
@@ -142,8 +109,6 @@ trait EscapeTable {
 struct StandardEscapeTable;
 
 impl EscapeTable for StandardEscapeTable {
-    const LONE_SURROGATES: bool = false;
-
     #[inline]
     fn get_escape_for_byte(b: u8) -> Escape {
         ESCAPE[b as usize]
@@ -190,45 +155,6 @@ impl EscapeTable for StandardEscapeTable {
         // Now any bytes needing escape = 0x80.
         // Any bytes not needing escape = 0.
         escapes & asciis
-    }
-}
-
-/// Escape table for strings containing lone surrogates (`impl ESTree for LoneSurrogatesString`).
-struct LoneSurrogatesEscapeTable;
-
-impl EscapeTable for LoneSurrogatesEscapeTable {
-    const LONE_SURROGATES: bool = true;
-
-    #[inline]
-    fn get_escape_for_byte(b: u8) -> Escape {
-        ESCAPE_LONE_SURROGATES[b as usize]
-    }
-
-    #[inline]
-    fn get_escapes_mask(bytes: [u8; 8]) -> u64 {
-        const LOSSYS: u64 = splat_u64(LOSSY_REPLACEMENT_CHAR_FIRST_BYTE);
-        const ONES: u64 = splat_u64(1);
-        const TOP_BITS: u64 = splat_u64(0x80);
-
-        // Get mask for ASCII escapes
-        let ascii_escapes = StandardEscapeTable::get_escapes_mask(bytes);
-
-        // Convert bytes to a `u64` in native byte order
-        let n = u64::from_ne_bytes(bytes);
-
-        // 0xEF -> 0xFF (top bit set).
-        // All other non-ASCII bytes -> values with top bit unset.
-        let lossys = (n ^ LOSSYS).wrapping_sub(ONES);
-        // ASCII bytes -> 0x00 (top bit unset).
-        // Non-ASCII bytes -> 0x80 (top bit set).
-        let non_ascii = n & TOP_BITS;
-        // Mask `lossys` to only top bits, and zero any ASCII bytes
-        let lossys = lossys & non_ascii;
-
-        // Combine masks for ASCII escapes and lossy replacement characters.
-        // Now any bytes needing escape = 0x80.
-        // Any bytes not needing escape = 0.
-        ascii_escapes | lossys
     }
 }
 
@@ -306,77 +232,9 @@ fn write_str<T: EscapeTable>(s: &str, buffer: &mut CodeBuffer) {
 
         // Found a character that needs escaping
 
-        // Handle lone surrogates.
-        // Skip this block if not escaping lone surrogates.
-        if T::LONE_SURROGATES && escape == Escape::LO {
-            // SAFETY: `0xEF` is always 1st byte in a 3-byte UTF-8 character,
-            // so reading next 2 bytes cannot be out of bounds
-            let next_2_bytes = unsafe { iter.as_slice().get_unchecked(1..3) };
-            if next_2_bytes == &LOSSY_REPLACEMENT_CHAR_BYTES[1..] {
-                // Lossy replacement character (U+FFFD) is used as an escape before lone surrogates,
-                // with the code point as 4 x hex characters after it e.g. `\u{FFFD}d800`.
-
-                // Print the chunk up to before the lossy replacement character.
-                // SAFETY: 0xEF is always the start of a 3-byte unicode character.
-                // Therefore `current_ptr` must be on a UTF-8 character boundary.
-                // `chunk_start_ptr` is start of string originally, and is only updated to be after
-                // an ASCII character, so must also be on a UTF-8 character boundary, and in bounds.
-                // `chunk_start_ptr` is after a previous byte so must be `<= current_ptr`.
-                unsafe {
-                    let current_ptr = iter.ptr();
-                    let len = current_ptr.offset_from_unsigned(chunk_start_ptr);
-                    let chunk = slice::from_raw_parts(chunk_start_ptr, len);
-                    buffer.print_bytes_unchecked(chunk);
-                }
-
-                // Consume the lossy replacement character.
-                // SAFETY: Lossy replacement character is 3 bytes.
-                unsafe { iter.advance_unchecked(3) };
-
-                let hex = iter.as_slice().get(..4).unwrap();
-                if hex == b"fffd" {
-                    // This is an actual lossy replacement character (not an escaped lone surrogate)
-                    buffer.print_str("\u{FFFD}");
-
-                    // Consume `fffd`.
-                    // SAFETY: We know next 4 bytes are `fffd`.
-                    unsafe { iter.advance_unchecked(4) };
-
-                    // Set `chunk_start_ptr` to after `\u{FFFD}fffd`.
-                    // That's a complete UTF-8 sequence, so `chunk_start_ptr` is definitely
-                    // left on a UTF-8 character boundary.
-                    chunk_start_ptr = iter.ptr();
-                } else {
-                    // This is an escaped lone surrogate.
-                    // Next 4 bytes should be code point encoded as 4 x hex bytes.
-                    #[cfg(debug_assertions)]
-                    for &b in hex {
-                        assert!(matches!(b, b'0'..=b'9' | b'a'..=b'f'));
-                    }
-
-                    // Print `\u`. Leave the hex bytes to be printed in next batch.
-                    // After lossy replacement character is definitely a UTF-8 boundary.
-                    buffer.print_str("\\u");
-                    chunk_start_ptr = iter.ptr();
-
-                    // SAFETY: `iter.as_slice().get(..4).unwrap()` above would have panicked
-                    // if there weren't at least 4 bytes remaining in `iter`.
-                    // We haven't checked that the 4 following bytes are ASCII, but it doesn't matter
-                    // whether `iter` is left on a UTF-8 char boundary or not.
-                    unsafe { iter.advance_unchecked(4) }
-                }
-            } else {
-                // Some other unicode character starting with 0xEF.
-                // Consume it and continue the loop.
-                // SAFETY: `0xEF` is always 1st byte in a 3-byte UTF-8 character.
-                unsafe { iter.advance_unchecked(3) };
-            }
-            continue;
-        }
-
         // Print the chunk up to before the character which requires escaping.
         let current_ptr = iter.ptr();
-        // SAFETY: `escape` is only non-zero for ASCII bytes, except `Escape::LO` which is handled above.
+        // SAFETY: `escape` is only non-zero for ASCII bytes.
         // Therefore `current_ptr` must be on an ASCII byte.
         // `chunk_start_ptr` is start of string originally, and is only updated to be after
         // an ASCII character, so must also be on a UTF-8 character boundary, and in bounds.
@@ -488,29 +346,6 @@ mod tests {
         for (input, output) in cases {
             let mut serializer = CompactSerializer::default();
             JsonSafeString(input).serialize(&mut serializer);
-            let s = serializer.into_string();
-            assert_eq!(&s, output);
-        }
-    }
-
-    #[test]
-    fn serialize_lone_surrogates_string() {
-        let cases = [
-            ("\u{FFFD}fffd", "\"\u{FFFD}\""),
-            ("_x_\u{FFFD}fffd_y_\u{FFFD}fffd_z_", "\"_x_\u{FFFD}_y_\u{FFFD}_z_\""),
-            ("\u{FFFD}d834\u{FFFD}d835", r#""\ud834\ud835""#),
-            ("_x_\u{FFFD}d834\u{FFFD}d835", r#""_x_\ud834\ud835""#),
-            ("\u{FFFD}d834\u{FFFD}d835_y_", r#""\ud834\ud835_y_""#),
-            ("_x_\u{FFFD}d834_y_\u{FFFD}d835_z_", r#""_x_\ud834_y_\ud835_z_""#),
-            (
-                "They call me \"Bob\" but I prefer \"Den\u{FFFD}d834\\qnis\", innit?",
-                r#""They call me \"Bob\" but I prefer \"Den\ud834\\qnis\", innit?""#,
-            ),
-        ];
-
-        for (input, output) in cases {
-            let mut serializer = CompactSerializer::default();
-            LoneSurrogatesString(input).serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
         }

--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -7,7 +7,7 @@ use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_formatter_core::Format;
 use oxc_span::GetSpan;
-use oxc_str::Ident;
+use oxc_str::{Ident, Str, Wtf8Str};
 use oxc_syntax::node::NodeId;
 
 use crate::ast_nodes::AstNode;
@@ -1684,11 +1684,6 @@ impl<'a> AstNode<'a, TemplateElement<'a>> {
     #[inline]
     pub fn tail(&self) -> bool {
         self.inner.tail
-    }
-
-    #[inline]
-    pub fn lone_surrogates(&self) -> bool {
-        self.inner.lone_surrogates
     }
 
     pub fn format_leading_comments(&self, f: &mut JsFormatter<'_, 'a>) {
@@ -6476,18 +6471,13 @@ impl<'a> AstNode<'a, StringLiteral<'a>> {
     }
 
     #[inline]
-    pub fn value(&self) -> Str<'a> {
+    pub fn value(&self) -> Wtf8Str<'a> {
         self.inner.value
     }
 
     #[inline]
     pub fn raw(&self) -> Option<Str<'a>> {
         self.inner.raw
-    }
-
-    #[inline]
-    pub fn lone_surrogates(&self) -> bool {
-        self.inner.lone_surrogates
     }
 
     pub fn format_leading_comments(&self, f: &mut JsFormatter<'_, 'a>) {
@@ -7293,7 +7283,7 @@ impl<'a> AstNode<'a, JSXText<'a>> {
     }
 
     #[inline]
-    pub fn value(&self) -> Str<'a> {
+    pub fn value(&self) -> Wtf8Str<'a> {
         self.inner.value
     }
 

--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -422,12 +422,14 @@ pub fn is_huggable_html_embed(expression: &Expression<'_>, f: &JsFormatter<'_, '
         .quasis
         .first()
         .and_then(|q| q.value.cooked.as_ref())
-        .is_some_and(|s| s.starts_with(|c: char| c.is_ascii_whitespace()));
+        .and_then(oxc_str::Wtf8Str::as_str)
+        .is_some_and(|t| t.starts_with(|c: char| c.is_ascii_whitespace()));
     let has_trailing_ws = template
         .quasis
         .last()
         .and_then(|q| q.value.cooked.as_ref())
-        .is_some_and(|s| s.ends_with(|c: char| c.is_ascii_whitespace()));
+        .and_then(oxc_str::Wtf8Str::as_str)
+        .is_some_and(|t| t.ends_with(|c: char| c.is_ascii_whitespace()));
     has_leading_ws && has_trailing_ws
 }
 

--- a/crates/oxc_formatter/src/print/jsx/child_list.rs
+++ b/crates/oxc_formatter/src/print/jsx/child_list.rs
@@ -388,8 +388,8 @@ impl FormatJsxChildList {
                     }
                 }
                 JSXChild::Text(text) => {
-                    meta.meaningful_text =
-                        meta.meaningful_text || is_meaningful_jsx_text(&text.value);
+                    meta.meaningful_text = meta.meaningful_text
+                        || is_meaningful_jsx_text(text.value.as_str().unwrap_or_default());
                 }
                 JSXChild::Spread(_) => {}
             }

--- a/crates/oxc_formatter/src/print/jsx/element.rs
+++ b/crates/oxc_formatter/src/print/jsx/element.rs
@@ -318,7 +318,7 @@ impl<'a, 'b> AnyJsxTagWithChildren<'a, 'b> {
 
                 match child.as_ast_nodes() {
                     AstNodes::JSXText(text) => {
-                        if is_meaningful_jsx_text(&text.value) {
+                        if is_meaningful_jsx_text(text.value.as_str().unwrap_or_default()) {
                             ElementLayout::Default
                         } else {
                             ElementLayout::NoChildren

--- a/crates/oxc_formatter/src/print/jsx/mod.rs
+++ b/crates/oxc_formatter/src/print/jsx/mod.rs
@@ -393,6 +393,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXSpreadChild<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, JSXText<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        write!(f, text(self.value().as_str()));
+        write!(f, text(self.value().as_str().unwrap_or_default()));
     }
 }

--- a/crates/oxc_formatter/src/print/jsx/opening_element.rs
+++ b/crates/oxc_formatter/src/print/jsx/opening_element.rs
@@ -63,7 +63,9 @@ fn is_multiline_string_literal_attribute(attribute: &JSXAttributeItem<'_>) -> bo
     let JSXAttributeItem::Attribute(attr) = attribute else {
         return false;
     };
-    attr.value.as_ref().is_some_and(|value| matches!(value, JSXAttributeValue::StringLiteral(string) if string.value.contains('\n')))
+    attr.value.as_ref().is_some_and(|value| {
+        matches!(value, JSXAttributeValue::StringLiteral(string) if string.value.as_str().is_some_and(|s| s.contains('\n')))
+    })
 }
 
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatOpeningElement<'a, '_> {
@@ -158,7 +160,8 @@ pub enum OpeningElementLayout {
 
 /// Returns `true` if this is an attribute with a string literal initializer that does not contain any new line characters.
 fn is_single_line_string_literal_attribute(attribute: &JSXAttributeItem) -> bool {
-    as_string_literal_attribute_value(attribute).is_some_and(|string| !string.value.contains('\n'))
+    as_string_literal_attribute_value(attribute)
+        .is_some_and(|string| !string.value.as_str().is_some_and(|s| s.contains('\n')))
 }
 
 /// Returns `Some` if the initializer value of this attribute is a string literal.

--- a/crates/oxc_formatter/src/print/template/embed/graphql.rs
+++ b/crates/oxc_formatter/src/print/template/embed/graphql.rs
@@ -35,7 +35,9 @@ pub(super) fn format_graphql_doc<'a>(
         let Some(cooked) = quasi_elem.value.cooked.as_ref() else {
             return false;
         };
-        let text = cooked.as_str();
+        let Some(text) = cooked.as_str() else {
+            return false;
+        };
         // `.cooked` has normalized line terminators
         let lines: Vec<&str> = text.split('\n').collect();
 

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -43,7 +43,9 @@ pub(super) fn format_html_doc<'a>(
         let Some(cooked) = quasis[0].value.cooked.as_ref() else {
             return false;
         };
-        let cooked = cooked.as_str();
+        let Some(cooked) = cooked.as_str() else {
+            return false;
+        };
 
         if cooked.trim().is_empty() {
             write!(f, ["``"]);
@@ -107,7 +109,10 @@ pub(super) fn format_html_doc<'a>(
             let Some(cooked) = quasi_elem.value.cooked.as_ref() else {
                 return false;
             };
-            sb.push_str(cooked.as_str());
+            let Some(cooked_str) = cooked.as_str() else {
+                return false;
+            };
+            sb.push_str(cooked_str);
         }
         sb.into_str()
     };

--- a/crates/oxc_formatter/src/utils/jsx.rs
+++ b/crates/oxc_formatter/src/utils/jsx.rs
@@ -112,7 +112,7 @@ pub fn is_whitespace_jsx_expression<'a>(
 ) -> bool {
     match &child.expression {
         JSXExpression::StringLiteral(literal) => {
-            matches!(literal.value.as_str(), " ") && !comments.has_comment_in_span(child.span)
+            matches!(literal.value.as_str(), Some(" ")) && !comments.has_comment_in_span(child.span)
         }
         _ => false,
     }
@@ -274,7 +274,7 @@ pub fn jsx_split_children<'a, 'b>(
                 // Split the text into words
                 // Keep track if there's any leading/trailing empty line, new line or whitespace
 
-                let text_value = &text.value;
+                let text_value = text.value.as_str().unwrap_or_default();
                 let mut chunks = JsxSplitChunksIterator::new(text_value).peekable();
 
                 // Text starting with a whitespace

--- a/crates/oxc_formatter_json/Cargo.toml
+++ b/crates/oxc_formatter_json/Cargo.toml
@@ -25,6 +25,7 @@ oxc_formatter_core = { workspace = true }
 oxc_parser = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
+oxc_wtf8 = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/oxc_formatter_json/src/print/object.rs
+++ b/crates/oxc_formatter_json/src/print/object.rs
@@ -223,7 +223,7 @@ fn json5_unquoted_key<'a>(lit: &StringLiteral<'a>) -> Option<&'a str> {
     let raw = lit.raw.as_ref()?.as_str();
     // Body between the quotes; bail on anything that isn't a well-formed quoted literal
     let inner = raw.get(1..raw.len().checked_sub(1)?)?;
-    let value = lit.value.as_str();
+    let value = lit.value.as_str()?;
     // Any escape makes the raw body differ from the cooked value -> not safe to unquote
     if inner != value {
         return None;

--- a/crates/oxc_formatter_json/src/print/stringify.rs
+++ b/crates/oxc_formatter_json/src/print/stringify.rs
@@ -178,7 +178,7 @@ fn write_template<'a>(template: &TemplateLiteral<'a>, f: &mut JsonFormatter<'_, 
         write!(f, FormatInvalidJson(template.span));
         return;
     };
-    let body = json_stringify_escape(cooked.as_str(), quasi.lone_surrogates);
+    let body = json_stringify_escape(cooked.as_wtf8());
     write_quoted_str(f, b'"', arena_cow_str(&body, f));
 }
 
@@ -186,65 +186,48 @@ fn write_template<'a>(template: &TemplateLiteral<'a>, f: &mut JsonFormatter<'_, 
 /// (the quotes themselves are not included): `"` and `\` get a backslash,
 /// control characters use their short escapes (`\b\f\n\r\t`) or `\uXXXX`.
 ///
-/// When `lone_surrogates` is set, `content` encodes each lone surrogate as
-/// `\u{FFFD}XXXX` (and a literal U+FFFD as `\u{FFFD}fffd`).
-/// The same scheme `oxc_codegen` decodes, `JSON.stringify` prints lone surrogates as `\uXXXX`.
-fn json_stringify_escape(content: &str, lone_surrogates: bool) -> Cow<'_, str> {
+/// Lone surrogates in WTF-8 are escaped as `\uXXXX`.
+fn json_stringify_escape(content: &oxc_wtf8::Wtf8) -> Cow<'_, str> {
     const HEX: &[u8; 16] = b"0123456789abcdef";
 
-    if !lone_surrogates && !content.bytes().any(|b| matches!(b, b'"' | b'\\') || b < 0x20) {
-        return Cow::Borrowed(content);
+    // Fast path: valid UTF-8 without escapes
+    if let Some(s) = content.as_str()
+        && !s.bytes().any(|b| matches!(b, b'"' | b'\\') || b < 0x20)
+    {
+        return Cow::Borrowed(s);
     }
 
     let mut out = String::with_capacity(content.len() + 8);
-    // Start of the pending run of as-is characters, flushed in one `push_str`
-    // before each escape (mirrors `oxc_formatter_core::spec::normalize_string`).
-    let mut copy_start = 0;
-    let mut chars = content.char_indices();
-    while let Some((i, c)) = chars.next() {
-        let short_escape = match c {
-            '"' => Some("\\\""),
-            '\\' => Some("\\\\"),
-            '\u{8}' => Some("\\b"),
-            '\u{c}' => Some("\\f"),
-            '\n' => Some("\\n"),
-            '\r' => Some("\\r"),
-            '\t' => Some("\\t"),
-            _ => None,
-        };
-        if let Some(escaped) = short_escape {
-            out.push_str(&content[copy_start..i]);
-            out.push_str(escaped);
-            copy_start = i + 1; // every short-escaped char is a single byte
-        } else if (c as u32) < 0x20 {
-            out.push_str(&content[copy_start..i]);
-            // Always `\u00XX` — the guard caps the code point below 0x20.
-            let code = c as u32;
-            out.push_str("\\u00");
-            out.push(HEX[(code >> 4) as usize] as char);
-            out.push(HEX[(code & 0xF) as usize] as char);
-            copy_start = i + 1;
-        } else if c == '\u{FFFD}' && lone_surrogates {
-            out.push_str(&content[copy_start..i]);
-            // 4 lowercase-hex ASCII chars always follow the 3-byte escape marker;
-            // `get` only guards against malformed input the parser never produces,
-            // falling back (like the `fffd` self-escape) to a literal U+FFFD.
-            let hex_start = i + 3;
-            match content.get(hex_start..hex_start + 4) {
-                Some(hex) if hex != "fffd" => {
-                    out.push_str("\\u");
-                    out.push_str(hex);
+    for cp in content.code_points() {
+        if let Some(c) = cp.to_char() {
+            match c {
+                '"' => out.push_str("\\\""),
+                '\\' => out.push_str("\\\\"),
+                '\u{8}' => out.push_str("\\b"),
+                '\u{c}' => out.push_str("\\f"),
+                '\n' => out.push_str("\\n"),
+                '\r' => out.push_str("\\r"),
+                '\t' => out.push_str("\\t"),
+                c if (c as u32) < 0x20 => {
+                    let code = c as u32;
+                    out.push_str("\\u00");
+                    out.push(HEX[(code >> 4) as usize] as char);
+                    out.push(HEX[(code & 0xF) as usize] as char);
                 }
-                _ => out.push('\u{FFFD}'),
+                _ => out.push(c),
             }
-            copy_start = (hex_start + 4).min(content.len());
-            // Skip the 4 (single-byte) hex chars.
-            for _ in 0..4 {
-                chars.next();
-            }
+        } else {
+            // Lone surrogate – emit \uXXXX
+            // (manual hex push: the project's `write!` macro shadows `std::write!`)
+            let code = cp.to_u32();
+            out.push('\\');
+            out.push('u');
+            out.push(HEX[((code >> 12) & 0xF) as usize] as char);
+            out.push(HEX[((code >> 8) & 0xF) as usize] as char);
+            out.push(HEX[((code >> 4) & 0xF) as usize] as char);
+            out.push(HEX[(code & 0xF) as usize] as char);
         }
     }
-    out.push_str(&content[copy_start..]);
     Cow::Owned(out)
 }
 
@@ -276,14 +259,26 @@ mod tests {
 
     #[test]
     fn stringify_escape() {
-        assert_eq!(json_stringify_escape("plain", false), "plain");
-        assert_eq!(json_stringify_escape("a\"b\\c", false), "a\\\"b\\\\c");
-        assert_eq!(json_stringify_escape("\u{8}\u{c}\n\r\t", false), "\\b\\f\\n\\r\\t");
-        assert_eq!(json_stringify_escape("\0\u{1}\u{1f}", false), "\\u0000\\u0001\\u001f");
+        use oxc_wtf8::{Wtf8, Wtf8Buf};
+
+        fn w(s: &str) -> &Wtf8 {
+            // SAFETY: `s` is valid UTF-8, so its bytes are valid WTF-8
+            unsafe { &*(std::ptr::from_ref::<[u8]>(s.as_bytes()) as *const Wtf8) }
+        }
+
+        assert_eq!(json_stringify_escape(w("plain")), "plain");
+        assert_eq!(json_stringify_escape(w("a\"b\\c")), "a\\\"b\\\\c");
+        assert_eq!(json_stringify_escape(w("\u{8}\u{c}\n\r\t")), "\\b\\f\\n\\r\\t");
+        assert_eq!(json_stringify_escape(w("\0\u{1}\u{1f}")), "\\u0000\\u0001\\u001f");
         // U+2028 / U+2029 are NOT escaped by `JSON.stringify`
-        assert_eq!(json_stringify_escape("\u{2028}\u{2029}", false), "\u{2028}\u{2029}");
-        // Lone surrogate `\u{FFFD}XXXX` encoding; `\u{FFFD}fffd` is a literal U+FFFD
-        assert_eq!(json_stringify_escape("a\u{FFFD}d800b", true), "a\\ud800b");
-        assert_eq!(json_stringify_escape("a\u{FFFD}fffdb", true), "a\u{FFFD}b");
+        assert_eq!(json_stringify_escape(w("\u{2028}\u{2029}")), "\u{2028}\u{2029}");
+        // Lone surrogates in WTF-8 are escaped as \uXXXX
+        let lone = Wtf8Buf::from_ill_formed_utf16(&[0xD800]);
+        let mut buf = Wtf8Buf::from_str("a");
+        buf.push_wtf8(&lone);
+        buf.push_str("b");
+        assert_eq!(json_stringify_escape(&buf), "a\\ud800b");
+        // Valid replacement character is not escaped
+        assert_eq!(json_stringify_escape(w("a\u{FFFD}b")), "a\u{FFFD}b");
     }
 }

--- a/crates/oxc_isolated_declarations/src/literal.rs
+++ b/crates/oxc_isolated_declarations/src/literal.rs
@@ -12,7 +12,7 @@ impl<'a> IsolatedDeclarations<'a> {
             lit.quasis.first().map(|item| {
                 StringLiteral::boxed(
                     lit.span,
-                    item.value.cooked.unwrap_or(item.value.raw),
+                    item.value.cooked.unwrap_or(item.value.raw.into()),
                     None,
                     self,
                 )

--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -70,8 +70,14 @@ impl<'a> IsolatedDeclarations<'a> {
     fn transform_property_key(&self, key: &PropertyKey<'a>) -> PropertyKey<'a> {
         match key {
             // ["string"] -> string
-            PropertyKey::StringLiteral(literal) if is_identifier_name(&literal.value) => {
-                PropertyKey::new_static_identifier(literal.span, literal.value.as_str(), self)
+            PropertyKey::StringLiteral(literal)
+                if literal.value.as_str().is_some_and(is_identifier_name) =>
+            {
+                PropertyKey::new_static_identifier(
+                    literal.span,
+                    literal.value.as_str().unwrap(),
+                    self,
+                )
             }
             // [`string`] -> string
             PropertyKey::TemplateLiteral(literal)

--- a/crates/oxc_lexer/src/token.rs
+++ b/crates/oxc_lexer/src/token.rs
@@ -403,7 +403,7 @@ pub struct StringSpan {
 
 #[expect(clippy::inline_always, reason = "cook-path hot: spans are packed per string/template")]
 impl StringSpan {
-    pub const LONE_SURROGATES_MASK: u32 = 0x8000_0000;
+    pub const HAS_WTF8_SURROGATE_MASK: u32 = 0x8000_0000;
     pub const END_MASK: u32 = 0x7FFF_FFFF;
     /// On `start`, template spans only: the body contained a
     /// `NotEscapeSequence` (bad `\u`/`\x`, octal, `\8`/`\9`). The equivalent
@@ -414,9 +414,10 @@ impl StringSpan {
 
     #[inline(always)]
     #[must_use]
-    pub const fn new(start: u32, end: u32, lone_surrogates: bool) -> Self {
+    pub const fn new(start: u32, end: u32, has_wtf8_surrogate: bool) -> Self {
         debug_assert!(end <= Self::END_MASK);
-        let end_and_flags = if lone_surrogates { end | Self::LONE_SURROGATES_MASK } else { end };
+        let end_and_flags =
+            if has_wtf8_surrogate { end | Self::HAS_WTF8_SURROGATE_MASK } else { end };
         Self { start, end_and_flags }
     }
 
@@ -446,8 +447,8 @@ impl StringSpan {
 
     #[inline(always)]
     #[must_use]
-    pub const fn lone_surrogates(self) -> bool {
-        (self.end_and_flags & Self::LONE_SURROGATES_MASK) != 0
+    pub const fn has_wtf8_surrogate(self) -> bool {
+        (self.end_and_flags & Self::HAS_WTF8_SURROGATE_MASK) != 0
     }
 }
 

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -316,8 +316,8 @@ pub fn extract_regex_flags<'a>(args: &'a ArenaVec<'a, Argument<'a>>) -> Option<R
         return Some(RegExpFlags::empty());
     }
     let flag_arg = match &args[1] {
-        Argument::StringLiteral(flag_arg) => flag_arg.value,
-        Argument::TemplateLiteral(template) => template.single_quasi()?,
+        Argument::StringLiteral(flag_arg) => flag_arg.value.as_str()?,
+        Argument::TemplateLiteral(template) => template.single_quasi()?.as_str(),
         _ => return None,
     };
     let mut flags = RegExpFlags::empty();
@@ -833,7 +833,7 @@ pub fn get_static_property_name<'a>(parent_node: &AstNode<'a>) -> Option<Cow<'a,
                 && template.quasis.len() == 1
                 && let Some(cooked) = &template.quasis[0].value.cooked
             {
-                return Some(Cow::Borrowed(cooked.as_str()));
+                return Some(Cow::Borrowed(cooked.as_str()?));
             }
 
             None

--- a/crates/oxc_linter/src/rules/eslint/func_name_matching.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_name_matching.rs
@@ -444,14 +444,14 @@ fn property_key_is_identifier(key: &PropertyKey) -> bool {
 
 fn string_literal_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
     match key {
-        PropertyKey::StringLiteral(lit) => Some(lit.value.as_str()),
+        PropertyKey::StringLiteral(lit) => Some(lit.value.as_str().unwrap_or("")),
         _ => None,
     }
 }
 
 fn string_literal_argument<'a>(argument: &'a Argument<'a>) -> Option<&'a str> {
     match argument.as_expression()?.without_parentheses() {
-        Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+        Expression::StringLiteral(lit) => Some(lit.value.as_str().unwrap_or("")),
         _ => None,
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/new_cap.rs
+++ b/crates/oxc_linter/src/rules/eslint/new_cap.rs
@@ -556,7 +556,7 @@ fn get_computed_member_name(
 
     match &expression {
         Expression::StringLiteral(lit) if !lit.value.is_empty() => {
-            Some((lit.value.as_ref().into(), lit.span))
+            Some((CompactStr::from(lit.value.as_str_or_default()), lit.span))
         }
         Expression::TemplateLiteral(lit)
             if lit.expressions.is_empty()

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
@@ -113,7 +113,7 @@ fn prop_key_name<'a>(key: &PropertyKey<'a>, ctx: &LintContext<'a>) -> &'a str {
         PropertyKey::Identifier(ident) => ident.name.as_str(),
         PropertyKey::StaticIdentifier(ident) => ident.name.as_str(),
         PropertyKey::PrivateIdentifier(ident) => ident.name.as_str(),
-        PropertyKey::StringLiteral(lit) => lit.value.as_str(),
+        PropertyKey::StringLiteral(lit) => lit.value.as_str().unwrap_or(""),
         PropertyKey::NumericLiteral(lit) => lit.raw.as_ref().unwrap().as_str(),
         _ => ctx.source_range(key.span()),
     }

--- a/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_implicit_coercion.rs
@@ -321,12 +321,12 @@ impl Rule for NoImplicitCoercion {
                         .value
                         .cooked
                         .as_ref()
-                        .is_some_and(|s| s.is_empty());
+                        .is_some_and(oxc_str::Wtf8Str::is_empty);
                     let last_is_empty = last_quasi
                         .value
                         .cooked
                         .as_ref()
-                        .is_some_and(|s| s.is_empty());
+                        .is_some_and(oxc_str::Wtf8Str::is_empty);
 
                     if first_is_empty && last_is_empty {
                         let expr = &template.expressions[0];

--- a/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
@@ -114,7 +114,7 @@ impl NoRegexSpaces {
         let Some(Argument::StringLiteral(pattern)) = args.first() else {
             return None;
         };
-        if !Self::has_double_space(&pattern.value) {
+        if !Self::has_double_space(pattern.value.as_str().unwrap_or_default()) {
             return None;
         }
 

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -340,14 +340,14 @@ impl NoRestrictedGlobals {
                     return;
                 }
                 let property_name = match &expression.expression {
-                    Expression::StringLiteral(str) => str.value.as_str(),
+                    Expression::StringLiteral(str) => str.value.as_str_or_default(),
                     Expression::TemplateLiteral(template)
                         if template.is_no_substitution_template() =>
                     {
                         let Some(cooked) = &template.quasis[0].value.cooked else {
                             return;
                         };
-                        cooked.as_str()
+                        cooked.as_str_or_default()
                     }
                     _ => return,
                 };

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -1285,7 +1285,7 @@ impl NoRestrictedImports {
         is_type: bool,
         is_dynamic_import: bool,
     ) {
-        let source = source_literal.value.as_str();
+        let source = source_literal.value.as_str_or_default();
 
         for path in &self.paths {
             if source != path.name.as_str() {

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_properties.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_properties.rs
@@ -401,7 +401,9 @@ impl NoRestrictedProperties {
 
 fn expression_property_name<'a>(expression: &'a Expression<'a>) -> Option<Cow<'a, str>> {
     match expression {
-        Expression::StringLiteral(literal) => Some(Cow::Borrowed(literal.value.as_str())),
+        Expression::StringLiteral(literal) => {
+            Some(Cow::Borrowed(literal.value.as_str().unwrap_or("")))
+        }
         Expression::RegExpLiteral(literal) => literal.raw.map(|r| Cow::Borrowed(r.as_str())),
         Expression::NumericLiteral(literal) => Some(Cow::Owned(literal.value.to_string())),
         Expression::BigIntLiteral(literal) => Some(Cow::Borrowed(literal.value.as_str())),
@@ -410,7 +412,7 @@ fn expression_property_name<'a>(expression: &'a Expression<'a>) -> Option<Cow<'a
         }
         Expression::NullLiteral(_) => Some(Cow::Borrowed("null")),
         Expression::TemplateLiteral(literal) if literal.quasis.len() == 1 => {
-            literal.quasis[0].value.cooked.map(|cooked| Cow::Borrowed(cooked.as_str()))
+            literal.quasis[0].value.cooked.map(|cooked| Cow::Owned(cooked.to_string()))
         }
         _ => None,
     }

--- a/crates/oxc_linter/src/rules/eslint/no_script_url.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_script_url.rs
@@ -45,7 +45,10 @@ impl Rule for NoScriptUrl {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::StringLiteral(literal)
-                if starts_with_ignore_case(&literal.value, "javascript:") =>
+                if starts_with_ignore_case(
+                    literal.value.as_str().unwrap_or_default(),
+                    "javascript:",
+                ) =>
             {
                 ctx.diagnostic(no_script_url_diagnostic(literal.span));
             }

--- a/crates/oxc_linter/src/rules/eslint/no_shadow/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow/mod.rs
@@ -458,7 +458,7 @@ impl NoShadow {
         let shadowed_declaration_id = ctx.scoping().symbol_declaration(shadowed_symbol_id);
         let import_source = ctx.nodes().ancestor_kinds(shadowed_declaration_id).find_map(|kind| {
             if let AstKind::ImportDeclaration(declaration) = kind {
-                Some(declaration.source.value.as_str())
+                Some(declaration.source.value.as_str_or_default())
             } else {
                 None
             }
@@ -472,7 +472,7 @@ impl NoShadow {
             if let AstKind::TSExternalModuleDeclaration(module_decl) = kind
                 && module_decl.declare
             {
-                Some(module_decl.id.value.as_str())
+                Some(module_decl.id.value.as_str_or_default())
             } else {
                 None
             }

--- a/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_template_curly_in_string.rs
@@ -57,7 +57,7 @@ impl Rule for NoTemplateCurlyInString {
             return;
         };
 
-        let text = literal.value.as_str();
+        let text = literal.value.as_str_or_default();
         let Some(start) = text.find("${") else { return };
 
         if text[start + 2..].contains('}') {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
@@ -208,7 +208,7 @@ fn check_computed_class_member(
 ) {
     match expr {
         Expression::StringLiteral(lit) => {
-            let key_name = lit.value.as_str();
+            let key_name = lit.value.as_str_or_default();
             let allowed = if is_static {
                 allow_static.contains(&key_name)
             } else {

--- a/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
@@ -259,7 +259,7 @@ fn resolve_flags<'a>(
     }
 
     match expr {
-        Expression::StringLiteral(lit) => Some(parse_flags(lit.value.as_str())),
+        Expression::StringLiteral(lit) => Some(parse_flags(lit.value.as_str().unwrap_or(""))),
         Expression::TemplateLiteral(template) => resolve_template_flags(template, ctx, next_depth),
         Expression::BooleanLiteral(lit) => {
             Some(if lit.value { RegExpFlags::U } else { RegExpFlags::empty() })
@@ -297,21 +297,21 @@ fn resolve_template_flags<'a>(
     let mut flags = RegExpFlags::empty();
 
     for (index, expression) in template.expressions.iter().enumerate() {
-        flags |= parse_flags(template.quasis.get(index)?.value.cooked?.as_str());
+        flags |= parse_flags(template.quasis.get(index)?.value.cooked?.as_str_or_default());
         flags |= resolve_flags(expression, ctx, true, depth)?;
     }
 
-    flags |= parse_flags(template.quasis.last()?.value.cooked?.as_str());
+    flags |= parse_flags(template.quasis.last()?.value.cooked?.as_str_or_default());
     Some(flags)
 }
 
 fn resolve_static_string<'a>(expr: &'a Expression<'a>, ctx: &LintContext<'a>) -> Option<&'a str> {
     match expr.get_inner_expression() {
-        Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+        Expression::StringLiteral(lit) => Some(lit.value.as_str().unwrap_or("")),
         Expression::TemplateLiteral(template) => Some(template.single_quasi()?.as_str()),
         Expression::Identifier(ident) => {
             match resolve_const_initializer(ident, ctx)?.get_inner_expression() {
-                Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+                Expression::StringLiteral(lit) => Some(lit.value.as_str().unwrap_or("")),
                 Expression::TemplateLiteral(template) => Some(template.single_quasi()?.as_str()),
                 _ => None,
             }

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -125,8 +125,8 @@ impl Rule for ValidTypeof {
         };
 
         if let Expression::StringLiteral(lit) = sibling {
-            if !VALID_TYPES.contains(&lit.value.as_str()) {
-                let help = get_typo_suggestion(lit.value.as_str())
+            if !VALID_TYPES.contains(&lit.value.as_str_or_default()) {
+                let help = get_typo_suggestion(lit.value.as_str().unwrap_or(""))
                     .map(|suggestion| format!("Did you mean `\"{suggestion}\"`?"));
                 ctx.diagnostic(invalid_value(help, sibling.span()));
             }

--- a/crates/oxc_linter/src/rules/eslint/yoda.rs
+++ b/crates/oxc_linter/src/rules/eslint/yoda.rs
@@ -470,7 +470,7 @@ fn is_target_literal(expr: &Expression) -> bool {
 
 fn get_string_literal<'a>(expr: &'a Expression) -> Option<&'a str> {
     match expr {
-        Expression::StringLiteral(string) => Some(&string.value),
+        Expression::StringLiteral(string) => Some(string.value.as_str().unwrap_or_default()),
         Expression::TemplateLiteral(template) => {
             if template.quasis.len() != 1 {
                 return None;

--- a/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
+++ b/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
@@ -321,12 +321,12 @@ fn is_declaration_file_import(import_decl: &ImportDeclaration) -> bool {
         return false;
     }
     // Slower check that parses the file name to check if it's a declaration file
-    let path = Path::new(source.as_str());
+    let path = Path::new(source.as_str_or_default());
     let Some(extension) = path.extension().and_then(std::ffi::os_str::OsStr::to_str) else {
         return false;
     };
     match FileExtension::from_str(extension) {
-        Ok(file_ext) => file_ext.is_ts_declaration(source),
+        Ok(file_ext) => file_ext.is_ts_declaration(source.as_str_or_default()),
         Err(_) => false,
     }
 }

--- a/crates/oxc_linter/src/rules/import/extensions.rs
+++ b/crates/oxc_linter/src/rules/import/extensions.rs
@@ -556,7 +556,7 @@ impl Rule for Extensions {
             if let Argument::StringLiteral(s) = argument {
                 self.process_import(
                     ctx,
-                    s.value.as_str(),
+                    s.value.as_str().unwrap_or(""),
                     call_expr.span,
                     false, // require() is never a type import
                     true,  // treat require as import for diagnostics

--- a/crates/oxc_linter/src/rules/import/first.rs
+++ b/crates/oxc_linter/src/rules/import/first.rs
@@ -107,7 +107,7 @@ impl Rule for First {
                 Statement::TSImportEqualsDeclaration(decl) => match &decl.module_reference {
                     TSModuleReference::ExternalModuleReference(mod_ref) => {
                         if matches!(self.0, AbsoluteFirst::AbsoluteFirst) {
-                            if is_relative_path(mod_ref.expression.value.as_str()) {
+                            if is_relative_path(mod_ref.expression.value.as_str().unwrap_or("")) {
                                 any_relative = true;
                             } else if any_relative {
                                 ctx.diagnostic(absolute_first_diagnostic(mod_ref.expression.span));
@@ -122,7 +122,7 @@ impl Rule for First {
                 },
                 Statement::ImportDeclaration(decl) => {
                     if matches!(self.0, AbsoluteFirst::AbsoluteFirst) {
-                        if is_relative_path(decl.source.value.as_str()) {
+                        if is_relative_path(decl.source.value.as_str().unwrap_or("")) {
                             any_relative = true;
                         } else if any_relative {
                             ctx.diagnostic(absolute_first_diagnostic(decl.source.span));

--- a/crates/oxc_linter/src/rules/import/no_absolute_path.rs
+++ b/crates/oxc_linter/src/rules/import/no_absolute_path.rs
@@ -118,7 +118,8 @@ impl Rule for NoAbsolutePath {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::ImportDeclaration(import_decl)
-                if self.esmodule && check_path_is_absolute(import_decl.source.value.as_str()) =>
+                if self.esmodule
+                    && check_path_is_absolute(import_decl.source.value.as_str().unwrap_or("")) =>
             {
                 ctx.diagnostic(no_absolute_path_diagnostic(import_decl.source.span));
             }
@@ -134,14 +135,16 @@ impl Rule for NoAbsolutePath {
                             if count == 1
                                 && func_name == "require"
                                 && self.commonjs
-                                && check_path_is_absolute(str_literal.value.as_str()) =>
+                                && check_path_is_absolute(
+                                    str_literal.value.as_str().unwrap_or(""),
+                                ) =>
                         {
                             ctx.diagnostic(no_absolute_path_diagnostic(str_literal.span));
                         }
                         Argument::ArrayExpression(arr_expr) if count == 2 && self.amd => {
                             for el in &arr_expr.elements {
                                 if let Some(el_expr) = el.as_expression()
-                                    && matches!(el_expr, Expression::StringLiteral(literal) if check_path_is_absolute(literal.value.as_str()))
+                                    && matches!(el_expr, Expression::StringLiteral(literal) if check_path_is_absolute(literal.value.as_str().unwrap_or("")))
                                 {
                                     ctx.diagnostic(no_absolute_path_diagnostic(el_expr.span()));
                                 }

--- a/crates/oxc_linter/src/rules/import/no_nodejs_modules.rs
+++ b/crates/oxc_linter/src/rules/import/no_nodejs_modules.rs
@@ -6,7 +6,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use oxc_str::CompactStr;
+use oxc_str::{CompactStr, Str};
 use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -91,7 +91,9 @@ impl Rule for NoNodejsModules {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let module_name = match node.kind() {
             AstKind::ImportExpression(import) => match &import.source {
-                Expression::StringLiteral(str_lit) => Some(str_lit.value),
+                Expression::StringLiteral(str_lit) => {
+                    Some(Str::from(str_lit.value.as_str_or_default()))
+                }
                 Expression::TemplateLiteral(temp_lit) if temp_lit.is_no_substitution_template() => {
                     temp_lit.single_quasi()
                 }
@@ -99,16 +101,22 @@ impl Rule for NoNodejsModules {
             },
             AstKind::TSImportEqualsDeclaration(import) => match &import.module_reference {
                 TSModuleReference::ExternalModuleReference(external) => {
-                    Some(external.expression.value)
+                    Some(Str::from(external.expression.value.as_str_or_default()))
                 }
                 _ => None,
             },
             AstKind::CallExpression(call) if !call.optional => {
-                call.common_js_require().map(|s| s.value)
+                call.common_js_require().map(|s| Str::from(s.value.as_str_or_default()))
             }
-            AstKind::ImportDeclaration(import) => Some(import.source.value),
-            AstKind::ExportFromDeclaration(export) => Some(export.source.value),
-            AstKind::ExportAllDeclaration(export_all) => Some(export_all.source.value),
+            AstKind::ImportDeclaration(import) => {
+                Some(Str::from(import.source.value.as_str_or_default()))
+            }
+            AstKind::ExportFromDeclaration(export) => {
+                Some(Str::from(export.source.value.as_str_or_default()))
+            }
+            AstKind::ExportAllDeclaration(export_all) => {
+                Some(Str::from(export_all.source.value.as_str_or_default()))
+            }
             _ => return,
         };
 

--- a/crates/oxc_linter/src/rules/import/no_relative_parent_imports.rs
+++ b/crates/oxc_linter/src/rules/import/no_relative_parent_imports.rs
@@ -56,26 +56,26 @@ impl Rule for NoRelativeParentImports {
         match node.kind() {
             // ESM import declarations
             AstKind::ImportDeclaration(import_decl)
-                if is_parent_import(import_decl.source.value.as_str()) =>
+                if is_parent_import(import_decl.source.value.as_str().unwrap_or("")) =>
             {
                 ctx.diagnostic(no_relative_parent_imports_diagnostic(import_decl.source.span));
             }
             // ESM export { } from '...'
             AstKind::ExportFromDeclaration(export_decl) => {
-                if is_parent_import(export_decl.source.value.as_str()) {
+                if is_parent_import(export_decl.source.value.as_str().unwrap_or("")) {
                     ctx.diagnostic(no_relative_parent_imports_diagnostic(export_decl.source.span));
                 }
             }
             // ESM export * from '...'
             AstKind::ExportAllDeclaration(export_decl)
-                if is_parent_import(export_decl.source.value.as_str()) =>
+                if is_parent_import(export_decl.source.value.as_str().unwrap_or("")) =>
             {
                 ctx.diagnostic(no_relative_parent_imports_diagnostic(export_decl.source.span));
             }
             // Dynamic import expressions: import('../foo')
             AstKind::ImportExpression(import_expr) => {
                 if let Expression::StringLiteral(str_literal) = &import_expr.source
-                    && is_parent_import(str_literal.value.as_str())
+                    && is_parent_import(str_literal.value.as_str().unwrap_or(""))
                 {
                     ctx.diagnostic(no_relative_parent_imports_diagnostic(str_literal.span));
                 }
@@ -83,7 +83,7 @@ impl Rule for NoRelativeParentImports {
             // CommonJS require() calls
             AstKind::CallExpression(call_expr) => {
                 if let Some(str_literal) = call_expr.common_js_require()
-                    && is_parent_import(str_literal.value.as_str())
+                    && is_parent_import(str_literal.value.as_str().unwrap_or(""))
                 {
                     ctx.diagnostic(no_relative_parent_imports_diagnostic(str_literal.span));
                 }

--- a/crates/oxc_linter/src/rules/import/no_unassigned_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_unassigned_import.rs
@@ -97,7 +97,7 @@ impl Rule for NoUnassignedImport {
                 if import_decl.specifiers.is_some() {
                     return;
                 }
-                if !self.is_match_allow_globs(import_decl.source.value.as_str()) {
+                if !self.is_match_allow_globs(import_decl.source.value.as_str().unwrap_or("")) {
                     ctx.diagnostic(no_unassigned_import_diagnostic(
                         import_decl.span,
                         "Imported module should be assigned",
@@ -115,7 +115,7 @@ impl Rule for NoUnassignedImport {
                 let Argument::StringLiteral(source_str) = first_arg else {
                     return;
                 };
-                if !self.is_match_allow_globs(source_str.value.as_str()) {
+                if !self.is_match_allow_globs(source_str.value.as_str().unwrap_or("")) {
                     ctx.diagnostic(no_unassigned_import_diagnostic(
                         call_expr.span,
                         "A `require()` style import is forbidden.",

--- a/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
+++ b/crates/oxc_linter/src/rules/import/no_webpack_loader_syntax.rs
@@ -78,7 +78,7 @@ impl Rule for NoWebpackLoaderSyntax {
 
                     if ident.value.contains('!') {
                         ctx.diagnostic(no_named_as_default_diagnostic(
-                            ident.value.as_str(),
+                            ident.value.as_str().unwrap_or(""),
                             ident.span,
                         ));
                     }

--- a/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
+++ b/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
@@ -140,13 +140,13 @@ impl NoUntypedMockFactory {
         if let Expression::StringLiteral(string_literal) = expr {
             ctx.diagnostic_with_fix(
                 add_type_parameter_to_module_mock_diagnostic(
-                    string_literal.value.as_str(),
+                    string_literal.value.as_str().unwrap_or(""),
                     property_span,
                 ),
                 |fixer| {
                     let mut code = String::with_capacity(string_literal.value.len() + 20);
                     code.push_str("<typeof import('");
-                    code.push_str(string_literal.value.as_str());
+                    code.push_str(string_literal.value.as_str().unwrap_or(""));
                     code.push_str("')>");
 
                     fixer.insert_text_after(&call_expr.callee, code)

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
@@ -185,7 +185,7 @@ fn get_accessible_text<'a, 'b>(
         .iter()
         .filter_map(|child| match child {
             JSXChild::Element(child_el) => get_accessible_text(child_el, ctx),
-            JSXChild::Text(text_el) => Some(Cow::Borrowed(text_el.value.as_str())),
+            JSXChild::Text(text_el) => Some(Cow::Borrowed(text_el.value.as_str().unwrap_or(""))),
             _ => None,
         })
         .collect();

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
@@ -249,7 +249,7 @@ impl AnchorIsValid {
         match value {
             JSXAttributeValue::Element(_) => HrefValueKind::Valid,
             JSXAttributeValue::StringLiteral(str_lit) => {
-                Self::href_value_kind_from_string(&str_lit.value)
+                Self::href_value_kind_from_string(str_lit.value.as_str().unwrap_or_default())
             }
             JSXAttributeValue::ExpressionContainer(exp) => match &exp.expression {
                 JSXExpression::Identifier(ident) if ident.name == "undefined" => {
@@ -257,7 +257,7 @@ impl AnchorIsValid {
                 }
                 JSXExpression::NullLiteral(_) => HrefValueKind::Nullish,
                 JSXExpression::StringLiteral(str_lit) => {
-                    Self::href_value_kind_from_string(&str_lit.value)
+                    Self::href_value_kind_from_string(str_lit.value.as_str().unwrap_or_default())
                 }
                 JSXExpression::TemplateLiteral(temp_lit) => {
                     if !temp_lit.expressions.is_empty() {

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -130,7 +130,7 @@ impl Rule for AriaRole {
                     }
                 }
                 Some(JSXAttributeValue::StringLiteral(str)) => {
-                    let value = str.value.as_str();
+                    let value = str.value.as_str_or_default();
                     if value.trim().is_empty() {
                         ctx.diagnostic(aria_role_diagnostic(str.span, ""));
                     } else if let Some(error_prop) = value.split_whitespace().find(|word| {

--- a/crates/oxc_linter/src/rules/jsx_a11y/control_has_associated_label.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/control_has_associated_label.rs
@@ -227,7 +227,7 @@ impl ControlHasAssociatedLabel {
                 match &attr.value {
                     None => false,
                     Some(JSXAttributeValue::StringLiteral(s)) => {
-                        !s.value.as_str().trim().is_empty()
+                        !s.value.as_str_or_default().trim().is_empty()
                     }
                     Some(_) => true,
                 }
@@ -247,7 +247,7 @@ impl ControlHasAssociatedLabel {
 
         match node {
             JSXChild::ExpressionContainer(_) => true,
-            JSXChild::Text(text) => !text.value.as_str().trim().is_empty(),
+            JSXChild::Text(text) => !text.value.as_str_or_default().trim().is_empty(),
             JSXChild::Element(element) => {
                 if self.has_labelling_prop(&element.opening_element.attributes) {
                     return true;

--- a/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
@@ -89,14 +89,14 @@ fn is_valid_lang_prop(item: &JSXAttributeItem) -> bool {
             | JSXExpression::BooleanLiteral(_)
             | JSXExpression::NumericLiteral(_) => false,
             JSXExpression::Identifier(id) => id.name != "undefined",
-            JSXExpression::StringLiteral(str) => !str.value.as_str().is_empty(),
+            JSXExpression::StringLiteral(str) => !str.value.as_str_or_default().is_empty(),
             JSXExpression::TemplateLiteral(t) => {
                 !t.expressions.is_empty()
                     || t.quasis.iter().filter(|q| !q.value.raw.is_empty()).count() > 0
             }
             _ => true,
         },
-        Some(JSXAttributeValue::StringLiteral(str)) => !str.value.as_str().is_empty(),
+        Some(JSXAttributeValue::StringLiteral(str)) => !str.value.as_str_or_default().is_empty(),
         _ => true,
     }
 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
@@ -78,7 +78,9 @@ impl Rule for IframeHasTitle {
         };
 
         match get_prop_value(alt_prop) {
-            Some(JSXAttributeValue::StringLiteral(str)) if !str.value.as_str().is_empty() => {
+            Some(JSXAttributeValue::StringLiteral(str))
+                if !str.value.as_str_or_default().is_empty() =>
+            {
                 return;
             }
             Some(JSXAttributeValue::ExpressionContainer(container)) => {

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -164,7 +164,7 @@ impl Rule for ImgRedundantAlt {
 
         match alt_attribute {
             JSXAttributeValue::StringLiteral(lit) => {
-                let alt_text = lit.value.as_str();
+                let alt_text = lit.value.as_str_or_default();
 
                 if self.is_redundant_alt_text(alt_text) {
                     ctx.diagnostic(img_redundant_alt_diagnostic(alt_attribute_name_span));
@@ -172,7 +172,7 @@ impl Rule for ImgRedundantAlt {
             }
             JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
                 JSXExpression::StringLiteral(lit) => {
-                    let alt_text = lit.value.as_str();
+                    let alt_text = lit.value.as_str_or_default();
 
                     if self.is_redundant_alt_text(alt_text) {
                         ctx.diagnostic(img_redundant_alt_diagnostic(alt_attribute_name_span));

--- a/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
@@ -337,7 +337,7 @@ impl LabelHasAssociatedControl {
 
         match node {
             JSXChild::ExpressionContainer(_) => true,
-            JSXChild::Text(text) => !text.value.as_str().trim().is_empty(),
+            JSXChild::Text(text) => !text.value.as_str_or_default().trim().is_empty(),
             JSXChild::Element(element) => {
                 let has_labelling_prop =
                     element.opening_element.attributes.iter().any(|attr| match attr {
@@ -347,7 +347,7 @@ impl LabelHasAssociatedControl {
                                     && attribute.value.as_ref().is_some_and(|attribute_value| {
                                         match attribute_value {
                                             JSXAttributeValue::StringLiteral(literal) => {
-                                                !literal.value.as_str().trim().is_empty()
+                                                !literal.value.as_str_or_default().trim().is_empty()
                                             }
                                             _ => true,
                                         }

--- a/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/lang.rs
@@ -90,7 +90,9 @@ fn is_valid_lang_prop(item: &JSXAttributeItem) -> bool {
             !container.expression.is_expression() || !container.expression.is_undefined()
         }
         Some(JSXAttributeValue::StringLiteral(str)) => {
-            LanguageTag::parse(str.value.as_str()).as_ref().is_ok_and(LanguageTag::is_valid)
+            LanguageTag::parse(str.value.as_str().unwrap_or(""))
+                .as_ref()
+                .is_ok_and(LanguageTag::is_valid)
         }
         _ => true,
     }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_interactive_element_to_noninteractive_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_interactive_element_to_noninteractive_role.rs
@@ -117,7 +117,7 @@ impl Rule for NoInteractiveElementToNoninteractiveRole {
             return;
         };
 
-        let role_str = role_value.value.as_str().trim();
+        let role_str = role_value.value.as_str_or_default().trim();
         let Some(first_role) = role_str.split_whitespace().next() else {
             return;
         };

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_interactions.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_interactions.rs
@@ -256,9 +256,9 @@ fn is_content_editable(jsx_el: &JSXOpeningElement) -> bool {
 fn role_value<'b>(jsx_el: &'b JSXOpeningElement<'_>) -> Option<&'b str> {
     has_jsx_prop_ignore_case(jsx_el, "role").and_then(get_prop_value).and_then(
         |value| match value {
-            JSXAttributeValue::StringLiteral(role) => Some(role.value.as_str()),
+            JSXAttributeValue::StringLiteral(role) => role.value.as_str(),
             JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
-                JSXExpression::StringLiteral(role) => Some(role.value.as_str()),
+                JSXExpression::StringLiteral(role) => role.value.as_str(),
                 _ => None,
             },
             _ => None,

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_to_interactive_role.rs
@@ -169,7 +169,7 @@ impl Rule for NoNoninteractiveElementToInteractiveRole {
             return;
         };
 
-        let role = role_value.value.as_str().trim();
+        let role = role_value.value.as_str_or_default().trim();
 
         // Take only the first role token (whitespace-separated).
         let Some(first_role) = role.split_whitespace().next() else {

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -198,12 +198,12 @@ fn get_select_implicit_role(jsx_el: &JSXOpeningElement) -> &'static str {
 
 fn get_static_string_prop_value<'a>(item: &'a JSXAttributeItem<'_>) -> Option<&'a str> {
     match get_prop_value(item)? {
-        JSXAttributeValue::StringLiteral(lit) => Some(lit.value.as_str()),
+        JSXAttributeValue::StringLiteral(lit) => Some(lit.value.as_str().unwrap_or("")),
         JSXAttributeValue::ExpressionContainer(container) => {
             let Expression::StringLiteral(lit) = container.expression.as_expression()? else {
                 return None;
             };
-            Some(lit.value.as_str())
+            Some(lit.value.as_str().unwrap_or(""))
         }
         _ => None,
     }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
@@ -151,7 +151,7 @@ impl Rule for NoStaticElementInteractions {
 
         match role_value {
             JSXAttributeValue::StringLiteral(role) => {
-                let role_str = role.value.as_str().cow_to_lowercase();
+                let role_str = role.value.as_str_or_default().cow_to_lowercase();
                 let roles: Vec<&str> = role_str.split_whitespace().collect();
 
                 if let Some(first_role) = roles.first() {

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -105,7 +105,7 @@ impl Rule for InlineScriptId {
             return;
         };
 
-        if import_decl.source.value.as_str() != "next/script" {
+        if import_decl.source.value.as_str_or_default() != "next/script" {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
@@ -122,7 +122,7 @@ impl Rule for NoBeforeInteractiveScriptOutsideDocument {
             };
 
             if let Some(JSXAttributeValue::StringLiteral(strategy_value)) = &strategy.value
-                && strategy_value.value.as_str() == "beforeInteractive"
+                && strategy_value.value.as_str_or_default() == "beforeInteractive"
             {
                 if is_document_page(file_path) {
                     return;

--- a/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
@@ -65,7 +65,7 @@ impl Rule for NoDocumentImportInPage {
             return;
         };
 
-        if import_decl.source.value.as_str() != "next/document" {
+        if import_decl.source.value.as_str_or_default() != "next/document" {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
@@ -85,7 +85,7 @@ impl Rule for NoHeadImportInDocument {
             return;
         };
 
-        if import_decl.source.value.as_str() != "next/head" {
+        if import_decl.source.value.as_str_or_default() != "next/head" {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/nextjs/no_html_link_for_pages.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_html_link_for_pages.rs
@@ -147,7 +147,7 @@ impl Rule for NoHtmlLinkForPages {
             match value {
                 // String literal href - check if it's an internal link
                 JSXAttributeValue::StringLiteral(str_lit) => {
-                    let href_value = str_lit.value.as_str();
+                    let href_value = str_lit.value.as_str_or_default();
                     is_internal_page_link(href_value)
                 }
                 // Expression href (dynamic) - ignore, can't statically determine if internal

--- a/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
@@ -73,7 +73,7 @@ impl Rule for NoScriptComponentInHead {
             return;
         };
 
-        if import_decl.source.value.as_str() != "next/head" {
+        if import_decl.source.value.as_str_or_default() != "next/head" {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
@@ -71,7 +71,7 @@ impl Rule for NoTitleInDocumentHead {
             return;
         };
 
-        if import_decl.source.value.as_str() != "next/document" {
+        if import_decl.source.value.as_str_or_default() != "next/document" {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
@@ -110,7 +110,7 @@ impl Rule for NoUnwantedPolyfillio {
             return;
         };
 
-        let src_str = src_value.value.as_str();
+        let src_str = src_value.value.as_str_or_default();
 
         // Check for unsafe polyfill.io domains first
         // These domains were compromised in a supply chain attack in 2024

--- a/crates/oxc_linter/src/rules/node/no_mixed_requires.rs
+++ b/crates/oxc_linter/src/rules/node/no_mixed_requires.rs
@@ -236,7 +236,7 @@ fn infer_module_type(init: &Expression) -> ModuleType {
     };
 
     let Some(value) = arg.as_expression().and_then(|expr| match expr {
-        Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+        Expression::StringLiteral(lit) => lit.value.as_str(),
         _ => None,
     }) else {
         return ModuleType::Computed;

--- a/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_char_at_comparison.rs
@@ -102,7 +102,7 @@ fn bad_char_at_comparison_operands(
 fn invalid_comparison_string(expr: &Expression) -> Option<(Span, usize)> {
     let expr = expr.without_parentheses();
     let value = match expr {
-        Expression::StringLiteral(literal) => literal.value.as_str(),
+        Expression::StringLiteral(literal) => literal.value.as_str_or_default(),
         Expression::TemplateLiteral(literal) if literal.expressions.is_empty() => {
             literal.quasis.first()?.value.cooked.as_deref()?
         }
@@ -178,7 +178,7 @@ fn is_static_string_index(expr: &Expression) -> bool {
     match expr.without_parentheses() {
         Expression::NumericLiteral(_) => true,
         Expression::StringLiteral(literal) => {
-            let value = literal.value.as_str();
+            let value = literal.value.as_str_or_default();
             value == "0"
                 || (!value.starts_with('0')
                     && value.bytes().all(|byte| byte.is_ascii_digit())

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -117,7 +117,7 @@ impl Rule for ButtonHasType {
                     return;
                 };
 
-                if str.value.as_str() != "button" {
+                if str.value.as_str_or_default() != "button" {
                     return;
                 }
 
@@ -195,7 +195,7 @@ impl ButtonHasType {
                 }
             }
             Some(JSXAttributeValue::StringLiteral(str)) => {
-                self.is_valid_button_type_prop_string_literal(str.value.as_str())
+                self.is_valid_button_type_prop_string_literal(str.value.as_str().unwrap_or(""))
             }
             _ => false,
         }
@@ -204,7 +204,7 @@ impl ButtonHasType {
     fn is_valid_button_type_prop_expression(&self, expr: &Expression) -> bool {
         match expr.without_parentheses() {
             Expression::StringLiteral(str) => {
-                self.is_valid_button_type_prop_string_literal(str.value.as_str())
+                self.is_valid_button_type_prop_string_literal(str.value.as_str().unwrap_or(""))
             }
             Expression::TemplateLiteral(template_literal) => template_literal
                 .single_quasi()

--- a/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
@@ -227,9 +227,9 @@ impl Rule for ForbidDomProps {
 
 fn static_jsx_string_value<'a>(value: &'a JSXAttributeValue<'a>) -> Option<&'a str> {
     match value {
-        JSXAttributeValue::StringLiteral(str_lit) => Some(str_lit.value.as_str()),
+        JSXAttributeValue::StringLiteral(str_lit) => Some(str_lit.value.as_str().unwrap_or("")),
         JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
-            JSXExpression::StringLiteral(str_lit) => Some(str_lit.value.as_str()),
+            JSXExpression::StringLiteral(str_lit) => Some(str_lit.value.as_str().unwrap_or("")),
             JSXExpression::TemplateLiteral(template_lit) => {
                 template_lit.single_quasi().map(|quasi| quasi.as_str())
             }

--- a/crates/oxc_linter/src/rules/react/forbid_elements.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_elements.rs
@@ -157,10 +157,14 @@ impl Rule for ForbidElements {
                         self.add_diagnostic_if_invalid_element(ctx, it.name.as_str(), it.span);
                     }
                     Argument::StringLiteral(str) => {
-                        if !is_valid_literal(&str.value) {
+                        if !is_valid_literal(str.value.as_str().unwrap_or_default()) {
                             return;
                         }
-                        self.add_diagnostic_if_invalid_element(ctx, str.value.as_str(), str.span);
+                        self.add_diagnostic_if_invalid_element(
+                            ctx,
+                            str.value.as_str().unwrap_or(""),
+                            str.span,
+                        );
                     }
                     Argument::StaticMemberExpression(member_expression) => {
                         let Some(it) = member_expression.object.get_identifier_reference() else {

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use lazy_regex::{Lazy, Regex, lazy_regex};
 use oxc_allocator::ArenaVec;
+use oxc_str::Str;
 
 use oxc_ast::{
     AstKind,
@@ -382,7 +383,7 @@ impl JsxCurlyBracePresence {
                     self.check_expression_container(ctx, container, node, false);
                 }
                 JSXChild::Text(text) => {
-                    let text_value = text.value.as_str();
+                    let text_value = text.value.as_str_or_default();
                     if self.children.is_always()
                         && !contains_only_html_entities(text_value)
                         && !is_whitespace(text_value)
@@ -425,7 +426,7 @@ impl JsxCurlyBracePresence {
                     report_missing_curly_for_string_attribute_value(
                         ctx,
                         string.span,
-                        string.value.as_str(),
+                        string.value.as_str().unwrap_or(""),
                     );
                 }
             }
@@ -592,7 +593,7 @@ fn report_unnecessary_curly<'a>(
             }
             JSXExpression::StringLiteral(string_literal) => {
                 let mut fix = fixer.codegen();
-                fix.print_str(string_literal.value.as_str());
+                fix.print_str(string_literal.value.as_str().unwrap_or(""));
 
                 fixer.replace(container.span, fix.into_source_text())
             }
@@ -616,7 +617,9 @@ fn report_unnecessary_curly_for_attribute_value<'a>(
     ctx.diagnostic_with_fix(jsx_curly_brace_presence_unnecessary_diagnostic(inner_span), |fixer| {
         let str = match &container.expression {
             JSXExpression::TemplateLiteral(template_lit) => template_lit.single_quasi().unwrap(),
-            JSXExpression::StringLiteral(string_lit) => string_lit.value,
+            JSXExpression::StringLiteral(string_lit) => {
+                Str::from(string_lit.value.as_str_or_default())
+            }
             JSXExpression::JSXElement(el) => {
                 return fixer.replace(container.span, ctx.source_range(el.span).to_owned());
             }

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -61,7 +61,7 @@ impl Rule for JsxNoCommentTextnodes {
             return;
         };
 
-        if has_comment_pattern(&jsx_text.value) {
+        if has_comment_pattern(jsx_text.value.as_str().unwrap_or_default()) {
             ctx.diagnostic(jsx_no_comment_textnodes_diagnostic(jsx_text.span));
         }
     }

--- a/crates/oxc_linter/src/rules/react/jsx_no_literals.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_literals.rs
@@ -259,7 +259,7 @@ impl JsxNoLiterals {
         for child in children {
             match child {
                 JSXChild::Text(text) => {
-                    let value = text.value.as_str();
+                    let value = text.value.as_str_or_default();
 
                     if Self::is_allowed_string(value, options) {
                         continue;
@@ -272,7 +272,10 @@ impl JsxNoLiterals {
                 JSXChild::ExpressionContainer(container) if options.no_strings => {
                     match &container.expression {
                         JSXExpression::StringLiteral(literal) => {
-                            if !Self::is_allowed_string(literal.value.as_str(), options) {
+                            if !Self::is_allowed_string(
+                                literal.value.as_str().unwrap_or(""),
+                                options,
+                            ) {
                                 ctx.diagnostic(literal_text_diagnostic(literal.span));
                             }
                         }
@@ -295,7 +298,7 @@ impl JsxNoLiterals {
     ) {
         match &expr {
             Expression::StringLiteral(literal) => {
-                if !Self::is_allowed_string(literal.value.as_str(), options) {
+                if !Self::is_allowed_string(literal.value.as_str().unwrap_or(""), options) {
                     ctx.diagnostic(literal_attribute_diagnostic(attr.span));
                 }
             }
@@ -326,7 +329,7 @@ impl JsxNoLiterals {
 
             match value {
                 JSXAttributeValue::StringLiteral(str_literal) => {
-                    if Self::is_allowed_string(str_literal.value.as_str(), options) {
+                    if Self::is_allowed_string(str_literal.value.as_str().unwrap_or(""), options) {
                         continue;
                     }
 

--- a/crates/oxc_linter/src/rules/react/jsx_no_script_url.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_script_url.rs
@@ -192,7 +192,9 @@ impl Rule for JsxNoScriptUrl {
                         };
                         if prop_value.as_string_literal().is_some_and(|val| {
                             link_props.contains(&attr.name.get_identifier().name.to_string())
-                                && JS_SCRIPT_REGEX.captures(&val.value).is_some()
+                                && JS_SCRIPT_REGEX
+                                    .captures(val.value.as_str().unwrap_or_default())
+                                    .is_some()
                         }) {
                             ctx.diagnostic(jsx_no_script_url_diagnostic(attr.span()));
                         }
@@ -209,7 +211,9 @@ impl Rule for JsxNoScriptUrl {
                                 component_name.as_str(),
                                 attr.name.get_identifier().name.to_string(),
                                 ctx,
-                            ) && JS_SCRIPT_REGEX.captures(&val.value).is_some()
+                            ) && JS_SCRIPT_REGEX
+                                .captures(val.value.as_str().unwrap_or_default())
+                                .is_some()
                         }) {
                             ctx.diagnostic(jsx_no_script_url_diagnostic(attr.span()));
                         }

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -263,7 +263,9 @@ fn match_href_expression(
     is_dynamic_link: &mut bool,
 ) {
     match expr {
-        Expression::StringLiteral(str) => *is_external_link = check_is_external_link(&str.value),
+        Expression::StringLiteral(str) => {
+            *is_external_link = check_is_external_link(str.value.as_str().unwrap_or_default());
+        }
         Expression::Identifier(_) => *is_dynamic_link = true,
         Expression::ConditionalExpression(expr) => {
             match_href_expression(&expr.consequent, is_external_link, is_dynamic_link);
@@ -283,7 +285,7 @@ fn check_href(
         matches!(enforce_dynamic_links, EnforceDynamicLinksEnum::Never);
     match attribute_value {
         JSXAttributeValue::StringLiteral(str) => {
-            is_external_link = check_is_external_link(&str.value);
+            is_external_link = check_is_external_link(str.value.as_str().unwrap_or_default());
         }
         JSXAttributeValue::ExpressionContainer(expr) => {
             if let Some(expr) = expr.expression.as_expression() {
@@ -309,7 +311,7 @@ fn check_href(
 }
 
 fn check_rel_val(str: &StringLiteral, allow_referrer: bool) -> bool {
-    let mut splits = str.value.as_str().split(' ');
+    let mut splits = str.value.as_str_or_default().split(' ');
     if allow_referrer {
         return splits.any(|str| {
             if str == "noopener" {

--- a/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
@@ -253,7 +253,7 @@ fn is_line_break(child: &JSXChild) -> bool {
         return false;
     };
     let is_multi_line = text.value.contains('\n');
-    is_multi_line && is_whitespace(text.value.as_str())
+    is_multi_line && is_whitespace(text.value.as_str().unwrap_or(""))
 }
 
 /// Given a JSX element, find the JSXAttributeItem with the given name.

--- a/crates/oxc_linter/src/rules/react/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/react/no_namespace.rs
@@ -68,7 +68,10 @@ impl Rule for NoNamespace {
                 };
 
                 if str_lit.value.contains(':') {
-                    ctx.diagnostic(no_namespace_diagnostic(str_lit.span, &str_lit.value));
+                    ctx.diagnostic(no_namespace_diagnostic(
+                        str_lit.span,
+                        str_lit.value.as_str().unwrap_or_default(),
+                    ));
                 }
             }
             _ => {}

--- a/crates/oxc_linter/src/rules/react/style_prop_object.rs
+++ b/crates/oxc_linter/src/rules/react/style_prop_object.rs
@@ -191,7 +191,7 @@ impl Rule for StylePropObject {
                 };
 
                 let name = match expr {
-                    Expression::StringLiteral(literal) => literal.value.as_str(),
+                    Expression::StringLiteral(literal) => literal.value.as_str_or_default(),
                     Expression::Identifier(identifier) => identifier.name.as_str(),
                     _ => return,
                 };

--- a/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
+++ b/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
@@ -118,7 +118,7 @@ impl Rule for VoidDomElementsNoChildren {
                     return;
                 };
 
-                if !is_void_dom_element(element_name.value.as_str()) {
+                if !is_void_dom_element(element_name.value.as_str().unwrap_or("")) {
                     return;
                 }
 
@@ -143,7 +143,7 @@ impl Rule for VoidDomElementsNoChildren {
 
                 if call_expr.arguments.get(2).is_some() || has_children_prop_or_danger {
                     ctx.diagnostic(void_dom_elements_no_children_diagnostic(
-                        &element_name.value,
+                        element_name.value.as_str().unwrap_or_default(),
                         element_name.span,
                     ));
                 }

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_identical_title.rs
@@ -125,7 +125,7 @@ fn filter_and_process_jest_result<'a>(
 
     match call_expr.arguments.first() {
         Some(Argument::StringLiteral(string_lit)) => {
-            Some((string_lit.span, &string_lit.value, kind, parent_id))
+            Some((string_lit.span, string_lit.value.as_str().unwrap_or_default(), kind, parent_id))
         }
         Some(Argument::TemplateLiteral(template_lit)) => template_lit
             .single_quasi()

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_mocks_import.rs
@@ -65,7 +65,7 @@ pub fn run_once(ctx: &LintContext) {
             return;
         };
 
-        if contains_mocks_dir(&string_literal.value) {
+        if contains_mocks_dir(string_literal.value.as_str().unwrap_or_default()) {
             ctx.diagnostic(no_mocks_import_diagnostic(string_literal.span));
         }
     }

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_lowercase_title.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/prefer_lowercase_title.rs
@@ -186,7 +186,7 @@ impl PreferLowercaseTitleConfig {
         };
 
         if let Argument::StringLiteral(string_expr) = arg {
-            self.lint_string(ctx, string_expr.value.as_str(), string_expr.span);
+            self.lint_string(ctx, string_expr.value.as_str().unwrap_or(""), string_expr.span);
         } else if let Argument::TemplateLiteral(template_expr) = arg {
             let Some(template_string) = template_expr.single_quasi() else {
                 return;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/valid_title.rs
@@ -234,7 +234,7 @@ impl ValidTitleConfig {
         match arg {
             Argument::StringLiteral(string_literal) => {
                 validate_title(
-                    &string_literal.value,
+                    string_literal.value.as_str().unwrap_or_default(),
                     string_literal.span,
                     config,
                     &jest_fn_call.name,

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -453,7 +453,7 @@ fn fix_to_type_import_declaration(options: &FixOptions<'_, '_>) -> FixerResult<R
     if !type_names_specifiers.is_empty() {
         // definitely all type references: `import type { A, B } from 'foo'`
         if let Some(type_only_named_import) =
-            get_type_only_named_import(ctx, import_decl.source.value.as_str())
+            get_type_only_named_import(ctx, import_decl.source.value.as_str().unwrap_or(""))
         {
             let new_options = FixOptions {
                 import_decl: type_only_named_import,

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -117,7 +117,9 @@ impl Rule for NoDuplicateEnumValues {
                     }
                 }
                 Expression::StringLiteral(s) => {
-                    if let Some(old_span) = seen_string_values.insert(s.value.as_str(), s.span) {
+                    if let Some(old_span) =
+                        seen_string_values.insert(s.value.as_str().unwrap_or(""), s.span)
+                    {
                         // Formatting here for prettier messages. This makes it
                         // look like "Duplicate enum value 'A'"
                         let v = format!("'{}'", s.value);

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -159,7 +159,7 @@ impl Rule for NoRequireImports {
                         Argument::StringLiteral(string_literal)
                             if match_argument_value_with_regex(
                                 &self.allow,
-                                &string_literal.value,
+                                string_literal.value.as_str().unwrap_or_default(),
                             ) =>
                         {
                             return;

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
@@ -10,7 +10,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
 use oxc_span::Span;
-use oxc_str::Str;
+use oxc_str::CompactStr;
 use rustc_hash::FxHashSet;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
@@ -110,8 +110,8 @@ impl Rule for NoUnnecessaryParameterPropertyAssignment {
 struct AssignmentVisitor<'a, 'b> {
     ctx: &'b LintContext<'a>,
     parameters: &'b [FormalParameter<'a>],
-    assigned_before_unnecessary: FxHashSet<Str<'a>>,
-    assigned_before_constructor: FxHashSet<Str<'a>>,
+    assigned_before_unnecessary: FxHashSet<CompactStr>,
+    assigned_before_constructor: FxHashSet<CompactStr>,
 }
 
 impl<'a> VisitJs<'a> for AssignmentVisitor<'a, '_> {
@@ -146,7 +146,7 @@ impl<'a> VisitJs<'a> for AssignmentVisitor<'a, '_> {
             let Some(binding_identifier) = param.pattern.get_binding_identifier() else {
                 continue;
             };
-            if binding_identifier.name != this_property_name {
+            if binding_identifier.name.as_str() != this_property_name.as_str() {
                 continue;
             }
             // name of property parameter matches the name of the assigned property
@@ -232,20 +232,20 @@ fn is_unnecessary_assignment_operator(operator: AssignmentOperator) -> bool {
     )
 }
 
-fn get_property_name<'a>(assignment_target: &AssignmentTarget<'a>) -> Option<Str<'a>> {
+fn get_property_name<'a>(assignment_target: &'a AssignmentTarget<'a>) -> Option<CompactStr> {
     match assignment_target {
         AssignmentTarget::StaticMemberExpression(expr)
             if matches!(&expr.object, Expression::ThisExpression(_)) =>
         {
             // this.property
-            Some(expr.property.name.into())
+            Some(expr.property.name.as_str().into())
         }
         AssignmentTarget::ComputedMemberExpression(expr)
             if matches!(&expr.object, Expression::ThisExpression(_)) =>
         {
             // this["property"]
             if let Expression::StringLiteral(str) = &expr.expression {
-                Some(str.value)
+                Some(CompactStr::from(str.value.as_str_or_default()))
             } else {
                 None
             }

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -127,7 +127,8 @@ impl Rule for TripleSlashReference {
                 match stmt {
                     Statement::TSImportEqualsDeclaration(decl) => match &decl.module_reference {
                         TSModuleReference::ExternalModuleReference(mod_ref) => {
-                            if let Some(v) = refs_for_import.get(mod_ref.expression.value.as_str())
+                            if let Some(v) =
+                                refs_for_import.get(mod_ref.expression.value.as_str_or_default())
                             {
                                 ctx.diagnostic(triple_slash_reference_diagnostic(
                                     &mod_ref.expression.value,
@@ -139,7 +140,8 @@ impl Rule for TripleSlashReference {
                         | TSModuleReference::QualifiedName(_) => {}
                     },
                     Statement::ImportDeclaration(decl) => {
-                        if let Some(v) = refs_for_import.get(decl.source.value.as_str()) {
+                        if let Some(v) = refs_for_import.get(decl.source.value.as_str_or_default())
+                        {
                             ctx.diagnostic(triple_slash_reference_diagnostic(
                                 &decl.source.value,
                                 *v,

--- a/crates/oxc_linter/src/rules/unicorn/consistent_assert.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_assert.rs
@@ -73,12 +73,12 @@ fn is_assert_module_import(import_decl: &ImportDeclaration) -> bool {
 }
 
 fn is_assert_module(import_decl: &ImportDeclaration) -> bool {
-    let module_name = import_decl.source.value.as_str();
+    let module_name = import_decl.source.value.as_str_or_default();
     ["assert", "node:assert"].contains(&module_name)
 }
 
 fn is_strict_assert_module(import_decl: &ImportDeclaration) -> bool {
-    let module_name = import_decl.source.value.as_str();
+    let module_name = import_decl.source.value.as_str_or_default();
     ["assert/strict", "node:assert/strict"].contains(&module_name)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/custom_error_definition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/custom_error_definition.rs
@@ -378,14 +378,14 @@ fn is_valid_name_property(name_property: Option<&PropertyDefinition>, class_name
     if let Some(prop) = name_property
         && let Some(Expression::StringLiteral(lit)) = &prop.value
     {
-        return lit.value.as_str() == class_name;
+        return lit.value.as_str_or_default() == class_name;
     }
 
     false
 }
 
 fn is_expected_string_literal(expr: &Expression, expected: &str) -> bool {
-    matches!(expr, Expression::StringLiteral(lit) if lit.value.as_str() == expected)
+    matches!(expr, Expression::StringLiteral(lit) if lit.value.as_str_or_default() == expected)
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/unicorn/import_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/import_style.rs
@@ -352,7 +352,7 @@ impl ImportStyle {
         let actual_styles = get_actual_import_declaration_styles(import_decl);
         self.report_if_needed(
             import_decl.span,
-            import_decl.source.value.as_str(),
+            import_decl.source.value.as_str().unwrap_or(""),
             actual_styles,
             SourceKind::ModuleSyntax,
             ctx,
@@ -366,7 +366,7 @@ impl ImportStyle {
     ) {
         self.report_if_needed(
             export_decl.span,
-            export_decl.source.value.as_str(),
+            export_decl.source.value.as_str().unwrap_or(""),
             StyleSet::namespace(),
             SourceKind::ModuleSyntax,
             ctx,
@@ -381,7 +381,7 @@ impl ImportStyle {
         let actual_styles = get_actual_export_declaration_styles(export_decl);
         self.report_if_needed(
             export_decl.span,
-            export_decl.source.value.as_str(),
+            export_decl.source.value.as_str().unwrap_or(""),
             actual_styles,
             SourceKind::ModuleSyntax,
             ctx,

--- a/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
@@ -75,7 +75,7 @@ impl Rule for NoConsoleSpaces {
             if let Some(expression_arg) = arg.as_expression() {
                 let (literal_raw, is_template_lit) = match expression_arg {
                     Expression::StringLiteral(string_lit) => {
-                        let literal_raw = string_lit.value.as_str();
+                        let literal_raw = string_lit.value.as_str_or_default();
 
                         (literal_raw, false)
                     }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_bigint_literals.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_bigint_literals.rs
@@ -80,7 +80,9 @@ impl Rule for PreferBigintLiterals {
 
         match argument_expression.get_inner_expression() {
             Expression::StringLiteral(string_literal) => {
-                if let Some(replacement) = bigint_literal_from_string(&string_literal.value) {
+                if let Some(replacement) =
+                    bigint_literal_from_string(string_literal.value.as_str().unwrap_or_default())
+                {
                     ctx.diagnostic_with_fix(
                         prefer_bigint_literals_diagnostic(arg.span()),
                         |fixer| fixer.replace(call.span, replacement),

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
@@ -110,7 +110,9 @@ impl Rule for PreferDomNodeDataset {
             return;
         };
 
-        let Some(dataset_property_name) = strip_data_prefix(&string_lit.value) else {
+        let Some(dataset_property_name) =
+            strip_data_prefix(string_lit.value.as_str().unwrap_or_default())
+        else {
             return;
         };
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -95,7 +95,9 @@ fn is_await_import_or_require_from_ignored_packages(expr: &Expression) -> bool {
                 && call_expr.callee.is_specific_id("require")
                 && call_expr.arguments.len() == 1
                 && match &call_expr.arguments[0] {
-                    Argument::StringLiteral(source) => is_ignored_package(source.value.as_str()),
+                    Argument::StringLiteral(source) => {
+                        is_ignored_package(source.value.as_str().unwrap_or(""))
+                    }
                     Argument::TemplateLiteral(source) => source
                         .single_quasi()
                         .is_some_and(|source| is_ignored_package(source.as_str())),
@@ -106,7 +108,9 @@ fn is_await_import_or_require_from_ignored_packages(expr: &Expression) -> bool {
         {
             Expression::ImportExpression(import_expr) => {
                 match import_expr.source.get_inner_expression() {
-                    Expression::StringLiteral(source) => is_ignored_package(source.value.as_str()),
+                    Expression::StringLiteral(source) => {
+                        is_ignored_package(source.value.as_str().unwrap_or(""))
+                    }
                     Expression::TemplateLiteral(source) => source
                         .single_quasi()
                         .is_some_and(|source| is_ignored_package(source.as_str())),

--- a/crates/oxc_linter/src/rules/unicorn/prefer_export_from.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_export_from.rs
@@ -147,7 +147,7 @@ impl PreferExportFrom {
 
         let re_export_decl = find_corresponding_export(ctx, import_decl);
 
-        let source = import_decl.source.value.as_str();
+        let source = import_decl.source.value.as_str_or_default();
         let with_clause = import_decl.with_clause.as_ref().map(|with_clause| {
             let keyword = match with_clause.keyword {
                 WithClauseKeyword::With => "with",
@@ -160,7 +160,7 @@ impl PreferExportFrom {
                     let key = match &attribute.key {
                         ImportAttributeKey::Identifier(ident_name) => ident_name.name.as_str(),
                         ImportAttributeKey::StringLiteral(string_literal) => {
-                            string_literal.value.as_str()
+                            string_literal.value.as_str().unwrap_or("")
                         }
                     };
                     let value = &attribute.value.raw.unwrap();
@@ -1148,7 +1148,7 @@ fn find_corresponding_export<'a>(
     ctx: &LintContext<'a>,
     import_decl: &'a ImportDeclaration<'a>,
 ) -> Option<&'a ExportFromDeclaration<'a>> {
-    let source = import_decl.source.value.as_str();
+    let source = import_decl.source.value.as_str_or_default();
     let program = ctx.nodes().program();
 
     for requested_module in ctx.module_record().requested_modules.get(source)? {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
@@ -93,7 +93,7 @@ impl Rule for PreferGlobalThis {
                     {
                         if let Some(Expression::StringLiteral(lit)) =
                             call_expr.arguments.first().and_then(|arg| arg.as_expression())
-                            && WINDOW_SPECIFIC_EVENTS.contains(&lit.value.as_str())
+                            && WINDOW_SPECIFIC_EVENTS.contains(&lit.value.as_str_or_default())
                         {
                             return;
                         }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_import_meta_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_import_meta_properties.rs
@@ -177,14 +177,14 @@ fn is_process_get_builtin_module_call(call: &CallExpression<'_>, modules: &[&str
     }
     matches!(
         &call.arguments[0],
-        Argument::StringLiteral(lit) if modules.contains(&lit.value.as_str())
+        Argument::StringLiteral(lit) if modules.contains(&lit.value.as_str_or_default())
     )
 }
 
 fn is_parent_literal(argument: &Argument<'_>) -> bool {
     matches!(
         argument,
-        Argument::StringLiteral(lit) if lit.value.as_str() == "." || lit.value.as_str() == "./"
+        Argument::StringLiteral(lit) if lit.value.as_str_or_default() == "." || lit.value.as_str_or_default() == "./"
     )
 }
 
@@ -317,7 +317,7 @@ fn import_declaration_source<'a>(
     else {
         return None;
     };
-    Some(import_declaration.source.value.as_str())
+    Some(import_declaration.source.value.as_str().unwrap_or(""))
 }
 
 fn check_variable_declarator(

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -138,7 +138,8 @@ impl Rule for PreferModernDomApis {
             Some(2),
             Some(2),
         ) && let Argument::StringLiteral(lit) = &call_expr.arguments[0]
-            && let Some(preferred_method) = get_replacement_for_position(lit.value.as_str())
+            && let Some(preferred_method) =
+                get_replacement_for_position(lit.value.as_str().unwrap_or(""))
         {
             let diagnostic = prefer_modern_dom_apis_diagnostic(
                 preferred_method,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -74,7 +74,9 @@ impl Rule for PreferNodeProtocol {
             return;
         };
         let module_name = string_lit_value.as_str();
-        if module_name.starts_with("node:") || !is_nodejs_builtin_module(module_name) {
+        if module_name.is_some_and(|s| s.starts_with("node:"))
+            || !is_nodejs_builtin_module(module_name.unwrap_or_default())
+        {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
@@ -151,7 +151,7 @@ impl Rule for PreferStringRaw {
             return;
         }
 
-        let value = string_literal.value.as_str();
+        let value = string_literal.value.as_str_or_default();
 
         // Cannot use String.raw if the value ends with an odd number of backslashes,
         // as the final backslash would escape the closing backtick.

--- a/crates/oxc_linter/src/rules/unicorn/relative_url_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/relative_url_style.rs
@@ -103,7 +103,7 @@ impl Rule for RelativeUrlStyle {
 
         match first_arg {
             Argument::StringLiteral(str_lit) => {
-                let url = str_lit.value.as_str();
+                let url = str_lit.value.as_str_or_default();
 
                 match self.0 {
                     RelativeUrlStyleConfig::Never => {
@@ -165,7 +165,7 @@ fn can_add_dot_slash(url: &str, new_expr: &NewExpression) -> bool {
     }
 
     if let Some(Argument::StringLiteral(base_lit)) = new_expr.arguments.get(1) {
-        let base = base_lit.value.as_str();
+        let base = base_lit.value.as_str_or_default();
         if is_safe_to_add_dot_slash(url, &[base]) {
             return true;
         }
@@ -180,7 +180,7 @@ fn can_remove_dot_slash(url: &str, new_expr: &NewExpression) -> bool {
     }
 
     if let Some(Argument::StringLiteral(base_lit)) = new_expr.arguments.get(1) {
-        let base = base_lit.value.as_str();
+        let base = base_lit.value.as_str_or_default();
         if is_safe_to_remove_dot_slash(url, &[base]) {
             return true;
         }

--- a/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
@@ -89,8 +89,10 @@ impl Rule for TextEncodingIdentifierCase {
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let (s, span) = match node.kind() {
-            AstKind::StringLiteral(string_lit) => (string_lit.value.as_str(), string_lit.span),
-            AstKind::JSXText(jsx_text) => (jsx_text.value.as_str(), jsx_text.span),
+            AstKind::StringLiteral(string_lit) => {
+                (string_lit.value.as_str_or_default(), string_lit.span)
+            }
+            AstKind::JSXText(jsx_text) => (jsx_text.value.as_str_or_default(), jsx_text.span),
             _ => return,
         };
 

--- a/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
@@ -111,7 +111,7 @@ impl Rule for ConsistentVitestVi {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::ImportDeclaration(import) => {
-                if !is_vitest_import_source(import.source.value.as_str()) {
+                if !is_vitest_import_source(import.source.value.as_str().unwrap_or("")) {
                     return;
                 }
 

--- a/crates/oxc_linter/src/rules/vitest/no_importing_vitest_globals.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_importing_vitest_globals.rs
@@ -137,7 +137,7 @@ impl Rule for NoImportingVitestGlobals {
                 );
             }
             AstKind::ImportDeclaration(import_decl) => {
-                if !is_vitest_import_source(import_decl.source.value.as_str()) {
+                if !is_vitest_import_source(import_decl.source.value.as_str().unwrap_or("")) {
                     return;
                 }
 
@@ -218,7 +218,7 @@ fn vitest_require_source<'a>(declaration: &'a VariableDeclarator<'a>) -> Option<
         return None;
     };
 
-    let import_source = require_import.value.as_str();
+    let import_source = require_import.value.as_str_or_default();
     if !is_vitest_import_source(import_source) {
         return None;
     }

--- a/crates/oxc_linter/src/rules/vitest/prefer_import_in_mock.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_import_in_mock.rs
@@ -130,7 +130,7 @@ impl PreferImportInMock {
 
                 fixer.replace(
                     import_value.span,
-                    format!("import('{}')", import_value.value.as_ref()),
+                    format!("import('{}')", import_value.value.as_str_or_default()),
                 )
             },
         );

--- a/crates/oxc_linter/src/rules/vitest/prefer_importing_vitest_globals.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_importing_vitest_globals.rs
@@ -137,7 +137,7 @@ impl Rule for PreferImportingVitestGlobals {
                 continue;
             };
 
-            if is_vitest_import_source(import_decl.source.value.as_str())
+            if is_vitest_import_source(import_decl.source.value.as_str().unwrap_or(""))
                 && import_decl.import_kind == ImportOrExportKind::Value
             {
                 continue;
@@ -257,7 +257,7 @@ impl PreferImportingVitestGlobals {
             let is_vitest_require = call.arguments.len() == 1
                 && call.arguments.first().is_some_and(|arg| {
                     arg.as_expression().is_some_and(|expr| {
-                        matches!(expr, Expression::StringLiteral(lit) if is_vitest_import_source(lit.value.as_str()))
+                        matches!(expr, Expression::StringLiteral(lit) if is_vitest_import_source(lit.value.as_str().unwrap_or("")))
                     })
                 });
 
@@ -314,7 +314,7 @@ impl PreferImportingVitestGlobals {
 
             let Some(source) = call.arguments.first().and_then(|arg| {
                 arg.as_expression().and_then(|expr| match expr {
-                    Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+                    Expression::StringLiteral(lit) => lit.value.as_str(),
                     _ => None,
                 })
             }) else {

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -317,7 +317,7 @@ fn report_or_add<'a>(
 /// Non-string literals are stringified like JS `String(value)`; `null` has no name.
 fn literal_element_name<'a>(expr: &Expression<'a>) -> Option<Cow<'a, str>> {
     match expr {
-        Expression::StringLiteral(s) => Some(Cow::Borrowed(s.value.as_str())),
+        Expression::StringLiteral(s) => Some(Cow::Borrowed(s.value.as_str().unwrap_or(""))),
         Expression::TemplateLiteral(t) => t.single_quasi().map(Into::into),
         Expression::NumericLiteral(n) => Some(Cow::Owned(n.value.to_js_string())),
         Expression::BooleanLiteral(b) => {

--- a/crates/oxc_linter/src/rules/vue/no_import_compiler_macros.rs
+++ b/crates/oxc_linter/src/rules/vue/no_import_compiler_macros.rs
@@ -88,7 +88,7 @@ impl Rule for NoImportCompilerMacros {
             return;
         };
 
-        if !VUE_MODULES.contains(&import_decl.source.value.as_str()) {
+        if !VUE_MODULES.contains(&import_decl.source.value.as_str_or_default()) {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/vue/no_reserved_component_names.rs
+++ b/crates/oxc_linter/src/rules/vue/no_reserved_component_names.rs
@@ -147,7 +147,7 @@ impl NoReservedComponentNames {
     fn check_name_expression<'a>(&self, expr: &Expression<'a>, ctx: &LintContext<'a>) {
         match expr {
             Expression::StringLiteral(lit) => {
-                self.report_if_reserved(&lit.value, lit.span, ctx);
+                self.report_if_reserved(lit.value.as_str().unwrap_or_default(), lit.span, ctx);
             }
             Expression::TemplateLiteral(tpl) => {
                 if let Some(value) = single_quasi_value(tpl) {

--- a/crates/oxc_linter/src/rules/vue/no_reserved_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_reserved_keys.rs
@@ -145,9 +145,9 @@ impl Rule for NoReservedKeys {
                             let Some(Expression::StringLiteral(lit)) = elem.as_expression() else {
                                 continue;
                             };
-                            if self.is_reserved(lit.value.as_str()) {
+                            if self.is_reserved(lit.value.as_str().unwrap_or("")) {
                                 ctx.diagnostic(reserved_key_diagnostic(
-                                    lit.value.as_str(),
+                                    lit.value.as_str().unwrap_or(""),
                                     lit.span,
                                 ));
                             }
@@ -243,9 +243,12 @@ impl NoReservedKeys {
                 Expression::ArrayExpression(arr) => {
                     for elem in &arr.elements {
                         if let Some(Expression::StringLiteral(lit)) = elem.as_expression()
-                            && self.is_reserved(lit.value.as_str())
+                            && self.is_reserved(lit.value.as_str().unwrap_or(""))
                         {
-                            ctx.diagnostic(reserved_key_diagnostic(lit.value.as_str(), lit.span));
+                            ctx.diagnostic(reserved_key_diagnostic(
+                                lit.value.as_str().unwrap_or(""),
+                                lit.span,
+                            ));
                         }
                     }
                 }

--- a/crates/oxc_linter/src/rules/vue/no_reserved_props.rs
+++ b/crates/oxc_linter/src/rules/vue/no_reserved_props.rs
@@ -146,7 +146,7 @@ impl NoReservedProps {
         for elem in &arr.elements {
             let Some(expr) = elem.as_expression() else { continue };
             let (name, span): (&str, Span) = match expr.get_inner_expression() {
-                Expression::StringLiteral(lit) => (lit.value.as_str(), lit.span),
+                Expression::StringLiteral(lit) => (lit.value.as_str().unwrap_or(""), lit.span),
                 Expression::TemplateLiteral(tpl) => match tpl.single_quasi() {
                     Some(quasi) => (quasi.as_str(), tpl.span),
                     None => continue,

--- a/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
@@ -161,7 +161,7 @@ impl PropNameCasing {
     fn check_array_props<'a>(&self, arr: &ArrayExpression<'a>, ctx: &LintContext<'a>) {
         for element in &arr.elements {
             let ArrayExpressionElement::StringLiteral(lit) = element else { continue };
-            self.report_if_invalid(lit.value.as_str(), lit.span, ctx);
+            self.report_if_invalid(lit.value.as_str().unwrap_or(""), lit.span, ctx);
         }
     }
 
@@ -199,7 +199,7 @@ impl PropNameCasing {
 /// resolved statically. Dynamic keys (computed identifiers, calls, binary
 /// expressions, etc.) return `None`.
 fn property_key_static_name<'a>(
-    key: &PropertyKey<'a>,
+    key: &'a PropertyKey<'a>,
 ) -> Option<(std::borrow::Cow<'a, str>, Span)> {
     match key {
         PropertyKey::StaticIdentifier(ident) => Some((ident.name.as_str().into(), ident.span)),
@@ -211,13 +211,15 @@ fn property_key_static_name<'a>(
             // unresolvable and skipped.
             let expr = key.as_expression()?.get_inner_expression();
             match expr {
-                Expression::StringLiteral(lit) => Some((lit.value.as_str().into(), lit.span)),
+                Expression::StringLiteral(lit) => {
+                    Some((lit.value.as_str_or_default().into(), lit.span))
+                }
                 Expression::TemplateLiteral(tpl)
                     if tpl.expressions.is_empty() && tpl.quasis.len() == 1 =>
                 {
                     let quasi = tpl.quasis.first()?;
                     let cooked = quasi.value.cooked.as_ref()?;
-                    Some((cooked.as_str().into(), tpl.span))
+                    Some((cooked.as_str_or_default().into(), tpl.span))
                 }
                 Expression::RegExpLiteral(regex) => {
                     Some((regex.raw.as_ref()?.as_str().into(), regex.span))

--- a/crates/oxc_linter/src/rules/vue/require_prop_type_constructor.rs
+++ b/crates/oxc_linter/src/rules/vue/require_prop_type_constructor.rs
@@ -178,7 +178,7 @@ fn is_forbidden_type(expr: &Expression) -> bool {
 fn literal_identifier_replacement(expr: &Expression) -> Option<String> {
     match expr {
         Expression::StringLiteral(lit) => {
-            let value = lit.value.as_str();
+            let value = lit.value.as_str_or_default();
             is_identifier_name(value).then(|| value.to_string())
         }
         Expression::TemplateLiteral(tpl) => single_quasi_identifier(tpl),
@@ -191,7 +191,8 @@ fn single_quasi_identifier(tpl: &TemplateLiteral) -> Option<String> {
         return None;
     }
     let cooked = tpl.quasis[0].value.cooked.as_ref()?;
-    is_identifier_name(cooked).then(|| cooked.to_string())
+    let cooked_str = cooked.as_str()?;
+    is_identifier_name(cooked_str).then(|| cooked_str.to_string())
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/vue/require_prop_types.rs
+++ b/crates/oxc_linter/src/rules/vue/require_prop_types.rs
@@ -135,7 +135,10 @@ impl RequirePropTypes {
                     return;
                 }
             }
-            ctx.diagnostic(require_type_diagnostic(call_expr.span, lit.value.as_str()));
+            ctx.diagnostic(require_type_diagnostic(
+                call_expr.span,
+                lit.value.as_str().unwrap_or(""),
+            ));
             return;
         }
 
@@ -240,7 +243,7 @@ impl RequirePropTypes {
         for elem in &arr.elements {
             let Some(expr) = elem.as_expression() else { continue };
             let name = match expr {
-                Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+                Expression::StringLiteral(lit) => lit.value.as_str(),
                 Expression::Identifier(id) => Some(id.name.as_str()),
                 Expression::TemplateLiteral(lit) if lit.expressions.is_empty() => {
                     lit.quasis.first().and_then(|q| q.value.cooked.as_deref())

--- a/crates/oxc_linter/src/utils/express.rs
+++ b/crates/oxc_linter/src/utils/express.rs
@@ -28,7 +28,7 @@ pub fn as_endpoint_registration<'a, 'n>(
     let first = call.arguments[0].as_expression()?;
     match first {
         Expression::StringLiteral(path) => {
-            Some((Some(path.value), &call.arguments.as_slice()[1..]))
+            Some((path.value.as_str().map(Str::from), &call.arguments.as_slice()[1..]))
         }
         Expression::TemplateLiteral(template) => {
             template.single_quasi().map(|quasi| (Some(quasi), &call.arguments.as_slice()[1..]))

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -233,7 +233,7 @@ fn collect_ids_referenced_to_import<'a, 'c>(
 
                 if matches!(
                     import_decl.source.value.as_str(),
-                    "@jest/globals" | "vitest" | "vite-plus/test" | "@effect/vitest"
+                    Some("@jest/globals" | "vitest" | "vite-plus/test" | "@effect/vitest")
                 ) {
                     let original = find_original_name(import_decl, name);
                     return Some(
@@ -285,7 +285,7 @@ pub fn get_node_name_vec<'a>(expr: &'a Expression<'a>) -> SmallVec<[Cow<'a, str>
     match expr {
         Expression::Identifier(ident) => chain.push(Cow::Borrowed(ident.name.as_str())),
         Expression::StringLiteral(string_literal) => {
-            chain.push(Cow::Borrowed(&string_literal.value));
+            chain.push(Cow::Borrowed(string_literal.value.as_str().unwrap_or_default()));
         }
         Expression::TemplateLiteral(template_literal) => {
             if let Some(quasi) = template_literal.single_quasi() {

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
@@ -498,7 +498,7 @@ impl<'a> KnownMemberExpressionProperty<'a> {
             MemberExpressionElement::Expression(expr) => match expr {
                 Expression::Identifier(ident) => Some(Cow::Borrowed(ident.name.as_str())),
                 Expression::StringLiteral(string_literal) => {
-                    Some(Cow::Borrowed(string_literal.value.as_str()))
+                    Some(Cow::Borrowed(string_literal.value.as_str().unwrap_or("")))
                 }
                 Expression::TemplateLiteral(template_literal) => Some(Cow::Borrowed(
                     template_literal.single_quasi().expect("get string content").as_str(),

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -87,7 +87,9 @@ pub fn get_jsx_attribute_name<'a>(attr: &JSXAttributeName<'a>) -> Cow<'a, str> {
 }
 
 pub fn get_string_literal_prop_value<'a>(item: &'a JSXAttributeItem<'_>) -> Option<&'a str> {
-    get_prop_value(item).and_then(JSXAttributeValue::as_string_literal).map(|s| s.value.as_str())
+    get_prop_value(item)
+        .and_then(JSXAttributeValue::as_string_literal)
+        .and_then(|s| s.value.as_str())
 }
 
 // TODO: Move the a11y methods to their own util for jsx-a11y?
@@ -693,7 +695,7 @@ pub fn get_element_type<'c, 'a>(
         })
         .and_then(get_prop_value)
         .and_then(JSXAttributeValue::as_string_literal)
-        .map(|s| s.value.as_str());
+        .and_then(|s| s.value.as_str());
 
     let raw_type = polymorphic_prop.map_or(name, Cow::Borrowed);
     match jsx_a11y.components.get(raw_type.as_ref()) {

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -64,7 +64,7 @@ pub fn is_import_from_module(
         return false;
     };
 
-    import_decl.source.value.as_str() == module_name
+    import_decl.source.value.as_str_or_default() == module_name
 }
 
 /// Returns `true` when `ident` resolves to a named import with the given source module and
@@ -398,7 +398,8 @@ pub fn is_same_member_expression(
             // x[/regex/] === x['/regex/']
             (Expression::StringLiteral(string_lit), Expression::RegExpLiteral(regex_lit))
             | (Expression::RegExpLiteral(regex_lit), Expression::StringLiteral(string_lit)) => {
-                if string_lit.value != regex_lit.raw.as_ref().unwrap() {
+                if string_lit.value.as_str_or_default() != regex_lit.raw.as_ref().unwrap().as_str()
+                {
                     return false;
                 }
             }

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -23,6 +23,7 @@ test = true
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
+oxc_wtf8 = { workspace = true }
 oxc_compat = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["stack"] }
 oxc_ecmascript = { workspace = true, features = ["constant_evaluation"] }

--- a/crates/oxc_minifier/src/peephole/convert_to_dotted_properties.rs
+++ b/crates/oxc_minifier/src/peephole/convert_to_dotted_properties.rs
@@ -20,8 +20,9 @@ impl<'a> PeepholeOptimizations {
     ) {
         let MemberExpression::ComputedMemberExpression(e) = expr else { return };
         let Expression::StringLiteral(s) = &e.expression else { return };
-        if is_identifier_name_patched(&s.value) {
-            let property = IdentifierName::new(s.span, s.value, ctx);
+        let Some(s_str) = s.value.as_str() else { return };
+        if is_identifier_name_patched(s_str) {
+            let property = IdentifierName::new(s.span, s_str, ctx);
             expr.replace_with(|expr| {
                 let MemberExpression::ComputedMemberExpression(e) = expr else { unreachable!() };
                 let ComputedMemberExpression { span, object, optional, .. } = e.unbox();
@@ -32,7 +33,7 @@ impl<'a> PeepholeOptimizations {
             ctx.notice_change();
             return;
         }
-        let v = s.value.as_str();
+        let Some(v) = s.value.as_str() else { return };
         if e.optional {
             return;
         }

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -7,7 +7,9 @@ use oxc_ecmascript::{
     with_number_literal,
 };
 use oxc_span::{GetSpan, SPAN};
+use oxc_str::Wtf8Str;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, LogicalOperator};
+use oxc_wtf8::Wtf8Buf;
 
 use crate::TraverseCtx;
 
@@ -641,7 +643,10 @@ impl<'a> PeepholeOptimizations {
                 let new_cooked = if let (Some(cooked1), Some(cooked2)) =
                     (left_last_quasi.value.cooked, right_first_quasi.value.cooked)
                 {
-                    Some(Str::from_strs_array_in([cooked1.as_str(), cooked2.as_str()], ctx))
+                    let mut buf = oxc_wtf8::Wtf8Buf::with_capacity(cooked1.len() + cooked2.len());
+                    buf.push_wtf8(cooked1.as_wtf8());
+                    buf.push_wtf8(cooked2.as_wtf8());
+                    Some(oxc_str::Wtf8Str::from_wtf8_buf_in(&buf, ctx))
                 } else {
                     None
                 };
@@ -667,7 +672,10 @@ impl<'a> PeepholeOptimizations {
                     ctx,
                 );
                 let new_cooked = last_quasi.value.cooked.map(|cooked| {
-                    Str::from_strs_array_in([cooked.as_str(), right_str.as_ref()], ctx)
+                    let mut buf = Wtf8Buf::with_capacity(cooked.len() + right_str.len());
+                    buf.push_wtf8(cooked.as_wtf8());
+                    buf.push_str(right_str.as_ref());
+                    Wtf8Str::from_wtf8_buf_in(&buf, ctx)
                 });
                 last_quasi.value.cooked = new_cooked;
                 return Some(left_expr.take_in(ctx));
@@ -688,7 +696,10 @@ impl<'a> PeepholeOptimizations {
                     ctx,
                 );
                 let new_cooked = first_quasi.value.cooked.map(|cooked| {
-                    Str::from_strs_array_in([left_str.as_ref(), cooked.as_str()], ctx)
+                    let mut buf = Wtf8Buf::with_capacity(left_str.len() + cooked.len());
+                    buf.push_str(left_str.as_ref());
+                    buf.push_wtf8(cooked.as_wtf8());
+                    Wtf8Str::from_wtf8_buf_in(&buf, ctx)
                 });
                 first_quasi.value.cooked = new_cooked;
                 return Some(right_expr.take_in(ctx));
@@ -851,7 +862,9 @@ impl<'a> PeepholeOptimizations {
             );
 
             let may_be_equal = match &e.right {
-                Expression::StringLiteral(string_lit) => is_typeof_string(&string_lit.value),
+                Expression::StringLiteral(string_lit) => {
+                    string_lit.value.as_str().is_some_and(is_typeof_string)
+                }
                 right => {
                     let ty = right.value_type(ctx);
                     matches!(ty, ValueType::Undetermined | ValueType::String)
@@ -1035,8 +1048,10 @@ impl<'a> PeepholeOptimizations {
                 .first()
                 .or_else(|| next_raw.as_bytes().first())
                 .is_some_and(u8::is_ascii_digit);
-            let cooked_ends_with_null =
-                quasi.value.cooked.is_some_and(|cooked| cooked.as_str().ends_with('\0'));
+            let cooked_ends_with_null = quasi
+                .value
+                .cooked
+                .is_some_and(|cooked| cooked.as_str().is_some_and(|s| s.ends_with('\0')));
             quasi.value.raw = if starts_with_digit
                 && cooked_ends_with_null
                 && let Some(prefix) = raw.strip_suffix("\\0")
@@ -1046,10 +1061,21 @@ impl<'a> PeepholeOptimizations {
                 Str::from_strs_array_in([raw, &escaped, next_raw], ctx)
             };
             let new_cooked = if let (Some(cooked1), Some(cooked2)) =
-                (quasi.value.cooked, next_quasi.as_ref().map(|q| q.value.cooked))
+                (quasi.value.cooked, next_quasi.as_ref().and_then(|q| q.value.cooked))
             {
-                let cooked2_str = cooked2.map(|c| c.as_str()).unwrap_or_default();
-                Some(Str::from_strs_array_in([cooked1.as_str(), &str, cooked2_str], ctx))
+                let mut buf = Wtf8Buf::with_capacity(cooked1.len() + str.len() + cooked2.len());
+                buf.push_wtf8(cooked1.as_wtf8());
+                buf.push_str(&str);
+                buf.push_wtf8(cooked2.as_wtf8());
+                Some(Wtf8Str::from_wtf8_buf_in(&buf, ctx))
+            } else if let Some(cooked1) = quasi.value.cooked {
+                let mut buf = Wtf8Buf::with_capacity(cooked1.len() + str.len());
+                buf.push_wtf8(cooked1.as_wtf8());
+                buf.push_str(&str);
+                if let Some(cooked2) = next_quasi.as_ref().and_then(|q| q.value.cooked) {
+                    buf.push_wtf8(cooked2.as_wtf8());
+                }
+                Some(Wtf8Str::from_wtf8_buf_in(&buf, ctx))
             } else {
                 None
             };

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -905,7 +905,7 @@ impl<'a> PeepholeOptimizations {
         match target {
             AssignmentTarget::StaticMemberExpression(e) => Some(e.property.name.as_str()),
             AssignmentTarget::ComputedMemberExpression(e) => match &e.expression {
-                Expression::StringLiteral(s) => Some(s.value.as_str()),
+                Expression::StringLiteral(s) => s.value.as_str(),
                 _ => None,
             },
             _ => None,

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -11,6 +11,7 @@ use oxc_ecmascript::{
     side_effects::{MayHaveSideEffects, is_regexp_syntax_supported},
 };
 use oxc_span::SPAN;
+use oxc_str::Wtf8Str;
 
 use crate::{TraverseCtx, generated::ancestor::Ancestor};
 
@@ -35,7 +36,7 @@ impl<'a> PeepholeOptimizations {
         let CallExpression { span, callee, arguments, .. } = ce.as_mut();
         let (name, object) = match &callee {
             Expression::StaticMemberExpression(member) if !member.optional => {
-                (member.property.name.as_str(), &member.object)
+                (Some(member.property.name.as_str()), &member.object)
             }
             Expression::ComputedMemberExpression(member) if !member.optional => {
                 match &member.expression {
@@ -45,6 +46,7 @@ impl<'a> PeepholeOptimizations {
             }
             _ => return,
         };
+        let Some(name) = name else { return };
         let replacement = match name {
             "concat" => Self::try_fold_concat(*span, arguments, callee, ctx),
             "pow" => Self::try_fold_pow(*span, arguments, object, ctx),
@@ -299,7 +301,7 @@ impl<'a> PeepholeOptimizations {
                 // separator quasi without a state-machine flag.
                 let scratch = &mut ctx.state.concat_scratch;
                 scratch.clear();
-                scratch.push_str(base_str.value.as_str());
+                scratch.push_str(base_str.value.as_str()?);
 
                 let mut expressions = ArenaVec::with_capacity_in(expression_count, ast);
                 let mut quasis = ArenaVec::with_capacity_in(expression_count + 1, ast);
@@ -307,11 +309,11 @@ impl<'a> PeepholeOptimizations {
                 for argument in args.drain(..) {
                     if let Argument::StringLiteral(str_lit) = argument {
                         // Append onto the in-progress quasi.
-                        scratch.push_str(&str_lit.value);
+                        scratch.push_str(str_lit.value.as_str()?);
                     } else {
                         // Flush the current quasi (possibly empty) before
                         // pushing the next expression.
-                        let cooked = Str::from_str_in(scratch, ast);
+                        let cooked = Wtf8Str::from_str_in(scratch, ast);
                         let raw_cow = Self::escape_string_for_template_literal(scratch);
                         let raw = Str::from_str_in(&raw_cow, ast);
                         // `raw` is already escaped
@@ -329,14 +331,14 @@ impl<'a> PeepholeOptimizations {
 
                 if expressions.is_empty() {
                     debug_assert_eq!(quasis.len(), 0);
-                    let s = Str::from_str_in(scratch, ast);
+                    let s = Wtf8Str::from_str_in(scratch, ast);
                     return Some(Expression::new_string_literal(span, s, None, ast));
                 }
 
                 // Flush the trailing quasi. If the last arg was an expression
                 // `scratch` is empty, giving the required trailing empty
                 // quasi; otherwise it holds the accumulated tail text.
-                let cooked = Str::from_str_in(scratch, ast);
+                let cooked = Wtf8Str::from_str_in(scratch, ast);
                 let raw_cow = Self::escape_string_for_template_literal(scratch);
                 let raw = Str::from_str_in(&raw_cow, ast);
                 // `raw` is already escaped
@@ -380,7 +382,7 @@ impl<'a> PeepholeOptimizations {
         let (name, object, span) = match node {
             Expression::StaticMemberExpression(member) if !member.optional => {
                 let span = member.span;
-                (member.property.name.as_str(), &mut member.object, span)
+                (Some(member.property.name.as_str()), &mut member.object, span)
             }
             Expression::ComputedMemberExpression(member) if !member.optional => {
                 match &member.expression {
@@ -424,6 +426,7 @@ impl<'a> PeepholeOptimizations {
             }
             _ => return,
         };
+        let Some(name) = name else { return };
 
         let replacement = match object {
             Expression::Identifier(ident) => {
@@ -552,10 +555,10 @@ impl<'a> PeepholeOptimizations {
         match object {
             Expression::StringLiteral(s) => {
                 if let StringCharAtResult::Value(c) =
-                    s.value.as_str().char_at(Some(property.into()))
+                    s.value.as_str()?.char_at(Some(property.into()))
                 {
                     s.span = span;
-                    s.value = Str::from_str_in(&c.to_string(), ctx);
+                    s.value = Wtf8Str::from_str_in(&c.to_string(), ctx);
                     s.raw = None;
                     Some(object.take_in(ctx))
                 } else {

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -124,7 +124,10 @@ impl<'a> PeepholeOptimizations {
         // Only check for computed property restrictions if this is actually a computed property
         if prop.computed
             && let PropertyKey::StringLiteral(str) = &prop.key
-            && property_key_parent.should_keep_as_computed_property(&str.value)
+            && str
+                .value
+                .as_str()
+                .is_some_and(|s| property_key_parent.should_keep_as_computed_property(s))
         {
             return;
         }
@@ -139,7 +142,10 @@ impl<'a> PeepholeOptimizations {
         // Only check for computed property restrictions if this is actually a computed property
         if prop.computed
             && let PropertyKey::StringLiteral(str) = &prop.key
-            && property_key_parent.should_keep_as_computed_property(&str.value)
+            && str
+                .value
+                .as_str()
+                .is_some_and(|s| property_key_parent.should_keep_as_computed_property(s))
         {
             return;
         }
@@ -154,7 +160,10 @@ impl<'a> PeepholeOptimizations {
         // Only check for computed property restrictions if this is actually a computed property
         if prop.computed
             && let PropertyKey::StringLiteral(str) = &prop.key
-            && property_key_parent.should_keep_as_computed_property(&str.value)
+            && str
+                .value
+                .as_str()
+                .is_some_and(|s| property_key_parent.should_keep_as_computed_property(s))
         {
             return;
         }
@@ -1427,11 +1436,11 @@ impl<'a> PeepholeOptimizations {
                 *computed = false;
             }
             PropertyKey::StringLiteral(s) => {
-                let value = s.value.as_str();
+                let Some(value) = s.value.as_str() else { return };
                 if is_identifier_name_patched(value) {
                     // Bool field flip on an existing AST node, not a slot replacement.
                     *computed = false;
-                    let new_key = PropertyKey::new_static_identifier(s.span, s.value, ctx);
+                    let new_key = PropertyKey::new_static_identifier(s.span, value, ctx);
                     ctx.replace_property_key(key, new_key);
                     return;
                 }
@@ -1752,13 +1761,20 @@ impl<'a> PeepholeOptimizations {
             return;
         }
 
-        let strings = array.elements.iter().map(|element| {
-            let Expression::StringLiteral(str) = element.to_expression() else { unreachable!() };
-            str.value.as_str()
-        });
-        let Some(delimiter) = Self::pick_delimiter(&strings) else { return };
+        let strings: Option<Vec<&str>> = array
+            .elements
+            .iter()
+            .map(|element| {
+                let Expression::StringLiteral(str) = element.to_expression() else {
+                    unreachable!()
+                };
+                str.value.as_str()
+            })
+            .collect();
+        let Some(strings) = strings else { return };
+        let Some(delimiter) = Self::pick_delimiter(&strings.iter().copied()) else { return };
 
-        let concatenated_string = strings.collect::<Vec<_>>().join(delimiter);
+        let concatenated_string = strings.join(delimiter);
 
         // "str1,str2".split(',')
         let new_value = Expression::new_call_expression_with_pure(

--- a/crates/oxc_minifier/src/property_mangler.rs
+++ b/crates/oxc_minifier/src/property_mangler.rs
@@ -14,7 +14,7 @@ use oxc_ast_visit::{Visit, VisitMut, walk, walk_mut};
 use oxc_ecmascript::StringToNumber;
 use oxc_mangler::base54;
 use oxc_span::Span;
-use oxc_str::{CompactStr, Ident, Str};
+use oxc_str::{CompactStr, Ident, Str, Wtf8Str};
 use oxc_syntax::{identifier::is_identifier_name, number::ToJsString};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -261,14 +261,19 @@ impl<'o> PropertyCollector<'o> {
     fn classify_key_expression(&mut self, expression: &Expression<'_>) {
         match expression.get_inner_expression() {
             Expression::StringLiteral(literal) if self.special_literal(literal.span) => {}
-            Expression::StringLiteral(literal) => self.quoted(literal.value.as_str()),
+            Expression::StringLiteral(literal) => {
+                if let Some(s) = literal.value.as_str() {
+                    self.quoted(s);
+                }
+            }
             Expression::TemplateLiteral(template)
                 if template.expressions.is_empty() && self.special_literal(template.span) => {}
             Expression::TemplateLiteral(template) if template.expressions.is_empty() => {
                 if let [quasi] = template.quasis.as_slice()
                     && let Some(cooked) = quasi.value.cooked
+                    && let Some(s) = cooked.as_str()
                 {
-                    self.quoted(cooked.as_str());
+                    self.quoted(s);
                 }
             }
             Expression::ConditionalExpression(expression) => {
@@ -304,7 +309,11 @@ impl<'o> PropertyCollector<'o> {
 impl<'a> Visit<'a> for PropertyCollector<'_> {
     fn visit_directive(&mut self, directive: &Directive<'a>) {
         // Directives are not property-name positions.
-        self.occupy(directive.expression.value.as_str());
+        if let Some(s) = directive.expression.value.as_str() {
+            self.occupy(s);
+        } else {
+            self.occupy(&directive.expression.value.to_string_lossy());
+        }
     }
 
     fn visit_ts_type(&mut self, _ty: &TSType<'a>) {}
@@ -360,7 +369,11 @@ impl<'a> Visit<'a> for PropertyCollector<'_> {
     }
 
     fn visit_string_literal(&mut self, literal: &StringLiteral<'a>) {
-        self.observe_literal(literal.span, literal.value.as_str());
+        if let Some(s) = literal.value.as_str() {
+            self.observe_literal(literal.span, s);
+        } else {
+            self.observe_literal(literal.span, &literal.value.to_string_lossy());
+        }
     }
 
     fn visit_template_literal(&mut self, template: &TemplateLiteral<'a>) {
@@ -368,7 +381,11 @@ impl<'a> Visit<'a> for PropertyCollector<'_> {
             && let [quasi] = template.quasis.as_slice()
             && let Some(cooked) = quasi.value.cooked
         {
-            self.observe_literal(template.span, cooked.as_str());
+            if let Some(s) = cooked.as_str() {
+                self.observe_literal(template.span, s);
+            } else {
+                self.observe_literal(template.span, &cooked.to_string_lossy());
+            }
         }
         walk::walk_template_literal(self, template);
     }
@@ -474,8 +491,9 @@ impl<'a> PropertyRewriter<'a, '_> {
         if !self.should_rewrite_literal(literal.span) {
             return;
         }
-        if let Some(target) = self.target(literal.value.as_str()) {
-            literal.value = Str::from_str_in(target.as_str(), &self.ast);
+        let Some(s) = literal.value.as_str() else { return };
+        if let Some(target) = self.target(s) {
+            literal.value = Wtf8Str::from_str_in(target.as_str(), &self.ast);
             literal.raw = None;
         }
     }
@@ -486,11 +504,14 @@ impl<'a> PropertyRewriter<'a, '_> {
         }
         if let [quasi] = template.quasis.as_mut_slice()
             && let Some(cooked) = quasi.value.cooked
-            && let Some(target) = self.target(cooked.as_str())
         {
-            let target = Str::from_str_in(target.as_str(), &self.ast);
-            quasi.value.cooked = Some(target);
-            quasi.value.raw = target;
+            let Some(s) = cooked.as_str() else { return };
+            if let Some(target) = self.target(s) {
+                let cooked_target = Wtf8Str::from_str_in(target.as_str(), &self.ast);
+                let raw_target = Str::from_str_in(target.as_str(), &self.ast);
+                quasi.value.cooked = Some(cooked_target);
+                quasi.value.raw = raw_target;
+            }
         }
     }
 
@@ -518,7 +539,8 @@ impl<'a> PropertyRewriter<'a, '_> {
 
     fn direct_string_key(key: &PropertyKey<'a>) -> Option<(CompactStr, Span)> {
         if let PropertyKey::StringLiteral(literal) = key {
-            Some((CompactStr::from(literal.value.as_str()), literal.span))
+            let s = literal.value.as_str()?;
+            Some((CompactStr::from(s), literal.span))
         } else {
             None
         }
@@ -577,8 +599,9 @@ impl<'a> VisitMut<'a> for PropertyRewriter<'a, '_> {
     fn visit_expression(&mut self, expression: &mut Expression<'a>) {
         if let Expression::ComputedMemberExpression(member) = expression
             && let Expression::StringLiteral(literal) = &member.expression
+            && let Some(s) = literal.value.as_str()
         {
-            let original = CompactStr::from(literal.value.as_str());
+            let original = CompactStr::from(s);
             let property_span = literal.span;
             if self.should_rewrite_literal(property_span)
                 && let Some(target) = self.target(original.as_str())

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -378,7 +378,7 @@ fn regexp_named_group_targets() {
 }
 
 #[test]
-fn keep_regexp_with_lone_surrogates() {
+fn keep_regexp_with_surrogates() {
     test_same(r"new RegExp('[\uD801-\uD800]')");
 }
 

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
+oxc_wtf8 = { workspace = true }
 oxc_data_structures = { workspace = true, features = [
   "assert_unchecked",
   "branch_hints",

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -4,7 +4,76 @@ use oxc_ast::ast::*;
 #[cfg(feature = "regular_expression")]
 use oxc_regular_expression::ast::Pattern;
 use oxc_span::{GetSpan, Span};
-use oxc_str::{Ident, Str};
+use oxc_str::{Ident, Str, Wtf8Str};
+use oxc_wtf8::{CodePoint, Wtf8Buf};
+
+fn wtf8_from_str<'a>(
+    s: &str,
+    has_wtf8_surrogate: bool,
+    allocator: &impl GetAllocator<'a>,
+) -> Wtf8Str<'a> {
+    if !has_wtf8_surrogate {
+        return Wtf8Str::from_str_in(s, allocator);
+    }
+    // Decode lossy replacement marker + hex escapes into WTF-8 surrogates.
+    let mut buf = Wtf8Buf::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\u{FFFD}' {
+            // Peek next 4 chars as hex
+            let mut hex = String::with_capacity(4);
+            let mut peeked = Vec::with_capacity(4);
+            let mut is_hex = true;
+            for _ in 0..4 {
+                match chars.peek() {
+                    Some(&ch) if ch.is_ascii_hexdigit() => {
+                        hex.push(ch);
+                        peeked.push(ch);
+                        chars.next();
+                    }
+                    _ => {
+                        is_hex = false;
+                        break;
+                    }
+                }
+            }
+            if is_hex && hex.len() == 4 {
+                if hex.eq_ignore_ascii_case("fffd") {
+                    buf.push_char('\u{FFFD}');
+                } else if let Ok(code) = u16::from_str_radix(&hex, 16) {
+                    // SAFETY: hex is 4 digits, code <= 0xFFFF, and for lone surrogates it's 0xD800..0xDFFF
+                    let cp = unsafe { CodePoint::from_u32_unchecked(u32::from(code)) };
+                    buf.push(cp);
+                } else {
+                    buf.push_char('\u{FFFD}');
+                    for ch in peeked {
+                        buf.push_char(ch);
+                    }
+                }
+            } else {
+                buf.push_char('\u{FFFD}');
+                for ch in peeked {
+                    buf.push_char(ch);
+                }
+                if !is_hex {
+                    // The peeked non-hex char is still in iterator (not consumed if break due to non-hex)
+                    // Actually we already break without consuming that char, so no need to push
+                }
+            }
+        } else {
+            buf.push_char(c);
+        }
+    }
+    Wtf8Str::from_wtf8_buf_in(&buf, allocator)
+}
+
+fn wtf8_from_option_str<'a>(
+    s: Option<&str>,
+    has_wtf8_surrogate: bool,
+    allocator: &impl GetAllocator<'a>,
+) -> Option<Wtf8Str<'a>> {
+    s.map(|st| wtf8_from_str(st, has_wtf8_surrogate, allocator))
+}
 use oxc_syntax::{
     number::{BigintBase, NumberBase},
     precedence::Precedence,
@@ -499,10 +568,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         let span = self.cur_token().span();
         let raw = Str::from(self.cur_src());
-        let value = self.cur_string();
-        let lone_surrogates = self.cur_token().lone_surrogates();
+        let value_str = self.cur_string();
+        let has_wtf8_surrogate = self.cur_token().has_wtf8_surrogate();
+        let value = wtf8_from_str(value_str, has_wtf8_surrogate, self);
         self.bump_any();
-        StringLiteral::new_with_lone_surrogates(span, value, Some(raw), lone_surrogates, self)
+        StringLiteral::new(span, value, Some(raw), self)
     }
 
     /// Section [Array Expression](https://tc39.es/ecma262/#prod-ArrayLiteral)
@@ -639,16 +709,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // Also replace `\r` with `\n` in `raw`.
         // If contains `\r`, then `escaped` must be `true` (because `\r` needs unescaping),
         // so we can skip searching for `\r` in common case where contains no escapes.
-        let (cooked, lone_surrogates) = if self.cur_token().escaped() {
+        let cooked = if self.cur_token().escaped() {
             // `cooked = None` when template literal has invalid escape sequence
-            let cooked = self.cur_template_string().map(Str::from);
-            if cooked.is_some() && raw.contains('\r') {
+            let cooked_str = self.cur_template_string();
+            let lone = self.cur_token().has_wtf8_surrogate();
+            if cooked_str.is_some() && raw.contains('\r') {
                 raw =
                     Str::from_str_in(&raw.cow_replace("\r\n", "\n").cow_replace('\r', "\n"), self);
             }
-            (cooked, self.cur_token().lone_surrogates())
+            wtf8_from_option_str(cooked_str, lone, self)
         } else {
-            (Some(raw), false)
+            Some(Wtf8Str::from(raw.as_str()))
         };
 
         self.bump_any();
@@ -663,13 +734,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let tail = matches!(cur_kind, Kind::TemplateTail | Kind::NoSubstitutionTemplate);
         // Parser provides already-escaped values from source, so no escaping needed here
-        TemplateElement::new_with_lone_surrogates(
-            span,
-            TemplateElementValue { raw, cooked },
-            tail,
-            lone_surrogates,
-            self,
-        )
+        TemplateElement::new(span, TemplateElementValue { raw, cooked }, tail, self)
     }
 
     /// Section 13.3 ImportCall or ImportMeta

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -971,7 +971,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 let literal = self.parse_literal_string();
                 // ModuleExportName : StringLiteral
                 // It is a Syntax Error if IsStringWellFormedUnicode(the SV of StringLiteral) is false.
-                if literal.lone_surrogates || !literal.is_string_well_formed_unicode() {
+                if !literal.is_string_well_formed_unicode() {
                     self.error(diagnostics::export_lone_surrogate(literal.span));
                 }
                 ModuleExportName::StringLiteral(literal)
@@ -992,13 +992,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 ModuleExportName::new_identifier_reference(ident.span, ident.name, self)
             }
             ModuleExportName::StringLiteral(literal) => {
-                ModuleExportName::new_string_literal_with_lone_surrogates(
-                    literal.span,
-                    literal.value,
-                    literal.raw,
-                    literal.lone_surrogates,
-                    self,
-                )
+                ModuleExportName::new_string_literal(literal.span, literal.value, literal.raw, self)
             }
         }
     }

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -3,7 +3,7 @@
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, Dummy, GetAllocator};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
-use oxc_str::Str;
+use oxc_str::{Str, Wtf8Str};
 
 use crate::{ParserConfig as Config, ParserImpl, diagnostics, lexer::Kind};
 
@@ -522,7 +522,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_jsx_text(&mut self) -> ArenaBox<'a, JSXText<'a>> {
         let span = self.cur_token().span();
         let raw = Str::from(self.cur_src());
-        let value = Str::from(self.cur_string());
+        // JSXText is always valid UTF-8 (source is valid UTF-8), so reinterpret as WTF-8 without copy.
+        let value = Wtf8Str::from(self.cur_string());
         self.bump_any();
         JSXText::boxed(span, value, Some(raw), self)
     }

--- a/crates/oxc_parser/src/lexer/string.rs
+++ b/crates/oxc_parser/src/lexer/string.rs
@@ -19,9 +19,9 @@ const fn to_bytes<const N: usize>(ch: char) -> [u8; N] {
 }
 
 /// Lossy replacement character (U+FFFD) as UTF-8 bytes.
-const LOSSY_REPLACEMENT_CHAR_BYTES: [u8; 3] = to_bytes('\u{FFFD}');
-const LOSSY_REPLACEMENT_CHAR_FIRST_BYTE: u8 = LOSSY_REPLACEMENT_CHAR_BYTES[0];
-const _: () = assert!(LOSSY_REPLACEMENT_CHAR_FIRST_BYTE == 0xEF);
+const WTF8_MARKER_CHAR_BYTES: [u8; 3] = to_bytes('\u{FFFD}');
+const WTF8_MARKER_CHAR_FIRST_BYTE: u8 = WTF8_MARKER_CHAR_BYTES[0];
+const _: () = assert!(WTF8_MARKER_CHAR_FIRST_BYTE == 0xEF);
 
 const MIN_ESCAPED_STR_LEN: usize = 16;
 
@@ -34,12 +34,12 @@ static SINGLE_QUOTE_STRING_END_TABLE: SafeByteMatchTable =
 // Same as above, but with 1st byte of lossy replacement character added
 static DOUBLE_QUOTE_ESCAPED_MATCH_TABLE: SafeByteMatchTable = safe_byte_match_table!(|b| matches!(
     b,
-    b'"' | b'\r' | b'\n' | b'\\' | LOSSY_REPLACEMENT_CHAR_FIRST_BYTE
+    b'"' | b'\r' | b'\n' | b'\\' | WTF8_MARKER_CHAR_FIRST_BYTE
 ));
 
 static SINGLE_QUOTE_ESCAPED_MATCH_TABLE: SafeByteMatchTable = safe_byte_match_table!(|b| matches!(
     b,
-    b'\'' | b'\r' | b'\n' | b'\\' | LOSSY_REPLACEMENT_CHAR_FIRST_BYTE
+    b'\'' | b'\r' | b'\n' | b'\\' | WTF8_MARKER_CHAR_FIRST_BYTE
 ));
 
 /// Macro to handle a string literal.
@@ -157,7 +157,7 @@ macro_rules! handle_string_literal_escape {
                         str.push_str(chunk);
                         continue 'outer;
                     }
-                    LOSSY_REPLACEMENT_CHAR_FIRST_BYTE => {
+                    WTF8_MARKER_CHAR_FIRST_BYTE => {
                         // If the string contains lone surrogates, the lossy replacement character (U+FFFD)
                         // is used as start of an escape sequence.
                         // So an actual lossy escape character has to be escaped too.
@@ -170,8 +170,8 @@ macro_rules! handle_string_literal_escape {
                         $lexer.source.next_byte_unchecked();
                         let next1 = $lexer.source.next_byte_unchecked();
                         let next2 = $lexer.source.next_byte_unchecked();
-                        if $lexer.token.lone_surrogates()
-                            && [next1, next2] == [LOSSY_REPLACEMENT_CHAR_BYTES[1], LOSSY_REPLACEMENT_CHAR_BYTES[2]]
+                        if $lexer.token.has_wtf8_surrogate()
+                            && [next1, next2] == [WTF8_MARKER_CHAR_BYTES[1], WTF8_MARKER_CHAR_BYTES[2]]
                         {
                             let chunk = $lexer.source.str_from_pos_to_current(chunk_start);
                             str.push_str(chunk);

--- a/crates/oxc_parser/src/lexer/template.rs
+++ b/crates/oxc_parser/src/lexer/template.rs
@@ -21,16 +21,16 @@ const fn to_bytes<const N: usize>(ch: char) -> [u8; N] {
 }
 
 /// Lossy replacement character (U+FFFD) as UTF-8 bytes.
-const LOSSY_REPLACEMENT_CHAR_BYTES: [u8; 3] = to_bytes('\u{FFFD}');
-const LOSSY_REPLACEMENT_CHAR_FIRST_BYTE: u8 = LOSSY_REPLACEMENT_CHAR_BYTES[0];
-const _: () = assert!(LOSSY_REPLACEMENT_CHAR_FIRST_BYTE == 0xEF);
+const WTF8_MARKER_CHAR_BYTES: [u8; 3] = to_bytes('\u{FFFD}');
+const WTF8_MARKER_CHAR_FIRST_BYTE: u8 = WTF8_MARKER_CHAR_BYTES[0];
+const _: () = assert!(WTF8_MARKER_CHAR_FIRST_BYTE == 0xEF);
 
 static TEMPLATE_LITERAL_TABLE: SafeByteMatchTable =
     safe_byte_match_table!(|b| matches!(b, b'$' | b'`' | b'\r' | b'\\'));
 
 // Same as above, but with 1st byte of lossy replacement character added
 static TEMPLATE_LITERAL_ESCAPED_MATCH_TABLE: SafeByteMatchTable = safe_byte_match_table!(
-    |b| matches!(b, b'$' | b'`' | b'\r' | b'\\' | LOSSY_REPLACEMENT_CHAR_FIRST_BYTE)
+    |b| matches!(b, b'$' | b'`' | b'\r' | b'\\' | WTF8_MARKER_CHAR_FIRST_BYTE)
 );
 
 /// 12.8.6 Template Literal Lexical Components
@@ -343,17 +343,17 @@ impl<'a, C: Config> Lexer<'a, C> {
                         _ => {
                             // `TEMPLATE_LITERAL_ESCAPED_MATCH_TABLE` only matches `$`, '`', `\r`, `\`,
                             // or first byte of lossy replacement character
-                            debug_assert_eq!(next_byte, LOSSY_REPLACEMENT_CHAR_FIRST_BYTE);
+                            debug_assert_eq!(next_byte, WTF8_MARKER_CHAR_FIRST_BYTE);
 
                             // SAFETY: 0xEF is always first byte of a 3-byte UTF-8 character,
                             // so there must be 2 more bytes to read
                             let next2 = unsafe { pos.add(1).read2() };
-                            if next2 == [LOSSY_REPLACEMENT_CHAR_BYTES[1], LOSSY_REPLACEMENT_CHAR_BYTES[2]]
-                                && self.token.lone_surrogates()
+                            if next2 == [WTF8_MARKER_CHAR_BYTES[1], WTF8_MARKER_CHAR_BYTES[2]]
+                                && self.token.has_wtf8_surrogate()
                             {
                                 str.push_str("\u{FFFD}fffd");
                             } else {
-                                let bytes = [LOSSY_REPLACEMENT_CHAR_FIRST_BYTE, next2[0], next2[1]];
+                                let bytes = [WTF8_MARKER_CHAR_FIRST_BYTE, next2[0], next2[1]];
                                 // SAFETY: 0xEF is always first byte of a 3-byte UTF-8 character,
                                 // so these 3 bytes must comprise a valid UTF-8 string
                                 let s = unsafe { str::from_utf8_unchecked(&bytes) };

--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -12,7 +12,7 @@ use super::kind::Kind;
 // - Bits 64-71 (8 bits): `kind` (`Kind`)
 // - Bits 72-79 (8 bits): `is_on_new_line` (`bool`)
 // - Bits 80-87 (8 bits): `escaped` (`bool`)
-// - Bits 88-95 (8 bits): `lone_surrogates` (`bool`)
+// - Bits 88-95 (8 bits): `has_wtf8_surrogate` (`bool`)
 // - Bits 96-103 (8 bits): `has_separator` (`bool`)
 // - Bits 104-127 (24 bits): unused
 
@@ -21,7 +21,7 @@ const END_SHIFT: usize = 32;
 const KIND_SHIFT: usize = 64;
 const IS_ON_NEW_LINE_SHIFT: usize = 72;
 const ESCAPED_SHIFT: usize = 80;
-const LONE_SURROGATES_SHIFT: usize = 88;
+const HAS_WTF8_SURROGATE_SHIFT: usize = 88;
 const HAS_SEPARATOR_SHIFT: usize = 96;
 
 const START_MASK: u128 = 0xFFFF_FFFF; // 32 bits
@@ -48,7 +48,7 @@ const _: () = {
     // Check flags fields are aligned on 8 and in bounds, so can be read/written via pointers
     assert!(is_valid_shift::<bool>(IS_ON_NEW_LINE_SHIFT));
     assert!(is_valid_shift::<bool>(ESCAPED_SHIFT));
-    assert!(is_valid_shift::<bool>(LONE_SURROGATES_SHIFT));
+    assert!(is_valid_shift::<bool>(HAS_WTF8_SURROGATE_SHIFT));
     assert!(is_valid_shift::<bool>(HAS_SEPARATOR_SHIFT));
 };
 
@@ -65,7 +65,7 @@ impl Default for Token {
         // kind: Kind::default(),
         // is_on_new_line: false,
         // escaped: false,
-        // lone_surrogates: false,
+        // has_wtf8_surrogate: false,
         // has_separator: false,
         const _: () = assert!(Kind::Eof as u8 == 0);
         Self(0)
@@ -80,7 +80,7 @@ impl fmt::Debug for Token {
             .field("end", &self.end())
             .field("is_on_new_line", &self.is_on_new_line())
             .field("escaped", &self.escaped())
-            .field("lone_surrogates", &self.lone_surrogates())
+            .field("has_wtf8_surrogate", &self.has_wtf8_surrogate())
             .field("has_separator", &self.has_separator())
             .finish()
     }
@@ -257,23 +257,23 @@ impl Token {
     }
 
     #[inline]
-    pub fn lone_surrogates(&self) -> bool {
+    pub fn has_wtf8_surrogate(&self) -> bool {
         // Use a pointer read rather than arithmetic as it produces less instructions.
-        // SAFETY: 8 bits starting at `LONE_SURROGATES_SHIFT` are only set in `Token::default` and
-        // `Token::set_lone_surrogates`. Both only set these bits to 0 or 1, so valid to read as a `bool`.
-        unsafe { self.read_bool(LONE_SURROGATES_SHIFT) }
+        // SAFETY: 8 bits starting at `HAS_WTF8_SURROGATE_SHIFT` are only set in `Token::default` and
+        // `Token::set_has_wtf8_surrogate`. Both only set these bits to 0 or 1, so valid to read as a `bool`.
+        unsafe { self.read_bool(HAS_WTF8_SURROGATE_SHIFT) }
     }
 
     #[inline]
-    pub(super) fn set_lone_surrogates(&mut self, value: bool) {
+    pub(super) fn set_has_wtf8_surrogate(&mut self, value: bool) {
         /*
         // Original version. Perf regressed in Rust 1.95.0.
-        self.0 &= !(BOOL_MASK << LONE_SURROGATES_SHIFT); // Clear current `lone_surrogates` bits
-        self.0 |= u128::from(value) << LONE_SURROGATES_SHIFT;
+        self.0 &= !(BOOL_MASK << HAS_WTF8_SURROGATE_SHIFT); // Clear current `has_wtf8_surrogate` bits
+        self.0 |= u128::from(value) << HAS_WTF8_SURROGATE_SHIFT;
         */
 
-        // SAFETY: `LONE_SURROGATES_SHIFT` is a valid `bool` field position in `Token`
-        unsafe { self.write_bool(LONE_SURROGATES_SHIFT, value) };
+        // SAFETY: `HAS_WTF8_SURROGATE_SHIFT` is a valid `bool` field position in `Token`
+        unsafe { self.write_bool(HAS_WTF8_SURROGATE_SHIFT, value) };
     }
 
     #[inline]
@@ -405,7 +405,7 @@ mod test {
         assert_eq!(token.kind(), Kind::Eof); // Kind::default() is Eof
         assert!(!token.is_on_new_line());
         assert!(!token.escaped());
-        assert!(!token.lone_surrogates());
+        assert!(!token.has_wtf8_surrogate());
         assert!(!token.has_separator());
     }
 
@@ -417,7 +417,7 @@ mod test {
         assert_eq!(token.kind(), Kind::Eof);
         assert!(token.is_on_new_line());
         assert!(!token.escaped());
-        assert!(!token.lone_surrogates());
+        assert!(!token.has_wtf8_surrogate());
         assert!(!token.has_separator());
     }
 
@@ -428,7 +428,7 @@ mod test {
         let end = start + 5u32;
         let is_on_new_line = true;
         let escaped = false;
-        let lone_surrogates = true;
+        let has_wtf8_surrogate = true;
         let has_separator = false;
 
         let mut token = Token::default();
@@ -437,7 +437,7 @@ mod test {
         token.set_end(end);
         token.set_is_on_new_line(is_on_new_line);
         token.set_escaped(escaped);
-        token.set_lone_surrogates(lone_surrogates);
+        token.set_has_wtf8_surrogate(has_wtf8_surrogate);
         if has_separator {
             // Assuming set_has_separator is not always called if false
             token.set_has_separator(true);
@@ -448,7 +448,7 @@ mod test {
         assert_eq!(token.end(), end);
         assert_eq!(token.is_on_new_line(), is_on_new_line);
         assert_eq!(token.escaped(), escaped);
-        assert_eq!(token.lone_surrogates(), lone_surrogates);
+        assert_eq!(token.has_wtf8_surrogate(), has_wtf8_surrogate);
         assert_eq!(token.has_separator(), has_separator);
     }
 
@@ -457,13 +457,13 @@ mod test {
         let mut token = Token::default();
         token.set_kind(Kind::Ident);
         token.set_span(Span::new(10, 15));
-        // is_on_new_line, escaped, lone_surrogates, has_separator are false by default from Token::default()
+        // is_on_new_line, escaped, has_wtf8_surrogate, has_separator are false by default from Token::default()
 
         assert_eq!(token.start(), 10);
         assert_eq!(token.end(), 15);
         assert!(!token.escaped());
         assert!(!token.is_on_new_line());
-        assert!(!token.lone_surrogates());
+        assert!(!token.has_wtf8_surrogate());
 
         // Test set_end
         let mut token_for_set_end = Token::default();
@@ -483,14 +483,14 @@ mod test {
         token_with_flags.set_end(33);
         token_with_flags.set_is_on_new_line(true);
         token_with_flags.set_escaped(true);
-        token_with_flags.set_lone_surrogates(true);
+        token_with_flags.set_has_wtf8_surrogate(true);
         token_with_flags.set_has_separator(true);
 
         token_with_flags.set_start(40);
         assert_eq!(token_with_flags.start(), 40);
         assert!(token_with_flags.is_on_new_line());
         assert!(token_with_flags.escaped());
-        assert!(token_with_flags.lone_surrogates());
+        assert!(token_with_flags.has_wtf8_surrogate());
         assert!(token_with_flags.has_separator());
 
         // Test that other flags are not affected by set_escaped
@@ -500,19 +500,19 @@ mod test {
         token_with_flags2.set_end(52);
         token_with_flags2.set_is_on_new_line(true);
         // escaped is false by default
-        token_with_flags2.set_lone_surrogates(true);
+        token_with_flags2.set_has_wtf8_surrogate(true);
         token_with_flags2.set_has_separator(true);
 
         token_with_flags2.set_escaped(true);
         assert_eq!(token_with_flags2.start(), 50);
         assert!(token_with_flags2.is_on_new_line());
         assert!(token_with_flags2.escaped());
-        assert!(token_with_flags2.lone_surrogates());
+        assert!(token_with_flags2.has_wtf8_surrogate());
         assert!(token_with_flags2.has_separator());
         token_with_flags2.set_escaped(false);
         assert!(!token_with_flags2.escaped());
         assert!(token_with_flags2.is_on_new_line()); // Check again
-        assert!(token_with_flags2.lone_surrogates()); // Check again
+        assert!(token_with_flags2.has_wtf8_surrogate()); // Check again
         assert!(token_with_flags2.has_separator()); // Check again
 
         // Test set_is_on_new_line does not affect other flags
@@ -522,42 +522,42 @@ mod test {
         token_flags_test_newline.set_end(62);
         // is_on_new_line is false by default
         token_flags_test_newline.set_escaped(true);
-        token_flags_test_newline.set_lone_surrogates(true);
+        token_flags_test_newline.set_has_wtf8_surrogate(true);
         token_flags_test_newline.set_has_separator(true);
 
         token_flags_test_newline.set_is_on_new_line(true);
         assert!(token_flags_test_newline.is_on_new_line());
         assert_eq!(token_flags_test_newline.start(), 60);
         assert!(token_flags_test_newline.escaped());
-        assert!(token_flags_test_newline.lone_surrogates());
+        assert!(token_flags_test_newline.has_wtf8_surrogate());
         assert!(token_flags_test_newline.has_separator());
         token_flags_test_newline.set_is_on_new_line(false);
         assert!(!token_flags_test_newline.is_on_new_line());
         assert!(token_flags_test_newline.escaped());
-        assert!(token_flags_test_newline.lone_surrogates());
+        assert!(token_flags_test_newline.has_wtf8_surrogate());
         assert!(token_flags_test_newline.has_separator());
 
-        // Test set_lone_surrogates does not affect other flags
-        let mut token_flags_test_lone_surrogates = Token::default();
-        token_flags_test_lone_surrogates.set_kind(Kind::Str);
-        token_flags_test_lone_surrogates.set_start(70);
-        token_flags_test_lone_surrogates.set_end(72);
-        token_flags_test_lone_surrogates.set_is_on_new_line(true);
-        token_flags_test_lone_surrogates.set_escaped(true);
-        // lone_surrogates is false by default
-        token_flags_test_lone_surrogates.set_has_separator(true);
+        // Test set_has_wtf8_surrogate does not affect other flags
+        let mut token_flags_test_has_wtf8_surrogate = Token::default();
+        token_flags_test_has_wtf8_surrogate.set_kind(Kind::Str);
+        token_flags_test_has_wtf8_surrogate.set_start(70);
+        token_flags_test_has_wtf8_surrogate.set_end(72);
+        token_flags_test_has_wtf8_surrogate.set_is_on_new_line(true);
+        token_flags_test_has_wtf8_surrogate.set_escaped(true);
+        // has_wtf8_surrogate is false by default
+        token_flags_test_has_wtf8_surrogate.set_has_separator(true);
 
-        token_flags_test_lone_surrogates.set_lone_surrogates(true);
-        assert!(token_flags_test_lone_surrogates.lone_surrogates());
-        assert_eq!(token_flags_test_lone_surrogates.start(), 70);
-        assert!(token_flags_test_lone_surrogates.is_on_new_line());
-        assert!(token_flags_test_lone_surrogates.escaped());
-        assert!(token_flags_test_lone_surrogates.has_separator());
-        token_flags_test_lone_surrogates.set_lone_surrogates(false);
-        assert!(!token_flags_test_lone_surrogates.lone_surrogates());
-        assert!(token_flags_test_lone_surrogates.is_on_new_line());
-        assert!(token_flags_test_lone_surrogates.escaped());
-        assert!(token_flags_test_lone_surrogates.has_separator());
+        token_flags_test_has_wtf8_surrogate.set_has_wtf8_surrogate(true);
+        assert!(token_flags_test_has_wtf8_surrogate.has_wtf8_surrogate());
+        assert_eq!(token_flags_test_has_wtf8_surrogate.start(), 70);
+        assert!(token_flags_test_has_wtf8_surrogate.is_on_new_line());
+        assert!(token_flags_test_has_wtf8_surrogate.escaped());
+        assert!(token_flags_test_has_wtf8_surrogate.has_separator());
+        token_flags_test_has_wtf8_surrogate.set_has_wtf8_surrogate(false);
+        assert!(!token_flags_test_has_wtf8_surrogate.has_wtf8_surrogate());
+        assert!(token_flags_test_has_wtf8_surrogate.is_on_new_line());
+        assert!(token_flags_test_has_wtf8_surrogate.escaped());
+        assert!(token_flags_test_has_wtf8_surrogate.has_separator());
     }
 
     #[test]
@@ -581,13 +581,13 @@ mod test {
     }
 
     #[test]
-    fn lone_surrogates() {
+    fn has_wtf8_surrogate() {
         let mut token = Token::default();
-        assert!(!token.lone_surrogates());
-        token.set_lone_surrogates(true);
-        assert!(token.lone_surrogates());
-        token.set_lone_surrogates(false);
-        assert!(!token.lone_surrogates());
+        assert!(!token.has_wtf8_surrogate());
+        token.set_has_wtf8_surrogate(true);
+        assert!(token.has_wtf8_surrogate());
+        token.set_has_wtf8_surrogate(false);
+        assert!(!token.has_wtf8_surrogate());
     }
 
     #[test]

--- a/crates/oxc_parser/src/lexer/unicode.rs
+++ b/crates/oxc_parser/src/lexer/unicode.rs
@@ -158,7 +158,7 @@ impl<'a, C: Config> Lexer<'a, C> {
         // For strings and templates, surrogate pairs are valid grammar, e.g. `"\uD83D\uDE00" === 😀`.
         match value {
             UnicodeEscape::CodePoint(ch) => {
-                if ch == '\u{FFFD}' && self.token.lone_surrogates() {
+                if ch == '\u{FFFD}' && self.token.has_wtf8_surrogate() {
                     // Lossy replacement character is being used as an escape marker. Escape it.
                     text.push_str("\u{FFFD}fffd");
                 } else {
@@ -179,8 +179,8 @@ impl<'a, C: Config> Lexer<'a, C> {
     fn string_lone_surrogate(&mut self, code_point: u32, text: &mut ArenaStringBuilder<'a>) {
         debug_assert!(code_point <= 0xFFFF);
 
-        if !self.token.lone_surrogates() {
-            self.token.set_lone_surrogates(true);
+        if !self.token.has_wtf8_surrogate() {
+            self.token.set_has_wtf8_surrogate(true);
 
             // We use `\u{FFFD}` (the lossy replacement character) as a marker indicating the start
             // of a lone surrogate. e.g. `\u{FFFD}d800` (which will be output as `\ud800`).

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -200,7 +200,10 @@ impl<'a> ModuleRecordBuilder<'a> {
     }
 
     pub fn visit_import_declaration(&mut self, decl: &ImportDeclaration<'a>) {
-        let module_request = NameSpan::new(decl.source.value, decl.source.span);
+        let module_request = NameSpan::new(
+            decl.source.value.as_str().map_or_else(|| oxc_str::Str::from(""), oxc_str::Str::from),
+            decl.source.span,
+        );
 
         if let Some(specifiers) = &decl.specifiers {
             for specifier in specifiers {
@@ -246,7 +249,10 @@ impl<'a> ModuleRecordBuilder<'a> {
     }
 
     pub fn visit_export_all_declaration(&mut self, decl: &ExportAllDeclaration<'a>) {
-        let module_request = NameSpan::new(decl.source.value, decl.source.span);
+        let module_request = NameSpan::new(
+            decl.source.value.as_str().map_or_else(|| oxc_str::Str::from(""), oxc_str::Str::from),
+            decl.source.span,
+        );
         let export_entry = ExportEntry {
             statement_span: decl.span,
             span: decl.span,
@@ -360,7 +366,10 @@ impl<'a> ModuleRecordBuilder<'a> {
     }
 
     pub fn visit_export_from_declaration(&mut self, decl: &ExportFromDeclaration<'a>) {
-        let module_request = NameSpan::new(decl.source.value, decl.source.span);
+        let module_request = NameSpan::new(
+            decl.source.value.as_str().map_or_else(|| oxc_str::Str::from(""), oxc_str::Str::from),
+            decl.source.span,
+        );
         self.add_module_request(
             module_request.name,
             RequestedModule {

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
@@ -233,12 +233,10 @@ pub fn validate_restricted_imports(
 
     for stmt in &program.body {
         if let Statement::ImportDeclaration(import) = stmt
-            && restricted.contains(import.source.value.as_str())
+            && let Some(src) = import.source.value.as_str()
+            && restricted.contains(src)
         {
-            diagnostics.push(diagnostics::blocklisted_import(
-                import.source.value.as_str(),
-                import.source.span,
-            ));
+            diagnostics.push(diagnostics::blocklisted_import(src, import.source.span));
         }
     }
 
@@ -261,7 +259,7 @@ pub fn has_memo_cache_function_import(program: &Program, module_name: &str) -> b
                     let imported_name = match &data.imported {
                         ModuleExportName::IdentifierName(id) => Some(id.name.as_str()),
                         ModuleExportName::IdentifierReference(id) => Some(id.name.as_str()),
-                        ModuleExportName::StringLiteral(s) => Some(s.value.as_str()),
+                        ModuleExportName::StringLiteral(s) => s.value.as_str(),
                     };
                     if imported_name == Some("c") {
                         return true;

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -1320,7 +1320,7 @@ fn body_directive_values<'a>(body: &FunctionBody<'a>) -> Vec<BodyDirective<'a>> 
     body.directives
         .iter()
         .map(|directive| BodyDirective {
-            value: directive.expression.value,
+            value: oxc_str::Str::from(directive.expression.value.as_str().unwrap_or_default()),
             span: directive.expression.span,
         })
         .collect()
@@ -2981,9 +2981,10 @@ fn ox_add_imports_to_program<'a>(
     let mut existing_import_indices: FxHashMap<&str, usize> = FxHashMap::default();
     for (idx, stmt) in program.body.iter().enumerate() {
         if let Statement::ImportDeclaration(import) = stmt
+            && let Some(src) = import.source.value.as_str()
             && ox_is_non_namespaced_import(import)
         {
-            existing_import_indices.entry(import.source.value.as_str()).or_insert(idx);
+            existing_import_indices.entry(src).or_insert(idx);
         }
     }
 
@@ -3157,7 +3158,7 @@ pub fn compile_program<'a, const EMIT: bool>(
 
     // Check for module-scope opt-out directive
     let has_module_scope_opt_out = find_directive_disabling_memoization(
-        program.directives.iter().map(|d| d.expression.value.as_str()),
+        program.directives.iter().filter_map(|d| d.expression.value.as_str()),
         options.custom_opt_out_directives.as_deref(),
     )
     .is_some();

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use assert_valid_block_nesting::{get_scopes, recursively_traverse_ite
 use oxc_allocator::{Allocator, CloneIn, CloneInSemanticIds, Vec as ArenaVec};
 use oxc_ast::ast::*;
 use oxc_index::define_nonmax_u32_index_type;
-use oxc_str::{Ident, Str};
+use oxc_str::{Ident, Str, Wtf8Str};
 use oxc_syntax::number::ToJsString;
 pub use raw::RawTypeCategory;
 pub use reactive::*;
@@ -962,7 +962,7 @@ pub enum PrimitiveValue<'a> {
     Undefined,
     Boolean(bool),
     Number(FloatValue),
-    String(Str<'a>),
+    String(Wtf8Str<'a>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/memoize_fbt_and_macro_operands_in_same_scope.rs
@@ -118,7 +118,9 @@ fn populate_macro_tags(
 
             match &instr.value {
                 InstructionValue::Primitive { value: PrimitiveValue::String(s), .. } => {
-                    if let Some(macro_def) = macro_kinds.get(s.as_str()) {
+                    if let Some(s_str) = s.as_str()
+                        && let Some(macro_def) = macro_kinds.get(s_str)
+                    {
                         // We don't distinguish between tag names and strings, so record
                         // all `fbt` string literals in case they are used as a jsx tag.
                         macro_tags.insert(lvalue_id, macro_def.clone());

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -21,7 +21,7 @@ use oxc_ast::ast::BinaryOperator;
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
-use oxc_str::{Ident, Str, format_ident, static_ident};
+use oxc_str::{Ident, Str, Wtf8Str, format_ident, static_ident};
 
 use crate::react_compiler_lowering::FunctionNode;
 use crate::react_compiler_lowering::find_context_identifiers::find_context_identifiers;
@@ -784,7 +784,7 @@ fn lower_inner<'a>(
             body_span = Some(block.span);
             directives = ArenaVec::from_iter_in(
                 block.directives.iter().map(|d| FunctionDirective {
-                    value: d.expression.value,
+                    value: oxc_str::Str::from(d.expression.value.as_str().unwrap_or_default()),
                     span: d.span,
                     expression_span: d.expression.span,
                 }),
@@ -1020,7 +1020,11 @@ fn lower_member_expression_impl<'a>(
 
 /// Build a HIR `TemplateQuasi` from an oxc `TemplateElement`.
 fn template_quasi_from_oxc<'a>(q: &oxc::TemplateElement<'a>) -> TemplateQuasi<'a> {
-    TemplateQuasi { raw: q.value.raw, cooked: q.value.cooked, span: q.span }
+    TemplateQuasi {
+        raw: q.value.raw,
+        cooked: q.value.cooked.map(|c| oxc_str::Str::from(c.as_str().unwrap_or_default())),
+        span: q.span,
+    }
 }
 
 /// Lower the `import` keyword callee of an `ImportExpression`. The original Babel
@@ -4646,16 +4650,17 @@ fn lower_jsx_element_expr<'a>(
                 let value = match &attr.value {
                     Some(oxc::JSXAttributeValue::StringLiteral(s)) => {
                         let str_span = Some(s.span);
-                        let decoded = match decode_jsx_entities(s.value.as_str()) {
-                            Cow::Borrowed(text) => Str::from(text),
-                            Cow::Owned(text) => {
-                                Str::from_str_in(&text, &builder.environment().allocator)
-                            }
-                        };
+                        let decoded =
+                            match decode_jsx_entities(s.value.as_str().unwrap_or_default()) {
+                                Cow::Borrowed(text) => Str::from(text),
+                                Cow::Owned(text) => {
+                                    Str::from_str_in(&text, &builder.environment().allocator)
+                                }
+                            };
                         lower_value_to_temporary(
                             builder,
                             InstructionValue::Primitive {
-                                value: PrimitiveValue::String(decoded),
+                                value: PrimitiveValue::String(decoded.into()),
                                 span: str_span,
                             },
                         )?
@@ -4889,7 +4894,7 @@ fn lower_jsx_element_name<'a>(
             let place = lower_value_to_temporary(
                 builder,
                 InstructionValue::Primitive {
-                    value: PrimitiveValue::String(Str::from_str_in(
+                    value: PrimitiveValue::String(Wtf8Str::from_str_in(
                         &tag,
                         &builder.environment().allocator,
                     )),
@@ -4971,7 +4976,7 @@ fn lower_jsx_element<'a>(
         oxc::JSXChild::Text(text) => {
             // oxc keeps JSX text raw; decode entities first so the value matches
             // Babel's `JSXText.value` (the Babel bridge decoded in convert_ast).
-            let decoded = decode_jsx_entities(text.value.as_str());
+            let decoded = decode_jsx_entities(text.value.as_str().unwrap_or_default());
             // FBT whitespace normalization differs from standard JSX.
             // Since the fbt transform runs after, preserve all whitespace
             // in FBT subtrees as is.
@@ -4994,8 +4999,10 @@ fn lower_jsx_element<'a>(
                 None => Ok(None),
                 Some((value, start)) => {
                     let mut span = text.span;
-                    span.start +=
-                        source_offset_for_decoded_jsx_text(text.value.as_str(), start) as u32;
+                    span.start += source_offset_for_decoded_jsx_text(
+                        text.value.as_str().unwrap_or_default(),
+                        start,
+                    ) as u32;
                     let place = lower_value_to_temporary(
                         builder,
                         InstructionValue::JSXText { value, span: Some(span) },
@@ -5575,7 +5582,7 @@ fn lower_object_property_key<'a>(
 ) -> Result<Option<ObjectPropertyKey<'a>>, OxcDiagnostic> {
     match key {
         oxc::PropertyKey::StringLiteral(lit) => Ok(Some(ObjectPropertyKey::String {
-            name: Ident::from(lit.value.as_str()),
+            name: Ident::from(lit.value.as_str().unwrap_or_default()),
             span: Some(lit.span),
         })),
         oxc::PropertyKey::StaticIdentifier(ident) if !computed => {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -28,7 +28,7 @@ use std::mem::replace;
 
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::Allocator;
+use oxc_allocator::{Allocator, GetAllocator};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::{StringToNumber, ToInt32, ToUint32};
 use oxc_str::{Ident, Str};
@@ -300,11 +300,14 @@ fn evaluate_instruction<'a>(
             let prop_value = read(constants, property);
             if let Some(Constant::Primitive { value: ref prim, .. }) = prop_value {
                 match prim {
-                    PrimitiveValue::String(s) if is_valid_identifier(s.as_str()) => {
+                    PrimitiveValue::String(s) if is_valid_identifier(s.as_str_or_default()) => {
                         let object = *object;
                         let property_span = property.span;
                         let span = *span;
-                        let new_property = PropertyLiteral::String(Ident::from(s.as_str()));
+                        let new_property = PropertyLiteral::String(Ident::from_str_in(
+                            s.as_str_or_default(),
+                            &env.allocator(),
+                        ));
                         func.instructions[instr_id.index()].value =
                             InstructionValue::PropertyLoad {
                                 object,
@@ -340,12 +343,15 @@ fn evaluate_instruction<'a>(
             let prop_value = read(constants, property);
             if let Some(Constant::Primitive { value: ref prim, .. }) = prop_value {
                 match prim {
-                    PrimitiveValue::String(s) if is_valid_identifier(s.as_str()) => {
+                    PrimitiveValue::String(s) if is_valid_identifier(s.as_str_or_default()) => {
                         let object = *object;
                         let property_span = property.span;
                         let store_value = *value;
                         let span = *span;
-                        let new_property = PropertyLiteral::String(Ident::from(s.as_str()));
+                        let new_property = PropertyLiteral::String(Ident::from_str_in(
+                            s.as_str_or_default(),
+                            &env.allocator(),
+                        ));
                         func.instructions[instr_id.index()].value =
                             InstructionValue::PropertyStore {
                                 object,
@@ -491,7 +497,7 @@ fn evaluate_instruction<'a>(
                 && prop_name == "length"
             {
                 // Use UTF-16 code unit count to match JS .length semantics
-                let len = s.as_str().encode_utf16().count() as f64;
+                let len = s.as_str_or_default().encode_utf16().count() as f64;
                 let span = *span;
                 let result = Constant::Primitive {
                     value: PrimitiveValue::Number(FloatValue::new(len)),
@@ -514,7 +520,7 @@ fn evaluate_instruction<'a>(
                 }
                 let span = *span;
                 let value =
-                    PrimitiveValue::String(Str::from_str_in(&result_string, &env.allocator));
+                    PrimitiveValue::String(Str::from_str_in(&result_string, &env.allocator).into());
                 let result = Constant::Primitive { value, span };
                 func.instructions[instr_id.index()].value =
                     InstructionValue::Primitive { value, span };
@@ -530,8 +536,7 @@ fn evaluate_instruction<'a>(
             }
 
             let mut quasi_index = 0usize;
-            let mut result_string =
-                quasis[quasi_index].cooked.as_ref().unwrap().as_str().to_string();
+            let mut result_string = quasis[quasi_index].cooked.as_ref().unwrap().to_string();
             quasi_index += 1;
 
             for sub_expr in subexprs {
@@ -545,7 +550,7 @@ fn evaluate_instruction<'a>(
                     PrimitiveValue::Null => "null".to_string(),
                     PrimitiveValue::Boolean(b) => b.to_string(),
                     PrimitiveValue::Number(n) => n.value().to_js_string(),
-                    PrimitiveValue::String(s) => s.as_str().to_string(),
+                    PrimitiveValue::String(s) => s.as_str_or_default().to_string(),
                     // TS rejects undefined subexpression values
                     PrimitiveValue::Undefined => return None,
                 };
@@ -558,7 +563,8 @@ fn evaluate_instruction<'a>(
             }
 
             let span = *span;
-            let value = PrimitiveValue::String(Str::from_str_in(&result_string, &env.allocator));
+            let value =
+                PrimitiveValue::String(Str::from_str_in(&result_string, &env.allocator).into());
             let result = Constant::Primitive { value, span };
             func.instructions[instr_id.index()].value = InstructionValue::Primitive { value, span };
             Some(result)
@@ -688,7 +694,7 @@ fn is_truthy(value: &PrimitiveValue) -> bool {
             let v = n.value();
             v != 0.0 && !v.is_nan()
         }
-        PrimitiveValue::String(s) => !s.as_str().is_empty(),
+        PrimitiveValue::String(s) => !s.as_str_or_default().is_empty(),
     }
 }
 
@@ -708,7 +714,8 @@ fn evaluate_binary_op<'a>(
                 Some(PrimitiveValue::Number(FloatValue::new(l.value() + r.value())))
             }
             (PrimitiveValue::String(l), PrimitiveValue::String(r)) => Some(PrimitiveValue::String(
-                Str::from_strs_array_in([l.as_str(), r.as_str()], &allocator),
+                Str::from_strs_array_in([l.as_str_or_default(), r.as_str_or_default()], &allocator)
+                    .into(),
             )),
             _ => None,
         },
@@ -862,7 +869,7 @@ fn js_abstract_equal(lhs: &PrimitiveValue, rhs: &PrimitiveValue) -> bool {
         (PrimitiveValue::Number(n), PrimitiveValue::String(s))
         | (PrimitiveValue::String(s), PrimitiveValue::Number(n)) => {
             // String is coerced to number using JS ToNumber semantics.
-            let sv = s.as_str().string_to_number();
+            let sv = s.as_str_or_default().string_to_number();
             let nv = n.value();
             if nv.is_nan() || sv.is_nan() { false } else { nv == sv }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -1407,9 +1407,12 @@ fn ox_convert_value_to_expression<'a>(
 ) -> oxc::Expression<'a> {
     match value {
         OxValue::Expression(e) => e,
-        OxValue::JsxText(text) => {
-            oxc_ast::ast::Expression::new_string_literal(text.span, text.value.as_str(), None, ast)
-        }
+        OxValue::JsxText(text) => oxc_ast::ast::Expression::new_string_literal(
+            text.span,
+            text.value.as_str().unwrap_or_default(),
+            None,
+            ast,
+        ),
     }
 }
 
@@ -3247,7 +3250,8 @@ fn ox_codegen_jsx_attribute<'a>(
             let inner_value = ox_codegen_place_to_expression(cx, place)?;
             let attr_value = match inner_value {
                 oxc::Expression::StringLiteral(ref s)
-                    if !ox_string_requires_expr_container(s.value.as_str()) || is_fbt_operand =>
+                    if !ox_string_requires_expr_container(s.value.as_str().unwrap_or_default())
+                        || is_fbt_operand =>
                 {
                     let value = s.value;
                     Some(oxc_ast::ast::JSXAttributeValue::new_string_literal(
@@ -3282,7 +3286,7 @@ fn ox_codegen_jsx_element<'a>(
     match value {
         OxValue::JsxText(text) => {
             let span = text.span;
-            let raw = text.value.as_str();
+            let raw = text.value.as_str().unwrap_or_default();
             if raw.contains(JSX_TEXT_CHILD_REQUIRES_EXPR_CONTAINER_PATTERN) {
                 let lit = oxc_ast::ast::Expression::new_string_literal(
                     span,
@@ -3339,7 +3343,7 @@ fn ox_codegen_jsx_fbt_child_element<'a>(
     match value {
         OxValue::JsxText(text) => {
             let span = text.span;
-            let encoded = ox_encode_jsx_text(text.value.as_str());
+            let encoded = ox_encode_jsx_text(text.value.as_str().unwrap_or_default());
             Ok(oxc_ast::ast::JSXChild::new_text(span, ox_str(&cx.ast, &encoded), None, &cx.ast))
         }
         OxValue::Expression(oxc::Expression::JSXElement(elem)) => {
@@ -3390,7 +3394,7 @@ fn ox_expression_to_jsx_tag<'a>(
             ))
         }
         oxc::Expression::StringLiteral(s) => {
-            let tag_text = s.value.as_str();
+            let tag_text = s.value.as_str().unwrap_or_default();
             if tag_text.contains(':') {
                 let parts: Vec<&str> = tag_text.splitn(2, ':').collect();
                 let namespace =
@@ -3582,7 +3586,7 @@ fn ox_convert_unary_operator(op: &crate::react_compiler_hir::UnaryOperator) -> o
 
 fn ox_codegen_primitive_value<'a>(
     ast: &oxc_ast::builder::AstBuilder<'a>,
-    value: &PrimitiveValue,
+    value: &PrimitiveValue<'a>,
     span: Span,
 ) -> oxc::Expression<'a> {
     match value {
@@ -3614,7 +3618,7 @@ fn ox_codegen_primitive_value<'a>(
         }
         PrimitiveValue::Boolean(b) => oxc_ast::ast::Expression::new_boolean_literal(span, *b, ast),
         PrimitiveValue::String(s) => {
-            oxc_ast::ast::Expression::new_string_literal(span, ox_str(ast, s.as_str()), None, ast)
+            oxc_ast::ast::Expression::new_string_literal(span, *s, None, ast)
         }
         PrimitiveValue::Null => oxc_ast::ast::Expression::new_null_literal(span, ast),
         PrimitiveValue::Undefined => {

--- a/crates/oxc_react_compiler/src/scope.rs
+++ b/crates/oxc_react_compiler/src/scope.rs
@@ -341,7 +341,10 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
             AstKind::ImportDefaultSpecifier(_) => {
                 let import_decl = self.find_import_declaration(decl_node.id())?;
                 Some(ImportBindingData {
-                    source: Str::from_str_in(import_decl.source.value.as_str(), &self.allocator),
+                    source: Str::from_str_in(
+                        import_decl.source.value.as_str().unwrap_or_default(),
+                        &self.allocator,
+                    ),
                     kind: ImportBindingKind::Default,
                     imported: None,
                 })
@@ -349,7 +352,10 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
             AstKind::ImportNamespaceSpecifier(_) => {
                 let import_decl = self.find_import_declaration(decl_node.id())?;
                 Some(ImportBindingData {
-                    source: Str::from_str_in(import_decl.source.value.as_str(), &self.allocator),
+                    source: Str::from_str_in(
+                        import_decl.source.value.as_str().unwrap_or_default(),
+                        &self.allocator,
+                    ),
                     kind: ImportBindingKind::Namespace,
                     imported: None,
                 })
@@ -359,10 +365,13 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
                 let imported_name = match &spec.imported {
                     ModuleExportName::IdentifierName(ident) => ident.name.as_str(),
                     ModuleExportName::IdentifierReference(ident) => ident.name.as_str(),
-                    ModuleExportName::StringLiteral(lit) => lit.value.as_str(),
+                    ModuleExportName::StringLiteral(lit) => lit.value.as_str().unwrap_or_default(),
                 };
                 Some(ImportBindingData {
-                    source: Str::from_str_in(import_decl.source.value.as_str(), &self.allocator),
+                    source: Str::from_str_in(
+                        import_decl.source.value.as_str().unwrap_or_default(),
+                        &self.allocator,
+                    ),
                     kind: ImportBindingKind::Named,
                     imported: Some(Ident::from_str_in(imported_name, &self.allocator)),
                 })

--- a/crates/oxc_react_compiler/tests/snapshots/lone-surrogate-string-values.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/lone-surrogate-string-values.snap
@@ -7,7 +7,7 @@ function Component() {
 	const $ = _c(1);
 	let t0;
 	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = <Emoji codepoints={["�d83e", "�dd21"]} size={16} />;
+		t0 = <Emoji codepoints={["\ud83e", "\udd21"]} size={16} />;
 		$[0] = t0;
 	} else {
 		t0 = $[0];

--- a/crates/oxc_semantic/src/ts_enum/eval.rs
+++ b/crates/oxc_semantic/src/ts_enum/eval.rs
@@ -73,7 +73,7 @@ pub fn evaluate_enum_members(decl: &TSEnumDeclaration<'_>, scoping: &mut Scoping
             let member_name = match &member.id {
                 TSEnumMemberName::Identifier(ident) => Some(ident.name.as_str()),
                 TSEnumMemberName::String(lit) | TSEnumMemberName::ComputedString(lit) => {
-                    Some(lit.value.as_str())
+                    lit.value.as_str()
                 }
                 TSEnumMemberName::ComputedTemplateString(_) => None,
             };
@@ -98,7 +98,8 @@ fn evaluate_expression(expr: &Expression<'_>, ctx: &EnumEvalCtx<'_>) -> Option<C
         Expression::UnaryExpression(expr) => eval_unary_expression(expr, ctx),
         Expression::NumericLiteral(lit) => Some(ConstantValue::Number(lit.value)),
         Expression::StringLiteral(lit) => {
-            Some(ConstantValue::String(CompactStr::from(lit.value.as_str())))
+            let s = lit.value.as_str()?;
+            Some(ConstantValue::String(CompactStr::from(s)))
         }
         Expression::TemplateLiteral(lit) => {
             if let Some(quasi) = lit.single_quasi() {
@@ -106,8 +107,13 @@ fn evaluate_expression(expr: &Expression<'_>, ctx: &EnumEvalCtx<'_>) -> Option<C
             } else {
                 let mut value = String::new();
                 for (i, quasi) in lit.quasis.iter().enumerate() {
-                    let cooked_or_raw = quasi.value.cooked.as_ref().unwrap_or(&quasi.value.raw);
-                    value.push_str(cooked_or_raw.as_str());
+                    let cooked_str = quasi
+                        .value
+                        .cooked
+                        .as_ref()
+                        .and_then(oxc_str::Wtf8Str::as_str)
+                        .unwrap_or(quasi.value.raw.as_str());
+                    value.push_str(cooked_str);
                     if i < lit.expressions.len() {
                         match evaluate_expression(&lit.expressions[i], ctx)? {
                             ConstantValue::String(s) => value.push_str(&s),
@@ -172,8 +178,9 @@ fn evaluate_ref(expr: &Expression<'_>, ctx: &EnumEvalCtx<'_>) -> Option<Constant
             let Expression::StringLiteral(prop_lit) = &member_expr.expression else {
                 return None;
             };
+            let prop_str = prop_lit.value.as_str()?;
             let obj_symbol_id = resolve_identifier_symbol(obj_ident, ctx)?;
-            find_in_enum_body_scopes(prop_lit.value.as_str(), obj_symbol_id, ctx.scoping)
+            find_in_enum_body_scopes(prop_str, obj_symbol_id, ctx.scoping)
         }
         _ => None,
     }

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -13,7 +13,7 @@ mod span;
 pub use cmp::ContentEq;
 pub use edit_distance::{best_match, min_edit_distance};
 pub use labeled_span::LabeledSpan;
-use oxc_str::{CompactStr, Ident, Str};
+use oxc_str::{CompactStr, Ident, Str, Wtf8Str};
 pub use source_type::{
     FileExtension, Language, LanguageVariant, ModuleKind, SourceType, UnknownExtension,
     VALID_EXTENSIONS,
@@ -51,6 +51,13 @@ impl ContentEq for Str<'_> {
 }
 
 impl ContentEq for Ident<'_> {
+    #[inline]
+    fn content_eq(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+impl ContentEq for Wtf8Str<'_> {
     #[inline]
     fn content_eq(&self, other: &Self) -> bool {
         self == other

--- a/crates/oxc_str/Cargo.toml
+++ b/crates/oxc_str/Cargo.toml
@@ -22,8 +22,10 @@ doctest = true
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_estree = { workspace = true }
+oxc_wtf8 = { workspace = true }
 
 compact_str = { workspace = true }
+cow-utils = { workspace = true }
 hashbrown = { workspace = true, default-features = false, features = ["inline-more"] }
 
 schemars = { workspace = true, optional = true }

--- a/crates/oxc_str/src/lib.rs
+++ b/crates/oxc_str/src/lib.rs
@@ -6,11 +6,13 @@ mod compact_str;
 mod ident;
 mod ident_hasher;
 mod str;
+mod wtf8_str;
 
 pub use compact_str::{CompactStr, MAX_INLINE_LEN};
 pub use ident::{ArenaIdentHashMap, Ident, IdentHashMap, IdentHashSet};
 pub use ident_hasher::{IdentBuildHasher, IdentHasher};
 pub use str::{Str, Str as ArenaStr};
+pub use wtf8_str::Wtf8Str;
 
 #[doc(hidden)]
 pub mod __internal {

--- a/crates/oxc_str/src/wtf8_str.rs
+++ b/crates/oxc_str/src/wtf8_str.rs
@@ -1,0 +1,829 @@
+use std::{
+    borrow::{Borrow, Cow},
+    fmt, hash,
+    ops::Deref,
+};
+
+use cow_utils::CowUtils;
+use oxc_allocator::{
+    Allocator, ArenaStringBuilder, CloneIn, CloneInSemanticIds, Dummy, FromIn, GetAllocator,
+};
+#[cfg(feature = "serialize")]
+use oxc_estree::{ESTree, Serializer as ESTreeSerializer};
+use oxc_wtf8::wtf8::Wtf8CodePoints;
+use oxc_wtf8::{Wtf8, Wtf8Buf};
+#[cfg(feature = "serialize")]
+use serde::{Serialize, Serializer as SerdeSerializer};
+
+use crate::CompactStr;
+
+/// An arena-allocated WTF-8 string for `oxc_allocator`.
+///
+/// Similar to [`crate::Str`] but can contain lone surrogates.
+/// Backed by `&'a Wtf8` allocated in the arena via `Allocator::alloc_slice_copy`.
+///
+/// Use [`Wtf8Str::as_wtf8`] to get the underlying `&Wtf8`,
+/// [`Wtf8Str::as_str`] for optional valid UTF-8 view,
+/// [`Wtf8Str::as_bytes`] for raw bytes.
+#[repr(transparent)]
+#[derive(Clone, Copy, Eq)]
+pub struct Wtf8Str<'a>(&'a Wtf8);
+
+impl Wtf8Str<'static> {
+    /// Get a [`Wtf8Str`] containing a static string.
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    pub const fn new_const(s: &'static str) -> Self {
+        // SAFETY: `&'static str` is valid WTF-8 (UTF-8 subset). `Wtf8` is transparent over `[u8]`.
+        unsafe { Self(core::mem::transmute::<&'static str, &'static Wtf8>(s)) }
+    }
+
+    /// Get a [`Wtf8Str`] containing a static WTF-8 string (may contain lone surrogates).
+    ///
+    /// # Safety
+    /// Caller must ensure `s` is valid WTF-8 bytes.
+    #[inline]
+    pub const unsafe fn new_const_wtf8(s: &'static Wtf8) -> Self {
+        Self(s)
+    }
+
+    /// Get a [`Wtf8Str`] containing the empty string.
+    #[inline]
+    pub const fn empty() -> Self {
+        Self::new_const("")
+    }
+}
+
+impl<'a> Wtf8Str<'a> {
+    /// Allocate provided `&str` into arena, and return a [`Wtf8Str<'a>`].
+    #[inline]
+    pub fn from_str_in(s: &str, allocator: &impl GetAllocator<'a>) -> Self {
+        Self::from_bytes_in(s.as_bytes(), allocator)
+    }
+
+    /// Allocate provided `&Wtf8` into arena.
+    #[inline]
+    pub fn from_wtf8_in(s: &Wtf8, allocator: &impl GetAllocator<'a>) -> Self {
+        Self::from_bytes_in(s.as_bytes(), allocator)
+    }
+
+    /// Allocate provided `Wtf8Buf` into arena.
+    #[inline]
+    pub fn from_wtf8_buf_in(buf: &Wtf8Buf, allocator: &impl GetAllocator<'a>) -> Self {
+        Self::from_bytes_in(buf.as_bytes(), allocator)
+    }
+
+    /// Allocate raw WTF-8 bytes into arena.
+    ///
+    /// # Panics
+    /// Panics if `bytes` is not valid WTF-8.
+    #[inline]
+    pub fn from_bytes_in(bytes: &[u8], allocator: &impl GetAllocator<'a>) -> Self {
+        assert!(Wtf8::from_bytes(bytes).is_ok(), "invalid WTF-8 bytes");
+        // SAFETY: validity asserted above.
+        unsafe { Self::from_bytes_unchecked_in(bytes, allocator) }
+    }
+
+    /// Allocate raw WTF-8 bytes into arena without validation.
+    ///
+    /// # Safety
+    /// Caller must ensure `bytes` is valid WTF-8.
+    #[inline]
+    pub unsafe fn from_bytes_unchecked_in(bytes: &[u8], allocator: &impl GetAllocator<'a>) -> Self {
+        let allocated: &'a [u8] = allocator.allocator().alloc_slice_copy(bytes);
+        // SAFETY: Wtf8 is transparent over [u8]; caller guarantees validity.
+        let wtf8: &'a Wtf8 =
+            unsafe { &*(std::ptr::from_ref::<[u8]>(allocated) as *const oxc_wtf8::Wtf8) };
+        Self(wtf8)
+    }
+
+    /// Borrow the underlying `&Wtf8`.
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    pub fn as_wtf8(&self) -> &'a Wtf8 {
+        self.0
+    }
+
+    /// Return raw bytes.
+    #[inline]
+    pub fn as_bytes(&self) -> &'a [u8] {
+        self.0.as_bytes()
+    }
+
+    /// If this WTF-8 string is valid UTF-8, return `Some(&str)`, else `None`.
+    ///
+    /// Lone surrogates cause `None`.
+    #[inline]
+    pub fn as_str(&self) -> Option<&'a str> {
+        self.0.as_str()
+    }
+
+    /// Convert to string lossily: lone surrogates become U+FFFD.
+    #[inline]
+    pub fn to_string_lossy(self) -> Cow<'a, str> {
+        self.0.to_string_lossy()
+    }
+
+    /// Return length in bytes.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Convert into `CompactStr` lossily (for interop where UTF-8 required).
+    #[inline]
+    pub fn to_compact_str_lossy(self) -> CompactStr {
+        CompactStr::new(&self.to_string_lossy())
+    }
+
+    /// Whether string is valid UTF-8 (i.e. contains no lone surrogates).
+    #[inline]
+    pub fn is_valid_utf8(&self) -> bool {
+        self.as_str().is_some()
+    }
+
+    /// Try to get `&str` if valid UTF-8, otherwise `None` (alias for `as_str`).
+    #[inline]
+    pub fn try_as_str(&self) -> Option<&'a str> {
+        self.as_str()
+    }
+
+    /// Iterate over code points (including lone surrogates as `CodePoint`).
+    #[inline]
+    pub fn code_points(&self) -> Wtf8CodePoints<'_> {
+        self.as_wtf8().code_points()
+    }
+
+    /// Create from `Cow<'a, Wtf8>`? For API symmetry we provide from_cow
+    #[inline]
+    pub fn from_cow_in(cow: Cow<'a, Wtf8>, allocator: &impl GetAllocator<'a>) -> Self {
+        match cow {
+            Cow::Borrowed(s) => Self(s),
+            Cow::Owned(buf) => Self::from_bytes_in(buf.as_bytes(), allocator),
+        }
+    }
+
+    /// Create from `Wtf8Buf` Cow?
+    #[inline]
+    pub fn from_wtf8_cow_in(cow: Cow<'a, Wtf8>, allocator: &impl GetAllocator<'a>) -> Self {
+        Self::from_cow_in(cow, allocator)
+    }
+
+    /// Returns `&str` if valid UTF-8, otherwise empty string.
+    ///
+    /// Convenience for linter/codegen where lone surrogates should be treated as empty.
+    #[inline]
+    pub fn as_str_or_default(&'a self) -> &'a str {
+        self.as_str().unwrap_or("")
+    }
+
+    /// Parse the string as `F`, using `as_str().unwrap_or_default()` as source.
+    /// # Errors
+    ///
+    /// Returns `F::Err` if parsing fails.
+    #[inline]
+    pub fn parse<F: std::str::FromStr>(&self) -> Result<F, F::Err> {
+        self.as_str_or_default().parse()
+    }
+
+    /// Returns an iterator over `char`s, using lossy `""` fallback for lone surrogates.
+    #[inline]
+    pub fn chars(&'a self) -> std::str::Chars<'a> {
+        self.as_str_or_default().chars()
+    }
+
+    /// Split by `pat` (char), lossy fallback.
+    #[inline]
+    pub fn split(&'a self, pat: char) -> std::str::Split<'a, char> {
+        self.as_str_or_default().split(pat)
+    }
+
+    /// Split by `pat` (&str), lossy fallback.
+    #[inline]
+    pub fn split_str(&'a self, pat: &'a str) -> std::str::Split<'a, &'a str> {
+        self.as_str_or_default().split(pat)
+    }
+
+    /// Split whitespace, lossy fallback.
+    #[inline]
+    pub fn split_whitespace(&'a self) -> std::str::SplitWhitespace<'a> {
+        self.as_str_or_default().split_whitespace()
+    }
+
+    /// Whether string equals `other` ignoring ASCII case, lossy fallback.
+    #[inline]
+    pub fn eq_ignore_ascii_case(&self, other: &str) -> bool {
+        self.as_str_or_default().eq_ignore_ascii_case(other)
+    }
+
+    /// Convert to `CompactStr` lossily (alias for `to_compact_str_lossy`).
+    #[inline]
+    pub fn to_compact_str(self) -> CompactStr {
+        self.to_compact_str_lossy()
+    }
+
+    /// Alias for `to_compact_str_lossy` for compatibility with `Atom::into_compact_str`.
+    #[inline]
+    pub fn into_compact_str(self) -> CompactStr {
+        self.to_compact_str_lossy()
+    }
+
+    /// Returns `true` if string contains `pat` (char), lossy fallback.
+    #[inline]
+    pub fn contains_char(&self, pat: char) -> bool {
+        self.as_str_or_default().contains(pat)
+    }
+
+    /// Returns `true` if string contains `pat` (&str), lossy fallback.
+    #[inline]
+    pub fn contains_str(&self, pat: &str) -> bool {
+        self.as_str_or_default().contains(pat)
+    }
+
+    /// Cow-based ASCII lowercase, lossy fallback.
+    ///
+    /// Delegates to [`CowUtils`], which returns a borrowed slice when unchanged.
+    #[inline]
+    pub fn cow_to_ascii_lowercase(&'a self) -> Cow<'a, str> {
+        self.as_str_or_default().cow_to_ascii_lowercase()
+    }
+
+    /// Cow-based ASCII uppercase, lossy fallback.
+    ///
+    /// Delegates to [`CowUtils`], which returns a borrowed slice when unchanged.
+    #[inline]
+    pub fn cow_to_ascii_uppercase(&'a self) -> Cow<'a, str> {
+        self.as_str_or_default().cow_to_ascii_uppercase()
+    }
+
+    /// Cow-based lowercase, lossy fallback.
+    ///
+    /// Delegates to [`CowUtils`], which returns a borrowed slice when unchanged.
+    #[inline]
+    pub fn cow_to_lowercase(&'a self) -> Cow<'a, str> {
+        self.as_str_or_default().cow_to_lowercase()
+    }
+
+    /// Cow-based uppercase, lossy fallback.
+    ///
+    /// Delegates to [`CowUtils`], which returns a borrowed slice when unchanged.
+    #[inline]
+    pub fn cow_to_uppercase(&'a self) -> Cow<'a, str> {
+        self.as_str_or_default().cow_to_uppercase()
+    }
+
+    /// Trim whitespace, lossy fallback.
+    #[inline]
+    pub fn trim(&'a self) -> &'a str {
+        self.as_str_or_default().trim()
+    }
+
+    /// Whether string starts with `pat` (&str), lossy fallback.
+    #[inline]
+    pub fn starts_with_str(&'a self, pat: &str) -> bool {
+        self.as_str_or_default().starts_with(pat)
+    }
+
+    /// Whether string ends with `pat` (&str), lossy fallback.
+    #[inline]
+    pub fn ends_with_str(&'a self, pat: &str) -> bool {
+        self.as_str_or_default().ends_with(pat)
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for Wtf8Str<'_> {
+    type Cloned = Wtf8Str<'new_alloc>;
+
+    #[inline]
+    fn clone_in_impl(
+        &self,
+        _with_semantic_ids: CloneInSemanticIds,
+        allocator: &'new_alloc Allocator,
+    ) -> Self::Cloned {
+        // Reallocate bytes into new allocator directly without GetAllocator indirection
+        let allocated: &'new_alloc [u8] = allocator.alloc_slice_copy(self.as_bytes());
+        // SAFETY: bytes copied from a valid `Wtf8Str` are valid WTF-8; transparent over `[u8]`.
+        unsafe { Wtf8Str(&*(std::ptr::from_ref::<[u8]>(allocated) as *const oxc_wtf8::Wtf8)) }
+    }
+}
+
+impl<'a> Dummy<'a> for Wtf8Str<'a> {
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn dummy(_allocator: &'a Allocator) -> Self {
+        // SAFETY: empty static WTF-8 is valid for any lifetime
+        unsafe { core::mem::transmute::<Wtf8Str<'static>, Wtf8Str<'a>>(Wtf8Str::empty()) }
+    }
+}
+
+impl<'alloc> FromIn<'alloc, &Wtf8Str<'alloc>> for Wtf8Str<'alloc> {
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn from_in(s: &Wtf8Str<'alloc>, _: &'alloc Allocator) -> Self {
+        *s
+    }
+}
+
+impl<'alloc> FromIn<'alloc, &'alloc Wtf8> for Wtf8Str<'alloc> {
+    #[inline]
+    fn from_in(s: &'alloc Wtf8, allocator: &'alloc Allocator) -> Self {
+        let allocated: &'alloc [u8] = allocator.alloc_slice_copy(s.as_bytes());
+        // SAFETY: source is valid WTF-8/UTF-8, so the copy is too; transparent over `[u8]`.
+        unsafe { Self(&*(std::ptr::from_ref::<[u8]>(allocated) as *const oxc_wtf8::Wtf8)) }
+    }
+}
+
+impl<'alloc> FromIn<'alloc, Wtf8Buf> for Wtf8Str<'alloc> {
+    #[inline]
+    fn from_in(s: Wtf8Buf, allocator: &'alloc Allocator) -> Self {
+        let allocated: &'alloc [u8] = allocator.alloc_slice_copy(s.as_bytes());
+        // SAFETY: source is valid WTF-8/UTF-8, so the copy is too; transparent over `[u8]`.
+        unsafe { Self(&*(std::ptr::from_ref::<[u8]>(allocated) as *const oxc_wtf8::Wtf8)) }
+    }
+}
+
+impl<'alloc> FromIn<'alloc, &str> for Wtf8Str<'alloc> {
+    #[inline]
+    fn from_in(s: &str, allocator: &'alloc Allocator) -> Self {
+        let allocated: &'alloc [u8] = allocator.alloc_slice_copy(s.as_bytes());
+        // SAFETY: source is valid WTF-8/UTF-8, so the copy is too; transparent over `[u8]`.
+        unsafe { Self(&*(std::ptr::from_ref::<[u8]>(allocated) as *const oxc_wtf8::Wtf8)) }
+    }
+}
+
+impl<'alloc> FromIn<'alloc, String> for Wtf8Str<'alloc> {
+    #[inline]
+    fn from_in(s: String, allocator: &'alloc Allocator) -> Self {
+        Self::from_in(s.as_str(), allocator)
+    }
+}
+
+impl<'alloc> FromIn<'alloc, &String> for Wtf8Str<'alloc> {
+    #[inline]
+    fn from_in(s: &String, allocator: &'alloc Allocator) -> Self {
+        Self::from_in(s.as_str(), allocator)
+    }
+}
+
+impl<'a> From<&'a Wtf8> for Wtf8Str<'a> {
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn from(s: &'a Wtf8) -> Self {
+        Self(s)
+    }
+}
+
+impl<'a> From<&'a str> for Wtf8Str<'a> {
+    #[inline]
+    fn from(s: &'a str) -> Self {
+        // SAFETY: &str bytes are valid WTF-8.
+        unsafe { Self(&*(std::ptr::from_ref::<str>(s) as *const oxc_wtf8::Wtf8)) }
+    }
+}
+
+impl<'a, 'b> From<crate::Str<'b>> for Wtf8Str<'a>
+where
+    'b: 'a,
+{
+    #[inline]
+    fn from(s: crate::Str<'b>) -> Self {
+        // SAFETY: Str bytes are valid UTF-8, hence valid WTF-8.
+        unsafe { Self(&*(std::ptr::from_ref::<str>(s.as_str()) as *const oxc_wtf8::Wtf8)) }
+    }
+}
+
+impl<'a, 'b> From<&'b crate::Str<'b>> for Wtf8Str<'a>
+where
+    'b: 'a,
+{
+    #[inline]
+    fn from(s: &'b crate::Str<'b>) -> Self {
+        // SAFETY: `Str` bytes are valid UTF-8, hence valid WTF-8.
+        unsafe { Self(&*(std::ptr::from_ref::<str>(s.as_str()) as *const oxc_wtf8::Wtf8)) }
+    }
+}
+
+impl<'a, 'b> From<crate::Ident<'b>> for Wtf8Str<'a>
+where
+    'b: 'a,
+{
+    #[inline]
+    fn from(s: crate::Ident<'b>) -> Self {
+        // SAFETY: `Ident` bytes are valid UTF-8, hence valid WTF-8.
+        unsafe { Self(&*(std::ptr::from_ref::<str>(s.as_str()) as *const oxc_wtf8::Wtf8)) }
+    }
+}
+
+impl<'a, 'b> From<&'b crate::Ident<'b>> for Wtf8Str<'a>
+where
+    'b: 'a,
+{
+    #[inline]
+    fn from(s: &'b crate::Ident<'b>) -> Self {
+        // SAFETY: `Ident` bytes are valid UTF-8, hence valid WTF-8.
+        unsafe { Self(&*(std::ptr::from_ref::<str>(s.as_str()) as *const oxc_wtf8::Wtf8)) }
+    }
+}
+
+impl<'alloc> From<ArenaStringBuilder<'alloc>> for Wtf8Str<'alloc> {
+    #[inline]
+    fn from(s: ArenaStringBuilder<'alloc>) -> Self {
+        // ArenaStringBuilder produces UTF-8 string; reinterpret as WTF-8
+        let str_ref: &str = s.into_str();
+        // SAFETY: `ArenaStringBuilder` produces UTF-8, hence valid WTF-8.
+        unsafe { Self(&*(std::ptr::from_ref::<str>(str_ref) as *const oxc_wtf8::Wtf8)) }
+    }
+}
+
+impl<'a> From<Wtf8Str<'a>> for &'a Wtf8 {
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn from(s: Wtf8Str<'a>) -> Self {
+        s.as_wtf8()
+    }
+}
+
+impl<'a> From<Wtf8Str<'a>> for &'a [u8] {
+    #[inline]
+    fn from(s: Wtf8Str<'a>) -> Self {
+        s.as_bytes()
+    }
+}
+
+impl Deref for Wtf8Str<'_> {
+    type Target = str;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_str_or_default()
+    }
+}
+
+impl AsRef<Wtf8> for Wtf8Str<'_> {
+    #[inline]
+    fn as_ref(&self) -> &Wtf8 {
+        self.0
+    }
+}
+
+impl AsRef<str> for Wtf8Str<'_> {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.as_str_or_default()
+    }
+}
+
+impl Borrow<Wtf8> for Wtf8Str<'_> {
+    #[inline]
+    fn borrow(&self) -> &Wtf8 {
+        self.0
+    }
+}
+
+impl Borrow<str> for Wtf8Str<'_> {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self.as_str_or_default()
+    }
+}
+
+impl PartialEq<Wtf8Str<'_>> for Wtf8Str<'_> {
+    #[inline]
+    fn eq(&self, other: &Wtf8Str<'_>) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl PartialEq<Wtf8> for Wtf8Str<'_> {
+    #[inline]
+    fn eq(&self, other: &Wtf8) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<Wtf8Str<'_>> for Wtf8 {
+    #[inline]
+    fn eq(&self, other: &Wtf8Str<'_>) -> bool {
+        self == other.0
+    }
+}
+
+impl PartialEq<&Wtf8> for Wtf8Str<'_> {
+    #[inline]
+    fn eq(&self, other: &&Wtf8) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<Wtf8Str<'_>> for &Wtf8 {
+    #[inline]
+    fn eq(&self, other: &Wtf8Str<'_>) -> bool {
+        *self == other.0
+    }
+}
+
+impl PartialEq<str> for Wtf8Str<'_> {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        self.as_str().is_some_and(|s| s == other)
+    }
+}
+
+impl PartialEq<Wtf8Str<'_>> for str {
+    #[inline]
+    fn eq(&self, other: &Wtf8Str<'_>) -> bool {
+        other == self
+    }
+}
+
+impl PartialEq<&str> for Wtf8Str<'_> {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        self == *other
+    }
+}
+
+impl PartialEq<Wtf8Str<'_>> for &str {
+    #[inline]
+    fn eq(&self, other: &Wtf8Str<'_>) -> bool {
+        other == *self
+    }
+}
+
+impl PartialEq<String> for Wtf8Str<'_> {
+    #[inline]
+    fn eq(&self, other: &String) -> bool {
+        self == other.as_str()
+    }
+}
+
+impl PartialEq<Wtf8Str<'_>> for String {
+    #[inline]
+    fn eq(&self, other: &Wtf8Str<'_>) -> bool {
+        other == self.as_str()
+    }
+}
+
+impl hash::Hash for Wtf8Str<'_> {
+    #[inline]
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl fmt::Debug for Wtf8Str<'_> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.0, f)
+    }
+}
+
+impl fmt::Display for Wtf8Str<'_> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Display lossily? Use Wtf8's Display which shows raw bytes? Use lossy.
+        // Wtf8's Display not defined, but Debug escapes surrogates. For Display we want to show replacement.
+        // Use to_string_lossy.
+        fmt::Display::fmt(&self.to_string_lossy(), f)
+    }
+}
+
+#[cfg(feature = "serialize")]
+impl Serialize for Wtf8Str<'_> {
+    fn serialize<S: SerdeSerializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Serialize as escaped string: lone surrogates as \uXXXX, literal \u escapes escaped.
+        // Mirrors SWC's Wtf8Atom serde: convert to escaped String then serialize_str.
+        let escaped = wtf8_serialize::wtf8_to_escaped_string(self.0);
+        Serialize::serialize(&escaped, serializer)
+    }
+}
+
+#[cfg(feature = "serialize")]
+impl ESTree for Wtf8Str<'_> {
+    fn serialize<S: ESTreeSerializer>(&self, mut serializer: S) {
+        if let Some(s) = self.as_str() {
+            // Valid UTF-8 – delegate to &str's ESTree (handles JSON escaping)
+            ESTree::serialize(s, serializer);
+            return;
+        }
+        // Contains lone surrogates – need WTF-8 aware JSON escaping
+        let buffer = serializer.buffer_mut();
+        buffer.print_ascii_byte(b'"');
+        for cp in self.as_wtf8().code_points() {
+            if let Some(c) = cp.to_char() {
+                match c {
+                    '"' => buffer.print_str("\\\""),
+                    '\\' => buffer.print_str("\\\\"),
+                    '\n' => buffer.print_str("\\n"),
+                    '\r' => buffer.print_str("\\r"),
+                    '\t' => buffer.print_str("\\t"),
+                    '\x08' => buffer.print_str("\\b"),
+                    '\x0C' => buffer.print_str("\\f"),
+                    '\x0B' => buffer.print_str("\\v"),
+                    '\0' => buffer.print_str("\\0"),
+                    c if c.is_control() => {
+                        buffer.print_str("\\u");
+                        let hex = format!("{:04x}", c as u32);
+                        buffer.print_str(&hex);
+                    }
+                    _ => {
+                        let mut buf = [0u8; 4];
+                        let s = c.encode_utf8(&mut buf);
+                        buffer.print_str(s);
+                    }
+                }
+            } else {
+                buffer.print_str("\\u");
+                let hex = format!("{:04x}", cp.to_u32());
+                buffer.print_str(&hex);
+            }
+        }
+        buffer.print_ascii_byte(b'"');
+    }
+}
+
+/// Helpers for WTF-8 serialization.
+#[cfg(feature = "serialize")]
+pub mod wtf8_serialize {
+    use oxc_wtf8::Wtf8;
+    use std::fmt::Write;
+
+    /// Convert WTF-8 to escaped string for JSON/ESTree.
+    /// Lone surrogates become `\uXXXX`, literal `\u` followed by 4 hex digits becomes `\\u`.
+    /// This mirrors SWC's `convert_wtf8_to_raw` in `wtf8_atom.rs`.
+    pub fn wtf8_to_escaped_string(s: &Wtf8) -> String {
+        let mut result = String::with_capacity(s.len());
+        let mut iter = s.code_points();
+        // One-item pushback so lookahead never needs a second iterator.
+        let mut pending: Option<oxc_wtf8::CodePoint> = None;
+
+        while let Some(cp) = pending.take().or_else(|| iter.next()) {
+            if let Some(c) = cp.to_char() {
+                if c == '\\' {
+                    // Check for `\uXXXX` (literal escape) — must be re-escaped as `\\u`.
+                    match pending.take().or_else(|| iter.next()) {
+                        Some(next) if next.to_u32() == 'u' as u32 => {
+                            // Look at the following 4 code points; put them back if not all hex.
+                            let mut hex: [Option<char>; 4] = [None; 4];
+                            let mut all_hex = true;
+                            for slot in &mut hex {
+                                if let Some(n) = pending.take().or_else(|| iter.next()) {
+                                    match n.to_char() {
+                                        Some(ch) if ch.is_ascii_hexdigit() => *slot = Some(ch),
+                                        _ => {
+                                            all_hex = false;
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    all_hex = false;
+                                    break;
+                                }
+                            }
+                            if all_hex {
+                                // Consume the 'u' and emit an escaped backslash before it.
+                                result.push_str("\\\\u");
+                                for ch in hex.iter().flatten() {
+                                    result.push(*ch);
+                                }
+                            } else {
+                                result.push(c);
+                                result.push('u');
+                                for ch in hex.iter().flatten() {
+                                    result.push(*ch);
+                                }
+                            }
+                        }
+                        Some(next) => {
+                            result.push(c);
+                            pending = Some(next);
+                        }
+                        None => result.push(c),
+                    }
+                } else {
+                    result.push(c);
+                }
+            } else {
+                // Lone surrogate
+                let _ = write!(result, "\\u{{{:04X}}}", cp.to_u32());
+            }
+        }
+        result
+    }
+}
+
+/// Create a [`Wtf8Str<'static>`] for a static string literal (valid UTF-8).
+#[macro_export]
+macro_rules! static_wtf8_str {
+    ($s:literal) => {
+        $crate::Wtf8Str::new_const($s)
+    };
+}
+
+/// Creates a [`Wtf8Str`] using interpolation of runtime expressions, allocated in arena.
+#[macro_export]
+macro_rules! format_wtf8_str {
+    ($allocator:expr, $($arg:tt)*) => {{
+        let s = oxc_allocator::Allocator::alloc_str(&$allocator, &format!($($arg)*));
+        // Actually need to allocate via Wtf8Str::from_str_in
+        $crate::Wtf8Str::from_str_in(&format!($($arg)*), $allocator)
+    }};
+}
+
+#[cfg(test)]
+mod test {
+    use oxc_allocator::Allocator;
+    use oxc_wtf8::Wtf8Buf;
+
+    use super::Wtf8Str;
+
+    #[test]
+    fn wtf8_str_basic() {
+        let allocator = Allocator::new();
+        let allocator = &allocator;
+        let w = Wtf8Buf::from_ill_formed_utf16(&[0xD800]);
+        let s = Wtf8Str::from_wtf8_buf_in(&w, &allocator);
+        assert_eq!(s.as_bytes(), &[0xED, 0xA0, 0x80]);
+        assert!(s.as_str().is_none());
+        assert_eq!(s.len(), 3);
+        assert!(!s.is_empty());
+        assert_eq!(s.to_string_lossy(), "\u{FFFD}");
+    }
+
+    #[test]
+    fn wtf8_str_valid_utf8() {
+        let allocator = Allocator::new();
+        let allocator = &allocator;
+        let s = Wtf8Str::from_str_in("hello", &allocator);
+        assert_eq!(s.as_str(), Some("hello"));
+        assert_eq!(s.as_bytes(), b"hello");
+        assert_eq!(s.to_string_lossy(), "hello");
+    }
+
+    #[test]
+    fn wtf8_str_clone_in() {
+        use oxc_allocator::{Allocator, CloneIn};
+        let allocator1 = Allocator::new();
+        let allocator1 = &allocator1;
+        let s1 = Wtf8Str::from_str_in("test", &allocator1);
+        let allocator2 = Allocator::new();
+        let s2 = s1.clone_in(&allocator2);
+        assert_eq!(s1, s2);
+        assert_eq!(s2.as_str(), Some("test"));
+    }
+
+    #[test]
+    fn wtf8_str_surrogate_pair_combined() {
+        let allocator = Allocator::new();
+        let allocator = &allocator;
+        // Pair should be stored as single codepoint, not two surrogates
+        let w = Wtf8Buf::from_ill_formed_utf16(&[0xD83D, 0xDE00]); // 😀
+        let s = Wtf8Str::from_wtf8_buf_in(&w, &allocator);
+        assert!(s.as_str().is_some());
+        assert_eq!(s.as_str().unwrap(), "😀");
+    }
+
+    #[cfg(feature = "serialize")]
+    #[test]
+    fn wtf8_str_estree_lone_surrogate() {
+        use oxc_estree::{CompactSerializer, ESTree};
+
+        let allocator = Allocator::new();
+        let allocator = &allocator;
+
+        // Lone surrogate should be escaped as \uXXXX
+        let w = Wtf8Buf::from_ill_formed_utf16(&[0xD800]);
+        let s = Wtf8Str::from_wtf8_buf_in(&w, &allocator);
+        let mut serializer = CompactSerializer::default();
+        s.serialize(&mut serializer);
+        assert_eq!(serializer.into_string(), r#""\ud800""#);
+
+        // Valid UTF-8 should delegate to &str handling (including " escaping)
+        let s2 = Wtf8Str::from_str_in(r#"a"b"#, &allocator);
+        let mut serializer2 = CompactSerializer::default();
+        s2.serialize(&mut serializer2);
+        assert_eq!(serializer2.into_string(), r#""a\"b""#);
+
+        // Multiple surrogates
+        let w2 = Wtf8Buf::from_ill_formed_utf16(&[0xD834, 0xD835]);
+        let s3 = Wtf8Str::from_wtf8_buf_in(&w2, &allocator);
+        let mut serializer3 = CompactSerializer::default();
+        s3.serialize(&mut serializer3);
+        assert_eq!(serializer3.into_string(), r#""\ud834\ud835""#);
+
+        // Mixed valid and lone surrogates with quotes
+        let mut w3 = Wtf8Buf::from_str("a\"b");
+        // SAFETY: 0xD800 is within the code point range.
+        w3.push(unsafe { oxc_wtf8::CodePoint::from_u32_unchecked(0xD800) });
+        w3.push_str("c");
+        let s4 = Wtf8Str::from_wtf8_buf_in(&w3, &allocator);
+        let mut serializer4 = CompactSerializer::default();
+        s4.serialize(&mut serializer4);
+        assert_eq!(serializer4.into_string(), r#""a\"b\ud800c""#);
+    }
+}

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -287,7 +287,9 @@ impl<'a> ClassProperties<'a> {
                     ctx,
                 )
             }
-            PropertyKey::StringLiteral(str_lit) if needs_define(&str_lit.value) => {
+            PropertyKey::StringLiteral(str_lit)
+                if str_lit.value.as_str().is_some_and(needs_define) =>
+            {
                 return self
                     .create_init_assignment_not_loose(prop, value, assignee, is_static, ctx);
             }

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -92,7 +92,7 @@ use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, GetAllocator, Replac
 use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_ecmascript::PropName;
 use oxc_span::{SPAN, Span};
-use oxc_str::{Ident, Str};
+use oxc_str::{Ident, Str, Wtf8Str};
 use oxc_syntax::{
     identifier::{is_identifier_name, is_white_space_single_line},
     keyword::is_reserved_keyword,
@@ -912,13 +912,15 @@ impl<'a> JsxImpl<'a> {
         match value {
             Some(JSXAttributeValue::StringLiteral(s)) => {
                 let mut decoded = None;
-                decode_entities(s.value.as_str(), &mut decoded, s.value.len(), ctx.allocator());
+                if let Some(str_val) = s.value.as_str() {
+                    decode_entities(str_val, &mut decoded, s.value.len(), ctx.allocator());
+                }
                 let jsx_text = if let Some(decoded) = decoded {
                     // Text contains HTML entities which were decoded.
-                    // `decoded` contains the decoded string as an `ArenaString`. Convert it to `Str`.
-                    Str::from(decoded)
+                    // `decoded` contains the decoded string as an `ArenaString`. Convert it to `Wtf8Str`.
+                    Wtf8Str::from(decoded)
                 } else {
-                    // No HTML entities needed to be decoded. Use the original `Str` without copying.
+                    // No HTML entities needed to be decoded. Use the original `Wtf8Str` without copying.
                     s.value
                 };
                 Expression::new_string_literal(s.span, jsx_text, None, ctx)
@@ -1026,43 +1028,33 @@ impl<'a> JsxImpl<'a> {
     ///
     /// <https://github.com/microsoft/TypeScript/blob/f0374ce2a9c465e27a15b7fa4a347e2bd9079450/src/compiler/transformers/jsx.ts#L557-L608>
     fn fixup_whitespace_and_decode_entities(
-        text: Str<'a>,
+        text: Wtf8Str<'a>,
         ctx: &TraverseCtx<'a>,
-    ) -> Option<Str<'a>> {
-        // Avoid copying strings in the common case where there's only 1 line of text,
-        // and it contains no HTML entities that need decoding.
-        //
-        // Where we do have to decode HTML entities, or concatenate multiple lines, assemble the
-        // concatenated text directly in arena, in an `ArenaString` (the accumulator `acc`),
-        // to avoid allocations. Initialize that `ArenaString` with capacity equal to length of
-        // the original text. This may be a bit more capacity than is required, once whitespace
-        // is removed, but it's highly unlikely to be insufficient capacity, so the `ArenaString`
-        // shouldn't need to reallocate while it's being constructed.
-        //
-        // When first line containing some text is found:
-        // * If it contains HTML entities, decode them and write decoded text to accumulator `acc`.
-        // * Otherwise, store trimmed text in `only_line` as a `Str<'a>`.
-        //
-        // When another line containing some text is found:
-        // * If accumulator isn't already initialized, initialize it, starting with `only_line`.
-        // * Push a space to the accumulator.
-        // * Decode current line into the accumulator.
-        //
-        // At the end:
-        // * If accumulator is initialized, convert the `ArenaString` to a `Str` and return it.
-        // * If `only_line` contains a string, that means only 1 line contained text, and that line
-        //   didn't contain any HTML entities which needed decoding.
-        //   So we can just return the `Str` that's in `only_line` (without any copying).
+    ) -> Option<Wtf8Str<'a>> {
+        // JSXText is now WTF-8. For the common case of valid UTF-8, reuse original
+        // whitespace-trimming logic. If the text contains lone surrogates (not valid UTF-8),
+        // whitespace handling is not critical; preserve the original value to avoid losing
+        // surrogates via lossy conversion. `ArenaStringBuilder` is UTF-8 only, so we cannot
+        // safely accumulate WTF-8 bytes there.
+        let Some(str_val) = text.as_str() else {
+            // Contains lone surrogates — return original without whitespace fixup.
+            // This preserves WTF-8 bytes; codegen will handle escaping.
+            if text.is_empty() {
+                return None;
+            }
+            return Some(text);
+        };
 
+        // Valid UTF-8 fast path — original logic, but producing `Wtf8Str`.
         let mut acc: Option<ArenaStringBuilder> = None;
-        let mut only_line: Option<Str<'a>> = None;
+        let mut only_line: Option<Wtf8Str<'a>> = None;
         let mut first_non_whitespace: Option<usize> = Some(0);
         let mut last_non_whitespace: Option<usize> = None;
-        for (index, c) in text.char_indices() {
+        for (index, c) in str_val.char_indices() {
             if is_line_terminator(c) {
                 if let (Some(first), Some(last)) = (first_non_whitespace, last_non_whitespace) {
                     Self::add_line_of_jsx_text(
-                        Str::from(&text.as_str()[first..last]),
+                        Wtf8Str::from(&str_val[first..last]),
                         &mut acc,
                         &mut only_line,
                         text.len(),
@@ -1080,7 +1072,7 @@ impl<'a> JsxImpl<'a> {
 
         if let Some(first) = first_non_whitespace {
             Self::add_line_of_jsx_text(
-                Str::from(&text.as_str()[first..]),
+                Wtf8Str::from(&str_val[first..]),
                 &mut acc,
                 &mut only_line,
                 text.len(),
@@ -1088,13 +1080,13 @@ impl<'a> JsxImpl<'a> {
             );
         }
 
-        if let Some(acc) = acc { Some(Str::from(acc)) } else { only_line }
+        if let Some(acc) = acc { Some(Wtf8Str::from(acc)) } else { only_line }
     }
 
     fn add_line_of_jsx_text(
-        trimmed_line: Str<'a>,
+        trimmed_line: Wtf8Str<'a>,
         acc: &mut Option<ArenaStringBuilder<'a>>,
-        only_line: &mut Option<Str<'a>>,
+        only_line: &mut Option<Wtf8Str<'a>>,
         text_len: usize,
         ctx: &TraverseCtx<'a>,
     ) {
@@ -1106,13 +1098,14 @@ impl<'a> JsxImpl<'a> {
             // Generate an accumulator containing previous line and a trailing space.
             // Current line will be added to the accumulator after it.
             let mut buffer = ArenaStringBuilder::with_capacity_in(text_len, ctx.allocator());
-            buffer.push_str(only_line.as_str());
+            // `only_line` came from valid UTF-8 `text`, so `as_str` is Some.
+            buffer.push_str(only_line.as_str().unwrap());
             buffer.push(' ');
             *acc = Some(buffer);
         }
 
         // Decode any HTML entities in this line
-        decode_entities(trimmed_line.as_str(), acc, text_len, ctx.allocator());
+        decode_entities(trimmed_line.as_str().unwrap(), acc, text_len, ctx.allocator());
 
         if acc.is_none() {
             // This is the first line containing text, and there are no HTML entities in this line.

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -475,7 +475,7 @@ impl<'a> StyledComponents<'a> {
         for statement in &program.body {
             let Statement::ImportDeclaration(import) = &statement else { continue };
             let Some(specifiers) = &import.specifiers else { continue };
-            if !is_valid_styled_component_source(&import.source.value) {
+            if !import.source.value.as_str().is_some_and(is_valid_styled_component_source) {
                 continue;
             }
 
@@ -1161,7 +1161,7 @@ mod tests {
                 SPAN,
                 TemplateElementValue {
                     raw: Str::from_str_in(input, &ast),
-                    cooked: Some(Str::from_str_in(input, &ast)),
+                    cooked: Some(Str::from_str_in(input, &ast).into()),
                 },
                 true,
                 &ast,

--- a/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
+++ b/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
@@ -157,7 +157,7 @@ impl<'a> TaggedTemplateTransform {
         let cooked_elements = ArenaVec::from_iter_in(
             template_lit.quasis.iter().map(|quasi| {
                 let expr = if let Some(cooked) = &quasi.value.cooked {
-                    if cooked.as_str() != quasi.value.raw.as_str() {
+                    if cooked.as_str() != Some(quasi.value.raw.as_str()) {
                         needs_raw_array = true;
                     }
                     Expression::new_string_literal(SPAN, *cooked, None, ctx)

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -480,9 +480,10 @@ impl<'a> TypeScriptEnum {
                 .get_binding(scope_id, ident.name.as_str().into())
                 .and_then(|sym_id| ctx.scoping().get_enum_member_value(sym_id))
                 .is_some(),
-            TSEnumMemberName::String(lit) | TSEnumMemberName::ComputedString(lit) => ctx
-                .scoping()
-                .get_binding(scope_id, lit.value.as_str().into())
+            TSEnumMemberName::String(lit) | TSEnumMemberName::ComputedString(lit) => lit
+                .value
+                .as_str()
+                .and_then(|name| ctx.scoping().get_binding(scope_id, name.into()))
                 .and_then(|sym_id| ctx.scoping().get_enum_member_value(sym_id))
                 .is_some(),
             TSEnumMemberName::ComputedTemplateString(_) => false,
@@ -533,7 +534,8 @@ impl<'a> TypeScriptEnum {
     ) -> Option<(ConstantValue, ReferenceId)> {
         let Expression::Identifier(ident) = &expr.object else { return None };
         let Expression::StringLiteral(prop) = &expr.expression else { return None };
-        self.resolve_enum_member(ident, prop.value.as_str(), ctx)
+        let prop_str = prop.value.as_str()?;
+        self.resolve_enum_member(ident, prop_str, ctx)
     }
 
     /// Resolve an enum member value by identifier and property name.

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -163,13 +163,7 @@ impl<'a> TypeScriptModule {
                 let callee =
                     ctx.create_ident_expr(SPAN, require, require_symbol_id, ReferenceFlags::Read);
                 let str_lit = &reference.expression;
-                let str_lit = StringLiteral::boxed_with_lone_surrogates(
-                    str_lit.span,
-                    str_lit.value,
-                    str_lit.raw,
-                    str_lit.lone_surrogates,
-                    ctx,
-                );
+                let str_lit = StringLiteral::boxed(str_lit.span, str_lit.value, str_lit.raw, ctx);
                 let argument = Argument::StringLiteral(str_lit);
                 (
                     VariableDeclarationKind::Const,

--- a/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
+++ b/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
@@ -53,8 +53,9 @@ impl TypeScriptRewriteExtensions {
     }
 
     pub fn rewrite_extensions<'a>(&self, source: &mut StringLiteral<'a>, ctx: &TraverseCtx<'a>) {
-        if let Some(rewritten) = rewritten_specifier(source.value.as_str(), self.mode, ctx) {
-            source.value = rewritten;
+        let Some(str_val) = source.value.as_str() else { return };
+        if let Some(rewritten) = rewritten_specifier(str_val, self.mode, ctx) {
+            source.value = rewritten.into();
             source.raw = None;
         }
     }
@@ -74,7 +75,7 @@ impl TypeScriptRewriteExtensions {
         // specifiers never do.
         if let Some(rewritten) = rewritten_specifier(quasi.value.raw.as_str(), self.mode, ctx) {
             quasi.value.raw = rewritten;
-            quasi.value.cooked = Some(rewritten);
+            quasi.value.cooked = Some(rewritten.into());
         }
     }
 }

--- a/crates/oxc_transformer_plugins/src/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/src/replace_global_defines.rs
@@ -675,7 +675,7 @@ impl<'a> ReplaceGlobalDefines<'a> {
         let leaf = static_property_name_of_computed_expr(member)?;
         // TODO: meta_property_define
         let value = self.find_dot_define_value(
-            leaf.as_str(),
+            leaf,
             DotDefineMemberExpression::ComputedMemberExpression(member),
         )?;
         Some(self.parse_value(&value))
@@ -963,7 +963,7 @@ impl<'a> ReplaceGlobalDefines<'a> {
                     }
                     Expression::ComputedMemberExpression(computed_member) => {
                         static_property_name_of_computed_expr(computed_member).map(|name| {
-                            cur_part_name = name.as_str();
+                            cur_part_name = name;
                             DotDefineMemberExpression::ComputedMemberExpression(computed_member)
                         })
                     }
@@ -1078,7 +1078,7 @@ impl<'b, 'a> DotDefineMemberExpression<'b, 'a> {
                 Some(expr.property.name.as_arena_str())
             }
             DotDefineMemberExpression::ComputedMemberExpression(expr) => {
-                static_property_name_of_computed_expr(expr).copied()
+                static_property_name_of_computed_expr(expr).map(Str::from)
             }
         }
     }
@@ -1091,13 +1091,13 @@ impl<'b, 'a> DotDefineMemberExpression<'b, 'a> {
     }
 }
 
-fn static_property_name_of_computed_expr<'b, 'a: 'b>(
-    expr: &'b ComputedMemberExpression<'a>,
-) -> Option<&'b Str<'a>> {
+fn static_property_name_of_computed_expr<'a>(
+    expr: &ComputedMemberExpression<'a>,
+) -> Option<&'a str> {
     match &expr.expression {
-        Expression::StringLiteral(lit) => Some(&lit.value),
+        Expression::StringLiteral(lit) => lit.value.as_str(),
         Expression::TemplateLiteral(lit) if lit.expressions.is_empty() && lit.quasis.len() == 1 => {
-            Some(&lit.quasis[0].value.raw)
+            Some(lit.quasis[0].value.raw.as_str())
         }
         _ => None,
     }

--- a/crates/oxc_traverse/src/ast_operations/gather_node_parts.rs
+++ b/crates/oxc_traverse/src/ast_operations/gather_node_parts.rs
@@ -575,7 +575,7 @@ impl<'a> GatherNodeParts<'a> for PrivateIdentifier<'a> {
 
 impl<'a> GatherNodeParts<'a> for StringLiteral<'a> {
     fn gather<F: FnMut(&str)>(&self, f: &mut F) {
-        f(self.value.as_str());
+        f(&self.value.to_string_lossy());
     }
 }
 

--- a/crates/oxc_type_checker/src/compiler/references.rs
+++ b/crates/oxc_type_checker/src/compiler/references.rs
@@ -168,19 +168,31 @@ impl Collector {
                     &decl.module_reference
                 {
                     let name = &reference.expression;
-                    self.add_static(name.span.start, &name.value, in_ambient_module);
+                    self.add_static(
+                        name.span.start,
+                        name.value.as_str().unwrap_or_default(),
+                        in_ambient_module,
+                    );
                 }
             }
             // Top-level imports/re-exports are already in the module record; only the ones
             // nested inside ambient module bodies need collecting here.
             Statement::ImportDeclaration(decl) => {
                 if in_ambient_module {
-                    self.add_static(decl.source.span.start, &decl.source.value, true);
+                    self.add_static(
+                        decl.source.span.start,
+                        decl.source.value.as_str().unwrap_or_default(),
+                        true,
+                    );
                 }
             }
             Statement::ExportFromDeclaration(decl) => {
                 if in_ambient_module {
-                    self.add_static(decl.source.span.start, &decl.source.value, true);
+                    self.add_static(
+                        decl.source.span.start,
+                        decl.source.value.as_str().unwrap_or_default(),
+                        true,
+                    );
                 }
             }
             Statement::ExportDeclaration(decl) => {
@@ -190,12 +202,20 @@ impl Collector {
                         &decl.module_reference
                 {
                     let name = &reference.expression;
-                    self.add_static(name.span.start, &name.value, in_ambient_module);
+                    self.add_static(
+                        name.span.start,
+                        name.value.as_str().unwrap_or_default(),
+                        in_ambient_module,
+                    );
                 }
             }
             Statement::ExportAllDeclaration(decl) => {
                 if in_ambient_module {
-                    self.add_static(decl.source.span.start, &decl.source.value, true);
+                    self.add_static(
+                        decl.source.span.start,
+                        decl.source.value.as_str().unwrap_or_default(),
+                        true,
+                    );
                 }
             }
             Statement::TSExternalModuleDeclaration(decl) => {
@@ -207,9 +227,13 @@ impl Collector {
                 // external modules: in an external module file, any of them; in a script file,
                 // the non-relative ones immediately nested in a top-level ambient module.
                 if self.is_external_module
-                    || (in_ambient_module && !is_external_module_name_relative(&name.value))
+                    || (in_ambient_module
+                        && !is_external_module_name_relative(
+                            name.value.as_str().unwrap_or_default(),
+                        ))
                 {
-                    self.module_augmentations.push(CompactStr::from(name.value.as_str()));
+                    self.module_augmentations
+                        .push(CompactStr::from(name.value.as_str().unwrap_or_default()));
                 } else if !in_ambient_module {
                     // A top-level ambient module declaration in a script file *declares* the
                     // module — nothing to resolve, but its body may reference other modules.
@@ -249,15 +273,19 @@ impl CallCollector<'_> {
         match expression {
             Expression::StringLiteral(literal) => {
                 if !literal.value.is_empty() {
-                    self.dynamics
-                        .push((literal.span.start, CompactStr::from(literal.value.as_str())));
+                    self.dynamics.push((
+                        literal.span.start,
+                        CompactStr::from(literal.value.as_str().unwrap_or_default()),
+                    ));
                 }
             }
             Expression::TemplateLiteral(template) if template.is_no_substitution_template() => {
-                let value = template.quasis[0].value.cooked.as_ref().map_or_else(
-                    || template.quasis[0].value.raw.as_str(),
-                    |cooked| cooked.as_str(),
-                );
+                let value = template.quasis[0]
+                    .value
+                    .cooked
+                    .as_ref()
+                    .and_then(oxc_str::Wtf8Str::as_str)
+                    .unwrap_or(template.quasis[0].value.raw.as_str());
                 if !value.is_empty() {
                     self.dynamics.push((template.span.start, CompactStr::from(value)));
                 }
@@ -275,7 +303,10 @@ impl<'a> Visit<'a> for CallCollector<'_> {
 
     fn visit_ts_import_type(&mut self, it: &TSImportType<'a>) {
         if !it.source.value.is_empty() {
-            self.dynamics.push((it.source.span.start, CompactStr::from(it.source.value.as_str())));
+            self.dynamics.push((
+                it.source.span.start,
+                CompactStr::from(it.source.value.as_str().unwrap_or_default()),
+            ));
         }
         // Type arguments may nest further import types.
         walk::walk_ts_import_type(self, it);

--- a/crates/oxc_wtf8/Cargo.toml
+++ b/crates/oxc_wtf8/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "oxc_wtf8"
+version = "0.146.0"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+include = ["/src"]
+keywords.workspace = true
+license.workspace = true
+publish = true
+repository.workspace = true
+rust-version.workspace = true
+description = "WTF-8 encoding for oxc — lone surrogate support"
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false
+
+[features]
+default = []

--- a/crates/oxc_wtf8/README.md
+++ b/crates/oxc_wtf8/README.md
@@ -1,0 +1,23 @@
+# `oxc_wtf8`
+
+WTF-8 encoding for oxc — lossless storage of JavaScript strings containing lone surrogates.
+
+## Overview
+
+[WTF-8](https://simonsapin.github.io/wtf-8/) is a superset of UTF-8 that additionally encodes
+lone surrogate code points (U+D800..U+DFFF) as 3-byte sequences (`ED A0 80` .. `ED BF BF`).
+
+JavaScript strings are arbitrary sequences of UTF-16 code units and may contain unpaired
+surrogates (e.g. `"\uD800"`). Standard UTF-8 cannot represent these, but WTF-8 can — so oxc
+uses WTF-8 as its internal string representation to store such strings **without loss**,
+while remaining byte-compatible with UTF-8 for all well-formed input.
+
+This crate is ported from SWC's `hstr::wtf8` (MIT), which itself derives from
+[`rust-wtf8`](https://github.com/SimonSapin/rust-wtf8) and Rust std's `Utf8Error` handling.
+
+## Relationship to `oxc_str`
+
+This crate provides the raw encoding primitives. The arena-friendly wrapper used across the
+oxc AST is [`oxc_str::Wtf8Str`](https://docs.rs/oxc_str/latest/oxc_str/struct.Wtf8Str.html)
+(`&'a Wtf8` allocated in an `oxc_allocator::Allocator`), which backs
+`StringLiteral::value`, `TemplateElementValue::cooked`, and `JSXText::value`.

--- a/crates/oxc_wtf8/src/lib.rs
+++ b/crates/oxc_wtf8/src/lib.rs
@@ -1,0 +1,17 @@
+//! WTF-8 encoding for oxc — allows storing lone surrogates.
+//! Ported from SWC's `hstr::wtf8` (MIT, originally rust-wtf8 / Rust std).
+//!
+//! WTF-8 is a superset of UTF-8 that also encodes lone surrogates (U+D800..U+DFFF)
+//! as 3-byte sequences (ED A0 80 .. ED BF BF). This lets JavaScript strings
+//! containing lone surrogates be stored without loss.
+
+#![allow(clippy::many_single_char_names)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::inline_always)]
+#![allow(unsafe_op_in_unsafe_fn)]
+
+extern crate alloc;
+
+pub mod wtf8;
+
+pub use wtf8::{CodePoint, Wtf8, Wtf8Buf};

--- a/crates/oxc_wtf8/src/wtf8/mod.rs
+++ b/crates/oxc_wtf8/src/wtf8/mod.rs
@@ -1,0 +1,1468 @@
+// Copyright (c) 2014 Simon Sapin
+// Licensed under the MIT License
+// Original source: https://github.com/SimonSapin/rust-wtf8
+
+/*!
+
+Implementation of [the WTF-8 encoding](https://simonsapin.github.io/wtf-8/).
+
+This library uses Rust’s type system to maintain
+[well-formedness](https://simonsapin.github.io/wtf-8/#well-formed),
+like the `String` and `&str` types do for UTF-8.
+
+Since [WTF-8 must not be used
+for interchange](https://simonsapin.github.io/wtf-8/#intended-audience),
+this library deliberately does not provide access to the underlying bytes
+of WTF-8 strings,
+nor can it decode WTF-8 from arbitrary bytes.
+WTF-8 strings can be obtained from UTF-8, UTF-16, or code points.
+
+*/
+
+extern crate alloc;
+
+use alloc::{
+    borrow::{Borrow, Cow},
+    string::String,
+    vec::Vec,
+};
+use core::ops::Add;
+use core::{
+    fmt, hash,
+    iter::{FromIterator, IntoIterator},
+    ops::Deref,
+    slice, str,
+    str::FromStr,
+};
+
+mod not_quite_std;
+
+static UTF8_REPLACEMENT_CHARACTER: &[u8] = b"\xEF\xBF\xBD";
+
+/// A Unicode code point: from U+0000 to U+10FFFF.
+///
+/// Compare with the `char` type,
+/// which represents a Unicode scalar value:
+/// a code point that is not a surrogate (U+D800 to U+DFFF).
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone)]
+pub struct CodePoint {
+    value: u32,
+}
+
+impl Copy for CodePoint {}
+
+/// Format the code point as `U+` followed by four to six hexadecimal digits.
+/// Example: `U+1F4A9`
+impl fmt::Debug for CodePoint {
+    #[inline]
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(formatter, "U+{:04X}", self.value)
+    }
+}
+
+impl CodePoint {
+    /// Unsafely create a new `CodePoint` without checking the value.
+    ///
+    /// # Safety
+    ///
+    /// Only use when `value` is known to be less than or equal to 0x10FFFF.
+    #[inline]
+    pub const unsafe fn from_u32_unchecked(value: u32) -> CodePoint {
+        CodePoint { value }
+    }
+
+    /// Create a new `CodePoint` if the value is a valid code point.
+    ///
+    /// Return `None` if `value` is above 0x10FFFF.
+    #[inline]
+    pub const fn from_u32(value: u32) -> Option<CodePoint> {
+        match value {
+            0..=0x10_FFFF => Some(CodePoint { value }),
+            _ => None,
+        }
+    }
+
+    /// Create a new `CodePoint` from a `char`.
+    ///
+    /// Since all Unicode scalar values are code points, this always succeeds.
+    #[inline]
+    pub const fn from_char(value: char) -> CodePoint {
+        CodePoint { value: value as u32 }
+    }
+
+    /// Return the numeric value of the code point.
+    #[inline]
+    pub fn to_u32(self) -> u32 {
+        self.value
+    }
+
+    /// Optionally return a Unicode scalar value for the code point.
+    ///
+    /// Return `None` if the code point is a surrogate (from U+D800 to U+DFFF).
+    #[inline]
+    pub fn to_char(self) -> Option<char> {
+        match self.value {
+            0xd800..=0xdfff => None,
+            // SAFETY: `self.value` is not a surrogate, so it is a valid `char`.
+            _ => Some(unsafe { char::from_u32_unchecked(self.value) }),
+        }
+    }
+
+    /// Return a Unicode scalar value for the code point.
+    ///
+    /// Return `'\u{FFFD}'` (the replacement character “�”)
+    /// if the code point is a surrogate (from U+D800 to U+DFFF).
+    #[inline]
+    pub fn to_char_lossy(self) -> char {
+        self.to_char().unwrap_or('\u{FFFD}')
+    }
+
+    /// Return `true` if the code point is in the ASCII range.
+    #[inline]
+    pub const fn is_ascii(self) -> bool {
+        self.value <= 0x7f
+    }
+}
+
+impl PartialEq<char> for CodePoint {
+    fn eq(&self, other: &char) -> bool {
+        self.value == *other as u32
+    }
+}
+
+/// An owned, growable string of well-formed WTF-8 data.
+///
+/// Similar to `String`, but can additionally contain surrogate code points
+/// if they’re not in a surrogate pair.
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone)]
+pub struct Wtf8Buf {
+    bytes: Vec<u8>,
+}
+
+impl Deref for Wtf8Buf {
+    type Target = Wtf8;
+
+    fn deref(&self) -> &Wtf8 {
+        // SAFETY: `Wtf8` is transparent over `[u8]`, and the bytes are valid WTF-8.
+        unsafe { &*(std::ptr::from_ref::<[u8]>(self.bytes.as_slice()) as *const Wtf8) }
+    }
+}
+
+/// Format the string with double quotes,
+/// and surrogates as `\u` followed by four hexadecimal digits.
+/// Example: `"a\u{D800}"` for a string with code points [U+0061, U+D800]
+impl fmt::Debug for Wtf8Buf {
+    #[inline]
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        Wtf8::fmt(self, formatter)
+    }
+}
+
+impl Default for Wtf8Buf {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FromStr for Wtf8Buf {
+    type Err = core::convert::Infallible;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Wtf8Buf { bytes: s.as_bytes().to_vec() })
+    }
+}
+
+impl fmt::Write for Wtf8Buf {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.push_str(s);
+        Ok(())
+    }
+}
+
+impl Add<&Wtf8> for Wtf8Buf {
+    type Output = Wtf8Buf;
+
+    fn add(self, rhs: &Wtf8) -> Self::Output {
+        let mut result = self;
+        result.push_wtf8(rhs);
+        result
+    }
+}
+
+impl Wtf8Buf {
+    /// Create an new, empty WTF-8 string.
+    #[inline]
+    pub fn new() -> Wtf8Buf {
+        Wtf8Buf { bytes: Vec::new() }
+    }
+
+    /// Create an new, empty WTF-8 string with pre-allocated capacity for `n`
+    /// bytes.
+    #[inline]
+    pub fn with_capacity(n: usize) -> Wtf8Buf {
+        Wtf8Buf { bytes: Vec::with_capacity(n) }
+    }
+
+    /// Create a WTF-8 string from an UTF-8 `String`.
+    ///
+    /// This takes ownership of the `String` and does not copy.
+    ///
+    /// Since WTF-8 is a superset of UTF-8, this always succeeds.
+    #[inline]
+    pub fn from_string(string: String) -> Wtf8Buf {
+        Wtf8Buf { bytes: string.into_bytes() }
+    }
+
+    /// Create a WTF-8 string from an UTF-8 `&str` slice.
+    ///
+    /// This copies the content of the slice.
+    ///
+    /// Since WTF-8 is a superset of UTF-8, this always succeeds.
+    #[inline]
+    #[expect(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Wtf8Buf {
+        Wtf8Buf { bytes: s.as_bytes().to_vec() }
+    }
+
+    /// Create a WTF-8 string from a potentially ill-formed UTF-16 slice of
+    /// 16-bit code units.
+    ///
+    /// This is lossless: calling `.to_ill_formed_utf16()` on the resulting
+    /// string will always return the original code units.
+    pub fn from_ill_formed_utf16(v: &[u16]) -> Wtf8Buf {
+        let mut string = Wtf8Buf::with_capacity(v.len());
+        for item in not_quite_std::decode_utf16(v.iter().copied()) {
+            match item {
+                Ok(c) => string.push_char(c),
+                Err(s) => {
+                    // SAFETY: surrogates are known to be in the code point range.
+                    let code_point = unsafe { CodePoint::from_u32_unchecked(u32::from(s)) };
+                    // Skip the WTF-8 concatenation check,
+                    // surrogate pairs are already decoded by utf16_items
+                    not_quite_std::push_code_point(&mut string, code_point);
+                }
+            }
+        }
+        string
+    }
+
+    /// Reserves capacity for at least `additional` more bytes to be inserted
+    /// in the given `Wtf8Buf`.
+    /// The collection may reserve more space to avoid frequent reallocations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `usize`.
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.bytes.reserve(additional);
+    }
+
+    /// Returns the number of bytes that this string buffer can hold without
+    /// reallocating.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.bytes.capacity()
+    }
+
+    /// Append an UTF-8 slice at the end of the string.
+    #[inline]
+    pub fn push_str(&mut self, other: &str) {
+        self.bytes.extend_from_slice(other.as_bytes());
+    }
+
+    /// Append a WTF-8 slice at the end of the string.
+    ///
+    /// This replaces newly paired surrogates at the boundary
+    /// with a supplementary code point,
+    /// like concatenating ill-formed UTF-16 strings effectively would.
+    #[inline]
+    pub fn push_wtf8(&mut self, other: &Wtf8) {
+        match (self.final_lead_surrogate(), other.initial_trail_surrogate()) {
+            // Replace newly paired surrogates by a supplementary code point.
+            (Some(lead), Some(trail)) => {
+                let len_without_lead_surrogate = self.len() - 3;
+                self.bytes.truncate(len_without_lead_surrogate);
+                let other_without_trail_surrogate = &other.bytes[3..];
+                // 4 bytes for the supplementary code point
+                self.bytes.reserve(4 + other_without_trail_surrogate.len());
+                self.push_char(decode_surrogate_pair(lead, trail));
+                self.bytes.extend_from_slice(other_without_trail_surrogate);
+            }
+            _ => self.bytes.extend_from_slice(&other.bytes),
+        }
+    }
+
+    /// Append a Unicode scalar value at the end of the string.
+    #[inline]
+    pub fn push_char(&mut self, c: char) {
+        not_quite_std::push_code_point(self, CodePoint::from_char(c));
+    }
+
+    /// Append a code point at the end of the string.
+    ///
+    /// This replaces newly paired surrogates at the boundary
+    /// with a supplementary code point,
+    /// like concatenating ill-formed UTF-16 strings effectively would.
+    #[inline]
+    pub fn push(&mut self, code_point: CodePoint) {
+        if let trail @ 0xdc00..=0xdfff = code_point.to_u32()
+            && let Some(lead) = self.final_lead_surrogate()
+        {
+            let len_without_lead_surrogate = self.len() - 3;
+            self.bytes.truncate(len_without_lead_surrogate);
+            self.push_char(decode_surrogate_pair(lead, trail as u16));
+            return;
+        }
+
+        // No newly paired surrogates at the boundary.
+        not_quite_std::push_code_point(self, code_point);
+    }
+
+    /// Shortens a string to the specified length.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `new_len` > current length,
+    /// or if `new_len` is not a code point boundary.
+    #[inline]
+    pub fn truncate(&mut self, new_len: usize) {
+        assert!(
+            not_quite_std::is_code_point_boundary(self, new_len),
+            "new_len {new_len} does not lie on a code point boundary"
+        );
+        self.bytes.truncate(new_len);
+    }
+
+    /// Clear the WTF-8 vector, removing all contents.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.bytes.clear();
+    }
+
+    /// Consume the WTF-8 string and try to convert it to UTF-8.
+    ///
+    /// This does not copy the data.
+    ///
+    /// If the contents are not well-formed UTF-8
+    /// (that is, if the string contains surrogates),
+    /// the original WTF-8 string is returned instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(self)` if the string contains surrogates.
+    pub fn into_string(self) -> Result<String, Wtf8Buf> {
+        match self.next_surrogate(0) {
+            // SAFETY: no surrogates, so the bytes are valid UTF-8.
+            None => Ok(unsafe { String::from_utf8_unchecked(self.bytes) }),
+            Some(_) => Err(self),
+        }
+    }
+
+    /// Consume the WTF-8 string and convert it lossily to UTF-8.
+    ///
+    /// This does not copy the data (but may overwrite parts of it in place).
+    ///
+    /// Surrogates are replaced with `"\u{FFFD}"` (the replacement character
+    /// “�”)
+    pub fn into_string_lossy(mut self) -> String {
+        let mut pos = 0;
+        loop {
+            match self.next_surrogate(pos) {
+                Some((surrogate_pos, _)) => {
+                    pos = surrogate_pos + 3;
+                    self.bytes[surrogate_pos..pos].copy_from_slice(UTF8_REPLACEMENT_CHARACTER);
+                }
+                // SAFETY: all surrogates have been replaced with U+FFFD, so valid UTF-8.
+                None => return unsafe { String::from_utf8_unchecked(self.bytes) },
+            }
+        }
+    }
+
+    /// Create a [Wtf8Buf] from a WTF-8 encoded byte vector.
+    ///
+    /// Returns `Ok(Wtf8Buf)` if the bytes are well-formed WTF-8, or
+    /// `Err(bytes)` with the original bytes if validation fails.
+    ///
+    /// This validates that:
+    /// - All bytes form valid UTF-8 sequences OR valid surrogate code point
+    ///   encodings
+    /// - Surrogate code points may appear unpaired and be encoded separately,
+    ///   but if they are paired, they must be encoded as a single 4-byte UTF-8
+    ///   sequence. For example, the byte sequence `[0xED, 0xA0, 0x80, 0xED,
+    ///   0xB0, 0x80]` is not valid WTF-8 because WTF-8 forbids encoding a
+    ///   surrogate pair as two separate 3-byte sequences.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(bytes)` with the original bytes if validation fails.
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, Vec<u8>> {
+        if not_quite_std::validate_wtf8(&bytes) { Ok(Self { bytes }) } else { Err(bytes) }
+    }
+
+    /// Create a [Wtf8Buf] from a WTF-8 encoded byte vector without checking
+    /// that the bytes contain valid WTF-8.
+    ///
+    /// For the safe version, see [Wtf8Buf::from_bytes].
+    ///
+    /// # Safety
+    ///
+    /// The bytes passed in must be valid WTF-8. See [Wtf8Buf::from_bytes] for
+    /// the requirements.
+    #[inline]
+    pub unsafe fn from_bytes_unchecked(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+}
+
+/// Create a new WTF-8 string from an iterator of code points.
+///
+/// This replaces surrogate code point pairs with supplementary code points,
+/// like concatenating ill-formed UTF-16 strings effectively would.
+impl FromIterator<CodePoint> for Wtf8Buf {
+    fn from_iter<T: IntoIterator<Item = CodePoint>>(iterable: T) -> Wtf8Buf {
+        let mut string = Wtf8Buf::new();
+        string.extend(iterable);
+        string
+    }
+}
+
+/// Append code points from an iterator to the string.
+///
+/// This replaces surrogate code point pairs with supplementary code points,
+/// like concatenating ill-formed UTF-16 strings effectively would.
+impl Extend<CodePoint> for Wtf8Buf {
+    fn extend<T: IntoIterator<Item = CodePoint>>(&mut self, iterable: T) {
+        let iterator = iterable.into_iter();
+        let (low, _high) = iterator.size_hint();
+        // Lower bound of one byte per code point (ASCII only)
+        self.bytes.reserve(low);
+        for code_point in iterator {
+            self.push(code_point);
+        }
+    }
+}
+
+/// A borrowed slice of well-formed WTF-8 data.
+///
+/// Similar to `&str`, but can additionally contain surrogate code points
+/// if they're not in a surrogate pair.
+#[repr(transparent)]
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub struct Wtf8 {
+    bytes: [u8],
+}
+
+/// Format the slice with double quotes,
+/// and surrogates as `\u` followed by four hexadecimal digits.
+/// Example: `"a\u{D800}"` for a slice with code points [U+0061, U+D800]
+impl fmt::Debug for Wtf8 {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        formatter.write_str("\"")?;
+        let mut pos = 0;
+        loop {
+            match self.next_surrogate(pos) {
+                None => break,
+                Some((surrogate_pos, surrogate)) => {
+                    // SAFETY: bytes before the surrogate are valid UTF-8.
+                    formatter.write_str(unsafe {
+                        str::from_utf8_unchecked(&self.bytes[pos..surrogate_pos])
+                    })?;
+                    write!(formatter, "\\u{{{surrogate:X}}}")?;
+                    pos = surrogate_pos + 3;
+                }
+            }
+        }
+        // SAFETY: bytes after the last surrogate are valid UTF-8.
+        formatter.write_str(unsafe { str::from_utf8_unchecked(&self.bytes[pos..]) })?;
+        formatter.write_str("\"")
+    }
+}
+
+impl Wtf8 {
+    /// Create a WTF-8 slice from a UTF-8 `&str` slice.
+    ///
+    /// Since WTF-8 is a superset of UTF-8, this always succeeds.
+    #[inline]
+    pub const fn from_str(value: &str) -> &Wtf8 {
+        // SAFETY: `Wtf8` is transparent over `[u8]`, and UTF-8 bytes are valid WTF-8.
+        unsafe { &*(std::ptr::from_ref::<[u8]>(value.as_bytes()) as *const Wtf8) }
+    }
+
+    /// Return the length, in WTF-8 bytes.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Return `true` if the string has a length of zero bytes.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
+    /// Return `true` if the string contains only ASCII characters.
+    #[inline]
+    pub const fn is_ascii(&self) -> bool {
+        let mut i = 0;
+
+        while i < self.bytes.len() {
+            if !self.bytes[i].is_ascii() {
+                return false;
+            }
+
+            i += 1;
+        }
+
+        true
+    }
+
+    /// Return a slice of the given string for the byte range [`begin`..`end`).
+    ///
+    /// # Failure
+    ///
+    /// Fails when `begin` and `end` do not point to code point boundaries,
+    /// or point beyond the end of the string.
+    #[inline]
+    pub fn slice(&self, begin: usize, end: usize) -> &Wtf8 {
+        // is_code_point_boundary checks that the index is in [0, .len()]
+        if begin <= end
+            && not_quite_std::is_code_point_boundary(self, begin)
+            && not_quite_std::is_code_point_boundary(self, end)
+        {
+            // SAFETY: `begin`/`end` are checked code point boundaries in bounds.
+            unsafe { not_quite_std::slice_unchecked(self, begin, end) }
+        } else {
+            not_quite_std::slice_error_fail(self, begin, end)
+        }
+    }
+
+    /// Return a slice of the given string from byte `begin` to its end.
+    ///
+    /// # Failure
+    ///
+    /// Fails when `begin` is not at a code point boundary,
+    /// or is beyond the end of the string.
+    #[inline]
+    pub fn slice_from(&self, begin: usize) -> &Wtf8 {
+        // is_code_point_boundary checks that the index is in [0, .len()]
+        if not_quite_std::is_code_point_boundary(self, begin) {
+            // SAFETY: `begin` is a checked code point boundary in bounds.
+            unsafe { not_quite_std::slice_unchecked(self, begin, self.len()) }
+        } else {
+            not_quite_std::slice_error_fail(self, begin, self.len())
+        }
+    }
+
+    /// Return a slice of the given string from its beginning to byte `end`.
+    ///
+    /// # Failure
+    ///
+    /// Fails when `end` is not at a code point boundary,
+    /// or is beyond the end of the string.
+    #[inline]
+    pub fn slice_to(&self, end: usize) -> &Wtf8 {
+        // is_code_point_boundary checks that the index is in [0, .len()]
+        if not_quite_std::is_code_point_boundary(self, end) {
+            // SAFETY: `end` is a checked code point boundary in bounds.
+            unsafe { not_quite_std::slice_unchecked(self, 0, end) }
+        } else {
+            not_quite_std::slice_error_fail(self, 0, end)
+        }
+    }
+
+    /// Return the code point at `position` if it is in the ASCII range,
+    /// or `b'\xFF' otherwise.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `position` is beyond the end of the string.
+    #[inline]
+    pub fn ascii_byte_at(&self, position: usize) -> u8 {
+        match self.bytes[position] {
+            ascii_byte @ 0x00..=0x7f => ascii_byte,
+            _ => 0xff,
+        }
+    }
+
+    /// Return an iterator for the string’s code points.
+    #[inline]
+    pub fn code_points(&self) -> Wtf8CodePoints<'_> {
+        Wtf8CodePoints { bytes: self.bytes.iter() }
+    }
+
+    /// Returns `true` if this WTF-8 string contains the given character.
+    #[inline]
+    pub fn contains_char(&self, ch: char) -> bool {
+        let target = CodePoint::from_char(ch);
+        self.contains(target)
+    }
+
+    /// Returns `true` if this WTF-8 string contains the given code point.
+    #[inline]
+    pub fn contains(&self, code_point: CodePoint) -> bool {
+        self.code_points().any(|cp| cp == code_point)
+    }
+
+    /// Returns `true` if this WTF-8 string starts with the given UTF-8 string.
+    #[inline]
+    pub fn starts_with(&self, pattern: &str) -> bool {
+        if pattern.len() > self.len() {
+            return false;
+        }
+
+        let pattern_wtf8 = self.slice_to(pattern.len());
+        if let Some(pattern_str) = pattern_wtf8.as_str() { pattern_str == pattern } else { false }
+    }
+
+    /// Try to convert the string to UTF-8 and return a `&str` slice.
+    ///
+    /// Return `None` if the string contains surrogates.
+    ///
+    /// This does not copy the data.
+    #[inline]
+    pub fn as_str(&self) -> Option<&str> {
+        // Well-formed WTF-8 is also well-formed UTF-8
+        // if and only if it contains no surrogate.
+        match self.next_surrogate(0) {
+            // SAFETY: no surrogates, so the bytes are valid UTF-8.
+            None => Some(unsafe { str::from_utf8_unchecked(&self.bytes) }),
+            Some(_) => None,
+        }
+    }
+
+    /// Return the underlying WTF-8 bytes.
+    #[inline]
+    pub const fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Lossily convert the string to UTF-8.
+    /// Return an UTF-8 `&str` slice if the contents are well-formed in UTF-8.
+    ///
+    /// Surrogates are replaced with `"\u{FFFD}"` (the replacement character
+    /// “�”).
+    ///
+    /// This only copies the data if necessary (if it contains any surrogate).
+    pub fn to_string_lossy(&self) -> Cow<'_, str> {
+        let surrogate_pos = match self.next_surrogate(0) {
+            // SAFETY: no surrogates, so the bytes are valid UTF-8.
+            None => return Cow::Borrowed(unsafe { str::from_utf8_unchecked(&self.bytes) }),
+            Some((pos, _)) => pos,
+        };
+        let wtf8_bytes = &self.bytes;
+        let mut utf8_bytes = Vec::with_capacity(self.len());
+        utf8_bytes.extend_from_slice(&wtf8_bytes[..surrogate_pos]);
+        utf8_bytes.extend_from_slice(UTF8_REPLACEMENT_CHARACTER);
+        let mut pos = surrogate_pos + 3;
+        loop {
+            if let Some((surrogate_pos, _)) = self.next_surrogate(pos) {
+                utf8_bytes.extend_from_slice(&wtf8_bytes[pos..surrogate_pos]);
+                utf8_bytes.extend_from_slice(UTF8_REPLACEMENT_CHARACTER);
+                pos = surrogate_pos + 3;
+            } else {
+                utf8_bytes.extend_from_slice(&wtf8_bytes[pos..]);
+                // SAFETY: all surrogates replaced with U+FFFD, so valid UTF-8.
+                return Cow::Owned(unsafe { String::from_utf8_unchecked(utf8_bytes) });
+            }
+        }
+    }
+
+    /// Convert the WTF-8 string to potentially ill-formed UTF-16
+    /// and return an iterator of 16-bit code units.
+    ///
+    /// This is lossless:
+    /// calling `Wtf8Buf::from_ill_formed_utf16` on the resulting code units
+    /// would always return the original WTF-8 string.
+    #[inline]
+    pub fn to_ill_formed_utf16(&self) -> IllFormedUtf16CodeUnits<'_> {
+        IllFormedUtf16CodeUnits { code_points: self.code_points(), extra: 0 }
+    }
+
+    /// Returns the uppercase equivalent of this wtf8 slice, as a new [Wtf8Buf].
+    #[inline]
+    pub fn to_uppercase(&self) -> Wtf8Buf {
+        let mut result = Wtf8Buf::with_capacity(self.len());
+        for cp in self.code_points() {
+            if let Some(ch) = cp.to_char() {
+                for upper_ch in ch.to_uppercase() {
+                    result.push_char(upper_ch);
+                }
+            } else {
+                // SAFETY: surrogates are known to be in the code point range.
+                let code_point = unsafe { CodePoint::from_u32_unchecked(cp.to_u32()) };
+                // Skip the WTF-8 concatenation check,
+                // surrogate pairs are already decoded by utf16_items
+                not_quite_std::push_code_point(&mut result, code_point);
+            }
+        }
+        result
+    }
+
+    /// Returns the lowercase equivalent of this wtf8 slice, as a new [Wtf8Buf].
+    #[inline]
+    pub fn to_lowercase(&self) -> Wtf8Buf {
+        let mut result = Wtf8Buf::with_capacity(self.len());
+        for cp in self.code_points() {
+            if let Some(ch) = cp.to_char() {
+                for lower_ch in ch.to_lowercase() {
+                    result.push_char(lower_ch);
+                }
+            } else {
+                // SAFETY: surrogates are known to be in the code point range.
+                let code_point = unsafe { CodePoint::from_u32_unchecked(cp.to_u32()) };
+                // Skip the WTF-8 concatenation check,
+                // surrogate pairs are already decoded by utf16_items
+                not_quite_std::push_code_point(&mut result, code_point);
+            }
+        }
+        result
+    }
+
+    /// Create a WTF-8 slice from a WTF-8 encoded byte slice.
+    ///
+    /// Returns `Ok(&Wtf8)` if the bytes are well-formed WTF-8, or
+    /// `Err(bytes)` with the original byte slice if validation fails.
+    ///
+    /// This validates that:
+    /// - All bytes form valid UTF-8 sequences OR valid surrogate code point
+    ///   encodings
+    /// - Surrogate code points may appear unpaired and be encoded separately,
+    ///   but if they are paired, they must be encoded as a single 4-byte UTF-8
+    ///   sequence. For example, the byte sequence `[0xED, 0xA0, 0x80, 0xED,
+    ///   0xB0, 0x80]` is not valid WTF-8 because WTF-8 forbids encoding a
+    ///   surrogate pair as two separate 3-byte sequences.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(bytes)` with the original byte slice if validation fails.
+    pub fn from_bytes(bytes: &[u8]) -> Result<&Wtf8, &[u8]> {
+        if not_quite_std::validate_wtf8(bytes) {
+            // SAFETY: `Wtf8` is transparent over `[u8]`, and bytes validated above.
+            Ok(unsafe { &*(std::ptr::from_ref::<[u8]>(bytes) as *const Wtf8) })
+        } else {
+            Err(bytes)
+        }
+    }
+
+    /// Create a WTF-8 slice from a WTF-8 encoded byte slice without checking
+    /// that the bytes contain valid WTF-8.
+    ///
+    /// For the safe version, see [Wtf8::from_bytes].
+    ///
+    /// # Safety
+    ///
+    /// The bytes passed in must be valid WTF-8. See [Wtf8::from_bytes] for
+    /// the requirements.
+    #[inline]
+    pub const unsafe fn from_bytes_unchecked(bytes: &[u8]) -> &Wtf8 {
+        // SAFETY: caller guarantees `bytes` is valid WTF-8; `Wtf8` is transparent over `[u8]`.
+        unsafe { &*(std::ptr::from_ref::<[u8]>(bytes) as *const Wtf8) }
+    }
+
+    #[inline]
+    fn next_surrogate(&self, mut pos: usize) -> Option<(usize, u16)> {
+        let mut iter = self.bytes[pos..].iter();
+        loop {
+            let b = match iter.next() {
+                None => return None,
+                Some(&b) => b,
+            };
+            if b < 0x80 {
+                pos += 1;
+            } else if b < 0xe0 {
+                iter.next();
+                pos += 2;
+            } else if b == 0xed {
+                match (iter.next(), iter.next()) {
+                    (Some(&b2), Some(&b3)) if b2 >= 0xa0 => {
+                        return Some((pos, decode_surrogate(b2, b3)));
+                    }
+                    _ => pos += 3,
+                }
+            } else if b < 0xf0 {
+                iter.next();
+                iter.next();
+                pos += 3;
+            } else {
+                iter.next();
+                iter.next();
+                iter.next();
+                pos += 4;
+            }
+        }
+    }
+
+    #[inline]
+    fn final_lead_surrogate(&self) -> Option<u16> {
+        let len = self.len();
+        if len < 3 {
+            return None;
+        }
+        let seq = &self.bytes[len - 3..];
+        if seq[0] == 0xed && 0xa0 <= seq[1] && seq[1] <= 0xaf {
+            Some(decode_surrogate(seq[1], seq[2]))
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn initial_trail_surrogate(&self) -> Option<u16> {
+        let len = self.len();
+        if len < 3 {
+            return None;
+        }
+        let seq = &self.bytes[..3];
+        if seq[0] == 0xed && 0xb0 <= seq[1] && seq[1] <= 0xbf {
+            Some(decode_surrogate(seq[1], seq[2]))
+        } else {
+            None
+        }
+    }
+}
+
+#[inline]
+fn decode_surrogate(second_byte: u8, third_byte: u8) -> u16 {
+    // The first byte is assumed to be 0xED
+    0xd800 | ((u16::from(second_byte) & 0x3f) << 6) | u16::from(third_byte) & 0x3f
+}
+
+#[inline]
+fn decode_surrogate_pair(lead: u16, trail: u16) -> char {
+    let code_point = 0x10000 + (((u32::from(lead) - 0xd800) << 10) | (u32::from(trail) - 0xdc00));
+    // SAFETY: a decoded surrogate pair is always a valid scalar value.
+    unsafe { char::from_u32_unchecked(code_point) }
+}
+
+/// Iterator for the code points of a WTF-8 string.
+///
+/// Created with the method `.code_points()`.
+#[derive(Clone)]
+pub struct Wtf8CodePoints<'a> {
+    bytes: slice::Iter<'a, u8>,
+}
+
+impl Iterator for Wtf8CodePoints<'_> {
+    type Item = CodePoint;
+
+    #[inline]
+    fn next(&mut self) -> Option<CodePoint> {
+        not_quite_std::next_code_point(&mut self.bytes).map(|value| {
+            // SAFETY: the Wtf8 invariant says `value` is a valid code point.
+            unsafe { CodePoint::from_u32_unchecked(value) }
+        })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (len, _) = self.bytes.size_hint();
+        (len.saturating_add(3) / 4, Some(len))
+    }
+}
+
+#[derive(Clone)]
+pub struct IllFormedUtf16CodeUnits<'a> {
+    code_points: Wtf8CodePoints<'a>,
+    extra: u16,
+}
+
+impl Iterator for IllFormedUtf16CodeUnits<'_> {
+    type Item = u16;
+
+    #[inline]
+    fn next(&mut self) -> Option<u16> {
+        not_quite_std::next_utf16_code_unit(self)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (low, high) = self.code_points.size_hint();
+        // every code point gets either one u16 or two u16,
+        // so this iterator is between 1 or 2 times as
+        // long as the underlying iterator.
+        (low, high.and_then(|n| n.checked_mul(2)))
+    }
+}
+
+impl PartialEq<&Wtf8> for Wtf8Buf {
+    fn eq(&self, other: &&Wtf8) -> bool {
+        **self == **other
+    }
+}
+
+impl PartialEq<Wtf8Buf> for &Wtf8 {
+    fn eq(&self, other: &Wtf8Buf) -> bool {
+        **self == **other
+    }
+}
+
+impl PartialEq<str> for &Wtf8 {
+    fn eq(&self, other: &str) -> bool {
+        match self.as_str() {
+            Some(s) => s == other,
+            None => false,
+        }
+    }
+}
+
+impl PartialEq<&str> for &Wtf8 {
+    fn eq(&self, other: &&str) -> bool {
+        match self.as_str() {
+            Some(s) => s == *other,
+            None => false,
+        }
+    }
+}
+
+impl hash::Hash for CodePoint {
+    #[inline]
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
+}
+
+impl hash::Hash for Wtf8Buf {
+    #[inline]
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        Wtf8::hash(self, state);
+    }
+}
+
+impl hash::Hash for Wtf8 {
+    #[inline]
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        state.write(&self.bytes);
+        0xfeu8.hash(state);
+    }
+}
+
+impl Borrow<Wtf8> for Wtf8Buf {
+    #[inline]
+    fn borrow(&self) -> &Wtf8 {
+        self
+    }
+}
+
+impl ToOwned for Wtf8 {
+    type Owned = Wtf8Buf;
+
+    #[inline]
+    fn to_owned(&self) -> Wtf8Buf {
+        Wtf8Buf { bytes: self.bytes.to_vec() }
+    }
+}
+
+impl<'a> From<&'a Wtf8> for Cow<'a, Wtf8> {
+    #[inline]
+    fn from(s: &'a Wtf8) -> Cow<'a, Wtf8> {
+        Cow::Borrowed(s)
+    }
+}
+
+impl<'a> From<&'a str> for &'a Wtf8 {
+    #[inline]
+    fn from(s: &'a str) -> &'a Wtf8 {
+        Wtf8::from_str(s)
+    }
+}
+
+impl<'a> From<Wtf8Buf> for Cow<'a, Wtf8> {
+    #[inline]
+    fn from(s: Wtf8Buf) -> Cow<'a, Wtf8> {
+        Cow::Owned(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, vec};
+
+    use super::*;
+
+    #[test]
+    fn code_point_from_u32() {
+        assert!(CodePoint::from_u32(0).is_some());
+        assert!(CodePoint::from_u32(0xd800).is_some());
+        assert!(CodePoint::from_u32(0x10_FFFF).is_some());
+        assert!(CodePoint::from_u32(0x11_0000).is_none());
+    }
+
+    #[test]
+    fn code_point_to_u32() {
+        fn c(value: u32) -> CodePoint {
+            CodePoint::from_u32(value).unwrap()
+        }
+        assert_eq!(c(0).to_u32(), 0);
+        assert_eq!(c(0xd800).to_u32(), 0xd800);
+        assert_eq!(c(0x10_FFFF).to_u32(), 0x10_FFFF);
+    }
+
+    #[test]
+    fn code_point_from_char() {
+        assert_eq!(CodePoint::from_char('a').to_u32(), 0x61);
+        assert_eq!(CodePoint::from_char('💩').to_u32(), 0x1f4a9);
+    }
+
+    #[test]
+    fn code_point_to_string() {
+        let cp_a = CodePoint::from_char('a');
+        assert_eq!(format!("{cp_a:?}"), "U+0061");
+        let cp_poop = CodePoint::from_char('💩');
+        assert_eq!(format!("{cp_poop:?}"), "U+1F4A9");
+    }
+
+    #[test]
+    fn code_point_to_char() {
+        fn c(value: u32) -> CodePoint {
+            CodePoint::from_u32(value).unwrap()
+        }
+        assert_eq!(c(0x61).to_char(), Some('a'));
+        assert_eq!(c(0x1f4a9).to_char(), Some('💩'));
+        assert_eq!(c(0xd800).to_char(), None);
+    }
+
+    #[test]
+    fn code_point_to_char_lossy() {
+        fn c(value: u32) -> CodePoint {
+            CodePoint::from_u32(value).unwrap()
+        }
+        assert_eq!(c(0x61).to_char_lossy(), 'a');
+        assert_eq!(c(0x1f4a9).to_char_lossy(), '💩');
+        assert_eq!(c(0xd800).to_char_lossy(), '\u{FFFD}');
+    }
+
+    #[test]
+    fn wtf8buf_new() {
+        assert_eq!(Wtf8Buf::new().bytes, b"");
+    }
+
+    #[test]
+    fn wtf8buf_from_str() {
+        assert_eq!(Wtf8Buf::from_str("").bytes, b"");
+        assert_eq!(Wtf8Buf::from_str("aé 💩").bytes, b"a\xC3\xA9 \xF0\x9F\x92\xA9");
+    }
+
+    #[test]
+    fn wtf8buf_from_string() {
+        assert_eq!(Wtf8Buf::from_string(String::new()).bytes, b"");
+        assert_eq!(
+            Wtf8Buf::from_string(String::from("aé 💩")).bytes,
+            b"a\xC3\xA9 \xF0\x9F\x92\xA9"
+        );
+    }
+
+    #[test]
+    fn wtf8buf_from_ill_formed_utf16() {
+        assert_eq!(Wtf8Buf::from_ill_formed_utf16(&[]).bytes, b"");
+        assert_eq!(
+            Wtf8Buf::from_ill_formed_utf16(&[0x61, 0xe9, 0x20, 0xd83d, 0xd83d, 0xdca9]).bytes,
+            b"a\xC3\xA9 \xED\xA0\xBD\xF0\x9F\x92\xA9"
+        );
+    }
+
+    #[test]
+    fn wtf8buf_push_str() {
+        let mut string = Wtf8Buf::new();
+        assert_eq!(string.bytes, b"");
+        string.push_str("aé 💩");
+        assert_eq!(string.bytes, b"a\xC3\xA9 \xF0\x9F\x92\xA9");
+    }
+
+    #[test]
+    fn wtf8buf_push_char() {
+        let mut string = Wtf8Buf::from_str("aé ");
+        assert_eq!(string.bytes, b"a\xC3\xA9 ");
+        string.push_char('💩');
+        assert_eq!(string.bytes, b"a\xC3\xA9 \xF0\x9F\x92\xA9");
+    }
+
+    #[test]
+    fn wtf8buf_push_code_points_of_each_encoded_width() {
+        fn code_point(value: u32) -> CodePoint {
+            CodePoint::from_u32(value).unwrap()
+        }
+
+        let mut string = Wtf8Buf::new();
+
+        string.push(code_point(0x7f));
+        assert_eq!(string.bytes, b"\x7f");
+
+        string.push(code_point(0x80));
+        assert_eq!(string.bytes, b"\x7f\xc2\x80");
+
+        string.push(code_point(0x800));
+        assert_eq!(string.bytes, b"\x7f\xc2\x80\xe0\xa0\x80");
+
+        string.push(code_point(0xd800));
+        assert_eq!(string.bytes, b"\x7f\xc2\x80\xe0\xa0\x80\xed\xa0\x80");
+
+        string.push(code_point(0x10000));
+        assert_eq!(string.bytes, b"\x7f\xc2\x80\xe0\xa0\x80\xed\xa0\x80\xf0\x90\x80\x80");
+    }
+
+    #[test]
+    fn wtf8buf_push() {
+        fn c(value: u32) -> CodePoint {
+            CodePoint::from_u32(value).unwrap()
+        }
+
+        let mut string = Wtf8Buf::from_str("aé ");
+        assert_eq!(string.bytes, b"a\xC3\xA9 ");
+        string.push(CodePoint::from_char('💩'));
+        assert_eq!(string.bytes, b"a\xC3\xA9 \xF0\x9F\x92\xA9");
+
+        let mut string = Wtf8Buf::new();
+        string.push(c(0xd83d)); // lead
+        string.push(c(0xdca9)); // trail
+        assert_eq!(string.bytes, b"\xF0\x9F\x92\xA9"); // Magic!
+
+        let mut string = Wtf8Buf::new();
+        string.push(c(0xd83d)); // lead
+        string.push(c(0x20)); // not surrogate
+        string.push(c(0xdca9)); // trail
+        assert_eq!(string.bytes, b"\xED\xA0\xBD \xED\xB2\xA9");
+
+        let mut string = Wtf8Buf::new();
+        string.push(c(0xd800)); // lead
+        string.push(c(0xdbff)); // lead
+        assert_eq!(string.bytes, b"\xED\xA0\x80\xED\xAF\xBF");
+
+        let mut string = Wtf8Buf::new();
+        string.push(c(0xd800)); // lead
+        string.push(c(0xe000)); // not surrogate
+        assert_eq!(string.bytes, b"\xED\xA0\x80\xEE\x80\x80");
+
+        let mut string = Wtf8Buf::new();
+        string.push(c(0xd7ff)); // not surrogate
+        string.push(c(0xdc00)); // trail
+        assert_eq!(string.bytes, b"\xED\x9F\xBF\xED\xB0\x80");
+
+        let mut string = Wtf8Buf::new();
+        string.push(c(0x61)); // not surrogate, < 3 bytes
+        string.push(c(0xdc00)); // trail
+        assert_eq!(string.bytes, b"\x61\xED\xB0\x80");
+
+        let mut string = Wtf8Buf::new();
+        string.push(c(0xdc00)); // trail
+        assert_eq!(string.bytes, b"\xED\xB0\x80");
+    }
+
+    #[test]
+    fn wtf8buf_push_wtf8() {
+        fn w(value: &[u8]) -> &Wtf8 {
+            // SAFETY: test inputs are valid WTF-8; `Wtf8` is transparent over `[u8]`.
+            unsafe { &*(std::ptr::from_ref::<[u8]>(value) as *const Wtf8) }
+        }
+
+        let mut string = Wtf8Buf::from_str("aé");
+        assert_eq!(string.bytes, b"a\xC3\xA9");
+        string.push_wtf8(Wtf8::from_str(" 💩"));
+        assert_eq!(string.bytes, b"a\xC3\xA9 \xF0\x9F\x92\xA9");
+
+        let mut string = Wtf8Buf::new();
+        string.push_wtf8(w(b"\xED\xA0\xBD")); // lead
+        string.push_wtf8(w(b"\xED\xB2\xA9")); // trail
+        assert_eq!(string.bytes, b"\xF0\x9F\x92\xA9"); // Magic!
+
+        let mut string = Wtf8Buf::new();
+        string.push_wtf8(w(b"\xED\xA0\xBD")); // lead
+        string.push_wtf8(w(b" ")); // not surrogate
+        string.push_wtf8(w(b"\xED\xB2\xA9")); // trail
+        assert_eq!(string.bytes, b"\xED\xA0\xBD \xED\xB2\xA9");
+
+        let mut string = Wtf8Buf::new();
+        string.push_wtf8(w(b"\xED\xA0\x80")); // lead
+        string.push_wtf8(w(b"\xED\xAF\xBF")); // lead
+        assert_eq!(string.bytes, b"\xED\xA0\x80\xED\xAF\xBF");
+
+        let mut string = Wtf8Buf::new();
+        string.push_wtf8(w(b"\xED\xA0\x80")); // lead
+        string.push_wtf8(w(b"\xEE\x80\x80")); // not surrogate
+        assert_eq!(string.bytes, b"\xED\xA0\x80\xEE\x80\x80");
+
+        let mut string = Wtf8Buf::new();
+        string.push_wtf8(w(b"\xED\x9F\xBF")); // not surrogate
+        string.push_wtf8(w(b"\xED\xB0\x80")); // trail
+        assert_eq!(string.bytes, b"\xED\x9F\xBF\xED\xB0\x80");
+
+        let mut string = Wtf8Buf::new();
+        string.push_wtf8(w(b"a")); // not surrogate, < 3 bytes
+        string.push_wtf8(w(b"\xED\xB0\x80")); // trail
+        assert_eq!(string.bytes, b"\x61\xED\xB0\x80");
+
+        let mut string = Wtf8Buf::new();
+        string.push_wtf8(w(b"\xED\xB0\x80")); // trail
+        assert_eq!(string.bytes, b"\xED\xB0\x80");
+    }
+
+    #[test]
+    fn wtf8buf_truncate() {
+        let mut string = Wtf8Buf::from_str("aé");
+        string.truncate(1);
+        assert_eq!(string.bytes, b"a");
+    }
+
+    #[test]
+    #[should_panic(expected = "does not lie on a code point boundary")]
+    fn wtf8buf_truncate_fail_code_point_boundary() {
+        let mut string = Wtf8Buf::from_str("aé");
+        string.truncate(2);
+    }
+
+    #[test]
+    #[should_panic(expected = "does not lie on a code point boundary")]
+    fn wtf8buf_truncate_fail_longer() {
+        let mut string = Wtf8Buf::from_str("aé");
+        string.truncate(4);
+    }
+
+    #[test]
+    fn wtf8buf_into_string() {
+        let mut string = Wtf8Buf::from_str("aé 💩");
+        assert_eq!(string.clone().into_string(), Ok(String::from("aé 💩")));
+        string.push(CodePoint::from_u32(0xd800).unwrap());
+        assert_eq!(string.clone().into_string(), Err(string));
+    }
+
+    #[test]
+    fn wtf8buf_into_string_lossy() {
+        let mut string = Wtf8Buf::from_str("aé 💩");
+        assert_eq!(string.clone().into_string_lossy(), String::from("aé 💩"));
+        string.push(CodePoint::from_u32(0xd800).unwrap());
+        assert_eq!(string.clone().into_string_lossy(), String::from("aé 💩�"));
+    }
+
+    #[test]
+    fn wtf8buf_from_iterator() {
+        fn f(values: &[u32]) -> Wtf8Buf {
+            values.iter().map(|&c| CodePoint::from_u32(c).unwrap()).collect::<Wtf8Buf>()
+        }
+        assert_eq!(f(&[0x61, 0xe9, 0x20, 0x1f4a9]).bytes, b"a\xC3\xA9 \xF0\x9F\x92\xA9");
+
+        assert_eq!(f(&[0xd83d, 0xdca9]).bytes, b"\xF0\x9F\x92\xA9"); // Magic!
+        assert_eq!(f(&[0xd83d, 0x20, 0xdca9]).bytes, b"\xED\xA0\xBD \xED\xB2\xA9");
+        assert_eq!(f(&[0xd800, 0xdbff]).bytes, b"\xED\xA0\x80\xED\xAF\xBF");
+        assert_eq!(f(&[0xd800, 0xe000]).bytes, b"\xED\xA0\x80\xEE\x80\x80");
+        assert_eq!(f(&[0xd7ff, 0xdc00]).bytes, b"\xED\x9F\xBF\xED\xB0\x80");
+        assert_eq!(f(&[0x61, 0xdc00]).bytes, b"\x61\xED\xB0\x80");
+        assert_eq!(f(&[0xdc00]).bytes, b"\xED\xB0\x80");
+    }
+
+    #[test]
+    fn wtf8buf_extend() {
+        fn e(initial: &[u32], extended: &[u32]) -> Wtf8Buf {
+            fn c(value: u32) -> CodePoint {
+                CodePoint::from_u32(value).unwrap()
+            }
+            let mut string = initial.iter().copied().map(c).collect::<Wtf8Buf>();
+            string.extend(extended.iter().copied().map(c));
+            string
+        }
+
+        assert_eq!(e(&[0x61, 0xe9], &[0x20, 0x1f4a9]).bytes, b"a\xC3\xA9 \xF0\x9F\x92\xA9");
+
+        assert_eq!(e(&[0xd83d], &[0xdca9]).bytes, b"\xF0\x9F\x92\xA9"); // Magic!
+        assert_eq!(e(&[0xd83d, 0x20], &[0xdca9]).bytes, b"\xED\xA0\xBD \xED\xB2\xA9");
+        assert_eq!(e(&[0xd800], &[0xdbff]).bytes, b"\xED\xA0\x80\xED\xAF\xBF");
+        assert_eq!(e(&[0xd800], &[0xe000]).bytes, b"\xED\xA0\x80\xEE\x80\x80");
+        assert_eq!(e(&[0xd7ff], &[0xdc00]).bytes, b"\xED\x9F\xBF\xED\xB0\x80");
+        assert_eq!(e(&[0x61], &[0xdc00]).bytes, b"\x61\xED\xB0\x80");
+        assert_eq!(e(&[], &[0xdc00]).bytes, b"\xED\xB0\x80");
+    }
+
+    #[test]
+    fn wtf8buf_debug() {
+        let mut string = Wtf8Buf::from_str("aé 💩");
+        string.push(CodePoint::from_u32(0xd800).unwrap());
+        assert_eq!(format!("{string:?}"), r#""aé 💩\u{D800}""#);
+    }
+
+    #[test]
+    fn wtf8buf_as_slice() {
+        assert_eq!(Wtf8Buf::from_str("aé"), Wtf8::from_str("aé"));
+    }
+
+    #[test]
+    fn wtf8_debug() {
+        let mut string = Wtf8Buf::from_str("aé 💩");
+        string.push(CodePoint::from_u32(0xd800).unwrap());
+        let string_ref = &*string;
+        assert_eq!(format!("{string_ref:?}"), r#""aé 💩\u{D800}""#);
+    }
+
+    #[test]
+    fn wtf8_from_str() {
+        assert_eq!(&Wtf8::from_str("").bytes, b"");
+        assert_eq!(&Wtf8::from_str("aé 💩").bytes, b"a\xC3\xA9 \xF0\x9F\x92\xA9");
+    }
+
+    #[test]
+    fn wtf8_as_bytes() {
+        assert_eq!(Wtf8::from_str("").as_bytes(), b"");
+        assert_eq!(Wtf8::from_str("aé 💩").as_bytes(), b"a\xC3\xA9 \xF0\x9F\x92\xA9");
+    }
+
+    #[test]
+    fn wtf8_from_bytes_unchecked() {
+        // SAFETY: inputs are valid WTF-8.
+        assert_eq!(unsafe { &Wtf8::from_bytes_unchecked(b"").bytes }, b"");
+        {
+            // SAFETY: input is valid WTF-8.
+            let bytes = unsafe { &Wtf8::from_bytes_unchecked(b"a\xC3\xA9 \xF0\x9F\x92\xA9").bytes };
+            assert_eq!(bytes, b"a\xC3\xA9 \xF0\x9F\x92\xA9");
+        }
+        {
+            // SAFETY: input is valid WTF-8.
+            let s = unsafe { Wtf8::from_bytes_unchecked(b"a\xC3\xA9 \xF0\x9F\x92\xA9") };
+            assert_eq!(s, Wtf8::from_str("aé 💩"));
+        }
+    }
+
+    #[test]
+    fn wtf8_cow() {
+        let s: Cow<Wtf8> = Cow::from(Wtf8::from_str("aé 💩"));
+        assert!(matches!(s, Cow::Borrowed(_)));
+        let owned: Wtf8Buf = s.into_owned();
+        assert_eq!(owned, Wtf8Buf::from_str("aé 💩"));
+    }
+
+    #[test]
+    fn wtf8_len() {
+        assert_eq!(Wtf8::from_str("").len(), 0);
+        assert_eq!(Wtf8::from_str("aé 💩").len(), 8);
+    }
+
+    #[test]
+    fn wtf8_slice() {
+        assert_eq!(&Wtf8::from_str("aé 💩").slice(1, 4).bytes, b"\xC3\xA9 ");
+    }
+
+    #[test]
+    #[should_panic(expected = "do not lie on character boundary")]
+    fn wtf8_slice_not_code_point_boundary() {
+        Wtf8::from_str("aé 💩").slice(2, 4);
+    }
+
+    #[test]
+    fn wtf8_slice_from() {
+        assert_eq!(&Wtf8::from_str("aé 💩").slice_from(1).bytes, b"\xC3\xA9 \xF0\x9F\x92\xA9");
+    }
+
+    #[test]
+    #[should_panic(expected = "do not lie on character boundary")]
+    fn wtf8_slice_from_not_code_point_boundary() {
+        Wtf8::from_str("aé 💩").slice_from(2);
+    }
+
+    #[test]
+    fn wtf8_slice_to() {
+        assert_eq!(&Wtf8::from_str("aé 💩").slice_to(4).bytes, b"a\xC3\xA9 ");
+    }
+
+    #[test]
+    #[should_panic(expected = "do not lie on character boundary")]
+    fn wtf8_slice_to_not_code_point_boundary() {
+        Wtf8::from_str("aé 💩").slice_from(5);
+    }
+
+    #[test]
+    fn wtf8_ascii_byte_at() {
+        let slice = Wtf8::from_str("aé 💩");
+        assert_eq!(slice.ascii_byte_at(0), b'a');
+        assert_eq!(slice.ascii_byte_at(1), b'\xFF');
+        assert_eq!(slice.ascii_byte_at(2), b'\xFF');
+        assert_eq!(slice.ascii_byte_at(3), b' ');
+        assert_eq!(slice.ascii_byte_at(4), b'\xFF');
+    }
+
+    #[test]
+    fn wtf8_code_points() {
+        fn c(value: u32) -> CodePoint {
+            CodePoint::from_u32(value).unwrap()
+        }
+        fn cp(string: &Wtf8Buf) -> Vec<Option<char>> {
+            string.code_points().map(super::CodePoint::to_char).collect::<Vec<_>>()
+        }
+        let mut string = Wtf8Buf::from_str("é ");
+        assert_eq!(cp(&string), vec![Some('é'), Some(' ')]);
+        string.push(c(0xd83d));
+        assert_eq!(cp(&string), vec![Some('é'), Some(' '), None]);
+        string.push(c(0xdca9));
+        assert_eq!(cp(&string), vec![Some('é'), Some(' '), Some('💩')]);
+    }
+
+    #[test]
+    fn wtf8_as_str() {
+        assert_eq!(Wtf8::from_str("").as_str(), Some(""));
+        assert_eq!(Wtf8::from_str("aé 💩").as_str(), Some("aé 💩"));
+        let mut string = Wtf8Buf::new();
+        string.push(CodePoint::from_u32(0xd800).unwrap());
+        assert_eq!(string.as_str(), None);
+    }
+
+    #[test]
+    fn wtf8_to_string_lossy() {
+        assert_eq!(Wtf8::from_str("").to_string_lossy(), Cow::Borrowed(""));
+        assert_eq!(Wtf8::from_str("aé 💩").to_string_lossy(), Cow::Borrowed("aé 💩"));
+        let mut string = Wtf8Buf::from_str("aé 💩");
+        string.push(CodePoint::from_u32(0xd800).unwrap());
+        assert_eq!(string.to_string_lossy(), {
+            let o: Cow<str> = Cow::Owned(String::from("aé 💩�"));
+            o
+        });
+    }
+
+    #[test]
+    fn wtf8_to_ill_formed_utf16() {
+        let mut string = Wtf8Buf::from_str("aé ");
+        string.push(CodePoint::from_u32(0xd83d).unwrap());
+        string.push_char('💩');
+        assert_eq!(
+            string.to_ill_formed_utf16().collect::<Vec<_>>(),
+            vec![0x61, 0xe9, 0x20, 0xd83d, 0xd83d, 0xdca9]
+        );
+    }
+
+    #[test]
+    fn wtf8buf_wtf8_from_bytes_valid() {
+        // Valid UTF-8
+        assert!(Wtf8Buf::from_bytes(b"hello".to_vec()).is_ok());
+        assert!(Wtf8Buf::from_bytes(b"a\xC3\xA9 \xF0\x9F\x92\xA9".to_vec()).is_ok());
+        assert!(Wtf8::from_bytes(b"hello").is_ok());
+        assert!(Wtf8::from_bytes(b"a\xC3\xA9 \xF0\x9F\x92\xA9").is_ok());
+
+        // Valid WTF-8 with unpaired surrogates
+        assert!(Wtf8Buf::from_bytes(b"\xED\xA0\x80".to_vec()).is_ok()); // lead surrogate
+        assert!(Wtf8Buf::from_bytes(b"\xED\xB0\x80".to_vec()).is_ok()); // trail surrogate
+        assert!(Wtf8Buf::from_bytes(b"a\xED\xA0\xBD".to_vec()).is_ok()); // text + lead
+        assert!(Wtf8Buf::from_bytes(b"\xED\xB2\xA9z".to_vec()).is_ok()); // trail + text
+        assert!(Wtf8Buf::from_bytes(b"\xED\xB2\xA9\xED\xA0\xBD".to_vec()).is_ok());
+        // trail + lead
+    }
+
+    #[test]
+    fn wtf8buf_wtf8_from_bytes_invalid() {
+        // Invalid: surrogate pair encoded as two 3-byte sequences
+        assert!(Wtf8Buf::from_bytes(b"\xED\xA0\x80\xED\xB0\x80".to_vec()).is_err());
+        assert!(Wtf8Buf::from_bytes(b"\xED\xA0\xBD\xED\xB2\xA9".to_vec()).is_err());
+        assert!(Wtf8::from_bytes(b"\xED\xA0\x80\xED\xB0\x80").is_err());
+        assert!(Wtf8::from_bytes(b"\xED\xA0\xBD\xED\xB2\xA9").is_err());
+
+        // Invalid UTF-8
+        assert!(Wtf8Buf::from_bytes(vec![0xff]).is_err());
+        assert!(Wtf8Buf::from_bytes(vec![0xc0, 0x80]).is_err()); // overlong
+        assert!(Wtf8Buf::from_bytes(vec![0xed, 0xa0]).is_err()); // truncated lead surrogate
+        assert!(Wtf8Buf::from_bytes(vec![0xf4, 0x90, 0x80, 0x80]).is_err()); // > U+10FFFF
+
+        // Verify we can recover the original bytes on failure
+        let original = vec![0xff, 0xfe];
+        let result = Wtf8Buf::from_bytes(original.clone());
+        assert_eq!(result.unwrap_err(), original);
+
+        let result = Wtf8::from_bytes(&original);
+        assert_eq!(result.unwrap_err(), original);
+    }
+}

--- a/crates/oxc_wtf8/src/wtf8/not_quite_std.rs
+++ b/crates/oxc_wtf8/src/wtf8/not_quite_std.rs
@@ -1,0 +1,364 @@
+// Copyright (c) 2014 Simon Sapin
+// Licensed under the MIT License
+// Original source: https://github.com/SimonSapin/rust-wtf8
+
+//! The code in this module is copied from Rust standard library
+//! (the `std` crate and crates it is a facade for)
+//! at commit 16d80de231abb2b1756f3951ffd4776d681035eb,
+//! with the signature changed to use `Wtf8Buf`, `Wtf8`, and `CodePoint`
+//! instead of `String`, `&str`, and `char`.
+//!
+//! FIXME: if and when this is moved into the standard library,
+//! try to avoid the code duplication.
+//! Maybe by having private generic code that is monomorphized to UTF-8 and
+//! WTF-8?
+
+use core::{char, mem::MaybeUninit, slice};
+
+use super::{CodePoint, IllFormedUtf16CodeUnits, Wtf8, Wtf8Buf};
+
+// UTF-8 ranges and tags for encoding characters
+// Copied from 48d5fe9ec560b53b1f5069219b0d62015e1de5ba^:src/libcore/char.rs
+const TAG_CONT: u8 = 0b1000_0000;
+const TAG_TWO_B: u8 = 0b1100_0000;
+const TAG_THREE_B: u8 = 0b1110_0000;
+const TAG_FOUR_B: u8 = 0b1111_0000;
+const MAX_ONE_B: u32 = 0x80;
+const MAX_TWO_B: u32 = 0x800;
+const MAX_THREE_B: u32 = 0x10000;
+
+/// Encode a code point into potentially uninitialized storage.
+///
+/// On success, exactly the first returned number of elements in `dst` are
+/// initialized. Copied from
+/// 48d5fe9ec560b53b1f5069219b0d62015e1de5ba^:src/libcore/char.rs.
+#[inline]
+fn encode_utf8_raw(code: u32, dst: &mut [MaybeUninit<u8>]) -> Option<usize> {
+    // Marked #[inline] to allow llvm optimizing it away
+    if code < MAX_ONE_B && !dst.is_empty() {
+        dst[0].write(code as u8);
+        Some(1)
+    } else if code < MAX_TWO_B && dst.len() >= 2 {
+        dst[0].write(((code >> 6) & 0x1f) as u8 | TAG_TWO_B);
+        dst[1].write((code & 0x3f) as u8 | TAG_CONT);
+        Some(2)
+    } else if code < MAX_THREE_B && dst.len() >= 3 {
+        dst[0].write(((code >> 12) & 0x0f) as u8 | TAG_THREE_B);
+        dst[1].write(((code >> 6) & 0x3f) as u8 | TAG_CONT);
+        dst[2].write((code & 0x3f) as u8 | TAG_CONT);
+        Some(3)
+    } else if dst.len() >= 4 {
+        dst[0].write(((code >> 18) & 0x07) as u8 | TAG_FOUR_B);
+        dst[1].write(((code >> 12) & 0x3f) as u8 | TAG_CONT);
+        dst[2].write(((code >> 6) & 0x3f) as u8 | TAG_CONT);
+        dst[3].write((code & 0x3f) as u8 | TAG_CONT);
+        Some(4)
+    } else {
+        None
+    }
+}
+
+/// Copied from 48d5fe9ec560b53b1f5069219b0d62015e1de5ba^:src/libcore/char.rs
+#[inline]
+fn encode_utf16_raw(mut ch: u32, dst: &mut [u16]) -> Option<usize> {
+    // Marked #[inline] to allow llvm optimizing it away
+    if (ch & 0xffff) == ch && !dst.is_empty() {
+        // The BMP falls through (assuming non-surrogate, as it should)
+        dst[0] = ch as u16;
+        Some(1)
+    } else if dst.len() >= 2 {
+        // Supplementary planes break into surrogates.
+        ch -= 0x1_0000;
+        dst[0] = 0xd800 | ((ch >> 10) as u16);
+        dst[1] = 0xdc00 | ((ch as u16) & 0x3ff);
+        Some(2)
+    } else {
+        None
+    }
+}
+
+/// Copied from core::str::next_code_point
+#[inline]
+pub fn next_code_point(bytes: &mut slice::Iter<u8>) -> Option<u32> {
+    // Decode UTF-8
+    let x = match bytes.next() {
+        None => return None,
+        Some(&next_byte) if next_byte < 128 => return Some(u32::from(next_byte)),
+        Some(&next_byte) => next_byte,
+    };
+
+    // Multibyte case follows
+    // Decode from a byte combination out of: [[[x y] z] w]
+    // NOTE: Performance is sensitive to the exact formulation here
+    let init = utf8_first_byte(x, 2);
+    let y = unwrap_or_0(bytes.next());
+    let mut ch = utf8_acc_cont_byte(init, y);
+    if x >= 0xe0 {
+        // [[x y z] w] case
+        // 5th bit in 0xE0 .. 0xEF is always clear, so `init` is still valid
+        let z = unwrap_or_0(bytes.next());
+        let y_z = utf8_acc_cont_byte(u32::from(y & CONT_MASK), z);
+        ch = (init << 12) | y_z;
+        if x >= 0xf0 {
+            // [x y z w] case
+            // use only the lower 3 bits of `init`
+            let w = unwrap_or_0(bytes.next());
+            ch = ((init & 7) << 18) | utf8_acc_cont_byte(y_z, w);
+        }
+    }
+
+    Some(ch)
+}
+
+#[inline]
+fn utf8_first_byte(byte: u8, width: u32) -> u32 {
+    u32::from(byte & (0x7f >> width))
+}
+
+/// Return the value of `ch` updated with continuation byte `byte`.
+#[inline]
+fn utf8_acc_cont_byte(ch: u32, byte: u8) -> u32 {
+    (ch << 6) | u32::from(byte & CONT_MASK)
+}
+
+#[inline]
+fn unwrap_or_0(opt: Option<&u8>) -> u8 {
+    match opt {
+        Some(&byte) => byte,
+        None => 0,
+    }
+}
+
+/// Mask of the value bits of a continuation byte
+const CONT_MASK: u8 = 0b0011_1111;
+
+/// Copied from String::push
+/// This does **not** include the WTF-8 concatenation check.
+#[inline]
+pub fn push_code_point(string: &mut Wtf8Buf, code_point: CodePoint) {
+    let cur_len = string.len();
+    // This may use up to 4 bytes.
+    string.reserve(4);
+
+    let used = {
+        let spare = string.bytes.spare_capacity_mut();
+        encode_utf8_raw(code_point.to_u32(), &mut spare[..4])
+            .expect("four bytes are sufficient to encode any code point")
+    };
+
+    // SAFETY: `reserve(4)` guarantees capacity for `cur_len + 4`, and
+    // `encode_utf8_raw` initialized exactly the first `used` spare bytes.
+    unsafe {
+        string.bytes.set_len(cur_len + used);
+    }
+}
+
+/// Copied from core::str::StrPrelude::is_char_boundary
+#[inline]
+pub fn is_code_point_boundary(slice: &Wtf8, index: usize) -> bool {
+    if index == slice.len() {
+        return true;
+    }
+    match slice.bytes.get(index) {
+        None => false,
+        Some(&b) => !(128u8..192u8).contains(&b),
+    }
+}
+
+/// Copied from core::str::raw::slice_unchecked
+#[inline]
+pub unsafe fn slice_unchecked(s: &Wtf8, begin: usize, end: usize) -> &Wtf8 {
+    // SAFETY: caller guarantees `begin`/`end` are code point boundaries in bounds;
+    // `Wtf8` is transparent over `[u8]`.
+    unsafe {
+        &*(std::ptr::from_ref::<[u8]>(slice::from_raw_parts(
+            s.bytes.as_ptr().add(begin),
+            end - begin,
+        )) as *const Wtf8)
+    }
+}
+
+/// Copied from core::str::raw::slice_error_fail
+#[inline(never)]
+pub fn slice_error_fail(s: &Wtf8, begin: usize, end: usize) -> ! {
+    assert!(begin <= end);
+    panic!("index {begin} and/or {end} in {s:?} do not lie on character boundary");
+}
+
+/// Copied from core::str::Utf16CodeUnits::next
+pub fn next_utf16_code_unit(iter: &mut IllFormedUtf16CodeUnits) -> Option<u16> {
+    if iter.extra != 0 {
+        let tmp = iter.extra;
+        iter.extra = 0;
+        return Some(tmp);
+    }
+
+    let mut buf = [0u16; 2];
+    iter.code_points.next().map(|code_point| {
+        let n = encode_utf16_raw(code_point.to_u32(), &mut buf).unwrap_or(0);
+        if n == 2 {
+            iter.extra = buf[1];
+        }
+        buf[0]
+    })
+}
+
+/// Copied from src/librustc_unicode/char.rs
+pub struct DecodeUtf16<I>
+where
+    I: Iterator<Item = u16>,
+{
+    iter: I,
+    buf: Option<u16>,
+}
+
+/// Copied from src/librustc_unicode/char.rs
+#[inline]
+pub fn decode_utf16<I: IntoIterator<Item = u16>>(iterable: I) -> DecodeUtf16<I::IntoIter> {
+    DecodeUtf16 { iter: iterable.into_iter(), buf: None }
+}
+
+/// Copied from src/librustc_unicode/char.rs
+impl<I: Iterator<Item = u16>> Iterator for DecodeUtf16<I> {
+    type Item = Result<char, u16>;
+
+    fn next(&mut self) -> Option<Result<char, u16>> {
+        let u = match self.buf.take() {
+            Some(buf) => buf,
+            None => self.iter.next()?,
+        };
+
+        if !(0xd800..=0xdfff).contains(&u) {
+            // SAFETY: not a surrogate, so a valid scalar value.
+            Some(Ok(unsafe { char::from_u32_unchecked(u32::from(u)) }))
+        } else if u >= 0xdc00 {
+            // a trailing surrogate
+            Some(Err(u))
+        } else {
+            let Some(u2) = self.iter.next() else {
+                // eof
+                return Some(Err(u));
+            };
+            if !(0xdc00..=0xdfff).contains(&u2) {
+                // not a trailing surrogate so we're not a valid
+                // surrogate pair, so rewind to redecode u2 next time.
+                self.buf = Some(u2);
+                return Some(Err(u));
+            }
+
+            // All ok, so let's decode it.
+            let c = ((u32::from(u - 0xd800) << 10) | u32::from(u2 - 0xdc00)) + 0x1_0000;
+            // SAFETY: a decoded surrogate pair is always a valid scalar value.
+            Some(Ok(unsafe { char::from_u32_unchecked(c) }))
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (low, high) = self.iter.size_hint();
+        // we could be entirely valid surrogates (2 elements per
+        // char), or entirely non-surrogates (1 element per char)
+        (low / 2, high)
+    }
+}
+
+/// Check if a byte is a valid UTF-8 continuation byte.
+#[inline]
+fn is_continuation_byte(byte: u8) -> bool {
+    byte & 0xc0 == 0x80
+}
+
+/// Check if bytes at position form a surrogate pair. A surrogate pair should be
+/// encoded as 4-byte sequence in UTF-8 instead of two separate 3-byte
+/// sequences.
+#[inline]
+fn is_surrogate_pair(bytes: &[u8], pos: usize) -> bool {
+    if pos + 5 >= bytes.len() {
+        return false;
+    }
+    bytes[pos] == 0xed
+        && (0xa0..0xb0).contains(&bytes[pos + 1])
+        && is_continuation_byte(bytes[pos + 2])
+        && bytes[pos + 3] == 0xed
+        && (0xb0..0xc0).contains(&bytes[pos + 4])
+        && is_continuation_byte(bytes[pos + 5])
+}
+
+/// Validate that bytes represent well-formed WTF-8.
+///
+/// This checks that:
+/// - All bytes form valid UTF-8 sequences OR valid surrogate code point
+///   encodings
+/// - Surrogate pairs are not encoded as two separate 3-byte sequences
+pub fn validate_wtf8(bytes: &[u8]) -> bool {
+    let mut i = 0;
+    while i < bytes.len() {
+        let byte = bytes[i];
+
+        // ASCII range (1-byte sequence)
+        if byte < 0x80 {
+            i += 1;
+            continue;
+        }
+
+        // 2-byte sequence
+        if byte < 0xe0 {
+            if i + 1 >= bytes.len() || !is_continuation_byte(bytes[i + 1]) || byte < 0xc2 {
+                return false; // Truncated, invalid continuation, or overlong
+            }
+            i += 2;
+            continue;
+        }
+
+        // 3-byte sequence
+        if byte < 0xf0 {
+            if i + 2 >= bytes.len()
+                || !is_continuation_byte(bytes[i + 1])
+                || !is_continuation_byte(bytes[i + 2])
+            {
+                return false; // Truncated or invalid continuation bytes
+            }
+
+            let b2 = bytes[i + 1];
+
+            // Check for overlong encoding
+            if byte == 0xe0 && b2 < 0xa0 {
+                return false;
+            }
+
+            // Check for surrogate pair (lead + trail) - invalid in WTF-8
+            if is_surrogate_pair(bytes, i) {
+                return false;
+            }
+
+            i += 3;
+            continue;
+        }
+
+        // 4-byte sequence
+        if byte < 0xf8 {
+            if i + 3 >= bytes.len()
+                || !is_continuation_byte(bytes[i + 1])
+                || !is_continuation_byte(bytes[i + 2])
+                || !is_continuation_byte(bytes[i + 3])
+            {
+                return false; // Truncated or invalid continuation bytes
+            }
+
+            let b2 = bytes[i + 1];
+
+            // Check for overlong encoding and valid range
+            if (byte == 0xf0 && b2 < 0x90) || (byte == 0xf4 && b2 >= 0x90) || byte > 0xf4 {
+                return false;
+            }
+
+            i += 4;
+            continue;
+        }
+
+        // Invalid byte (>= 0xF8)
+        return false;
+    }
+
+    true
+}

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -503,16 +503,10 @@ function deserializeTaggedTemplateExpression(pos) {
 function deserializeTemplateElement(pos) {
   let tail = deserializeBool(pos + 12),
     start = deserializeI32(pos),
-    end = deserializeI32(pos + 4),
-    value = deserializeTemplateElementValue(pos + 16);
-  value.cooked !== null
-    && deserializeBool(pos + 13)
-    && (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
+    end = deserializeI32(pos + 4);
   return {
     type: "TemplateElement",
-    value,
+    value: deserializeTemplateElementValue(pos + 16),
     tail,
     start,
     end,
@@ -2525,13 +2519,8 @@ function deserializeStringLiteral(pos) {
           : sourceText.slice(start, end),
       start,
       end,
-    },
-    value = deserializeStr(pos + 16);
-  deserializeBool(pos + 12)
-    && (value = value.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
-  node.value = value;
+    };
+  node.value = deserializeStr(pos + 16);
   return node;
 }
 

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -526,16 +526,10 @@ function deserializeTaggedTemplateExpression(pos) {
 function deserializeTemplateElement(pos) {
   let tail = deserializeBool(pos + 12),
     start = deserializeI32(pos),
-    end = deserializeI32(pos + 4),
-    value = deserializeTemplateElementValue(pos + 16);
-  value.cooked !== null
-    && deserializeBool(pos + 13)
-    && (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
+    end = deserializeI32(pos + 4);
   return {
     type: "TemplateElement",
-    value,
+    value: deserializeTemplateElementValue(pos + 16),
     tail,
     start,
     end,
@@ -2801,13 +2795,8 @@ function deserializeStringLiteral(pos) {
       start,
       end,
       parent,
-    }),
-    value = deserializeStr(pos + 16);
-  deserializeBool(pos + 12)
-    && (value = value.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
-  node.value = value;
+    });
+  node.value = deserializeStr(pos + 16);
   parent = previousParent;
   return node;
 }

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -529,16 +529,10 @@ function deserializeTaggedTemplateExpression(pos) {
 function deserializeTemplateElement(pos) {
   let tail = deserializeBool(pos + 12),
     start = deserializeI32(pos),
-    end = deserializeI32(pos + 4),
-    value = deserializeTemplateElementValue(pos + 16);
-  value.cooked !== null
-    && deserializeBool(pos + 13)
-    && (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
+    end = deserializeI32(pos + 4);
   return {
     type: "TemplateElement",
-    value,
+    value: deserializeTemplateElementValue(pos + 16),
     tail,
     start,
     end,
@@ -2804,13 +2798,8 @@ function deserializeStringLiteral(pos) {
       start,
       end,
       range: [start, end],
-    },
-    value = deserializeStr(pos + 16);
-  deserializeBool(pos + 12)
-    && (value = value.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
-  node.value = value;
+    };
+  node.value = deserializeStr(pos + 16);
   return node;
 }
 

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -552,16 +552,10 @@ function deserializeTaggedTemplateExpression(pos) {
 function deserializeTemplateElement(pos) {
   let tail = deserializeBool(pos + 12),
     start = deserializeI32(pos),
-    end = deserializeI32(pos + 4),
-    value = deserializeTemplateElementValue(pos + 16);
-  value.cooked !== null
-    && deserializeBool(pos + 13)
-    && (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
+    end = deserializeI32(pos + 4);
   return {
     type: "TemplateElement",
-    value,
+    value: deserializeTemplateElementValue(pos + 16),
     tail,
     start,
     end,
@@ -3079,13 +3073,8 @@ function deserializeStringLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    }),
-    value = deserializeStr(pos + 16);
-  deserializeBool(pos + 12)
-    && (value = value.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
-  node.value = value;
+    });
+  node.value = deserializeStr(pos + 16);
   parent = previousParent;
   return node;
 }

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -537,16 +537,10 @@ function deserializeTaggedTemplateExpression(pos) {
 function deserializeTemplateElement(pos) {
   let tail = deserializeBool(pos + 12),
     start = deserializeI32(pos) - 1,
-    end = deserializeI32(pos + 4) + 2 - tail,
-    value = deserializeTemplateElementValue(pos + 16);
-  value.cooked !== null
-    && deserializeBool(pos + 13)
-    && (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
+    end = deserializeI32(pos + 4) + 2 - tail;
   return {
     type: "TemplateElement",
-    value,
+    value: deserializeTemplateElementValue(pos + 16),
     tail,
     start,
     end,
@@ -2770,13 +2764,8 @@ function deserializeStringLiteral(pos) {
           : sourceText.slice(start, end),
       start,
       end,
-    },
-    value = deserializeStr(pos + 16);
-  deserializeBool(pos + 12)
-    && (value = value.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
-  node.value = value;
+    };
+  node.value = deserializeStr(pos + 16);
   return node;
 }
 

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -560,16 +560,10 @@ function deserializeTaggedTemplateExpression(pos) {
 function deserializeTemplateElement(pos) {
   let tail = deserializeBool(pos + 12),
     start = deserializeI32(pos) - 1,
-    end = deserializeI32(pos + 4) + 2 - tail,
-    value = deserializeTemplateElementValue(pos + 16);
-  value.cooked !== null
-    && deserializeBool(pos + 13)
-    && (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
+    end = deserializeI32(pos + 4) + 2 - tail;
   return {
     type: "TemplateElement",
-    value,
+    value: deserializeTemplateElementValue(pos + 16),
     tail,
     start,
     end,
@@ -3065,13 +3059,8 @@ function deserializeStringLiteral(pos) {
       start,
       end,
       parent,
-    }),
-    value = deserializeStr(pos + 16);
-  deserializeBool(pos + 12)
-    && (value = value.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
-  node.value = value;
+    });
+  node.value = deserializeStr(pos + 16);
   parent = previousParent;
   return node;
 }

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -563,16 +563,10 @@ function deserializeTaggedTemplateExpression(pos) {
 function deserializeTemplateElement(pos) {
   let tail = deserializeBool(pos + 12),
     start = deserializeI32(pos) - 1,
-    end = deserializeI32(pos + 4) + 2 - tail,
-    value = deserializeTemplateElementValue(pos + 16);
-  value.cooked !== null
-    && deserializeBool(pos + 13)
-    && (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
+    end = deserializeI32(pos + 4) + 2 - tail;
   return {
     type: "TemplateElement",
-    value,
+    value: deserializeTemplateElementValue(pos + 16),
     tail,
     start,
     end,
@@ -3070,13 +3064,8 @@ function deserializeStringLiteral(pos) {
       start,
       end,
       range: [start, end],
-    },
-    value = deserializeStr(pos + 16);
-  deserializeBool(pos + 12)
-    && (value = value.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
-  node.value = value;
+    };
+  node.value = deserializeStr(pos + 16);
   return node;
 }
 

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -586,16 +586,10 @@ function deserializeTaggedTemplateExpression(pos) {
 function deserializeTemplateElement(pos) {
   let tail = deserializeBool(pos + 12),
     start = deserializeI32(pos) - 1,
-    end = deserializeI32(pos + 4) + 2 - tail,
-    value = deserializeTemplateElementValue(pos + 16);
-  value.cooked !== null
-    && deserializeBool(pos + 13)
-    && (value.cooked = value.cooked.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
+    end = deserializeI32(pos + 4) + 2 - tail;
   return {
     type: "TemplateElement",
-    value,
+    value: deserializeTemplateElementValue(pos + 16),
     tail,
     start,
     end,
@@ -3364,13 +3358,8 @@ function deserializeStringLiteral(pos) {
       end,
       range: [start, end],
       parent,
-    }),
-    value = deserializeStr(pos + 16);
-  deserializeBool(pos + 12)
-    && (value = value.replace(/\uFFFD(.{4})/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    ));
-  node.value = value;
+    });
+  node.value = deserializeStr(pos + 16);
   parent = previousParent;
   return node;
 }

--- a/napi/parser/src-js/generated/lazy/constructors.js
+++ b/napi/parser/src-js/generated/lazy/constructors.js
@@ -13696,6 +13696,11 @@ function constructF64(pos, ast) {
   return ast.buffer.float64[pos >> 3];
 }
 
+function constructOptionStr(pos, ast) {
+  if (ast.buffer.int32[pos >> 2] === 0 && ast.buffer.int32[(pos >> 2) + 1] === 0) return null;
+  return constructStr(pos, ast);
+}
+
 function constructU8(pos, ast) {
   return ast.buffer[pos];
 }

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -500,7 +500,7 @@ impl<'s> StructSerializerGenerator<'s> {
             let value = match field.type_def(self.schema) {
                 TypeDef::Primitive(primitive_def) => match primitive_def.name() {
                     "&str" => Some(quote!( JsonSafeString(#self_path.#field_name_ident) )),
-                    "Str" | "Ident" => {
+                    "Str" | "Wtf8Str" | "Ident" => {
                         Some(quote!( JsonSafeString(#self_path.#field_name_ident.as_str()) ))
                     }
                     _ => None,
@@ -512,7 +512,7 @@ impl<'s> StructSerializerGenerator<'s> {
                         "&str" => Some(quote! {
                             #self_path.#field_name_ident.map(|s| JsonSafeString(s))
                         }),
-                        "Str" | "Ident" => Some(quote! {
+                        "Str" | "Wtf8Str" | "Ident" => Some(quote! {
                             #self_path.#field_name_ident.map(|s| JsonSafeString(s.as_str()))
                         }),
                         _ => None,

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -561,7 +561,7 @@ impl LayoutCalculator<'_> {
             "f32" => Layout::from_type::<f32>(),
             "f64" => Layout::from_type::<f64>(),
             "&str" => str_layout,
-            "Str" => str_layout,
+            "Str" | "Wtf8Str" => str_layout,
             // `Ident` is `NonNull<u8>` + `u64` on 64-bit, `NonNull<u8>` + `u32` + `u32` on 32-bit.
             // Niche for 0 on the pointer field.
             "Ident" => Layout {

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -92,7 +92,7 @@ impl Generator for AstBuilderGenerator {
 
             ///@@line_break
             use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator, IntoIn};
-            use oxc_str::{Ident, Str};
+            use oxc_str::{Ident, Str, Wtf8Str};
             use oxc_syntax::{scope::ScopeId, symbol::SymbolId, reference::ReferenceId};
 
             ///@@line_break
@@ -333,7 +333,7 @@ fn get_struct_params<'s>(
 
             let generic_type = match type_def {
                 TypeDef::Primitive(primitive_def)
-                    if matches!(primitive_def.name(), "Str" | "Ident") =>
+                    if matches!(primitive_def.name(), "Str" | "Wtf8Str" | "Ident") =>
                 {
                     Some(GenericType::Into)
                 }

--- a/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
+++ b/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
@@ -108,7 +108,7 @@ impl Generator for FormatterAstNodesGenerator {
             use oxc_ast::ast::*;
             use oxc_formatter_core::Format;
             use oxc_span::GetSpan;
-            use oxc_str::Ident;
+            use oxc_str::{Ident, Str, Wtf8Str};
             use oxc_syntax::node::NodeId;
             ///@@line_break
             use crate::ast_nodes::AstNode;

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -266,6 +266,11 @@ fn generate_deserializers(
         export declare function resetBuffer(): void;
     ".to_string();
 
+    // Track generated deserializer function names to avoid duplicates.
+    // Multiple types can map to the same deserializer name (e.g. `Option<Str>` and
+    // `Option<Wtf8Str>` both produce `deserializeOptionStr`).
+    let mut generated_deserializer_names = FxHashSet::default();
+
     for type_def in &schema.types {
         match type_def {
             TypeDef::Struct(struct_def) => {
@@ -275,16 +280,39 @@ fn generate_deserializers(
                 generate_enum(enum_def, &mut code, estree_derive_id, schema);
             }
             TypeDef::Primitive(primitive_def) => {
-                generate_primitive(primitive_def, &mut code, schema);
+                generate_primitive(
+                    primitive_def,
+                    &mut code,
+                    &mut generated_deserializer_names,
+                    schema,
+                );
             }
             TypeDef::Option(option_def) => {
-                generate_option(option_def, &mut code, estree_derive_id, schema);
+                generate_option(
+                    option_def,
+                    &mut code,
+                    &mut generated_deserializer_names,
+                    estree_derive_id,
+                    schema,
+                );
             }
             TypeDef::Box(box_def) => {
-                generate_box(box_def, &mut code, estree_derive_id, schema);
+                generate_box(
+                    box_def,
+                    &mut code,
+                    &mut generated_deserializer_names,
+                    estree_derive_id,
+                    schema,
+                );
             }
             TypeDef::Vec(vec_def) => {
-                generate_vec(vec_def, &mut code, estree_derive_id, schema);
+                generate_vec(
+                    vec_def,
+                    &mut code,
+                    &mut generated_deserializer_names,
+                    estree_derive_id,
+                    schema,
+                );
             }
             TypeDef::Cell(_cell_def) => {
                 // No deserializers for `Cell`s - use inner type's deserializer
@@ -740,7 +768,7 @@ impl<'s> StructDeserializerGenerator<'s> {
             };
 
             if inner_type.as_primitive().is_none_or(|primitive_def| {
-                !matches!(primitive_def.name(), "Str" | "Ident" | "&str")
+                !matches!(primitive_def.name(), "Str" | "Wtf8Str" | "Ident" | "&str")
             }) {
                 panic!(
                     "`#[estree(from_span)]` can only be on a field of type `Str`, `Ident`, `&str`, or `Option` containing one of those types: `{}::{}`",
@@ -906,11 +934,16 @@ fn generate_enum(
 }
 
 /// Generate deserialize function for a primitive.
-fn generate_primitive(primitive_def: &PrimitiveDef, code: &mut String, schema: &Schema) {
+fn generate_primitive(
+    primitive_def: &PrimitiveDef,
+    code: &mut String,
+    generated_names: &mut FxHashSet<String>,
+    schema: &Schema,
+) {
     #[expect(clippy::match_same_arms)]
     let ret = match primitive_def.name() {
         // Reuse deserializer for `&str`
-        "Str" | "Ident" => return,
+        "Str" | "Wtf8Str" | "Ident" => return,
         // Dummy type
         "PointerAlign" => return,
         "bool" => "return uint8[pos] === 1;",
@@ -943,6 +976,9 @@ fn generate_primitive(primitive_def: &PrimitiveDef, code: &mut String, schema: &
     };
 
     let fn_name = primitive_def.deser_name(schema);
+    if !generated_names.insert(fn_name.to_string()) {
+        return;
+    }
 
     #[rustfmt::skip]
     write_it!(code, "
@@ -1016,6 +1052,7 @@ static STR_DESERIALIZER_BODY: &str = "
 fn generate_option(
     option_def: &OptionDef,
     code: &mut String,
+    generated_names: &mut FxHashSet<String>,
     estree_derive_id: DeriveId,
     schema: &Schema,
 ) {
@@ -1025,6 +1062,9 @@ fn generate_option(
     }
 
     let fn_name = option_def.deser_name(schema);
+    if !generated_names.insert(fn_name.to_string()) {
+        return;
+    }
     let inner_fn_name = inner_type.deser_name(schema);
 
     let (none_condition, payload_offset) =
@@ -1074,13 +1114,22 @@ fn get_option_none_condition_and_offset(
 }
 
 /// Generate deserialize function for a `Box`.
-fn generate_box(box_def: &BoxDef, code: &mut String, estree_derive_id: DeriveId, schema: &Schema) {
+fn generate_box(
+    box_def: &BoxDef,
+    code: &mut String,
+    generated_names: &mut FxHashSet<String>,
+    estree_derive_id: DeriveId,
+    schema: &Schema,
+) {
     let inner_type = box_def.inner_type(schema);
     if should_skip_innermost_type(inner_type, estree_derive_id, schema) {
         return;
     }
 
     let fn_name = box_def.deser_name(schema);
+    if !generated_names.insert(fn_name.to_string()) {
+        return;
+    }
     let inner_fn_name = inner_type.deser_name(schema);
 
     #[rustfmt::skip]
@@ -1092,13 +1141,22 @@ fn generate_box(box_def: &BoxDef, code: &mut String, estree_derive_id: DeriveId,
 }
 
 /// Generate deserialize function for a `Vec`.
-fn generate_vec(vec_def: &VecDef, code: &mut String, estree_derive_id: DeriveId, schema: &Schema) {
+fn generate_vec(
+    vec_def: &VecDef,
+    code: &mut String,
+    generated_names: &mut FxHashSet<String>,
+    estree_derive_id: DeriveId,
+    schema: &Schema,
+) {
     let inner_type = vec_def.inner_type(schema);
     if should_skip_innermost_type(inner_type, estree_derive_id, schema) {
         return;
     }
 
     let fn_name = vec_def.deser_name(schema);
+    if !generated_names.insert(fn_name.to_string()) {
+        return;
+    }
     let inner_fn_name = inner_type.deser_name(schema);
     let inner_type_size = inner_type.layout_64().size;
 
@@ -1401,7 +1459,7 @@ impl_deser_name_concat!(VecDef, "Vec");
 impl DeserializeFunctionName for PrimitiveDef {
     fn plain_name<'s>(&'s self, _schema: &'s Schema) -> Cow<'s, str> {
         let type_name = self.name();
-        if matches!(type_name, "&str" | "Str" | "Ident") {
+        if matches!(type_name, "&str" | "Str" | "Wtf8Str" | "Ident") {
             // Use 1 deserializer for `&str`, `Str`, and `Ident`
             Cow::Borrowed("Str")
         } else if let Some(type_name) = type_name.strip_prefix("NonZero") {

--- a/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
@@ -571,7 +571,7 @@ impl<'s> LocalCacheTypes<'s> {
                 }
             }
             TypeDef::Primitive(primitive_def) => {
-                matches!(primitive_def.name(), "&str" | "Str" | "Ident")
+                matches!(primitive_def.name(), "&str" | "Str" | "Wtf8Str" | "Ident")
             }
             TypeDef::Vec(_) => true,
             TypeDef::Option(option_def) => {
@@ -908,7 +908,7 @@ fn generate_primitive(primitive_def: &PrimitiveDef, state: &mut State, schema: &
     #[expect(clippy::match_same_arms)]
     let ret = match primitive_def.name() {
         // Reuse constructor for `&str`
-        "Str" | "Ident" => return,
+        "Str" | "Wtf8Str" | "Ident" => return,
         // Dummy type
         "PointerAlign" => return,
         "bool" => "return ast.buffer[pos] === 1;",
@@ -1260,7 +1260,7 @@ impl_deser_name_concat!(VecDef, "Vec");
 impl FunctionNames for PrimitiveDef {
     fn plain_name<'s>(&'s self, _schema: &'s Schema) -> Cow<'s, str> {
         let type_name = self.name();
-        if matches!(type_name, "&str" | "Str" | "Ident") {
+        if matches!(type_name, "&str" | "Str" | "Wtf8Str" | "Ident") {
             // Use 1 constructor for `&str`, `Str`, and `Ident`
             Cow::Borrowed("Str")
         } else if let Some(type_name) = type_name.strip_prefix("NonZero") {

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -395,7 +395,7 @@ fn ts_type_name<'s>(type_def: &'s TypeDef, schema: &'s Schema) -> Cow<'s, str> {
             | "i8" | "i16" | "i32" | "i64" | "i128" | "isize"
             | "f32" | "f64" => "number",
             "bool" => "boolean",
-            "&str" | "Str" | "Ident" => "string",
+            "&str" | "Str" | "Wtf8Str" | "Ident" => "string",
             name => name,
         }),
         TypeDef::Option(option_def) => {

--- a/tasks/ast_tools/src/parse/parse.rs
+++ b/tasks/ast_tools/src/parse/parse.rs
@@ -279,6 +279,7 @@ impl<'c> Parser<'c> {
             "AtomicPtr" => primitive("AtomicPtr"),
             "&str" => primitive("&str"),
             "Str" => primitive("Str"),
+            "Wtf8Str" => primitive("Wtf8Str"),
             "Ident" => primitive("Ident"),
             // TODO: Remove the need for this by adding
             // `#[cfg_attr(target_pointer_width = "64", repr(align(8)))]` to all AST types

--- a/tasks/ast_tools/src/schema/defs/primitive.rs
+++ b/tasks/ast_tools/src/schema/defs/primitive.rs
@@ -49,7 +49,7 @@ impl Def for PrimitiveDef {
     /// Get if type has a lifetime.
     #[expect(unused_variables)]
     fn has_lifetime(&self, schema: &Schema) -> bool {
-        matches!(self.name(), "&str" | "Str" | "Ident")
+        matches!(self.name(), "&str" | "Str" | "Wtf8Str" | "Ident")
     }
 
     /// Get type signature (including lifetimes).
@@ -69,6 +69,13 @@ impl Def for PrimitiveDef {
                     quote!(Str<'_>)
                 } else {
                     quote!(Str<'a>)
+                }
+            }
+            "Wtf8Str" => {
+                if anon {
+                    quote!(Wtf8Str<'_>)
+                } else {
+                    quote!(Wtf8Str<'a>)
                 }
             }
             "Ident" => {

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -274,7 +274,7 @@ impl<'a> VisitJs<'a> for TestCase {
                 let ArrayExpressionElement::StringLiteral(lit) = arg else {
                     continue;
                 };
-                code.push_str(lit.value.as_str());
+                code.push_str(lit.value.as_str().unwrap_or_default());
                 code.push('\n');
             }
             self.code = Some(code);
@@ -316,7 +316,7 @@ impl<'a> VisitJs<'a> for TestCase {
                                         .iter()
                                         .map(|arg| match arg {
                                             ArrayExpressionElement::StringLiteral(string) => {
-                                                string.value.as_str()
+                                                string.value.as_str().unwrap_or_default()
                                             }
                                             _ => "",
                                         })
@@ -984,11 +984,11 @@ impl<'a> RuleConfig<'a> {
     // Helper function to parse type string literals
     fn parse_type_string_literal(&mut self, lit: &StringLiteral) -> Option<RuleConfigElement> {
         match lit.value.as_str() {
-            "string" => Some(RuleConfigElement::String),
-            "boolean" => Some(RuleConfigElement::Boolean),
-            "number" => Some(RuleConfigElement::Number),
-            "integer" => Some(RuleConfigElement::Integer),
-            "array" | "object" => None,
+            Some("string") => Some(RuleConfigElement::String),
+            Some("boolean") => Some(RuleConfigElement::Boolean),
+            Some("number") => Some(RuleConfigElement::Number),
+            Some("integer") => Some(RuleConfigElement::Integer),
+            Some("array" | "object") => None,
             _ => {
                 self.log_error(&format!("Unhandled `type` value: {}", lit.value));
                 None
@@ -1097,7 +1097,9 @@ impl<'a> RuleConfig<'a> {
             .iter()
             .filter_map(|arg| match arg {
                 ArrayExpressionElement::StringLiteral(string_literal) => {
-                    Some(RuleConfigElement::StringLiteral(string_literal.value.into()))
+                    Some(RuleConfigElement::StringLiteral(
+                        string_literal.value.as_str().unwrap_or_default().to_string(),
+                    ))
                 }
                 ArrayExpressionElement::BooleanLiteral(boolean_literal) => {
                     if boolean_literal.value {


### PR DESCRIPTION
This pr fixes the pretty big enough issue for WTF-8 (#16886) by introducing a new crate `oxc_wtf8`. Its readme kinda explains whats done. The diff for this pr is quite big, given the swc prs are around a ~4k change, this is similar.

This is a retry of #20681, though a ground up one.

This pr is ai-assisted. This time I have my computer.
