### PR TITLE
feat(formatter): support experimental ternaries

### DIFF
--- a/.agents/skills/migrate-oxfmt/SKILL.md
+++ b/.agents/skills/migrate-oxfmt/SKILL.md
@@ -90,7 +90,6 @@ These Prettier options are skipped during migration:
 | Option                          | Status                                           |
 | ------------------------------- | ------------------------------------------------ |
 | `endOfLine: "auto"`             | Not supported. Use `"lf"` or `"crlf"` explicitly |
-| `experimentalTernaries`         | Not supported in JS/TS files yet                 |
 | `requirePragma`, `insertPragma` | Not supported                                    |
 | `parser`, `filepath`            | Not applicable to oxfmt                          |
 

--- a/apps/oxfmt/src-js/cli/migration/migrate-prettier.ts
+++ b/apps/oxfmt/src-js/cli/migration/migrate-prettier.ts
@@ -92,12 +92,6 @@ export async function runMigratePrettier() {
       console.error(`  - "endOfLine: auto" is not supported, skipping...`);
       continue;
     }
-    // Oxfmt does not support this experimental option yet
-    if (key === "experimentalTernaries") {
-      console.error(`  - "${key}" is not supported yet`);
-      continue;
-    }
-
     // Skip plugin-specific options - handled separately
     if (key.startsWith("tailwind") || key.startsWith("svelte")) {
       continue;

--- a/apps/oxfmt/src-js/config.generated.ts
+++ b/apps/oxfmt/src-js/config.generated.ts
@@ -102,6 +102,13 @@ export interface Oxfmtrc {
    */
   experimentalOperatorPosition?: OperatorPositionConfig;
   /**
+   * Use curious ternaries, with the question mark after the condition.
+   *
+   * - Languages: JS, JSX, TS, TSX
+   * - Default: `false`
+   */
+  experimentalTernaries?: boolean;
+  /**
    * Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
    *
    * - Languages: HTML, Angular, Vue, Handlebars, Svelte
@@ -438,6 +445,13 @@ export interface FormatConfig {
    * - Default: `"end"`
    */
   experimentalOperatorPosition?: OperatorPositionConfig;
+  /**
+   * Use curious ternaries, with the question mark after the condition.
+   *
+   * - Languages: JS, JSX, TS, TSX
+   * - Default: `false`
+   */
+  experimentalTernaries?: boolean;
   /**
    * Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
    *

--- a/apps/oxfmt/src/core/options/to_oxc_formatter.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter.rs
@@ -29,9 +29,6 @@ pub fn to_oxc_formatter(
     let mut format_options = JsFormatOptions::default();
     format_options.apply_core(core_options);
 
-    // NOTE: [Prettier] experimentalTernaries is not yet supported;
-    // rejected at deserialize time (`oxfmtrc::reject_experimental_ternaries`) so it never reaches here.
-
     // [Prettier] singleQuote: boolean
     if let Some(single_quote) = config.single_quote {
         format_options.quote_style =
@@ -108,6 +105,11 @@ pub fn to_oxc_formatter(
             OperatorPositionConfig::Start => OperatorPosition::Start,
             OperatorPositionConfig::End => OperatorPosition::End,
         };
+    }
+
+    // [Prettier] experimentalTernaries: boolean
+    if let Some(experimental_ternaries) = config.experimental_ternaries {
+        format_options.experimental_ternaries = experimental_ternaries;
     }
 
     // [Prettier] htmlWhitespaceSensitivity: "css" | "strict" | "ignore"
@@ -363,6 +365,7 @@ mod tests {
             "printWidth": 100,
             "singleQuote": true,
             "semi": false,
+            "experimentalTernaries": true,
             "experimentalSortImports": {
                 "partitionByNewline": true,
                 "order": "desc",
@@ -379,6 +382,7 @@ mod tests {
         assert_eq!(format_options.line_width.value(), 100);
         assert!(!format_options.quote_style.is_double());
         assert!(format_options.semicolons.is_as_needed());
+        assert!(format_options.experimental_ternaries);
 
         let sort_imports = format_options.sort_imports.unwrap();
         assert!(sort_imports.partition_by_newline);

--- a/apps/oxfmt/src/core/options/to_prettier.rs
+++ b/apps/oxfmt/src/core/options/to_prettier.rs
@@ -115,6 +115,9 @@ pub fn to_prettier(config: &FormatConfig) -> Value {
             }),
         );
     }
+    if let Some(v) = config.experimental_ternaries {
+        obj.insert("experimentalTernaries".to_string(), Value::from(v));
+    }
     if let Some(v) = config.embedded_language_formatting {
         obj.insert(
             "embeddedLanguageFormatting".to_string(),
@@ -387,6 +390,7 @@ mod tests_to_prettier {
                 "quoteProps": "consistent",
                 "objectWrap": "collapse",
                 "experimentalOperatorPosition": "start",
+                "experimentalTernaries": true,
                 "embeddedLanguageFormatting": "off",
                 "proseWrap": "always",
                 "htmlWhitespaceSensitivity": "ignore",
@@ -403,6 +407,7 @@ mod tests_to_prettier {
         assert_eq!(obj.get("quoteProps"), Some(&Value::from("consistent")));
         assert_eq!(obj.get("objectWrap"), Some(&Value::from("collapse")));
         assert_eq!(obj.get("experimentalOperatorPosition"), Some(&Value::from("start")));
+        assert_eq!(obj.get("experimentalTernaries"), Some(&Value::from(true)));
         assert_eq!(obj.get("embeddedLanguageFormatting"), Some(&Value::from("off")));
         assert_eq!(obj.get("proseWrap"), Some(&Value::from("always")));
         assert_eq!(obj.get("htmlWhitespaceSensitivity"), Some(&Value::from("ignore")));
@@ -435,7 +440,6 @@ mod tests_to_prettier {
             "jsdoc",
             "overrides",
             "ignorePatterns",
-            "experimentalTernaries",
         ] {
             assert!(!obj.contains_key(key), "Key `{key}` must NOT be in Prettier options");
         }

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -167,14 +167,11 @@ pub struct FormatConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental_operator_position: Option<OperatorPositionConfig>,
 
-    // NOTE: This experimental option is not yet supported.
-    // Reject at deserialize time so all entry paths (base / overrides / NAPI `resolve()`) are covered uniformly.
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "reject_experimental_ternaries",
-        default
-    )]
-    #[schemars(skip)]
+    /// Use curious ternaries, with the question mark after the condition.
+    ///
+    /// - Languages: JS, JSX, TS, TSX
+    /// - Default: `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental_ternaries: Option<bool>,
 
     /// Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
@@ -350,19 +347,6 @@ impl FormatConfig {
         let merged = json_deep_merge(base, overlay);
         *self = serde_json::from_value(merged).unwrap();
     }
-}
-
-// ---
-
-fn reject_experimental_ternaries<'de, D>(d: D) -> Result<Option<bool>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let v = Option::<bool>::deserialize(d)?;
-    if v.is_some() {
-        return Err(serde::de::Error::custom("Unsupported option: `experimentalTernaries`"));
-    }
-    Ok(v)
 }
 
 // ---
@@ -994,34 +978,5 @@ mod tests_json_deep_merge {
             merged,
             json!({ "experimentalSortImports": { "order": "desc", "ignoreCase": true } })
         );
-    }
-}
-
-// ---
-
-#[cfg(test)]
-mod tests_reject_experimental {
-    use super::*;
-
-    #[test]
-    fn test_reject_experimental_ternaries_in_base() {
-        let json = r#"{ "experimentalTernaries": true }"#;
-        let err = serde_json::from_str::<FormatConfig>(json).unwrap_err();
-        assert!(err.to_string().contains("experimentalTernaries"));
-    }
-
-    #[test]
-    fn test_reject_experimental_in_overrides() {
-        // `OxfmtOverrideConfig.options: FormatConfig` so the same deserialize_with applies
-        let json = r#"{
-            "overrides": [
-                {
-                    "files": ["*.ts"],
-                    "options": { "experimentalTernaries": true }
-                }
-            ]
-        }"#;
-        let err = serde_json::from_str::<Oxfmtrc>(json).unwrap_err();
-        assert!(err.to_string().contains("experimentalTernaries"));
     }
 }

--- a/apps/oxfmt/test/cli/migrate_prettier/2.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/2.snap.md
@@ -66,6 +66,7 @@ Created `.oxfmtrc.json`.
   "singleQuote": true,
   "tabWidth": 4,
   "printWidth": 120,
+  "experimentalTernaries": true,
   "sortPackageJson": false,
   "ignorePatterns": []
 }

--- a/apps/oxfmt/test/cli/migrate_prettier/fixtures/basic_config/.prettierrc
+++ b/apps/oxfmt/test/cli/migrate_prettier/fixtures/basic_config/.prettierrc
@@ -1,1 +1,1 @@
-{"semi":false,"singleQuote":true,"tabWidth":4,"printWidth":120}
+{"semi":false,"singleQuote":true,"tabWidth":4,"printWidth":120,"experimentalTernaries":true}

--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -383,6 +383,46 @@ impl<'a> Comments<'a> {
         self.inner.get(first).is_some_and(|comment| comment.span.end <= end)
     }
 
+    /// Whether `(start, end)` contains a comment after `character`, including already-printed
+    /// comments. The range must contain only trivia and the operator being searched for.
+    pub fn has_comment_after_character_in_range(
+        &self,
+        mut start: u32,
+        end: u32,
+        character: u8,
+    ) -> bool {
+        let first = self.inner.partition_point(|comment| comment.span.start < start);
+        for comment in self.inner[first..].iter().take_while(|comment| comment.span.end <= end) {
+            if self.source_text.bytes_contain(start, comment.span.start, character) {
+                return true;
+            }
+            start = comment.span.end;
+        }
+        false
+    }
+
+    /// Whether `(start, end)` contains an inline single-line comment before `character`, including
+    /// already-printed comments. The range must contain only trivia and the operator being searched
+    /// for.
+    pub fn has_inline_single_line_comment_before_character_in_range(
+        &self,
+        mut start: u32,
+        end: u32,
+        character: u8,
+    ) -> bool {
+        let first = self.inner.partition_point(|comment| comment.span.start < start);
+        for comment in self.inner[first..].iter().take_while(|comment| comment.span.end <= end) {
+            if self.source_text.bytes_contain(start, comment.span.start, character) {
+                return false;
+            }
+            if !comment.preceded_by_newline() && !comment.is_multiline_block() {
+                return true;
+            }
+            start = comment.span.end;
+        }
+        false
+    }
+
     pub fn has_end_of_line_comment_after(&self, pos: u32) -> bool {
         !self.end_of_line_comments_after(pos).is_empty()
     }

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -54,7 +54,7 @@ pub struct JsFormatOptions {
     /// - `"start"`: Places the operator at the beginning of the next line.
     /// - `"end"`: Places the operator at the end of the current line (default).
     pub operator_position: OperatorPosition,
-    /// Try prettier's new ternary formatting before it becomes the default behavior. [**NOT SUPPORTED YET**]
+    /// Try Prettier's new ternary formatting before it becomes the default behavior.
     ///
     /// Valid options:
     /// - `true` - Use curious ternaries, with the question mark after the condition.
@@ -223,6 +223,7 @@ impl fmt::Display for JsFormatOptions {
         writeln!(f, "Attribute Position: {}", self.attribute_position)?;
         writeln!(f, "Expand lists: {}", self.expand)?;
         writeln!(f, "Operator position: {}", self.operator_position)?;
+        writeln!(f, "Experimental ternaries: {}", self.experimental_ternaries)?;
         writeln!(f, "Sort imports: {:?}", self.sort_imports)?;
         writeln!(f, "Sort tailwindcss: {:?}", self.sort_tailwindcss)?;
         writeln!(f, "JSDoc: {:?}", self.jsdoc)

--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -548,6 +548,12 @@ impl NeedsParentheses<'_> for AstNode<'_, ConditionalExpression<'_>> {
         }
 
         let parent = self.parent();
+        if f.options().experimental_ternaries
+            && matches!(parent, AstNodes::ConditionalExpression(parent) if parent.test.span() == self.span())
+        {
+            return false;
+        }
+
         if matches!(
             parent,
             AstNodes::UnaryExpression(_)

--- a/crates/oxc_formatter/src/print/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/print/return_or_throw_statement.rs
@@ -157,7 +157,15 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatAdjacentArgument<'a, '_> {
                 }
             });
             write!(f, [token("("), &block_indent(&inner), token(")")]);
-        } else if argument.is_binaryish() {
+        } else if argument.is_binaryish()
+            || (f.options().experimental_ternaries
+                && matches!(
+                    argument.as_ref(),
+                    Expression::ConditionalExpression(conditional)
+                        if matches!(conditional.consequent, Expression::ConditionalExpression(_))
+                            || matches!(conditional.alternate, Expression::ConditionalExpression(_))
+                ))
+        {
             write!(
                 f,
                 [group(&format_args!(

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -14,6 +14,7 @@ use crate::{
         alias_union_breaks_after_operator, is_trailing_own_line_jsdoc_comment, type_alias_left_end,
     },
     utils::{
+        conditional::{ConditionalLike, format_conditional_like_with_assignment_layout},
         format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
         member_chain::is_member_call_chain,
         object::{format_property_key, write_member_name},
@@ -395,11 +396,21 @@ impl<'a> AssignmentLike<'a, '_> {
                 write!(f, [with_assignment_layout(property.value().unwrap(), Some(layout))]);
             }
             Self::TSTypeAliasDeclaration(declaration) => {
-                if let AstNodes::TSUnionType(union) = declaration.type_annotation().as_ast_nodes() {
-                    union.write(f);
-                    union.format_trailing_comments(f);
-                } else {
-                    write!(f, [declaration.type_annotation()]);
+                match declaration.type_annotation().as_ast_nodes() {
+                    AstNodes::TSUnionType(union) => {
+                        union.write(f);
+                        union.format_trailing_comments(f);
+                    }
+                    AstNodes::TSConditionalType(conditional)
+                        if f.options().experimental_ternaries =>
+                    {
+                        format_conditional_like_with_assignment_layout(
+                            ConditionalLike::TSConditionalType(conditional),
+                            Some(layout),
+                            f,
+                        );
+                    }
+                    _ => write!(f, [declaration.type_annotation()]),
                 }
             }
         }
@@ -432,6 +443,26 @@ impl<'a> AssignmentLike<'a, '_> {
 
         if self.should_break_left_hand_side(left_may_break) {
             return AssignmentLikeLayout::BreakLeftHandSide;
+        }
+
+        // Prettier's conditional group contains multiline branch comments without forcing the
+        // surrounding assignment group to break. Oxfmt propagates expanded child groups, so keep
+        // the assignment operator adjacent explicitly for this equivalent observable layout.
+        let keep_multiline_conditional_assignment_adjacent = f.options().experimental_ternaries
+            && matches!(self, AssignmentLike::AssignmentExpression(_))
+            && right_expression.is_some_and(|right| {
+                matches!(right.as_ref(), Expression::ConditionalExpression(_))
+                    && f.comments()
+                        .comments_in_range(right.span().start, right.span().end)
+                        .iter()
+                        .any(|comment| {
+                            comment.is_block()
+                                && f.source_text()
+                                    .contains_newline_between(comment.span.start, comment.span.end)
+                        })
+            });
+        if keep_multiline_conditional_assignment_adjacent {
+            return AssignmentLikeLayout::NeverBreakAfterOperator;
         }
 
         if self.should_break_after_operator(right_expression, is_left_short, f) {
@@ -635,6 +666,10 @@ impl<'a> AssignmentLike<'a, '_> {
             // For TSTypeAliasDeclaration, check if the type annotation is a union type with comments
             match &decl.type_annotation {
                 TSType::TSConditionalType(conditional_type) => {
+                    if f.options().experimental_ternaries {
+                        return true;
+                    }
+
                     let is_generic = |ts_type: &TSType<'a>| -> bool {
                         match ts_type {
                             TSType::TSFunctionType(function) => function.type_parameters.is_some(),
@@ -780,15 +815,22 @@ fn should_break_after_operator<'a>(
         Expression::LogicalExpression(logical) => {
             !BinaryLikeExpression::can_inline_logical_expr(logical)
         }
-        Expression::ConditionalExpression(conditional) => match &conditional.test {
-            // A cast-parenthesized test is opaque, same as the whole-RHS case above
-            test if classify_type_cast(test.span(), f).is_target() => false,
-            Expression::BinaryExpression(_) => true,
-            Expression::LogicalExpression(logical) => {
-                !BinaryLikeExpression::can_inline_logical_expr(logical)
+        Expression::ConditionalExpression(conditional) => {
+            if f.options().experimental_ternaries {
+                matches!(conditional.consequent, Expression::ConditionalExpression(_))
+                    || matches!(conditional.alternate, Expression::ConditionalExpression(_))
+            } else {
+                match &conditional.test {
+                    // A cast-parenthesized test is opaque, same as the whole-RHS case above
+                    test if classify_type_cast(test.span(), f).is_target() => false,
+                    Expression::BinaryExpression(_) => true,
+                    Expression::LogicalExpression(logical) => {
+                        !BinaryLikeExpression::can_inline_logical_expr(logical)
+                    }
+                    _ => false,
+                }
             }
-            _ => false,
-        },
+        }
         Expression::ClassExpression(class) => !class.decorators.is_empty(),
         // Based on https://github.com/prettier/prettier/blob/0273e33fc691e28e4ab3f3c8ee86918b65cf823d/src/language-js/print/assignment.js#L235-L263
         _ if is_left_short => false,
@@ -974,6 +1016,13 @@ impl<'a> Format<'a, JsFormatContext<'a>> for WithAssignmentLayout<'a, '_> {
                 },
                 f,
             ),
+            AstNodes::ConditionalExpression(conditional) if f.options().experimental_ternaries => {
+                format_conditional_like_with_assignment_layout(
+                    ConditionalLike::ConditionalExpression(conditional),
+                    self.layout,
+                    f,
+                );
+            }
             _ => self.expression.fmt(f),
         }
     }
@@ -1119,6 +1168,26 @@ fn is_short_argument(argument: &Expression, threshold: u16, f: &JsFormatter) -> 
         | Expression::NumericLiteral(_) => true,
         _ => false,
     }
+}
+
+/// Prettier's short-argument predicate, including its requirement that the expression has no
+/// attached comments. `test_end` and `alternate_start` include comments adjacent to the expression
+/// because Oxc's AST spans exclude them. Kept separate from [`is_short_argument`] to avoid changing
+/// legacy assignment layout.
+pub(super) fn is_lone_short_argument(
+    argument: &Expression,
+    test_end: u32,
+    alternate_start: u32,
+    f: &JsFormatter<'_, '_>,
+) -> bool {
+    let comments = f.comments();
+    !comments.has_comment_after_character_in_range(test_end, argument.span().start, b'?')
+        && !comments.has_inline_single_line_comment_before_character_in_range(
+            argument.span().end,
+            alternate_start,
+            b':',
+        )
+        && is_short_argument(argument, f.options().line_width.value() / 4, f)
 }
 
 /// This function checks if `TSTypeArguments` is complex.

--- a/crates/oxc_formatter/src/utils/conditional.rs
+++ b/crates/oxc_formatter/src/utils/conditional.rs
@@ -1,20 +1,28 @@
 use std::ops::Deref;
 
 use oxc_ast::ast::*;
+use oxc_formatter_core::FormatElement;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
     Format,
     ast_nodes::{AstNode, AstNodes},
+    format_args,
     formatter::{
         JsFormatter,
         prelude::*,
-        trivia::{FormatLeadingComments, FormatTrailingComments},
+        trivia::{
+            DanglingIndentMode, FormatDanglingComments, FormatLeadingComments,
+            FormatTrailingComments,
+        },
     },
+    parentheses::NeedsParentheses,
+    utils::assignment_like::{AssignmentLikeLayout, is_lone_short_argument},
     utils::format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
     write,
 };
 
+#[derive(Clone, Copy)]
 pub enum ConditionalLike<'a, 'b> {
     ConditionalExpression(&'b AstNode<'a, ConditionalExpression<'a>>),
     TSConditionalType(&'b AstNode<'a, TSConditionalType<'a>>),
@@ -163,7 +171,109 @@ fn format_trailing_comments<'a>(
     FormatTrailingComments::Comments(comments).fmt(f);
 }
 
+/// Prints comments that occur before a conditional operator. Unlike the legacy ternary printer,
+/// curious ternaries keep own-line comments on the branch preceding `?` or `:`.
+fn format_comments_before_operator<'a>(
+    mut start: u32,
+    end: u32,
+    operator: u8,
+    f: &mut JsFormatter<'_, 'a>,
+) {
+    let mut get_comments = |f: &mut JsFormatter<'_, 'a>| -> &'a [Comment] {
+        let source = f.source_text();
+        let comments = f.context().comments().unprinted_comments();
+        let mut count = 0;
+
+        for comment in comments {
+            if comment.span.end > end || comment.preceded_by_newline() {
+                break;
+            }
+
+            let follows_operator = source.bytes_contain(start, comment.span.start, operator);
+            // Match Prettier's attachment for `test ? consequent :/* multiline */ alternate`:
+            // the comment is printed as a trailing comment of the consequent, before `:`.
+            let is_attached_multiline_comment = operator == b':'
+                && comment.is_multiline_block()
+                && comment.span.start.checked_sub(1).is_some_and(|offset| {
+                    source.as_bytes().get(offset as usize) == Some(&operator)
+                });
+            if follows_operator && !is_attached_multiline_comment {
+                break;
+            }
+
+            count += 1;
+            start = comment.span.end;
+
+            if follows_operator {
+                break;
+            }
+        }
+
+        &comments[..count]
+    };
+
+    let comments = get_comments(f);
+    FormatTrailingComments::Comments(comments).fmt(f);
+}
+
 impl<'a> FormatConditionalLike<'a, '_> {
+    /// Returns comments to print before `:` and whether an end-of-line directive must remain after
+    /// the colon. Preserved directives also disable alternate parenthesization so their line-based
+    /// semantics stay intact.
+    fn alternate_comments(&self, f: &JsFormatter<'_, 'a>) -> (&'a [Comment], bool) {
+        if matches!(self.conditional, ConditionalLike::TSConditionalType(_)) {
+            return (&[], false);
+        }
+
+        let (mut start, end) = match self.conditional {
+            ConditionalLike::ConditionalExpression(conditional) => {
+                (conditional.consequent.span().end, conditional.alternate.span().start)
+            }
+            ConditionalLike::TSConditionalType(conditional) => {
+                (conditional.true_type.span().end, conditional.false_type.span().start)
+            }
+        };
+        let source = f.source_text();
+        let comments = f.context().comments().unprinted_comments();
+        let mut count = 0;
+        let mut passed_colon = false;
+
+        for comment in comments {
+            if comment.span.end > end {
+                break;
+            }
+
+            passed_colon |= source.bytes_contain(start, comment.span.start, b':');
+            if passed_colon && comment.is_line() && !comment.preceded_by_newline() {
+                let content = source.text_for(&comment.content_span()).trim_start();
+                let marker = content.split_ascii_whitespace().next().unwrap_or_default();
+                let is_line_directive = comment.is_annotation()
+                    || f.comments().is_suppression_comment(comment)
+                    || marker.starts_with('@')
+                    || marker.contains(':')
+                    || marker.contains("-disable")
+                    || marker.contains("-ignore");
+                if is_line_directive {
+                    return (&comments[..count], true);
+                }
+            }
+
+            let is_alternate_comment = if passed_colon {
+                comment.is_line() || comment.is_multiline_block()
+            } else {
+                comment.preceded_by_newline()
+            };
+            if !is_alternate_comment {
+                break;
+            }
+
+            count += 1;
+            start = comment.span.end;
+        }
+
+        (&comments[..count], false)
+    }
+
     /// Determines the layout of this conditional based on its parent
     fn layout(&self, f: &JsFormatter<'_, 'a>) -> ConditionalLayout {
         let self_span = self.span();
@@ -193,8 +303,9 @@ impl<'a> FormatConditionalLike<'a, '_> {
                 }
             }
             _ => {
-                let jsx_chain =
-                    f.context().source_type().is_jsx() && self.is_jsx_conditional_chain();
+                let jsx_chain = !f.options().experimental_ternaries
+                    && f.context().source_type().is_jsx()
+                    && self.is_jsx_conditional_chain();
                 ConditionalLayout::Root { jsx_chain }
             }
         }
@@ -477,7 +588,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for ConditionalLike<'a, '_> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         FormatConditionalLike {
             conditional: self,
-            options: FormatConditionalLikeOptions { jsx_chain: false },
+            options: FormatConditionalLikeOptions { jsx_chain: false, assignment_layout: None },
         }
         .fmt(f);
     }
@@ -489,11 +600,37 @@ struct FormatConditionalLikeOptions {
     ///
     /// Doesn't apply for [`TSConditionalType`].
     jsx_chain: bool,
+    /// Assignment layout selected by the parent assignment-like node.
+    assignment_layout: Option<AssignmentLikeLayout>,
 }
 
 struct FormatConditionalLike<'a, 'b> {
     conditional: &'b ConditionalLike<'a, 'b>,
     options: FormatConditionalLikeOptions,
+}
+
+#[derive(Clone)]
+struct ReusedFormatElement<'a>(Option<FormatElement<'a>>);
+
+impl<'a> Format<'a, JsFormatContext<'a>> for ReusedFormatElement<'a> {
+    fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
+        if let Some(element) = &self.0 {
+            f.write_element(element.clone());
+        }
+    }
+}
+
+/// Formats a conditional while carrying the assignment layout selected by its parent.
+pub fn format_conditional_like_with_assignment_layout<'a>(
+    conditional: ConditionalLike<'a, '_>,
+    assignment_layout: Option<AssignmentLikeLayout>,
+    f: &mut JsFormatter<'_, 'a>,
+) {
+    FormatConditionalLike {
+        conditional: &conditional,
+        options: FormatConditionalLikeOptions { jsx_chain: false, assignment_layout },
+    }
+    .fmt(f);
 }
 
 impl<'a, 'b> Deref for FormatConditionalLike<'a, 'b> {
@@ -505,8 +642,762 @@ impl<'a, 'b> Deref for FormatConditionalLike<'a, 'b> {
     }
 }
 
+impl<'a> FormatConditionalLike<'a, '_> {
+    fn first_non_conditional_parent(&self) -> &AstNodes<'a> {
+        let mut previous_span = self.span();
+        let mut parent = self.parent();
+
+        loop {
+            let continues_chain = match (self.conditional, parent) {
+                (
+                    ConditionalLike::ConditionalExpression(_),
+                    AstNodes::ConditionalExpression(conditional),
+                ) => conditional.test.span() != previous_span,
+                (
+                    ConditionalLike::TSConditionalType(_),
+                    AstNodes::TSConditionalType(conditional),
+                ) => {
+                    conditional.check_type.span() != previous_span
+                        && conditional.extends_type.span() != previous_span
+                }
+                _ => false,
+            };
+
+            if !continues_chain {
+                return parent;
+            }
+
+            previous_span = parent.span();
+            parent = parent.parent();
+        }
+    }
+
+    fn has_multiline_block_comments(&self, f: &JsFormatter<'_, 'a>) -> bool {
+        let source = f.source_text();
+        let span = self.span();
+        f.comments().comments_in_range(span.start, span.end).iter().any(|comment| {
+            comment.is_block()
+                && source.contains_newline_between(comment.span.start, comment.span.end)
+        })
+    }
+
+    fn format_experimental_test(&self, f: &mut JsFormatter<'_, 'a>) {
+        match self.conditional {
+            ConditionalLike::ConditionalExpression(conditional) => {
+                let test = format_with(|f| {
+                    write!(f, [FormatNodeWithoutTrailingComments(conditional.test())]);
+                    format_trailing_comments(
+                        conditional.test.span().end,
+                        conditional.consequent.span().start,
+                        b'?',
+                        f,
+                    );
+                });
+
+                write!(
+                    f,
+                    [
+                        if_group_breaks(&token("(")),
+                        indent(&format_args!(soft_line_break(), test)),
+                        soft_line_break(),
+                        if_group_breaks(&token(")")),
+                        matches!(conditional.test, Expression::ConditionalExpression(_))
+                            .then_some(expand_parent())
+                    ]
+                );
+            }
+            ConditionalLike::TSConditionalType(conditional) => {
+                write!(f, [conditional.check_type(), space(), "extends", space()]);
+
+                let extends_type = format_with(|f| {
+                    write!(f, [FormatNodeWithoutTrailingComments(conditional.extends_type())]);
+                    format_trailing_comments(
+                        conditional.extends_type.span().end,
+                        conditional.true_type.span().start,
+                        b'?',
+                        f,
+                    );
+                });
+
+                if matches!(
+                    conditional.extends_type,
+                    TSType::TSConditionalType(_) | TSType::TSMappedType(_)
+                ) {
+                    write!(f, [extends_type]);
+                } else {
+                    write!(
+                        f,
+                        [group(&format_args!(
+                            if_group_breaks(&token("(")),
+                            indent(&format_args!(soft_line_break(), extends_type)),
+                            soft_line_break(),
+                            if_group_breaks(&token(")")),
+                        ))]
+                    );
+                }
+            }
+        }
+    }
+
+    fn fmt_experimental(&self, f: &mut JsFormatter<'_, 'a>) {
+        let layout = self.layout(f);
+        let parent = self.parent();
+        let first_non_conditional_parent = self.first_non_conditional_parent();
+
+        let is_parent_ternary = matches!(
+            (self.conditional, parent),
+            (ConditionalLike::ConditionalExpression(_), AstNodes::ConditionalExpression(_))
+                | (ConditionalLike::TSConditionalType(_), AstNodes::TSConditionalType(_))
+        );
+        let is_in_test = layout.is_nested_test();
+        let is_in_alternate = layout.is_nested_alternate();
+        let is_ts_conditional = matches!(self.conditional, ConditionalLike::TSConditionalType(_));
+
+        let (is_consequent_ternary, is_alternate_ternary) = match self.conditional {
+            ConditionalLike::ConditionalExpression(conditional) => (
+                matches!(conditional.consequent, Expression::ConditionalExpression(_)),
+                matches!(conditional.alternate, Expression::ConditionalExpression(_)),
+            ),
+            ConditionalLike::TSConditionalType(conditional) => (
+                matches!(conditional.true_type, TSType::TSConditionalType(_)),
+                matches!(conditional.false_type, TSType::TSConditionalType(_)),
+            ),
+        };
+        let is_in_chain = is_alternate_ternary || is_in_alternate;
+
+        let is_on_same_line_as_assignment = self
+            .options
+            .assignment_layout
+            .is_some_and(|layout| layout != AssignmentLikeLayout::BreakAfterOperator)
+            && matches!(
+                parent,
+                AstNodes::AssignmentExpression(_)
+                    | AstNodes::VariableDeclarator(_)
+                    | AstNodes::PropertyDefinition(_)
+                    | AstNodes::AccessorProperty(_)
+                    | AstNodes::ObjectProperty(_)
+            );
+        let is_on_same_line_as_return =
+            matches!(parent, AstNodes::ReturnStatement(_) | AstNodes::ThrowStatement(_))
+                && !(is_consequent_ternary || is_alternate_ternary);
+
+        let is_in_jsx = self.is_conditional_expression()
+            && matches!(first_non_conditional_parent, AstNodes::JSXExpressionContainer(_))
+            && !matches!(first_non_conditional_parent.parent(), AstNodes::JSXAttribute(_));
+        let should_extra_indent = self.should_extra_indent(layout);
+        let break_closing_paren = self.is_conditional_expression()
+            && matches!(
+                parent,
+                AstNodes::StaticMemberExpression(_) | AstNodes::PrivateFieldExpression(_)
+            );
+        let break_ts_closing_paren = match self.conditional {
+            ConditionalLike::TSConditionalType(conditional) => conditional.needs_parentheses(f),
+            ConditionalLike::ConditionalExpression(_) => false,
+        };
+
+        let has_multiline_block_comments = self.has_multiline_block_comments(f);
+        let should_break =
+            has_multiline_block_comments || is_consequent_ternary || is_alternate_ternary;
+
+        let printed_test =
+            ReusedFormatElement(f.intern(&format_once(|f| self.format_experimental_test(f))));
+        let printed_consequent =
+            ReusedFormatElement(f.intern(&format_once(|f| match self.conditional {
+                ConditionalLike::ConditionalExpression(conditional) => {
+                    write!(f, [FormatNodeWithoutTrailingComments(conditional.consequent())]);
+                    format_comments_before_operator(
+                        conditional.consequent.span().end,
+                        conditional.alternate.span().start,
+                        b':',
+                        f,
+                    );
+                }
+                ConditionalLike::TSConditionalType(conditional) => {
+                    write!(f, [FormatNodeWithoutTrailingComments(conditional.true_type())]);
+                    format_comments_before_operator(
+                        conditional.true_type.span().end,
+                        conditional.false_type.span().start,
+                        b':',
+                        f,
+                    );
+                }
+            })));
+        let (alternate_comments, has_alternate_eol_directive) = self.alternate_comments(f);
+        let has_alternate_comments = !alternate_comments.is_empty();
+        let try_to_parenthesize_alternate = !has_alternate_eol_directive
+            && !is_in_chain
+            && !is_parent_ternary
+            && !is_ts_conditional
+            && match self.conditional {
+                ConditionalLike::ConditionalExpression(conditional) if is_in_jsx => {
+                    matches!(conditional.consequent, Expression::NullLiteral(_))
+                }
+                ConditionalLike::ConditionalExpression(conditional) => {
+                    is_lone_short_argument(
+                        &conditional.consequent,
+                        conditional.test.span().end,
+                        conditional.alternate.span().start,
+                        f,
+                    ) && is_simple_expression_by_node_count(&conditional.test, 3)
+                }
+                ConditionalLike::TSConditionalType(_) => false,
+            };
+        let should_group_test_and_consequent = is_in_chain
+            || is_in_alternate
+            || (is_ts_conditional && !is_parent_ternary)
+            || (is_parent_ternary
+                && self.is_conditional_expression()
+                && match self.conditional {
+                    ConditionalLike::ConditionalExpression(conditional) => {
+                        is_simple_expression_by_node_count(&conditional.test, 1)
+                    }
+                    ConditionalLike::TSConditionalType(_) => false,
+                })
+            || try_to_parenthesize_alternate;
+        let printed_alternate_comments = ReusedFormatElement(f.intern(&format_once(|f| {
+            FormatDanglingComments::Comments {
+                comments: alternate_comments,
+                indent: DanglingIndentMode::None,
+            }
+            .fmt(f);
+        })));
+        let printed_alternate =
+            ReusedFormatElement(f.intern(&format_once(|f| match self.conditional {
+                ConditionalLike::ConditionalExpression(conditional) => {
+                    conditional.alternate().fmt(f);
+                }
+                ConditionalLike::TSConditionalType(conditional) => {
+                    conditional.false_type().fmt(f);
+                }
+            })));
+
+        let test_id = f.group_id("conditional-test");
+        let consequent_id = f.group_id("conditional-consequent");
+        let test_and_consequent_id = f.group_id("conditional-test-and-consequent");
+        let is_big_tabs =
+            f.options().indent_width.value() > 2 || !f.options().indent_style.is_space();
+        let use_tabs = !f.options().indent_style.is_space();
+        let fill_width = f.options().indent_width.value().saturating_sub(1);
+
+        let parts = format_once(|f| {
+            let printed_test_with_question = format_with(|f| {
+                write!(f, [printed_test.clone(), space(), "?"]);
+            });
+            let printed_test_with_question =
+                group(&printed_test_with_question).with_group_id(Some(test_id));
+
+            let consequent = format_with(|f| {
+                let separator = if is_consequent_ternary
+                    || (is_in_jsx
+                        && (consequent_is_jsx(self.conditional)
+                            || is_parent_ternary
+                            || is_in_chain))
+                {
+                    hard_line_break()
+                } else {
+                    soft_line_break_or_space()
+                };
+                write!(f, [indent(&format_args!(separator, printed_consequent.clone()))]);
+            });
+
+            let test_and_consequent = format_with(|f| {
+                write!(f, [printed_test_with_question]);
+                if !should_group_test_and_consequent || is_in_chain {
+                    write!(f, [consequent]);
+                } else {
+                    write!(
+                        f,
+                        [
+                            if_group_breaks(&consequent).with_group_id(Some(test_id)),
+                            if_group_fits_on_line(
+                                &group(&consequent).with_group_id(Some(consequent_id))
+                            )
+                            .with_group_id(Some(test_id))
+                        ]
+                    );
+                }
+            });
+
+            if should_group_test_and_consequent {
+                write!(
+                    f,
+                    [group(&test_and_consequent).with_group_id(Some(test_and_consequent_id))]
+                );
+            } else {
+                write!(f, [test_and_consequent]);
+            }
+
+            if has_alternate_comments {
+                write!(
+                    f,
+                    [
+                        indent(&format_args!(
+                            hard_line_break(),
+                            printed_alternate_comments.clone()
+                        )),
+                        hard_line_break()
+                    ]
+                );
+            } else if is_alternate_ternary {
+                write!(f, [hard_line_break()]);
+            } else if try_to_parenthesize_alternate {
+                write!(
+                    f,
+                    [
+                        if_group_breaks(&soft_line_break_or_space())
+                            .with_group_id(Some(test_and_consequent_id)),
+                        if_group_fits_on_line(&space()).with_group_id(Some(test_and_consequent_id))
+                    ]
+                );
+            } else {
+                write!(f, [soft_line_break_or_space()]);
+            }
+
+            write!(f, [":"]);
+
+            let fill_tab = format_with(|f| {
+                if use_tabs {
+                    write!(f, [text("\t")]);
+                } else {
+                    const SPACES: &str = "                                ";
+                    write!(f, [text(&SPACES[..usize::from(fill_width)])]);
+                }
+            });
+
+            if is_alternate_ternary || !is_big_tabs {
+                write!(f, [space()]);
+            } else if should_group_test_and_consequent {
+                let flat_fill = format_with(|f| {
+                    if is_in_chain || try_to_parenthesize_alternate {
+                        write!(f, [space()]);
+                    } else {
+                        write!(f, [fill_tab]);
+                    }
+                });
+                write!(
+                    f,
+                    [
+                        if_group_breaks(&fill_tab).with_group_id(Some(test_and_consequent_id)),
+                        if_group_fits_on_line(&format_args!(
+                            if_group_breaks(&flat_fill),
+                            if_group_fits_on_line(&space()),
+                        ))
+                        .with_group_id(Some(test_and_consequent_id))
+                    ]
+                );
+            } else {
+                write!(f, [if_group_breaks(&fill_tab), if_group_fits_on_line(&space())]);
+            }
+
+            let alternate_with_parens = format_with(|f| {
+                let wrapped = format_with(|f| {
+                    write!(
+                        f,
+                        [
+                            if_group_breaks(&token("(")),
+                            indent(&format_args!(soft_line_break(), printed_alternate.clone())),
+                            soft_line_break(),
+                            if_group_breaks(&token(")")),
+                        ]
+                    );
+                });
+                write!(
+                    f,
+                    [
+                        if_group_breaks(&printed_alternate.clone())
+                            .with_group_id(Some(test_and_consequent_id)),
+                        if_group_fits_on_line(&dedent(&wrapped))
+                            .with_group_id(Some(test_and_consequent_id))
+                    ]
+                );
+            });
+
+            let alternate = format_with(|f| {
+                if try_to_parenthesize_alternate {
+                    write!(f, [alternate_with_parens]);
+                } else {
+                    write!(f, [printed_alternate.clone()]);
+                }
+            });
+
+            if is_alternate_ternary {
+                write!(f, [alternate]);
+            } else {
+                write!(
+                    f,
+                    [group(&format_args!(
+                        indent(&alternate),
+                        (is_in_jsx && !try_to_parenthesize_alternate).then_some(soft_line_break())
+                    ))]
+                );
+            }
+
+            if break_closing_paren && !should_extra_indent {
+                write!(f, [soft_line_break()]);
+            }
+            if should_break {
+                write!(f, [expand_parent()]);
+            }
+        });
+
+        if is_on_same_line_as_assignment && !should_break {
+            write!(f, [group(&indent(&format_args!(soft_line_break(), group(&parts))))]);
+        } else if is_on_same_line_as_assignment || is_on_same_line_as_return {
+            write!(f, [group(&indent(&parts))]);
+        } else if should_extra_indent || (is_ts_conditional && is_in_test) {
+            write!(
+                f,
+                [group(&format_args!(
+                    indent(&format_args!(soft_line_break(), parts)),
+                    break_ts_closing_paren.then_some(soft_line_break())
+                ))]
+            );
+        } else if std::ptr::eq(parent, first_non_conditional_parent) {
+            write!(f, [group(&parts)]);
+        } else {
+            write!(f, [parts]);
+        }
+    }
+}
+
+fn consequent_is_jsx(conditional: &ConditionalLike<'_, '_>) -> bool {
+    matches!(
+        conditional,
+        ConditionalLike::ConditionalExpression(conditional)
+            if matches!(conditional.consequent, Expression::JSXElement(_) | Expression::JSXFragment(_))
+    )
+}
+
+/// A bounded implementation of Prettier's generic AST-node counter. Only object-valued AST fields
+/// count as children; node arrays such as arguments, elements, properties, and parameters do not.
+fn is_simple_expression_by_node_count(expression: &Expression<'_>, max_count: usize) -> bool {
+    fn visit_leaf(count: &mut usize, max_count: usize) -> bool {
+        *count += 1;
+        *count <= max_count
+    }
+
+    fn visit_optional_leaf(present: bool, count: &mut usize, max_count: usize) -> bool {
+        !present || visit_leaf(count, max_count)
+    }
+
+    fn visit_child(expression: &Expression<'_>, count: &mut usize, max_count: usize) -> bool {
+        visit_leaf(count, max_count) && visit_children(expression, count, max_count)
+    }
+
+    fn visit_static_member_children(
+        expression: &StaticMemberExpression<'_>,
+        count: &mut usize,
+        max_count: usize,
+    ) -> bool {
+        visit_child(&expression.object, count, max_count) && visit_leaf(count, max_count)
+    }
+
+    fn visit_private_member_children(
+        expression: &PrivateFieldExpression<'_>,
+        count: &mut usize,
+        max_count: usize,
+    ) -> bool {
+        visit_child(&expression.object, count, max_count) && visit_leaf(count, max_count)
+    }
+
+    fn visit_computed_member_children(
+        expression: &ComputedMemberExpression<'_>,
+        count: &mut usize,
+        max_count: usize,
+    ) -> bool {
+        visit_child(&expression.object, count, max_count)
+            && visit_child(&expression.expression, count, max_count)
+    }
+
+    fn visit_simple_assignment_target_children(
+        target: &SimpleAssignmentTarget<'_>,
+        count: &mut usize,
+        max_count: usize,
+    ) -> bool {
+        match target {
+            SimpleAssignmentTarget::AssignmentTargetIdentifier(_) => true,
+            SimpleAssignmentTarget::TSAsExpression(expression) => {
+                visit_child(&expression.expression, count, max_count)
+                    && visit_leaf(count, max_count)
+            }
+            SimpleAssignmentTarget::TSSatisfiesExpression(expression) => {
+                visit_child(&expression.expression, count, max_count)
+                    && visit_leaf(count, max_count)
+            }
+            SimpleAssignmentTarget::TSTypeAssertion(expression) => {
+                visit_leaf(count, max_count)
+                    && visit_child(&expression.expression, count, max_count)
+            }
+            SimpleAssignmentTarget::TSNonNullExpression(expression) => {
+                visit_child(&expression.expression, count, max_count)
+            }
+            SimpleAssignmentTarget::StaticMemberExpression(expression) => {
+                visit_static_member_children(expression, count, max_count)
+            }
+            SimpleAssignmentTarget::PrivateFieldExpression(expression) => {
+                visit_private_member_children(expression, count, max_count)
+            }
+            SimpleAssignmentTarget::ComputedMemberExpression(expression) => {
+                visit_computed_member_children(expression, count, max_count)
+            }
+        }
+    }
+
+    fn visit_assignment_target(
+        target: &AssignmentTarget<'_>,
+        count: &mut usize,
+        max_count: usize,
+    ) -> bool {
+        visit_leaf(count, max_count)
+            && target.as_simple_assignment_target().is_none_or(|target| {
+                visit_simple_assignment_target_children(target, count, max_count)
+            })
+    }
+
+    fn visit_chain_element(
+        element: &ChainElement<'_>,
+        count: &mut usize,
+        max_count: usize,
+    ) -> bool {
+        if !visit_leaf(count, max_count) {
+            return false;
+        }
+
+        match element {
+            ChainElement::CallExpression(expression) => {
+                visit_child(&expression.callee, count, max_count)
+                    && visit_optional_leaf(expression.type_arguments.is_some(), count, max_count)
+            }
+            ChainElement::TSNonNullExpression(expression) => {
+                visit_child(&expression.expression, count, max_count)
+            }
+            ChainElement::StaticMemberExpression(expression) => {
+                visit_static_member_children(expression, count, max_count)
+            }
+            ChainElement::PrivateFieldExpression(expression) => {
+                visit_private_member_children(expression, count, max_count)
+            }
+            ChainElement::ComputedMemberExpression(expression) => {
+                visit_computed_member_children(expression, count, max_count)
+            }
+        }
+    }
+
+    fn visit_jsx_member_object(
+        object: &JSXMemberExpressionObject<'_>,
+        count: &mut usize,
+        max_count: usize,
+    ) -> bool {
+        visit_leaf(count, max_count)
+            && match object {
+                JSXMemberExpressionObject::MemberExpression(expression) => {
+                    visit_jsx_member_children(expression, count, max_count)
+                }
+                JSXMemberExpressionObject::IdentifierReference(_)
+                | JSXMemberExpressionObject::ThisExpression(_) => true,
+            }
+    }
+
+    fn visit_jsx_member_children(
+        expression: &JSXMemberExpression<'_>,
+        count: &mut usize,
+        max_count: usize,
+    ) -> bool {
+        visit_jsx_member_object(&expression.object, count, max_count)
+            && visit_leaf(count, max_count)
+    }
+
+    fn visit_jsx_name(name: &JSXElementName<'_>, count: &mut usize, max_count: usize) -> bool {
+        if !visit_leaf(count, max_count) {
+            return false;
+        }
+
+        match name {
+            JSXElementName::NamespacedName(_) => {
+                visit_leaf(count, max_count) && visit_leaf(count, max_count)
+            }
+            JSXElementName::MemberExpression(expression) => {
+                visit_jsx_member_children(expression, count, max_count)
+            }
+            JSXElementName::Identifier(_)
+            | JSXElementName::IdentifierReference(_)
+            | JSXElementName::ThisExpression(_) => true,
+        }
+    }
+
+    fn visit_children(expression: &Expression<'_>, count: &mut usize, max_count: usize) -> bool {
+        match expression {
+            Expression::ArrayExpression(_)
+            | Expression::ObjectExpression(_)
+            | Expression::SequenceExpression(_)
+            | Expression::TemplateLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::BigIntLiteral(_)
+            | Expression::RegExpLiteral(_)
+            | Expression::StringLiteral(_)
+            | Expression::Identifier(_)
+            | Expression::ThisExpression(_)
+            | Expression::Super(_)
+            | Expression::ImportMeta(_)
+            | Expression::NewTarget(_) => true,
+            Expression::ArrowFunctionExpression(expression) => {
+                visit_optional_leaf(expression.type_parameters.is_some(), count, max_count)
+                    && visit_optional_leaf(expression.return_type.is_some(), count, max_count)
+                    && if let Some(body) = expression.body.as_expression() {
+                        visit_child(body, count, max_count)
+                    } else {
+                        visit_leaf(count, max_count)
+                    }
+            }
+            Expression::AssignmentExpression(expression) => {
+                visit_assignment_target(&expression.left, count, max_count)
+                    && visit_child(&expression.right, count, max_count)
+            }
+            Expression::AwaitExpression(expression) => {
+                visit_child(&expression.argument, count, max_count)
+            }
+            Expression::BinaryExpression(expression) => {
+                visit_child(&expression.left, count, max_count)
+                    && visit_child(&expression.right, count, max_count)
+            }
+            Expression::CallExpression(expression) => {
+                visit_child(&expression.callee, count, max_count)
+                    && visit_optional_leaf(expression.type_arguments.is_some(), count, max_count)
+            }
+            Expression::ChainExpression(expression) => {
+                visit_chain_element(&expression.expression, count, max_count)
+            }
+            Expression::ClassExpression(expression) => {
+                if !visit_optional_leaf(expression.id.is_some(), count, max_count)
+                    || !visit_optional_leaf(expression.type_parameters.is_some(), count, max_count)
+                {
+                    return false;
+                }
+                if let Some(heritage) = &expression.heritage
+                    && (!visit_child(&heritage.expression, count, max_count)
+                        || !visit_optional_leaf(
+                            heritage.type_arguments.is_some(),
+                            count,
+                            max_count,
+                        ))
+                {
+                    return false;
+                }
+                visit_leaf(count, max_count)
+            }
+            Expression::LogicalExpression(expression) => {
+                visit_child(&expression.left, count, max_count)
+                    && visit_child(&expression.right, count, max_count)
+            }
+            Expression::ConditionalExpression(expression) => {
+                visit_child(&expression.test, count, max_count)
+                    && visit_child(&expression.consequent, count, max_count)
+                    && visit_child(&expression.alternate, count, max_count)
+            }
+            Expression::FunctionExpression(expression) => {
+                visit_optional_leaf(expression.id.is_some(), count, max_count)
+                    && visit_optional_leaf(expression.type_parameters.is_some(), count, max_count)
+                    && visit_optional_leaf(expression.return_type.is_some(), count, max_count)
+                    && visit_optional_leaf(expression.body.is_some(), count, max_count)
+            }
+            Expression::ImportExpression(expression) => {
+                visit_child(&expression.source, count, max_count)
+                    && expression
+                        .options
+                        .as_ref()
+                        .is_none_or(|options| visit_child(options, count, max_count))
+            }
+            Expression::NewExpression(expression) => {
+                visit_child(&expression.callee, count, max_count)
+                    && visit_optional_leaf(expression.type_arguments.is_some(), count, max_count)
+            }
+            Expression::ParenthesizedExpression(expression) => {
+                visit_child(&expression.expression, count, max_count)
+            }
+            Expression::TaggedTemplateExpression(expression) => {
+                visit_child(&expression.tag, count, max_count)
+                    && visit_optional_leaf(expression.type_arguments.is_some(), count, max_count)
+                    && visit_leaf(count, max_count)
+            }
+            Expression::TSAsExpression(expression) => {
+                visit_child(&expression.expression, count, max_count)
+                    && visit_leaf(count, max_count)
+            }
+            Expression::TSSatisfiesExpression(expression) => {
+                visit_child(&expression.expression, count, max_count)
+                    && visit_leaf(count, max_count)
+            }
+            Expression::TSTypeAssertion(expression) => {
+                visit_leaf(count, max_count)
+                    && visit_child(&expression.expression, count, max_count)
+            }
+            Expression::TSNonNullExpression(expression) => {
+                visit_child(&expression.expression, count, max_count)
+            }
+            Expression::TSInstantiationExpression(expression) => {
+                visit_child(&expression.expression, count, max_count)
+                    && visit_leaf(count, max_count)
+            }
+            Expression::UnaryExpression(expression) => {
+                visit_child(&expression.argument, count, max_count)
+            }
+            Expression::UpdateExpression(expression) => {
+                visit_leaf(count, max_count)
+                    && visit_simple_assignment_target_children(
+                        &expression.argument,
+                        count,
+                        max_count,
+                    )
+            }
+            Expression::YieldExpression(expression) => expression
+                .argument
+                .as_ref()
+                .is_none_or(|argument| visit_child(argument, count, max_count)),
+            Expression::PrivateInExpression(expression) => {
+                visit_leaf(count, max_count) && visit_child(&expression.right, count, max_count)
+            }
+            Expression::StaticMemberExpression(expression) => {
+                visit_static_member_children(expression, count, max_count)
+            }
+            Expression::PrivateFieldExpression(expression) => {
+                visit_private_member_children(expression, count, max_count)
+            }
+            Expression::ComputedMemberExpression(expression) => {
+                visit_computed_member_children(expression, count, max_count)
+            }
+            Expression::JSXElement(expression) => {
+                visit_leaf(count, max_count)
+                    && visit_jsx_name(&expression.opening_element.name, count, max_count)
+                    && visit_optional_leaf(
+                        expression.opening_element.type_arguments.is_some(),
+                        count,
+                        max_count,
+                    )
+                    && expression.closing_element.as_ref().is_none_or(|closing| {
+                        visit_leaf(count, max_count)
+                            && visit_jsx_name(&closing.name, count, max_count)
+                    })
+            }
+            Expression::JSXFragment(_) => {
+                visit_leaf(count, max_count) && visit_leaf(count, max_count)
+            }
+            Expression::V8IntrinsicExpression(_) => visit_leaf(count, max_count),
+        }
+    }
+
+    let mut count = 0;
+    visit_children(expression, &mut count, max_count) && count <= max_count
+}
+
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatConditionalLike<'a, '_> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
+        if f.options().experimental_ternaries {
+            self.fmt_experimental(f);
+            return;
+        }
+
         let layout = self.layout(f);
         let should_extra_indent = self.should_extra_indent(layout);
         let is_jsx_chain = self.options.jsx_chain || layout.is_jsx_chain();
@@ -646,7 +1537,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatJsxChainExpression<'a, '_> {
             if let AstNodes::ConditionalExpression(conditional) = self.expression.as_ast_nodes() {
                 FormatConditionalLike {
                     conditional: &ConditionalLike::ConditionalExpression(conditional),
-                    options: FormatConditionalLikeOptions { jsx_chain: true },
+                    options: FormatConditionalLikeOptions {
+                        jsx_chain: true,
+                        assignment_layout: None,
+                    },
                 }
                 .fmt(f);
             } else {

--- a/crates/oxc_formatter/tests/conformance.rs
+++ b/crates/oxc_formatter/tests/conformance.rs
@@ -117,17 +117,12 @@ const IGNORE: &[&str] = &[
     "js/quotes/objects.js",
 ];
 
-/// Option combinations not supported yet; dropped from the test population entirely.
-fn skip_unsupported_options(spec: &OptionSet) -> bool {
-    spec.get("experimentalTernaries").and_then(serde_json::Value::as_bool) == Some(true)
-}
-
 const JS: ConformanceConfig = ConformanceConfig {
     language: "js",
     fixture_roots: &["js", "jsx"],
     exact_parser: None,
     ignore: IGNORE,
-    skip_spec: Some(skip_unsupported_options),
+    skip_spec: None,
 };
 
 const TS: ConformanceConfig = ConformanceConfig {
@@ -137,7 +132,7 @@ const TS: ConformanceConfig = ConformanceConfig {
     fixture_roots: &["typescript", "jsx"],
     exact_parser: None,
     ignore: IGNORE,
-    skip_spec: Some(skip_unsupported_options),
+    skip_spec: None,
 };
 
 fn parse_options(spec: &OptionSet) -> JsFormatOptions {

--- a/crates/oxc_formatter/tests/fixtures/js/experimental-ternaries/directives-and-spread.js
+++ b/crates/oxc_formatter/tests/fixtures/js/experimental-ternaries/directives-and-spread.js
@@ -1,0 +1,23 @@
+const spread = foo(...args) ? value : someExtremelyLongAlternateExpressionThatCannotPossiblyFitOnThisLine;
+
+const ignored = condition ? consequent : // oxfmt-ignore
+foo(    1,2,3,4);
+
+const prettierIgnored = condition ? consequent : // prettier-ignore
+foo(    1,2,3,4);
+
+const linted = condition ? consequent : // eslint-disable-line no-alert
+alert(  "message"  );
+
+const tslinted = condition ? consequent : // tslint:disable-line
+alternate;
+
+condition ? /* comment */ bar : someExtremelyLongAlternateExpression;
+condition ? bar /* comment */ : someExtremelyLongAlternateExpression;
+
+({ foo: bar }).foo ? short : someExtremelyLongAlternateExpression;
+[foo].length ? short : someExtremelyLongAlternateExpression;
+foo++ ? short : someExtremelyLongAlternateExpression;
+(foo = bar) ? short : someExtremelyLongAlternateExpression;
+(foo => bar) ? short : someExtremelyLongAlternateExpression;
+foo(bar, baz, qux) ? short : someExtremelyLongAlternateExpression;

--- a/crates/oxc_formatter/tests/fixtures/js/experimental-ternaries/directives-and-spread.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/experimental-ternaries/directives-and-spread.js.snap
@@ -1,0 +1,170 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+const spread = foo(...args) ? value : someExtremelyLongAlternateExpressionThatCannotPossiblyFitOnThisLine;
+
+const ignored = condition ? consequent : // oxfmt-ignore
+foo(    1,2,3,4);
+
+const prettierIgnored = condition ? consequent : // prettier-ignore
+foo(    1,2,3,4);
+
+const linted = condition ? consequent : // eslint-disable-line no-alert
+alert(  "message"  );
+
+const tslinted = condition ? consequent : // tslint:disable-line
+alternate;
+
+condition ? /* comment */ bar : someExtremelyLongAlternateExpression;
+condition ? bar /* comment */ : someExtremelyLongAlternateExpression;
+
+({ foo: bar }).foo ? short : someExtremelyLongAlternateExpression;
+[foo].length ? short : someExtremelyLongAlternateExpression;
+foo++ ? short : someExtremelyLongAlternateExpression;
+(foo = bar) ? short : someExtremelyLongAlternateExpression;
+(foo => bar) ? short : someExtremelyLongAlternateExpression;
+foo(bar, baz, qux) ? short : someExtremelyLongAlternateExpression;
+
+==================== Output ====================
+-----------------------------------------------
+{ experimentalTernaries: true, printWidth: 40 }
+-----------------------------------------------
+const spread =
+  foo(...args) ? value : (
+    someExtremelyLongAlternateExpressionThatCannotPossiblyFitOnThisLine
+  );
+
+const ignored =
+  condition ?
+    consequent
+  : // oxfmt-ignore
+    foo(    1,2,3,4);
+
+const prettierIgnored =
+  condition ?
+    consequent
+  : // prettier-ignore
+    foo(    1,2,3,4);
+
+const linted =
+  condition ?
+    consequent
+  : // eslint-disable-line no-alert
+    alert("message");
+
+const tslinted =
+  condition ?
+    consequent
+  : // tslint:disable-line
+    alternate;
+
+condition ?
+  /* comment */ bar
+: someExtremelyLongAlternateExpression;
+condition ?
+  bar /* comment */
+: someExtremelyLongAlternateExpression;
+
+({ foo: bar }).foo ? short : (
+  someExtremelyLongAlternateExpression
+);
+[foo].length ? short : (
+  someExtremelyLongAlternateExpression
+);
+foo++ ? short : (
+  someExtremelyLongAlternateExpression
+);
+(foo = bar) ? short : (
+  someExtremelyLongAlternateExpression
+);
+((foo) => bar) ? short : (
+  someExtremelyLongAlternateExpression
+);
+foo(bar, baz, qux) ? short : (
+  someExtremelyLongAlternateExpression
+);
+
+-----------------------------------------------
+{ experimentalTernaries: true, printWidth: 80 }
+-----------------------------------------------
+const spread =
+  foo(...args) ? value : (
+    someExtremelyLongAlternateExpressionThatCannotPossiblyFitOnThisLine
+  );
+
+const ignored =
+  condition ?
+    consequent
+  : // oxfmt-ignore
+    foo(    1,2,3,4);
+
+const prettierIgnored =
+  condition ?
+    consequent
+  : // prettier-ignore
+    foo(    1,2,3,4);
+
+const linted =
+  condition ?
+    consequent
+  : // eslint-disable-line no-alert
+    alert("message");
+
+const tslinted =
+  condition ?
+    consequent
+  : // tslint:disable-line
+    alternate;
+
+condition ? /* comment */ bar : someExtremelyLongAlternateExpression;
+condition ? bar /* comment */ : someExtremelyLongAlternateExpression;
+
+({ foo: bar }).foo ? short : someExtremelyLongAlternateExpression;
+[foo].length ? short : someExtremelyLongAlternateExpression;
+foo++ ? short : someExtremelyLongAlternateExpression;
+(foo = bar) ? short : someExtremelyLongAlternateExpression;
+((foo) => bar) ? short : someExtremelyLongAlternateExpression;
+foo(bar, baz, qux) ? short : someExtremelyLongAlternateExpression;
+
+------------------------------------------------
+{ experimentalTernaries: true, printWidth: 100 }
+------------------------------------------------
+const spread =
+  foo(...args) ? value : someExtremelyLongAlternateExpressionThatCannotPossiblyFitOnThisLine;
+
+const ignored =
+  condition ?
+    consequent
+  : // oxfmt-ignore
+    foo(    1,2,3,4);
+
+const prettierIgnored =
+  condition ?
+    consequent
+  : // prettier-ignore
+    foo(    1,2,3,4);
+
+const linted =
+  condition ?
+    consequent
+  : // eslint-disable-line no-alert
+    alert("message");
+
+const tslinted =
+  condition ?
+    consequent
+  : // tslint:disable-line
+    alternate;
+
+condition ? /* comment */ bar : someExtremelyLongAlternateExpression;
+condition ? bar /* comment */ : someExtremelyLongAlternateExpression;
+
+({ foo: bar }).foo ? short : someExtremelyLongAlternateExpression;
+[foo].length ? short : someExtremelyLongAlternateExpression;
+foo++ ? short : someExtremelyLongAlternateExpression;
+(foo = bar) ? short : someExtremelyLongAlternateExpression;
+((foo) => bar) ? short : someExtremelyLongAlternateExpression;
+foo(bar, baz, qux) ? short : someExtremelyLongAlternateExpression;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/experimental-ternaries/options.json
+++ b/crates/oxc_formatter/tests/fixtures/js/experimental-ternaries/options.json
@@ -1,0 +1,1 @@
+[{ "experimentalTernaries": true, "printWidth": 40 }]

--- a/napi/playground/index.d.ts
+++ b/napi/playground/index.d.ts
@@ -110,6 +110,8 @@ export interface OxcFormatterOptions {
   singleAttributePerLine?: boolean
   /** Where to print operators when binary expressions wrap lines: "start" | "end" (default: "end") */
   experimentalOperatorPosition?: string
+  /** Use curious ternaries, with the question mark after the condition (default: false) */
+  experimentalTernaries?: boolean
   /** Sort imports configuration (default: None) */
   sortImports?: OxcSortImportsOptions
 }

--- a/napi/playground/playground.wasi.d.cts
+++ b/napi/playground/playground.wasi.d.cts
@@ -110,6 +110,8 @@ export interface OxcFormatterOptions {
   singleAttributePerLine?: boolean
   /** Where to print operators when binary expressions wrap lines: "start" | "end" (default: "end") */
   experimentalOperatorPosition?: string
+  /** Use curious ternaries, with the question mark after the condition (default: false) */
+  experimentalTernaries?: boolean
   /** Sort imports configuration (default: None) */
   sortImports?: OxcSortImportsOptions
 }

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -526,6 +526,10 @@ impl Oxc {
             format_options.operator_position = position;
         }
 
+        if let Some(experimental_ternaries) = options.experimental_ternaries {
+            format_options.experimental_ternaries = experimental_ternaries;
+        }
+
         if let Some(ref sort_imports_config) = options.sort_imports {
             let order = sort_imports_config
                 .order

--- a/napi/playground/src/options.rs
+++ b/napi/playground/src/options.rs
@@ -152,6 +152,8 @@ pub struct OxcFormatterOptions {
     pub single_attribute_per_line: Option<bool>,
     /// Where to print operators when binary expressions wrap lines: "start" | "end" (default: "end")
     pub experimental_operator_position: Option<String>,
+    /// Use curious ternaries, with the question mark after the condition (default: false)
+    pub experimental_ternaries: Option<bool>,
     /// Sort imports configuration (default: None)
     pub sort_imports: Option<OxcSortImportsOptions>,
 }

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -50,6 +50,11 @@
       ],
       "markdownDescription": "When expressions wrap lines, print operators at the start of new lines (`\"start\"`)\nor at the end of previous lines (`\"end\"`).\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"end\"`"
     },
+    "experimentalTernaries": {
+      "description": "Use curious ternaries, with the question mark after the condition.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `false`",
+      "type": "boolean",
+      "markdownDescription": "Use curious ternaries, with the question mark after the condition.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `false`"
+    },
     "htmlWhitespaceSensitivity": {
       "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Languages: HTML, Angular, Vue, Handlebars, Svelte\n- Default: `\"css\"`",
       "allOf": [
@@ -324,6 +329,11 @@
             }
           ],
           "markdownDescription": "When expressions wrap lines, print operators at the start of new lines (`\"start\"`)\nor at the end of previous lines (`\"end\"`).\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"end\"`"
+        },
+        "experimentalTernaries": {
+          "description": "Use curious ternaries, with the question mark after the condition.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `false`",
+          "type": "boolean",
+          "markdownDescription": "Use curious ternaries, with the question mark after the condition.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `false`"
         },
         "htmlWhitespaceSensitivity": {
           "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Languages: HTML, Angular, Vue, Handlebars, Svelte\n- Default: `\"css\"`",

--- a/tasks/website_common/Cargo.toml
+++ b/tasks/website_common/Cargo.toml
@@ -17,4 +17,4 @@ handlebars = { workspace = true }
 itertools = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -83,6 +83,17 @@ or at the end of previous lines (`"end"`).
 - Default: `"end"`
 
 
+## experimentalTernaries
+
+type: `boolean`
+
+
+Use curious ternaries, with the question mark after the condition.
+
+- Languages: JS, JSX, TS, TSX
+- Default: `false`
+
+
 ## htmlWhitespaceSensitivity
 
 type: `"css" | "strict" | "ignore"`


### PR DESCRIPTION
Support Prettier’s experimentalTernaries formatting for JS/JSX and TypeScript conditional types. Plumb the option through Oxfmt config, migration, schemas, and playground APIs. Enable the pinned Prettier conformance cases for the option.

AI assistance: Codex was used to implement and verify this change.