### PR TITLE
perf(react-compiler): compute post-dominator frontiers together

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_hir/dominator.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/dominator.rs
@@ -9,7 +9,7 @@
 //! Uses the Cooper/Harvey/Kennedy algorithm from
 //! https://www.cs.rice.edu/~keith/Embed/dom.pdf
 
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_index::{IndexSlice, IndexVec};
@@ -30,12 +30,29 @@ pub struct PostDominator {
     nodes: IndexVec<BlockId, Option<BlockId>>,
 }
 
+/// Stores the post-dominator frontier for each block.
+pub struct PostDominatorFrontiers {
+    frontiers: FxHashMap<BlockId, FxHashSet<BlockId>>,
+}
+
+impl PostDominatorFrontiers {
+    /// Iterates over the blocks in `id`'s post-dominator frontier.
+    pub fn iter(&self, id: BlockId) -> impl Iterator<Item = BlockId> + '_ {
+        self.frontiers.get(&id).into_iter().flatten().copied()
+    }
+}
+
 impl PostDominator {
     /// Returns the immediate post-dominator of the given block, or None if
     /// the block post-dominates itself (i.e., it is the exit node).
     pub fn get(&self, id: BlockId) -> Option<BlockId> {
         let dominator = self.nodes[id].expect("Unknown node in post-dominator tree");
         if dominator == id { None } else { Some(dominator) }
+    }
+
+    /// Iterates over `id` and its ancestors in the post-dominator tree.
+    fn ancestors(&self, id: BlockId) -> impl Iterator<Item = BlockId> + '_ {
+        std::iter::successors(Some(id), |&id| self.get(id))
     }
 }
 
@@ -249,62 +266,35 @@ fn intersect(
 // Post-dominator frontier
 // =============================================================================
 
-/// Computes the post-dominator frontier of `target_id`. These are immediate
-/// predecessors of nodes that post-dominate `target_id` from which execution may
-/// not reach `target_id`. Intuitively, these are the earliest blocks from which
-/// execution branches such that it may or may not reach the target block.
-pub fn post_dominator_frontier(
+/// Computes the post-dominator frontiers of all blocks using the Cytron algorithm.
+///
+/// The frontier of a block contains the earliest blocks from which execution branches
+/// such that it may or may not reach that block. Walking each CFG edge up the immediate
+/// post-dominator chain avoids separately reverse-walking the whole CFG for every block.
+pub fn compute_post_dominator_frontiers(
     func: &HirFunction,
-    post_dominators: &PostDominator,
-    target_id: BlockId,
-) -> FxHashSet<BlockId> {
-    let target_post_dominators = post_dominators_of(func, post_dominators, target_id);
-    let mut visited = FxHashSet::default();
-    let mut frontier = FxHashSet::default();
+    next_block_id_counter: u32,
+    include_throws_as_exit_node: bool,
+) -> Result<PostDominatorFrontiers, OxcDiagnostic> {
+    let post_dominators =
+        compute_post_dominator_tree(func, next_block_id_counter, include_throws_as_exit_node)?;
+    let mut frontiers: FxHashMap<BlockId, FxHashSet<BlockId>> = FxHashMap::default();
 
-    let mut to_visit: Vec<BlockId> = target_post_dominators.iter().copied().collect();
-    to_visit.push(target_id);
-
-    for block_id in to_visit {
-        if !visited.insert(block_id) {
-            continue;
-        }
-        if let Some(block) = func.body.blocks.get(&block_id) {
-            for &pred in &block.preds {
-                if !target_post_dominators.contains(&pred) {
-                    frontier.insert(pred);
-                }
+    // Apply Cytron's dominance-frontier algorithm to the reverse CFG. An original
+    // edge `block_id -> successor` is `successor -> block_id` in the reverse CFG,
+    // whose dominator tree is the post-dominator tree computed above.
+    for (&block_id, block) in &func.body.blocks {
+        let stop = post_dominators.get(block_id);
+        for successor in each_terminal_successor(&block.terminal) {
+            for runner in
+                post_dominators.ancestors(successor).take_while(|&runner| Some(runner) != stop)
+            {
+                frontiers.entry(runner).or_default().insert(block_id);
             }
         }
     }
-    frontier
-}
 
-/// Walks up the post-dominator tree to collect all blocks that post-dominate `target_id`.
-fn post_dominators_of(
-    func: &HirFunction,
-    post_dominators: &PostDominator,
-    target_id: BlockId,
-) -> FxHashSet<BlockId> {
-    let mut result = FxHashSet::default();
-    let mut visited = FxHashSet::default();
-    let mut queue = vec![target_id];
-
-    while let Some(current_id) = queue.pop() {
-        if !visited.insert(current_id) {
-            continue;
-        }
-        if let Some(block) = func.body.blocks.get(&current_id) {
-            for &pred in &block.preds {
-                let pred_post_dom = post_dominators.get(pred).unwrap_or(pred);
-                if pred_post_dom == target_id || result.contains(&pred_post_dom) {
-                    result.insert(pred);
-                }
-                queue.push(pred);
-            }
-        }
-    }
-    result
+    Ok(PostDominatorFrontiers { frontiers })
 }
 
 // =============================================================================

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
@@ -17,10 +17,12 @@
 
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_index::IndexVec;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 use crate::diagnostics;
-use crate::react_compiler_hir::dominator::{compute_post_dominator_tree, post_dominator_frontier};
+use crate::react_compiler_hir::dominator::{
+    PostDominatorFrontiers, compute_post_dominator_frontiers,
+};
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::object_shape::HookKind;
 use crate::react_compiler_hir::visitors;
@@ -58,22 +60,11 @@ pub fn infer_reactive_places(
         reactive_map.mark_reactive(place.identifier);
     }
 
-    // Compute control dominators
-    let post_dominators =
-        compute_post_dominator_tree(func, env.next_block_id().index() as u32, false)?;
-
     // Collect block IDs for iteration
     let block_ids: Vec<BlockId> = func.body.blocks.keys().copied().collect();
 
-    // Post-dominator frontiers depend only on the CFG, which is invariant across
-    // the fixpoint below. Compute each block's frontier once here instead of
-    // re-deriving it (a full reverse-CFG walk that allocates several sets) on every
-    // `is_reactive_controlled_block` call — previously once per block plus once per
-    // phi operand, on every fixpoint iteration.
-    let frontiers: FxHashMap<BlockId, FxHashSet<BlockId>> = block_ids
-        .iter()
-        .map(|&block_id| (block_id, post_dominator_frontier(func, &post_dominators, block_id)))
-        .collect();
+    let frontiers =
+        compute_post_dominator_frontiers(func, env.next_block_id().index() as u32, false)?;
 
     // Track phi operand reactive flags during fixpoint.
     // In TS, isReactive() sets place.reactive as a side effect. But when a phi
@@ -363,12 +354,11 @@ impl StableSidemap {
 fn is_reactive_controlled_block(
     block_id: BlockId,
     func: &HirFunction,
-    frontiers: &FxHashMap<BlockId, FxHashSet<BlockId>>,
+    frontiers: &PostDominatorFrontiers,
     reactive_map: &mut ReactivityMap,
 ) -> bool {
-    let Some(frontier) = frontiers.get(&block_id) else { return false };
-    for frontier_block_id in frontier {
-        let control_block = func.body.blocks.get(frontier_block_id).unwrap();
+    for frontier_block_id in frontiers.iter(block_id) {
+        let control_block = func.body.blocks.get(&frontier_block_id).unwrap();
         match &control_block.terminal {
             Terminal::If { test, .. } | Terminal::Branch { test, .. } => {
                 if reactive_map.is_reactive(test.identifier) {

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
@@ -21,7 +21,7 @@ use crate::diagnostics;
 use crate::react_compiler_hir::ArrayPatternElement;
 use crate::react_compiler_hir::ObjectPropertyOrSpread;
 use crate::react_compiler_hir::Pattern;
-use crate::react_compiler_hir::dominator::{compute_post_dominator_tree, post_dominator_frontier};
+use crate::react_compiler_hir::dominator::compute_post_dominator_frontiers;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
     BlockId, FunctionId, HirFunction, Identifier, IdentifierId, InstructionValue, PlaceOrSpread,
@@ -230,15 +230,14 @@ fn create_ref_controlled_block_checker(
     identifiers: &IndexSlice<IdentifierId, [Identifier]>,
     types: &IndexSlice<TypeId, [Type]>,
 ) -> Result<FxHashMap<BlockId, bool>, OxcDiagnostic> {
-    let post_dominators = compute_post_dominator_tree(func, next_block_id_counter, false)?;
+    let frontiers = compute_post_dominator_frontiers(func, next_block_id_counter, false)?;
     let mut cache: FxHashMap<BlockId, bool> = FxHashMap::default();
 
     for (block_id, _block) in &func.body.blocks {
-        let frontier = post_dominator_frontier(func, &post_dominators, *block_id);
         let mut is_controlled = false;
 
-        for frontier_block_id in &frontier {
-            let control_block = &func.body.blocks[frontier_block_id];
+        for frontier_block_id in frontiers.iter(*block_id) {
+            let control_block = &func.body.blocks[&frontier_block_id];
             match &control_block.terminal {
                 Terminal::If { test, .. } | Terminal::Branch { test, .. } => {
                     if is_derived_from_ref(test.identifier, ref_derived_values, identifiers, types)


### PR DESCRIPTION
Compute all post-dominator frontiers in one Cytron-style pass, avoiding a reverse CFG walk for every block. Reuse the result in reactive-place inference and set-state validation.

AI usage: Codex was used to implement and validate this change; the contributor remains responsible for review before merge.