### PR TITLE
feat(linter/typescript/no-confusing-non-null-assertion): implement suggestion

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -4,12 +4,13 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
+use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator};
 
 use crate::{
     AstNode,
     context::{ContextHost, LintContext},
+    fixer::{RuleFix, RuleFixer},
     rule::Rule,
 };
 
@@ -48,7 +49,7 @@ declare_oxc_lint!(
     NoConfusingNonNullAssertion,
     typescript,
     suspicious,
-    pending,
+    suggestion,
     version = "0.6.1",
     short_description = "Disallow non-null assertion in locations that may be confusing.",
 );
@@ -125,21 +126,49 @@ impl Rule for NoConfusingNonNullAssertion {
                 let Some(bang_depth) = get_depth_ends_in_bang(&binary_expr.left) else {
                     return;
                 };
+                let operator = binary_expr.operator.as_str();
+                let left_span = binary_expr.left.span();
                 if matches!(binary_expr.operator, BinaryOperator::In | BinaryOperator::Instanceof) {
-                    ctx.diagnostic(confusing_non_null_operator_diagnostic(
-                        binary_expr.operator.as_str(),
-                        binary_expr.span,
-                    ));
+                    let diagnostic =
+                        confusing_non_null_operator_diagnostic(operator, binary_expr.span);
+                    if bang_depth == 0 {
+                        let fixer = RuleFixer::new(FixKind::Suggestion, ctx);
+                        ctx.diagnostic_with_suggestions(
+                            diagnostic,
+                            [
+                                remove_non_null_assertion_fix(fixer, left_span).with_message(
+                                    format!(
+                                        "Remove possibly unnecessary non-null assertion (!) in the left operand of the `{operator}` operator."
+                                    ),
+                                ),
+                                wrap_left_fix(fixer, left_span, operator),
+                            ],
+                        );
+                    } else {
+                        ctx.diagnostic_with_suggestion(diagnostic, |fixer| {
+                            wrap_left_fix(fixer, left_span, operator)
+                        });
+                    }
                 } else if bang_depth == 0 {
-                    ctx.diagnostic(not_need_no_confusing_non_null_assertion_diagnostic(
-                        binary_expr.operator.as_str(),
-                        binary_expr.span,
-                    ));
+                    ctx.diagnostic_with_suggestion(
+                        not_need_no_confusing_non_null_assertion_diagnostic(
+                            operator,
+                            binary_expr.span,
+                        ),
+                        |fixer| {
+                            remove_non_null_assertion_fix(fixer, left_span).with_message(
+                                "Remove unnecessary non-null assertion (!) in equality test.",
+                            )
+                        },
+                    );
                 } else {
-                    ctx.diagnostic(wrap_up_no_confusing_non_null_assertion_diagnostic(
-                        binary_expr.operator.as_str(),
-                        binary_expr.span,
-                    ));
+                    ctx.diagnostic_with_suggestion(
+                        wrap_up_no_confusing_non_null_assertion_diagnostic(
+                            operator,
+                            binary_expr.span,
+                        ),
+                        |fixer| wrap_left_fix(fixer, left_span, operator),
+                    );
                 }
             }
             AstKind::AssignmentExpression(assignment_expr)
@@ -148,11 +177,21 @@ impl Rule for NoConfusingNonNullAssertion {
                 let Some(simple_target) = assignment_expr.left.as_simple_assignment_target() else {
                     return;
                 };
-                let SimpleAssignmentTarget::TSNonNullExpression(_) = simple_target else { return };
-                ctx.diagnostic(confusing_non_null_assignment_assertion_diagnostic(
-                    assignment_expr.operator.as_str(),
-                    assignment_expr.span,
-                ));
+                let SimpleAssignmentTarget::TSNonNullExpression(non_null_expr) = simple_target
+                else {
+                    return;
+                };
+                ctx.diagnostic_with_suggestion(
+                    confusing_non_null_assignment_assertion_diagnostic(
+                        assignment_expr.operator.as_str(),
+                        assignment_expr.span,
+                    ),
+                    |fixer| {
+                        remove_non_null_assertion_fix(fixer, non_null_expr.span).with_message(
+                            "Remove unnecessary non-null assertion (!) in assignment left-hand side.",
+                        )
+                    },
+                );
             }
             _ => {}
         }
@@ -163,9 +202,23 @@ impl Rule for NoConfusingNonNullAssertion {
     }
 }
 
+fn remove_non_null_assertion_fix(fixer: RuleFixer<'_, '_>, span: Span) -> RuleFix {
+    fixer.delete_range(Span::sized(span.end - 1, 1))
+}
+
+fn wrap_left_fix(fixer: RuleFixer<'_, '_>, span: Span, operator: &str) -> RuleFix {
+    let fixer = fixer.for_multifix();
+    let mut fix = fixer.new_fix_with_capacity(2);
+    fix.push(fixer.insert_text_before_range(span, "("));
+    fix.push(fixer.insert_text_after_range(span, ")"));
+    fix.with_message(format!(
+        r#"Wrap the left-hand side in parentheses to avoid confusion with "{operator}" operator."#
+    ))
+}
+
 #[test]
 fn test() {
-    use crate::tester::Tester;
+    use crate::tester::{ExpectFixTestCase, Tester};
 
     let pass = vec![
         "a == b!;",
@@ -204,11 +257,30 @@ fn test() {
         "foo?.bar! instanceof C;",
     ];
 
-    // let fix = vec![
-    //     // source, expected, rule_config?
-    //     // ("f = 1 + d! == 2", "f = (1 + d!) == 2", None), TODO: Add suggest or the weird ;() fix
-    //     // ("f =  d! == 2", "f = d == 2", None), TODO: Add suggest remove bang
-    // ];
+    let fix: Vec<ExpectFixTestCase> = vec![
+        ("a! == b;", "a == b;").into(),
+        ("a! === b;", "a === b;").into(),
+        ("a + b! == c;", "(a + b!) == c;").into(),
+        (
+            "(obj = new new OuterObj().InnerObj).Name! == c;",
+            "(obj = new new OuterObj().InnerObj).Name == c;",
+        )
+            .into(),
+        ("(a==b)! ==c;", "(a==b) ==c;").into(),
+        ("a! = b;", "a = b;").into(),
+        (
+            "(obj = new new OuterObj().InnerObj).Name! = c;",
+            "(obj = new new OuterObj().InnerObj).Name = c;",
+        )
+            .into(),
+        ("a! in b;", ("a in b;", "(a!) in b;")).into(),
+        ("a !in b;", ("a in b;", "(a !)in b;")).into(),
+        ("a! instanceof b;", ("a instanceof b;", "(a!) instanceof b;")).into(),
+        ("foo?.bar! in obj;", ("foo?.bar in obj;", "(foo?.bar!) in obj;")).into(),
+        ("foo?.bar! instanceof C;", ("foo?.bar instanceof C;", "(foo?.bar!) instanceof C;")).into(),
+    ];
+
     Tester::new(NoConfusingNonNullAssertion::NAME, NoConfusingNonNullAssertion::PLUGIN, pass, fail)
+        .expect_fix(fix)
         .test_and_snapshot();
 }


### PR DESCRIPTION
implements suggestion for `typescript/no-confusing-non-null-assertion`, used tests from upstream. Issue #2180