### PR TITLE
fix(linter): preserve JSX attribute values in curly-brace fixes

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -623,16 +623,37 @@ fn report_unnecessary_curly_for_attribute_value<'a>(
             _ => unreachable!(),
         };
 
-        let mut fix = fixer.codegen();
+        let Some(quoted) = quote_jsx_attribute_value(str.as_str()) else {
+            return fixer.noop();
+        };
 
-        if !contains_double_quote_characters(str.as_str()) {
-            fix = fix.with_options(CodegenOptions::default());
-        }
-
-        fix.print_string(str.as_str());
-
-        fixer.replace(container.span, fix.into_source_text())
+        fixer.replace(container.span, quoted)
     });
+}
+
+fn quote_jsx_attribute_value(value: &str) -> Option<String> {
+    if value.chars().any(char::is_control) {
+        return None;
+    }
+
+    let quote =
+        if contains_double_quote_characters(value) && !contains_single_quote_characters(value) {
+            '\''
+        } else {
+            '"'
+        };
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push(quote);
+    for character in value.chars() {
+        match character {
+            '&' => quoted.push_str("&amp;"),
+            '"' if quote == '"' => quoted.push_str("&quot;"),
+            '\'' if quote == '\'' => quoted.push_str("&apos;"),
+            _ => quoted.push(character),
+        }
+    }
+    quoted.push(quote);
+    Some(quoted)
 }
 
 fn report_missing_curly_for_expression(ctx: &LintContext, span: Span) {
@@ -1047,14 +1068,8 @@ fn test() {
     ];
 
     let fail = vec![
-        (
-            r#"<Markdown content={`\\* Want to learn more`} />"#,
-            Some(json!([{ "props": "never" }])),
-        ),
-        (
-            r#"<Markdown content={"\\* Want to learn more"} />"#,
-            Some(json!([{ "props": "never" }])),
-        ),
+        (r#"<Markdown content={`\\* Want to learn more`} />"#, Some(json!([{ "props": "never" }]))),
+        (r#"<Markdown content={"\\* Want to learn more"} />"#, Some(json!([{ "props": "never" }]))),
         (r#"<Markdown content={"\x26copy;"} />"#, Some(json!([{ "props": "never" }]))),
         (r#"<Markdown content={"\tWant to learn more"} />"#, Some(json!([{ "props": "never" }]))),
         ("<App prop={`foo`} />", Some(json!([{ "props": "never" }]))),

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -1047,6 +1047,10 @@ fn test() {
     ];
 
     let fail = vec![
+        (
+            r#"<Markdown content={`\\* Want to learn more`} />"#,
+            Some(json!([{ "props": "never" }])),
+        ),
         ("<App prop={`foo`} />", Some(json!([{ "props": "never" }]))),
         ("<App>{<myApp></myApp>}</App>", Some(json!([{ "children": "never" }]))),
         ("<App>{<myApp></myApp>}</App>", None),
@@ -1199,6 +1203,16 @@ fn test() {
     ];
 
     let fix = vec![
+        (
+            r#"<Markdown content={`\\* Want to learn more`} />"#,
+            r#"<Markdown content="\* Want to learn more" />"#,
+            Some(json!([{ "props": "never" }])),
+        ),
+        (
+            "<Markdown content={`Want to learn more`} />",
+            r#"<Markdown content="Want to learn more" />"#,
+            Some(json!([{ "props": "never" }])),
+        ),
         ("<App prop={`foo`} />", r#"<App prop="foo" />"#, Some(json!([{ "props": "never" }]))),
         (
             "<App>{<myApp></myApp>}</App>",

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -1051,6 +1051,12 @@ fn test() {
             r#"<Markdown content={`\\* Want to learn more`} />"#,
             Some(json!([{ "props": "never" }])),
         ),
+        (
+            r#"<Markdown content={"\\* Want to learn more"} />"#,
+            Some(json!([{ "props": "never" }])),
+        ),
+        (r#"<Markdown content={"\x26copy;"} />"#, Some(json!([{ "props": "never" }]))),
+        (r#"<Markdown content={"\tWant to learn more"} />"#, Some(json!([{ "props": "never" }]))),
         ("<App prop={`foo`} />", Some(json!([{ "props": "never" }]))),
         ("<App>{<myApp></myApp>}</App>", Some(json!([{ "children": "never" }]))),
         ("<App>{<myApp></myApp>}</App>", None),
@@ -1206,6 +1212,21 @@ fn test() {
         (
             r#"<Markdown content={`\\* Want to learn more`} />"#,
             r#"<Markdown content="\* Want to learn more" />"#,
+            Some(json!([{ "props": "never" }])),
+        ),
+        (
+            r#"<Markdown content={"\\* Want to learn more"} />"#,
+            r#"<Markdown content="\* Want to learn more" />"#,
+            Some(json!([{ "props": "never" }])),
+        ),
+        (
+            r#"<Markdown content={"\x26copy;"} />"#,
+            r#"<Markdown content="&amp;copy;" />"#,
+            Some(json!([{ "props": "never" }])),
+        ),
+        (
+            r#"<Markdown content={"\tWant to learn more"} />"#,
+            r#"<Markdown content={"\tWant to learn more"} />"#,
             Some(json!([{ "props": "never" }])),
         ),
         (

--- a/crates/oxc_linter/src/snapshots/react_jsx_curly_brace_presence.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_curly_brace_presence.snap
@@ -3,6 +3,33 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ react(jsx-curly-brace-presence): Curly braces are unnecessary here.
+   ╭─[jsx_curly_brace_presence.tsx:1:20]
+ 1 │ <Markdown content={`\\* Want to learn more`} />
+   ·                    ────────────────────────
+   ╰────
+  help: Replace `{`\\* Want to learn more`}` with `"\* Want to learn more"`.
+
+  ⚠ react(jsx-curly-brace-presence): Curly braces are unnecessary here.
+   ╭─[jsx_curly_brace_presence.tsx:1:20]
+ 1 │ <Markdown content={"\\* Want to learn more"} />
+   ·                    ────────────────────────
+   ╰────
+  help: Replace `{"\\* Want to learn more"}` with `"\* Want to learn more"`.
+
+  ⚠ react(jsx-curly-brace-presence): Curly braces are unnecessary here.
+   ╭─[jsx_curly_brace_presence.tsx:1:20]
+ 1 │ <Markdown content={"\x26copy;"} />
+   ·                    ───────────
+   ╰────
+  help: Replace `{"\x26copy;"}` with `"&amp;copy;"`.
+
+  ⚠ react(jsx-curly-brace-presence): Curly braces are unnecessary here.
+   ╭─[jsx_curly_brace_presence.tsx:1:20]
+ 1 │ <Markdown content={"\tWant to learn more"} />
+   ·                    ──────────────────────
+   ╰────
+
+  ⚠ react(jsx-curly-brace-presence): Curly braces are unnecessary here.
    ╭─[jsx_curly_brace_presence.tsx:1:12]
  1 │ <App prop={`foo`} />
    ·            ─────


### PR DESCRIPTION
## Summary

Fixes #25934.

`react/jsx-curly-brace-presence` now emits JSX attribute syntax from the cooked value instead of passing it through JavaScript string code generation. This preserves literal backslashes and escapes ampersands before JSX's entity-decoding pass, so the standard autofix no longer changes the prop value.

Values containing control characters keep the diagnostic but receive no fix because they cannot be represented safely as a quoted JSX attribute. Existing safe string and template-literal fixes continue to apply.

## Test plan

- `cargo test -p oxc_linter -- jsx_curly_brace_presence --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy -p oxc_linter --lib -- -D warnings`

The focused fixtures cover escaped backslashes from both template and string literals, entity-like cooked values, control characters, and an ordinary safe conversion.

## AI assistance

Codex assisted with reproducing the fixer output, developing the regression cases, and reviewing the implementation. I traced the cooked-value and JSX entity semantics, reviewed the final diff, and ran the checks above locally.
