### PR TITLE
perf(react-compiler): optimize non-null propagation

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -16,6 +16,7 @@ use crate::react_compiler_utils::FxIndexMap;
 use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
 use oxc_index::IndexVec;
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 use std::collections::BTreeSet;
 use std::ptr::eq;
 
@@ -788,6 +789,46 @@ struct PropertyPathRegistry<'a> {
     alloc: &'a Allocator,
 }
 
+type PropertyPathSet = SmallVec<[usize; 8]>;
+
+#[inline]
+fn insert_property_path(paths: &mut PropertyPathSet, path: usize) {
+    if let Err(index) = paths.binary_search(&path) {
+        paths.insert(index, path);
+    }
+}
+
+#[inline]
+fn remove_property_path(paths: &mut PropertyPathSet, path: usize) {
+    if let Ok(index) = paths.binary_search(&path) {
+        paths.remove(index);
+    }
+}
+
+fn union_property_paths(
+    paths: &mut PropertyPathSet,
+    original_paths: &[usize],
+    propagated_paths: &[usize],
+) {
+    paths.clear();
+    paths.reserve(original_paths.len() + propagated_paths.len());
+
+    let mut original = original_paths.iter().copied().peekable();
+    let mut propagated = propagated_paths.iter().copied().peekable();
+    while let (Some(&original_path), Some(&propagated_path)) = (original.peek(), propagated.peek())
+    {
+        paths.push(original_path.min(propagated_path));
+        if original_path <= propagated_path {
+            original.next();
+        }
+        if propagated_path <= original_path {
+            propagated.next();
+        }
+    }
+    paths.extend(original);
+    paths.extend(propagated);
+}
+
 impl<'a> PropertyPathRegistry<'a> {
     fn new(alloc: &'a Allocator) -> Self {
         Self { nodes: Vec::new(), roots: FxHashMap::default(), alloc }
@@ -879,9 +920,9 @@ impl<'a> PropertyPathRegistry<'a> {
 /// `<base>.PROPERTY`.
 ///
 /// Port of `reduceMaybeOptionalChains` from CollectHoistablePropertyLoads.ts.
-fn reduce_maybe_optional_chains(nodes: &mut BTreeSet<usize>, registry: &mut PropertyPathRegistry) {
+fn reduce_maybe_optional_chains(nodes: &mut PropertyPathSet, registry: &mut PropertyPathRegistry) {
     // Collect indices of nodes that have optional in their path
-    let mut optional_chain_nodes: BTreeSet<usize> =
+    let mut optional_chain_nodes: PropertyPathSet =
         nodes.iter().copied().filter(|&idx| registry.nodes[idx].has_optional).collect();
 
     if optional_chain_nodes.is_empty() {
@@ -892,7 +933,7 @@ fn reduce_maybe_optional_chains(nodes: &mut BTreeSet<usize>, registry: &mut Prop
         let mut changed = false;
 
         // Collect the indices to process (snapshot to avoid borrow issues)
-        let to_process: Vec<usize> = optional_chain_nodes.iter().copied().collect();
+        let to_process = optional_chain_nodes.clone();
 
         for original_idx in to_process {
             let full_path = registry.nodes[original_idx].full_path.clone_in(registry.alloc);
@@ -905,7 +946,7 @@ fn reduce_maybe_optional_chains(nodes: &mut BTreeSet<usize>, registry: &mut Prop
 
             for entry in &full_path.path {
                 // If the base is known to be non-null (in the set), replace optional with non-optional
-                let next_entry = if entry.optional && nodes.contains(&curr_node) {
+                let next_entry = if entry.optional && nodes.binary_search(&curr_node).is_ok() {
                     DependencyPathEntry {
                         property: entry.property,
                         computed: entry.computed,
@@ -920,10 +961,10 @@ fn reduce_maybe_optional_chains(nodes: &mut BTreeSet<usize>, registry: &mut Prop
 
             if curr_node != original_idx {
                 changed = true;
-                optional_chain_nodes.remove(&original_idx);
-                optional_chain_nodes.insert(curr_node);
-                nodes.remove(&original_idx);
-                nodes.insert(curr_node);
+                remove_property_path(&mut optional_chain_nodes, original_idx);
+                insert_property_path(&mut optional_chain_nodes, curr_node);
+                remove_property_path(nodes, original_idx);
+                insert_property_path(nodes, curr_node);
             }
         }
 
@@ -935,7 +976,7 @@ fn reduce_maybe_optional_chains(nodes: &mut BTreeSet<usize>, registry: &mut Prop
 
 #[derive(Debug, Clone)]
 struct BlockInfo {
-    assumed_non_null_objects: BTreeSet<usize>, // indices into PropertyPathRegistry
+    assumed_non_null_objects: PropertyPathSet, // indices into PropertyPathRegistry
 }
 
 struct CollectHoistableContext<'a, 'e> {
@@ -1139,13 +1180,13 @@ fn collect_non_nulls_in_blocks<'a>(
     registry: &mut PropertyPathRegistry<'a>,
 ) -> FxHashMap<BlockId, BlockInfo> {
     // Known non-null identifiers (e.g. component props)
-    let mut known_non_null: BTreeSet<usize> = BTreeSet::new();
+    let mut known_non_null = PropertyPathSet::default();
     if func.fn_type == ReactFunctionType::Component
         && !func.params.is_empty()
         && let ParamPattern::Place(place) = &func.params[0]
     {
         let node_idx = registry.get_or_create_identifier(place.identifier, true, place.span);
-        known_non_null.insert(node_idx);
+        insert_property_path(&mut known_non_null, node_idx);
     }
 
     let mut nodes: FxHashMap<BlockId, BlockInfo> = FxHashMap::default();
@@ -1156,7 +1197,7 @@ fn collect_non_nulls_in_blocks<'a>(
         // Check hoistable from optionals
         if let Some(optional_chain) = ctx.hoistable_from_optionals.get(block_id) {
             let node_idx = registry.get_or_create_property(optional_chain);
-            assumed.insert(node_idx);
+            insert_property_path(&mut assumed, node_idx);
         }
 
         for &instr_id in &block.instructions {
@@ -1167,7 +1208,7 @@ fn collect_non_nulls_in_blocks<'a>(
                 let path_ident = path.identifier;
                 if is_immutable_at_instr(path_ident, instr.id, env, ctx) {
                     let node_idx = registry.get_or_create_property(&path);
-                    assumed.insert(node_idx);
+                    insert_property_path(&mut assumed, node_idx);
                 }
             }
 
@@ -1194,7 +1235,7 @@ fn collect_non_nulls_in_blocks<'a>(
                                 span: dep.span,
                             };
                             let node_idx = registry.get_or_create_property(&sub_dep);
-                            assumed.insert(node_idx);
+                            insert_property_path(&mut assumed, node_idx);
                         }
                     }
                 }
@@ -1235,7 +1276,7 @@ fn collect_non_nulls_in_blocks<'a>(
                 let inner_entry = inner_func.body.entry;
                 if let Some(inner_set) = inner_working.get(&inner_entry) {
                     for &node_idx in inner_set {
-                        assumed.insert(node_idx);
+                        insert_property_path(&mut assumed, node_idx);
                     }
                 }
             }
@@ -1258,7 +1299,7 @@ fn propagate_non_null(
     func: &HirFunction,
     nodes: &FxHashMap<BlockId, BlockInfo>,
     registry: &mut PropertyPathRegistry,
-) -> FxHashMap<BlockId, BTreeSet<usize>> {
+) -> FxHashMap<BlockId, PropertyPathSet> {
     // Build successor map. Use BTreeSet to iterate successors in sorted BlockId
     // order, matching the TS Set<BlockId> insertion order (blocks are created in
     // ascending BlockId order).
@@ -1270,44 +1311,48 @@ fn propagate_non_null(
     }
 
     // Clone nodes into mutable working set
-    let mut working: FxHashMap<BlockId, BTreeSet<usize>> =
+    let mut working: FxHashMap<BlockId, PropertyPathSet> =
         nodes.iter().map(|(k, v)| (*k, v.assumed_non_null_objects.clone())).collect();
 
     let block_ids: Vec<BlockId> = func.body.blocks.keys().copied().collect();
     let mut reversed_block_ids = block_ids.clone();
     reversed_block_ids.reverse();
 
+    let mut state = NonNullPropagationState {
+        traversal_state: FxHashMap::default(),
+        neighbor_intersection: PropertyPathSet::default(),
+        previous_objects: PropertyPathSet::default(),
+    };
+
     for _ in 0..100 {
         let mut changed = false;
 
         // Forward pass (using predecessors)
-        let mut traversal_state: FxHashMap<BlockId, TraversalState> = FxHashMap::default();
+        state.traversal_state.clear();
         for &block_id in &block_ids {
-            let block_changed = recursively_propagate_non_null(
+            changed |= recursively_propagate_non_null(
                 block_id,
                 PropagationDirection::Forward,
-                &mut traversal_state,
+                &mut state,
                 &mut working,
                 func,
                 &block_successors,
                 registry,
             );
-            changed |= block_changed;
         }
 
         // Backward pass (using successors)
-        traversal_state.clear();
+        state.traversal_state.clear();
         for &block_id in &reversed_block_ids {
-            let block_changed = recursively_propagate_non_null(
+            changed |= recursively_propagate_non_null(
                 block_id,
                 PropagationDirection::Backward,
-                &mut traversal_state,
+                &mut state,
                 &mut working,
                 func,
                 &block_successors,
                 registry,
             );
-            changed |= block_changed;
         }
 
         if !changed {
@@ -1330,20 +1375,26 @@ enum PropagationDirection {
     Backward,
 }
 
+struct NonNullPropagationState {
+    traversal_state: FxHashMap<BlockId, TraversalState>,
+    neighbor_intersection: PropertyPathSet,
+    previous_objects: PropertyPathSet,
+}
+
 fn recursively_propagate_non_null(
     node_id: BlockId,
     direction: PropagationDirection,
-    traversal_state: &mut FxHashMap<BlockId, TraversalState>,
-    working: &mut FxHashMap<BlockId, BTreeSet<usize>>,
+    state: &mut NonNullPropagationState,
+    working: &mut FxHashMap<BlockId, PropertyPathSet>,
     func: &HirFunction,
     block_successors: &FxHashMap<BlockId, BTreeSet<BlockId>>,
     registry: &mut PropertyPathRegistry,
 ) -> bool {
     // Avoid re-visiting computed or currently active nodes
-    if traversal_state.contains_key(&node_id) {
+    if state.traversal_state.contains_key(&node_id) {
         return false;
     }
-    traversal_state.insert(node_id, TraversalState::Active);
+    state.traversal_state.insert(node_id, TraversalState::Active);
 
     let neighbors: Vec<BlockId> = match direction {
         PropagationDirection::Backward => {
@@ -1359,44 +1410,48 @@ fn recursively_propagate_non_null(
 
     let mut changed = false;
     for &neighbor in &neighbors {
-        if !traversal_state.contains_key(&neighbor) {
-            let neighbor_changed = recursively_propagate_non_null(
+        if !state.traversal_state.contains_key(&neighbor) {
+            changed |= recursively_propagate_non_null(
                 neighbor,
                 direction,
-                traversal_state,
+                state,
                 working,
                 func,
                 block_successors,
                 registry,
             );
-            changed |= neighbor_changed;
         }
     }
 
-    // Compute intersection of 'done' neighbors only (filter out 'active' = cycle nodes)
-    let done_neighbor_sets: Vec<BTreeSet<usize>> = neighbors
-        .iter()
-        .filter(|n| traversal_state.get(n) == Some(&TraversalState::Done))
-        .filter_map(|n| working.get(n).cloned())
-        .collect();
+    // Compute the intersection of 'done' neighbors only (filter out 'active' cycle nodes),
+    // reusing one scratch set for every block in the traversal.
+    state.neighbor_intersection.clear();
+    let mut has_done_neighbor = false;
+    for neighbor in &neighbors {
+        if state.traversal_state.get(neighbor) != Some(&TraversalState::Done) {
+            continue;
+        }
+        let Some(neighbor_objects) = working.get(neighbor) else {
+            continue;
+        };
+        if has_done_neighbor {
+            state.neighbor_intersection.retain(|path| neighbor_objects.binary_search(path).is_ok());
+        } else {
+            state.neighbor_intersection.clone_from(neighbor_objects);
+            has_done_neighbor = true;
+        }
+    }
 
-    let neighbor_intersection = if done_neighbor_sets.is_empty() {
-        BTreeSet::new()
-    } else {
-        let mut iter = done_neighbor_sets.into_iter();
-        let first = iter.next().unwrap();
-        iter.fold(first, |acc, s| acc.intersection(&s).copied().collect())
-    };
+    let objects = working.get_mut(&node_id).expect("missing non-null propagation block");
+    state.previous_objects.clone_from(objects);
+    if has_done_neighbor {
+        union_property_paths(objects, &state.previous_objects, &state.neighbor_intersection);
+    }
+    reduce_maybe_optional_chains(objects, registry);
 
-    let prev_objects = working.get(&node_id).cloned().unwrap_or_default();
-    let mut merged: BTreeSet<usize> = prev_objects.union(&neighbor_intersection).copied().collect();
-    reduce_maybe_optional_chains(&mut merged, registry);
+    state.traversal_state.insert(node_id, TraversalState::Done);
 
-    working.insert(node_id, merged.clone());
-    traversal_state.insert(node_id, TraversalState::Done);
-
-    // Compare with previous value — can't just check size due to reduce_maybe_optional_chains
-    changed |= prev_objects != merged;
+    changed |= state.previous_objects != *objects;
     changed
 }
 
@@ -1405,7 +1460,7 @@ fn collect_hoistable_and_propagate<'a>(
     env: &Environment<'a>,
     temporaries: &TemporariesMap<'a>,
     hoistable_from_optionals: &FxHashMap<BlockId, ReactiveScopeDependency<'a>>,
-) -> (FxHashMap<BlockId, BTreeSet<usize>>, PropertyPathRegistry<'a>) {
+) -> (FxHashMap<BlockId, PropertyPathSet>, PropertyPathRegistry<'a>) {
     let mut registry = PropertyPathRegistry::new(env.allocator);
     let assumed_invoked_fns = get_assumed_invoked_functions(func, env);
     let known_immutable_identifiers: FxHashSet<IdentifierId> = if func.fn_type


### PR DESCRIPTION
Replace tree-based property-path sets with sorted inline sets and reuse scratch storage across fixpoint passes while preserving sorted block traversal.

Fixture benchmark: React Compiler time 10.30s → 9.26s.

AI assistance was used to investigate, implement, and benchmark this change.