### PR TITLE
fix(formatter): stabilize balanced JSDoc list wrapping

### DIFF
--- a/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/mod.rs
+++ b/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/mod.rs
@@ -146,7 +146,30 @@ pub fn format_description_mdast(
     serialize_children(&root, 0, opts.tag_string_length, &opts, &mut lines);
 
     let output = lines.into_string();
-    restore_in_string(&output, &placeholders).into_owned()
+    let output = restore_in_string(&output, &placeholders).into_owned();
+
+    // Greedy fallback in balance mode can move a prose dash to the start of a
+    // line after markdown parsing has already finished. Stabilize that newly
+    // created list marker now, rather than discovering it on the next format.
+    if matches!(line_wrapping_style, crate::LineWrappingStyle::Balance)
+        && contains_dash_list_marker(&output)
+        && !contains_dash_list_marker(text.as_ref())
+    {
+        return format_description_mdast(
+            &output,
+            max_width,
+            tag_string_length,
+            capitalize,
+            format_options,
+            session,
+        );
+    }
+
+    output
+}
+
+fn contains_dash_list_marker(text: &str) -> bool {
+    text.lines().any(|line| line.trim_start().starts_with("- "))
 }
 
 pub(super) struct SerializeOptions<'a> {

--- a/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/mod.rs
+++ b/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/mod.rs
@@ -35,6 +35,64 @@ pub fn format_description_mdast(
     format_options: &JsFormatOptions,
     session: &FormatSession<'_>,
 ) -> String {
+    format_description_mdast_impl(
+        text,
+        max_width,
+        tag_string_length,
+        capitalize,
+        format_options,
+        session,
+        true,
+    )
+}
+
+fn format_description_mdast_impl(
+    text: &str,
+    max_width: usize,
+    tag_string_length: usize,
+    capitalize: bool,
+    format_options: &JsFormatOptions,
+    session: &FormatSession<'_>,
+    allow_stabilization: bool,
+) -> String {
+    let output = format_description_mdast_once(
+        text,
+        max_width,
+        tag_string_length,
+        capitalize,
+        format_options,
+        session,
+    );
+    let is_balance = format_options.jsdoc.as_ref().is_some_and(|options| {
+        matches!(options.line_wrapping_style, crate::LineWrappingStyle::Balance)
+    });
+
+    // Greedy fallback in balance mode can move a prose dash to the start of a
+    // line after markdown parsing has already finished. Allow one explicit
+    // stabilization pass so the new list marker is recognized immediately.
+    if allow_stabilization && is_balance && contains_dash_list_marker(&output) {
+        return format_description_mdast_impl(
+            &output,
+            max_width,
+            tag_string_length,
+            capitalize,
+            format_options,
+            session,
+            false,
+        );
+    }
+
+    output
+}
+
+fn format_description_mdast_once(
+    text: &str,
+    max_width: usize,
+    tag_string_length: usize,
+    capitalize: bool,
+    format_options: &JsFormatOptions,
+    session: &FormatSession<'_>,
+) -> String {
     if text.trim().is_empty() {
         return String::new();
     }
@@ -146,26 +204,7 @@ pub fn format_description_mdast(
     serialize_children(&root, 0, opts.tag_string_length, &opts, &mut lines);
 
     let output = lines.into_string();
-    let output = restore_in_string(&output, &placeholders).into_owned();
-
-    // Greedy fallback in balance mode can move a prose dash to the start of a
-    // line after markdown parsing has already finished. Stabilize that newly
-    // created list marker now, rather than discovering it on the next format.
-    if matches!(line_wrapping_style, crate::LineWrappingStyle::Balance)
-        && contains_dash_list_marker(&output)
-        && !contains_dash_list_marker(text.as_ref())
-    {
-        return format_description_mdast(
-            &output,
-            max_width,
-            tag_string_length,
-            capitalize,
-            format_options,
-            session,
-        );
-    }
-
-    output
+    restore_in_string(&output, &placeholders).into_owned()
 }
 
 fn contains_dash_list_marker(text: &str) -> bool {

--- a/crates/oxc_formatter/tests/jsdoc/fixtures/line-wrapping-balance/007-mid-paragraph-list-marker.options.json
+++ b/crates/oxc_formatter/tests/jsdoc/fixtures/line-wrapping-balance/007-mid-paragraph-list-marker.options.json
@@ -1,0 +1,5 @@
+{
+  "comment_line_strategy": "multiline",
+  "line_wrapping_style": "balance",
+  "print_width": 80
+}

--- a/crates/oxc_formatter/tests/jsdoc/fixtures/line-wrapping-balance/007-mid-paragraph-list-marker.output.ts
+++ b/crates/oxc_formatter/tests/jsdoc/fixtures/line-wrapping-balance/007-mid-paragraph-list-marker.output.ts
@@ -1,0 +1,14 @@
+/**
+ * @file The pure layer of the config-loader system: the per-handler quota
+ *   shapes, the payer roles, the model-name helpers, and the tally that turns
+ *   Database message rows into per-handler spend. The I/O that reads those rows
+ *   from SQLite and the providers' own surfaces lives in
+ *   `config-loader-read.mts` so this module can be imported by a SQLite-free
+ *   renderer (the natively-built statusline entry) without pulling
+ *   `node:sqlite` or the credential-backed readers into it. EVERY PROVIDER HAS
+ *   A DIFFERENT METER. Fireworks bills dollars. Synthetic sells a REQUEST rate
+ *
+ *   - 500 per rolling 5 hours - so a dollar gauge over it would fill on the wrong
+ *     axis and read full right up until the requests ran out.
+ */
+export const value = 1;

--- a/crates/oxc_formatter/tests/jsdoc/fixtures/line-wrapping-balance/007-mid-paragraph-list-marker.ts
+++ b/crates/oxc_formatter/tests/jsdoc/fixtures/line-wrapping-balance/007-mid-paragraph-list-marker.ts
@@ -1,0 +1,13 @@
+/**
+ * @file The pure layer of the config-loader system: the per-handler quota
+ *   shapes, the payer roles, the model-name helpers, and the tally that turns
+ *   Database message rows into per-handler spend. The I/O that reads those
+ *   rows from SQLite and the providers' own surfaces lives in `config-loader-read.mts`
+ *   so this module can be imported by a SQLite-free renderer (the natively-built
+ *   statusline entry) without pulling `node:sqlite` or the credential-backed
+ *   readers into it. EVERY PROVIDER HAS A DIFFERENT METER. Fireworks bills
+ *   dollars. Synthetic sells a REQUEST rate - 500 per rolling 5 hours - so a
+ *   dollar gauge over it would fill on the wrong axis and read full right up
+ *   until the requests ran out.
+ */
+export const value = 1

--- a/crates/oxc_formatter/tests/jsdoc/fixtures/line-wrapping-balance/008-existing-list-and-generated-marker.options.json
+++ b/crates/oxc_formatter/tests/jsdoc/fixtures/line-wrapping-balance/008-existing-list-and-generated-marker.options.json
@@ -1,0 +1,5 @@
+{
+  "comment_line_strategy": "multiline",
+  "line_wrapping_style": "balance",
+  "print_width": 80
+}

--- a/crates/oxc_formatter/tests/jsdoc/fixtures/line-wrapping-balance/008-existing-list-and-generated-marker.output.ts
+++ b/crates/oxc_formatter/tests/jsdoc/fixtures/line-wrapping-balance/008-existing-list-and-generated-marker.output.ts
@@ -1,0 +1,15 @@
+/**
+ * @file The pure layer of the config-loader system: the per-handler quota
+ *   shapes, the payer roles, the model-name helpers, and the tally that turns
+ *   Database message rows into per-handler spend. The I/O that reads those rows
+ *   from SQLite and the providers' own surfaces lives in
+ *   `config-loader-read.mts` so this module can be imported by a SQLite-free
+ *   renderer (the natively-built statusline entry) without pulling
+ *   `node:sqlite` or the credential-backed readers into it. EVERY PROVIDER HAS
+ *   A DIFFERENT METER. Fireworks bills dollars. Synthetic sells a REQUEST rate
+ *
+ *   - 500 per rolling 5 hours - so a dollar gauge over it would fill on the wrong
+ *     axis and read full right up until the requests ran out.
+ *   - Existing list item.
+ */
+export const value = 1;

--- a/crates/oxc_formatter/tests/jsdoc/fixtures/line-wrapping-balance/008-existing-list-and-generated-marker.ts
+++ b/crates/oxc_formatter/tests/jsdoc/fixtures/line-wrapping-balance/008-existing-list-and-generated-marker.ts
@@ -1,0 +1,15 @@
+/**
+ * @file The pure layer of the config-loader system: the per-handler quota
+ *   shapes, the payer roles, the model-name helpers, and the tally that turns
+ *   Database message rows into per-handler spend. The I/O that reads those
+ *   rows from SQLite and the providers' own surfaces lives in `config-loader-read.mts`
+ *   so this module can be imported by a SQLite-free renderer (the natively-built
+ *   statusline entry) without pulling `node:sqlite` or the credential-backed
+ *   readers into it. EVERY PROVIDER HAS A DIFFERENT METER. Fireworks bills
+ *   dollars. Synthetic sells a REQUEST rate - 500 per rolling 5 hours - so a
+ *   dollar gauge over it would fill on the wrong axis and read full right up
+ *   until the requests ran out.
+ *
+ *   - Existing list item.
+ */
+export const value = 1


### PR DESCRIPTION
## Summary

Fixes #25825.

Balanced JSDoc wrapping can move prose beginning with `- ` to the start of a line after the Markdown tree has already been parsed. The first formatter run therefore treats it as prose, while the second run reparses it as a list and changes the output again.

This change allows one explicitly bounded stabilization pass when balanced output contains a dash-list candidate. The second pass recognizes the generated list immediately, making the first result a fixed point without permitting unbounded recursion. The guard is pass-based rather than document-wide, so an unrelated existing list cannot suppress stabilization elsewhere in the same comment.

## Test plan

- `cargo test -p oxc_formatter --test jsdoc`
- `cargo test -p oxc_formatter --lib`
- `cargo fmt --all -- --check`
- `cargo clippy -p oxc_formatter --test jsdoc -- -D warnings`

The fixtures cover the reported mid-paragraph marker and a mixed comment containing both a pre-existing list and a newly generated marker.

## AI assistance

Codex assisted with reproducing the two-pass behavior, developing the regression fixtures, and reviewing the implementation. I inspected the Markdown serialization path, verified the bounded-pass behavior, reviewed the final diff, and ran the checks above locally.
