### PR TITLE
fix(linter/eslint/no-useless-rename): preserve type modifiers

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -2,7 +2,7 @@ use oxc_ast::{
     AstKind,
     ast::{
         AssignmentTargetMaybeDefault, AssignmentTargetProperty, AssignmentTargetPropertyProperty,
-        BindingPattern, BindingProperty,
+        BindingPattern, BindingProperty, ImportOrExportKind,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -157,11 +157,15 @@ impl Rule for NoUselessRename {
                 ctx.diagnostic_with_fix(
                     no_useless_rename_diagnostic(import_specifier.local.span),
                     |fixer| {
-                        // Always replace the entire specifier with just the local identifier
-                        // The local identifier is the name that will be used in the code
                         let local_text =
                             import_specifier.local.span.source_text(ctx.source_text()).to_string();
-                        fixer.replace(import_specifier.span, local_text)
+                        let replacement =
+                            if import_specifier.import_kind == ImportOrExportKind::Type {
+                                format!("type {local_text}")
+                            } else {
+                                local_text
+                            };
+                        fixer.replace(import_specifier.span, replacement)
                     },
                 );
             }
@@ -176,14 +180,20 @@ impl Rule for NoUselessRename {
                         ctx.diagnostic_with_fix(
                             no_useless_rename_diagnostic(specifier.local.span()),
                             |fixer| {
-                                // Always replace the entire specifier with just the local part
-                                // The local is what the variable is named inside the module
+                                // Always replace the entire specifier with just the local part.
+                                // The local is what the variable is named inside the module.
                                 let local_text = specifier
                                     .local
                                     .span()
                                     .source_text(ctx.source_text())
                                     .to_string();
-                                fixer.replace(specifier.span, local_text)
+                                let replacement =
+                                    if specifier.export_kind == ImportOrExportKind::Type {
+                                        format!("type {local_text}")
+                                    } else {
+                                        local_text
+                                    };
+                                fixer.replace(specifier.span, replacement)
                             },
                         );
                     }
@@ -205,7 +215,13 @@ impl Rule for NoUselessRename {
                                     .span()
                                     .source_text(ctx.source_text())
                                     .to_string();
-                                fixer.replace(specifier.span, local_text)
+                                let replacement =
+                                    if specifier.export_kind == ImportOrExportKind::Type {
+                                        format!("type {local_text}")
+                                    } else {
+                                        local_text
+                                    };
+                                fixer.replace(specifier.span, replacement)
                             },
                         );
                     }
@@ -590,6 +606,10 @@ fn test() {
         ("import {foo as foo, bar as baz} from 'foo';", "import {foo, bar as baz} from 'foo';"),
         ("import {foo as bar, baz as baz} from 'foo';", "import {foo as bar, baz} from 'foo';"),
         ("import {foo as foo, bar as bar} from 'foo';", "import {foo, bar} from 'foo';"),
+        (
+            "export { type Foo as Foo } from 'mod'; import { type Bar as Bar } from 'mod'; type Baz = unknown; export { type Baz as Baz };",
+            "export { type Foo } from 'mod'; import { type Bar } from 'mod'; type Baz = unknown; export { type Baz };",
+        ),
         ("var foo = 0; export {foo as foo};", "var foo = 0; export {foo};"),
         ("var foo = 0; export {foo as 'foo'};", "var foo = 0; export {foo};"),
         ("export {foo as 'foo'} from 'bar';", "export {foo} from 'bar';"),


### PR DESCRIPTION
Preserves inline `type` modifiers when `no-useless-rename` removes a redundant import or export alias, avoiding semantic changes under `verbatimModuleSyntax`.

fixes #26004