### PR TITLE
fix(formatter): preserve class decorators before export when the statement is suppressed

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -473,10 +473,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Expression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -486,14 +486,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierReference<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -506,10 +506,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierReference<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -519,10 +519,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingIdentifier<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabelIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -532,14 +532,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabelIdentifier<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThisExpression> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -552,14 +552,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThisExpression> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, true, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -613,10 +613,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayExpressionElement<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Elision> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -626,14 +626,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Elision> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, true, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -676,10 +676,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectPropertyKind<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectProperty<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -730,14 +730,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PropertyKey<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -750,14 +750,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TaggedTemplateExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -770,10 +770,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TaggedTemplateExpressio
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            self.format_leading_comments(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+            format_leading_comments(self.suppressed_span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -823,14 +823,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, MemberExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ComputedMemberExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -843,14 +843,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ComputedMemberExpressio
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticMemberExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -863,14 +863,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticMemberExpression<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateFieldExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -883,14 +883,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateFieldExpression<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CallExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -903,14 +903,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CallExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -923,14 +923,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportMeta> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -943,14 +943,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportMeta> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewTarget> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -963,10 +963,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewTarget> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SpreadElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1007,14 +1007,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Argument<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UpdateExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1027,14 +1027,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UpdateExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UnaryExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1047,14 +1047,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UnaryExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BinaryExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1067,14 +1067,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BinaryExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateInExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1087,14 +1087,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateInExpression<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LogicalExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1107,14 +1107,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LogicalExpression<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ConditionalExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1127,14 +1127,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ConditionalExpression<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1280,10 +1280,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPattern
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayAssignmentTarget<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1293,10 +1293,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayAssignmentTarget<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectAssignmentTarget<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1306,10 +1306,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectAssignmentTarget<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetRest<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1350,10 +1350,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetMaybeDe
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetWithDefault<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1393,10 +1393,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropert
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropertyIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1406,10 +1406,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropert
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropertyProperty<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1419,14 +1419,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentTargetPropert
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SequenceExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1439,14 +1439,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SequenceExpression<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Super> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1459,14 +1459,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Super> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AwaitExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1479,14 +1479,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AwaitExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ChainExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1540,14 +1540,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ChainElement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ParenthesizedExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1785,10 +1785,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Statement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Directive<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1798,10 +1798,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Directive<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Hashbang<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1811,10 +1811,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Hashbang<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BlockStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1934,10 +1934,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Declaration<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1947,10 +1947,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclaration<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclarator<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1960,10 +1960,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, VariableDeclarator<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, EmptyStatement> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1973,10 +1973,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, EmptyStatement> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExpressionStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            self.format_leading_comments(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+            format_leading_comments(self.suppressed_span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -1986,7 +1986,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExpressionStatement<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IfStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
             self.write_suppressed(f);
@@ -1999,7 +1999,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IfStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, DoWhileStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
             self.write_suppressed(f);
@@ -2012,7 +2012,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, DoWhileStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WhileStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
             self.write_suppressed(f);
@@ -2025,7 +2025,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WhileStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
             self.write_suppressed(f);
@@ -2069,7 +2069,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForStatementInit<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForInStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
             self.write_suppressed(f);
@@ -2113,7 +2113,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForStatementLeft<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForOfStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
             self.write_suppressed(f);
@@ -2126,7 +2126,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ForOfStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ContinueStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
             self.write_suppressed(f);
@@ -2139,7 +2139,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ContinueStatement<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BreakStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
             self.write_suppressed(f);
@@ -2152,7 +2152,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BreakStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ReturnStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
             self.write_suppressed(f);
@@ -2165,7 +2165,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ReturnStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
             self.write_suppressed(f);
@@ -2178,10 +2178,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2191,10 +2191,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchCase<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2204,7 +2204,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SwitchCase<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabeledStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
             self.write_suppressed(f);
@@ -2217,7 +2217,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LabeledStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThrowStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
             self.write_suppressed(f);
@@ -2230,10 +2230,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThrowStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TryStatement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2243,10 +2243,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TryStatement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchClause<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            self.format_leading_comments(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+            format_leading_comments(self.suppressed_span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2256,10 +2256,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchClause<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchParameter<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            self.format_leading_comments(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+            format_leading_comments(self.suppressed_span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2269,7 +2269,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CatchParameter<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, DebuggerStatement> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
             self.write_suppressed(f);
@@ -2332,10 +2332,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingPattern<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentPattern<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2345,10 +2345,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentPattern<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectPattern<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2358,10 +2358,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectPattern<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingProperty<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2371,10 +2371,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingProperty<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayPattern<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2384,10 +2384,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayPattern<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingRestElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2397,14 +2397,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BindingRestElement<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Function<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2417,14 +2417,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Function<'a>> {
 
 impl<'a> AstNode<'a, Function<'a>> {
     pub fn fmt_with_options(&self, options: FormatFunctionOptions, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write_with_options(options, f);
         }
@@ -2437,10 +2437,10 @@ impl<'a> AstNode<'a, Function<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameters<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            self.format_leading_comments(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+            format_leading_comments(self.suppressed_span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2450,10 +2450,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameters<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameter<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2463,10 +2463,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameter<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameterRest<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2476,10 +2476,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameterRest<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FunctionBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            self.format_leading_comments(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+            format_leading_comments(self.suppressed_span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2520,14 +2520,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionBody<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2544,14 +2544,14 @@ impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
         options: FormatJsArrowFunctionExpressionOptions,
         f: &mut JsFormatter<'_, 'a>,
     ) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write_with_options(options, f);
         }
@@ -2564,14 +2564,14 @@ impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, YieldExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2584,14 +2584,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, YieldExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Class<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2604,10 +2604,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Class<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassHeritage<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2617,10 +2617,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassHeritage<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            self.format_leading_comments(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+            format_leading_comments(self.suppressed_span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -2690,10 +2690,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ClassElement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, MethodDefinition<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2703,10 +2703,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, MethodDefinition<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PropertyDefinition<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2716,10 +2716,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PropertyDefinition<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2729,10 +2729,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateIdentifier<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticBlock<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2832,10 +2832,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ModuleDeclaration<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AccessorProperty<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2845,14 +2845,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AccessorProperty<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2865,10 +2865,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2918,10 +2918,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDeclarationSpecif
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportSpecifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2931,10 +2931,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportSpecifier<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDefaultSpecifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2944,10 +2944,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportDefaultSpecifier<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportNamespaceSpecifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2957,10 +2957,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportNamespaceSpecifie
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithClause<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -2970,10 +2970,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, WithClause<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportAttribute<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3013,10 +3013,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportAttributeKey<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            self.format_leading_comments(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+            format_leading_comments(self.suppressed_span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -3026,10 +3026,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportDeclaration<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportNamedDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            self.format_leading_comments(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+            format_leading_comments(self.suppressed_span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -3039,10 +3039,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportNamedDeclaration<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportFromDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            self.format_leading_comments(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+            format_leading_comments(self.suppressed_span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -3052,10 +3052,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportFromDeclaration<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportDefaultDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if is_suppressed {
-            self.format_leading_comments(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+            format_leading_comments(self.suppressed_span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
             self.format_trailing_comments(f);
         } else {
             self.write(f);
@@ -3065,10 +3065,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportDefaultDeclaratio
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportAllDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3078,10 +3078,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportAllDeclaration<'a
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ExportSpecifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3182,14 +3182,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ModuleExportName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, V8IntrinsicExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3202,14 +3202,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, V8IntrinsicExpression<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BooleanLiteral> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3222,14 +3222,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BooleanLiteral> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NullLiteral> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3242,14 +3242,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NullLiteral> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NumericLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3262,14 +3262,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NumericLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StringLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3282,14 +3282,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StringLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BigIntLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3302,14 +3302,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BigIntLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, RegExpLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3338,10 +3338,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXElement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3351,10 +3351,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningElement<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXClosingElement<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3380,10 +3380,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXFragment<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningFragment> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3393,10 +3393,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXOpeningFragment> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXClosingFragment> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3466,10 +3466,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXElementName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXNamespacedName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3479,10 +3479,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXNamespacedName<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXMemberExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3532,10 +3532,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXMemberExpressionObje
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXExpressionContainer<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3576,10 +3576,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXEmptyExpression> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3619,10 +3619,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXAttributeItem<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXAttribute<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3632,10 +3632,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXAttribute<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXSpreadAttribute<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3725,10 +3725,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXAttributeValue<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXIdentifier<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3798,10 +3798,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXChild<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXSpreadChild<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3811,10 +3811,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXSpreadChild<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXText<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3824,10 +3824,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSXText<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisParameter<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3837,10 +3837,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisParameter<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3850,10 +3850,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumDeclaration<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3863,10 +3863,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumBody<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumMember<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3926,10 +3926,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSEnumMemberName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAnnotation<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -3939,10 +3939,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAnnotation<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSLiteralType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4402,14 +4402,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConditionalType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4422,15 +4422,15 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConditionalType<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnionType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_outer_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            self.format_leading_comments(f);
-            FormatSuppressedNode(self.span()).fmt(f);
+            format_leading_comments(self.suppressed_span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4443,14 +4443,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnionType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntersectionType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4463,10 +4463,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntersectionType<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSParenthesizedType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4476,14 +4476,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSParenthesizedType<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeOperator<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4496,10 +4496,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeOperator<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSArrayType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4509,10 +4509,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSArrayType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexedAccessType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4522,10 +4522,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexedAccessType<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTupleType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4535,10 +4535,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTupleType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamedTupleMember<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4548,10 +4548,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamedTupleMember<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSOptionalType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4561,10 +4561,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSOptionalType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSRestType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4615,10 +4615,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTupleElement<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAnyKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4628,10 +4628,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAnyKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSStringKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4641,10 +4641,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSStringKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBooleanKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4654,10 +4654,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBooleanKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNumberKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4667,10 +4667,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNumberKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNeverKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4680,10 +4680,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNeverKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntrinsicKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4693,10 +4693,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntrinsicKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnknownKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4706,10 +4706,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUnknownKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNullKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4719,10 +4719,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNullKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUndefinedKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4732,10 +4732,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSUndefinedKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSVoidKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4745,10 +4745,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSVoidKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSymbolKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4758,10 +4758,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSymbolKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisType> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4771,10 +4771,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSThisType> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSObjectKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4784,10 +4784,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSObjectKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBigIntKeyword> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4797,10 +4797,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSBigIntKeyword> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeReference<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4850,10 +4850,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSQualifiedName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4863,10 +4863,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSQualifiedName<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterInstantiation<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4876,10 +4876,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterInstanti
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameter<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4889,10 +4889,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameter<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4902,10 +4902,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeParameterDeclarat
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAliasDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4915,10 +4915,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAliasDeclaration<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSClassImplements<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4928,10 +4928,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSClassImplements<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4941,10 +4941,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceDeclaration<
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceBody<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -4954,10 +4954,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceBody<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSPropertySignature<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5027,10 +5027,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSignature<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignature<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5040,10 +5040,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignature<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSCallSignatureDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5053,10 +5053,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSCallSignatureDeclarat
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMethodSignature<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5066,10 +5066,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMethodSignature<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructSignatureDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5079,10 +5079,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructSignatureDec
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignatureName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5092,10 +5092,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIndexSignatureName<'a
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceHeritage<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5105,10 +5105,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInterfaceHeritage<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypePredicate<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5148,10 +5148,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypePredicateName<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5161,10 +5161,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleDeclara
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5204,10 +5204,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceDeclarationB
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSGlobalDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5217,10 +5217,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSGlobalDeclaration<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSModuleBlock<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5230,10 +5230,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSModuleBlock<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeLiteral<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5243,14 +5243,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeLiteral<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInferType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5263,14 +5263,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInferType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeQuery<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5314,10 +5314,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeQueryExprName<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5357,10 +5357,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportTypeQualifier<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportTypeQualifiedName<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5370,14 +5370,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportTypeQualifiedNa
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSFunctionType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5390,14 +5390,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSFunctionType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructorType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5410,10 +5410,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructorType<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMappedType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5423,10 +5423,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSMappedType<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTemplateLiteralType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5436,14 +5436,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTemplateLiteralType<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAsExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5456,14 +5456,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAsExpression<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSatisfiesExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5476,14 +5476,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSatisfiesExpression<'
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAssertion<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5496,10 +5496,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAssertion<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSImportEqualsDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5549,10 +5549,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSModuleReference<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleReference<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5562,14 +5562,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExternalModuleReferen
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNonNullExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5582,10 +5582,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNonNullExpression<'a>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Decorator<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5595,10 +5595,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Decorator<'a>> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExportAssignment<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5608,10 +5608,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSExportAssignment<'a>>
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceExportDeclaration<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5621,14 +5621,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNamespaceExportDeclar
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInstantiationExpression<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         if !is_suppressed && format_type_cast_comment_node(self, false, f) {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
         format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5641,10 +5641,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInstantiationExpressi
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNullableType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5654,10 +5654,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNullableType<'a>> 
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNonNullableType<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }
@@ -5667,10 +5667,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocNonNullableType<'a
 
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, JSDocUnknownType> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.span().start);
+        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
         self.format_leading_comments(f);
         if is_suppressed {
-            FormatSuppressedNode(self.span()).fmt(f);
+            FormatSuppressedNode(self.suppressed_span()).fmt(f);
         } else {
             self.write(f);
         }

--- a/crates/oxc_formatter/src/ast_nodes/iterator.rs
+++ b/crates/oxc_formatter/src/ast_nodes/iterator.rs
@@ -4,13 +4,13 @@
 //! The span getter returns `None` for elements the formatter never prints (dropped empty statements, elision holes),
 //! which are skipped when computing `following_span_start`.
 
-use std::cmp::min;
-
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
-use crate::utils::is_dropped_statement;
+use crate::utils::{
+    export_declaration_span, export_default_declaration_span, is_dropped_statement,
+};
 
 use super::{AstNode, AstNodes};
 
@@ -52,23 +52,9 @@ fn get_statement_span(stmt: &Statement<'_>) -> Option<u32> {
     }
     Some(match stmt {
         Statement::ExportDefaultDeclaration(export) => {
-            if let ExportDefaultDeclarationKind::ClassDeclaration(class) = &export.declaration
-                && let Some(decorator) = class.decorators.first()
-            {
-                min(decorator.span.start, export.span.start)
-            } else {
-                export.span.start
-            }
+            export_default_declaration_span(export).start
         }
-        Statement::ExportDeclaration(export) => {
-            if let Declaration::ClassDeclaration(class) = &export.declaration
-                && let Some(decorator) = class.decorators.first()
-            {
-                min(decorator.span.start, export.span.start)
-            } else {
-                export.span.start
-            }
-        }
+        Statement::ExportDeclaration(export) => export_declaration_span(export).start,
         _ => stmt.span().start,
     })
 }

--- a/crates/oxc_formatter/src/print/export_declarations.rs
+++ b/crates/oxc_formatter/src/print/export_declarations.rs
@@ -16,6 +16,9 @@ use crate::{
         import_declaration::format_source_with_clause_and_semicolon,
         semicolon::{FormatContentWithSemicolon, OptionalSemicolon},
     },
+    utils::{
+        decorators_before_export_start, export_declaration_span, export_default_declaration_span,
+    },
     write,
 };
 
@@ -40,7 +43,7 @@ fn format_export_keyword_with_class_decorators<'a>(
     {
         // `@decorator export class Cls {}`
         // decorators are placed before the export keyword
-        if class.decorators[0].span.end < span.start {
+        if decorators_before_export_start(&class.decorators, span).is_some() {
             write!(
                 f,
                 [class.decorators(), hard_line_break(), format_leading_comments, keyword, space()]
@@ -114,6 +117,10 @@ fn format_export_specifiers_block<'a>(
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ExportDefaultDeclaration<'a>> {
+    fn suppressed_span(&self) -> Span {
+        export_default_declaration_span(self)
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let declaration = self.declaration();
         format_export_keyword_with_class_decorators(
@@ -156,6 +163,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportAllDeclaration<'a>> {
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ExportDeclaration<'a>> {
+    fn suppressed_span(&self) -> Span {
+        export_declaration_span(self)
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let declaration = self.declaration();
         format_export_keyword_with_class_decorators(

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -107,10 +107,20 @@ pub trait FormatWrite<'ast, T = ()> {
     fn write_with_options(&self, _options: T, _f: &mut JsFormatter<'_, 'ast>) {
         unreachable!("Please implement it first.");
     }
+    /// The source range printed verbatim when the node is suppressed (`oxfmt-ignore` / `prettier-ignore`),
+    /// also the bound for the suppression check and the suppressed leading comments in the generated `fmt`.
+    /// Defaults to the node's span; overridden when the range starts earlier
+    /// (class decorators before export (`@deco export class X {}`) sit outside the export node's span).
+    fn suppressed_span(&self) -> Span
+    where
+        Self: GetSpan,
+    {
+        self.span()
+    }
     /// Formats the node when it is suppressed (`oxfmt-ignore` / `prettier-ignore`).
     /// Only called for statements whose ignored range must exclude the trailing semicolon,
     /// so the formatter prints its own terminator, like Prettier;
-    /// every other node prints its whole span verbatim in the generated `fmt`.
+    /// every other node prints its whole `suppressed_span` verbatim in the generated `fmt`.
     fn write_suppressed(&self, _f: &mut JsFormatter<'_, 'ast>) {
         unreachable!(
             "Implement `write_suppressed` for every node listed in \

--- a/crates/oxc_formatter/src/print/program.rs
+++ b/crates/oxc_formatter/src/print/program.rs
@@ -11,7 +11,7 @@ use crate::{
     ir_transform::sort_imports_chunk,
     print::semicolon::OptionalSemicolon,
     utils::{
-        is_dropped_statement,
+        export_declaration_span, export_default_declaration_span, is_dropped_statement,
         string::{FormatLiteralStringToken, StringLiteralParentKind},
     },
     write,
@@ -80,30 +80,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatStatementsWithImports<'a, '_>
             }
 
             let span = match stmt.as_ref() {
-                // `@decorator export class A {}`
-                // Get the span of the decorator.
-                Statement::ExportDeclaration(export) => {
-                    if let Declaration::ClassDeclaration(decl) = &export.declaration
-                        && let Some(decorator) = decl.decorators.first()
-                        && decorator.span().start < export.span.start
-                    {
-                        decorator.span()
-                    } else {
-                        export.span
-                    }
-                }
-                // `@decorator export default class A {}`
-                // Get the span of the decorator.
+                // `@decorator export class A {}`: Start the span at the decorator
+                Statement::ExportDeclaration(export) => export_declaration_span(export),
                 Statement::ExportDefaultDeclaration(export) => {
-                    if let ExportDefaultDeclarationKind::ClassDeclaration(decl) =
-                        &export.declaration
-                        && let Some(decorator) = decl.decorators.first()
-                        && decorator.span().start < export.span.start
-                    {
-                        decorator.span()
-                    } else {
-                        export.span
-                    }
+                    export_default_declaration_span(export)
                 }
                 _ => stmt.span(),
             };

--- a/crates/oxc_formatter/src/utils/mod.rs
+++ b/crates/oxc_formatter/src/utils/mod.rs
@@ -14,7 +14,11 @@ pub mod tailwindcss;
 pub mod typecast;
 pub mod typescript;
 
-use oxc_ast::ast::{CallExpression, PropertyKey, Statement};
+use oxc_ast::ast::{
+    CallExpression, Declaration, Decorator, ExportDeclaration, ExportDefaultDeclaration,
+    ExportDefaultDeclarationKind, PropertyKey, Statement,
+};
+use oxc_span::Span;
 
 use crate::ast_nodes::{AstNode, AstNodes};
 
@@ -22,6 +26,36 @@ use crate::ast_nodes::{AstNode, AstNodes};
 /// so following-span computation and emptiness checks must treat them as absent.
 pub fn is_dropped_statement(stmt: &Statement<'_>) -> bool {
     matches!(stmt, Statement::EmptyStatement(_))
+}
+
+/// Span of an export statement extended over class decorators placed before the `export` keyword
+/// (`@dec export class C {}`), which the parser leaves outside the export node's span.
+pub fn export_declaration_span(export: &ExportDeclaration<'_>) -> Span {
+    if let Declaration::ClassDeclaration(class) = &export.declaration {
+        span_with_decorators_before_export(&class.decorators, export.span)
+    } else {
+        export.span
+    }
+}
+
+/// See [`export_declaration_span`].
+pub fn export_default_declaration_span(export: &ExportDefaultDeclaration<'_>) -> Span {
+    if let ExportDefaultDeclarationKind::ClassDeclaration(class) = &export.declaration {
+        span_with_decorators_before_export(&class.decorators, export.span)
+    } else {
+        export.span
+    }
+}
+
+/// First-decorator start when the decorators precede the `export` keyword;
+/// `None` for `export @dec class C {}` (decorators inside the export span).
+pub fn decorators_before_export_start(decorators: &[Decorator<'_>], span: Span) -> Option<u32> {
+    decorators.first().map(|decorator| decorator.span.start).filter(|start| *start < span.start)
+}
+
+fn span_with_decorators_before_export(decorators: &[Decorator<'_>], span: Span) -> Span {
+    decorators_before_export_start(decorators, span)
+        .map_or(span, |start| Span::new(start, span.end))
 }
 
 /// Tests if the property key is an identifier named `static`, `get` or `set`,

--- a/crates/oxc_formatter/tests/fixtures/ts/ignore/decorated-class-export.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/ignore/decorated-class-export.ts
@@ -1,0 +1,31 @@
+// Issue #25911: class decorators before `export` sit outside the statement span;
+// suppression must detect and print from the first decorator, not `span.start`.
+declare function M(o: unknown): ClassDecorator;
+
+// An ignore inside a decorator suppresses only the nearest node (the property),
+// not the whole statement.
+@M({
+  // prettier-ignore
+  a: [1,   2],
+  b:    2,
+})
+export class A {}
+
+// An ignore before the decorators suppresses the whole statement, decorators included.
+// prettier-ignore
+@M({ a: [1,   2] })
+export   class B {}
+
+// prettier-ignore
+@M({ a: [1,   2] })
+export   default   class C {}
+
+// An own-line ignore after `export` also suppresses the decorated class.
+export
+// prettier-ignore
+@M({ a: [1,   2] })
+class D {}
+
+// prettier-ignore
+@M({ a: [1,   2] })
+class E {}

--- a/crates/oxc_formatter/tests/fixtures/ts/ignore/decorated-class-export.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/ignore/decorated-class-export.ts.snap
@@ -1,0 +1,108 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Issue #25911: class decorators before `export` sit outside the statement span;
+// suppression must detect and print from the first decorator, not `span.start`.
+declare function M(o: unknown): ClassDecorator;
+
+// An ignore inside a decorator suppresses only the nearest node (the property),
+// not the whole statement.
+@M({
+  // prettier-ignore
+  a: [1,   2],
+  b:    2,
+})
+export class A {}
+
+// An ignore before the decorators suppresses the whole statement, decorators included.
+// prettier-ignore
+@M({ a: [1,   2] })
+export   class B {}
+
+// prettier-ignore
+@M({ a: [1,   2] })
+export   default   class C {}
+
+// An own-line ignore after `export` also suppresses the decorated class.
+export
+// prettier-ignore
+@M({ a: [1,   2] })
+class D {}
+
+// prettier-ignore
+@M({ a: [1,   2] })
+class E {}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Issue #25911: class decorators before `export` sit outside the statement span;
+// suppression must detect and print from the first decorator, not `span.start`.
+declare function M(o: unknown): ClassDecorator;
+
+// An ignore inside a decorator suppresses only the nearest node (the property),
+// not the whole statement.
+@M({
+  // prettier-ignore
+  a: [1,   2],
+  b: 2,
+})
+export class A {}
+
+// An ignore before the decorators suppresses the whole statement, decorators included.
+// prettier-ignore
+@M({ a: [1,   2] })
+export   class B {}
+
+// prettier-ignore
+@M({ a: [1,   2] })
+export   default   class C {}
+
+// An own-line ignore after `export` also suppresses the decorated class.
+export
+// prettier-ignore
+@M({ a: [1,   2] })
+class D {}
+
+// prettier-ignore
+@M({ a: [1,   2] })
+class E {}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Issue #25911: class decorators before `export` sit outside the statement span;
+// suppression must detect and print from the first decorator, not `span.start`.
+declare function M(o: unknown): ClassDecorator;
+
+// An ignore inside a decorator suppresses only the nearest node (the property),
+// not the whole statement.
+@M({
+  // prettier-ignore
+  a: [1,   2],
+  b: 2,
+})
+export class A {}
+
+// An ignore before the decorators suppresses the whole statement, decorators included.
+// prettier-ignore
+@M({ a: [1,   2] })
+export   class B {}
+
+// prettier-ignore
+@M({ a: [1,   2] })
+export   default   class C {}
+
+// An own-line ignore after `export` also suppresses the decorated class.
+export
+// prettier-ignore
+@M({ a: [1,   2] })
+class D {}
+
+// prettier-ignore
+@M({ a: [1,   2] })
+class E {}
+
+===================== End =====================

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -218,11 +218,15 @@ fn generate_struct_implementation(
         };
 
         // `Program` can't be suppressed.
-        // `JSXElement` and `JSXFragment` implement suppression formatting in their formatting logic
+        // `JSXElement` and `JSXFragment` implement suppression formatting in their formatting logic.
+        //
+        // The check, the suppressed leading comments, and the verbatim range are all bounded by
+        // `FormatWrite::suppressed_span` (default: the node's span),
+        // which nodes override when the ignored range starts before their span (class decorators before `export`).
         let suppressed_check = (!matches!(struct_name, "Program" | "JSXElement" | "JSXFragment"))
             .then(|| {
                 quote! {
-                    let is_suppressed = f.comments().is_suppressed(self.span().start);
+                    let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
                 }
             });
 
@@ -233,13 +237,13 @@ fn generate_struct_implementation(
                 if AST_NODE_WITH_CUSTOM_SUPPRESSED_FORMATTING.contains(&struct_name) {
                     quote! { self.write_suppressed(f); }
                 } else {
-                    quote! { FormatSuppressedNode(self.span()).fmt(f); }
+                    quote! { FormatSuppressedNode(self.suppressed_span()).fmt(f); }
                 };
             // When `fmt` doesn't print leading/trailing comments itself,
             // the suppressed path still has to print them, or the suppression comment would be lost.
             let suppressed_leading_comments = do_not_print_leading_comment.then(|| {
                 quote! {
-                    self.format_leading_comments(f);
+                    format_leading_comments(self.suppressed_span()).fmt(f);
                 }
             });
             let suppressed_trailing_comments = do_not_print_comment.then(|| {


### PR DESCRIPTION
Fixes #25911

---

As syntax, these two forms are equivalent:

```ts
@deco export class X {}
export @deco class X {}
```

However, in the former, the decorators lie outside the span of both the `ExportDeclaration` and the `Class`, they are inside no node's span.

The formatter's suppression path prints the `ExportDeclaration`'s span verbatim, so the decorators were silently dropped.
The latter form is unaffected because the decorators fall inside the export node's span.
