### PR TITLE
refactor(formatter): replace `fmt_with_options` with a context handoff

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -13,7 +13,7 @@ use crate::{
         trivia::{format_leading_comments, format_trailing_comments},
     },
     parentheses::NeedsParentheses,
-    print::{FormatFunctionOptions, FormatJsArrowFunctionExpressionOptions, FormatWrite},
+    print::FormatWrite,
     utils::{
         suppressed::FormatSuppressedNode,
         typecast::{
@@ -2415,26 +2415,6 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Function<'a>> {
     }
 }
 
-impl<'a> AstNode<'a, Function<'a>> {
-    pub fn fmt_with_options(&self, options: FormatFunctionOptions, f: &mut JsFormatter<'_, 'a>) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
-            return;
-        }
-        let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write_with_options(options, f);
-        }
-        if needs_parentheses {
-            ")".fmt(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
 impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, FormalParameters<'a>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
@@ -2530,30 +2510,6 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionExpression
             self.write_suppressed(f);
         } else {
             self.write(f);
-        }
-        if needs_parentheses {
-            ")".fmt(f);
-        }
-        self.format_trailing_comments(f);
-    }
-}
-
-impl<'a> AstNode<'a, ArrowFunctionExpression<'a>> {
-    pub fn fmt_with_options(
-        &self,
-        options: FormatJsArrowFunctionExpressionOptions,
-        f: &mut JsFormatter<'_, 'a>,
-    ) {
-        let is_suppressed = f.comments().is_suppressed(self.suppressed_span().start);
-        if !is_suppressed && format_type_cast_comment_node(self, false, f) {
-            return;
-        }
-        let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
-        if is_suppressed {
-            self.write_suppressed(f);
-        } else {
-            self.write_with_options(options, f);
         }
         if needs_parentheses {
             ")".fmt(f);

--- a/crates/oxc_formatter/src/formatter/context.rs
+++ b/crates/oxc_formatter/src/formatter/context.rs
@@ -5,7 +5,7 @@ use oxc_formatter_core::{FormatElement, SourceText};
 use oxc_span::{GetSpan, SourceType, Span};
 use rustc_hash::FxHashMap;
 
-use crate::options::JsFormatOptions;
+use crate::{options::JsFormatOptions, utils::assignment_like::AssignmentLikeLayout};
 
 use super::Comments;
 
@@ -90,6 +90,11 @@ pub struct JsFormatContext<'ast> {
 
     cached_elements: FxHashMap<Span, FormatElement<'ast>>,
 
+    /// One-shot handoff of the assignment layout to the arrow expression on the RHS of an assignment-like,
+    /// keyed by the arrow's span so no other node can consume it.
+    /// Set (and cleared) by `WithAssignmentLayout` around formatting the arrow, taken by the arrow's `write`.
+    arrow_assignment_layout: Option<(Span, AssignmentLikeLayout)>,
+
     /// Tracks whether quotes are needed for properties in the current object-like node.
     ///
     /// When [`JsFormatOptions::quote_properties`] is [`crate::QuoteProperties::Consistent`], each entry indicates
@@ -158,6 +163,7 @@ impl<'ast> JsFormatContext<'ast> {
             source_type,
             comments: Comments::new(source_text, comments),
             cached_elements: FxHashMap::default(),
+            arrow_assignment_layout: None,
             quote_needed_stack: Vec::new(),
             tailwind_classes: Vec::new(),
             tailwind_context_stack: Vec::new(),
@@ -192,6 +198,36 @@ impl<'ast> JsFormatContext<'ast> {
     /// Caches the formatted element for the given key.
     pub(crate) fn cache_element<T: GetSpan>(&mut self, key: &T, formatted: FormatElement<'ast>) {
         self.cached_elements.insert(key.span(), formatted);
+    }
+
+    /// See the [`Self::arrow_assignment_layout`] field.
+    pub(crate) fn set_arrow_assignment_layout(&mut self, span: Span, layout: AssignmentLikeLayout) {
+        debug_assert!(
+            self.arrow_assignment_layout.is_none(),
+            "a previous arrow assignment layout was neither taken nor cleared"
+        );
+        self.arrow_assignment_layout = Some((span, layout));
+    }
+
+    /// See the [`Self::arrow_assignment_layout`] field.
+    pub(crate) fn take_arrow_assignment_layout(
+        &mut self,
+        span: Span,
+    ) -> Option<AssignmentLikeLayout> {
+        match self.arrow_assignment_layout {
+            Some((key, layout)) if key == span => {
+                self.arrow_assignment_layout = None;
+                Some(layout)
+            }
+            _ => None,
+        }
+    }
+
+    /// See the [`Self::arrow_assignment_layout`] field.
+    /// Clears a layout left behind when the arrow was printed without running
+    /// `write` (a suppressed arrow prints its source verbatim instead).
+    pub(crate) fn clear_arrow_assignment_layout(&mut self) {
+        self.arrow_assignment_layout = None;
     }
 
     /// Pushes a new quote needed state onto the stack.

--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -18,18 +18,14 @@ use crate::{
 
 use super::{FormatWrite, parameters::has_only_simple_parameters};
 
-impl<'a> FormatWrite<'a, FormatJsArrowFunctionExpressionOptions>
-    for AstNode<'a, ArrowFunctionExpression<'a>>
-{
+impl<'a> FormatWrite<'a> for AstNode<'a, ArrowFunctionExpression<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        FormatJsArrowFunctionExpression::new(self).fmt(f);
-    }
-
-    fn write_with_options(
-        &self,
-        options: FormatJsArrowFunctionExpressionOptions,
-        f: &mut JsFormatter<'_, 'a>,
-    ) {
+        let options = FormatJsArrowFunctionExpressionOptions {
+            // Handed over by `WithAssignmentLayout` when this arrow is the RHS of an assignment-like;
+            // the span key ensures only this arrow can consume it.
+            assignment_layout: f.context_mut().take_arrow_assignment_layout(self.span()),
+            ..FormatJsArrowFunctionExpressionOptions::default()
+        };
         FormatJsArrowFunctionExpression::new_with_options(self, options).fmt(f);
     }
 }
@@ -78,10 +74,6 @@ pub enum FunctionCacheMode {
 }
 
 impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
-    pub fn new(arrow: &'b AstNode<'a, ArrowFunctionExpression<'a>>) -> Self {
-        Self { arrow, options: FormatJsArrowFunctionExpressionOptions::default() }
-    }
-
     pub fn new_with_options(
         arrow: &'b AstNode<'a, ArrowFunctionExpression<'a>>,
         options: FormatJsArrowFunctionExpressionOptions,

--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -16,8 +16,7 @@ use crate::{
         trivia::format_dangling_comments,
     },
     print::{
-        FormatFunctionOptions, FormatJsArrowFunctionExpression,
-        FormatJsArrowFunctionExpressionOptions,
+        FormatJsArrowFunctionExpression, FormatJsArrowFunctionExpressionOptions,
         array_element_list::can_concisely_print_array_list,
         arrow_function_expression::{
             FunctionCacheMode, GroupedCallArgumentLayout, is_huggable_html_embed,
@@ -639,19 +638,7 @@ fn write_grouped_arguments<'a>(
                                     || function_has_only_simple_parameters(&function.params)) =>
                         {
                             has_cached = true;
-                            return write!(
-                                f,
-                                [
-                                    FormatFunction::new_with_options(
-                                        function,
-                                        FormatFunctionOptions {
-                                            cache_mode: FunctionCacheMode::Cache,
-                                            ..FormatFunctionOptions::default()
-                                        },
-                                    ),
-                                    comma
-                                ]
-                            );
+                            return write!(f, [FormatFunction::new_cached(function), comma]);
                         }
                         AstNodes::ArrowFunctionExpression(arrow) => {
                             has_cached = true;
@@ -894,14 +881,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatGroupedLastArgument<'a, '_> {
             AstNodes::Function(function)
                 if !self.is_only || function_has_only_simple_parameters(&function.params) =>
             {
-                FormatFunction::new_with_options(
-                    function,
-                    FormatFunctionOptions {
-                        cache_mode: FunctionCacheMode::Cache,
-                        call_argument_layout: Some(GroupedCallArgumentLayout::GroupedLastArgument),
-                    },
-                )
-                .fmt(f);
+                FormatFunction::new_cached(function).fmt(f);
             }
             AstNodes::ArrowFunctionExpression(arrow) => {
                 FormatJsArrowFunctionExpression::new_with_options(

--- a/crates/oxc_formatter/src/print/function.rs
+++ b/crates/oxc_formatter/src/print/function.rs
@@ -4,9 +4,7 @@ use oxc_ast::ast::*;
 use oxc_formatter_core::Buffer;
 
 use super::{
-    FormatWrite,
-    arrow_function_expression::{FunctionCacheMode, GroupedCallArgumentLayout},
-    block_statement::is_empty_block,
+    FormatWrite, arrow_function_expression::FunctionCacheMode, block_statement::is_empty_block,
 };
 use crate::{
     ast_nodes::AstNode,
@@ -16,26 +14,15 @@ use crate::{
     write,
 };
 
-impl<'a> FormatWrite<'a, FormatFunctionOptions> for AstNode<'a, Function<'a>> {
+impl<'a> FormatWrite<'a> for AstNode<'a, Function<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         FormatFunction::new(self).fmt(f);
     }
-
-    fn write_with_options(&self, options: FormatFunctionOptions, f: &mut JsFormatter<'_, 'a>) {
-        FormatFunction::new_with_options(self, options).fmt(f);
-    }
-}
-
-#[derive(Copy, Clone, Debug, Default)]
-pub struct FormatFunctionOptions {
-    pub call_argument_layout: Option<GroupedCallArgumentLayout>,
-    // Determine whether the signature and body should be cached.
-    pub cache_mode: FunctionCacheMode,
 }
 
 pub struct FormatFunction<'a, 'b> {
     pub function: &'b AstNode<'a, Function<'a>>,
-    pub options: FormatFunctionOptions,
+    pub cache_mode: FunctionCacheMode,
 }
 
 impl<'a> Deref for FormatFunction<'a, '_> {
@@ -48,14 +35,11 @@ impl<'a> Deref for FormatFunction<'a, '_> {
 
 impl<'a, 'b> FormatFunction<'a, 'b> {
     pub fn new(function: &'b AstNode<'a, Function<'a>>) -> Self {
-        Self { function, options: FormatFunctionOptions::default() }
+        Self { function, cache_mode: FunctionCacheMode::NoCache }
     }
 
-    pub fn new_with_options(
-        function: &'b AstNode<'a, Function<'a>>,
-        options: FormatFunctionOptions,
-    ) -> Self {
-        Self { function, options }
+    pub fn new_cached(function: &'b AstNode<'a, Function<'a>>) -> Self {
+        Self { function, cache_mode: FunctionCacheMode::Cache }
     }
 
     #[inline]
@@ -74,14 +58,11 @@ impl<'a, 'b> FormatFunction<'a, 'b> {
                 ]
             );
         });
-        FormatContentWithCacheMode::new(self.span, head, self.options.cache_mode).fmt(f);
+        FormatContentWithCacheMode::new(self.span, head, self.cache_mode).fmt(f);
 
-        let format_parameters = FormatContentWithCacheMode::new(
-            self.params.span,
-            self.params(),
-            self.options.cache_mode,
-        )
-        .memoized();
+        let format_parameters =
+            FormatContentWithCacheMode::new(self.params.span, self.params(), self.cache_mode)
+                .memoized();
 
         let format_return_type = self
             .return_type()
@@ -91,7 +72,7 @@ impl<'a, 'b> FormatFunction<'a, 'b> {
                         f.context().comments().has_comment_before(return_type.span.start);
                     write!(f, [maybe_space(needs_space), return_type]);
                 });
-                FormatContentWithCacheMode::new(return_type.span, content, self.options.cache_mode)
+                FormatContentWithCacheMode::new(return_type.span, content, self.cache_mode)
             })
             .memoized();
 
@@ -122,13 +103,7 @@ impl<'a, 'b> FormatFunction<'a, 'b> {
         );
 
         if let Some(body) = self.body() {
-            write!(
-                f,
-                [
-                    space(),
-                    FormatContentWithCacheMode::new(body.span, body, self.options.cache_mode)
-                ]
-            );
+            write!(f, [space(), FormatContentWithCacheMode::new(body.span, body, self.cache_mode)]);
         }
 
         if self.is_ts_declare_function() {

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -39,7 +39,6 @@ pub use arrow_function_expression::{
 };
 pub use binary_like_expression::{BinaryLikeExpression, should_flatten};
 pub use fragment::{FormatFunctionParams, FormatTypeParameters};
-pub use function::FormatFunctionOptions;
 pub use union_type::{
     alias_union_breaks_after_operator, is_trailing_own_line_jsdoc_comment, type_alias_left_end,
 };
@@ -102,11 +101,8 @@ use self::{
     type_parameters::{FormatTSTypeParameters, FormatTSTypeParametersOptions},
 };
 
-pub trait FormatWrite<'ast, T = ()> {
+pub trait FormatWrite<'ast> {
     fn write(&self, f: &mut JsFormatter<'_, 'ast>);
-    fn write_with_options(&self, _options: T, _f: &mut JsFormatter<'_, 'ast>) {
-        unreachable!("Please implement it first.");
-    }
     /// The source range printed verbatim when the node is suppressed (`oxfmt-ignore` / `prettier-ignore`),
     /// also the bound for the suppression check and the suppressed leading comments in the generated `fmt`.
     /// Defaults to the node's span; overridden when the range starts earlier

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -10,8 +10,8 @@ use crate::{
         trivia::FormatTrailingComments,
     },
     print::{
-        BinaryLikeExpression, FormatJsArrowFunctionExpressionOptions, FormatWrite,
-        alias_union_breaks_after_operator, is_trailing_own_line_jsdoc_comment, type_alias_left_end,
+        BinaryLikeExpression, FormatWrite, alias_union_breaks_after_operator,
+        is_trailing_own_line_jsdoc_comment, type_alias_left_end,
     },
     utils::{
         format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
@@ -966,15 +966,17 @@ pub fn with_assignment_layout<'a, 'b>(
 
 impl<'a> Format<'a, JsFormatContext<'a>> for WithAssignmentLayout<'a, '_> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        match self.expression.as_ast_nodes() {
-            AstNodes::ArrowFunctionExpression(arrow) => arrow.fmt_with_options(
-                FormatJsArrowFunctionExpressionOptions {
-                    assignment_layout: self.layout,
-                    ..FormatJsArrowFunctionExpressionOptions::default()
-                },
-                f,
-            ),
-            _ => self.expression.fmt(f),
+        // An arrow needs the layout inside its `write`,
+        // which is reached through the shared generated `fmt` (suppression, type casts, parentheses, comments);
+        // the span-keyed context slot hands it across that frame.
+        if let (Some(layout), AstNodes::ArrowFunctionExpression(arrow)) =
+            (self.layout, self.expression.as_ast_nodes())
+        {
+            f.context_mut().set_arrow_assignment_layout(arrow.span(), layout);
+            arrow.fmt(f);
+            f.context_mut().clear_arrow_assignment_layout();
+        } else {
+            self.expression.fmt(f);
         }
     }
 }

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -1,5 +1,14 @@
 //! Generator for `oxc_formatter`.
 //!
+//! Boundary with the handwritten side:
+//!
+//! - The node lists here decide which fragments of the `fmt` skeleton are EMITTED (comment-printing ownership, parentheses frames)
+//!   - they change the shape of the generated code, nothing else
+//! - Behavior the skeleton queries per node lives on `FormatWrite` (`write`, `suppressed_span`, `write_suppressed`)
+//!   - defaults cover the common case, overrides sit next to the node's `write` and need no regeneration
+//!
+//! Add a new list only for a variation the emitted shape must express;
+//! for anything a node merely answers, add a trait method with a total default.
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -50,11 +59,6 @@ const AST_NODE_NEEDS_PARENTHESES: &[&str] = &[
     "TSTypeOperator",
 ];
 
-const NEEDS_IMPLEMENTING_FMT_WITH_OPTIONS: phf::Map<&'static str, &'static str> = phf::phf_map! {
-    "ArrowFunctionExpression" => "FormatJsArrowFunctionExpressionOptions",
-    "Function" => "FormatFunctionOptions",
-};
-
 pub struct FormatterFormatGenerator;
 
 define_generator!(FormatterFormatGenerator);
@@ -78,11 +82,6 @@ impl Generator for FormatterFormatGenerator {
             })
             .collect::<TokenStream>();
 
-        let options = NEEDS_IMPLEMENTING_FMT_WITH_OPTIONS.values().map(|o| {
-            let ident = format_ident!("{}", o);
-            quote! { , #ident }
-        });
-
         let output = quote! {
             #![expect(clippy::match_same_arms)]
             use oxc_ast::ast::*;
@@ -95,7 +94,7 @@ impl Generator for FormatterFormatGenerator {
                 parentheses::NeedsParentheses,
                 ast_nodes::AstNode,
                 utils::{suppressed::FormatSuppressedNode, typecast::{format_type_cast_comment_node, format_leading_comments_and_open_paren, format_outer_leading_comments_and_open_paren}},
-                print::{FormatWrite #(#options)*},
+                print::FormatWrite,
             };
 
             #impls
@@ -177,15 +176,9 @@ fn generate_struct_implementation(
         quote! {}
     };
 
-    let generate_fmt_implementation = |has_options: bool| {
-        let write_call = if has_options {
-            quote! {
-                self.write_with_options(options, f);
-            }
-        } else {
-            quote! {
-                self.write(f);
-            }
+    let fmt_implementation = {
+        let write_call = quote! {
+            self.write(f);
         };
 
         // `Program` can't be suppressed.
@@ -271,23 +264,6 @@ fn generate_struct_implementation(
         }
     };
 
-    let fmt_implementation = generate_fmt_implementation(false);
-    let fmt_options =
-        NEEDS_IMPLEMENTING_FMT_WITH_OPTIONS.get(struct_name).map(|str| format_ident!("{}", str));
-    let fmt_with_options_inherent = if let Some(ref fmt_options) = fmt_options {
-        let implementation = generate_fmt_implementation(true);
-        quote! {
-            ///@@line_break
-            impl<'a> #type_ty {
-                pub fn fmt_with_options(&self, options: #fmt_options, f: &mut JsFormatter<'_, 'a>) {
-                    #implementation
-                }
-            }
-        }
-    } else {
-        quote! {}
-    };
-
     quote! {
         ///@@line_break
         impl<'a> Format<'a, JsFormatContext<'a>> for #type_ty {
@@ -295,8 +271,6 @@ fn generate_struct_implementation(
                 #fmt_implementation
             }
         }
-
-        #fmt_with_options_inherent
     }
 }
 


### PR DESCRIPTION
Remove `fmt_with_options` impl to justify what to be generated and not.

In the first place, for `Function` one was not used.