### PR TITLE
fix(formatter): print the idempotent placement for comments in dropped parens

### DIFF
--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -172,6 +172,9 @@ The entries documented so far are not yet an exhaustive audit against the confor
 - A union's leading comments normalize to behind the leading `|` (`| /* c */ A`) whenever no comment ends its source line, regardless of the source shape
   - Prettier does the same except for nested single-member paren sources (`| (/* c */ | A ...`) and multiline block comments starting their line, where it keeps `/* c */ | A`
     - An output it then reformats into `| /* c */ A` itself for the first shape, not idempotent
+- Two comment placements print Prettier's second-pass fixpoint directly, where the pinned Prettier is not idempotent (fixed upstream in prettier#19893/#19894; converge and drop when the pin catches up):
+  - a trailing comment inside an expression statement's dropped parentheses moves behind the `;` (`assigned = (a = c /* c */);` -> `assigned = a = c; /* c */`), including the chain-leaf shapes prettier#19893 left out
+  - a comment inside a sequence's parenthesized first element leads the sequence, outside the formatter-added parens (`((/* c */ a), b);` -> `/* c */ (a, b);`)
 
 ## Verification
 

--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -491,7 +491,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, IdentifierReference<'a>
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -537,7 +542,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ThisExpression> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -557,7 +567,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrayExpression<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -631,7 +646,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ObjectExpression<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -735,7 +755,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TemplateLiteral<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -755,7 +780,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TaggedTemplateExpressio
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -828,7 +858,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ComputedMemberExpressio
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -848,7 +883,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StaticMemberExpression<
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -868,7 +908,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateFieldExpression<
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -888,7 +933,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, CallExpression<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -908,7 +958,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewExpression<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -928,7 +983,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportMeta> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -948,7 +1008,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NewTarget> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -1012,7 +1077,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UpdateExpression<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -1032,7 +1102,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, UnaryExpression<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -1052,7 +1127,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BinaryExpression<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -1072,7 +1152,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, PrivateInExpression<'a>
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -1092,7 +1177,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, LogicalExpression<'a>> 
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -1112,7 +1202,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ConditionalExpression<'
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -1132,7 +1227,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AssignmentExpression<'a
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -1424,7 +1524,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, SequenceExpression<'a>>
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -1444,7 +1549,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Super> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -1464,7 +1574,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, AwaitExpression<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -1484,7 +1599,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ChainExpression<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -1545,7 +1665,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ParenthesizedExpression
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -2402,7 +2527,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Function<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -2505,7 +2635,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArrowFunctionExpression
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -2525,7 +2660,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, YieldExpression<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -2545,7 +2685,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Class<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -2806,7 +2951,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ImportExpression<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -3143,7 +3293,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, V8IntrinsicExpression<'
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -3163,7 +3318,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BooleanLiteral> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -3183,7 +3343,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NullLiteral> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -3203,7 +3368,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, NumericLiteral<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -3223,7 +3393,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, StringLiteral<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -3243,7 +3418,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, BigIntLiteral<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -3263,7 +3443,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, RegExpLiteral<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -4363,7 +4548,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConditionalType<'a>> 
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -4404,7 +4594,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSIntersectionType<'a>>
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -4437,7 +4632,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeOperator<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -5204,7 +5404,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInferType<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -5224,7 +5429,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeQuery<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -5331,7 +5541,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSFunctionType<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -5351,7 +5566,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSConstructorType<'a>> 
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -5397,7 +5617,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSAsExpression<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -5417,7 +5642,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSSatisfiesExpression<'
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -5437,7 +5667,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSTypeAssertion<'a>> {
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -5523,7 +5758,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSNonNullExpression<'a>
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {
@@ -5582,7 +5822,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, TSInstantiationExpressi
             return;
         }
         let needs_parentheses = self.needs_parentheses(f);
-        format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+        format_leading_comments_and_open_paren(
+            self.span(),
+            self.leading_comments_start(),
+            needs_parentheses,
+            f,
+        );
         if is_suppressed {
             self.write_suppressed(f);
         } else {

--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -16,7 +16,10 @@ use crate::{
     write,
 };
 
-use super::{FormatWrite, parameters::has_only_simple_parameters};
+use super::{
+    FormatWrite, parameters::has_only_simple_parameters,
+    sequence_expression::sequence_leading_comments_start,
+};
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ArrowFunctionExpression<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
@@ -132,7 +135,7 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
 
                 if let Some(Expression::SequenceExpression(sequence)) = arrow_expression {
                     return if let Some(format_sequence) =
-                        format_sequence_with_leading_comment(sequence.span(), &format_body, f)
+                        format_sequence_with_leading_comment(sequence, &format_body, f)
                     {
                         write!(f, [group(&format_args!(formatted_signature, format_sequence))]);
                     } else {
@@ -629,7 +632,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for ArrowChain<'a, '_> {
             // body breaks
             if let Some(Expression::SequenceExpression(sequence)) = tail.get_expression() {
                 if let Some(format_sequence) =
-                    format_sequence_with_leading_comment(sequence.span(), &format_tail_body, f)
+                    format_sequence_with_leading_comment(sequence, &format_tail_body, f)
                 {
                     write!(f, format_sequence);
                 } else {
@@ -834,18 +837,22 @@ fn format_signature<'a, 'b>(
 ///
 /// Handles `oxfmt-ignore` by preserving original source text when suppressed.
 fn format_sequence_with_leading_comment<'a, 'b>(
-    sequence_span: Span,
+    sequence: &SequenceExpression<'a>,
     format_body: &'b impl Format<'a, JsFormatContext<'a>>,
     f: &JsFormatter<'_, 'a>,
 ) -> Option<impl Format<'a, JsFormatContext<'a>> + 'b> {
-    if !f.comments().has_comment_before(sequence_span.start) {
+    let sequence_span = sequence.span;
+    // Comments inside the first element's dropped source parentheses lead the sequence
+    // (see `sequence_leading_comments_start`), so they take this path too.
+    let leading_comments_start = sequence_leading_comments_start(sequence);
+    if !f.comments().has_comment_before(leading_comments_start) {
         return None;
     }
 
     let is_suppressed = f.comments().is_suppressed(sequence_span.start);
 
     let format_sequence = format_with(move |f| {
-        format_leading_comments_and_open_paren(sequence_span, true, f);
+        format_leading_comments_and_open_paren(sequence_span, leading_comments_start, true, f);
         if is_suppressed {
             write!(f, FormatSuppressedNode(sequence_span));
         } else {

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -95,8 +95,8 @@ use self::{
     program::FormatStatementsWithImports,
     return_or_throw_statement::FormatAdjacentArgument,
     semicolon::{
-        FormatContentWithSemicolon, OptionalSemicolon, keeps_trailing_comment_inside_parens,
-        write_trailing_comments_inside_parens,
+        FormatContentWithSemicolon, OptionalSemicolon, assignment_chain_leaf_end,
+        keeps_trailing_comment_inside_parens, write_trailing_comments_inside_parens,
     },
     type_parameters::{FormatTSTypeParameters, FormatTSTypeParametersOptions},
 };
@@ -112,6 +112,18 @@ pub trait FormatWrite<'ast> {
         Self: GetSpan,
     {
         self.span()
+    }
+    /// Position bounding the node's leading comments in the generated `fmt`:
+    /// pending comments ending at or before it print as the node's leading comments,
+    /// OUTSIDE any formatter-added parentheses.
+    /// Defaults to the node's span start; overridden when the span starts at a leftmost
+    /// descendant's dropped source parenthesis whose inner comments lead the node itself
+    /// (`((/* c */ a), b)`: the sequence spans from the dropped `(`, the comment leads the sequence).
+    fn leading_comments_start(&self) -> u32
+    where
+        Self: GetSpan,
+    {
+        self.span().start
     }
     /// Formats the node when it is suppressed (`oxfmt-ignore` / `prettier-ignore`):
     /// prints `suppressed_span` verbatim.
@@ -665,11 +677,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExpressionStatement<'a>> {
         // sequence/assignment stays inside the parentheses;
         // extend the content past the closing paren so the comment is not moved behind the semicolon
         // (the sub-expression prints it, see `keeps_trailing_comment_inside_parens`).
-        let expression_end = expression.span().end;
         let content_end = if keeps_trailing_comment_inside_parens(expression.as_ref(), false) {
-            f.comments().end_including_source_parens(expression_end, self.span().end)
+            f.comments().end_including_source_parens(expression.span().end, self.span().end)
         } else {
-            expression_end
+            assignment_chain_leaf_end(expression.as_ref())
         };
         write!(f, FormatContentWithSemicolon::new(expression, content_end, self.span().end));
     }

--- a/crates/oxc_formatter/src/print/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/print/return_or_throw_statement.rs
@@ -150,7 +150,11 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatAdjacentArgument<'a, '_> {
             // e.g. `return ( // comment\n a, b )` -> `return (\n  // comment\n  (a, b)\n)`
             let inner = format_with(|f| {
                 if matches!(argument.as_ref(), Expression::SequenceExpression(_)) {
-                    format_leading_comments_and_open_paren(argument.span(), true, f);
+                    // The argument's parentheses survive here,
+                    // so even a comment inside the first element's source parens stays inside:
+                    // bound at the span start.
+                    let span = argument.span();
+                    format_leading_comments_and_open_paren(span, span.start, true, f);
                     write!(f, [argument, token(")")]);
                 } else {
                     write!(f, argument);

--- a/crates/oxc_formatter/src/print/semicolon.rs
+++ b/crates/oxc_formatter/src/print/semicolon.rs
@@ -1,5 +1,6 @@
 use oxc_ast::ast::{Comment, Expression};
 use oxc_formatter_core::{Buffer, Format};
+use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::AstNodes,
@@ -77,6 +78,20 @@ pub fn keeps_trailing_comment_inside_parens(expr: &Expression<'_>, gated: bool) 
             .is_some_and(|body| keeps_trailing_comment_inside_parens(body, true)),
         _ => false,
     }
+}
+
+/// The opposite outcome of [`keeps_trailing_comment_inside_parens`]:
+/// where that table says the parentheses do NOT survive, the semicolon directly follows the content,
+/// so trailing comments move behind it even from inside the dropped parentheses.
+/// Those parentheses are excluded from the chain's rightmost leaf's span but included in the chain's,
+/// so the leaf's end bounds the content
+/// (`assigned = (a = c /* c */);` -> `assigned = a = c; /* c */`, prettier#19893).
+pub fn assignment_chain_leaf_end(expr: &Expression<'_>) -> u32 {
+    let mut leaf = expr;
+    while let Expression::AssignmentExpression(assignment) = leaf {
+        leaf = &assignment.right;
+    }
+    leaf.span().end
 }
 
 /// The printing half of [`keeps_trailing_comment_inside_parens`]:

--- a/crates/oxc_formatter/src/print/sequence_expression.rs
+++ b/crates/oxc_formatter/src/print/sequence_expression.rs
@@ -1,5 +1,6 @@
 use oxc_ast::ast::*;
 use oxc_formatter_core::Format;
+use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
@@ -10,7 +11,19 @@ use crate::{
 
 use super::FormatWrite;
 
+/// The sequence spans from the first element's source `(` when it is parenthesized,
+/// so a comment inside those dropped parentheses sits within the sequence's span but leads the sequence,
+/// not the element: it prints OUTSIDE the formatter-added parentheses
+/// (`((/* c */ a), b);` -> `/* c */ (a, b);`, prettier#19894's fixpoint).
+pub fn sequence_leading_comments_start(sequence: &SequenceExpression<'_>) -> u32 {
+    sequence.expressions.first().map_or(sequence.span.start, |e| e.span().start)
+}
+
 impl<'a> FormatWrite<'a> for AstNode<'a, SequenceExpression<'a>> {
+    fn leading_comments_start(&self) -> u32 {
+        sequence_leading_comments_start(self)
+    }
+
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let is_arrow_body = matches!(self.parent(), AstNodes::ArrowFunctionExpression(_));
 

--- a/crates/oxc_formatter/src/utils/typecast.rs
+++ b/crates/oxc_formatter/src/utils/typecast.rs
@@ -141,6 +141,10 @@ pub fn format_type_cast_comment_node<'a>(
 /// Prints a node's leading comments and the formatter-added `(` in the correct order.
 /// The caller prints the matching `)` when `needs_parentheses` is true.
 ///
+/// `leading_comments_start` bounds the leading-comments query
+/// (see `FormatWrite::leading_comments_start`; usually `span.start`).
+/// Type-cast classification always uses the node's real `span`.
+///
 /// When the leading comments end with a cast comment binding into the node (see [`TypeCast::BindsInner`]),
 /// printing them all first would insert the added `(` between the comment and its cast target,
 /// rebinding the cast and changing the type semantics:
@@ -158,9 +162,11 @@ pub fn format_type_cast_comment_node<'a>(
 /// So the cast comment is printed inside the added parenthesis.
 pub fn format_leading_comments_and_open_paren(
     span: Span,
+    leading_comments_start: u32,
     needs_parentheses: bool,
     f: &mut JsFormatter<'_, '_>,
 ) {
+    let leading_span = Span::new(leading_comments_start, span.end);
     if needs_parentheses {
         if let TypeCast::BindsInner(comments) = classify_type_cast(span, f)
             && let Some((cast_comment, rest)) = comments.split_last()
@@ -175,10 +181,10 @@ pub fn format_leading_comments_and_open_paren(
                 ]
             );
         } else {
-            write!(f, [format_leading_comments(span), "("]);
+            write!(f, [format_leading_comments(leading_span), "("]);
         }
     } else {
-        write!(f, format_leading_comments(span));
+        write!(f, format_leading_comments(leading_span));
     }
 }
 

--- a/crates/oxc_formatter/tests/fixtures/js/sequence-expression/leading-comment-in-first-element-parens.js
+++ b/crates/oxc_formatter/tests/fixtures/js/sequence-expression/leading-comment-in-first-element-parens.js
@@ -1,0 +1,29 @@
+// A comment inside the first element's dropped source parentheses sits within
+// the sequence's span but leads the sequence, not the element: it prints
+// outside the formatter-added parentheses.
+// (Prettier 3.9 prints it inside on its first pass and moves it out on the
+// second; oxfmt prints that fixpoint directly, see prettier#19894)
+((/* c */ a), b);
+((/* c1 */ /* c2 */ a), b);
+((
+  // own line
+  a
+), b);
+const v = ((/* c */ a), b);
+
+// A comment on a later element stays with that element
+((a), /* c */ b);
+
+// A cast comment keeps its target
+(/** @type {T} */ (a), b);
+
+// Arrow body: the comment leads the sequence and forces the body onto its own line
+ret = () => ((/* c */ a), b);
+
+// return keeps its argument parentheses; the comment stays inside them
+function g() {
+  return ((/* c */ a), b);
+}
+
+// for-init adds no parentheses
+for ((/* c */ a), b; ; );

--- a/crates/oxc_formatter/tests/fixtures/js/sequence-expression/leading-comment-in-first-element-parens.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/sequence-expression/leading-comment-in-first-element-parens.js.snap
@@ -1,0 +1,100 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A comment inside the first element's dropped source parentheses sits within
+// the sequence's span but leads the sequence, not the element: it prints
+// outside the formatter-added parentheses.
+// (Prettier 3.9 prints it inside on its first pass and moves it out on the
+// second; oxfmt prints that fixpoint directly, see prettier#19894)
+((/* c */ a), b);
+((/* c1 */ /* c2 */ a), b);
+((
+  // own line
+  a
+), b);
+const v = ((/* c */ a), b);
+
+// A comment on a later element stays with that element
+((a), /* c */ b);
+
+// A cast comment keeps its target
+(/** @type {T} */ (a), b);
+
+// Arrow body: the comment leads the sequence and forces the body onto its own line
+ret = () => ((/* c */ a), b);
+
+// return keeps its argument parentheses; the comment stays inside them
+function g() {
+  return ((/* c */ a), b);
+}
+
+// for-init adds no parentheses
+for ((/* c */ a), b; ; );
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A comment inside the first element's dropped source parentheses sits within
+// the sequence's span but leads the sequence, not the element: it prints
+// outside the formatter-added parentheses.
+// (Prettier 3.9 prints it inside on its first pass and moves it out on the
+// second; oxfmt prints that fixpoint directly, see prettier#19894)
+/* c */ (a, b);
+/* c1 */ /* c2 */ (a, b);
+// own line
+(a, b);
+const v = /* c */ (a, b);
+
+// A comment on a later element stays with that element
+(a, /* c */ b);
+
+// A cast comment keeps its target
+(/** @type {T} */ (a), b);
+
+// Arrow body: the comment leads the sequence and forces the body onto its own line
+ret = () =>
+  /* c */ (a, b);
+
+// return keeps its argument parentheses; the comment stays inside them
+function g() {
+  return (/* c */ a, b);
+}
+
+// for-init adds no parentheses
+for (/* c */ a, b; ;);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A comment inside the first element's dropped source parentheses sits within
+// the sequence's span but leads the sequence, not the element: it prints
+// outside the formatter-added parentheses.
+// (Prettier 3.9 prints it inside on its first pass and moves it out on the
+// second; oxfmt prints that fixpoint directly, see prettier#19894)
+/* c */ (a, b);
+/* c1 */ /* c2 */ (a, b);
+// own line
+(a, b);
+const v = /* c */ (a, b);
+
+// A comment on a later element stays with that element
+(a, /* c */ b);
+
+// A cast comment keeps its target
+(/** @type {T} */ (a), b);
+
+// Arrow body: the comment leads the sequence and forces the body onto its own line
+ret = () =>
+  /* c */ (a, b);
+
+// return keeps its argument parentheses; the comment stays inside them
+function g() {
+  return (/* c */ a, b);
+}
+
+// for-init adds no parentheses
+for (/* c */ a, b; ;);
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/semi/trailing-comments.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/semi/trailing-comments.ts
@@ -62,9 +62,19 @@ function afterCloseParenReturn() {
     anotherLongLongLongLongCondition
   ) /* moves */;
 }
-// A comment inside a parenthesized sub-expression belongs to that expression
-// and stays attached, like Prettier
-parenthesized = (someValue /* stays */);
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = (someValue /* moves */);
+parenthesizedChain = (inner = someValue /* moves */);
+parenthesizedNested = (inner = (someValue /* moves */));
+parenthesizedTernary = (cond ? someValue : other /* moves */);
+parenthesizedLine = (inner = someValue // moves
+);
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */);
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed

--- a/crates/oxc_formatter/tests/fixtures/ts/semi/trailing-comments.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/semi/trailing-comments.ts.snap
@@ -66,9 +66,19 @@ function afterCloseParenReturn() {
     anotherLongLongLongLongCondition
   ) /* moves */;
 }
-// A comment inside a parenthesized sub-expression belongs to that expression
-// and stays attached, like Prettier
-parenthesized = (someValue /* stays */);
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = (someValue /* moves */);
+parenthesizedChain = (inner = someValue /* moves */);
+parenthesizedNested = (inner = (someValue /* moves */));
+parenthesizedTernary = (cond ? someValue : other /* moves */);
+parenthesizedLine = (inner = someValue // moves
+);
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */);
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed
@@ -222,9 +232,18 @@ function afterCloseParenReturn() {
     aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
   ) /* moves */
 }
-// A comment inside a parenthesized sub-expression belongs to that expression
-// and stays attached, like Prettier
-parenthesized = someValue /* stays */
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = someValue /* moves */
+parenthesizedChain = inner = someValue /* moves */
+parenthesizedNested = inner = someValue /* moves */
+parenthesizedTernary = cond ? someValue : other /* moves */
+parenthesizedLine = inner = someValue // moves
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */)
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed
@@ -370,9 +389,18 @@ function ownLineCommentReturn() {
 function afterCloseParenReturn() {
   return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition /* moves */
 }
-// A comment inside a parenthesized sub-expression belongs to that expression
-// and stays attached, like Prettier
-parenthesized = someValue /* stays */
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = someValue /* moves */
+parenthesizedChain = inner = someValue /* moves */
+parenthesizedNested = inner = someValue /* moves */
+parenthesizedTernary = cond ? someValue : other /* moves */
+parenthesizedLine = inner = someValue // moves
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */)
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed
@@ -517,9 +545,18 @@ function afterCloseParenReturn() {
     aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
   ); /* moves */
 }
-// A comment inside a parenthesized sub-expression belongs to that expression
-// and stays attached, like Prettier
-parenthesized = someValue /* stays */;
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = someValue; /* moves */
+parenthesizedChain = inner = someValue; /* moves */
+parenthesizedNested = inner = someValue; /* moves */
+parenthesizedTernary = cond ? someValue : other; /* moves */
+parenthesizedLine = inner = someValue; // moves
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */);
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed
@@ -665,9 +702,18 @@ function afterCloseParenReturn() {
     aLongLongLongLongLongCondition && anotherLongLongLongLongCondition
   ); /* moves */
 }
-// A comment inside a parenthesized sub-expression belongs to that expression
-// and stays attached, like Prettier
-parenthesized = someValue; /* stays */
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = someValue; /* moves */
+parenthesizedChain = inner = someValue; /* moves */
+parenthesizedNested = inner = someValue; /* moves */
+parenthesizedTernary = cond ? someValue : other; /* moves */
+parenthesizedLine = inner = someValue; // moves
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */);
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed
@@ -813,9 +859,18 @@ function ownLineCommentReturn() {
 function afterCloseParenReturn() {
   return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition; /* moves */
 }
-// A comment inside a parenthesized sub-expression belongs to that expression
-// and stays attached, like Prettier
-parenthesized = someValue /* stays */;
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = someValue; /* moves */
+parenthesizedChain = inner = someValue; /* moves */
+parenthesizedNested = inner = someValue; /* moves */
+parenthesizedTernary = cond ? someValue : other; /* moves */
+parenthesizedLine = inner = someValue; // moves
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */);
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed
@@ -956,9 +1011,18 @@ function ownLineCommentReturn() {
 function afterCloseParenReturn() {
   return aLongLongLongLongLongCondition && anotherLongLongLongLongCondition; /* moves */
 }
-// A comment inside a parenthesized sub-expression belongs to that expression
-// and stays attached, like Prettier
-parenthesized = someValue; /* stays */
+// In an expression statement the parentheses are dropped, so the semicolon
+// directly follows the content: a comment inside them also moves behind it,
+// even from a nested assignment's dropped parentheses.
+// (Prettier 3.9 moves these only on its second pass; oxfmt prints that
+// fixpoint directly, see prettier#19893)
+parenthesized = someValue; /* moves */
+parenthesizedChain = inner = someValue; /* moves */
+parenthesizedNested = inner = someValue; /* moves */
+parenthesizedTernary = cond ? someValue : other; /* moves */
+parenthesizedLine = inner = someValue; // moves
+// ... but not where the parentheses survive in the output (`keeps_trailing_comment_inside_parens`)
+const parenthesizedInit = (inner = someValue /* stays */);
 
 // The `;` on a later line still moves the comment: in the output the semicolon
 // directly follows the content, so nothing is crossed

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_formatter/tests/conformance.rs
 expression: report
 ---
-js compatibility: 773/810 (95.43%), 23 files skipped
+js compatibility: 771/810 (95.19%), 23 files skipped
 
 # Failed
 
@@ -42,6 +42,8 @@ js compatibility: 773/810 (95.43%), 23 files skipped
 | js/if/condition-break/unary-expression.js | 💥 | 61.38% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 0.00% |
 | js/logical-expressions/in-unary-expression.js | 💥 | 79.49% |
+| js/sequence-expression/parenthesized-trailing-comment-unstable.js | 💥 | 66.67% |
+| js/sequence-expression/parenthesized.js | 💥 | 85.71% |
 | js/template-literals/expression-break.js | 💥 | 80.00% |
 | js/template-literals/expressions.js | 💥 | 97.64% |
 | js/test-declarations/jest-each.js | 💥💥 | 95.71% |
@@ -88,7 +90,5 @@ js compatibility: 773/810 (95.43%), 23 files skipped
 - js/for/continue-and-break-comment-without-blocks.js
 - js/function/issue-12967.js
 - js/object-prop-break-in/short-keys.js
-- js/sequence-expression/parenthesized-trailing-comment-unstable.js
-- js/sequence-expression/parenthesized.js
 - jsx/comments/in-attributes.js
 - jsx/spread/child.js

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -159,7 +159,7 @@ fn generate_struct_implementation(
             // or the cast would rebind to them.
             quote! {
                 let needs_parentheses = self.needs_parentheses(f);
-                format_leading_comments_and_open_paren(self.span(), needs_parentheses, f);
+                format_leading_comments_and_open_paren(self.span(), self.leading_comments_start(), needs_parentheses, f);
             }
         }
     } else {


### PR DESCRIPTION
Fixes non-idempotent formatting with comment and dropped parens.
