### PR TITLE
fix(linter/eslint/no-unassigned-vars): skip Svelte and Vue files

### DIFF
--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_frameworks@astro__debugger.astro_vue__debugger.vue_svelte__debugger.svelte_nextjs__[[..rest]]__debugger.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_frameworks@astro__debugger.astro_vue__debugger.vue_svelte__debugger.svelte_nextjs__[[..rest]]__debugger.ts.snap
@@ -426,28 +426,6 @@ severity: Some(Warning)
 source: Some("oxc")
 tags: None
 
-code: "eslint(no-unassigned-vars)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unassigned-vars.html"
-message: "'title' is always 'undefined' because it's never assigned.\nhelp: Variable declared without assignment. Either assign a value or remove the declaration."
-range: Range { start: Position { line: 3, character: 12 }, end: Position { line: 3, character: 17 } }
-related_information[0].message: ""
-related_information[0].location.uri: "file://<variable>/fixtures/lsp/frameworks/svelte/debugger.svelte"
-related_information[0].location.range: Range { start: Position { line: 3, character: 12 }, end: Position { line: 3, character: 17 } }
-severity: Some(Warning)
-source: Some("oxc")
-tags: None
-
-code: "eslint(no-unassigned-vars)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unassigned-vars.html"
-message: "'person' is always 'undefined' because it's never assigned.\nhelp: Variable declared without assignment. Either assign a value or remove the declaration."
-range: Range { start: Position { line: 4, character: 12 }, end: Position { line: 4, character: 18 } }
-related_information[0].message: ""
-related_information[0].location.uri: "file://<variable>/fixtures/lsp/frameworks/svelte/debugger.svelte"
-related_information[0].location.range: Range { start: Position { line: 4, character: 12 }, end: Position { line: 4, character: 18 } }
-severity: Some(Warning)
-source: Some("oxc")
-tags: None
-
 ########### Code Actions/Commands
 CodeAction: 
 Title: Remove the debugger statement
@@ -500,78 +478,6 @@ TextEdit: TextEdit {
         },
     },
     new_text: "// oxlint-disable no-debugger\n",
-}
-
-
-CodeAction: 
-Title: Disable no-unassigned-vars for this line
-Is Preferred: Some(false)
-TextEdit: TextEdit {
-    range: Range {
-        start: Position {
-            line: 3,
-            character: 0,
-        },
-        end: Position {
-            line: 3,
-            character: 0,
-        },
-    },
-    new_text: "\t// oxlint-disable-next-line no-unassigned-vars\n",
-}
-
-
-CodeAction: 
-Title: Disable no-unassigned-vars for this whole file
-Is Preferred: Some(false)
-TextEdit: TextEdit {
-    range: Range {
-        start: Position {
-            line: 1,
-            character: 0,
-        },
-        end: Position {
-            line: 1,
-            character: 0,
-        },
-    },
-    new_text: "// oxlint-disable no-unassigned-vars\n",
-}
-
-
-CodeAction: 
-Title: Disable no-unassigned-vars for this line
-Is Preferred: Some(false)
-TextEdit: TextEdit {
-    range: Range {
-        start: Position {
-            line: 4,
-            character: 0,
-        },
-        end: Position {
-            line: 4,
-            character: 0,
-        },
-    },
-    new_text: "\t// oxlint-disable-next-line no-unassigned-vars\n",
-}
-
-
-CodeAction: 
-Title: Disable no-unassigned-vars for this whole file
-Is Preferred: Some(false)
-TextEdit: TextEdit {
-    range: Range {
-        start: Position {
-            line: 1,
-            character: 0,
-        },
-        end: Position {
-            line: 1,
-            character: 0,
-        },
-    },
-    new_text: "// oxlint-disable no-unassigned-vars\n",
 }
 
 

--- a/apps/oxlint/src/snapshots/_fixtures__cli__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__cli__svelte__debugger.svelte@oxlint.snap
@@ -15,25 +15,7 @@ working directory:
    `----
   help: Remove the debugger statement
 
-  ! eslint(no-unassigned-vars): 'title' is always 'undefined' because it's never assigned.
-   ,-[fixtures/cli/svelte/debugger.svelte:4:13]
- 3 | 
- 4 |     export let title;
-   :                ^^^^^
- 5 |     export let person;
-   `----
-  help: Variable declared without assignment. Either assign a value or remove the declaration.
-
-  ! eslint(no-unassigned-vars): 'person' is always 'undefined' because it's never assigned.
-   ,-[fixtures/cli/svelte/debugger.svelte:5:13]
- 4 |     export let title;
- 5 |     export let person;
-   :                ^^^^^^
- 6 | 
-   `----
-  help: Variable declared without assignment. Either assign a value or remove the declaration.
-
-Found 3 warnings and 0 errors.
+Found 1 warning and 0 errors.
 Finished in <variable>ms on 1 file with 96 rules using 1 threads.
 ----------
 CLI result: LintSucceeded

--- a/crates/oxc_linter/src/rules/eslint/no_unassigned_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unassigned_vars.rs
@@ -23,6 +23,14 @@ declare_oxc_lint!(
     ///
     /// Disallow let or var variables that are read but never assigned.
     ///
+    /// #### Ignored Files
+    /// This rule ignores `.svelte` and `.vue` files entirely. Oxlint only parses the
+    /// `<script>` blocks of these files, so a binding that the template assigns looks
+    /// like it is never assigned. In Svelte the template writes through
+    /// `bind:this={el}` and `bind:value={x}`; in Vue a `<script setup>` `let` is a
+    /// `setup-let` binding that `v-model="x"` and inline handlers such as
+    /// `@click="x = 1"` assign to directly.
+    ///
     /// ### Why is this bad?
     ///
     /// This rule flags let or var declarations that are never assigned a value but are still read or used in the code.
@@ -103,6 +111,11 @@ impl Rule for NoUnassignedVars {
             ctx.diagnostic(no_unassigned_vars_diagnostic(ident.span, ident.name.as_str()));
         }
     }
+
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
+        // ignore svelte/vue: their templates can assign a binding, which we can't see.
+        !ctx.file_extension().is_some_and(|ext| ext == "svelte" || ext == "vue")
+    }
 }
 
 #[test]
@@ -159,4 +172,62 @@ fn test() {
     ];
 
     Tester::new(NoUnassignedVars::NAME, NoUnassignedVars::PLUGIN, pass, fail).test_and_snapshot();
+}
+
+#[test]
+fn test_svelte() {
+    use crate::tester::Tester;
+
+    // The markup is stripped before linting; it documents the template-side write
+    // (`bind:this`, `bind:value`) that makes these bindings assigned in reality.
+    let pass = vec![
+        "<script lang=\"ts\">
+            let dialog: HTMLDialogElement;
+            function openDialog() { dialog.showModal(); }
+         </script>
+         <dialog bind:this={dialog}></dialog>",
+        "<script>
+            let value;
+            log(value);
+         </script>
+         <input bind:value />",
+        // Both blocks of a two-script component are linted; neither may report.
+        "<script module>
+            let shared;
+            log(shared);
+         </script>
+         <script>
+            let value;
+            log(value);
+         </script>
+         <input bind:value />",
+    ];
+
+    Tester::new(NoUnassignedVars::NAME, NoUnassignedVars::PLUGIN, pass, vec![])
+        .change_rule_path("test.svelte")
+        .test();
+}
+
+#[test]
+fn test_vue() {
+    use crate::tester::Tester;
+
+    // A `<script setup>` `let` is a `setup-let` binding: `v-model` and inline handlers
+    // compile to direct assignments to it, so the script alone cannot see the write.
+    let pass = vec![
+        "<script setup>
+            let msg;
+            log(msg);
+         </script>
+         <template><input v-model=\"msg\" /></template>",
+        "<script setup>
+            let count;
+            log(count);
+         </script>
+         <template><button @click=\"count = 1\">go</button></template>",
+    ];
+
+    Tester::new(NoUnassignedVars::NAME, NoUnassignedVars::PLUGIN, pass, vec![])
+        .change_rule_path("test.vue")
+        .test();
 }


### PR DESCRIPTION
## Summary

Closes #26038.

`no-unassigned-vars` is a `correctness` rule, so this fires by default with no config:

```svelte
<script lang="ts">
  let dialog: HTMLDialogElement;

  function openDialog() {
    dialog.showModal();
  }
</script>

<dialog bind:this={dialog}>Hello</dialog>
```

```text
repro.svelte:2:7: warning eslint(no-unassigned-vars): 'dialog' is always 'undefined' because it's never assigned.
```

## Why the rule cannot get this right today

The rule's decision is `has_read && no reference is_write()`, taken over the symbol's references in the current script block. Oxlint reaches `.svelte`/`.vue` through `PartialLoader`, which extracts the `<script>` blocks and throws the markup away before parsing — so the template's write is not in the AST the rule sees, and no reference on `dialog` is ever a write. Every ingredient of the diagnostic is satisfied, and the diagnostic is still wrong: Svelte assigns the element to `dialog` on mount.

The same shape exists in Vue, where a `<script setup>` `let` is a `setup-let` binding that `v-model="x"` and inline handlers such as `@click="x = 1"` compile to direct assignments against.

This is not a matter of tightening the check — the write is in a part of the file the linter never parses.

## The change

`prefer-const` hit exactly this and already skips both extensions ([#25148](https://github.com/oxc-project/oxc/pull/25148)):

```rust
fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
    // ignore svelte/vue: their templates can reassign a binding, which we can't see.
    !ctx.file_extension().is_some_and(|ext| ext == "svelte" || ext == "vue")
}
```

This applies the sibling rule's guard rather than inventing one, and documents it in the rule docs under an `#### Ignored Files` heading, matching `prefer-const`'s wording.

`.astro` is deliberately **not** included: an Astro template renders a frontmatter binding but has no construct that writes back to it, so the false positive does not arise there. `prefer-const` drew the same line.

## Scope, stated honestly

This trades a false positive for lost coverage: a genuinely unassigned variable inside a `.svelte`/`.vue` `<script>` block is no longer reported. That matches the precedent and the reporter's own request, and a `correctness` false positive that fires on the documented Svelte idiom costs more than the missed report. Restoring coverage needs template-aware analysis, which is the language-support effort tracked separately (#13017, #17991).

## Verification

- `cargo test -p oxc_linter --lib` — **1254 passed, 0 failed**.
- Two new tests, `test_svelte` and `test_vue`, cover the reported repro, `bind:value`, a two-`<script>` Svelte component, `v-model`, and an inline `@click` handler.
- **Revert-checked:** with `should_run` removed and the tests kept, exactly those two tests fail and the rest pass. The failure output reproduces the reported diagnostic verbatim, including the `let shared` case from the two-script component — so the tests fail for the right reason, not because the fixture path changed.
- `cargo clippy -p oxc_linter --lib --all-features` — no new findings (the two `FromIterator::from_iter` warnings are pre-existing, in `tsgolint.rs` and `lib.rs`).
- `cargo fmt --check` clean.
- The rule is not part of `docs_rule_pages.snap`, so the doc addition needs no snapshot regeneration.

Built and tested on Windows with the `1.97.1-x86_64-pc-windows-gnu` toolchain rather than the pinned `1.98.0`, and with `RUSTFLAGS` overridden to drop the MSVC-only link args that `.cargo/config.toml` applies to every `target_os = "windows"` target. Nothing in the repository was changed for that.

---
Written with AI assistance (Claude Code), reviewed and tested by me before submitting, per AGENTS.md.
