### PR TITLE
fix(linter/oxc/double-comparisons): handle grouped logical expressions

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
@@ -54,21 +54,30 @@ impl Rule for DoubleComparisons {
             return;
         };
 
-        let (lkind, llhs, lrhs, rkind, rlhs, rrhs) = match (&logical_expr.left, &logical_expr.right)
-        {
-            (
-                Expression::BinaryExpression(left_bin_expr),
-                Expression::BinaryExpression(right_bin_expr),
-            ) => (
-                left_bin_expr.operator,
-                &left_bin_expr.left,
-                &left_bin_expr.right,
-                right_bin_expr.operator,
-                &right_bin_expr.left,
-                &right_bin_expr.right,
-            ),
+        let left_bin_expr = match &logical_expr.left {
+            Expression::BinaryExpression(left_bin_expr) => left_bin_expr,
+            Expression::LogicalExpression(left_logical_expr)
+                if left_logical_expr.operator == logical_expr.operator =>
+            {
+                let Expression::BinaryExpression(left_bin_expr) = &left_logical_expr.right else {
+                    return;
+                };
+                left_bin_expr
+            }
             _ => return,
         };
+        let Expression::BinaryExpression(right_bin_expr) = &logical_expr.right else {
+            return;
+        };
+
+        let (lkind, llhs, lrhs, rkind, rlhs, rrhs) = (
+            left_bin_expr.operator,
+            &left_bin_expr.left,
+            &left_bin_expr.right,
+            right_bin_expr.operator,
+            &right_bin_expr.left,
+            &right_bin_expr.right,
+        );
 
         // check that (LLHS === RLHS && LRHS === RRHS) || (LLHS === RRHS && LRHS === RLHS)
         let rhs_operator =
@@ -97,22 +106,20 @@ impl Rule for DoubleComparisons {
             _ => return,
         };
 
-        ctx.diagnostic_with_suggestion(
-            double_comparisons_diagnostic(logical_expr.span, new_op),
-            |fixer| {
-                let modified_code = {
-                    let mut codegen = fixer.codegen();
-                    codegen.print_expression(llhs);
-                    codegen.print_ascii_byte(b' ');
-                    codegen.print_str(new_op);
-                    codegen.print_ascii_byte(b' ');
-                    codegen.print_expression(lrhs);
-                    codegen.into_source_text()
-                };
+        let span = Span::new(left_bin_expr.span.start, right_bin_expr.span.end);
+        ctx.diagnostic_with_suggestion(double_comparisons_diagnostic(span, new_op), |fixer| {
+            let modified_code = {
+                let mut codegen = fixer.codegen();
+                codegen.print_expression(llhs);
+                codegen.print_ascii_byte(b' ');
+                codegen.print_str(new_op);
+                codegen.print_ascii_byte(b' ');
+                codegen.print_expression(lrhs);
+                codegen.into_source_text()
+            };
 
-                fixer.replace(logical_expr.span, modified_code)
-            },
-        );
+            fixer.replace(span, modified_code)
+        });
     }
 }
 
@@ -141,6 +148,9 @@ fn test() {
         "x >= y && y <= x",
         "x < y || y > x",
         "x > y || y < x",
+        "a && x === y || x > y",
+        "a || x >= y",
+        "(a || x >= y) && b",
     ];
 
     let fail = vec![
@@ -160,6 +170,10 @@ fn test() {
         "y < x || x === y",
         "x === y || y > x",
         "y > x || x === y",
+        "a || x === y || x > y",
+        "(a || x === y || x > y) && b",
+        "a && x <= y && x >= y",
+        "a || x <= y && x >= y",
     ];
 
     let fix = vec![
@@ -180,6 +194,10 @@ fn test() {
         ("y < x || x === y", "y <= x"),
         ("x === y || y > x", "x <= y"),
         ("y > x || x === y", "y >= x"),
+        ("a || x === y || x > y", "a || x >= y"),
+        ("(a || x === y || x > y) && b", "(a || x >= y) && b"),
+        ("a && x <= y && x >= y", "a && x == y"),
+        ("a || x <= y && x >= y", "a || x == y"),
     ];
 
     Tester::new(DoubleComparisons::NAME, DoubleComparisons::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/oxc_double_comparisons.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_double_comparisons.snap
@@ -113,3 +113,31 @@ source: crates/oxc_linter/src/tester.rs
    · ────────────────
    ╰────
   help: This logical expression can be simplified. Try using the `>=` operator instead.
+
+  ⚠ oxc(double-comparisons): Unexpected double comparisons.
+   ╭─[double_comparisons.tsx:1:6]
+ 1 │ a || x === y || x > y
+   ·      ────────────────
+   ╰────
+  help: This logical expression can be simplified. Try using the `>=` operator instead.
+
+  ⚠ oxc(double-comparisons): Unexpected double comparisons.
+   ╭─[double_comparisons.tsx:1:7]
+ 1 │ (a || x === y || x > y) && b
+   ·       ────────────────
+   ╰────
+  help: This logical expression can be simplified. Try using the `>=` operator instead.
+
+  ⚠ oxc(double-comparisons): Unexpected double comparisons.
+   ╭─[double_comparisons.tsx:1:6]
+ 1 │ a && x <= y && x >= y
+   ·      ────────────────
+   ╰────
+  help: This logical expression can be simplified. Try using the `==` operator instead.
+
+  ⚠ oxc(double-comparisons): Unexpected double comparisons.
+   ╭─[double_comparisons.tsx:1:6]
+ 1 │ a || x <= y && x >= y
+   ·      ────────────────
+   ╰────
+  help: This logical expression can be simplified. Try using the `==` operator instead.


### PR DESCRIPTION
## Summary

- detect adjacent comparisons across left-associated logical-expression groups
- limit the diagnostic and suggestion span to the comparisons being simplified
- cover mixed precedence, parentheses, grouped `&&`, and reparsed suggestion outputs