### PR TITLE
fix(codegen): require sourcemap for example

### DIFF
--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -19,6 +19,10 @@ workspace = true
 [lib]
 doctest = true
 
+[[example]]
+name = "codegen"
+required-features = ["sourcemap"]
+
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }

--- a/crates/oxc_codegen/examples/codegen.rs
+++ b/crates/oxc_codegen/examples/codegen.rs
@@ -15,6 +15,7 @@
 //!
 //! - `--minify`: Generate minified output
 //! - `--twice`: Test idempotency by parsing and generating twice
+//! - `--sourcemap`: Print the generated source map (requires the `sourcemap` feature)
 
 use std::path::Path;
 


### PR DESCRIPTION
## Summary

- require the sourcemap feature when building the codegen example
- document the example's sourcemap option
- allow oxc_codegen to test cleanly without default features