### PR TITLE
chore(deps): bump oxc-resolver to 11.24.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ javascript-globals = "1.5.1" # JavaScript global definitions
 json-strip-comments = "3.1.1" # Strip JSON comments
 oxc-browserslist = "5.0.0" # Browser compatibility queries
 oxc_index = { version = "5.0.0", features = ["nonmax", "serde"] } # Type-safe indices
-oxc_resolver = "11.23.0" # Module resolution
+oxc_resolver = "11.24.3" # Module resolution
 oxc_sourcemap = "8.0.2" # Source map generation
 
 #


### PR DESCRIPTION
Bumps `oxc-resolver` to 11.24.3. The arm64 macOS oxlint release binary remains 12,542,400 bytes (0-byte change).

AI assistance was used to update the dependency, measure binary size, and prepare this PR. I reviewed and take responsibility for the changes.