### PR TITLE
fix(codegen): preserve names in duplicate source mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,6 +1883,7 @@ dependencies = [
  "oxc_data_structures",
  "oxc_ecmascript",
  "oxc_index",
+ "oxc_mangler",
  "oxc_parser",
  "oxc_semantic",
  "oxc_sourcemap",

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -42,6 +42,7 @@ smallvec = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
+oxc_mangler = { workspace = true }
 oxc_parser = { workspace = true }
 pico-args = { workspace = true }
 

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -54,6 +54,7 @@ pub struct SourcemapBuilder<'a> {
     tokens: Vec<oxc_sourcemap::Token>,
     last_generated_update: usize,
     last_position: Option<u32>,
+    last_token_name: Option<u32>,
     line_offset_tables: LineOffsetTables,
     generated_line: u32,
     generated_column: u32,
@@ -74,6 +75,7 @@ impl<'a> SourcemapBuilder<'a> {
             tokens: Vec::new(),
             last_generated_update: 0,
             last_position: None,
+            last_token_name: None,
             line_offset_tables,
             generated_line: 0,
             generated_column: 0,
@@ -135,6 +137,21 @@ impl<'a> SourcemapBuilder<'a> {
 
     pub fn add_source_mapping(&mut self, output: &[u8], position: u32, name: Option<&'a str>) {
         if self.last_position == Some(position) {
+            if let Some(name) = name
+                && self.last_token_name.is_none()
+            {
+                let name_id = self.add_name(name);
+                let token = self.tokens.last_mut().unwrap();
+                *token = oxc_sourcemap::Token::new(
+                    token.get_dst_line(),
+                    token.get_dst_col(),
+                    token.get_src_line(),
+                    token.get_src_col(),
+                    token.get_source_id(),
+                    Some(name_id),
+                );
+                self.last_token_name = Some(name_id);
+            }
             return;
         }
         let (original_line, original_column) = self.search_original_line_and_column(position);
@@ -149,6 +166,7 @@ impl<'a> SourcemapBuilder<'a> {
             name_id,
         ));
         self.last_position = Some(position);
+        self.last_token_name = name_id;
     }
 
     fn add_name(&mut self, name: &'a str) -> u32 {

--- a/crates/oxc_codegen/tests/integration/snapshots/stacktrace_is_correct.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/stacktrace_is_correct.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_codegen/tests/integration/sourcemap.rs
-assertion_line: 466
 ---
 Node.js version: v26.5.0
 

--- a/crates/oxc_codegen/tests/integration/snapshots/stacktrace_is_correct.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/stacktrace_is_correct.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_codegen/tests/integration/sourcemap.rs
+assertion_line: 466
 ---
 Node.js version: v26.5.0
 
@@ -262,3 +263,37 @@ make().prop;
 Error
     at Object.get prop (/project/input.js:4:15)
     at <anonymous> (/project/input.js:7:7)
+
+------------------------------------------------------
+## Mangled identifier source-map names
+["longFunctionName", "longName"]
+
+## Input
+export {};
+function longFunctionName(longName) {
+    (longName = () => {
+        Error.stackTraceLimit = 2;
+        throw new Error();
+    })();
+}
+longFunctionName(0);
+
+## Output
+export {};
+function e(e) {
+	(e = () => {
+		Error.stackTraceLimit = 2;
+		throw new Error();
+	})();
+}
+e(0);
+
+
+## Stderr
+/project/input.js:6
+        throw new Error();
+              ^
+
+Error
+    at longName (/project/input.js:6:15)
+    at e (/project/input.js:7:7)

--- a/crates/oxc_codegen/tests/integration/sourcemap.rs
+++ b/crates/oxc_codegen/tests/integration/sourcemap.rs
@@ -5,6 +5,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::{Expression, Statement};
 use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_index::IndexVec;
+use oxc_mangler::{MangleOptions, Mangler};
 use oxc_parser::Parser;
 use oxc_span::{SourceType, Span};
 use oxc_str::CompactStr;
@@ -440,6 +441,22 @@ const make = () => ({
 make().prop",
     ];
 
+    // The identifier is first mapped by its enclosing AssignmentExpression. The map must retain
+    // the later identifier mapping's original name so Node can restore the inferred function name.
+    // `export {}` makes this a module, allowing the enclosing function to be mangled as well.
+    let mangled_case = r#"
+export {};
+function longFunctionName(longName) {
+    (longName = () => {
+        Error.stackTraceLimit = 2;
+        throw new Error();
+    })();
+}
+longFunctionName(0);
+"#;
+    let (mangled_output, mangled_sourcemap_url, mangled_names) = codegen_mangled(mangled_case);
+    assert_eq!(mangled_names, ["longFunctionName", "longName"]);
+
     let node_version = std::process::Command::new("node").arg("--version").output().map_or_else(
         |_| "unknown".to_string(),
         |output| String::from_utf8_lossy(&output.stdout).trim().to_string(),
@@ -454,7 +471,13 @@ make().prop",
                 cases.iter().map(|s| {
                     let (output, sourcemap_url) = codegen(s);
                     format!("## Input\n{}\n\n## Output\n{}\n\n## Stderr\n{}", s, output, execute_with_node(&output, &sourcemap_url))
-                }).collect::<Vec<_>>().join("\n------------------------------------------------------\n")
+                }).chain(std::iter::once(format!(
+                    "## Mangled identifier source-map names\n{:?}\n\n## Input\n{}\n\n## Output\n{}\n\n## Stderr\n{}",
+                    mangled_names,
+                    mangled_case.trim(),
+                    mangled_output,
+                    execute_with_node(&mangled_output, &mangled_sourcemap_url),
+                ))).collect::<Vec<_>>().join("\n------------------------------------------------------\n")
             )
         );
     });
@@ -509,6 +532,27 @@ fn private_identifier_is_named_only_when_mangled() {
     // The token is `#ab`, so that is the name recorded - not `ab`, which would describe a region
     // of the output which includes the `#`
     assert_eq!(mangled_private_names(source_text, &[("ab", "a")]), vec!["#ab".to_string()]);
+}
+
+fn codegen_mangled(code: &str) -> (String, String, Vec<String>) {
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, code, SourceType::mjs()).parse();
+    assert!(ret.diagnostics.is_empty());
+    let program = ret.program;
+    let mangler = Mangler::new()
+        .with_options(MangleOptions { top_level: Some(true), ..MangleOptions::default() })
+        .build(&program);
+    let ret = Codegen::new()
+        .with_options(CodegenOptions {
+            source_map_path: Some(PathBuf::from("input.js")),
+            ..Default::default()
+        })
+        .with_scoping(Some(mangler.scoping))
+        .with_private_member_mappings(Some(mangler.class_private_mappings))
+        .build(&program);
+    let map = ret.map.unwrap();
+    let names = map.get_names().map(str::to_owned).collect();
+    (ret.code, map.to_data_url(), names)
 }
 
 fn execute_with_node(code: &str, sourcemap_url: &str) -> String {

--- a/crates/oxc_codegen/tests/integration/sourcemap.rs
+++ b/crates/oxc_codegen/tests/integration/sourcemap.rs
@@ -444,7 +444,7 @@ make().prop",
     // The identifier is first mapped by its enclosing AssignmentExpression. The map must retain
     // the later identifier mapping's original name so Node can restore the inferred function name.
     // `export {}` makes this a module, allowing the enclosing function to be mangled as well.
-    let mangled_case = r#"
+    let mangled_case = r"
 export {};
 function longFunctionName(longName) {
     (longName = () => {
@@ -453,7 +453,7 @@ function longFunctionName(longName) {
     })();
 }
 longFunctionName(0);
-"#;
+";
     let (mangled_output, mangled_sourcemap_url, mangled_names) = codegen_mangled(mangled_case);
     assert_eq!(mangled_names, ["longFunctionName", "longName"]);
 

--- a/packages/codegen/src-js/print/write.ts
+++ b/packages/codegen/src-js/print/write.ts
@@ -719,10 +719,12 @@ function markMapNamed(
   const { sourceText } = state;
   if (start > sourceText.length) return;
 
-  // `oxc_codegen` suppresses consecutive source positions as it records them. Do this before
-  // recovering a name or retaining the mapping, since member-level marks commonly duplicate keys.
-  const { mapPositions } = state;
-  if (mapPositions[mapPositions.length - 1] === start) return;
+  // `oxc_codegen` suppresses consecutive source positions as it records them. A named child can
+  // still enrich its unnamed parent mapping, but a mapping which already has a name is complete.
+  const { mapNames, mapPositions } = state;
+  const mappingIndex = mapPositions.length >> 1;
+  const duplicatePosition = mapPositions[mapPositions.length - 1] === start;
+  if (duplicatePosition && mapNames[mapNames.length - 2] === mappingIndex - 1) return;
 
   // A mapping carries a name only when the identifier printed differs from the one in the source.
   // When possible, the mapping records the name from source, but if the source range is invalid,
@@ -762,14 +764,14 @@ function markMapNamed(
     // A transformed or hand-authored AST can carry ranges unrelated to `sourceText`.
     // Preserve the existing fallback in that case instead of recording an arbitrary source substring.
     if (originalName === undefined || !isSameToken(originalName, printedName, hashLength)) {
-      state.mapNames.push(
-        mapPositions.length >> 1,
+      mapNames.push(
+        duplicatePosition ? mappingIndex - 1 : mappingIndex,
         originalName === undefined ? printedName : originalName,
       );
     }
   }
 
-  mapPositions.push(state.output.length, start);
+  if (!duplicatePosition) mapPositions.push(state.output.length, start);
 }
 
 /**


### PR DESCRIPTION
When an unnamed parent node and a mangled identifier begin at the same source position, codegen deduplicated the identifier mapping. This retained location data but discarded the original identifier name, leaving consumers unable to restore inferred function names in source-mapped Node stack traces.

```mermaid
flowchart LR
    A[AssignmentExpression mapping<br/>unnamed] --> B[Token at source position P<br/>name: none]
    C[Identifier mapping<br/>name: longName] --> D{Same source position P?}
    D -->|before| E[Drop duplicate<br/>names: empty]
    D -->|after| F[Enrich existing token<br/>name: longName]
```

### Changes

- Cache whether the last emitted token has a name, keeping duplicate-position handling cheap in the source-map builder hot path.
- Enrich an unnamed duplicate token when a later identifier mapping supplies the original name.
- Add a unit regression test for the builder behavior.
- Extend the existing Node source-map stack-trace snapshot test with a mangled ES module fixture.

The Node fixture verifies:

```text
function longFunctionName(longName) { ... }
            ↓ mangled
function e(e) { ... }
```

and asserts that the source map includes both original names while Node restores the inferred inner frame as:

```text
at longName (/project/input.js:6:15)
```
