### PR TITLE
fix(transformer): avoid filtered exec snapshot updates

### DIFF
--- a/tasks/transform_conformance/src/exec.rs
+++ b/tasks/transform_conformance/src/exec.rs
@@ -25,6 +25,10 @@ impl TestRunner {
         let content = if output.stderr.is_empty() { output.stdout } else { output.stderr };
         let output = String::from_utf8(content).unwrap();
         let output = version + &output;
-        self.snapshot.save(dest, &output);
+        if self.options.should_update_snapshots() {
+            self.snapshot.save(dest, &output);
+        } else {
+            print!("{output}");
+        }
     }
 }

--- a/tasks/transform_conformance/src/lib.rs
+++ b/tasks/transform_conformance/src/lib.rs
@@ -33,6 +33,12 @@ pub struct TestRunnerOptions {
     pub r#override: bool,
 }
 
+impl TestRunnerOptions {
+    fn should_update_snapshots(&self) -> bool {
+        self.filter.is_none()
+    }
+}
+
 /// The test runner which walks the babel repository and searches for transformation tests.
 pub struct TestRunner {
     options: TestRunnerOptions,
@@ -184,7 +190,7 @@ impl TestRunner {
             }
         }
 
-        if self.options.filter.is_none() {
+        if self.options.should_update_snapshots() {
             let all_passed =
                 all_passed.into_iter().map(|s| format!("* {s}")).collect::<Vec<_>>().join("\n");
             let snapshot = format!(


### PR DESCRIPTION
## Summary

- prevent filtered transform exec runs from overwriting aggregate snapshots
- print filtered Vitest output while preserving snapshot updates for unfiltered runs
