### PR TITLE
fix(react-compiler): support expression for initializers

### DIFF
--- a/crates/oxc_react_compiler/fixtures/for-expression-initializer.js
+++ b/crates/oxc_react_compiler/fixtures/for-expression-initializer.js
@@ -1,0 +1,29 @@
+function Component({ start, end }) {
+  let index;
+  let initCount = 0;
+  const values = [];
+
+  for (index = 0; index < start; index++) {
+    values.push(index);
+  }
+
+  for (index = start, initCount++; index < end; index++) {
+    values.push(index);
+  }
+
+  for (start < end ? values.push(-1) : values.push(-2); false;) {}
+  for (start && values.push(-3); false;) {}
+  const optionalValues = start ? values : null;
+  for (optionalValues?.push(-4); false;) {}
+
+  return `${initCount}:${values.join(",")}`;
+}
+
+export const FIXTURE_ENTRYPOINT = {
+  fn: Component,
+  params: [{ start: 1, end: 3 }],
+  sequentialRenders: [
+    { start: 2, end: 5 },
+    { start: 0, end: 0 },
+  ],
+};

--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -1043,21 +1043,6 @@ where
 }
 
 #[cold]
-pub fn todo_build_hir_lower_statement_handle_non_variable_initialization_statement<L, T>(
-    labels: T,
-) -> OxcDiagnostic
-where
-    L: Into<oxc_diagnostics::LabeledSpan>,
-    T: IntoIterator<Item = L>,
-{
-    diagnostic(
-        ErrorCategory::Todo,
-        "(BuildHIR::lowerStatement) Handle non-variable initialization in ForStatement",
-    )
-    .with_labels(labels)
-}
-
-#[cold]
 pub fn todo_build_hir_lower_statement_handle_await_loops<L, T>(labels: T) -> OxcDiagnostic
 where
     L: Into<oxc_diagnostics::LabeledSpan>,

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -372,6 +372,7 @@ pub enum Terminal<'a> {
     },
     For {
         init: BlockId,
+        init_is_direct_expression: bool,
         test: BlockId,
         update: Option<BlockId>,
         loop_block: BlockId,
@@ -1687,6 +1688,7 @@ impl<'a> CloneIn<'a> for Terminal<'a> {
             }
             Terminal::For {
                 init,
+                init_is_direct_expression,
                 test,
                 update,
                 loop_block,
@@ -1696,6 +1698,7 @@ impl<'a> CloneIn<'a> for Terminal<'a> {
                 span,
             } => Terminal::For {
                 init: *init,
+                init_is_direct_expression: *init_is_direct_expression,
                 test: *test,
                 update: *update,
                 loop_block: *loop_block,

--- a/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
@@ -181,6 +181,7 @@ pub enum ReactiveTerminal<'a> {
     },
     For {
         init: ReactiveValue<'a>,
+        init_is_direct_expression: bool,
         test: ReactiveValue<'a>,
         update: Option<ReactiveValue<'a>>,
         loop_block: ReactiveBlock<'a>,
@@ -427,16 +428,23 @@ impl<'a> CloneIn<'a> for ReactiveTerminal<'a> {
                     id: *id,
                 }
             }
-            ReactiveTerminal::For { init, test, update, loop_block, loop_block_span, id } => {
-                ReactiveTerminal::For {
-                    init: init.clone_in_impl(sem, alloc),
-                    test: test.clone_in_impl(sem, alloc),
-                    update: update.as_ref().map(|value| value.clone_in_impl(sem, alloc)),
-                    loop_block: clone_reactive_block_in(loop_block, sem, alloc),
-                    loop_block_span: *loop_block_span,
-                    id: *id,
-                }
-            }
+            ReactiveTerminal::For {
+                init,
+                init_is_direct_expression,
+                test,
+                update,
+                loop_block,
+                loop_block_span,
+                id,
+            } => ReactiveTerminal::For {
+                init: init.clone_in_impl(sem, alloc),
+                init_is_direct_expression: *init_is_direct_expression,
+                test: test.clone_in_impl(sem, alloc),
+                update: update.as_ref().map(|value| value.clone_in_impl(sem, alloc)),
+                loop_block: clone_reactive_block_in(loop_block, sem, alloc),
+                loop_block_span: *loop_block_span,
+                id: *id,
+            },
             ReactiveTerminal::ForOf {
                 init,
                 test,

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -5920,15 +5920,14 @@ fn lower_statement<'a>(
             let continuation_block = builder.reserve(BlockKind::Block);
             let continuation_id = continuation_block.id;
 
-            // Init block: lower init expression/declaration, then goto test
+            // Init block: lower initializer, then goto test
+            let mut init_is_direct_expression = false;
             let init_block = builder.try_enter(BlockKind::Loop, |builder, _block_id| {
                 let init_span = match &for_stmt.init {
                     None => {
-                        // No init expression (e.g., `for (; ...)`), add a placeholder
-                        let placeholder = InstructionValue::Primitive {
-                            value: PrimitiveValue::Undefined,
-                            span,
-                        };
+                        // No initializer (e.g., `for (; ...)`), add a placeholder
+                        let placeholder =
+                            InstructionValue::Primitive { value: PrimitiveValue::Undefined, span };
                         lower_value_to_temporary(builder, placeholder)?;
                         span
                     }
@@ -5940,10 +5939,23 @@ fn lower_statement<'a>(
                     Some(init) => {
                         let expr = init.to_expression();
                         let init_span = Some(expr.span());
-                                                builder.record_error(
-                            diagnostics::todo_build_hir_lower_statement_handle_non_variable_initialization_statement(span),
-                        )?;
-                        lower_expression_to_temporary(builder, expr)?;
+                        let value = lower_expression_to_temporary(builder, expr)?;
+                        init_is_direct_expression = builder.current_block_has_instructions();
+                        if !init_is_direct_expression {
+                            // Expressions that lower through a value block finish in an empty
+                            // continuation block. Store their result so the block remains
+                            // reachable, and emit the initializer in declaration form.
+                            let place = build_temporary_place(builder, init_span);
+                            promote_temporary(builder, place.identifier);
+                            lower_value_to_temporary(
+                                builder,
+                                InstructionValue::StoreLocal {
+                                    lvalue: LValue { place, kind: InstructionKind::Const },
+                                    value,
+                                    span: init_span,
+                                },
+                            )?;
+                        }
                         init_span
                     }
                 };
@@ -5990,6 +6002,7 @@ fn lower_statement<'a>(
             builder.terminate_with_continuation(
                 Terminal::For {
                     init: init_block,
+                    init_is_direct_expression,
                     test: test_block_id,
                     update: update_block_id,
                     loop_block: body_block,

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -578,6 +578,11 @@ impl<'a, 'b> HirBuilder<'a, 'b> {
         self.current.kind
     }
 
+    /// Return whether the current block has instructions.
+    pub fn current_block_has_instructions(&self) -> bool {
+        !self.current.instructions.is_empty()
+    }
+
     /// Construct the final HIR and instruction table from the completed blocks.
     ///
     /// Performs these post-build passes:

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -545,6 +545,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
 
                 Terminal::For {
                     init,
+                    init_is_direct_expression,
                     test,
                     update,
                     loop_block,
@@ -572,7 +573,11 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                     )?);
 
                     let init_result = self.visit_value_block(*init, *span, None)?;
-                    let init_value = self.value_block_result_to_sequence(init_result, *span);
+                    let init_value = if *init_is_direct_expression {
+                        init_result.value
+                    } else {
+                        self.value_block_result_to_sequence(init_result, *span)
+                    };
 
                     let test_result = self.visit_value_block(*test, *span, None)?;
 
@@ -594,6 +599,7 @@ impl<'a, 'b, 'h> Driver<'a, 'b, 'h> {
                         ReactiveTerminalStatement {
                             terminal: ReactiveTerminal::For {
                                 init: init_value,
+                                init_is_direct_expression: *init_is_direct_expression,
                                 test: test_result.value,
                                 update: update_result.map(|r| r.value),
                                 loop_block: loop_body,

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -1073,8 +1073,22 @@ fn ox_codegen_terminal<'a>(
                 &cx.ast,
             )))
         }
-        ReactiveTerminal::For { init, test, update, loop_block, loop_block_span, .. } => {
-            let init_val = ox_codegen_for_init(cx, init)?;
+        ReactiveTerminal::For {
+            init,
+            init_is_direct_expression,
+            test,
+            update,
+            loop_block,
+            loop_block_span,
+            ..
+        } => {
+            let init_val = if *init_is_direct_expression {
+                Some(oxc::ForStatementInit::from(ox_codegen_instruction_value_to_expression(
+                    cx, init,
+                )?))
+            } else {
+                ox_codegen_for_init(cx, init)?
+            };
             let test_expr = ox_codegen_instruction_value_to_expression(cx, test)?;
             let update_expr = update
                 .as_ref()

--- a/crates/oxc_react_compiler/tests/snapshots/for-expression-initializer.snap
+++ b/crates/oxc_react_compiler/tests/snapshots/for-expression-initializer.snap
@@ -1,0 +1,45 @@
+---
+source: crates/oxc_react_compiler/tests/snapshot.rs
+input_file: crates/oxc_react_compiler/fixtures/for-expression-initializer.js
+---
+import { c as _c } from "react/compiler-runtime";
+function Component(t0) {
+	const $ = _c(3);
+	const { start, end } = t0;
+	let values;
+	if ($[0] !== end || $[1] !== start) {
+		let index;
+		let initCount = 0;
+		values = [];
+		for (index = 0; index < start; index++) {
+			values.push(index);
+		}
+		for (const t1 = (index = start, initCount++); index < end; index++) {
+			values.push(index);
+		}
+		for (const t2 = start < end ? values.push(-1) : values.push(-2); false;) {}
+		for (const t3 = start && values.push(-3); false;) {}
+		const optionalValues = start ? values : null;
+		for (const t4 = optionalValues?.push(-4); false;) {}
+		$[0] = end;
+		$[1] = start;
+		$[2] = values;
+	} else {
+		values = $[2];
+	}
+	return `${1}:${values.join(",")}`;
+}
+export const FIXTURE_ENTRYPOINT = {
+	fn: Component,
+	params: [{
+		start: 1,
+		end: 3
+	}],
+	sequentialRenders: [{
+		start: 2,
+		end: 5
+	}, {
+		start: 0,
+		end: 0
+	}]
+};


### PR DESCRIPTION
Support expression initializers in `for` statements by lowering their result through a generated temporary.

AI-assisted; reviewed and validated by the contributor.