### PR TITLE
docs(linter): document bulk suppression flags

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -73,14 +73,15 @@ pub struct LintCommand {
     pub paths: Vec<PathBuf>,
 }
 
+/// Suppress Violations
 #[derive(Debug, Clone, Bpaf)]
 pub struct SuppressionOptions {
     /// Generate suppressions for all current violations
-    #[bpaf(switch, hide)]
+    #[bpaf(switch, hide_usage)]
     pub suppress_all: bool,
 
     /// Remove entries for violations that no longer exist
-    #[bpaf(switch, hide)]
+    #[bpaf(switch, hide_usage)]
     pub prune_suppressions: bool,
 }
 

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -148,6 +148,14 @@ Arguments:
 
 
 
+## Suppress Violations
+- **`    --suppress-all`** &mdash; 
+  Generate suppressions for all current violations
+- **`    --prune-suppressions`** &mdash; 
+  Remove entries for violations that no longer exist
+
+
+
 ## Available positional items:
 - _`PATH`_ &mdash; 
   Single file, single path or list of paths

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -96,6 +96,10 @@ Inline Configuration Comments
                               severity level of the reported errors. Only one of these two options
                               can be used at a time.
 
+Suppress Violations
+        --suppress-all        Generate suppressions for all current violations
+        --prune-suppressions  Remove entries for violations that no longer exist
+
 Available positional items:
     PATH                      Single file, single path or list of paths
 


### PR DESCRIPTION
## Open question

#22328 intentionally hid `--suppress-all` and `--prune-suppressions` from the CLI help and generated documentation while maintainers decided whether the feature should ship and to preserve room for breaking changes.

The later RFC update in #22198 documents a direction for the suppression file and LSP behavior, but I could not find an explicit decision to expose these CLI flags publicly. Is the decision from #22328 still in effect?

This PR is kept as a draft until that is confirmed.

## Proposed change

- expose `--suppress-all` and `--prune-suppressions` in `oxlint --help`
- group both flags under a dedicated **Suppress Violations** section, matching ESLint's CLI organization
- update the generated website CLI documentation snapshots

Bulk suppressions have been available since oxlint v1.64.0, so this is the minimal change needed if the CLI is now intended to be discoverable. It does not change suppression behavior.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p website_linter`
- `cargo test -p oxlint command::lint`
- `just ready` (Node.js v26.5.0, with the caller's `NO_COLOR` environment override removed to match the checked-in CLI color snapshots)

## AI assistance

Codex was used to investigate the implementation and project history, make the documentation change, run verification, and draft this PR description.
