### PR TITLE
fix(formatter): place comments between a head and open paren

### DIFF
--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -861,33 +861,43 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatCommentForEmptyStatement<'a, 
     }
 }
 
-struct FormatTestOfIfAndWhileStatement<'a, 'b> {
-    test: &'b AstNode<'a, Expression<'a>>,
+/// The rightmost expression inside a statement head's parentheses
+/// (if/while test, for-in/for-of right, with object),
+/// printed without its generic trailing pass so the head's `)` bounds its comments.
+/// Comments past the `)` are left pending: for the statement body's leading pass,
+/// or the caller's `FormatCommentForEmptyStatement` where one applies.
+struct FormatParenHeadExpression<'a, 'b> {
+    expression: &'b AstNode<'a, Expression<'a>>,
     /// Start of the statement's body;
-    /// the last `)` before it is the condition's closing paren,
+    /// the last `)` before it is the head's closing paren,
     /// and it bounds the lexical scan (see `Comments::end_including_source_parens`).
     body_start: u32,
 }
-impl<'a> Format<'a, JsFormatContext<'a>> for FormatTestOfIfAndWhileStatement<'a, '_> {
+impl<'a> Format<'a, JsFormatContext<'a>> for FormatParenHeadExpression<'a, '_> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        // FormatNodeWithoutTrailingComments already handles suppression comments internally,
-        // so no separate has_trailing_suppression_comment check is needed here.
-        write!(f, FormatNodeWithoutTrailingComments(self.test));
-        // Comments before the condition's closing paren print inside the parens,
-        // also from between a parenthesized test's re-printed `)` and it
+        // `FormatNodeWithoutTrailingComments` already handles suppression comments internally,
+        // so no separate `has_trailing_suppression_comment` check is needed here.
+        write!(f, FormatNodeWithoutTrailingComments(self.expression));
+        // Comments before the head's closing paren print inside the parens,
+        // also from between a parenthesized expression's re-printed `)` and it
         // (`if ((0, 0) /* c */) {}` keeps the comment inside);
         // comments after it lead the body instead.
-        let test_end = self.test.span().end;
-        if !f.comments().has_comment_in_range(test_end, self.body_start) {
+        let expression_end = self.expression.span().end;
+        if !f.comments().has_comment_in_range(expression_end, self.body_start) {
             return;
         }
 
-        let rparen_end = f.comments().end_including_source_parens(test_end, self.body_start);
+        let rparen_end = f.comments().end_including_source_parens(expression_end, self.body_start);
         // `comments_before` returns a prefix of the unprinted comments,
         // as the printed-count cursor requires;
-        // the range check above fences out stale pre-`test_end` entries.
+        // the range check above fences out stale pre-`expression_end` entries.
         let comments = f.context().comments().comments_before(rparen_end);
         if !comments.is_empty() {
+            // Nothing may escape the head's `)`:
+            // a grouped head (if/while/with) flushes a pending line comment at its own break;
+            // an ungrouped head (for-in/for-of) must emit `line_suffix_boundary()` before its `)` instead.
+            // (The boundary must NOT be emitted here for grouped heads:
+            // its presence poisons the enclosing fits measurement, breaking content that fits.)
             write!(f, [space(), FormatTrailingComments::Comments(comments)]);
         }
     }
@@ -907,8 +917,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
                 space(),
                 "(",
                 group(&soft_block_indent(&format_args!(
-                    FormatTestOfIfAndWhileStatement {
-                        test: self.test(),
+                    FormatParenHeadExpression {
+                        expression: self.test(),
                         body_start: body.span().start
                     },
                     FormatCommentForEmptyStatement(body)
@@ -992,8 +1002,18 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
                 space(),
                 "in",
                 space(),
-                self.right(),
+                // NOTE: The head is deliberately not grouped, unlike if/while/with:
+                // Prettier never breaks a for-in/for-of head at its parens,
+                // and a plain `group` would expand on multiline content (arrow bodies, array literals),
+                // breaking the hugged layout.
+                FormatParenHeadExpression {
+                    expression: self.right(),
+                    body_start: body.span().start
+                },
                 FormatCommentForEmptyStatement(body),
+                // Flushes a pending in-paren line comment before the `)`
+                // (this head is ungrouped, so no break would flush it otherwise)
+                line_suffix_boundary(),
                 ")",
                 FormatStatementBody::new(body)
             ))
@@ -1028,7 +1048,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForOfStatement<'a>> {
                     space(),
                     "of",
                     space(),
-                    right,
+                    // NOTE: Not grouped, like the for-in head above.
+                    FormatParenHeadExpression { expression: right, body_start: body.span().start },
+                    line_suffix_boundary(),
                     ")",
                     FormatStatementBody::new(body)
                 ]
@@ -1065,8 +1087,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
                 "if",
                 space(),
                 "(",
-                group(&soft_block_indent(&FormatTestOfIfAndWhileStatement {
-                    test,
+                group(&soft_block_indent(&FormatParenHeadExpression {
+                    expression: test,
                     body_start: consequent.span().start
                 })),
                 ")",
@@ -1169,15 +1191,19 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WithStatement<'a>> {
     }
 
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
+        let body = self.body();
         write!(
             f,
             group(&format_args!(
                 "with",
                 space(),
                 "(",
-                self.object(),
+                group(&soft_block_indent(&FormatParenHeadExpression {
+                    expression: self.object(),
+                    body_start: body.span().start
+                })),
                 ")",
-                FormatStatementBody::new(self.body())
+                FormatStatementBody::new(body)
             ))
         );
     }

--- a/crates/oxc_formatter/src/print/switch_statement.rs
+++ b/crates/oxc_formatter/src/print/switch_statement.rs
@@ -4,14 +4,17 @@ use oxc_span::GetSpan;
 
 use crate::{
     Format,
-    ast_nodes::{AstNode, AstNodes},
+    ast_nodes::AstNode,
     format_args,
     formatter::{
         JsFormatter,
         prelude::*,
-        trivia::{DanglingIndentMode, FormatDanglingComments},
+        trivia::{DanglingIndentMode, FormatDanglingComments, FormatTrailingComments},
     },
-    utils::is_dropped_statement,
+    utils::{
+        format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
+        is_dropped_statement, statement_body::FormatStatementBody,
+    },
     write,
 };
 
@@ -59,15 +62,37 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, SwitchCase
 
 impl<'a> FormatWrite<'a> for AstNode<'a, SwitchCase<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
+        // Whether the first statement in the clause is a `BlockStatement`
+        // and there are no other non-empty statements.
+        // Empties may show up when parsing depending on if the input code includes certain newlines.
+        let is_single_block_statement =
+            matches!(self.consequent.first(), Some(Statement::BlockStatement(_)))
+                && self.consequent.iter().skip(1).all(is_dropped_statement);
+
         let is_default = if let Some(test) = self.test() {
-            write!(f, ["case", space(), test, ":"]);
+            write!(f, ["case", space()]);
+            if is_single_block_statement {
+                // The test's generic trailing pass would claim an end-of-line comment
+                // after the `:` as a `line_suffix` and flush it past the block's `{`;
+                // bound the test's comments at the `:` (comments after it lead the block).
+                // For non-block consequents the flush lands before their line break,
+                // keeping the comment on the clause line, so the generic pass is correct there.
+                write!(f, FormatNodeWithoutTrailingComments(test));
+                let comments =
+                    f.context().comments().comments_before_character(test.span().end, b':');
+                if !comments.is_empty() {
+                    write!(f, [space(), FormatTrailingComments::Comments(comments)]);
+                }
+            } else {
+                write!(f, test);
+            }
+            write!(f, ":");
             false
         } else {
             write!(f, ["default", ":"]);
             true
         };
 
-        let consequent = self.consequent();
         // When the case block is empty, the case becomes a fallthrough, so it
         // is collapsed directly on top of the next case (just a single
         // hardline).
@@ -99,65 +124,44 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SwitchCase<'a>> {
         //   default:
         //     break;
         // }
-        if consequent.is_empty() {
+        if self.consequent.is_empty() {
             // Print nothing to ensure that trailing comments on the same line
             // are printed on the same line. The parent list formatter takes
             // care of inserting a hard line break between cases.
             return;
         }
 
-        // The first statement in the clause when it is a `BlockStatement`
-        // and there are no other non-empty statements.
-        // Empties may show up when parsing depending on if the input code includes certain newlines.
-        let first_statement = consequent.first().unwrap();
-        let single_block_statement = match first_statement.as_ast_nodes() {
-            AstNodes::BlockStatement(block)
-                if consequent
-                    .iter()
-                    .skip(1)
-                    .all(|statement| is_dropped_statement(statement.as_ref())) =>
-            {
-                Some(block)
-            }
-            _ => None,
-        };
-        let is_single_block_statement = single_block_statement.is_some();
+        let consequent = self.consequent();
+        if is_single_block_statement {
+            // The head-body comment policy applies:
+            // comments between the `:` and the `{` stay outside the braces.
+            // `unwrap` is safe: the empty consequent returned above.
+            write!(f, FormatStatementBody::new(consequent.first().unwrap()));
+            return;
+        }
 
-        // Comments between the `:` and the clause body:
-        // block comments before a single-block body print outside its `{` for every clause;
-        // the end-of-line handling stays default-only
-        // (after `case a:` they belong to the consequent's leading pass instead).
-        let comments = f.context().comments();
-        let comments = if is_single_block_statement {
-            comments.block_comments_before(first_statement.span().start)
-        } else if is_default {
+        if is_default {
+            // No test node to carry a trailing comment,
+            // so synthesize the head's end from the keyword (escapes are illegal in keywords).
+            // NOTE: relies on `:` being in `end_of_line_comments_after`'s trivia allowlist.
             #[expect(clippy::cast_possible_truncation)]
             const DEFAULT_LEN: u32 = "default".len() as u32;
-            comments.end_of_line_comments_after(self.span.start + DEFAULT_LEN)
-        } else {
-            &[]
-        };
-
-        if !comments.is_empty() {
-            write!(
-                f,
-                [
-                    space(),
-                    FormatDanglingComments::Comments { comments, indent: DanglingIndentMode::None },
-                ]
-            );
+            let comments =
+                f.context().comments().end_of_line_comments_after(self.span.start + DEFAULT_LEN);
+            if !comments.is_empty() {
+                write!(
+                    f,
+                    [
+                        space(),
+                        FormatDanglingComments::Comments {
+                            comments,
+                            indent: DanglingIndentMode::None
+                        },
+                    ]
+                );
+            }
         }
-
-        if let Some(block) = single_block_statement {
-            // The clause pulls pending line comments between the `:` and the `{`
-            // INSIDE the block (`default: // c` + `{` -> `default: { // c`);
-            // its block comments are printed outside above.
-            // Use `write` to skip the block's leading-comments pass.
-            write!(f, [space()]);
-            block.write(f);
-        } else {
-            // no line break needed after because it is added by the indent in the switch statement
-            write!(f, indent(&format_args!(hard_line_break(), consequent)));
-        }
+        // No line break needed after because it is added by the indent in the switch statement
+        write!(f, indent(&format_args!(hard_line_break(), consequent)));
     }
 }

--- a/crates/oxc_formatter/tests/fixtures/js/comments/head-paren-line-comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/head-paren-line-comment.js
@@ -1,0 +1,39 @@
+// A line comment inside a statement head's parentheses stays inside them,
+// flushed before the `)`.
+// - for-in / for-of: diverges — Prettier is not idempotent (prettier#12880),
+//   its first pass moves the comment past the body's `{`
+// - with / while: no divergence (their grouped heads break), the control cases
+for (a in b // c
+) {}
+
+for (a of b // c
+) {}
+
+with (a // c
+) {}
+
+while (x // c
+) {}
+
+// The remaining paren-headed constructs need no special handling
+// (their grouped heads + the generic trailing pass already flush before `)`,
+// also across a parenthesized inner expression's re-printed `)`):
+switch ((0, 0) // c
+) { case a: b(); }
+
+do {} while ((0, 0) // c
+);
+
+for (a; b; (0, 0) // c
+) {}
+
+try {} catch (e // c
+) {}
+
+// Also with an empty-statement body; for-in diverges here too
+// (Prettier moves the comment past the `)` and the `;`: `for (a in b); // c`)
+for (a in b // c
+);
+
+if (x // c
+);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/head-paren-line-comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/head-paren-line-comment.js.snap
@@ -1,0 +1,164 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A line comment inside a statement head's parentheses stays inside them,
+// flushed before the `)`.
+// - for-in / for-of: diverges — Prettier is not idempotent (prettier#12880),
+//   its first pass moves the comment past the body's `{`
+// - with / while: no divergence (their grouped heads break), the control cases
+for (a in b // c
+) {}
+
+for (a of b // c
+) {}
+
+with (a // c
+) {}
+
+while (x // c
+) {}
+
+// The remaining paren-headed constructs need no special handling
+// (their grouped heads + the generic trailing pass already flush before `)`,
+// also across a parenthesized inner expression's re-printed `)`):
+switch ((0, 0) // c
+) { case a: b(); }
+
+do {} while ((0, 0) // c
+);
+
+for (a; b; (0, 0) // c
+) {}
+
+try {} catch (e // c
+) {}
+
+// Also with an empty-statement body; for-in diverges here too
+// (Prettier moves the comment past the `)` and the `;`: `for (a in b); // c`)
+for (a in b // c
+);
+
+if (x // c
+);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A line comment inside a statement head's parentheses stays inside them,
+// flushed before the `)`.
+// - for-in / for-of: diverges — Prettier is not idempotent (prettier#12880),
+//   its first pass moves the comment past the body's `{`
+// - with / while: no divergence (their grouped heads break), the control cases
+for (a in b // c
+) {
+}
+
+for (a of b // c
+) {
+}
+
+with (
+  a // c
+) {
+}
+
+while (
+  x // c
+) {}
+
+// The remaining paren-headed constructs need no special handling
+// (their grouped heads + the generic trailing pass already flush before `)`,
+// also across a parenthesized inner expression's re-printed `)`):
+switch (
+  (0, 0) // c
+) {
+  case a:
+    b();
+}
+
+do {} while (
+  (0, 0) // c
+);
+
+for (
+  a;
+  b;
+  0, 0 // c
+) {}
+
+try {
+} catch (
+  e // c
+) {}
+
+// Also with an empty-statement body; for-in diverges here too
+// (Prettier moves the comment past the `)` and the `;`: `for (a in b); // c`)
+for (a in b // c
+);
+
+if (
+  x // c
+);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A line comment inside a statement head's parentheses stays inside them,
+// flushed before the `)`.
+// - for-in / for-of: diverges — Prettier is not idempotent (prettier#12880),
+//   its first pass moves the comment past the body's `{`
+// - with / while: no divergence (their grouped heads break), the control cases
+for (a in b // c
+) {
+}
+
+for (a of b // c
+) {
+}
+
+with (
+  a // c
+) {
+}
+
+while (
+  x // c
+) {}
+
+// The remaining paren-headed constructs need no special handling
+// (their grouped heads + the generic trailing pass already flush before `)`,
+// also across a parenthesized inner expression's re-printed `)`):
+switch (
+  (0, 0) // c
+) {
+  case a:
+    b();
+}
+
+do {} while (
+  (0, 0) // c
+);
+
+for (
+  a;
+  b;
+  0, 0 // c
+) {}
+
+try {
+} catch (
+  e // c
+) {}
+
+// Also with an empty-statement body; for-in diverges here too
+// (Prettier moves the comment past the `)` and the `;`: `for (a in b); // c`)
+for (a in b // c
+);
+
+if (
+  x // c
+);
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/switch/clause-block-comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/switch/clause-block-comment.js
@@ -1,6 +1,12 @@
-// A block comment between a clause's `:` and its single-block body prints
-// outside the `{`, for case and default alike
-// (the conformance suite covers only the default clause).
+// Comments between a clause's `:` and its single-block body stay outside the
+// `{` (head-body comment policy), for case and default alike:
+// a block comment inline, a line comment keeping its position with the `{`
+// forced onto the next line, an own-line comment keeping its own line.
+// Known divergence (js/switch/comments.js): Prettier treats the same shape
+// unevenly -- `case b: { // c` (past the `{`) but `default: {` + own-lined
+// `// d` inside the block, and an own-line comment inlined to `case c: // own`
+// -- attachment artifacts of the kind prettier is currently fixing elsewhere
+// (prettier#19894 family).
 switch (x) {
   case a: /* c */ {
     break;
@@ -8,4 +14,31 @@ switch (x) {
   default: /* d */ {
     break;
   }
+}
+switch (x) {
+  case b: // c
+  {
+    break;
+  }
+  default: // d
+  {
+    break;
+  }
+}
+switch (x) {
+  case c:
+  // own line
+  {
+    break;
+  }
+}
+// A fallthrough clause's trailing comment stays on its line,
+// and a non-block consequent keeps its clause-line comment,
+// also after `default:`
+switch (x) {
+  case d: // fallthrough
+  case e: // consequent
+    f();
+  default: // dangling
+    g();
 }

--- a/crates/oxc_formatter/tests/fixtures/js/switch/clause-block-comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/switch/clause-block-comment.js.snap
@@ -2,9 +2,15 @@
 source: crates/oxc_formatter/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
-// A block comment between a clause's `:` and its single-block body prints
-// outside the `{`, for case and default alike
-// (the conformance suite covers only the default clause).
+// Comments between a clause's `:` and its single-block body stay outside the
+// `{` (head-body comment policy), for case and default alike:
+// a block comment inline, a line comment keeping its position with the `{`
+// forced onto the next line, an own-line comment keeping its own line.
+// Known divergence (js/switch/comments.js): Prettier treats the same shape
+// unevenly -- `case b: { // c` (past the `{`) but `default: {` + own-lined
+// `// d` inside the block, and an own-line comment inlined to `case c: // own`
+// -- attachment artifacts of the kind prettier is currently fixing elsewhere
+// (prettier#19894 family).
 switch (x) {
   case a: /* c */ {
     break;
@@ -12,15 +18,48 @@ switch (x) {
   default: /* d */ {
     break;
   }
+}
+switch (x) {
+  case b: // c
+  {
+    break;
+  }
+  default: // d
+  {
+    break;
+  }
+}
+switch (x) {
+  case c:
+  // own line
+  {
+    break;
+  }
+}
+// A fallthrough clause's trailing comment stays on its line,
+// and a non-block consequent keeps its clause-line comment,
+// also after `default:`
+switch (x) {
+  case d: // fallthrough
+  case e: // consequent
+    f();
+  default: // dangling
+    g();
 }
 
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
 ------------------
-// A block comment between a clause's `:` and its single-block body prints
-// outside the `{`, for case and default alike
-// (the conformance suite covers only the default clause).
+// Comments between a clause's `:` and its single-block body stay outside the
+// `{` (head-body comment policy), for case and default alike:
+// a block comment inline, a line comment keeping its position with the `{`
+// forced onto the next line, an own-line comment keeping its own line.
+// Known divergence (js/switch/comments.js): Prettier treats the same shape
+// unevenly -- `case b: { // c` (past the `{`) but `default: {` + own-lined
+// `// d` inside the block, and an own-line comment inlined to `case c: // own`
+// -- attachment artifacts of the kind prettier is currently fixing elsewhere
+// (prettier#19894 family).
 switch (x) {
   case a: /* c */ {
     break;
@@ -29,13 +68,46 @@ switch (x) {
     break;
   }
 }
+switch (x) {
+  case b: // c
+  {
+    break;
+  }
+  default: // d
+  {
+    break;
+  }
+}
+switch (x) {
+  case c:
+  // own line
+  {
+    break;
+  }
+}
+// A fallthrough clause's trailing comment stays on its line,
+// and a non-block consequent keeps its clause-line comment,
+// also after `default:`
+switch (x) {
+  case d: // fallthrough
+  case e: // consequent
+    f();
+  default: // dangling
+    g();
+}
 
 -------------------
 { printWidth: 100 }
 -------------------
-// A block comment between a clause's `:` and its single-block body prints
-// outside the `{`, for case and default alike
-// (the conformance suite covers only the default clause).
+// Comments between a clause's `:` and its single-block body stay outside the
+// `{` (head-body comment policy), for case and default alike:
+// a block comment inline, a line comment keeping its position with the `{`
+// forced onto the next line, an own-line comment keeping its own line.
+// Known divergence (js/switch/comments.js): Prettier treats the same shape
+// unevenly -- `case b: { // c` (past the `{`) but `default: {` + own-lined
+// `// d` inside the block, and an own-line comment inlined to `case c: // own`
+// -- attachment artifacts of the kind prettier is currently fixing elsewhere
+// (prettier#19894 family).
 switch (x) {
   case a: /* c */ {
     break;
@@ -43,6 +115,33 @@ switch (x) {
   default: /* d */ {
     break;
   }
+}
+switch (x) {
+  case b: // c
+  {
+    break;
+  }
+  default: // d
+  {
+    break;
+  }
+}
+switch (x) {
+  case c:
+  // own line
+  {
+    break;
+  }
+}
+// A fallthrough clause's trailing comment stays on its line,
+// and a non-block consequent keeps its clause-line comment,
+// also after `default:`
+switch (x) {
+  case d: // fallthrough
+  case e: // consequent
+    f();
+  default: // dangling
+    g();
 }
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/oxc_formatter/tests/conformance.rs
-assertion_line: 172
 expression: report
 ---
-js compatibility: 777/810 (95.93%), 23 files skipped
+js compatibility: 778/810 (96.05%), 23 files skipped
 
 # Failed
 
@@ -19,17 +18,15 @@ js compatibility: 777/810 (95.93%), 23 files skipped
 | js/comments/return-statement.js | 💥💥 | 97.25% |
 | js/comments/tagged-template-literal.js | 💥💥 | 89.66% |
 | js/comments/assignment/variable-declarator.js | 💥 | 88.00% |
-| js/comments/between-head-and-body/between-head-and-body.js | 💥 | 68.61% |
-| js/comments/between-head-and-body/empty-statement.js | 💥 | 51.25% |
-| js/comments/between-head-and-body/non-block.js | 💥 | 82.86% |
+| js/comments/between-head-and-body/between-head-and-body.js | 💥 | 87.89% |
+| js/comments/between-head-and-body/empty-statement.js | 💥 | 66.27% |
 | js/comments/first-argument/first-argument.js | 💥 | 92.98% |
 | js/comments/in-list/dangling-comment-in-list.js | 💥 | 95.91% |
-| js/comments/while-like/with.js | 💥 | 80.00% |
 | js/comments-closure-typecast/closure-compiler-type-cast.js | 💥 | 88.00% |
 | js/comments-closure-typecast/iife.js | 💥 | 76.92% |
 | js/explicit-resource-management/valid-await-using-comments.js | 💥 | 85.71% |
 | js/for/continue-and-break-comment-without-blocks.js | 💥 | 74.24% |
-| js/for-of/comments.js | 💥 | 50.00% |
+| js/for-of/comments.js | 💥 | 42.11% |
 | js/function/iife.js | 💥 | 14.89% |
 | js/function/issue-12967.js | 💥 | 0.00% |
 | js/if/blank-lines.js | 💥 | 94.83% |
@@ -39,6 +36,7 @@ js compatibility: 777/810 (95.93%), 23 files skipped
 | js/logical-expressions/in-unary-expression.js | 💥 | 79.49% |
 | js/sequence-expression/parenthesized-trailing-comment-unstable.js | 💥 | 66.67% |
 | js/sequence-expression/parenthesized.js | 💥 | 85.71% |
+| js/switch/comments.js | 💥 | 94.74% |
 | js/template-literals/expression-break.js | 💥 | 80.00% |
 | js/template-literals/expressions.js | 💥 | 97.64% |
 | js/test-declarations/jest-each.js | 💥💥 | 95.71% |
@@ -75,11 +73,8 @@ js compatibility: 777/810 (95.93%), 23 files skipped
 - js/arrays/numbers-with-holes.js
 - js/arrows/arrow-chain-with-trailing-comments.js
 - js/comments/return-statement.js
-- js/comments/between-head-and-body/between-head-and-body.js
 - js/comments/between-head-and-body/empty-statement.js
 - js/comments/first-argument/first-argument.js
-- js/comments/while-like/with.js
-- js/for/9812-2.js
 - js/for/continue-and-break-comment-without-blocks.js
 - js/function/issue-12967.js
 - js/object-prop-break-in/short-keys.js

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 19382
   sys alloc bytes: 6767781 # 6.77 MB
   sys peak growth: 2973674 # 2.97 MB
-  arena allocs: 1065443
+  arena allocs: 1062591
   arena reallocs: 927
-  arena size: 90048592 # 90.05 MB
+  arena size: 89951672 # 89.95 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,7 +16,7 @@ App.tsx:
   sys deallocs: 5191
   sys alloc bytes: 1564670 # 1.56 MB
   sys peak growth: 435358 # 435.36 kB
-  arena allocs: 208783
+  arena allocs: 208770
   arena reallocs: 364
   arena size: 16832304 # 16.83 MB
 
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 9775
   sys alloc bytes: 3141552 # 3.14 MB
   sys peak growth: 1156432 # 1.16 MB
-  arena allocs: 427894
+  arena allocs: 427306
   arena reallocs: 428
-  arena size: 29377816 # 29.38 MB
+  arena size: 29358712 # 29.36 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 90042
   sys alloc bytes: 76472316 # 76.47 MB
   sys peak growth: 50737424 # 50.74 MB
-  arena allocs: 2504225
+  arena allocs: 2503532
   arena reallocs: 1889
-  arena size: 244479144 # 244.48 MB
+  arena size: 244457832 # 244.46 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,9 +60,9 @@ binder.ts:
   sys deallocs: 972
   sys alloc bytes: 356005 # 356.00 kB
   sys peak growth: 195149 # 195.15 kB
-  arena allocs: 63721
+  arena allocs: 63109
   arena reallocs: 38
-  arena size: 5686072 # 5.69 MB
+  arena size: 5665552 # 5.67 MB
 
 kitchen-sink.tsx:
   file size: 732898 # 732.90 kB
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 17087
   sys alloc bytes: 4436340 # 4.44 MB
   sys peak growth: 1491796 # 1.49 MB
-  arena allocs: 555658
+  arena allocs: 555201
   arena reallocs: 1041
-  arena size: 38316800 # 38.32 MB
+  arena size: 38301664 # 38.30 MB


### PR DESCRIPTION
Fixes inconsistency and idempotency issue for control statements.

e.g.

```js
while (x // THIS should stay here
) {
  // ...
}
```
