### PR TITLE
perf(react_compiler): remove avoidable string allocations

### DIFF
--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -1161,7 +1161,7 @@ fn compile_outlined_functions<'a, 'b, 'p, 's, const EMIT: bool>(
             break 'queue;
         }
         let semantic = semantic_ret.semantic;
-        let scope = ScopeResolver::new(&semantic, ast.allocator());
+        let scope = ScopeResolver::new(&semantic, ast.allocator(), &program);
         let sources = program
             .body
             .iter()
@@ -3174,7 +3174,7 @@ pub fn compile_program<'a, const EMIT: bool>(
     // The codegen back-end builds oxc nodes directly via this `AstBuilder`; `scope`
     // is a read-through view over `Semantic` for binding/reference lookups.
     let ast = AstBuilder::new(allocator);
-    let scope = ScopeResolver::new(semantic, allocator);
+    let scope = ScopeResolver::new(semantic, allocator, program);
 
     // Initialize known referenced names from scope bindings for UID collision detection
     context.init_from_scope(&scope);

--- a/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
@@ -83,25 +83,31 @@ pub enum HookKind {
     Custom,
 }
 
+impl HookKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            HookKind::UseContext => "useContext",
+            HookKind::UseState => "useState",
+            HookKind::UseActionState => "useActionState",
+            HookKind::UseReducer => "useReducer",
+            HookKind::UseRef => "useRef",
+            HookKind::UseEffect => "useEffect",
+            HookKind::UseLayoutEffect => "useLayoutEffect",
+            HookKind::UseInsertionEffect => "useInsertionEffect",
+            HookKind::UseMemo => "useMemo",
+            HookKind::UseCallback => "useCallback",
+            HookKind::UseTransition => "useTransition",
+            HookKind::UseImperativeHandle => "useImperativeHandle",
+            HookKind::UseEffectEvent => "useEffectEvent",
+            HookKind::UseOptimistic => "useOptimistic",
+            HookKind::Custom => "Custom",
+        }
+    }
+}
+
 impl Display for HookKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            HookKind::UseContext => write!(f, "useContext"),
-            HookKind::UseState => write!(f, "useState"),
-            HookKind::UseActionState => write!(f, "useActionState"),
-            HookKind::UseReducer => write!(f, "useReducer"),
-            HookKind::UseRef => write!(f, "useRef"),
-            HookKind::UseEffect => write!(f, "useEffect"),
-            HookKind::UseLayoutEffect => write!(f, "useLayoutEffect"),
-            HookKind::UseInsertionEffect => write!(f, "useInsertionEffect"),
-            HookKind::UseMemo => write!(f, "useMemo"),
-            HookKind::UseCallback => write!(f, "useCallback"),
-            HookKind::UseTransition => write!(f, "useTransition"),
-            HookKind::UseImperativeHandle => write!(f, "useImperativeHandle"),
-            HookKind::UseEffectEvent => write!(f, "useEffectEvent"),
-            HookKind::UseOptimistic => write!(f, "useOptimistic"),
-            HookKind::Custom => write!(f, "Custom"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -1,6 +1,3 @@
-use std::borrow::Cow;
-
-use cow_utils::CowUtils;
 use rustc_hash::FxHashSet;
 
 use crate::diagnostics;
@@ -14,14 +11,14 @@ use crate::scope::ScopeKind;
 use crate::scope::ScopeResolver;
 use crate::scope::SymbolId;
 
-use oxc_allocator::CloneIn;
 use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::{ArenaStringBuilder, CloneIn};
 use oxc_ast::ast as oxc;
 use oxc_ast::ast::BinaryOperator;
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
-use oxc_str::{Ident, Str, format_ident, static_ident};
+use oxc_str::{Ident, Str, format_ident, format_str, static_ident};
 
 use crate::react_compiler_lowering::FunctionNode;
 use crate::react_compiler_lowering::find_context_identifiers::find_context_identifiers;
@@ -3590,7 +3587,7 @@ fn lower_expression<'a>(
         oxc::Expression::RegExpLiteral(regexp) => Ok(InstructionValue::RegExpLiteral {
             pattern: regexp.regex.pattern.text,
             flags: Str::from_str_in(
-                &regexp.regex.flags.to_string(),
+                regexp.regex.flags.to_inline_string().as_str(),
                 &builder.environment().allocator,
             ),
             span: Some(regexp.span),
@@ -4646,12 +4643,8 @@ fn lower_jsx_element_expr<'a>(
                 let value = match &attr.value {
                     Some(oxc::JSXAttributeValue::StringLiteral(s)) => {
                         let str_span = Some(s.span);
-                        let decoded = match decode_jsx_entities(s.value.as_str()) {
-                            Cow::Borrowed(text) => Str::from(text),
-                            Cow::Owned(text) => {
-                                Str::from_str_in(&text, &builder.environment().allocator)
-                            }
-                        };
+                        let decoded =
+                            decode_jsx_entities(s.value.as_str(), builder.environment().allocator);
                         lower_value_to_temporary(
                             builder,
                             InstructionValue::Primitive {
@@ -4881,7 +4874,6 @@ fn lower_jsx_element_name<'a>(
         oxc::JSXElementName::NamespacedName(ns) => {
             let namespace = ns.namespace.name.as_str();
             let name = ns.name.name.as_str();
-            let tag = format!("{}:{}", namespace, name);
             let span = Some(ns.span);
             if namespace.contains(':') || name.contains(':') {
                 builder.record_error(diagnostics::invalid_jsx_namespace(namespace, name, span))?;
@@ -4889,9 +4881,9 @@ fn lower_jsx_element_name<'a>(
             let place = lower_value_to_temporary(
                 builder,
                 InstructionValue::Primitive {
-                    value: PrimitiveValue::String(Str::from_str_in(
-                        &tag,
-                        &builder.environment().allocator,
+                    value: PrimitiveValue::String(format_str!(
+                        builder.environment().allocator,
+                        "{namespace}:{name}"
                     )),
                     span,
                 },
@@ -4971,24 +4963,15 @@ fn lower_jsx_element<'a>(
         oxc::JSXChild::Text(text) => {
             // oxc keeps JSX text raw; decode entities first so the value matches
             // Babel's `JSXText.value` (the Babel bridge decoded in convert_ast).
-            let decoded = decode_jsx_entities(text.value.as_str());
+            let allocator = builder.environment().allocator;
+            let decoded = decode_jsx_entities(text.value.as_str(), allocator);
             // FBT whitespace normalization differs from standard JSX.
             // Since the fbt transform runs after, preserve all whitespace
             // in FBT subtrees as is.
             let value = if builder.fbt_depth > 0 {
-                Some((
-                    match decoded {
-                        Cow::Borrowed(text) => Str::from(text),
-                        Cow::Owned(ref text) => {
-                            Str::from_str_in(text, &builder.environment().allocator)
-                        }
-                    },
-                    0,
-                ))
+                Some((decoded, 0))
             } else {
-                trim_jsx_text(&decoded).map(|(text, start)| {
-                    (Str::from_str_in(&text, &builder.environment().allocator), start)
-                })
+                trim_jsx_text(decoded.as_str(), allocator)
             };
             match value {
                 None => Ok(None),
@@ -5279,95 +5262,91 @@ fn collect_fbt_sub_tags_from_stmts(
     }
 }
 
-/// Split a string on line endings, handling \r\n, \n, and \r.
-fn split_line_endings(s: &str) -> Vec<&str> {
-    let mut lines = Vec::new();
-    let mut start = 0;
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'\r' {
-            lines.push(&s[start..i]);
-            if i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
-                i += 2;
-            } else {
-                i += 1;
-            }
-            start = i;
-        } else if bytes[i] == b'\n' {
-            lines.push(&s[start..i]);
-            i += 1;
-            start = i;
+/// Split a string on line endings, handling \r\n, \n, and \r without allocating.
+/// The second tuple element is the byte length of the line ending.
+fn split_line_endings(s: &str) -> impl Iterator<Item = (&str, usize)> {
+    let mut remaining = Some(s);
+    std::iter::from_fn(move || {
+        let line = remaining.take()?;
+        let bytes = line.as_bytes();
+        let end = bytes.iter().position(|byte| matches!(byte, b'\r' | b'\n'));
+        if let Some(end) = end {
+            let line_ending_len =
+                if bytes[end] == b'\r' && bytes.get(end + 1) == Some(&b'\n') { 2 } else { 1 };
+            remaining = Some(&line[end + line_ending_len..]);
+            Some((&line[..end], line_ending_len))
         } else {
-            i += 1;
+            Some((line, 0))
         }
-    }
-    lines.push(&s[start..]);
-    lines
+    })
 }
 
 /// Trims whitespace according to the JSX spec.
 /// Implementation ported from Babel's cleanJSXElementLiteralChild.
-fn trim_jsx_text(original: &str) -> Option<(String, usize)> {
-    // Split on \r\n, \n, or \r to handle all line ending styles (matching TS split(/\r\n|\n|\r/))
-    let lines: Vec<&str> = split_line_endings(original);
+fn trim_jsx_text<'a>(
+    original: &'a str,
+    allocator: &'a oxc_allocator::Allocator,
+) -> Option<(Str<'a>, usize)> {
+    if !original.bytes().any(|byte| matches!(byte, b'\r' | b'\n' | b'\t')) {
+        return (!original.is_empty()).then_some((Str::from(original), 0));
+    }
+
+    // Split on \r\n, \n, or \r to handle all line ending styles (matching TS split(/\r\n|\n|\r/)).
+    let mut line_count = 0;
+    let mut last_non_empty_line = None;
+    for (i, (line, _)) in split_line_endings(original).enumerate() {
+        line_count += 1;
+        if line.bytes().any(|byte| !matches!(byte, b' ' | b'\t')) {
+            last_non_empty_line = Some(i);
+        }
+    }
+    let last_non_empty_line = match last_non_empty_line {
+        Some(line) => line,
+        None if line_count == 1 => 0,
+        None => return None,
+    };
 
     // NOTE: when builder.fbt_depth > 0, the TS skips whitespace trimming entirely.
     // That check is handled by the caller (lower_jsx_element) before calling this function.
 
-    let mut last_non_empty_line = 0;
-    for (i, line) in lines.iter().enumerate() {
-        if line.contains(|c: char| c != ' ' && c != '\t') {
-            last_non_empty_line = i;
-        }
-    }
-
-    let mut str = String::new();
+    let mut str = ArenaStringBuilder::with_capacity_in(original.len(), allocator);
     let mut first_retained_offset = None;
     let mut line_offset = 0;
 
-    for (i, line) in lines.iter().enumerate() {
+    for (i, (line, line_ending_len)) in split_line_endings(original).enumerate() {
         let is_first_line = i == 0;
-        let is_last_line = i == lines.len() - 1;
+        let is_last_line = i == line_count - 1;
         let is_last_non_empty_line = i == last_non_empty_line;
 
-        // Replace rendered whitespace tabs with spaces
-        let mut trimmed_line = line.cow_replace('\t', " ").into_owned();
+        let mut trimmed_line = line;
         let mut leading_trimmed = 0;
 
         // Trim whitespace touching a newline (leading whitespace on non-first lines)
         if !is_first_line {
             let original_len = trimmed_line.len();
-            trimmed_line = trimmed_line.trim_start_matches(' ').to_string();
+            trimmed_line = trimmed_line.trim_start_matches([' ', '\t']);
             leading_trimmed = original_len - trimmed_line.len();
         }
 
         // Trim whitespace touching an endline (trailing whitespace on non-last lines)
         if !is_last_line {
-            trimmed_line = trimmed_line.trim_end_matches(' ').to_string();
+            trimmed_line = trimmed_line.trim_end_matches([' ', '\t']);
         }
 
         if !trimmed_line.is_empty() {
             first_retained_offset.get_or_insert(line_offset + leading_trimmed);
-            if !is_last_non_empty_line {
-                trimmed_line.push(' ');
+            for c in trimmed_line.chars() {
+                str.push(if c == '\t' { ' ' } else { c });
             }
-            str.push_str(&trimmed_line);
+            if !is_last_non_empty_line {
+                str.push(' ');
+            }
         }
 
-        line_offset += line.len();
-        if !is_last_line {
-            line_offset += if original.as_bytes().get(line_offset) == Some(&b'\r')
-                && original.as_bytes().get(line_offset + 1) == Some(&b'\n')
-            {
-                2
-            } else {
-                1
-            };
-        }
+        line_offset += line.len() + line_ending_len;
     }
 
-    first_retained_offset.map(|offset| (str, offset))
+    first_retained_offset.map(|offset| (Str::from(str), offset))
 }
 
 fn source_offset_for_decoded_jsx_text(source: &str, target_offset: usize) -> usize {
@@ -5412,11 +5391,11 @@ fn source_offset_for_decoded_jsx_text(source: &str, target_offset: usize) -> usi
 /// Babel's decoded text. oxc keeps JSX text raw in the AST. Mirrors the
 /// `decode_jsx_entities` helper in `convert_ast.rs`. Unrecognized `&…;` sequences
 /// are kept verbatim.
-fn decode_jsx_entities(s: &str) -> Cow<'_, str> {
+fn decode_jsx_entities<'a>(s: &'a str, allocator: &'a oxc_allocator::Allocator) -> Str<'a> {
     if !s.contains('&') {
-        return Cow::Borrowed(s);
+        return Str::from(s);
     }
-    let mut out = String::with_capacity(s.len());
+    let mut out = ArenaStringBuilder::with_capacity_in(s.len(), allocator);
     let mut chars = s.char_indices();
     let mut prev = 0;
     while let Some((i, c)) = chars.next() {
@@ -5448,7 +5427,7 @@ fn decode_jsx_entities(s: &str) -> Cow<'_, str> {
         }
     }
     out.push_str(&s[prev..]);
-    Cow::Owned(out)
+    Str::from(out)
 }
 
 fn decode_jsx_entity(word: &str) -> Option<char> {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
@@ -50,8 +50,8 @@ struct BindingInfo {
     referenced_by_inner_fn: bool,
 }
 
-struct ContextIdentifierVisitor<'a> {
-    scope: &'a ScopeResolver<'a, 'a>,
+struct ContextIdentifierVisitor<'r, 's, 'alloc> {
+    scope: &'r ScopeResolver<'s, 'alloc>,
     /// The active scope stack. Initialized with the function-being-compiled's
     /// scope and pushed/popped for every scope-creating node, mirroring the
     /// original `AstWalker`.
@@ -62,7 +62,7 @@ struct ContextIdentifierVisitor<'a> {
     binding_info: FxHashMap<SymbolId, BindingInfo>,
 }
 
-impl<'a> ContextIdentifierVisitor<'a> {
+impl<'r, 's, 'alloc> ContextIdentifierVisitor<'r, 's, 'alloc> {
     fn current_scope(&self) -> ScopeId {
         self.scope_stack.last().copied().unwrap_or_else(|| self.scope.program_scope())
     }
@@ -127,7 +127,7 @@ impl<'a> ContextIdentifierVisitor<'a> {
     }
 }
 
-impl<'a> VisitJs<'a> for ContextIdentifierVisitor<'a> {
+impl<'a, 'r, 's, 'alloc> VisitJs<'a> for ContextIdentifierVisitor<'r, 's, 'alloc> {
     // ---- function scopes (push BOTH the generic scope and the function stack) ----
 
     fn visit_function(&mut self, it: &Function<'a>, _flags: ScopeFlags) {
@@ -281,10 +281,10 @@ impl<'a> VisitJs<'a> for ContextIdentifierVisitor<'a> {
     fn visit_ts_namespace_declaration(&mut self, _it: &TSNamespaceDeclaration<'a>) {}
 }
 
-impl<'a> ContextIdentifierVisitor<'a> {
+impl<'r, 's, 'alloc> ContextIdentifierVisitor<'r, 's, 'alloc> {
     /// Recursively walk an assignment target to find all reassignment target
     /// identifiers, mirroring the original `walk_lval_for_reassignment`.
-    fn walk_assignment_target_for_reassignment(
+    fn walk_assignment_target_for_reassignment<'a>(
         &mut self,
         target: &AssignmentTarget<'a>,
         current_scope: ScopeId,
@@ -348,7 +348,7 @@ impl<'a> ContextIdentifierVisitor<'a> {
         }
     }
 
-    fn walk_assignment_target_expression_for_reassignment(
+    fn walk_assignment_target_expression_for_reassignment<'a>(
         &mut self,
         expression: &Expression<'a>,
         current_scope: ScopeId,
@@ -364,7 +364,7 @@ impl<'a> ContextIdentifierVisitor<'a> {
         }
     }
 
-    fn walk_simple_assignment_target_for_reassignment(
+    fn walk_simple_assignment_target_for_reassignment<'a>(
         &mut self,
         target: &SimpleAssignmentTarget<'a>,
         current_scope: ScopeId,
@@ -403,7 +403,7 @@ impl<'a> ContextIdentifierVisitor<'a> {
         }
     }
 
-    fn walk_maybe_default_for_reassignment(
+    fn walk_maybe_default_for_reassignment<'a>(
         &mut self,
         target: &AssignmentTargetMaybeDefault<'a>,
         current_scope: ScopeId,

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -28,7 +28,7 @@ use std::mem::replace;
 
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::Allocator;
+use oxc_allocator::{Allocator, ArenaStringBuilder};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::{StringToNumber, ToInt32, ToUint32};
 use oxc_str::{Ident, Str};
@@ -507,14 +507,26 @@ fn evaluate_instruction<'a>(
         }
         InstructionValue::TemplateLiteral { subexprs, quasis, span } => {
             if subexprs.is_empty() {
-                // No subexpressions: join all cooked quasis
-                let mut result_string = String::new();
-                for q in quasis {
-                    result_string.push_str(q.cooked.as_ref()?);
-                }
+                // A template without substitutions normally has one quasi, whose
+                // arena-backed string can be reused directly.
+                let value = match quasis.as_slice() {
+                    [] => Str::empty(),
+                    [quasi] => quasi.cooked?,
+                    quasis => {
+                        let capacity = quasis
+                            .iter()
+                            .map(|quasi| quasi.cooked.map(|value| value.len()))
+                            .sum::<Option<usize>>()?;
+                        let mut result =
+                            ArenaStringBuilder::with_capacity_in(capacity, env.allocator);
+                        for quasi in quasis {
+                            result.push_str(quasi.cooked.unwrap().as_str());
+                        }
+                        Str::from(result)
+                    }
+                };
                 let span = *span;
-                let value =
-                    PrimitiveValue::String(Str::from_str_in(&result_string, &env.allocator));
+                let value = PrimitiveValue::String(value);
                 let result = Constant::Primitive { value, span };
                 func.instructions[instr_id.index()].value =
                     InstructionValue::Primitive { value, span };
@@ -529,36 +541,54 @@ fn evaluate_instruction<'a>(
                 return None;
             }
 
+            let mut capacity = quasis.iter().map(|quasi| quasi.cooked.unwrap().len()).sum();
+            for sub_expr in subexprs {
+                let Some(Constant::Primitive { value, .. }) = constants.get(&sub_expr.identifier)
+                else {
+                    return None;
+                };
+                capacity += match value {
+                    PrimitiveValue::Null => 4,
+                    PrimitiveValue::Boolean(true) => 4,
+                    PrimitiveValue::Boolean(false) => 5,
+                    // Longest possible ECMAScript number representation is below 32 bytes.
+                    PrimitiveValue::Number(_) => 32,
+                    PrimitiveValue::String(value) => value.len(),
+                    // TS rejects undefined subexpression values.
+                    PrimitiveValue::Undefined => return None,
+                };
+            }
+
             let mut quasi_index = 0usize;
-            let mut result_string =
-                quasis[quasi_index].cooked.as_ref().unwrap().as_str().to_string();
+            let mut result_string = ArenaStringBuilder::with_capacity_in(capacity, env.allocator);
+            result_string.push_str(quasis[quasi_index].cooked.unwrap().as_str());
             quasi_index += 1;
 
             for sub_expr in subexprs {
-                let sub_expr_value = read(constants, sub_expr);
-                let sub_prim = match sub_expr_value {
-                    Some(Constant::Primitive { ref value, .. }) => value,
-                    _ => return None,
+                let Some(Constant::Primitive { value, .. }) = constants.get(&sub_expr.identifier)
+                else {
+                    unreachable!();
                 };
-
-                let expression_str = match sub_prim {
-                    PrimitiveValue::Null => "null".to_string(),
-                    PrimitiveValue::Boolean(b) => b.to_string(),
-                    PrimitiveValue::Number(n) => n.value().to_js_string(),
-                    PrimitiveValue::String(s) => s.as_str().to_string(),
-                    // TS rejects undefined subexpression values
-                    PrimitiveValue::Undefined => return None,
-                };
+                match value {
+                    PrimitiveValue::Null => result_string.push_str("null"),
+                    PrimitiveValue::Boolean(value) => {
+                        result_string.push_str(if *value { "true" } else { "false" });
+                    }
+                    PrimitiveValue::Number(value) => {
+                        result_string.push_str(&value.value().to_js_string());
+                    }
+                    PrimitiveValue::String(value) => result_string.push_str(value),
+                    PrimitiveValue::Undefined => unreachable!(),
+                }
 
                 let suffix = quasis[quasi_index].cooked?;
                 quasi_index += 1;
 
-                result_string.push_str(&expression_str);
                 result_string.push_str(&suffix);
             }
 
             let span = *span;
-            let value = PrimitiveValue::String(Str::from_str_in(&result_string, &env.allocator));
+            let value = PrimitiveValue::String(Str::from(result_string));
             let result = Constant::Primitive { value, span };
             func.instructions[instr_id.index()].value = InstructionValue::Primitive { value, span };
             Some(result)

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
@@ -11,8 +11,6 @@
 //!
 //! Conditional on `env.config.enable_name_anonymous_functions`.
 
-use std::borrow::Cow;
-
 use rustc_hash::FxHashMap;
 
 use oxc_allocator::Allocator;
@@ -38,7 +36,7 @@ pub fn name_anonymous_functions<'a>(func: &mut HirFunction<'a>, env: &mut Enviro
 
     fn visit<'a>(
         node: &Node<'a>,
-        prefix: &str,
+        prefix: &mut String,
         updates: &mut Vec<(FunctionId, Ident<'a>)>,
         allocator: &'a Allocator,
     ) {
@@ -53,16 +51,19 @@ pub fn name_anonymous_functions<'a>(func: &mut HirFunction<'a>, env: &mut Enviro
         // traverse into its nested functions to assign them names
         let label =
             node.generated_name.as_deref().or(node.fn_name.as_deref()).unwrap_or("<anonymous>");
-        let next_prefix = format!("{}{} > ", prefix, label);
+        let previous_len = prefix.len();
+        prefix.push_str(label);
+        prefix.push_str(" > ");
         for inner in &node.inner {
-            visit(inner, &next_prefix, updates, allocator);
+            visit(inner, prefix, updates, allocator);
         }
+        prefix.truncate(previous_len);
     }
 
     let mut updates: Vec<(FunctionId, Ident<'a>)> = Vec::new();
-    let prefix = format!("{}[", fn_id);
+    let mut prefix = format!("{}[", fn_id);
     for node in &nodes {
-        visit(node, &prefix, &mut updates, env.allocator);
+        visit(node, &mut prefix, &mut updates, env.allocator);
     }
 
     if updates.is_empty() {
@@ -237,18 +238,14 @@ fn handle_call<'a>(
     let callee_ty = &env.types[callee_ident.type_];
     let hook_kind = env.get_hook_kind_for_type(callee_ty).ok().flatten();
 
-    let callee_name: Cow<'_, str> = if let Some(hk) = hook_kind {
+    let callee_name = if let Some(hk) = hook_kind {
         if *hk != HookKind::Custom {
-            Cow::Owned(hk.to_string())
+            hk.as_str()
         } else {
-            names
-                .get(&callee_id)
-                .map_or(Cow::Borrowed("(anonymous)"), |name| Cow::Borrowed(name.as_str()))
+            names.get(&callee_id).map_or("(anonymous)", Ident::as_str)
         }
     } else {
-        names
-            .get(&callee_id)
-            .map_or(Cow::Borrowed("(anonymous)"), |name| Cow::Borrowed(name.as_str()))
+        names.get(&callee_id).map_or("(anonymous)", Ident::as_str)
     };
 
     // Count how many args are tracked functions

--- a/crates/oxc_react_compiler/src/scope.rs
+++ b/crates/oxc_react_compiler/src/scope.rs
@@ -1,8 +1,8 @@
 use oxc_allocator::Allocator;
 use oxc_ast::AstKind;
 use oxc_ast::ast::{
-    BindingIdentifier, BindingPattern, IdentifierReference, ImportDeclaration, ModuleExportName,
-    PropertyKind,
+    BindingIdentifier, BindingPattern, IdentifierReference, ImportDeclarationSpecifier,
+    ModuleExportName, Program, PropertyKind, Statement,
 };
 use oxc_semantic::{AstNodes, NodeId, Scoping, Semantic};
 use oxc_span::{GetSpan, Span};
@@ -10,6 +10,7 @@ use oxc_str::{Ident, Str};
 use oxc_syntax::scope::ScopeFlags;
 use oxc_syntax::symbol::SymbolFlags;
 use rustc_hash::FxHashSet;
+use smallvec::SmallVec;
 
 pub use oxc_syntax::reference::ReferenceId;
 pub use oxc_syntax::scope::ScopeId;
@@ -87,7 +88,7 @@ impl DeclKind {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ImportBindingData<'a> {
     /// The module specifier string (e.g., "react" in `import {useState} from 'react'`).
     pub source: Str<'a>,
@@ -97,21 +98,75 @@ pub struct ImportBindingData<'a> {
     pub imported: Option<Ident<'a>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum ImportBindingKind {
     Default,
     Named,
     Namespace,
 }
 
+type ImportBindings<'a> = SmallVec<[(SymbolId, ImportBindingData<'a>); 4]>;
+
+fn collect_imports<'a>(program: &Program<'a>) -> ImportBindings<'a> {
+    let import_count = program
+        .body
+        .iter()
+        .filter_map(|statement| match statement {
+            Statement::ImportDeclaration(declaration) => declaration.specifiers.as_ref(),
+            _ => None,
+        })
+        .map(|specifiers| specifiers.len())
+        .sum();
+    let mut imports = SmallVec::with_capacity(import_count);
+    for statement in &program.body {
+        let Statement::ImportDeclaration(declaration) = statement else {
+            continue;
+        };
+        let Some(specifiers) = &declaration.specifiers else {
+            continue;
+        };
+
+        for specifier in specifiers {
+            let (local, kind, imported) = match specifier {
+                ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => {
+                    (&specifier.local, ImportBindingKind::Default, None)
+                }
+                ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => {
+                    (&specifier.local, ImportBindingKind::Namespace, None)
+                }
+                ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
+                    let imported = match &specifier.imported {
+                        ModuleExportName::IdentifierName(identifier) => identifier.name,
+                        ModuleExportName::IdentifierReference(identifier) => identifier.name,
+                        ModuleExportName::StringLiteral(literal) => literal.value.into(),
+                    };
+                    (&specifier.local, ImportBindingKind::Named, Some(imported))
+                }
+            };
+            if let Some(symbol_id) = local.symbol_id.get() {
+                imports.push((
+                    symbol_id,
+                    ImportBindingData { source: declaration.source.value, kind, imported },
+                ));
+            }
+        }
+    }
+    imports.sort_unstable_by_key(|(symbol_id, _)| *symbol_id);
+    imports
+}
+
 /// Read-through view over `Semantic`, replacing the old materialized
 /// `ScopeInfo` copy. Scope and symbol identity comes from the semantic ID
 /// cells on the AST (`scope_id`/`symbol_id`/`reference_id`); everything else
-/// is derived from `Scoping` on demand.
+/// is derived from `Scoping` on demand. Import strings are cached as zero-copy
+/// arena views because their AST lifetime outlives the `Semantic` borrow.
 pub struct ScopeResolver<'s, 'a> {
     scoping: &'s Scoping,
     nodes: &'s AstNodes<'s>,
     allocator: &'a Allocator,
+    /// Import metadata copied from the arena-backed AST. The strings themselves
+    /// remain zero-copy views into the arena, independent of the `Semantic` borrow.
+    imports: ImportBindings<'a>,
     /// All Function-kind scopes, in scope-tree order.
     function_scopes: Vec<ScopeId>,
     /// `(start, end)` source windows of Function-kind scopes, used by the
@@ -122,7 +177,11 @@ pub struct ScopeResolver<'s, 'a> {
 }
 
 impl<'s, 'a> ScopeResolver<'s, 'a> {
-    pub fn new<'ast>(semantic: &'s Semantic<'ast>, allocator: &'a Allocator) -> Self {
+    pub fn new<'ast>(
+        semantic: &'s Semantic<'ast>,
+        allocator: &'a Allocator,
+        program: &Program<'a>,
+    ) -> Self {
         let scoping = semantic.scoping();
         // `AstNodes` is covariant in its lifetime; shrink the AST references to
         // the `Semantic` borrow so the resolver needs no third lifetime.
@@ -132,6 +191,7 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
             scoping,
             nodes,
             allocator,
+            imports: collect_imports(program),
             function_scopes: Vec::new(),
             function_scope_ranges: Vec::new(),
         };
@@ -336,60 +396,10 @@ impl<'s, 'a> ScopeResolver<'s, 'a> {
 
     /// For import bindings: the source module and import details.
     pub fn import_data(&self, symbol_id: SymbolId) -> Option<ImportBindingData<'a>> {
-        let decl_node = self.nodes.get_node(self.scoping.symbol_declaration(symbol_id));
-        match decl_node.kind() {
-            AstKind::ImportDefaultSpecifier(_) => {
-                let import_decl = self.find_import_declaration(decl_node.id())?;
-                Some(ImportBindingData {
-                    source: Str::from_str_in(import_decl.source.value.as_str(), &self.allocator),
-                    kind: ImportBindingKind::Default,
-                    imported: None,
-                })
-            }
-            AstKind::ImportNamespaceSpecifier(_) => {
-                let import_decl = self.find_import_declaration(decl_node.id())?;
-                Some(ImportBindingData {
-                    source: Str::from_str_in(import_decl.source.value.as_str(), &self.allocator),
-                    kind: ImportBindingKind::Namespace,
-                    imported: None,
-                })
-            }
-            AstKind::ImportSpecifier(spec) => {
-                let import_decl = self.find_import_declaration(decl_node.id())?;
-                let imported_name = match &spec.imported {
-                    ModuleExportName::IdentifierName(ident) => ident.name.as_str(),
-                    ModuleExportName::IdentifierReference(ident) => ident.name.as_str(),
-                    ModuleExportName::StringLiteral(lit) => lit.value.as_str(),
-                };
-                Some(ImportBindingData {
-                    source: Str::from_str_in(import_decl.source.value.as_str(), &self.allocator),
-                    kind: ImportBindingKind::Named,
-                    imported: Some(Ident::from_str_in(imported_name, &self.allocator)),
-                })
-            }
-            _ => None,
-        }
-    }
-
-    /// Find the ImportDeclaration node that contains the given import specifier.
-    fn find_import_declaration(
-        &self,
-        specifier_node_id: NodeId,
-    ) -> Option<&'s ImportDeclaration<'s>> {
-        let mut current_id = specifier_node_id;
-        // Walk up the parent chain (max 10 levels to avoid infinite loop)
-        for _ in 0..10 {
-            let parent_id = self.nodes.parent_id(current_id);
-            if parent_id == current_id {
-                // Root node, no more parents
-                return None;
-            }
-            if let AstKind::ImportDeclaration(decl) = self.nodes.get_node(parent_id).kind() {
-                return Some(decl);
-            }
-            current_id = parent_id;
-        }
-        None
+        self.imports
+            .binary_search_by_key(&symbol_id, |(symbol_id, _)| *symbol_id)
+            .ok()
+            .map(|index| self.imports[index].1)
     }
 
     /// The symbol's resolved reference IDs (including TS type references).


### PR DESCRIPTION
## Summary

- cache zero-copy import metadata from the arena-backed Program and avoid per-reference module/name copies
- build JSX entity decoding, whitespace normalization, namespaced tags, and folded template strings directly in the arena
- avoid temporary allocations for regexp flags, built-in hook names, and nested anonymous-function prefixes
- separate resolver, semantic, AST, and allocator lifetimes where the previous covariance masked an invalid constraint
