### PR TITLE
chore(npm): update funding URL

### DIFF
--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -21,7 +21,7 @@
     "directory": "napi/minify"
   },
   "funding": {
-    "url": "https://github.com/sponsors/Boshen"
+    "url": "https://github.com/sponsors/oxc-project"
   },
   "files": [
     "browser.js",

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -20,7 +20,7 @@
     "directory": "napi/parser"
   },
   "funding": {
-    "url": "https://github.com/sponsors/Boshen"
+    "url": "https://github.com/sponsors/oxc-project"
   },
   "files": [
     "src-js/bindings.js",

--- a/napi/transform-react/package.json
+++ b/napi/transform-react/package.json
@@ -22,7 +22,7 @@
     "directory": "napi/transform-react"
   },
   "funding": {
-    "url": "https://github.com/sponsors/Boshen"
+    "url": "https://github.com/sponsors/oxc-project"
   },
   "files": [
     "browser.js",

--- a/napi/transform-relay/package.json
+++ b/napi/transform-relay/package.json
@@ -20,7 +20,7 @@
     "directory": "napi/transform-relay"
   },
   "funding": {
-    "url": "https://github.com/sponsors/Boshen"
+    "url": "https://github.com/sponsors/oxc-project"
   },
   "files": [
     "browser.js",

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -22,7 +22,7 @@
     "directory": "napi/transform"
   },
   "funding": {
-    "url": "https://github.com/sponsors/Boshen"
+    "url": "https://github.com/sponsors/oxc-project"
   },
   "files": [
     "browser.js",

--- a/npm/oxc-types/package.json
+++ b/npm/oxc-types/package.json
@@ -16,7 +16,7 @@
     "directory": "npm/oxc-types"
   },
   "funding": {
-    "url": "https://github.com/sponsors/Boshen"
+    "url": "https://github.com/sponsors/oxc-project"
   },
   "files": [
     "types.d.ts"

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -20,7 +20,7 @@
     "directory": "npm/oxfmt"
   },
   "funding": {
-    "url": "https://github.com/sponsors/Boshen"
+    "url": "https://github.com/sponsors/oxc-project"
   },
   "bin": {
     "oxfmt": "bin/oxfmt"

--- a/npm/oxlint-plugin-eslint/package.json
+++ b/npm/oxlint-plugin-eslint/package.json
@@ -18,7 +18,7 @@
     "directory": "npm/oxlint-plugin-eslint"
   },
   "funding": {
-    "url": "https://github.com/sponsors/Boshen"
+    "url": "https://github.com/sponsors/oxc-project"
   },
   "files": [
     "index.js",

--- a/npm/oxlint-plugins/package.json
+++ b/npm/oxlint-plugins/package.json
@@ -18,7 +18,7 @@
     "directory": "npm/oxlint-plugins"
   },
   "funding": {
-    "url": "https://github.com/sponsors/Boshen"
+    "url": "https://github.com/sponsors/oxc-project"
   },
   "files": [
     "index.js",

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -20,7 +20,7 @@
     "directory": "npm/oxlint"
   },
   "funding": {
-    "url": "https://github.com/sponsors/Boshen"
+    "url": "https://github.com/sponsors/oxc-project"
   },
   "bin": {
     "oxlint": "bin/oxlint"


### PR DESCRIPTION
Update npm package funding links to the Oxc organization sponsorship page.

Closes #26062.

AI-assisted with Codex.