### PR TITLE
docs(lsp): update `LanguageId` docs to target the file extension first

### DIFF
--- a/crates/oxc_language_server/src/language_id.rs
+++ b/crates/oxc_language_server/src/language_id.rs
@@ -1,10 +1,11 @@
 /// Represents language IDs passed from the client in `textDocument/didOpen` notifications.
 ///
-/// These are used to select the appropriate parser strategy for a given file.
-/// The language ID should be preferred over the file extension for determining the language of the content.
-/// The tool can fall back to using the file extension or other heuristics, if the language ID is unrecognized or unsupported.
-/// Files like `.oxlintrc.json` can support comments like jsonc.
-/// The editor/IDE should know the preferred language for such files, and send the appropriate language ID to the server.
+/// These are used to select the appropriate parser strategy for a given non-file document.
+/// To be aligned with the CLI integration, for files the extension should be used.
+/// If the document is not a file (protocol not `file://`), or the extension is not known,
+/// the language ID is used to select the parser strategy.
+/// For non file protocols (e.g. `untitled://`, `vscode-notebook-cell://`, etc.),
+/// the language ID is always used to select the parser strategy.
 ///
 /// For a starting list of known language identifiers, see:
 /// <https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers>


### PR DESCRIPTION
Updated the `LanguageId` docs, to reflect how the real implementation works.
We did a "rollback" to check for the file extension first, to align with the CLI. 
This was specially a problem for jsonc LanguageId with json file extension, where a trailing comma was always added by the editor.

Related https://github.com/oxc-project/oxc/issues/25893
