### PR TITLE
fix(formatter): keep comments between a head and its body out of the braces across all constructs

### DIFF
--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -235,8 +235,9 @@ impl<'a> Comments<'a> {
 
     /// Returns comments that occur before the first instance of a specific character.
     ///
-    /// Lexical byte scan: the range starting at `start` must contain only trivia and punctuation
-    /// (e.g. an expression end up to its enclosing delimiter).
+    /// Lexical byte scan: the range starting at `start` must contain only trivia
+    /// and tokens that cannot contain `character`
+    /// (punctuation, or a keyword scanned for its first byte, e.g. `e` for `else`, `f` for `finally`).
     /// A range covering code would false-match the character inside a string literal or nested syntax.
     pub(crate) fn comments_before_character(&self, mut start: u32, character: u8) -> &'a [Comment] {
         let comments = self.comments_after(start);

--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -169,7 +169,21 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                     });
 
                 if body_has_soft_line_break {
-                    write!(f, [space(), format_body]);
+                    // A block body pushed down by its head-side comments is indented under the arrow:
+                    // ```js
+                    // g = () =>
+                    //   // c
+                    //   {};
+                    // ```
+                    // Without comments no break exists and the indent would be inert,
+                    // but it must not wrap the block's own inner breaks.
+                    if arrow.get_expression().is_none()
+                        && f.comments().has_comment_before(body.span().start)
+                    {
+                        write!(f, [space(), indent(&format_body)]);
+                    } else {
+                        write!(f, [space(), format_body]);
+                    }
                 } else {
                     let should_add_parens = body.as_expression().is_some_and(should_add_parens);
 

--- a/crates/oxc_formatter/src/print/block_statement.rs
+++ b/crates/oxc_formatter/src/print/block_statement.rs
@@ -5,7 +5,6 @@ use oxc_formatter_core::Buffer;
 use super::FormatWrite;
 use crate::{
     ast_nodes::{AstNode, AstNodes},
-    format_args,
     formatter::prelude::*,
     utils::is_dropped_statement,
     write,
@@ -22,44 +21,14 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BlockStatement<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         write!(f, "{");
 
-        let comments_before_catch_clause = if let AstNodes::CatchClause(catch) = self.parent() {
-            f.context().get_cached_element(&catch.span)
-        } else {
-            None
-        };
-
-        let has_comment_before_catch_clause = comments_before_catch_clause.is_some();
-        // See reason in `[AstNode<'a, CatchClause<'a>>::write]`
-        let formatted_comments_before_catch_clause = format_once(|f| {
-            if let Some(comments) = comments_before_catch_clause {
-                f.write_element(comments);
-            }
-        });
-
         if is_empty_block(&self.body) {
-            // `if (a) /* comment */ {}`
-            // should be formatted like:
-            // `if (a) { /* comment */ }`
-            //
-            // Some comments are not inside the block, but we need to print them inside the block.
-            if has_comment_before_catch_clause
-                || f.context().comments().has_comment_before(self.span.end)
-            {
-                write!(
-                    f,
-                    block_indent(&format_args!(
-                        &formatted_comments_before_catch_clause,
-                        format_dangling_comments(self.span)
-                    ))
-                );
+            if f.context().comments().has_comment_before(self.span.end) {
+                write!(f, block_indent(&format_dangling_comments(self.span)));
             } else if is_non_collapsible(self.parent()) {
                 write!(f, hard_line_break());
             }
         } else {
-            write!(
-                f,
-                block_indent(&format_args!(&formatted_comments_before_catch_clause, self.body()))
-            );
+            write!(f, block_indent(&self.body()));
         }
         write!(f, "}");
     }

--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -27,6 +27,7 @@ use crate::{
         },
         is_keyword_property_key,
         object::{format_property_key, should_preserve_quote},
+        statement_body::write_head_body_separator,
     },
     write,
 };
@@ -305,7 +306,14 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatClass<'a, '_> {
 
         let head = format_with(|f| {
             if let Some(id) = self.id() {
-                write!(f, [space(), id]);
+                write!(f, space());
+                if type_parameters.is_none() && super_class.is_none() && implements.is_empty() {
+                    // The id's trailing pass would claim an end-of-line comment
+                    // and flush it past the body's `{`; leave it for the head-body separator.
+                    FormatNodeWithoutTrailingComments(id).fmt(f);
+                } else {
+                    write!(f, id);
+                }
             }
 
             if let Some(type_parameters) = &type_parameters {
@@ -463,10 +471,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatClass<'a, '_> {
             write!(f, [head, format_heritage_clauses, space()]);
         }
 
-        let leading_comments = f.context().comments().comments_before(self.body.span.start);
-        if leading_comments.iter().any(|c| !c.is_line()) {
-            write!(f, FormatLeadingComments::Comments(leading_comments));
-        }
+        write_head_body_separator(self.body.span.start, f);
 
         if body.body.is_empty() {
             write!(f, ["{", format_dangling_comments(self.span).with_block_indent(), "}"]);

--- a/crates/oxc_formatter/src/print/function.rs
+++ b/crates/oxc_formatter/src/print/function.rs
@@ -7,11 +7,8 @@ use super::{
     FormatWrite, arrow_function_expression::FunctionCacheMode, block_statement::is_empty_block,
 };
 use crate::{
-    ast_nodes::AstNode,
-    format_args,
-    formatter::{prelude::*, trivia::FormatLeadingComments},
-    print::semicolon::OptionalSemicolon,
-    write,
+    ast_nodes::AstNode, format_args, formatter::prelude::*, print::semicolon::OptionalSemicolon,
+    utils::statement_body::write_head_body_separator, write,
 };
 
 impl<'a> FormatWrite<'a> for AstNode<'a, Function<'a>> {
@@ -120,8 +117,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatFunction<'a, '_> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, FunctionBody<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        let comments = f.context().comments().block_comments_before(self.span.start);
-        write!(f, [space(), FormatLeadingComments::Comments(comments)]);
+        write_head_body_separator(self.span.start, f);
 
         let statements = self.statements();
         let directives = self.directives();

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -59,8 +59,8 @@ use crate::{
         separated::FormatSeparatedIter,
         token::number::{format_number_token, format_trimmed_number, is_simple_number},
         trivia::{
-            DanglingIndentMode, FormatDanglingComments, FormatLeadingComments,
-            FormatTrailingComments, format_leading_comments, format_trailing_comments,
+            FormatLeadingComments, FormatTrailingComments, format_leading_comments,
+            format_trailing_comments,
         },
     },
     options::{FormatTrailingCommas, Semicolons, TrailingSeparator},
@@ -71,13 +71,18 @@ use crate::{
         assignment_like::AssignmentLike,
         conditional::ConditionalLike,
         expression::ExpressionLeftSide,
-        format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
+        format_node_without_trailing_comments::{
+            FormatNodeWithoutTrailingComments, format_content_without_comments_after,
+        },
         is_keyword_property_key,
         object::{
             format_property_key, is_quoted_new_method_signature, should_preserve_quote,
             should_preserve_quote_for_enum_member,
         },
-        statement_body::FormatStatementBody,
+        statement_body::{
+            FormatStatementBody, write_comments_between_blocks, write_head_body_separator,
+            write_node_with_trailing_comments_before,
+        },
         string::{FormatLiteralStringToken, StringLiteralParentKind},
         suppressed::FormatSuppressedNode,
         tailwindcss::{tailwind_context_for_string_literal, write_tailwind_string_literal},
@@ -1081,6 +1086,20 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
         let consequent = self.consequent();
         let alternate = self.alternate();
 
+        let format_consequent = format_with(|f| {
+            let body = FormatStatementBody::new(consequent);
+            // The consequent's trailing pass would claim a comment past the `else` keyword;
+            // leave everything after it for the split below.
+            // A trailing suppression comment must stay visible to the consequent,
+            // so it preserves its original text.
+            if alternate.is_some()
+                && !f.comments().has_trailing_suppression_comment(consequent.span().end)
+            {
+                format_content_without_comments_after(&body, consequent.span().end, f);
+            } else {
+                body.fmt(f);
+            }
+        });
         write!(
             f,
             group(&format_args!(
@@ -1092,44 +1111,18 @@ impl<'a> FormatWrite<'a> for AstNode<'a, IfStatement<'a>> {
                     body_start: consequent.span().start
                 })),
                 ")",
-                FormatStatementBody::new(consequent),
+                format_consequent,
             ))
         );
         if let Some(alternate) = alternate {
-            let alternate_start = alternate.span().start;
-            let comments = f.context().comments().comments_before(alternate_start);
-
-            let has_line_comment = comments.iter().any(|comment| comment.is_line());
-            let has_dangling_comments = comments
-                .last()
-                .or(f.comments().printed_comments().last())
-                .is_some_and(|last_comment| {
-                    // Ensure the comments are placed before the else keyword or on a new line
-                    f.source_text().slice_range(last_comment.span.end, alternate_start).trim()
-                        == "else"
-                });
-
-            let else_on_same_line = matches!(consequent.as_ref(), Statement::BlockStatement(_))
-                && (!has_line_comment || !has_dangling_comments);
-
-            if else_on_same_line {
-                write!(f, [space(), has_dangling_comments.then(line_suffix_boundary)]);
-            } else {
-                write!(f, hard_line_break());
-            }
-
-            if has_dangling_comments && let Some(first_comment) = comments.first() {
-                if f.lines_before(first_comment.span) > 1 {
-                    write!(f, empty_line());
-                }
-                write!(
-                    f,
-                    FormatDanglingComments::Comments { comments, indent: DanglingIndentMode::None }
-                );
-                if has_line_comment {
-                    write!(f, hard_line_break());
-                } else {
+            // Lexical scan for the keyword's first byte: the gap holds only trivia and `else`.
+            let comments =
+                f.context().comments().comments_before_character(consequent.span().end, b'e');
+            if write_comments_between_blocks(comments, f) {
+                if matches!(consequent.as_ref(), Statement::BlockStatement(_)) {
                     write!(f, space());
+                } else {
+                    write!(f, hard_line_break());
                 }
             }
 
@@ -1216,12 +1209,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, LabeledStatement<'a>> {
     }
 
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        let comments = f.context().comments().line_comments_before(self.body.span().start);
-        FormatLeadingComments::Comments(comments).fmt(f);
-
         let label = self.label();
         let body = self.body();
-        write!(f, [label, ":"]);
+        write_node_with_trailing_comments_before(label, b':', f);
+        write!(f, ":");
         if matches!(body.as_ref(), Statement::EmptyStatement(_)) {
             let empty_comments = f.context().comments().comments_before(self.span.end);
             write!(
@@ -1234,7 +1225,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, LabeledStatement<'a>> {
                 ]
             );
         } else {
-            write!(f, [space(), body]);
+            write_head_body_separator(body.span().start, f);
+            write!(f, body);
         }
     }
 }
@@ -1448,7 +1440,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumDeclaration<'a>> {
         if self.r#const() {
             write!(f, ["const", space()]);
         }
-        write!(f, ["enum", space(), self.id(), space(), "{", self.body(), "}"]);
+        let body = self.body();
+        write!(f, ["enum", space(), FormatNodeWithoutTrailingComments(self.id())]);
+        write_head_body_separator(body.span().start, f);
+        write!(f, ["{", body, "}"]);
     }
 }
 
@@ -1840,14 +1835,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
                     write!(f, [space(), format_extends]);
                 }
             }
-
-            let has_leading_own_line_comment =
-                f.context().comments().has_leading_own_line_comment(self.body.span().start);
-
-            if !has_leading_own_line_comment {
-                write!(f, [space()]);
-                body.format_leading_comments(f);
-            }
         });
 
         let content = format_with(|f| {
@@ -1867,8 +1854,8 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
                 write!(f, [&format_args!(format_id, format_extends)]);
             }
 
-            write!(f, [space()]);
-            // Avoid printing leading comments of body
+            write_head_body_separator(body.span().start, f);
+            // Leading comments are printed by the separator above
             body.write(f);
         });
 
@@ -2044,12 +2031,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSExternalModuleDeclaration<'a>> {
             write!(f, ["declare", space()]);
         }
 
-        write!(f, ["module", space(), self.id()]);
-
+        write!(f, ["module", space()]);
         if let Some(body) = self.body() {
-            write!(f, [space(), body]);
+            write!(f, FormatNodeWithoutTrailingComments(self.id()));
+            write_head_body_separator(body.span().start, f);
+            write!(f, body);
         } else {
-            write!(f, OptionalSemicolon);
+            write!(f, [self.id(), OptionalSemicolon]);
         }
     }
 }
@@ -2060,19 +2048,21 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSNamespaceDeclaration<'a>> {
             write!(f, ["declare", space()]);
         }
 
-        write!(f, self.kind().as_str());
+        write!(f, [self.kind().as_str(), space()]);
 
-        write!(f, [space(), self.id()]);
-
+        let mut id = self.id();
         let mut body = self.body();
         loop {
             match body.as_ast_nodes() {
                 AstNodes::TSNamespaceDeclaration(namespace) => {
-                    write!(f, [".", namespace.id()]);
+                    write!(f, [id, "."]);
+                    id = namespace.id();
                     body = namespace.body();
                 }
-                AstNodes::TSModuleBlock(body) => {
-                    write!(f, [space(), body]);
+                AstNodes::TSModuleBlock(block) => {
+                    write!(f, FormatNodeWithoutTrailingComments(id));
+                    write_head_body_separator(block.span().start, f);
+                    write!(f, block);
                     break;
                 }
                 _ => {
@@ -2090,7 +2080,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSGlobalDeclaration<'a>> {
         }
         let comments_before_global = f.context().comments().comments_before(self.global_span.start);
         write!(f, FormatLeadingComments::Comments(comments_before_global));
-        write!(f, ["global", space(), self.body()]);
+        let body = self.body();
+        write!(f, "global");
+        write_head_body_separator(body.span().start, f);
+        write!(f, body);
     }
 }
 

--- a/crates/oxc_formatter/src/print/semicolon.rs
+++ b/crates/oxc_formatter/src/print/semicolon.rs
@@ -84,8 +84,13 @@ pub fn keeps_trailing_comment_inside_parens(expr: &Expression<'_>, gated: bool) 
 /// where that table says the parentheses do NOT survive, the semicolon directly follows the content,
 /// so trailing comments move behind it even from inside the dropped parentheses.
 /// Those parentheses are excluded from the chain's rightmost leaf's span but included in the chain's,
-/// so the leaf's end bounds the content
-/// (`assigned = (a = c /* c */);` -> `assigned = a = c; /* c */`, prettier#19893).
+/// so the leaf's end bounds the content (prettier#19893):
+///
+/// ```js
+/// assigned = (a = c /* c */);
+/// // ->
+/// assigned = a = c; /* c */
+/// ```
 pub fn assignment_chain_leaf_end(expr: &Expression<'_>) -> u32 {
     let mut leaf = expr;
     while let Expression::AssignmentExpression(assignment) = leaf {

--- a/crates/oxc_formatter/src/print/sequence_expression.rs
+++ b/crates/oxc_formatter/src/print/sequence_expression.rs
@@ -14,7 +14,13 @@ use super::FormatWrite;
 /// The sequence spans from the first element's source `(` when it is parenthesized,
 /// so a comment inside those dropped parentheses sits within the sequence's span but leads the sequence,
 /// not the element: it prints OUTSIDE the formatter-added parentheses
-/// (`((/* c */ a), b);` -> `/* c */ (a, b);`, prettier#19894's fixpoint).
+/// (prettier#19894's fixpoint):
+///
+/// ```js
+/// ((/* c */ a), b);
+/// // ->
+/// /* c */ (a, b);
+/// ```
 pub fn sequence_leading_comments_start(sequence: &SequenceExpression<'_>) -> u32 {
     sequence.expressions.first().map_or(sequence.span.start, |e| e.span().start)
 }

--- a/crates/oxc_formatter/src/print/switch_statement.rs
+++ b/crates/oxc_formatter/src/print/switch_statement.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
-use oxc_span::GetSpan;
 
 use crate::{
     Format,
@@ -9,11 +8,11 @@ use crate::{
     formatter::{
         JsFormatter,
         prelude::*,
-        trivia::{DanglingIndentMode, FormatDanglingComments, FormatTrailingComments},
+        trivia::{DanglingIndentMode, FormatDanglingComments},
     },
     utils::{
-        format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
-        is_dropped_statement, statement_body::FormatStatementBody,
+        is_dropped_statement,
+        statement_body::{FormatStatementBody, write_node_with_trailing_comments_before},
     },
     write,
 };
@@ -72,17 +71,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SwitchCase<'a>> {
         let is_default = if let Some(test) = self.test() {
             write!(f, ["case", space()]);
             if is_single_block_statement {
-                // The test's generic trailing pass would claim an end-of-line comment
-                // after the `:` as a `line_suffix` and flush it past the block's `{`;
-                // bound the test's comments at the `:` (comments after it lead the block).
-                // For non-block consequents the flush lands before their line break,
-                // keeping the comment on the clause line, so the generic pass is correct there.
-                write!(f, FormatNodeWithoutTrailingComments(test));
-                let comments =
-                    f.context().comments().comments_before_character(test.span().end, b':');
-                if !comments.is_empty() {
-                    write!(f, [space(), FormatTrailingComments::Comments(comments)]);
-                }
+                // For non-block consequents the generic pass's `line_suffix` flush lands
+                // before their line break, keeping the comment on the clause line,
+                // so the bound is only needed before a block's `{`.
+                write_node_with_trailing_comments_before(test, b':', f);
             } else {
                 write!(f, test);
             }
@@ -94,14 +86,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SwitchCase<'a>> {
         };
 
         // When the case block is empty, the case becomes a fallthrough, so it
-        // is collapsed directly on top of the next case (just a single
-        // hardline).
+        // is collapsed directly on top of the next case (just a single hardline).
         // When the block is a single statement _and_ it's a block statement,
-        // then the opening brace of the block can hug the same line as the
-        // case. But, if there's more than one statement, then the block
-        // _cannot_ hug. This distinction helps clarify that the case continues
-        // past the end of the block statement, despite the braces making it
-        // seem like it might end.
+        // then the opening brace of the block can hug the same line as the case.
+        // But, if there's more than one statement, then the block _cannot_ hug.
+        // This distinction helps clarify that the case continues past the end of the block statement,
+        // despite the braces making it seem like it might end.
         // Lastly, the default case is just to break and indent the body.
         //
         // switch (key) {
@@ -133,8 +123,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SwitchCase<'a>> {
 
         let consequent = self.consequent();
         if is_single_block_statement {
-            // The head-body comment policy applies:
-            // comments between the `:` and the `{` stay outside the braces.
             // `unwrap` is safe: the empty consequent returned above.
             write!(f, FormatStatementBody::new(consequent.first().unwrap()));
             return;

--- a/crates/oxc_formatter/src/print/try_statement.rs
+++ b/crates/oxc_formatter/src/print/try_statement.rs
@@ -12,67 +12,64 @@ use crate::{
 };
 
 use super::FormatWrite;
+use crate::utils::{
+    format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
+    statement_body::{write_comments_between_blocks, write_head_body_separator},
+};
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TryStatement<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let block = self.block();
         let handler = self.handler();
         let finalizer = self.finalizer();
-        write!(f, ["try", space()]);
 
-        if f.comments().has_leading_own_line_comment(block.span.start) {
-            // Use `write` rather than `write!` in order to avoid printing leading own line comments for `block`.
-            block.write(f);
-        } else {
-            write!(f, block);
-        }
+        write!(f, "try");
+        write_head_body_separator(block.span.start, f);
+        write_block_before_keyword(block, handler.is_some() || finalizer.is_some(), f);
 
         if let Some(handler) = handler {
-            write!(f, [space(), handler]);
+            write!(f, space());
+            write_block_before_keyword(handler, finalizer.is_some(), f);
         }
         if let Some(finalizer) = finalizer {
-            write!(f, [space(), "finally", space()]);
-            if f.comments().has_leading_own_line_comment(finalizer.span.start) {
-                // Use `write` rather than `write!` in order to avoid printing leading own line comments for `finalizer`.
-                finalizer.write(f);
-            } else {
-                write!(f, finalizer);
-            }
+            // Lexical scan for the keyword's first byte: the gap holds only trivia and `finally`.
+            let previous_end = handler.map_or(block.span().end, |handler| handler.span().end);
+            let before_keyword =
+                f.context().comments().comments_before_character(previous_end, b'f');
+            // The pending space is dropped at a line start and coalesced otherwise
+            write_comments_between_blocks(before_keyword, f);
+            write!(f, [space(), "finally"]);
+            write_head_body_separator(finalizer.span.start, f);
+            write!(f, finalizer);
         }
+    }
+}
+
+/// Prints `node`, suppressing its generic trailing pass when a keyword (`catch`/`finally`) follows,
+/// so it cannot claim a line comment past that keyword; the keyword site splits the comments instead.
+fn write_block_before_keyword<'a, T>(node: &T, keyword_follows: bool, f: &mut JsFormatter<'_, 'a>)
+where
+    T: Format<'a, JsFormatContext<'a>> + GetSpan,
+{
+    if keyword_follows {
+        FormatNodeWithoutTrailingComments(node).fmt(f);
+    } else {
+        node.fmt(f);
     }
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, CatchClause<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        let comments = f.context().comments();
-        let leading_comments = comments.comments_before(self.span.start);
-        let has_line_comment = leading_comments.iter().any(|comment| comment.has_newlines_around());
-
-        if has_line_comment {
-            // `try {} /* comment */\n catch (e) {}`
-            // should be formatted like:
-            // `try {} catch (e) { /* comment */ }`
-            //
-            // Comments before the catch clause should be printed in the block statement.
-            // We cache them here to avoid the `params` printing them accidentally.
-            let printed_comments = f.intern(&FormatLeadingComments::Comments(leading_comments));
-            if let Some(comments) = printed_comments {
-                f.context_mut().cache_element(&self.span, comments);
-            }
-        } else if !leading_comments.is_empty() {
-            // otherwise, print them before `catch`
-            write!(f, [FormatTrailingComments::Comments(leading_comments), space()]);
+        let leading_comments = f.context().comments().comments_before(self.span.start);
+        if write_comments_between_blocks(leading_comments, f) {
+            write!(f, space());
         }
 
-        write!(f, ["catch", space(), self.param(), space()]);
+        write!(f, ["catch", space(), self.param()]);
 
         let block = self.body();
-        if f.comments().has_leading_own_line_comment(block.span.start) {
-            // Use `write` rather than `write!` in order to avoid printing leading own line comments for `block`.
-            block.write(f);
-        } else {
-            write!(f, block);
-        }
+        write_head_body_separator(block.span.start, f);
+        write!(f, block);
     }
 }
 
@@ -98,19 +95,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CatchParameter<'a>> {
                 f,
                 soft_block_indent(&format_with(|f| {
                     write!(f, [FormatLeadingComments::Comments(leading_comments)]);
-                    let printed_len_before_pattern =
-                        f.context().comments().printed_comments().len();
                     write!(f, self.pattern());
                     write!(f, self.type_annotation());
-                    if trailing_comments.is_empty() ||
-                    // The `pattern` cannot print comments that are below it, so we need to check whether there
-                    // are any trailing comments that haven't been printed yet. If there are, print them.
-                    f.context().comments().printed_comments().len() - printed_len_before_pattern
-                        == trailing_comments.len()
-                    {
-                    } else {
-                        write!(f, FormatTrailingComments::Comments(trailing_comments));
-                    }
+                    // Re-queried after the cursor advanced:
+                    // the pattern may have printed part of the earlier `trailing_comments` slice already
+                    let remaining =
+                        f.context().comments().comments_before_character(self.span().end, b')');
+                    write!(f, FormatTrailingComments::Comments(remaining));
                 }))
             );
         } else {
@@ -118,7 +109,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CatchParameter<'a>> {
             write!(f, self.type_annotation());
         }
 
-        self.format_trailing_comments(f);
+        // Bound the trailing print at the `)`:
+        // the generic pass would claim an end-of-line comment past it and flush it beyond the catch body's `{`.
+        // (Re-queried again: the branch above advances the cursor.)
+        let remaining = f.context().comments().comments_before_character(self.span().end, b')');
+        write!(f, FormatTrailingComments::Comments(remaining));
 
         write!(f, ")");
     }

--- a/crates/oxc_formatter/src/utils/format_node_without_trailing_comments.rs
+++ b/crates/oxc_formatter/src/utils/format_node_without_trailing_comments.rs
@@ -45,6 +45,10 @@ pub fn format_content_without_comments_after<'a, T>(
 ) where
     T: Format<'a, JsFormatContext<'a>>,
 {
+    // Hiding a trailing suppression comment would silently reformat the suppressed content;
+    // every caller must check (or route through `FormatNodeWithoutTrailingComments`, which does) before hiding.
+    debug_assert!(!f.comments().has_trailing_suppression_comment(end));
+
     // Save the current comment view limit and temporarily restrict it
     // to hide comments that start at or after the end position.
     let previous_limit = f.context_mut().comments_mut().limit_comments_up_to(end);

--- a/crates/oxc_formatter/src/utils/statement_body.rs
+++ b/crates/oxc_formatter/src/utils/statement_body.rs
@@ -1,18 +1,106 @@
-use oxc_ast::ast::Statement;
+use oxc_ast::{Comment, ast::Statement};
 use oxc_formatter_core::{Buffer, Format};
 use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::{AstNode, AstNodes},
     formatter::{
-        JsFormatContext, JsFormatter,
-        prelude::{format_once, hard_line_break, soft_line_indent_or_space, space},
-        trivia::{FormatTrailingComments, format_leading_comments},
+        JsFormatContext, JsFormatter, JsFormatterExt as _,
+        prelude::{empty_line, format_once, hard_line_break, soft_line_indent_or_space, space},
+        trivia::{FormatLeadingComments, FormatTrailingComments},
     },
     utils::format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
-    utils::suppressed::FormatSuppressedNode,
     write,
 };
+
+/// The separator between a construct's head and its `{`-delimited body,
+/// followed by the pending head-side comments, which stay OUTSIDE the braces (head-body comment policy):
+/// a same-line comment follows the space,
+/// a line comment then forces the `{` onto the next line via its own break,
+/// and an own-line comment keeps its own line:
+///
+/// ```js
+/// while (x) /* c */ {}
+///
+/// while (x) // c
+/// {}
+///
+/// if (x)
+/// // c
+/// {
+/// }
+/// ```
+///
+/// The caller prints the body (or its `{`) right after;
+/// when the head ends with a node, print it via `FormatNodeWithoutTrailingComments`,
+/// so its generic trailing pass cannot claim a line comment first.
+/// A pending `space()` a caller has already emitted is safe:
+/// the printer coalesces consecutive spaces and drops them at a line start.
+pub fn write_head_body_separator(body_start: u32, f: &mut JsFormatter<'_, '_>) {
+    let comments = f.context().comments().comments_before(body_start);
+    if comments.first().is_some_and(|comment| comment.preceded_by_newline()) {
+        write!(f, hard_line_break());
+    } else {
+        write!(f, space());
+    }
+    FormatLeadingComments::Comments(comments).fmt(f);
+}
+
+/// Prints `node` with its generic trailing pass suppressed, then its trailing
+/// comments bounded at the next `character` (a `:` clause colon, a head's `)`).
+/// The caller prints that token next; comments past it are left pending
+/// (they lead whatever follows). Without the bound, the generic pass would
+/// claim an end-of-line comment and flush it past the following body's `{`.
+pub fn write_node_with_trailing_comments_before<'a, T>(
+    node: &T,
+    character: u8,
+    f: &mut JsFormatter<'_, 'a>,
+) where
+    T: Format<'a, JsFormatContext<'a>> + GetSpan,
+{
+    FormatNodeWithoutTrailingComments(node).fmt(f);
+    let comments = f.context().comments().comments_before_character(node.span().end, character);
+    FormatTrailingComments::Comments(comments).fmt(f);
+}
+
+/// Comments between a block's `}` and a following keyword (`else`/`catch`/`finally`)
+/// keep their positions: the same-line prefix trails the previous block,
+/// own-line comments keep their own lines (ending with their own break or space).
+///
+/// A same-line line comment rides a `line_suffix` and flushes at the emitted
+/// hard break — NEVER at a `line_suffix_boundary`, whose presence would
+/// poison the preceding group's fits measurement and expand content that fits.
+///
+/// Returns whether the caller still has to write its default separator
+/// before the keyword (`false` when the comments ended with their own).
+pub fn write_comments_between_blocks<'a>(
+    comments: &'a [Comment],
+    f: &mut JsFormatter<'_, 'a>,
+) -> bool {
+    let same_line_count =
+        comments.iter().take_while(|comment| !comment.preceded_by_newline()).count();
+    let (same_line, own_line) = comments.split_at(same_line_count);
+
+    if !same_line.is_empty() {
+        FormatTrailingComments::Comments(same_line).fmt(f);
+    }
+    if let Some(first) = own_line.first() {
+        // Flushes a pending same-line line comment, then starts the own-line run
+        write!(f, hard_line_break());
+        if f.lines_before(first.span) > 1 {
+            write!(f, empty_line());
+        }
+        FormatLeadingComments::Comments(own_line).fmt(f);
+        false
+    } else if same_line.last().is_some_and(|comment| comment.is_line()) {
+        // Only the last same-line comment can be a line comment
+        // (anything after one starts a new line, landing in `own_line`)
+        write!(f, hard_line_break());
+        false
+    } else {
+        true
+    }
+}
 
 pub struct FormatStatementBody<'a, 'b> {
     body: &'b AstNode<'a, Statement<'a>>,
@@ -43,14 +131,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatStatementBody<'a, '_> {
             }
             write!(f, empty);
         } else if let AstNodes::BlockStatement(block) = self.body.as_ast_nodes() {
-            // Comments between the parent's head and the `{` lead the block and stay
-            // outside the braces (`while (x) /* c */ {}`);
-            // an own-line comment keeps its own line (`if (x)\n// c\n{}`).
-            if f.context().comments().own_line_comments_before(block.span().start).is_empty() {
-                write!(f, [space()]);
-            } else {
-                write!(f, [hard_line_break()]);
-            }
+            write_head_body_separator(block.span().start, f);
             write!(f, [block]);
         } else if self.force_space {
             write!(f, [space(), self.body]);
@@ -58,15 +139,10 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatStatementBody<'a, '_> {
             write!(
                 f,
                 [soft_line_indent_or_space(&format_once(|f| {
-                    // ```js
-                    // if (condition)
-                    //     statement; // comment1
-                    // // comment2
-                    // else {}
-                    // ```
-                    // The following logic is to ensure that `comment1` is printed as a trailing comment of the
-                    // statement, and leave `comment2` to be printed in the IfStatement's alternate.
-
+                    // Only live for a suppressed `if` consequent (`stuff() // oxfmt-ignore` before `else`):
+                    // print it verbatim, then flush its end-of-line comments.
+                    // Otherwise the `IfStatement` wrapper has hidden everything past the consequent already,
+                    // and this reduces to the `else` arm.
                     let body_span = self.body.span();
                     let is_consequent_of_if_statement_parent = matches!(
                         self.body.parent(),
@@ -74,12 +150,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatStatementBody<'a, '_> {
                         if if_stmt.consequent.span() == body_span && if_stmt.alternate.is_some()
                     );
                     if is_consequent_of_if_statement_parent {
-                        if f.context().comments().has_trailing_suppression_comment(body_span.end) {
-                            write!(f, format_leading_comments(body_span));
-                            write!(f, FormatSuppressedNode(body_span));
-                        } else {
-                            write!(f, FormatNodeWithoutTrailingComments(self.body));
-                        }
+                        write!(f, FormatNodeWithoutTrailingComments(self.body));
                         let comments =
                             f.context().comments().end_of_line_comments_after(body_span.end);
                         FormatTrailingComments::Comments(comments).fmt(f);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/head-body-blocks.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/head-body-blocks.js
@@ -1,0 +1,67 @@
+// Comments between a head and its body `{` stay outside the braces for
+// function/arrow/method/class/labeled heads too (head-body comment policy).
+// Known divergences (js/comments/function*, js/class-comment/*, js/label/comment.js):
+// Prettier pulls line and own-line comments inside the braces, hoists a labeled
+// statement's comment above the label, and breaks an `if` consequent whose
+// trailing line comment its attachment marks as multiline -- artifacts of the
+// kind prettier is currently fixing elsewhere (prettier#19894 family,
+// open prettier#7745 / #5900).
+// An arrow's block body pushed down by its head comments indents under the
+// arrow (own-line converges with Prettier; for a same-line line comment
+// Prettier own-lines the comment, we keep its position).
+function f1() /* c */ {}
+function f2() // c
+{}
+function f3()
+// c
+{}
+
+g1 = () => /* c */ {};
+g2 = () => // c
+{};
+g3 = () =>
+// c
+{};
+
+class C {
+  m1() /* c */ {}
+  m2() // c
+  {}
+}
+
+class A1 /* c */ {}
+class A2 // c
+{}
+class A3
+// c
+{}
+class A4 extends B // c
+{}
+
+foo1: /* c */ {
+  break foo1;
+}
+foo2: // c
+{
+  break foo2;
+}
+foo3: // c
+bar();
+
+// An `if` consequent's trailing line comment rides the line without forcing
+// the consequent onto its own line, and `else` comments keep their positions
+if (a) doSomething(); // c
+else if (b) other(); // d
+else {}
+
+if (a) {} /* b4 */ else {}
+if (a) {} // b4
+else {}
+if (a) {}
+// own
+else {}
+if (a) {} else /* c */ if (b) {} else /* d */ {}
+
+// A trailing suppression comment keeps the consequent's original text
+if (a) ugly(  1  ) // prettier-ignore
+else b();

--- a/crates/oxc_formatter/tests/fixtures/js/comments/head-body-blocks.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/head-body-blocks.js.snap
@@ -1,0 +1,238 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Comments between a head and its body `{` stay outside the braces for
+// function/arrow/method/class/labeled heads too (head-body comment policy).
+// Known divergences (js/comments/function*, js/class-comment/*, js/label/comment.js):
+// Prettier pulls line and own-line comments inside the braces, hoists a labeled
+// statement's comment above the label, and breaks an `if` consequent whose
+// trailing line comment its attachment marks as multiline -- artifacts of the
+// kind prettier is currently fixing elsewhere (prettier#19894 family,
+// open prettier#7745 / #5900).
+// An arrow's block body pushed down by its head comments indents under the
+// arrow (own-line converges with Prettier; for a same-line line comment
+// Prettier own-lines the comment, we keep its position).
+function f1() /* c */ {}
+function f2() // c
+{}
+function f3()
+// c
+{}
+
+g1 = () => /* c */ {};
+g2 = () => // c
+{};
+g3 = () =>
+// c
+{};
+
+class C {
+  m1() /* c */ {}
+  m2() // c
+  {}
+}
+
+class A1 /* c */ {}
+class A2 // c
+{}
+class A3
+// c
+{}
+class A4 extends B // c
+{}
+
+foo1: /* c */ {
+  break foo1;
+}
+foo2: // c
+{
+  break foo2;
+}
+foo3: // c
+bar();
+
+// An `if` consequent's trailing line comment rides the line without forcing
+// the consequent onto its own line, and `else` comments keep their positions
+if (a) doSomething(); // c
+else if (b) other(); // d
+else {}
+
+if (a) {} /* b4 */ else {}
+if (a) {} // b4
+else {}
+if (a) {}
+// own
+else {}
+if (a) {} else /* c */ if (b) {} else /* d */ {}
+
+// A trailing suppression comment keeps the consequent's original text
+if (a) ugly(  1  ) // prettier-ignore
+else b();
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Comments between a head and its body `{` stay outside the braces for
+// function/arrow/method/class/labeled heads too (head-body comment policy).
+// Known divergences (js/comments/function*, js/class-comment/*, js/label/comment.js):
+// Prettier pulls line and own-line comments inside the braces, hoists a labeled
+// statement's comment above the label, and breaks an `if` consequent whose
+// trailing line comment its attachment marks as multiline -- artifacts of the
+// kind prettier is currently fixing elsewhere (prettier#19894 family,
+// open prettier#7745 / #5900).
+// An arrow's block body pushed down by its head comments indents under the
+// arrow (own-line converges with Prettier; for a same-line line comment
+// Prettier own-lines the comment, we keep its position).
+function f1() /* c */ {}
+function f2() // c
+{}
+function f3()
+// c
+{}
+
+g1 = () => /* c */ {};
+g2 = () => // c
+  {};
+g3 = () =>
+  // c
+  {};
+
+class C {
+  m1() /* c */ {}
+  m2() // c
+  {}
+}
+
+class A1 /* c */ {}
+class A2 // c
+{}
+class A3
+// c
+{}
+class A4 extends B // c
+{}
+
+foo1: /* c */ {
+  break foo1;
+}
+foo2: // c
+{
+  break foo2;
+}
+foo3: // c
+bar();
+
+// An `if` consequent's trailing line comment rides the line without forcing
+// the consequent onto its own line, and `else` comments keep their positions
+if (a) doSomething(); // c
+else if (b) other(); // d
+else {
+}
+
+if (a) {
+} /* b4 */ else {
+}
+if (a) {
+} // b4
+else {
+}
+if (a) {
+}
+// own
+else {
+}
+if (a) {
+} else /* c */ if (b) {
+} else /* d */ {
+}
+
+// A trailing suppression comment keeps the consequent's original text
+if (a)
+  ugly(  1  ) // prettier-ignore
+else b();
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Comments between a head and its body `{` stay outside the braces for
+// function/arrow/method/class/labeled heads too (head-body comment policy).
+// Known divergences (js/comments/function*, js/class-comment/*, js/label/comment.js):
+// Prettier pulls line and own-line comments inside the braces, hoists a labeled
+// statement's comment above the label, and breaks an `if` consequent whose
+// trailing line comment its attachment marks as multiline -- artifacts of the
+// kind prettier is currently fixing elsewhere (prettier#19894 family,
+// open prettier#7745 / #5900).
+// An arrow's block body pushed down by its head comments indents under the
+// arrow (own-line converges with Prettier; for a same-line line comment
+// Prettier own-lines the comment, we keep its position).
+function f1() /* c */ {}
+function f2() // c
+{}
+function f3()
+// c
+{}
+
+g1 = () => /* c */ {};
+g2 = () => // c
+  {};
+g3 = () =>
+  // c
+  {};
+
+class C {
+  m1() /* c */ {}
+  m2() // c
+  {}
+}
+
+class A1 /* c */ {}
+class A2 // c
+{}
+class A3
+// c
+{}
+class A4 extends B // c
+{}
+
+foo1: /* c */ {
+  break foo1;
+}
+foo2: // c
+{
+  break foo2;
+}
+foo3: // c
+bar();
+
+// An `if` consequent's trailing line comment rides the line without forcing
+// the consequent onto its own line, and `else` comments keep their positions
+if (a) doSomething(); // c
+else if (b) other(); // d
+else {
+}
+
+if (a) {
+} /* b4 */ else {
+}
+if (a) {
+} // b4
+else {
+}
+if (a) {
+}
+// own
+else {
+}
+if (a) {
+} else /* c */ if (b) {
+} else /* d */ {
+}
+
+// A trailing suppression comment keeps the consequent's original text
+if (a)
+  ugly(  1  ) // prettier-ignore
+else b();
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/try-catch-finally-head.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/try-catch-finally-head.js
@@ -1,0 +1,50 @@
+// Comments between try/catch/finally heads and their `{` stay outside the
+// braces (head-body comment policy), and comments before the `finally`
+// keyword never cross it.
+// Known divergence (js/try/try.js, js/comments/try.js): Prettier pulls
+// line and own-line comments into the following block instead -- attachment
+// artifacts of the kind prettier is currently fixing elsewhere
+// (prettier#19894 family).
+try /* c */ {} catch {}
+try // c
+{} catch {}
+try
+// c
+{} catch {}
+
+try {} catch (e) /* c */ {}
+try {} catch (e) // c
+{}
+try {} catch (e)
+// c
+{}
+
+try {} finally /* c */ {}
+try {} finally // c
+{}
+try {} finally
+// c
+{}
+
+// Before the `finally` keyword: trailing the previous block
+try {} /* a */ finally {}
+try {} // a
+finally {}
+try {}
+// a
+finally {}
+try {} catch {} // a
+finally {}
+
+// Before the `catch` keyword: same rule
+// (divergence: Prettier pulls all but the inline-block shape into the catch block)
+try {} /* a */ catch {}
+try {} /* a */
+catch {}
+try {} // a
+catch {}
+try {}
+// a
+catch {}
+try {} // a
+catch (e) {} finally {}

--- a/crates/oxc_formatter/tests/fixtures/js/comments/try-catch-finally-head.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/try-catch-finally-head.js.snap
@@ -1,0 +1,219 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Comments between try/catch/finally heads and their `{` stay outside the
+// braces (head-body comment policy), and comments before the `finally`
+// keyword never cross it.
+// Known divergence (js/try/try.js, js/comments/try.js): Prettier pulls
+// line and own-line comments into the following block instead -- attachment
+// artifacts of the kind prettier is currently fixing elsewhere
+// (prettier#19894 family).
+try /* c */ {} catch {}
+try // c
+{} catch {}
+try
+// c
+{} catch {}
+
+try {} catch (e) /* c */ {}
+try {} catch (e) // c
+{}
+try {} catch (e)
+// c
+{}
+
+try {} finally /* c */ {}
+try {} finally // c
+{}
+try {} finally
+// c
+{}
+
+// Before the `finally` keyword: trailing the previous block
+try {} /* a */ finally {}
+try {} // a
+finally {}
+try {}
+// a
+finally {}
+try {} catch {} // a
+finally {}
+
+// Before the `catch` keyword: same rule
+// (divergence: Prettier pulls all but the inline-block shape into the catch block)
+try {} /* a */ catch {}
+try {} /* a */
+catch {}
+try {} // a
+catch {}
+try {}
+// a
+catch {}
+try {} // a
+catch (e) {} finally {}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Comments between try/catch/finally heads and their `{` stay outside the
+// braces (head-body comment policy), and comments before the `finally`
+// keyword never cross it.
+// Known divergence (js/try/try.js, js/comments/try.js): Prettier pulls
+// line and own-line comments into the following block instead -- attachment
+// artifacts of the kind prettier is currently fixing elsewhere
+// (prettier#19894 family).
+try /* c */ {
+} catch {}
+try // c
+{
+} catch {}
+try
+// c
+{
+} catch {}
+
+try {
+} catch (e) /* c */ {}
+try {
+} catch (e) // c
+{}
+try {
+} catch (e)
+// c
+{}
+
+try {
+} finally /* c */ {
+}
+try {
+} finally // c
+{
+}
+try {
+} finally
+// c
+{
+}
+
+// Before the `finally` keyword: trailing the previous block
+try {
+} /* a */ finally {
+}
+try {
+} // a
+finally {
+}
+try {
+}
+// a
+finally {
+}
+try {
+} catch {
+} // a
+finally {
+}
+
+// Before the `catch` keyword: same rule
+// (divergence: Prettier pulls all but the inline-block shape into the catch block)
+try {
+} /* a */ catch {}
+try {
+} /* a */ catch {}
+try {
+} // a
+catch {}
+try {
+}
+// a
+catch {}
+try {
+} // a
+catch (e) {
+} finally {
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Comments between try/catch/finally heads and their `{` stay outside the
+// braces (head-body comment policy), and comments before the `finally`
+// keyword never cross it.
+// Known divergence (js/try/try.js, js/comments/try.js): Prettier pulls
+// line and own-line comments into the following block instead -- attachment
+// artifacts of the kind prettier is currently fixing elsewhere
+// (prettier#19894 family).
+try /* c */ {
+} catch {}
+try // c
+{
+} catch {}
+try
+// c
+{
+} catch {}
+
+try {
+} catch (e) /* c */ {}
+try {
+} catch (e) // c
+{}
+try {
+} catch (e)
+// c
+{}
+
+try {
+} finally /* c */ {
+}
+try {
+} finally // c
+{
+}
+try {
+} finally
+// c
+{
+}
+
+// Before the `finally` keyword: trailing the previous block
+try {
+} /* a */ finally {
+}
+try {
+} // a
+finally {
+}
+try {
+}
+// a
+finally {
+}
+try {
+} catch {
+} // a
+finally {
+}
+
+// Before the `catch` keyword: same rule
+// (divergence: Prettier pulls all but the inline-block shape into the catch block)
+try {
+} /* a */ catch {}
+try {
+} /* a */ catch {}
+try {
+} // a
+catch {}
+try {
+}
+// a
+catch {}
+try {
+} // a
+catch (e) {
+} finally {
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/if/issue-16137.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/if/issue-16137.js.snap
@@ -25,7 +25,8 @@ else if (x) {
 }
 
 if (cond) stuff;
-/* comment*/ else stuff;
+/* comment*/
+else stuff;
 
 -------------------
 { printWidth: 100 }
@@ -38,6 +39,7 @@ else if (x) {
 }
 
 if (cond) stuff;
-/* comment*/ else stuff;
+/* comment*/
+else stuff;
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/declaration-head-body.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/declaration-head-body.ts
@@ -1,0 +1,39 @@
+// Comments between a declaration's head and its body `{` stay outside the
+// braces (head-body comment policy): a block comment inline, a line comment
+// keeping its position with the `{` forced onto the next line, an own-line
+// comment keeping its own line.
+// Known divergence (typescript/interface{,2}/comments*.ts): Prettier pulls
+// line and own-line comments inside the braces (`{\n  // c`), or past them
+// entirely for enum/namespace (`enum E {} // c`) -- attachment artifacts of
+// the kind prettier is currently fixing elsewhere (prettier#19894 family,
+// open prettier#5900).
+enum E1 /* c */ {}
+enum E2 // c
+{}
+enum E3
+// c
+{}
+
+interface I1 /* c */ {}
+interface I2 // c
+{}
+interface I3
+// c
+{}
+interface I4 extends Base /* c */ {}
+interface I5 extends Base // c
+{}
+
+namespace N1 /* c */ {}
+namespace N2 // c
+{}
+namespace N3
+// c
+{}
+namespace A.B /* c */ {}
+
+declare module "m1" /* c */ {}
+declare module "m2" // c
+{}
+
+declare global /* c */ {}

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/declaration-head-body.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/declaration-head-body.ts.snap
@@ -1,0 +1,132 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Comments between a declaration's head and its body `{` stay outside the
+// braces (head-body comment policy): a block comment inline, a line comment
+// keeping its position with the `{` forced onto the next line, an own-line
+// comment keeping its own line.
+// Known divergence (typescript/interface{,2}/comments*.ts): Prettier pulls
+// line and own-line comments inside the braces (`{\n  // c`), or past them
+// entirely for enum/namespace (`enum E {} // c`) -- attachment artifacts of
+// the kind prettier is currently fixing elsewhere (prettier#19894 family,
+// open prettier#5900).
+enum E1 /* c */ {}
+enum E2 // c
+{}
+enum E3
+// c
+{}
+
+interface I1 /* c */ {}
+interface I2 // c
+{}
+interface I3
+// c
+{}
+interface I4 extends Base /* c */ {}
+interface I5 extends Base // c
+{}
+
+namespace N1 /* c */ {}
+namespace N2 // c
+{}
+namespace N3
+// c
+{}
+namespace A.B /* c */ {}
+
+declare module "m1" /* c */ {}
+declare module "m2" // c
+{}
+
+declare global /* c */ {}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Comments between a declaration's head and its body `{` stay outside the
+// braces (head-body comment policy): a block comment inline, a line comment
+// keeping its position with the `{` forced onto the next line, an own-line
+// comment keeping its own line.
+// Known divergence (typescript/interface{,2}/comments*.ts): Prettier pulls
+// line and own-line comments inside the braces (`{\n  // c`), or past them
+// entirely for enum/namespace (`enum E {} // c`) -- attachment artifacts of
+// the kind prettier is currently fixing elsewhere (prettier#19894 family,
+// open prettier#5900).
+enum E1 /* c */ {}
+enum E2 // c
+{}
+enum E3
+// c
+{}
+
+interface I1 /* c */ {}
+interface I2 // c
+{}
+interface I3
+// c
+{}
+interface I4 extends Base /* c */ {}
+interface I5 extends Base // c
+{}
+
+namespace N1 /* c */ {}
+namespace N2 // c
+{}
+namespace N3
+// c
+{}
+namespace A.B /* c */ {}
+
+declare module "m1" /* c */ {}
+declare module "m2" // c
+{}
+
+declare global /* c */ {}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Comments between a declaration's head and its body `{` stay outside the
+// braces (head-body comment policy): a block comment inline, a line comment
+// keeping its position with the `{` forced onto the next line, an own-line
+// comment keeping its own line.
+// Known divergence (typescript/interface{,2}/comments*.ts): Prettier pulls
+// line and own-line comments inside the braces (`{\n  // c`), or past them
+// entirely for enum/namespace (`enum E {} // c`) -- attachment artifacts of
+// the kind prettier is currently fixing elsewhere (prettier#19894 family,
+// open prettier#5900).
+enum E1 /* c */ {}
+enum E2 // c
+{}
+enum E3
+// c
+{}
+
+interface I1 /* c */ {}
+interface I2 // c
+{}
+interface I3
+// c
+{}
+interface I4 extends Base /* c */ {}
+interface I5 extends Base // c
+{}
+
+namespace N1 /* c */ {}
+namespace N2 // c
+{}
+namespace N3
+// c
+{}
+namespace A.B /* c */ {}
+
+declare module "m1" /* c */ {}
+declare module "m2" // c
+{}
+
+declare global /* c */ {}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/if.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/if.ts
@@ -1,3 +1,6 @@
+// Known divergence: the blank line between `// comment2` and `else` is
+// preserved, as in every other leading-comment position; Prettier collapses
+// it only here.
 if (true) {}
 
 // comment1

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/if.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/if.ts.snap
@@ -2,6 +2,9 @@
 source: crates/oxc_formatter/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
+// Known divergence: the blank line between `// comment2` and `else` is
+// preserved, as in every other leading-comment position; Prettier collapses
+// it only here.
 if (true) {}
 
 // comment1
@@ -14,6 +17,9 @@ else {}
 ------------------
 { printWidth: 80 }
 ------------------
+// Known divergence: the blank line between `// comment2` and `else` is
+// preserved, as in every other leading-comment position; Prettier collapses
+// it only here.
 if (true) {
 }
 
@@ -22,12 +28,16 @@ else if (false) {
 }
 
 // comment2
+
 else {
 }
 
 -------------------
 { printWidth: 100 }
 -------------------
+// Known divergence: the blank line between `// comment2` and `else` is
+// preserved, as in every other leading-comment position; Prettier collapses
+// it only here.
 if (true) {
 }
 
@@ -36,6 +46,7 @@ else if (false) {
 }
 
 // comment2
+
 else {
 }
 

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/method.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/method.ts.snap
@@ -34,12 +34,12 @@ class A {
   ): void /* block comment */ {
     // method body
   }
-  m3(tagName: string, rect: number[]): void {
-    // line comment
+  m3(tagName: string, rect: number[]): void // line comment
+  {
     // method body
   }
-  m4(tagName: string, rect: number[]) {
-    // line comment
+  m4(tagName: string, rect: number[]) // line comment
+  {
     // method body
   }
 }
@@ -54,12 +54,12 @@ class A {
   m2(element: Element, key: string, undefined: undefined): void /* block comment */ {
     // method body
   }
-  m3(tagName: string, rect: number[]): void {
-    // line comment
+  m3(tagName: string, rect: number[]): void // line comment
+  {
     // method body
   }
-  m4(tagName: string, rect: number[]) {
-    // line comment
+  m4(tagName: string, rect: number[]) // line comment
+  {
     // method body
   }
 }

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
@@ -2,25 +2,31 @@
 source: crates/oxc_formatter/tests/conformance.rs
 expression: report
 ---
-js compatibility: 778/810 (96.05%), 23 files skipped
+js compatibility: 767/810 (94.69%), 23 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
-| js/arrows/issue-17421.js | 💥💥 | 90.43% |
+| js/arrows/issue-17421.js | 💥💥 | 88.70% |
 | js/assignment-comments/indentable-block-comment.js | 💥 | 12.50% |
 | js/assignment-comments/string.js | 💥 | 96.59% |
 | js/binary-expressions/mutiple-comments/17192.js | 💥✨ | 45.83% |
 | js/call/no-argument/no-arguments.js | 💥 | 57.53% |
+| js/class-comment/misc.js | 💥 | 66.67% |
+| js/class-comment/superclass.js | 💥 | 70.33% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
+| js/comments/function-declaration.js | 💥💥 | 92.80% |
 | js/comments/return-statement-2.js | 💥💥 | 87.32% |
 | js/comments/return-statement.js | 💥💥 | 97.25% |
 | js/comments/tagged-template-literal.js | 💥💥 | 89.66% |
+| js/comments/try.js | 💥💥 | 66.67% |
 | js/comments/assignment/variable-declarator.js | 💥 | 88.00% |
-| js/comments/between-head-and-body/between-head-and-body.js | 💥 | 87.89% |
-| js/comments/between-head-and-body/empty-statement.js | 💥 | 66.27% |
+| js/comments/between-head-and-body/between-head-and-body.js | 💥 | 92.83% |
+| js/comments/between-head-and-body/empty-statement.js | 💥 | 77.38% |
 | js/comments/first-argument/first-argument.js | 💥 | 92.98% |
+| js/comments/function/18146.js | 💥 | 51.80% |
+| js/comments/function/between-parentheses-and-function-body.js | 💥 | 47.62% |
 | js/comments/in-list/dangling-comment-in-list.js | 💥 | 95.91% |
 | js/comments-closure-typecast/closure-compiler-type-cast.js | 💥 | 88.00% |
 | js/comments-closure-typecast/iife.js | 💥 | 76.92% |
@@ -29,9 +35,12 @@ js compatibility: 778/810 (96.05%), 23 files skipped
 | js/for-of/comments.js | 💥 | 42.11% |
 | js/function/iife.js | 💥 | 14.89% |
 | js/function/issue-12967.js | 💥 | 0.00% |
-| js/if/blank-lines.js | 💥 | 94.83% |
+| js/if/expr_and_same_line_comments.js | 💥 | 81.93% |
+| js/if/issue-15168.js | 💥 | 91.43% |
+| js/if/non-block.js | 💥 | 82.35% |
 | js/if/condition-break/boolean-expression.js | 💥 | 94.03% |
 | js/if/condition-break/unary-expression.js | 💥 | 61.38% |
+| js/label/comment.js | 💥 | 58.82% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 0.00% |
 | js/logical-expressions/in-unary-expression.js | 💥 | 79.49% |
 | js/sequence-expression/parenthesized-trailing-comment-unstable.js | 💥 | 66.67% |
@@ -40,6 +49,8 @@ js compatibility: 778/810 (96.05%), 23 files skipped
 | js/template-literals/expression-break.js | 💥 | 80.00% |
 | js/template-literals/expressions.js | 💥 | 97.64% |
 | js/test-declarations/jest-each.js | 💥💥 | 95.71% |
+| js/trailing-comma/trailing_whitespace.js | 💥💥💥 | 96.55% |
+| js/try/try.js | 💥 | 44.44% |
 
 # Skipped (parse error, TODO: should be ignored or supported)
 
@@ -73,7 +84,6 @@ js compatibility: 778/810 (96.05%), 23 files skipped
 - js/arrays/numbers-with-holes.js
 - js/arrows/arrow-chain-with-trailing-comments.js
 - js/comments/return-statement.js
-- js/comments/between-head-and-body/empty-statement.js
 - js/comments/first-argument/first-argument.js
 - js/for/continue-and-break-comment-without-blocks.js
 - js/function/issue-12967.js

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-ts.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-ts.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_formatter/tests/conformance.rs
 expression: report
 ---
-ts compatibility: 629/659 (95.45%), 16 files skipped
+ts compatibility: 624/659 (94.69%), 16 files skipped
 
 # Failed
 
@@ -13,12 +13,17 @@ ts compatibility: 629/659 (95.45%), 16 files skipped
 | typescript/as/comments/17407.ts | 💥 | 47.06% |
 | typescript/call/callee-comments.ts | 💥 | 75.00% |
 | typescript/cast/18406.ts | 💥 | 84.21% |
+| typescript/class-comment/class-implements.ts | 💥 | 93.33% |
+| typescript/class-comment/declare.ts | 💥 | 72.00% |
 | typescript/comments/method_types.ts | 💥 | 82.05% |
 | typescript/comments/type-parameters.ts | 💥 | 81.82% |
 | typescript/comments/first-argument/first-argument.ts | 💥 | 81.16% |
 | typescript/conformance/types/union/unionTypeCallSignatures.ts | 💥 | 85.25% |
 | typescript/conformance/types/union/unionTypeConstructSignatures.ts | 💥 | 91.62% |
 | typescript/conformance/types/union/unionTypeIndexSignature.ts | 💥 | 83.64% |
+| typescript/interface/comments-generic.ts | 💥💥 | 91.80% |
+| typescript/interface2/comments-declare.ts | 💥 | 60.00% |
+| typescript/interface2/comments.ts | 💥 | 65.79% |
 | typescript/intersection/intersection-parens.ts | 💥💥✨ | 65.96% |
 | typescript/intersection/consistent-with-flow/intersection-parens.ts | 💥 | 97.67% |
 | typescript/intersection/consistent-with-flow/single-member.ts | 💥 | 88.24% |

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -40,7 +40,7 @@ pdf.mjs:
   sys peak growth: 1156432 # 1.16 MB
   arena allocs: 427306
   arena reallocs: 428
-  arena size: 29358712 # 29.36 MB
+  arena size: 29360200 # 29.36 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -51,7 +51,7 @@ antd.js:
   sys peak growth: 50737424 # 50.74 MB
   arena allocs: 2503532
   arena reallocs: 1889
-  arena size: 244457832 # 244.46 MB
+  arena size: 244459008 # 244.46 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB


### PR DESCRIPTION
Fix inconsisntet and also non-idempotent formatting around:

```js
  m3(tagName: string, rect: number[]): void // THIS should stay
  {
    // ...
  }
```
