### PR TITLE
fix(formatter): keep comments in their for-head slot, before an empty-statement body and do-while

### DIFF
--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -183,13 +183,7 @@ impl<'a> Comments<'a> {
         &self.unprinted_comments()[..index]
     }
 
-    /// Returns all block comments that end before or at the given position.
-    pub fn block_comments_before(&self, pos: u32) -> &'a [Comment] {
-        let index = self.comments_before_iter(pos).take_while(|c| c.is_block()).count();
-        &self.unprinted_comments()[..index]
-    }
-
-    /// Returns all block comments that end before or at the given position.
+    /// Returns all line comments that end before or at the given position.
     pub fn line_comments_before(&self, pos: u32) -> &'a [Comment] {
         let index = self.comments_before_iter(pos).take_while(|c| c.is_line()).count();
         &self.unprinted_comments()[..index]
@@ -250,6 +244,35 @@ impl<'a> Comments<'a> {
         }
 
         comments
+    }
+
+    /// Position just past the first instance of `character` at or after `start`.
+    /// Unlike the unprinted-comment queries, this skips every comment's interior (printed ones included),
+    /// so `character` inside a comment cannot false-match.
+    ///
+    /// Same lexical contract as [`Self::comments_before_character`],
+    /// and `character` must occur in the scanned range (guaranteed by grammar at the call sites).
+    pub(crate) fn position_after_character(&self, start: u32, character: u8) -> u32 {
+        // An empty sentinel span at end-of-source makes the tail just another gap
+        let source_end = u32::try_from(self.source_text.as_str().len()).unwrap();
+        let first = self.inner.partition_point(|comment| comment.span.start < start);
+        let mut cursor = start;
+        for span in self.inner[first..]
+            .iter()
+            .map(|comment| comment.span)
+            .chain(std::iter::once(Span::empty(source_end)))
+        {
+            if let Some(offset) = self
+                .source_text
+                .bytes_range(cursor, span.start)
+                .iter()
+                .position(|&byte| byte == character)
+            {
+                return cursor + u32::try_from(offset).unwrap() + 1;
+            }
+            cursor = span.end;
+        }
+        unreachable!("the caller guarantees the character occurs outside a comment")
     }
 
     /// Comments sitting between `pos` and a closing source paren:

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -81,7 +81,7 @@ use crate::{
         },
         statement_body::{
             FormatStatementBody, write_comments_between_blocks, write_head_body_separator,
-            write_node_with_trailing_comments_before,
+            write_node_with_trailing_comments_before, write_trailing_comments_before,
         },
         string::{FormatLiteralStringToken, StringLiteralParentKind},
         suppressed::FormatSuppressedNode,
@@ -808,11 +808,25 @@ impl<'a> FormatWrite<'a> for AstNode<'a, DoWhileStatement<'a>> {
 
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let body = self.body();
-        write!(f, group(&format_args!("do", FormatStatementBody::new(body))));
-        if matches!(body.as_ref(), Statement::BlockStatement(_)) {
-            write!(f, space());
+        let is_block_body = matches!(body.as_ref(), Statement::BlockStatement(_));
+        if is_block_body {
+            // The block's trailing pass would claim a comment past the `while` keyword;
+            // the keyword site splits the comments instead.
+            write!(f, "do");
+            write_head_body_separator(body.span().start, f);
+            FormatNodeWithoutTrailingComments(body).fmt(f);
         } else {
-            write!(f, hard_line_break());
+            write!(f, group(&format_args!("do", FormatStatementBody::new(body))));
+        }
+
+        // Lexical scan for the keyword's first byte: the gap holds only trivia and `while`
+        let comments = f.context().comments().comments_before_character(body.span().end, b'w');
+        if write_comments_between_blocks(comments, f) {
+            if is_block_body {
+                write!(f, space());
+            } else {
+                write!(f, hard_line_break());
+            }
         }
 
         // Comments inside the parens belong to the test and stay there;
@@ -833,44 +847,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, DoWhileStatement<'a>> {
     }
 }
 
-/// Formats comments that appear before empty statements in control structures.
-///
-/// Example:
-/// ```js
-/// // Input:
-/// for (init;;) /* comment */ ;
-/// for (init;;update) /* comment */ ;
-/// for (init of iterable) /* comment */ ;
-/// for (init in iterable) /* comment */ ;
-/// while (test) /* comment */ ;
-/// if (test) /* comment */ ;
-///
-/// // Output:
-/// for (init /* comment */;; );
-/// for (init; ; update /* comment */);
-/// for (init of iterable /* comment */) ;
-/// for (init in iterable /* comment */) ;
-/// while (test /* comment */) ;
-/// if (test /* comment */) ;
-/// ```
-///
-/// This ensures compatibility with [Prettier's comment handling for empty statements](https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/comments/printer-methods.js#L15).
-struct FormatCommentForEmptyStatement<'a, 'b>(&'b AstNode<'a, Statement<'a>>);
-impl<'a> Format<'a, JsFormatContext<'a>> for FormatCommentForEmptyStatement<'a, '_> {
-    fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        if let AstNodes::EmptyStatement(empty) = self.0.as_ast_nodes() {
-            let comments = f.context().comments().comments_before(empty.span.start);
-            FormatTrailingComments::Comments(comments).fmt(f);
-            empty.format_trailing_comments(f);
-        }
-    }
-}
-
 /// The rightmost expression inside a statement head's parentheses
 /// (if/while test, for-in/for-of right, with object),
 /// printed without its generic trailing pass so the head's `)` bounds its comments.
-/// Comments past the `)` are left pending: for the statement body's leading pass,
-/// or the caller's `FormatCommentForEmptyStatement` where one applies.
+/// Comments past the `)` are left pending for the statement body's leading pass.
 struct FormatParenHeadExpression<'a, 'b> {
     expression: &'b AstNode<'a, Expression<'a>>,
     /// Start of the statement's body;
@@ -878,6 +858,7 @@ struct FormatParenHeadExpression<'a, 'b> {
     /// and it bounds the lexical scan (see `Comments::end_including_source_parens`).
     body_start: u32,
 }
+
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatParenHeadExpression<'a, '_> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         // `FormatNodeWithoutTrailingComments` already handles suppression comments internally,
@@ -907,6 +888,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatParenHeadExpression<'a, '_> {
         }
     }
 }
+
 impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
     fn write_suppressed(&self, f: &mut JsFormatter<'_, 'a>) {
         let (content_end, print_semicolon) = suppressed_statement_content_end(&self.body, f);
@@ -921,18 +903,37 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
                 "while",
                 space(),
                 "(",
-                group(&soft_block_indent(&format_args!(
-                    FormatParenHeadExpression {
-                        expression: self.test(),
-                        body_start: body.span().start
-                    },
-                    FormatCommentForEmptyStatement(body)
-                ))),
+                group(&soft_block_indent(&FormatParenHeadExpression {
+                    expression: self.test(),
+                    body_start: body.span().start
+                })),
                 ")",
                 FormatStatementBody::new(body)
             ))
         );
     }
+}
+
+/// A for-head `;`-bounded slot (init/test):
+/// the node (if any) with its trailing comments bounded at the slot's closing `;`,
+/// or the slot's pending comments alone when it is empty.
+/// Returns the scan cursor advanced past the `;`
+/// (the next slot's anchor when that slot has no node).
+///
+/// The update slot is different:
+/// its closing token is the head's `)`, which a parenthesized update's own `)` would false-match.
+/// It reuses `FormatParenHeadExpression` (whose `end_including_source_parens` scan resolves the right `)`) instead.
+fn write_for_head_slot<'a, T>(node: Option<&T>, cursor: u32, f: &mut JsFormatter<'_, 'a>) -> u32
+where
+    T: Format<'a, JsFormatContext<'a>> + GetSpan,
+{
+    let anchor = node.map_or(cursor, |node| node.span().end);
+    if let Some(node) = node {
+        write_node_with_trailing_comments_before(node, b';', f);
+    } else {
+        write_trailing_comments_before(anchor, b';', f);
+    }
+    f.comments().position_after_character(anchor, b';')
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
@@ -946,37 +947,55 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
         let test = self.test();
         let update = self.update();
         let body = self.body();
-        let format_body = FormatStatementBody::new(body);
-        if init.is_none() && test.is_none() && update.is_none() {
-            return write!(f, [group(&format_args!("for", space(), "(;;)", format_body))]);
-        }
+        // `for (;;)` prints without the slot separator spaces
+        let is_headless = init.is_none() && test.is_none() && update.is_none();
 
-        let format_inner = format_with(|f| {
-            write!(
-                f,
-                [
-                    "for",
-                    space(),
-                    "(",
-                    group(&soft_block_indent(&format_args!(
-                        init,
-                        (test.is_none() && update.is_none())
-                            .then_some(FormatCommentForEmptyStatement(body)),
-                        ";",
-                        soft_line_break_or_space(),
-                        test,
-                        (update.is_none()).then_some(FormatCommentForEmptyStatement(body)),
-                        ";",
-                        update.is_some().then_some(soft_line_break_or_space()),
-                        update,
-                        FormatCommentForEmptyStatement(body)
-                    ))),
-                    ")",
-                    format_body
-                ]
-            );
+        let format_head = format_once(|f| {
+            // Comments keep their side of the head's `;`s and its `)` (comments after the `)` lead the body);
+            // each slot owns the comments before its closing token, with or without a node to anchor on.
+            // Lexical scans: each gap holds only trivia and `;`.
+            if f.comments().has_comment_before(body.span().start) {
+                let mut cursor = f.comments().position_after_character(self.span().start, b'(');
+                cursor = write_for_head_slot(init, cursor, f);
+                write!(f, ";");
+                if !is_headless {
+                    write!(f, soft_line_break_or_space());
+                }
+                cursor = write_for_head_slot(test, cursor, f);
+                write!(f, ";");
+                if update.is_some() {
+                    write!(f, soft_line_break_or_space());
+                }
+                if let Some(update) = update {
+                    FormatParenHeadExpression { expression: update, body_start: body.span().start }
+                        .fmt(f);
+                } else {
+                    write_trailing_comments_before(cursor, b')', f);
+                }
+            } else {
+                // No comment can need placing; skip the lexical scans
+                write!(f, [init, ";"]);
+                if !is_headless {
+                    write!(f, soft_line_break_or_space());
+                }
+                write!(f, [test, ";"]);
+                if update.is_some() {
+                    write!(f, soft_line_break_or_space());
+                }
+                write!(f, update);
+            }
         });
-        write!(f, group(&format_inner));
+        write!(
+            f,
+            group(&format_args!(
+                "for",
+                space(),
+                "(",
+                group(&soft_block_indent(&format_head)),
+                ")",
+                FormatStatementBody::new(body)
+            ))
+        );
     }
 }
 
@@ -1015,7 +1034,6 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForInStatement<'a>> {
                     expression: self.right(),
                     body_start: body.span().start
                 },
-                FormatCommentForEmptyStatement(body),
                 // Flushes a pending in-paren line comment before the `)`
                 // (this head is ungrouped, so no break would flush it otherwise)
                 line_suffix_boundary(),

--- a/crates/oxc_formatter/src/utils/statement_body.rs
+++ b/crates/oxc_formatter/src/utils/statement_body.rs
@@ -59,8 +59,37 @@ pub fn write_node_with_trailing_comments_before<'a, T>(
     T: Format<'a, JsFormatContext<'a>> + GetSpan,
 {
     FormatNodeWithoutTrailingComments(node).fmt(f);
-    let comments = f.context().comments().comments_before_character(node.span().end, character);
-    FormatTrailingComments::Comments(comments).fmt(f);
+    write_trailing_comments_before(node.span().end, character, f);
+}
+
+/// The node-less half of [`write_node_with_trailing_comments_before`]:
+/// prints the pending comments bounded at the next `character` as trailing comments
+/// (e.g. an empty for-head slot's comments before its `;`).
+pub fn write_trailing_comments_before(start: u32, character: u8, f: &mut JsFormatter<'_, '_>) {
+    let comments = f.context().comments().comments_before_character(start, character);
+    let same_line_count =
+        comments.iter().take_while(|comment| !comment.preceded_by_newline()).count();
+    let (same_line, own_line) = comments.split_at(same_line_count);
+
+    FormatTrailingComments::Comments(same_line).fmt(f);
+    // Own-line comments print in place, never via `line_suffix`:
+    // deferred, they would escape past the caller's token (and whatever follows before the flush).
+    // The hard break both flushes a pending same-line line comment and expands the enclosing group,
+    // as the own-line invariant requires;
+    // the caller's token follows a block comment directly (`/* c */;`),
+    // the stable form its own broken output re-parses to.
+    for comment in own_line {
+        if f.lines_before(comment.span) > 1 {
+            write!(f, empty_line());
+        } else {
+            write!(f, hard_line_break());
+        }
+        f.context_mut().comments_mut().increment_printed_count();
+        write!(f, comment);
+        if comment.is_line() {
+            write!(f, hard_line_break());
+        }
+    }
 }
 
 /// Comments between a block's `}` and a following keyword (`else`/`catch`/`finally`)
@@ -123,11 +152,10 @@ impl<'a, 'b> FormatStatementBody<'a, 'b> {
 impl<'a> Format<'a, JsFormatContext<'a>> for FormatStatementBody<'a, '_> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         if let AstNodes::EmptyStatement(empty) = self.body.as_ast_nodes() {
-            // Add space before empty statement if it has leading comments
-            // e.g., `for (x of y) /*comment*/ ;`
-            let has_leading_comments = f.context().comments().has_comment_before(empty.span.start);
-            if has_leading_comments {
-                write!(f, [space()]);
+            // The `;` IS the body (content), so the head-body separator applies before it too;
+            // without comments no separator is written (`while (x);`).
+            if f.context().comments().has_comment_before(empty.span.start) {
+                write_head_body_separator(empty.span.start, f);
             }
             write!(f, empty);
         } else if let AstNodes::BlockStatement(block) = self.body.as_ast_nodes() {

--- a/crates/oxc_formatter/tests/fixtures/js/comments/do-while-head.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/do-while-head.js
@@ -1,0 +1,17 @@
+// Comments between a do-body's `}` and the `while` keyword keep their
+// positions (head-body comment policy), like the `else`/`catch`/`finally` gaps.
+// Known divergence (js/comments/between-head-and-body/between-head-and-body.js):
+// Prettier flushes a line comment past the whole `while (x);` head and pulls an
+// own-line comment into the parens (`while (\n// a\nx)`) -- attachment
+// artifacts of the kind prettier is currently fixing elsewhere
+// (prettier#19894 family).
+do {} /* a */ while (x);
+do {} // a
+while (x);
+do {}
+// a
+while (x);
+do x();
+// a
+while (y);
+do {} while (x); // real trailing

--- a/crates/oxc_formatter/tests/fixtures/js/comments/do-while-head.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/do-while-head.js.snap
@@ -1,0 +1,66 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Comments between a do-body's `}` and the `while` keyword keep their
+// positions (head-body comment policy), like the `else`/`catch`/`finally` gaps.
+// Known divergence (js/comments/between-head-and-body/between-head-and-body.js):
+// Prettier flushes a line comment past the whole `while (x);` head and pulls an
+// own-line comment into the parens (`while (\n// a\nx)`) -- attachment
+// artifacts of the kind prettier is currently fixing elsewhere
+// (prettier#19894 family).
+do {} /* a */ while (x);
+do {} // a
+while (x);
+do {}
+// a
+while (x);
+do x();
+// a
+while (y);
+do {} while (x); // real trailing
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Comments between a do-body's `}` and the `while` keyword keep their
+// positions (head-body comment policy), like the `else`/`catch`/`finally` gaps.
+// Known divergence (js/comments/between-head-and-body/between-head-and-body.js):
+// Prettier flushes a line comment past the whole `while (x);` head and pulls an
+// own-line comment into the parens (`while (\n// a\nx)`) -- attachment
+// artifacts of the kind prettier is currently fixing elsewhere
+// (prettier#19894 family).
+do {} /* a */ while (x);
+do {} // a
+while (x);
+do {}
+// a
+while (x);
+do x();
+// a
+while (y);
+do {} while (x); // real trailing
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Comments between a do-body's `}` and the `while` keyword keep their
+// positions (head-body comment policy), like the `else`/`catch`/`finally` gaps.
+// Known divergence (js/comments/between-head-and-body/between-head-and-body.js):
+// Prettier flushes a line comment past the whole `while (x);` head and pulls an
+// own-line comment into the parens (`while (\n// a\nx)`) -- attachment
+// artifacts of the kind prettier is currently fixing elsewhere
+// (prettier#19894 family).
+do {} /* a */ while (x);
+do {} // a
+while (x);
+do {}
+// a
+while (x);
+do x();
+// a
+while (y);
+do {} while (x); // real trailing
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/empty-statement-head.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/empty-statement-head.js
@@ -1,0 +1,25 @@
+// A comment between a head's `)` and its empty-statement body `;` keeps its
+// position (the `;` is content, head-body comment policy): an inline block
+// comment stays, a line comment keeps its line with the `;` forced onto the
+// next line, an own-line comment keeps its own line.
+// Known divergences (js/comments/between-head-and-body/empty-statement.js,
+// js/for/9812-2.js, js/for-of/comments.js): Prettier pulls the comment
+// backward into the parentheses (`while (x /* c */);`) or hoists an own-line
+// comment onto the head line (`for (x of y) // c`) -- attachment artifacts of
+// the kind prettier is currently fixing elsewhere (prettier#19894 family).
+while (a) /* c */;
+while (a) // c
+;
+while (a)
+// c
+;
+
+for (a;;) /* c */;
+for (a; b; c) /* c */;
+for (x in y) /* c */;
+for (x of y) /* c */;
+for (x of y)
+// c
+;
+if (a) /* c */;
+with (a) /* c */;

--- a/crates/oxc_formatter/tests/fixtures/js/comments/empty-statement-head.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/empty-statement-head.js.snap
@@ -1,0 +1,90 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A comment between a head's `)` and its empty-statement body `;` keeps its
+// position (the `;` is content, head-body comment policy): an inline block
+// comment stays, a line comment keeps its line with the `;` forced onto the
+// next line, an own-line comment keeps its own line.
+// Known divergences (js/comments/between-head-and-body/empty-statement.js,
+// js/for/9812-2.js, js/for-of/comments.js): Prettier pulls the comment
+// backward into the parentheses (`while (x /* c */);`) or hoists an own-line
+// comment onto the head line (`for (x of y) // c`) -- attachment artifacts of
+// the kind prettier is currently fixing elsewhere (prettier#19894 family).
+while (a) /* c */;
+while (a) // c
+;
+while (a)
+// c
+;
+
+for (a;;) /* c */;
+for (a; b; c) /* c */;
+for (x in y) /* c */;
+for (x of y) /* c */;
+for (x of y)
+// c
+;
+if (a) /* c */;
+with (a) /* c */;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A comment between a head's `)` and its empty-statement body `;` keeps its
+// position (the `;` is content, head-body comment policy): an inline block
+// comment stays, a line comment keeps its line with the `;` forced onto the
+// next line, an own-line comment keeps its own line.
+// Known divergences (js/comments/between-head-and-body/empty-statement.js,
+// js/for/9812-2.js, js/for-of/comments.js): Prettier pulls the comment
+// backward into the parentheses (`while (x /* c */);`) or hoists an own-line
+// comment onto the head line (`for (x of y) // c`) -- attachment artifacts of
+// the kind prettier is currently fixing elsewhere (prettier#19894 family).
+while (a) /* c */ ;
+while (a) // c
+;
+while (a)
+// c
+;
+
+for (a; ;) /* c */ ;
+for (a; b; c) /* c */ ;
+for (x in y) /* c */ ;
+for (x of y) /* c */ ;
+for (x of y)
+// c
+;
+if (a) /* c */ ;
+with (a) /* c */ ;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A comment between a head's `)` and its empty-statement body `;` keeps its
+// position (the `;` is content, head-body comment policy): an inline block
+// comment stays, a line comment keeps its line with the `;` forced onto the
+// next line, an own-line comment keeps its own line.
+// Known divergences (js/comments/between-head-and-body/empty-statement.js,
+// js/for/9812-2.js, js/for-of/comments.js): Prettier pulls the comment
+// backward into the parentheses (`while (x /* c */);`) or hoists an own-line
+// comment onto the head line (`for (x of y) // c`) -- attachment artifacts of
+// the kind prettier is currently fixing elsewhere (prettier#19894 family).
+while (a) /* c */ ;
+while (a) // c
+;
+while (a)
+// c
+;
+
+for (a; ;) /* c */ ;
+for (a; b; c) /* c */ ;
+for (x in y) /* c */ ;
+for (x of y) /* c */ ;
+for (x of y)
+// c
+;
+if (a) /* c */ ;
+with (a) /* c */ ;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/for-head-slots.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/for-head-slots.js
@@ -1,0 +1,17 @@
+// Comments in a classic for-head keep their slot: they never cross the head's
+// `;`s or its `)` in either direction, with or without a node in the slot.
+// Known divergence (js/explicit-resource-management/valid-await-using-comments.js):
+// Prettier moves empty-slot comments backward across the `;`s onto the init
+// (`for (a /*8*/ /*9*/;;)`) -- an attachment artifact of the kind prettier is
+// currently fixing elsewhere (prettier#19894 family).
+for (a; /*8*/; /*9*/) ;
+for (a;; /* c */) ;
+for (a;; /* c */) {}
+for (a /* c */;;) ;
+for (a; b /* c */;) {}
+for (; /*t*/ b;) ;
+for (/*s0*/;;) ;
+for (;/*s1*/;) {}
+for (;;/*s2*/) ;
+for (/*s0*/; /*s1*/; /*s2*/) ;
+for (;;) /* after */ ;

--- a/crates/oxc_formatter/tests/fixtures/js/comments/for-head-slots.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/for-head-slots.js.snap
@@ -1,0 +1,66 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Comments in a classic for-head keep their slot: they never cross the head's
+// `;`s or its `)` in either direction, with or without a node in the slot.
+// Known divergence (js/explicit-resource-management/valid-await-using-comments.js):
+// Prettier moves empty-slot comments backward across the `;`s onto the init
+// (`for (a /*8*/ /*9*/;;)`) -- an attachment artifact of the kind prettier is
+// currently fixing elsewhere (prettier#19894 family).
+for (a; /*8*/; /*9*/) ;
+for (a;; /* c */) ;
+for (a;; /* c */) {}
+for (a /* c */;;) ;
+for (a; b /* c */;) {}
+for (; /*t*/ b;) ;
+for (/*s0*/;;) ;
+for (;/*s1*/;) {}
+for (;;/*s2*/) ;
+for (/*s0*/; /*s1*/; /*s2*/) ;
+for (;;) /* after */ ;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Comments in a classic for-head keep their slot: they never cross the head's
+// `;`s or its `)` in either direction, with or without a node in the slot.
+// Known divergence (js/explicit-resource-management/valid-await-using-comments.js):
+// Prettier moves empty-slot comments backward across the `;`s onto the init
+// (`for (a /*8*/ /*9*/;;)`) -- an attachment artifact of the kind prettier is
+// currently fixing elsewhere (prettier#19894 family).
+for (a; /*8*/; /*9*/);
+for (a; ; /* c */);
+for (a; ; /* c */) {}
+for (a /* c */; ;);
+for (a; b /* c */;) {}
+for (; /*t*/ b;);
+for ( /*s0*/;;);
+for (; /*s1*/;) {}
+for (;; /*s2*/);
+for ( /*s0*/; /*s1*/; /*s2*/);
+for (;;) /* after */ ;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Comments in a classic for-head keep their slot: they never cross the head's
+// `;`s or its `)` in either direction, with or without a node in the slot.
+// Known divergence (js/explicit-resource-management/valid-await-using-comments.js):
+// Prettier moves empty-slot comments backward across the `;`s onto the init
+// (`for (a /*8*/ /*9*/;;)`) -- an attachment artifact of the kind prettier is
+// currently fixing elsewhere (prettier#19894 family).
+for (a; /*8*/; /*9*/);
+for (a; ; /* c */);
+for (a; ; /* c */) {}
+for (a /* c */; ;);
+for (a; b /* c */;) {}
+for (; /*t*/ b;);
+for ( /*s0*/;;);
+for (; /*s1*/;) {}
+for (;; /*s2*/);
+for ( /*s0*/; /*s1*/; /*s2*/);
+for (;;) /* after */ ;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/multiline-block-head.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/multiline-block-head.js
@@ -1,0 +1,30 @@
+// A multiline block comment between a head and its `{` stays inline like any
+// other same-line block comment (head-body comment policy, no exception for
+// multiline content).
+// Known divergence (js/comments/between-head-and-body/between-head-and-body.js):
+// Prettier moves it onto its own line for while/do/else heads only, keeping it
+// inline everywhere else -- an internal inconsistency, one uniform rule instead.
+while (x) /* one
+two */ {}
+do /*
+c */ {} while (y);
+if (x) {} else /* p
+q */ {}
+
+// Inline everywhere else in both formatters (control)
+function f() /* a
+b */ {}
+class A /* a
+b */ {}
+try /* a
+b */ {} catch (e) /* c
+d */ {} finally /* e
+f */ {}
+foo: /* a
+b */ {
+  break foo;
+}
+while (x) /* a
+b */;
+do {} /* a
+b */ while (y);

--- a/crates/oxc_formatter/tests/fixtures/js/comments/multiline-block-head.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/multiline-block-head.js.snap
@@ -1,0 +1,115 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// A multiline block comment between a head and its `{` stays inline like any
+// other same-line block comment (head-body comment policy, no exception for
+// multiline content).
+// Known divergence (js/comments/between-head-and-body/between-head-and-body.js):
+// Prettier moves it onto its own line for while/do/else heads only, keeping it
+// inline everywhere else -- an internal inconsistency, one uniform rule instead.
+while (x) /* one
+two */ {}
+do /*
+c */ {} while (y);
+if (x) {} else /* p
+q */ {}
+
+// Inline everywhere else in both formatters (control)
+function f() /* a
+b */ {}
+class A /* a
+b */ {}
+try /* a
+b */ {} catch (e) /* c
+d */ {} finally /* e
+f */ {}
+foo: /* a
+b */ {
+  break foo;
+}
+while (x) /* a
+b */;
+do {} /* a
+b */ while (y);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// A multiline block comment between a head and its `{` stays inline like any
+// other same-line block comment (head-body comment policy, no exception for
+// multiline content).
+// Known divergence (js/comments/between-head-and-body/between-head-and-body.js):
+// Prettier moves it onto its own line for while/do/else heads only, keeping it
+// inline everywhere else -- an internal inconsistency, one uniform rule instead.
+while (x) /* one
+two */ {}
+do /*
+c */ {} while (y);
+if (x) {
+} else /* p
+q */ {
+}
+
+// Inline everywhere else in both formatters (control)
+function f() /* a
+b */ {}
+class A /* a
+b */ {}
+try /* a
+b */ {
+} catch (e) /* c
+d */ {
+} finally /* e
+f */ {
+}
+foo: /* a
+b */ {
+  break foo;
+}
+while (x) /* a
+b */ ;
+do {} /* a
+b */ while (y);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// A multiline block comment between a head and its `{` stays inline like any
+// other same-line block comment (head-body comment policy, no exception for
+// multiline content).
+// Known divergence (js/comments/between-head-and-body/between-head-and-body.js):
+// Prettier moves it onto its own line for while/do/else heads only, keeping it
+// inline everywhere else -- an internal inconsistency, one uniform rule instead.
+while (x) /* one
+two */ {}
+do /*
+c */ {} while (y);
+if (x) {
+} else /* p
+q */ {
+}
+
+// Inline everywhere else in both formatters (control)
+function f() /* a
+b */ {}
+class A /* a
+b */ {}
+try /* a
+b */ {
+} catch (e) /* c
+d */ {
+} finally /* e
+f */ {
+}
+foo: /* a
+b */ {
+  break foo;
+}
+while (x) /* a
+b */ ;
+do {} /* a
+b */ while (y);
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
+++ b/crates/oxc_formatter/tests/snapshots/conformance__prettier-js.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_formatter/tests/conformance.rs
 expression: report
 ---
-js compatibility: 767/810 (94.69%), 23 files skipped
+js compatibility: 766/810 (94.57%), 23 files skipped
 
 # Failed
 
@@ -22,17 +22,18 @@ js compatibility: 767/810 (94.69%), 23 files skipped
 | js/comments/tagged-template-literal.js | 💥💥 | 89.66% |
 | js/comments/try.js | 💥💥 | 66.67% |
 | js/comments/assignment/variable-declarator.js | 💥 | 88.00% |
-| js/comments/between-head-and-body/between-head-and-body.js | 💥 | 92.83% |
-| js/comments/between-head-and-body/empty-statement.js | 💥 | 77.38% |
+| js/comments/between-head-and-body/between-head-and-body.js | 💥 | 90.85% |
+| js/comments/between-head-and-body/empty-statement.js | 💥 | 86.05% |
 | js/comments/first-argument/first-argument.js | 💥 | 92.98% |
 | js/comments/function/18146.js | 💥 | 51.80% |
 | js/comments/function/between-parentheses-and-function-body.js | 💥 | 47.62% |
 | js/comments/in-list/dangling-comment-in-list.js | 💥 | 95.91% |
 | js/comments-closure-typecast/closure-compiler-type-cast.js | 💥 | 88.00% |
 | js/comments-closure-typecast/iife.js | 💥 | 76.92% |
-| js/explicit-resource-management/valid-await-using-comments.js | 💥 | 85.71% |
+| js/explicit-resource-management/valid-await-using-comments.js | 💥 | 88.24% |
+| js/for/9812-2.js | 💥 | 88.89% |
 | js/for/continue-and-break-comment-without-blocks.js | 💥 | 74.24% |
-| js/for-of/comments.js | 💥 | 42.11% |
+| js/for-of/comments.js | 💥 | 44.83% |
 | js/function/iife.js | 💥 | 14.89% |
 | js/function/issue-12967.js | 💥 | 0.00% |
 | js/if/expr_and_same_line_comments.js | 💥 | 81.93% |

--- a/tasks/track_memory_allocations/allocs_formatter.yaml
+++ b/tasks/track_memory_allocations/allocs_formatter.yaml
@@ -5,9 +5,9 @@ checker.ts:
   sys deallocs: 19382
   sys alloc bytes: 6767781 # 6.77 MB
   sys peak growth: 2973674 # 2.97 MB
-  arena allocs: 1062591
+  arena allocs: 1062221
   arena reallocs: 927
-  arena size: 89951672 # 89.95 MB
+  arena size: 89942128 # 89.94 MB
 
 App.tsx:
   file size: 415342 # 415.34 kB
@@ -16,7 +16,7 @@ App.tsx:
   sys deallocs: 5191
   sys alloc bytes: 1564670 # 1.56 MB
   sys peak growth: 435358 # 435.36 kB
-  arena allocs: 208770
+  arena allocs: 208764
   arena reallocs: 364
   arena size: 16832304 # 16.83 MB
 
@@ -38,9 +38,9 @@ pdf.mjs:
   sys deallocs: 9775
   sys alloc bytes: 3141552 # 3.14 MB
   sys peak growth: 1156432 # 1.16 MB
-  arena allocs: 427306
+  arena allocs: 427080
   arena reallocs: 428
-  arena size: 29360200 # 29.36 MB
+  arena size: 29354040 # 29.35 MB
 
 antd.js:
   file size: 6686316 # 6.69 MB
@@ -49,9 +49,9 @@ antd.js:
   sys deallocs: 90042
   sys alloc bytes: 76472316 # 76.47 MB
   sys peak growth: 50737424 # 50.74 MB
-  arena allocs: 2503532
+  arena allocs: 2502783
   arena reallocs: 1889
-  arena size: 244459008 # 244.46 MB
+  arena size: 244438216 # 244.44 MB
 
 binder.ts:
   file size: 193077 # 193.08 kB
@@ -60,7 +60,7 @@ binder.ts:
   sys deallocs: 972
   sys alloc bytes: 356005 # 356.00 kB
   sys peak growth: 195149 # 195.15 kB
-  arena allocs: 63109
+  arena allocs: 63089
   arena reallocs: 38
   arena size: 5665552 # 5.67 MB
 
@@ -71,6 +71,6 @@ kitchen-sink.tsx:
   sys deallocs: 17087
   sys alloc bytes: 4436340 # 4.44 MB
   sys peak growth: 1491796 # 1.49 MB
-  arena allocs: 555201
+  arena allocs: 554778
   arena reallocs: 1041
-  arena size: 38301664 # 38.30 MB
+  arena size: 38290408 # 38.29 MB


### PR DESCRIPTION
Keep comments inside `for (init; test; update)`.