### PR TITLE
fix(formatter): apply head body policy everywhere

### DIFF
--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -81,7 +81,8 @@ use crate::{
         },
         statement_body::{
             FormatStatementBody, write_comments_between_blocks, write_head_body_separator,
-            write_node_with_trailing_comments_before, write_trailing_comments_before,
+            write_node_with_terminator, write_node_with_trailing_comments_before,
+            write_trailing_comments_before,
         },
         string::{FormatLiteralStringToken, StringLiteralParentKind},
         suppressed::FormatSuppressedNode,
@@ -548,6 +549,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, EmptyStatement> {
                 | AstNodes::ForInStatement(_)
                 | AstNodes::ForOfStatement(_)
                 | AstNodes::WithStatement(_)
+                | AstNodes::LabeledStatement(_)
         ) {
             write!(f, ";");
         }
@@ -914,9 +916,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WhileStatement<'a>> {
     }
 }
 
-/// A for-head `;`-bounded slot (init/test):
+/// A for-head `;`-terminated slot (init/test):
 /// the node (if any) with its trailing comments bounded at the slot's closing `;`,
-/// or the slot's pending comments alone when it is empty.
+/// the `;` itself, and the `;`'s end-of-line trail
+/// (`for (a; // c`: this very shape's re-parse must keep the comment on the slot's line,
+/// not lead the next slot's node).
 /// Returns the scan cursor advanced past the `;`
 /// (the next slot's anchor when that slot has no node).
 ///
@@ -928,12 +932,19 @@ where
     T: Format<'a, JsFormatContext<'a>> + GetSpan,
 {
     let anchor = node.map_or(cursor, |node| node.span().end);
-    if let Some(node) = node {
-        write_node_with_trailing_comments_before(node, b';', f);
+    // Discarded flush obligation:
+    // a riding line comment's `expand_parent` breaks the head group,
+    // so a real break already follows this slot's `;`
+    let _line_comment_riding = if let Some(node) = node {
+        write_node_with_trailing_comments_before(node, b';', f)
     } else {
-        write_trailing_comments_before(anchor, b';', f);
-    }
-    f.comments().position_after_character(anchor, b';')
+        write_trailing_comments_before(anchor, b';', f)
+    };
+    write!(f, ";");
+    let cursor = f.comments().position_after_character(anchor, b';');
+    let end_of_line = f.context().comments().end_of_line_comments_after(cursor);
+    FormatTrailingComments::Comments(end_of_line).fmt(f);
+    cursor
 }
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
@@ -957,12 +968,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
             if f.comments().has_comment_before(body.span().start) {
                 let mut cursor = f.comments().position_after_character(self.span().start, b'(');
                 cursor = write_for_head_slot(init, cursor, f);
-                write!(f, ";");
                 if !is_headless {
                     write!(f, soft_line_break_or_space());
                 }
                 cursor = write_for_head_slot(test, cursor, f);
-                write!(f, ";");
                 if update.is_some() {
                     write!(f, soft_line_break_or_space());
                 }
@@ -970,7 +979,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ForStatement<'a>> {
                     FormatParenHeadExpression { expression: update, body_start: body.span().start }
                         .fmt(f);
                 } else {
-                    write_trailing_comments_before(cursor, b')', f);
+                    // Discarded flush obligation:
+                    // a riding line comment flushes at the expanded head's closing break,
+                    // still before the `)`.
+                    let _line_comment_riding = write_trailing_comments_before(cursor, b')', f);
                 }
             } else {
                 // No comment can need placing; skip the lexical scans
@@ -1229,20 +1241,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, LabeledStatement<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
         let label = self.label();
         let body = self.body();
-        write_node_with_trailing_comments_before(label, b':', f);
-        write!(f, ":");
+        write_node_with_terminator(label, ":", f);
         if matches!(body.as_ref(), Statement::EmptyStatement(_)) {
-            let empty_comments = f.context().comments().comments_before(self.span.end);
-            write!(
-                f,
-                [
-                    FormatTrailingComments::Comments(empty_comments),
-                    maybe_space(!empty_comments.is_empty()),
-                    // If the body is an empty statement, force semicolon insertion
-                    ";"
-                ]
-            );
+            write!(f, FormatStatementBody::new(body));
         } else {
+            // Not `FormatStatementBody`:
+            // a labeled non-block body stays on the label's line instead of soft-indenting.
             write_head_body_separator(body.span().start, f);
             write!(f, body);
         }

--- a/crates/oxc_formatter/src/print/switch_statement.rs
+++ b/crates/oxc_formatter/src/print/switch_statement.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     utils::{
         is_dropped_statement,
-        statement_body::{FormatStatementBody, write_node_with_trailing_comments_before},
+        statement_body::{FormatStatementBody, write_node_with_terminator},
     },
     write,
 };
@@ -74,11 +74,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SwitchCase<'a>> {
                 // For non-block consequents the generic pass's `line_suffix` flush lands
                 // before their line break, keeping the comment on the clause line,
                 // so the bound is only needed before a block's `{`.
-                write_node_with_trailing_comments_before(test, b':', f);
+                write_node_with_terminator(test, ":", f);
             } else {
-                write!(f, test);
+                write!(f, [test, ":"]);
             }
-            write!(f, ":");
             false
         } else {
             write!(f, ["default", ":"]);

--- a/crates/oxc_formatter/src/utils/statement_body.rs
+++ b/crates/oxc_formatter/src/utils/statement_body.rs
@@ -51,21 +51,52 @@ pub fn write_head_body_separator(body_start: u32, f: &mut JsFormatter<'_, '_>) {
 /// The caller prints that token next; comments past it are left pending
 /// (they lead whatever follows). Without the bound, the generic pass would
 /// claim an end-of-line comment and flush it past the following body's `{`.
+///
+/// Returns whether a claimed line comment is riding a `line_suffix`:
+/// the caller must guarantee a line break RIGHT AFTER its token (write one, or already have one),
+/// or the flush drags the comment past whatever else follows.
+/// [`write_node_with_terminator`] wraps the token-plus-flush half.
+#[must_use = "a riding line comment needs a line break right after the caller's token"]
 pub fn write_node_with_trailing_comments_before<'a, T>(
     node: &T,
     character: u8,
     f: &mut JsFormatter<'_, 'a>,
-) where
+) -> bool
+where
     T: Format<'a, JsFormatContext<'a>> + GetSpan,
 {
     FormatNodeWithoutTrailingComments(node).fmt(f);
-    write_trailing_comments_before(node.span().end, character, f);
+    write_trailing_comments_before(node.span().end, character, f)
+}
+
+/// [`write_node_with_trailing_comments_before`] plus the terminator itself
+/// and the flush break a riding line comment requires.
+/// For an in-head terminator whose following content brings no break of its own
+/// (a label's or a single-block case test's `:`).
+pub fn write_node_with_terminator<'a, T>(
+    node: &T,
+    terminator: &'static str,
+    f: &mut JsFormatter<'_, 'a>,
+) where
+    T: Format<'a, JsFormatContext<'a>> + GetSpan,
+{
+    let needs_flush = write_node_with_trailing_comments_before(node, terminator.as_bytes()[0], f);
+    write!(f, terminator);
+    if needs_flush {
+        write!(f, hard_line_break());
+    }
 }
 
 /// The node-less half of [`write_node_with_trailing_comments_before`]:
 /// prints the pending comments bounded at the next `character` as trailing comments
-/// (e.g. an empty for-head slot's comments before its `;`).
-pub fn write_trailing_comments_before(start: u32, character: u8, f: &mut JsFormatter<'_, '_>) {
+/// (e.g. an empty for-head slot's comments before its `;`),
+/// with the same returned flush obligation.
+#[must_use = "a riding line comment needs a line break right after the caller's token"]
+pub fn write_trailing_comments_before(
+    start: u32,
+    character: u8,
+    f: &mut JsFormatter<'_, '_>,
+) -> bool {
     let comments = f.context().comments().comments_before_character(start, character);
     let same_line_count =
         comments.iter().take_while(|comment| !comment.preceded_by_newline()).count();
@@ -90,6 +121,8 @@ pub fn write_trailing_comments_before(start: u32, character: u8, f: &mut JsForma
             write!(f, hard_line_break());
         }
     }
+    // The own-line loop's breaks have already flushed a pending same-line line comment
+    own_line.is_empty() && same_line.last().is_some_and(|comment| comment.is_line())
 }
 
 /// Comments between a block's `}` and a following keyword (`else`/`catch`/`finally`)

--- a/crates/oxc_formatter/tests/fixtures/js/comments/for-head-slots.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/for-head-slots.js
@@ -1,9 +1,11 @@
-// Comments in a classic for-head keep their slot: they never cross the head's
-// `;`s or its `)` in either direction, with or without a node in the slot.
+// Block and own-line comments in a classic for-head keep their slot, never
+// crossing the head's `;`s or its `)`, with or without a node in the slot
+// (a same-line line comment moves just behind its `;` instead: `a; // c`).
 // Known divergence (js/explicit-resource-management/valid-await-using-comments.js):
 // Prettier moves empty-slot comments backward across the `;`s onto the init
-// (`for (a /*8*/ /*9*/;;)`) -- an attachment artifact of the kind prettier is
-// currently fixing elsewhere (prettier#19894 family).
+// (`for (a /*8*/ /*9*/;;)`), or forward out of the parens entirely when every
+// slot is empty (`for (;;) /*s0*/ ;`) -- attachment artifacts of the kind
+// prettier is currently fixing elsewhere (prettier#19894 family).
 for (a; /*8*/; /*9*/) ;
 for (a;; /* c */) ;
 for (a;; /* c */) {}
@@ -15,3 +17,10 @@ for (;/*s1*/;) {}
 for (;;/*s2*/) ;
 for (/*s0*/; /*s1*/; /*s2*/) ;
 for (;;) /* after */ ;
+
+// A line comment around a `;` trails its slot's line and stays there
+// (`a; // c` is its own re-parse's fixpoint; control, converges with Prettier)
+for (a // c1
+; b; c) {}
+for (a; // t
+b; c) {}

--- a/crates/oxc_formatter/tests/fixtures/js/comments/for-head-slots.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/for-head-slots.js.snap
@@ -2,12 +2,14 @@
 source: crates/oxc_formatter/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
-// Comments in a classic for-head keep their slot: they never cross the head's
-// `;`s or its `)` in either direction, with or without a node in the slot.
+// Block and own-line comments in a classic for-head keep their slot, never
+// crossing the head's `;`s or its `)`, with or without a node in the slot
+// (a same-line line comment moves just behind its `;` instead: `a; // c`).
 // Known divergence (js/explicit-resource-management/valid-await-using-comments.js):
 // Prettier moves empty-slot comments backward across the `;`s onto the init
-// (`for (a /*8*/ /*9*/;;)`) -- an attachment artifact of the kind prettier is
-// currently fixing elsewhere (prettier#19894 family).
+// (`for (a /*8*/ /*9*/;;)`), or forward out of the parens entirely when every
+// slot is empty (`for (;;) /*s0*/ ;`) -- attachment artifacts of the kind
+// prettier is currently fixing elsewhere (prettier#19894 family).
 for (a; /*8*/; /*9*/) ;
 for (a;; /* c */) ;
 for (a;; /* c */) {}
@@ -20,16 +22,25 @@ for (;;/*s2*/) ;
 for (/*s0*/; /*s1*/; /*s2*/) ;
 for (;;) /* after */ ;
 
+// A line comment around a `;` trails its slot's line and stays there
+// (`a; // c` is its own re-parse's fixpoint; control, converges with Prettier)
+for (a // c1
+; b; c) {}
+for (a; // t
+b; c) {}
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
 ------------------
-// Comments in a classic for-head keep their slot: they never cross the head's
-// `;`s or its `)` in either direction, with or without a node in the slot.
+// Block and own-line comments in a classic for-head keep their slot, never
+// crossing the head's `;`s or its `)`, with or without a node in the slot
+// (a same-line line comment moves just behind its `;` instead: `a; // c`).
 // Known divergence (js/explicit-resource-management/valid-await-using-comments.js):
 // Prettier moves empty-slot comments backward across the `;`s onto the init
-// (`for (a /*8*/ /*9*/;;)`) -- an attachment artifact of the kind prettier is
-// currently fixing elsewhere (prettier#19894 family).
+// (`for (a /*8*/ /*9*/;;)`), or forward out of the parens entirely when every
+// slot is empty (`for (;;) /*s0*/ ;`) -- attachment artifacts of the kind
+// prettier is currently fixing elsewhere (prettier#19894 family).
 for (a; /*8*/; /*9*/);
 for (a; ; /* c */);
 for (a; ; /* c */) {}
@@ -42,15 +53,30 @@ for (;; /*s2*/);
 for ( /*s0*/; /*s1*/; /*s2*/);
 for (;;) /* after */ ;
 
+// A line comment around a `;` trails its slot's line and stays there
+// (`a; // c` is its own re-parse's fixpoint; control, converges with Prettier)
+for (
+  a; // c1
+  b;
+  c
+) {}
+for (
+  a; // t
+  b;
+  c
+) {}
+
 -------------------
 { printWidth: 100 }
 -------------------
-// Comments in a classic for-head keep their slot: they never cross the head's
-// `;`s or its `)` in either direction, with or without a node in the slot.
+// Block and own-line comments in a classic for-head keep their slot, never
+// crossing the head's `;`s or its `)`, with or without a node in the slot
+// (a same-line line comment moves just behind its `;` instead: `a; // c`).
 // Known divergence (js/explicit-resource-management/valid-await-using-comments.js):
 // Prettier moves empty-slot comments backward across the `;`s onto the init
-// (`for (a /*8*/ /*9*/;;)`) -- an attachment artifact of the kind prettier is
-// currently fixing elsewhere (prettier#19894 family).
+// (`for (a /*8*/ /*9*/;;)`), or forward out of the parens entirely when every
+// slot is empty (`for (;;) /*s0*/ ;`) -- attachment artifacts of the kind
+// prettier is currently fixing elsewhere (prettier#19894 family).
 for (a; /*8*/; /*9*/);
 for (a; ; /* c */);
 for (a; ; /* c */) {}
@@ -62,5 +88,18 @@ for (; /*s1*/;) {}
 for (;; /*s2*/);
 for ( /*s0*/; /*s1*/; /*s2*/);
 for (;;) /* after */ ;
+
+// A line comment around a `;` trails its slot's line and stays there
+// (`a; // c` is its own re-parse's fixpoint; control, converges with Prettier)
+for (
+  a; // c1
+  b;
+  c
+) {}
+for (
+  a; // t
+  b;
+  c
+) {}
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/head-body-blocks.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/head-body-blocks.js
@@ -47,6 +47,17 @@ foo2: // c
 }
 foo3: // c
 bar();
+// A line comment between the label and its `:` moves just behind the `:`
+// (terminator move-behind) and flushes there, never reaching the body;
+// a block comment stays before the `:` (divergence: Prettier hoists both above the label)
+foo4 // lc
+: bar();
+foo5 /* bc */
+: bar();
+// An empty-statement body's `;` is content: the comment stays before it
+foo6 // ec
+: ;
+foo7: /* c */ ;
 
 // An `if` consequent's trailing line comment rides the line without forcing
 // the consequent onto its own line, and `else` comments keep their positions

--- a/crates/oxc_formatter/tests/fixtures/js/comments/head-body-blocks.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/head-body-blocks.js.snap
@@ -51,6 +51,17 @@ foo2: // c
 }
 foo3: // c
 bar();
+// A line comment between the label and its `:` moves just behind the `:`
+// (terminator move-behind) and flushes there, never reaching the body;
+// a block comment stays before the `:` (divergence: Prettier hoists both above the label)
+foo4 // lc
+: bar();
+foo5 /* bc */
+: bar();
+// An empty-statement body's `;` is content: the comment stays before it
+foo6 // ec
+: ;
+foo7: /* c */ ;
 
 // An `if` consequent's trailing line comment rides the line without forcing
 // the consequent onto its own line, and `else` comments keep their positions
@@ -123,6 +134,16 @@ foo2: // c
 }
 foo3: // c
 bar();
+// A line comment between the label and its `:` moves just behind the `:`
+// (terminator move-behind) and flushes there, never reaching the body;
+// a block comment stays before the `:` (divergence: Prettier hoists both above the label)
+foo4: // lc
+bar();
+foo5 /* bc */: bar();
+// An empty-statement body's `;` is content: the comment stays before it
+foo6: // ec
+;
+foo7: /* c */ ;
 
 // An `if` consequent's trailing line comment rides the line without forcing
 // the consequent onto its own line, and `else` comments keep their positions
@@ -205,6 +226,16 @@ foo2: // c
 }
 foo3: // c
 bar();
+// A line comment between the label and its `:` moves just behind the `:`
+// (terminator move-behind) and flushes there, never reaching the body;
+// a block comment stays before the `:` (divergence: Prettier hoists both above the label)
+foo4: // lc
+bar();
+foo5 /* bc */: bar();
+// An empty-statement body's `;` is content: the comment stays before it
+foo6: // ec
+;
+foo7: /* c */ ;
 
 // An `if` consequent's trailing line comment rides the line without forcing
 // the consequent onto its own line, and `else` comments keep their positions

--- a/crates/oxc_formatter/tests/fixtures/js/switch/clause-block-comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/switch/clause-block-comment.js
@@ -42,3 +42,17 @@ switch (x) {
   default: // dangling
     g();
 }
+// A line comment between the test and its `:` moves just behind the `:`
+// (terminator move-behind) and flushes there, never reaching the `{`;
+// a block comment stays before the `:`.
+// (divergence: Prettier pulls the line comment past the `{`: `case g: { // c`)
+switch (x) {
+  case g // c
+  : {
+    break;
+  }
+  case h /* c */
+  : {
+    break;
+  }
+}

--- a/crates/oxc_formatter/tests/fixtures/js/switch/clause-block-comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/switch/clause-block-comment.js.snap
@@ -46,6 +46,20 @@ switch (x) {
   default: // dangling
     g();
 }
+// A line comment between the test and its `:` moves just behind the `:`
+// (terminator move-behind) and flushes there, never reaching the `{`;
+// a block comment stays before the `:`.
+// (divergence: Prettier pulls the line comment past the `{`: `case g: { // c`)
+switch (x) {
+  case g // c
+  : {
+    break;
+  }
+  case h /* c */
+  : {
+    break;
+  }
+}
 
 ==================== Output ====================
 ------------------
@@ -95,6 +109,19 @@ switch (x) {
   default: // dangling
     g();
 }
+// A line comment between the test and its `:` moves just behind the `:`
+// (terminator move-behind) and flushes there, never reaching the `{`;
+// a block comment stays before the `:`.
+// (divergence: Prettier pulls the line comment past the `{`: `case g: { // c`)
+switch (x) {
+  case g: // c
+  {
+    break;
+  }
+  case h /* c */: {
+    break;
+  }
+}
 
 -------------------
 { printWidth: 100 }
@@ -142,6 +169,19 @@ switch (x) {
     f();
   default: // dangling
     g();
+}
+// A line comment between the test and its `:` moves just behind the `:`
+// (terminator move-behind) and flushes there, never reaching the `{`;
+// a block comment stays before the `:`.
+// (divergence: Prettier pulls the line comment past the `{`: `case g: { // c`)
+switch (x) {
+  case g: // c
+  {
+    break;
+  }
+  case h /* c */: {
+    break;
+  }
 }
 
 ===================== End =====================


### PR DESCRIPTION
Covered more cases like `label` / `case`.