### PR TITLE
feat(allocator)!: remove `Allocator::cursor_ptr` and `data_end_ptr` from public API

### DIFF
--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -97,13 +97,6 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
         Self::new_impl(start_ptr, cursor_ptr, Some(chunk_footer_ptr))
     }
 
-    /// Get the current cursor pointer for this [`Arena`]'s current chunk.
-    ///
-    /// If the `Arena` is empty (has no chunks), this returns a dangling pointer aligned to `CHUNK_ALIGN`.
-    pub fn cursor_ptr(&self) -> NonNull<u8> {
-        self.cursor_ptr.get()
-    }
-
     /// Set cursor pointer for this [`Arena`]'s current chunk.
     ///
     /// This is dangerous, and this method should not ordinarily be used.

--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -1,9 +1,8 @@
 //! Define additional methods, used only by raw transfer:
 //!
 //! * [`Allocator::from_raw_parts`]
-//! * [`Allocator::cursor_ptr`]
 //! * [`Allocator::set_cursor_ptr`]
-//! * [`Allocator::data_end_ptr`]
+//! * [`Allocator::data_end_ptr`] (private within crate)
 
 use std::{alloc::Layout, ptr::NonNull};
 
@@ -68,13 +67,6 @@ impl Allocator {
         Self::from_arena(arena)
     }
 
-    /// Get the current cursor pointer for this [`Allocator`]'s current chunk.
-    ///
-    /// If the `Allocator` is empty (has no chunks), this returns a dangling pointer.
-    pub fn cursor_ptr(&self) -> NonNull<u8> {
-        self.arena().cursor_ptr()
-    }
-
     /// Set cursor pointer for this [`Allocator`]'s current chunk.
     ///
     /// This is dangerous, and this method should not ordinarily be used.
@@ -100,7 +92,7 @@ impl Allocator {
     /// i.e to the start of the `ChunkFooter`.
     ///
     /// If the `Allocator` is empty (has no chunks), this returns a dangling pointer.
-    pub fn data_end_ptr(&self) -> NonNull<u8> {
+    pub(crate) fn data_end_ptr(&self) -> NonNull<u8> {
         self.arena().data_end_ptr()
     }
 }


### PR DESCRIPTION
`Allocator::cursor_ptr` and `Allocator::data_end_ptr` were only exposed for `oxc_linter` to use for some dodgy pointer laundering. #26077 removed that code, so these methods no longer need to be exposed.

Remove them from public API - it's not ideal to be exposing the internals of the allocator to user code. Both are still used within `oxc_allocator` crate, so they're not removed entirely, but become `pub(crate)`.