### PR TITLE
fix(linter/plugins): fix interaction between JS plugins and Vue rules

### DIFF
--- a/apps/oxlint/test/fixtures/vue_multiple_scripts/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/vue_multiple_scripts/.oxlintrc.json
@@ -1,0 +1,11 @@
+{
+  "plugins": ["vue"],
+  "categories": {
+    "correctness": "off"
+  },
+  "jsPlugins": ["./plugin.ts"],
+  "rules": {
+    "vue/valid-define-emits": "error",
+    "vue-scripts-plugin/no-debugger": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/vue_multiple_scripts/files/define-in-both.vue
+++ b/apps/oxlint/test/fixtures/vue_multiple_scripts/files/define-in-both.vue
@@ -1,0 +1,12 @@
+<script>
+export default {
+  emits: ["notify"],
+};
+debugger;
+</script>
+
+<script setup>
+// `emits` is declared in the other `<script>` block too, so this is an error.
+defineEmits(["submit"]);
+debugger;
+</script>

--- a/apps/oxlint/test/fixtures/vue_multiple_scripts/files/emits-in-other-script.vue
+++ b/apps/oxlint/test/fixtures/vue_multiple_scripts/files/emits-in-other-script.vue
@@ -1,0 +1,12 @@
+<script>
+export default {
+  emits: ["notify"],
+};
+debugger;
+</script>
+
+<script setup>
+// Valid: the events are declared in the other `<script>` block.
+defineEmits();
+debugger;
+</script>

--- a/apps/oxlint/test/fixtures/vue_multiple_scripts/output.snap.md
+++ b/apps/oxlint/test/fixtures/vue_multiple_scripts/output.snap.md
@@ -1,0 +1,53 @@
+# Exit code
+1
+
+# stdout
+```
+  x vue-scripts-plugin(no-debugger): Unexpected Debugger Statement
+   ,-[files/define-in-both.vue:5:1]
+ 4 | };
+ 5 | debugger;
+   : ^^^^^^^^^
+ 6 | </script>
+   `----
+
+  x vue(valid-define-emits): Custom events are defined in both `defineEmits` and `export default {}`.
+    ,-[files/define-in-both.vue:10:1]
+  9 | // `emits` is declared in the other `<script>` block too, so this is an error.
+ 10 | defineEmits(["submit"]);
+    : ^^^^^^^^^^^^^^^^^^^^^^^
+ 11 | debugger;
+    `----
+  help: Remove `export default`.
+
+  x vue-scripts-plugin(no-debugger): Unexpected Debugger Statement
+    ,-[files/define-in-both.vue:11:1]
+ 10 | defineEmits(["submit"]);
+ 11 | debugger;
+    : ^^^^^^^^^
+ 12 | </script>
+    `----
+
+  x vue-scripts-plugin(no-debugger): Unexpected Debugger Statement
+   ,-[files/emits-in-other-script.vue:5:1]
+ 4 | };
+ 5 | debugger;
+   : ^^^^^^^^^
+ 6 | </script>
+   `----
+
+  x vue-scripts-plugin(no-debugger): Unexpected Debugger Statement
+    ,-[files/emits-in-other-script.vue:11:1]
+ 10 | defineEmits();
+ 11 | debugger;
+    : ^^^^^^^^^
+ 12 | </script>
+    `----
+
+Found 0 warnings and 5 errors.
+Finished in Xms on 2 files with 2 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/vue_multiple_scripts/plugin.ts
+++ b/apps/oxlint/test/fixtures/vue_multiple_scripts/plugin.ts
@@ -1,0 +1,31 @@
+import type { Plugin } from "#oxlint/plugins";
+
+// Reports every `debugger` statement.
+//
+// This plugin exists so that the linter takes the JS plugin code path. That path consumes the AST
+// of each `<script>` block as it lints it, which used to leave native rules that read the *other*
+// `<script>` blocks of the same file (e.g. `vue/valid-define-emits`) looking at an emptied AST.
+//
+// It reports in both blocks, so the snapshot also records that JS plugins run on every block,
+// not just the last one.
+const plugin: Plugin = {
+  meta: {
+    name: "vue-scripts-plugin",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -361,6 +361,11 @@ impl<'a> ContextHost<'a> {
         self.diagnostics.borrow_mut().extend(diagnostics);
     }
 
+    // move the context back to the first sub host, so they can be iterated over again
+    pub fn rewind_sub_hosts(&self) {
+        self.current_sub_host_index.set(0);
+    }
+
     // move the context to the next sub host
     pub fn next_sub_host(&self) -> bool {
         let next_index = self.current_sub_host_index.get() + 1;

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -367,6 +367,24 @@ impl Linter {
             .file_extension()
             .is_some_and(|ext| LINT_PARTIAL_LOADER_EXTENSIONS.iter().any(|e| e == &ext));
 
+        // Linting is done in 3 passes over the sub hosts.
+        //
+        // 1. Native rules
+        // 2. JS plugin rules
+        // 3. Unused directives
+        //
+        // Each pass must be complete before the next can start:
+        //
+        // `run_external_rules` (JS plugins) destroys the AST of the sub host it runs on - it clears the AST references
+        // from that sub host's `Semantic`, and converts that AST's spans to UTF-16 in place.
+        // Some native rules read the ASTs of *other* sub hosts via `ContextHost::other_file_hosts`
+        // (e.g. `vue/valid-define-emits` checks the `<script>` block for `export default { emits }`
+        // while linting the `<script setup>` block), so no AST can be destroyed or mutated until pass 1 is complete.
+        //
+        // A directive counts as used if it suppressed a diagnostic from either a native rule or a JS plugin rule,
+        // so this has to come after both passes above.
+
+        // Pass 1: Run native rules on every sub host in turn
         loop {
             let semantic = ctx_host.semantic();
             let rules = rules
@@ -445,10 +463,20 @@ impl Linter {
                 });
             }
 
-            // Drop `rules` to release its `Rc` clones of `ctx_host`, ensuring `run_external_rules`
-            // can mutably access `ctx_host` via `Rc::get_mut` without panicking due to multiple references.
-            drop(rules);
+            // If no next `<script>` block found, the complete file is finished linting
+            if !ctx_host.next_sub_host() {
+                break;
+            }
 
+            #[cfg(debug_assertions)]
+            {
+                current_diagnostic_index = ctx_host.diagnostic_count();
+            }
+        }
+
+        // Pass 2: Run JS plugin rules on every sub host in turn
+        ctx_host.rewind_sub_hosts();
+        loop {
             self.run_external_rules(
                 &external_rules,
                 path,
@@ -457,23 +485,25 @@ impl Linter {
                 js_allocator_pool,
             );
 
-            // Report unused directives is now handled differently with type-aware linting
-
-            if let Some(severity) = self.options.report_unused_directive
-                && severity.is_warn_deny()
-                && is_partial_loader_file
-            {
-                ctx_host.report_unused_directives(severity.into());
-            }
-
-            // no next `<script>` block found, the complete file is finished linting
             if !ctx_host.next_sub_host() {
                 break;
             }
+        }
 
-            #[cfg(debug_assertions)]
-            {
-                current_diagnostic_index = ctx_host.diagnostic_count();
+        // Pass 3: Report unused enable/disable directives for every sub host.
+        // Reporting unused directives is handled differently with type-aware linting,
+        // so this only applies to partial loader files (Vue/Astro/Svelte).
+        if let Some(severity) = self.options.report_unused_directive
+            && severity.is_warn_deny()
+            && is_partial_loader_file
+        {
+            ctx_host.rewind_sub_hosts();
+            loop {
+                ctx_host.report_unused_directives(severity.into());
+
+                if !ctx_host.next_sub_host() {
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
While working on #26077, Claude spotted another related bug.

JS plugins have to run last because they need to mutate the AST, and in the process they destroy the stored AST.

For files with multiple sections (Vue, Astro, Svelte), we ran native rules then JS rules for each section in turn. That appeared fine - JS rules do run last. But the problem is that some rules e.g. `vue/valid-define-emits` also access _earlier_ sections. Because JS plugins already ran on those previous sections, their ASTs have been discarded already, leading to incorrect results.

Instead, lint in 3 separate passes which each run on _all_ sections before going on to the next pass:

1. Native rules.
2. JS rules.
3. Unused directives.

i.e.:

- Before: section 1 native, section 1 JS, section 2 native, section 2 JS.
- After: section 1 native, section 2 native, section 1 JS, section 2 JS.

Unused directives check has to be in a separate final pass, as it requires both native rules and JS rules to have run before it.

Looping over sections is cheap compared to the work that happens in each turn of the loops, so I very much doubt this has a measurable impact on perf.

This change does have one visible effect: The order of diagnostics will change for multi-section files. Previously diagnostics would be output in section order, now they're in rule type (native/JS) order. I don't _think_ that matters.