### PR TITLE
feat(allocator)!: make `Allocator::cursor_ptr` and `data_end_ptr` private

### DIFF
--- a/crates/oxc_allocator/src/arena/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/arena/from_raw_parts.rs
@@ -100,6 +100,9 @@ impl<const MIN_ALIGN: usize> Arena<MIN_ALIGN> {
     /// Get the current cursor pointer for this [`Arena`]'s current chunk.
     ///
     /// If the `Arena` is empty (has no chunks), this returns a dangling pointer aligned to `CHUNK_ALIGN`.
+    ///
+    /// Only used in tests for fixed-sized allocators on Windows.
+    #[cfg(all(test, target_os = "windows"))]
     pub fn cursor_ptr(&self) -> NonNull<u8> {
         self.cursor_ptr.get()
     }

--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -1,9 +1,9 @@
 //! Define additional methods, used only by raw transfer:
 //!
 //! * [`Allocator::from_raw_parts`]
-//! * [`Allocator::cursor_ptr`]
 //! * [`Allocator::set_cursor_ptr`]
-//! * [`Allocator::data_end_ptr`]
+//! * `Allocator::data_end_ptr` (private within crate)
+//! * `Allocator::cursor_ptr` (private within crate, only used in tests for fixed-sized allocators on Windows)
 
 use std::{alloc::Layout, ptr::NonNull};
 
@@ -71,7 +71,10 @@ impl Allocator {
     /// Get the current cursor pointer for this [`Allocator`]'s current chunk.
     ///
     /// If the `Allocator` is empty (has no chunks), this returns a dangling pointer.
-    pub fn cursor_ptr(&self) -> NonNull<u8> {
+    ///
+    /// Only used in tests for fixed-sized allocators on Windows.
+    #[cfg(all(test, target_os = "windows"))]
+    pub(crate) fn cursor_ptr(&self) -> NonNull<u8> {
         self.arena().cursor_ptr()
     }
 
@@ -100,7 +103,7 @@ impl Allocator {
     /// i.e to the start of the `ChunkFooter`.
     ///
     /// If the `Allocator` is empty (has no chunks), this returns a dangling pointer.
-    pub fn data_end_ptr(&self) -> NonNull<u8> {
+    pub(crate) fn data_end_ptr(&self) -> NonNull<u8> {
         self.arena().data_end_ptr()
     }
 }


### PR DESCRIPTION
`Allocator::cursor_ptr` and `Allocator::data_end_ptr` were only exposed for `oxc_linter` to use for some dodgy pointer laundering. #26077 removed that code, so these methods no longer need to be exposed.

Remove them from public API - it's not ideal to be exposing the internals of the allocator to user code. Both are still used within `oxc_allocator` crate, so they're not removed entirely, but become `pub(crate)`.