### PR TITLE
docs(linter/typescript/switch-exhaustiveness-check): clarify default case comment pattern

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -6212,9 +6212,11 @@ export interface SwitchExhaustivenessCheckConfig {
    */
   considerDefaultExhaustiveForUnions?: boolean;
   /**
-   * Regular expression pattern that when matched in a default case comment,
-   * will suppress the exhaustiveness check.
-   * Example: `"@skip-exhaustive-check"` to allow `default: // @skip-exhaustive-check`
+   * Regular expression pattern for a comment that acts as an omitted `default` case.
+   * The comment must appear after the final case and the switch must not have a `default` case.
+   * For union types, it suppresses the exhaustiveness check only when
+   * `considerDefaultExhaustiveForUnions` is enabled.
+   * Example: `"^skip default$"` to allow a switch ending in `// skip default`.
    */
   defaultCaseCommentPattern?: string;
   /**

--- a/crates/oxc_linter/src/rules/typescript/switch_exhaustiveness_check.rs
+++ b/crates/oxc_linter/src/rules/typescript/switch_exhaustiveness_check.rs
@@ -17,9 +17,11 @@ pub struct SwitchExhaustivenessCheckConfig {
     /// When true, a switch statement with a `default` case is considered exhaustive
     /// even if not all union members are handled explicitly.
     pub consider_default_exhaustive_for_unions: bool,
-    /// Regular expression pattern that when matched in a default case comment,
-    /// will suppress the exhaustiveness check.
-    /// Example: `"@skip-exhaustive-check"` to allow `default: // @skip-exhaustive-check`
+    /// Regular expression pattern for a comment that acts as an omitted `default` case.
+    /// The comment must appear after the final case and the switch must not have a `default` case.
+    /// For union types, it suppresses the exhaustiveness check only when
+    /// `considerDefaultExhaustiveForUnions` is enabled.
+    /// Example: `"^skip default$"` to allow a switch ending in `// skip default`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_case_comment_pattern: Option<String>,
     /// Whether to require default cases on switches over union types that are not exhaustive.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -19247,9 +19247,9 @@
           "markdownDescription": "Whether to consider `default` cases exhaustive for union types.\nWhen true, a switch statement with a `default` case is considered exhaustive\neven if not all union members are handled explicitly."
         },
         "defaultCaseCommentPattern": {
-          "description": "Regular expression pattern that when matched in a default case comment,\nwill suppress the exhaustiveness check.\nExample: `\"@skip-exhaustive-check\"` to allow `default: // @skip-exhaustive-check`",
+          "description": "Regular expression pattern for a comment that acts as an omitted `default` case.\nThe comment must appear after the final case and the switch must not have a `default` case.\nFor union types, it suppresses the exhaustiveness check only when\n`considerDefaultExhaustiveForUnions` is enabled.\nExample: `\"^skip default$\"` to allow a switch ending in `// skip default`.",
           "type": "string",
-          "markdownDescription": "Regular expression pattern that when matched in a default case comment,\nwill suppress the exhaustiveness check.\nExample: `\"@skip-exhaustive-check\"` to allow `default: // @skip-exhaustive-check`"
+          "markdownDescription": "Regular expression pattern for a comment that acts as an omitted `default` case.\nThe comment must appear after the final case and the switch must not have a `default` case.\nFor union types, it suppresses the exhaustiveness check only when\n`considerDefaultExhaustiveForUnions` is enabled.\nExample: `\"^skip default$\"` to allow a switch ending in `// skip default`."
         },
         "requireDefaultForNonUnion": {
           "description": "Whether to require default cases on switches over union types that are not exhaustive.\nWhen true, switches with non-exhaustive union types must have a default case.",


### PR DESCRIPTION
## Summary
- clarify that `defaultCaseCommentPattern` recognizes a trailing comment in place of an omitted `default` clause
- document the required location, absence of a live `default`, and the `considerDefaultExhaustiveForUnions` requirement for union switches
- regenerate the JSON schema and TypeScript configuration types

Fixes #26087
