### PR TITLE
test(linter): cover unused directives with JS plugins in Vue

### DIFF
--- a/apps/oxlint/test/fixtures/unused_disable_directives_js_plugin_vue/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/unused_disable_directives_js_plugin_vue/.oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "jsPlugins": ["./plugin.ts"],
+  "rules": {
+    "test-plugin/noop": "error",
+    "typescript/no-explicit-any": "error"
+  },
+  "options": {
+    "reportUnusedDisableDirectives": "warn"
+  }
+}

--- a/apps/oxlint/test/fixtures/unused_disable_directives_js_plugin_vue/files/test.vue
+++ b/apps/oxlint/test/fixtures/unused_disable_directives_js_plugin_vue/files/test.vue
@@ -1,0 +1,4 @@
+<script setup lang="ts">
+// oxlint-disable-next-line typescript/no-explicit-any FORWARD does not exist on Icon enum
+const icon = Yoco.Icon.FORWARD as any;
+</script>

--- a/apps/oxlint/test/fixtures/unused_disable_directives_js_plugin_vue/output.snap.md
+++ b/apps/oxlint/test/fixtures/unused_disable_directives_js_plugin_vue/output.snap.md
@@ -1,0 +1,68 @@
+# Exit code
+0
+
+# stdout
+```
+  ! Unused oxlint-disable directive (no problems were reported from FORWARD).
+   ,-[files/test.vue:2:56]
+ 1 | <script setup lang="ts">
+ 2 | // oxlint-disable-next-line typescript/no-explicit-any FORWARD does not exist on Icon enum
+   :                                                        ^^^^^^^
+ 3 | const icon = Yoco.Icon.FORWARD as any;
+   `----
+
+  ! Unused oxlint-disable directive (no problems were reported from does).
+   ,-[files/test.vue:2:64]
+ 1 | <script setup lang="ts">
+ 2 | // oxlint-disable-next-line typescript/no-explicit-any FORWARD does not exist on Icon enum
+   :                                                                ^^^^
+ 3 | const icon = Yoco.Icon.FORWARD as any;
+   `----
+
+  ! Unused oxlint-disable directive (no problems were reported from not).
+   ,-[files/test.vue:2:69]
+ 1 | <script setup lang="ts">
+ 2 | // oxlint-disable-next-line typescript/no-explicit-any FORWARD does not exist on Icon enum
+   :                                                                     ^^^
+ 3 | const icon = Yoco.Icon.FORWARD as any;
+   `----
+
+  ! Unused oxlint-disable directive (no problems were reported from exist).
+   ,-[files/test.vue:2:73]
+ 1 | <script setup lang="ts">
+ 2 | // oxlint-disable-next-line typescript/no-explicit-any FORWARD does not exist on Icon enum
+   :                                                                         ^^^^^
+ 3 | const icon = Yoco.Icon.FORWARD as any;
+   `----
+
+  ! Unused oxlint-disable directive (no problems were reported from on).
+   ,-[files/test.vue:2:79]
+ 1 | <script setup lang="ts">
+ 2 | // oxlint-disable-next-line typescript/no-explicit-any FORWARD does not exist on Icon enum
+   :                                                                               ^^
+ 3 | const icon = Yoco.Icon.FORWARD as any;
+   `----
+
+  ! Unused oxlint-disable directive (no problems were reported from Icon).
+   ,-[files/test.vue:2:82]
+ 1 | <script setup lang="ts">
+ 2 | // oxlint-disable-next-line typescript/no-explicit-any FORWARD does not exist on Icon enum
+   :                                                                                  ^^^^
+ 3 | const icon = Yoco.Icon.FORWARD as any;
+   `----
+
+  ! Unused oxlint-disable directive (no problems were reported from enum).
+   ,-[files/test.vue:2:87]
+ 1 | <script setup lang="ts">
+ 2 | // oxlint-disable-next-line typescript/no-explicit-any FORWARD does not exist on Icon enum
+   :                                                                                       ^^^^
+ 3 | const icon = Yoco.Icon.FORWARD as any;
+   `----
+
+Found 7 warnings and 0 errors.
+Finished in Xms on 1 file with 98 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/unused_disable_directives_js_plugin_vue/plugin.ts
+++ b/apps/oxlint/test/fixtures/unused_disable_directives_js_plugin_vue/plugin.ts
@@ -1,0 +1,17 @@
+import type { Plugin } from "#oxlint/plugins";
+
+const plugin: Plugin = {
+  meta: {
+    name: "test-plugin",
+  },
+  rules: {
+    // Enables the JS plugin execution path required to reproduce issue #25892.
+    noop: {
+      create() {
+        return {};
+      },
+    },
+  },
+};
+
+export default plugin;


### PR DESCRIPTION
## Summary

- Add an end-to-end regression fixture for unused disable directives in Vue files when a JavaScript plugin is enabled.
- Exercise the original #25892 source and snapshot the unused rule-name diagnostics instead of panicking.

## Testing

- Confirmed the same fixture aborts with the reported out-of-bounds panic on detached pre-fix commit 9d97da14c8.

Closes #25892
Closes #25922

Originally fixed by #25280.