### PR TITLE
fix(transformer): preserve object rest parameter defaults

### DIFF
--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -29,14 +29,18 @@
 
 use std::{iter, mem};
 
+use rustc_hash::FxHashSet;
 use serde::Deserialize;
 
 use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress, GetAllocator, ReplaceWith, TakeIn};
 use oxc_ast::ast::*;
+use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::{BoundNames, ToJsString, WithoutGlobalReferenceInformation};
-use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
+use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags, SymbolId};
 use oxc_span::{GetSpan, SPAN};
+use oxc_str::static_ident;
+use oxc_syntax::number::NumberBase;
 use oxc_traverse::{Ancestor, MaybeBoundIdentifier, Traverse};
 
 use crate::{
@@ -58,6 +62,92 @@ pub struct ObjectRestSpread<'a> {
     options: ObjectRestSpreadOptions,
 
     excluded_variable_declarators: Vec<VariableDeclarator<'a>>,
+}
+
+struct ParameterReferenceFinder<'a, 'ctx> {
+    rest_symbols: &'ctx FxHashSet<SymbolId>,
+    ctx: &'ctx TraverseCtx<'a>,
+    found: bool,
+}
+
+impl<'a> Visit<'a> for ParameterReferenceFinder<'a, '_> {
+    fn visit_binding_identifier(&mut self, ident: &BindingIdentifier<'a>) {
+        self.found |= self.rest_symbols.contains(&ident.symbol_id());
+    }
+
+    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
+        self.found |= self
+            .ctx
+            .scoping()
+            .get_reference(ident.reference_id())
+            .symbol_id()
+            .is_some_and(|symbol_id| self.rest_symbols.contains(&symbol_id));
+    }
+
+    // Bindings referenced from nested scopes do not need to run in the parameter initializer.
+    fn visit_function(&mut self, _func: &Function<'a>, _flags: ScopeFlags) {}
+
+    fn visit_arrow_function_expression(&mut self, _arrow: &ArrowFunctionExpression<'a>) {}
+
+    fn visit_class(&mut self, _class: &Class<'a>) {}
+
+    fn visit_ts_type(&mut self, _ty: &TSType<'a>) {}
+}
+
+struct BodyShadowFinder<'a, 'ctx> {
+    function_scope_id: ScopeId,
+    ctx: &'ctx TraverseCtx<'a>,
+    found: bool,
+}
+
+impl<'a> Visit<'a> for BodyShadowFinder<'a, '_> {
+    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
+        let scoping = self.ctx.scoping();
+        let Some(body_symbol_id) = scoping.get_binding(self.function_scope_id, ident.name) else {
+            return;
+        };
+        let reference_symbol_id = scoping.get_reference(ident.reference_id()).symbol_id();
+        if reference_symbol_id == Some(body_symbol_id) {
+            return;
+        }
+
+        let resolves_inside_function = reference_symbol_id.is_some_and(|symbol_id| {
+            let symbol_scope_id = scoping.symbol_scope_id(symbol_id);
+            symbol_scope_id == self.function_scope_id
+                || scoping.scope_is_descendant_of(symbol_scope_id, self.function_scope_id)
+        });
+        self.found |= !resolves_inside_function;
+    }
+
+    fn visit_ts_type(&mut self, _ty: &TSType<'a>) {}
+}
+
+struct FunctionBodyScopeMover<'a, 'ctx> {
+    old_scope_id: ScopeId,
+    new_scope_id: ScopeId,
+    ctx: &'ctx mut TraverseCtx<'a>,
+}
+
+impl<'a> Visit<'a> for FunctionBodyScopeMover<'a, '_> {
+    fn enter_scope(&mut self, _flags: ScopeFlags, scope_id: &std::cell::Cell<Option<ScopeId>>) {
+        let scope_id = scope_id.get().unwrap();
+        if scope_id != self.old_scope_id
+            && self.ctx.scoping().scope_parent_id(scope_id) == Some(self.old_scope_id)
+        {
+            self.ctx.scoping_mut().change_scope_parent_id(scope_id, Some(self.new_scope_id));
+        }
+    }
+
+    fn visit_binding_identifier(&mut self, ident: &BindingIdentifier<'a>) {
+        let symbol_id = ident.symbol_id();
+        if self.ctx.scoping().symbol_scope_id(symbol_id) == self.old_scope_id {
+            self.ctx.scoping_mut().move_binding_by_symbol_id(
+                self.old_scope_id,
+                self.new_scope_id,
+                symbol_id,
+            );
+        }
+    }
 }
 
 impl<'a> ObjectRestSpread<'a> {
@@ -565,34 +655,374 @@ impl<'a> ObjectRestSpread<'a> {
     fn transform_function(func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
         let scope_id = func.scope_id();
         let Some(body) = func.body.as_mut() else { return };
-        for param in &mut func.params.items {
-            if Self::has_nested_object_rest(&param.pattern) {
-                Self::replace_rest_element(
-                    VariableDeclarationKind::Var,
-                    &mut param.pattern,
-                    &mut body.statements,
-                    scope_id,
-                    ctx,
-                );
-            }
-        }
+        Self::transform_function_parameters(
+            &mut func.params,
+            &mut body.statements,
+            scope_id,
+            func.r#async,
+            func.generator,
+            ctx,
+        );
     }
 
     // Transform `(...x) => {}`.
     fn transform_arrow(arrow: &mut ArrowFunctionExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+        if !arrow.params.items.iter().any(|param| Self::has_nested_object_rest(&param.pattern)) {
+            return;
+        }
         let scope_id = arrow.scope_id();
-        for param in &mut arrow.params.items {
-            if Self::has_nested_object_rest(&param.pattern) {
-                // `({ ...args }) => { args }`
-                let body = arrow_function_body_as_function_body_mut(&mut arrow.body, ctx);
+        // `({ ...args }) => { args }`
+        let body = arrow_function_body_as_function_body_mut(&mut arrow.body, ctx);
+        Self::transform_function_parameters(
+            &mut arrow.params,
+            &mut body.statements,
+            scope_id,
+            arrow.r#async,
+            false,
+            ctx,
+        );
+    }
+
+    fn transform_function_parameters(
+        params: &mut FormalParameters<'a>,
+        body: &mut ArenaVec<'a, Statement<'a>>,
+        scope_id: ScopeId,
+        r#async: bool,
+        generator: bool,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        let params_with_rest = params
+            .items
+            .iter()
+            .map(|param| Self::has_nested_object_rest(&param.pattern))
+            .collect::<Vec<_>>();
+        if !params_with_rest.iter().any(|has_rest| *has_rest) {
+            return;
+        }
+
+        let mut rest_symbols = FxHashSet::default();
+        for (param, has_rest) in params.items.iter().zip(&params_with_rest) {
+            if *has_rest {
+                param.pattern.bound_names(&mut |ident| {
+                    rest_symbols.insert(ident.symbol_id());
+                });
+            }
+        }
+
+        // Once a parameter references a binding moved out of the parameter list, that parameter
+        // and every parameter after it must move with the binding.
+        let first_reference = params.items.iter().enumerate().find_map(|(index, param)| {
+            (!params_with_rest[index]
+                && Self::parameter_references_rest_binding(param, &rest_symbols, ctx))
+            .then_some(index)
+        });
+
+        let Some(first_reference) = first_reference else {
+            for (param, has_rest) in params.items.iter_mut().zip(params_with_rest) {
+                if has_rest {
+                    Self::replace_rest_element(
+                        VariableDeclarationKind::Var,
+                        &mut param.pattern,
+                        body,
+                        scope_id,
+                        ctx,
+                    );
+                }
+            }
+            return;
+        };
+
+        let needs_scope_iife = Self::parameter_initializers_need_scope_iife(
+            params,
+            &params_with_rest,
+            first_reference,
+            scope_id,
+            ctx,
+        );
+
+        let mut prefix = ArenaVec::new_in(ctx);
+        let mut first_optional = None;
+        for (index, has_rest) in params_with_rest.into_iter().enumerate() {
+            if index < first_reference && !has_rest {
+                continue;
+            }
+
+            let param = &mut params.items[index];
+            let mut rest_statements = ArenaVec::new_in(ctx);
+            if has_rest {
                 Self::replace_rest_element(
                     VariableDeclarationKind::Var,
                     &mut param.pattern,
-                    &mut body.statements,
+                    &mut rest_statements,
                     scope_id,
                     ctx,
                 );
             }
+
+            if let Some(default) = param.initializer.take() {
+                first_optional.get_or_insert(index);
+                let pattern = param.pattern.take_in(ctx);
+                prefix.push(Self::create_default_parameter_statement(
+                    pattern,
+                    default.unbox(),
+                    index,
+                    scope_id,
+                    ctx,
+                ));
+            } else if first_optional.is_some() {
+                let pattern = param.pattern.take_in(ctx);
+                prefix
+                    .push(Self::create_trailing_parameter_statement(pattern, index, scope_id, ctx));
+            } else if matches!(
+                param.pattern,
+                BindingPattern::ObjectPattern(_) | BindingPattern::ArrayPattern(_)
+            ) {
+                let declaration = Self::create_temporary_reference_for_binding(
+                    VariableDeclarationKind::Var,
+                    &mut param.pattern,
+                    scope_id,
+                    ctx,
+                );
+                prefix.push(Statement::VariableDeclaration(declaration));
+            }
+
+            prefix.extend(rest_statements);
+        }
+
+        if let Some(first_optional) = first_optional {
+            params.items.truncate(first_optional);
+        }
+        if needs_scope_iife {
+            // Parameter initializers cannot see declarations from the function body. Keep that
+            // boundary when a moved initializer would otherwise bind to a body declaration.
+            let original_body = body.take_in(ctx);
+            prefix.push(Self::create_scope_iife_return(
+                original_body,
+                scope_id,
+                r#async,
+                generator,
+                ctx,
+            ));
+            *body = prefix;
+        } else {
+            body.splice(0..0, prefix);
+        }
+    }
+
+    fn parameter_references_rest_binding(
+        param: &FormalParameter<'a>,
+        rest_symbols: &FxHashSet<SymbolId>,
+        ctx: &TraverseCtx<'a>,
+    ) -> bool {
+        let mut finder = ParameterReferenceFinder { rest_symbols, ctx, found: false };
+        finder.visit_binding_pattern(&param.pattern);
+        if !finder.found
+            && let Some(initializer) = &param.initializer
+        {
+            finder.visit_expression(initializer);
+        }
+        finder.found
+    }
+
+    fn parameter_initializers_need_scope_iife(
+        params: &FormalParameters<'a>,
+        params_with_rest: &[bool],
+        first_reference: usize,
+        scope_id: ScopeId,
+        ctx: &TraverseCtx<'a>,
+    ) -> bool {
+        let mut finder = BodyShadowFinder { function_scope_id: scope_id, ctx, found: false };
+        for (index, param) in params.items.iter().enumerate() {
+            if index < first_reference && !params_with_rest[index] {
+                continue;
+            }
+            finder.visit_binding_pattern(&param.pattern);
+            if let Some(initializer) = &param.initializer {
+                finder.visit_expression(initializer);
+            }
+        }
+        finder.found
+    }
+
+    fn create_scope_iife_return(
+        statements: ArenaVec<'a, Statement<'a>>,
+        parent_scope_id: ScopeId,
+        r#async: bool,
+        generator: bool,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Statement<'a> {
+        let parent_flags = ctx.scoping().scope_flags(parent_scope_id);
+        let mut scope_flags = ScopeFlags::Function;
+        scope_flags.set(ScopeFlags::Arrow, !generator);
+        scope_flags.set(ScopeFlags::StrictMode, parent_flags.is_strict_mode());
+        scope_flags.set(ScopeFlags::DirectEval, parent_flags.contains_direct_eval());
+        let scope_id = ctx.create_child_scope(parent_scope_id, scope_flags);
+
+        FunctionBodyScopeMover { old_scope_id: parent_scope_id, new_scope_id: scope_id, ctx }
+            .visit_statements(&statements);
+
+        let params_kind = if generator {
+            FormalParameterKind::FormalParameter
+        } else {
+            FormalParameterKind::ArrowFormalParameters
+        };
+        let params = FormalParameters::boxed(SPAN, params_kind, [], None, ctx);
+        let body = FunctionBody::boxed(SPAN, [], statements, ctx);
+        let callee = if generator {
+            Expression::new_function_expression_with_scope_id_and_pure_and_pife(
+                SPAN,
+                FunctionType::FunctionExpression,
+                None,
+                true,
+                r#async,
+                false,
+                None,
+                None,
+                params,
+                None,
+                Some(body),
+                scope_id,
+                false,
+                false,
+                ctx,
+            )
+        } else {
+            Expression::new_arrow_function_expression_with_scope_id_and_pure_and_pife(
+                SPAN,
+                r#async,
+                None,
+                params,
+                None,
+                ArrowFunctionBody::FunctionBody(body),
+                scope_id,
+                false,
+                false,
+                ctx,
+            )
+        };
+        let call = Expression::new_call_expression(SPAN, callee, None, [], false, ctx);
+        let result = if generator {
+            Expression::new_yield_expression(SPAN, true, Some(call), ctx)
+        } else {
+            call
+        };
+        Statement::new_return_statement(SPAN, Some(result), ctx)
+    }
+
+    fn create_default_parameter_statement(
+        pattern: BindingPattern<'a>,
+        default: Expression<'a>,
+        index: usize,
+        scope_id: ScopeId,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Statement<'a> {
+        let length_test = Expression::new_binary_expression(
+            SPAN,
+            Self::create_arguments_length(ctx),
+            BinaryOperator::GreaterThan,
+            Self::create_parameter_index(index, ctx),
+            ctx,
+        );
+        let defined_test = Expression::new_binary_expression(
+            SPAN,
+            Self::create_arguments_access(index, ctx),
+            BinaryOperator::StrictInequality,
+            Self::create_undefined(scope_id, ctx),
+            ctx,
+        );
+        let test = Expression::new_logical_expression(
+            SPAN,
+            length_test,
+            LogicalOperator::And,
+            defined_test,
+            ctx,
+        );
+        let init = Expression::new_conditional_expression(
+            SPAN,
+            test,
+            Self::create_arguments_access(index, ctx),
+            default,
+            ctx,
+        );
+        Self::create_parameter_binding_statement(pattern, init, ctx)
+    }
+
+    fn create_trailing_parameter_statement(
+        pattern: BindingPattern<'a>,
+        index: usize,
+        scope_id: ScopeId,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Statement<'a> {
+        let test = Expression::new_binary_expression(
+            SPAN,
+            Self::create_arguments_length(ctx),
+            BinaryOperator::GreaterThan,
+            Self::create_parameter_index(index, ctx),
+            ctx,
+        );
+        let init = Expression::new_conditional_expression(
+            SPAN,
+            test,
+            Self::create_arguments_access(index, ctx),
+            Self::create_undefined(scope_id, ctx),
+            ctx,
+        );
+        Self::create_parameter_binding_statement(pattern, init, ctx)
+    }
+
+    fn create_parameter_binding_statement(
+        pattern: BindingPattern<'a>,
+        init: Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Statement<'a> {
+        pattern.bound_names(&mut |ident| {
+            *ctx.scoping_mut().symbol_flags_mut(ident.symbol_id()) =
+                SymbolFlags::BlockScopedVariable;
+        });
+        let declaration = VariableDeclarator::new(SPAN, pattern, None, Some(init), false, ctx);
+        Statement::VariableDeclaration(VariableDeclaration::boxed(
+            SPAN,
+            VariableDeclarationKind::Let,
+            [declaration],
+            false,
+            ctx,
+        ))
+    }
+
+    fn create_arguments_length(ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
+        let arguments =
+            ctx.create_unbound_ident_expr(SPAN, static_ident!("arguments"), ReferenceFlags::Read);
+        Expression::new_static_member_expression(
+            SPAN,
+            arguments,
+            IdentifierName::new(SPAN, static_ident!("length"), ctx),
+            false,
+            ctx,
+        )
+    }
+
+    fn create_arguments_access(index: usize, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
+        let arguments =
+            ctx.create_unbound_ident_expr(SPAN, static_ident!("arguments"), ReferenceFlags::Read);
+        Expression::new_computed_member_expression(
+            SPAN,
+            arguments,
+            Self::create_parameter_index(index, ctx),
+            false,
+            ctx,
+        )
+    }
+
+    fn create_parameter_index(index: usize, ctx: &TraverseCtx<'a>) -> Expression<'a> {
+        let index = f64::from(u32::try_from(index).unwrap());
+        Expression::new_numeric_literal(SPAN, index, None, NumberBase::Decimal, ctx)
+    }
+
+    fn create_undefined(scope_id: ScopeId, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
+        if ctx.scoping().find_binding(scope_id, static_ident!("undefined")).is_some() {
+            Expression::new_void_0(SPAN, ctx)
+        } else {
+            ctx.create_unbound_ident_expr(SPAN, static_ident!("undefined"), ReferenceFlags::Read)
         }
     }
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: b465fdbf
 
 semantic_typescript Summary:
 AST Parsed     : 4720/4720 (100.00%)
-Positive Passed: 3489/4720 (73.92%)
+Positive Passed: 3490/4720 (73.94%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
@@ -17576,17 +17576,6 @@ rebuilt        : SymbolId(0): Span { start: 38, end: 39 }
 Symbol redeclarations mismatch for "f":
 after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 38, end: 39 }]
 rebuilt        : SymbolId(0): []
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionParameterObjectRestAndInitializers.ts
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(6): []
-Reference symbol mismatch for "a":
-after transform: SymbolId(1) "a"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: ["require"]
-rebuilt        : ["a", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/generators/generatorYieldContextualType.ts
 Bindings mismatch:

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters-object-rest-used-in-default/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters-object-rest-used-in-default/output.js
@@ -1,26 +1,36 @@
 const _excluded = ["X"];
-(_ref, a = R) => {
-	let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref), _ref));
+(_ref) => {
+  let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref), _ref));
+  let a = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : R;
 };
-(_ref2, { a = { Y } }) => {
-	let { X: Y } = _ref2, R = babelHelpers.objectWithoutProperties(_ref2, _excluded);
+(_ref2, _ref3) => {
+  let { X: Y } = _ref2, R = babelHelpers.objectWithoutProperties(_ref2, _excluded);
+  let { a = { Y } } = _ref3;
 };
-(a = R, _ref3) => {
-	let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref3), _ref3));
+() => {
+  let a = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : R;
+  let _ref4 = arguments.length > 1 ? arguments[1] : undefined;
+  let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref4), _ref4));
 };
-(_ref4, e, c = 2, a = R, f = q) => {
-	let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref4), _ref4));
-	let q;
+(_ref5, e, c = 2) => {
+  let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref5), _ref5));
+  let a = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : R;
+  let f = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : q;
+  return (() => {
+    let q;
+  })();
 };
-(_ref5, a = f(R)) => {
-	let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref5), _ref5));
+(_ref6) => {
+  let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref6), _ref6));
+  let a = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : f(R);
 };
-(_ref6, { [R.key]: a = 42 }) => {
-	let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref6), _ref6));
+(_ref7, _ref8) => {
+  let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref7), _ref7));
+  let { [R.key]: a = 42 } = _ref8;
 };
-(_ref7, { a = { R: b } }) => {
-	let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref7), _ref7));
+(_ref9, { a = { R: b } }) => {
+  let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref9), _ref9));
 };
-(_ref8, { a = (R) => R } = { b: (R) => R }) => {
-	let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref8), _ref8));
+(_ref10, { a = (R) => R } = { b: (R) => R }) => {
+  let R = babelHelpers.extends({}, (babelHelpers.objectDestructuringEmpty(_ref10), _ref10));
 };

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 1eac4481
 
-Passed: 731/1162
+Passed: 732/1162
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -924,7 +924,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-object-rest-spread (28/39)
+# babel-plugin-transform-object-rest-spread (29/39)
 * object-rest/for-x/input.js
 x Output mismatch
 
@@ -945,47 +945,6 @@ x Output mismatch
 
 * object-rest/object-ref-computed/input.js
 x Output mismatch
-
-* object-rest/parameters-object-rest-used-in-default/input.js
-Symbol reference IDs mismatch for "R":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "Y":
-after transform: SymbolId(2): [ReferenceId(1)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "R":
-after transform: SymbolId(6): [ReferenceId(2)]
-rebuilt        : SymbolId(10): []
-Symbol reference IDs mismatch for "R":
-after transform: SymbolId(7): [ReferenceId(3)]
-rebuilt        : SymbolId(16): []
-Symbol reference IDs mismatch for "R":
-after transform: SymbolId(13): [ReferenceId(6)]
-rebuilt        : SymbolId(20): []
-Symbol reference IDs mismatch for "R":
-after transform: SymbolId(15): [ReferenceId(7)]
-rebuilt        : SymbolId(23): []
-Reference symbol mismatch for "R":
-after transform: SymbolId(0) "R"
-rebuilt        : <None>
-Reference symbol mismatch for "Y":
-after transform: SymbolId(2) "Y"
-rebuilt        : <None>
-Reference symbol mismatch for "R":
-after transform: SymbolId(6) "R"
-rebuilt        : <None>
-Reference symbol mismatch for "R":
-after transform: SymbolId(7) "R"
-rebuilt        : <None>
-Reference symbol mismatch for "R":
-after transform: SymbolId(13) "R"
-rebuilt        : <None>
-Reference symbol mismatch for "R":
-after transform: SymbolId(15) "R"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: ["b", "babelHelpers", "f", "q"]
-rebuilt        : ["R", "Y", "b", "babelHelpers", "f", "q"]
 
 * object-rest/symbol/input.js
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 1eac4481
 
-Passed: 270/398
+Passed: 271/399
 
 # All Passed:
 * babel-plugin-transform-class-static-block

--- a/tasks/transform_conformance/snapshots/oxc_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc_exec.snap.md
@@ -2,7 +2,7 @@ commit: 1eac4481
 
 node: v26.5.0
 
-Passed: 15 of 17 (88.24%)
+Passed: 16 of 18 (88.89%)
 
 Failures:
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters-reference-rest-binding/exec.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters-reference-rest-binding/exec.js
@@ -1,0 +1,33 @@
+function readAfter({ value, ...rest }, selected = value) {
+  return [rest, selected];
+}
+
+expect(readAfter({ value: 1, other: 2 })).toEqual([{ other: 2 }, 1]);
+expect(readAfter({ value: 1, other: 2 }, 3)).toEqual([{ other: 2 }, 3]);
+
+const rest = "outer";
+function readBefore(selected = rest, { ...rest }) {
+  return selected;
+}
+
+expect(() => readBefore(undefined, { other: 2 })).toThrow(ReferenceError);
+
+const value = "outer";
+const receiver = {
+  readShadowed({ ...rest }, selected = rest, shadowed = value) {
+    let value;
+    return [this, arguments[0], rest, selected, shadowed];
+  },
+};
+
+const argument = { other: 2 };
+expect(receiver.readShadowed(argument)).toEqual([
+  receiver,
+  argument,
+  { other: 2 },
+  { other: 2 },
+  "outer",
+]);
+
+expect(readAfter.length).toBe(1);
+expect(readBefore.length).toBe(0);

--- a/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters-reference-rest-binding/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters-reference-rest-binding/input.js
@@ -1,0 +1,9 @@
+const rest = "outer";
+
+function readAfter({ value, ...rest }, selected = value) {
+  return [rest, selected];
+}
+
+function readBefore(selected = rest, { ...rest }) {
+  return selected;
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters-reference-rest-binding/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-object-rest-spread/test/fixtures/object-rest/parameters-reference-rest-binding/output.js
@@ -1,0 +1,25 @@
+const _excluded = ["value"];
+const rest = "outer";
+
+function readAfter(_ref) {
+  let { value } = _ref,
+    rest = babelHelpers.objectWithoutProperties(_ref, _excluded);
+  let selected =
+    arguments.length > 1 && arguments[1] !== undefined
+      ? arguments[1]
+      : value;
+  return [rest, selected];
+}
+
+function readBefore() {
+  let selected =
+    arguments.length > 0 && arguments[0] !== undefined
+      ? arguments[0]
+      : rest;
+  let _ref2 = arguments.length > 1 ? arguments[1] : undefined;
+  let rest = babelHelpers.extends(
+    {},
+    (babelHelpers.objectDestructuringEmpty(_ref2), _ref2),
+  );
+  return selected;
+}


### PR DESCRIPTION
Stacked on #26099.

Object-rest parameters are moved into the function body. Later defaults that reference those bindings must move with them too; otherwise they run before the lowered binding exists and throw at runtime.

This preserves function length and the parameter/body scope boundary, with output and runtime coverage for TDZ, shadowing, `this`, and `arguments`.

Related: rolldown/rolldown#10779. Long-term scope model: oxc-project/backlog#176.

Verified with transformer unit, conformance, exec, coverage, traverse, clippy, and formatting checks. `just ready` only stops on the repository Node snapshot because this machine uses v25.8.1 while the snapshot records v26.5.0.

AI assistance: Codex helped implement and test this change. I reviewed the code and take responsibility for it.
