### PR TITLE
perf(packages/codegen): ensure indent strings are flattened

### DIFF
--- a/packages/codegen/src-js/print/indent.ts
+++ b/packages/codegen/src-js/print/indent.ts
@@ -43,10 +43,10 @@ function growIndents(state: State, level: number): string {
   let { length } = indents;
   let indent = indents[length - 1];
   for (; length <= level; length++) {
-    indent += indentString;
-    // Force the cons string flat.
-    // That costs here, but it is appended to the output many times afterwards.
-    indent.charCodeAt(0);
+    // Use `join` instead of `indent += indentString` to produce a flat string instead of a rope.
+    // That costs a little here, but is a one-time cost, and it is appended to the output many times afterwards,
+    // so reduces the number of segments in `output` rope string for every file.
+    indent = [indent, indentString].join("");
     indents.push(indent);
   }
 


### PR DESCRIPTION
Codegen pre-prepares strings for writing indentation and caches them.

This PR ensure that these strings are properly flattened. They already were - `indent.charCodeAt(0)` does that. But that's only the case as long as `growIndents` doesn't get tiered up to TurboFan. If it does, TurboFan treats `indent.charCodeAt(0)` as a no-op, and removes it as dead code, which removes the flattening.

`growIndents` is a cold path, so it's unlikely to get tiered up, but make sure that even if it does, we don't lose the flattening by using `indent = [indent, indentString].join("");` instead.

No effect on benchmarks, because TurboFan wasn't kicking in here.